### PR TITLE
Phase 17A: Settings Consolidation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1840,7 +1840,7 @@ Within 16B, all tasks are independent and can be parallelized.
 
 ---
 
-## Phase 17A: Settings Consolidation
+## Phase 17A: Settings Consolidation ✅
 
 Enhances the settings page to be the single surface for all app configuration. Absorbs the settings tasks from Phase 13B (13B.3-13B.7) and adds provider configuration that previously lived in the wizard. The settings page becomes a single page with collapsible card sections.
 
@@ -1848,65 +1848,65 @@ Enhances the settings page to be the single surface for all app configuration. A
 
 **Note:** Phase 13B tasks 13B.1 and 13B.2 (wizard enhancements) are superseded by Phase 17B. Tasks 13B.3-13B.7 are absorbed here. 13B.8 (family members connection count) remains independent.
 
-### 17A.1 Settings Page Restructure
+### 17A.1 Settings Page Restructure ✅
 
-- [ ] Reorganize the settings page into distinct card sections (DaisyUI `card` or `<article>` with clear headers):
+- [x] Reorganize the settings page into distinct card sections (DaisyUI `card` or `<article>` with clear headers):
   - **Providers** — Plaid config, Teller config, CSV status
   - **Sync & Scheduling** — sync interval, webhook URL
   - **Security** — admin password change, encryption key status
   - **System** — app version, Go version, PostgreSQL version, uptime, provider count
-- [ ] Each section is a collapsible card (DaisyUI `collapse` or `<details>`) — all expanded by default
-- [ ] Each section has its own form/save button (independent saves, not one giant form)
-- [ ] Remove the "Re-run Setup Wizard" link from settings footer
+- [x] Each section is a collapsible card (DaisyUI `collapse` or `<details>`) — all expanded by default
+- [x] Each section has its own form/save button (independent saves, not one giant form)
+- [x] Remove the "Re-run Setup Wizard" link from settings footer
 - **Absorbs:** 13B.4 (system info section structure), 13B.7 (safety indicators structure)
 - **Ref:** `internal/admin/settings.go` (lines 22-128), `internal/templates/pages/settings.html`
 - **Files:** `internal/admin/settings.go`, `internal/templates/pages/settings.html`
 
-### 17A.2 Provider Configuration Section
+### 17A.2 Provider Configuration Section ✅
 
-- [ ] **Plaid** (existing, enhanced): Client ID, Secret, Environment fields — editable when not from env vars. "Test Connection" button. Show "(from env)" badges when values come from environment.
-- [ ] **Teller** (new editability): Make `teller_app_id` and `teller_env` editable in the form when NOT set via env vars (they already have DB fallback paths in `config.LoadWithDB`). Cert/key paths remain read-only (file system paths, env-var-only). Show clear status: "Active (from env)" / "Partially configured" / "Not configured". Include copy-ready env var snippet in expandable `<details>` for the cert/key setup.
-- [ ] **CSV**: Read-only status line: "CSV Import: Always available" with link to `/admin/connections/import-csv` (Phase 11)
-- [ ] Provider test buttons: "Test Plaid" and "Test Teller" with inline result display
+- [x] **Plaid** (existing, enhanced): Client ID, Secret, Environment fields — editable when not from env vars. "Test Connection" button. Show "(from env)" badges when values come from environment.
+- [x] **Teller** (new editability): Make `teller_app_id` and `teller_env` editable in the form when NOT set via env vars (they already have DB fallback paths in `config.LoadWithDB`). Cert/key paths remain read-only (file system paths, env-var-only). Show clear status: "Active (from env)" / "Partially configured" / "Not configured". Include copy-ready env var snippet in expandable `<details>` for the cert/key setup.
+- [x] **CSV**: Read-only status line: "CSV Import: Always available" with link to `/admin/connections/import-csv` (Phase 11)
+- [x] Provider test buttons: "Test Plaid" and "Test Teller" with inline result display
 - **Absorbs:** 13B.6 (Teller configuration guidance)
 - **Ref:** `internal/admin/settings.go` (lines 22-43 for GET data, lines 46-128 for POST), `internal/config/load.go` (Teller DB fallback)
 - **Files:** `internal/admin/settings.go`, `internal/templates/pages/settings.html`
 
-### 17A.3 Sync & Scheduling Section
+### 17A.3 Sync & Scheduling Section ✅
 
-- [ ] Sync interval: dropdown with options (15m, 30m, 1h, 4h, 8h, 12h, 24h) — same as current settings, stored as `sync_interval_minutes`
-- [ ] Webhook URL: text input with HTTPS validation — same as current settings
-- [ ] Add brief explanatory text: "Breadbox automatically syncs bank data on this schedule. Webhooks provide real-time updates when supported by the provider."
-- [ ] Show next scheduled sync time if possible (from cron scheduler state)
+- [x] Sync interval: dropdown with options (15m, 30m, 1h, 4h, 8h, 12h, 24h) — same as current settings, stored as `sync_interval_minutes`
+- [x] Webhook URL: text input with HTTPS validation — same as current settings
+- [x] Add brief explanatory text: "Breadbox automatically syncs bank data on this schedule. Webhooks provide real-time updates when supported by the provider."
+- [x] Show next scheduled sync time if possible (from cron scheduler state)
 - **Files:** `internal/admin/settings.go`, `internal/templates/pages/settings.html`
 
-### 17A.4 Security Section
+### 17A.4 Security Section ✅
 
-- [ ] **Change Admin Password**: current password + new password + confirm new password form
-- [ ] New sqlc query: `UpdateAdminPassword(ctx, id, hashed_password)` — or `UpdateAdminPasswordByUsername`
-- [ ] Validate current password before accepting change. Minimum 8 characters (same as setup)
-- [ ] Flash: "Password updated successfully"
-- [ ] **Encryption Key Status**: Read-only indicator — "Configured" (green badge) or "NOT SET — access tokens cannot be stored" (red badge). Never show the actual key.
-- [ ] **Plaid Environment Change Warning**: if Plaid env is being changed from current value, show confirmation dialog warning about breaking live connections
+- [x] **Change Admin Password**: current password + new password + confirm new password form
+- [x] New sqlc query: `UpdateAdminPassword(ctx, id, hashed_password)` — or `UpdateAdminPasswordByUsername`
+- [x] Validate current password before accepting change. Minimum 8 characters (same as setup)
+- [x] Flash: "Password updated successfully"
+- [x] **Encryption Key Status**: Read-only indicator — "Configured" (green badge) or "NOT SET — access tokens cannot be stored" (red badge). Never show the actual key.
+- [x] **Plaid Environment Change Warning**: if Plaid env is being changed from current value, show confirmation dialog warning about breaking live connections
 - **Absorbs:** 13B.3 (change admin password), 13B.7 (safety indicators)
 - **Files:** `internal/admin/settings.go`, `internal/templates/pages/settings.html`, `internal/db/queries/admin_accounts.sql`
 
-### 17A.5 System Information Section
+### 17A.5 System Information Section ✅
 
-- [ ] Read-only, informational — primarily for operator debugging
-- [ ] Display: Breadbox version (from build-time `-ldflags -X`), Go runtime version (`runtime.Version()`), PostgreSQL version (`SELECT version()`), server uptime (`time.Since(startTime)`), configured providers count
-- [ ] Requires passing `startTime` from app init to the settings handler (or a global)
-- [ ] Collapsible by default (less important than other sections)
+- [x] Read-only, informational — primarily for operator debugging
+- [x] Display: Breadbox version (from build-time `-ldflags -X`), Go runtime version (`runtime.Version()`), PostgreSQL version (`SELECT version()`), server uptime (`time.Since(startTime)`), configured providers count
+- [x] Requires passing `startTime` from app init to the settings handler (or a global)
+- [x] Collapsible by default (less important than other sections)
 - **Absorbs:** 13B.4 (system information section)
 - **Files:** `internal/admin/settings.go`, `internal/templates/pages/settings.html`
 
-### 17A.6 Config Source Badges
+### 17A.6 Config Source Badges ✅
 
-- [ ] Add `ConfigSources map[string]string` (key → "env" / "db" / "default") populated during `config.LoadWithDB`
-- [ ] Pass to settings template alongside config values
-- [ ] Render muted badge next to each setting value: "(from env)", "(from database)", "(default)"
-- [ ] Makes the config precedence model (env → DB → default) visible and debuggable
-- [ ] Values from env are shown as read-only (cannot override env vars via the UI)
+- [x] Add `ConfigSources map[string]string` (key → "env" / "db" / "default") populated during `config.LoadWithDB`
+- [x] Pass to settings template alongside config values
+- [x] Render muted badge next to each setting value: "(from env)", "(from database)", "(default)"
+- [x] Makes the config precedence model (env → DB → default) visible and debuggable
+- [x] Values from env are shown as read-only (cannot override env vars via the UI)
 - **Absorbs:** 13B.5 (config source badges)
 - **Files:** `internal/config/config.go`, `internal/config/load.go`, `internal/admin/settings.go`, `internal/templates/pages/settings.html`
 

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -78,7 +78,8 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/accounts/{id}", AccountDetailHandler(a, sm, tr, svc))
 		r.Get("/sync-logs", SyncLogsHandler(a, sm, tr, svc))
 		r.Get("/settings", SettingsGetHandler(a, sm, tr))
-		r.Post("/settings", SettingsPostHandler(a, sm, tr, svc))
+		r.Post("/settings/sync", SettingsSyncPostHandler(a, sm))
+		r.Post("/settings/providers", SettingsProvidersPostHandler(a, sm))
 		r.Post("/settings/password", ChangePasswordHandler(a, sm))
 	})
 

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -13,13 +13,24 @@ import (
 	"breadbox/internal/db"
 	plaidprovider "breadbox/internal/provider/plaid"
 	tellerprovider "breadbox/internal/provider/teller"
-	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/crypto/bcrypt"
 )
+
+// formatNextSync returns a human-readable string for the next sync time.
+func formatNextSync(nextRun time.Time) string {
+	if nextRun.IsZero() {
+		return ""
+	}
+	d := time.Until(nextRun)
+	if d <= 0 {
+		return "any moment now"
+	}
+	return "in " + formatUptime(d)
+}
 
 // SettingsGetHandler serves GET /admin/settings.
 func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
@@ -56,21 +67,26 @@ func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 			"ConfigSources":   a.Config.ConfigSources,
 			// Safety indicators (13B.7)
 			"HasEncryptionKey": len(a.Config.EncryptionKey) > 0,
+			// Next sync time (17A.3)
+			"NextSyncTime": func() string {
+				if a.Scheduler != nil {
+					return formatNextSync(a.Scheduler.NextRun())
+				}
+				return ""
+			}(),
 		}
 		tr.Render(w, r, "settings.html", data)
 	}
 }
 
-// SettingsPostHandler serves POST /admin/settings.
-func SettingsPostHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service) http.HandlerFunc {
+// SettingsSyncPostHandler serves POST /admin/settings/sync.
+func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		// Parse form values.
 		syncIntervalStr := r.FormValue("sync_interval_minutes")
 		webhookURL := strings.TrimSpace(r.FormValue("webhook_url"))
 
-		// Validate sync interval.
 		syncInterval, err := strconv.Atoi(syncIntervalStr)
 		if err != nil || !isValidSyncInterval(syncInterval) {
 			SetFlash(ctx, sm, "error", "Invalid sync interval.")
@@ -78,14 +94,12 @@ func SettingsPostHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRendere
 			return
 		}
 
-		// Validate webhook URL.
 		if webhookURL != "" && !strings.HasPrefix(webhookURL, "https://") {
 			SetFlash(ctx, sm, "error", "Webhook URL must use HTTPS.")
 			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
 			return
 		}
 
-		// Save sync settings.
 		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 			Key:   "sync_interval_minutes",
 			Value: pgtype.Text{String: fmt.Sprintf("%d", syncInterval), Valid: true},
@@ -108,6 +122,16 @@ func SettingsPostHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRendere
 		}
 		a.Config.WebhookURL = webhookURL
 
+		SetFlash(ctx, sm, "success", "Sync settings saved.")
+		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+	}
+}
+
+// SettingsProvidersPostHandler serves POST /admin/settings/providers.
+func SettingsProvidersPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
 		// Handle Plaid credentials if not set from environment.
 		if os.Getenv("PLAID_CLIENT_ID") == "" {
 			plaidClientID := strings.TrimSpace(r.FormValue("plaid_client_id"))
@@ -115,7 +139,6 @@ func SettingsPostHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRendere
 			plaidEnv := strings.TrimSpace(r.FormValue("plaid_env"))
 
 			if plaidClientID != "" && plaidSecret != "" && plaidEnv != "" {
-				// Validate credentials before saving.
 				if err := plaidprovider.ValidateCredentials(ctx, plaidClientID, plaidSecret, plaidEnv); err != nil {
 					SetFlash(ctx, sm, "error", "Invalid Plaid credentials: "+err.Error())
 					http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
@@ -141,7 +164,7 @@ func SettingsPostHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRendere
 			}
 		}
 
-		// Handle Teller credentials if not set from environment (13B.6).
+		// Handle Teller credentials if not set from environment.
 		if os.Getenv("TELLER_APP_ID") == "" {
 			tellerAppID := strings.TrimSpace(r.FormValue("teller_app_id"))
 			tellerEnv := strings.TrimSpace(r.FormValue("teller_env"))
@@ -171,7 +194,7 @@ func SettingsPostHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRendere
 			}
 		}
 
-		SetFlash(ctx, sm, "success", "Settings saved.")
+		SetFlash(ctx, sm, "success", "Provider settings saved.")
 		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
 	}
 }

--- a/internal/sync/scheduler.go
+++ b/internal/sync/scheduler.go
@@ -52,6 +52,16 @@ func (s *Scheduler) IsRunning() bool {
 	return len(s.cron.Entries()) > 0
 }
 
+// NextRun returns the next scheduled cron fire time.
+// Returns zero time if no entries are scheduled.
+func (s *Scheduler) NextRun() time.Time {
+	entries := s.cron.Entries()
+	if len(entries) == 0 {
+		return time.Time{}
+	}
+	return entries[0].Next
+}
+
 // Stop gracefully stops the scheduler, waiting for any running jobs to finish.
 func (s *Scheduler) Stop() {
 	ctx := s.cron.Stop()

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -1,44 +1,15 @@
 {{define "content"}}
 <h1 class="text-2xl font-bold mb-6">Settings</h1>
 
-{{if .HasEncryptionKey}}
-<div class="alert alert-success mb-6">Encryption: Configured</div>
-{{else}}
-<div class="alert alert-error mb-6">Encryption: NOT SET &mdash; access tokens cannot be stored</div>
-{{end}}
+<!-- Providers Section -->
+<div class="collapse collapse-arrow bg-base-100 shadow-sm mb-6">
+  <input type="checkbox" checked />
+  <div class="collapse-title text-xl font-medium">Providers</div>
+  <div class="collapse-content">
+    <form method="POST" action="/admin/settings/providers">
+      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
-<form method="POST" action="/admin/settings">
-  <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-
-  <div class="card bg-base-100 shadow-sm mb-6">
-    <div class="card-body">
-      <h2 class="card-title">Sync Settings</h2>
-
-      <label class="flex flex-col gap-1 text-sm" for="sync_interval_minutes">
-        Sync Interval {{configSource .ConfigSources "sync_interval_minutes"}}
-      </label>
-      <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm w-full max-w-xs">
-        <option value="15"{{if eq .SyncIntervalMinutes 15}} selected{{end}}>Every 15 minutes</option>
-        <option value="30"{{if eq .SyncIntervalMinutes 30}} selected{{end}}>Every 30 minutes</option>
-        <option value="60"{{if eq .SyncIntervalMinutes 60}} selected{{end}}>Every hour</option>
-        <option value="240"{{if eq .SyncIntervalMinutes 240}} selected{{end}}>Every 4 hours</option>
-        <option value="480"{{if eq .SyncIntervalMinutes 480}} selected{{end}}>Every 8 hours</option>
-        <option value="720"{{if eq .SyncIntervalMinutes 720}} selected{{end}}>Every 12 hours</option>
-        <option value="1440"{{if eq .SyncIntervalMinutes 1440}} selected{{end}}>Every 24 hours</option>
-      </select>
-
-      <label class="flex flex-col gap-1 text-sm mt-4" for="webhook_url">
-        Webhook URL {{configSource .ConfigSources "webhook_url"}}
-      </label>
-      <input type="url" id="webhook_url" name="webhook_url" value="{{.WebhookURL}}" placeholder="https://example.com/webhooks/plaid" class="input input-sm w-full max-w-md">
-      <p class="text-xs text-base-content/60 mt-1">Plaid will send transaction updates to this URL. Must use HTTPS. Leave empty to disable.</p>
-    </div>
-  </div>
-
-  <div class="card bg-base-100 shadow-sm mb-6">
-    <div class="card-body">
-      <h2 class="card-title">Plaid Credentials</h2>
-
+      <h3 class="font-semibold text-sm mb-2">Plaid</h3>
       {{if .PlaidFromEnv}}
       <p class="text-sm">Plaid credentials are configured via environment variables and cannot be changed here.</p>
       <dl class="bb-info-grid mt-2">
@@ -77,13 +48,10 @@
         <span id="test-plaid-result" class="text-sm"></span>
       </div>
       {{end}}
-    </div>
-  </div>
 
-  <div class="card bg-base-100 shadow-sm mb-6">
-    <div class="card-body">
-      <h2 class="card-title">Teller</h2>
+      <div class="divider"></div>
 
+      <h3 class="font-semibold text-sm mb-2">Teller</h3>
       {{if .TellerFromEnv}}
       <p class="text-sm">Teller is configured via environment variables.</p>
       <dl class="bb-info-grid mt-2">
@@ -148,15 +116,78 @@ TELLER_WEBHOOK_SECRET=your-webhook-secret</code></pre>
         <span id="test-teller-result" class="text-sm"></span>
       </div>
       {{end}}
-    </div>
+
+      <div class="divider"></div>
+
+      <h3 class="font-semibold text-sm mb-2">CSV Import</h3>
+      <p class="text-sm">Always available. <a href="/admin/connections/import-csv" class="link link-primary">Import CSV file</a></p>
+
+      {{if or (not .PlaidFromEnv) (not .TellerFromEnv)}}
+      <div class="mt-4">
+        <button type="submit" class="btn btn-primary btn-sm">Save Provider Settings</button>
+      </div>
+      {{end}}
+    </form>
   </div>
+</div>
 
-  <button type="submit" class="btn btn-primary">Save Settings</button>
-</form>
+<!-- Sync & Scheduling Section -->
+<div class="collapse collapse-arrow bg-base-100 shadow-sm mb-6">
+  <input type="checkbox" checked />
+  <div class="collapse-title text-xl font-medium">Sync &amp; Scheduling</div>
+  <div class="collapse-content">
+    <p class="text-sm text-base-content/70 mb-4">Breadbox automatically syncs bank data on this schedule. Webhooks provide real-time updates when supported by the provider.</p>
+    <form method="POST" action="/admin/settings/sync">
+      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
-<div class="card bg-base-100 shadow-sm mb-6 mt-6">
-  <div class="card-body">
-    <h2 class="card-title">Security</h2>
+      <label class="flex flex-col gap-1 text-sm" for="sync_interval_minutes">
+        Sync Interval {{configSource .ConfigSources "sync_interval_minutes"}}
+      </label>
+      <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm w-full max-w-xs">
+        <option value="15"{{if eq .SyncIntervalMinutes 15}} selected{{end}}>Every 15 minutes</option>
+        <option value="30"{{if eq .SyncIntervalMinutes 30}} selected{{end}}>Every 30 minutes</option>
+        <option value="60"{{if eq .SyncIntervalMinutes 60}} selected{{end}}>Every hour</option>
+        <option value="240"{{if eq .SyncIntervalMinutes 240}} selected{{end}}>Every 4 hours</option>
+        <option value="480"{{if eq .SyncIntervalMinutes 480}} selected{{end}}>Every 8 hours</option>
+        <option value="720"{{if eq .SyncIntervalMinutes 720}} selected{{end}}>Every 12 hours</option>
+        <option value="1440"{{if eq .SyncIntervalMinutes 1440}} selected{{end}}>Every 24 hours</option>
+      </select>
+
+      <label class="flex flex-col gap-1 text-sm mt-4" for="webhook_url">
+        Webhook URL {{configSource .ConfigSources "webhook_url"}}
+      </label>
+      <input type="url" id="webhook_url" name="webhook_url" value="{{.WebhookURL}}" placeholder="https://example.com/webhooks/plaid" class="input input-sm w-full max-w-md">
+      <p class="text-xs text-base-content/60 mt-1">Plaid will send transaction updates to this URL. Must use HTTPS. Leave empty to disable.</p>
+
+      {{if ne .NextSyncTime ""}}
+      <p class="text-xs text-base-content/60 mt-4">Next scheduled sync: {{.NextSyncTime}}</p>
+      {{end}}
+
+      <div class="mt-4">
+        <button type="submit" class="btn btn-primary btn-sm">Save Sync Settings</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Security Section -->
+<div class="collapse collapse-arrow bg-base-100 shadow-sm mb-6">
+  <input type="checkbox" checked />
+  <div class="collapse-title text-xl font-medium">Security</div>
+  <div class="collapse-content">
+    <div class="mb-4">
+      <span class="text-sm font-medium">Encryption Key:</span>
+      {{if .HasEncryptionKey}}
+      <span class="badge badge-success badge-sm">Configured</span>
+      {{else}}
+      <span class="badge badge-error badge-sm">NOT SET</span>
+      <span class="text-xs text-error ml-1">Access tokens cannot be stored</span>
+      {{end}}
+    </div>
+
+    <div class="divider"></div>
+
+    <h3 class="font-semibold text-sm mb-2">Change Password</h3>
     <form method="POST" action="/admin/settings/password">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
       <label class="flex flex-col gap-1 text-sm" for="current_password">Current Password</label>
@@ -172,9 +203,11 @@ TELLER_WEBHOOK_SECRET=your-webhook-secret</code></pre>
   </div>
 </div>
 
-<div class="card bg-base-100 shadow-sm mb-6">
-  <div class="card-body">
-    <h2 class="card-title">System</h2>
+<!-- System Section (collapsed by default) -->
+<div class="collapse collapse-arrow bg-base-100 shadow-sm mb-6">
+  <input type="checkbox" />
+  <div class="collapse-title text-xl font-medium">System</div>
+  <div class="collapse-content">
     <dl class="bb-info-grid">
       <dt>Breadbox Version</dt><dd>{{.Version}}</dd>
       <dt>Go Runtime</dt><dd>{{.GoVersion}}</dd>


### PR DESCRIPTION
Restructure the settings page into 4 collapsible card sections (Providers, Sync & Scheduling, Security, System) with independent forms per section. Split the single POST handler into separate sync and providers handlers with their own routes.

Changes:
- Add NextRun() to Scheduler for next sync time display
- Split SettingsPostHandler into SettingsSyncPostHandler and SettingsProvidersPostHandler with separate POST routes
- Restructure settings.html into 4 DaisyUI collapse sections
- Move encryption key status from top-level alert into Security card
- Add CSV Import status line with link in Providers section
- Add explanatory text and next sync time to Sync section
- System section collapsed by default
- Mark Phase 17A complete in ROADMAP.md

https://claude.ai/code/session_01JMjhJe2HLo1xPFmr3BHAr1