### PR TITLE
perf: use pre-built sqlc binary instead of compiling from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
     name: Deploy
     needs: build
     runs-on: ubuntu-latest
+    environment: breadbox-dev
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
       - name: Deploy via SSH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,10 @@ jobs:
         with:
           go-version: "1.24"
 
-      - name: Install sqlc
-        run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
-
-      - name: Generate sqlc
-        run: sqlc generate
+      - name: Install sqlc and generate
+        run: |
+          curl -sL https://github.com/sqlc-dev/sqlc/releases/download/v1.30.0/sqlc_1.30.0_linux_amd64.tar.gz | tar xz -C /usr/local/bin sqlc
+          sqlc generate
 
       - name: Run go vet
         run: go vet ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ RUN go mod download
 COPY . .
 
 # Generate sqlc code (generated files are gitignored)
-RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest && sqlc generate
+# Use pre-built binary — compiling from source is very slow under QEMU emulation.
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') \
+    && wget -qO- "https://github.com/sqlc-dev/sqlc/releases/download/v1.30.0/sqlc_1.30.0_linux_${ARCH}.tar.gz" | tar xz -C /usr/local/bin sqlc \
+    && sqlc generate
 
 # Build CSS: download tailwindcss-extra (musl variant for Alpine) and compile input.css
 RUN apk add --no-cache libstdc++ libgcc \


### PR DESCRIPTION
go install compiles sqlc from source, which takes 25+ minutes on the arm64 builder running under QEMU emulation. Downloading the pre-built binary takes seconds.

https://claude.ai/code/session_01DmNu6HqQECQrJe5C5E9LHZ