### PR TITLE
fix: register providers.html template in basePages list

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -155,6 +155,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/api_key_created.html",
 		"pages/sync_logs.html",
 		"pages/settings.html",
+		"pages/providers.html",
 		"pages/csv_import.html",
 		"pages/transactions.html",
 		"pages/account_detail.html",


### PR DESCRIPTION
The providers page template was added in 62eec0c (Phase 19) but was never
registered in the basePages slice in templates.go, causing "template not
found: providers.html" when visiting /admin/providers.

https://claude.ai/code/session_017xo9X1gus74uv1JVxqeTFE