### PR TITLE
refactor: move webhook URL from settings to providers page

### DIFF
--- a/internal/admin/providers.go
+++ b/internal/admin/providers.go
@@ -33,6 +33,7 @@ func ProvidersGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRendere
 			"PlaidFromEnv":    os.Getenv("PLAID_CLIENT_ID") != "",
 			"PlaidClientID":   a.Config.PlaidClientID,
 			"PlaidEnv":        a.Config.PlaidEnv,
+			"WebhookURL":      a.Config.WebhookURL,
 			"ConfigSources":   a.Config.ConfigSources,
 
 			// Teller state
@@ -65,6 +66,7 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 		plaidClientID := strings.TrimSpace(r.FormValue("plaid_client_id"))
 		plaidSecret := strings.TrimSpace(r.FormValue("plaid_secret"))
 		plaidEnv := strings.TrimSpace(r.FormValue("plaid_env"))
+		webhookURL := strings.TrimSpace(r.FormValue("webhook_url"))
 
 		// If secret is empty, keep the existing one (user didn't change it).
 		if plaidSecret == "" {
@@ -73,7 +75,7 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 
 		if plaidClientID == "" {
 			// Clearing Plaid config.
-			for _, key := range []string{"plaid_client_id", "plaid_secret", "plaid_env"} {
+			for _, key := range []string{"plaid_client_id", "plaid_secret", "plaid_env", "webhook_url"} {
 				_ = a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 					Key: key, Value: pgtype.Text{},
 				})
@@ -81,6 +83,7 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 			a.Config.PlaidClientID = ""
 			a.Config.PlaidSecret = ""
 			a.Config.PlaidEnv = "sandbox"
+			a.Config.WebhookURL = ""
 			_ = a.ReinitProvider("plaid")
 			SetFlash(ctx, sm, "success", "Plaid configuration cleared.")
 			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
@@ -89,6 +92,12 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 
 		if plaidSecret == "" {
 			SetFlash(ctx, sm, "error", "Plaid secret is required.")
+			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			return
+		}
+
+		if webhookURL != "" && !strings.HasPrefix(webhookURL, "https://") {
+			SetFlash(ctx, sm, "error", "Webhook URL must use HTTPS.")
 			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
 			return
 		}
@@ -103,6 +112,7 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 			{Key: "plaid_client_id", Value: pgtype.Text{String: plaidClientID, Valid: true}},
 			{Key: "plaid_secret", Value: pgtype.Text{String: plaidSecret, Valid: true}},
 			{Key: "plaid_env", Value: pgtype.Text{String: plaidEnv, Valid: true}},
+			{Key: "webhook_url", Value: pgtype.Text{String: webhookURL, Valid: webhookURL != ""}},
 		}
 		for _, entry := range entries {
 			if err := a.Queries.SetAppConfig(ctx, entry); err != nil {
@@ -116,9 +126,11 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 		a.Config.PlaidClientID = plaidClientID
 		a.Config.PlaidSecret = plaidSecret
 		a.Config.PlaidEnv = plaidEnv
+		a.Config.WebhookURL = webhookURL
 		a.Config.ConfigSources["plaid_client_id"] = "db"
 		a.Config.ConfigSources["plaid_secret"] = "db"
 		a.Config.ConfigSources["plaid_env"] = "db"
+		a.Config.ConfigSources["webhook_url"] = "db"
 
 		if err := a.ReinitProvider("plaid"); err != nil {
 			a.Logger.Error("reinit plaid provider", "error", err)

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"breadbox/internal/app"
@@ -43,7 +42,6 @@ func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 			"CSRFToken":           GetCSRFToken(r),
 			"Flash":               GetFlash(ctx, sm),
 			"SyncIntervalMinutes": a.Config.SyncIntervalMinutes,
-			"WebhookURL":          a.Config.WebhookURL,
 			// System info
 			"Version":         a.Config.Version,
 			"GoVersion":       runtime.Version(),
@@ -72,17 +70,10 @@ func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 		ctx := r.Context()
 
 		syncIntervalStr := r.FormValue("sync_interval_minutes")
-		webhookURL := strings.TrimSpace(r.FormValue("webhook_url"))
 
 		syncInterval, err := strconv.Atoi(syncIntervalStr)
 		if err != nil || !isValidSyncInterval(syncInterval) {
 			SetFlash(ctx, sm, "error", "Invalid sync interval.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
-			return
-		}
-
-		if webhookURL != "" && !strings.HasPrefix(webhookURL, "https://") {
-			SetFlash(ctx, sm, "error", "Webhook URL must use HTTPS.")
 			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
 			return
 		}
@@ -97,17 +88,6 @@ func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 			return
 		}
 		a.Config.SyncIntervalMinutes = syncInterval
-
-		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
-			Key:   "webhook_url",
-			Value: pgtype.Text{String: webhookURL, Valid: webhookURL != ""},
-		}); err != nil {
-			a.Logger.Error("save webhook url", "error", err)
-			SetFlash(ctx, sm, "error", "Failed to save webhook URL.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
-			return
-		}
-		a.Config.WebhookURL = webhookURL
 
 		SetFlash(ctx, sm, "success", "Sync settings saved.")
 		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)

--- a/internal/templates/pages/providers.html
+++ b/internal/templates/pages/providers.html
@@ -26,6 +26,8 @@
         <dd><code class="font-mono text-xs">{{.PlaidClientID}}</code></dd>
         <dt>Secret</dt>
         <dd><code class="font-mono text-xs">********</code></dd>
+        <dt>Webhook URL</dt>
+        <dd>{{if .WebhookURL}}<code class="font-mono text-xs">{{.WebhookURL}}</code>{{else}}<span class="text-base-content/60">Not set</span>{{end}}</dd>
       </dl>
       {{else}}
       <form method="POST" action="/admin/providers/plaid" autocomplete="off">
@@ -50,6 +52,12 @@
           <option value="production"{{if eq .PlaidEnv "production"}} selected{{end}}>Production</option>
         </select>
         <p class="text-xs text-base-content/60 mt-1">Credentials will be validated before saving.</p>
+
+        <label class="flex flex-col gap-1 text-sm mt-4" for="webhook_url">
+          Webhook URL {{configSource .ConfigSources "webhook_url"}}
+        </label>
+        <input type="url" id="webhook_url" name="webhook_url" value="{{.WebhookURL}}" placeholder="https://example.com/webhooks/plaid" autocomplete="off" class="input input-sm w-full">
+        <p class="text-xs text-base-content/60 mt-1">Plaid will send transaction updates to this URL. Must use HTTPS. Leave empty to disable.</p>
 
         <div class="mt-4">
           <button type="submit" class="btn btn-primary btn-sm">Save Plaid Settings</button>

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -23,12 +23,6 @@
         <option value="1440"{{if eq .SyncIntervalMinutes 1440}} selected{{end}}>Every 24 hours</option>
       </select>
 
-      <label class="flex flex-col gap-1 text-sm mt-4" for="webhook_url">
-        Webhook URL {{configSource .ConfigSources "webhook_url"}}
-      </label>
-      <input type="url" id="webhook_url" name="webhook_url" value="{{.WebhookURL}}" placeholder="https://example.com/webhooks/plaid" class="input input-sm w-full max-w-md">
-      <p class="text-xs text-base-content/60 mt-1">Plaid will send transaction updates to this URL. Must use HTTPS. Leave empty to disable.</p>
-
       {{if ne .NextSyncTime ""}}
       <p class="text-xs text-base-content/60 mt-4">Next scheduled sync: {{.NextSyncTime}}</p>
       {{end}}


### PR DESCRIPTION
The webhook URL is Plaid-specific, so it belongs in the Plaid card on the providers page rather than in the general sync settings. Adds HTTPS validation and clears the webhook URL when Plaid config is cleared.

https://claude.ai/code/session_017xo9X1gus74uv1JVxqeTFE