### PR TITLE
Phase 21: Transaction comments & audit log

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -4,12 +4,16 @@ import (
 	"net/http"
 
 	"breadbox/internal/db"
+	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
 	"golang.org/x/crypto/bcrypt"
 )
 
-const sessionKeyAdminID = "admin_id"
+const (
+	sessionKeyAdminID       = "admin_id"
+	sessionKeyAdminUsername = "admin_username"
+)
 
 // LoginHandler returns an http.HandlerFunc that handles GET and POST /login.
 func LoginHandler(sm *scs.SessionManager, queries *db.Queries, tr *TemplateRenderer) http.HandlerFunc {
@@ -71,8 +75,19 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, tr *TemplateRende
 		}
 
 		sm.Put(r.Context(), sessionKeyAdminID, formatUUID(admin.ID))
+		sm.Put(r.Context(), sessionKeyAdminUsername, admin.Username)
 		http.Redirect(w, r, "/admin/", http.StatusSeeOther)
 	}
+}
+
+// ActorFromSession builds a service.Actor from the admin session.
+func ActorFromSession(sm *scs.SessionManager, r *http.Request) service.Actor {
+	id := sm.GetString(r.Context(), sessionKeyAdminID)
+	name := sm.GetString(r.Context(), sessionKeyAdminUsername)
+	if name == "" {
+		name = "admin"
+	}
+	return service.Actor{Type: "user", ID: id, Name: name}
 }
 
 // LogoutHandler returns an http.HandlerFunc that handles POST /logout.

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -9,7 +9,9 @@ import (
 	"breadbox/internal/app"
 	"breadbox/internal/db"
 	"breadbox/internal/provider"
+	"breadbox/internal/service"
 
+	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -371,7 +373,7 @@ func ConnectionReauthCompleteHandler(a *app.App) http.HandlerFunc {
 }
 
 // DeleteConnectionHandler serves DELETE /admin/api/connections/{id}.
-func DeleteConnectionHandler(a *app.App) http.HandlerFunc {
+func DeleteConnectionHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := chi.URLParam(r, "id")
 		ctx := r.Context()
@@ -406,6 +408,11 @@ func DeleteConnectionHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		actor := ActorFromSession(sm, r)
+		_ = a.Service.WriteAuditLog(ctx, []service.AuditLogEntry{{
+			EntityType: "connection", EntityID: idStr, Action: "delete", Actor: actor,
+		}})
+
 		w.WriteHeader(http.StatusNoContent)
 	}
 }
@@ -438,7 +445,7 @@ func SyncConnectionHandler(a *app.App) http.HandlerFunc {
 }
 
 // UpdateAccountExcludedHandler serves POST /admin/api/accounts/{id}/excluded.
-func UpdateAccountExcludedHandler(a *app.App) http.HandlerFunc {
+func UpdateAccountExcludedHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := chi.URLParam(r, "id")
 
@@ -456,6 +463,10 @@ func UpdateAccountExcludedHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		// Capture old value for audit.
+		oldAccount, _ := a.Queries.GetAccount(r.Context(), accountID)
+		oldVal := fmt.Sprintf("%t", oldAccount.Excluded)
+
 		account, err := a.Queries.UpdateAccountExcluded(r.Context(), db.UpdateAccountExcludedParams{
 			ID:       accountID,
 			Excluded: req.Excluded,
@@ -466,12 +477,20 @@ func UpdateAccountExcludedHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		actor := ActorFromSession(sm, r)
+		field := "excluded"
+		newVal := fmt.Sprintf("%t", req.Excluded)
+		_ = a.Service.WriteAuditLog(r.Context(), []service.AuditLogEntry{{
+			EntityType: "account", EntityID: idStr, Action: "update",
+			Field: &field, OldValue: &oldVal, NewValue: &newVal, Actor: actor,
+		}})
+
 		writeJSON(w, http.StatusOK, account)
 	}
 }
 
 // UpdateAccountDisplayNameHandler serves POST /admin/api/accounts/{id}/display-name.
-func UpdateAccountDisplayNameHandler(a *app.App) http.HandlerFunc {
+func UpdateAccountDisplayNameHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := chi.URLParam(r, "id")
 
@@ -489,6 +508,10 @@ func UpdateAccountDisplayNameHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		// Capture old value for audit.
+		oldAccount, _ := a.Queries.GetAccount(r.Context(), accountID)
+		oldVal := oldAccount.DisplayName.String
+
 		var displayName pgtype.Text
 		if req.DisplayName != nil && *req.DisplayName != "" {
 			displayName = pgtype.Text{String: *req.DisplayName, Valid: true}
@@ -504,12 +527,20 @@ func UpdateAccountDisplayNameHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		actor := ActorFromSession(sm, r)
+		field := "display_name"
+		newVal := displayName.String
+		_ = a.Service.WriteAuditLog(r.Context(), []service.AuditLogEntry{{
+			EntityType: "account", EntityID: idStr, Action: "update",
+			Field: &field, OldValue: &oldVal, NewValue: &newVal, Actor: actor,
+		}})
+
 		writeJSON(w, http.StatusOK, account)
 	}
 }
 
 // UpdateConnectionPausedHandler serves POST /admin/api/connections/{id}/paused.
-func UpdateConnectionPausedHandler(a *app.App) http.HandlerFunc {
+func UpdateConnectionPausedHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := chi.URLParam(r, "id")
 
@@ -527,6 +558,10 @@ func UpdateConnectionPausedHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		// Capture old value.
+		oldConn, _ := a.Queries.GetBankConnection(r.Context(), connID)
+		oldVal := fmt.Sprintf("%t", oldConn.Paused)
+
 		conn, err := a.Queries.UpdateConnectionPaused(r.Context(), db.UpdateConnectionPausedParams{
 			ID:     connID,
 			Paused: req.Paused,
@@ -537,12 +572,20 @@ func UpdateConnectionPausedHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		actor := ActorFromSession(sm, r)
+		field := "paused"
+		newVal := fmt.Sprintf("%t", req.Paused)
+		_ = a.Service.WriteAuditLog(r.Context(), []service.AuditLogEntry{{
+			EntityType: "connection", EntityID: idStr, Action: "update",
+			Field: &field, OldValue: &oldVal, NewValue: &newVal, Actor: actor,
+		}})
+
 		writeJSON(w, http.StatusOK, conn)
 	}
 }
 
 // UpdateConnectionSyncIntervalHandler serves POST /admin/api/connections/{id}/sync-interval.
-func UpdateConnectionSyncIntervalHandler(a *app.App) http.HandlerFunc {
+func UpdateConnectionSyncIntervalHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := chi.URLParam(r, "id")
 
@@ -560,6 +603,13 @@ func UpdateConnectionSyncIntervalHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		// Capture old value.
+		oldConn, _ := a.Queries.GetBankConnection(r.Context(), connID)
+		oldVal := ""
+		if oldConn.SyncIntervalOverrideMinutes.Valid {
+			oldVal = fmt.Sprintf("%d", oldConn.SyncIntervalOverrideMinutes.Int32)
+		}
+
 		var interval pgtype.Int4
 		if req.Minutes != nil {
 			interval = pgtype.Int4{Int32: *req.Minutes, Valid: true}
@@ -574,6 +624,17 @@ func UpdateConnectionSyncIntervalHandler(a *app.App) http.HandlerFunc {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to update connection"})
 			return
 		}
+
+		actor := ActorFromSession(sm, r)
+		field := "sync_interval_override_minutes"
+		newVal := ""
+		if req.Minutes != nil {
+			newVal = fmt.Sprintf("%d", *req.Minutes)
+		}
+		_ = a.Service.WriteAuditLog(r.Context(), []service.AuditLogEntry{{
+			EntityType: "connection", EntityID: idStr, Action: "update",
+			Field: &field, OldValue: &oldVal, NewValue: &newVal, Actor: actor,
+		}})
 
 		writeJSON(w, http.StatusOK, conn)
 	}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -63,6 +63,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		})
 
 		r.Get("/transactions", TransactionListHandler(a, sm, tr, svc))
+		r.Get("/transactions/{id}", TransactionDetailHandler(a, sm, tr, svc))
 		r.Get("/accounts/{id}", AccountDetailHandler(a, sm, tr, svc))
 		r.Get("/sync-logs", SyncLogsHandler(a, sm, tr, svc))
 
@@ -87,14 +88,14 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/connections/{id}/reauth", ConnectionReauthAPIHandler(a))
 		r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))
 		r.Post("/connections/{id}/sync", SyncConnectionHandler(a))
-		r.Post("/connections/{id}/paused", UpdateConnectionPausedHandler(a))
-		r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(a))
-		r.Delete("/connections/{id}", DeleteConnectionHandler(a))
-		r.Post("/accounts/{id}/excluded", UpdateAccountExcludedHandler(a))
-		r.Post("/accounts/{id}/display-name", UpdateAccountDisplayNameHandler(a))
+		r.Post("/connections/{id}/paused", UpdateConnectionPausedHandler(a, sm))
+		r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(a, sm))
+		r.Delete("/connections/{id}", DeleteConnectionHandler(a, sm))
+		r.Post("/accounts/{id}/excluded", UpdateAccountExcludedHandler(a, sm))
+		r.Post("/accounts/{id}/display-name", UpdateAccountDisplayNameHandler(a, sm))
 		r.Post("/test-provider/{provider}", ProvidersTestHandler(a))
-		r.Post("/users", CreateUserHandler(a))
-		r.Put("/users/{id}", UpdateUserHandler(a))
+		r.Post("/users", CreateUserHandler(a, sm))
+		r.Put("/users/{id}", UpdateUserHandler(a, sm))
 
 		r.Post("/csv/upload", CSVUploadHandler(a, sm))
 		r.Post("/csv/preview", CSVPreviewHandler(a, sm))
@@ -123,6 +124,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// Transaction category override
 		r.Post("/transactions/{id}/category", SetTransactionCategoryAdminHandler(svc))
 		r.Delete("/transactions/{id}/category", ResetTransactionCategoryAdminHandler(svc))
+
+		// Transaction comments
+		r.Post("/transactions/{id}/comments", CreateTransactionCommentHandler(a, sm, svc))
+		r.Delete("/transactions/{id}/comments/{comment_id}", DeleteTransactionCommentHandler(a, sm, svc))
 	})
 
 	return r

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -161,6 +161,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/account_detail.html",
 		"pages/categories.html",
 		"pages/category_mappings.html",
+		"pages/transaction_detail.html",
 	}
 
 	// Pages using the wizard layout (login + first-run admin creation).

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -236,4 +238,134 @@ func floatParamPtr(r *http.Request, key string) *string {
 		return nil
 	}
 	return &v
+}
+
+// TransactionDetailHandler serves GET /admin/transactions/{id}.
+func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		idStr := chi.URLParam(r, "id")
+
+		txn, err := svc.GetTransaction(ctx, idStr)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				http.NotFound(w, r)
+				return
+			}
+			a.Logger.Error("get transaction detail", "error", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		comments, err := svc.ListComments(ctx, idStr)
+		if err != nil && !errors.Is(err, service.ErrNotFound) {
+			a.Logger.Error("list transaction comments", "error", err)
+		}
+
+		auditResult, err := svc.ListAuditLog(ctx, service.AuditLogListParams{
+			EntityType: "transaction",
+			EntityID:   idStr,
+			Limit:      50,
+		})
+		if err != nil {
+			a.Logger.Error("list transaction audit log", "error", err)
+		}
+
+		// Resolve account name and user name.
+		var accountName, userName, accountID string
+		if txn.AccountID != nil {
+			accountID = *txn.AccountID
+			var acctUUID pgtype.UUID
+			if err := acctUUID.Scan(accountID); err == nil {
+				acct, err := a.Queries.GetAccount(ctx, acctUUID)
+				if err == nil {
+					accountName = acct.Name
+					if acct.ConnectionID.Valid {
+						conn, err := a.Queries.GetBankConnection(ctx, acct.ConnectionID)
+						if err == nil && conn.UserID.Valid {
+							user, err := a.Queries.GetUser(ctx, conn.UserID)
+							if err == nil {
+								userName = user.Name
+							}
+						}
+					}
+				}
+			}
+		}
+
+		var entries []service.AuditLogResponse
+		if auditResult != nil {
+			entries = auditResult.Entries
+		}
+
+		data := map[string]any{
+			"PageTitle":     txn.Name,
+			"CurrentPage":   "transactions",
+			"CSRFToken":     GetCSRFToken(r),
+			"Flash":         GetFlash(ctx, sm),
+			"Transaction":   txn,
+			"TransactionID": idStr,
+			"AccountID":     accountID,
+			"AccountName":   accountName,
+			"UserName":      userName,
+			"Comments":      comments,
+			"AuditEntries":  entries,
+		}
+		tr.Render(w, r, "transaction_detail.html", data)
+	}
+}
+
+// CreateTransactionCommentHandler serves POST /admin/api/transactions/{id}/comments.
+func CreateTransactionCommentHandler(a *app.App, sm *scs.SessionManager, svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		txnID := chi.URLParam(r, "id")
+		actor := ActorFromSession(sm, r)
+
+		var input struct {
+			Content string `json:"content"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+			return
+		}
+
+		comment, err := svc.CreateComment(r.Context(), service.CreateCommentParams{
+			TransactionID: txnID,
+			Content:       input.Content,
+			Actor:         actor,
+		})
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "Transaction not found"})
+				return
+			}
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, comment)
+	}
+}
+
+// DeleteTransactionCommentHandler serves DELETE /admin/api/transactions/{id}/comments/{comment_id}.
+func DeleteTransactionCommentHandler(a *app.App, sm *scs.SessionManager, svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		commentID := chi.URLParam(r, "comment_id")
+		actor := ActorFromSession(sm, r)
+
+		if err := svc.DeleteComment(r.Context(), commentID, actor); err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				writeJSON(w, http.StatusNotFound, map[string]string{"error": "Comment not found"})
+				return
+			}
+			if errors.Is(err, service.ErrForbidden) {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": "You can only delete your own comments"})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to delete comment"})
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
 }

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"breadbox/internal/app"
@@ -271,26 +272,16 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			a.Logger.Error("list transaction audit log", "error", err)
 		}
 
-		// Resolve account name and user name.
+		// Use denormalized names from the transaction response.
 		var accountName, userName, accountID string
 		if txn.AccountID != nil {
 			accountID = *txn.AccountID
-			var acctUUID pgtype.UUID
-			if err := acctUUID.Scan(accountID); err == nil {
-				acct, err := a.Queries.GetAccount(ctx, acctUUID)
-				if err == nil {
-					accountName = acct.Name
-					if acct.ConnectionID.Valid {
-						conn, err := a.Queries.GetBankConnection(ctx, acct.ConnectionID)
-						if err == nil && conn.UserID.Valid {
-							user, err := a.Queries.GetUser(ctx, conn.UserID)
-							if err == nil {
-								userName = user.Name
-							}
-						}
-					}
-				}
-			}
+		}
+		if txn.AccountName != nil {
+			accountName = *txn.AccountName
+		}
+		if txn.UserName != nil {
+			userName = *txn.UserName
 		}
 
 		var entries []service.AuditLogResponse
@@ -339,7 +330,13 @@ func CreateTransactionCommentHandler(a *app.App, sm *scs.SessionManager, svc *se
 				writeJSON(w, http.StatusNotFound, map[string]string{"error": "Transaction not found"})
 				return
 			}
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			// Content validation errors are safe to surface; log and genericize others.
+			if strings.Contains(err.Error(), "content must be") {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			a.Logger.Error("create comment", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to create comment"})
 			return
 		}
 

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -8,7 +8,9 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/db"
+	"breadbox/internal/service"
 
+	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -97,7 +99,7 @@ type createUserRequest struct {
 }
 
 // CreateUserHandler serves POST /admin/api/users.
-func CreateUserHandler(a *app.App) http.HandlerFunc {
+func CreateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req createUserRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -134,8 +136,14 @@ func CreateUserHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
+		actor := ActorFromSession(sm, r)
+		userID := formatUUID(user.ID)
+		_ = a.Service.WriteAuditLog(r.Context(), []service.AuditLogEntry{{
+			EntityType: "user", EntityID: userID, Action: "create", Actor: actor,
+		}})
+
 		writeJSON(w, http.StatusCreated, map[string]any{
-			"id":         formatUUID(user.ID),
+			"id":         userID,
 			"name":       user.Name,
 			"email":      nullTextToPtr(user.Email),
 			"created_at": user.CreatedAt.Time,
@@ -151,7 +159,7 @@ type updateUserRequest struct {
 }
 
 // UpdateUserHandler serves PUT /admin/api/users/{id}.
-func UpdateUserHandler(a *app.App) http.HandlerFunc {
+func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		idStr := chi.URLParam(r, "id")
 
@@ -213,6 +221,31 @@ func UpdateUserHandler(a *app.App) http.HandlerFunc {
 			a.Logger.Error("update user", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to update user"})
 			return
+		}
+
+		// Write audit log entries for changed fields.
+		actor := ActorFromSession(sm, r)
+		var entries []service.AuditLogEntry
+		if name != existing.Name {
+			field := "name"
+			oldVal := existing.Name
+			newVal := name
+			entries = append(entries, service.AuditLogEntry{
+				EntityType: "user", EntityID: idStr, Action: "update",
+				Field: &field, OldValue: &oldVal, NewValue: &newVal, Actor: actor,
+			})
+		}
+		if email != existing.Email {
+			field := "email"
+			oldVal := existing.Email.String
+			newVal := email.String
+			entries = append(entries, service.AuditLogEntry{
+				EntityType: "user", EntityID: idStr, Action: "update",
+				Field: &field, OldValue: &oldVal, NewValue: &newVal, Actor: actor,
+			})
+		}
+		if len(entries) > 0 {
+			_ = a.Service.WriteAuditLog(r.Context(), entries)
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{

--- a/internal/api/audit.go
+++ b/internal/api/audit.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ListAuditLogHandler returns audit log entries with optional filters.
+func ListAuditLogHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		limit := 50
+		if v := q.Get("limit"); v != "" {
+			parsed, err := strconv.Atoi(v)
+			if err != nil || parsed < 1 || parsed > 200 {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "limit must be between 1 and 200")
+				return
+			}
+			limit = parsed
+		}
+
+		// If both entity_type and entity_id are provided, use entity-scoped query.
+		entityType := q.Get("entity_type")
+		entityID := q.Get("entity_id")
+
+		if entityType != "" && entityID != "" {
+			result, err := svc.ListAuditLog(r.Context(), service.AuditLogListParams{
+				EntityType: entityType,
+				EntityID:   entityID,
+				Limit:      limit,
+				Cursor:     q.Get("cursor"),
+			})
+			if err != nil {
+				if errors.Is(err, service.ErrInvalidCursor) {
+					mw.WriteError(w, http.StatusBadRequest, "INVALID_CURSOR", "The provided cursor is not valid")
+					return
+				}
+				mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to query audit log")
+				return
+			}
+			writeData(w, result)
+			return
+		}
+
+		// Global query.
+		var entityTypePtr *string
+		if entityType != "" {
+			entityTypePtr = &entityType
+		}
+		var actorType *string
+		if v := q.Get("actor_type"); v != "" {
+			actorType = &v
+		}
+
+		result, err := svc.ListAuditLogGlobal(r.Context(), service.AuditLogGlobalParams{
+			EntityType: entityTypePtr,
+			ActorType:  actorType,
+			Limit:      limit,
+			Cursor:     q.Get("cursor"),
+		})
+		if err != nil {
+			if errors.Is(err, service.ErrInvalidCursor) {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_CURSOR", "The provided cursor is not valid")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to query audit log")
+			return
+		}
+
+		writeData(w, result)
+	}
+}
+
+// ListTransactionAuditLogHandler returns audit log for a specific transaction.
+func ListTransactionAuditLogHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		txnID := chi.URLParam(r, "id")
+		q := r.URL.Query()
+
+		limit := 50
+		if v := q.Get("limit"); v != "" {
+			parsed, err := strconv.Atoi(v)
+			if err != nil || parsed < 1 || parsed > 200 {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "limit must be between 1 and 200")
+				return
+			}
+			limit = parsed
+		}
+
+		result, err := svc.ListAuditLog(r.Context(), service.AuditLogListParams{
+			EntityType: "transaction",
+			EntityID:   txnID,
+			Limit:      limit,
+			Cursor:     q.Get("cursor"),
+		})
+		if err != nil {
+			if errors.Is(err, service.ErrInvalidCursor) {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_CURSOR", "The provided cursor is not valid")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to query audit log")
+			return
+		}
+
+		writeData(w, result)
+	}
+}

--- a/internal/api/comments.go
+++ b/internal/api/comments.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ListCommentsHandler returns all comments for a transaction.
+func ListCommentsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		txnID := chi.URLParam(r, "transaction_id")
+
+		comments, err := svc.ListComments(r.Context(), txnID)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list comments")
+			return
+		}
+
+		writeData(w, map[string]any{"comments": comments})
+	}
+}
+
+// CreateCommentHandler creates a new comment on a transaction.
+func CreateCommentHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		txnID := chi.URLParam(r, "transaction_id")
+
+		var input struct {
+			Content string `json:"content"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			return
+		}
+
+		actor := service.ActorFromContext(r.Context())
+
+		comment, err := svc.CreateComment(r.Context(), service.CreateCommentParams{
+			TransactionID: txnID,
+			Content:       input.Content,
+			Actor:         actor,
+		})
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				return
+			}
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, comment)
+	}
+}
+
+// UpdateCommentHandler updates a comment's content.
+func UpdateCommentHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		commentID := chi.URLParam(r, "id")
+
+		var input struct {
+			Content string `json:"content"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			return
+		}
+
+		actor := service.ActorFromContext(r.Context())
+
+		comment, err := svc.UpdateComment(r.Context(), commentID, service.UpdateCommentParams{
+			Content: input.Content,
+			Actor:   actor,
+		})
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Comment not found")
+				return
+			}
+			if errors.Is(err, service.ErrForbidden) {
+				mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "You can only edit your own comments")
+				return
+			}
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+
+		writeData(w, comment)
+	}
+}
+
+// DeleteCommentHandler deletes a comment.
+func DeleteCommentHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		commentID := chi.URLParam(r, "id")
+		actor := service.ActorFromContext(r.Context())
+
+		if err := svc.DeleteComment(r.Context(), commentID, actor); err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Comment not found")
+				return
+			}
+			if errors.Is(err, service.ErrForbidden) {
+				mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "You can only delete your own comments")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete comment")
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/api/comments.go
+++ b/internal/api/comments.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
@@ -55,7 +56,11 @@ func CreateCommentHandler(svc *service.Service) http.HandlerFunc {
 				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
 			}
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			if strings.Contains(err.Error(), "content must be") {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create comment")
 			return
 		}
 
@@ -91,7 +96,11 @@ func UpdateCommentHandler(svc *service.Service) http.HandlerFunc {
 				mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "You can only edit your own comments")
 				return
 			}
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			if strings.Contains(err.Error(), "content must be") {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update comment")
 			return
 		}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -61,6 +61,16 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/connections", ListConnectionsHandler(svc))
 		r.Get("/connections/{id}/status", GetConnectionStatusHandler(svc))
 		r.Post("/sync", TriggerSyncHandler(svc))
+
+		// Transaction comments
+		r.Get("/transactions/{transaction_id}/comments", ListCommentsHandler(svc))
+		r.Post("/transactions/{transaction_id}/comments", CreateCommentHandler(svc))
+		r.Put("/transactions/{transaction_id}/comments/{id}", UpdateCommentHandler(svc))
+		r.Delete("/transactions/{transaction_id}/comments/{id}", DeleteCommentHandler(svc))
+
+		// Audit log
+		r.Get("/audit-log", ListAuditLogHandler(svc))
+		r.Get("/transactions/{id}/audit-log", ListTransactionAuditLogHandler(svc))
 	})
 
 	// MCP server — API key authenticated.

--- a/internal/db/migrations/00021_transaction_comments.sql
+++ b/internal/db/migrations/00021_transaction_comments.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+CREATE TABLE transaction_comments (
+    id              UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    transaction_id  UUID          NOT NULL REFERENCES transactions (id) ON DELETE CASCADE,
+    author_type     TEXT          NOT NULL CHECK (author_type IN ('user', 'agent', 'system')),
+    author_id       TEXT          NULL,
+    author_name     TEXT          NOT NULL,
+    content         TEXT          NOT NULL,
+    created_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX transaction_comments_transaction_id_idx ON transaction_comments (transaction_id, created_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS transaction_comments_transaction_id_idx;
+DROP TABLE IF EXISTS transaction_comments;

--- a/internal/db/migrations/00022_audit_log.sql
+++ b/internal/db/migrations/00022_audit_log.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+CREATE TABLE audit_log (
+    id              UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    entity_type     TEXT          NOT NULL,
+    entity_id       UUID          NOT NULL,
+    action          TEXT          NOT NULL CHECK (action IN ('create', 'update', 'delete')),
+    field           TEXT          NULL,
+    old_value       TEXT          NULL,
+    new_value       TEXT          NULL,
+    actor_type      TEXT          NOT NULL CHECK (actor_type IN ('user', 'agent', 'system')),
+    actor_id        TEXT          NULL,
+    actor_name      TEXT          NOT NULL,
+    metadata        JSONB         NULL,
+    created_at      TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX audit_log_entity_idx ON audit_log (entity_type, entity_id, created_at DESC);
+CREATE INDEX audit_log_created_at_idx ON audit_log (created_at DESC);
+CREATE INDEX audit_log_actor_idx ON audit_log (actor_type, actor_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS audit_log_actor_idx;
+DROP INDEX IF EXISTS audit_log_created_at_idx;
+DROP INDEX IF EXISTS audit_log_entity_idx;
+DROP TABLE IF EXISTS audit_log;

--- a/internal/db/queries/audit_log.sql
+++ b/internal/db/queries/audit_log.sql
@@ -1,0 +1,3 @@
+-- name: InsertAuditLogEntry :exec
+INSERT INTO audit_log (entity_type, entity_id, action, field, old_value, new_value, actor_type, actor_id, actor_name, metadata)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);

--- a/internal/db/queries/comments.sql
+++ b/internal/db/queries/comments.sql
@@ -1,0 +1,24 @@
+-- name: CreateComment :one
+INSERT INTO transaction_comments (transaction_id, author_type, author_id, author_name, content)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING *;
+
+-- name: ListCommentsByTransaction :many
+SELECT * FROM transaction_comments
+WHERE transaction_id = $1
+ORDER BY created_at ASC;
+
+-- name: GetComment :one
+SELECT * FROM transaction_comments WHERE id = $1;
+
+-- name: UpdateComment :one
+UPDATE transaction_comments
+SET content = $2, updated_at = NOW()
+WHERE id = $1
+RETURNING *;
+
+-- name: DeleteComment :exec
+DELETE FROM transaction_comments WHERE id = $1;
+
+-- name: CountCommentsByTransaction :one
+SELECT COUNT(*) FROM transaction_comments WHERE transaction_id = $1;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -51,7 +51,13 @@ RECOMMENDED QUERY PATTERNS:
 4. Query transactions with date ranges and category_slug filters
 5. Use count_transactions to get totals before paginating
 6. Check get_sync_status to verify data freshness
-7. Use list_unmapped_categories to identify categorization gaps`,
+7. Use list_unmapped_categories to identify categorization gaps
+
+COMMENTS & AUDIT LOG:
+- Use add_transaction_comment to explain your reasoning when recategorizing transactions
+- Check list_transaction_comments before modifying a transaction to see prior context
+- Use get_transaction_history to understand how a transaction has been modified over time
+- Use query_audit_log with actor_type='user' to learn the family's categorization preferences`,
 		},
 	)
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -61,6 +61,26 @@ func (s *MCPServer) registerTools() {
 		Name:        "list_unmapped_categories",
 		Description: "List distinct raw provider category strings from transactions that currently have no category mapping. These are transactions the system couldn't automatically categorize. Results show the raw primary and detailed category strings from the provider.",
 	}, s.handleListUnmappedCategories)
+
+	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
+		Name:        "add_transaction_comment",
+		Description: "Add a comment to a transaction. Use this to explain categorization decisions, flag unusual transactions, or leave notes for the family. Comments are visible on the transaction detail page and to other agents. Supports markdown formatting.",
+	}, s.handleAddTransactionComment)
+
+	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
+		Name:        "list_transaction_comments",
+		Description: "List all comments on a transaction, ordered chronologically. Check comments before making changes to understand prior context and decisions by other agents or family members.",
+	}, s.handleListTransactionComments)
+
+	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
+		Name:        "get_transaction_history",
+		Description: "Get the change history (audit log) for a specific transaction. Shows all modifications including category changes, comment additions, and sync updates. Use this to understand how a transaction's categorization evolved over time and learn from past decisions.",
+	}, s.handleGetTransactionHistory)
+
+	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
+		Name:        "query_audit_log",
+		Description: "Query the global audit log to see all changes across the system. Use entity_type to focus on specific data types. Filter by actor_type='agent' to see what other AI agents have done, or actor_type='user' to see manual changes by the family. Useful for learning patterns: e.g., query all category overrides to understand the family's preferences.",
+	}, s.handleQueryAuditLog)
 }
 
 // --- Input types ---
@@ -108,6 +128,27 @@ type categorizeTransactionInput struct {
 
 type resetTransactionCategoryInput struct {
 	TransactionID string `json:"transaction_id" jsonschema:"The transaction ID to reset"`
+}
+
+type addTransactionCommentInput struct {
+	TransactionID string `json:"transaction_id" jsonschema:"required,UUID of the transaction to comment on"`
+	Content       string `json:"content" jsonschema:"required,Comment text (markdown supported, max 10000 chars)"`
+}
+
+type listTransactionCommentsInput struct {
+	TransactionID string `json:"transaction_id" jsonschema:"required,UUID of the transaction"`
+}
+
+type getTransactionHistoryInput struct {
+	TransactionID string `json:"transaction_id" jsonschema:"required,UUID of the transaction"`
+	Limit         int    `json:"limit,omitempty" jsonschema:"Max entries to return (default 50, max 200)"`
+}
+
+type queryAuditLogInput struct {
+	EntityType string `json:"entity_type,omitempty" jsonschema:"Filter by entity type: transaction, account, connection, user"`
+	ActorType  string `json:"actor_type,omitempty" jsonschema:"Filter by who made the change: user, agent, system"`
+	Limit      int    `json:"limit,omitempty" jsonschema:"Max entries to return (default 50, max 200)"`
+	Cursor     string `json:"cursor,omitempty" jsonschema:"Pagination cursor from previous result"`
 }
 
 // --- Handlers ---
@@ -321,6 +362,66 @@ func (s *MCPServer) handleListUnmappedCategories(_ context.Context, _ *mcpsdk.Ca
 		return errorResult(err), nil, nil
 	}
 	return jsonResult(unmapped)
+}
+
+func (s *MCPServer) handleAddTransactionComment(ctx context.Context, _ *mcpsdk.CallToolRequest, input addTransactionCommentInput) (*mcpsdk.CallToolResult, any, error) {
+	if input.TransactionID == "" || input.Content == "" {
+		return errorResult(fmt.Errorf("transaction_id and content are required")), nil, nil
+	}
+	actor := service.ActorFromContext(ctx)
+	comment, err := s.svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: input.TransactionID,
+		Content:       input.Content,
+		Actor:         actor,
+	})
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(comment)
+}
+
+func (s *MCPServer) handleListTransactionComments(ctx context.Context, _ *mcpsdk.CallToolRequest, input listTransactionCommentsInput) (*mcpsdk.CallToolResult, any, error) {
+	if input.TransactionID == "" {
+		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
+	}
+	comments, err := s.svc.ListComments(ctx, input.TransactionID)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(comments)
+}
+
+func (s *MCPServer) handleGetTransactionHistory(ctx context.Context, _ *mcpsdk.CallToolRequest, input getTransactionHistoryInput) (*mcpsdk.CallToolResult, any, error) {
+	if input.TransactionID == "" {
+		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
+	}
+	result, err := s.svc.ListAuditLog(ctx, service.AuditLogListParams{
+		EntityType: "transaction",
+		EntityID:   input.TransactionID,
+		Limit:      input.Limit,
+	})
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(result)
+}
+
+func (s *MCPServer) handleQueryAuditLog(ctx context.Context, _ *mcpsdk.CallToolRequest, input queryAuditLogInput) (*mcpsdk.CallToolResult, any, error) {
+	params := service.AuditLogGlobalParams{
+		Limit:  input.Limit,
+		Cursor: input.Cursor,
+	}
+	if input.EntityType != "" {
+		params.EntityType = &input.EntityType
+	}
+	if input.ActorType != "" {
+		params.ActorType = &input.ActorType
+	}
+	result, err := s.svc.ListAuditLogGlobal(ctx, params)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(result)
 }
 
 // --- Helpers ---

--- a/internal/middleware/apikey.go
+++ b/internal/middleware/apikey.go
@@ -2,10 +2,21 @@ package middleware
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"breadbox/internal/service"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
+
+func formatUUID(u pgtype.UUID) string {
+	if !u.Valid {
+		return ""
+	}
+	b := u.Bytes
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
 
 // APIKeyAuth returns middleware that validates the X-API-Key header against
 // the database using the service layer.
@@ -18,7 +29,7 @@ func APIKeyAuth(svc *service.Service) func(http.Handler) http.Handler {
 				return
 			}
 
-			_, err := svc.ValidateAPIKey(r.Context(), key)
+			apiKey, err := svc.ValidateAPIKey(r.Context(), key)
 			if err != nil {
 				if errors.Is(err, service.ErrInvalidAPIKey) {
 					WriteError(w, http.StatusUnauthorized, "INVALID_API_KEY", "The provided API key is not valid")
@@ -30,7 +41,10 @@ func APIKeyAuth(svc *service.Service) func(http.Handler) http.Handler {
 				return
 			}
 
-			next.ServeHTTP(w, r)
+			// Store API key identity in context for actor resolution.
+			keyID := formatUUID(apiKey.ID)
+			ctx := service.ContextWithAPIKey(r.Context(), keyID, apiKey.Name)
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/internal/service/actor.go
+++ b/internal/service/actor.go
@@ -1,0 +1,41 @@
+package service
+
+import "context"
+
+// Actor identifies who performed an action, used for audit logging and comments.
+type Actor struct {
+	Type string // "user", "agent", "system"
+	ID   string // admin_account ID, API key ID, or ""
+	Name string // display name
+}
+
+// SystemActor returns an Actor for system-initiated actions.
+func SystemActor() Actor {
+	return Actor{Type: "system", ID: "", Name: "Breadbox"}
+}
+
+type contextKey int
+
+const (
+	ctxKeyAPIKeyID   contextKey = iota
+	ctxKeyAPIKeyName contextKey = iota
+)
+
+// ContextWithAPIKey stores API key identity in the context.
+func ContextWithAPIKey(ctx context.Context, id, name string) context.Context {
+	ctx = context.WithValue(ctx, ctxKeyAPIKeyID, id)
+	ctx = context.WithValue(ctx, ctxKeyAPIKeyName, name)
+	return ctx
+}
+
+// ActorFromContext builds an Actor from the request context.
+// If API key info is present (set by APIKeyAuth middleware), returns an agent actor.
+// Otherwise returns a system actor.
+func ActorFromContext(ctx context.Context) Actor {
+	id, _ := ctx.Value(ctxKeyAPIKeyID).(string)
+	name, _ := ctx.Value(ctxKeyAPIKeyName).(string)
+	if id != "" {
+		return Actor{Type: "agent", ID: id, Name: name}
+	}
+	return SystemActor()
+}

--- a/internal/service/audit.go
+++ b/internal/service/audit.go
@@ -158,6 +158,11 @@ func (s *Service) queryAuditLog(ctx context.Context, query string, args []any, l
 	defer rows.Close()
 
 	var entries []AuditLogResponse
+	type entryWithTime struct {
+		resp AuditLogResponse
+		ts   time.Time
+	}
+	var allEntries []entryWithTime
 	for rows.Next() {
 		var (
 			id         pgtype.UUID
@@ -189,7 +194,7 @@ func (s *Service) queryAuditLog(ctx context.Context, query string, args []any, l
 			ActorType:  actorType,
 			ActorID:    textPtr(actorID),
 			ActorName:  actorName,
-			CreatedAt:  createdAt.Time.UTC().Format(time.RFC3339),
+			CreatedAt:  createdAt.Time.UTC().Format(time.RFC3339Nano),
 		}
 
 		if len(metadata) > 0 {
@@ -199,22 +204,26 @@ func (s *Service) queryAuditLog(ctx context.Context, query string, args []any, l
 			}
 		}
 
-		entries = append(entries, entry)
+		allEntries = append(allEntries, entryWithTime{resp: entry, ts: createdAt.Time.UTC()})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("rows audit log: %w", err)
 	}
 
-	hasMore := len(entries) > limit
+	hasMore := len(allEntries) > limit
 	if hasMore {
-		entries = entries[:limit]
+		allEntries = allEntries[:limit]
+	}
+
+	entries = make([]AuditLogResponse, len(allEntries))
+	for i, e := range allEntries {
+		entries[i] = e.resp
 	}
 
 	var nextCursor string
-	if hasMore && len(entries) > 0 {
-		last := entries[len(entries)-1]
-		t, _ := time.Parse(time.RFC3339, last.CreatedAt)
-		nextCursor = encodeTimestampCursor(t, last.ID)
+	if hasMore && len(allEntries) > 0 {
+		last := allEntries[len(allEntries)-1]
+		nextCursor = encodeTimestampCursor(last.ts, last.resp.ID)
 	}
 
 	return &AuditLogListResult{

--- a/internal/service/audit.go
+++ b/internal/service/audit.go
@@ -1,0 +1,225 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// WriteAuditLog writes one or more audit log entries using a batch insert.
+func (s *Service) WriteAuditLog(ctx context.Context, entries []AuditLogEntry) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// Build multi-row INSERT for efficiency.
+	var sb strings.Builder
+	sb.WriteString("INSERT INTO audit_log (entity_type, entity_id, action, field, old_value, new_value, actor_type, actor_id, actor_name, metadata) VALUES ")
+
+	args := make([]any, 0, len(entries)*10)
+	for i, e := range entries {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		base := i * 10
+		sb.WriteString(fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
+			base+1, base+2, base+3, base+4, base+5, base+6, base+7, base+8, base+9, base+10))
+
+		entityID, err := parseUUID(e.EntityID)
+		if err != nil {
+			return fmt.Errorf("invalid entity_id %q: %w", e.EntityID, err)
+		}
+
+		var field pgtype.Text
+		if e.Field != nil {
+			field = pgtype.Text{String: *e.Field, Valid: true}
+		}
+		var oldValue pgtype.Text
+		if e.OldValue != nil {
+			oldValue = pgtype.Text{String: *e.OldValue, Valid: true}
+		}
+		var newValue pgtype.Text
+		if e.NewValue != nil {
+			newValue = pgtype.Text{String: *e.NewValue, Valid: true}
+		}
+		var actorID pgtype.Text
+		if e.Actor.ID != "" {
+			actorID = pgtype.Text{String: e.Actor.ID, Valid: true}
+		}
+
+		var metadata []byte
+		if len(e.Metadata) > 0 {
+			metadata, _ = json.Marshal(e.Metadata)
+		}
+
+		args = append(args, e.EntityType, entityID, e.Action, field, oldValue, newValue,
+			e.Actor.Type, actorID, e.Actor.Name, metadata)
+	}
+
+	_, err := s.Pool.Exec(ctx, sb.String(), args...)
+	if err != nil {
+		return fmt.Errorf("write audit log: %w", err)
+	}
+	return nil
+}
+
+// ListAuditLog returns audit log entries for a specific entity.
+func (s *Service) ListAuditLog(ctx context.Context, params AuditLogListParams) (*AuditLogListResult, error) {
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	entityID, err := parseUUID(params.EntityID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid entity_id: %w", err)
+	}
+
+	query := "SELECT id, entity_type, entity_id, action, field, old_value, new_value, actor_type, actor_id, actor_name, metadata, created_at FROM audit_log WHERE entity_type = $1 AND entity_id = $2"
+	args := []any{params.EntityType, entityID}
+	argN := 3
+
+	if params.Cursor != "" {
+		cursorTime, cursorIDStr, err := decodeTimestampCursor(params.Cursor)
+		if err != nil {
+			return nil, ErrInvalidCursor
+		}
+		cursorUUID, err := parseUUID(cursorIDStr)
+		if err != nil {
+			return nil, ErrInvalidCursor
+		}
+		query += fmt.Sprintf(" AND (created_at, id) < ($%d, $%d)", argN, argN+1)
+		args = append(args, pgtype.Timestamptz{Time: cursorTime, Valid: true}, cursorUUID)
+		argN += 2
+	}
+
+	query += fmt.Sprintf(" ORDER BY created_at DESC, id DESC LIMIT $%d", argN)
+	args = append(args, limit+1)
+
+	return s.queryAuditLog(ctx, query, args, limit)
+}
+
+// ListAuditLogGlobal returns audit log entries across all entities.
+func (s *Service) ListAuditLogGlobal(ctx context.Context, params AuditLogGlobalParams) (*AuditLogListResult, error) {
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	query := "SELECT id, entity_type, entity_id, action, field, old_value, new_value, actor_type, actor_id, actor_name, metadata, created_at FROM audit_log WHERE 1=1"
+	args := []any{}
+	argN := 1
+
+	if params.EntityType != nil {
+		query += fmt.Sprintf(" AND entity_type = $%d", argN)
+		args = append(args, *params.EntityType)
+		argN++
+	}
+	if params.ActorType != nil {
+		query += fmt.Sprintf(" AND actor_type = $%d", argN)
+		args = append(args, *params.ActorType)
+		argN++
+	}
+	if params.Cursor != "" {
+		cursorTime, cursorIDStr, err := decodeTimestampCursor(params.Cursor)
+		if err != nil {
+			return nil, ErrInvalidCursor
+		}
+		cursorUUID, err := parseUUID(cursorIDStr)
+		if err != nil {
+			return nil, ErrInvalidCursor
+		}
+		query += fmt.Sprintf(" AND (created_at, id) < ($%d, $%d)", argN, argN+1)
+		args = append(args, pgtype.Timestamptz{Time: cursorTime, Valid: true}, cursorUUID)
+		argN += 2
+	}
+
+	query += fmt.Sprintf(" ORDER BY created_at DESC, id DESC LIMIT $%d", argN)
+	args = append(args, limit+1)
+
+	return s.queryAuditLog(ctx, query, args, limit)
+}
+
+func (s *Service) queryAuditLog(ctx context.Context, query string, args []any, limit int) (*AuditLogListResult, error) {
+	rows, err := s.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query audit log: %w", err)
+	}
+	defer rows.Close()
+
+	var entries []AuditLogResponse
+	for rows.Next() {
+		var (
+			id         pgtype.UUID
+			entityType string
+			entityID   pgtype.UUID
+			action     string
+			field      pgtype.Text
+			oldValue   pgtype.Text
+			newValue   pgtype.Text
+			actorType  string
+			actorID    pgtype.Text
+			actorName  string
+			metadata   []byte
+			createdAt  pgtype.Timestamptz
+		)
+		if err := rows.Scan(&id, &entityType, &entityID, &action, &field, &oldValue, &newValue,
+			&actorType, &actorID, &actorName, &metadata, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan audit log: %w", err)
+		}
+
+		entry := AuditLogResponse{
+			ID:         formatUUID(id),
+			EntityType: entityType,
+			EntityID:   formatUUID(entityID),
+			Action:     action,
+			Field:      textPtr(field),
+			OldValue:   textPtr(oldValue),
+			NewValue:   textPtr(newValue),
+			ActorType:  actorType,
+			ActorID:    textPtr(actorID),
+			ActorName:  actorName,
+			CreatedAt:  createdAt.Time.UTC().Format(time.RFC3339),
+		}
+
+		if len(metadata) > 0 {
+			var m map[string]string
+			if json.Unmarshal(metadata, &m) == nil {
+				entry.Metadata = m
+			}
+		}
+
+		entries = append(entries, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("rows audit log: %w", err)
+	}
+
+	hasMore := len(entries) > limit
+	if hasMore {
+		entries = entries[:limit]
+	}
+
+	var nextCursor string
+	if hasMore && len(entries) > 0 {
+		last := entries[len(entries)-1]
+		t, _ := time.Parse(time.RFC3339, last.CreatedAt)
+		nextCursor = encodeTimestampCursor(t, last.ID)
+	}
+
+	return &AuditLogListResult{
+		Entries:    entries,
+		NextCursor: nextCursor,
+		HasMore:    hasMore,
+	}, nil
+}

--- a/internal/service/comments.go
+++ b/internal/service/comments.go
@@ -1,0 +1,190 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const maxCommentLength = 10000
+
+// CreateComment adds a comment to a transaction.
+func (s *Service) CreateComment(ctx context.Context, params CreateCommentParams) (*CommentResponse, error) {
+	content := strings.TrimSpace(params.Content)
+	if content == "" || len(content) > maxCommentLength {
+		return nil, fmt.Errorf("content must be between 1 and %d characters", maxCommentLength)
+	}
+
+	// Verify transaction exists and is not soft-deleted.
+	txnID, err := parseUUID(params.TransactionID)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	var deletedAt pgtype.Timestamptz
+	err = s.Pool.QueryRow(ctx, "SELECT deleted_at FROM transactions WHERE id = $1", txnID).Scan(&deletedAt)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("check transaction: %w", err)
+	}
+	if deletedAt.Valid {
+		return nil, ErrNotFound
+	}
+
+	var authorID pgtype.Text
+	if params.Actor.ID != "" {
+		authorID = pgtype.Text{String: params.Actor.ID, Valid: true}
+	}
+
+	comment, err := s.Queries.CreateComment(ctx, db.CreateCommentParams{
+		TransactionID: txnID,
+		AuthorType:    params.Actor.Type,
+		AuthorID:      authorID,
+		AuthorName:    params.Actor.Name,
+		Content:       content,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create comment: %w", err)
+	}
+
+	// Write audit log entry.
+	preview := content
+	if len(preview) > 100 {
+		preview = preview[:100] + "…"
+	}
+	field := "comment_added"
+	_ = s.WriteAuditLog(ctx, []AuditLogEntry{{
+		EntityType: "transaction",
+		EntityID:   params.TransactionID,
+		Action:     "update",
+		Field:      &field,
+		NewValue:   &preview,
+		Actor:      params.Actor,
+	}})
+
+	resp := commentFromRow(comment)
+	return &resp, nil
+}
+
+// ListComments returns all comments for a transaction, ordered by created_at ASC.
+func (s *Service) ListComments(ctx context.Context, transactionID string) ([]CommentResponse, error) {
+	txnID, err := parseUUID(transactionID)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	rows, err := s.Queries.ListCommentsByTransaction(ctx, txnID)
+	if err != nil {
+		return nil, fmt.Errorf("list comments: %w", err)
+	}
+
+	result := make([]CommentResponse, len(rows))
+	for i, r := range rows {
+		result[i] = commentFromRow(r)
+	}
+	return result, nil
+}
+
+// UpdateComment updates the content of an existing comment.
+func (s *Service) UpdateComment(ctx context.Context, id string, params UpdateCommentParams) (*CommentResponse, error) {
+	content := strings.TrimSpace(params.Content)
+	if content == "" || len(content) > maxCommentLength {
+		return nil, fmt.Errorf("content must be between 1 and %d characters", maxCommentLength)
+	}
+
+	commentID, err := parseUUID(id)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	existing, err := s.Queries.GetComment(ctx, commentID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get comment: %w", err)
+	}
+
+	// Check authorization: author match or admin.
+	if !canModifyComment(existing, params.Actor) {
+		return nil, ErrForbidden
+	}
+
+	updated, err := s.Queries.UpdateComment(ctx, db.UpdateCommentParams{
+		ID:      commentID,
+		Content: content,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update comment: %w", err)
+	}
+
+	resp := commentFromRow(updated)
+	return &resp, nil
+}
+
+// DeleteComment hard-deletes a comment.
+func (s *Service) DeleteComment(ctx context.Context, id string, actor Actor) error {
+	commentID, err := parseUUID(id)
+	if err != nil {
+		return ErrNotFound
+	}
+
+	existing, err := s.Queries.GetComment(ctx, commentID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return ErrNotFound
+		}
+		return fmt.Errorf("get comment: %w", err)
+	}
+
+	if !canModifyComment(existing, actor) {
+		return ErrForbidden
+	}
+
+	if err := s.Queries.DeleteComment(ctx, commentID); err != nil {
+		return fmt.Errorf("delete comment: %w", err)
+	}
+
+	// Write audit log entry.
+	field := "comment_deleted"
+	txnID := formatUUID(existing.TransactionID)
+	_ = s.WriteAuditLog(ctx, []AuditLogEntry{{
+		EntityType: "transaction",
+		EntityID:   txnID,
+		Action:     "update",
+		Field:      &field,
+		Actor:      actor,
+	}})
+
+	return nil
+}
+
+// canModifyComment checks if the actor can edit/delete a comment.
+// The original author can always modify. Admins (user type) can moderate.
+func canModifyComment(comment db.TransactionComment, actor Actor) bool {
+	if actor.Type == "user" {
+		return true // admins can moderate
+	}
+	return comment.AuthorType == actor.Type && comment.AuthorID.Valid && comment.AuthorID.String == actor.ID
+}
+
+func commentFromRow(c db.TransactionComment) CommentResponse {
+	return CommentResponse{
+		ID:            formatUUID(c.ID),
+		TransactionID: formatUUID(c.TransactionID),
+		AuthorType:    c.AuthorType,
+		AuthorID:      textPtr(c.AuthorID),
+		AuthorName:    c.AuthorName,
+		Content:       c.Content,
+		CreatedAt:     c.CreatedAt.Time.UTC().Format(time.RFC3339),
+		UpdatedAt:     c.UpdatedAt.Time.UTC().Format(time.RFC3339),
+	}
+}

--- a/internal/service/cursor.go
+++ b/internal/service/cursor.go
@@ -38,3 +38,38 @@ func DecodeCursor(cursor string) (date time.Time, id string, err error) {
 	}
 	return date, p.ID, nil
 }
+
+// Timestamp-based cursors for audit log and other timestamp-ordered queries.
+
+type timestampCursorPayload struct {
+	Timestamp string `json:"t"`
+	ID        string `json:"i"`
+}
+
+func encodeTimestampCursor(ts time.Time, id string) string {
+	p := timestampCursorPayload{
+		Timestamp: ts.UTC().Format(time.RFC3339Nano),
+		ID:        id,
+	}
+	b, _ := json.Marshal(p)
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func decodeTimestampCursor(cursor string) (ts time.Time, id string, err error) {
+	b, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return time.Time{}, "", ErrInvalidCursor
+	}
+	var p timestampCursorPayload
+	if err := json.Unmarshal(b, &p); err != nil {
+		return time.Time{}, "", ErrInvalidCursor
+	}
+	ts, err = time.Parse(time.RFC3339Nano, p.Timestamp)
+	if err != nil {
+		return time.Time{}, "", ErrInvalidCursor
+	}
+	if p.ID == "" {
+		return time.Time{}, "", ErrInvalidCursor
+	}
+	return ts, p.ID, nil
+}

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -8,4 +8,5 @@ var (
 	ErrRevokedAPIKey  = errors.New("api key has been revoked")
 	ErrInvalidCursor  = errors.New("invalid cursor")
 	ErrSyncInProgress = errors.New("sync already in progress")
+	ErrForbidden      = errors.New("forbidden")
 )

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -234,3 +234,75 @@ type AdminAccountDetail struct {
 	UserName        string
 	ConnectionID    string
 }
+
+// Comment types
+
+type CreateCommentParams struct {
+	TransactionID string
+	Content       string
+	Actor         Actor
+}
+
+type UpdateCommentParams struct {
+	Content string
+	Actor   Actor
+}
+
+type CommentResponse struct {
+	ID            string  `json:"id"`
+	TransactionID string  `json:"transaction_id"`
+	AuthorType    string  `json:"author_type"`
+	AuthorID      *string `json:"author_id"`
+	AuthorName    string  `json:"author_name"`
+	Content       string  `json:"content"`
+	CreatedAt     string  `json:"created_at"`
+	UpdatedAt     string  `json:"updated_at"`
+}
+
+// Audit log types
+
+type AuditLogEntry struct {
+	EntityType string
+	EntityID   string
+	Action     string // "create", "update", "delete"
+	Field      *string
+	OldValue   *string
+	NewValue   *string
+	Actor      Actor
+	Metadata   map[string]string
+}
+
+type AuditLogListParams struct {
+	EntityType string
+	EntityID   string
+	Limit      int
+	Cursor     string
+}
+
+type AuditLogGlobalParams struct {
+	EntityType *string
+	ActorType  *string
+	Limit      int
+	Cursor     string
+}
+
+type AuditLogListResult struct {
+	Entries    []AuditLogResponse `json:"entries"`
+	NextCursor string             `json:"next_cursor,omitempty"`
+	HasMore    bool               `json:"has_more"`
+}
+
+type AuditLogResponse struct {
+	ID         string            `json:"id"`
+	EntityType string            `json:"entity_type"`
+	EntityID   string            `json:"entity_id"`
+	Action     string            `json:"action"`
+	Field      *string           `json:"field,omitempty"`
+	OldValue   *string           `json:"old_value,omitempty"`
+	NewValue   *string           `json:"new_value,omitempty"`
+	ActorType  string            `json:"actor_type"`
+	ActorID    *string           `json:"actor_id,omitempty"`
+	ActorName  string            `json:"actor_name"`
+	Metadata   map[string]string `json:"metadata,omitempty"`
+	CreatedAt  string            `json:"created_at"`
+}

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -107,7 +107,7 @@
       <tr @click="expanded = !expanded" class="cursor-pointer hover:bg-base-300">
         <td>{{.Date}}</td>
         <td>
-          {{.Name}}
+          <a href="/admin/transactions/{{.ID}}" @click.stop class="link link-hover">{{.Name}}</a>
           {{if .MerchantName}}<small class="text-base-content/60"> ({{.MerchantName}})</small>{{end}}
         </td>
         <td class="bb-amount{{if lt .Amount 0.0}} text-error{{end}}">

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -1,0 +1,169 @@
+{{define "content"}}
+<div class="breadcrumbs text-sm mb-4">
+  <ul>
+    <li><a href="/admin/transactions">Transactions</a></li>
+    <li>{{.Transaction.Name}}</li>
+  </ul>
+</div>
+
+<h1 class="text-2xl font-bold mb-6">{{.Transaction.Name}}</h1>
+
+<dl class="bb-info-grid mb-6">
+  <dt>Amount</dt>
+  <dd class="bb-amount{{if lt .Transaction.Amount 0.0}} text-error{{end}}">
+    {{printf "%.2f" .Transaction.Amount}}{{if .Transaction.IsoCurrencyCode}} {{.Transaction.IsoCurrencyCode}}{{end}}
+  </dd>
+  <dt>Date</dt>
+  <dd>{{.Transaction.Date}}</dd>
+  {{if .Transaction.MerchantName}}
+  <dt>Merchant</dt>
+  <dd>{{.Transaction.MerchantName}}</dd>
+  {{end}}
+  {{if .AccountName}}
+  <dt>Account</dt>
+  <dd><a href="/admin/accounts/{{.AccountID}}">{{.AccountName}}</a></dd>
+  {{end}}
+  {{if .UserName}}
+  <dt>Family Member</dt>
+  <dd>{{.UserName}}</dd>
+  {{end}}
+  <dt>Category</dt>
+  <dd>
+    {{if .Transaction.Category}}
+      {{if .Transaction.Category.DisplayName}}{{.Transaction.Category.DisplayName}}{{end}}
+      {{if .Transaction.CategoryOverride}} <span class="badge badge-outline badge-xs">override</span>{{end}}
+    {{else}}
+      &mdash;
+    {{end}}
+  </dd>
+  {{if .Transaction.CategoryPrimaryRaw}}
+  <dt>Raw Category</dt>
+  <dd>{{.Transaction.CategoryPrimaryRaw}}{{if .Transaction.CategoryDetailedRaw}} &rarr; {{.Transaction.CategoryDetailedRaw}}{{end}}</dd>
+  {{end}}
+  {{if .Transaction.PaymentChannel}}
+  <dt>Payment Channel</dt>
+  <dd>{{.Transaction.PaymentChannel}}</dd>
+  {{end}}
+  <dt>Status</dt>
+  <dd>{{if .Transaction.Pending}}<span class="badge badge-warning badge-sm">Pending</span>{{else}}Posted{{end}}</dd>
+  <dt>Transaction ID</dt>
+  <dd><code class="font-mono text-xs">{{.Transaction.ID}}</code></dd>
+  <dt>Created</dt>
+  <dd>{{.Transaction.CreatedAt}}</dd>
+  <dt>Updated</dt>
+  <dd>{{.Transaction.UpdatedAt}}</dd>
+</dl>
+
+<h2 class="text-xl font-semibold mb-4">Comments</h2>
+
+<div x-data="commentManager()" class="mb-8">
+  {{if .Comments}}
+  <div class="space-y-3 mb-4">
+    {{range .Comments}}
+    <div class="card bg-base-100 border border-base-300 p-4" data-comment-id="{{.ID}}">
+      <div class="flex items-start justify-between gap-2">
+        <div class="flex-1">
+          <p class="text-sm whitespace-pre-wrap">{{.Content}}</p>
+          <p class="text-xs text-base-content/60 mt-1">
+            <span class="badge badge-ghost badge-xs">{{.AuthorType}}</span>
+            {{.AuthorName}} &middot; {{.CreatedAt}}
+          </p>
+        </div>
+        <button class="btn btn-ghost btn-xs text-error" @click="deleteComment('{{.ID}}')" title="Delete">
+          <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+        </button>
+      </div>
+    </div>
+    {{end}}
+  </div>
+  {{else}}
+  <p class="text-sm text-base-content/60 mb-4">No comments yet.</p>
+  {{end}}
+
+  <div class="flex gap-2">
+    <textarea x-model="newComment" placeholder="Add a comment..." class="textarea textarea-bordered textarea-sm flex-1" rows="2"></textarea>
+    <button @click="addComment()" class="btn btn-sm btn-primary self-end" :disabled="!newComment.trim()">Add</button>
+  </div>
+</div>
+
+{{if .AuditEntries}}
+<h2 class="text-xl font-semibold mb-4">History</h2>
+<div class="overflow-x-auto border border-base-300 rounded-lg mb-6">
+  <table class="table table-zebra table-sm">
+    <thead>
+      <tr>
+        <th>Time</th>
+        <th>Action</th>
+        <th>Field</th>
+        <th>Old Value</th>
+        <th>New Value</th>
+        <th>Actor</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{range .AuditEntries}}
+      <tr>
+        <td class="text-xs">{{.CreatedAt}}</td>
+        <td><span class="badge badge-ghost badge-xs">{{.Action}}</span></td>
+        <td>{{if .Field}}{{.Field}}{{else}}&mdash;{{end}}</td>
+        <td class="text-xs max-w-32 truncate">{{if .OldValue}}{{.OldValue}}{{else}}&mdash;{{end}}</td>
+        <td class="text-xs max-w-32 truncate">{{if .NewValue}}{{.NewValue}}{{else}}&mdash;{{end}}</td>
+        <td><span class="badge badge-ghost badge-xs">{{.ActorType}}</span> {{.ActorName}}</td>
+      </tr>
+      {{end}}
+    </tbody>
+  </table>
+</div>
+{{end}}
+
+<script>
+function showToast(message, type) {
+  window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
+}
+
+function commentManager() {
+  return {
+    newComment: '',
+    addComment() {
+      var self = this;
+      var content = this.newComment.trim();
+      if (!content) return;
+      fetch('/admin/api/transactions/{{.TransactionID}}/comments', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({content: content})
+      })
+      .then(function(res) {
+        if (res.ok) {
+          self.newComment = '';
+          showToast('Comment added.', 'success');
+          location.reload();
+        } else {
+          return res.json().then(function(data) {
+            showToast(data.error || 'Failed to add comment.');
+          });
+        }
+      })
+      .catch(function() { showToast('Network error.'); });
+    },
+    deleteComment(id) {
+      if (!confirm('Delete this comment?')) return;
+      fetch('/admin/api/transactions/{{.TransactionID}}/comments/' + id, {
+        method: 'DELETE'
+      })
+      .then(function(res) {
+        if (res.ok || res.status === 204) {
+          showToast('Comment deleted.', 'success');
+          location.reload();
+        } else {
+          return res.json().then(function(data) {
+            showToast(data.error || 'Failed to delete comment.');
+          });
+        }
+      })
+      .catch(function() { showToast('Network error.'); });
+    }
+  };
+}
+</script>
+{{end}}

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -95,7 +95,7 @@
       <tr @click="expanded = !expanded" class="cursor-pointer hover:bg-base-300">
         <td>{{.Date}}</td>
         <td>
-          {{.Name}}
+          <a href="/admin/transactions/{{.ID}}" @click.stop class="link link-hover">{{.Name}}</a>
           {{if .MerchantName}}<small class="text-base-content/60"> ({{.MerchantName}})</small>{{end}}
         </td>
         <td class="bb-amount{{if lt .Amount 0.0}} text-error{{end}}">


### PR DESCRIPTION
Add transaction comments system and audit log infrastructure:
- DB migrations for transaction_comments and audit_log tables
- Actor identity propagation via context (API key middleware + admin session)
- Service layer: comments CRUD with authorization, audit log batch writer
- REST API: 6 new endpoints for comments and audit log
- MCP tools: add_transaction_comment, list_transaction_comments,
  get_transaction_history, query_audit_log
- Admin dashboard: transaction detail page with comments and history
- Instrument existing admin handlers with audit logging (connections,
  accounts, users)
- Linkify transaction names in transaction list and account detail pages

https://claude.ai/code/session_01KmhH1WNvfJTqKXJwpjQYXf