### PR TITLE
Phase 22: Agent-optimized APIs & token efficiency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,10 @@ One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), M
 - Category API: transaction responses include structured `category` object; raw fields renamed to `category_primary_raw`/`category_detailed_raw`. Filter by `category_slug` param.
 - `ListDistinctCategories` returns `[]CategoryPair{Primary, Detailed}` (not `[]string`). Will be replaced by `ListCategories` returning full taxonomy tree (Phase 20B).
 - MCP `min_amount`/`max_amount` use `*float64` (not `float64`) to allow filtering by zero values
+- Field selection: `?fields=` param on `GET /api/v1/transactions`, `GET /api/v1/transactions/{id}`, and MCP `query_transactions`. Aliases: `core` (id,date,amount,name,iso_currency_code), `category` (category,category_primary_raw,category_detailed_raw), `timestamps` (created_at,updated_at,datetime,authorized_datetime). `id` always included. Filtering happens in handlers, not service layer.
+- Transaction summary: `GET /api/v1/transactions/summary` and MCP `transaction_summary` tool. Server-side aggregation with `group_by`: category, month, week, day, category_month. Multi-currency handled per-row. Default date range: 30 days.
+- Category mapping MCP tools: `list_category_mappings`, `create_category_mapping`, `update_category_mapping`, `delete_category_mapping`. Accept category slugs (not IDs). Lookup by ID or (provider, provider_category) pair.
+- Enhanced overview resource: `breadbox://overview` includes users list, accounts_by_type, connections with account counts, 30-day spending summary with top 5 categories, pending transaction count.
 - CSS framework: DaisyUI 5 + Tailwind CSS v4 via `tailwindcss-extra` standalone CLI binary. No Node.js. Replaces Pico CSS.
 - CSS build: `make css` compiles `input.css` → `static/css/styles.css`. `make css-watch` for dev. Dockerfile runs `make css` in build stage.
 - DaisyUI theme: `light` (default) + `dark` auto-switch via `prefers-color-scheme`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2403,12 +2403,13 @@ Data foundation for agentic review and human collaboration.
 
 ---
 
-### Phase 22: Agent-Optimized APIs & Token Efficiency
+### Phase 22: Agent-Optimized APIs & Token Efficiency ✅
 
 Make the API surface efficient for AI agent consumption.
 
 - **Spec:** [`docs/phase-22-agent-optimized-apis.md`](phase-22-agent-optimized-apis.md)
 - **Key deliverables:** `?fields=` param on transactions, category mapping MCP CRUD, `transaction_summary` aggregation tool, enriched `breadbox://overview`, response size reduction
+- **Status:** Complete. Field selection (REST+MCP), transaction summary (REST+MCP), 4 category mapping MCP tools, enhanced overview with users/connections/spending summary, updated MCP instructions.
 
 ---
 

--- a/docs/phase-22-agent-optimized-apis.md
+++ b/docs/phase-22-agent-optimized-apis.md
@@ -79,8 +79,10 @@ Every JSON field on `TransactionResponse` is selectable. The canonical set:
 | `authorized_datetime` | `authorized_datetime` | `t.authorized_datetime` | No |
 | `name` | `name` | `t.name` | No |
 | `merchant_name` | `merchant_name` | `t.merchant_name` | No |
-| `category_primary` | `category_primary` | `t.category_primary` | No |
-| `category_detailed` | `category_detailed` | `t.category_detailed` | No |
+| `category` | `category` | Structured category object (slug, display_name, icon, color) | No |
+| `category_override` | `category_override` | `t.category_override` | No |
+| `category_primary_raw` | `category_primary_raw` | `t.category_primary` (raw provider string) | No |
+| `category_detailed_raw` | `category_detailed_raw` | `t.category_detailed` (raw provider string) | No |
 | `category_confidence` | `category_confidence` | `t.category_confidence` | No |
 | `payment_channel` | `payment_channel` | `t.payment_channel` | No |
 | `pending` | `pending` | `t.pending` | No |
@@ -96,10 +98,10 @@ For common agent patterns, provide aliases that expand to multiple fields:
 | Alias | Expands To |
 |-------|-----------|
 | `core` | `id,date,amount,name,iso_currency_code` |
-| `category` | `category_primary,category_detailed` |
+| `category` | `category,category_primary_raw,category_detailed_raw` |
 | `timestamps` | `created_at,updated_at,datetime,authorized_datetime` |
 
-Example: `?fields=core,category,account_name` expands to `id,date,amount,name,iso_currency_code,category_primary,category_detailed,account_name`.
+Example: `?fields=core,category,account_name` expands to `id,date,amount,name,iso_currency_code,category,category_primary_raw,category_detailed_raw,account_name`.
 
 Aliases and explicit fields can be mixed. Duplicates are deduplicated.
 
@@ -110,15 +112,16 @@ var validFields = map[string]bool{
     "id": true, "account_id": true, "account_name": true, "user_name": true,
     "amount": true, "iso_currency_code": true, "date": true,
     "authorized_date": true, "datetime": true, "authorized_datetime": true,
-    "name": true, "merchant_name": true, "category_primary": true,
-    "category_detailed": true, "category_confidence": true,
+    "name": true, "merchant_name": true, "category": true,
+    "category_override": true, "category_primary_raw": true,
+    "category_detailed_raw": true, "category_confidence": true,
     "payment_channel": true, "pending": true, "created_at": true,
     "updated_at": true,
 }
 
 var fieldAliases = map[string][]string{
     "core":       {"id", "date", "amount", "name", "iso_currency_code"},
-    "category":   {"category_primary", "category_detailed"},
+    "category":   {"category", "category_primary_raw", "category_detailed_raw"},
     "timestamps": {"created_at", "updated_at", "datetime", "authorized_datetime"},
 }
 ```
@@ -190,8 +193,10 @@ func FilterTransactionFields(t TransactionResponse, fields map[string]bool) map[
     if fields["authorized_datetime"] { m["authorized_datetime"] = t.AuthorizedDatetime }
     if fields["name"] { m["name"] = t.Name }
     if fields["merchant_name"] { m["merchant_name"] = t.MerchantName }
-    if fields["category_primary"] { m["category_primary"] = t.CategoryPrimary }
-    if fields["category_detailed"] { m["category_detailed"] = t.CategoryDetailed }
+    if fields["category"] { m["category"] = t.Category }
+    if fields["category_override"] { m["category_override"] = t.CategoryOverride }
+    if fields["category_primary_raw"] { m["category_primary_raw"] = t.CategoryPrimaryRaw }
+    if fields["category_detailed_raw"] { m["category_detailed_raw"] = t.CategoryDetailedRaw }
     if fields["category_confidence"] { m["category_confidence"] = t.CategoryConfidence }
     if fields["payment_channel"] { m["payment_channel"] = t.PaymentChannel }
     if fields["pending"] { m["pending"] = t.Pending }
@@ -217,7 +222,7 @@ Add `fields` to the `queryTransactionsInput` struct:
 ```go
 type queryTransactionsInput struct {
     // ... existing fields ...
-    Fields string `json:"fields,omitempty" jsonschema:"Comma-separated list of fields to include in response. Aliases: core (id,date,amount,name,iso_currency_code), category (category_primary,category_detailed), timestamps (created_at,updated_at,datetime,authorized_datetime). Default: all fields. id is always included."`
+    Fields string `json:"fields,omitempty" jsonschema:"Comma-separated list of fields to include in response. Aliases: core (id,date,amount,name,iso_currency_code), category (category,category_primary_raw,category_detailed_raw), timestamps (created_at,updated_at,datetime,authorized_datetime). Default: all fields. id is always included."`
 }
 ```
 

--- a/internal/api/category_mappings.go
+++ b/internal/api/category_mappings.go
@@ -20,7 +20,8 @@ func ListMappingsHandler(svc *service.Service) http.HandlerFunc {
 			providerPtr = &provider
 		}
 
-		mappings, err := svc.ListMappings(r.Context(), providerPtr)
+		categorySlug := r.URL.Query().Get("category_slug")
+		mappings, err := svc.ListMappings(r.Context(), providerPtr, categorySlug)
 		if err != nil {
 			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list mappings")
 			return

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -44,6 +44,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/accounts/{id}", GetAccountHandler(svc))
 		r.Get("/transactions", ListTransactionsHandler(svc))
 		r.Get("/transactions/count", CountTransactionsHandler(svc))
+		r.Get("/transactions/summary", TransactionSummaryHandler(svc))
 		r.Get("/transactions/{id}", GetTransactionHandler(svc))
 		r.Patch("/transactions/{id}/category", SetTransactionCategoryHandler(svc))
 		r.Delete("/transactions/{id}/category", ResetTransactionCategoryHandler(svc))

--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -172,6 +172,13 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			SortOrder:    sortOrder,
 		}
 
+		// Parse fields for field selection.
+		fieldSet, err := service.ParseFields(q.Get("fields"))
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_FIELDS", err.Error())
+			return
+		}
+
 		result, err := svc.ListTransactions(r.Context(), params)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidCursor) {
@@ -179,6 +186,20 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 				return
 			}
 			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list transactions")
+			return
+		}
+
+		if fieldSet != nil {
+			filtered := make([]map[string]any, len(result.Transactions))
+			for i, t := range result.Transactions {
+				filtered[i] = service.FilterTransactionFields(t, fieldSet)
+			}
+			writeData(w, map[string]any{
+				"transactions": filtered,
+				"next_cursor":  result.NextCursor,
+				"has_more":     result.HasMore,
+				"limit":        result.Limit,
+			})
 			return
 		}
 
@@ -307,6 +328,12 @@ func GetTransactionHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 
+		fieldSet, err := service.ParseFields(r.URL.Query().Get("fields"))
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_FIELDS", err.Error())
+			return
+		}
+
 		txn, err := svc.GetTransaction(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
@@ -317,7 +344,68 @@ func GetTransactionHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 
+		if fieldSet != nil {
+			writeData(w, service.FilterTransactionFields(*txn, fieldSet))
+			return
+		}
+
 		writeData(w, txn)
+	}
+}
+
+// TransactionSummaryHandler returns aggregated transaction totals.
+func TransactionSummaryHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+
+		groupBy := q.Get("group_by")
+		if groupBy == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "group_by is required (category, month, week, day, category_month)")
+			return
+		}
+
+		params := service.TransactionSummaryParams{
+			GroupBy: groupBy,
+		}
+
+		if v := q.Get("start_date"); v != "" {
+			t, err := time.Parse("2006-01-02", v)
+			if err != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "start_date must be in YYYY-MM-DD format")
+				return
+			}
+			params.StartDate = &t
+		}
+
+		if v := q.Get("end_date"); v != "" {
+			t, err := time.Parse("2006-01-02", v)
+			if err != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "end_date must be in YYYY-MM-DD format")
+				return
+			}
+			params.EndDate = &t
+		}
+
+		if v := q.Get("account_id"); v != "" {
+			params.AccountID = &v
+		}
+		if v := q.Get("user_id"); v != "" {
+			params.UserID = &v
+		}
+		if v := q.Get("category"); v != "" {
+			params.Category = &v
+		}
+		if q.Get("include_pending") == "true" {
+			params.IncludePending = true
+		}
+
+		result, err := svc.GetTransactionSummary(r.Context(), params)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+
+		writeData(w, result)
 	}
 }
 

--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -401,7 +401,11 @@ func TransactionSummaryHandler(svc *service.Service) http.HandlerFunc {
 
 		result, err := svc.GetTransactionSummary(r.Context(), params)
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			if errors.Is(err, service.ErrInvalidParameter) {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get transaction summary")
 			return
 		}
 

--- a/internal/db/queries/category_mappings.sql
+++ b/internal/db/queries/category_mappings.sql
@@ -35,6 +35,14 @@ ON CONFLICT (provider, provider_category) DO UPDATE
 SET category_id = EXCLUDED.category_id, updated_at = NOW()
 RETURNING *;
 
+-- name: GetCategoryMappingByProviderCategory :one
+SELECT * FROM category_mappings
+WHERE provider = $1 AND provider_category = $2;
+
+-- name: DeleteCategoryMappingByProviderCategory :exec
+DELETE FROM category_mappings
+WHERE provider = $1 AND provider_category = $2;
+
 -- name: ListMappingsForResolver :many
 SELECT provider_category, category_id
 FROM category_mappings

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -43,12 +43,18 @@ CATEGORY SYSTEM:
 - Use categorize_transaction to manually override a transaction's category
 - Use reset_transaction_category to undo a manual override
 - Use list_unmapped_categories to find raw provider categories without mappings
+- Use list_category_mappings, create_category_mapping, update_category_mapping, delete_category_mapping to manage how provider category strings map to user categories
+
+TOKEN EFFICIENCY:
+- Use the fields parameter on query_transactions to request only needed fields (e.g., fields=core,category). Aliases: core (id,date,amount,name,iso_currency_code), category (category,category_primary_raw,category_detailed_raw), timestamps (created_at,updated_at,datetime,authorized_datetime)
+- Use transaction_summary for aggregated spending analysis instead of paginating through individual transactions. Supports group_by: category, month, week, day, category_month
+- The breadbox://overview resource includes users, connections, accounts by type, and 30-day spending summary — often eliminates the need for separate list_users + list_accounts calls
 
 RECOMMENDED QUERY PATTERNS:
-1. Start with list_users to identify family members
-2. Use list_accounts to see available bank accounts
-3. Use list_categories to understand the category taxonomy
-4. Query transactions with date ranges and category_slug filters
+1. Read breadbox://overview first for dataset context (users, connections, accounts, spending)
+2. Use transaction_summary for spending analysis (group by category, month, etc.)
+3. Use query_transactions with fields=core,category for browsing individual transactions
+4. Use list_categories to understand the category taxonomy
 5. Use count_transactions to get totals before paginating
 6. Check get_sync_status to verify data freshness
 7. Use list_unmapped_categories to identify categorization gaps

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -19,7 +19,7 @@ func (s *MCPServer) registerTools() {
 
 	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
 		Name:        "query_transactions",
-		Description: "Query bank transactions with optional filters and cursor-based pagination. Amounts: positive = money out (debit), negative = money in (credit). Dates: YYYY-MM-DD, start_date inclusive, end_date exclusive. Filter by category_slug (use list_categories to find slugs); parent slugs include all children. Results ordered by date desc by default. Pagination: pass next_cursor from response.",
+		Description: "Query bank transactions with optional filters and cursor-based pagination. Amounts: positive = money out (debit), negative = money in (credit). Dates: YYYY-MM-DD, start_date inclusive, end_date exclusive. Filter by category_slug (use list_categories to find slugs); parent slugs include all children. Results ordered by date desc by default. Pagination: pass next_cursor from response. Use the fields parameter to request only the fields you need (e.g., fields=core,category) to significantly reduce response size.",
 	}, s.handleQueryTransactions)
 
 	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
@@ -81,6 +81,31 @@ func (s *MCPServer) registerTools() {
 		Name:        "query_audit_log",
 		Description: "Query the global audit log to see all changes across the system. Use entity_type to focus on specific data types. Filter by actor_type='agent' to see what other AI agents have done, or actor_type='user' to see manual changes by the family. Useful for learning patterns: e.g., query all category overrides to understand the family's preferences.",
 	}, s.handleQueryAuditLog)
+
+	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
+		Name:        "transaction_summary",
+		Description: "Get aggregated transaction totals grouped by category and/or time period. Replaces the need to paginate through thousands of individual transactions for spending analysis. Amounts follow the convention: positive = money out (debit), negative = money in (credit). Only includes non-deleted, non-pending transactions by default.",
+	}, s.handleTransactionSummary)
+
+	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
+		Name:        "list_category_mappings",
+		Description: "List category mappings that translate provider-specific category strings to user categories. Filter by provider to see mappings for a specific bank data source. Returns the provider, raw provider category string, and the mapped user category slug and display name.",
+	}, s.handleListCategoryMappings)
+
+	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
+		Name:        "create_category_mapping",
+		Description: "Create a new category mapping that tells the system how to translate a provider's raw category string to a user category. For example, map Teller's 'dining' to your 'food_and_drink_restaurant' category. The mapping takes effect on the next sync — existing transactions are not retroactively updated.",
+	}, s.handleCreateCategoryMapping)
+
+	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
+		Name:        "update_category_mapping",
+		Description: "Update an existing category mapping to point to a different user category. Identified by mapping ID or by the (provider, provider_category) pair. Does not retroactively update transactions — wait for next sync.",
+	}, s.handleUpdateCategoryMapping)
+
+	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
+		Name:        "delete_category_mapping",
+		Description: "Delete a category mapping. After deletion, transactions with this provider category string will fall back to 'uncategorized' on next sync. Identified by mapping ID or by (provider, provider_category) pair.",
+	}, s.handleDeleteCategoryMapping)
 }
 
 // --- Input types ---
@@ -103,6 +128,7 @@ type queryTransactionsInput struct {
 	Cursor       string   `json:"cursor,omitempty" jsonschema:"Pagination cursor from previous result"`
 	SortBy       string   `json:"sort_by,omitempty" jsonschema:"Sort: date (default), amount, name"`
 	SortOrder    string   `json:"sort_order,omitempty" jsonschema:"Sort direction: desc (default) or asc"`
+	Fields       string   `json:"fields,omitempty" jsonschema:"Comma-separated list of fields to include in response. Aliases: core (id,date,amount,name,iso_currency_code), category (category,category_primary_raw,category_detailed_raw), timestamps (created_at,updated_at,datetime,authorized_datetime). Default: all fields. id is always included."`
 }
 
 type countTransactionsInput struct {
@@ -149,6 +175,39 @@ type queryAuditLogInput struct {
 	ActorType  string `json:"actor_type,omitempty" jsonschema:"Filter by who made the change: user, agent, system"`
 	Limit      int    `json:"limit,omitempty" jsonschema:"Max entries to return (default 50, max 200)"`
 	Cursor     string `json:"cursor,omitempty" jsonschema:"Pagination cursor from previous result"`
+}
+
+type transactionSummaryInput struct {
+	StartDate      string `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD) inclusive. Defaults to 30 days ago."`
+	EndDate        string `json:"end_date,omitempty" jsonschema:"End date (YYYY-MM-DD) exclusive. Defaults to today."`
+	GroupBy        string `json:"group_by" jsonschema:"required,How to group results: category, month, week, day, or category_month"`
+	AccountID      string `json:"account_id,omitempty" jsonschema:"Filter by account ID"`
+	UserID         string `json:"user_id,omitempty" jsonschema:"Filter by user ID (family member)"`
+	Category       string `json:"category,omitempty" jsonschema:"Filter by primary category before aggregating"`
+	IncludePending *bool  `json:"include_pending,omitempty" jsonschema:"Include pending transactions (default false)"`
+}
+
+type listCategoryMappingsInput struct {
+	Provider string `json:"provider,omitempty" jsonschema:"Filter by provider: plaid, teller, or csv"`
+}
+
+type createCategoryMappingInput struct {
+	Provider         string `json:"provider" jsonschema:"required,Provider type: plaid, teller, or csv"`
+	ProviderCategory string `json:"provider_category" jsonschema:"required,Raw category string from the provider (e.g. FOOD_AND_DRINK_GROCERIES for Plaid or dining for Teller)"`
+	CategorySlug     string `json:"category_slug" jsonschema:"required,Slug of the target user category (e.g. food_and_drink_restaurant). Use list_categories to find valid slugs."`
+}
+
+type updateCategoryMappingInput struct {
+	ID               string `json:"id,omitempty" jsonschema:"Mapping ID to update (alternative to provider + provider_category)"`
+	Provider         string `json:"provider,omitempty" jsonschema:"Provider type (required if not using id)"`
+	ProviderCategory string `json:"provider_category,omitempty" jsonschema:"Raw provider category string (required if not using id)"`
+	CategorySlug     string `json:"category_slug" jsonschema:"required,New target category slug"`
+}
+
+type deleteCategoryMappingInput struct {
+	ID               string `json:"id,omitempty" jsonschema:"Mapping ID to delete (alternative to provider + provider_category)"`
+	Provider         string `json:"provider,omitempty" jsonschema:"Provider type (required if not using id)"`
+	ProviderCategory string `json:"provider_category,omitempty" jsonschema:"Raw provider category string (required if not using id)"`
 }
 
 // --- Handlers ---
@@ -217,9 +276,27 @@ func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToo
 		params.SortOrder = &input.SortOrder
 	}
 
+	fieldSet, err := service.ParseFields(input.Fields)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+
 	result, err := s.svc.ListTransactions(ctx, params)
 	if err != nil {
 		return errorResult(err), nil, nil
+	}
+
+	if fieldSet != nil {
+		filtered := make([]map[string]any, len(result.Transactions))
+		for i, t := range result.Transactions {
+			filtered[i] = service.FilterTransactionFields(t, fieldSet)
+		}
+		return jsonResult(map[string]any{
+			"transactions": filtered,
+			"next_cursor":  result.NextCursor,
+			"has_more":     result.HasMore,
+			"limit":        result.Limit,
+		})
 	}
 
 	return jsonResult(result)
@@ -422,6 +499,147 @@ func (s *MCPServer) handleQueryAuditLog(ctx context.Context, _ *mcpsdk.CallToolR
 		return errorResult(err), nil, nil
 	}
 	return jsonResult(result)
+}
+
+func (s *MCPServer) handleTransactionSummary(_ context.Context, _ *mcpsdk.CallToolRequest, input transactionSummaryInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+
+	params := service.TransactionSummaryParams{
+		GroupBy: input.GroupBy,
+	}
+
+	if input.StartDate != "" {
+		t, err := time.Parse("2006-01-02", input.StartDate)
+		if err != nil {
+			return errorResult(fmt.Errorf("invalid start_date: %w", err)), nil, nil
+		}
+		params.StartDate = &t
+	}
+	if input.EndDate != "" {
+		t, err := time.Parse("2006-01-02", input.EndDate)
+		if err != nil {
+			return errorResult(fmt.Errorf("invalid end_date: %w", err)), nil, nil
+		}
+		params.EndDate = &t
+	}
+	if input.AccountID != "" {
+		params.AccountID = &input.AccountID
+	}
+	if input.UserID != "" {
+		params.UserID = &input.UserID
+	}
+	if input.Category != "" {
+		params.Category = &input.Category
+	}
+	if input.IncludePending != nil && *input.IncludePending {
+		params.IncludePending = true
+	}
+
+	result, err := s.svc.GetTransactionSummary(ctx, params)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+
+	return jsonResult(result)
+}
+
+func (s *MCPServer) handleListCategoryMappings(_ context.Context, _ *mcpsdk.CallToolRequest, input listCategoryMappingsInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+
+	var provider *string
+	if input.Provider != "" {
+		provider = &input.Provider
+	}
+
+	mappings, err := s.svc.ListMappings(ctx, provider)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+
+	return jsonResult(map[string]any{
+		"mappings": mappings,
+		"count":    len(mappings),
+	})
+}
+
+func (s *MCPServer) handleCreateCategoryMapping(_ context.Context, _ *mcpsdk.CallToolRequest, input createCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+
+	if input.Provider == "" || input.ProviderCategory == "" || input.CategorySlug == "" {
+		return errorResult(fmt.Errorf("provider, provider_category, and category_slug are required")), nil, nil
+	}
+
+	switch input.Provider {
+	case "plaid", "teller", "csv":
+	default:
+		return errorResult(fmt.Errorf("invalid provider '%s'. Must be plaid, teller, or csv", input.Provider)), nil, nil
+	}
+
+	mapping, err := s.svc.CreateMappingBySlug(ctx, input.Provider, input.ProviderCategory, input.CategorySlug)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+
+	return jsonResult(mapping)
+}
+
+func (s *MCPServer) handleUpdateCategoryMapping(_ context.Context, _ *mcpsdk.CallToolRequest, input updateCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+
+	if input.CategorySlug == "" {
+		return errorResult(fmt.Errorf("category_slug is required")), nil, nil
+	}
+	if input.ID == "" && (input.Provider == "" || input.ProviderCategory == "") {
+		return errorResult(fmt.Errorf("either id or (provider, provider_category) is required")), nil, nil
+	}
+
+	var id, provider, providerCategory *string
+	if input.ID != "" {
+		id = &input.ID
+	}
+	if input.Provider != "" {
+		provider = &input.Provider
+	}
+	if input.ProviderCategory != "" {
+		providerCategory = &input.ProviderCategory
+	}
+
+	mapping, err := s.svc.UpdateMappingBySlug(ctx, id, provider, providerCategory, input.CategorySlug)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+
+	return jsonResult(mapping)
+}
+
+func (s *MCPServer) handleDeleteCategoryMapping(_ context.Context, _ *mcpsdk.CallToolRequest, input deleteCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+
+	if input.ID == "" && (input.Provider == "" || input.ProviderCategory == "") {
+		return errorResult(fmt.Errorf("either id or (provider, provider_category) is required")), nil, nil
+	}
+
+	var id, provider, providerCategory *string
+	if input.ID != "" {
+		id = &input.ID
+	}
+	if input.Provider != "" {
+		provider = &input.Provider
+	}
+	if input.ProviderCategory != "" {
+		providerCategory = &input.ProviderCategory
+	}
+
+	prov, provCat, err := s.svc.DeleteMappingByLookup(ctx, id, provider, providerCategory)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+
+	return jsonResult(map[string]any{
+		"deleted":           true,
+		"provider":          prov,
+		"provider_category": provCat,
+	})
 }
 
 // --- Helpers ---

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -188,7 +188,8 @@ type transactionSummaryInput struct {
 }
 
 type listCategoryMappingsInput struct {
-	Provider string `json:"provider,omitempty" jsonschema:"Filter by provider: plaid, teller, or csv"`
+	Provider     string `json:"provider,omitempty" jsonschema:"Filter by provider: plaid, teller, or csv"`
+	CategorySlug string `json:"category_slug,omitempty" jsonschema:"Filter by target category slug (e.g. food_and_drink_restaurant). Use list_categories to find valid slugs."`
 }
 
 type createCategoryMappingInput struct {
@@ -551,7 +552,7 @@ func (s *MCPServer) handleListCategoryMappings(_ context.Context, _ *mcpsdk.Call
 		provider = &input.Provider
 	}
 
-	mappings, err := s.svc.ListMappings(ctx, provider)
+	mappings, err := s.svc.ListMappings(ctx, provider, input.CategorySlug)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -634,6 +634,120 @@ func (s *Service) getMappingResponse(ctx context.Context, id pgtype.UUID) (*Cate
 	}, nil
 }
 
+// CreateMappingBySlug creates a category mapping using category slug instead of ID.
+func (s *Service) CreateMappingBySlug(ctx context.Context, provider, providerCategory, categorySlug string) (*CategoryMappingResponse, error) {
+	cat, err := s.Queries.GetCategoryBySlug(ctx, categorySlug)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("category '%s' not found. Use list_categories to see valid slugs", categorySlug)
+		}
+		return nil, fmt.Errorf("lookup category: %w", err)
+	}
+
+	m, err := s.Queries.InsertCategoryMapping(ctx, db.InsertCategoryMappingParams{
+		Provider:         db.ProviderType(provider),
+		ProviderCategory: providerCategory,
+		CategoryID:       cat.ID,
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique constraint") {
+			return nil, fmt.Errorf("mapping already exists for (%s, %s). Use update_category_mapping to change it", provider, providerCategory)
+		}
+		return nil, fmt.Errorf("insert mapping: %w", err)
+	}
+
+	return s.getMappingResponse(ctx, m.ID)
+}
+
+// UpdateMappingBySlug updates a category mapping's target using slug, found by ID or (provider, provider_category).
+func (s *Service) UpdateMappingBySlug(ctx context.Context, id *string, provider *string, providerCategory *string, categorySlug string) (*CategoryMappingResponse, error) {
+	cat, err := s.Queries.GetCategoryBySlug(ctx, categorySlug)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("category '%s' not found. Use list_categories to see valid slugs", categorySlug)
+		}
+		return nil, fmt.Errorf("lookup category: %w", err)
+	}
+
+	var mappingID pgtype.UUID
+	if id != nil && *id != "" {
+		mappingID, err = parseUUID(*id)
+		if err != nil {
+			return nil, ErrMappingNotFound
+		}
+	} else if provider != nil && providerCategory != nil {
+		m, err2 := s.Queries.GetCategoryMappingByProviderCategory(ctx, db.GetCategoryMappingByProviderCategoryParams{
+			Provider:         db.ProviderType(*provider),
+			ProviderCategory: *providerCategory,
+		})
+		if err2 != nil {
+			if errors.Is(err2, pgx.ErrNoRows) {
+				return nil, ErrMappingNotFound
+			}
+			return nil, fmt.Errorf("lookup mapping: %w", err2)
+		}
+		mappingID = m.ID
+	} else {
+		return nil, fmt.Errorf("either id or (provider, provider_category) is required")
+	}
+
+	m, err := s.Queries.UpdateCategoryMapping(ctx, db.UpdateCategoryMappingParams{
+		ID:         mappingID,
+		CategoryID: cat.ID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrMappingNotFound
+		}
+		return nil, fmt.Errorf("update mapping: %w", err)
+	}
+
+	return s.getMappingResponse(ctx, m.ID)
+}
+
+// DeleteMappingByLookup deletes a mapping by ID or (provider, provider_category).
+func (s *Service) DeleteMappingByLookup(ctx context.Context, id *string, provider *string, providerCategory *string) (string, string, error) {
+	if id != nil && *id != "" {
+		mUID, err := parseUUID(*id)
+		if err != nil {
+			return "", "", ErrMappingNotFound
+		}
+		m, err := s.Queries.GetCategoryMappingByID(ctx, mUID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return "", "", ErrMappingNotFound
+			}
+			return "", "", fmt.Errorf("get mapping: %w", err)
+		}
+		if err := s.Queries.DeleteCategoryMapping(ctx, mUID); err != nil {
+			return "", "", fmt.Errorf("delete mapping: %w", err)
+		}
+		return string(m.Provider), m.ProviderCategory, nil
+	}
+
+	if provider != nil && providerCategory != nil {
+		_, err := s.Queries.GetCategoryMappingByProviderCategory(ctx, db.GetCategoryMappingByProviderCategoryParams{
+			Provider:         db.ProviderType(*provider),
+			ProviderCategory: *providerCategory,
+		})
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return "", "", ErrMappingNotFound
+			}
+			return "", "", fmt.Errorf("lookup mapping: %w", err)
+		}
+		if err := s.Queries.DeleteCategoryMappingByProviderCategory(ctx, db.DeleteCategoryMappingByProviderCategoryParams{
+			Provider:         db.ProviderType(*provider),
+			ProviderCategory: *providerCategory,
+		}); err != nil {
+			return "", "", fmt.Errorf("delete mapping: %w", err)
+		}
+		return *provider, *providerCategory, nil
+	}
+
+	return "", "", fmt.Errorf("either id or (provider, provider_category) is required")
+}
+
 // GenerateSlug creates a URL-safe slug from a display name.
 func GenerateSlug(displayName string) string {
 	s := strings.ToLower(displayName)

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -466,8 +466,8 @@ func (s *Service) BulkReMap(ctx context.Context, oldCategoryID, newCategoryID st
 
 // Category mapping CRUD
 
-// ListMappings returns all category mappings, optionally filtered by provider.
-func (s *Service) ListMappings(ctx context.Context, provider *string) ([]CategoryMappingResponse, error) {
+// ListMappings returns all category mappings, optionally filtered by provider and/or category slug.
+func (s *Service) ListMappings(ctx context.Context, provider *string, categorySlug ...string) ([]CategoryMappingResponse, error) {
 	var rows []db.ListCategoryMappingsRow
 	var err error
 
@@ -496,8 +496,17 @@ func (s *Service) ListMappings(ctx context.Context, provider *string) ([]Categor
 		}
 	}
 
+	// Determine optional category slug filter.
+	var slugFilter string
+	if len(categorySlug) > 0 && categorySlug[0] != "" {
+		slugFilter = categorySlug[0]
+	}
+
 	var result []CategoryMappingResponse
 	for _, r := range rows {
+		if slugFilter != "" && r.CategorySlug != slugFilter {
+			continue
+		}
 		result = append(result, CategoryMappingResponse{
 			ID:                  formatUUID(r.ID),
 			Provider:            string(r.Provider),

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -3,10 +3,11 @@ package service
 import "errors"
 
 var (
-	ErrNotFound       = errors.New("not found")
-	ErrInvalidAPIKey  = errors.New("invalid api key")
-	ErrRevokedAPIKey  = errors.New("api key has been revoked")
-	ErrInvalidCursor  = errors.New("invalid cursor")
-	ErrSyncInProgress = errors.New("sync already in progress")
-	ErrForbidden      = errors.New("forbidden")
+	ErrNotFound         = errors.New("not found")
+	ErrInvalidAPIKey    = errors.New("invalid api key")
+	ErrRevokedAPIKey    = errors.New("api key has been revoked")
+	ErrInvalidCursor    = errors.New("invalid cursor")
+	ErrInvalidParameter = errors.New("invalid parameter")
+	ErrSyncInProgress   = errors.New("sync already in progress")
+	ErrForbidden        = errors.New("forbidden")
 )

--- a/internal/service/fields.go
+++ b/internal/service/fields.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -70,6 +71,7 @@ func ParseFields(raw string) (map[string]bool, error) {
 		for k := range fieldAliases {
 			validList = append(validList, k)
 		}
+		sort.Strings(validList)
 		return nil, fmt.Errorf("unknown field(s): %s. Valid fields: %s", strings.Join(unknown, ", "), strings.Join(validList, ", "))
 	}
 	fields["id"] = true // always include

--- a/internal/service/fields.go
+++ b/internal/service/fields.go
@@ -1,0 +1,150 @@
+package service
+
+import (
+	"fmt"
+	"strings"
+)
+
+// validFields is the set of JSON field names that can be selected on TransactionResponse.
+var validFields = map[string]bool{
+	"id":                   true,
+	"account_id":           true,
+	"account_name":         true,
+	"user_name":            true,
+	"amount":               true,
+	"iso_currency_code":    true,
+	"date":                 true,
+	"authorized_date":      true,
+	"datetime":             true,
+	"authorized_datetime":  true,
+	"name":                 true,
+	"merchant_name":        true,
+	"category":             true,
+	"category_override":    true,
+	"category_primary_raw": true,
+	"category_detailed_raw": true,
+	"category_confidence":  true,
+	"payment_channel":      true,
+	"pending":              true,
+	"created_at":           true,
+	"updated_at":           true,
+}
+
+// fieldAliases expand shorthand names to groups of fields.
+var fieldAliases = map[string][]string{
+	"core":       {"id", "date", "amount", "name", "iso_currency_code"},
+	"category":   {"category", "category_primary_raw", "category_detailed_raw"},
+	"timestamps": {"created_at", "updated_at", "datetime", "authorized_datetime"},
+}
+
+// ParseFields parses and validates the fields query parameter.
+// Returns nil if no field selection (return all fields).
+func ParseFields(raw string) (map[string]bool, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	fields := make(map[string]bool)
+	var unknown []string
+	for _, f := range strings.Split(raw, ",") {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		if expanded, ok := fieldAliases[f]; ok {
+			for _, ef := range expanded {
+				fields[ef] = true
+			}
+			continue
+		}
+		if !validFields[f] {
+			unknown = append(unknown, f)
+			continue
+		}
+		fields[f] = true
+	}
+	if len(unknown) > 0 {
+		validList := make([]string, 0, len(validFields)+len(fieldAliases))
+		for k := range validFields {
+			validList = append(validList, k)
+		}
+		for k := range fieldAliases {
+			validList = append(validList, k)
+		}
+		return nil, fmt.Errorf("unknown field(s): %s. Valid fields: %s", strings.Join(unknown, ", "), strings.Join(validList, ", "))
+	}
+	fields["id"] = true // always include
+	return fields, nil
+}
+
+// FilterTransactionFields returns a map with only the requested fields.
+// If fields is nil, returns nil to signal the caller should use the full struct.
+func FilterTransactionFields(t TransactionResponse, fields map[string]bool) map[string]any {
+	if fields == nil {
+		return nil
+	}
+	m := make(map[string]any, len(fields))
+	if fields["id"] {
+		m["id"] = t.ID
+	}
+	if fields["account_id"] {
+		m["account_id"] = t.AccountID
+	}
+	if fields["account_name"] {
+		m["account_name"] = t.AccountName
+	}
+	if fields["user_name"] {
+		m["user_name"] = t.UserName
+	}
+	if fields["amount"] {
+		m["amount"] = t.Amount
+	}
+	if fields["iso_currency_code"] {
+		m["iso_currency_code"] = t.IsoCurrencyCode
+	}
+	if fields["date"] {
+		m["date"] = t.Date
+	}
+	if fields["authorized_date"] {
+		m["authorized_date"] = t.AuthorizedDate
+	}
+	if fields["datetime"] {
+		m["datetime"] = t.Datetime
+	}
+	if fields["authorized_datetime"] {
+		m["authorized_datetime"] = t.AuthorizedDatetime
+	}
+	if fields["name"] {
+		m["name"] = t.Name
+	}
+	if fields["merchant_name"] {
+		m["merchant_name"] = t.MerchantName
+	}
+	if fields["category"] {
+		m["category"] = t.Category
+	}
+	if fields["category_override"] {
+		m["category_override"] = t.CategoryOverride
+	}
+	if fields["category_primary_raw"] {
+		m["category_primary_raw"] = t.CategoryPrimaryRaw
+	}
+	if fields["category_detailed_raw"] {
+		m["category_detailed_raw"] = t.CategoryDetailedRaw
+	}
+	if fields["category_confidence"] {
+		m["category_confidence"] = t.CategoryConfidence
+	}
+	if fields["payment_channel"] {
+		m["payment_channel"] = t.PaymentChannel
+	}
+	if fields["pending"] {
+		m["pending"] = t.Pending
+	}
+	if fields["created_at"] {
+		m["created_at"] = t.CreatedAt
+	}
+	if fields["updated_at"] {
+		m["updated_at"] = t.UpdatedAt
+	}
+	return m
+}

--- a/internal/service/fields_test.go
+++ b/internal/service/fields_test.go
@@ -1,0 +1,204 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseFields_Empty(t *testing.T) {
+	fields, err := ParseFields("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fields != nil {
+		t.Fatal("expected nil for empty input")
+	}
+}
+
+func TestParseFields_SingleField(t *testing.T) {
+	fields, err := ParseFields("amount")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fields["amount"] {
+		t.Error("expected amount to be selected")
+	}
+	if !fields["id"] {
+		t.Error("id should always be included")
+	}
+}
+
+func TestParseFields_MultipleFields(t *testing.T) {
+	fields, err := ParseFields("amount,date,name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range []string{"id", "amount", "date", "name"} {
+		if !fields[f] {
+			t.Errorf("expected %s to be selected", f)
+		}
+	}
+	if fields["merchant_name"] {
+		t.Error("merchant_name should not be selected")
+	}
+}
+
+func TestParseFields_CoreAlias(t *testing.T) {
+	fields, err := ParseFields("core")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range []string{"id", "date", "amount", "name", "iso_currency_code"} {
+		if !fields[f] {
+			t.Errorf("core alias should include %s", f)
+		}
+	}
+}
+
+func TestParseFields_CategoryAlias(t *testing.T) {
+	fields, err := ParseFields("category")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range []string{"id", "category", "category_primary_raw", "category_detailed_raw"} {
+		if !fields[f] {
+			t.Errorf("category alias should include %s", f)
+		}
+	}
+}
+
+func TestParseFields_TimestampsAlias(t *testing.T) {
+	fields, err := ParseFields("timestamps")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range []string{"id", "created_at", "updated_at", "datetime", "authorized_datetime"} {
+		if !fields[f] {
+			t.Errorf("timestamps alias should include %s", f)
+		}
+	}
+}
+
+func TestParseFields_MixedAliasAndField(t *testing.T) {
+	fields, err := ParseFields("core,merchant_name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fields["amount"] {
+		t.Error("core alias should expand")
+	}
+	if !fields["merchant_name"] {
+		t.Error("explicit field should be included")
+	}
+}
+
+func TestParseFields_UnknownField(t *testing.T) {
+	_, err := ParseFields("amount,bogus_field")
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	if !strings.Contains(err.Error(), "bogus_field") {
+		t.Errorf("error should mention the unknown field: %v", err)
+	}
+}
+
+func TestParseFields_UnknownFieldSortedList(t *testing.T) {
+	_, err := ParseFields("zzz_bad")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	// Find the "Valid fields:" portion and verify it's sorted
+	idx := strings.Index(msg, "Valid fields: ")
+	if idx == -1 {
+		t.Fatal("expected 'Valid fields:' in error message")
+	}
+	fieldListStr := msg[idx+len("Valid fields: "):]
+	fieldList := strings.Split(fieldListStr, ", ")
+	for i := 1; i < len(fieldList); i++ {
+		if fieldList[i-1] > fieldList[i] {
+			t.Errorf("valid fields not sorted: %q > %q", fieldList[i-1], fieldList[i])
+			break
+		}
+	}
+}
+
+func TestParseFields_WhitespaceHandling(t *testing.T) {
+	fields, err := ParseFields(" amount , date , name ")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, f := range []string{"amount", "date", "name"} {
+		if !fields[f] {
+			t.Errorf("expected %s to be selected after trimming", f)
+		}
+	}
+}
+
+func TestParseFields_EmptySegments(t *testing.T) {
+	fields, err := ParseFields("amount,,date")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fields["amount"] || !fields["date"] {
+		t.Error("should skip empty segments")
+	}
+}
+
+func TestParseFields_IDAlwaysIncluded(t *testing.T) {
+	fields, err := ParseFields("amount")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !fields["id"] {
+		t.Error("id should always be included even when not requested")
+	}
+}
+
+func TestFilterTransactionFields_Nil(t *testing.T) {
+	txn := TransactionResponse{ID: "abc"}
+	result := FilterTransactionFields(txn, nil)
+	if result != nil {
+		t.Error("nil fields should return nil (signal to use full struct)")
+	}
+}
+
+func TestFilterTransactionFields_SelectsCorrectly(t *testing.T) {
+	txn := TransactionResponse{
+		ID:     "txn-1",
+		Amount: 42.50,
+		Name:   "Test Store",
+		Date:   "2024-01-15",
+	}
+	fields := map[string]bool{"id": true, "amount": true, "name": true}
+	result := FilterTransactionFields(txn, fields)
+
+	if result["id"] != "txn-1" {
+		t.Error("expected id")
+	}
+	if result["amount"] != 42.50 {
+		t.Error("expected amount")
+	}
+	if result["name"] != "Test Store" {
+		t.Error("expected name")
+	}
+	if _, ok := result["date"]; ok {
+		t.Error("date should not be in filtered result")
+	}
+}
+
+func TestFilterTransactionFields_AllFields(t *testing.T) {
+	// Build a fieldSet with all valid fields
+	fields, err := ParseFields("id,account_id,account_name,user_name,amount,iso_currency_code,date,authorized_date,datetime,authorized_datetime,name,merchant_name,category,category_override,category_primary_raw,category_detailed_raw,category_confidence,payment_channel,pending,created_at,updated_at")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	txn := TransactionResponse{ID: "txn-all"}
+	result := FilterTransactionFields(txn, fields)
+
+	// Should have all valid field keys
+	if len(result) != len(validFields) {
+		t.Errorf("expected %d fields, got %d", len(validFields), len(result))
+	}
+}

--- a/internal/service/overview.go
+++ b/internal/service/overview.go
@@ -3,18 +3,55 @@ package service
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 // OverviewStats contains high-level statistics about the Breadbox dataset.
 type OverviewStats struct {
-	UserCount        int    `json:"user_count"`
-	ConnectionCount  int    `json:"connection_count"`
-	AccountCount     int    `json:"account_count"`
-	TransactionCount int64  `json:"transaction_count"`
-	CategoryCount    int    `json:"category_count"`
-	UnmappedCount    int    `json:"unmapped_transaction_count"`
-	EarliestDate     string `json:"earliest_transaction_date,omitempty"`
-	LatestDate       string `json:"latest_transaction_date,omitempty"`
+	UserCount               int                    `json:"user_count"`
+	ConnectionCount         int                    `json:"connection_count"`
+	AccountCount            int                    `json:"account_count"`
+	TransactionCount        int64                  `json:"transaction_count"`
+	PendingTransactionCount int64                  `json:"pending_transaction_count"`
+	CategoryCount           int                    `json:"category_count"`
+	UnmappedCount           int                    `json:"unmapped_transaction_count"`
+	EarliestDate            string                 `json:"earliest_transaction_date,omitempty"`
+	LatestDate              string                 `json:"latest_transaction_date,omitempty"`
+	Users                   []OverviewUser         `json:"users"`
+	AccountsByType          map[string]int         `json:"accounts_by_type"`
+	Connections             []OverviewConnection   `json:"connections"`
+	SpendingSummary30d      *OverviewSpending      `json:"spending_summary_30d,omitempty"`
+}
+
+// OverviewUser is a minimal user representation for the overview.
+type OverviewUser struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// OverviewConnection is a connection summary for the overview.
+type OverviewConnection struct {
+	ID              string  `json:"id"`
+	Provider        string  `json:"provider"`
+	InstitutionName *string `json:"institution_name"`
+	Status          string  `json:"status"`
+	LastSyncedAt    *string `json:"last_synced_at"`
+	AccountCount    int     `json:"account_count"`
+}
+
+// OverviewSpending is a 30-day spending summary for the overview.
+type OverviewSpending struct {
+	TotalAmount      float64                `json:"total_amount"`
+	TransactionCount int64                  `json:"transaction_count"`
+	IsoCurrencyCode  string                 `json:"iso_currency_code"`
+	TopCategories    []OverviewCategorySpend `json:"top_categories"`
+}
+
+// OverviewCategorySpend is a category spending row for the overview.
+type OverviewCategorySpend struct {
+	Category string  `json:"category"`
+	Amount   float64 `json:"amount"`
+	Count    int64   `json:"count"`
 }
 
 // GetOverviewStats returns aggregate counts and the transaction date range.
@@ -43,6 +80,13 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		return nil, fmt.Errorf("count transactions: %w", err)
 	}
 
+	err = s.Pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM transactions WHERE deleted_at IS NULL AND pending = true").
+		Scan(&stats.PendingTransactionCount)
+	if err != nil {
+		return nil, fmt.Errorf("count pending: %w", err)
+	}
+
 	err = s.Pool.QueryRow(ctx, "SELECT COUNT(*) FROM categories").Scan(&stats.CategoryCount)
 	if err != nil {
 		return nil, fmt.Errorf("count categories: %w", err)
@@ -53,6 +97,121 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		Scan(&stats.UnmappedCount)
 	if err != nil {
 		return nil, fmt.Errorf("count unmapped: %w", err)
+	}
+
+	// Users list
+	userRows, err := s.Pool.Query(ctx, "SELECT id, name FROM users ORDER BY name")
+	if err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	defer userRows.Close()
+	stats.Users = []OverviewUser{}
+	for userRows.Next() {
+		var u OverviewUser
+		var id [16]byte
+		if err := userRows.Scan(&id, &u.Name); err != nil {
+			return nil, fmt.Errorf("scan user: %w", err)
+		}
+		u.ID = fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
+		stats.Users = append(stats.Users, u)
+	}
+
+	// Accounts by type
+	stats.AccountsByType = map[string]int{}
+	typeRows, err := s.Pool.Query(ctx, "SELECT type, COUNT(*) FROM accounts GROUP BY type ORDER BY COUNT(*) DESC")
+	if err != nil {
+		return nil, fmt.Errorf("accounts by type: %w", err)
+	}
+	defer typeRows.Close()
+	for typeRows.Next() {
+		var t string
+		var c int
+		if err := typeRows.Scan(&t, &c); err != nil {
+			return nil, fmt.Errorf("scan account type: %w", err)
+		}
+		stats.AccountsByType[t] = c
+	}
+
+	// Connections with account counts
+	stats.Connections = []OverviewConnection{}
+	connRows, err := s.Pool.Query(ctx, `
+		SELECT bc.id, bc.provider, bc.institution_name, bc.status, bc.last_synced_at,
+			(SELECT COUNT(*) FROM accounts WHERE connection_id = bc.id)
+		FROM bank_connections bc
+		WHERE bc.status != 'disconnected'
+		ORDER BY bc.institution_name`)
+	if err != nil {
+		return nil, fmt.Errorf("list connections: %w", err)
+	}
+	defer connRows.Close()
+	for connRows.Next() {
+		var c OverviewConnection
+		var id [16]byte
+		var instName *string
+		var lastSynced *time.Time
+		if err := connRows.Scan(&id, &c.Provider, &instName, &c.Status, &lastSynced, &c.AccountCount); err != nil {
+			return nil, fmt.Errorf("scan connection: %w", err)
+		}
+		c.ID = fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
+		c.InstitutionName = instName
+		if lastSynced != nil {
+			s := lastSynced.UTC().Format(time.RFC3339)
+			c.LastSyncedAt = &s
+		}
+		stats.Connections = append(stats.Connections, c)
+	}
+
+	// 30-day spending summary
+	thirtyDaysAgo := time.Now().AddDate(0, 0, -30).Format("2006-01-02")
+	var spendTotal float64
+	var spendCount int64
+	var spendCurrency *string
+	var currencyCount int
+	err = s.Pool.QueryRow(ctx, `
+		SELECT COALESCE(SUM(amount), 0), COUNT(*), COUNT(DISTINCT iso_currency_code)
+		FROM transactions
+		WHERE deleted_at IS NULL AND pending = false AND date >= $1 AND amount > 0`,
+		thirtyDaysAgo).Scan(&spendTotal, &spendCount, &currencyCount)
+	if err != nil {
+		return nil, fmt.Errorf("spending summary: %w", err)
+	}
+
+	if spendCount > 0 && currencyCount == 1 {
+		err = s.Pool.QueryRow(ctx, `
+			SELECT iso_currency_code FROM transactions
+			WHERE deleted_at IS NULL AND pending = false AND date >= $1 AND amount > 0 LIMIT 1`,
+			thirtyDaysAgo).Scan(&spendCurrency)
+		if err != nil {
+			return nil, fmt.Errorf("spending currency: %w", err)
+		}
+
+		spending := &OverviewSpending{
+			TotalAmount:      spendTotal,
+			TransactionCount: spendCount,
+			IsoCurrencyCode:  *spendCurrency,
+			TopCategories:    []OverviewCategorySpend{},
+		}
+
+		catRows, err := s.Pool.Query(ctx, `
+			SELECT COALESCE(category_primary, 'UNCATEGORIZED'), SUM(amount), COUNT(*)
+			FROM transactions
+			WHERE deleted_at IS NULL AND pending = false AND date >= $1 AND amount > 0
+			GROUP BY category_primary
+			ORDER BY SUM(amount) DESC
+			LIMIT 5`, thirtyDaysAgo)
+		if err != nil {
+			return nil, fmt.Errorf("top categories: %w", err)
+		}
+		defer catRows.Close()
+		for catRows.Next() {
+			var cs OverviewCategorySpend
+			if err := catRows.Scan(&cs.Category, &cs.Amount, &cs.Count); err != nil {
+				return nil, fmt.Errorf("scan category spend: %w", err)
+			}
+			spending.TopCategories = append(spending.TopCategories, cs)
+		}
+
+		stats.SpendingSummary30d = spending
 	}
 
 	return stats, nil

--- a/internal/service/overview.go
+++ b/internal/service/overview.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // OverviewStats contains high-level statistics about the Breadbox dataset.
@@ -108,12 +110,15 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 	stats.Users = []OverviewUser{}
 	for userRows.Next() {
 		var u OverviewUser
-		var id [16]byte
+		var id pgtype.UUID
 		if err := userRows.Scan(&id, &u.Name); err != nil {
 			return nil, fmt.Errorf("scan user: %w", err)
 		}
-		u.ID = fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
+		u.ID = fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", id.Bytes[0:4], id.Bytes[4:6], id.Bytes[6:8], id.Bytes[8:10], id.Bytes[10:16])
 		stats.Users = append(stats.Users, u)
+	}
+	if err := userRows.Err(); err != nil {
+		return nil, fmt.Errorf("user rows: %w", err)
 	}
 
 	// Accounts by type
@@ -131,6 +136,9 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		}
 		stats.AccountsByType[t] = c
 	}
+	if err := typeRows.Err(); err != nil {
+		return nil, fmt.Errorf("account type rows: %w", err)
+	}
 
 	// Connections with account counts
 	stats.Connections = []OverviewConnection{}
@@ -146,19 +154,22 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 	defer connRows.Close()
 	for connRows.Next() {
 		var c OverviewConnection
-		var id [16]byte
+		var id pgtype.UUID
 		var instName *string
 		var lastSynced *time.Time
 		if err := connRows.Scan(&id, &c.Provider, &instName, &c.Status, &lastSynced, &c.AccountCount); err != nil {
 			return nil, fmt.Errorf("scan connection: %w", err)
 		}
-		c.ID = fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", id[0:4], id[4:6], id[6:8], id[8:10], id[10:16])
+		c.ID = fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", id.Bytes[0:4], id.Bytes[4:6], id.Bytes[6:8], id.Bytes[8:10], id.Bytes[10:16])
 		c.InstitutionName = instName
 		if lastSynced != nil {
 			s := lastSynced.UTC().Format(time.RFC3339)
 			c.LastSyncedAt = &s
 		}
 		stats.Connections = append(stats.Connections, c)
+	}
+	if err := connRows.Err(); err != nil {
+		return nil, fmt.Errorf("connection rows: %w", err)
 	}
 
 	// 30-day spending summary
@@ -209,6 +220,9 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 				return nil, fmt.Errorf("scan category spend: %w", err)
 			}
 			spending.TopCategories = append(spending.TopCategories, cs)
+		}
+		if err := catRows.Err(); err != nil {
+			return nil, fmt.Errorf("category spend rows: %w", err)
 		}
 
 		stats.SpendingSummary30d = spending

--- a/internal/service/transaction_summary.go
+++ b/internal/service/transaction_summary.go
@@ -1,0 +1,198 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// TransactionSummaryParams holds parameters for aggregated transaction queries.
+type TransactionSummaryParams struct {
+	StartDate      *time.Time
+	EndDate        *time.Time
+	GroupBy        string // "category", "month", "week", "day", "category_month"
+	AccountID      *string
+	UserID         *string
+	Category       *string
+	IncludePending bool
+}
+
+// TransactionSummaryResult is the response for a transaction summary query.
+type TransactionSummaryResult struct {
+	Summary []TransactionSummaryRow    `json:"summary"`
+	Totals  TransactionSummaryTotals   `json:"totals"`
+	Filters TransactionSummaryFilters  `json:"filters"`
+}
+
+// TransactionSummaryRow is a single aggregated row.
+type TransactionSummaryRow struct {
+	Category         *string `json:"category,omitempty"`
+	Period           *string `json:"period,omitempty"`
+	TotalAmount      float64 `json:"total_amount"`
+	TransactionCount int64   `json:"transaction_count"`
+	IsoCurrencyCode  string  `json:"iso_currency_code"`
+}
+
+// TransactionSummaryTotals holds grand totals across all rows.
+type TransactionSummaryTotals struct {
+	TotalAmount      *float64 `json:"total_amount,omitempty"`
+	TransactionCount int64    `json:"transaction_count"`
+	Note             string   `json:"note,omitempty"`
+}
+
+// TransactionSummaryFilters echoes the applied filters back.
+type TransactionSummaryFilters struct {
+	StartDate string `json:"start_date"`
+	EndDate   string `json:"end_date"`
+	GroupBy   string `json:"group_by"`
+}
+
+var validGroupBy = map[string]bool{
+	"category":       true,
+	"month":          true,
+	"week":           true,
+	"day":            true,
+	"category_month": true,
+}
+
+// GetTransactionSummary returns aggregated transaction totals.
+func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionSummaryParams) (*TransactionSummaryResult, error) {
+	if !validGroupBy[params.GroupBy] {
+		return nil, fmt.Errorf("invalid group_by: %s. Must be one of: category, month, week, day, category_month", params.GroupBy)
+	}
+
+	// Default date range: 30 days ago to tomorrow (exclusive end).
+	now := time.Now()
+	if params.StartDate == nil {
+		t := now.AddDate(0, 0, -30)
+		params.StartDate = &t
+	}
+	if params.EndDate == nil {
+		t := now.AddDate(0, 0, 1)
+		params.EndDate = &t
+	}
+
+	// Build SELECT clause based on group_by.
+	var selectCols, groupCols, orderCols string
+	switch params.GroupBy {
+	case "category":
+		selectCols = "t.category_primary AS category, t.iso_currency_code"
+		groupCols = "t.category_primary, t.iso_currency_code"
+		orderCols = "SUM(t.amount) DESC"
+	case "month":
+		selectCols = "to_char(date_trunc('month', t.date), 'YYYY-MM') AS period, t.iso_currency_code"
+		groupCols = "date_trunc('month', t.date), t.iso_currency_code"
+		orderCols = "date_trunc('month', t.date) DESC"
+	case "week":
+		selectCols = "to_char(date_trunc('week', t.date), 'YYYY-MM-DD') AS period, t.iso_currency_code"
+		groupCols = "date_trunc('week', t.date), t.iso_currency_code"
+		orderCols = "date_trunc('week', t.date) DESC"
+	case "day":
+		selectCols = "t.date::text AS period, t.iso_currency_code"
+		groupCols = "t.date, t.iso_currency_code"
+		orderCols = "t.date DESC"
+	case "category_month":
+		selectCols = "t.category_primary AS category, to_char(date_trunc('month', t.date), 'YYYY-MM') AS period, t.iso_currency_code"
+		groupCols = "t.category_primary, date_trunc('month', t.date), t.iso_currency_code"
+		orderCols = "date_trunc('month', t.date) DESC, SUM(t.amount) DESC"
+	}
+
+	query := fmt.Sprintf(`SELECT %s, SUM(t.amount) AS total_amount, COUNT(*) AS transaction_count
+FROM transactions t
+JOIN accounts a ON t.account_id = a.id
+LEFT JOIN bank_connections bc ON a.connection_id = bc.id
+WHERE t.deleted_at IS NULL`, selectCols)
+
+	args := []any{}
+	argN := 1
+
+	if !params.IncludePending {
+		query += " AND t.pending = false"
+	}
+
+	query += fmt.Sprintf(" AND t.date >= $%d", argN)
+	args = append(args, *params.StartDate)
+	argN++
+
+	query += fmt.Sprintf(" AND t.date < $%d", argN)
+	args = append(args, *params.EndDate)
+	argN++
+
+	if params.AccountID != nil {
+		query += fmt.Sprintf(" AND t.account_id = $%d", argN)
+		args = append(args, *params.AccountID)
+		argN++
+	}
+
+	if params.UserID != nil {
+		query += fmt.Sprintf(" AND bc.user_id = $%d", argN)
+		args = append(args, *params.UserID)
+		argN++
+	}
+
+	if params.Category != nil {
+		query += fmt.Sprintf(" AND t.category_primary = $%d", argN)
+		args = append(args, *params.Category)
+		argN++
+	}
+
+	query += fmt.Sprintf(" GROUP BY %s ORDER BY %s", groupCols, orderCols)
+
+	rows, err := s.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("transaction summary query: %w", err)
+	}
+	defer rows.Close()
+
+	var summary []TransactionSummaryRow
+	currencies := map[string]bool{}
+	var grandTotal float64
+	var grandCount int64
+
+	for rows.Next() {
+		var row TransactionSummaryRow
+		switch params.GroupBy {
+		case "category":
+			err = rows.Scan(&row.Category, &row.IsoCurrencyCode, &row.TotalAmount, &row.TransactionCount)
+		case "month", "week", "day":
+			err = rows.Scan(&row.Period, &row.IsoCurrencyCode, &row.TotalAmount, &row.TransactionCount)
+		case "category_month":
+			err = rows.Scan(&row.Category, &row.Period, &row.IsoCurrencyCode, &row.TotalAmount, &row.TransactionCount)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("scan summary row: %w", err)
+		}
+		summary = append(summary, row)
+		currencies[row.IsoCurrencyCode] = true
+		grandTotal += row.TotalAmount
+		grandCount += row.TransactionCount
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("summary rows: %w", err)
+	}
+
+	totals := TransactionSummaryTotals{
+		TransactionCount: grandCount,
+	}
+	if len(currencies) <= 1 {
+		totals.TotalAmount = &grandTotal
+	} else {
+		totals.Note = "Multiple currencies — see per-row totals."
+	}
+
+	result := &TransactionSummaryResult{
+		Summary: summary,
+		Totals:  totals,
+		Filters: TransactionSummaryFilters{
+			StartDate: params.StartDate.Format("2006-01-02"),
+			EndDate:   params.EndDate.Format("2006-01-02"),
+			GroupBy:   params.GroupBy,
+		},
+	}
+
+	if result.Summary == nil {
+		result.Summary = []TransactionSummaryRow{}
+	}
+
+	return result, nil
+}

--- a/internal/service/transaction_summary.go
+++ b/internal/service/transaction_summary.go
@@ -58,7 +58,7 @@ var validGroupBy = map[string]bool{
 // GetTransactionSummary returns aggregated transaction totals.
 func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionSummaryParams) (*TransactionSummaryResult, error) {
 	if !validGroupBy[params.GroupBy] {
-		return nil, fmt.Errorf("invalid group_by: %s. Must be one of: category, month, week, day, category_month", params.GroupBy)
+		return nil, fmt.Errorf("%w: invalid group_by: %s. Must be one of: category, month, week, day, category_month", ErrInvalidParameter, params.GroupBy)
 	}
 
 	// Default date range: 30 days ago to tomorrow (exclusive end).
@@ -133,10 +133,10 @@ WHERE t.deleted_at IS NULL`, selectCols)
 	if params.Category != nil {
 		query += fmt.Sprintf(" AND t.category_primary = $%d", argN)
 		args = append(args, *params.Category)
-		argN++
+		argN++ //nolint:ineffassign // kept for consistency with other filters
 	}
 
-	query += fmt.Sprintf(" GROUP BY %s ORDER BY %s", groupCols, orderCols)
+	query += fmt.Sprintf(" GROUP BY %s ORDER BY %s LIMIT 1000", groupCols, orderCols)
 
 	rows, err := s.Pool.Query(ctx, query, args...)
 	if err != nil {

--- a/internal/service/transaction_summary_test.go
+++ b/internal/service/transaction_summary_test.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGetTransactionSummary_InvalidGroupBy(t *testing.T) {
+	svc := &Service{} // no pool needed for validation check
+	_, err := svc.GetTransactionSummary(nil, TransactionSummaryParams{GroupBy: "invalid"})
+	if err == nil {
+		t.Fatal("expected error for invalid group_by")
+	}
+	if !errors.Is(err, ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got: %v", err)
+	}
+}
+
+func TestGetTransactionSummary_ValidGroupByValues(t *testing.T) {
+	for _, gb := range []string{"category", "month", "week", "day", "category_month"} {
+		if !validGroupBy[gb] {
+			t.Errorf("expected %q to be a valid group_by", gb)
+		}
+	}
+}


### PR DESCRIPTION
- Field selection (`?fields=` param) on REST transactions endpoints and
  MCP query_transactions tool with aliases (core, category, timestamps)
- Transaction summary service + REST endpoint + MCP tool with group_by
  options (category, month, week, day, category_month)
- Category mapping MCP CRUD tools (list/create/update/delete) using
  category slugs and (provider, provider_category) lookup
- Enhanced breadbox://overview resource with users list, accounts by
  type, connections with account counts, 30-day spending summary
- Updated MCP server instructions with token efficiency patterns
- New sqlc queries for mapping lookup by provider+category pair

https://claude.ai/code/session_01LhhrhzX8JhukuF1Sen6AMT