### PR TITLE
Fix session-start hook failing silently on Claude Code web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,28 +1,41 @@
 #!/bin/bash
-set -euo pipefail
+# Session startup hook for Claude Code Web.
+# Installs tools and generates gitignored build artifacts.
 
 # Only run in Claude Code Web (remote) sessions
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
-cd "$CLAUDE_PROJECT_DIR"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+cd "$PROJECT_DIR"
 
+SQLC_VERSION="1.30.0"
+
+# --- Go modules ---
 echo "==> Downloading Go modules..."
-GONOSUMCHECK=* GONOSUMDB=* GOPROXY=direct go mod download
+if ! GONOSUMCHECK=* GONOSUMDB=* GOPROXY=direct go mod download 2>&1; then
+  echo "WARN: go mod download failed, continuing anyway"
+fi
 
-echo "==> Installing sqlc..."
-SQLC_VERSION="1.28.0"
-if ! command -v sqlc &>/dev/null; then
-  curl -sL "https://github.com/sqlc-dev/sqlc/releases/download/v${SQLC_VERSION}/sqlc_${SQLC_VERSION}_linux_amd64.tar.gz" -o /tmp/sqlc.tar.gz
-  tar -xzf /tmp/sqlc.tar.gz -C /usr/local/bin sqlc
-  rm -f /tmp/sqlc.tar.gz
+# --- sqlc ---
+echo "==> Installing sqlc ${SQLC_VERSION}..."
+if ! command -v sqlc &>/dev/null || [ "$(sqlc version 2>/dev/null)" != "v${SQLC_VERSION}" ]; then
+  curl -sL "https://github.com/sqlc-dev/sqlc/releases/download/v${SQLC_VERSION}/sqlc_${SQLC_VERSION}_linux_amd64.tar.gz" \
+    | tar xz -C /usr/local/bin sqlc \
+    && echo "    sqlc $(sqlc version) installed" \
+    || echo "WARN: sqlc install failed"
 fi
 
 echo "==> Generating sqlc code..."
-sqlc generate
+if ! sqlc generate 2>&1; then
+  echo "WARN: sqlc generate failed"
+fi
 
+# --- CSS ---
 echo "==> Building CSS (downloads tailwindcss-extra if needed)..."
-make css
+if ! make css 2>&1; then
+  echo "WARN: make css failed"
+fi
 
 echo "==> Session setup complete."


### PR DESCRIPTION
The hook was using `set -euo pipefail` which caused it to abort
silently when any step failed — `set -u` on unset CLAUDE_PROJECT_DIR,
or `set -e` when go mod download hit network issues. This meant sqlc
never got installed and generated files were missing every session.

Changes:
- Remove set -euo pipefail, add per-step error handling with warnings
- Add CLAUDE_PROJECT_DIR fallback to $(pwd)
- Bump sqlc from v1.28.0 to v1.30.0 (matches CI and Dockerfile)
- Add version check so sqlc gets reinstalled if outdated

https://claude.ai/code/session_01WNebd55YPMzBeE634DmFkN