### PR TITLE
Fix category mapping bug: use actual provider instead of hardcoded 'plaid'

### DIFF
--- a/internal/db/queries/categories.sql
+++ b/internal/db/queries/categories.sql
@@ -62,10 +62,12 @@ SET category_override = FALSE, updated_at = NOW()
 WHERE id = $1;
 
 -- name: ListUnmappedCategories :many
-SELECT DISTINCT category_primary, category_detailed
-FROM transactions
-WHERE category_id = (SELECT id FROM categories WHERE slug = 'uncategorized')
-  AND category_override = FALSE
-  AND deleted_at IS NULL
-  AND (category_primary IS NOT NULL OR category_detailed IS NOT NULL)
-ORDER BY category_primary, category_detailed;
+SELECT DISTINCT bc.provider, t.category_primary, t.category_detailed
+FROM transactions t
+JOIN accounts a ON t.account_id = a.id
+JOIN bank_connections bc ON a.connection_id = bc.id
+WHERE t.category_id = (SELECT id FROM categories WHERE slug = 'uncategorized')
+  AND t.category_override = FALSE
+  AND t.deleted_at IS NULL
+  AND (t.category_primary IS NOT NULL OR t.category_detailed IS NOT NULL)
+ORDER BY bc.provider, t.category_primary, t.category_detailed;

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -47,6 +47,7 @@ type CategoryMappingResponse struct {
 
 // UnmappedCategoryPair represents a provider category pair with no mapping.
 type UnmappedCategoryPair struct {
+	Provider string  `json:"provider"`
 	Primary  *string `json:"primary"`
 	Detailed *string `json:"detailed"`
 }
@@ -612,6 +613,7 @@ func (s *Service) ListUnmappedCategories(ctx context.Context) ([]UnmappedCategor
 	var result []UnmappedCategoryPair
 	for _, r := range rows {
 		result = append(result, UnmappedCategoryPair{
+			Provider: string(r.Provider),
 			Primary:  textPtr(r.CategoryPrimary),
 			Detailed: textPtr(r.CategoryDetailed),
 		})

--- a/internal/templates/pages/category_mappings.html
+++ b/internal/templates/pages/category_mappings.html
@@ -25,11 +25,12 @@
     <div class="overflow-x-auto">
       <table class="table table-sm">
         <thead>
-          <tr><th>Primary</th><th>Detailed</th><th>Map To</th></tr>
+          <tr><th>Provider</th><th>Primary</th><th>Detailed</th><th>Map To</th></tr>
         </thead>
         <tbody>
           {{range .UnmappedCategories}}
           <tr x-data="{categoryId: '', submitting: false}">
+            <td><span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}}">{{.Provider}}</span></td>
             <td>{{if .Primary}}{{.Primary}}{{else}}&mdash;{{end}}</td>
             <td>{{if .Detailed}}{{.Detailed}}{{else}}&mdash;{{end}}</td>
             <td class="flex gap-2">
@@ -42,8 +43,8 @@
               <button class="btn btn-sm btn-primary" :disabled="!categoryId || submitting" @click="
                 submitting = true;
                 let provCat = '{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}';
-                fetch('/admin/api/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: 'plaid', provider_category: provCat, category_id: categoryId})})
-                .then(r => { if(r.ok) location.reload(); else { submitting = false; } })
+                fetch('/admin/api/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: categoryId})})
+                .then(r => { if(r.ok) location.reload(); else { submitting = false; alert('Failed to create mapping'); } })
                 .catch(() => { submitting = false; })
               ">Map</button>
             </td>


### PR DESCRIPTION
The unmapped categories mapping UI was hardcoding provider as 'plaid' when
creating mappings. This caused mappings for Teller/CSV categories to be
created with the wrong provider, so they never took effect during sync.
The page would reload but the category remained unmapped, appearing as if
"nothing happened."

Changes:
- SQL query now JOINs through accounts → bank_connections to get provider
- UnmappedCategoryPair struct includes Provider field
- Template uses actual provider and shows provider badge column
- Added error feedback (alert) when mapping creation fails

https://claude.ai/code/session_018DFLjNrXEg22iGZPmaKBcE