### PR TITLE
Phase 23: MCP permissions & custom instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,11 @@ One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), M
 - Docker socket detection: `os.Stat("/var/run/docker.sock")` at startup → `App.DockerSocketAvailable`. Used by update handler to pull images via Docker Engine API (`net/http` with Unix socket transport, no Docker SDK dependency).
 - Update flow: dashboard banner shows when GitHub release is newer than current. Pull via Docker socket if available, then user runs `docker compose up -d`. Dismiss stores `update_dismissed_version` in `app_config`.
 - Dev VM: `breadbox.exe.xyz` hosted on exe.dev. exe.dev handles TLS termination and HTTP proxying automatically (no Caddy needed on dev). Breadbox listens on a local port and exe.dev proxies `https://breadbox.exe.xyz` to it. Auto-deploy from GitHub Actions on main merge via SSH (`appleboy/ssh-action`). Secrets: `DEPLOY_SSH_KEY`, `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PATH`.
+- MCP permissions: global `mcp_mode` (read_only/read_write), per-tool enable/disable via `mcp_disabled_tools` JSON array, custom instructions via `mcp_custom_instructions` — all stored in `app_config`. Default mode is `read_only`.
+- MCP tool registry: `MCPServer.allTools []ToolDef` with `ToolClassification` (read/write). `BuildServer(MCPServerConfig)` creates a filtered `*mcpsdk.Server` per request. Write tools suppressed when mode is read_only, tool is in disabled list, or API key scope is read_only.
+- MCP instruction templates: hardcoded Go constants in `internal/mcp/templates.go` (spend_review, monthly_analysis, reporting). Loaded into editor via Alpine.js, saved as `mcp_custom_instructions`.
+- API key scope: `scope TEXT NOT NULL DEFAULT 'full_access'` column on `api_keys`. Values: `full_access`, `read_only`. `RequireWriteScope()` middleware blocks read-only keys from write REST endpoints. Full API key record stored in request context via `middleware.SetAPIKey()`/`GetAPIKey()`.
+- MCP admin page: `/admin/mcp` with four cards — global mode, tool access, server instructions, API key scope info. Nav item with `bot` Lucide icon between API Keys and Sync Logs.
 
 ## Canonical Enums
 
@@ -95,6 +100,9 @@ One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), M
 - Sync status: `in_progress`, `success`, `error`
 - Sync trigger: `cron`, `webhook`, `manual`, `initial`
 - Provider type: `plaid`, `teller`, `csv`
+- API key scope: `full_access`, `read_only`
+- MCP mode: `read_only`, `read_write`
+- MCP tool classification: `read`, `write`
 
 ## Spec Documents
 

--- a/cmd/breadbox/main.go
+++ b/cmd/breadbox/main.go
@@ -308,6 +308,23 @@ func runMCPStdio() error {
 
 	mcpServer := breadboxmcp.NewMCPServer(a.Service, version)
 
+	// Load MCP config from DB for stdio mode.
+	mcpCfg, err := a.Service.GetMCPConfig(ctx)
+	if err != nil {
+		logger.Warn("failed to load MCP config, using defaults", "error", err)
+		mcpCfg = &service.MCPConfig{
+			Mode:          "read_only",
+			DisabledTools: []string{},
+		}
+	}
+
+	server := mcpServer.BuildServer(breadboxmcp.MCPServerConfig{
+		Mode:               mcpCfg.Mode,
+		DisabledTools:      mcpCfg.DisabledTools,
+		CustomInstructions: mcpCfg.CustomInstructions,
+		APIKeyScope:        "full_access", // stdio has no API key
+	})
+
 	// Graceful shutdown on SIGINT/SIGTERM.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -317,7 +334,7 @@ func runMCPStdio() error {
 	}()
 
 	logger.Info("starting MCP stdio server", "version", version)
-	return mcpServer.Server().Run(ctx, &mcpsdk.StdioTransport{})
+	return server.Run(ctx, &mcpsdk.StdioTransport{})
 }
 
 func runAPIKeys() error {
@@ -370,7 +387,7 @@ func runAPIKeys() error {
 		if len(os.Args) > 3 {
 			name = os.Args[3]
 		}
-		result, err := svc.CreateAPIKey(ctx, name)
+		result, err := svc.CreateAPIKey(ctx, name, "full_access")
 		if err != nil {
 			return fmt.Errorf("create api key: %w", err)
 		}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2413,12 +2413,13 @@ Make the API surface efficient for AI agent consumption.
 
 ---
 
-### Phase 23: MCP Permissions & Custom Instructions
+### Phase 23: MCP Permissions & Custom Instructions ✅
 
 Admin control over what agents can do and how they behave.
 
 - **Spec:** [`docs/phase-23-mcp-permissions.md`](phase-23-mcp-permissions.md)
 - **Key deliverables:** global read-only/read-write mode, per-tool enable/disable, custom MCP instructions editor at `/admin/mcp`, API key scoping (read-only vs full-access)
+- **Status:** Complete. Global mode (read_only/read_write), per-tool enable/disable, custom instructions with templates, API key scope (full_access/read_only), RequireWriteScope middleware, per-request MCP server filtering, `/admin/mcp` settings page.
 
 ---
 

--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -17,7 +17,8 @@ import (
 func CreateAPIKeyHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
-			Name string `json:"name"`
+			Name  string `json:"name"`
+			Scope string `json:"scope"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
@@ -30,7 +31,10 @@ func CreateAPIKeyHandler(svc *service.Service) http.HandlerFunc {
 			})
 			return
 		}
-		result, err := svc.CreateAPIKey(r.Context(), req.Name)
+		if req.Scope == "" {
+			req.Scope = "full_access"
+		}
+		result, err := svc.CreateAPIKey(r.Context(), req.Name, req.Scope)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to create API key"})
 			return
@@ -106,7 +110,11 @@ func APIKeyCreatePageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 			http.Redirect(w, r, "/admin/api-keys/new", http.StatusSeeOther)
 			return
 		}
-		result, err := svc.CreateAPIKey(r.Context(), name)
+		scope := r.FormValue("scope")
+		if scope == "" {
+			scope = "full_access"
+		}
+		result, err := svc.CreateAPIKey(r.Context(), name, scope)
 		if err != nil {
 			SetFlash(r.Context(), sm, "error", "Failed to create API key")
 			http.Redirect(w, r, "/admin/api-keys/new", http.StatusSeeOther)

--- a/internal/admin/mcp.go
+++ b/internal/admin/mcp.go
@@ -1,0 +1,140 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	breadboxmcp "breadbox/internal/mcp"
+	"breadbox/internal/service"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+// MCPSettingsGetHandler serves GET /admin/mcp.
+func MCPSettingsGetHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cfg, err := svc.GetMCPConfig(r.Context())
+		if err != nil {
+			http.Error(w, "Failed to load MCP config", http.StatusInternalServerError)
+			return
+		}
+
+		// Build tool list for display.
+		type toolInfo struct {
+			Name           string
+			Description    string
+			Classification string
+			Enabled        bool
+			WriteLocked    bool // true when global mode is read-only and tool is write
+		}
+		disabledSet := make(map[string]bool)
+		for _, t := range cfg.DisabledTools {
+			disabledSet[t] = true
+		}
+
+		var tools []toolInfo
+		for _, td := range mcpServer.AllToolDefs() {
+			enabled := !disabledSet[td.Tool.Name]
+			writeLocked := string(td.Classification) == "write" && cfg.Mode == "read_only"
+			tools = append(tools, toolInfo{
+				Name:           td.Tool.Name,
+				Description:    td.Tool.Description,
+				Classification: string(td.Classification),
+				Enabled:        enabled,
+				WriteLocked:    writeLocked,
+			})
+		}
+
+		// Count API keys by scope.
+		keys, _ := svc.ListAPIKeys(r.Context())
+		fullAccessCount := 0
+		readOnlyCount := 0
+		for _, k := range keys {
+			if k.RevokedAt != nil {
+				continue
+			}
+			if k.Scope == "read_only" {
+				readOnlyCount++
+			} else {
+				fullAccessCount++
+			}
+		}
+
+		// Serialize templates as JSON for Alpine.js.
+		templatesJSON, _ := json.Marshal(breadboxmcp.InstructionTemplates)
+
+		data := BaseTemplateData(r, sm, "mcp", "MCP Settings")
+		data["MCPConfig"] = cfg
+		data["Tools"] = tools
+		data["Templates"] = breadboxmcp.InstructionTemplates
+		data["TemplatesJSON"] = string(templatesJSON)
+		data["FullAccessCount"] = fullAccessCount
+		data["ReadOnlyCount"] = readOnlyCount
+		data["BuiltInInstructions"] = breadboxmcp.BuiltInInstructions
+
+		tr.Render(w, r, "mcp_settings.html", data)
+	}
+}
+
+// MCPSaveModeHandler handles POST /admin/mcp/mode.
+func MCPSaveModeHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		mode := r.FormValue("mode")
+		if err := svc.SaveMCPMode(r.Context(), mode); err != nil {
+			SetFlash(r.Context(), sm, "error", "Invalid mode: must be read_only or read_write")
+			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			return
+		}
+		SetFlash(r.Context(), sm, "success", "MCP mode updated.")
+		http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+	}
+}
+
+// MCPSaveToolsHandler handles POST /admin/mcp/tools.
+func MCPSaveToolsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			SetFlash(r.Context(), sm, "error", "Invalid form data")
+			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			return
+		}
+
+		// Enabled tools come as form values. Build disabled list from what's NOT checked.
+		enabledSet := make(map[string]bool)
+		for _, name := range r.Form["enabled_tools"] {
+			enabledSet[name] = true
+		}
+
+		var disabled []string
+		for _, td := range mcpServer.AllToolDefs() {
+			if !enabledSet[td.Tool.Name] {
+				disabled = append(disabled, td.Tool.Name)
+			}
+		}
+
+		if err := svc.SaveMCPDisabledTools(r.Context(), disabled); err != nil {
+			SetFlash(r.Context(), sm, "error", "Failed to save tool settings")
+			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			return
+		}
+		SetFlash(r.Context(), sm, "success", "Tool access updated.")
+		http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+	}
+}
+
+// MCPSaveInstructionsHandler handles POST /admin/mcp/instructions.
+func MCPSaveInstructionsHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		instructions := strings.TrimSpace(r.FormValue("instructions"))
+		templateSlug := r.FormValue("template")
+
+		if err := svc.SaveMCPInstructions(r.Context(), instructions, templateSlug); err != nil {
+			SetFlash(r.Context(), sm, "error", err.Error())
+			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			return
+		}
+		SetFlash(r.Context(), sm, "success", "Instructions saved.")
+		http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+	}
+}

--- a/internal/admin/mcp.go
+++ b/internal/admin/mcp.go
@@ -106,8 +106,22 @@ func MCPSaveToolsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer,
 			enabledSet[name] = true
 		}
 
+		// Load current mode so we can skip write tools when in read-only mode.
+		// Write tools are mode-locked (disabled checkboxes don't submit), so they
+		// should not be added to the disabled list — otherwise switching to
+		// read-write later would leave them stuck as disabled.
+		mcpCfg, err := svc.GetMCPConfig(r.Context())
+		if err != nil {
+			SetFlash(r.Context(), sm, "error", "Failed to load MCP config")
+			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			return
+		}
+
 		var disabled []string
 		for _, td := range mcpServer.AllToolDefs() {
+			if mcpCfg.Mode == "read_only" && td.Classification == breadboxmcp.ToolWrite {
+				continue // skip — write tools are suppressed by mode, not per-tool disable
+			}
 			if !enabledSet[td.Tool.Name] {
 				disabled = append(disabled, td.Tool.Name)
 			}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"breadbox/internal/app"
+	breadboxmcp "breadbox/internal/mcp"
 	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
@@ -11,7 +12,7 @@ import (
 // NewAdminRouter creates the chi.Router for all admin dashboard routes.
 // It includes unauthenticated routes (login, setup) and authenticated routes
 // (dashboard, connections, users, admin API).
-func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service) chi.Router {
+func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service, mcpServer *breadboxmcp.MCPServer) chi.Router {
 	r := chi.NewRouter()
 
 	// Session middleware wraps everything so session data is available.
@@ -69,6 +70,13 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 		r.Get("/categories", CategoriesPageHandler(svc, sm, tr))
 		r.Get("/categories/mappings", MappingsPageHandler(svc, sm, tr))
+
+		r.Route("/mcp", func(r chi.Router) {
+			r.Get("/", MCPSettingsGetHandler(svc, mcpServer, sm, tr))
+			r.Post("/mode", MCPSaveModeHandler(svc, sm))
+			r.Post("/tools", MCPSaveToolsHandler(svc, mcpServer, sm))
+			r.Post("/instructions", MCPSaveInstructionsHandler(svc, sm))
+		})
 
 		r.Get("/providers", ProvidersGetHandler(a, sm, tr))
 		r.Post("/providers/plaid", ProvidersSavePlaidHandler(a, sm))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -162,6 +162,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/categories.html",
 		"pages/category_mappings.html",
 		"pages/transaction_detail.html",
+		"pages/mcp_settings.html",
 	}
 
 	// Pages using the wizard layout (login + first-run admin creation).

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -40,43 +40,46 @@ func NewRouter(a *app.App, version string) http.Handler {
 	svc := service.New(a.Queries, a.DB, a.SyncEngine, a.Logger)
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Use(mw.APIKeyAuth(svc))
+
+		// Read endpoints — all API keys.
 		r.Get("/accounts", ListAccountsHandler(svc))
 		r.Get("/accounts/{id}", GetAccountHandler(svc))
 		r.Get("/transactions", ListTransactionsHandler(svc))
 		r.Get("/transactions/count", CountTransactionsHandler(svc))
 		r.Get("/transactions/summary", TransactionSummaryHandler(svc))
 		r.Get("/transactions/{id}", GetTransactionHandler(svc))
-		r.Patch("/transactions/{id}/category", SetTransactionCategoryHandler(svc))
-		r.Delete("/transactions/{id}/category", ResetTransactionCategoryHandler(svc))
 		r.Get("/categories", ListCategoriesHandler(svc))
 		r.Get("/categories/unmapped", ListUnmappedCategoriesHandler(svc))
 		r.Get("/categories/{id}", GetCategoryHandler(svc))
-		r.Post("/categories", CreateCategoryHandler(svc))
-		r.Put("/categories/{id}", UpdateCategoryHandler(svc))
-		r.Delete("/categories/{id}", DeleteCategoryHandler(svc))
-		r.Post("/categories/{id}/merge", MergeCategoriesHandler(svc))
 		r.Get("/category-mappings", ListMappingsHandler(svc))
-		r.Put("/category-mappings", BulkUpsertMappingsHandler(svc))
-		r.Delete("/category-mappings/{id}", DeleteMappingHandler(svc))
 		r.Get("/users", ListUsersHandler(svc))
 		r.Get("/connections", ListConnectionsHandler(svc))
 		r.Get("/connections/{id}/status", GetConnectionStatusHandler(svc))
-		r.Post("/sync", TriggerSyncHandler(svc))
-
-		// Transaction comments
 		r.Get("/transactions/{transaction_id}/comments", ListCommentsHandler(svc))
-		r.Post("/transactions/{transaction_id}/comments", CreateCommentHandler(svc))
-		r.Put("/transactions/{transaction_id}/comments/{id}", UpdateCommentHandler(svc))
-		r.Delete("/transactions/{transaction_id}/comments/{id}", DeleteCommentHandler(svc))
-
-		// Audit log
 		r.Get("/audit-log", ListAuditLogHandler(svc))
 		r.Get("/transactions/{id}/audit-log", ListTransactionAuditLogHandler(svc))
+
+		// Write endpoints — full_access API keys only.
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Patch("/transactions/{id}/category", SetTransactionCategoryHandler(svc))
+			r.Delete("/transactions/{id}/category", ResetTransactionCategoryHandler(svc))
+			r.Post("/categories", CreateCategoryHandler(svc))
+			r.Put("/categories/{id}", UpdateCategoryHandler(svc))
+			r.Delete("/categories/{id}", DeleteCategoryHandler(svc))
+			r.Post("/categories/{id}/merge", MergeCategoriesHandler(svc))
+			r.Put("/category-mappings", BulkUpsertMappingsHandler(svc))
+			r.Delete("/category-mappings/{id}", DeleteMappingHandler(svc))
+			r.Post("/sync", TriggerSyncHandler(svc))
+			r.Post("/transactions/{transaction_id}/comments", CreateCommentHandler(svc))
+			r.Put("/transactions/{transaction_id}/comments/{id}", UpdateCommentHandler(svc))
+			r.Delete("/transactions/{transaction_id}/comments/{id}", DeleteCommentHandler(svc))
+		})
 	})
 
-	// MCP server — API key authenticated.
+	// MCP server — API key authenticated, per-request filtering.
 	mcpServer := breadboxmcp.NewMCPServer(svc, version)
-	mcpHandler := breadboxmcp.NewHTTPHandler(mcpServer)
+	mcpHandler := breadboxmcp.NewHTTPHandler(mcpServer, svc)
 	r.Group(func(r chi.Router) {
 		r.Use(mw.APIKeyAuth(svc))
 		r.Handle("/mcp", mcpHandler)
@@ -93,7 +96,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 	if err != nil {
 		a.Logger.Error("failed to initialize template renderer", "error", err)
 	} else {
-		adminRouter := admin.NewAdminRouter(a, sm, tr, svc)
+		adminRouter := admin.NewAdminRouter(a, sm, tr, svc, mcpServer)
 		r.Mount("/", adminRouter)
 	}
 

--- a/internal/db/migrations/00023_api_key_scope.sql
+++ b/internal/db/migrations/00023_api_key_scope.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE api_keys ADD COLUMN scope TEXT NOT NULL DEFAULT 'full_access';
+
+-- +goose Down
+ALTER TABLE api_keys DROP COLUMN scope;

--- a/internal/db/queries/api_keys.sql
+++ b/internal/db/queries/api_keys.sql
@@ -1,5 +1,5 @@
 -- name: CreateApiKey :one
-INSERT INTO api_keys (name, key_hash, key_prefix) VALUES ($1, $2, $3) RETURNING *;
+INSERT INTO api_keys (name, key_hash, key_prefix, scope) VALUES ($1, $2, $3, $4) RETURNING *;
 
 -- name: GetApiKeyByHash :one
 SELECT * FROM api_keys WHERE key_hash = $1;

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -8,15 +8,6 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func (s *MCPServer) registerResources() {
-	s.server.AddResource(&mcpsdk.Resource{
-		Name:        "Overview",
-		URI:         "breadbox://overview",
-		Description: "Live summary of the Breadbox data model: user, connection, account, and transaction counts plus the transaction date range. Read this first to understand the dataset scope.",
-		MIMEType:    "application/json",
-	}, s.handleOverviewResource)
-}
-
 func (s *MCPServer) handleOverviewResource(_ context.Context, _ *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
 	ctx := context.Background()
 	stats, err := s.svc.GetOverviewStats(ctx)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -261,10 +261,20 @@ func NewHTTPHandler(s *MCPServer, svc *service.Service) http.Handler {
 	)
 }
 
-// checkWritePermission verifies the requesting API key has write access.
-func checkWritePermission(ctx context.Context) error {
+// checkWritePermission verifies the requesting API key has write access and
+// that the global MCP mode allows writes. This is a belt-and-suspenders guard
+// since BuildServer already filters out write tools — but protects against
+// TOCTOU races between config changes and server construction.
+func (s *MCPServer) checkWritePermission(ctx context.Context) error {
 	if apiKey := mw.GetAPIKey(ctx); apiKey != nil && apiKey.Scope == "read_only" {
 		return fmt.Errorf("this API key has read-only access and cannot perform write operations")
+	}
+	mcpCfg, err := s.svc.GetMCPConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to verify MCP permissions")
+	}
+	if mcpCfg.Mode == "read_only" {
+		return fmt.Errorf("MCP server is in read-only mode")
 	}
 	return nil
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1,28 +1,18 @@
 package mcp
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 
+	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// MCPServer wraps the MCP SDK server and the breadbox service layer.
-type MCPServer struct {
-	server *mcpsdk.Server
-	svc    *service.Service
-}
-
-// NewMCPServer creates a new MCP server, registers all tools, and returns it.
-func NewMCPServer(svc *service.Service, version string) *MCPServer {
-	server := mcpsdk.NewServer(
-		&mcpsdk.Implementation{
-			Name:    "breadbox",
-			Version: version,
-		},
-		&mcpsdk.ServerOptions{
-			Instructions: `Breadbox is a self-hosted financial data aggregation server for families. It syncs bank data from Plaid, Teller, and CSV imports into a unified PostgreSQL database.
+// BuiltInInstructions contains the default MCP server instructions.
+const BuiltInInstructions = `Breadbox is a self-hosted financial data aggregation server for families. It syncs bank data from Plaid, Teller, and CSV imports into a unified PostgreSQL database.
 
 DATA MODEL:
 - Users: family members who own bank connections
@@ -63,32 +53,218 @@ COMMENTS & AUDIT LOG:
 - Use add_transaction_comment to explain your reasoning when recategorizing transactions
 - Check list_transaction_comments before modifying a transaction to see prior context
 - Use get_transaction_history to understand how a transaction has been modified over time
-- Use query_audit_log with actor_type='user' to learn the family's categorization preferences`,
-		},
-	)
+- Use query_audit_log with actor_type='user' to learn the family's categorization preferences`
 
+// ToolClassification indicates whether a tool is read-only or performs writes.
+type ToolClassification string
+
+const (
+	ToolRead  ToolClassification = "read"
+	ToolWrite ToolClassification = "write"
+)
+
+// ToolDef holds a tool definition, its handler, and classification metadata.
+type ToolDef struct {
+	Tool           mcpsdk.Tool
+	Classification ToolClassification
+	// register is a function that registers this tool on a server.
+	register func(server *mcpsdk.Server)
+}
+
+// MCPServerConfig holds runtime MCP permissions loaded from app_config + API key.
+type MCPServerConfig struct {
+	Mode              string   // "read_only" or "read_write"
+	DisabledTools     []string // tool names to suppress
+	CustomInstructions string  // markdown appended to built-in instructions
+	APIKeyScope       string   // "full_access" or "read_only" — from request context
+}
+
+// MCPServer wraps the MCP SDK server and the breadbox service layer.
+type MCPServer struct {
+	svc      *service.Service
+	version  string
+	allTools []ToolDef
+}
+
+// NewMCPServer creates a new MCP server with all tools registered in a registry.
+func NewMCPServer(svc *service.Service, version string) *MCPServer {
 	s := &MCPServer{
-		server: server,
-		svc:    svc,
+		svc:     svc,
+		version: version,
 	}
-
-	s.registerTools()
-	s.registerResources()
-
+	s.buildToolRegistry()
 	return s
 }
 
-// Server returns the underlying MCP SDK server.
-func (s *MCPServer) Server() *mcpsdk.Server {
-	return s.server
+// buildToolRegistry populates the allTools slice with all available tools and their classifications.
+func (s *MCPServer) buildToolRegistry() {
+	s.allTools = []ToolDef{
+		makeToolDef("list_accounts", ToolRead,
+			"List all bank accounts synced from Plaid, Teller, or CSV import. Each account belongs to a bank connection and optionally a user (family member). Returns account type, balances, institution name, and currency. Filter by user_id to see one family member's accounts.",
+			s.handleListAccounts),
+		makeToolDef("query_transactions", ToolRead,
+			"Query bank transactions with optional filters and cursor-based pagination. Amounts: positive = money out (debit), negative = money in (credit). Dates: YYYY-MM-DD, start_date inclusive, end_date exclusive. Filter by category_slug (use list_categories to find slugs); parent slugs include all children. Results ordered by date desc by default. Pagination: pass next_cursor from response. Use the fields parameter to request only the fields you need (e.g., fields=core,category) to significantly reduce response size.",
+			s.handleQueryTransactions),
+		makeToolDef("count_transactions", ToolRead,
+			"Count transactions matching optional filters. Same filters as query_transactions except cursor, limit, sort_by, and sort_order. Use this to get totals before paginating, or to compare counts across date ranges or categories.",
+			s.handleCountTransactions),
+		makeToolDef("list_categories", ToolRead,
+			"List the full category taxonomy as a tree. Categories have: slug (stable identifier for filtering), display_name (human label), icon, color, and optional children. Use category slugs with the category_slug filter in query_transactions and count_transactions. Parent slugs include all children when filtering.",
+			s.handleListCategories),
+		makeToolDef("list_users", ToolRead,
+			"List all users (family members) in the system. Each user can own bank connections and their associated accounts. Use the returned user IDs to filter accounts or transactions by family member.",
+			s.handleListUsers),
+		makeToolDef("get_sync_status", ToolRead,
+			"Get the status of all bank connections including provider type (plaid/teller/csv), sync status (active/error/pending_reauth), last sync time, and any error details. Use this to check data freshness or diagnose sync issues.",
+			s.handleGetSyncStatus),
+		makeToolDef("trigger_sync", ToolWrite,
+			"Trigger a manual sync of bank data from the provider (Plaid or Teller). Optionally specify a connection_id to sync a single connection; otherwise syncs all active connections. Returns immediately — the sync runs in the background. Check get_sync_status for results.",
+			s.handleTriggerSync),
+		makeToolDef("categorize_transaction", ToolWrite,
+			"Manually override a transaction's category. Use list_categories to find the category ID, then pass both the transaction_id and category_id. This creates a permanent override that won't be changed by automatic sync.",
+			s.handleCategorizeTransaction),
+		makeToolDef("reset_transaction_category", ToolWrite,
+			"Remove a manual category override from a transaction and re-resolve its category from the automatic mapping rules. Use this to undo a categorize_transaction action.",
+			s.handleResetTransactionCategory),
+		makeToolDef("list_unmapped_categories", ToolRead,
+			"List distinct raw provider category strings from transactions that currently have no category mapping. These are transactions the system couldn't automatically categorize. Results show the raw primary and detailed category strings from the provider.",
+			s.handleListUnmappedCategories),
+		makeToolDef("add_transaction_comment", ToolWrite,
+			"Add a comment to a transaction. Use this to explain categorization decisions, flag unusual transactions, or leave notes for the family. Comments are visible on the transaction detail page and to other agents. Supports markdown formatting.",
+			s.handleAddTransactionComment),
+		makeToolDef("list_transaction_comments", ToolRead,
+			"List all comments on a transaction, ordered chronologically. Check comments before making changes to understand prior context and decisions by other agents or family members.",
+			s.handleListTransactionComments),
+		makeToolDef("get_transaction_history", ToolRead,
+			"Get the change history (audit log) for a specific transaction. Shows all modifications including category changes, comment additions, and sync updates. Use this to understand how a transaction's categorization evolved over time and learn from past decisions.",
+			s.handleGetTransactionHistory),
+		makeToolDef("query_audit_log", ToolRead,
+			"Query the global audit log to see all changes across the system. Use entity_type to focus on specific data types. Filter by actor_type='agent' to see what other AI agents have done, or actor_type='user' to see manual changes by the family. Useful for learning patterns: e.g., query all category overrides to understand the family's preferences.",
+			s.handleQueryAuditLog),
+		makeToolDef("transaction_summary", ToolRead,
+			"Get aggregated transaction totals grouped by category and/or time period. Replaces the need to paginate through thousands of individual transactions for spending analysis. Amounts follow the convention: positive = money out (debit), negative = money in (credit). Only includes non-deleted, non-pending transactions by default.",
+			s.handleTransactionSummary),
+		makeToolDef("list_category_mappings", ToolRead,
+			"List category mappings that translate provider-specific category strings to user categories. Filter by provider to see mappings for a specific bank data source. Returns the provider, raw provider category string, and the mapped user category slug and display name.",
+			s.handleListCategoryMappings),
+		makeToolDef("create_category_mapping", ToolWrite,
+			"Create a new category mapping that tells the system how to translate a provider's raw category string to a user category. For example, map Teller's 'dining' to your 'food_and_drink_restaurant' category. The mapping takes effect on the next sync — existing transactions are not retroactively updated.",
+			s.handleCreateCategoryMapping),
+		makeToolDef("update_category_mapping", ToolWrite,
+			"Update an existing category mapping to point to a different user category. Identified by mapping ID or by the (provider, provider_category) pair. Does not retroactively update transactions — wait for next sync.",
+			s.handleUpdateCategoryMapping),
+		makeToolDef("delete_category_mapping", ToolWrite,
+			"Delete a category mapping. After deletion, transactions with this provider category string will fall back to 'uncategorized' on next sync. Identified by mapping ID or by (provider, provider_category) pair.",
+			s.handleDeleteCategoryMapping),
+	}
 }
 
-// NewHTTPHandler wraps the MCP server in a Streamable HTTP handler.
-func NewHTTPHandler(s *MCPServer) http.Handler {
+// makeToolDef is a helper to create a ToolDef with a typed handler.
+func makeToolDef[T any](name string, classification ToolClassification, description string, handler func(context.Context, *mcpsdk.CallToolRequest, T) (*mcpsdk.CallToolResult, any, error)) ToolDef {
+	return ToolDef{
+		Tool: mcpsdk.Tool{
+			Name:        name,
+			Description: description,
+		},
+		Classification: classification,
+		register: func(server *mcpsdk.Server) {
+			mcpsdk.AddTool(server, &mcpsdk.Tool{
+				Name:        name,
+				Description: description,
+			}, handler)
+		},
+	}
+}
+
+// BuildServer creates a filtered *mcpsdk.Server for the given config.
+func (s *MCPServer) BuildServer(cfg MCPServerConfig) *mcpsdk.Server {
+	instructions := BuiltInInstructions
+	if cfg.CustomInstructions != "" {
+		instructions += "\n\nCUSTOM INSTRUCTIONS:\n" + cfg.CustomInstructions
+	}
+
+	server := mcpsdk.NewServer(
+		&mcpsdk.Implementation{Name: "breadbox", Version: s.version},
+		&mcpsdk.ServerOptions{Instructions: instructions},
+	)
+
+	disabledSet := make(map[string]bool)
+	for _, name := range cfg.DisabledTools {
+		disabledSet[name] = true
+	}
+
+	for _, td := range s.allTools {
+		if disabledSet[td.Tool.Name] {
+			continue
+		}
+		if td.Classification == ToolWrite && (cfg.Mode == "read_only" || cfg.APIKeyScope == "read_only") {
+			continue
+		}
+		td.register(server)
+	}
+
+	s.registerResources(server)
+	return server
+}
+
+// Server returns a default MCP server with all tools registered (for backward compat / stdio).
+func (s *MCPServer) Server() *mcpsdk.Server {
+	return s.BuildServer(MCPServerConfig{
+		Mode:        "read_write",
+		APIKeyScope: "full_access",
+	})
+}
+
+// registerResources adds MCP resources to a server.
+func (s *MCPServer) registerResources(server *mcpsdk.Server) {
+	server.AddResource(&mcpsdk.Resource{
+		Name:        "Overview",
+		URI:         "breadbox://overview",
+		Description: "Live summary of the Breadbox data model: user, connection, account, and transaction counts plus the transaction date range. Read this first to understand the dataset scope.",
+		MIMEType:    "application/json",
+	}, s.handleOverviewResource)
+}
+
+// AllToolDefs returns the full tool registry for admin display.
+func (s *MCPServer) AllToolDefs() []ToolDef {
+	return s.allTools
+}
+
+// NewHTTPHandler wraps the MCP server in a Streamable HTTP handler with per-request filtering.
+func NewHTTPHandler(s *MCPServer, svc *service.Service) http.Handler {
 	return mcpsdk.NewStreamableHTTPHandler(
 		func(r *http.Request) *mcpsdk.Server {
-			return s.server
+			// Load MCP config from DB.
+			mcpCfg, err := svc.GetMCPConfig(r.Context())
+			if err != nil {
+				// Fall back to defaults on error.
+				mcpCfg = &service.MCPConfig{
+					Mode:          "read_only",
+					DisabledTools: []string{},
+				}
+			}
+
+			// Get API key scope from context.
+			apiKeyScope := "full_access"
+			if apiKey := mw.GetAPIKey(r.Context()); apiKey != nil {
+				apiKeyScope = apiKey.Scope
+			}
+
+			return s.BuildServer(MCPServerConfig{
+				Mode:               mcpCfg.Mode,
+				DisabledTools:      mcpCfg.DisabledTools,
+				CustomInstructions: mcpCfg.CustomInstructions,
+				APIKeyScope:        apiKeyScope,
+			})
 		},
 		nil,
 	)
+}
+
+// checkWritePermission verifies the requesting API key has write access.
+func checkWritePermission(ctx context.Context) error {
+	if apiKey := mw.GetAPIKey(ctx); apiKey != nil && apiKey.Scope == "read_only" {
+		return fmt.Errorf("this API key has read-only access and cannot perform write operations")
+	}
+	return nil
 }

--- a/internal/mcp/templates.go
+++ b/internal/mcp/templates.go
@@ -1,0 +1,83 @@
+package mcp
+
+// InstructionTemplate represents a pre-built instruction set.
+type InstructionTemplate struct {
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Content     string `json:"content"`
+}
+
+// InstructionTemplates is the list of built-in instruction templates.
+var InstructionTemplates = []InstructionTemplate{
+	{
+		Slug:        "spend_review",
+		Name:        "Spending Review",
+		Description: "Guide agents to analyze spending patterns, flag anomalies, and suggest budgets.",
+		Content: `You are reviewing household spending for a family.
+
+APPROACH:
+1. Start by reading the breadbox://overview resource to understand the data scope.
+2. Query the last 30 days of transactions to establish a baseline.
+3. Group spending by category and identify the top 5 categories.
+4. Flag any individual transactions over $500 or unusual patterns.
+5. Compare this month's spending to the previous month if data is available.
+
+OUTPUT FORMAT:
+- Use clear section headers
+- Show amounts in the local currency with 2 decimal places
+- Always note which date range you analyzed
+- Highlight concerning patterns with specific transaction details`,
+	},
+	{
+		Slug:        "monthly_analysis",
+		Name:        "Monthly Analysis",
+		Description: "Structured monthly financial summary with income, expenses, and trends.",
+		Content: `You are preparing a monthly financial summary for a family.
+
+ANALYSIS STEPS:
+1. Determine the current month's date range (1st to last day).
+2. Query all transactions for the month.
+3. Separate income (negative amounts = money in) from expenses (positive amounts = money out).
+4. Calculate net cash flow.
+5. Break down expenses by category.
+6. List the top 10 largest individual expenses.
+
+REPORT STRUCTURE:
+## Monthly Summary (Month Year)
+- Total Income: $X
+- Total Expenses: $X
+- Net Cash Flow: $X
+
+## Expense Breakdown by Category
+(table of categories with amounts and percentages)
+
+## Top 10 Expenses
+(list with date, merchant, amount, category)
+
+## Notable Observations
+(any anomalies, trends, or recommendations)`,
+	},
+	{
+		Slug:        "reporting",
+		Name:        "Data Export & Reporting",
+		Description: "Instruct agents to produce structured, exportable data summaries.",
+		Content: `You are a financial data assistant. When asked for reports, follow these conventions:
+
+DATA ACCURACY:
+- Always verify data freshness by checking get_sync_status first.
+- Never estimate or approximate — only report actual transaction data.
+- If data seems incomplete, note the gap and suggest a sync.
+
+FORMATTING:
+- Use markdown tables for tabular data.
+- Round amounts to 2 decimal places.
+- Always include the currency code.
+- Date ranges should be explicit (start and end dates).
+
+LIMITATIONS:
+- Do not make financial advice or predictions.
+- Do not compare to external benchmarks.
+- If asked about future spending, explain you can only report historical data.`,
+	},
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -284,7 +284,7 @@ func (s *MCPServer) handleGetSyncStatus(_ context.Context, _ *mcpsdk.CallToolReq
 }
 
 func (s *MCPServer) handleTriggerSync(ctx context.Context, _ *mcpsdk.CallToolRequest, input triggerSyncInput) (*mcpsdk.CallToolResult, any, error) {
-	if err := checkWritePermission(ctx); err != nil {
+	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
 	ctx = context.Background()
@@ -310,7 +310,7 @@ func (s *MCPServer) handleTriggerSync(ctx context.Context, _ *mcpsdk.CallToolReq
 }
 
 func (s *MCPServer) handleCategorizeTransaction(ctx context.Context, _ *mcpsdk.CallToolRequest, input categorizeTransactionInput) (*mcpsdk.CallToolResult, any, error) {
-	if err := checkWritePermission(ctx); err != nil {
+	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
 	ctx = context.Background()
@@ -328,7 +328,7 @@ func (s *MCPServer) handleCategorizeTransaction(ctx context.Context, _ *mcpsdk.C
 }
 
 func (s *MCPServer) handleResetTransactionCategory(ctx context.Context, _ *mcpsdk.CallToolRequest, input resetTransactionCategoryInput) (*mcpsdk.CallToolResult, any, error) {
-	if err := checkWritePermission(ctx); err != nil {
+	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
 	ctx = context.Background()
@@ -355,7 +355,7 @@ func (s *MCPServer) handleListUnmappedCategories(_ context.Context, _ *mcpsdk.Ca
 }
 
 func (s *MCPServer) handleAddTransactionComment(ctx context.Context, _ *mcpsdk.CallToolRequest, input addTransactionCommentInput) (*mcpsdk.CallToolResult, any, error) {
-	if err := checkWritePermission(ctx); err != nil {
+	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
 	if input.TransactionID == "" || input.Content == "" {
@@ -479,7 +479,7 @@ func (s *MCPServer) handleListCategoryMappings(_ context.Context, _ *mcpsdk.Call
 }
 
 func (s *MCPServer) handleCreateCategoryMapping(ctx context.Context, _ *mcpsdk.CallToolRequest, input createCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
-	if err := checkWritePermission(ctx); err != nil {
+	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
 	ctx = context.Background()
@@ -503,7 +503,7 @@ func (s *MCPServer) handleCreateCategoryMapping(ctx context.Context, _ *mcpsdk.C
 }
 
 func (s *MCPServer) handleUpdateCategoryMapping(ctx context.Context, _ *mcpsdk.CallToolRequest, input updateCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
-	if err := checkWritePermission(ctx); err != nil {
+	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
 	ctx = context.Background()
@@ -535,7 +535,7 @@ func (s *MCPServer) handleUpdateCategoryMapping(ctx context.Context, _ *mcpsdk.C
 }
 
 func (s *MCPServer) handleDeleteCategoryMapping(ctx context.Context, _ *mcpsdk.CallToolRequest, input deleteCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
-	if err := checkWritePermission(ctx); err != nil {
+	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
 	ctx = context.Background()

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -11,103 +11,6 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func (s *MCPServer) registerTools() {
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "list_accounts",
-		Description: "List all bank accounts synced from Plaid, Teller, or CSV import. Each account belongs to a bank connection and optionally a user (family member). Returns account type, balances, institution name, and currency. Filter by user_id to see one family member's accounts.",
-	}, s.handleListAccounts)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "query_transactions",
-		Description: "Query bank transactions with optional filters and cursor-based pagination. Amounts: positive = money out (debit), negative = money in (credit). Dates: YYYY-MM-DD, start_date inclusive, end_date exclusive. Filter by category_slug (use list_categories to find slugs); parent slugs include all children. Results ordered by date desc by default. Pagination: pass next_cursor from response. Use the fields parameter to request only the fields you need (e.g., fields=core,category) to significantly reduce response size.",
-	}, s.handleQueryTransactions)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "count_transactions",
-		Description: "Count transactions matching optional filters. Same filters as query_transactions except cursor, limit, sort_by, and sort_order. Use this to get totals before paginating, or to compare counts across date ranges or categories.",
-	}, s.handleCountTransactions)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "list_categories",
-		Description: "List the full category taxonomy as a tree. Categories have: slug (stable identifier for filtering), display_name (human label), icon, color, and optional children. Use category slugs with the category_slug filter in query_transactions and count_transactions. Parent slugs include all children when filtering.",
-	}, s.handleListCategories)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "list_users",
-		Description: "List all users (family members) in the system. Each user can own bank connections and their associated accounts. Use the returned user IDs to filter accounts or transactions by family member.",
-	}, s.handleListUsers)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "get_sync_status",
-		Description: "Get the status of all bank connections including provider type (plaid/teller/csv), sync status (active/error/pending_reauth), last sync time, and any error details. Use this to check data freshness or diagnose sync issues.",
-	}, s.handleGetSyncStatus)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "trigger_sync",
-		Description: "Trigger a manual sync of bank data from the provider (Plaid or Teller). Optionally specify a connection_id to sync a single connection; otherwise syncs all active connections. Returns immediately — the sync runs in the background. Check get_sync_status for results.",
-	}, s.handleTriggerSync)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "categorize_transaction",
-		Description: "Manually override a transaction's category. Use list_categories to find the category ID, then pass both the transaction_id and category_id. This creates a permanent override that won't be changed by automatic sync.",
-	}, s.handleCategorizeTransaction)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "reset_transaction_category",
-		Description: "Remove a manual category override from a transaction and re-resolve its category from the automatic mapping rules. Use this to undo a categorize_transaction action.",
-	}, s.handleResetTransactionCategory)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "list_unmapped_categories",
-		Description: "List distinct raw provider category strings from transactions that currently have no category mapping. These are transactions the system couldn't automatically categorize. Results show the raw primary and detailed category strings from the provider.",
-	}, s.handleListUnmappedCategories)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "add_transaction_comment",
-		Description: "Add a comment to a transaction. Use this to explain categorization decisions, flag unusual transactions, or leave notes for the family. Comments are visible on the transaction detail page and to other agents. Supports markdown formatting.",
-	}, s.handleAddTransactionComment)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "list_transaction_comments",
-		Description: "List all comments on a transaction, ordered chronologically. Check comments before making changes to understand prior context and decisions by other agents or family members.",
-	}, s.handleListTransactionComments)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "get_transaction_history",
-		Description: "Get the change history (audit log) for a specific transaction. Shows all modifications including category changes, comment additions, and sync updates. Use this to understand how a transaction's categorization evolved over time and learn from past decisions.",
-	}, s.handleGetTransactionHistory)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "query_audit_log",
-		Description: "Query the global audit log to see all changes across the system. Use entity_type to focus on specific data types. Filter by actor_type='agent' to see what other AI agents have done, or actor_type='user' to see manual changes by the family. Useful for learning patterns: e.g., query all category overrides to understand the family's preferences.",
-	}, s.handleQueryAuditLog)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "transaction_summary",
-		Description: "Get aggregated transaction totals grouped by category and/or time period. Replaces the need to paginate through thousands of individual transactions for spending analysis. Amounts follow the convention: positive = money out (debit), negative = money in (credit). Only includes non-deleted, non-pending transactions by default.",
-	}, s.handleTransactionSummary)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "list_category_mappings",
-		Description: "List category mappings that translate provider-specific category strings to user categories. Filter by provider to see mappings for a specific bank data source. Returns the provider, raw provider category string, and the mapped user category slug and display name.",
-	}, s.handleListCategoryMappings)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "create_category_mapping",
-		Description: "Create a new category mapping that tells the system how to translate a provider's raw category string to a user category. For example, map Teller's 'dining' to your 'food_and_drink_restaurant' category. The mapping takes effect on the next sync — existing transactions are not retroactively updated.",
-	}, s.handleCreateCategoryMapping)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "update_category_mapping",
-		Description: "Update an existing category mapping to point to a different user category. Identified by mapping ID or by the (provider, provider_category) pair. Does not retroactively update transactions — wait for next sync.",
-	}, s.handleUpdateCategoryMapping)
-
-	mcpsdk.AddTool(s.server, &mcpsdk.Tool{
-		Name:        "delete_category_mapping",
-		Description: "Delete a category mapping. After deletion, transactions with this provider category string will fall back to 'uncategorized' on next sync. Identified by mapping ID or by (provider, provider_category) pair.",
-	}, s.handleDeleteCategoryMapping)
-}
-
 // --- Input types ---
 
 type listAccountsInput struct {
@@ -380,8 +283,11 @@ func (s *MCPServer) handleGetSyncStatus(_ context.Context, _ *mcpsdk.CallToolReq
 	return jsonResult(connections)
 }
 
-func (s *MCPServer) handleTriggerSync(_ context.Context, _ *mcpsdk.CallToolRequest, input triggerSyncInput) (*mcpsdk.CallToolResult, any, error) {
-	ctx := context.Background()
+func (s *MCPServer) handleTriggerSync(ctx context.Context, _ *mcpsdk.CallToolRequest, input triggerSyncInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	ctx = context.Background()
 	var connectionID *string
 	if input.ConnectionID != "" {
 		connectionID = &input.ConnectionID
@@ -403,8 +309,11 @@ func (s *MCPServer) handleTriggerSync(_ context.Context, _ *mcpsdk.CallToolReque
 	}, nil, nil
 }
 
-func (s *MCPServer) handleCategorizeTransaction(_ context.Context, _ *mcpsdk.CallToolRequest, input categorizeTransactionInput) (*mcpsdk.CallToolResult, any, error) {
-	ctx := context.Background()
+func (s *MCPServer) handleCategorizeTransaction(ctx context.Context, _ *mcpsdk.CallToolRequest, input categorizeTransactionInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	ctx = context.Background()
 	if input.TransactionID == "" || input.CategoryID == "" {
 		return errorResult(fmt.Errorf("transaction_id and category_id are required")), nil, nil
 	}
@@ -418,8 +327,11 @@ func (s *MCPServer) handleCategorizeTransaction(_ context.Context, _ *mcpsdk.Cal
 	}, nil, nil
 }
 
-func (s *MCPServer) handleResetTransactionCategory(_ context.Context, _ *mcpsdk.CallToolRequest, input resetTransactionCategoryInput) (*mcpsdk.CallToolResult, any, error) {
-	ctx := context.Background()
+func (s *MCPServer) handleResetTransactionCategory(ctx context.Context, _ *mcpsdk.CallToolRequest, input resetTransactionCategoryInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	ctx = context.Background()
 	if input.TransactionID == "" {
 		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
 	}
@@ -443,6 +355,9 @@ func (s *MCPServer) handleListUnmappedCategories(_ context.Context, _ *mcpsdk.Ca
 }
 
 func (s *MCPServer) handleAddTransactionComment(ctx context.Context, _ *mcpsdk.CallToolRequest, input addTransactionCommentInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
 	if input.TransactionID == "" || input.Content == "" {
 		return errorResult(fmt.Errorf("transaction_id and content are required")), nil, nil
 	}
@@ -563,8 +478,11 @@ func (s *MCPServer) handleListCategoryMappings(_ context.Context, _ *mcpsdk.Call
 	})
 }
 
-func (s *MCPServer) handleCreateCategoryMapping(_ context.Context, _ *mcpsdk.CallToolRequest, input createCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
-	ctx := context.Background()
+func (s *MCPServer) handleCreateCategoryMapping(ctx context.Context, _ *mcpsdk.CallToolRequest, input createCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	ctx = context.Background()
 
 	if input.Provider == "" || input.ProviderCategory == "" || input.CategorySlug == "" {
 		return errorResult(fmt.Errorf("provider, provider_category, and category_slug are required")), nil, nil
@@ -584,8 +502,11 @@ func (s *MCPServer) handleCreateCategoryMapping(_ context.Context, _ *mcpsdk.Cal
 	return jsonResult(mapping)
 }
 
-func (s *MCPServer) handleUpdateCategoryMapping(_ context.Context, _ *mcpsdk.CallToolRequest, input updateCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
-	ctx := context.Background()
+func (s *MCPServer) handleUpdateCategoryMapping(ctx context.Context, _ *mcpsdk.CallToolRequest, input updateCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	ctx = context.Background()
 
 	if input.CategorySlug == "" {
 		return errorResult(fmt.Errorf("category_slug is required")), nil, nil
@@ -613,8 +534,11 @@ func (s *MCPServer) handleUpdateCategoryMapping(_ context.Context, _ *mcpsdk.Cal
 	return jsonResult(mapping)
 }
 
-func (s *MCPServer) handleDeleteCategoryMapping(_ context.Context, _ *mcpsdk.CallToolRequest, input deleteCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
-	ctx := context.Background()
+func (s *MCPServer) handleDeleteCategoryMapping(ctx context.Context, _ *mcpsdk.CallToolRequest, input deleteCategoryMappingInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	ctx = context.Background()
 
 	if input.ID == "" && (input.Provider == "" || input.ProviderCategory == "") {
 		return errorResult(fmt.Errorf("either id or (provider, provider_category) is required")), nil, nil

--- a/internal/middleware/apikey.go
+++ b/internal/middleware/apikey.go
@@ -44,6 +44,8 @@ func APIKeyAuth(svc *service.Service) func(http.Handler) http.Handler {
 			// Store API key identity in context for actor resolution.
 			keyID := formatUUID(apiKey.ID)
 			ctx := service.ContextWithAPIKey(r.Context(), keyID, apiKey.Name)
+			// Store full API key record for scope checks.
+			ctx = SetAPIKey(ctx, apiKey)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/internal/middleware/context.go
+++ b/internal/middleware/context.go
@@ -1,0 +1,22 @@
+package middleware
+
+import (
+	"context"
+
+	"breadbox/internal/db"
+)
+
+type contextKey string
+
+const apiKeyContextKey contextKey = "api_key"
+
+// SetAPIKey stores the full API key record in the request context.
+func SetAPIKey(ctx context.Context, key *db.ApiKey) context.Context {
+	return context.WithValue(ctx, apiKeyContextKey, key)
+}
+
+// GetAPIKey retrieves the API key record from the request context.
+func GetAPIKey(ctx context.Context) *db.ApiKey {
+	key, _ := ctx.Value(apiKeyContextKey).(*db.ApiKey)
+	return key
+}

--- a/internal/middleware/scope.go
+++ b/internal/middleware/scope.go
@@ -1,0 +1,18 @@
+package middleware
+
+import "net/http"
+
+// RequireWriteScope rejects requests from read_only API keys.
+func RequireWriteScope() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			apiKey := GetAPIKey(r.Context())
+			if apiKey != nil && apiKey.Scope == "read_only" {
+				WriteError(w, http.StatusForbidden, "INSUFFICIENT_SCOPE",
+					"This API key has read-only access and cannot perform write operations")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -15,7 +15,14 @@ import (
 
 const base62Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
-func (s *Service) CreateAPIKey(ctx context.Context, name string) (*CreateAPIKeyResult, error) {
+func (s *Service) CreateAPIKey(ctx context.Context, name string, scope string) (*CreateAPIKeyResult, error) {
+	if scope == "" {
+		scope = "full_access"
+	}
+	if scope != "full_access" && scope != "read_only" {
+		return nil, fmt.Errorf("invalid scope: %s", scope)
+	}
+
 	// Generate 32 random bytes
 	randomBytes := make([]byte, 32)
 	if _, err := rand.Read(randomBytes); err != nil {
@@ -46,6 +53,7 @@ func (s *Service) CreateAPIKey(ctx context.Context, name string) (*CreateAPIKeyR
 		Name:      name,
 		KeyHash:   keyHash,
 		KeyPrefix: keyPrefix,
+		Scope:     scope,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create api key: %w", err)
@@ -106,6 +114,7 @@ func apiKeyFromRow(r db.ApiKey) APIKeyResponse {
 		ID:         formatUUID(r.ID),
 		Name:       r.Name,
 		KeyPrefix:  r.KeyPrefix,
+		Scope:      r.Scope,
 		LastUsedAt: timestampStr(r.LastUsedAt),
 		RevokedAt:  timestampStr(r.RevokedAt),
 		CreatedAt:  r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),

--- a/internal/service/mcp_config.go
+++ b/internal/service/mcp_config.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// MCPConfig represents the MCP permission and instruction settings.
+type MCPConfig struct {
+	Mode                string   `json:"mode"`                 // "read_only" or "read_write"
+	DisabledTools       []string `json:"disabled_tools"`       // tool names
+	CustomInstructions  string   `json:"custom_instructions"`  // markdown
+	InstructionTemplate string   `json:"instruction_template"` // template slug
+}
+
+// GetMCPConfig loads MCP configuration from app_config.
+func (s *Service) GetMCPConfig(ctx context.Context) (*MCPConfig, error) {
+	cfg := &MCPConfig{
+		Mode:          "read_only",
+		DisabledTools: []string{},
+	}
+
+	rows, err := s.Queries.ListAppConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list app config: %w", err)
+	}
+
+	for _, row := range rows {
+		switch row.Key {
+		case "mcp_mode":
+			if row.Value.Valid {
+				cfg.Mode = row.Value.String
+			}
+		case "mcp_disabled_tools":
+			if row.Value.Valid && row.Value.String != "" {
+				if err := json.Unmarshal([]byte(row.Value.String), &cfg.DisabledTools); err != nil {
+					cfg.DisabledTools = []string{}
+				}
+			}
+		case "mcp_custom_instructions":
+			if row.Value.Valid {
+				cfg.CustomInstructions = row.Value.String
+			}
+		case "mcp_instruction_template":
+			if row.Value.Valid {
+				cfg.InstructionTemplate = row.Value.String
+			}
+		}
+	}
+
+	return cfg, nil
+}
+
+// SaveMCPMode saves the global MCP mode.
+func (s *Service) SaveMCPMode(ctx context.Context, mode string) error {
+	if mode != "read_only" && mode != "read_write" {
+		return fmt.Errorf("invalid MCP mode: %s", mode)
+	}
+	return s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   "mcp_mode",
+		Value: pgtype.Text{String: mode, Valid: true},
+	})
+}
+
+// SaveMCPDisabledTools saves the list of disabled tool names.
+func (s *Service) SaveMCPDisabledTools(ctx context.Context, tools []string) error {
+	if tools == nil {
+		tools = []string{}
+	}
+	data, err := json.Marshal(tools)
+	if err != nil {
+		return fmt.Errorf("marshal disabled tools: %w", err)
+	}
+	return s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   "mcp_disabled_tools",
+		Value: pgtype.Text{String: string(data), Valid: true},
+	})
+}
+
+// SaveMCPInstructions saves custom instructions and the template slug.
+func (s *Service) SaveMCPInstructions(ctx context.Context, instructions string, templateSlug string) error {
+	if len(instructions) > 10000 {
+		return fmt.Errorf("instructions exceed maximum length of 10,000 characters")
+	}
+	if err := s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   "mcp_custom_instructions",
+		Value: pgtype.Text{String: instructions, Valid: true},
+	}); err != nil {
+		return fmt.Errorf("save custom instructions: %w", err)
+	}
+	return s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   "mcp_instruction_template",
+		Value: pgtype.Text{String: templateSlug, Valid: true},
+	})
+}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -141,6 +141,7 @@ type APIKeyResponse struct {
 	ID         string  `json:"id"`
 	Name       string  `json:"name"`
 	KeyPrefix  string  `json:"key_prefix"`
+	Scope      string  `json:"scope"`
 	LastUsedAt *string `json:"last_used_at"`
 	RevokedAt  *string `json:"revoked_at"`
 	CreatedAt  string  `json:"created_at"`

--- a/internal/templates/pages/api_key_new.html
+++ b/internal/templates/pages/api_key_new.html
@@ -10,6 +10,14 @@
         <input type="text" id="name" name="name" class="input w-full" placeholder="e.g., Claude MCP, Dashboard" required autofocus>
         <p class="text-sm text-base-content/60 mt-1">A descriptive name to identify this API key.</p>
       </fieldset>
+      <fieldset class="fieldset mt-3">
+        <label class="fieldset-label" for="scope">Scope</label>
+        <select id="scope" name="scope" class="select select-bordered w-full">
+          <option value="full_access">Full Access &mdash; read and write</option>
+          <option value="read_only">Read Only &mdash; query data only</option>
+        </select>
+        <p class="text-sm text-base-content/60 mt-1">Read-only keys cannot trigger syncs, categorize transactions, or use write MCP tools.</p>
+      </fieldset>
       <div class="flex gap-2 mt-4">
         <button type="submit" class="btn btn-primary">Create API Key</button>
         <a href="/admin/api-keys" class="btn btn-ghost">Cancel</a>

--- a/internal/templates/pages/api_key_new.html
+++ b/internal/templates/pages/api_key_new.html
@@ -16,7 +16,7 @@
           <option value="full_access">Full Access &mdash; read and write</option>
           <option value="read_only">Read Only &mdash; query data only</option>
         </select>
-        <p class="text-sm text-base-content/60 mt-1">Read-only keys cannot trigger syncs, categorize transactions, or use write MCP tools.</p>
+        <p class="text-sm text-base-content/60 mt-1">Read-only keys cannot trigger syncs, categorize transactions, or use write MCP tools. Scope cannot be changed after creation.</p>
       </fieldset>
       <div class="flex gap-2 mt-4">
         <button type="submit" class="btn btn-primary">Create API Key</button>

--- a/internal/templates/pages/api_keys.html
+++ b/internal/templates/pages/api_keys.html
@@ -13,6 +13,7 @@
     <thead>
       <tr>
         <th>Name</th>
+        <th>Scope</th>
         <th>Key Prefix</th>
         <th>Last Used</th>
         <th>Status</th>
@@ -24,6 +25,13 @@
       {{range .Keys}}
       <tr class="hover:bg-base-300">
         <td>{{.Name}}</td>
+        <td>
+          {{if eq .Scope "read_only"}}
+            <span class="badge badge-warning badge-sm">Read Only</span>
+          {{else}}
+            <span class="badge badge-info badge-sm">Full Access</span>
+          {{end}}
+        </td>
         <td><code class="font-mono text-sm">{{.KeyPrefix}}...</code></td>
         <td>{{if .LastUsedAt}}{{.LastUsedAt}}{{else}}&mdash;{{end}}</td>
         <td>

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -1,0 +1,189 @@
+{{define "content"}}
+<h1 class="text-2xl font-bold mb-6">MCP Settings</h1>
+
+<div class="grid gap-6">
+
+  <!-- Card 1: Global Mode -->
+  <div class="card bg-base-100 border border-base-300">
+    <div class="card-body">
+      <h2 class="card-title text-lg">
+        <i data-lucide="shield" class="w-5 h-5"></i>
+        Global Mode
+      </h2>
+      <p class="text-sm text-base-content/70 mb-4">Controls whether MCP-connected agents can perform write operations (sync, categorize, comment) or are limited to read-only data queries.</p>
+      <form method="POST" action="/admin/mcp/mode">
+        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+        <div class="flex flex-col gap-3">
+          <label class="label cursor-pointer justify-start gap-3">
+            <input type="radio" name="mode" value="read_only" class="radio radio-primary" {{if eq .MCPConfig.Mode "read_only"}}checked{{end}}>
+            <div>
+              <span class="font-medium">Read Only</span>
+              <span class="badge badge-ghost badge-sm ml-2">Default</span>
+              <p class="text-sm text-base-content/60">Agents can query data but cannot trigger syncs, categorize transactions, or make changes.</p>
+            </div>
+          </label>
+          <label class="label cursor-pointer justify-start gap-3">
+            <input type="radio" name="mode" value="read_write" class="radio radio-primary" {{if eq .MCPConfig.Mode "read_write"}}checked{{end}}>
+            <div>
+              <span class="font-medium">Read & Write</span>
+              <p class="text-sm text-base-content/60">Agents can query data and perform write operations like syncing, categorizing, and commenting.</p>
+            </div>
+          </label>
+        </div>
+        <div class="mt-4">
+          <button type="submit" class="btn btn-primary btn-sm">Save Mode</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Card 2: Tool Access -->
+  <div class="card bg-base-100 border border-base-300">
+    <div class="card-body">
+      <h2 class="card-title text-lg">
+        <i data-lucide="wrench" class="w-5 h-5"></i>
+        Tool Access
+      </h2>
+      <p class="text-sm text-base-content/70 mb-4">Enable or disable individual tools. Disabled tools are hidden from all agents. Write tools are automatically disabled when global mode is Read Only.</p>
+      <form method="POST" action="/admin/mcp/tools">
+        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+        <div class="overflow-x-auto">
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th>Enabled</th>
+                <th>Tool</th>
+                <th>Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{range .Tools}}
+              <tr>
+                <td>
+                  {{if .WriteLocked}}
+                    <input type="checkbox" class="toggle toggle-sm" disabled title="Disabled by Read Only mode">
+                  {{else}}
+                    <input type="checkbox" name="enabled_tools" value="{{.Name}}" class="toggle toggle-sm toggle-primary" {{if .Enabled}}checked{{end}}>
+                  {{end}}
+                </td>
+                <td>
+                  <div class="font-mono text-sm">{{.Name}}</div>
+                  <div class="text-xs text-base-content/50 max-w-md truncate">{{.Description}}</div>
+                </td>
+                <td>
+                  {{if eq .Classification "write"}}
+                    <span class="badge badge-warning badge-sm">write</span>
+                  {{else}}
+                    <span class="badge badge-info badge-sm">read</span>
+                  {{end}}
+                  {{if .WriteLocked}}
+                    <i data-lucide="lock" class="w-3 h-3 inline text-base-content/40" title="Locked by Read Only mode"></i>
+                  {{end}}
+                </td>
+              </tr>
+              {{end}}
+            </tbody>
+          </table>
+        </div>
+        <div class="mt-4">
+          <button type="submit" class="btn btn-primary btn-sm">Save Tool Access</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Card 3: Server Instructions -->
+  <div class="card bg-base-100 border border-base-300" x-data="{
+    instructions: {{.MCPConfig.CustomInstructions | printf `%q`}},
+    template: '{{.MCPConfig.InstructionTemplate}}',
+    templates: {{.TemplatesJSON}},
+    showPreview: false,
+    loadTemplate(slug) {
+      if (slug === '') {
+        return;
+      }
+      const t = this.templates.find(t => t.slug === slug);
+      if (t) {
+        if (this.instructions && this.instructions !== t.content) {
+          if (!confirm('Replace current instructions with template?')) {
+            this.template = '{{.MCPConfig.InstructionTemplate}}';
+            return;
+          }
+        }
+        this.instructions = t.content;
+      }
+    }
+  }">
+    <div class="card-body">
+      <h2 class="card-title text-lg">
+        <i data-lucide="file-text" class="w-5 h-5"></i>
+        Server Instructions
+      </h2>
+      <p class="text-sm text-base-content/70 mb-4">Custom instructions appended to the built-in MCP server instructions. Agents see these when they connect. Use markdown formatting.</p>
+      <form method="POST" action="/admin/mcp/instructions">
+        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+
+        <div class="form-control mb-3">
+          <label class="label"><span class="label-text font-medium">Template</span></label>
+          <select name="template" class="select select-bordered select-sm w-full max-w-xs" x-model="template" @change="loadTemplate(template)">
+            <option value="">Custom</option>
+            {{range .Templates}}
+            <option value="{{.Slug}}">{{.Name}} &mdash; {{.Description}}</option>
+            {{end}}
+          </select>
+        </div>
+
+        <div class="form-control mb-3">
+          <label class="label"><span class="label-text font-medium">Custom Instructions</span></label>
+          <textarea name="instructions" class="textarea textarea-bordered font-mono text-sm h-48 w-full" maxlength="10000" x-model="instructions" placeholder="Enter custom instructions for MCP agents..."></textarea>
+          <label class="label">
+            <span class="label-text-alt" x-text="instructions.length + '/10000'"></span>
+          </label>
+        </div>
+
+        <div class="flex gap-2 items-center mb-3">
+          <button type="submit" class="btn btn-primary btn-sm">Save Instructions</button>
+          <button type="button" class="btn btn-ghost btn-sm" @click="showPreview = !showPreview" x-text="showPreview ? 'Hide Preview' : 'Show Preview'"></button>
+        </div>
+      </form>
+
+      <div x-show="showPreview" x-cloak class="mt-2">
+        <h3 class="font-medium text-sm mb-2">Full Instructions (Built-in + Custom)</h3>
+        <pre class="bg-base-200 p-4 rounded-lg text-xs overflow-auto max-h-96 whitespace-pre-wrap">{{.BuiltInInstructions}}
+
+<template x-if="instructions.length > 0"><span x-text="'\n\nCUSTOM INSTRUCTIONS:\n' + instructions"></span></template></pre>
+      </div>
+    </div>
+  </div>
+
+  <!-- Card 4: API Key Scopes -->
+  <div class="card bg-base-100 border border-base-300">
+    <div class="card-body">
+      <h2 class="card-title text-lg">
+        <i data-lucide="key" class="w-5 h-5"></i>
+        API Key Scopes
+      </h2>
+      <p class="text-sm text-base-content/70 mb-4">Each API key can be scoped to limit what operations it can perform. Read-only keys cannot invoke write tools or write REST endpoints, even when global mode is Read & Write.</p>
+      <div class="stats shadow">
+        <div class="stat">
+          <div class="stat-title">Full Access</div>
+          <div class="stat-value text-2xl">{{.FullAccessCount}}</div>
+          <div class="stat-desc">Read + Write</div>
+        </div>
+        <div class="stat">
+          <div class="stat-title">Read Only</div>
+          <div class="stat-value text-2xl">{{.ReadOnlyCount}}</div>
+          <div class="stat-desc">Query only</div>
+        </div>
+      </div>
+      <div class="mt-4">
+        <a href="/admin/api-keys" class="btn btn-ghost btn-sm">
+          <i data-lucide="external-link" class="w-4 h-4"></i>
+          Manage API Keys
+        </a>
+      </div>
+    </div>
+  </div>
+
+</div>
+{{end}}

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -151,7 +151,7 @@
         <h3 class="font-medium text-sm mb-2">Full Instructions (Built-in + Custom)</h3>
         <pre class="bg-base-200 p-4 rounded-lg text-xs overflow-auto max-h-96 whitespace-pre-wrap">{{.BuiltInInstructions}}
 
-<template x-if="instructions.length > 0"><span x-text="'\n\nCUSTOM INSTRUCTIONS:\n' + instructions"></span></template></pre>
+<span x-show="instructions.length > 0" x-text="'\n\nCUSTOM INSTRUCTIONS:\n' + instructions"></span></pre>
       </div>
     </div>
   </div>

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -9,6 +9,7 @@
   <li class="menu-title">System</li>
   <li><a href="/admin/providers"{{if eq .CurrentPage "providers"}} class="menu-active"{{end}}><i data-lucide="plug" class="w-4 h-4"></i> Providers</a></li>
   <li><a href="/admin/api-keys"{{if eq .CurrentPage "api-keys"}} class="menu-active"{{end}}><i data-lucide="key" class="w-4 h-4"></i> API Keys</a></li>
+  <li><a href="/admin/mcp"{{if eq .CurrentPage "mcp"}} class="menu-active"{{end}}><i data-lucide="bot" class="w-4 h-4"></i> MCP</a></li>
   <li><a href="/admin/sync-logs"{{if eq .CurrentPage "sync-logs"}} class="menu-active"{{end}}><i data-lucide="refresh-cw" class="w-4 h-4"></i> Sync Logs</a></li>
   <li><a href="/admin/settings"{{if eq .CurrentPage "settings"}} class="menu-active"{{end}}><i data-lucide="settings" class="w-4 h-4"></i> Settings</a></li>
 </ul>


### PR DESCRIPTION
Add admin control over MCP agent capabilities:
- Global read-only/read-write mode toggle (default: read_only)
- Per-tool enable/disable with tool classification (read/write)
- Custom MCP server instructions editor with pre-built templates
- API key scope (full_access/read_only) with RequireWriteScope middleware
- Per-request MCP server filtering based on mode, disabled tools, and key scope
- New /admin/mcp settings page with four configuration cards
- Write permission guards on all write tool handlers (belt-and-suspenders)
- REST API write endpoints grouped behind scope middleware

https://claude.ai/code/session_016MYWf37Csk11QSs45LbWpK