### PR TITLE
Add merge_group trigger to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI/CD
 on:
   pull_request:
     branches: [main]
+  merge_group:
   push:
     branches: [main]
     tags: ["v*"]


### PR DESCRIPTION
Enables the merge queue feature by triggering CI tests on merge group
events. This allows PRs to be queued for merge while tests run.

https://claude.ai/code/session_01V3QgBZsEBFVofdX7pji1CE