### PR TITLE
Fix providers configured via DB not loading on startup

### DIFF
--- a/cmd/breadbox/main.go
+++ b/cmd/breadbox/main.go
@@ -157,6 +157,20 @@ func runServe() error {
 		logger.Warn("failed to load app_config", "error", err)
 	}
 
+	// Re-initialize providers that may now be configured from DB values.
+	// app.New() runs before LoadWithDB, so providers configured via the
+	// dashboard (stored in app_config) won't have been created yet.
+	if a.Providers["plaid"] == nil && cfg.PlaidClientID != "" {
+		if err := a.ReinitProvider("plaid"); err != nil {
+			logger.Warn("failed to reinit plaid provider from db config", "error", err)
+		}
+	}
+	if a.Providers["teller"] == nil && cfg.TellerAppID != "" {
+		if err := a.ReinitProvider("teller"); err != nil {
+			logger.Warn("failed to reinit teller provider from db config", "error", err)
+		}
+	}
+
 	// Validate ENCRYPTION_KEY when bank providers are configured.
 	if cfg.EncryptionKey == nil && (cfg.PlaidClientID != "" || cfg.TellerAppID != "") {
 		return fmt.Errorf("ENCRYPTION_KEY is required when Plaid or Teller providers are configured. Generate one with: openssl rand -hex 32")


### PR DESCRIPTION
Providers are initialized in app.New() before config.LoadWithDB() merges
app_config values into the config struct. This means Teller (and Plaid)
configured through the dashboard rather than env vars would appear as
"not configured" after a restart, requiring a re-save to trigger
ReinitProvider.

After LoadWithDB populates the config from the database, reinitialize
any providers that are now configured but weren't created during
app.New().

https://claude.ai/code/session_01Db9n3NvjDjscL8uVSkEdjN