### PR TITLE
Add backdrop overlay to category picker on mobile

### DIFF
--- a/internal/templates/partials/category_picker.html
+++ b/internal/templates/partials/category_picker.html
@@ -155,7 +155,14 @@ function categoryPicker(config) {
   .bb-cat-icon { width: 1rem; height: 1rem; flex-shrink: 0; opacity: 0.7; }
   .bb-cat-empty { padding: 1rem; text-align: center; font-size: 0.875rem; color: oklch(var(--color-base-content) / 0.5); }
   @media (max-width: 640px) {
-    .bb-cat-picker-dropdown { position: fixed; left: 0.5rem; right: 0.5rem; top: 0.5rem; bottom: auto; max-height: 70vh; border-radius: var(--rounded-btn, 0.5rem); }
+    .bb-cat-picker-dropdown {
+      position: fixed; left: 0.5rem; right: 0.5rem; top: 0.5rem; bottom: auto;
+      max-height: 70vh; border-radius: var(--rounded-btn, 0.5rem);
+    }
+    .bb-cat-picker-dropdown::before {
+      content: ''; position: fixed; inset: 0; z-index: -1;
+      background: rgba(0,0,0,.4);
+    }
   }
 </style>
 {{end}}


### PR DESCRIPTION
The fixed-position dropdown was transparent on mobile because it lacked a visible backdrop. Add a ::before pseudo-element that covers the screen with a semi-transparent overlay, making the dropdown clearly float above the page content.

https://claude.ai/code/session_01XEJMSCGseTZMDe2FFi8S4j