### PR TITLE
Add full replace mode toggle for bulk category/mapping import

### DIFF
--- a/internal/admin/category_mappings.go
+++ b/internal/admin/category_mappings.go
@@ -210,7 +210,9 @@ func ImportCategoriesTSVAdminHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 
-		result, err := svc.ImportCategoriesTSV(r.Context(), string(body))
+		replaceMode := r.URL.Query().Get("replace") == "true"
+
+		result, err := svc.ImportCategoriesTSV(r.Context(), string(body), replaceMode)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]any{
 				"error": map[string]string{"code": "IMPORT_ERROR", "message": err.Error()},
@@ -249,8 +251,9 @@ func ImportMappingsTSVAdminHandler(svc *service.Service) http.HandlerFunc {
 		}
 
 		applyRetroactively := r.URL.Query().Get("apply_retroactively") == "true"
+		replaceMode := r.URL.Query().Get("replace") == "true"
 
-		result, err := svc.ImportMappingsTSV(r.Context(), string(body), applyRetroactively)
+		result, err := svc.ImportMappingsTSV(r.Context(), string(body), applyRetroactively, replaceMode)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]any{
 				"error": map[string]string{"code": "IMPORT_ERROR", "message": err.Error()},

--- a/internal/api/category_bulk.go
+++ b/internal/api/category_bulk.go
@@ -35,7 +35,9 @@ func ImportCategoriesTSVHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 
-		result, err := svc.ImportCategoriesTSV(r.Context(), string(body))
+		replaceMode := r.URL.Query().Get("replace") == "true"
+
+		result, err := svc.ImportCategoriesTSV(r.Context(), string(body), replaceMode)
 		if err != nil {
 			mw.WriteError(w, http.StatusBadRequest, "IMPORT_ERROR", err.Error())
 			return
@@ -72,8 +74,9 @@ func ImportMappingsTSVHandler(svc *service.Service) http.HandlerFunc {
 		}
 
 		applyRetroactively := r.URL.Query().Get("apply_retroactively") == "true"
+		replaceMode := r.URL.Query().Get("replace") == "true"
 
-		result, err := svc.ImportMappingsTSV(r.Context(), string(body), applyRetroactively)
+		result, err := svc.ImportMappingsTSV(r.Context(), string(body), applyRetroactively, replaceMode)
 		if err != nil {
 			mw.WriteError(w, http.StatusBadRequest, "IMPORT_ERROR", err.Error())
 			return

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -617,7 +617,7 @@ func (s *MCPServer) handleImportCategories(ctx context.Context, _ *mcpsdk.CallTo
 	if input.Content == "" {
 		return errorResult(fmt.Errorf("content is required")), nil, nil
 	}
-	result, err := s.svc.ImportCategoriesTSV(context.Background(), input.Content)
+	result, err := s.svc.ImportCategoriesTSV(context.Background(), input.Content, false)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}
@@ -644,7 +644,7 @@ func (s *MCPServer) handleImportCategoryMappings(ctx context.Context, _ *mcpsdk.
 	if input.Content == "" {
 		return errorResult(fmt.Errorf("content is required")), nil, nil
 	}
-	result, err := s.svc.ImportMappingsTSV(context.Background(), input.Content, input.ApplyRetroactively)
+	result, err := s.svc.ImportMappingsTSV(context.Background(), input.Content, input.ApplyRetroactively, false)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -853,6 +853,7 @@ type CategoryImportResult struct {
 	Created   int      `json:"created"`
 	Updated   int      `json:"updated"`
 	Unchanged int      `json:"unchanged"`
+	Deleted   int      `json:"deleted"`
 	Errors    []string `json:"errors,omitempty"`
 }
 
@@ -861,6 +862,7 @@ type MappingImportResult struct {
 	Created             int      `json:"created"`
 	Updated             int      `json:"updated"`
 	Unchanged           int      `json:"unchanged"`
+	Deleted             int      `json:"deleted"`
 	TransactionsUpdated int64    `json:"transactions_updated"`
 	Errors              []string `json:"errors,omitempty"`
 }
@@ -921,8 +923,9 @@ func categoryToTSVRow(c CategoryResponse) []string {
 
 // ImportCategoriesTSV parses TSV content and creates/updates categories.
 // Existing slugs are updated (display_name, icon, color, sort_order, hidden).
-// New slugs are created. Missing slugs are not deleted.
-func (s *Service) ImportCategoriesTSV(ctx context.Context, content string) (*CategoryImportResult, error) {
+// New slugs are created. If replaceMode is true, non-system categories not
+// present in the import are deleted (transactions set to uncategorized).
+func (s *Service) ImportCategoriesTSV(ctx context.Context, content string, replaceMode bool) (*CategoryImportResult, error) {
 	rows, err := parseTSV(content, 7)
 	if err != nil {
 		return nil, fmt.Errorf("parse TSV: %w", err)
@@ -1066,6 +1069,36 @@ func (s *Service) ImportCategoriesTSV(ctx context.Context, content string) (*Cat
 		process(rd)
 	}
 
+	// Replace mode: delete non-system categories not present in the import.
+	if replaceMode {
+		// Collect all slugs from the import.
+		importedSlugs := make(map[string]bool)
+		for _, rd := range parents {
+			importedSlugs[rd.slug] = true
+		}
+		for _, rd := range children {
+			importedSlugs[rd.slug] = true
+		}
+
+		allCats, err := s.ListCategories(ctx)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("replace mode: failed to list categories: %v", err))
+			return result, nil
+		}
+
+		for _, c := range allCats {
+			if c.IsSystem || importedSlugs[c.Slug] {
+				continue
+			}
+			// Delete: reassign transactions to uncategorized, then delete.
+			if _, err := s.DeleteCategory(ctx, c.ID); err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("replace mode: failed to delete '%s': %v", c.Slug, err))
+				continue
+			}
+			result.Deleted++
+		}
+	}
+
 	return result, nil
 }
 
@@ -1088,7 +1121,8 @@ func (s *Service) ExportMappingsTSV(ctx context.Context) (string, error) {
 // ImportMappingsTSV parses TSV content and upserts category mappings.
 // If applyRetroactively is true, ALL non-overridden transactions matching
 // the raw category strings are re-categorized (not just uncategorized ones).
-func (s *Service) ImportMappingsTSV(ctx context.Context, content string, applyRetroactively bool) (*MappingImportResult, error) {
+// If replaceMode is true, mappings not present in the import are deleted.
+func (s *Service) ImportMappingsTSV(ctx context.Context, content string, applyRetroactively bool, replaceMode bool) (*MappingImportResult, error) {
 	rows, err := parseTSV(content, 3)
 	if err != nil {
 		return nil, fmt.Errorf("parse TSV: %w", err)
@@ -1184,6 +1218,36 @@ func (s *Service) ImportMappingsTSV(ctx context.Context, content string, applyRe
 				result.Errors = append(result.Errors, fmt.Sprintf("line %d: re-resolve error: %v", lineNum, err))
 				continue
 			}
+		}
+	}
+
+	// Replace mode: delete mappings not present in the import.
+	if replaceMode {
+		type mappingKey struct{ provider, category string }
+		importedKeys := make(map[mappingKey]bool)
+		for _, cols := range rows {
+			provider := strings.TrimSpace(cols[0])
+			providerCategory := strings.TrimSpace(cols[1])
+			if provider != "" && providerCategory != "" {
+				importedKeys[mappingKey{provider, providerCategory}] = true
+			}
+		}
+
+		allMappings, err := s.ListMappings(ctx, nil)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("replace mode: failed to list mappings: %v", err))
+			return result, nil
+		}
+
+		for _, m := range allMappings {
+			if importedKeys[mappingKey{m.Provider, m.ProviderCategory}] {
+				continue
+			}
+			if err := s.DeleteMapping(ctx, m.ID); err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("replace mode: failed to delete mapping %s/%s: %v", m.Provider, m.ProviderCategory, err))
+				continue
+			}
+			result.Deleted++
 		}
 	}
 

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -758,7 +758,7 @@ func TestImportCategoriesTSV_CreateAndUpdate(t *testing.T) {
 	tsv += "new_parent\tNew Parent\t\tfolder\t\t0\tfalse\n"
 	tsv += "new_child\tNew Child\tnew_parent\tfile\t\t0\tfalse\n"
 
-	result, err := svc.ImportCategoriesTSV(ctx, tsv)
+	result, err := svc.ImportCategoriesTSV(ctx, tsv, false)
 	if err != nil {
 		t.Fatalf("ImportCategoriesTSV: %v", err)
 	}
@@ -816,7 +816,7 @@ func TestImportCategoriesTSV_ValidationErrors(t *testing.T) {
 	tsv += "orphan_child\tOrphan Child\tghost_parent\t\t\t0\tfalse\n"
 	tsv += "valid_cat\tValid Category\t\t\t\t0\tfalse\n"
 
-	result, err := svc.ImportCategoriesTSV(ctx, tsv)
+	result, err := svc.ImportCategoriesTSV(ctx, tsv, false)
 	if err != nil {
 		t.Fatalf("ImportCategoriesTSV: %v", err)
 	}
@@ -922,7 +922,7 @@ func TestImportMappingsTSV_CreateAndUpdate(t *testing.T) {
 	tsv += "csv\ttest_food\tfood_and_drink_groceries\n"
 	tsv += "csv\ttest_new\tfood_and_drink_restaurant\n"
 
-	result, err := svc.ImportMappingsTSV(ctx, tsv, false)
+	result, err := svc.ImportMappingsTSV(ctx, tsv, false, false)
 	if err != nil {
 		t.Fatalf("ImportMappingsTSV: %v", err)
 	}
@@ -992,7 +992,7 @@ func TestImportMappingsTSV_ApplyRetroactively(t *testing.T) {
 	tsv := "provider\tprovider_category\tcategory_slug\n"
 	tsv += "plaid\tFOOD_TEST\tfood_and_drink_groceries\n"
 
-	result, err := svc.ImportMappingsTSV(ctx, tsv, true)
+	result, err := svc.ImportMappingsTSV(ctx, tsv, true, false)
 	if err != nil {
 		t.Fatalf("ImportMappingsTSV: %v", err)
 	}
@@ -1066,7 +1066,7 @@ func TestRoundTrip_CategoriesTSV(t *testing.T) {
 	dataLines := len(lines) - 1 // exclude header
 
 	// Import same content
-	result, err := svc.ImportCategoriesTSV(ctx, tsv)
+	result, err := svc.ImportCategoriesTSV(ctx, tsv, false)
 	if err != nil {
 		t.Fatalf("ImportCategoriesTSV round-trip: %v", err)
 	}
@@ -1127,7 +1127,7 @@ func TestRoundTrip_MappingsTSV(t *testing.T) {
 	dataLines := len(lines) - 1
 
 	// Import same content
-	result, err := svc.ImportMappingsTSV(ctx, tsv, false)
+	result, err := svc.ImportMappingsTSV(ctx, tsv, false, false)
 	if err != nil {
 		t.Fatalf("ImportMappingsTSV round-trip: %v", err)
 	}
@@ -1143,6 +1143,139 @@ func TestRoundTrip_MappingsTSV(t *testing.T) {
 	}
 	if len(result.Errors) != 0 {
 		t.Errorf("expected 0 errors on round-trip, got %v", result.Errors)
+	}
+}
+
+func TestImportCategoriesTSV_ReplaceMode(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Seed the uncategorized system category (required for DeleteCategory).
+	_, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "uncategorized", DisplayName: "Uncategorized", IsSystem: true,
+	})
+	if err != nil {
+		t.Fatalf("seed uncategorized: %v", err)
+	}
+
+	// Create three custom categories.
+	_, err = svc.CreateCategory(ctx, service.CreateCategoryParams{
+		DisplayName: "Keep Me",
+	})
+	if err != nil {
+		t.Fatalf("create keep_me: %v", err)
+	}
+	_, err = svc.CreateCategory(ctx, service.CreateCategoryParams{
+		DisplayName: "Delete Me",
+	})
+	if err != nil {
+		t.Fatalf("create delete_me: %v", err)
+	}
+	_, err = svc.CreateCategory(ctx, service.CreateCategoryParams{
+		DisplayName: "Also Delete",
+	})
+	if err != nil {
+		t.Fatalf("create also_delete: %v", err)
+	}
+
+	// Import with only "keep_me" — replace mode should delete the other two.
+	// System categories (uncategorized) are never deleted regardless.
+	tsv := "slug\tdisplay_name\tparent_slug\ticon\tcolor\tsort_order\thidden\n"
+	tsv += "keep_me\tKeep Me\t\t\t\t0\tfalse\n"
+
+	result, err := svc.ImportCategoriesTSV(ctx, tsv, true)
+	if err != nil {
+		t.Fatalf("ImportCategoriesTSV replace: %v", err)
+	}
+
+	if result.Deleted != 2 {
+		t.Errorf("expected Deleted=2, got %d; errors=%v", result.Deleted, result.Errors)
+	}
+	if result.Unchanged != 1 {
+		t.Errorf("expected Unchanged=1, got %d (keep_me); created=%d updated=%d", result.Unchanged, result.Created, result.Updated)
+	}
+
+	// Verify deleted categories no longer exist.
+	_, err = svc.GetCategoryBySlug(ctx, "delete_me")
+	if err == nil {
+		t.Error("expected delete_me to be deleted")
+	}
+	_, err = svc.GetCategoryBySlug(ctx, "also_delete")
+	if err == nil {
+		t.Error("expected also_delete to be deleted")
+	}
+
+	// Verify kept category still exists.
+	_, err = svc.GetCategoryBySlug(ctx, "keep_me")
+	if err != nil {
+		t.Errorf("expected keep_me to still exist: %v", err)
+	}
+}
+
+func TestImportMappingsTSV_ReplaceMode(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Create two categories.
+	catA, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "cat_a", DisplayName: "Category A",
+	})
+	if err != nil {
+		t.Fatalf("create cat_a: %v", err)
+	}
+	catB, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "cat_b", DisplayName: "Category B",
+	})
+	if err != nil {
+		t.Fatalf("create cat_b: %v", err)
+	}
+
+	// Create three mappings.
+	_, err = queries.InsertCategoryMapping(ctx, db.InsertCategoryMappingParams{
+		Provider: db.ProviderTypePlaid, ProviderCategory: "FOOD", CategoryID: catA.ID,
+	})
+	if err != nil {
+		t.Fatalf("create mapping 1: %v", err)
+	}
+	_, err = queries.InsertCategoryMapping(ctx, db.InsertCategoryMappingParams{
+		Provider: db.ProviderTypePlaid, ProviderCategory: "TRAVEL", CategoryID: catB.ID,
+	})
+	if err != nil {
+		t.Fatalf("create mapping 2: %v", err)
+	}
+	_, err = queries.InsertCategoryMapping(ctx, db.InsertCategoryMappingParams{
+		Provider: db.ProviderTypeTeller, ProviderCategory: "shopping", CategoryID: catA.ID,
+	})
+	if err != nil {
+		t.Fatalf("create mapping 3: %v", err)
+	}
+
+	// Import with only one mapping — replace mode should delete the other two.
+	tsv := "provider\tprovider_category\tcategory_slug\n"
+	tsv += "plaid\tFOOD\tcat_a\n"
+
+	result, err := svc.ImportMappingsTSV(ctx, tsv, false, true)
+	if err != nil {
+		t.Fatalf("ImportMappingsTSV replace: %v", err)
+	}
+
+	if result.Deleted != 2 {
+		t.Errorf("expected Deleted=2, got %d", result.Deleted)
+	}
+	if result.Unchanged != 1 {
+		t.Errorf("expected Unchanged=1, got %d", result.Unchanged)
+	}
+
+	// Verify only one mapping remains.
+	mappings, err := svc.ListMappings(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListMappings: %v", err)
+	}
+	if len(mappings) != 1 {
+		t.Errorf("expected 1 mapping remaining, got %d", len(mappings))
+	}
+	if len(mappings) > 0 && mappings[0].ProviderCategory != "FOOD" {
+		t.Errorf("expected remaining mapping to be FOOD, got %q", mappings[0].ProviderCategory)
 	}
 }
 

--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -362,6 +362,14 @@
             </div>
           </div>
           <textarea x-model="catText" class="textarea textarea-bordered w-full font-mono text-xs leading-relaxed" rows="12" placeholder="Click Export to load current categories, or paste TSV data here...&#10;&#10;slug&#9;display_name&#9;parent_slug&#9;icon&#9;color&#9;sort_order&#9;hidden&#10;food_and_drink&#9;Food & Drink&#9;&#9;utensils&#9;#ef4444&#9;0&#9;false" spellcheck="false"></textarea>
+          <!-- Import mode toggle -->
+          <label class="label cursor-pointer justify-start gap-3 mt-1">
+            <input type="checkbox" x-model="catReplace" class="toggle toggle-sm toggle-error">
+            <div>
+              <span class="label-text">Full replace</span>
+              <span class="text-xs text-base-content/50 block">Delete categories not in the import (system categories are kept). Off = only add &amp; update.</span>
+            </div>
+          </label>
           <!-- Result -->
           <template x-if="catResult">
             <div class="mt-2">
@@ -369,6 +377,7 @@
                 <span x-show="catResult.created > 0" class="badge badge-success badge-sm" x-text="catResult.created + ' created'"></span>
                 <span x-show="catResult.updated > 0" class="badge badge-info badge-sm" x-text="catResult.updated + ' updated'"></span>
                 <span x-show="catResult.unchanged > 0" class="badge badge-ghost badge-sm" x-text="catResult.unchanged + ' unchanged'"></span>
+                <span x-show="catResult.deleted > 0" class="badge badge-error badge-sm" x-text="catResult.deleted + ' deleted'"></span>
               </div>
               <template x-if="catResult.errors && catResult.errors.length > 0">
                 <div class="mt-2 text-sm text-error">
@@ -405,14 +414,23 @@
             </div>
           </div>
           <textarea x-model="mapText" class="textarea textarea-bordered w-full font-mono text-xs leading-relaxed" rows="12" placeholder="Click Export to load current mappings, or paste TSV data here...&#10;&#10;provider&#9;provider_category&#9;category_slug&#10;plaid&#9;FOOD_AND_DRINK_GROCERIES&#9;food_and_drink_groceries" spellcheck="false"></textarea>
-          <!-- Apply retroactively toggle -->
-          <label class="label cursor-pointer justify-start gap-3 mt-1">
-            <input type="checkbox" x-model="mapRetroactive" class="toggle toggle-sm">
-            <div>
-              <span class="label-text">Apply retroactively</span>
-              <span class="text-xs text-base-content/50 block">Re-categorize existing transactions that match updated mappings</span>
-            </div>
-          </label>
+          <!-- Import options -->
+          <div class="space-y-1 mt-1">
+            <label class="label cursor-pointer justify-start gap-3">
+              <input type="checkbox" x-model="mapReplace" class="toggle toggle-sm toggle-error">
+              <div>
+                <span class="label-text">Full replace</span>
+                <span class="text-xs text-base-content/50 block">Delete mappings not in the import. Off = only add &amp; update.</span>
+              </div>
+            </label>
+            <label class="label cursor-pointer justify-start gap-3">
+              <input type="checkbox" x-model="mapRetroactive" class="toggle toggle-sm">
+              <div>
+                <span class="label-text">Apply retroactively</span>
+                <span class="text-xs text-base-content/50 block">Re-categorize existing transactions that match updated mappings</span>
+              </div>
+            </label>
+          </div>
           <!-- Result -->
           <template x-if="mapResult">
             <div class="mt-2">
@@ -420,6 +438,7 @@
                 <span x-show="mapResult.created > 0" class="badge badge-success badge-sm" x-text="mapResult.created + ' created'"></span>
                 <span x-show="mapResult.updated > 0" class="badge badge-info badge-sm" x-text="mapResult.updated + ' updated'"></span>
                 <span x-show="mapResult.unchanged > 0" class="badge badge-ghost badge-sm" x-text="mapResult.unchanged + ' unchanged'"></span>
+                <span x-show="mapResult.deleted > 0" class="badge badge-error badge-sm" x-text="mapResult.deleted + ' deleted'"></span>
                 <span x-show="mapResult.transactions_updated > 0" class="badge badge-warning badge-sm" x-text="mapResult.transactions_updated + ' transactions re-categorized'"></span>
               </div>
               <template x-if="mapResult.errors && mapResult.errors.length > 0">
@@ -437,7 +456,7 @@
         <i data-lucide="info" class="w-5 h-5"></i>
         <div class="text-sm">
           <p class="font-semibold">How bulk edit works</p>
-          <p>Export loads the current data into the text area as tab-separated values. Edit the text (or paste from a spreadsheet), then click Import. Existing entries are updated, new ones are created. Rows you remove from the text will <strong>not</strong> be deleted — use the Categories or Mappings tabs to delete individual items.</p>
+          <p>Export loads the current data into the text area as tab-separated values. Edit the text (or paste from a spreadsheet), then click Import. By default, existing entries are updated and new ones are created — rows you remove are <strong>not</strong> deleted. Enable <strong>Full replace</strong> to also delete any entries not present in the import.</p>
         </div>
       </div>
     </div>
@@ -699,11 +718,13 @@ function bulkEditTab() {
     catLoading: false,
     catImporting: false,
     catResult: null,
+    catReplace: false,
     mapText: '',
     mapLoading: false,
     mapImporting: false,
     mapResult: null,
     mapRetroactive: false,
+    mapReplace: false,
 
     exportCategories() {
       this.catLoading = true;
@@ -717,9 +738,11 @@ function bulkEditTab() {
 
     importCategories() {
       if (!this.catText.trim()) return;
+      if (this.catReplace && !confirm('Full replace is enabled. Categories not in the import will be deleted and their transactions set to Uncategorized. Continue?')) return;
       this.catImporting = true;
       this.catResult = null;
-      fetch('/admin/api/categories/import-tsv', {
+      const params = this.catReplace ? '?replace=true' : '';
+      fetch('/admin/api/categories/import-tsv' + params, {
         method: 'POST',
         headers: {'Content-Type': 'text/tab-separated-values'},
         body: this.catText
@@ -730,7 +753,7 @@ function bulkEditTab() {
             window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: data.error.message || data.error, type:'error'}}));
           } else {
             this.catResult = data;
-            if (data.created > 0 || data.updated > 0) {
+            if (data.created > 0 || data.updated > 0 || data.deleted > 0) {
               window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Categories imported successfully', type:'success'}}));
             }
           }
@@ -751,9 +774,14 @@ function bulkEditTab() {
 
     importMappings() {
       if (!this.mapText.trim()) return;
+      if (this.mapReplace && !confirm('Full replace is enabled. Mappings not in the import will be deleted. Continue?')) return;
       this.mapImporting = true;
       this.mapResult = null;
-      const url = '/admin/api/category-mappings/import-tsv' + (this.mapRetroactive ? '?apply_retroactively=true' : '');
+      const qp = new URLSearchParams();
+      if (this.mapRetroactive) qp.set('apply_retroactively', 'true');
+      if (this.mapReplace) qp.set('replace', 'true');
+      const qs = qp.toString();
+      const url = '/admin/api/category-mappings/import-tsv' + (qs ? '?' + qs : '');
       fetch(url, {
         method: 'POST',
         headers: {'Content-Type': 'text/tab-separated-values'},
@@ -765,7 +793,7 @@ function bulkEditTab() {
             window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: data.error.message || data.error, type:'error'}}));
           } else {
             this.mapResult = data;
-            if (data.created > 0 || data.updated > 0) {
+            if (data.created > 0 || data.updated > 0 || data.deleted > 0) {
               window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Mappings imported successfully', type:'success'}}));
             }
           }


### PR DESCRIPTION
Service layer:
- ImportCategoriesTSV and ImportMappingsTSV accept a replaceMode param
- When enabled, categories/mappings not present in the import are deleted
- System categories (uncategorized) are never deleted in replace mode
- Result structs include a Deleted count

Admin UI:
- "Full replace" toggle (off by default) on both Categories and Mappings sections in the Bulk Edit tab, with red toggle styling and clear description
- Confirmation dialog when replace mode is enabled before import
- Deleted count shown as red badge in results

API:
- All import endpoints accept ?replace=true query param
- MCP tool callers pass false for backwards compatibility

Integration tests:
- TestImportCategoriesTSV_ReplaceMode: verifies deletion of non-imported categories while preserving system and imported ones
- TestImportMappingsTSV_ReplaceMode: verifies deletion of non-imported mappings while preserving imported ones

https://claude.ai/code/session_01HsNjqY6U5X1zV8ncMvVi7p