### PR TITLE
Add merge_into column for category consolidation during bulk import

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -35,6 +35,7 @@ CATEGORY SYSTEM:
 - Use list_unmapped_categories to find raw provider categories without mappings
 - Use list_category_mappings, create_category_mapping, update_category_mapping, delete_category_mapping to manage how provider category strings map to user categories
 - For bulk editing: use export_categories / import_categories and export_category_mappings / import_category_mappings to export TSV text, edit it, and re-import. Set apply_retroactively=true on import_category_mappings to update ALL matching transactions (not just uncategorized)
+- To simplify/consolidate categories: export categories, then set the merge_into column to a target slug for categories you want to merge. All transactions and mappings from the source are moved to the target. This preserves categorization history while reducing complexity
 
 TOKEN EFFICIENCY:
 - Use the fields parameter on query_transactions to request only needed fields (e.g., fields=core,category). Aliases: core (id,date,amount,name,iso_currency_code), category (category,category_primary_raw,category_detailed_raw), timestamps (created_at,updated_at,datetime,authorized_datetime)
@@ -152,10 +153,10 @@ func (s *MCPServer) buildToolRegistry() {
 			"Get aggregated transaction totals grouped by category and/or time period. Replaces the need to paginate through thousands of individual transactions for spending analysis. Amounts follow the convention: positive = money out (debit), negative = money in (credit). Only includes non-deleted, non-pending transactions by default.",
 			s.handleTransactionSummary),
 		makeToolDef("export_categories", ToolRead,
-			"Export all category definitions as TSV text. The returned format can be edited externally (in a text editor, by an AI agent, etc.) and re-imported via import_categories. Columns: slug, display_name, parent_slug, icon, color, sort_order, hidden. Slugs are immutable identifiers; display_name and other fields can be changed.",
+			"Export all category definitions as TSV text. The returned format can be edited externally (in a text editor, by an AI agent, etc.) and re-imported via import_categories. Columns: slug, display_name, parent_slug, icon, color, sort_order, hidden, merge_into. Slugs are immutable identifiers; display_name and other fields can be changed. The merge_into column is empty on export.",
 			s.handleExportCategories),
 		makeToolDef("import_categories", ToolWrite,
-			"Import category definitions from TSV text. Existing slugs are updated (display_name, icon, color, sort_order, hidden). New slugs are created. Missing slugs are NOT deleted. Parents must appear before children. Use export_categories to get the current state, edit it, then import the modified version.",
+			"Import category definitions from TSV text. Existing slugs are updated (display_name, icon, color, sort_order, hidden). New slugs are created. Missing slugs are NOT deleted. Parents must appear before children. Use export_categories to get the current state, edit it, then import the modified version. To merge/consolidate categories, set the merge_into column to the target category slug — all transactions and mappings from the source are reassigned to the target, then the source is deleted. This is useful for simplifying a complex taxonomy without losing transaction categorization.",
 			s.handleImportCategories),
 		makeToolDef("export_category_mappings", ToolRead,
 			"Export all category mappings as TSV text. Columns: provider, provider_category, category_slug. The returned format can be edited and re-imported via import_category_mappings. Use this for bulk editing of how provider category strings map to user categories.",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -108,7 +108,7 @@ type submitReviewInput struct {
 type exportCategoriesInput struct{}
 
 type importCategoriesInput struct {
-	Content string `json:"content" jsonschema:"required,TSV content with category definitions. Columns: slug, display_name, parent_slug, icon, color, sort_order, hidden"`
+	Content string `json:"content" jsonschema:"required,TSV content with category definitions. Columns: slug, display_name, parent_slug, icon, color, sort_order, hidden, merge_into. The merge_into column is optional — set to a target slug to merge the source category into the target (transactions and mappings reassigned then source deleted)."`
 }
 
 type exportCategoryMappingsInput struct{}

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -853,6 +853,7 @@ type CategoryImportResult struct {
 	Created   int      `json:"created"`
 	Updated   int      `json:"updated"`
 	Unchanged int      `json:"unchanged"`
+	Merged    int      `json:"merged"`
 	Deleted   int      `json:"deleted"`
 	Errors    []string `json:"errors,omitempty"`
 }
@@ -877,7 +878,7 @@ func (s *Service) ExportCategoriesTSV(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("list categories: %w", err)
 	}
 
-	headers := []string{"slug", "display_name", "parent_slug", "icon", "color", "sort_order", "hidden"}
+	headers := []string{"slug", "display_name", "parent_slug", "icon", "color", "sort_order", "hidden", "merge_into"}
 	var rows [][]string
 
 	// Parents first, then children — stable ordering
@@ -918,6 +919,7 @@ func categoryToTSVRow(c CategoryResponse) []string {
 		color,
 		strconv.Itoa(int(c.SortOrder)),
 		strconv.FormatBool(c.Hidden),
+		"", // merge_into — empty on export
 	}
 }
 
@@ -926,7 +928,7 @@ func categoryToTSVRow(c CategoryResponse) []string {
 // New slugs are created. If replaceMode is true, non-system categories not
 // present in the import are deleted (transactions set to uncategorized).
 func (s *Service) ImportCategoriesTSV(ctx context.Context, content string, replaceMode bool) (*CategoryImportResult, error) {
-	rows, err := parseTSV(content, 7)
+	rows, err := parseTSV(content, 7, 8)
 	if err != nil {
 		return nil, fmt.Errorf("parse TSV: %w", err)
 	}
@@ -942,9 +944,11 @@ func (s *Service) ImportCategoriesTSV(ctx context.Context, content string, repla
 		color       string
 		sortOrder   int32
 		hidden      bool
+		mergeInto   string
 	}
 
 	var parents, children []rowData
+	var merges []rowData // rows with merge_into set
 
 	for i, cols := range rows {
 		lineNum := i + 2 // 1-indexed, skip header
@@ -952,6 +956,7 @@ func (s *Service) ImportCategoriesTSV(ctx context.Context, content string, repla
 		slug := strings.TrimSpace(cols[0])
 		displayName := strings.TrimSpace(cols[1])
 		parentSlug := strings.TrimSpace(cols[2])
+		mergeInto := strings.TrimSpace(cols[7]) // 8th column, empty if not present
 
 		if slug == "" {
 			result.Errors = append(result.Errors, fmt.Sprintf("line %d: slug is required", lineNum))
@@ -961,6 +966,13 @@ func (s *Service) ImportCategoriesTSV(ctx context.Context, content string, repla
 			result.Errors = append(result.Errors, fmt.Sprintf("line %d: invalid slug '%s' (must be lowercase alphanumeric with underscores)", lineNum, slug))
 			continue
 		}
+
+		// If merge_into is set, this row is a merge instruction — not a category definition.
+		if mergeInto != "" {
+			merges = append(merges, rowData{lineNum: lineNum, slug: slug, mergeInto: mergeInto})
+			continue
+		}
+
 		if displayName == "" {
 			result.Errors = append(result.Errors, fmt.Sprintf("line %d: display_name is required", lineNum))
 			continue
@@ -1069,6 +1081,53 @@ func (s *Service) ImportCategoriesTSV(ctx context.Context, content string, repla
 		process(rd)
 	}
 
+	// Process merge instructions: merge source → target (transactions + mappings reassigned).
+	// Children of the source are also merged into the target before the source is deleted.
+	for _, m := range merges {
+		source, err := s.Queries.GetCategoryBySlug(ctx, m.slug)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				// Source doesn't exist — nothing to merge, skip silently
+				continue
+			}
+			result.Errors = append(result.Errors, fmt.Sprintf("line %d: merge lookup error for '%s': %v", m.lineNum, m.slug, err))
+			continue
+		}
+		target, err := s.Queries.GetCategoryBySlug(ctx, m.mergeInto)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				result.Errors = append(result.Errors, fmt.Sprintf("line %d: merge target '%s' not found", m.lineNum, m.mergeInto))
+			} else {
+				result.Errors = append(result.Errors, fmt.Sprintf("line %d: merge target lookup error: %v", m.lineNum, err))
+			}
+			continue
+		}
+
+		sourceID := formatUUID(source.ID)
+		targetID := formatUUID(target.ID)
+
+		// Merge children of source into target first
+		childIDs, err := s.Queries.ListChildCategoryIDs(ctx, source.ID)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("line %d: list children error: %v", m.lineNum, err))
+			continue
+		}
+		for _, childID := range childIDs {
+			childIDStr := formatUUID(childID)
+			if err := s.MergeCategories(ctx, childIDStr, targetID); err != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("line %d: merge child error: %v", m.lineNum, err))
+			} else {
+				result.Merged++
+			}
+		}
+
+		if err := s.MergeCategories(ctx, sourceID, targetID); err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("line %d: merge '%s' → '%s' error: %v", m.lineNum, m.slug, m.mergeInto, err))
+			continue
+		}
+		result.Merged++
+	}
+
 	// Replace mode: delete non-system categories not present in the import.
 	if replaceMode {
 		// Collect all slugs from the import.
@@ -1123,7 +1182,7 @@ func (s *Service) ExportMappingsTSV(ctx context.Context) (string, error) {
 // the raw category strings are re-categorized (not just uncategorized ones).
 // If replaceMode is true, mappings not present in the import are deleted.
 func (s *Service) ImportMappingsTSV(ctx context.Context, content string, applyRetroactively bool, replaceMode bool) (*MappingImportResult, error) {
-	rows, err := parseTSV(content, 3)
+	rows, err := parseTSV(content, 3, 3)
 	if err != nil {
 		return nil, fmt.Errorf("parse TSV: %w", err)
 	}
@@ -1290,8 +1349,10 @@ func formatTSV(headers []string, rows [][]string) string {
 }
 
 // parseTSV parses TSV content, validates column count, skips empty lines.
-// Returns data rows (header excluded).
-func parseTSV(content string, expectedCols int) ([][]string, error) {
+// Returns data rows (header excluded). Rows are padded to maxCols if shorter.
+// minCols is the minimum accepted column count; maxCols is the maximum.
+// If minCols == maxCols, the column count must be exact.
+func parseTSV(content string, minCols, maxCols int) ([][]string, error) {
 	// Normalize line endings
 	content = strings.ReplaceAll(content, "\r\n", "\n")
 	content = strings.ReplaceAll(content, "\r", "\n")
@@ -1311,8 +1372,11 @@ func parseTSV(content string, expectedCols int) ([][]string, error) {
 	}
 
 	headerCols := strings.Split(lines[headerIdx], "\t")
-	if len(headerCols) != expectedCols {
-		return nil, fmt.Errorf("expected %d columns, got %d in header", expectedCols, len(headerCols))
+	if len(headerCols) < minCols || len(headerCols) > maxCols {
+		if minCols == maxCols {
+			return nil, fmt.Errorf("expected %d columns, got %d in header", minCols, len(headerCols))
+		}
+		return nil, fmt.Errorf("expected %d-%d columns, got %d in header", minCols, maxCols, len(headerCols))
 	}
 
 	var rows [][]string
@@ -1321,8 +1385,15 @@ func parseTSV(content string, expectedCols int) ([][]string, error) {
 			continue
 		}
 		cols := strings.Split(line, "\t")
-		if len(cols) != expectedCols {
-			return nil, fmt.Errorf("expected %d columns, got %d: %s", expectedCols, len(cols), line)
+		if len(cols) < minCols || len(cols) > maxCols {
+			if minCols == maxCols {
+				return nil, fmt.Errorf("expected %d columns, got %d: %s", minCols, len(cols), line)
+			}
+			return nil, fmt.Errorf("expected %d-%d columns, got %d: %s", minCols, maxCols, len(cols), line)
+		}
+		// Pad to maxCols for uniform access
+		for len(cols) < maxCols {
+			cols = append(cols, "")
 		}
 		rows = append(rows, cols)
 	}

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -712,7 +712,7 @@ func TestExportCategoriesTSV(t *testing.T) {
 	}
 
 	// Check header
-	expectedHeader := "slug\tdisplay_name\tparent_slug\ticon\tcolor\tsort_order\thidden"
+	expectedHeader := "slug\tdisplay_name\tparent_slug\ticon\tcolor\tsort_order\thidden\tmerge_into"
 	if lines[0] != expectedHeader {
 		t.Errorf("expected header %q, got %q", expectedHeader, lines[0])
 	}
@@ -1276,6 +1276,198 @@ func TestImportMappingsTSV_ReplaceMode(t *testing.T) {
 	}
 	if len(mappings) > 0 && mappings[0].ProviderCategory != "FOOD" {
 		t.Errorf("expected remaining mapping to be FOOD, got %q", mappings[0].ProviderCategory)
+	}
+}
+
+func TestImportCategoriesTSV_MergeInto(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	// Seed uncategorized (required for DeleteCategory inside MergeCategories).
+	_, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "uncategorized", DisplayName: "Uncategorized", IsSystem: true,
+	})
+	if err != nil {
+		t.Fatalf("seed uncategorized: %v", err)
+	}
+
+	// Create source and target categories directly in DB.
+	sourceCat, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "old_coffee", DisplayName: "Coffee Shops",
+	})
+	if err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+	targetCat, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "food_and_drink", DisplayName: "Food & Drink",
+	})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+
+	// Create a transaction categorized under the source.
+	user := testutil.MustCreateUser(t, queries, "merge-user")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "merge-conn")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "merge-acct", "Merge Account")
+
+	_, err = queries.UpsertTransaction(ctx, db.UpsertTransactionParams{
+		AccountID:             acct.ID,
+		ExternalTransactionID: "txn_merge_1",
+		Amount:                pgtype.Numeric{Int: big.NewInt(550), Exp: -2, Valid: true},
+		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
+		Date:                  pgtype.Date{Time: testutil.MustParseDate("2025-01-15"), Valid: true},
+		Name:                  "Starbucks",
+		CategoryID:            sourceCat.ID,
+	})
+	if err != nil {
+		t.Fatalf("create transaction: %v", err)
+	}
+
+	// Create a mapping pointing to source.
+	_, err = queries.InsertCategoryMapping(ctx, db.InsertCategoryMappingParams{
+		Provider: db.ProviderTypePlaid, ProviderCategory: "COFFEE", CategoryID: sourceCat.ID,
+	})
+	if err != nil {
+		t.Fatalf("create mapping: %v", err)
+	}
+
+	// Import with merge_into: old_coffee → food_and_drink
+	tsv := "slug\tdisplay_name\tparent_slug\ticon\tcolor\tsort_order\thidden\tmerge_into\n"
+	tsv += "food_and_drink\tFood & Drink\t\tutensils\t#f97316\t0\tfalse\t\n"
+	tsv += "old_coffee\t\t\t\t\t\t\tfood_and_drink\n"
+
+	result, err := svc.ImportCategoriesTSV(ctx, tsv, false)
+	if err != nil {
+		t.Fatalf("ImportCategoriesTSV merge: %v", err)
+	}
+
+	if result.Merged != 1 {
+		t.Errorf("expected Merged=1, got %d; errors=%v", result.Merged, result.Errors)
+	}
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+
+	// Verify source category no longer exists.
+	_, err = svc.GetCategoryBySlug(ctx, "old_coffee")
+	if err == nil {
+		t.Error("expected old_coffee to be deleted after merge")
+	}
+
+	// Verify transaction was reassigned to target.
+	var gotCatID pgtype.UUID
+	err = pool.QueryRow(ctx,
+		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_merge_1'",
+	).Scan(&gotCatID)
+	if err != nil {
+		t.Fatalf("query transaction: %v", err)
+	}
+	if gotCatID.Bytes != targetCat.ID.Bytes {
+		t.Errorf("expected transaction category_id=%v, got %v", targetCat.ID, gotCatID)
+	}
+
+	// Verify mapping was reassigned to target.
+	mapping, err := queries.GetCategoryMappingByProviderCategory(ctx, db.GetCategoryMappingByProviderCategoryParams{
+		Provider: db.ProviderTypePlaid, ProviderCategory: "COFFEE",
+	})
+	if err != nil {
+		t.Fatalf("get mapping: %v", err)
+	}
+	if mapping.CategoryID.Bytes != targetCat.ID.Bytes {
+		t.Errorf("expected mapping category_id=%v, got %v", targetCat.ID, mapping.CategoryID)
+	}
+}
+
+func TestImportCategoriesTSV_MergeWithChildren(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Seed uncategorized.
+	_, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "uncategorized", DisplayName: "Uncategorized", IsSystem: true,
+	})
+	if err != nil {
+		t.Fatalf("seed uncategorized: %v", err)
+	}
+
+	// Create parent with children.
+	parent, err := svc.CreateCategory(ctx, service.CreateCategoryParams{
+		Slug: "old_parent", DisplayName: "Old Parent",
+	})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	_, err = svc.CreateCategory(ctx, service.CreateCategoryParams{
+		Slug: "old_child_1", DisplayName: "Old Child 1", ParentID: &parent.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child 1: %v", err)
+	}
+	_, err = svc.CreateCategory(ctx, service.CreateCategoryParams{
+		Slug: "old_child_2", DisplayName: "Old Child 2", ParentID: &parent.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child 2: %v", err)
+	}
+
+	// Create target.
+	_, err = svc.CreateCategory(ctx, service.CreateCategoryParams{
+		Slug: "new_target", DisplayName: "New Target",
+	})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+
+	// Merge parent (which has 2 children) → target. Should merge 3 total (2 children + 1 parent).
+	tsv := "slug\tdisplay_name\tparent_slug\ticon\tcolor\tsort_order\thidden\tmerge_into\n"
+	tsv += "new_target\tNew Target\t\t\t\t0\tfalse\t\n"
+	tsv += "old_parent\t\t\t\t\t\t\tnew_target\n"
+
+	result, err := svc.ImportCategoriesTSV(ctx, tsv, false)
+	if err != nil {
+		t.Fatalf("ImportCategoriesTSV merge with children: %v", err)
+	}
+
+	if result.Merged != 3 {
+		t.Errorf("expected Merged=3 (2 children + 1 parent), got %d; errors=%v", result.Merged, result.Errors)
+	}
+
+	// All three should be gone.
+	for _, slug := range []string{"old_parent", "old_child_1", "old_child_2"} {
+		_, err := svc.GetCategoryBySlug(ctx, slug)
+		if err == nil {
+			t.Errorf("expected %s to be deleted after merge", slug)
+		}
+	}
+}
+
+func TestImportCategoriesTSV_MergeNonexistentSource(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	// Create target only — source doesn't exist. Should skip silently.
+	_, err := svc.CreateCategory(ctx, service.CreateCategoryParams{
+		Slug: "target_cat", DisplayName: "Target",
+	})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+
+	tsv := "slug\tdisplay_name\tparent_slug\ticon\tcolor\tsort_order\thidden\tmerge_into\n"
+	tsv += "target_cat\tTarget\t\t\t\t0\tfalse\t\n"
+	tsv += "nonexistent\t\t\t\t\t\t\ttarget_cat\n"
+
+	result, err := svc.ImportCategoriesTSV(ctx, tsv, false)
+	if err != nil {
+		t.Fatalf("ImportCategoriesTSV: %v", err)
+	}
+
+	// Should skip the nonexistent source silently (no error, no merge count).
+	if result.Merged != 0 {
+		t.Errorf("expected Merged=0, got %d", result.Merged)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("expected 0 errors, got %v", result.Errors)
 	}
 }
 

--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -346,9 +346,12 @@
                 <i data-lucide="list-tree" class="w-5 h-5"></i>
                 Categories
               </h2>
-              <p class="text-xs text-base-content/50 mt-0.5">TSV format: slug, display_name, parent_slug, icon, color, sort_order, hidden</p>
+              <p class="text-xs text-base-content/50 mt-0.5">TSV format: slug, display_name, parent_slug, icon, color, sort_order, hidden, merge_into</p>
             </div>
             <div class="flex gap-2">
+              <button class="btn btn-sm btn-ghost btn-square" title="Copy agent instructions" @click="copyAgentInstructions()">
+                <i data-lucide="bot" class="w-4 h-4"></i>
+              </button>
               <button class="btn btn-sm btn-outline" :disabled="catLoading" @click="exportCategories()">
                 <i data-lucide="download" class="w-4 h-4"></i>
                 <span x-show="!catLoading">Export</span>
@@ -361,7 +364,7 @@
               </button>
             </div>
           </div>
-          <textarea x-model="catText" class="textarea textarea-bordered w-full font-mono text-xs leading-relaxed" rows="12" placeholder="Click Export to load current categories, or paste TSV data here...&#10;&#10;slug&#9;display_name&#9;parent_slug&#9;icon&#9;color&#9;sort_order&#9;hidden&#10;food_and_drink&#9;Food & Drink&#9;&#9;utensils&#9;#ef4444&#9;0&#9;false" spellcheck="false"></textarea>
+          <textarea x-model="catText" class="textarea textarea-bordered w-full font-mono text-xs leading-relaxed" rows="12" placeholder="Click Export to load current categories, or paste TSV data here...&#10;&#10;slug&#9;display_name&#9;parent_slug&#9;icon&#9;color&#9;sort_order&#9;hidden&#9;merge_into&#10;food_and_drink&#9;Food & Drink&#9;&#9;utensils&#9;#ef4444&#9;0&#9;false&#9;&#10;old_category&#9;&#9;&#9;&#9;&#9;&#9;&#9;food_and_drink" spellcheck="false"></textarea>
           <!-- Import mode toggle -->
           <label class="label cursor-pointer justify-start gap-3 mt-1">
             <input type="checkbox" x-model="catReplace" class="toggle toggle-sm toggle-error">
@@ -377,6 +380,7 @@
                 <span x-show="catResult.created > 0" class="badge badge-success badge-sm" x-text="catResult.created + ' created'"></span>
                 <span x-show="catResult.updated > 0" class="badge badge-info badge-sm" x-text="catResult.updated + ' updated'"></span>
                 <span x-show="catResult.unchanged > 0" class="badge badge-ghost badge-sm" x-text="catResult.unchanged + ' unchanged'"></span>
+                <span x-show="catResult.merged > 0" class="badge badge-warning badge-sm" x-text="catResult.merged + ' merged'"></span>
                 <span x-show="catResult.deleted > 0" class="badge badge-error badge-sm" x-text="catResult.deleted + ' deleted'"></span>
               </div>
               <template x-if="catResult.errors && catResult.errors.length > 0">
@@ -457,6 +461,7 @@
         <div class="text-sm">
           <p class="font-semibold">How bulk edit works</p>
           <p>Export loads the current data into the text area as tab-separated values. Edit the text (or paste from a spreadsheet), then click Import. By default, existing entries are updated and new ones are created — rows you remove are <strong>not</strong> deleted. Enable <strong>Full replace</strong> to also delete any entries not present in the import.</p>
+          <p class="mt-1"><strong>Merging categories:</strong> To consolidate categories, set the <code>merge_into</code> column to the target category's slug. All transactions and mappings from the source category are moved to the target, then the source is deleted. Great for simplifying a complex taxonomy. Use the <i data-lucide="bot" class="w-3 h-3 inline"></i> button to copy instructions for an AI agent to help you edit the file.</p>
         </div>
       </div>
     </div>
@@ -725,6 +730,48 @@ function bulkEditTab() {
     mapResult: null,
     mapRetroactive: false,
     mapReplace: false,
+
+    copyAgentInstructions() {
+      const instructions = `## Breadbox Category Editor Instructions
+
+You are editing the category taxonomy for a personal finance app. The data is in TSV (tab-separated values) format with these columns:
+
+slug | display_name | parent_slug | icon | color | sort_order | hidden | merge_into
+
+### Column Reference
+- **slug**: Unique identifier (lowercase_with_underscores). Immutable once created.
+- **display_name**: Human-readable name shown in the UI.
+- **parent_slug**: Leave empty for top-level categories. Set to a parent's slug for subcategories (two-level hierarchy max).
+- **icon**: Lucide icon name (e.g., "utensils", "car", "home"). See lucide.dev/icons.
+- **color**: Hex color (e.g., "#ef4444"). Used in charts and badges.
+- **sort_order**: Integer for display ordering within a level. Lower numbers appear first.
+- **hidden**: "true" or "false". Hidden categories still work for mapping but don't appear in the UI.
+- **merge_into**: Leave empty to keep/create the category. Set to another slug to merge this category INTO that target — all transactions and mappings will be reassigned to the target, then this category is deleted.
+
+### How to Simplify Categories
+1. Keep the rows for categories you want to retain (edit display_name, icon, etc. as needed).
+2. For categories you want to consolidate, set \`merge_into\` to the target slug. You can leave display_name and other fields empty on merge rows since the row will be deleted after merging.
+3. For categories you want to delete entirely (transactions go to "uncategorized"), simply remove the row and enable "Full replace" mode on import.
+4. The "uncategorized" system category cannot be deleted or merged.
+5. Parents must appear before their children in the file.
+
+### Example
+\`\`\`tsv
+slug	display_name	parent_slug	icon	color	sort_order	hidden	merge_into
+food_and_drink	Food & Drink		utensils	#f97316	0	false
+food_and_drink_groceries	Groceries	food_and_drink	shopping-cart	#22c55e	1	false
+food_and_drink_coffee							food_and_drink
+food_and_drink_fast_food							food_and_drink
+\`\`\`
+In this example, "coffee" and "fast_food" are merged into "food_and_drink" (their transactions move to the parent).
+
+### Current Category Data
+Paste the exported TSV below this line, then edit it according to the instructions above.
+`;
+      navigator.clipboard.writeText(instructions).then(() => {
+        window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Agent instructions copied to clipboard',type:'success'}}));
+      });
+    },
 
     exportCategories() {
       this.catLoading = true;


### PR DESCRIPTION
Enables users (and AI agents) to merge categories during TSV import by setting the optional 8th column (merge_into) to a target category slug. All transactions and mappings from the source are reassigned to the target, then the source is deleted. Children of the source are also merged into the target automatically.

Service layer:
- parseTSV now accepts min/max column counts for flexible parsing
- ImportCategoriesTSV accepts 7 or 8 columns (backwards compatible)
- Merge rows are processed after creates/updates but before replace mode deletes, ensuring merge targets exist
- CategoryImportResult includes a Merged count
- Source categories that don't exist are silently skipped

Admin UI:
- Agent instructions button (bot icon) copies a detailed prompt to clipboard explaining the TSV format, merge_into semantics, and how to simplify a taxonomy
- Info card explains the merge_into workflow
- Merged count shown as warning badge in results
- Updated placeholder shows merge_into example

MCP:
- Updated export_categories, import_categories tool descriptions
- Updated input struct jsonschema description
- Added consolidation guidance to server instructions

Integration tests:
- TestImportCategoriesTSV_MergeInto: verifies transactions and mappings are reassigned from source to target
- TestImportCategoriesTSV_MergeWithChildren: verifies parent with children merges all 3 categories into target
- TestImportCategoriesTSV_MergeNonexistentSource: verifies silent skip

https://claude.ai/code/session_01HsNjqY6U5X1zV8ncMvVi7p