### PR TITLE
Add "Dismiss All" batch action for pending reviews

### DIFF
--- a/internal/admin/reviews.go
+++ b/internal/admin/reviews.go
@@ -198,6 +198,22 @@ func EnqueueReviewAdminHandler(a *app.App, sm *scs.SessionManager, svc *service.
 	}
 }
 
+// DismissAllReviewsAdminHandler handles POST /admin/api/reviews/dismiss-all.
+func DismissAllReviewsAdminHandler(a *app.App, sm *scs.SessionManager, svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		actor := ActorFromSession(sm, r)
+
+		count, err := svc.DismissAllPendingReviews(r.Context(), actor)
+		if err != nil {
+			a.Logger.Error("dismiss all reviews", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal server error"})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "dismissed": count})
+	}
+}
+
 // ReviewSettingsHandler handles POST /admin/api/reviews/settings.
 func ReviewSettingsHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -148,6 +148,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// Review queue
 		r.Post("/reviews/{id}/submit", SubmitReviewAdminHandler(a, sm, svc))
 		r.Post("/reviews/{id}/dismiss", DismissReviewAdminHandler(a, sm, svc))
+		r.Post("/reviews/dismiss-all", DismissAllReviewsAdminHandler(a, sm, svc))
 		r.Post("/reviews/enqueue", EnqueueReviewAdminHandler(a, sm, svc))
 		r.Post("/reviews/settings", ReviewSettingsHandler(a, sm))
 	})

--- a/internal/db/queries/reviews.sql
+++ b/internal/db/queries/reviews.sql
@@ -25,6 +25,9 @@ RETURNING *;
 -- name: DeleteReview :exec
 DELETE FROM review_queue WHERE id = $1 AND status = 'pending';
 
+-- name: DeleteAllPendingReviews :execrows
+DELETE FROM review_queue WHERE status = 'pending';
+
 -- name: CountPendingReviews :one
 SELECT COUNT(*) FROM review_queue WHERE status = 'pending';
 

--- a/internal/service/reviews.go
+++ b/internal/service/reviews.go
@@ -688,6 +688,28 @@ func (s *Service) DismissReview(ctx context.Context, id string, actor Actor) err
 	return nil
 }
 
+// DismissAllPendingReviews removes all pending review items from the queue.
+func (s *Service) DismissAllPendingReviews(ctx context.Context, actor Actor) (int64, error) {
+	count, err := s.Queries.DeleteAllPendingReviews(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("delete all pending reviews: %w", err)
+	}
+
+	if count > 0 {
+		_ = s.WriteAuditLog(ctx, []AuditLogEntry{{
+			EntityType: "review_queue",
+			EntityID:   "all",
+			Action:     "bulk_delete",
+			Actor:      actor,
+			Metadata: map[string]string{
+				"count": fmt.Sprintf("%d", count),
+			},
+		}})
+	}
+
+	return count, nil
+}
+
 // reviewFromRow converts a db.ReviewQueue row to a ReviewResponse, enriching with category slugs.
 func (s *Service) reviewFromRow(ctx context.Context, r db.ReviewQueue) ReviewResponse {
 	resp := ReviewResponse{

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -3,6 +3,48 @@
 
 <div class="flex items-center justify-between mb-6 flex-wrap gap-3">
   <h1 class="text-2xl font-bold">Reviews</h1>
+  {{if and (eq .StatusFilter "pending") .Counts (gt .Counts.Pending 0)}}
+  <div x-data="{ dismissing: false, confirmOpen: false }">
+    <button class="btn btn-sm btn-error btn-outline gap-1" @click="confirmOpen = true" :disabled="dismissing">
+      <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+      Dismiss All
+    </button>
+    <!-- Confirmation modal -->
+    <dialog class="modal" :class="{ 'modal-open': confirmOpen }">
+      <div class="modal-box">
+        <h3 class="text-lg font-bold">Dismiss all pending reviews?</h3>
+        <p class="py-4">This will permanently remove all <strong>{{.Counts.Pending}}</strong> pending reviews from the queue. This cannot be undone.</p>
+        <div class="modal-action">
+          <button class="btn btn-ghost" @click="confirmOpen = false" :disabled="dismissing">Cancel</button>
+          <button class="btn btn-error gap-1" :disabled="dismissing"
+            @click="dismissing = true;
+              fetch('/admin/api/reviews/dismiss-all', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken }
+              })
+              .then(r => r.json())
+              .then(data => {
+                if (data.error) {
+                  window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: data.error, type:'error'}}));
+                  dismissing = false;
+                } else {
+                  window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: data.dismissed + ' reviews dismissed', type:'info'}}));
+                  setTimeout(() => window.location.reload(), 500);
+                }
+              })
+              .catch(() => {
+                window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Network error', type:'error'}}));
+                dismissing = false;
+              })">
+            <span x-show="!dismissing">Dismiss All</span>
+            <span x-show="dismissing" class="loading loading-spinner loading-xs"></span>
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop" @click="confirmOpen = false"><button>close</button></form>
+    </dialog>
+  </div>
+  {{end}}
 </div>
 
 <!-- Stats -->


### PR DESCRIPTION
Adds a button in the review page header (visible when viewing pending reviews) that dismisses all pending reviews at once with a confirmation modal. Includes a new DeleteAllPendingReviews SQL query, service method with audit logging, and admin API endpoint at POST /admin/api/reviews/dismiss-all.

https://claude.ai/code/session_01SY5m45RcQFyzaoEazPDbdX