### PR TITLE
Soft-delete transactions when removing a connection

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -400,10 +400,36 @@ func DeleteConnectionHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 			}
 		}
 
-		// Soft-delete the connection locally.
-		err = a.Queries.DeleteBankConnection(ctx, connID)
+		// Soft-delete related transactions and the connection in a single transaction.
+		tx, err := a.DB.Begin(ctx)
+		if err != nil {
+			a.Logger.Error("begin delete connection tx", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to delete connection"})
+			return
+		}
+		defer tx.Rollback(ctx)
+
+		txQueries := a.Queries.WithTx(tx)
+
+		deleted, err := txQueries.SoftDeleteTransactionsByConnectionID(ctx, connID)
+		if err != nil {
+			a.Logger.Error("soft delete transactions for connection", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to delete connection"})
+			return
+		}
+		if deleted > 0 {
+			a.Logger.Info("soft-deleted transactions for connection", "connection_id", idStr, "count", deleted)
+		}
+
+		err = txQueries.DeleteBankConnection(ctx, connID)
 		if err != nil {
 			a.Logger.Error("delete bank connection", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to delete connection"})
+			return
+		}
+
+		if err := tx.Commit(ctx); err != nil {
+			a.Logger.Error("commit delete connection tx", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to delete connection"})
 			return
 		}

--- a/internal/db/queries/transactions.sql
+++ b/internal/db/queries/transactions.sql
@@ -35,5 +35,10 @@ RETURNING *;
 -- name: SoftDeleteTransactionByExternalID :exec
 UPDATE transactions SET deleted_at = NOW() WHERE external_transaction_id = $1 AND deleted_at IS NULL;
 
+-- name: SoftDeleteTransactionsByConnectionID :execrows
+UPDATE transactions SET deleted_at = NOW()
+WHERE account_id IN (SELECT id FROM accounts WHERE connection_id = $1)
+  AND deleted_at IS NULL;
+
 -- name: GetTransaction :one
 SELECT * FROM transactions WHERE id = $1 AND deleted_at IS NULL;

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -1481,3 +1481,42 @@ func formatUUID(u pgtype.UUID) string {
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
 		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
+
+// --- Connection Deletion Soft-Deletes Transactions ---
+
+func TestSoftDeleteTransactionsByConnectionID(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Create two connections with accounts and transactions.
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn1 := testutil.MustCreateConnection(t, queries, user.ID, "item_del_1")
+	conn2 := testutil.MustCreateConnection(t, queries, user.ID, "item_del_2")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_acct_1", "Checking")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_acct_2", "Savings")
+
+	testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_c1_a", "Coffee", 5, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_c1_b", "Lunch", 15, "2025-01-16")
+	testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_c2_a", "Groceries", 50, "2025-01-15")
+
+	// Soft-delete transactions for connection 1 only.
+	deleted, err := queries.SoftDeleteTransactionsByConnectionID(ctx, conn1.ID)
+	if err != nil {
+		t.Fatalf("soft delete by connection: %v", err)
+	}
+	if deleted != 2 {
+		t.Fatalf("expected 2 deleted, got %d", deleted)
+	}
+
+	// Only connection 2's transaction should remain visible.
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{})
+	if err != nil {
+		t.Fatalf("list transactions: %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 visible transaction, got %d", len(result.Transactions))
+	}
+	if result.Transactions[0].Name != "Groceries" {
+		t.Errorf("expected Groceries, got %s", result.Transactions[0].Name)
+	}
+}


### PR DESCRIPTION
When a connection is deleted, all transactions belonging to its accounts
are now soft-deleted (deleted_at = NOW()) within the same DB transaction.
This ensures removed connections' transactions don't appear in listings.

https://claude.ai/code/session_01B27ZZ2iVG51xsMBfbPTeKi