### PR TITLE
Fix transactions page performance: concurrent queries, minimal COUNT, deduplicate category JSON

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -6,9 +6,11 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"breadbox/internal/app"
+	"breadbox/internal/db"
 	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
@@ -83,26 +85,48 @@ func TransactionListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRend
 			return
 		}
 
-		// Load filter dropdowns.
-		accounts, err := svc.ListAccounts(ctx, nil)
-		if err != nil {
-			a.Logger.Error("list accounts for transaction filters", "error", err)
-		}
-
-		users, err := a.Queries.ListUsers(ctx)
-		if err != nil {
-			a.Logger.Error("list users for transaction filters", "error", err)
-		}
-
-		categoryTree, err := svc.ListCategoryTree(ctx)
-		if err != nil {
-			a.Logger.Error("list categories for transaction filters", "error", err)
-		}
-
-		connections, err := a.Queries.ListBankConnections(ctx)
-		if err != nil {
-			a.Logger.Error("list connections for transaction filters", "error", err)
-		}
+		// Load filter dropdowns concurrently.
+		var (
+			accounts     []service.AccountResponse
+			users        []db.User
+			categoryTree []service.CategoryResponse
+			connections  []db.ListBankConnectionsRow
+			wg           sync.WaitGroup
+		)
+		wg.Add(4)
+		go func() {
+			defer wg.Done()
+			var err error
+			accounts, err = svc.ListAccounts(ctx, nil)
+			if err != nil {
+				a.Logger.Error("list accounts for transaction filters", "error", err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			var err error
+			users, err = a.Queries.ListUsers(ctx)
+			if err != nil {
+				a.Logger.Error("list users for transaction filters", "error", err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			var err error
+			categoryTree, err = svc.ListCategoryTree(ctx)
+			if err != nil {
+				a.Logger.Error("list categories for transaction filters", "error", err)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			var err error
+			connections, err = a.Queries.ListBankConnections(ctx)
+			if err != nil {
+				a.Logger.Error("list connections for transaction filters", "error", err)
+			}
+		}()
+		wg.Wait()
 
 		data := map[string]any{
 			"PageTitle":        "Transactions",

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -400,17 +400,26 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		"LEFT JOIN categories c ON t.category_id = c.id "
 	query := selectPrefix + fromClause + "WHERE t.deleted_at IS NULL"
 
+	// Track which JOINs are needed for the WHERE clause (used by the count query).
+	var needAccountJoin, needConnectionJoin, needUserJoin, needCategoryJoin bool
+
 	var args []any
 	argN := 1
+	whereClauses := ""
 
 	if params.UserID != nil {
 		uid, err := parseUUID(*params.UserID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid user id: %w", err)
 		}
-		query += fmt.Sprintf(" AND bc.user_id = $%d", argN)
+		clause := fmt.Sprintf(" AND bc.user_id = $%d", argN)
+		query += clause
+		whereClauses += clause
 		args = append(args, uid)
 		argN++
+		needAccountJoin = true
+		needConnectionJoin = true
+		needUserJoin = true
 	}
 
 	if params.ConnectionID != nil {
@@ -418,9 +427,12 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		if err != nil {
 			return nil, fmt.Errorf("invalid connection id: %w", err)
 		}
-		query += fmt.Sprintf(" AND a.connection_id = $%d", argN)
+		clause := fmt.Sprintf(" AND a.connection_id = $%d", argN)
+		query += clause
+		whereClauses += clause
 		args = append(args, cid)
 		argN++
+		needAccountJoin = true
 	}
 
 	if params.AccountID != nil {
@@ -428,19 +440,25 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		if err != nil {
 			return nil, fmt.Errorf("invalid account id: %w", err)
 		}
-		query += fmt.Sprintf(" AND t.account_id = $%d", argN)
+		clause := fmt.Sprintf(" AND t.account_id = $%d", argN)
+		query += clause
+		whereClauses += clause
 		args = append(args, aid)
 		argN++
 	}
 
 	if params.StartDate != nil {
-		query += fmt.Sprintf(" AND t.date >= $%d", argN)
+		clause := fmt.Sprintf(" AND t.date >= $%d", argN)
+		query += clause
+		whereClauses += clause
 		args = append(args, pgtype.Date{Time: *params.StartDate, Valid: true})
 		argN++
 	}
 
 	if params.EndDate != nil {
-		query += fmt.Sprintf(" AND t.date < $%d", argN)
+		clause := fmt.Sprintf(" AND t.date < $%d", argN)
+		query += clause
+		whereClauses += clause
 		args = append(args, pgtype.Date{Time: *params.EndDate, Valid: true})
 		argN++
 	}
@@ -452,44 +470,68 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			return &AdminTransactionListResult{Transactions: []AdminTransactionRow{}, Total: 0, Page: 1, PageSize: params.PageSize, TotalPages: 0}, nil
 		}
 		if !catRow.ParentID.Valid {
-			query += fmt.Sprintf(" AND (c.id = $%d OR c.parent_id = $%d)", argN, argN)
+			clause := fmt.Sprintf(" AND (c.id = $%d OR c.parent_id = $%d)", argN, argN)
+			query += clause
+			whereClauses += clause
 			args = append(args, catRow.ID)
 			argN++
+			needCategoryJoin = true
 		} else {
-			query += fmt.Sprintf(" AND t.category_id = $%d", argN)
+			clause := fmt.Sprintf(" AND t.category_id = $%d", argN)
+			query += clause
+			whereClauses += clause
 			args = append(args, catRow.ID)
 			argN++
 		}
 	}
 
 	if params.MinAmount != nil {
-		query += fmt.Sprintf(" AND t.amount >= $%d", argN)
+		clause := fmt.Sprintf(" AND t.amount >= $%d", argN)
+		query += clause
+		whereClauses += clause
 		args = append(args, *params.MinAmount)
 		argN++
 	}
 
 	if params.MaxAmount != nil {
-		query += fmt.Sprintf(" AND t.amount <= $%d", argN)
+		clause := fmt.Sprintf(" AND t.amount <= $%d", argN)
+		query += clause
+		whereClauses += clause
 		args = append(args, *params.MaxAmount)
 		argN++
 	}
 
 	if params.Pending != nil {
-		query += fmt.Sprintf(" AND t.pending = $%d", argN)
+		clause := fmt.Sprintf(" AND t.pending = $%d", argN)
+		query += clause
+		whereClauses += clause
 		args = append(args, *params.Pending)
 		argN++
 	}
 
 	if params.Search != nil {
-		query += fmt.Sprintf(" AND (t.name ILIKE '%%' || $%d || '%%' OR t.merchant_name ILIKE '%%' || $%d || '%%')", argN, argN)
+		clause := fmt.Sprintf(" AND (t.name ILIKE '%%' || $%d || '%%' OR t.merchant_name ILIKE '%%' || $%d || '%%')", argN, argN)
+		query += clause
+		whereClauses += clause
 		args = append(args, *params.Search)
 		argN++
 	}
 
-	// Count query with same filters — extract WHERE clauses from the built query.
-	countQuery := "SELECT COUNT(*) " + fromClause + "WHERE t.deleted_at IS NULL"
-	whereClause := query[len(selectPrefix+fromClause+"WHERE t.deleted_at IS NULL"):]
-	countQuery += whereClause
+	// Build a minimal count query with only the JOINs needed for WHERE filters.
+	countFrom := "FROM transactions t "
+	if needAccountJoin || needConnectionJoin || needUserJoin {
+		countFrom += "LEFT JOIN accounts a ON t.account_id = a.id "
+	}
+	if needConnectionJoin || needUserJoin {
+		countFrom += "LEFT JOIN bank_connections bc ON a.connection_id = bc.id "
+	}
+	if needUserJoin {
+		countFrom += "LEFT JOIN users u ON bc.user_id = u.id "
+	}
+	if needCategoryJoin {
+		countFrom += "LEFT JOIN categories c ON t.category_id = c.id "
+	}
+	countQuery := "SELECT COUNT(*) " + countFrom + "WHERE t.deleted_at IS NULL" + whereClauses
 
 	var total int64
 	if err := s.Pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -41,7 +41,7 @@
   </label>
   <label>
     Category
-    <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
+    <div class="bb-cat-picker" x-data="categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
       <input type="hidden" name="category" x-ref="catInput" value="{{.FilterCategory}}">
       <button type="button" class="select select-sm select-bordered w-auto min-w-[8rem] text-left flex items-center gap-2" @click="openPicker()">
         <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
@@ -116,7 +116,7 @@
         </td>
         <td><a href="/admin/accounts/{{.AccountID}}" @click.stop>{{.AccountName}}</a></td>
         <td @click.stop>
-          <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+          <div class="bb-cat-picker" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
             <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
               <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
               <span x-text="displayLabel" class="text-sm"></span>
@@ -188,6 +188,7 @@
 
 {{template "category-picker-script" .}}
 <script>
+window.__bbCategories = {{toJSON .Categories}};
 function quickSetCategory(txId, categoryId) {
   if (!categoryId) {
     fetch('/admin/api/transactions/' + txId + '/category', { method: 'DELETE' })


### PR DESCRIPTION
Three optimizations for the admin transactions page:

1. Move category tree JSON to a single window.__bbCategories variable instead
   of embedding it via {{toJSON}} in every transaction row's x-data attribute.
   With 50 rows and a non-trivial category tree, this eliminates ~50x duplication
   in the HTML response.

2. Run the 4 filter dropdown queries (accounts, users, categories, connections)
   concurrently using goroutines instead of sequentially.

3. Build the COUNT query with only the JOINs needed for active WHERE filters
   instead of always including all 4 LEFT JOINs. The default unfiltered page
   now counts with zero JOINs.

https://claude.ai/code/session_01PyW73qvroFmuCYgzyRP5yg