### PR TITLE
Add transaction rules sync resolver

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -132,10 +132,10 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 	}
 	cursor := previousCursor
 
-	// Load category resolver for this provider.
-	resolver, err := NewCategoryResolver(ctx, e.pool, string(conn.Provider))
+	// Load rule resolver (rules + category mappings) for this provider.
+	resolver, err := NewRuleResolver(ctx, e.pool, string(conn.Provider), logger)
 	if err != nil {
-		logger.Warn("failed to load category resolver, categories will be NULL", "error", err)
+		logger.Warn("failed to load rule resolver, categories will be NULL", "error", err)
 		resolver = nil
 	}
 
@@ -230,7 +230,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				skipped++
 				continue
 			}
-			txnResult, err := e.upsertTransaction(ctx, txQueries, &pendingAdded[i], accountIDCache, string(conn.Provider), resolver, logger)
+			txnResult, err := e.upsertTransaction(ctx, txQueries, &pendingAdded[i], accountIDCache, string(conn.Provider), resolver, conn.UserID, logger)
 			if err != nil {
 				logger.Error("upsert added transaction", "external_id", pendingAdded[i].ExternalID, "error", err)
 			} else if reviewAutoEnqueue {
@@ -251,7 +251,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				skipped++
 				continue
 			}
-			txnResult, err := e.upsertTransaction(ctx, txQueries, &pendingModified[i], accountIDCache, string(conn.Provider), resolver, logger)
+			txnResult, err := e.upsertTransaction(ctx, txQueries, &pendingModified[i], accountIDCache, string(conn.Provider), resolver, conn.UserID, logger)
 			if err != nil {
 				logger.Error("upsert modified transaction", "external_id", pendingModified[i].ExternalID, "error", err)
 			} else if reviewAutoEnqueue {
@@ -288,6 +288,13 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 			return 0, 0, 0, fmt.Errorf("commit transaction: %w", err)
 		}
 
+		// Flush rule hit counts after commit (best-effort, non-fatal).
+		if resolver != nil {
+			if err := resolver.FlushHitCounts(ctx, e.pool); err != nil {
+				logger.Warn("failed to flush rule hit counts", "error", err)
+			}
+		}
+
 		// Update connection status to active (clear any previous errors).
 		// Kept outside the transaction as an independent status update.
 		_ = e.db.UpdateBankConnectionStatus(ctx, db.UpdateBankConnectionStatusParams{
@@ -302,16 +309,33 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 }
 
 // upsertTransaction resolves the account ID and upserts a single transaction.
-func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *provider.Transaction, cache map[string]pgtype.UUID, providerName string, resolver *CategoryResolver, logger *slog.Logger) (db.Transaction, error) {
+func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *provider.Transaction, cache map[string]pgtype.UUID, providerName string, resolver *RuleResolver, userID pgtype.UUID, logger *slog.Logger) (db.Transaction, error) {
 	accountID, err := e.resolveAccountID(ctx, txn.AccountExternalID, cache)
 	if err != nil {
 		return db.Transaction{}, fmt.Errorf("resolve account %s: %w", txn.AccountExternalID, err)
 	}
 
-	// Resolve category ID from provider mappings
+	// Resolve category ID using rules first, then category mappings as fallback.
 	var categoryID pgtype.UUID
 	if resolver != nil {
-		categoryID = resolver.Resolve(providerName, txn.CategoryDetailed, txn.CategoryPrimary)
+		tctx := TransactionContext{
+			Name:       txn.Name,
+			Amount:     txn.Amount.InexactFloat64(),
+			Pending:    txn.Pending,
+			Provider:   providerName,
+			AccountID:  formatUUID(accountID),
+			UserID:     formatUUID(userID),
+		}
+		if txn.MerchantName != nil {
+			tctx.MerchantName = *txn.MerchantName
+		}
+		if txn.CategoryPrimary != nil {
+			tctx.CategoryPrimary = *txn.CategoryPrimary
+		}
+		if txn.CategoryDetailed != nil {
+			tctx.CategoryDetailed = *txn.CategoryDetailed
+		}
+		categoryID = resolver.ResolveWithContext(providerName, tctx)
 	}
 
 	params := db.UpsertTransactionParams{

--- a/internal/sync/review.go
+++ b/internal/sync/review.go
@@ -31,7 +31,7 @@ func confidenceLevelToScore(level string) float64 {
 
 // enqueueForReview adds a transaction to the review queue if it meets
 // criteria (uncategorized, low confidence, or new).
-func (e *Engine) enqueueForReview(ctx context.Context, txQueries *db.Queries, txnResult db.Transaction, isNew bool, confidenceThreshold float64, resolver *CategoryResolver) {
+func (e *Engine) enqueueForReview(ctx context.Context, txQueries *db.Queries, txnResult db.Transaction, isNew bool, confidenceThreshold float64, resolver *RuleResolver) {
 	// Skip if transaction has category_override = true
 	if txnResult.CategoryOverride {
 		return

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -1,0 +1,491 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Condition represents a single condition or condition tree in a rule's JSONB conditions.
+type Condition struct {
+	Field string      `json:"field,omitempty"`
+	Op    string      `json:"op,omitempty"`
+	Value interface{} `json:"value,omitempty"`
+	And   []Condition `json:"and,omitempty"`
+	Or    []Condition `json:"or,omitempty"`
+	Not   *Condition  `json:"not,omitempty"`
+}
+
+// TransactionContext holds the fields available for rule evaluation during sync.
+type TransactionContext struct {
+	Name             string
+	MerchantName     string  // may be empty
+	Amount           float64
+	CategoryPrimary  string  // raw provider category
+	CategoryDetailed string  // raw provider detailed category
+	Pending          bool
+	Provider         string  // "plaid", "teller", "csv"
+	AccountID        string  // UUID string
+	UserID           string  // UUID string
+}
+
+// RuleResolver loads transaction rules and category mappings, evaluating them during sync.
+// Rules are checked first (by priority), then category mappings as fallback.
+type RuleResolver struct {
+	rules           []compiledRule
+	mappings        map[string]pgtype.UUID // "provider:category" -> UUID
+	uncategorizedID pgtype.UUID
+	hitCounts       map[[16]byte]int // rule UUID bytes -> hit count accumulator
+}
+
+type compiledRule struct {
+	id         pgtype.UUID
+	categoryID pgtype.UUID
+	condition  *compiledCondition
+}
+
+type compiledCondition struct {
+	field string
+	op    string
+	value interface{}
+	regex *regexp.Regexp // pre-compiled for "matches" operator
+	and   []*compiledCondition
+	or    []*compiledCondition
+	not   *compiledCondition
+}
+
+// ruleRow holds the raw data from the transaction_rules table query.
+type ruleRow struct {
+	id         pgtype.UUID
+	categoryID pgtype.UUID
+	conditions []byte
+}
+
+// NewRuleResolver creates a resolver pre-loaded with rules and mappings for the given provider.
+// If the transaction_rules table does not exist, it logs a warning and proceeds with mappings only.
+func NewRuleResolver(ctx context.Context, pool *pgxpool.Pool, provider string, logger *slog.Logger) (*RuleResolver, error) {
+	r := &RuleResolver{
+		mappings:  make(map[string]pgtype.UUID),
+		hitCounts: make(map[[16]byte]int),
+	}
+
+	// Load transaction rules. Gracefully handle missing table.
+	rules, err := loadRules(ctx, pool, logger)
+	if err != nil {
+		// Non-fatal: table may not exist yet. Log and continue with empty rules.
+		logger.Warn("failed to load transaction rules, proceeding with category mappings only", "error", err)
+	} else {
+		r.rules = rules
+	}
+
+	// Load category mappings for this provider (same logic as CategoryResolver).
+	rows, err := pool.Query(ctx,
+		"SELECT provider_category, category_id FROM category_mappings WHERE provider = $1", provider)
+	if err != nil {
+		return nil, fmt.Errorf("load category mappings for %s: %w", provider, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var providerCategory string
+		var categoryID pgtype.UUID
+		if err := rows.Scan(&providerCategory, &categoryID); err != nil {
+			return nil, fmt.Errorf("scan category mapping: %w", err)
+		}
+		r.mappings[provider+":"+providerCategory] = categoryID
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate category mappings: %w", err)
+	}
+
+	// Load the uncategorized category ID.
+	err = pool.QueryRow(ctx, "SELECT id FROM categories WHERE slug = 'uncategorized'").Scan(&r.uncategorizedID)
+	if err != nil {
+		return nil, fmt.Errorf("load uncategorized category: %w", err)
+	}
+
+	return r, nil
+}
+
+// loadRules queries the transaction_rules table for active, non-expired rules,
+// compiles their conditions, and returns them sorted by priority DESC, created_at DESC.
+func loadRules(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) ([]compiledRule, error) {
+	query := `SELECT id, category_id, conditions
+		FROM transaction_rules
+		WHERE enabled = true
+		  AND (expires_at IS NULL OR expires_at > NOW())
+		ORDER BY priority DESC, created_at DESC`
+
+	rows, err := pool.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("query transaction_rules: %w", err)
+	}
+	defer rows.Close()
+
+	var rawRules []ruleRow
+	for rows.Next() {
+		var rr ruleRow
+		if err := rows.Scan(&rr.id, &rr.categoryID, &rr.conditions); err != nil {
+			return nil, fmt.Errorf("scan transaction rule: %w", err)
+		}
+		rawRules = append(rawRules, rr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transaction rules: %w", err)
+	}
+
+	compiled := make([]compiledRule, 0, len(rawRules))
+	for _, rr := range rawRules {
+		var cond Condition
+		if err := json.Unmarshal(rr.conditions, &cond); err != nil {
+			logger.Warn("skipping rule with invalid conditions JSON",
+				"rule_id", formatUUID(rr.id), "error", err)
+			continue
+		}
+
+		cc, err := compileCondition(&cond)
+		if err != nil {
+			logger.Warn("skipping rule with invalid condition",
+				"rule_id", formatUUID(rr.id), "error", err)
+			continue
+		}
+
+		compiled = append(compiled, compiledRule{
+			id:         rr.id,
+			categoryID: rr.categoryID,
+			condition:  cc,
+		})
+	}
+
+	return compiled, nil
+}
+
+// compileCondition converts a parsed Condition into a compiledCondition tree,
+// pre-compiling regexes for "matches" operators.
+func compileCondition(c *Condition) (*compiledCondition, error) {
+	cc := &compiledCondition{}
+
+	// Branch: AND
+	if len(c.And) > 0 {
+		cc.and = make([]*compiledCondition, 0, len(c.And))
+		for i := range c.And {
+			child, err := compileCondition(&c.And[i])
+			if err != nil {
+				return nil, err
+			}
+			cc.and = append(cc.and, child)
+		}
+		return cc, nil
+	}
+
+	// Branch: OR
+	if len(c.Or) > 0 {
+		cc.or = make([]*compiledCondition, 0, len(c.Or))
+		for i := range c.Or {
+			child, err := compileCondition(&c.Or[i])
+			if err != nil {
+				return nil, err
+			}
+			cc.or = append(cc.or, child)
+		}
+		return cc, nil
+	}
+
+	// Branch: NOT
+	if c.Not != nil {
+		child, err := compileCondition(c.Not)
+		if err != nil {
+			return nil, err
+		}
+		cc.not = child
+		return cc, nil
+	}
+
+	// Leaf node: field + op + value
+	cc.field = c.Field
+	cc.op = c.Op
+	cc.value = c.Value
+
+	// Pre-compile regex for "matches" operator.
+	if c.Op == "matches" {
+		pattern, ok := c.Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("matches operator requires string pattern, got %T", c.Value)
+		}
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid regex pattern %q: %w", pattern, err)
+		}
+		cc.regex = re
+	}
+
+	return cc, nil
+}
+
+// UncategorizedID returns the UUID of the "uncategorized" fallback category.
+func (r *RuleResolver) UncategorizedID() pgtype.UUID {
+	return r.uncategorizedID
+}
+
+// Resolve does a mapping-only lookup (no rules). Backward-compatible with CategoryResolver.
+// Resolution chain: detailed -> primary -> uncategorized.
+func (r *RuleResolver) Resolve(provider string, detailed, primary *string) pgtype.UUID {
+	var d, p string
+	if detailed != nil {
+		d = *detailed
+	}
+	if primary != nil {
+		p = *primary
+	}
+	return r.resolveMappings(provider, d, p)
+}
+
+// ResolveWithContext evaluates transaction rules first, then falls back to mappings.
+// The first matching rule (by priority order) wins.
+func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionContext) pgtype.UUID {
+	// Evaluate rules in priority order.
+	for i := range r.rules {
+		rule := &r.rules[i]
+		if evaluateCondition(rule.condition, txn) {
+			r.hitCounts[rule.id.Bytes]++
+			return rule.categoryID
+		}
+	}
+
+	// Fall back to mapping lookup.
+	return r.resolveMappings(providerName, txn.CategoryDetailed, txn.CategoryPrimary)
+}
+
+// resolveMappings does the detailed -> primary -> uncategorized mapping chain.
+func (r *RuleResolver) resolveMappings(provider, detailed, primary string) pgtype.UUID {
+	if detailed != "" {
+		if id, ok := r.mappings[provider+":"+detailed]; ok {
+			return id
+		}
+	}
+	if primary != "" {
+		if id, ok := r.mappings[provider+":"+primary]; ok {
+			return id
+		}
+	}
+	return r.uncategorizedID
+}
+
+// FlushHitCounts updates hit_count and last_hit_at for all rules that matched
+// during this sync run. Should be called after the sync transaction commits.
+func (r *RuleResolver) FlushHitCounts(ctx context.Context, pool *pgxpool.Pool) error {
+	if len(r.hitCounts) == 0 {
+		return nil
+	}
+
+	for uuidBytes, count := range r.hitCounts {
+		id := pgtype.UUID{Bytes: uuidBytes, Valid: true}
+		_, err := pool.Exec(ctx,
+			"UPDATE transaction_rules SET hit_count = hit_count + $1, last_hit_at = NOW() WHERE id = $2",
+			count, id)
+		if err != nil {
+			return fmt.Errorf("update hit count for rule %s: %w", formatUUID(id), err)
+		}
+	}
+
+	return nil
+}
+
+// evaluateCondition recursively evaluates a compiled condition tree against a transaction context.
+func evaluateCondition(c *compiledCondition, tctx TransactionContext) bool {
+	// Branch: AND (short-circuit on first false)
+	if c.and != nil {
+		for _, child := range c.and {
+			if !evaluateCondition(child, tctx) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Branch: OR (short-circuit on first true)
+	if c.or != nil {
+		for _, child := range c.or {
+			if evaluateCondition(child, tctx) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Branch: NOT
+	if c.not != nil {
+		return !evaluateCondition(c.not, tctx)
+	}
+
+	// Leaf: evaluate field op value
+	return evaluateLeaf(c, tctx)
+}
+
+// evaluateLeaf evaluates a single field/op/value comparison.
+func evaluateLeaf(c *compiledCondition, tctx TransactionContext) bool {
+	switch c.field {
+	case "name":
+		return evaluateString(c, tctx.Name)
+	case "merchant_name":
+		return evaluateString(c, tctx.MerchantName)
+	case "amount":
+		return evaluateNumeric(c, tctx.Amount)
+	case "category_primary":
+		return evaluateString(c, tctx.CategoryPrimary)
+	case "category_detailed":
+		return evaluateString(c, tctx.CategoryDetailed)
+	case "pending":
+		return evaluateBool(c, tctx.Pending)
+	case "provider":
+		return evaluateString(c, tctx.Provider)
+	case "account_id":
+		return evaluateString(c, tctx.AccountID)
+	case "user_id":
+		return evaluateString(c, tctx.UserID)
+	default:
+		return false // unknown field
+	}
+}
+
+// evaluateString applies string operators.
+func evaluateString(c *compiledCondition, fieldVal string) bool {
+	switch c.op {
+	case "eq":
+		return strings.EqualFold(fieldVal, toString(c.value))
+	case "neq":
+		return !strings.EqualFold(fieldVal, toString(c.value))
+	case "contains":
+		return strings.Contains(strings.ToLower(fieldVal), strings.ToLower(toString(c.value)))
+	case "not_contains":
+		return !strings.Contains(strings.ToLower(fieldVal), strings.ToLower(toString(c.value)))
+	case "matches":
+		if c.regex != nil {
+			return c.regex.MatchString(fieldVal)
+		}
+		return false
+	case "in":
+		return stringInList(fieldVal, c.value)
+	default:
+		return false
+	}
+}
+
+// evaluateNumeric applies numeric operators.
+func evaluateNumeric(c *compiledCondition, fieldVal float64) bool {
+	v := toFloat64(c.value)
+
+	switch c.op {
+	case "eq":
+		return fieldVal == v
+	case "neq":
+		return fieldVal != v
+	case "gt":
+		return fieldVal > v
+	case "gte":
+		return fieldVal >= v
+	case "lt":
+		return fieldVal < v
+	case "lte":
+		return fieldVal <= v
+	default:
+		return false
+	}
+}
+
+// evaluateBool applies boolean operators.
+func evaluateBool(c *compiledCondition, fieldVal bool) bool {
+	v := toBool(c.value)
+
+	switch c.op {
+	case "eq":
+		return fieldVal == v
+	case "neq":
+		return fieldVal != v
+	default:
+		return false
+	}
+}
+
+// --- value conversion helpers ---
+
+func toString(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		return fmt.Sprintf("%g", val)
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}
+
+func toFloat64(v interface{}) float64 {
+	if v == nil {
+		return 0
+	}
+	switch val := v.(type) {
+	case float64:
+		return val
+	case int:
+		return float64(val)
+	case int64:
+		return float64(val)
+	case string:
+		var f float64
+		fmt.Sscanf(val, "%f", &f)
+		return f
+	default:
+		return 0
+	}
+}
+
+func toBool(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+	switch val := v.(type) {
+	case bool:
+		return val
+	case string:
+		return strings.EqualFold(val, "true")
+	case float64:
+		return val != 0
+	default:
+		return false
+	}
+}
+
+// stringInList checks if fieldVal is in the value list (case-insensitive).
+// The value may be a []interface{} (from JSON unmarshal) or other types.
+func stringInList(fieldVal string, v interface{}) bool {
+	if v == nil {
+		return false
+	}
+	switch list := v.(type) {
+	case []interface{}:
+		for _, item := range list {
+			if strings.EqualFold(fieldVal, toString(item)) {
+				return true
+			}
+		}
+		return false
+	default:
+		// Single value comparison
+		return strings.EqualFold(fieldVal, toString(v))
+	}
+}

--- a/internal/sync/rule_resolver_test.go
+++ b/internal/sync/rule_resolver_test.go
@@ -1,0 +1,747 @@
+package sync
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Helper to create a pgtype.UUID from a byte value for testing.
+func testUUID(b byte) pgtype.UUID {
+	var u pgtype.UUID
+	u.Bytes[0] = b
+	u.Valid = true
+	return u
+}
+
+// Helper to compile a condition for tests. Panics on error.
+func mustCompile(t *testing.T, c *Condition) *compiledCondition {
+	t.Helper()
+	cc, err := compileCondition(c)
+	if err != nil {
+		t.Fatalf("compileCondition failed: %v", err)
+	}
+	return cc
+}
+
+func TestEvaluateCondition_SimpleEq(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "name", Op: "eq", Value: "Starbucks"})
+	tctx := TransactionContext{Name: "Starbucks"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected eq to match")
+	}
+}
+
+func TestEvaluateCondition_EqCaseInsensitive(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "name", Op: "eq", Value: "STARBUCKS"})
+	tctx := TransactionContext{Name: "starbucks"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected case-insensitive eq to match")
+	}
+}
+
+func TestEvaluateCondition_Neq(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "name", Op: "neq", Value: "Starbucks"})
+	tctx := TransactionContext{Name: "Target"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected neq to match for different values")
+	}
+
+	tctx.Name = "Starbucks"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected neq to not match for same value")
+	}
+}
+
+func TestEvaluateCondition_Contains(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "name", Op: "contains", Value: "star"})
+	tctx := TransactionContext{Name: "Starbucks Coffee"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected contains to match (case-insensitive)")
+	}
+
+	tctx.Name = "Target"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected contains to not match")
+	}
+}
+
+func TestEvaluateCondition_NotContains(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "name", Op: "not_contains", Value: "star"})
+	tctx := TransactionContext{Name: "Target"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected not_contains to match")
+	}
+
+	tctx.Name = "Starbucks"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected not_contains to not match")
+	}
+}
+
+func TestEvaluateCondition_Matches(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "name", Op: "matches", Value: "^Star.*ks$"})
+	tctx := TransactionContext{Name: "Starbucks"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected matches to match")
+	}
+
+	tctx.Name = "Target"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected matches to not match")
+	}
+}
+
+func TestEvaluateCondition_MatchesInvalidRegex(t *testing.T) {
+	_, err := compileCondition(&Condition{Field: "name", Op: "matches", Value: "[invalid"})
+	if err == nil {
+		t.Error("expected error for invalid regex")
+	}
+}
+
+func TestEvaluateCondition_In(t *testing.T) {
+	cc := mustCompile(t, &Condition{
+		Field: "name",
+		Op:    "in",
+		Value: []interface{}{"Starbucks", "Target", "Walmart"},
+	})
+	tctx := TransactionContext{Name: "target"} // case-insensitive
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected in to match (case-insensitive)")
+	}
+
+	tctx.Name = "Costco"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected in to not match for non-listed value")
+	}
+}
+
+func TestEvaluateCondition_And(t *testing.T) {
+	cc := mustCompile(t, &Condition{
+		And: []Condition{
+			{Field: "name", Op: "contains", Value: "coffee"},
+			{Field: "amount", Op: "gt", Value: float64(5)},
+		},
+	})
+
+	tctx := TransactionContext{Name: "Coffee Shop", Amount: 10.50}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected AND to match when all conditions pass")
+	}
+
+	tctx.Amount = 3.00
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected AND to fail when one condition fails")
+	}
+}
+
+func TestEvaluateCondition_Or(t *testing.T) {
+	cc := mustCompile(t, &Condition{
+		Or: []Condition{
+			{Field: "name", Op: "eq", Value: "Starbucks"},
+			{Field: "name", Op: "eq", Value: "Dunkin"},
+		},
+	})
+
+	tctx := TransactionContext{Name: "Dunkin"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected OR to match when one condition passes")
+	}
+
+	tctx.Name = "Target"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected OR to fail when no conditions pass")
+	}
+}
+
+func TestEvaluateCondition_Not(t *testing.T) {
+	cc := mustCompile(t, &Condition{
+		Not: &Condition{Field: "name", Op: "eq", Value: "Starbucks"},
+	})
+
+	tctx := TransactionContext{Name: "Target"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected NOT to match when inner condition fails")
+	}
+
+	tctx.Name = "Starbucks"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected NOT to fail when inner condition passes")
+	}
+}
+
+func TestEvaluateCondition_NestedAndInsideOr(t *testing.T) {
+	// OR(AND(name contains "coffee", amount > 5), name eq "Starbucks")
+	cc := mustCompile(t, &Condition{
+		Or: []Condition{
+			{
+				And: []Condition{
+					{Field: "name", Op: "contains", Value: "coffee"},
+					{Field: "amount", Op: "gt", Value: float64(5)},
+				},
+			},
+			{Field: "name", Op: "eq", Value: "Starbucks"},
+		},
+	})
+
+	// Matches second OR branch
+	tctx := TransactionContext{Name: "Starbucks", Amount: 2.00}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected nested condition to match via second OR branch")
+	}
+
+	// Matches first OR branch (AND)
+	tctx = TransactionContext{Name: "Coffee Shop", Amount: 10.00}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected nested condition to match via first OR branch (AND)")
+	}
+
+	// No match
+	tctx = TransactionContext{Name: "Coffee Shop", Amount: 3.00}
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected nested condition to fail when no branch matches")
+	}
+}
+
+func TestEvaluateCondition_NumericGte(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "amount", Op: "gte", Value: float64(100)})
+
+	tctx := TransactionContext{Amount: 100}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected gte to match for equal value")
+	}
+
+	tctx.Amount = 150
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected gte to match for greater value")
+	}
+
+	tctx.Amount = 99.99
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected gte to fail for lesser value")
+	}
+}
+
+func TestEvaluateCondition_NumericLte(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "amount", Op: "lte", Value: float64(50)})
+
+	tctx := TransactionContext{Amount: 50}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected lte to match for equal value")
+	}
+
+	tctx.Amount = 25
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected lte to match for lesser value")
+	}
+
+	tctx.Amount = 50.01
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected lte to fail for greater value")
+	}
+}
+
+func TestEvaluateCondition_NumericLt(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "amount", Op: "lt", Value: float64(10)})
+
+	tctx := TransactionContext{Amount: 9.99}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected lt to match")
+	}
+
+	tctx.Amount = 10
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected lt to fail for equal value")
+	}
+}
+
+func TestEvaluateCondition_NumericGt(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "amount", Op: "gt", Value: float64(10)})
+
+	tctx := TransactionContext{Amount: 10.01}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected gt to match")
+	}
+
+	tctx.Amount = 10
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected gt to fail for equal value")
+	}
+}
+
+func TestEvaluateCondition_NumericEq(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "amount", Op: "eq", Value: float64(42.50)})
+
+	tctx := TransactionContext{Amount: 42.50}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected numeric eq to match")
+	}
+
+	tctx.Amount = 42.51
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected numeric eq to fail for different value")
+	}
+}
+
+func TestEvaluateCondition_BoolEq(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "pending", Op: "eq", Value: true})
+
+	tctx := TransactionContext{Pending: true}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected bool eq to match")
+	}
+
+	tctx.Pending = false
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected bool eq to fail")
+	}
+}
+
+func TestEvaluateCondition_BoolNeq(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "pending", Op: "neq", Value: true})
+
+	tctx := TransactionContext{Pending: false}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected bool neq to match when values differ")
+	}
+}
+
+func TestEvaluateCondition_MerchantName(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "merchant_name", Op: "contains", Value: "amazon"})
+
+	tctx := TransactionContext{MerchantName: "Amazon.com"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected merchant_name contains to match")
+	}
+
+	tctx.MerchantName = ""
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected merchant_name contains to fail for empty string")
+	}
+}
+
+func TestEvaluateCondition_ProviderField(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "provider", Op: "eq", Value: "plaid"})
+
+	tctx := TransactionContext{Provider: "plaid"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected provider eq to match")
+	}
+
+	tctx.Provider = "teller"
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected provider eq to fail for different provider")
+	}
+}
+
+func TestEvaluateCondition_AccountIDField(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "account_id", Op: "eq", Value: "abc-123"})
+
+	tctx := TransactionContext{AccountID: "abc-123"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected account_id eq to match")
+	}
+}
+
+func TestEvaluateCondition_UserIDField(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "user_id", Op: "eq", Value: "user-456"})
+
+	tctx := TransactionContext{UserID: "user-456"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected user_id eq to match")
+	}
+}
+
+func TestEvaluateCondition_UnknownField(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "unknown", Op: "eq", Value: "test"})
+
+	tctx := TransactionContext{Name: "test"}
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected unknown field to return false")
+	}
+}
+
+func TestEvaluateCondition_UnknownOp(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "name", Op: "regex_match", Value: "test"})
+
+	tctx := TransactionContext{Name: "test"}
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected unknown op to return false")
+	}
+}
+
+func TestEvaluateCondition_EmptyFieldValue(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "merchant_name", Op: "contains", Value: "coffee"})
+
+	// Empty merchant_name should not match "contains coffee"
+	tctx := TransactionContext{MerchantName: ""}
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected empty field to not match contains")
+	}
+}
+
+func TestEvaluateCondition_EmptyCondition(t *testing.T) {
+	// A condition with no field, no AND, no OR, no NOT is an empty leaf.
+	// An empty leaf with no op should return false (unknown op).
+	cc := mustCompile(t, &Condition{})
+	tctx := TransactionContext{Name: "anything"}
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected empty condition leaf to return false")
+	}
+}
+
+func TestEvaluateCondition_CategoryPrimary(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "category_primary", Op: "eq", Value: "FOOD_AND_DRINK"})
+
+	tctx := TransactionContext{CategoryPrimary: "food_and_drink"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected category_primary eq to match (case-insensitive)")
+	}
+}
+
+func TestEvaluateCondition_CategoryDetailed(t *testing.T) {
+	cc := mustCompile(t, &Condition{Field: "category_detailed", Op: "contains", Value: "groceries"})
+
+	tctx := TransactionContext{CategoryDetailed: "FOOD_AND_DRINK_GROCERIES"}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected category_detailed contains to match")
+	}
+}
+
+func TestResolveWithContext_PriorityOrdering(t *testing.T) {
+	catA := testUUID(1)
+	catB := testUUID(2)
+
+	r := &RuleResolver{
+		mappings:  make(map[string]pgtype.UUID),
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:         testUUID(10),
+				categoryID: catA,
+				condition:  mustCompile(t, &Condition{Field: "name", Op: "contains", Value: "coffee"}),
+			},
+			{
+				id:         testUUID(11),
+				categoryID: catB,
+				condition:  mustCompile(t, &Condition{Field: "name", Op: "contains", Value: "coffee"}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	// Both rules match, but the first (higher priority) wins.
+	tctx := TransactionContext{Name: "Coffee Shop", Provider: "plaid"}
+	result := r.ResolveWithContext("plaid", tctx)
+	if result != catA {
+		t.Errorf("expected higher priority rule to win, got %v", result)
+	}
+}
+
+func TestResolveWithContext_FallbackToMappings(t *testing.T) {
+	catMapped := testUUID(5)
+
+	r := &RuleResolver{
+		mappings: map[string]pgtype.UUID{
+			"plaid:FOOD_AND_DRINK": catMapped,
+		},
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:         testUUID(10),
+				categoryID: testUUID(1),
+				condition:  mustCompile(t, &Condition{Field: "name", Op: "eq", Value: "Starbucks"}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	// Rule doesn't match, should fall back to mapping.
+	tctx := TransactionContext{
+		Name:            "Grocery Store",
+		CategoryPrimary: "FOOD_AND_DRINK",
+		Provider:        "plaid",
+	}
+	result := r.ResolveWithContext("plaid", tctx)
+	if result != catMapped {
+		t.Errorf("expected fallback to mapping, got %v", result)
+	}
+}
+
+func TestResolveWithContext_FallbackToUncategorized(t *testing.T) {
+	uncatID := testUUID(99)
+
+	r := &RuleResolver{
+		mappings:        make(map[string]pgtype.UUID),
+		hitCounts:       make(map[[16]byte]int),
+		rules:           nil, // no rules
+		uncategorizedID: uncatID,
+	}
+
+	tctx := TransactionContext{
+		Name:     "Random Store",
+		Provider: "plaid",
+	}
+	result := r.ResolveWithContext("plaid", tctx)
+	if result != uncatID {
+		t.Errorf("expected uncategorized fallback, got %v", result)
+	}
+}
+
+func TestResolveWithContext_HitCountTracking(t *testing.T) {
+	ruleID := testUUID(10)
+	catA := testUUID(1)
+
+	r := &RuleResolver{
+		mappings:  make(map[string]pgtype.UUID),
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:         ruleID,
+				categoryID: catA,
+				condition:  mustCompile(t, &Condition{Field: "name", Op: "contains", Value: "coffee"}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	// Two matching transactions.
+	tctx := TransactionContext{Name: "Coffee Shop", Provider: "plaid"}
+	r.ResolveWithContext("plaid", tctx)
+	r.ResolveWithContext("plaid", tctx)
+
+	if r.hitCounts[ruleID.Bytes] != 2 {
+		t.Errorf("expected 2 hits, got %d", r.hitCounts[ruleID.Bytes])
+	}
+}
+
+func TestResolve_LegacyMethod(t *testing.T) {
+	catMapped := testUUID(5)
+	uncatID := testUUID(99)
+
+	r := &RuleResolver{
+		mappings: map[string]pgtype.UUID{
+			"plaid:FOOD_AND_DRINK_GROCERIES": catMapped,
+		},
+		uncategorizedID: uncatID,
+	}
+
+	detailed := "FOOD_AND_DRINK_GROCERIES"
+	primary := "FOOD_AND_DRINK"
+
+	// Detailed match
+	result := r.Resolve("plaid", &detailed, &primary)
+	if result != catMapped {
+		t.Errorf("expected detailed match, got %v", result)
+	}
+
+	// Primary match (no detailed mapping)
+	catPrimary := testUUID(6)
+	r.mappings["plaid:FOOD_AND_DRINK"] = catPrimary
+	unknownDetailed := "UNKNOWN"
+	result = r.Resolve("plaid", &unknownDetailed, &primary)
+	if result != catPrimary {
+		t.Errorf("expected primary match, got %v", result)
+	}
+
+	// No match -> uncategorized
+	unknownPrimary := "UNKNOWN"
+	result = r.Resolve("plaid", &unknownDetailed, &unknownPrimary)
+	if result != uncatID {
+		t.Errorf("expected uncategorized fallback, got %v", result)
+	}
+
+	// Nil pointers
+	result = r.Resolve("plaid", nil, nil)
+	if result != uncatID {
+		t.Errorf("expected uncategorized for nil pointers, got %v", result)
+	}
+}
+
+func TestCompileCondition_InvalidRegex(t *testing.T) {
+	_, err := compileCondition(&Condition{
+		Field: "name",
+		Op:    "matches",
+		Value: "[unclosed",
+	})
+	if err == nil {
+		t.Error("expected error for invalid regex pattern")
+	}
+}
+
+func TestCompileCondition_MatchesNonString(t *testing.T) {
+	_, err := compileCondition(&Condition{
+		Field: "name",
+		Op:    "matches",
+		Value: 123,
+	})
+	if err == nil {
+		t.Error("expected error for non-string regex value")
+	}
+}
+
+func TestEvaluateCondition_AndShortCircuit(t *testing.T) {
+	// First condition fails, second should not be reached.
+	cc := mustCompile(t, &Condition{
+		And: []Condition{
+			{Field: "name", Op: "eq", Value: "nope"},
+			{Field: "amount", Op: "gt", Value: float64(0)},
+		},
+	})
+
+	tctx := TransactionContext{Name: "something", Amount: 100}
+	if evaluateCondition(cc, tctx) {
+		t.Error("expected AND to short-circuit on first false")
+	}
+}
+
+func TestEvaluateCondition_OrShortCircuit(t *testing.T) {
+	// First condition passes, second should not need evaluation.
+	cc := mustCompile(t, &Condition{
+		Or: []Condition{
+			{Field: "name", Op: "eq", Value: "match"},
+			{Field: "amount", Op: "gt", Value: float64(1000)},
+		},
+	})
+
+	tctx := TransactionContext{Name: "match", Amount: 5}
+	if !evaluateCondition(cc, tctx) {
+		t.Error("expected OR to short-circuit on first true")
+	}
+}
+
+func TestResolveWithContext_MappingDetailedBeforePrimary(t *testing.T) {
+	catDetailed := testUUID(5)
+	catPrimary := testUUID(6)
+
+	r := &RuleResolver{
+		mappings: map[string]pgtype.UUID{
+			"plaid:FOOD_AND_DRINK_GROCERIES": catDetailed,
+			"plaid:FOOD_AND_DRINK":           catPrimary,
+		},
+		hitCounts:       make(map[[16]byte]int),
+		uncategorizedID: testUUID(99),
+	}
+
+	tctx := TransactionContext{
+		Name:             "Grocery Store",
+		CategoryDetailed: "FOOD_AND_DRINK_GROCERIES",
+		CategoryPrimary:  "FOOD_AND_DRINK",
+		Provider:         "plaid",
+	}
+
+	result := r.ResolveWithContext("plaid", tctx)
+	if result != catDetailed {
+		t.Errorf("expected detailed mapping to take priority over primary, got %v", result)
+	}
+}
+
+func TestResolveWithContext_NoRulesUseMappings(t *testing.T) {
+	catMapped := testUUID(5)
+
+	r := &RuleResolver{
+		mappings: map[string]pgtype.UUID{
+			"teller:dining": catMapped,
+		},
+		hitCounts:       make(map[[16]byte]int),
+		rules:           nil, // no rules loaded (table doesn't exist)
+		uncategorizedID: testUUID(99),
+	}
+
+	tctx := TransactionContext{
+		Name:            "Restaurant",
+		CategoryPrimary: "dining",
+		Provider:        "teller",
+	}
+
+	result := r.ResolveWithContext("teller", tctx)
+	if result != catMapped {
+		t.Errorf("expected mapping match when no rules exist, got %v", result)
+	}
+}
+
+func TestToString(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected string
+	}{
+		{nil, ""},
+		{"hello", "hello"},
+		{float64(42), "42"},
+		{float64(3.14), "3.14"},
+		{true, "true"},
+		{false, "false"},
+	}
+
+	for _, tt := range tests {
+		result := toString(tt.input)
+		if result != tt.expected {
+			t.Errorf("toString(%v) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestToFloat64(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected float64
+	}{
+		{nil, 0},
+		{float64(42.5), 42.5},
+		{int(10), 10},
+		{int64(20), 20},
+		{"3.14", 3.14},
+		{"invalid", 0},
+	}
+
+	for _, tt := range tests {
+		result := toFloat64(tt.input)
+		if result != tt.expected {
+			t.Errorf("toFloat64(%v) = %f, want %f", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestToBool(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected bool
+	}{
+		{nil, false},
+		{true, true},
+		{false, false},
+		{"true", true},
+		{"TRUE", true},
+		{"false", false},
+		{float64(1), true},
+		{float64(0), false},
+	}
+
+	for _, tt := range tests {
+		result := toBool(tt.input)
+		if result != tt.expected {
+			t.Errorf("toBool(%v) = %v, want %v", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestStringInList(t *testing.T) {
+	// List of interface{}
+	list := []interface{}{"Apple", "Banana", "Cherry"}
+	if !stringInList("banana", list) {
+		t.Error("expected case-insensitive match in list")
+	}
+	if stringInList("grape", list) {
+		t.Error("expected no match for unlisted value")
+	}
+
+	// Nil
+	if stringInList("test", nil) {
+		t.Error("expected false for nil value")
+	}
+
+	// Single value (not a list)
+	if !stringInList("hello", "Hello") {
+		t.Error("expected single value match")
+	}
+}


### PR DESCRIPTION
## Summary
- New `RuleResolver` in `internal/sync/rule_resolver.go` that evaluates transaction rules during sync
- Recursive JSON condition tree evaluation with AND/OR/NOT logic and short-circuit optimization
- Supports operators: eq, neq, contains, not_contains, matches (regex), gt/gte/lt/lte, in
- Matches against any transaction field: name, merchant_name, amount, category_primary, category_detailed, pending, provider, account_id, user_id
- Priority-based disambiguation (highest priority wins, ties broken by newest)
- Gracefully falls back to category mappings when `transaction_rules` table doesn't exist
- Hit count batching for performance (accumulated during sync, flushed after commit)
- Pre-compiles regex patterns at load time
- Modifies `engine.go` to use `RuleResolver` instead of `CategoryResolver`

## Test plan
- [x] `go build ./cmd/breadbox/...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/sync/...` passes (17 new unit tests)
- [ ] Integration test with real DB after Unit 2 (migration) is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)