### PR TITLE
Add review instructions dashboard page

### DIFF
--- a/internal/admin/review_instructions.go
+++ b/internal/admin/review_instructions.go
@@ -1,0 +1,19 @@
+package admin
+
+import (
+	"net/http"
+
+	breadboxmcp "breadbox/internal/mcp"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+// ReviewInstructionsPageHandler serves GET /admin/review-instructions.
+func ReviewInstructionsPageHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data := BaseTemplateData(r, sm, "review-instructions", "Review Instructions")
+		data["InitialReviewInstructions"] = breadboxmcp.InitialReviewInstructions
+		data["RecurringReviewInstructions"] = breadboxmcp.RecurringReviewInstructions
+		tr.Render(w, r, "review_instructions.html", data)
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -69,6 +69,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/sync-logs", SyncLogsHandler(a, sm, tr, svc))
 
 		r.Get("/reviews", ReviewsPageHandler(a, sm, tr, svc))
+		r.Get("/review-instructions", ReviewInstructionsPageHandler(sm, tr))
 		r.Get("/rules", RulesPageHandler(svc, sm, tr, a.Config.Version))
 
 		r.Get("/categories", CategoriesPageHandler(svc, sm, tr))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -210,6 +210,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/mcp_settings.html",
 		"pages/reviews.html",
 		"pages/rules.html",
+		"pages/review_instructions.html",
 	}
 
 	// Pages using the wizard layout (login + first-run admin creation).

--- a/internal/mcp/templates.go
+++ b/internal/mcp/templates.go
@@ -1,5 +1,35 @@
 package mcp
 
+// InitialReviewInstructions provides guidance for bulk initial categorization.
+const InitialReviewInstructions = `You are reviewing a batch of transactions for initial categorization. This is typically done when a new bank account is synced and has many uncategorized transactions.
+
+STRATEGY:
+1. First, query some transactions to understand what category_primary values exist
+   (use query_transactions with fields=core,category to see raw provider categories)
+2. Create broad category_primary rules FIRST — one rule per raw provider category covers
+   hundreds of transactions at once
+   Example: {"and": [{"field": "provider", "op": "eq", "value": "teller"}, {"field": "category_primary", "op": "eq", "value": "dining"}]} → food_and_drink_restaurant
+3. Then create name-pattern rules for transaction types that span merchants:
+   "ATM Withdrawal" → withdrawals, "Wire Transfer" → transfer_out, "Service Charge" → bank_fees
+4. Process the review queue with batch_submit_reviews — approve with the correct category_slug
+5. Create per-merchant rules only for merchants that get miscategorized by the broad rules
+
+Focus on COVERAGE — your goal is to reduce future review work as much as possible.
+Prioritize rules that match the most transactions. Check list_transaction_rules before creating to avoid duplicates.`
+
+// RecurringReviewInstructions provides guidance for routine daily/weekly reviews.
+const RecurringReviewInstructions = `You are performing a routine review of recent transactions. Review 10-20 pending transactions, categorize them, and create rules for any new patterns you notice.
+
+STRATEGY:
+1. List pending reviews (limit 15-20)
+2. Review each transaction — approve with the correct category_slug, skip if uncertain
+3. Look for new merchants or patterns not covered by existing rules (check list_transaction_rules)
+4. For recurring merchants (seen 2+ times), create a specific rule
+5. Use batch_submit_reviews for efficiency
+
+Focus on ACCURACY — take time to categorize correctly since there are fewer transactions.
+Create specific rules for new recurring merchants you encounter. Prefer contains over exact match for merchant names.`
+
 // InstructionTemplate represents a pre-built instruction set.
 type InstructionTemplate struct {
 	Slug        string `json:"slug"`

--- a/internal/templates/pages/review_instructions.html
+++ b/internal/templates/pages/review_instructions.html
@@ -1,0 +1,112 @@
+{{define "content"}}
+<h1 class="text-2xl font-bold mb-6">Review Instructions</h1>
+<p class="text-sm text-base-content/60 mb-6">Pre-built instruction blocks to pass to MCP agents for transaction review. Copy the instructions and paste them into your agent's prompt.</p>
+
+<div class="grid gap-6">
+
+  <!-- Card 1: Initial Review Mode -->
+  <div class="card bg-base-100 border border-base-300" x-data="{ copied: false }">
+    <div class="card-body">
+      <div class="flex items-center gap-2 mb-1">
+        <h2 class="card-title text-lg">
+          <i data-lucide="layers" class="w-5 h-5"></i>
+          Initial Review
+        </h2>
+        <span class="badge badge-primary badge-sm">Bulk Analysis</span>
+      </div>
+      <p class="text-sm text-base-content/70 mb-4">Use when a new account is synced and you have many uncategorized transactions. Focuses on creating broad rules for maximum coverage.</p>
+      <div class="relative">
+        <pre class="bg-base-200 rounded-lg p-4 text-sm whitespace-pre-wrap overflow-auto max-h-80 font-mono">{{.InitialReviewInstructions}}</pre>
+        <button
+          class="btn btn-sm btn-ghost absolute top-2 right-2"
+          @click="navigator.clipboard.writeText({{.InitialReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })"
+        >
+          <template x-if="!copied">
+            <span class="flex items-center gap-1"><i data-lucide="copy" class="w-4 h-4"></i> Copy</span>
+          </template>
+          <template x-if="copied">
+            <span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-4 h-4"></i> Copied!</span>
+          </template>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Card 2: Recurring Review Mode -->
+  <div class="card bg-base-100 border border-base-300" x-data="{ copied: false }">
+    <div class="card-body">
+      <div class="flex items-center gap-2 mb-1">
+        <h2 class="card-title text-lg">
+          <i data-lucide="repeat" class="w-5 h-5"></i>
+          Recurring Review
+        </h2>
+        <span class="badge badge-secondary badge-sm">Daily / Weekly</span>
+      </div>
+      <p class="text-sm text-base-content/70 mb-4">Use for routine review of incoming transactions. Reviews a small batch with more attention per transaction.</p>
+      <div class="relative">
+        <pre class="bg-base-200 rounded-lg p-4 text-sm whitespace-pre-wrap overflow-auto max-h-80 font-mono">{{.RecurringReviewInstructions}}</pre>
+        <button
+          class="btn btn-sm btn-ghost absolute top-2 right-2"
+          @click="navigator.clipboard.writeText({{.RecurringReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })"
+        >
+          <template x-if="!copied">
+            <span class="flex items-center gap-1"><i data-lucide="copy" class="w-4 h-4"></i> Copy</span>
+          </template>
+          <template x-if="copied">
+            <span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-4 h-4"></i> Copied!</span>
+          </template>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Card 3: Connection Info -->
+  <div class="card bg-base-100 border border-base-300" x-data="{ copiedConfig: false }">
+    <div class="card-body">
+      <h2 class="card-title text-lg">
+        <i data-lucide="plug" class="w-5 h-5"></i>
+        Review MCP Connection
+      </h2>
+      <p class="text-sm text-base-content/70 mb-4">Connect your MCP agent to the review server using one of the methods below.</p>
+
+      <div class="grid gap-4">
+        <div>
+          <h3 class="font-medium text-sm mb-1">HTTP Endpoint</h3>
+          <div class="bg-base-200 rounded-lg p-3 font-mono text-sm break-all">https://&lt;host&gt;/mcp/review</div>
+        </div>
+
+        <div>
+          <h3 class="font-medium text-sm mb-1">Stdio Command</h3>
+          <div class="bg-base-200 rounded-lg p-3 font-mono text-sm">docker exec -i breadbox-app-1 /app/breadbox mcp-stdio-review</div>
+        </div>
+
+        <div>
+          <h3 class="font-medium text-sm mb-2">Claude Desktop Config (stdio)</h3>
+          <div class="relative">
+            <pre class="bg-base-200 rounded-lg p-4 text-sm font-mono overflow-auto">{
+  "mcpServers": {
+    "breadbox-review": {
+      "command": "docker",
+      "args": ["exec", "-i", "breadbox-app-1", "/app/breadbox", "mcp-stdio-review"]
+    }
+  }
+}</pre>
+            <button
+              class="btn btn-sm btn-ghost absolute top-2 right-2"
+              @click="navigator.clipboard.writeText(JSON.stringify({mcpServers:{'breadbox-review':{command:'docker',args:['exec','-i','breadbox-app-1','/app/breadbox','mcp-stdio-review']}}}, null, 2)).then(() => { copiedConfig = true; setTimeout(() => copiedConfig = false, 2000) })"
+            >
+              <template x-if="!copiedConfig">
+                <span class="flex items-center gap-1"><i data-lucide="copy" class="w-4 h-4"></i> Copy</span>
+              </template>
+              <template x-if="copiedConfig">
+                <span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-4 h-4"></i> Copied!</span>
+              </template>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+{{end}}

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -5,6 +5,7 @@
   <li><a href="/admin/connections"{{if eq .CurrentPage "connections"}} class="menu-active"{{end}}><i data-lucide="link" class="w-4 h-4"></i> Connections</a></li>
   <li><a href="/admin/transactions"{{if eq .CurrentPage "transactions"}} class="menu-active"{{end}}><i data-lucide="receipt" class="w-4 h-4"></i> Transactions</a></li>
   <li><a href="/admin/reviews"{{if eq .CurrentPage "reviews"}} class="menu-active"{{end}}><i data-lucide="clipboard-check" class="w-4 h-4"></i> Reviews</a></li>
+  <li><a href="/admin/review-instructions"{{if eq .CurrentPage "review-instructions"}} class="menu-active"{{end}}><i data-lucide="message-square-code" class="w-4 h-4"></i> Review Agent</a></li>
   <li><a href="/admin/rules"{{if eq .CurrentPage "rules"}} class="menu-active"{{end}}><i data-lucide="list-filter" class="w-4 h-4"></i> Rules</a></li>
   <li><a href="/admin/categories"{{if eq .CurrentPage "categories"}} class="menu-active"{{end}}><i data-lucide="tag" class="w-4 h-4"></i> Categories</a></li>
   <li><a href="/admin/users"{{if eq .CurrentPage "users"}} class="menu-active"{{end}}><i data-lucide="users" class="w-4 h-4"></i> Family Members</a></li>


### PR DESCRIPTION
## Summary
- New `/admin/review-instructions` page with two pre-built instruction blocks for MCP agents (initial bulk review and recurring daily/weekly review)
- Each instruction block has a copy-to-clipboard button with Alpine.js feedback
- Connection info card shows HTTP endpoint, stdio command, and Claude Desktop JSON config
- Nav item added under "Reviews" in the Data section

## Test plan
- [ ] Visit `/admin/review-instructions` and verify the three cards render correctly
- [ ] Click each "Copy" button and verify clipboard contents match the displayed text
- [ ] Verify nav highlights correctly when on the page
- [ ] `go build ./cmd/breadbox/...` compiles cleanly
- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)