### PR TITLE
Add missing development option to Teller env dropdown

### DIFF
--- a/internal/templates/pages/providers.html
+++ b/internal/templates/pages/providers.html
@@ -113,6 +113,7 @@
         </label>
         <select id="teller_env" name="teller_env" class="select select-sm w-full max-w-xs">
           <option value="sandbox"{{if eq .TellerEnv "sandbox"}} selected{{end}}>Sandbox</option>
+          <option value="development"{{if eq .TellerEnv "development"}} selected{{end}}>Development</option>
           <option value="production"{{if eq .TellerEnv "production"}} selected{{end}}>Production</option>
         </select>
 


### PR DESCRIPTION
## Summary
- Teller provider settings only offered Sandbox and Production environments
- Added the missing Development option to match Plaid's dropdown

## Test plan
- [ ] Verify Teller environment dropdown shows Sandbox, Development, Production
- [ ] Verify selecting Development saves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)