### PR TITLE
Remove /admin/ prefix from all web routes

### DIFF
--- a/cmd/breadbox/main.go
+++ b/cmd/breadbox/main.go
@@ -261,7 +261,7 @@ func runServe() error {
 		logger.Warn("ENCRYPTION_KEY not set — encrypted provider credentials will not work")
 	}
 	if adminCount == 0 {
-		logger.Warn("no admin account — create one at /admin/setup or via 'breadbox create-admin'")
+		logger.Warn("no admin account — create one at /setup or via 'breadbox create-admin'")
 	}
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("http server: %w", err)

--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -107,7 +107,7 @@ func APIKeyCreatePageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
 			SetFlash(r.Context(), sm, "error", "Name is required")
-			http.Redirect(w, r, "/admin/api-keys/new", http.StatusSeeOther)
+			http.Redirect(w, r, "/api-keys/new", http.StatusSeeOther)
 			return
 		}
 		scope := r.FormValue("scope")
@@ -117,13 +117,13 @@ func APIKeyCreatePageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 		result, err := svc.CreateAPIKey(r.Context(), name, scope)
 		if err != nil {
 			SetFlash(r.Context(), sm, "error", "Failed to create API key")
-			http.Redirect(w, r, "/admin/api-keys/new", http.StatusSeeOther)
+			http.Redirect(w, r, "/api-keys/new", http.StatusSeeOther)
 			return
 		}
 		// Store the plaintext key in the session so the "created" page can display it once.
 		sm.Put(r.Context(), "created_api_key", result.PlaintextKey)
 		sm.Put(r.Context(), "created_api_key_name", result.Name)
-		http.Redirect(w, r, "/admin/api-keys/"+result.ID+"/created", http.StatusSeeOther)
+		http.Redirect(w, r, "/api-keys/"+result.ID+"/created", http.StatusSeeOther)
 	}
 }
 
@@ -135,7 +135,7 @@ func APIKeyCreatedPageHandler(sm *scs.SessionManager, tr *TemplateRenderer) http
 		name := sm.PopString(r.Context(), "created_api_key_name")
 		if key == "" {
 			// Key already shown or session expired — redirect to list.
-			http.Redirect(w, r, "/admin/api-keys", http.StatusSeeOther)
+			http.Redirect(w, r, "/api-keys", http.StatusSeeOther)
 			return
 		}
 		data := map[string]any{
@@ -158,6 +158,6 @@ func APIKeyRevokePageHandler(svc *service.Service, sm *scs.SessionManager) http.
 		} else {
 			SetFlash(r.Context(), sm, "success", "API key revoked successfully")
 		}
-		http.Redirect(w, r, "/admin/api-keys", http.StatusSeeOther)
+		http.Redirect(w, r, "/api-keys", http.StatusSeeOther)
 	}
 }

--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -76,7 +76,7 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, tr *TemplateRende
 
 		sm.Put(r.Context(), sessionKeyAdminID, formatUUID(admin.ID))
 		sm.Put(r.Context(), sessionKeyAdminUsername, admin.Username)
-		http.Redirect(w, r, "/admin/", http.StatusSeeOther)
+		http.Redirect(w, r, "/", http.StatusSeeOther)
 	}
 }
 

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -132,7 +132,7 @@ func DismissOnboardingHandler(a *app.App) http.HandlerFunc {
 			Key:   "onboarding_dismissed",
 			Value: pgtype.Text{String: "true", Valid: true},
 		})
-		http.Redirect(w, r, "/admin/", http.StatusSeeOther)
+		http.Redirect(w, r, "/", http.StatusSeeOther)
 	}
 }
 

--- a/internal/admin/mcp.go
+++ b/internal/admin/mcp.go
@@ -83,11 +83,11 @@ func MCPSaveModeHandler(svc *service.Service, sm *scs.SessionManager) http.Handl
 		mode := r.FormValue("mode")
 		if err := svc.SaveMCPMode(r.Context(), mode); err != nil {
 			SetFlash(r.Context(), sm, "error", "Invalid mode: must be read_only or read_write")
-			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "MCP mode updated.")
-		http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+		http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
 	}
 }
 
@@ -96,7 +96,7 @@ func MCPSaveToolsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer,
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			SetFlash(r.Context(), sm, "error", "Invalid form data")
-			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
 			return
 		}
 
@@ -113,7 +113,7 @@ func MCPSaveToolsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer,
 		mcpCfg, err := svc.GetMCPConfig(r.Context())
 		if err != nil {
 			SetFlash(r.Context(), sm, "error", "Failed to load MCP config")
-			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
 			return
 		}
 
@@ -129,11 +129,11 @@ func MCPSaveToolsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer,
 
 		if err := svc.SaveMCPDisabledTools(r.Context(), disabled); err != nil {
 			SetFlash(r.Context(), sm, "error", "Failed to save tool settings")
-			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Tool access updated.")
-		http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+		http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
 	}
 }
 
@@ -145,10 +145,10 @@ func MCPSaveInstructionsHandler(svc *service.Service, sm *scs.SessionManager) ht
 
 		if err := svc.SaveMCPInstructions(r.Context(), instructions, templateSlug); err != nil {
 			SetFlash(r.Context(), sm, "error", err.Error())
-			http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+			http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Instructions saved.")
-		http.Redirect(w, r, "/admin/mcp", http.StatusSeeOther)
+		http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
 	}
 }

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -40,7 +40,7 @@ func SetupDetection(queries *db.Queries) func(http.Handler) http.Handler {
 					next.ServeHTTP(w, r)
 					return
 				}
-				http.Redirect(w, r, "/admin/setup", http.StatusSeeOther)
+				http.Redirect(w, r, "/setup", http.StatusSeeOther)
 				return
 			}
 
@@ -51,5 +51,5 @@ func SetupDetection(queries *db.Queries) func(http.Handler) http.Handler {
 
 // isSetupRoute checks whether the path is a setup or setup API route.
 func isSetupRoute(path string) bool {
-	return path == "/admin/setup" || path == "/admin/api/setup"
+	return path == "/setup" || path == "/-/setup"
 }

--- a/internal/admin/providers.go
+++ b/internal/admin/providers.go
@@ -59,7 +59,7 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 
 		if os.Getenv("PLAID_CLIENT_ID") != "" {
 			SetFlash(ctx, sm, "error", "Plaid is configured via environment variables and cannot be changed here.")
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
@@ -86,25 +86,25 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 			a.Config.WebhookURL = ""
 			_ = a.ReinitProvider("plaid")
 			SetFlash(ctx, sm, "success", "Plaid configuration cleared.")
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
 		if plaidSecret == "" {
 			SetFlash(ctx, sm, "error", "Plaid secret is required.")
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
 		if webhookURL != "" && !strings.HasPrefix(webhookURL, "https://") {
 			SetFlash(ctx, sm, "error", "Webhook URL must use HTTPS.")
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
 		if err := plaidprovider.ValidateCredentials(ctx, plaidClientID, plaidSecret, plaidEnv); err != nil {
 			SetFlash(ctx, sm, "error", "Invalid Plaid credentials: "+err.Error())
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
@@ -118,7 +118,7 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 			if err := a.Queries.SetAppConfig(ctx, entry); err != nil {
 				a.Logger.Error("save plaid config", "error", err, "key", entry.Key)
 				SetFlash(ctx, sm, "error", "Failed to save Plaid credentials.")
-				http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+				http.Redirect(w, r, "/providers", http.StatusSeeOther)
 				return
 			}
 		}
@@ -135,12 +135,12 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 		if err := a.ReinitProvider("plaid"); err != nil {
 			a.Logger.Error("reinit plaid provider", "error", err)
 			SetFlash(ctx, sm, "error", "Plaid credentials saved but provider failed to initialize: "+err.Error())
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
 		SetFlash(ctx, sm, "success", "Plaid configuration saved and provider initialized.")
-		http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+		http.Redirect(w, r, "/providers", http.StatusSeeOther)
 	}
 }
 
@@ -151,14 +151,14 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 
 		if os.Getenv("TELLER_APP_ID") != "" {
 			SetFlash(ctx, sm, "error", "Teller is configured via environment variables and cannot be changed here.")
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
 		// Parse multipart form (10MB max for cert/key files).
 		if err := r.ParseMultipartForm(10 << 20); err != nil {
 			SetFlash(ctx, sm, "error", "Failed to parse form data.")
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
@@ -180,7 +180,7 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 			a.Config.TellerKeyPEM = nil
 			_ = a.ReinitProvider("teller")
 			SetFlash(ctx, sm, "success", "Teller configuration cleared.")
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
@@ -203,7 +203,7 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 			if err := a.Queries.SetAppConfig(ctx, entry); err != nil {
 				a.Logger.Error("save teller config", "error", err, "key", entry.Key)
 				SetFlash(ctx, sm, "error", "Failed to save Teller configuration.")
-				http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+				http.Redirect(w, r, "/providers", http.StatusSeeOther)
 				return
 			}
 		}
@@ -221,7 +221,7 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 			certPEM, keyPEM, err := readTellerCertFiles(r)
 			if err != nil {
 				SetFlash(ctx, sm, "error", err.Error())
-				http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+				http.Redirect(w, r, "/providers", http.StatusSeeOther)
 				return
 			}
 
@@ -229,13 +229,13 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 				// Validate the key pair.
 				if err := tellerprovider.ValidateCredentialsPEM(certPEM, keyPEM); err != nil {
 					SetFlash(ctx, sm, "error", "Invalid certificate/key: "+err.Error())
-					http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+					http.Redirect(w, r, "/providers", http.StatusSeeOther)
 					return
 				}
 
 				if len(a.Config.EncryptionKey) == 0 {
 					SetFlash(ctx, sm, "error", "Encryption key is required to store certificates. Set ENCRYPTION_KEY environment variable.")
-					http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+					http.Redirect(w, r, "/providers", http.StatusSeeOther)
 					return
 				}
 
@@ -243,13 +243,13 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 				encCert, err := crypto.Encrypt(certPEM, a.Config.EncryptionKey)
 				if err != nil {
 					SetFlash(ctx, sm, "error", "Failed to encrypt certificate.")
-					http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+					http.Redirect(w, r, "/providers", http.StatusSeeOther)
 					return
 				}
 				encKey, err := crypto.Encrypt(keyPEM, a.Config.EncryptionKey)
 				if err != nil {
 					SetFlash(ctx, sm, "error", "Failed to encrypt private key.")
-					http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+					http.Redirect(w, r, "/providers", http.StatusSeeOther)
 					return
 				}
 
@@ -260,14 +260,14 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 					Key: "teller_cert_pem", Value: pgtype.Text{String: certB64, Valid: true},
 				}); err != nil {
 					SetFlash(ctx, sm, "error", "Failed to save certificate.")
-					http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+					http.Redirect(w, r, "/providers", http.StatusSeeOther)
 					return
 				}
 				if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 					Key: "teller_key_pem", Value: pgtype.Text{String: keyB64, Valid: true},
 				}); err != nil {
 					SetFlash(ctx, sm, "error", "Failed to save private key.")
-					http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+					http.Redirect(w, r, "/providers", http.StatusSeeOther)
 					return
 				}
 
@@ -279,12 +279,12 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 		if err := a.ReinitProvider("teller"); err != nil {
 			a.Logger.Error("reinit teller provider", "error", err)
 			SetFlash(ctx, sm, "error", "Teller settings saved but provider failed to initialize: "+err.Error())
-			http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+			http.Redirect(w, r, "/providers", http.StatusSeeOther)
 			return
 		}
 
 		SetFlash(ctx, sm, "success", "Teller configuration saved.")
-		http.Redirect(w, r, "/admin/providers", http.StatusSeeOther)
+		http.Redirect(w, r, "/providers", http.StatusSeeOther)
 	}
 }
 

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -27,14 +27,14 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 	r.Post("/logout", LogoutHandler(sm))
 
 	// First-run admin creation (unauthenticated).
-	r.Get("/admin/setup", CreateAdminHandler(a.Queries, sm, tr))
-	r.Post("/admin/setup", CreateAdminHandler(a.Queries, sm, tr))
+	r.Get("/setup", CreateAdminHandler(a.Queries, sm, tr))
+	r.Post("/setup", CreateAdminHandler(a.Queries, sm, tr))
 
 	// Programmatic setup API (unauthenticated).
-	r.Post("/admin/api/setup", ProgrammaticSetupHandler(a.Queries, sm))
+	r.Post("/-/setup", ProgrammaticSetupHandler(a.Queries, sm))
 
 	// Authenticated admin routes (HTML pages).
-	r.Route("/admin", func(r chi.Router) {
+	r.Group(func(r chi.Router) {
 		r.Use(RequireAuth(sm))
 		r.Use(CSRFMiddleware(sm))
 
@@ -75,7 +75,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/categories", CategoriesPageHandler(svc, sm, tr))
 		r.Get("/categories/mappings", MappingsPageHandler(svc, sm, tr))
 
-		r.Route("/mcp", func(r chi.Router) {
+		r.Route("/mcp-settings", func(r chi.Router) {
 			r.Get("/", MCPSettingsGetHandler(svc, mcpServer, sm, tr))
 			r.Post("/mode", MCPSaveModeHandler(svc, sm))
 			r.Post("/tools", MCPSaveToolsHandler(svc, mcpServer, sm))
@@ -92,7 +92,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 	})
 
 	// Admin API (authenticated, JSON responses).
-	r.Route("/admin/api", func(r chi.Router) {
+	r.Route("/-", func(r chi.Router) {
 		r.Use(RequireAuth(sm))
 
 		r.Post("/link-token", LinkTokenHandler(a))

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -74,7 +74,7 @@ func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 		syncInterval, err := strconv.Atoi(syncIntervalStr)
 		if err != nil || !isValidSyncInterval(syncInterval) {
 			SetFlash(ctx, sm, "error", "Invalid sync interval.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
 
@@ -84,13 +84,13 @@ func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 		}); err != nil {
 			a.Logger.Error("save sync interval", "error", err)
 			SetFlash(ctx, sm, "error", "Failed to save sync interval.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
 		a.Config.SyncIntervalMinutes = syncInterval
 
 		SetFlash(ctx, sm, "success", "Sync settings saved.")
-		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 	}
 }
 
@@ -108,14 +108,14 @@ func ChangePasswordHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc 
 		var adminID pgtype.UUID
 		if err := adminID.Scan(adminIDStr); err != nil {
 			SetFlash(ctx, sm, "error", "Invalid session.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
 
 		admin, err := a.Queries.GetAdminAccountByID(ctx, adminID)
 		if err != nil {
 			SetFlash(ctx, sm, "error", "Account not found.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
 
@@ -125,26 +125,26 @@ func ChangePasswordHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc 
 
 		if err := bcrypt.CompareHashAndPassword(admin.HashedPassword, []byte(currentPassword)); err != nil {
 			SetFlash(ctx, sm, "error", "Current password is incorrect.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
 
 		if len(newPassword) < 8 {
 			SetFlash(ctx, sm, "error", "New password must be at least 8 characters.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
 
 		if newPassword != confirmPassword {
 			SetFlash(ctx, sm, "error", "New passwords do not match.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
 
 		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
 		if err != nil {
 			SetFlash(ctx, sm, "error", "Failed to hash password.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
 
@@ -154,12 +154,12 @@ func ChangePasswordHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc 
 		}); err != nil {
 			a.Logger.Error("update admin password", "error", err)
 			SetFlash(ctx, sm, "error", "Failed to update password.")
-			http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
 			return
 		}
 
 		SetFlash(ctx, sm, "success", "Password updated successfully.")
-		http.Redirect(w, r, "/admin/settings", http.StatusSeeOther)
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 	}
 }
 

--- a/internal/admin/setup.go
+++ b/internal/admin/setup.go
@@ -24,7 +24,7 @@ func CreateAdminHandler(queries *db.Queries, sm *scs.SessionManager, tr *Templat
 		// If admin accounts already exist, redirect to dashboard.
 		count, err := queries.CountAdminAccounts(ctx)
 		if err == nil && count > 0 {
-			http.Redirect(w, r, "/admin/", http.StatusSeeOther)
+			http.Redirect(w, r, "/", http.StatusSeeOther)
 			return
 		}
 

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -38,7 +38,7 @@
       <label for="bb-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
       <aside class="bg-base-200 min-h-full w-60 p-4 flex flex-col">
         <!-- Brand -->
-        <a href="/admin/" class="text-xl font-bold px-4 py-2 mb-4 no-underline text-base-content">
+        <a href="/" class="text-xl font-bold px-4 py-2 mb-4 no-underline text-base-content">
           <i data-lucide="package" class="w-5 h-5 inline-block mr-1"></i>
           Breadbox
         </a>

--- a/internal/templates/pages/404.html
+++ b/internal/templates/pages/404.html
@@ -5,7 +5,7 @@
       <i data-lucide="search" class="w-12 h-12 text-base-content/30 mb-2"></i>
       <h1 class="text-2xl font-bold">Page Not Found</h1>
       <p class="text-base-content/70">The page you requested doesn't exist.</p>
-      <a href="/admin/" class="btn btn-primary mt-4">Back to Dashboard</a>
+      <a href="/" class="btn btn-primary mt-4">Back to Dashboard</a>
     </div>
   </div>
 </div>

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -3,7 +3,7 @@
 
 <div class="breadcrumbs text-sm mb-4">
   <ul>
-    <li><a href="/admin/connections/{{.Account.ConnectionID}}">{{.Account.InstitutionName}}</a></li>
+    <li><a href="/connections/{{.Account.ConnectionID}}">{{.Account.InstitutionName}}</a></li>
     <li>{{if .Account.DisplayName}}{{.Account.DisplayName}}{{else}}{{.Account.Name}}{{end}}</li>
   </ul>
 </div>
@@ -28,7 +28,7 @@
   <dd>{{printf "%.2f" .Account.BalanceLimit}} {{.Account.IsoCurrencyCode}}</dd>
   {{end}}
   <dt>Connection</dt>
-  <dd><a href="/admin/connections/{{.Account.ConnectionID}}">{{.Account.InstitutionName}}</a></dd>
+  <dd><a href="/connections/{{.Account.ConnectionID}}">{{.Account.InstitutionName}}</a></dd>
   <dt>Family Member</dt>
   <dd>{{if .Account.UserName}}{{.Account.UserName}}{{else}}&mdash;{{end}}</dd>
   <dt>Provider</dt>
@@ -51,7 +51,7 @@
 
 <h2 class="text-xl font-semibold mb-4">Transactions</h2>
 
-<form method="GET" action="/admin/accounts/{{.AccountID}}" class="bb-filter-bar" x-data>
+<form method="GET" action="/accounts/{{.AccountID}}" class="bb-filter-bar" x-data>
   <label>
     Start Date
     <input type="date" name="start_date" value="{{.FilterStartDate}}">
@@ -99,7 +99,7 @@
   </label>
   <button type="submit" class="btn btn-sm btn-primary self-end">Filter</button>
   {{if or .FilterStartDate .FilterEndDate .FilterCategory .FilterPending .FilterSearch}}
-  <a href="/admin/accounts/{{.AccountID}}" class="btn btn-sm btn-ghost self-end">Clear</a>
+  <a href="/accounts/{{.AccountID}}" class="btn btn-sm btn-ghost self-end">Clear</a>
   {{end}}
 </form>
 
@@ -120,7 +120,7 @@
       <tr @click="expanded = !expanded" class="cursor-pointer hover:bg-base-300">
         <td>{{.Date}}</td>
         <td>
-          <a href="/admin/transactions/{{.ID}}" @click.stop class="link link-hover">{{.Name}}</a>
+          <a href="/transactions/{{.ID}}" @click.stop class="link link-hover">{{.Name}}</a>
           {{if .MerchantName}}<small class="text-base-content/60"> ({{.MerchantName}})</small>{{end}}
         </td>
         <td class="bb-amount{{if lt .Amount 0.0}} text-error{{end}}">
@@ -171,7 +171,7 @@
   <div>
     {{if gt .Page 1}}
     <div class="join">
-      <a href="/admin/accounts/{{$.AccountID}}?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}" class="join-item btn btn-sm">&laquo; Previous</a>
+      <a href="/accounts/{{$.AccountID}}?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}" class="join-item btn btn-sm">&laquo; Previous</a>
     </div>
     {{end}}
   </div>
@@ -179,7 +179,7 @@
   <div>
     {{if lt .Page .TotalPages}}
     <div class="join">
-      <a href="/admin/accounts/{{$.AccountID}}?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}" class="join-item btn btn-sm">Next &raquo;</a>
+      <a href="/accounts/{{$.AccountID}}?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}" class="join-item btn btn-sm">Next &raquo;</a>
     </div>
     {{end}}
   </div>
@@ -190,7 +190,7 @@
 <div class="card bg-base-100 border border-base-300 text-center p-8">
   <p>No transactions found for this account.</p>
   {{if or .FilterStartDate .FilterEndDate .FilterCategory .FilterPending .FilterSearch}}
-  <a href="/admin/accounts/{{.AccountID}}" class="btn btn-sm btn-ghost mt-4">Clear filters</a>
+  <a href="/accounts/{{.AccountID}}" class="btn btn-sm btn-ghost mt-4">Clear filters</a>
   {{end}}
 </div>
 {{end}}
@@ -203,13 +203,13 @@ function showToast(message, type) {
 
 function quickSetCategory(txId, categoryId) {
   if (!categoryId) {
-    fetch('/admin/api/transactions/' + txId + '/category', { method: 'DELETE' })
+    fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
     .then(function(r) {
       if (r.ok || r.status === 204) showToast('Category reset', 'success');
     });
     return;
   }
-  fetch('/admin/api/transactions/' + txId + '/category', {
+  fetch('/-/transactions/' + txId + '/category', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({category_id: categoryId})
@@ -222,7 +222,7 @@ function quickSetCategory(txId, categoryId) {
 
 function updateDisplayName(accountId, val) {
   var body = val === "" ? {display_name: null} : {display_name: val};
-  fetch("/admin/api/accounts/" + accountId + "/display-name", {
+  fetch("/-/accounts/" + accountId + "/display-name", {
     method: "POST",
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify(body)
@@ -242,7 +242,7 @@ function updateDisplayName(accountId, val) {
 }
 
 function toggleExcluded(accountId, checked) {
-  fetch("/admin/api/accounts/" + accountId + "/excluded", {
+  fetch("/-/accounts/" + accountId + "/excluded", {
     method: "POST",
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify({excluded: checked})

--- a/internal/templates/pages/api_key_created.html
+++ b/internal/templates/pages/api_key_created.html
@@ -24,7 +24,7 @@
         <span x-show="!copied">Copy to Clipboard</span>
         <span x-show="copied" x-cloak>Copied!</span>
       </button>
-      <a href="/admin/api-keys" class="btn btn-ghost">Done</a>
+      <a href="/api-keys" class="btn btn-ghost">Done</a>
     </div>
   </div>
 </div>

--- a/internal/templates/pages/api_key_new.html
+++ b/internal/templates/pages/api_key_new.html
@@ -3,7 +3,7 @@
 
 <div class="card bg-base-100 border border-base-300 max-w-lg">
   <div class="card-body">
-    <form method="POST" action="/admin/api-keys/new">
+    <form method="POST" action="/api-keys/new">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
       <fieldset class="fieldset">
         <label class="fieldset-label" for="name">Name</label>
@@ -20,7 +20,7 @@
       </fieldset>
       <div class="flex gap-2 mt-4">
         <button type="submit" class="btn btn-primary">Create API Key</button>
-        <a href="/admin/api-keys" class="btn btn-ghost">Cancel</a>
+        <a href="/api-keys" class="btn btn-ghost">Cancel</a>
       </div>
     </form>
   </div>

--- a/internal/templates/pages/api_keys.html
+++ b/internal/templates/pages/api_keys.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <div class="flex items-center justify-between mb-6">
   <h1 class="text-2xl font-bold m-0">API Keys</h1>
-  <a href="/admin/api-keys/new" class="btn btn-primary">
+  <a href="/api-keys/new" class="btn btn-primary">
     <i data-lucide="plus" class="w-4 h-4"></i>
     Create API Key
   </a>
@@ -44,7 +44,7 @@
         <td>{{.CreatedAt}}</td>
         <td>
           {{if not .RevokedAt}}
-          <form method="POST" action="/admin/api-keys/{{.ID}}/revoke" class="inline" x-data="{ confirming: false }">
+          <form method="POST" action="/api-keys/{{.ID}}/revoke" class="inline" x-data="{ confirming: false }">
             <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
             <button type="button" class="btn btn-ghost btn-xs" x-show="!confirming" @click="confirming = true">Revoke</button>
             <span x-show="confirming" x-cloak>
@@ -64,7 +64,7 @@
   <div class="card-body items-center text-center py-12">
     <i data-lucide="key" class="w-12 h-12 text-base-content/30 mb-2"></i>
     <p class="text-base-content/70">No API keys yet.</p>
-    <a href="/admin/api-keys/new" class="btn btn-primary mt-2">
+    <a href="/api-keys/new" class="btn btn-primary mt-2">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Create your first API key
     </a>

--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -182,7 +182,7 @@
                     <button class="btn btn-sm btn-primary" :disabled="!selectedId || submitting" @click="
                       submitting = true;
                       let provCat = '{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}';
-                      fetch('/admin/api/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: selectedId})})
+                      fetch('/-/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: selectedId})})
                       .then(r => { if(r.ok) location.reload(); else { submitting = false; window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Failed to create mapping',type:'error'}})); } })
                       .catch(() => { submitting = false; })
                     ">Map</button>
@@ -227,7 +227,7 @@
               <button class="btn btn-sm btn-primary" :disabled="!selectedId || submitting" @click="
                 submitting = true;
                 let provCat = '{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}';
-                fetch('/admin/api/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: selectedId})})
+                fetch('/-/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: selectedId})})
                 .then(r => { if(r.ok) location.reload(); else { submitting = false; } })
                 .catch(() => { submitting = false; })
               ">Map</button>
@@ -251,7 +251,7 @@
             <option value="csv"{{if eq .FilterProvider "csv"}} selected{{end}}>CSV</option>
           </select>
         </label>
-        {{if .FilterProvider}}<a href="/admin/categories#mappings" class="btn btn-sm btn-ghost">Clear</a>{{end}}
+        {{if .FilterProvider}}<a href="/categories#mappings" class="btn btn-sm btn-ghost">Clear</a>{{end}}
       </form>
       <div class="ml-auto">
         <input type="text" placeholder="Search mappings..." class="input input-sm input-bordered w-48" @input="mappingSearch = $event.target.value">
@@ -305,7 +305,7 @@
                       </div>
                       <button class="btn btn-sm btn-primary" :disabled="submitting" @click="
                         submitting = true;
-                        fetch('/admin/api/category-mappings/{{.ID}}', {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({category_id: categoryId})})
+                        fetch('/-/category-mappings/{{.ID}}', {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({category_id: categoryId})})
                         .then(r => { if(r.ok) location.reload(); else { submitting = false; editing = false; } })
                         .catch(() => { submitting = false; })
                       ">Save</button>
@@ -316,7 +316,7 @@
                 <td>
                   <button class="btn btn-ghost btn-xs text-error" @click="
                     if(confirm('Delete this mapping?')) {
-                      fetch('/admin/api/category-mappings/{{.ID}}', {method: 'DELETE'})
+                      fetch('/-/category-mappings/{{.ID}}', {method: 'DELETE'})
                       .then(r => { if(r.ok) location.reload(); })
                     }
                   "><i data-lucide="trash-2" class="w-4 h-4"></i></button>
@@ -475,7 +475,7 @@
     presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c']
   }" @submit.prevent="
     submitting = true;
-    fetch('/admin/api/categories', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({display_name: displayName, parent_id: parentId || undefined, icon: icon || undefined, color: color || undefined, sort_order: sortOrder})})
+    fetch('/-/categories', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({display_name: displayName, parent_id: parentId || undefined, icon: icon || undefined, color: color || undefined, sort_order: sortOrder})})
     .then(r => { if(r.ok) location.reload(); else r.json().then(d => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Error', type:'error'}})); submitting = false; }); })
     .catch(() => { submitting = false; })
   ">
@@ -631,7 +631,7 @@
       <button type="button" class="btn" onclick="document.getElementById('edit-modal').close()">Cancel</button>
       <button type="button" class="btn btn-primary" :disabled="submitting || !editDisplayName" @click="
         submitting = true;
-        fetch('/admin/api/categories/' + editId, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({display_name: editDisplayName, icon: editIcon || undefined, color: editColor || undefined, sort_order: editSortOrder, hidden: editHidden})})
+        fetch('/-/categories/' + editId, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({display_name: editDisplayName, icon: editIcon || undefined, color: editColor || undefined, sort_order: editSortOrder, hidden: editHidden})})
         .then(r => { if(r.ok) location.reload(); else r.json().then(d => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Error', type:'error'}})); submitting = false; }); })
         .catch(() => { submitting = false; })
       ">
@@ -652,7 +652,7 @@
       <button type="button" class="btn" onclick="document.getElementById('delete-modal').close()">Cancel</button>
       <button type="button" class="btn btn-error" :disabled="submitting" @click="
         submitting = true;
-        fetch('/admin/api/categories/' + deleteId, {method: 'DELETE'})
+        fetch('/-/categories/' + deleteId, {method: 'DELETE'})
         .then(r => { if(r.ok) location.reload(); else r.json().then(d => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Error', type:'error'}})); submitting = false; }); })
         .catch(() => { submitting = false; })
       ">
@@ -706,7 +706,7 @@ function mappingsTab() {
         const [provider, providerCategory] = v.split('||');
         return { provider, provider_category: providerCategory, category_id: this.bulkCategoryId };
       });
-      fetch('/admin/api/category-mappings/bulk', {
+      fetch('/-/category-mappings/bulk', {
         method: 'PUT',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({mappings})
@@ -776,7 +776,7 @@ Paste the exported TSV below this line, then edit it according to the instructio
     exportCategories() {
       this.catLoading = true;
       this.catResult = null;
-      fetch('/admin/api/categories/export-tsv')
+      fetch('/-/categories/export-tsv')
         .then(r => { if (!r.ok) throw new Error('Export failed'); return r.text(); })
         .then(text => { this.catText = text; })
         .catch(() => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Failed to export categories',type:'error'}})); })
@@ -789,7 +789,7 @@ Paste the exported TSV below this line, then edit it according to the instructio
       this.catImporting = true;
       this.catResult = null;
       const params = this.catReplace ? '?replace=true' : '';
-      fetch('/admin/api/categories/import-tsv' + params, {
+      fetch('/-/categories/import-tsv' + params, {
         method: 'POST',
         headers: {'Content-Type': 'text/tab-separated-values'},
         body: this.catText
@@ -812,7 +812,7 @@ Paste the exported TSV below this line, then edit it according to the instructio
     exportMappings() {
       this.mapLoading = true;
       this.mapResult = null;
-      fetch('/admin/api/category-mappings/export-tsv')
+      fetch('/-/category-mappings/export-tsv')
         .then(r => { if (!r.ok) throw new Error('Export failed'); return r.text(); })
         .then(text => { this.mapText = text; })
         .catch(() => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Failed to export mappings',type:'error'}})); })
@@ -828,7 +828,7 @@ Paste the exported TSV below this line, then edit it according to the instructio
       if (this.mapRetroactive) qp.set('apply_retroactively', 'true');
       if (this.mapReplace) qp.set('replace', 'true');
       const qs = qp.toString();
-      const url = '/admin/api/category-mappings/import-tsv' + (qs ? '?' + qs : '');
+      const url = '/-/category-mappings/import-tsv' + (qs ? '?' + qs : '');
       fetch(url, {
         method: 'POST',
         headers: {'Content-Type': 'text/tab-separated-values'},

--- a/internal/templates/pages/category_mappings.html
+++ b/internal/templates/pages/category_mappings.html
@@ -4,7 +4,7 @@
     <h1 class="text-2xl font-bold">Category Mappings</h1>
     <p class="text-sm text-base-content/60 mt-1">Map provider category strings to your category taxonomy</p>
   </div>
-  <a href="/admin/categories" class="btn btn-sm btn-outline">
+  <a href="/categories" class="btn btn-sm btn-outline">
     <i data-lucide="tag" class="w-4 h-4"></i> Back to Categories
   </a>
 </div>
@@ -43,7 +43,7 @@
               <button class="btn btn-sm btn-primary" :disabled="!categoryId || submitting" @click="
                 submitting = true;
                 let provCat = '{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}';
-                fetch('/admin/api/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: categoryId})})
+                fetch('/-/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: categoryId})})
                 .then(r => { if(r.ok) location.reload(); else { submitting = false; alert('Failed to create mapping'); } })
                 .catch(() => { submitting = false; })
               ">Map</button>
@@ -68,7 +68,7 @@
         <option value="csv"{{if eq .FilterProvider "csv"}} selected{{end}}>CSV</option>
       </select>
     </label>
-    {{if .FilterProvider}}<a href="/admin/categories/mappings" class="btn btn-sm btn-ghost">Clear</a>{{end}}
+    {{if .FilterProvider}}<a href="/categories/mappings" class="btn btn-sm btn-ghost">Clear</a>{{end}}
   </form>
 </div>
 
@@ -101,7 +101,7 @@
                   </select>
                   <button class="btn btn-sm btn-primary" :disabled="submitting" @click="
                     submitting = true;
-                    fetch('/admin/api/category-mappings/{{.ID}}', {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({category_id: categoryId})})
+                    fetch('/-/category-mappings/{{.ID}}', {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({category_id: categoryId})})
                     .then(r => { if(r.ok) location.reload(); else { submitting = false; editing = false; } })
                     .catch(() => { submitting = false; })
                   ">Save</button>
@@ -112,7 +112,7 @@
             <td>
               <button class="btn btn-ghost btn-xs text-error" @click="
                 if(confirm('Delete this mapping?')) {
-                  fetch('/admin/api/category-mappings/{{.ID}}', {method: 'DELETE'})
+                  fetch('/-/category-mappings/{{.ID}}', {method: 'DELETE'})
                   .then(r => { if(r.ok) location.reload(); })
                 }
               "><i data-lucide="trash-2" class="w-4 h-4"></i></button>

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <div class="breadcrumbs text-sm mb-4">
   <ul>
-    <li><a href="/admin/connections">Connections</a></li>
+    <li><a href="/connections">Connections</a></li>
     <li>{{.Connection.InstitutionName.String}}</li>
   </ul>
 </div>
@@ -12,7 +12,7 @@
   <div>
     <strong>This connection requires re-authentication.</strong> The bank may have changed its login requirements, or your session may have expired.
     {{if .Connection.ErrorCode.Valid}}<br><small>{{errorMessage .Connection.ErrorCode.String}}</small>{{else if .Connection.ErrorMessage.Valid}}<br><small>{{.Connection.ErrorMessage.String}}</small>{{end}}
-    <br><a href="/admin/connections/{{.ConnID}}/reauth" class="link font-semibold">Re-authenticate &rarr;</a>
+    <br><a href="/connections/{{.ConnID}}/reauth" class="link font-semibold">Re-authenticate &rarr;</a>
   </div>
 </div>
 {{end}}
@@ -34,10 +34,10 @@
 
 <div class="bb-action-bar">
   {{if or (eq (printf "%s" .Connection.Status) "error") (eq (printf "%s" .Connection.Status) "pending_reauth")}}
-  <a href="/admin/connections/{{.ConnID}}/reauth" class="btn btn-outline btn-sm">Re-authenticate</a>
+  <a href="/connections/{{.ConnID}}/reauth" class="btn btn-outline btn-sm">Re-authenticate</a>
   {{end}}
   {{if eq (printf "%s" .Connection.Provider) "csv"}}
-  <a href="/admin/connections/import-csv?connection_id={{.ConnID}}" class="btn btn-outline btn-sm">Import More</a>
+  <a href="/connections/import-csv?connection_id={{.ConnID}}" class="btn btn-outline btn-sm">Import More</a>
   {{end}}
   {{if eq (printf "%s" .Connection.Status) "active"}}
   <button class="btn btn-outline btn-sm" onclick="syncConnection()" id="sync-btn">
@@ -91,7 +91,7 @@
     <tbody>
       {{range .Accounts}}
       <tr class="hover:bg-base-300{{if .Excluded}} opacity-60{{end}}">
-        <td><a href="/admin/accounts/{{formatUUID .ID}}">{{.Name}}</a></td>
+        <td><a href="/accounts/{{formatUUID .ID}}">{{.Name}}</a></td>
         <td>
           <input type="text" value="{{.DisplayName.String}}" placeholder="{{.Name}}"
             onchange="updateDisplayName('{{formatUUID .ID}}', this.value)"
@@ -165,7 +165,7 @@ function syncConnection() {
   var btn = document.getElementById('sync-btn');
   btn.disabled = true;
   btn.textContent = 'Syncing...';
-  fetch("/admin/api/connections/{{.ConnID}}/sync", {
+  fetch("/-/connections/{{.ConnID}}/sync", {
     method: "POST"
   })
   .then(function(res) {
@@ -188,12 +188,12 @@ function syncConnection() {
 }
 
 function removeConnection() {
-  fetch("/admin/api/connections/{{.ConnID}}", {
+  fetch("/-/connections/{{.ConnID}}", {
     method: "DELETE"
   })
   .then(function (res) {
     if (res.ok) {
-      window.location.href = "/admin/connections";
+      window.location.href = "/connections";
     } else {
       return res.json().then(function (data) {
         showToast(data.error || "Failed to remove connection.");
@@ -210,7 +210,7 @@ function togglePause() {
   var isPaused = btn.textContent.trim() === 'Resume';
   var newPaused = !isPaused;
   btn.disabled = true;
-  fetch("/admin/api/connections/{{.ConnID}}/paused", {
+  fetch("/-/connections/{{.ConnID}}/paused", {
     method: "POST",
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify({paused: newPaused})
@@ -235,7 +235,7 @@ function updateSyncInterval(val) {
   var body = val === "" ? {minutes: null} : {minutes: parseInt(val, 10)};
   var status = document.getElementById('interval-status');
   status.textContent = 'Saving...';
-  fetch("/admin/api/connections/{{.ConnID}}/sync-interval", {
+  fetch("/-/connections/{{.ConnID}}/sync-interval", {
     method: "POST",
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify(body)
@@ -257,7 +257,7 @@ function updateSyncInterval(val) {
 
 function updateDisplayName(accountId, val) {
   var body = val === "" ? {display_name: null} : {display_name: val};
-  fetch("/admin/api/accounts/" + accountId + "/display-name", {
+  fetch("/-/accounts/" + accountId + "/display-name", {
     method: "POST",
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify(body)
@@ -275,7 +275,7 @@ function updateDisplayName(accountId, val) {
 }
 
 function toggleExcluded(accountId, checked) {
-  fetch("/admin/api/accounts/" + accountId + "/excluded", {
+  fetch("/-/accounts/" + accountId + "/excluded", {
     method: "POST",
     headers: {"Content-Type": "application/json"},
     body: JSON.stringify({excluded: checked})

--- a/internal/templates/pages/connection_new.html
+++ b/internal/templates/pages/connection_new.html
@@ -7,11 +7,11 @@
     <h2 class="card-title">No Providers Configured</h2>
     <p class="text-base-content/70">You need to configure at least one bank provider before creating connections.</p>
     <div class="mt-2">
-      <a href="/admin/providers" class="btn btn-primary btn-sm">Configure Providers</a>
+      <a href="/providers" class="btn btn-primary btn-sm">Configure Providers</a>
     </div>
   </div>
 </div>
-<p class="mt-4"><a href="/admin/connections" class="link">&larr; Back to Connections</a></p>
+<p class="mt-4"><a href="/connections" class="link">&larr; Back to Connections</a></p>
 {{else}}
 <div id="step-select" {{if .ShowLink}}class="hidden"{{end}}>
   <div class="card bg-base-100 border border-base-300">
@@ -44,7 +44,7 @@
       </form>
     </div>
   </div>
-  <p class="mt-4"><a href="/admin/connections" class="link">&larr; Back to Connections</a></p>
+  <p class="mt-4"><a href="/connections" class="link">&larr; Back to Connections</a></p>
 </div>
 
 <div id="step-link" class="hidden">
@@ -81,7 +81,7 @@
     selectedProvider = document.getElementById("provider").value || "plaid";
     if (!selectedUserId) return;
     if (selectedProvider === "csv") {
-      window.location.href = "/admin/connections/import-csv";
+      window.location.href = "/connections/import-csv";
       return;
     }
     memberNameEl.textContent = select.options[select.selectedIndex].text;
@@ -135,7 +135,7 @@
     linkStatus.classList.add("text-base-content/70");
     retryBtn.classList.add("hidden");
 
-    fetch("/admin/api/link-token", {
+    fetch("/-/link-token", {
       method: "POST",
       headers: {"Content-Type": "application/json"},
       body: JSON.stringify({user_id: selectedUserId, provider: selectedProvider})
@@ -162,7 +162,7 @@
       token: token,
       onSuccess: function (publicToken, metadata) {
         showMessage("Saving connection...");
-        fetch("/admin/api/exchange-token", {
+        fetch("/-/exchange-token", {
           method: "POST",
           headers: {"Content-Type": "application/json"},
           body: JSON.stringify({
@@ -177,7 +177,7 @@
         .then(function (res) { return res.json(); })
         .then(function (data) {
           if (data.connection_id) {
-            window.location.href = "/admin/connections/" + data.connection_id;
+            window.location.href = "/connections/" + data.connection_id;
           } else {
             showError(data.error || "An unknown error occurred.");
           }
@@ -209,7 +209,7 @@
           enrollment_id: enrollment.enrollment.id,
           institution_name: enrollment.enrollment.institution.name
         });
-        fetch("/admin/api/exchange-token", {
+        fetch("/-/exchange-token", {
           method: "POST",
           headers: {"Content-Type": "application/json"},
           body: JSON.stringify({
@@ -223,7 +223,7 @@
         .then(function(res) { return res.json(); })
         .then(function(data) {
           if (data.connection_id) {
-            window.location.href = "/admin/connections/" + data.connection_id;
+            window.location.href = "/connections/" + data.connection_id;
           } else {
             showError(data.error || "An unknown error occurred.");
           }

--- a/internal/templates/pages/connection_reauth.html
+++ b/internal/templates/pages/connection_reauth.html
@@ -7,8 +7,8 @@
 
 <div class="breadcrumbs text-sm mb-4">
   <ul>
-    <li><a href="/admin/connections">Connections</a></li>
-    <li><a href="/admin/connections/{{.ConnID}}">{{.Connection.InstitutionName.String}}</a></li>
+    <li><a href="/connections">Connections</a></li>
+    <li><a href="/connections/{{.ConnID}}">{{.Connection.InstitutionName.String}}</a></li>
     <li>Re-authenticate</li>
   </ul>
 </div>
@@ -49,7 +49,7 @@
     linkStatus.classList.add("text-base-content/70");
     retryBtn.classList.add("hidden");
 
-    fetch("/admin/api/connections/" + connId + "/reauth", {
+    fetch("/-/connections/" + connId + "/reauth", {
       method: "POST",
       headers: {"Content-Type": "application/json"}
     })
@@ -75,7 +75,7 @@
       token: token,
       onSuccess: function (publicToken, metadata) {
         showMessage("Completing re-authentication...");
-        fetch("/admin/api/connections/" + connId + "/reauth-complete", {
+        fetch("/-/connections/" + connId + "/reauth-complete", {
           method: "POST",
           headers: {"Content-Type": "application/json"},
           body: JSON.stringify({public_token: publicToken})
@@ -83,7 +83,7 @@
         .then(function (res) { return res.json(); })
         .then(function (data) {
           if (data.status === "active") {
-            window.location.href = "/admin/connections/" + connId;
+            window.location.href = "/connections/" + connId;
           } else {
             showError(data.error || "Re-authentication failed.");
           }
@@ -110,14 +110,14 @@
       environment: "{{.TellerEnv}}",
       onSuccess: function(enrollment) {
         showMessage("Completing re-authentication...");
-        fetch("/admin/api/connections/" + connId + "/reauth-complete", {
+        fetch("/-/connections/" + connId + "/reauth-complete", {
           method: "POST",
           headers: {"Content-Type": "application/json"}
         })
         .then(function(res) { return res.json(); })
         .then(function(data) {
           if (data.status === "active") {
-            window.location.href = "/admin/connections/" + connId;
+            window.location.href = "/connections/" + connId;
           } else {
             showError(data.error || "Re-authentication failed.");
           }

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <div class="flex items-center justify-between mb-6">
   <h1 class="text-2xl font-bold m-0">Bank Connections</h1>
-  <a href="/admin/connections/new" class="btn btn-primary">
+  <a href="/connections/new" class="btn btn-primary">
     <i data-lucide="plus" class="w-4 h-4"></i>
     Connect New Bank
   </a>
@@ -31,9 +31,9 @@
         </td>
         <td>{{if .LastSyncedAt.Valid}}{{relativeTime .LastSyncedAt.Time}}{{else}}Never{{end}}</td>
         <td class="flex gap-2">
-          <a href="/admin/connections/{{formatUUID .ID}}" class="btn btn-ghost btn-xs">View</a>
+          <a href="/connections/{{formatUUID .ID}}" class="btn btn-ghost btn-xs">View</a>
           {{if or (eq (printf "%s" .Status) "error") (eq (printf "%s" .Status) "pending_reauth")}}
-            <a href="/admin/connections/{{formatUUID .ID}}/reauth" class="btn btn-outline btn-warning btn-xs">Re-auth</a>
+            <a href="/connections/{{formatUUID .ID}}/reauth" class="btn btn-outline btn-warning btn-xs">Re-auth</a>
           {{end}}
         </td>
       </tr>
@@ -46,7 +46,7 @@
   <div class="flex flex-col items-center gap-4">
     <i data-lucide="inbox" class="w-12 h-12 text-base-content/30"></i>
     <p class="text-base-content/70">No bank connections yet. Connect your first bank to get started.</p>
-    <a href="/admin/connections/new" class="btn btn-primary">
+    <a href="/connections/new" class="btn btn-primary">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Connect New Bank
     </a>

--- a/internal/templates/pages/csv_import.html
+++ b/internal/templates/pages/csv_import.html
@@ -1,5 +1,5 @@
 {{define "content"}}
-<p class="mb-4"><a href="/admin/connections" class="link">&larr; Connections</a></p>
+<p class="mb-4"><a href="/connections" class="link">&larr; Connections</a></p>
 <h1 class="text-2xl font-bold mb-6">Import CSV</h1>
 
 <div id="step-1" {{if .ConnectionID}}class="hidden"{{end}}>
@@ -217,7 +217,7 @@
     var formData = new FormData();
     formData.append("file", fileInput.files[0]);
 
-    fetch("/admin/api/csv/upload", {
+    fetch("/-/csv/upload", {
       method: "POST",
       headers: {"X-CSRF-Token": csrfToken},
       body: formData
@@ -316,7 +316,7 @@
     var positiveIsDebit = document.querySelector('input[name="sign-convention"]:checked').value === "debit";
     var hasDebitCredit = document.getElementById("has-debit-credit").checked;
 
-    fetch("/admin/api/csv/preview", {
+    fetch("/-/csv/preview", {
       method: "POST",
       headers: {"Content-Type": "application/json", "X-CSRF-Token": csrfToken},
       body: JSON.stringify({
@@ -435,7 +435,7 @@
       body.account_name = document.getElementById("account-name").value || "CSV Import";
     }
 
-    fetch("/admin/api/csv/import", {
+    fetch("/-/csv/import", {
       method: "POST",
       headers: {"Content-Type": "application/json", "X-CSRF-Token": csrfToken},
       body: JSON.stringify(body)
@@ -475,7 +475,7 @@
       document.getElementById("skip-reasons").classList.remove("hidden");
     }
 
-    document.getElementById("result-link").href = "/admin/connections/" + data.ConnectionID;
+    document.getElementById("result-link").href = "/connections/" + data.ConnectionID;
     goToStep(4);
   }
 

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -24,7 +24,7 @@
       x-show="!pulled"
       :disabled="pulling"
       @click="pulling = true; error = '';
-        fetch('/admin/api/update', {method: 'POST', headers: {'Content-Type': 'application/json'}})
+        fetch('/-/update', {method: 'POST', headers: {'Content-Type': 'application/json'}})
           .then(r => r.json())
           .then(d => { if (d.ok) { pulled = true; } else { error = d.error || 'Update failed'; } })
           .catch(() => { error = 'Network error'; })
@@ -40,7 +40,7 @@
       </div>
     </div>
     <button class="btn btn-sm btn-ghost"
-      @click="fetch('/admin/api/update/dismiss', {
+      @click="fetch('/-/update/dismiss', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({version: '{{.LatestVersion}}'})
@@ -64,17 +64,17 @@
         <span class="text-left">Create admin account</span>
       </li>
       <li class="step{{if .HasProvider}} step-primary{{end}}">
-        <span class="text-left">{{if .HasProvider}}Bank provider configured{{else}}<a href="/admin/providers" class="link">Configure a bank provider</a>{{end}}</span>
+        <span class="text-left">{{if .HasProvider}}Bank provider configured{{else}}<a href="/providers" class="link">Configure a bank provider</a>{{end}}</span>
       </li>
       <li class="step{{if .HasMember}} step-primary{{end}}">
-        <span class="text-left">{{if .HasMember}}Family member added{{else}}<a href="/admin/users/new" class="link">Add a family member</a>{{end}}</span>
+        <span class="text-left">{{if .HasMember}}Family member added{{else}}<a href="/users/new" class="link">Add a family member</a>{{end}}</span>
       </li>
       <li class="step{{if .HasConnection}} step-primary{{end}}">
-        <span class="text-left">{{if .HasConnection}}Bank connected{{else}}<a href="/admin/connections/new" class="link">Connect your first bank</a>{{end}}</span>
+        <span class="text-left">{{if .HasConnection}}Bank connected{{else}}<a href="/connections/new" class="link">Connect your first bank</a>{{end}}</span>
       </li>
     </ul>
     <div class="card-actions justify-end mt-2">
-      <form method="POST" action="/admin/onboarding/dismiss">
+      <form method="POST" action="/onboarding/dismiss">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
         <button type="submit" class="btn btn-ghost btn-sm">Dismiss</button>
       </form>
@@ -88,7 +88,7 @@
   <i data-lucide="alert-triangle" class="w-5 h-5"></i>
   <div>
     <strong>{{.NeedsAttention}} connection(s) need attention.</strong>
-    <a href="/admin/connections" class="link ml-1">View connections &rarr;</a>
+    <a href="/connections" class="link ml-1">View connections &rarr;</a>
   </div>
 </div>
 {{end}}
@@ -101,7 +101,7 @@
     <div class="stat-title">Accounts Connected</div>
     <div class="stat-value">{{.AccountCount}}</div>
   </div>
-  <a href="/admin/transactions" class="stat hover:bg-base-300 no-underline">
+  <a href="/transactions" class="stat hover:bg-base-300 no-underline">
     <div class="stat-figure text-base-content/50">
       <i data-lucide="trending-up" class="w-8 h-8"></i>
     </div>
@@ -116,7 +116,7 @@
     <div class="stat-value text-lg">{{.LastSync}}</div>
   </div>
   {{if gt .NeedsAttention 0}}
-  <a href="/admin/connections" class="stat border-l-4 border-warning hover:bg-base-300 no-underline">
+  <a href="/connections" class="stat border-l-4 border-warning hover:bg-base-300 no-underline">
     <div class="stat-figure text-warning">
       <i data-lucide="alert-triangle" class="w-8 h-8"></i>
     </div>
@@ -133,7 +133,7 @@
   </div>
   {{end}}
   {{if gt .ReviewPending 0}}
-  <a href="/admin/reviews" class="stat border-l-4 border-info hover:bg-base-300 no-underline">
+  <a href="/reviews" class="stat border-l-4 border-info hover:bg-base-300 no-underline">
     <div class="stat-figure text-info">
       <i data-lucide="clipboard-check" class="w-8 h-8"></i>
     </div>
@@ -162,7 +162,7 @@
     <tbody>
       {{range .RecentLogs}}
       <tr class="hover:bg-base-300">
-        <td><a href="/admin/connections/{{formatUUID .ConnectionID}}">{{.InstitutionName.String}}</a></td>
+        <td><a href="/connections/{{formatUUID .ConnectionID}}">{{.InstitutionName.String}}</a></td>
         <td>{{.Trigger}}</td>
         <td>{{syncBadge (printf "%s" .Status)}}</td>
         <td>{{.AddedCount}}</td>
@@ -179,10 +179,10 @@
 {{end}}
 
 <div class="flex gap-3 mt-6">
-  <a href="/admin/connections/new" class="btn btn-primary">
+  <a href="/connections/new" class="btn btn-primary">
     <i data-lucide="plus" class="w-4 h-4"></i>
     Connect New Bank
   </a>
-  <a href="/admin/sync-logs" class="btn btn-ghost">View All Sync Logs</a>
+  <a href="/sync-logs" class="btn btn-ghost">View All Sync Logs</a>
 </div>
 {{end}}

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -11,7 +11,7 @@
         Global Mode
       </h2>
       <p class="text-sm text-base-content/70 mb-4">Controls whether MCP-connected agents can perform write operations (sync, categorize, comment) or are limited to read-only data queries.</p>
-      <form method="POST" action="/admin/mcp/mode">
+      <form method="POST" action="/mcp-settings/mode">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
         <div class="flex flex-col gap-3">
           <label class="label cursor-pointer justify-start gap-3">
@@ -45,7 +45,7 @@
         Tool Access
       </h2>
       <p class="text-sm text-base-content/70 mb-4">Enable or disable individual tools. Disabled tools are hidden from all agents. Write tools are automatically disabled when global mode is Read Only.</p>
-      <form method="POST" action="/admin/mcp/tools">
+      <form method="POST" action="/mcp-settings/tools">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
         <div class="overflow-x-auto">
           <table class="table table-sm">
@@ -120,7 +120,7 @@
         Server Instructions
       </h2>
       <p class="text-sm text-base-content/70 mb-4">Custom instructions appended to the built-in MCP server instructions. Agents see these when they connect. Use markdown formatting.</p>
-      <form method="POST" action="/admin/mcp/instructions">
+      <form method="POST" action="/mcp-settings/instructions">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
         <div class="form-control mb-3">
@@ -177,7 +177,7 @@
         </div>
       </div>
       <div class="mt-4">
-        <a href="/admin/api-keys" class="btn btn-ghost btn-sm">
+        <a href="/api-keys" class="btn btn-ghost btn-sm">
           <i data-lucide="external-link" class="w-4 h-4"></i>
           Manage API Keys
         </a>

--- a/internal/templates/pages/providers.html
+++ b/internal/templates/pages/providers.html
@@ -30,7 +30,7 @@
         <dd>{{if .WebhookURL}}<code class="font-mono text-xs">{{.WebhookURL}}</code>{{else}}<span class="text-base-content/60">Not set</span>{{end}}</dd>
       </dl>
       {{else}}
-      <form method="POST" action="/admin/providers/plaid" autocomplete="off">
+      <form method="POST" action="/providers/plaid" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
         <label class="flex flex-col gap-1 text-sm" for="plaid_client_id">
@@ -100,7 +100,7 @@
         <dd>{{if .TellerWebhookConfigured}}Configured{{else}}Not configured{{end}}</dd>
       </dl>
       {{else}}
-      <form method="POST" action="/admin/providers/teller" enctype="multipart/form-data" autocomplete="off">
+      <form method="POST" action="/providers/teller" enctype="multipart/form-data" autocomplete="off">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
         <label class="flex flex-col gap-1 text-sm" for="teller_app_id">
@@ -169,7 +169,7 @@
         <span class="badge badge-success badge-sm">Always Available</span>
       </div>
       <p class="text-sm text-base-content/70 mb-4">Import transactions from CSV files. No configuration needed.</p>
-      <a href="/admin/connections/import-csv" class="btn btn-sm btn-ghost">Import CSV File</a>
+      <a href="/connections/import-csv" class="btn btn-sm btn-ghost">Import CSV File</a>
     </div>
   </div>
 
@@ -182,7 +182,7 @@ function testProvider(name) {
   btn.disabled = true;
   result.textContent = '';
   result.innerHTML = '<span class="loading loading-spinner loading-sm"></span> Testing...';
-  fetch("/admin/api/test-provider/" + name, {
+  fetch("/-/test-provider/" + name, {
     method: "POST"
   })
   .then(function(res) { return res.json(); })

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -18,7 +18,7 @@
           <button class="btn btn-ghost" @click="confirmOpen = false" :disabled="dismissing">Cancel</button>
           <button class="btn btn-error gap-1" :disabled="dismissing"
             @click="dismissing = true;
-              fetch('/admin/api/reviews/dismiss-all', {
+              fetch('/-/reviews/dismiss-all', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken }
               })
@@ -88,7 +88,7 @@
       </div>
       <button class="btn btn-primary btn-sm" :disabled="saving"
         @click="saving = true;
-          fetch('/admin/api/reviews/settings', {
+          fetch('/-/reviews/settings', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
             body: JSON.stringify({ auto_enqueue: autoEnqueue, confidence_threshold: parseFloat(threshold) })
@@ -108,7 +108,7 @@
 
 <!-- Filter Bar -->
 <div class="bb-filter-bar mb-6">
-  <form method="GET" action="/admin/reviews" class="flex flex-wrap gap-3 items-end">
+  <form method="GET" action="/reviews" class="flex flex-wrap gap-3 items-end">
     <div class="form-control">
       <label class="label label-text text-xs">Status</label>
       <select name="status" class="select select-bordered select-sm">
@@ -148,7 +148,7 @@
       </select>
     </div>
     <button type="submit" class="btn btn-sm btn-primary">Filter</button>
-    <a href="/admin/reviews" class="btn btn-sm btn-ghost">Reset</a>
+    <a href="/reviews" class="btn btn-sm btn-ghost">Reset</a>
   </form>
 </div>
 
@@ -188,7 +188,7 @@
       {{if .Transaction}}
       <div class="flex items-start justify-between mt-2 gap-3">
         <div class="min-w-0">
-          <a href="/admin/transactions/{{.TransactionID}}" class="font-semibold link link-hover">{{.Transaction.Name}}</a>
+          <a href="/transactions/{{.TransactionID}}" class="font-semibold link link-hover">{{.Transaction.Name}}</a>
           {{if .Transaction.MerchantName}}<div class="text-sm text-base-content/70">{{.Transaction.MerchantName}}</div>{{end}}
           <div class="text-xs text-base-content/50 mt-0.5">
             {{if .Transaction.AccountName}}{{.Transaction.AccountName}}{{end}}
@@ -311,7 +311,7 @@
   <!-- Pagination -->
   {{if .HasMore}}
   <div class="flex justify-center mt-6">
-    <a href="/admin/reviews?cursor={{.NextCursor}}&status={{.StatusFilter}}{{if .ReviewTypeFilter}}&review_type={{.ReviewTypeFilter}}{{end}}{{if .AccountIDFilter}}&account_id={{.AccountIDFilter}}{{end}}{{if .UserIDFilter}}&user_id={{.UserIDFilter}}{{end}}" class="btn btn-outline btn-sm">
+    <a href="/reviews?cursor={{.NextCursor}}&status={{.StatusFilter}}{{if .ReviewTypeFilter}}&review_type={{.ReviewTypeFilter}}{{end}}{{if .AccountIDFilter}}&account_id={{.AccountIDFilter}}{{end}}{{if .UserIDFilter}}&user_id={{.UserIDFilter}}{{end}}" class="btn btn-outline btn-sm">
       Load More
     </a>
   </div>
@@ -359,7 +359,7 @@ function reviewQueue() {
         body.note = noteParts.join(' ');
       }
 
-      fetch('/admin/api/reviews/' + id + '/submit', {
+      fetch('/-/reviews/' + id + '/submit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
         body: JSON.stringify(body)
@@ -389,7 +389,7 @@ function reviewQueue() {
       const cardData = Alpine.$data(card);
       cardData.submitting = true;
 
-      fetch('/admin/api/reviews/' + id + '/dismiss', {
+      fetch('/-/reviews/' + id + '/dismiss', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken }
       })

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -33,7 +33,7 @@
       </select>
     </label>
     <button type="submit" class="btn btn-sm btn-ghost">Filter</button>
-    {{if or .SearchFilter .CategoryFilter .EnabledFilter}}<a href="/admin/rules" class="btn btn-sm btn-ghost">Clear</a>{{end}}
+    {{if or .SearchFilter .CategoryFilter .EnabledFilter}}<a href="/rules" class="btn btn-sm btn-ghost">Clear</a>{{end}}
   </form>
 </div>
 
@@ -109,7 +109,7 @@
 <!-- Pagination -->
 {{if .HasMore}}
 <div class="flex justify-center mt-4">
-  <a href="/admin/rules?cursor={{.NextCursor}}{{if .SearchFilter}}&search={{.SearchFilter}}{{end}}{{if .CategoryFilter}}&category_slug={{.CategoryFilter}}{{end}}{{if .EnabledFilter}}&enabled={{.EnabledFilter}}{{end}}" class="btn btn-sm btn-outline">Load More</a>
+  <a href="/rules?cursor={{.NextCursor}}{{if .SearchFilter}}&search={{.SearchFilter}}{{end}}{{if .CategoryFilter}}&category_slug={{.CategoryFilter}}{{end}}{{if .EnabledFilter}}&enabled={{.EnabledFilter}}{{end}}" class="btn btn-sm btn-outline">Load More</a>
 </div>
 {{end}}
 
@@ -231,7 +231,7 @@ function rulesPage() {
             category_slug: this.form.category_slug,
             priority: this.form.priority
           };
-          const resp = await fetch('/admin/api/rules/' + this.editingId, {
+          const resp = await fetch('/-/rules/' + this.editingId, {
             method: 'PUT',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify(body)
@@ -250,7 +250,7 @@ function rulesPage() {
             priority: this.form.priority,
             expires_in: this.form.expires_in || undefined
           };
-          const resp = await fetch('/admin/api/rules', {
+          const resp = await fetch('/-/rules', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify(body)
@@ -270,7 +270,7 @@ function rulesPage() {
     },
     async toggleRule(id) {
       try {
-        const resp = await fetch('/admin/api/rules/' + id + '/toggle', { method: 'POST' });
+        const resp = await fetch('/-/rules/' + id + '/toggle', { method: 'POST' });
         if (resp.ok) location.reload();
       } catch (e) {
         // ignore
@@ -279,7 +279,7 @@ function rulesPage() {
     async deleteRule(id, el) {
       if (!confirm('Delete this rule? This cannot be undone.')) return;
       try {
-        const resp = await fetch('/admin/api/rules/' + id, { method: 'DELETE' });
+        const resp = await fetch('/-/rules/' + id, { method: 'DELETE' });
         if (resp.ok) location.reload();
       } catch (e) {
         // ignore

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -7,7 +7,7 @@
   <div class="collapse-title text-xl font-medium">Sync &amp; Scheduling</div>
   <div class="collapse-content">
     <p class="text-sm text-base-content/70 mb-4">Breadbox automatically syncs bank data on this schedule. Webhooks provide real-time updates when supported by the provider.</p>
-    <form method="POST" action="/admin/settings/sync">
+    <form method="POST" action="/settings/sync">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
       <label class="flex flex-col gap-1 text-sm" for="sync_interval_minutes">
@@ -52,7 +52,7 @@
     <div class="divider"></div>
 
     <h3 class="font-semibold text-sm mb-2">Change Password</h3>
-    <form method="POST" action="/admin/settings/password">
+    <form method="POST" action="/settings/password">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
       <label class="flex flex-col gap-1 text-sm" for="current_password">Current Password</label>
       <input type="password" id="current_password" name="current_password" required class="input input-sm w-full max-w-md">

--- a/internal/templates/pages/setup_create_admin.html
+++ b/internal/templates/pages/setup_create_admin.html
@@ -9,7 +9,7 @@
 <div role="alert" class="alert alert-error mb-4">{{.Error}}</div>
 {{end}}
 
-<form method="POST" action="/admin/setup">
+<form method="POST" action="/setup">
   {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
 
   <fieldset class="fieldset">

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <h1 class="text-2xl font-bold mb-6">Sync Logs</h1>
 
-<form method="GET" action="/admin/sync-logs" class="bb-filter-bar">
+<form method="GET" action="/sync-logs" class="bb-filter-bar">
   <label>
     Connection
     <select name="connection_id">
@@ -22,7 +22,7 @@
   </label>
   <button type="submit" class="btn btn-sm btn-primary self-end">Filter</button>
   {{if or .FilterConnID .FilterStatus}}
-  <a href="/admin/sync-logs" class="btn btn-sm btn-ghost self-end">Clear</a>
+  <a href="/sync-logs" class="btn btn-sm btn-ghost self-end">Clear</a>
   {{end}}
 </form>
 
@@ -71,13 +71,13 @@
 <div class="bb-pagination">
   <div>
     {{if gt .Page 1}}
-    <a href="/admin/sync-logs?page={{sub .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost">&laquo; Previous</a>
+    <a href="/sync-logs?page={{sub .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost">&laquo; Previous</a>
     {{end}}
   </div>
   <small class="text-base-content/70">Page {{.Page}} of {{.TotalPages}} ({{.Total}} total)</small>
   <div>
     {{if lt .Page .TotalPages}}
-    <a href="/admin/sync-logs?page={{add .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost">Next &raquo;</a>
+    <a href="/sync-logs?page={{add .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost">Next &raquo;</a>
     {{end}}
   </div>
 </div>
@@ -89,7 +89,7 @@
     <i data-lucide="refresh-cw" class="w-12 h-12 text-base-content/30 mb-2"></i>
     <p class="text-base-content/70">No sync logs found.</p>
     {{if or .FilterConnID .FilterStatus}}
-    <a href="/admin/sync-logs" class="btn btn-ghost btn-sm mt-2">Clear filters</a>
+    <a href="/sync-logs" class="btn btn-ghost btn-sm mt-2">Clear filters</a>
     {{end}}
   </div>
 </div>

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -3,7 +3,7 @@
 
 <div class="breadcrumbs text-sm mb-4">
   <ul>
-    <li><a href="/admin/transactions">Transactions</a></li>
+    <li><a href="/transactions">Transactions</a></li>
     <li>{{.Transaction.Name}}</li>
   </ul>
 </div>
@@ -23,7 +23,7 @@
   {{end}}
   {{if .AccountName}}
   <dt>Account</dt>
-  <dd><a href="/admin/accounts/{{.AccountID}}">{{.AccountName}}</a></dd>
+  <dd><a href="/accounts/{{.AccountID}}">{{.AccountName}}</a></dd>
   {{end}}
   {{if .UserName}}
   <dt>Family Member</dt>
@@ -125,7 +125,7 @@ function txCategoryEditor() {
         return;
       }
       this.saving = true;
-      fetch('/admin/api/transactions/{{.TransactionID}}/category', {
+      fetch('/-/transactions/{{.TransactionID}}/category', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({category_id: detail.id})
@@ -143,7 +143,7 @@ function txCategoryEditor() {
     },
     resetCategory() {
       this.saving = true;
-      fetch('/admin/api/transactions/{{.TransactionID}}/category', { method: 'DELETE' })
+      fetch('/-/transactions/{{.TransactionID}}/category', { method: 'DELETE' })
       .then(r => {
         this.saving = false;
         if (r.ok || r.status === 204) {
@@ -170,7 +170,7 @@ function commentManager() {
       var self = this;
       var content = this.newComment.trim();
       if (!content) return;
-      fetch('/admin/api/transactions/{{.TransactionID}}/comments', {
+      fetch('/-/transactions/{{.TransactionID}}/comments', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({content: content})
@@ -190,7 +190,7 @@ function commentManager() {
     },
     deleteComment(id) {
       if (!confirm('Delete this comment?')) return;
-      fetch('/admin/api/transactions/{{.TransactionID}}/comments/' + id, {
+      fetch('/-/transactions/{{.TransactionID}}/comments/' + id, {
         method: 'DELETE'
       })
       .then(function(res) {

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -3,7 +3,7 @@
 
 <h1 class="text-2xl font-bold mb-6">Transactions</h1>
 
-<form method="GET" action="/admin/transactions" class="bb-filter-bar" x-data>
+<form method="GET" action="/transactions" class="bb-filter-bar" x-data>
   <label>
     Start Date
     <input type="date" name="start_date" value="{{.FilterStartDate}}">
@@ -86,7 +86,7 @@
   </label>
   <button type="submit" class="btn btn-sm btn-primary self-end">Filter</button>
   {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}
-  <a href="/admin/transactions" class="btn btn-sm btn-ghost self-end">Clear</a>
+  <a href="/transactions" class="btn btn-sm btn-ghost self-end">Clear</a>
   {{end}}
 </form>
 
@@ -108,13 +108,13 @@
       <tr @click="expanded = !expanded" class="cursor-pointer hover:bg-base-300">
         <td>{{.Date}}</td>
         <td>
-          <a href="/admin/transactions/{{.ID}}" @click.stop class="link link-hover">{{.Name}}</a>
+          <a href="/transactions/{{.ID}}" @click.stop class="link link-hover">{{.Name}}</a>
           {{if .MerchantName}}<small class="text-base-content/60"> ({{.MerchantName}})</small>{{end}}
         </td>
         <td class="bb-amount{{if lt .Amount 0.0}} text-error{{end}}">
           {{printf "%.2f" .Amount}}{{if .IsoCurrencyCode}} {{.IsoCurrencyCode}}{{end}}
         </td>
-        <td><a href="/admin/accounts/{{.AccountID}}" @click.stop>{{.AccountName}}</a></td>
+        <td><a href="/accounts/{{.AccountID}}" @click.stop>{{.AccountName}}</a></td>
         <td @click.stop>
           <div class="bb-cat-picker" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
             <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
@@ -162,7 +162,7 @@
   <div>
     {{if gt .Page 1}}
     <div class="join">
-      <a href="/admin/transactions?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="join-item btn btn-sm">&laquo; Previous</a>
+      <a href="/transactions?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="join-item btn btn-sm">&laquo; Previous</a>
     </div>
     {{end}}
   </div>
@@ -170,7 +170,7 @@
   <div>
     {{if lt .Page .TotalPages}}
     <div class="join">
-      <a href="/admin/transactions?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="join-item btn btn-sm">Next &raquo;</a>
+      <a href="/transactions?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="join-item btn btn-sm">Next &raquo;</a>
     </div>
     {{end}}
   </div>
@@ -181,7 +181,7 @@
 <div class="card bg-base-100 border border-base-300 text-center p-8">
   <p>No transactions found.</p>
   {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}
-  <a href="/admin/transactions" class="btn btn-sm btn-ghost mt-4">Clear filters</a>
+  <a href="/transactions" class="btn btn-sm btn-ghost mt-4">Clear filters</a>
   {{end}}
 </div>
 {{end}}
@@ -191,7 +191,7 @@
 window.__bbCategories = {{toJSON .Categories}};
 function quickSetCategory(txId, categoryId) {
   if (!categoryId) {
-    fetch('/admin/api/transactions/' + txId + '/category', { method: 'DELETE' })
+    fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
     .then(r => {
       if (r.ok || r.status === 204) {
         window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Category reset', type:'success'}}));
@@ -199,7 +199,7 @@ function quickSetCategory(txId, categoryId) {
     });
     return;
   }
-  fetch('/admin/api/transactions/' + txId + '/category', {
+  fetch('/-/transactions/' + txId + '/category', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({category_id: categoryId})

--- a/internal/templates/pages/user_form.html
+++ b/internal/templates/pages/user_form.html
@@ -1,5 +1,5 @@
 {{define "content"}}
-<p class="mb-4"><a href="/admin/users" class="link">&larr; Back to Family Members</a></p>
+<p class="mb-4"><a href="/users" class="link">&larr; Back to Family Members</a></p>
 
 <h1 class="text-2xl font-bold mb-6">{{if .IsEdit}}Edit {{.User.Name}}{{else}}Add Family Member{{end}}</h1>
 
@@ -24,7 +24,7 @@
 
       <div class="flex gap-2 mt-4">
         <button type="submit" class="btn btn-primary">{{if .IsEdit}}Save Changes{{else}}Create Member{{end}}</button>
-        <a href="/admin/users" class="btn btn-ghost">Cancel</a>
+        <a href="/users" class="btn btn-ghost">Cancel</a>
       </div>
     </form>
   </div>
@@ -55,7 +55,7 @@
       body.email = email;
     }
 
-    var url = isEdit ? "/admin/api/users/" + userId : "/admin/api/users";
+    var url = isEdit ? "/-/users/" + userId : "/-/users";
     var method = isEdit ? "PUT" : "POST";
 
     fetch(url, {
@@ -65,7 +65,7 @@
     })
     .then(function (res) {
       if (res.ok) {
-        window.location.href = "/admin/users";
+        window.location.href = "/users";
       } else {
         return res.json().then(function (data) {
           var msg = "An error occurred.";

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -1,14 +1,14 @@
 {{define "content"}}
 <div class="flex items-center justify-between mb-6">
   <h1 class="text-2xl font-bold m-0">Family Members</h1>
-  <a href="/admin/users/new" class="btn btn-primary">
+  <a href="/users/new" class="btn btn-primary">
     <i data-lucide="plus" class="w-4 h-4"></i>
     Add Family Member
   </a>
 </div>
 
 {{if .Created}}
-<div class="alert alert-success mb-4">Member created. <a href="/admin/connections/new" class="link">Connect a bank for them &rarr;</a></div>
+<div class="alert alert-success mb-4">Member created. <a href="/connections/new" class="link">Connect a bank for them &rarr;</a></div>
 {{end}}
 
 {{if .Users}}
@@ -31,7 +31,7 @@
         <td>{{index $.ConnectionCounts (formatUUID .ID)}}</td>
         <td>{{if .CreatedAt.Valid}}{{.CreatedAt.Time.Format "Jan 2, 2006"}}{{end}}</td>
         <td>
-          <a href="/admin/users/{{formatUUID .ID}}/edit" class="btn btn-ghost btn-xs">Edit</a>
+          <a href="/users/{{formatUUID .ID}}/edit" class="btn btn-ghost btn-xs">Edit</a>
         </td>
       </tr>
       {{end}}
@@ -43,7 +43,7 @@
   <div class="card-body items-center text-center py-12">
     <i data-lucide="users" class="w-12 h-12 text-base-content/30 mb-2"></i>
     <p class="text-base-content/70">No family members yet.</p>
-    <a href="/admin/users/new" class="btn btn-primary mt-2">
+    <a href="/users/new" class="btn btn-primary mt-2">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Add your first family member
     </a>

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -1,20 +1,20 @@
 {{define "nav"}}
 <ul class="menu menu-md flex-1">
   <li class="menu-title">Data</li>
-  <li><a href="/admin/"{{if eq .CurrentPage "dashboard"}} class="menu-active"{{end}}><i data-lucide="layout-dashboard" class="w-4 h-4"></i> Dashboard</a></li>
-  <li><a href="/admin/connections"{{if eq .CurrentPage "connections"}} class="menu-active"{{end}}><i data-lucide="link" class="w-4 h-4"></i> Connections</a></li>
-  <li><a href="/admin/transactions"{{if eq .CurrentPage "transactions"}} class="menu-active"{{end}}><i data-lucide="receipt" class="w-4 h-4"></i> Transactions</a></li>
-  <li><a href="/admin/reviews"{{if eq .CurrentPage "reviews"}} class="menu-active"{{end}}><i data-lucide="clipboard-check" class="w-4 h-4"></i> Reviews</a></li>
-  <li><a href="/admin/review-instructions"{{if eq .CurrentPage "review-instructions"}} class="menu-active"{{end}}><i data-lucide="message-square-code" class="w-4 h-4"></i> Review Agent</a></li>
-  <li><a href="/admin/rules"{{if eq .CurrentPage "rules"}} class="menu-active"{{end}}><i data-lucide="list-filter" class="w-4 h-4"></i> Rules</a></li>
-  <li><a href="/admin/categories"{{if eq .CurrentPage "categories"}} class="menu-active"{{end}}><i data-lucide="tag" class="w-4 h-4"></i> Categories</a></li>
-  <li><a href="/admin/users"{{if eq .CurrentPage "users"}} class="menu-active"{{end}}><i data-lucide="users" class="w-4 h-4"></i> Family Members</a></li>
+  <li><a href="/"{{if eq .CurrentPage "dashboard"}} class="menu-active"{{end}}><i data-lucide="layout-dashboard" class="w-4 h-4"></i> Dashboard</a></li>
+  <li><a href="/connections"{{if eq .CurrentPage "connections"}} class="menu-active"{{end}}><i data-lucide="link" class="w-4 h-4"></i> Connections</a></li>
+  <li><a href="/transactions"{{if eq .CurrentPage "transactions"}} class="menu-active"{{end}}><i data-lucide="receipt" class="w-4 h-4"></i> Transactions</a></li>
+  <li><a href="/reviews"{{if eq .CurrentPage "reviews"}} class="menu-active"{{end}}><i data-lucide="clipboard-check" class="w-4 h-4"></i> Reviews</a></li>
+  <li><a href="/review-instructions"{{if eq .CurrentPage "review-instructions"}} class="menu-active"{{end}}><i data-lucide="message-square-code" class="w-4 h-4"></i> Review Agent</a></li>
+  <li><a href="/rules"{{if eq .CurrentPage "rules"}} class="menu-active"{{end}}><i data-lucide="list-filter" class="w-4 h-4"></i> Rules</a></li>
+  <li><a href="/categories"{{if eq .CurrentPage "categories"}} class="menu-active"{{end}}><i data-lucide="tag" class="w-4 h-4"></i> Categories</a></li>
+  <li><a href="/users"{{if eq .CurrentPage "users"}} class="menu-active"{{end}}><i data-lucide="users" class="w-4 h-4"></i> Family Members</a></li>
   <li class="menu-title">System</li>
-  <li><a href="/admin/providers"{{if eq .CurrentPage "providers"}} class="menu-active"{{end}}><i data-lucide="plug" class="w-4 h-4"></i> Providers</a></li>
-  <li><a href="/admin/api-keys"{{if eq .CurrentPage "api-keys"}} class="menu-active"{{end}}><i data-lucide="key" class="w-4 h-4"></i> API Keys</a></li>
-  <li><a href="/admin/mcp"{{if eq .CurrentPage "mcp"}} class="menu-active"{{end}}><i data-lucide="bot" class="w-4 h-4"></i> MCP</a></li>
-  <li><a href="/admin/sync-logs"{{if eq .CurrentPage "sync-logs"}} class="menu-active"{{end}}><i data-lucide="refresh-cw" class="w-4 h-4"></i> Sync Logs</a></li>
-  <li><a href="/admin/settings"{{if eq .CurrentPage "settings"}} class="menu-active"{{end}}><i data-lucide="settings" class="w-4 h-4"></i> Settings</a></li>
+  <li><a href="/providers"{{if eq .CurrentPage "providers"}} class="menu-active"{{end}}><i data-lucide="plug" class="w-4 h-4"></i> Providers</a></li>
+  <li><a href="/api-keys"{{if eq .CurrentPage "api-keys"}} class="menu-active"{{end}}><i data-lucide="key" class="w-4 h-4"></i> API Keys</a></li>
+  <li><a href="/mcp-settings"{{if eq .CurrentPage "mcp"}} class="menu-active"{{end}}><i data-lucide="bot" class="w-4 h-4"></i> MCP</a></li>
+  <li><a href="/sync-logs"{{if eq .CurrentPage "sync-logs"}} class="menu-active"{{end}}><i data-lucide="refresh-cw" class="w-4 h-4"></i> Sync Logs</a></li>
+  <li><a href="/settings"{{if eq .CurrentPage "settings"}} class="menu-active"{{end}}><i data-lucide="settings" class="w-4 h-4"></i> Settings</a></li>
 </ul>
 <!-- Sign out -->
 <form method="POST" action="/logout" class="mt-auto px-2">


### PR DESCRIPTION
## Summary
- All dashboard pages now served at root (`/`, `/connections`, `/settings`, etc.) instead of under `/admin/`
- Internal AJAX API moved from `/admin/api/*` to `/-/*` to avoid conflicts with REST API at `/api/v1`
- MCP settings page renamed to `/mcp-settings` to avoid conflict with the MCP protocol endpoint at `/mcp`
- Router structure changed from `r.Route("/admin", ...)` to `r.Group(...)` (middleware grouping without path prefix)
- Setup route moved from `/admin/setup` to `/setup`

## Test plan
- [ ] Visit `/` — should show dashboard (was `/admin/`)
- [ ] Navigate all sidebar links — connections, transactions, settings, etc.
- [ ] Test login/logout flow (redirects to `/` after login)
- [ ] Test first-run setup redirect (should go to `/setup`)
- [ ] Verify AJAX actions work (sync, delete, create) — now via `/-/` prefix
- [ ] Verify REST API at `/api/v1/*` still works independently
- [ ] Verify MCP endpoint at `/mcp` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)