### PR TITLE
Handle Teller 404 enrollment.disconnected as reauth required

### DIFF
--- a/internal/provider/teller/balances.go
+++ b/internal/provider/teller/balances.go
@@ -47,7 +47,7 @@ func (p *TellerProvider) GetBalances(ctx context.Context, conn provider.Connecti
 			return nil, fmt.Errorf("teller balance get for %s: %w", acct.ExternalID, err)
 		}
 
-		if resp.StatusCode == http.StatusForbidden {
+		if isReauthResponse(resp) {
 			resp.Body.Close()
 			return nil, ErrReauthRequired
 		}

--- a/internal/provider/teller/errors.go
+++ b/internal/provider/teller/errors.go
@@ -1,7 +1,11 @@
 package teller
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 
 	"breadbox/internal/provider"
 )
@@ -9,3 +13,29 @@ import (
 // ErrReauthRequired indicates that the Teller enrollment is disconnected
 // and the user needs to re-authenticate.
 var ErrReauthRequired = fmt.Errorf("teller: enrollment disconnected: %w", provider.ErrReauthRequired)
+
+// isReauthResponse checks if a Teller API response indicates the enrollment
+// is disconnected and requires re-authentication. Teller returns 403 for some
+// disconnects and 404 with "enrollment.disconnected.*" codes for others (e.g., MFA required).
+// The response body is consumed and the caller should not read it again.
+func isReauthResponse(resp *http.Response) bool {
+	if resp.StatusCode == http.StatusForbidden {
+		return true
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		var tellerErr struct {
+			Error struct {
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		if json.Unmarshal(body, &tellerErr) == nil &&
+			strings.HasPrefix(tellerErr.Error.Code, "enrollment.disconnected") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/provider/teller/link.go
+++ b/internal/provider/teller/link.go
@@ -83,7 +83,7 @@ func (p *TellerProvider) fetchAccounts(ctx context.Context, accessToken string) 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusForbidden {
+	if isReauthResponse(resp) {
 		return nil, ErrReauthRequired
 	}
 	if resp.StatusCode != http.StatusOK {

--- a/internal/provider/teller/sync.go
+++ b/internal/provider/teller/sync.go
@@ -113,7 +113,7 @@ func (p *TellerProvider) fetchTransactionsForAccount(
 			return nil, fmt.Errorf("teller transactions get: %w", err)
 		}
 
-		if resp.StatusCode == http.StatusForbidden {
+		if isReauthResponse(resp) {
 			resp.Body.Close()
 			return nil, ErrReauthRequired
 		}


### PR DESCRIPTION
## Summary
- Teller returns 404 with `enrollment.disconnected.*` error codes (e.g., `mfa_required`) for disconnected enrollments, not just 403
- The existing reauth check only handled 403, causing these disconnects to show as generic sync errors instead of marking the connection as `pending_reauth`
- Adds shared `isReauthResponse()` helper that checks both 403 and 404-with-enrollment-disconnected, applied to all three Teller API call sites (accounts, transactions, balances)

## Test plan
- [ ] Sync a Teller connection with a disconnected enrollment (MFA required) and verify it gets marked as `pending_reauth` instead of erroring
- [ ] Sync a healthy Teller connection and verify normal sync still works
- [ ] Verify `go build ./...` and `go vet ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)