### PR TITLE
Add screenshot and image hosting skills

### DIFF
--- a/.claude/skills/app-screenshot/SKILL.md
+++ b/.claude/skills/app-screenshot/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: app-screenshot
+description: >
+  Take a screenshot of any page in the Breadbox app running at localhost:8080.
+  Captures the Chrome window, saves to /tmp, and optionally uploads to img402.dev
+  for embedding in GitHub PRs/issues. Handles Chrome focus, tab switching, login,
+  and image resizing. Triggers: "take a screenshot of the app", "screenshot the
+  transactions page", "capture the page", "show me how it looks", or any task
+  needing a visual of the running app.
+---
+
+# Breadbox App Screenshot
+
+Capture a screenshot of any page in the Breadbox app for review or GitHub embedding.
+
+## Prerequisites
+
+- Breadbox running locally at `http://localhost:8080` (via `make dev` or Docker)
+- Google Chrome open with at least one tab
+- macOS `screencapture` with Screen Recording permission enabled for the terminal
+
+## Steps
+
+### 1. Ensure the app is running
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health/live
+```
+
+If not 200, start it: `make dev` (or `docker compose up -d`).
+
+### 2. Navigate Chrome to the target page
+
+Use Chrome MCP to navigate to whatever page you want to capture. Common pages:
+
+- `/` or `/admin/` — Dashboard
+- `/admin/transactions` — Transactions list
+- `/admin/connections` — Bank connections
+- `/admin/reviews` — Review queue
+- `/admin/rules` — Transaction rules
+- `/admin/categories` — Categories
+- `/admin/providers` — Provider settings
+- `/admin/mcp` — MCP configuration
+- `/admin/settings` — System settings
+
+```
+mcp__claude-in-chrome__navigate(tabId=<tab>, url="http://localhost:8080/<path>")
+```
+
+If redirected to `/login`, use JavaScript to submit the login form:
+
+```
+mcp__claude-in-chrome__javascript_tool(action="javascript_exec", tabId=<tab>, text="
+  document.querySelector('input[type=\"text\"]').value = 'canalesb93@gmail.com';
+  document.querySelector('input[type=\"password\"]').value = 'password';
+  document.querySelector('form').submit();
+")
+```
+
+Wait 2 seconds after navigation/login for the page to render, then navigate again to the target page if you were redirected to login.
+
+### 3. Focus Chrome and capture screenshot
+
+**IMPORTANT**: The AppleScript must activate Chrome, delay, AND capture the screenshot all within the same `osascript` block. If you run `screencapture` from a separate bash command, the terminal will steal focus back before the capture happens.
+
+Match tabs by **title** containing "Breadbox" (all app pages include it) since Chrome MCP tab navigation doesn't always update the visible tab. Use a descriptive filename based on the page being captured:
+
+```bash
+PAGE_NAME="dashboard"  # Change to match what you're capturing
+osascript <<APPLESCRIPT
+tell application "Google Chrome"
+    set winCount to count of windows
+    repeat with i from 1 to winCount
+        set w to window i
+        set tabCount to count of tabs of w
+        repeat with j from 1 to tabCount
+            if title of tab j of w contains "Breadbox" then
+                set active tab index of w to j
+                set index of w to 1
+                activate
+                delay 2
+                do shell script "screencapture -x /tmp/app-screenshot-${PAGE_NAME}.png"
+                return "Captured"
+            end if
+        end repeat
+    end repeat
+end tell
+APPLESCRIPT
+```
+
+### 4. Verify and resize if needed
+
+Must be under 1MB for free img402 upload:
+
+```bash
+FILE_SIZE=$(stat -f%z /tmp/app-screenshot-${PAGE_NAME}.png)
+if [ "$FILE_SIZE" -gt 1000000 ]; then
+    sips -Z 1400 /tmp/app-screenshot-${PAGE_NAME}.png --out /tmp/app-screenshot-${PAGE_NAME}.png
+fi
+```
+
+### 5. Upload (optional)
+
+Use the `github-image-hosting` skill to upload and embed in a PR/issue:
+
+```bash
+URL=$(curl -s -X POST https://img402.dev/api/free -F image=@/tmp/app-screenshot-${PAGE_NAME}.png | grep -o '"url":"[^"]*"' | cut -d'"' -f4)
+echo "$URL"
+```
+
+Then embed in GitHub:
+
+```bash
+gh pr comment <PR_NUMBER> --body "![${PAGE_NAME} screenshot]($URL)"
+```
+
+## Tips
+
+- Use unique `PAGE_NAME` values when capturing multiple pages (e.g., `dashboard`, `transactions`, `connections`)
+- The screenshot captures the full Chrome window. Maximize Chrome for best results.
+- After template/CSS changes, restart the app (`kill` process on port 8080 + `make dev`) before capturing.
+- If you need to scroll to capture content below the fold, use Chrome MCP to scroll first, then capture.
+- For before/after comparisons, capture with `PAGE_NAME="before"` and `PAGE_NAME="after"`.

--- a/.claude/skills/github-image-hosting/SKILL.md
+++ b/.claude/skills/github-image-hosting/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: github-image-hosting
+description: >
+  Upload images to img402.dev for embedding in GitHub PRs, issues, and comments.
+  Images under 1MB are uploaded free (no payment, no auth) and persist for 7 days.
+  Use when the agent needs to share an image in a GitHub context — screenshots, mockups,
+  diagrams, or any visual. Triggers: "screenshot this", "attach an image", "add a screenshot
+  to the PR", "upload this mockup", or any task producing an image for GitHub.
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - curl
+        - gh
+---
+
+# Image Upload for GitHub
+
+Upload an image to img402.dev's free tier and embed the returned URL in GitHub markdown.
+
+## Quick reference
+
+```bash
+# Upload (multipart)
+curl -s -X POST https://img402.dev/api/free -F image=@/tmp/screenshot.png
+
+# Response
+# {"url":"https://i.img402.dev/aBcDeFgHiJ.png","id":"aBcDeFgHiJ","contentType":"image/png","sizeBytes":182400,"expiresAt":"2026-02-17T..."}
+```
+
+## Workflow
+
+1. **Get image**: Use an existing file, or capture a screenshot:
+   ```bash
+   screencapture -x /tmp/screenshot.png        # macOS — full screen
+   screencapture -xw /tmp/screenshot.png       # macOS — frontmost window
+   ```
+2. **Verify size**: Must be under 1MB. If larger, resize:
+   ```bash
+   sips -Z 1600 /tmp/screenshot.png  # macOS — scale longest edge to 1600px
+   ```
+3. **Upload**:
+   ```bash
+   curl -s -X POST https://img402.dev/api/free -F image=@/tmp/screenshot.png
+   ```
+4. **Embed** the returned `url` in GitHub markdown:
+   ```markdown
+   ![Screenshot description](https://i.img402.dev/aBcDeFgHiJ.png)
+   ```
+
+## GitHub integration
+
+Use `gh` CLI to embed images in PRs and issues:
+
+```bash
+# Add to PR description
+gh pr edit --body "$(gh pr view --json body -q .body)
+
+![Screenshot](https://i.img402.dev/aBcDeFgHiJ.png)"
+
+# Add as PR comment
+gh pr comment --body "![Screenshot](https://i.img402.dev/aBcDeFgHiJ.png)"
+
+# Add to issue
+gh issue comment 123 --body "![Screenshot](https://i.img402.dev/aBcDeFgHiJ.png)"
+```
+
+## Constraints
+
+- **Max size**: 1MB
+- **Retention**: 7 days — suitable for PR reviews, not permanent docs
+- **Formats**: PNG, JPEG, GIF, WebP
+- **Rate limit**: 1,000 free uploads/day (global)
+- **No auth required**
+
+## Tips
+
+- Prefer PNG for UI screenshots (sharp text). Use JPEG for photos.
+- If a screenshot is too large, reduce dimensions with `sips -Z 1600` before uploading.
+- When adding to a PR body or comment, use `gh pr comment` or `gh pr edit` with the image markdown.
+
+## Paid tier
+
+For permanent images (1 year, 5MB max), use the paid endpoint at $0.01 USDC via x402. See https://img402.dev/blog/paying-x402-apis for details.


### PR DESCRIPTION
## Summary
- **app-screenshot** skill: Captures any Breadbox page via Chrome focus (AppleScript) + `screencapture`. Handles login, page navigation, resize, and img402 upload.
- **github-image-hosting** skill: Uploads images to img402.dev free tier (1MB, 7-day retention) for embedding in GitHub PRs/issues.

These enable the autonomous UX improvement loop — agents can visually verify changes and attach screenshots to their PRs.

## Test plan
- [x] Validated `screencapture` captures correct Chrome window via AppleScript
- [x] Validated img402.dev upload returns public URL
- [x] Validated image renders in GitHub PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)