### PR TITLE
Add dashboard charts and recent transactions

### DIFF
--- a/.claude/commands/ux-improve.md
+++ b/.claude/commands/ux-improve.md
@@ -1,0 +1,185 @@
+---
+description: Autonomous UX improvement iteration for the Breadbox admin dashboard
+---
+
+You are an autonomous UX improvement agent. You are part of a relay — a series of agents each making one focused improvement to the Breadbox financial dashboard. The goal is ambitious: **in 8 hours, the app should be unrecognizable from where it started.** The owner wants to come back to a completely redesigned, modern, polished UI that feels snappy and professional — on par with the best fintech dashboards (Mercury, Copilot Money, Monarch).
+
+Every agent before you made the app a little better. Your job is to pick up where they left off and push it further. Make your improvement count.
+
+## Phase 1: Discovery
+
+Understand what's been done so far:
+
+```bash
+gh pr list --label auto-improvement --state all --limit 20 --json number,title,state,headRefName
+git log ux-sprint --oneline -15
+```
+
+Read the tracking issue:
+
+```bash
+gh issue view 55 --json body
+```
+
+Browse the current templates and CSS to see the state of the UI:
+
+```bash
+ls internal/templates/pages/ internal/templates/partials/ internal/templates/layouts/
+```
+
+Also **look at the actual app** — use Chrome MCP to navigate to `http://localhost:8080` and take a screenshot to see what it currently looks like. This is critical for choosing what to work on.
+
+## Phase 2: Choose Your Focus
+
+Pick ONE area that will have the most visual impact given what's already been done. Think like a designer: what would make the biggest difference right now?
+
+**The vision**: A modern fintech dashboard with clean typography, thoughtful spacing, smooth interactions, rich data visualization, and a cohesive design language. Not a generic admin template — a product that looks like it was designed by a team that cares.
+
+Priority areas (pick based on what's needed most right now):
+
+- **Dashboard overhaul** — Spending charts, category breakdowns, balance trends, recent activity feed. Chart.js via CDN. Make the dashboard actually useful, not just stat cards.
+- **Transaction list** — The core screen. Needs to be fast, filterable, sortable, with amount formatting, category color badges, merchant icons, and smooth pagination. Think Mint/Monarch level.
+- **Navigation & layout** — Sidebar polish, active states, transitions, section grouping, responsive collapse, app-wide visual consistency.
+- **Typography & design system** — Font sizing scale, color palette refinement, consistent component styling, micro-interactions (hover states, focus rings, transitions).
+- **Data visualization** — Charts, sparklines, progress bars, trend indicators. Make financial data visual and glanceable.
+- **Page-specific redesigns** — Pick any page (connections, reviews, rules, categories, settings, providers, MCP) and transform it from functional to beautiful.
+- **Empty states & polish** — Loading skeletons, helpful empty states, error pages, toasts, confirmation dialogs. The details that make an app feel finished.
+- **Mobile & responsiveness** — Make it work beautifully on tablets and phones. Collapsible sidebar, responsive tables, touch-friendly targets.
+
+DO NOT duplicate work from previous agents. Build on it or tackle something new.
+
+## Phase 3: Implement
+
+### Setup
+
+```bash
+git checkout ux-sprint
+git pull origin ux-sprint
+git checkout -b auto-improvement/<short-descriptive-name>
+```
+
+### Tech Stack
+
+- **Templates**: Go html/template in `internal/templates/` (layouts, pages, partials)
+- **CSS**: DaisyUI 5 + Tailwind CSS v4. Edit `input.css`, run `make css` to compile.
+- **JS**: Alpine.js v3 for interactivity. Chart.js via CDN for charts. Lucide icons via CDN.
+- **No Node.js**, no npm, no build step beyond `make css`.
+- **Go handlers** in `internal/api/`, service layer in `internal/service/`.
+
+### Design Principles
+
+- **Modern and clean** — Generous whitespace, clear hierarchy, no visual clutter.
+- **Snappy** — CSS transitions (150-250ms), no jarring reflows, smooth hover states.
+- **Consistent** — Use DaisyUI semantic classes. Reuse patterns. Don't invent one-off styles.
+- **Dark mode first** — The app uses `prefers-color-scheme` auto-switch. Design for dark, verify it works in light.
+- **Data-dense but readable** — Financial apps need to show lots of data. Use typography and spacing to keep it scannable.
+
+### What NOT to do
+
+- Don't modify Go backend logic, database schema, or API endpoints unless your UI change absolutely requires it.
+- Don't break existing functionality.
+- Don't add npm/Node dependencies.
+- Don't make half-finished changes — complete what you start.
+
+### Build and Test
+
+```bash
+make css
+lsof -ti:8080 | xargs kill 2>/dev/null; sleep 1
+nohup make dev > /tmp/breadbox.log 2>&1 &
+sleep 6
+curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/health/ready
+```
+
+If the app fails to start, check `tail -20 /tmp/breadbox.log` and fix the issue before proceeding.
+
+## Phase 4: Screenshot
+
+Take 1-2 screenshots that show the impact of your changes. Use the `app-screenshot` skill:
+
+1. Navigate Chrome MCP to the page you changed
+2. If redirected to login, use JS to submit: `canalesb93@gmail.com` / `password`
+3. Wait for render, then capture and upload:
+
+```bash
+PAGE_NAME="<descriptive-name>"
+osascript <<APPLESCRIPT
+tell application "Google Chrome"
+    set winCount to count of windows
+    repeat with i from 1 to winCount
+        set w to window i
+        set tabCount to count of tabs of w
+        repeat with j from 1 to tabCount
+            if title of tab j of w contains "Breadbox" then
+                set active tab index of w to j
+                set index of w to 1
+                activate
+                delay 2
+                do shell script "screencapture -x /tmp/app-screenshot-${PAGE_NAME}.png"
+                return "Captured"
+            end if
+        end repeat
+    end repeat
+end tell
+APPLESCRIPT
+
+FILE_SIZE=$(stat -f%z /tmp/app-screenshot-${PAGE_NAME}.png)
+if [ "$FILE_SIZE" -gt 1000000 ]; then
+    sips -Z 1400 /tmp/app-screenshot-${PAGE_NAME}.png --out /tmp/app-screenshot-${PAGE_NAME}.png
+fi
+
+IMG_URL=$(curl -s -X POST https://img402.dev/api/free -F image=@/tmp/app-screenshot-${PAGE_NAME}.png | grep -o '"url":"[^"]*"' | cut -d'"' -f4)
+echo "Screenshot URL: $IMG_URL"
+```
+
+You don't need to screenshot everything — just enough to show the improvement in the PR.
+
+## Phase 5: Submit PR
+
+```bash
+git add -A
+git commit -m "<concise description>
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+
+git push -u origin auto-improvement/<your-branch-name>
+
+gh pr create \
+  --title "<short title under 70 chars>" \
+  --label "auto-improvement" \
+  --base main \
+  --body "## Summary
+<what you changed and why — 2-3 bullets>
+
+## Screenshots
+<1-2 screenshots showing the improvement>
+
+Relates to #55
+
+🤖 Generated by autonomous UX improvement agent"
+```
+
+## Phase 6: Merge to Integration Branch
+
+```bash
+git checkout ux-sprint
+git merge auto-improvement/<your-branch-name> --no-edit
+git push origin ux-sprint
+```
+
+## Phase 7: Update Tracking Issue
+
+```bash
+CURRENT_BODY=$(gh issue view 55 --json body -q .body)
+gh issue edit 55 --body "${CURRENT_BODY}
+| <next#> | UX Agent | <area> | #<PR#> | open |"
+```
+
+## Rules
+
+- ONE focused improvement per run. Quality over quantity.
+- The app must compile and run after your changes. Verify before submitting.
+- Don't duplicate previous agents' work. Build on it or do something new.
+- Include at least one screenshot in the PR.
+- Don't delete existing features — improve them.
+- Be bold. The goal is transformation, not incremental tweaks.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"180bc97d-300f-40a0-8a57-3ce5d41da8b7","pid":50619,"acquiredAt":1774336104223}

--- a/input.css
+++ b/input.css
@@ -60,4 +60,52 @@
   .menu li > .menu-active {
     @apply border-l-3 border-primary;
   }
+
+  /* Dashboard stat cards */
+  .bb-stat-card {
+    @apply flex items-center gap-4 rounded-xl border border-base-300 bg-base-100 px-5 py-4
+           shadow-sm transition-all duration-200 ease-in-out
+           hover:shadow-md hover:-translate-y-0.5
+           border-l-4;
+  }
+
+  .bb-stat-card--primary {
+    @apply border-l-primary;
+  }
+
+  .bb-stat-card--secondary {
+    @apply border-l-secondary;
+  }
+
+  .bb-stat-card--accent {
+    @apply border-l-accent;
+  }
+
+  .bb-stat-card--warning {
+    @apply border-l-warning;
+  }
+
+  .bb-stat-card--info {
+    @apply border-l-info;
+  }
+
+  .bb-stat-card--neutral {
+    @apply border-l-base-content/20;
+  }
+
+  .bb-stat-card__icon {
+    @apply flex items-center justify-center w-10 h-10 rounded-lg bg-base-200/60 shrink-0;
+  }
+
+  .bb-stat-card__body {
+    @apply flex flex-col min-w-0;
+  }
+
+  .bb-stat-card__value {
+    @apply text-2xl font-bold leading-tight tabular-nums;
+  }
+
+  .bb-stat-card__label {
+    @apply text-xs font-medium uppercase tracking-wide text-base-content/60 mt-0.5;
+  }
 }

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -1,18 +1,21 @@
 package admin
 
 import (
+	"encoding/json"
 	"fmt"
+	"html/template"
 	"net/http"
 	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/db"
+	"breadbox/internal/service"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // DashboardHandler serves GET /admin/ — the dashboard home page.
-func DashboardHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
+func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -53,6 +56,80 @@ func DashboardHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 		lastSyncText := "Never"
 		if lastSync.Valid {
 			lastSyncText = relativeTime(lastSync.Time)
+		}
+
+		// Spending by category (last 30 days).
+		categorySummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy: "category",
+		})
+		if err != nil {
+			a.Logger.Error("category summary", "error", err)
+		}
+		var categoryLabelsJSON, categoryAmountsJSON template.JS
+		if categorySummary != nil && len(categorySummary.Summary) > 0 {
+			labels := make([]string, 0, len(categorySummary.Summary))
+			amounts := make([]float64, 0, len(categorySummary.Summary))
+			for _, row := range categorySummary.Summary {
+				label := "Uncategorized"
+				if row.Category != nil && *row.Category != "" {
+					label = *row.Category
+				}
+				// Only include positive amounts (spending)
+				if row.TotalAmount > 0 {
+					labels = append(labels, label)
+					amounts = append(amounts, row.TotalAmount)
+				}
+			}
+			if lb, err := json.Marshal(labels); err == nil {
+				categoryLabelsJSON = template.JS(lb)
+			}
+			if ab, err := json.Marshal(amounts); err == nil {
+				categoryAmountsJSON = template.JS(ab)
+			}
+		}
+
+		// Daily spending trend (last 30 days).
+		dailySummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy: "day",
+		})
+		if err != nil {
+			a.Logger.Error("daily summary", "error", err)
+		}
+		var dailyLabelsJSON, dailyAmountsJSON template.JS
+		if dailySummary != nil && len(dailySummary.Summary) > 0 {
+			// Reverse so oldest is first (API returns DESC).
+			rows := dailySummary.Summary
+			labels := make([]string, 0, len(rows))
+			amounts := make([]float64, 0, len(rows))
+			for i := len(rows) - 1; i >= 0; i-- {
+				row := rows[i]
+				label := ""
+				if row.Period != nil {
+					label = *row.Period
+				}
+				labels = append(labels, label)
+				// Use absolute value for spending trend
+				amt := row.TotalAmount
+				if amt < 0 {
+					amt = -amt
+				}
+				amounts = append(amounts, amt)
+			}
+			if lb, err := json.Marshal(labels); err == nil {
+				dailyLabelsJSON = template.JS(lb)
+			}
+			if ab, err := json.Marshal(amounts); err == nil {
+				dailyAmountsJSON = template.JS(ab)
+			}
+		}
+
+		// Recent transactions (last 10).
+		recentTx, err := svc.ListTransactionsAdmin(ctx, service.AdminTransactionListParams{
+			Page:     1,
+			PageSize: 8,
+		})
+		if err != nil {
+			a.Logger.Error("recent transactions", "error", err)
 		}
 
 		// Onboarding checklist detection.
@@ -101,6 +178,18 @@ func DashboardHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			}
 		}
 
+		// Build recent transactions data for template.
+		var recentTransactions []service.AdminTransactionRow
+		if recentTx != nil {
+			recentTransactions = recentTx.Transactions
+		}
+
+		// Total spending (30 days).
+		var totalSpending float64
+		if categorySummary != nil && categorySummary.Totals.TotalAmount != nil {
+			totalSpending = *categorySummary.Totals.TotalAmount
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Dashboard",
 			"CurrentPage":            "dashboard",
@@ -120,6 +209,12 @@ func DashboardHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			"CurrentVersion":         currentVersion,
 			"DockerSocketAvailable":  a.DockerSocketAvailable,
 			"ReviewPending":          reviewPending,
+			"CategoryLabels":         categoryLabelsJSON,
+			"CategoryAmounts":        categoryAmountsJSON,
+			"DailyLabels":            dailyLabelsJSON,
+			"DailyAmounts":           dailyAmountsJSON,
+			"RecentTransactions":     recentTransactions,
+			"TotalSpending":          totalSpending,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -38,7 +38,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Use(RequireAuth(sm))
 		r.Use(CSRFMiddleware(sm))
 
-		r.Get("/", DashboardHandler(a, tr))
+		r.Get("/", DashboardHandler(a, svc, tr))
 		r.Post("/onboarding/dismiss", DismissOnboardingHandler(a))
 
 		r.Route("/connections", func(r chi.Router) {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -158,6 +158,12 @@ func NewTemplateRenderer() (*TemplateRenderer, error) {
 				}
 				return t.Before(time.Now())
 			},
+			"formatAmount": func(amount float64) string {
+				if amount < 0 {
+					return fmt.Sprintf("-$%.2f", -amount)
+				}
+				return fmt.Sprintf("$%.2f", amount)
+			},
 			"formatNumeric": func(n pgtype.Numeric) string {
 				if !n.Valid {
 					return ""

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -8,6 +8,7 @@
   <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
   <link rel="stylesheet" href="/static/css/styles.css">
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 </head>
 <body>
   <div class="drawer lg:drawer-open">
@@ -27,7 +28,7 @@
         </div>
       </div>
       <!-- Page content -->
-      <main class="p-6 max-w-5xl min-h-screen">
+      <main class="p-6 max-w-6xl min-h-screen">
         {{template "flash" .}}
         {{block "content" .}}{{end}}
       </main>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -1,5 +1,8 @@
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">Dashboard</h1>
+<div class="flex items-center justify-between mb-6">
+  <h1 class="text-2xl font-bold">Dashboard</h1>
+  <span class="text-sm text-base-content/50">Last 30 days</span>
+</div>
 
 {{if .ShowUpdateBanner}}
 <div class="alert alert-info mb-6" x-data="{ pulling: false, pulled: false, error: '' }">
@@ -93,6 +96,7 @@
 </div>
 {{end}}
 
+<!-- Stat Cards -->
 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 mb-8">
   <div class="bb-stat-card bb-stat-card--primary">
     <div class="bb-stat-card__icon text-primary">
@@ -100,16 +104,16 @@
     </div>
     <div class="bb-stat-card__body">
       <span class="bb-stat-card__value">{{.AccountCount}}</span>
-      <span class="bb-stat-card__label">Accounts Connected</span>
+      <span class="bb-stat-card__label">Accounts</span>
     </div>
   </div>
   <a href="/transactions" class="bb-stat-card bb-stat-card--secondary no-underline">
     <div class="bb-stat-card__icon text-secondary">
-      <i data-lucide="trending-up" class="w-6 h-6"></i>
+      <i data-lucide="receipt" class="w-6 h-6"></i>
     </div>
     <div class="bb-stat-card__body">
       <span class="bb-stat-card__value">{{.TxCount}}</span>
-      <span class="bb-stat-card__label">Transactions Synced</span>
+      <span class="bb-stat-card__label">Transactions</span>
     </div>
   </a>
   <div class="bb-stat-card bb-stat-card--accent">
@@ -117,7 +121,7 @@
       <i data-lucide="clock" class="w-6 h-6"></i>
     </div>
     <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value text-xl">{{.LastSync}}</span>
+      <span class="bb-stat-card__value text-lg">{{.LastSync}}</span>
       <span class="bb-stat-card__label">Last Sync</span>
     </div>
   </div>
@@ -155,46 +159,304 @@
   {{end}}
 </div>
 
-<h2 class="text-lg font-semibold mb-4">Recent Sync Activity</h2>
-
-{{if .RecentLogs}}
-<div class="overflow-x-auto border border-base-300 rounded-lg">
-  <table class="table table-zebra table-sm">
-    <thead>
-      <tr>
-        <th>Institution</th>
-        <th>Trigger</th>
-        <th>Status</th>
-        <th>+Add</th>
-        <th>~Mod</th>
-        <th>-Rem</th>
-        <th>When</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{range .RecentLogs}}
-      <tr class="hover:bg-base-300">
-        <td><a href="/connections/{{formatUUID .ConnectionID}}">{{.InstitutionName.String}}</a></td>
-        <td>{{.Trigger}}</td>
-        <td>{{syncBadge (printf "%s" .Status)}}</td>
-        <td>{{.AddedCount}}</td>
-        <td>{{.ModifiedCount}}</td>
-        <td>{{.RemovedCount}}</td>
-        <td>{{relativeTime .StartedAt}}</td>
-      </tr>
+<!-- Charts Row -->
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+  <!-- Spending Trend Chart -->
+  <div class="card bg-base-100 shadow-sm border border-base-300 lg:col-span-2">
+    <div class="card-body p-5">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="card-title text-base">
+          <i data-lucide="trending-up" class="w-4 h-4 text-primary"></i>
+          Daily Spending
+        </h2>
+      </div>
+      {{if .DailyLabels}}
+      <div class="h-56">
+        <canvas id="spendingTrendChart"></canvas>
+      </div>
+      {{else}}
+      <div class="flex items-center justify-center h-56 text-base-content/40">
+        <div class="text-center">
+          <i data-lucide="bar-chart-3" class="w-10 h-10 mx-auto mb-2 opacity-40"></i>
+          <p class="text-sm">No spending data yet</p>
+        </div>
+      </div>
       {{end}}
-    </tbody>
-  </table>
-</div>
-{{else}}
-<p class="text-base-content/70">No sync activity yet. Connect a bank to get started.</p>
-{{end}}
+    </div>
+  </div>
 
-<div class="flex gap-3 mt-6">
-  <a href="/connections/new" class="btn btn-primary">
-    <i data-lucide="plus" class="w-4 h-4"></i>
-    Connect New Bank
-  </a>
-  <a href="/sync-logs" class="btn btn-ghost">View All Sync Logs</a>
+  <!-- Category Breakdown Chart -->
+  <div class="card bg-base-100 shadow-sm border border-base-300">
+    <div class="card-body p-5">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="card-title text-base">
+          <i data-lucide="pie-chart" class="w-4 h-4 text-secondary"></i>
+          By Category
+        </h2>
+      </div>
+      {{if .CategoryLabels}}
+      <div class="h-56 flex items-center justify-center">
+        <canvas id="categoryChart"></canvas>
+      </div>
+      {{else}}
+      <div class="flex items-center justify-center h-56 text-base-content/40">
+        <div class="text-center">
+          <i data-lucide="pie-chart" class="w-10 h-10 mx-auto mb-2 opacity-40"></i>
+          <p class="text-sm">No category data yet</p>
+        </div>
+      </div>
+      {{end}}
+    </div>
+  </div>
 </div>
+
+<!-- Recent Transactions + Sync Activity -->
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+  <!-- Recent Transactions -->
+  <div class="card bg-base-100 shadow-sm border border-base-300 lg:col-span-2">
+    <div class="card-body p-5">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="card-title text-base">
+          <i data-lucide="list" class="w-4 h-4 text-accent"></i>
+          Recent Transactions
+        </h2>
+        <a href="/transactions" class="btn btn-ghost btn-xs">View all</a>
+      </div>
+      {{if .RecentTransactions}}
+      <div class="overflow-x-auto -mx-5">
+        <table class="table table-sm">
+          <thead>
+            <tr class="text-xs text-base-content/50 uppercase">
+              <th>Description</th>
+              <th>Account</th>
+              <th>Category</th>
+              <th class="text-right">Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .RecentTransactions}}
+            <tr class="hover:bg-base-200/50 transition-colors duration-150">
+              <td>
+                <div class="flex flex-col">
+                  <span class="font-medium text-sm truncate max-w-48">{{.Name}}</span>
+                  <span class="text-xs text-base-content/50">{{.Date}}</span>
+                </div>
+              </td>
+              <td class="text-sm text-base-content/70">{{.AccountName}}</td>
+              <td>
+                {{if .CategoryDisplayName}}
+                <span class="badge badge-ghost badge-sm">{{if .CategoryIcon}}{{.CategoryIcon}} {{end}}{{deref .CategoryDisplayName}}</span>
+                {{else}}
+                <span class="text-base-content/30 text-xs">—</span>
+                {{end}}
+              </td>
+              <td class="text-right tabular-nums text-sm font-medium{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">
+                {{formatAmount .Amount}}
+              </td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+      {{else}}
+      <div class="flex items-center justify-center py-8 text-base-content/40">
+        <div class="text-center">
+          <i data-lucide="receipt" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
+          <p class="text-sm">No transactions yet</p>
+          <a href="/connections/new" class="btn btn-primary btn-sm mt-3">Connect a bank</a>
+        </div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+
+  <!-- Recent Sync Activity -->
+  <div class="card bg-base-100 shadow-sm border border-base-300">
+    <div class="card-body p-5">
+      <div class="flex items-center justify-between mb-3">
+        <h2 class="card-title text-base">
+          <i data-lucide="refresh-cw" class="w-4 h-4 text-info"></i>
+          Sync Activity
+        </h2>
+        <a href="/sync-logs" class="btn btn-ghost btn-xs">View all</a>
+      </div>
+      {{if .RecentLogs}}
+      <div class="space-y-2">
+        {{range .RecentLogs}}
+        <a href="/connections/{{formatUUID .ConnectionID}}" class="flex items-center justify-between p-2.5 rounded-lg hover:bg-base-200/60 transition-colors duration-150 no-underline group">
+          <div class="flex items-center gap-3 min-w-0">
+            <div class="w-8 h-8 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
+              <i data-lucide="building-2" class="w-4 h-4 text-base-content/60"></i>
+            </div>
+            <div class="min-w-0">
+              <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.InstitutionName.String}}</div>
+              <div class="text-xs text-base-content/50">{{relativeTime .StartedAt}}</div>
+            </div>
+          </div>
+          <div class="flex items-center gap-2 shrink-0">
+            {{if .AddedCount}}<span class="text-xs text-success font-medium">+{{.AddedCount}}</span>{{end}}
+            {{syncBadge (printf "%s" .Status)}}
+          </div>
+        </a>
+        {{end}}
+      </div>
+      {{else}}
+      <div class="flex items-center justify-center py-8 text-base-content/40">
+        <div class="text-center">
+          <i data-lucide="refresh-cw" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
+          <p class="text-sm">No sync activity yet</p>
+        </div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+</div>
+
+<!-- Quick Actions -->
+<div class="flex gap-3">
+  <a href="/connections/new" class="btn btn-primary btn-sm">
+    <i data-lucide="plus" class="w-4 h-4"></i>
+    Connect Bank
+  </a>
+  <a href="/reviews" class="btn btn-ghost btn-sm">
+    <i data-lucide="clipboard-check" class="w-4 h-4"></i>
+    Review Queue
+  </a>
+</div>
+
+<!-- Chart.js Initialization -->
+{{if .DailyLabels}}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';
+  const textColor = isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.5)';
+
+  Chart.defaults.font.family = 'system-ui, -apple-system, sans-serif';
+
+  // Spending Trend
+  const trendCtx = document.getElementById('spendingTrendChart');
+  if (trendCtx) {
+    const dailyLabels = {{.DailyLabels}};
+    const dailyData = {{.DailyAmounts}};
+
+    // Format labels to short dates
+    const shortLabels = dailyLabels.map(d => {
+      const date = new Date(d + 'T00:00:00');
+      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    });
+
+    new Chart(trendCtx, {
+      type: 'line',
+      data: {
+        labels: shortLabels,
+        datasets: [{
+          label: 'Spending',
+          data: dailyData,
+          borderColor: isDark ? '#6366f1' : '#4f46e5',
+          backgroundColor: isDark ? 'rgba(99,102,241,0.1)' : 'rgba(79,70,229,0.08)',
+          fill: true,
+          tension: 0.3,
+          borderWidth: 2,
+          pointRadius: 0,
+          pointHoverRadius: 4,
+          pointHoverBackgroundColor: isDark ? '#6366f1' : '#4f46e5',
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: 'index', intersect: false },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            backgroundColor: isDark ? '#1e1e2e' : '#fff',
+            titleColor: isDark ? '#cdd6f4' : '#1e1b4b',
+            bodyColor: isDark ? '#a6adc8' : '#4b5563',
+            borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
+            borderWidth: 1,
+            padding: 10,
+            displayColors: false,
+            callbacks: {
+              label: ctx => '$' + ctx.parsed.y.toFixed(2)
+            }
+          }
+        },
+        scales: {
+          x: {
+            grid: { display: false },
+            ticks: { color: textColor, font: { size: 10 }, maxTicksLimit: 8, maxRotation: 0 }
+          },
+          y: {
+            grid: { color: gridColor },
+            ticks: {
+              color: textColor,
+              font: { size: 10 },
+              callback: v => '$' + v.toLocaleString()
+            }
+          }
+        }
+      }
+    });
+  }
+
+  // Category Doughnut
+  {{if .CategoryLabels}}
+  const catCtx = document.getElementById('categoryChart');
+  if (catCtx) {
+    const categoryLabels = {{.CategoryLabels}};
+    const categoryData = {{.CategoryAmounts}};
+
+    const palette = [
+      '#6366f1', '#8b5cf6', '#a78bfa', '#c084fc',
+      '#e879f9', '#f472b6', '#fb7185', '#f97316',
+      '#facc15', '#34d399', '#22d3ee', '#38bdf8'
+    ];
+
+    new Chart(catCtx, {
+      type: 'doughnut',
+      data: {
+        labels: categoryLabels,
+        datasets: [{
+          data: categoryData,
+          backgroundColor: palette.slice(0, categoryData.length),
+          borderWidth: 0,
+          hoverOffset: 4
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        cutout: '65%',
+        plugins: {
+          legend: {
+            position: 'bottom',
+            labels: {
+              color: textColor,
+              font: { size: 10 },
+              boxWidth: 10,
+              padding: 8,
+              usePointStyle: true,
+              pointStyle: 'circle'
+            }
+          },
+          tooltip: {
+            backgroundColor: isDark ? '#1e1e2e' : '#fff',
+            titleColor: isDark ? '#cdd6f4' : '#1e1b4b',
+            bodyColor: isDark ? '#a6adc8' : '#4b5563',
+            borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
+            borderWidth: 1,
+            padding: 10,
+            callbacks: {
+              label: ctx => ctx.label + ': $' + ctx.parsed.toFixed(2)
+            }
+          }
+        }
+      }
+    });
+  }
+  {{end}}
+});
+</script>
+{{end}}
 {{end}}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -93,52 +93,64 @@
 </div>
 {{end}}
 
-<div class="stats stats-vertical lg:stats-horizontal shadow border border-base-300 mb-8 w-full">
-  <div class="stat">
-    <div class="stat-figure text-base-content/50">
-      <i data-lucide="building-2" class="w-8 h-8"></i>
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 mb-8">
+  <div class="bb-stat-card bb-stat-card--primary">
+    <div class="bb-stat-card__icon text-primary">
+      <i data-lucide="building-2" class="w-6 h-6"></i>
     </div>
-    <div class="stat-title">Accounts Connected</div>
-    <div class="stat-value">{{.AccountCount}}</div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value">{{.AccountCount}}</span>
+      <span class="bb-stat-card__label">Accounts Connected</span>
+    </div>
   </div>
-  <a href="/transactions" class="stat hover:bg-base-300 no-underline">
-    <div class="stat-figure text-base-content/50">
-      <i data-lucide="trending-up" class="w-8 h-8"></i>
+  <a href="/transactions" class="bb-stat-card bb-stat-card--secondary no-underline">
+    <div class="bb-stat-card__icon text-secondary">
+      <i data-lucide="trending-up" class="w-6 h-6"></i>
     </div>
-    <div class="stat-title">Transactions Synced</div>
-    <div class="stat-value">{{.TxCount}}</div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value">{{.TxCount}}</span>
+      <span class="bb-stat-card__label">Transactions Synced</span>
+    </div>
   </a>
-  <div class="stat">
-    <div class="stat-figure text-base-content/50">
-      <i data-lucide="clock" class="w-8 h-8"></i>
+  <div class="bb-stat-card bb-stat-card--accent">
+    <div class="bb-stat-card__icon text-accent">
+      <i data-lucide="clock" class="w-6 h-6"></i>
     </div>
-    <div class="stat-title">Last Sync</div>
-    <div class="stat-value text-lg">{{.LastSync}}</div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value text-xl">{{.LastSync}}</span>
+      <span class="bb-stat-card__label">Last Sync</span>
+    </div>
   </div>
   {{if gt .NeedsAttention 0}}
-  <a href="/connections" class="stat border-l-4 border-warning hover:bg-base-300 no-underline">
-    <div class="stat-figure text-warning">
-      <i data-lucide="alert-triangle" class="w-8 h-8"></i>
+  <a href="/connections" class="bb-stat-card bb-stat-card--warning no-underline">
+    <div class="bb-stat-card__icon text-warning">
+      <i data-lucide="alert-triangle" class="w-6 h-6"></i>
     </div>
-    <div class="stat-title">Needs Attention</div>
-    <div class="stat-value text-warning">{{.NeedsAttention}}</div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value text-warning">{{.NeedsAttention}}</span>
+      <span class="bb-stat-card__label">Needs Attention</span>
+    </div>
   </a>
   {{else}}
-  <div class="stat">
-    <div class="stat-figure text-base-content/50">
-      <i data-lucide="alert-triangle" class="w-8 h-8"></i>
+  <div class="bb-stat-card bb-stat-card--neutral">
+    <div class="bb-stat-card__icon text-base-content/40">
+      <i data-lucide="check-circle" class="w-6 h-6"></i>
     </div>
-    <div class="stat-title">Needs Attention</div>
-    <div class="stat-value">{{.NeedsAttention}}</div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value">0</span>
+      <span class="bb-stat-card__label">Needs Attention</span>
+    </div>
   </div>
   {{end}}
   {{if gt .ReviewPending 0}}
-  <a href="/reviews" class="stat border-l-4 border-info hover:bg-base-300 no-underline">
-    <div class="stat-figure text-info">
-      <i data-lucide="clipboard-check" class="w-8 h-8"></i>
+  <a href="/reviews" class="bb-stat-card bb-stat-card--info no-underline">
+    <div class="bb-stat-card__icon text-info">
+      <i data-lucide="clipboard-check" class="w-6 h-6"></i>
     </div>
-    <div class="stat-title">Pending Reviews</div>
-    <div class="stat-value text-info">{{.ReviewPending}}</div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value text-info">{{.ReviewPending}}</span>
+      <span class="bb-stat-card__label">Pending Reviews</span>
+    </div>
   </a>
   {{end}}
 </div>


### PR DESCRIPTION
## Summary
- Added Chart.js-powered spending trend line chart (30-day daily spending) and category breakdown doughnut chart to the dashboard
- Added recent transactions table showing last 8 transactions with category badges, account names, and formatted amounts
- Redesigned sync activity section from a full table into compact clickable cards with institution icons and status badges
- Backend: leveraged existing `GetTransactionSummary` service with `category` and `day` grouping, plus `ListTransactionsAdmin` for recent transactions

## Screenshots
![Dashboard with charts](https://i.img402.dev/327habgyyh.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent