### PR TITLE
Premium color palette: Mercury-inspired light and dark themes

### DIFF
--- a/input.css
+++ b/input.css
@@ -1,6 +1,100 @@
 @import "tailwindcss";
 @plugin "daisyui" {
-  themes: light --default, dark --prefersdark;
+  themes: false;
+}
+
+/* ─── Breadbox Light Theme (Mercury-inspired) ─── */
+@plugin "daisyui/theme" {
+  name: "breadbox-light";
+  default: true;
+  color-scheme: light;
+
+  /* Backgrounds: pure white cards on warm off-white canvas */
+  --color-base-100: oklch(100% 0 0);
+  --color-base-200: oklch(97.5% 0.003 250);
+  --color-base-300: oklch(93% 0.005 250);
+  --color-base-content: oklch(18% 0.005 250);
+
+  /* Primary: refined deep indigo — the singular brand accent */
+  --color-primary: oklch(48% 0.17 265);
+  --color-primary-content: oklch(98% 0.005 265);
+
+  /* Secondary: cool slate — for secondary actions and muted UI */
+  --color-secondary: oklch(55% 0.04 260);
+  --color-secondary-content: oklch(98% 0.003 260);
+
+  /* Accent: soft teal — for special highlights and differentiation */
+  --color-accent: oklch(62% 0.1 195);
+  --color-accent-content: oklch(98% 0.005 195);
+
+  /* Neutral: deep charcoal — for badges, tags, overlays */
+  --color-neutral: oklch(20% 0.005 250);
+  --color-neutral-content: oklch(95% 0.003 250);
+
+  /* Semantic: muted, sophisticated tones (not neon) */
+  --color-info: oklch(62% 0.1 245);
+  --color-info-content: oklch(98% 0.005 245);
+  --color-success: oklch(62% 0.14 155);
+  --color-success-content: oklch(98% 0.005 155);
+  --color-warning: oklch(72% 0.14 75);
+  --color-warning-content: oklch(25% 0.05 75);
+  --color-error: oklch(60% 0.17 20);
+  --color-error-content: oklch(98% 0.005 20);
+
+  /* Shape: generous radius, subtle depth */
+  --radius-selector: 0.625rem;
+  --radius-field: 0.5rem;
+  --radius-box: 1rem;
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
+}
+
+/* ─── Breadbox Dark Theme (rich, warm — not "inverted light") ─── */
+@plugin "daisyui/theme" {
+  name: "breadbox-dark";
+  prefersdark: true;
+  color-scheme: dark;
+
+  /* Backgrounds: warm charcoal tones, NOT blue-tinted */
+  --color-base-100: oklch(20% 0.006 270);
+  --color-base-200: oklch(17.5% 0.005 270);
+  --color-base-300: oklch(15% 0.004 270);
+  --color-base-content: oklch(93% 0.005 250);
+
+  /* Primary: lighter indigo for dark bg contrast */
+  --color-primary: oklch(68% 0.16 265);
+  --color-primary-content: oklch(15% 0.02 265);
+
+  /* Secondary: lifted slate */
+  --color-secondary: oklch(65% 0.03 260);
+  --color-secondary-content: oklch(15% 0.01 260);
+
+  /* Accent: brightened teal */
+  --color-accent: oklch(72% 0.1 195);
+  --color-accent-content: oklch(15% 0.02 195);
+
+  /* Neutral: lifted dark for subtle contrasts */
+  --color-neutral: oklch(25% 0.006 270);
+  --color-neutral-content: oklch(90% 0.003 250);
+
+  /* Semantic: slightly brighter for dark bg readability */
+  --color-info: oklch(70% 0.1 245);
+  --color-info-content: oklch(15% 0.02 245);
+  --color-success: oklch(70% 0.14 155);
+  --color-success-content: oklch(15% 0.02 155);
+  --color-warning: oklch(78% 0.13 75);
+  --color-warning-content: oklch(20% 0.04 75);
+  --color-error: oklch(68% 0.16 20);
+  --color-error-content: oklch(15% 0.02 20);
+
+  /* Shape: same generous radius */
+  --radius-selector: 0.625rem;
+  --radius-field: 0.5rem;
+  --radius-box: 1rem;
+  --border: 1px;
+  --depth: 1;
+  --noise: 0;
 }
 
 /* Utility: hide Alpine.js elements until initialized */
@@ -8,13 +102,6 @@
 
 /* ─── Mercury-inspired global overrides ─── */
 @layer base {
-  /* Softer, rounder defaults for all DaisyUI components */
-  :root {
-    --rounded-box: 1rem;
-    --rounded-btn: 0.625rem;
-    --rounded-badge: 0.5rem;
-  }
-
   /* Smoother scrolling */
   html { scroll-behavior: smooth; }
 

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -329,10 +329,10 @@
 <script>
 document.addEventListener('DOMContentLoaded', function() {
   const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)';
-  const textColor = isDark ? 'rgba(255,255,255,0.5)' : 'rgba(0,0,0,0.5)';
+  const gridColor = isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.05)';
+  const textColor = isDark ? 'rgba(255,255,255,0.4)' : 'rgba(0,0,0,0.4)';
 
-  Chart.defaults.font.family = 'system-ui, -apple-system, sans-serif';
+  Chart.defaults.font.family = 'Inter, system-ui, -apple-system, sans-serif';
 
   // Spending Trend
   const trendCtx = document.getElementById('spendingTrendChart');
@@ -353,14 +353,16 @@ document.addEventListener('DOMContentLoaded', function() {
         datasets: [{
           label: 'Spending',
           data: dailyData,
-          borderColor: isDark ? '#6366f1' : '#4f46e5',
-          backgroundColor: isDark ? 'rgba(99,102,241,0.1)' : 'rgba(79,70,229,0.08)',
+          borderColor: isDark ? '#8b8cf7' : '#4338a8',
+          backgroundColor: isDark ? 'rgba(139,140,247,0.08)' : 'rgba(67,56,168,0.06)',
           fill: true,
-          tension: 0.3,
+          tension: 0.35,
           borderWidth: 2,
           pointRadius: 0,
-          pointHoverRadius: 4,
-          pointHoverBackgroundColor: isDark ? '#6366f1' : '#4f46e5',
+          pointHoverRadius: 5,
+          pointHoverBackgroundColor: isDark ? '#8b8cf7' : '#4338a8',
+          pointHoverBorderColor: isDark ? '#1a1a2e' : '#ffffff',
+          pointHoverBorderWidth: 2,
         }]
       },
       options: {
@@ -370,12 +372,13 @@ document.addEventListener('DOMContentLoaded', function() {
         plugins: {
           legend: { display: false },
           tooltip: {
-            backgroundColor: isDark ? '#1e1e2e' : '#fff',
-            titleColor: isDark ? '#cdd6f4' : '#1e1b4b',
-            bodyColor: isDark ? '#a6adc8' : '#4b5563',
-            borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
+            backgroundColor: isDark ? '#1a1a2e' : '#fff',
+            titleColor: isDark ? '#e0e0ec' : '#1a1a2e',
+            bodyColor: isDark ? '#a0a0b8' : '#555566',
+            borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
             borderWidth: 1,
-            padding: 10,
+            padding: 12,
+            cornerRadius: 10,
             displayColors: false,
             callbacks: {
               label: ctx => '$' + ctx.parsed.y.toFixed(2)
@@ -407,11 +410,14 @@ document.addEventListener('DOMContentLoaded', function() {
     const categoryLabels = {{.CategoryLabels}};
     const categoryData = {{.CategoryAmounts}};
 
-    const palette = [
-      '#6366f1', '#8b5cf6', '#a78bfa', '#c084fc',
-      '#e879f9', '#f472b6', '#fb7185', '#f97316',
-      '#facc15', '#34d399', '#22d3ee', '#38bdf8'
-    ];
+    /* Refined palette: indigo core with desaturated complementary tones */
+    const palette = isDark
+      ? ['#8b8cf7', '#a39ef5', '#7b9cf0', '#6db8c4', '#82c9a0',
+         '#c4a66d', '#d4907a', '#b88bb4', '#8a9baa', '#6e8b9e',
+         '#a08db8', '#7eaab4']
+      : ['#4338a8', '#5e4fb8', '#3b6daa', '#2d8f9a', '#3d8f6a',
+         '#9a7b3d', '#b86050', '#8f5f8a', '#5a6e80', '#4a7080',
+         '#7a6898', '#4d8a8f'];
 
     new Chart(catCtx, {
       type: 'doughnut',
@@ -441,12 +447,13 @@ document.addEventListener('DOMContentLoaded', function() {
             }
           },
           tooltip: {
-            backgroundColor: isDark ? '#1e1e2e' : '#fff',
-            titleColor: isDark ? '#cdd6f4' : '#1e1b4b',
-            bodyColor: isDark ? '#a6adc8' : '#4b5563',
-            borderColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)',
+            backgroundColor: isDark ? '#1a1a2e' : '#fff',
+            titleColor: isDark ? '#e0e0ec' : '#1a1a2e',
+            bodyColor: isDark ? '#a0a0b8' : '#555566',
+            borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
             borderWidth: 1,
-            padding: 10,
+            padding: 12,
+            cornerRadius: 10,
             callbacks: {
               label: ctx => ctx.label + ': $' + ctx.parsed.toFixed(2)
             }


### PR DESCRIPTION
## Summary
- Replace stock DaisyUI `light`/`dark` themes with custom `breadbox-light` and `breadbox-dark` palettes using DaisyUI 5's `@plugin "daisyui/theme"` syntax
- **Light mode**: Pure white cards, warm off-white canvas, deep indigo primary, muted sage/rose/amber semantic colors — Mercury-level restraint
- **Dark mode**: Warm charcoal tones (hue 270, not blue-tinted 252) for a rich, premium feel instead of "inverted light mode"
- Chart colors refined: monochromatic indigo-based palette replaces rainbow, tooltips get rounded corners and softer styling
- Shape tokens (radius, border) moved from manual `:root` overrides into the theme definitions

## Design Decisions
| Token | Light | Dark | Rationale |
|-------|-------|------|-----------|
| base-100 | Pure white | oklch(20% .006 270) | Cards/sidebar — warm charcoal, not blue |
| base-200 | oklch(97.5% .003 250) | oklch(17.5% .005 270) | Canvas — subtle warmth |
| primary | oklch(48% .17 265) | oklch(68% .16 265) | Deep indigo — singular brand accent |
| secondary | oklch(55% .04 260) | oklch(65% .03 260) | Cool slate, not hot pink |
| success | oklch(62% .14 155) | oklch(70% .14 155) | Sage green, not neon |
| error | oklch(60% .17 20) | oklch(68% .16 20) | Muted rose, not fire truck red |

## Screenshots

### Dark mode
![Dark mode dashboard](https://i.img402.dev/9dc96a44cu.png)

### Light mode
![Light mode dashboard](https://i.img402.dev/mbefyek7r3.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent