### PR TITLE
Redesign system pages: Settings, Users, API Keys, Sync Logs

### DIFF
--- a/internal/templates/pages/api_keys.html
+++ b/internal/templates/pages/api_keys.html
@@ -1,72 +1,72 @@
 {{define "content"}}
-<div class="flex items-center justify-between mb-6">
-  <h1 class="text-2xl font-bold m-0">API Keys</h1>
-  <a href="/api-keys/new" class="btn btn-primary">
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">API Keys</h1>
+    <p class="text-sm text-base-content/50 mt-1">Manage keys for REST API and MCP access</p>
+  </div>
+  <a href="/api-keys/new" class="btn btn-primary btn-sm">
     <i data-lucide="plus" class="w-4 h-4"></i>
-    Create API Key
+    Create Key
   </a>
 </div>
 
 {{if .Keys}}
-<div class="overflow-x-auto border border-base-300 rounded-lg">
-  <table class="table table-zebra table-sm">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Scope</th>
-        <th>Key Prefix</th>
-        <th>Last Used</th>
-        <th>Status</th>
-        <th>Created</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{range .Keys}}
-      <tr class="hover:bg-base-300">
-        <td>{{.Name}}</td>
-        <td>
+<div class="space-y-3">
+  {{range .Keys}}
+  <div class="bb-card p-5 flex items-center justify-between gap-4 flex-wrap" x-data="{ confirming: false }">
+    <div class="flex items-center gap-4 min-w-0">
+      <div class="flex items-center justify-center w-10 h-10 rounded-xl shrink-0
+        {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-primary/8{{end}}">
+        <i data-lucide="key" class="w-5 h-5 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-primary{{end}}"></i>
+      </div>
+      <div class="min-w-0">
+        <div class="flex items-center gap-2 flex-wrap">
+          <span class="font-semibold text-sm {{if .RevokedAt}}text-base-content/40 line-through{{end}}">{{.Name}}</span>
           {{if eq .Scope "read_only"}}
-            <span class="badge badge-warning badge-sm">Read Only</span>
+          <span class="badge badge-soft badge-warning badge-xs">Read Only</span>
           {{else}}
-            <span class="badge badge-info badge-sm">Full Access</span>
+          <span class="badge badge-soft badge-primary badge-xs">Full Access</span>
           {{end}}
-        </td>
-        <td><code class="font-mono text-sm">{{.KeyPrefix}}...</code></td>
-        <td>{{if .LastUsedAt}}{{.LastUsedAt}}{{else}}&mdash;{{end}}</td>
-        <td>
           {{if .RevokedAt}}
-            <span class="badge badge-error badge-sm">Revoked</span>
-          {{else}}
-            <span class="badge badge-success badge-sm">Active</span>
+          <span class="badge badge-soft badge-error badge-xs">Revoked</span>
           {{end}}
-        </td>
-        <td>{{.CreatedAt}}</td>
-        <td>
-          {{if not .RevokedAt}}
-          <form method="POST" action="/api-keys/{{.ID}}/revoke" class="inline" x-data="{ confirming: false }">
-            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
-            <button type="button" class="btn btn-ghost btn-xs" x-show="!confirming" @click="confirming = true">Revoke</button>
-            <span x-show="confirming" x-cloak>
-              <button type="submit" class="btn btn-error btn-xs">Confirm</button>
-              <button type="button" class="btn btn-ghost btn-xs" @click="confirming = false">Cancel</button>
-            </span>
-          </form>
-          {{end}}
-        </td>
-      </tr>
-      {{end}}
-    </tbody>
-  </table>
+        </div>
+        <div class="flex items-center gap-3 mt-0.5 text-xs text-base-content/40">
+          <code class="font-mono bg-base-200/50 px-1.5 py-0.5 rounded">{{.KeyPrefix}}...</code>
+          <span>Created {{.CreatedAt}}</span>
+          {{if .LastUsedAt}}<span>Last used {{.LastUsedAt}}</span>{{end}}
+        </div>
+      </div>
+    </div>
+
+    {{if not .RevokedAt}}
+    <div class="shrink-0">
+      <form method="POST" action="/api-keys/{{.ID}}/revoke" class="inline">
+        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+        <button type="button" class="btn btn-ghost btn-sm text-base-content/50 hover:text-error" x-show="!confirming" @click="confirming = true">
+          Revoke
+        </button>
+        <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
+          <button type="submit" class="btn btn-error btn-sm btn-soft">Confirm</button>
+          <button type="button" class="btn btn-ghost btn-sm" @click="confirming = false">Cancel</button>
+        </span>
+      </form>
+    </div>
+    {{end}}
+  </div>
+  {{end}}
 </div>
 {{else}}
-<div class="card bg-base-100 border border-base-300">
-  <div class="card-body items-center text-center py-12">
-    <i data-lucide="key" class="w-12 h-12 text-base-content/30 mb-2"></i>
-    <p class="text-base-content/70">No API keys yet.</p>
-    <a href="/api-keys/new" class="btn btn-primary mt-2">
+<div class="bb-card p-12 text-center">
+  <div class="flex flex-col items-center">
+    <div class="w-16 h-16 rounded-2xl bg-base-200/60 flex items-center justify-center mb-4">
+      <i data-lucide="key" class="w-8 h-8 text-base-content/25"></i>
+    </div>
+    <h3 class="text-lg font-semibold mb-1">No API keys yet</h3>
+    <p class="text-sm text-base-content/50 mb-5 max-w-sm">Create an API key to connect MCP agents or integrate with external tools.</p>
+    <a href="/api-keys/new" class="btn btn-primary btn-sm">
       <i data-lucide="plus" class="w-4 h-4"></i>
-      Create your first API key
+      Create your first key
     </a>
   </div>
 </div>

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -1,19 +1,32 @@
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">Settings</h1>
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Settings</h1>
+    <p class="text-sm text-base-content/50 mt-1">Manage sync schedule, security, and system info</p>
+  </div>
+</div>
 
-<!-- Sync & Scheduling Section -->
-<div class="collapse collapse-arrow bg-base-100 border border-base-300 mb-6">
-  <input type="checkbox" checked />
-  <div class="collapse-title text-xl font-medium">Sync &amp; Scheduling</div>
-  <div class="collapse-content">
-    <p class="text-sm text-base-content/70 mb-4">Breadbox automatically syncs bank data on this schedule. Webhooks provide real-time updates when supported by the provider.</p>
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+
+  <!-- Sync & Scheduling -->
+  <div class="bb-card p-6">
+    <div class="flex items-center gap-3 mb-5">
+      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
+        <i data-lucide="refresh-cw" class="w-5 h-5 text-primary"></i>
+      </div>
+      <div>
+        <h2 class="text-base font-semibold">Sync Schedule</h2>
+        <p class="text-xs text-base-content/45">Automatic bank data sync interval</p>
+      </div>
+    </div>
+
     <form method="POST" action="/settings/sync">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
-      <label class="flex flex-col gap-1 text-sm" for="sync_interval_minutes">
+      <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="sync_interval_minutes">
         Sync Interval {{configSource .ConfigSources "sync_interval_minutes"}}
       </label>
-      <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm w-full max-w-xs">
+      <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm w-full bg-base-200/50 border-base-200 focus:border-primary">
         <option value="15"{{if eq .SyncIntervalMinutes 15}} selected{{end}}>Every 15 minutes</option>
         <option value="30"{{if eq .SyncIntervalMinutes 30}} selected{{end}}>Every 30 minutes</option>
         <option value="60"{{if eq .SyncIntervalMinutes 60}} selected{{end}}>Every hour</option>
@@ -24,62 +37,109 @@
       </select>
 
       {{if ne .NextSyncTime ""}}
-      <p class="text-xs text-base-content/60 mt-4">Next scheduled sync: {{.NextSyncTime}}</p>
+      <p class="text-xs text-base-content/40 mt-3 flex items-center gap-1.5">
+        <i data-lucide="clock" class="w-3.5 h-3.5"></i>
+        Next sync: {{.NextSyncTime}}
+      </p>
       {{end}}
 
-      <div class="mt-4">
-        <button type="submit" class="btn btn-primary btn-sm">Save Sync Settings</button>
+      <div class="mt-5 pt-4 border-t border-base-200">
+        <button type="submit" class="btn btn-primary btn-sm">Save Schedule</button>
       </div>
     </form>
   </div>
-</div>
 
-<!-- Security Section -->
-<div class="collapse collapse-arrow bg-base-100 border border-base-300 mb-6">
-  <input type="checkbox" checked />
-  <div class="collapse-title text-xl font-medium">Security</div>
-  <div class="collapse-content">
-    <div class="mb-4">
-      <span class="text-sm font-medium">Encryption Key:</span>
+  <!-- Security -->
+  <div class="bb-card p-6">
+    <div class="flex items-center gap-3 mb-5">
+      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-error/8">
+        <i data-lucide="shield" class="w-5 h-5 text-error"></i>
+      </div>
+      <div>
+        <h2 class="text-base font-semibold">Security</h2>
+        <p class="text-xs text-base-content/45">Encryption and authentication</p>
+      </div>
+    </div>
+
+    <!-- Encryption Key Status -->
+    <div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40 mb-5">
+      <div class="flex items-center gap-2.5">
+        <i data-lucide="key-round" class="w-4 h-4 text-base-content/50"></i>
+        <span class="text-sm font-medium">Encryption Key</span>
+      </div>
       {{if .HasEncryptionKey}}
-      <span class="badge badge-success badge-sm">Configured</span>
+      <span class="badge badge-success badge-sm">Active</span>
       {{else}}
-      <span class="badge badge-error badge-sm">NOT SET</span>
-      <span class="text-xs text-error ml-1">Access tokens cannot be stored</span>
+      <div class="flex items-center gap-1.5">
+        <span class="badge badge-error badge-sm">Not Set</span>
+      </div>
       {{end}}
     </div>
 
-    <div class="divider"></div>
+    {{if not .HasEncryptionKey}}
+    <div class="text-xs text-error/80 bg-error/5 rounded-lg p-3 mb-5">
+      <i data-lucide="alert-triangle" class="w-3.5 h-3.5 inline mr-1"></i>
+      Access tokens cannot be stored without an encryption key. Set the ENCRYPTION_KEY environment variable.
+    </div>
+    {{end}}
 
-    <h3 class="font-semibold text-sm mb-2">Change Password</h3>
-    <form method="POST" action="/settings/password">
+    <!-- Change Password -->
+    <h3 class="text-sm font-semibold text-base-content/70 mb-3">Change Password</h3>
+    <form method="POST" action="/settings/password" class="space-y-3">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-      <label class="flex flex-col gap-1 text-sm" for="current_password">Current Password</label>
-      <input type="password" id="current_password" name="current_password" required class="input input-sm w-full max-w-md">
-      <label class="flex flex-col gap-1 text-sm mt-4" for="new_password">New Password</label>
-      <input type="password" id="new_password" name="new_password" required minlength="8" class="input input-sm w-full max-w-md">
-      <label class="flex flex-col gap-1 text-sm mt-4" for="confirm_password">Confirm New Password</label>
-      <input type="password" id="confirm_password" name="confirm_password" required class="input input-sm w-full max-w-md">
-      <div class="mt-4">
-        <button type="submit" class="btn btn-primary btn-sm">Change Password</button>
+      <div>
+        <label class="text-xs font-medium text-base-content/50 mb-1 block" for="current_password">Current Password</label>
+        <input type="password" id="current_password" name="current_password" required class="input input-sm w-full bg-base-200/50 border-base-200 focus:border-primary">
+      </div>
+      <div>
+        <label class="text-xs font-medium text-base-content/50 mb-1 block" for="new_password">New Password</label>
+        <input type="password" id="new_password" name="new_password" required minlength="8" class="input input-sm w-full bg-base-200/50 border-base-200 focus:border-primary">
+      </div>
+      <div>
+        <label class="text-xs font-medium text-base-content/50 mb-1 block" for="confirm_password">Confirm New Password</label>
+        <input type="password" id="confirm_password" name="confirm_password" required class="input input-sm w-full bg-base-200/50 border-base-200 focus:border-primary">
+      </div>
+      <div class="pt-2">
+        <button type="submit" class="btn btn-primary btn-sm">Update Password</button>
       </div>
     </form>
   </div>
-</div>
 
-<!-- System Section (collapsed by default) -->
-<div class="collapse collapse-arrow bg-base-100 border border-base-300 mb-6">
-  <input type="checkbox" />
-  <div class="collapse-title text-xl font-medium">System</div>
-  <div class="collapse-content">
-    <dl class="bb-info-grid">
-      <dt>Breadbox Version</dt><dd>{{.Version}}</dd>
-      <dt>Go Runtime</dt><dd>{{.GoVersion}}</dd>
-      <dt>PostgreSQL</dt><dd>{{.PostgresVersion}}</dd>
-      <dt>Uptime</dt><dd>{{.Uptime}}</dd>
-      <dt>Providers</dt><dd>{{.ProviderCount}} configured</dd>
-    </dl>
+  <!-- System Info -->
+  <div class="bb-card p-6 lg:col-span-2">
+    <div class="flex items-center gap-3 mb-5">
+      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-base-200/60">
+        <i data-lucide="cpu" class="w-5 h-5 text-base-content/50"></i>
+      </div>
+      <div>
+        <h2 class="text-base font-semibold">System</h2>
+        <p class="text-xs text-base-content/45">Runtime and version information</p>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
+      <div class="p-3.5 rounded-xl bg-base-200/40">
+        <div class="text-xs font-medium text-base-content/40 mb-1">Version</div>
+        <div class="text-sm font-semibold tabular-nums">{{.Version}}</div>
+      </div>
+      <div class="p-3.5 rounded-xl bg-base-200/40">
+        <div class="text-xs font-medium text-base-content/40 mb-1">Go Runtime</div>
+        <div class="text-sm font-semibold">{{.GoVersion}}</div>
+      </div>
+      <div class="p-3.5 rounded-xl bg-base-200/40">
+        <div class="text-xs font-medium text-base-content/40 mb-1">PostgreSQL</div>
+        <div class="text-sm font-semibold truncate" title="{{.PostgresVersion}}">{{.PostgresVersion}}</div>
+      </div>
+      <div class="p-3.5 rounded-xl bg-base-200/40">
+        <div class="text-xs font-medium text-base-content/40 mb-1">Uptime</div>
+        <div class="text-sm font-semibold">{{.Uptime}}</div>
+      </div>
+      <div class="p-3.5 rounded-xl bg-base-200/40">
+        <div class="text-xs font-medium text-base-content/40 mb-1">Providers</div>
+        <div class="text-sm font-semibold">{{.ProviderCount}} configured</div>
+      </div>
+    </div>
   </div>
-</div>
 
+</div>
 {{end}}

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -1,80 +1,109 @@
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">Sync Logs</h1>
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Sync Logs</h1>
+    <p class="text-sm text-base-content/50 mt-1">History of bank data synchronizations</p>
+  </div>
+</div>
 
-<form method="GET" action="/sync-logs" class="bb-filter-bar">
-  <label>
-    Connection
-    <select name="connection_id">
-      <option value="">All connections</option>
-      {{range .Connections}}
-      <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
-      {{end}}
-    </select>
-  </label>
-  <label>
-    Status
-    <select name="status">
-      <option value="">All statuses</option>
-      <option value="success"{{if eq .FilterStatus "success"}} selected{{end}}>Success</option>
-      <option value="error"{{if eq .FilterStatus "error"}} selected{{end}}>Error</option>
-      <option value="in_progress"{{if eq .FilterStatus "in_progress"}} selected{{end}}>In Progress</option>
-    </select>
-  </label>
-  <button type="submit" class="btn btn-sm btn-primary self-end">Filter</button>
-  {{if or .FilterConnID .FilterStatus}}
-  <a href="/sync-logs" class="btn btn-sm btn-ghost self-end">Clear</a>
-  {{end}}
-</form>
+<!-- Filter Bar -->
+<div class="bb-card p-4 mb-6">
+  <form method="GET" action="/sync-logs" class="flex flex-wrap items-end gap-3">
+    <div class="form-control">
+      <label class="text-xs font-medium text-base-content/50 mb-1">Connection</label>
+      <select name="connection_id" class="select select-sm bg-base-200/50 border-base-200 min-w-[10rem]">
+        <option value="">All connections</option>
+        {{range .Connections}}
+        <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
+        {{end}}
+      </select>
+    </div>
+    <div class="form-control">
+      <label class="text-xs font-medium text-base-content/50 mb-1">Status</label>
+      <select name="status" class="select select-sm bg-base-200/50 border-base-200 min-w-[8rem]">
+        <option value="">All statuses</option>
+        <option value="success"{{if eq .FilterStatus "success"}} selected{{end}}>Success</option>
+        <option value="error"{{if eq .FilterStatus "error"}} selected{{end}}>Error</option>
+        <option value="in_progress"{{if eq .FilterStatus "in_progress"}} selected{{end}}>In Progress</option>
+      </select>
+    </div>
+    <button type="submit" class="btn btn-primary btn-sm">Filter</button>
+    {{if or .FilterConnID .FilterStatus}}
+    <a href="/sync-logs" class="btn btn-ghost btn-sm">Clear</a>
+    {{end}}
+  </form>
+</div>
 
 {{if .Logs}}
-<div class="overflow-x-auto max-h-[70vh] border border-base-300 rounded-lg">
-  <table class="table table-zebra table-sm table-pin-rows">
-    <thead>
-      <tr>
-        <th>Connection</th>
-        <th>Trigger</th>
-        <th>Status</th>
-        <th>+Add</th>
-        <th>~Mod</th>
-        <th>-Rem</th>
-        <th>Duration</th>
-        <th>Started</th>
-        <th>Error</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{range .Logs}}
-      <tr class="hover:bg-base-300">
-        <td>{{.InstitutionName}}</td>
-        <td>{{.Trigger}}</td>
-        <td>{{syncBadge .Status}}</td>
-        <td>{{.AddedCount}}</td>
-        <td>{{.ModifiedCount}}</td>
-        <td>{{.RemovedCount}}</td>
-        <td>{{if .Duration}}{{.Duration}}{{else}}&mdash;{{end}}</td>
-        <td>{{if .StartedAt}}{{.StartedAt}}{{else}}&mdash;{{end}}</td>
-        <td>
-          {{if .ErrorMessage}}
-          <details>
-            <summary class="cursor-pointer text-sm link">View</summary>
-            <small class="text-error">{{.ErrorMessage}}</small>
-          </details>
-          {{else}}&mdash;{{end}}
-        </td>
-      </tr>
+<!-- Results count -->
+<div class="text-xs text-base-content/40 mb-3 px-1">{{.Total}} sync log{{if ne .Total 1}}s{{end}}</div>
+
+<div class="space-y-2">
+  {{range .Logs}}
+  <div class="bb-card px-5 py-3.5 flex items-center gap-4 flex-wrap">
+    <!-- Institution icon + name -->
+    <div class="flex items-center gap-3 min-w-0 w-44 shrink-0">
+      <div class="w-8 h-8 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0">
+        <i data-lucide="building-2" class="w-4 h-4 text-base-content/40"></i>
+      </div>
+      <div class="min-w-0">
+        <div class="text-sm font-medium truncate">{{.InstitutionName}}</div>
+        <div class="text-xs text-base-content/40">{{if .StartedAt}}{{.StartedAt}}{{end}}</div>
+      </div>
+    </div>
+
+    <!-- Trigger -->
+    <div class="w-16 shrink-0">
+      <span class="badge badge-ghost badge-xs uppercase tracking-wide">{{.Trigger}}</span>
+    </div>
+
+    <!-- Counts -->
+    <div class="flex items-center gap-3 text-xs tabular-nums flex-1">
+      {{if .AddedCount}}
+      <span class="text-success font-medium">+{{.AddedCount}}</span>
       {{end}}
-    </tbody>
-  </table>
+      {{if .ModifiedCount}}
+      <span class="text-info font-medium">~{{.ModifiedCount}}</span>
+      {{end}}
+      {{if .RemovedCount}}
+      <span class="text-error font-medium">-{{.RemovedCount}}</span>
+      {{end}}
+      {{if and (not .AddedCount) (not .ModifiedCount) (not .RemovedCount)}}
+      <span class="text-base-content/25">No changes</span>
+      {{end}}
+    </div>
+
+    <!-- Duration -->
+    <div class="w-20 text-xs text-base-content/50 text-right shrink-0">
+      {{if .Duration}}{{.Duration}}{{else}}&mdash;{{end}}
+    </div>
+
+    <!-- Status + Error -->
+    <div class="w-24 shrink-0 flex items-center justify-end gap-2">
+      {{if .ErrorMessage}}
+      <div class="dropdown dropdown-end">
+        <div tabindex="0" role="button" class="btn btn-ghost btn-xs text-error">
+          <i data-lucide="alert-circle" class="w-3.5 h-3.5"></i>
+        </div>
+        <div tabindex="0" class="dropdown-content card card-compact bg-base-100 shadow-xl border border-base-200 p-3 w-72 z-10">
+          <p class="text-xs text-error font-mono break-all">{{.ErrorMessage}}</p>
+        </div>
+      </div>
+      {{end}}
+      {{syncBadge .Status}}
+    </div>
+  </div>
+  {{end}}
 </div>
 
 {{if gt .TotalPages 1}}
-<div class="bb-pagination">
+<div class="flex items-center justify-between mt-6">
   <div>
     {{if gt .Page 1}}
     <a href="/sync-logs?page={{sub .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost">&laquo; Previous</a>
     {{end}}
   </div>
-  <small class="text-base-content/70">Page {{.Page}} of {{.TotalPages}} ({{.Total}} total)</small>
+  <span class="text-xs text-base-content/40">Page {{.Page}} of {{.TotalPages}}</span>
   <div>
     {{if lt .Page .TotalPages}}
     <a href="/sync-logs?page={{add .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost">Next &raquo;</a>
@@ -84,12 +113,15 @@
 {{end}}
 
 {{else}}
-<div class="card bg-base-100 border border-base-300">
-  <div class="card-body items-center text-center py-12">
-    <i data-lucide="refresh-cw" class="w-12 h-12 text-base-content/30 mb-2"></i>
-    <p class="text-base-content/70">No sync logs found.</p>
+<div class="bb-card p-12 text-center">
+  <div class="flex flex-col items-center">
+    <div class="w-16 h-16 rounded-2xl bg-base-200/60 flex items-center justify-center mb-4">
+      <i data-lucide="refresh-cw" class="w-8 h-8 text-base-content/25"></i>
+    </div>
+    <h3 class="text-lg font-semibold mb-1">No sync logs found</h3>
+    <p class="text-sm text-base-content/50 mb-5">{{if or .FilterConnID .FilterStatus}}Try adjusting your filters.{{else}}Sync logs will appear here after your first bank sync.{{end}}</p>
     {{if or .FilterConnID .FilterStatus}}
-    <a href="/sync-logs" class="btn btn-ghost btn-sm mt-2">Clear filters</a>
+    <a href="/sync-logs" class="btn btn-ghost btn-sm">Clear filters</a>
     {{end}}
   </div>
 </div>

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -1,51 +1,71 @@
 {{define "content"}}
-<div class="flex items-center justify-between mb-6">
-  <h1 class="text-2xl font-bold m-0">Family Members</h1>
-  <a href="/users/new" class="btn btn-primary">
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Family Members</h1>
+    <p class="text-sm text-base-content/50 mt-1">Manage who has bank connections in Breadbox</p>
+  </div>
+  <a href="/users/new" class="btn btn-primary btn-sm">
     <i data-lucide="plus" class="w-4 h-4"></i>
-    Add Family Member
+    Add Member
   </a>
 </div>
 
 {{if .Created}}
-<div class="alert alert-success mb-4">Member created. <a href="/connections/new" class="link">Connect a bank for them &rarr;</a></div>
+<div class="alert alert-success mb-6 rounded-2xl">
+  <i data-lucide="check-circle" class="w-5 h-5"></i>
+  <span>Member created. <a href="/connections/new" class="link font-medium">Connect a bank for them</a></span>
+</div>
 {{end}}
 
 {{if .Users}}
-<div class="overflow-x-auto border border-base-300 rounded-lg">
-  <table class="table table-zebra table-sm">
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Email</th>
-        <th>Connections</th>
-        <th>Created</th>
-        <th>Actions</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{range .Users}}
-      <tr class="hover:bg-base-300">
-        <td>{{.Name}}</td>
-        <td>{{if .Email.Valid}}{{.Email.String}}{{else}}&mdash;{{end}}</td>
-        <td>{{index $.ConnectionCounts (formatUUID .ID)}}</td>
-        <td>{{if .CreatedAt.Valid}}{{.CreatedAt.Time.Format "Jan 2, 2006"}}{{end}}</td>
-        <td>
-          <a href="/users/{{formatUUID .ID}}/edit" class="btn btn-ghost btn-xs">Edit</a>
-        </td>
-      </tr>
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+  {{range .Users}}
+  <div class="bb-card bb-card--interactive p-6 group">
+    <div class="flex items-start justify-between mb-4">
+      <div class="flex items-center gap-3">
+        <div class="w-11 h-11 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold text-base">
+          {{slice .Name 0 1}}
+        </div>
+        <div>
+          <h3 class="font-semibold text-base">{{.Name}}</h3>
+          {{if .Email.Valid}}
+          <p class="text-xs text-base-content/45">{{.Email.String}}</p>
+          {{else}}
+          <p class="text-xs text-base-content/30 italic">No email</p>
+          {{end}}
+        </div>
+      </div>
+      <a href="/users/{{formatUUID .ID}}/edit" class="btn btn-ghost btn-xs opacity-0 group-hover:opacity-100 transition-opacity">
+        <i data-lucide="pencil" class="w-3.5 h-3.5"></i>
+      </a>
+    </div>
+
+    <div class="flex items-center gap-4 pt-3 border-t border-base-200">
+      <div class="flex items-center gap-1.5 text-xs text-base-content/50">
+        <i data-lucide="link" class="w-3.5 h-3.5"></i>
+        <span class="font-medium text-base-content/70">{{index $.ConnectionCounts (formatUUID .ID)}}</span> connections
+      </div>
+      {{if .CreatedAt.Valid}}
+      <div class="flex items-center gap-1.5 text-xs text-base-content/40">
+        <i data-lucide="calendar" class="w-3.5 h-3.5"></i>
+        {{.CreatedAt.Time.Format "Jan 2, 2006"}}
+      </div>
       {{end}}
-    </tbody>
-  </table>
+    </div>
+  </div>
+  {{end}}
 </div>
 {{else}}
-<div class="card bg-base-100 border border-base-300">
-  <div class="card-body items-center text-center py-12">
-    <i data-lucide="users" class="w-12 h-12 text-base-content/30 mb-2"></i>
-    <p class="text-base-content/70">No family members yet.</p>
-    <a href="/users/new" class="btn btn-primary mt-2">
+<div class="bb-card p-12 text-center">
+  <div class="flex flex-col items-center">
+    <div class="w-16 h-16 rounded-2xl bg-base-200/60 flex items-center justify-center mb-4">
+      <i data-lucide="users" class="w-8 h-8 text-base-content/25"></i>
+    </div>
+    <h3 class="text-lg font-semibold mb-1">No family members yet</h3>
+    <p class="text-sm text-base-content/50 mb-5 max-w-sm">Add family members to connect their bank accounts and track spending across the household.</p>
+    <a href="/users/new" class="btn btn-primary btn-sm">
       <i data-lucide="plus" class="w-4 h-4"></i>
-      Add your first family member
+      Add your first member
     </a>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- **Settings page**: Replaced collapse accordions with Mercury-style card grid (Sync Schedule, Security, System Info cards). System info now uses mini stat tiles instead of a definition list.
- **Users page**: Replaced plain table with avatar card grid. Each member gets a card with initial avatar, email, connection count, and hover-reveal edit button.
- **API Keys page**: Replaced table with stacked card rows. Each key shows colored icon based on scope/status, badges, and inline revoke flow.
- **Sync Logs page**: Replaced zebra-striped table with card-based rows. Filter bar wrapped in its own card. Error messages accessible via dropdown instead of inline `<details>`.

All four pages now use `bb-card`, `bb-page-header`, `bb-page-title` components and follow the Mercury design language (soft rounded corners, generous whitespace, subtle shadows, muted typography hierarchy).

## Screenshots

### Settings
![Settings](https://i.img402.dev/q9wkfahjoz.png)

### Family Members
![Users](https://i.img402.dev/th9u6wucfi.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent