### PR TITLE
Redesign Reviews, Rules, Providers, MCP, Review Instructions

### DIFF
--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -1,99 +1,104 @@
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">MCP Settings</h1>
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">MCP Settings</h1>
+    <p class="text-sm text-base-content/50 mt-1">Configure how AI agents interact with your financial data</p>
+  </div>
+</div>
 
 <div class="grid gap-6">
 
   <!-- Card 1: Global Mode -->
-  <div class="card bg-base-100 border border-base-300">
-    <div class="card-body">
-      <h2 class="card-title text-lg">
-        <i data-lucide="shield" class="w-5 h-5"></i>
-        Global Mode
-      </h2>
-      <p class="text-sm text-base-content/70 mb-4">Controls whether MCP-connected agents can perform write operations (sync, categorize, comment) or are limited to read-only data queries.</p>
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
+        <i data-lucide="shield" class="w-5 h-5 text-primary"></i>
+      </div>
+      <div>
+        <h2 class="font-semibold">Global Mode</h2>
+        <p class="text-xs text-base-content/40">Control agent read/write permissions</p>
+      </div>
+    </div>
+    <div class="px-6 py-5">
       <form method="POST" action="/mcp-settings/mode">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
         <div class="flex flex-col gap-3">
-          <label class="label cursor-pointer justify-start gap-3">
-            <input type="radio" name="mode" value="read_only" class="radio radio-primary" {{if eq .MCPConfig.Mode "read_only"}}checked{{end}}>
+          <label class="flex items-start gap-3 cursor-pointer p-3 rounded-xl hover:bg-base-200/50 transition-colors duration-150">
+            <input type="radio" name="mode" value="read_only" class="radio radio-primary mt-0.5" {{if eq .MCPConfig.Mode "read_only"}}checked{{end}}>
             <div>
-              <span class="font-medium">Read Only</span>
-              <span class="badge badge-ghost badge-sm ml-2">Default</span>
-              <p class="text-sm text-base-content/60">Agents can query data but cannot trigger syncs, categorize transactions, or make changes.</p>
+              <div class="flex items-center gap-2">
+                <span class="font-medium text-sm">Read Only</span>
+                <span class="badge badge-ghost badge-xs rounded-lg">Default</span>
+              </div>
+              <p class="text-xs text-base-content/40 mt-0.5">Agents can query data but cannot trigger syncs, categorize transactions, or make changes.</p>
             </div>
           </label>
-          <label class="label cursor-pointer justify-start gap-3">
-            <input type="radio" name="mode" value="read_write" class="radio radio-primary" {{if eq .MCPConfig.Mode "read_write"}}checked{{end}}>
+          <label class="flex items-start gap-3 cursor-pointer p-3 rounded-xl hover:bg-base-200/50 transition-colors duration-150">
+            <input type="radio" name="mode" value="read_write" class="radio radio-primary mt-0.5" {{if eq .MCPConfig.Mode "read_write"}}checked{{end}}>
             <div>
-              <span class="font-medium">Read & Write</span>
-              <p class="text-sm text-base-content/60">Agents can query data and perform write operations like syncing, categorizing, and commenting.</p>
+              <span class="font-medium text-sm">Read & Write</span>
+              <p class="text-xs text-base-content/40 mt-0.5">Agents can query data and perform write operations like syncing, categorizing, and commenting.</p>
             </div>
           </label>
         </div>
-        <div class="mt-4">
-          <button type="submit" class="btn btn-primary btn-sm">Save Mode</button>
+        <div class="mt-5">
+          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Mode</button>
         </div>
       </form>
     </div>
   </div>
 
   <!-- Card 2: Tool Access -->
-  <div class="card bg-base-100 border border-base-300">
-    <div class="card-body">
-      <h2 class="card-title text-lg">
-        <i data-lucide="wrench" class="w-5 h-5"></i>
-        Tool Access
-      </h2>
-      <p class="text-sm text-base-content/70 mb-4">Enable or disable individual tools. Disabled tools are hidden from all agents. Write tools are automatically disabled when global mode is Read Only.</p>
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-secondary/10 flex items-center justify-center">
+        <i data-lucide="wrench" class="w-5 h-5 text-secondary"></i>
+      </div>
+      <div>
+        <h2 class="font-semibold">Tool Access</h2>
+        <p class="text-xs text-base-content/40">Enable or disable individual MCP tools</p>
+      </div>
+    </div>
+    <div class="px-6 py-5">
+      <p class="text-sm text-base-content/50 mb-4">Disabled tools are hidden from all agents. Write tools are automatically disabled in Read Only mode.</p>
       <form method="POST" action="/mcp-settings/tools">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-        <div class="overflow-x-auto">
-          <table class="table table-sm">
-            <thead>
-              <tr>
-                <th>Enabled</th>
-                <th>Tool</th>
-                <th>Type</th>
-              </tr>
-            </thead>
-            <tbody>
-              {{range .Tools}}
-              <tr>
-                <td>
-                  {{if .WriteLocked}}
-                    <input type="checkbox" class="toggle toggle-sm" disabled title="Disabled by Read Only mode">
-                  {{else}}
-                    <input type="checkbox" name="enabled_tools" value="{{.Name}}" class="toggle toggle-sm toggle-primary" {{if .Enabled}}checked{{end}}>
-                  {{end}}
-                </td>
-                <td>
-                  <div class="font-mono text-sm">{{.Name}}</div>
-                  <div class="text-xs text-base-content/50 max-w-md truncate">{{.Description}}</div>
-                </td>
-                <td>
-                  {{if eq .Classification "write"}}
-                    <span class="badge badge-warning badge-sm">write</span>
-                  {{else}}
-                    <span class="badge badge-info badge-sm">read</span>
-                  {{end}}
-                  {{if .WriteLocked}}
-                    <i data-lucide="lock" class="w-3 h-3 inline text-base-content/40" title="Locked by Read Only mode"></i>
-                  {{end}}
-                </td>
-              </tr>
+        <div class="space-y-1">
+          {{range .Tools}}
+          <div class="flex items-center justify-between p-3 rounded-xl hover:bg-base-200/50 transition-colors duration-150">
+            <div class="flex items-center gap-3 min-w-0">
+              {{if .WriteLocked}}
+                <input type="checkbox" class="toggle toggle-sm" disabled title="Disabled by Read Only mode">
+              {{else}}
+                <input type="checkbox" name="enabled_tools" value="{{.Name}}" class="toggle toggle-sm toggle-primary" {{if .Enabled}}checked{{end}}>
               {{end}}
-            </tbody>
-          </table>
+              <div class="min-w-0">
+                <div class="font-mono text-sm">{{.Name}}</div>
+                <div class="text-xs text-base-content/40 truncate max-w-md">{{.Description}}</div>
+              </div>
+            </div>
+            <div class="flex items-center gap-1.5 flex-shrink-0 ml-3">
+              {{if eq .Classification "write"}}
+                <span class="badge badge-warning badge-xs rounded-lg">write</span>
+              {{else}}
+                <span class="badge badge-info badge-xs rounded-lg">read</span>
+              {{end}}
+              {{if .WriteLocked}}
+                <i data-lucide="lock" class="w-3 h-3 text-base-content/30"></i>
+              {{end}}
+            </div>
+          </div>
+          {{end}}
         </div>
-        <div class="mt-4">
-          <button type="submit" class="btn btn-primary btn-sm">Save Tool Access</button>
+        <div class="mt-5">
+          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Tool Access</button>
         </div>
       </form>
     </div>
   </div>
 
   <!-- Card 3: Server Instructions -->
-  <div class="card bg-base-100 border border-base-300" x-data="{
+  <div class="bb-card p-0 overflow-hidden" x-data="{
     instructions: {{.MCPConfig.CustomInstructions | printf `%q`}},
     template: '{{.MCPConfig.InstructionTemplate}}',
     templates: {{.TemplatesJSON}},
@@ -114,18 +119,22 @@
       }
     }
   }">
-    <div class="card-body">
-      <h2 class="card-title text-lg">
-        <i data-lucide="file-text" class="w-5 h-5"></i>
-        Server Instructions
-      </h2>
-      <p class="text-sm text-base-content/70 mb-4">Custom instructions appended to the built-in MCP server instructions. Agents see these when they connect. Use markdown formatting.</p>
+    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center">
+        <i data-lucide="file-text" class="w-5 h-5 text-accent"></i>
+      </div>
+      <div>
+        <h2 class="font-semibold">Server Instructions</h2>
+        <p class="text-xs text-base-content/40">Custom instructions for connected agents</p>
+      </div>
+    </div>
+    <div class="px-6 py-5">
       <form method="POST" action="/mcp-settings/instructions">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
-        <div class="form-control mb-3">
-          <label class="label"><span class="label-text font-medium">Template</span></label>
-          <select name="template" class="select select-bordered select-sm w-full max-w-xs" x-model="template" @change="loadTemplate(template)">
+        <div class="form-control mb-4">
+          <label class="label"><span class="label-text text-sm font-medium">Template</span></label>
+          <select name="template" class="select select-bordered select-sm w-full max-w-xs rounded-xl" x-model="template" @change="loadTemplate(template)">
             <option value="">Custom</option>
             {{range .Templates}}
             <option value="{{.Slug}}">{{.Name}} &mdash; {{.Description}}</option>
@@ -133,23 +142,23 @@
           </select>
         </div>
 
-        <div class="form-control mb-3">
-          <label class="label"><span class="label-text font-medium">Custom Instructions</span></label>
-          <textarea name="instructions" class="textarea textarea-bordered font-mono text-sm h-48 w-full" maxlength="10000" x-model="instructions" placeholder="Enter custom instructions for MCP agents..."></textarea>
+        <div class="form-control mb-4">
+          <label class="label"><span class="label-text text-sm font-medium">Custom Instructions</span></label>
+          <textarea name="instructions" class="textarea textarea-bordered font-mono text-sm h-48 w-full rounded-xl" maxlength="10000" x-model="instructions" placeholder="Enter custom instructions for MCP agents..."></textarea>
           <label class="label">
-            <span class="label-text-alt" x-text="instructions.length + '/10000'"></span>
+            <span class="label-text-alt text-base-content/40" x-text="instructions.length + '/10000'"></span>
           </label>
         </div>
 
-        <div class="flex gap-2 items-center mb-3">
-          <button type="submit" class="btn btn-primary btn-sm">Save Instructions</button>
-          <button type="button" class="btn btn-ghost btn-sm" @click="showPreview = !showPreview" x-text="showPreview ? 'Hide Preview' : 'Show Preview'"></button>
+        <div class="flex gap-2 items-center">
+          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Instructions</button>
+          <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="showPreview = !showPreview" x-text="showPreview ? 'Hide Preview' : 'Show Preview'"></button>
         </div>
       </form>
 
-      <div x-show="showPreview" x-cloak class="mt-2">
-        <h3 class="font-medium text-sm mb-2">Full Instructions (Built-in + Custom)</h3>
-        <pre class="bg-base-200 p-4 rounded-lg text-xs overflow-auto max-h-96 whitespace-pre-wrap">{{.BuiltInInstructions}}
+      <div x-show="showPreview" x-cloak class="mt-4">
+        <h3 class="font-medium text-sm mb-2 text-base-content/60">Full Instructions (Built-in + Custom)</h3>
+        <pre class="bg-base-200 p-4 rounded-xl text-xs overflow-auto max-h-96 whitespace-pre-wrap">{{.BuiltInInstructions}}
 
 <span x-show="instructions.length > 0" x-text="'\n\nCUSTOM INSTRUCTIONS:\n' + instructions"></span></pre>
       </div>
@@ -157,31 +166,42 @@
   </div>
 
   <!-- Card 4: API Key Scopes -->
-  <div class="card bg-base-100 border border-base-300">
-    <div class="card-body">
-      <h2 class="card-title text-lg">
-        <i data-lucide="key" class="w-5 h-5"></i>
-        API Key Scopes
-      </h2>
-      <p class="text-sm text-base-content/70 mb-4">Each API key can be scoped to limit what operations it can perform. Read-only keys cannot invoke write tools or write REST endpoints, even when global mode is Read & Write.</p>
-      <div class="stats shadow">
-        <div class="stat">
-          <div class="stat-title">Full Access</div>
-          <div class="stat-value text-2xl">{{.FullAccessCount}}</div>
-          <div class="stat-desc">Read + Write</div>
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-warning/10 flex items-center justify-center">
+        <i data-lucide="key" class="w-5 h-5 text-warning"></i>
+      </div>
+      <div>
+        <h2 class="font-semibold">API Key Scopes</h2>
+        <p class="text-xs text-base-content/40">Manage API key access levels</p>
+      </div>
+    </div>
+    <div class="px-6 py-5">
+      <p class="text-sm text-base-content/50 mb-5">Read-only keys cannot invoke write tools or write REST endpoints, even when global mode is Read & Write.</p>
+      <div class="grid grid-cols-2 gap-4 mb-5">
+        <div class="bb-stat-card">
+          <div class="bb-stat-card__icon text-primary">
+            <i data-lucide="shield-check" class="w-5 h-5"></i>
+          </div>
+          <div class="bb-stat-card__body">
+            <span class="bb-stat-card__value">{{.FullAccessCount}}</span>
+            <span class="bb-stat-card__label">Full Access</span>
+          </div>
         </div>
-        <div class="stat">
-          <div class="stat-title">Read Only</div>
-          <div class="stat-value text-2xl">{{.ReadOnlyCount}}</div>
-          <div class="stat-desc">Query only</div>
+        <div class="bb-stat-card">
+          <div class="bb-stat-card__icon text-secondary">
+            <i data-lucide="eye" class="w-5 h-5"></i>
+          </div>
+          <div class="bb-stat-card__body">
+            <span class="bb-stat-card__value">{{.ReadOnlyCount}}</span>
+            <span class="bb-stat-card__label">Read Only</span>
+          </div>
         </div>
       </div>
-      <div class="mt-4">
-        <a href="/api-keys" class="btn btn-ghost btn-sm">
-          <i data-lucide="external-link" class="w-4 h-4"></i>
-          Manage API Keys
-        </a>
-      </div>
+      <a href="/api-keys" class="btn btn-ghost btn-sm rounded-xl">
+        <i data-lucide="external-link" class="w-4 h-4"></i>
+        Manage API Keys
+      </a>
     </div>
   </div>
 

--- a/internal/templates/pages/providers.html
+++ b/internal/templates/pages/providers.html
@@ -1,24 +1,34 @@
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">Providers</h1>
-<p class="text-base-content/70 mb-6">Configure bank data providers. Only configured providers will be available when creating new connections.</p>
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Providers</h1>
+    <p class="text-sm text-base-content/50 mt-1">Configure bank data providers for syncing accounts and transactions</p>
+  </div>
+</div>
 
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
 
   <!-- Plaid Card -->
-  <div class="card bg-base-100 shadow-sm">
-    <div class="card-body">
-      <div class="flex items-center justify-between mb-2">
-        <h2 class="card-title"><i data-lucide="building-2" class="w-5 h-5"></i> Plaid</h2>
-        {{if .PlaidConfigured}}
-        <span class="badge badge-success badge-sm">Configured</span>
-        {{else}}
-        <span class="badge badge-ghost badge-sm">Not Configured</span>
-        {{end}}
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="px-6 py-5 border-b border-base-200 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
+          <i data-lucide="building-2" class="w-5 h-5 text-primary"></i>
+        </div>
+        <div>
+          <h2 class="font-semibold">Plaid</h2>
+          <p class="text-xs text-base-content/40">Thousands of financial institutions</p>
+        </div>
       </div>
-      <p class="text-sm text-base-content/70 mb-4">Connect bank accounts via Plaid Link. Supports thousands of financial institutions.</p>
-
+      {{if .PlaidConfigured}}
+      <span class="badge badge-success badge-sm rounded-lg">Configured</span>
+      {{else}}
+      <span class="badge badge-ghost badge-sm rounded-lg">Not Configured</span>
+      {{end}}
+    </div>
+    <div class="px-6 py-5">
       {{if .PlaidFromEnv}}
-      <p class="text-sm text-base-content/60 mb-2">Configured via environment variables (read-only).</p>
+      <p class="text-sm text-base-content/50 mb-4">Configured via environment variables (read-only).</p>
       <dl class="bb-info-grid">
         <dt>Environment {{configSource .ConfigSources "plaid_env"}}</dt>
         <dd>{{.PlaidEnv}}</dd>
@@ -27,47 +37,53 @@
         <dt>Secret</dt>
         <dd><code class="font-mono text-xs">********</code></dd>
         <dt>Webhook URL</dt>
-        <dd>{{if .WebhookURL}}<code class="font-mono text-xs">{{.WebhookURL}}</code>{{else}}<span class="text-base-content/60">Not set</span>{{end}}</dd>
+        <dd>{{if .WebhookURL}}<code class="font-mono text-xs">{{.WebhookURL}}</code>{{else}}<span class="text-base-content/40">Not set</span>{{end}}</dd>
       </dl>
       {{else}}
-      <form method="POST" action="/providers/plaid" autocomplete="off">
+      <form method="POST" action="/providers/plaid" autocomplete="off" class="space-y-4">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
-        <label class="flex flex-col gap-1 text-sm" for="plaid_client_id">
-          Client ID {{configSource .ConfigSources "plaid_client_id"}}
-        </label>
-        <input type="text" id="plaid_client_id" name="plaid_client_id" value="{{.PlaidClientID}}" placeholder="Plaid Client ID" autocomplete="off" class="input input-sm w-full">
+        <div class="form-control">
+          <label class="label label-text text-sm font-medium" for="plaid_client_id">
+            Client ID {{configSource .ConfigSources "plaid_client_id"}}
+          </label>
+          <input type="text" id="plaid_client_id" name="plaid_client_id" value="{{.PlaidClientID}}" placeholder="Plaid Client ID" autocomplete="off" class="input input-sm input-bordered w-full rounded-xl">
+        </div>
 
-        <label class="flex flex-col gap-1 text-sm mt-4" for="plaid_secret">
-          Secret
-        </label>
-        <input type="password" id="plaid_secret" name="plaid_secret" value="" placeholder="{{if .PlaidConfigured}}Unchanged (enter to update){{else}}Plaid Secret{{end}}" autocomplete="new-password" class="input input-sm w-full">
+        <div class="form-control">
+          <label class="label label-text text-sm font-medium" for="plaid_secret">Secret</label>
+          <input type="password" id="plaid_secret" name="plaid_secret" value="" placeholder="{{if .PlaidConfigured}}Unchanged (enter to update){{else}}Plaid Secret{{end}}" autocomplete="new-password" class="input input-sm input-bordered w-full rounded-xl">
+        </div>
 
-        <label class="flex flex-col gap-1 text-sm mt-4" for="plaid_env">
-          Environment {{configSource .ConfigSources "plaid_env"}}
-        </label>
-        <select id="plaid_env" name="plaid_env" class="select select-sm w-full max-w-xs">
-          <option value="sandbox"{{if eq .PlaidEnv "sandbox"}} selected{{end}}>Sandbox</option>
-          <option value="development"{{if eq .PlaidEnv "development"}} selected{{end}}>Development</option>
-          <option value="production"{{if eq .PlaidEnv "production"}} selected{{end}}>Production</option>
-        </select>
-        <p class="text-xs text-base-content/60 mt-1">Credentials will be validated before saving.</p>
+        <div class="form-control">
+          <label class="label label-text text-sm font-medium" for="plaid_env">
+            Environment {{configSource .ConfigSources "plaid_env"}}
+          </label>
+          <select id="plaid_env" name="plaid_env" class="select select-sm select-bordered w-full max-w-xs rounded-xl">
+            <option value="sandbox"{{if eq .PlaidEnv "sandbox"}} selected{{end}}>Sandbox</option>
+            <option value="development"{{if eq .PlaidEnv "development"}} selected{{end}}>Development</option>
+            <option value="production"{{if eq .PlaidEnv "production"}} selected{{end}}>Production</option>
+          </select>
+          <p class="text-xs text-base-content/40 mt-1.5">Credentials will be validated before saving.</p>
+        </div>
 
-        <label class="flex flex-col gap-1 text-sm mt-4" for="webhook_url">
-          Webhook URL {{configSource .ConfigSources "webhook_url"}}
-        </label>
-        <input type="url" id="webhook_url" name="webhook_url" value="{{.WebhookURL}}" placeholder="https://example.com/webhooks/plaid" autocomplete="off" class="input input-sm w-full">
-        <p class="text-xs text-base-content/60 mt-1">Plaid will send transaction updates to this URL. Must use HTTPS. Leave empty to disable.</p>
+        <div class="form-control">
+          <label class="label label-text text-sm font-medium" for="webhook_url">
+            Webhook URL {{configSource .ConfigSources "webhook_url"}}
+          </label>
+          <input type="url" id="webhook_url" name="webhook_url" value="{{.WebhookURL}}" placeholder="https://example.com/webhooks/plaid" autocomplete="off" class="input input-sm input-bordered w-full rounded-xl">
+          <p class="text-xs text-base-content/40 mt-1.5">Plaid will send transaction updates to this URL. Must use HTTPS.</p>
+        </div>
 
-        <div class="mt-4">
-          <button type="submit" class="btn btn-primary btn-sm">Save Plaid Settings</button>
+        <div class="pt-2">
+          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Plaid Settings</button>
         </div>
       </form>
       {{end}}
 
       {{if .PlaidConfigured}}
-      <div class="mt-4 flex items-center gap-3 border-t border-base-200 pt-3">
-        <button type="button" class="btn btn-sm btn-ghost" onclick="testProvider('plaid')" id="test-plaid-btn">Test Connection</button>
+      <div class="mt-5 flex items-center gap-3 border-t border-base-200 pt-4">
+        <button type="button" class="btn btn-sm btn-ghost rounded-xl" onclick="testProvider('plaid')" id="test-plaid-btn">Test Connection</button>
         <span id="test-plaid-result" class="text-sm"></span>
       </div>
       {{end}}
@@ -75,20 +91,26 @@
   </div>
 
   <!-- Teller Card -->
-  <div class="card bg-base-100 shadow-sm">
-    <div class="card-body">
-      <div class="flex items-center justify-between mb-2">
-        <h2 class="card-title"><i data-lucide="landmark" class="w-5 h-5"></i> Teller</h2>
-        {{if .TellerConfigured}}
-        <span class="badge badge-success badge-sm">Configured</span>
-        {{else}}
-        <span class="badge badge-ghost badge-sm">Not Configured</span>
-        {{end}}
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="px-6 py-5 border-b border-base-200 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div class="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center">
+          <i data-lucide="landmark" class="w-5 h-5 text-accent"></i>
+        </div>
+        <div>
+          <h2 class="font-semibold">Teller</h2>
+          <p class="text-xs text-base-content/40">mTLS certificate authentication</p>
+        </div>
       </div>
-      <p class="text-sm text-base-content/70 mb-4">Connect bank accounts via Teller Connect. Uses mTLS certificate authentication.</p>
-
+      {{if .TellerConfigured}}
+      <span class="badge badge-success badge-sm rounded-lg">Configured</span>
+      {{else}}
+      <span class="badge badge-ghost badge-sm rounded-lg">Not Configured</span>
+      {{end}}
+    </div>
+    <div class="px-6 py-5">
       {{if .TellerFromEnv}}
-      <p class="text-sm text-base-content/60 mb-2">Configured via environment variables (read-only).</p>
+      <p class="text-sm text-base-content/50 mb-4">Configured via environment variables (read-only).</p>
       <dl class="bb-info-grid">
         <dt>App ID {{configSource .ConfigSources "teller_app_id"}}</dt>
         <dd><code class="font-mono text-xs">{{.TellerAppID}}</code></dd>
@@ -100,61 +122,67 @@
         <dd>{{if .TellerWebhookConfigured}}Configured{{else}}Not configured{{end}}</dd>
       </dl>
       {{else}}
-      <form method="POST" action="/providers/teller" enctype="multipart/form-data" autocomplete="off">
+      <form method="POST" action="/providers/teller" enctype="multipart/form-data" autocomplete="off" class="space-y-4">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
-        <label class="flex flex-col gap-1 text-sm" for="teller_app_id">
-          App ID
-        </label>
-        <input type="text" id="teller_app_id" name="teller_app_id" value="{{.TellerAppID}}" placeholder="Teller App ID" autocomplete="off" class="input input-sm w-full">
+        <div class="form-control">
+          <label class="label label-text text-sm font-medium" for="teller_app_id">App ID</label>
+          <input type="text" id="teller_app_id" name="teller_app_id" value="{{.TellerAppID}}" placeholder="Teller App ID" autocomplete="off" class="input input-sm input-bordered w-full rounded-xl">
+        </div>
 
-        <label class="flex flex-col gap-1 text-sm mt-4" for="teller_env">
-          Environment
-        </label>
-        <select id="teller_env" name="teller_env" class="select select-sm w-full max-w-xs">
-          <option value="sandbox"{{if eq .TellerEnv "sandbox"}} selected{{end}}>Sandbox</option>
-          <option value="development"{{if eq .TellerEnv "development"}} selected{{end}}>Development</option>
-          <option value="production"{{if eq .TellerEnv "production"}} selected{{end}}>Production</option>
-        </select>
+        <div class="form-control">
+          <label class="label label-text text-sm font-medium" for="teller_env">Environment</label>
+          <select id="teller_env" name="teller_env" class="select select-sm select-bordered w-full max-w-xs rounded-xl">
+            <option value="sandbox"{{if eq .TellerEnv "sandbox"}} selected{{end}}>Sandbox</option>
+            <option value="development"{{if eq .TellerEnv "development"}} selected{{end}}>Development</option>
+            <option value="production"{{if eq .TellerEnv "production"}} selected{{end}}>Production</option>
+          </select>
+        </div>
 
         {{if not .TellerCertFromEnv}}
-        <div class="divider text-xs">mTLS Certificate</div>
+        <div class="border-t border-base-200 pt-4 mt-4">
+          <h3 class="text-sm font-medium mb-3 text-base-content/60">mTLS Certificate</h3>
 
-        {{if .TellerCertConfigured}}
-        <p class="text-sm text-success mb-2"><i data-lucide="check-circle" class="w-4 h-4 inline"></i> Certificate and private key are configured. Upload new files to replace.</p>
-        {{end}}
+          {{if .TellerCertConfigured}}
+          <p class="text-sm text-success mb-3 flex items-center gap-1.5">
+            <i data-lucide="check-circle" class="w-4 h-4"></i> Certificate and private key are configured.
+          </p>
+          {{end}}
 
-        <label class="flex flex-col gap-1 text-sm" for="teller_cert_file">
-          Certificate File (.pem)
-        </label>
-        <input type="file" id="teller_cert_file" name="teller_cert_file" accept=".pem,.crt,.cert" class="file-input file-input-sm w-full">
+          <div class="form-control mb-3">
+            <label class="label label-text text-sm font-medium" for="teller_cert_file">Certificate File (.pem)</label>
+            <input type="file" id="teller_cert_file" name="teller_cert_file" accept=".pem,.crt,.cert" class="file-input file-input-sm file-input-bordered w-full rounded-xl">
+          </div>
 
-        <label class="flex flex-col gap-1 text-sm mt-4" for="teller_key_file">
-          Private Key File (.pem)
-        </label>
-        <input type="file" id="teller_key_file" name="teller_key_file" accept=".pem,.key" class="file-input file-input-sm w-full">
+          <div class="form-control">
+            <label class="label label-text text-sm font-medium" for="teller_key_file">Private Key File (.pem)</label>
+            <input type="file" id="teller_key_file" name="teller_key_file" accept=".pem,.key" class="file-input file-input-sm file-input-bordered w-full rounded-xl">
+          </div>
 
-        {{if not .HasEncryptionKey}}
-        <p class="text-xs text-warning mt-2"><i data-lucide="alert-triangle" class="w-3 h-3 inline"></i> ENCRYPTION_KEY must be set to store certificates.</p>
-        {{end}}
+          {{if not .HasEncryptionKey}}
+          <p class="text-xs text-warning mt-3 flex items-center gap-1.5">
+            <i data-lucide="alert-triangle" class="w-3.5 h-3.5"></i> ENCRYPTION_KEY must be set to store certificates.
+          </p>
+          {{end}}
+        </div>
         {{else}}
-        <p class="text-xs text-base-content/60 mt-2">Certificate configured via environment file paths.</p>
+        <p class="text-xs text-base-content/40 mt-2">Certificate configured via environment file paths.</p>
         {{end}}
 
-        <label class="flex flex-col gap-1 text-sm mt-4" for="teller_webhook_secret">
-          Webhook Secret
-        </label>
-        <input type="password" id="teller_webhook_secret" name="teller_webhook_secret" value="" placeholder="{{if .TellerWebhookConfigured}}Unchanged (enter to update){{else}}Teller Webhook Secret (optional){{end}}" autocomplete="new-password" class="input input-sm w-full">
+        <div class="form-control">
+          <label class="label label-text text-sm font-medium" for="teller_webhook_secret">Webhook Secret</label>
+          <input type="password" id="teller_webhook_secret" name="teller_webhook_secret" value="" placeholder="{{if .TellerWebhookConfigured}}Unchanged (enter to update){{else}}Teller Webhook Secret (optional){{end}}" autocomplete="new-password" class="input input-sm input-bordered w-full rounded-xl">
+        </div>
 
-        <div class="mt-4">
-          <button type="submit" class="btn btn-primary btn-sm">Save Teller Settings</button>
+        <div class="pt-2">
+          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Teller Settings</button>
         </div>
       </form>
       {{end}}
 
       {{if .TellerConfigured}}
-      <div class="mt-4 flex items-center gap-3 border-t border-base-200 pt-3">
-        <button type="button" class="btn btn-sm btn-ghost" onclick="testProvider('teller')" id="test-teller-btn">Test Connection</button>
+      <div class="mt-5 flex items-center gap-3 border-t border-base-200 pt-4">
+        <button type="button" class="btn btn-sm btn-ghost rounded-xl" onclick="testProvider('teller')" id="test-teller-btn">Test Connection</button>
         <span id="test-teller-result" class="text-sm"></span>
       </div>
       {{end}}
@@ -162,14 +190,25 @@
   </div>
 
   <!-- CSV Card -->
-  <div class="card bg-base-100 shadow-sm">
-    <div class="card-body">
-      <div class="flex items-center justify-between mb-2">
-        <h2 class="card-title"><i data-lucide="file-spreadsheet" class="w-5 h-5"></i> CSV Import</h2>
-        <span class="badge badge-success badge-sm">Always Available</span>
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="px-6 py-5 border-b border-base-200 flex items-center justify-between">
+      <div class="flex items-center gap-3">
+        <div class="w-10 h-10 rounded-xl bg-success/10 flex items-center justify-center">
+          <i data-lucide="file-spreadsheet" class="w-5 h-5 text-success"></i>
+        </div>
+        <div>
+          <h2 class="font-semibold">CSV Import</h2>
+          <p class="text-xs text-base-content/40">No configuration needed</p>
+        </div>
       </div>
-      <p class="text-sm text-base-content/70 mb-4">Import transactions from CSV files. No configuration needed.</p>
-      <a href="/connections/import-csv" class="btn btn-sm btn-ghost">Import CSV File</a>
+      <span class="badge badge-success badge-sm rounded-lg">Always Available</span>
+    </div>
+    <div class="px-6 py-5">
+      <p class="text-sm text-base-content/50 mb-4">Import transactions from CSV files exported from your bank or financial institution.</p>
+      <a href="/connections/import-csv" class="btn btn-sm btn-ghost rounded-xl">
+        <i data-lucide="upload" class="w-4 h-4"></i>
+        Import CSV File
+      </a>
     </div>
   </div>
 

--- a/internal/templates/pages/review_instructions.html
+++ b/internal/templates/pages/review_instructions.html
@@ -1,24 +1,30 @@
 {{define "content"}}
-<h1 class="text-2xl font-bold mb-6">Review Instructions</h1>
-<p class="text-sm text-base-content/60 mb-6">Pre-built instruction blocks to pass to MCP agents for transaction review. Copy the instructions and paste them into your agent's prompt.</p>
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Review Instructions</h1>
+    <p class="text-sm text-base-content/50 mt-1">Pre-built instruction blocks for MCP agents doing transaction review</p>
+  </div>
+</div>
 
 <div class="grid gap-6">
 
   <!-- Card 1: Initial Review Mode -->
-  <div class="card bg-base-100 border border-base-300" x-data="{ copied: false }">
-    <div class="card-body">
-      <div class="flex items-center gap-2 mb-1">
-        <h2 class="card-title text-lg">
-          <i data-lucide="layers" class="w-5 h-5"></i>
-          Initial Review
-        </h2>
-        <span class="badge badge-primary badge-sm">Bulk Analysis</span>
+  <div class="bb-card p-0 overflow-hidden" x-data="{ copied: false }">
+    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
+        <i data-lucide="layers" class="w-5 h-5 text-primary"></i>
       </div>
-      <p class="text-sm text-base-content/70 mb-4">Use when a new account is synced and you have many uncategorized transactions. Focuses on creating broad rules for maximum coverage.</p>
+      <div class="flex items-center gap-2">
+        <h2 class="font-semibold">Initial Review</h2>
+        <span class="badge badge-primary badge-xs rounded-lg">Bulk Analysis</span>
+      </div>
+    </div>
+    <div class="px-6 py-5">
+      <p class="text-sm text-base-content/50 mb-4">Use when a new account is synced and you have many uncategorized transactions. Focuses on creating broad rules for maximum coverage.</p>
       <div class="relative">
-        <pre class="bg-base-200 rounded-lg p-4 text-sm whitespace-pre-wrap overflow-auto max-h-80 font-mono">{{.InitialReviewInstructions}}</pre>
+        <pre class="bg-base-200 rounded-xl p-4 text-sm whitespace-pre-wrap overflow-auto max-h-80 font-mono text-base-content/70">{{.InitialReviewInstructions}}</pre>
         <button
-          class="btn btn-sm btn-ghost absolute top-2 right-2"
+          class="btn btn-sm btn-ghost rounded-xl absolute top-2 right-2"
           @click="navigator.clipboard.writeText({{.InitialReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })"
         >
           <template x-if="!copied">
@@ -33,20 +39,22 @@
   </div>
 
   <!-- Card 2: Recurring Review Mode -->
-  <div class="card bg-base-100 border border-base-300" x-data="{ copied: false }">
-    <div class="card-body">
-      <div class="flex items-center gap-2 mb-1">
-        <h2 class="card-title text-lg">
-          <i data-lucide="repeat" class="w-5 h-5"></i>
-          Recurring Review
-        </h2>
-        <span class="badge badge-secondary badge-sm">Daily / Weekly</span>
+  <div class="bb-card p-0 overflow-hidden" x-data="{ copied: false }">
+    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-secondary/10 flex items-center justify-center">
+        <i data-lucide="repeat" class="w-5 h-5 text-secondary"></i>
       </div>
-      <p class="text-sm text-base-content/70 mb-4">Use for routine review of incoming transactions. Reviews a small batch with more attention per transaction.</p>
+      <div class="flex items-center gap-2">
+        <h2 class="font-semibold">Recurring Review</h2>
+        <span class="badge badge-secondary badge-xs rounded-lg">Daily / Weekly</span>
+      </div>
+    </div>
+    <div class="px-6 py-5">
+      <p class="text-sm text-base-content/50 mb-4">Use for routine review of incoming transactions. Reviews a small batch with more attention per transaction.</p>
       <div class="relative">
-        <pre class="bg-base-200 rounded-lg p-4 text-sm whitespace-pre-wrap overflow-auto max-h-80 font-mono">{{.RecurringReviewInstructions}}</pre>
+        <pre class="bg-base-200 rounded-xl p-4 text-sm whitespace-pre-wrap overflow-auto max-h-80 font-mono text-base-content/70">{{.RecurringReviewInstructions}}</pre>
         <button
-          class="btn btn-sm btn-ghost absolute top-2 right-2"
+          class="btn btn-sm btn-ghost rounded-xl absolute top-2 right-2"
           @click="navigator.clipboard.writeText({{.RecurringReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })"
         >
           <template x-if="!copied">
@@ -61,29 +69,32 @@
   </div>
 
   <!-- Card 3: Connection Info -->
-  <div class="card bg-base-100 border border-base-300" x-data="{ copiedConfig: false }">
-    <div class="card-body">
-      <h2 class="card-title text-lg">
-        <i data-lucide="plug" class="w-5 h-5"></i>
-        Review MCP Connection
-      </h2>
-      <p class="text-sm text-base-content/70 mb-4">Connect your MCP agent to the review server using one of the methods below.</p>
-
-      <div class="grid gap-4">
+  <div class="bb-card p-0 overflow-hidden" x-data="{ copiedConfig: false }">
+    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center">
+        <i data-lucide="plug" class="w-5 h-5 text-accent"></i>
+      </div>
+      <div>
+        <h2 class="font-semibold">Review MCP Connection</h2>
+        <p class="text-xs text-base-content/40">Connect your MCP agent to the review server</p>
+      </div>
+    </div>
+    <div class="px-6 py-5">
+      <div class="space-y-5">
         <div>
-          <h3 class="font-medium text-sm mb-1">HTTP Endpoint</h3>
-          <div class="bg-base-200 rounded-lg p-3 font-mono text-sm break-all">https://&lt;host&gt;/mcp/review</div>
+          <h3 class="font-medium text-sm mb-2 text-base-content/60">HTTP Endpoint</h3>
+          <div class="bg-base-200 rounded-xl p-3 font-mono text-sm break-all text-base-content/70">https://&lt;host&gt;/mcp/review</div>
         </div>
 
         <div>
-          <h3 class="font-medium text-sm mb-1">Stdio Command</h3>
-          <div class="bg-base-200 rounded-lg p-3 font-mono text-sm">docker exec -i breadbox-app-1 /app/breadbox mcp-stdio-review</div>
+          <h3 class="font-medium text-sm mb-2 text-base-content/60">Stdio Command</h3>
+          <div class="bg-base-200 rounded-xl p-3 font-mono text-sm text-base-content/70">docker exec -i breadbox-app-1 /app/breadbox mcp-stdio-review</div>
         </div>
 
         <div>
-          <h3 class="font-medium text-sm mb-2">Claude Desktop Config (stdio)</h3>
+          <h3 class="font-medium text-sm mb-2 text-base-content/60">Claude Desktop Config (stdio)</h3>
           <div class="relative">
-            <pre class="bg-base-200 rounded-lg p-4 text-sm font-mono overflow-auto">{
+            <pre class="bg-base-200 rounded-xl p-4 text-sm font-mono overflow-auto text-base-content/70">{
   "mcpServers": {
     "breadbox-review": {
       "command": "docker",
@@ -92,7 +103,7 @@
   }
 }</pre>
             <button
-              class="btn btn-sm btn-ghost absolute top-2 right-2"
+              class="btn btn-sm btn-ghost rounded-xl absolute top-2 right-2"
               @click="navigator.clipboard.writeText(JSON.stringify({mcpServers:{'breadbox-review':{command:'docker',args:['exec','-i','breadbox-app-1','/app/breadbox','mcp-stdio-review']}}}, null, 2)).then(() => { copiedConfig = true; setTimeout(() => copiedConfig = false, 2000) })"
             >
               <template x-if="!copiedConfig">

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -1,22 +1,24 @@
 {{define "content"}}
 {{template "category-picker-styles" .}}
 
-<div class="flex items-center justify-between mb-6 flex-wrap gap-3">
-  <h1 class="text-2xl font-bold">Reviews</h1>
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Reviews</h1>
+    <p class="text-sm text-base-content/50 mt-1">Review and categorize transactions flagged during sync</p>
+  </div>
   {{if and (eq .StatusFilter "pending") .Counts (gt .Counts.Pending 0)}}
   <div x-data="{ dismissing: false, confirmOpen: false }">
-    <button class="btn btn-sm btn-error btn-outline gap-1" @click="confirmOpen = true" :disabled="dismissing">
-      <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/></svg>
+    <button class="btn btn-sm btn-error btn-outline rounded-xl gap-1" @click="confirmOpen = true" :disabled="dismissing">
+      <i data-lucide="trash-2" class="w-4 h-4"></i>
       Dismiss All
     </button>
-    <!-- Confirmation modal -->
     <dialog class="modal" :class="{ 'modal-open': confirmOpen }">
-      <div class="modal-box">
+      <div class="modal-box rounded-2xl">
         <h3 class="text-lg font-bold">Dismiss all pending reviews?</h3>
-        <p class="py-4">This will permanently remove all <strong>{{.Counts.Pending}}</strong> pending reviews from the queue. This cannot be undone.</p>
+        <p class="py-4 text-base-content/70">This will permanently remove all <strong>{{.Counts.Pending}}</strong> pending reviews from the queue. This cannot be undone.</p>
         <div class="modal-action">
-          <button class="btn btn-ghost" @click="confirmOpen = false" :disabled="dismissing">Cancel</button>
-          <button class="btn btn-error gap-1" :disabled="dismissing"
+          <button class="btn btn-ghost rounded-xl" @click="confirmOpen = false" :disabled="dismissing">Cancel</button>
+          <button class="btn btn-error rounded-xl gap-1" :disabled="dismissing"
             @click="dismissing = true;
               fetch('/-/reviews/dismiss-all', {
                 method: 'POST',
@@ -47,71 +49,96 @@
   {{end}}
 </div>
 
-<!-- Stats -->
+<!-- Stat Cards -->
 {{if .Counts}}
-<div class="stats stats-vertical sm:stats-horizontal shadow border border-base-300 w-full mb-6">
-  <div class="stat py-3 px-5">
-    <div class="stat-title text-xs">Pending</div>
-    <div class="stat-value text-lg {{if gt .Counts.Pending 0}}text-warning{{end}}">{{.Counts.Pending}}</div>
+<div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
+  <div class="bb-stat-card">
+    <div class="bb-stat-card__icon text-warning">
+      <i data-lucide="clock" class="w-5 h-5"></i>
+    </div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value{{if gt .Counts.Pending 0}} text-warning{{end}}">{{.Counts.Pending}}</span>
+      <span class="bb-stat-card__label">Pending</span>
+    </div>
   </div>
-  <div class="stat py-3 px-5">
-    <div class="stat-title text-xs">Approved today</div>
-    <div class="stat-value text-lg text-success">{{.Counts.ApprovedToday}}</div>
+  <div class="bb-stat-card">
+    <div class="bb-stat-card__icon text-success">
+      <i data-lucide="check-circle" class="w-5 h-5"></i>
+    </div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value text-success">{{.Counts.ApprovedToday}}</span>
+      <span class="bb-stat-card__label">Approved Today</span>
+    </div>
   </div>
-  <div class="stat py-3 px-5">
-    <div class="stat-title text-xs">Rejected today</div>
-    <div class="stat-value text-lg text-error">{{.Counts.RejectedToday}}</div>
+  <div class="bb-stat-card">
+    <div class="bb-stat-card__icon text-error">
+      <i data-lucide="x-circle" class="w-5 h-5"></i>
+    </div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value text-error">{{.Counts.RejectedToday}}</span>
+      <span class="bb-stat-card__label">Rejected Today</span>
+    </div>
   </div>
-  <div class="stat py-3 px-5">
-    <div class="stat-title text-xs">Skipped today</div>
-    <div class="stat-value text-lg">{{.Counts.SkippedToday}}</div>
+  <div class="bb-stat-card">
+    <div class="bb-stat-card__icon text-base-content/40">
+      <i data-lucide="skip-forward" class="w-5 h-5"></i>
+    </div>
+    <div class="bb-stat-card__body">
+      <span class="bb-stat-card__value">{{.Counts.SkippedToday}}</span>
+      <span class="bb-stat-card__label">Skipped Today</span>
+    </div>
   </div>
 </div>
 {{end}}
 
-<!-- Review Settings -->
-<div class="collapse collapse-arrow bg-base-100 border border-base-300 mb-6">
-  <input type="checkbox" />
-  <div class="collapse-title font-medium">Review Settings</div>
-  <div class="collapse-content" x-data="{ autoEnqueue: {{.ReviewAutoEnqueue}}, threshold: '{{.ReviewConfidenceThreshold}}', saving: false }">
-    <div class="flex flex-wrap gap-6 items-end pt-2">
-      <div class="form-control">
-        <label class="label cursor-pointer gap-2">
-          <span class="label-text">Auto-enqueue on sync</span>
-          <input type="checkbox" class="toggle toggle-primary toggle-sm" x-model="autoEnqueue">
-        </label>
-      </div>
-      <div class="form-control">
-        <label class="label label-text text-xs">Confidence threshold <span class="badge badge-ghost badge-xs ml-1">Plaid only</span></label>
-        <input type="number" step="0.1" min="0" max="1" class="input input-bordered input-sm w-24"
-          x-model="threshold" :disabled="!autoEnqueue">
-      </div>
-      <button class="btn btn-primary btn-sm" :disabled="saving"
-        @click="saving = true;
-          fetch('/-/reviews/settings', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
-            body: JSON.stringify({ auto_enqueue: autoEnqueue, confidence_threshold: parseFloat(threshold) })
-          }).then(r => r.json()).then(d => { saving = false; }).catch(() => { saving = false; })">
-        <span x-show="!saving">Save</span>
-        <span x-show="saving" class="loading loading-spinner loading-xs"></span>
-      </button>
+<!-- Review Settings (collapsible) -->
+<div class="bb-card mb-6" x-data="{ open: false }">
+  <button class="w-full flex items-center justify-between px-6 py-4 cursor-pointer" @click="open = !open">
+    <div class="flex items-center gap-3">
+      <i data-lucide="settings" class="w-4 h-4 text-base-content/50"></i>
+      <span class="font-medium text-sm">Review Settings</span>
     </div>
-    <p class="text-xs text-base-content/50 mt-2">
-      When enabled, new transactions are automatically added to the review queue during sync.
-      The confidence threshold only applies to <strong>Plaid</strong> transactions — Plaid provides a category confidence level
-      (very_high, high, medium, low) which is compared against this threshold. Teller and CSV transactions
-      are always enqueued as "uncategorized" or "new transaction" since they don't provide confidence scores.
-    </p>
+    <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 transition-transform duration-200" :class="open && 'rotate-180'"></i>
+  </button>
+  <div x-show="open" x-cloak x-collapse x-data="{ autoEnqueue: {{.ReviewAutoEnqueue}}, threshold: '{{.ReviewConfidenceThreshold}}', saving: false }">
+    <div class="px-6 pb-6 pt-0 border-t border-base-200">
+      <div class="flex flex-wrap gap-6 items-end pt-4">
+        <div class="form-control">
+          <label class="label cursor-pointer gap-3">
+            <span class="label-text text-sm">Auto-enqueue on sync</span>
+            <input type="checkbox" class="toggle toggle-primary toggle-sm" x-model="autoEnqueue">
+          </label>
+        </div>
+        <div class="form-control">
+          <label class="label label-text text-xs text-base-content/50">Confidence threshold <span class="badge badge-ghost badge-xs ml-1">Plaid only</span></label>
+          <input type="number" step="0.1" min="0" max="1" class="input input-bordered input-sm w-24 rounded-xl"
+            x-model="threshold" :disabled="!autoEnqueue">
+        </div>
+        <button class="btn btn-primary btn-sm rounded-xl" :disabled="saving"
+          @click="saving = true;
+            fetch('/-/reviews/settings', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+              body: JSON.stringify({ auto_enqueue: autoEnqueue, confidence_threshold: parseFloat(threshold) })
+            }).then(r => r.json()).then(d => { saving = false; }).catch(() => { saving = false; })">
+          <span x-show="!saving">Save</span>
+          <span x-show="saving" class="loading loading-spinner loading-xs"></span>
+        </button>
+      </div>
+      <p class="text-xs text-base-content/40 mt-3">
+        When enabled, new transactions are automatically added to the review queue during sync.
+        The confidence threshold only applies to Plaid transactions.
+      </p>
+    </div>
   </div>
 </div>
 
 <!-- Filter Bar -->
-<div class="bb-filter-bar mb-6">
-  <form method="GET" action="/reviews" class="flex flex-wrap gap-3 items-end">
+<div class="bb-card px-6 py-4 mb-6">
+  <form method="GET" action="/reviews" class="flex flex-wrap gap-4 items-end">
     <div class="form-control">
-      <label class="label label-text text-xs">Status</label>
-      <select name="status" class="select select-bordered select-sm">
+      <label class="label label-text text-xs text-base-content/50 pb-1">Status</label>
+      <select name="status" class="select select-bordered select-sm rounded-xl">
         <option value="pending"{{if eq .StatusFilter "pending"}} selected{{end}}>Pending</option>
         <option value="approved"{{if eq .StatusFilter "approved"}} selected{{end}}>Approved</option>
         <option value="rejected"{{if eq .StatusFilter "rejected"}} selected{{end}}>Rejected</option>
@@ -120,8 +147,8 @@
       </select>
     </div>
     <div class="form-control">
-      <label class="label label-text text-xs">Type</label>
-      <select name="review_type" class="select select-bordered select-sm">
+      <label class="label label-text text-xs text-base-content/50 pb-1">Type</label>
+      <select name="review_type" class="select select-bordered select-sm rounded-xl">
         <option value="">All Types</option>
         <option value="new_transaction"{{if eq .ReviewTypeFilter "new_transaction"}} selected{{end}}>New Transaction</option>
         <option value="uncategorized"{{if eq .ReviewTypeFilter "uncategorized"}} selected{{end}}>Uncategorized</option>
@@ -130,8 +157,8 @@
       </select>
     </div>
     <div class="form-control">
-      <label class="label label-text text-xs">Account</label>
-      <select name="account_id" class="select select-bordered select-sm">
+      <label class="label label-text text-xs text-base-content/50 pb-1">Account</label>
+      <select name="account_id" class="select select-bordered select-sm rounded-xl">
         <option value="">All Accounts</option>
         {{range .Accounts}}
         <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.AccountIDFilter}} selected{{end}}>{{.Name}}</option>
@@ -139,16 +166,18 @@
       </select>
     </div>
     <div class="form-control">
-      <label class="label label-text text-xs">Family Member</label>
-      <select name="user_id" class="select select-bordered select-sm">
+      <label class="label label-text text-xs text-base-content/50 pb-1">Family Member</label>
+      <select name="user_id" class="select select-bordered select-sm rounded-xl">
         <option value="">All Members</option>
         {{range .Users}}
         <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.UserIDFilter}} selected{{end}}>{{.Name}}</option>
         {{end}}
       </select>
     </div>
-    <button type="submit" class="btn btn-sm btn-primary">Filter</button>
-    <a href="/reviews" class="btn btn-sm btn-ghost">Reset</a>
+    <div class="flex gap-2">
+      <button type="submit" class="btn btn-sm btn-primary rounded-xl">Filter</button>
+      <a href="/reviews" class="btn btn-sm btn-ghost rounded-xl">Reset</a>
+    </div>
   </form>
 </div>
 
@@ -156,66 +185,67 @@
 <div x-data="reviewQueue()" class="space-y-4">
   {{if .Reviews}}
   {{range .Reviews}}
-  <div class="card bg-base-100 shadow border border-base-300 review-card" x-data="{ submitting: false, selectedCatId: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', suggestedCatId: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', feedback: '', pickerShake: false }" id="review-{{.ID}}">
-    <div class="card-body p-4">
+  <div class="bb-card bb-card--interactive p-0 overflow-hidden review-card" x-data="{ submitting: false, selectedCatId: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', suggestedCatId: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', feedback: '', pickerShake: false }" id="review-{{.ID}}">
+    <div class="p-6">
       <!-- Header row: badges + timestamp -->
-      <div class="flex items-center justify-between flex-wrap gap-1">
+      <div class="flex items-center justify-between flex-wrap gap-2">
         <div class="flex items-center gap-2 flex-wrap">
           {{if eq .ReviewType "new_transaction"}}
-          <span class="badge badge-soft badge-info badge-sm">New Transaction</span>
+          <span class="badge badge-soft badge-info badge-sm rounded-lg">New Transaction</span>
           {{else if eq .ReviewType "uncategorized"}}
-          <span class="badge badge-soft badge-warning badge-sm">Uncategorized</span>
+          <span class="badge badge-soft badge-warning badge-sm rounded-lg">Uncategorized</span>
           {{else if eq .ReviewType "low_confidence"}}
-          <span class="badge badge-soft badge-error badge-sm">Low Confidence{{if .ConfidenceScore}} ({{printf "%.0f" (mulFloat .ConfidenceScore 100.0)}}%){{end}}</span>
+          <span class="badge badge-soft badge-error badge-sm rounded-lg">Low Confidence{{if .ConfidenceScore}} ({{printf "%.0f" (mulFloat .ConfidenceScore 100.0)}}%){{end}}</span>
           {{else if eq .ReviewType "manual"}}
-          <span class="badge badge-soft badge-neutral badge-sm">Manual</span>
+          <span class="badge badge-soft badge-neutral badge-sm rounded-lg">Manual</span>
           {{end}}
           {{if .Provider}}
-          <span class="badge badge-ghost badge-xs uppercase">{{.Provider}}</span>
+          <span class="badge badge-ghost badge-xs uppercase rounded-lg">{{.Provider}}</span>
           {{end}}
           {{if eq .Status "approved"}}
-          <span class="badge badge-success badge-sm">Approved</span>
+          <span class="badge badge-success badge-sm rounded-lg">Approved</span>
           {{else if eq .Status "rejected"}}
-          <span class="badge badge-error badge-sm">Rejected</span>
+          <span class="badge badge-error badge-sm rounded-lg">Rejected</span>
           {{else if eq .Status "skipped"}}
-          <span class="badge badge-ghost badge-sm">Skipped</span>
+          <span class="badge badge-ghost badge-sm rounded-lg">Skipped</span>
           {{end}}
         </div>
-        <span class="text-xs text-base-content/50">{{relativeTime .CreatedAt}}</span>
+        <span class="text-xs text-base-content/40">{{relativeTime .CreatedAt}}</span>
       </div>
 
       <!-- Transaction info -->
       {{if .Transaction}}
-      <div class="flex items-start justify-between mt-2 gap-3">
+      <div class="flex items-start justify-between mt-4 gap-4">
         <div class="min-w-0">
-          <a href="/transactions/{{.TransactionID}}" class="font-semibold link link-hover">{{.Transaction.Name}}</a>
-          {{if .Transaction.MerchantName}}<div class="text-sm text-base-content/70">{{.Transaction.MerchantName}}</div>{{end}}
-          <div class="text-xs text-base-content/50 mt-0.5">
+          <a href="/transactions/{{.TransactionID}}" class="text-base font-semibold link link-hover">{{.Transaction.Name}}</a>
+          {{if .Transaction.MerchantName}}<div class="text-sm text-base-content/60 mt-0.5">{{.Transaction.MerchantName}}</div>{{end}}
+          <div class="text-xs text-base-content/40 mt-1">
             {{if .Transaction.AccountName}}{{.Transaction.AccountName}}{{end}}
             {{if .Transaction.UserName}} &middot; {{.Transaction.UserName}}{{end}}
           </div>
         </div>
         <div class="text-right flex-shrink-0">
-          <div class="font-mono font-semibold text-base bb-amount{{if lt .Transaction.Amount 0.0}} text-error{{end}}">
+          <div class="text-xl font-bold tabular-nums{{if lt .Transaction.Amount 0.0}} text-error{{end}}">
             {{printf "%.2f" .Transaction.Amount}}
-            <span class="text-xs text-base-content/50 font-normal">{{if .Transaction.IsoCurrencyCode}}{{.Transaction.IsoCurrencyCode}}{{end}}</span>
           </div>
-          <div class="text-xs text-base-content/50">{{.Transaction.Date}}</div>
+          <div class="text-xs text-base-content/40 mt-0.5">
+            {{if .Transaction.IsoCurrencyCode}}{{.Transaction.IsoCurrencyCode}} &middot; {{end}}{{.Transaction.Date}}
+          </div>
         </div>
       </div>
 
       <!-- Category info with inline thumbs for suggestions -->
-      <div class="text-sm mt-2">
+      <div class="text-sm mt-3">
         {{if .SuggestedCategory}}
         <div class="flex items-center gap-2">
-          <span class="text-base-content/70">Suggested:</span>
+          <span class="text-base-content/50">Suggested:</span>
           <span class="font-medium">{{.SuggestedCategory}}</span>
           {{if eq .Status "pending"}}
           <div class="flex items-center gap-1 ml-auto">
-            <button class="btn btn-xs btn-circle" :class="feedback === 'up' ? 'btn-success' : 'btn-ghost text-base-content/40'" @click="feedback = feedback === 'up' ? '' : 'up'">
+            <button class="btn btn-xs btn-circle" :class="feedback === 'up' ? 'btn-success' : 'btn-ghost text-base-content/30'" @click="feedback = feedback === 'up' ? '' : 'up'">
               <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>
             </button>
-            <button class="btn btn-xs btn-circle" :class="feedback === 'down' ? 'btn-error' : 'btn-ghost text-base-content/40'"
+            <button class="btn btn-xs btn-circle" :class="feedback === 'down' ? 'btn-error' : 'btn-ghost text-base-content/30'"
               @click="if (feedback === 'down') { feedback = ''; } else { feedback = 'down'; if (selectedCatId === suggestedCatId) { pickerShake = true; setTimeout(() => pickerShake = false, 600); } }">
               <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 14V2"/><path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22a3.13 3.13 0 0 1-3-3.88Z"/></svg>
             </button>
@@ -223,31 +253,31 @@
           {{end}}
         </div>
         {{else if .Transaction.Category}}
-        <span class="text-base-content/70">Category:</span>
+        <span class="text-base-content/50">Category:</span>
         <span class="font-medium">{{.Transaction.Category.DisplayName}}</span>
         {{else}}
-        <span class="text-base-content/50 italic">No category assigned</span>
+        <span class="text-base-content/40 italic">No category assigned</span>
         {{end}}
       </div>
       {{end}}
 
       {{if eq .Status "pending"}}
       <!-- Action bar for pending reviews -->
-      <div class="border-t border-base-300 pt-3 mt-3">
+      <div class="border-t border-base-200 pt-4 mt-4">
         <!-- Category picker -->
         <div class="form-control" :class="{ 'bb-picker-shake': pickerShake }">
-          <label class="label label-text text-xs py-0.5">
+          <label class="label label-text text-xs text-base-content/40 py-0.5">
             {{if .SuggestedCategoryID}}Correct category{{else}}Assign category{{end}}
           </label>
           <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', placeholder: 'Keep current', allowEmpty: true, emptyLabel: 'Keep current'})" @category-change="selectedCatId = $event.detail.id; if (selectedCatId !== suggestedCatId && suggestedCatId) { feedback = 'down'; }">
-            <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start border border-base-300" @click="openPicker()">
+            <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start border border-base-200 rounded-xl" @click="openPicker()">
               <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
               <span x-text="displayLabel" class="text-sm truncate"></span>
               <svg class="w-3 h-3 ml-auto opacity-40" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
             </button>
             <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-              <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full">
+              <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+                <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full rounded-xl">
               </div>
               <div x-ref="listbox">
                 <template x-for="(item, idx) in filteredList" :key="item.id || idx">
@@ -263,43 +293,37 @@
           </div>
         </div>
         <!-- Note -->
-        <div class="form-control mt-2">
-          <label class="label label-text text-xs py-0.5">Note <span class="text-base-content/40">(optional feedback for future categorization)</span></label>
-          <input type="text" class="input input-bordered input-sm w-full" placeholder="Add context for future reference..." id="note-{{.ID}}">
+        <div class="form-control mt-3">
+          <label class="label label-text text-xs text-base-content/40 py-0.5">Note <span class="text-base-content/30">(optional)</span></label>
+          <input type="text" class="input input-bordered input-sm w-full rounded-xl" placeholder="Add context for future reference..." id="note-{{.ID}}">
         </div>
         <!-- Action buttons -->
-        <div class="flex gap-2 flex-wrap mt-3 items-center">
-          <div class="tooltip tooltip-bottom" data-tip="Accept and apply selected category">
-            <button class="btn btn-success btn-sm gap-1" :disabled="submitting"
-              @click="if (feedback === 'down' && selectedCatId === suggestedCatId) { pickerShake = true; setTimeout(() => pickerShake = false, 600); } else { submitReview('{{.ID}}', 'approved', selectedCatId, feedback); }">
-              <span x-show="!submitting" class="flex items-center gap-1">
-                <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
-                Accept
-              </span>
-              <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
-            </button>
-          </div>
-          <div class="tooltip tooltip-bottom" data-tip="Skip for now — review later">
-            <button class="btn btn-ghost btn-sm gap-1" :disabled="submitting"
-              @click="submitReview('{{.ID}}', 'skipped', null, '')">
-              <span x-show="!submitting" class="flex items-center gap-1">
-                <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-                Skip
-              </span>
-              <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
-            </button>
-          </div>
-          <div class="tooltip tooltip-bottom" data-tip="Remove from review queue permanently">
-            <button class="btn btn-ghost btn-sm text-base-content/40" :disabled="submitting"
-              @click="dismissReview('{{.ID}}')">
-              <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg>
-            </button>
-          </div>
+        <div class="flex gap-2 flex-wrap mt-4 items-center">
+          <button class="btn btn-success btn-sm rounded-xl gap-1" :disabled="submitting"
+            @click="if (feedback === 'down' && selectedCatId === suggestedCatId) { pickerShake = true; setTimeout(() => pickerShake = false, 600); } else { submitReview('{{.ID}}', 'approved', selectedCatId, feedback); }">
+            <span x-show="!submitting" class="flex items-center gap-1">
+              <i data-lucide="check" class="w-4 h-4"></i>
+              Accept
+            </span>
+            <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+          </button>
+          <button class="btn btn-ghost btn-sm rounded-xl gap-1" :disabled="submitting"
+            @click="submitReview('{{.ID}}', 'skipped', null, '')">
+            <span x-show="!submitting" class="flex items-center gap-1">
+              <i data-lucide="skip-forward" class="w-4 h-4"></i>
+              Skip
+            </span>
+            <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+          </button>
+          <button class="btn btn-ghost btn-sm rounded-xl text-base-content/30" :disabled="submitting"
+            @click="dismissReview('{{.ID}}')">
+            <i data-lucide="trash-2" class="w-4 h-4"></i>
+          </button>
         </div>
       </div>
       {{else if .ReviewerName}}
       <!-- Resolved info -->
-      <div class="border-t border-base-300 pt-2 mt-2 text-xs text-base-content/50">
+      <div class="border-t border-base-200 pt-3 mt-4 text-xs text-base-content/40">
         Reviewed by {{.ReviewerName}} {{if .ReviewedAt}} &middot; {{relativeTime .ReviewedAt}}{{end}}
         {{if .ReviewNote}}<br>Note: {{.ReviewNote}}{{end}}
       </div>
@@ -310,19 +334,21 @@
 
   <!-- Pagination -->
   {{if .HasMore}}
-  <div class="flex justify-center mt-6">
-    <a href="/reviews?cursor={{.NextCursor}}&status={{.StatusFilter}}{{if .ReviewTypeFilter}}&review_type={{.ReviewTypeFilter}}{{end}}{{if .AccountIDFilter}}&account_id={{.AccountIDFilter}}{{end}}{{if .UserIDFilter}}&user_id={{.UserIDFilter}}{{end}}" class="btn btn-outline btn-sm">
+  <div class="flex justify-center mt-8">
+    <a href="/reviews?cursor={{.NextCursor}}&status={{.StatusFilter}}{{if .ReviewTypeFilter}}&review_type={{.ReviewTypeFilter}}{{end}}{{if .AccountIDFilter}}&account_id={{.AccountIDFilter}}{{end}}{{if .UserIDFilter}}&user_id={{.UserIDFilter}}{{end}}" class="btn btn-outline btn-sm rounded-xl">
       Load More
     </a>
   </div>
   {{end}}
 
   {{else}}
-  <div class="card bg-base-100 shadow border border-base-300">
-    <div class="card-body items-center text-center py-12">
-      <svg class="w-12 h-12 text-success mb-2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="m9 11 3 3L22 4"/></svg>
-      <h2 class="card-title text-lg">All caught up!</h2>
-      <p class="text-base-content/70">No {{.StatusFilter}} reviews to show.</p>
+  <div class="bb-card">
+    <div class="flex flex-col items-center text-center py-16 px-6">
+      <div class="w-16 h-16 rounded-2xl bg-success/10 flex items-center justify-center mb-4">
+        <i data-lucide="check-circle" class="w-8 h-8 text-success"></i>
+      </div>
+      <h2 class="text-lg font-semibold mb-1">All caught up!</h2>
+      <p class="text-base-content/50 text-sm">No {{.StatusFilter}} reviews to show.</p>
     </div>
   </div>
   {{end}}
@@ -345,7 +371,6 @@ function reviewQueue() {
         body.category_id = categoryId;
       }
 
-      // Build note with feedback prefix for audit trail
       let noteParts = [];
       if (feedback === 'up') {
         noteParts.push('[suggestion accepted]');
@@ -370,10 +395,11 @@ function reviewQueue() {
           window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: data.error, type:'error'}}));
           cardData.submitting = false;
         } else {
-          card.style.transition = 'opacity 0.3s, max-height 0.3s';
+          card.style.transition = 'opacity 0.3s, max-height 0.3s, margin 0.3s';
           card.style.opacity = '0';
           card.style.maxHeight = '0';
           card.style.overflow = 'hidden';
+          card.style.marginBottom = '0';
           setTimeout(() => card.remove(), 300);
           window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Review ' + decision, type:'success'}}));
         }
@@ -399,10 +425,11 @@ function reviewQueue() {
           window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: data.error, type:'error'}}));
           cardData.submitting = false;
         } else {
-          card.style.transition = 'opacity 0.3s, max-height 0.3s';
+          card.style.transition = 'opacity 0.3s, max-height 0.3s, margin 0.3s';
           card.style.opacity = '0';
           card.style.maxHeight = '0';
           card.style.overflow = 'hidden';
+          card.style.marginBottom = '0';
           setTimeout(() => card.remove(), 300);
           window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Review dismissed', type:'info'}}));
         }

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -1,131 +1,169 @@
 {{define "content"}}
 <div x-data="rulesPage()" x-init="init()">
 
-<div class="flex items-center justify-between mb-6">
+<div class="bb-page-header">
   <div>
-    <h1 class="text-2xl font-bold">Transaction Rules</h1>
-    <p class="text-sm text-base-content/60 mt-1">Rules auto-categorize future transactions based on pattern matching</p>
+    <h1 class="bb-page-title">Transaction Rules</h1>
+    <p class="text-sm text-base-content/50 mt-1">Auto-categorize future transactions based on pattern matching</p>
   </div>
-  <button class="btn btn-primary btn-sm" @click="showCreateModal = true">
+  <button class="btn btn-primary btn-sm rounded-xl" @click="showCreateModal = true">
     <i data-lucide="plus" class="w-4 h-4"></i> New Rule
   </button>
 </div>
 
 <!-- Filter bar -->
-<div class="bb-filter-bar mb-4">
-  <form method="GET" class="flex items-center gap-3 flex-wrap">
-    <label class="form-control">
-      <input type="text" name="search" placeholder="Search by name..." value="{{.SearchFilter}}" class="input input-bordered input-sm w-48" />
-    </label>
-    <label class="form-control">
-      <select name="category_slug" class="select select-bordered select-sm" onchange="this.form.submit()">
+<div class="bb-card px-6 py-4 mb-6">
+  <form method="GET" class="flex items-end gap-4 flex-wrap">
+    <div class="form-control">
+      <label class="label label-text text-xs text-base-content/50 pb-1">Search</label>
+      <input type="text" name="search" placeholder="Search by name..." value="{{.SearchFilter}}" class="input input-bordered input-sm w-48 rounded-xl" />
+    </div>
+    <div class="form-control">
+      <label class="label label-text text-xs text-base-content/50 pb-1">Category</label>
+      <select name="category_slug" class="select select-bordered select-sm rounded-xl" onchange="this.form.submit()">
         <option value="">All Categories</option>
         {{range .FlatCategories}}
         <option value="{{.Slug}}"{{if eq $.CategoryFilter .Slug}} selected{{end}}>{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
         {{end}}
       </select>
-    </label>
-    <label class="form-control">
-      <select name="enabled" class="select select-bordered select-sm" onchange="this.form.submit()">
-        <option value="">All Status</option>
+    </div>
+    <div class="form-control">
+      <label class="label label-text text-xs text-base-content/50 pb-1">Status</label>
+      <select name="enabled" class="select select-bordered select-sm rounded-xl" onchange="this.form.submit()">
+        <option value="">All</option>
         <option value="true"{{if eq .EnabledFilter "true"}} selected{{end}}>Enabled</option>
         <option value="false"{{if eq .EnabledFilter "false"}} selected{{end}}>Disabled</option>
       </select>
-    </label>
-    <button type="submit" class="btn btn-sm btn-ghost">Filter</button>
-    {{if or .SearchFilter .CategoryFilter .EnabledFilter}}<a href="/rules" class="btn btn-sm btn-ghost">Clear</a>{{end}}
+    </div>
+    <div class="flex gap-2">
+      <button type="submit" class="btn btn-sm btn-ghost rounded-xl">Filter</button>
+      {{if or .SearchFilter .CategoryFilter .EnabledFilter}}<a href="/rules" class="btn btn-sm btn-ghost rounded-xl">Clear</a>{{end}}
+    </div>
   </form>
 </div>
 
 <!-- Rules count -->
-<div class="text-sm text-base-content/60 mb-3">
+<div class="text-sm text-base-content/40 mb-4 px-1">
   {{.Total}} rule{{if ne .Total 1}}s{{end}} found
 </div>
 
-<!-- Rules table -->
-<div class="card bg-base-100 shadow-sm">
-  <div class="card-body p-0">
-    <div class="overflow-x-auto">
-      <table class="table table-sm">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Conditions</th>
-            <th>Category</th>
-            <th>Priority</th>
-            <th>Hits</th>
-            <th>Status</th>
-            <th>Created By</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {{if not .Rules}}
-          <tr><td colspan="8" class="text-center text-base-content/60 py-8">No rules found. Create one to start auto-categorizing transactions.</td></tr>
+<!-- Rules as cards instead of table for Mercury feel -->
+{{if not .Rules}}
+<div class="bb-card">
+  <div class="flex flex-col items-center text-center py-16 px-6">
+    <div class="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mb-4">
+      <i data-lucide="list-filter" class="w-8 h-8 text-primary"></i>
+    </div>
+    <h2 class="text-lg font-semibold mb-1">No rules yet</h2>
+    <p class="text-base-content/50 text-sm mb-4">Create a rule to start auto-categorizing transactions.</p>
+    <button class="btn btn-primary btn-sm rounded-xl" @click="showCreateModal = true">
+      <i data-lucide="plus" class="w-4 h-4"></i> Create Rule
+    </button>
+  </div>
+</div>
+{{end}}
+
+<div class="space-y-3">
+{{range .Rules}}
+<div class="bb-card p-0 overflow-hidden" x-data="{deleting: false}">
+  <div class="flex items-center gap-4 px-6 py-4">
+    <!-- Status indicator -->
+    <div class="flex-shrink-0">
+      {{if .Enabled}}
+        {{if and .ExpiresAt (expired .ExpiresAt)}}
+        <div class="w-10 h-10 rounded-xl bg-warning/10 flex items-center justify-center">
+          <i data-lucide="clock" class="w-5 h-5 text-warning"></i>
+        </div>
+        {{else}}
+        <div class="w-10 h-10 rounded-xl bg-success/10 flex items-center justify-center">
+          <i data-lucide="zap" class="w-5 h-5 text-success"></i>
+        </div>
+        {{end}}
+      {{else}}
+      <div class="w-10 h-10 rounded-xl bg-base-200 flex items-center justify-center">
+        <i data-lucide="pause" class="w-5 h-5 text-base-content/30"></i>
+      </div>
+      {{end}}
+    </div>
+
+    <!-- Main info -->
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center gap-2">
+        <span class="font-semibold text-sm truncate">{{.Name}}</span>
+        {{if .Enabled}}
+          {{if and .ExpiresAt (expired .ExpiresAt)}}
+          <span class="badge badge-warning badge-xs rounded-lg">Expired</span>
           {{end}}
-          {{range .Rules}}
-          <tr x-data="{deleting: false}">
-            <td class="font-medium max-w-48 truncate" title="{{.Name}}">{{.Name}}</td>
-            <td class="text-xs font-mono max-w-64 truncate" title="{{conditionSummary .Conditions}}">{{conditionSummary .Conditions}}</td>
-            <td>
-              {{if .CategoryName}}<span class="badge badge-outline badge-sm">{{deref .CategoryName}}</span>{{else}}<span class="text-base-content/40">&mdash;</span>{{end}}
-            </td>
-            <td>{{.Priority}}</td>
-            <td>{{.HitCount}}</td>
-            <td>
-              {{if .Enabled}}
-                {{if and .ExpiresAt (expired .ExpiresAt)}}
-                  <span class="badge badge-warning badge-sm">Expired</span>
-                {{else}}
-                  <span class="badge badge-success badge-sm">Enabled</span>
-                {{end}}
-              {{else}}
-                <span class="badge badge-ghost badge-sm">Disabled</span>
-              {{end}}
-            </td>
-            <td class="text-sm">
-              <span class="badge badge-ghost badge-xs">{{.CreatedByType}}</span>
-              {{.CreatedByName}}
-            </td>
-            <td class="flex gap-1">
-              <button class="btn btn-ghost btn-xs" title="Toggle" @click="toggleRule('{{.ID}}')">
-                {{if .Enabled}}<i data-lucide="pause" class="w-4 h-4"></i>{{else}}<i data-lucide="play" class="w-4 h-4"></i>{{end}}
-              </button>
-              <button class="btn btn-ghost btn-xs" title="Edit" @click="editRule({{toJSON .}})">
-                <i data-lucide="pencil" class="w-4 h-4"></i>
-              </button>
-              <button class="btn btn-ghost btn-xs text-error" title="Delete" :disabled="deleting" @click="deleteRule('{{.ID}}', $el)">
-                <i data-lucide="trash-2" class="w-4 h-4"></i>
-              </button>
-            </td>
-          </tr>
-          {{end}}
-        </tbody>
-      </table>
+        {{else}}
+        <span class="badge badge-ghost badge-xs rounded-lg">Disabled</span>
+        {{end}}
+      </div>
+      <div class="text-xs text-base-content/40 mt-0.5 font-mono truncate" title="{{conditionSummary .Conditions}}">{{conditionSummary .Conditions}}</div>
+    </div>
+
+    <!-- Category -->
+    <div class="hidden sm:flex flex-col items-end gap-0.5 flex-shrink-0">
+      {{if .CategoryName}}
+      <span class="badge badge-outline badge-sm rounded-lg">{{deref .CategoryName}}</span>
+      {{else}}
+      <span class="text-base-content/30 text-xs">&mdash;</span>
+      {{end}}
+    </div>
+
+    <!-- Stats -->
+    <div class="hidden md:flex items-center gap-4 text-xs text-base-content/40 flex-shrink-0">
+      <div class="text-center">
+        <div class="font-semibold text-sm text-base-content/70 tabular-nums">{{.HitCount}}</div>
+        <div>hits</div>
+      </div>
+      <div class="text-center">
+        <div class="font-semibold text-sm text-base-content/70 tabular-nums">{{.Priority}}</div>
+        <div>priority</div>
+      </div>
+    </div>
+
+    <!-- Creator badge -->
+    <div class="hidden lg:block flex-shrink-0">
+      <span class="badge badge-ghost badge-xs rounded-lg">{{.CreatedByType}}</span>
+    </div>
+
+    <!-- Actions -->
+    <div class="flex items-center gap-1 flex-shrink-0">
+      <button class="btn btn-ghost btn-xs btn-square rounded-lg" title="Toggle" @click="toggleRule('{{.ID}}')">
+        {{if .Enabled}}<i data-lucide="pause" class="w-4 h-4"></i>{{else}}<i data-lucide="play" class="w-4 h-4"></i>{{end}}
+      </button>
+      <button class="btn btn-ghost btn-xs btn-square rounded-lg" title="Edit" @click="editRule({{toJSON .}})">
+        <i data-lucide="pencil" class="w-4 h-4"></i>
+      </button>
+      <button class="btn btn-ghost btn-xs btn-square rounded-lg text-error/60" title="Delete" :disabled="deleting" @click="deleteRule('{{.ID}}', $el)">
+        <i data-lucide="trash-2" class="w-4 h-4"></i>
+      </button>
     </div>
   </div>
+</div>
+{{end}}
 </div>
 
 <!-- Pagination -->
 {{if .HasMore}}
-<div class="flex justify-center mt-4">
-  <a href="/rules?cursor={{.NextCursor}}{{if .SearchFilter}}&search={{.SearchFilter}}{{end}}{{if .CategoryFilter}}&category_slug={{.CategoryFilter}}{{end}}{{if .EnabledFilter}}&enabled={{.EnabledFilter}}{{end}}" class="btn btn-sm btn-outline">Load More</a>
+<div class="flex justify-center mt-8">
+  <a href="/rules?cursor={{.NextCursor}}{{if .SearchFilter}}&search={{.SearchFilter}}{{end}}{{if .CategoryFilter}}&category_slug={{.CategoryFilter}}{{end}}{{if .EnabledFilter}}&enabled={{.EnabledFilter}}{{end}}" class="btn btn-sm btn-outline rounded-xl">Load More</a>
 </div>
 {{end}}
 
 <!-- Create/Edit Rule Modal -->
 <dialog class="modal" :class="{'modal-open': showCreateModal || showEditModal}">
-  <div class="modal-box max-w-lg">
-    <h3 class="font-bold text-lg mb-4" x-text="showEditModal ? 'Edit Rule' : 'Create Rule'"></h3>
+  <div class="modal-box max-w-lg rounded-2xl">
+    <h3 class="font-bold text-lg mb-6" x-text="showEditModal ? 'Edit Rule' : 'Create Rule'"></h3>
     <form @submit.prevent="submitRule()">
-      <div class="form-control mb-3">
-        <label class="label"><span class="label-text">Name</span></label>
-        <input type="text" x-model="form.name" class="input input-bordered input-sm" placeholder="e.g., Uber Eats transactions" required />
+      <div class="form-control mb-4">
+        <label class="label"><span class="label-text text-sm font-medium">Name</span></label>
+        <input type="text" x-model="form.name" class="input input-bordered input-sm rounded-xl" placeholder="e.g., Uber Eats transactions" required />
       </div>
 
-      <div class="form-control mb-3">
-        <label class="label"><span class="label-text">Category</span></label>
-        <select x-model="form.category_slug" class="select select-bordered select-sm" required>
+      <div class="form-control mb-4">
+        <label class="label"><span class="label-text text-sm font-medium">Category</span></label>
+        <select x-model="form.category_slug" class="select select-bordered select-sm rounded-xl" required>
           <option value="">Select category...</option>
           {{range .FlatCategories}}
           <option value="{{.Slug}}">{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
@@ -133,37 +171,36 @@
         </select>
       </div>
 
-      <div class="form-control mb-3">
-        <label class="label"><span class="label-text">Priority</span></label>
-        <input type="number" x-model.number="form.priority" class="input input-bordered input-sm w-24" min="0" max="1000" />
-        <label class="label"><span class="label-text-alt">Higher priority rules are evaluated first (default: 10)</span></label>
+      <div class="form-control mb-4">
+        <label class="label"><span class="label-text text-sm font-medium">Priority</span></label>
+        <input type="number" x-model.number="form.priority" class="input input-bordered input-sm w-24 rounded-xl" min="0" max="1000" />
+        <label class="label"><span class="label-text-alt text-base-content/40">Higher priority rules are evaluated first (default: 10)</span></label>
       </div>
 
-      <div class="form-control mb-3">
-        <label class="label"><span class="label-text">Conditions (JSON)</span></label>
-        <textarea x-model="form.conditions_json" class="textarea textarea-bordered textarea-sm font-mono text-xs" rows="6" placeholder='{"field": "name", "op": "contains", "value": "uber eats"}' required></textarea>
+      <div class="form-control mb-4">
+        <label class="label"><span class="label-text text-sm font-medium">Conditions (JSON)</span></label>
+        <textarea x-model="form.conditions_json" class="textarea textarea-bordered textarea-sm font-mono text-xs rounded-xl" rows="6" placeholder='{"field": "name", "op": "contains", "value": "uber eats"}' required></textarea>
         <label class="label">
-          <span class="label-text-alt">
+          <span class="label-text-alt text-base-content/40">
             Fields: name, merchant_name, amount, category_primary, category_detailed, pending, provider, account_id, user_id.
-            Operators: eq, neq, contains, not_contains, matches (regex), gt, gte, lt, lte, in.
-            Use and/or/not for logical operators.
+            Operators: eq, neq, contains, not_contains, matches, gt, gte, lt, lte, in.
           </span>
         </label>
       </div>
 
-      <div class="form-control mb-3" x-show="!showEditModal">
-        <label class="label"><span class="label-text">Expires In (optional)</span></label>
-        <input type="text" x-model="form.expires_in" class="input input-bordered input-sm w-32" placeholder="e.g., 30d" />
-        <label class="label"><span class="label-text-alt">Duration: 24h, 7d, 4w. Leave empty for no expiry.</span></label>
+      <div class="form-control mb-4" x-show="!showEditModal">
+        <label class="label"><span class="label-text text-sm font-medium">Expires In</span> <span class="text-base-content/40 text-xs">(optional)</span></label>
+        <input type="text" x-model="form.expires_in" class="input input-bordered input-sm w-32 rounded-xl" placeholder="e.g., 30d" />
+        <label class="label"><span class="label-text-alt text-base-content/40">Duration: 24h, 7d, 4w. Leave empty for no expiry.</span></label>
       </div>
 
-      <div x-show="formError" class="alert alert-error alert-sm mb-3">
+      <div x-show="formError" class="alert alert-error text-sm mb-4 rounded-xl">
         <span x-text="formError"></span>
       </div>
 
       <div class="modal-action">
-        <button type="button" class="btn btn-ghost btn-sm" @click="closeModal()">Cancel</button>
-        <button type="submit" class="btn btn-primary btn-sm" :disabled="submitting">
+        <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="closeModal()">Cancel</button>
+        <button type="submit" class="btn btn-primary btn-sm rounded-xl" :disabled="submitting">
           <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
           <span x-text="showEditModal ? 'Save' : 'Create'"></span>
         </button>


### PR DESCRIPTION
## Summary
- **Reviews page**: Mercury stat cards replacing cramped DaisyUI stats bar, soft rounded review cards with generous spacing, collapsible settings panel, improved empty state with icon
- **Rules page**: Card-based rule list replacing dense table, status indicator icons, inline stats (hits/priority), cleaner filter bar, premium empty state
- **Providers page**: Structured card headers with colored icon backgrounds, cleaner form layouts with consistent spacing, improved section separation
- **MCP Settings page**: Icon-header cards matching providers style, radio options with hover states, tool list with row-based toggles replacing table
- **Review Instructions page**: Consistent card structure with icon headers, improved code block styling

All pages now use `bb-card`, `bb-page-header`, `bb-page-title`, `bb-stat-card` patterns with `rounded-xl`/`rounded-2xl` shapes, `border-base-200` borders, and Mercury-inspired spacing.

## Screenshots
### Providers
![Providers](https://i.img402.dev/2pdzdlwdc0.png)

### MCP Settings
![MCP Settings](https://i.img402.dev/lzaev11l58.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent