### PR TITLE
Add navigation progress bar, skeleton loading states, and page transitions

### DIFF
--- a/.claude/commands/ux-improve.md
+++ b/.claude/commands/ux-improve.md
@@ -76,16 +76,25 @@ git checkout -b auto-improvement/<short-descriptive-name>
 - **No Node.js**, no npm, no build step beyond `make css`.
 - **Go handlers** in `internal/api/`, service layer in `internal/service/`.
 
-### Design Principles — "Mercury Style"
+### Design Principles — "shadcn/ui aesthetic via DaisyUI"
 
-- **Light and airy** — Think white space, soft shadows, generous padding. The app should feel calm and premium, not dense and busy. Prefer `bg-base-100` cards on `bg-base-200` backgrounds with subtle separation.
-- **Soft shapes** — Use `rounded-2xl` for cards and containers. Avoid sharp corners. Buttons should be rounded too.
-- **Minimal borders** — Prefer shadows and background color contrast over visible borders. If borders are needed, use very subtle ones (`border-base-200` not `border-base-300`).
-- **Typography over decoration** — Use font size and weight to create hierarchy, not colors or icons. Financial amounts should be large and bold. Labels should be small and muted.
-- **Sparing color** — Mostly grayscale/neutral palette. Green for positive amounts/success, red for negative/errors. One accent color max. No rainbow badges.
-- **Snappy** — CSS transitions (150-250ms), smooth hover states, subtle lift on interactive cards.
-- **Consistent design system** — Before implementing, read `input.css` and existing templates. Reuse and extend existing patterns. If you add new reusable patterns, define them in `input.css`. Use DaisyUI semantic classes consistently.
-- **Dark mode aware** — The app uses `prefers-color-scheme` auto-switch. Design should work in both, but dark mode should still feel "Mercury-esque" — dark grays, not pure black, with the same soft aesthetic.
+The target aesthetic is **shadcn/ui** (https://ui.shadcn.com) — the gold standard for modern web UIs. We use DaisyUI for structural components but override its theme to match shadcn's visual language.
+
+**shadcn design DNA:**
+- **Neutral-first palette** — Almost entirely grayscale. Pure white backgrounds, near-black text. Color is used only for semantic meaning (destructive red, success green) and one primary accent.
+- **OKLCH color space** — shadcn uses OKLCH. Light mode: `background: oklch(1 0 0)`, `foreground: oklch(0.145 0 0)`, `border: oklch(0.922 0 0)`. Dark mode: `background: oklch(0.145 0 0)`, `foreground: oklch(0.985 0 0)`, `border: oklch(1 0 0 / 10%)`.
+- **Subtle borders over shadows** — shadcn prefers thin `1px` borders in muted gray over box-shadows. Cards have `border-border` not `shadow-md`.
+- **Consistent radius** — `--radius: 0.625rem` for most elements. Cards slightly larger. Not overly rounded.
+- **Tight, purposeful spacing** — Not as padded as Mercury. More like `p-4` to `p-6`, not `p-8`. Dense but clean.
+- **Typography hierarchy via weight** — Semibold headings, normal body, muted secondary text (`text-muted-foreground`). No uppercase labels.
+- **Minimal decoration** — No colored left borders, no gradient backgrounds, no icon circles. Let content speak.
+- **Dark mode: true dark** — Near-black background (`oklch(0.145 0 0)`), slightly lighter cards (`oklch(0.205 0 0)`), muted borders. Rich and clean.
+
+**How to apply with DaisyUI:**
+- Use `@plugin "daisyui/theme"` to define custom themes with shadcn's OKLCH values mapped to DaisyUI's semantic tokens (`--color-base-100`, `--color-base-content`, `--color-primary`, etc.)
+- Keep DaisyUI structural components (`drawer`, `table`, `modal`, `collapse`, `badge`) but ensure they're styled to match shadcn's minimal aesthetic
+- Avoid DaisyUI's more opinionated components (colored badges, gradient buttons) — use ghost/outline variants
+- Use `border-base-200` (light) or `border-base-content/10` (dark) for all borders
 
 ### What NOT to do
 

--- a/input.css
+++ b/input.css
@@ -514,6 +514,16 @@
     80% { transform: translateX(3px); }
   }
 
+  /* ── Mobile transaction cards ── */
+  .bb-tx-card {
+    @apply overflow-hidden;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .bb-tx-card:active {
+    @apply bg-base-200/30;
+  }
+
   /* ── Smooth collapse for filter panels ── */
   [x-collapse] {
     transition: height 0.2s ease-out, opacity 0.15s ease !important;

--- a/input.css
+++ b/input.css
@@ -562,4 +562,180 @@
       @apply border-b-0 pb-0;
     }
   }
+
+  /* ─── Command Palette (Cmd+K) ─── */
+  .bb-cmdk-backdrop {
+    @apply fixed inset-0 z-50;
+    background: oklch(0 0 0 / 0.4);
+    backdrop-filter: blur(4px);
+    animation: bb-cmdk-backdrop-in 0.15s ease-out;
+  }
+
+  @keyframes bb-cmdk-backdrop-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .bb-cmdk-dialog {
+    @apply fixed z-50 bg-base-100 border border-base-300 rounded-xl overflow-hidden;
+    top: min(20%, 140px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(95vw, 560px);
+    max-height: min(70vh, 460px);
+    box-shadow: 0 16px 70px oklch(0 0 0 / 0.15), 0 0 0 1px oklch(0 0 0 / 0.04);
+    animation: bb-cmdk-dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-cmdk-dialog {
+      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
+    }
+  }
+
+  @keyframes bb-cmdk-dialog-in {
+    from {
+      opacity: 0;
+      transform: translateX(-50%) scale(0.96) translateY(-8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(-50%) scale(1) translateY(0);
+    }
+  }
+
+  .bb-cmdk-input-wrap {
+    @apply flex items-center gap-3 px-4 border-b border-base-300;
+  }
+
+  .bb-cmdk-input-wrap svg,
+  .bb-cmdk-input-wrap i {
+    @apply w-4 h-4 text-base-content/30 shrink-0;
+  }
+
+  .bb-cmdk-input {
+    @apply w-full py-3.5 text-sm bg-transparent border-none outline-none placeholder:text-base-content/30;
+  }
+
+  .bb-cmdk-input:focus {
+    outline: none;
+    box-shadow: none;
+  }
+
+  .bb-cmdk-list {
+    @apply overflow-y-auto;
+    max-height: min(55vh, 370px);
+    scrollbar-width: thin;
+  }
+
+  .bb-cmdk-group {
+    @apply py-2;
+  }
+
+  .bb-cmdk-group-label {
+    @apply px-4 py-1.5 text-[0.65rem] font-medium text-base-content/35;
+  }
+
+  .bb-cmdk-item {
+    @apply flex items-center gap-3 px-4 py-2 mx-2 rounded-lg text-sm cursor-pointer;
+    transition: background-color 0.1s ease, color 0.1s ease;
+  }
+
+  .bb-cmdk-item:hover,
+  .bb-cmdk-item[data-active="true"] {
+    @apply bg-base-200 text-base-content;
+  }
+
+  .bb-cmdk-item[data-active="true"] {
+    @apply bg-primary/8;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-cmdk-item[data-active="true"] {
+      @apply bg-primary/12;
+    }
+  }
+
+  .bb-cmdk-item-icon {
+    @apply w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0;
+  }
+
+  .bb-cmdk-item[data-active="true"] .bb-cmdk-item-icon {
+    @apply bg-primary/10;
+  }
+
+  .bb-cmdk-item-icon svg,
+  .bb-cmdk-item-icon i {
+    @apply w-4 h-4 text-base-content/40;
+  }
+
+  .bb-cmdk-item[data-active="true"] .bb-cmdk-item-icon svg,
+  .bb-cmdk-item[data-active="true"] .bb-cmdk-item-icon i {
+    @apply text-primary;
+  }
+
+  .bb-cmdk-item-label {
+    @apply flex-1 min-w-0;
+  }
+
+  .bb-cmdk-item-title {
+    @apply text-sm font-medium truncate;
+  }
+
+  .bb-cmdk-item-desc {
+    @apply text-xs text-base-content/40 truncate;
+  }
+
+  .bb-cmdk-item-shortcut {
+    @apply flex items-center gap-1 shrink-0;
+  }
+
+  .bb-cmdk-kbd {
+    @apply inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1
+           text-[0.6rem] font-medium text-base-content/40 bg-base-200 border border-base-300 rounded;
+  }
+
+  .bb-cmdk-footer {
+    @apply flex items-center justify-between px-4 py-2.5 border-t border-base-300 text-[0.65rem] text-base-content/30;
+  }
+
+  .bb-cmdk-footer kbd {
+    @apply inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1
+           text-[0.6rem] font-medium text-base-content/40 bg-base-200 border border-base-300 rounded mx-0.5;
+  }
+
+  .bb-cmdk-empty {
+    @apply flex flex-col items-center justify-center py-12 text-base-content/30;
+  }
+
+  .bb-cmdk-empty svg,
+  .bb-cmdk-empty i {
+    @apply w-8 h-8 mb-2 opacity-40;
+  }
+
+  /* ── Sidebar Cmd+K trigger ── */
+  .bb-sidebar-search {
+    @apply flex items-center gap-2.5 px-3 py-2 mx-0 mb-3 rounded-lg
+           text-sm text-base-content/35 bg-base-200/50 border border-base-300/50
+           cursor-pointer select-none;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .bb-sidebar-search:hover {
+    @apply bg-base-200 border-base-300;
+  }
+
+  .bb-sidebar-search svg,
+  .bb-sidebar-search i {
+    @apply w-3.5 h-3.5;
+  }
+
+  .bb-sidebar-search-hint {
+    @apply ml-auto flex items-center gap-0.5 text-[0.6rem] text-base-content/25;
+  }
+
+  .bb-sidebar-search-hint kbd {
+    @apply inline-flex items-center justify-center min-w-[1.1rem] h-4 px-0.5
+           text-[0.55rem] font-medium bg-base-200 border border-base-300 rounded;
+  }
 }

--- a/input.css
+++ b/input.css
@@ -789,4 +789,113 @@
   .bb-sidebar-version svg, .bb-sidebar-version i {
     @apply opacity-50;
   }
+
+  /* ─── Keyboard Shortcuts Help Overlay ─── */
+  .bb-shortcuts-backdrop {
+    @apply fixed inset-0 z-50;
+    background: oklch(0 0 0 / 0.45);
+    backdrop-filter: blur(6px);
+    animation: bb-shortcuts-backdrop-in 0.15s ease-out;
+  }
+
+  @keyframes bb-shortcuts-backdrop-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .bb-shortcuts-dialog {
+    @apply fixed z-50 bg-base-100 border border-base-300 rounded-xl overflow-hidden;
+    top: min(12%, 100px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(95vw, 640px);
+    max-height: min(80vh, 560px);
+    overflow-y: auto;
+    box-shadow: 0 16px 70px oklch(0 0 0 / 0.15), 0 0 0 1px oklch(0 0 0 / 0.04);
+    animation: bb-shortcuts-dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-shortcuts-dialog {
+      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
+    }
+  }
+
+  @keyframes bb-shortcuts-dialog-in {
+    from {
+      opacity: 0;
+      transform: translateX(-50%) scale(0.96) translateY(-8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(-50%) scale(1) translateY(0);
+    }
+  }
+
+  .bb-shortcuts-header {
+    @apply flex items-center justify-between px-6 py-4 border-b border-base-300 sticky top-0 bg-base-100 z-10;
+  }
+
+  .bb-shortcuts-title {
+    @apply text-sm font-semibold;
+  }
+
+  .bb-shortcuts-close {
+    @apply flex items-center justify-center w-7 h-7 rounded-md
+           text-base-content/40 cursor-pointer border-0 bg-transparent;
+    transition: background-color 0.15s ease, color 0.15s ease;
+  }
+
+  .bb-shortcuts-close:hover {
+    @apply bg-base-200 text-base-content/70;
+  }
+
+  .bb-shortcuts-close svg, .bb-shortcuts-close i {
+    @apply w-4 h-4;
+  }
+
+  .bb-shortcuts-body {
+    @apply px-6 py-5;
+  }
+
+  .bb-shortcuts-group {
+    @apply mb-5;
+  }
+
+  .bb-shortcuts-group:last-child {
+    @apply mb-0;
+  }
+
+  .bb-shortcuts-group-label {
+    @apply text-[0.65rem] font-medium text-base-content/35 mb-2;
+  }
+
+  .bb-shortcuts-row {
+    @apply flex items-center justify-between py-2;
+  }
+
+  .bb-shortcuts-row + .bb-shortcuts-row {
+    @apply border-t border-base-300/50;
+  }
+
+  .bb-shortcuts-label {
+    @apply text-sm text-base-content/70;
+  }
+
+  .bb-shortcuts-keys {
+    @apply flex items-center gap-1.5;
+  }
+
+  .bb-shortcuts-kbd {
+    @apply inline-flex items-center justify-center min-w-[1.5rem] h-6 px-1.5
+           text-[0.65rem] font-medium text-base-content/50 bg-base-200 border border-base-300 rounded;
+  }
+
+  .bb-shortcuts-then {
+    @apply text-[0.6rem] text-base-content/25;
+  }
+
+  .bb-shortcuts-footer {
+    @apply px-6 py-3 border-t border-base-300 text-[0.6rem] text-base-content/25 text-center;
+  }
 }

--- a/input.css
+++ b/input.css
@@ -3,109 +3,107 @@
   themes: false;
 }
 
-/* ─── Breadbox Light Theme (Mercury-inspired) ─── */
+/* ─── Breadbox Light Theme (shadcn/ui neutral palette) ─── */
 @plugin "daisyui/theme" {
   name: "breadbox-light";
   default: true;
   color-scheme: light;
 
-  /* Backgrounds: pure white cards on warm off-white canvas */
-  --color-base-100: oklch(100% 0 0);
-  --color-base-200: oklch(97.5% 0.003 250);
-  --color-base-300: oklch(93% 0.005 250);
-  --color-base-content: oklch(18% 0.005 250);
+  /* Backgrounds: pure white surfaces on very subtle gray canvas */
+  --color-base-100: oklch(1 0 0);          /* pure white — cards, main surfaces */
+  --color-base-200: oklch(0.97 0 0);       /* subtle gray — secondary surfaces, hover */
+  --color-base-300: oklch(0.922 0 0);      /* border gray — dividers, borders */
+  --color-base-content: oklch(0.145 0 0);  /* near-black — primary text */
 
-  /* Primary: refined deep indigo — the singular brand accent */
-  --color-primary: oklch(48% 0.17 265);
-  --color-primary-content: oklch(98% 0.005 265);
+  /* Primary: near-black (shadcn neutral primary) */
+  --color-primary: oklch(0.205 0 0);
+  --color-primary-content: oklch(0.985 0 0);
 
-  /* Secondary: cool slate — for secondary actions and muted UI */
-  --color-secondary: oklch(55% 0.04 260);
-  --color-secondary-content: oklch(98% 0.003 260);
+  /* Secondary: light gray background (shadcn secondary) */
+  --color-secondary: oklch(0.97 0 0);
+  --color-secondary-content: oklch(0.205 0 0);
 
-  /* Accent: soft teal — for special highlights and differentiation */
-  --color-accent: oklch(62% 0.1 195);
-  --color-accent-content: oklch(98% 0.005 195);
+  /* Accent: same as secondary — shadcn is monochrome-first */
+  --color-accent: oklch(0.97 0 0);
+  --color-accent-content: oklch(0.205 0 0);
 
-  /* Neutral: deep charcoal — for badges, tags, overlays */
-  --color-neutral: oklch(20% 0.005 250);
-  --color-neutral-content: oklch(95% 0.003 250);
+  /* Neutral: dark for badges, overlays */
+  --color-neutral: oklch(0.269 0 0);
+  --color-neutral-content: oklch(0.985 0 0);
 
-  /* Semantic: muted, sophisticated tones (not neon) */
-  --color-info: oklch(62% 0.1 245);
-  --color-info-content: oklch(98% 0.005 245);
-  --color-success: oklch(62% 0.14 155);
-  --color-success-content: oklch(98% 0.005 155);
-  --color-warning: oklch(72% 0.14 75);
-  --color-warning-content: oklch(25% 0.05 75);
-  --color-error: oklch(60% 0.17 20);
-  --color-error-content: oklch(98% 0.005 20);
+  /* Semantic: restrained, professional tones */
+  --color-info: oklch(0.62 0.1 245);
+  --color-info-content: oklch(0.985 0 0);
+  --color-success: oklch(0.62 0.14 155);
+  --color-success-content: oklch(0.985 0 0);
+  --color-warning: oklch(0.72 0.14 75);
+  --color-warning-content: oklch(0.205 0 0);
+  --color-error: oklch(0.577 0.245 27.325);
+  --color-error-content: oklch(0.985 0 0);
 
-  /* Shape: generous radius, subtle depth */
+  /* Shape: shadcn radius (0.625rem), minimal depth */
   --radius-selector: 0.625rem;
   --radius-field: 0.5rem;
-  --radius-box: 1rem;
+  --radius-box: 0.75rem;
   --border: 1px;
-  --depth: 1;
+  --depth: 0;
   --noise: 0;
 }
 
-/* ─── Breadbox Dark Theme (rich, warm — not "inverted light") ─── */
+/* ─── Breadbox Dark Theme (shadcn/ui neutral dark) ─── */
 @plugin "daisyui/theme" {
   name: "breadbox-dark";
   prefersdark: true;
   color-scheme: dark;
 
-  /* Backgrounds: warm charcoal tones, NOT blue-tinted */
-  --color-base-100: oklch(20% 0.006 270);
-  --color-base-200: oklch(17.5% 0.005 270);
-  --color-base-300: oklch(15% 0.004 270);
-  --color-base-content: oklch(93% 0.005 250);
+  /* Backgrounds: true dark, slightly lighter cards */
+  --color-base-100: oklch(0.205 0 0);     /* card/surface — slightly lighter than bg */
+  --color-base-200: oklch(0.145 0 0);     /* canvas — near-black background */
+  --color-base-300: oklch(0.269 0 0);     /* borders — subtle separation */
+  --color-base-content: oklch(0.985 0 0); /* near-white text */
 
-  /* Primary: lighter indigo for dark bg contrast */
-  --color-primary: oklch(68% 0.16 265);
-  --color-primary-content: oklch(15% 0.02 265);
+  /* Primary: near-white (inverted from light) */
+  --color-primary: oklch(0.922 0 0);
+  --color-primary-content: oklch(0.205 0 0);
 
-  /* Secondary: lifted slate */
-  --color-secondary: oklch(65% 0.03 260);
-  --color-secondary-content: oklch(15% 0.01 260);
+  /* Secondary: dark gray surface */
+  --color-secondary: oklch(0.269 0 0);
+  --color-secondary-content: oklch(0.985 0 0);
 
-  /* Accent: brightened teal */
-  --color-accent: oklch(72% 0.1 195);
-  --color-accent-content: oklch(15% 0.02 195);
+  /* Accent: same as secondary */
+  --color-accent: oklch(0.269 0 0);
+  --color-accent-content: oklch(0.985 0 0);
 
-  /* Neutral: lifted dark for subtle contrasts */
-  --color-neutral: oklch(25% 0.006 270);
-  --color-neutral-content: oklch(90% 0.003 250);
+  /* Neutral: slightly lifted dark */
+  --color-neutral: oklch(0.269 0 0);
+  --color-neutral-content: oklch(0.985 0 0);
 
   /* Semantic: slightly brighter for dark bg readability */
-  --color-info: oklch(70% 0.1 245);
-  --color-info-content: oklch(15% 0.02 245);
-  --color-success: oklch(70% 0.14 155);
-  --color-success-content: oklch(15% 0.02 155);
-  --color-warning: oklch(78% 0.13 75);
-  --color-warning-content: oklch(20% 0.04 75);
-  --color-error: oklch(68% 0.16 20);
-  --color-error-content: oklch(15% 0.02 20);
+  --color-info: oklch(0.70 0.1 245);
+  --color-info-content: oklch(0.145 0 0);
+  --color-success: oklch(0.70 0.14 155);
+  --color-success-content: oklch(0.145 0 0);
+  --color-warning: oklch(0.78 0.13 75);
+  --color-warning-content: oklch(0.205 0 0);
+  --color-error: oklch(0.704 0.191 22.216);
+  --color-error-content: oklch(0.145 0 0);
 
-  /* Shape: same generous radius */
+  /* Shape: same radius */
   --radius-selector: 0.625rem;
   --radius-field: 0.5rem;
-  --radius-box: 1rem;
+  --radius-box: 0.75rem;
   --border: 1px;
-  --depth: 1;
+  --depth: 0;
   --noise: 0;
 }
 
 /* Utility: hide Alpine.js elements until initialized */
 [x-cloak] { display: none !important; }
 
-/* ─── Mercury-inspired global overrides ─── */
+/* ─── shadcn-inspired global overrides ─── */
 @layer base {
-  /* Smoother scrolling */
   html { scroll-behavior: smooth; }
 
-  /* Better font rendering */
   body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -115,22 +113,22 @@
 /* ─── App-specific component classes ─── */
 @layer components {
 
-  /* ── Cards: Mercury-style soft containers ── */
+  /* ── Cards: shadcn-style — border, not shadow ── */
   .bb-card {
-    @apply bg-base-100 rounded-2xl shadow-sm border border-base-200 transition-shadow duration-200;
+    @apply bg-base-100 rounded-xl border border-base-300 transition-colors duration-150;
   }
 
   .bb-card--interactive {
-    @apply hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 cursor-pointer;
+    @apply hover:bg-base-200/50 cursor-pointer;
   }
 
   /* ── Sidebar ── */
   .bb-sidebar {
-    @apply bg-base-100 min-h-full w-64 px-4 py-6 flex flex-col border-r border-base-200;
+    @apply bg-base-100 min-h-full w-64 px-3 py-5 flex flex-col border-r border-base-300;
   }
 
   .bb-sidebar-brand {
-    @apply text-xl font-bold px-3 py-1 mb-6 no-underline text-base-content flex items-center gap-2;
+    @apply text-lg font-semibold px-3 py-1 mb-5 no-underline text-base-content flex items-center gap-2;
   }
 
   .bb-sidebar-nav {
@@ -138,14 +136,14 @@
   }
 
   .bb-sidebar-section {
-    @apply text-[0.65rem] font-semibold uppercase tracking-widest text-base-content/40 px-3 pt-5 pb-1.5;
+    @apply text-[0.65rem] font-medium uppercase tracking-widest text-base-content/40 px-3 pt-5 pb-1.5;
   }
 
   .bb-sidebar-link {
-    @apply flex items-center gap-3 px-3 py-2 rounded-xl text-sm font-medium
-           text-base-content/70 no-underline
-           transition-all duration-150
-           hover:bg-base-200/80 hover:text-base-content;
+    @apply flex items-center gap-3 px-3 py-1.5 rounded-lg text-sm font-medium
+           text-base-content/60 no-underline
+           transition-colors duration-100
+           hover:bg-base-200 hover:text-base-content;
   }
 
   .bb-sidebar-link--active {
@@ -153,7 +151,7 @@
   }
 
   .bb-sidebar-link i, .bb-sidebar-link svg {
-    @apply w-[1.125rem] h-[1.125rem] opacity-60;
+    @apply w-4 h-4 opacity-50;
   }
 
   .bb-sidebar-link--active i, .bb-sidebar-link--active svg {
@@ -162,7 +160,7 @@
 
   /* ── Filter bar ── */
   .bb-filter-bar {
-    @apply flex flex-wrap items-end gap-4 mb-6;
+    @apply flex flex-wrap items-end gap-3 mb-5;
   }
 
   .bb-filter-bar label {
@@ -213,11 +211,10 @@
     @apply text-base-content;
   }
 
-  /* ── Stat cards (Mercury: soft, no colored borders) ── */
+  /* ── Stat cards (shadcn: clean border, no shadow, no hover lift) ── */
   .bb-stat-card {
-    @apply flex items-center gap-4 rounded-2xl bg-base-100 px-6 py-5
-           shadow-sm border border-base-200 transition-all duration-200 ease-in-out
-           hover:shadow-md hover:-translate-y-0.5;
+    @apply flex items-center gap-4 rounded-xl bg-base-100 px-5 py-4
+           border border-base-300;
   }
 
   .bb-stat-card--primary,
@@ -226,11 +223,11 @@
   .bb-stat-card--warning,
   .bb-stat-card--info,
   .bb-stat-card--neutral {
-    /* No colored left borders in Mercury style — keep them uniform */
+    /* No colored variants — monochrome first */
   }
 
   .bb-stat-card__icon {
-    @apply flex items-center justify-center w-11 h-11 rounded-xl bg-base-200/60 shrink-0;
+    @apply flex items-center justify-center w-10 h-10 rounded-lg bg-base-200 shrink-0;
   }
 
   .bb-stat-card__body {
@@ -238,46 +235,33 @@
   }
 
   .bb-stat-card__value {
-    @apply text-2xl font-bold leading-tight tabular-nums;
+    @apply text-2xl font-semibold leading-tight tabular-nums;
   }
 
   .bb-stat-card__label {
-    @apply text-xs font-medium text-base-content/45 mt-0.5;
+    @apply text-xs font-medium text-base-content/50 mt-0.5;
   }
 
   /* ── Page header pattern ── */
   .bb-page-header {
-    @apply flex items-center justify-between mb-8;
+    @apply flex items-center justify-between mb-6;
   }
 
   .bb-page-title {
-    @apply text-2xl font-bold tracking-tight;
+    @apply text-xl font-semibold tracking-tight;
   }
 
   /* ── Wizard / Auth pages (login, setup, error) ── */
   .bb-wizard-bg {
-    @apply bg-base-200 min-h-screen flex items-center justify-center p-4 relative overflow-hidden;
+    @apply bg-base-200 min-h-screen flex items-center justify-center p-4;
   }
 
   .bb-wizard-orb {
-    @apply absolute pointer-events-none;
-    width: 600px;
-    height: 600px;
-    top: -200px;
-    right: -100px;
-    border-radius: 50%;
-    background: radial-gradient(circle, oklch(48% 0.17 265 / 0.06) 0%, transparent 70%);
-    filter: blur(60px);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    .bb-wizard-orb {
-      background: radial-gradient(circle, oklch(68% 0.16 265 / 0.08) 0%, transparent 70%);
-    }
+    @apply hidden;
   }
 
   .bb-wizard-container {
-    @apply relative z-10 w-full max-w-[420px];
+    @apply w-full max-w-[420px];
   }
 
   .bb-wizard-brand {
@@ -285,26 +269,25 @@
   }
 
   .bb-wizard-brand-icon {
-    @apply w-12 h-12 rounded-2xl bg-primary text-primary-content
-           flex items-center justify-center shadow-md;
+    @apply w-10 h-10 rounded-xl bg-primary text-primary-content
+           flex items-center justify-center;
   }
 
   .bb-wizard-card {
-    @apply bg-base-100 rounded-3xl shadow-lg border border-base-200 p-8;
-    animation: bb-wizard-enter 0.4s ease-out;
+    @apply bg-base-100 rounded-xl border border-base-300 p-6;
+    animation: bb-wizard-enter 0.3s ease-out;
   }
 
   @keyframes bb-wizard-enter {
     from {
       opacity: 0;
-      transform: translateY(12px);
+      transform: translateY(8px);
     }
     to {
       opacity: 1;
       transform: translateY(0);
     }
   }
-
 
   /* ── Error pages (404, 500) ── */
   .bb-error-page {
@@ -318,14 +301,14 @@
   }
 
   .bb-error-icon {
-    @apply w-14 h-14 rounded-2xl flex items-center justify-center mb-6;
+    @apply w-12 h-12 rounded-xl flex items-center justify-center mb-5;
   }
 
   .bb-error-title {
-    @apply text-xl font-bold mb-2;
+    @apply text-lg font-semibold mb-2;
   }
 
   .bb-error-message {
-    @apply text-sm text-base-content/50 max-w-sm mb-8 leading-relaxed;
+    @apply text-sm text-base-content/50 max-w-sm mb-6 leading-relaxed;
   }
 }

--- a/input.css
+++ b/input.css
@@ -249,11 +249,11 @@
   }
 
   .bb-filter-bar select {
-    @apply select select-sm w-auto min-w-[8rem];
+    @apply select select-sm w-full sm:w-auto sm:min-w-[8rem];
   }
 
   .bb-filter-bar input {
-    @apply input input-sm w-auto min-w-[8rem];
+    @apply input input-sm w-full sm:w-auto sm:min-w-[8rem];
   }
 
   /* ── Pagination ── */
@@ -338,7 +338,7 @@
 
   /* ── Page header pattern ── */
   .bb-page-header {
-    @apply flex items-center justify-between mb-6;
+    @apply flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6;
   }
 
   .bb-page-title {
@@ -527,5 +527,39 @@
   /* ── Smooth collapse for filter panels ── */
   [x-collapse] {
     transition: height 0.2s ease-out, opacity 0.15s ease !important;
+  }
+
+  /* ── Mobile sidebar overlay above sticky navbar ── */
+  .drawer-side {
+    z-index: 40 !important;
+  }
+
+  /* ── Responsive stat cards: stack value/label tighter on small screens ── */
+  @media (max-width: 639px) {
+    .bb-stat-card {
+      @apply px-4 py-3 gap-3;
+    }
+    .bb-stat-card__value {
+      @apply text-xl;
+    }
+    .bb-stat-card__icon {
+      @apply w-9 h-9;
+    }
+  }
+
+  /* ── Mobile-friendly info grid ── */
+  @media (max-width: 639px) {
+    .bb-info-grid {
+      @apply grid-cols-1 gap-y-3;
+    }
+    .bb-info-grid dt {
+      @apply mb-0.5;
+    }
+    .bb-info-grid dd {
+      @apply pb-3 border-b border-base-300/50;
+    }
+    .bb-info-grid dd:last-of-type {
+      @apply border-b-0 pb-0;
+    }
   }
 }

--- a/input.css
+++ b/input.css
@@ -898,4 +898,199 @@
   .bb-shortcuts-footer {
     @apply px-6 py-3 border-t border-base-300 text-[0.6rem] text-base-content/25 text-center;
   }
+
+  /* ─── Navigation Progress Bar (YouTube/GitHub style) ─── */
+  .bb-progress-bar {
+    @apply fixed top-0 left-0 right-0 z-[100] h-[2.5px] pointer-events-none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+
+  .bb-progress-bar--active {
+    opacity: 1;
+  }
+
+  .bb-progress-bar__fill {
+    @apply h-full;
+    width: 0%;
+    background: oklch(0.205 0 0);
+    border-radius: 0 2px 2px 0;
+    transition: width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 0 8px oklch(0.205 0 0 / 0.3);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-progress-bar__fill {
+      background: oklch(0.922 0 0);
+      box-shadow: 0 0 8px oklch(0.922 0 0 / 0.3);
+    }
+  }
+
+  .bb-progress-bar__fill--done {
+    width: 100% !important;
+    transition: width 0.2s ease-out;
+  }
+
+  .bb-progress-bar--fade {
+    opacity: 0;
+    transition: opacity 0.4s ease 0.1s;
+  }
+
+  /* ─── Skeleton Loading System ─── */
+  .bb-skeleton {
+    @apply rounded-md;
+    background: oklch(0.95 0 0);
+    position: relative;
+    overflow: hidden;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-skeleton {
+      background: oklch(0.25 0 0);
+    }
+  }
+
+  .bb-skeleton::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      oklch(1 0 0 / 0.4) 50%,
+      transparent 100%
+    );
+    animation: bb-shimmer 1.8s ease-in-out infinite;
+    transform: translateX(-100%);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-skeleton::after {
+      background: linear-gradient(
+        90deg,
+        transparent 0%,
+        oklch(1 0 0 / 0.06) 50%,
+        transparent 100%
+      );
+    }
+  }
+
+  @keyframes bb-shimmer {
+    0% {
+      transform: translateX(-100%);
+    }
+    60%, 100% {
+      transform: translateX(100%);
+    }
+  }
+
+  /* Skeleton size variants */
+  .bb-skeleton--text {
+    @apply h-3.5 rounded;
+    width: 100%;
+  }
+
+  .bb-skeleton--text-sm {
+    @apply h-3 rounded;
+    width: 80%;
+  }
+
+  .bb-skeleton--text-xs {
+    @apply h-2.5 rounded;
+    width: 60%;
+  }
+
+  .bb-skeleton--heading {
+    @apply h-5 rounded w-48;
+  }
+
+  .bb-skeleton--title {
+    @apply h-6 rounded w-56;
+  }
+
+  .bb-skeleton--badge {
+    @apply h-5 w-16 rounded-full;
+  }
+
+  .bb-skeleton--circle {
+    @apply rounded-full;
+    width: 40px;
+    height: 40px;
+  }
+
+  .bb-skeleton--circle-sm {
+    @apply rounded-full;
+    width: 32px;
+    height: 32px;
+  }
+
+  .bb-skeleton--avatar {
+    @apply rounded-xl;
+    width: 48px;
+    height: 48px;
+  }
+
+  .bb-skeleton--amount {
+    @apply h-7 w-24 rounded;
+  }
+
+  .bb-skeleton--btn {
+    @apply h-8 w-20 rounded-lg;
+  }
+
+  .bb-skeleton--card {
+    @apply rounded-xl border border-base-300 p-6;
+    background: oklch(0.98 0 0);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-skeleton--card {
+      background: oklch(0.22 0 0);
+    }
+  }
+
+  /* Pre-built skeleton patterns */
+  .bb-skeleton-stat {
+    @apply flex items-center gap-4 rounded-xl border border-base-300 px-5 py-4;
+  }
+
+  .bb-skeleton-table-row {
+    @apply flex items-center gap-4 px-4 py-3 border-b border-base-300/50;
+  }
+
+  .bb-skeleton-table-row:last-child {
+    @apply border-b-0;
+  }
+
+  .bb-skeleton-list-item {
+    @apply flex items-center gap-3 p-3 rounded-xl;
+  }
+
+  /* Page-level skeleton overlay (shown during nav transitions) */
+  .bb-page-skeleton {
+    @apply min-h-[60vh];
+    animation: bb-skeleton-enter 0.2s ease-out both;
+  }
+
+  @keyframes bb-skeleton-enter {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  /* Inline loading fade */
+  .bb-loading-fade {
+    opacity: 0.5;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+
+  /* Pulse animation for active skeleton areas */
+  .bb-skeleton-pulse {
+    animation: bb-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  }
+
+  @keyframes bb-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+  }
 }

--- a/input.css
+++ b/input.css
@@ -108,6 +108,66 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+
+  /* ── Themed text selection ── */
+  ::selection {
+    background: oklch(0.205 0 0 / 0.15);
+    color: oklch(0.145 0 0);
+  }
+  @media (prefers-color-scheme: dark) {
+    ::selection {
+      background: oklch(0.922 0 0 / 0.2);
+      color: oklch(0.985 0 0);
+    }
+  }
+
+  /* ── Focus rings: accessible, consistent, shadcn-style ── */
+  :focus-visible {
+    outline: 2px solid oklch(0.205 0 0 / 0.4);
+    outline-offset: 2px;
+    border-radius: inherit;
+  }
+  @media (prefers-color-scheme: dark) {
+    :focus-visible {
+      outline-color: oklch(0.922 0 0 / 0.4);
+    }
+  }
+
+  /* ── Thin scrollbars ── */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: oklch(0.922 0 0 / 0.5) transparent;
+  }
+  @media (prefers-color-scheme: dark) {
+    * {
+      scrollbar-color: oklch(0.269 0 0 / 0.7) transparent;
+    }
+  }
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: oklch(0.922 0 0 / 0.5);
+    border-radius: 3px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: oklch(0.922 0 0 / 0.7);
+  }
+  @media (prefers-color-scheme: dark) {
+    ::-webkit-scrollbar-thumb {
+      background: oklch(0.269 0 0 / 0.7);
+    }
+    ::-webkit-scrollbar-thumb:hover {
+      background: oklch(0.4 0 0 / 0.7);
+    }
+  }
+
+  /* ── Global link transitions ── */
+  a { transition: color 0.15s ease; }
 }
 
 /* ─── App-specific component classes ─── */
@@ -115,11 +175,23 @@
 
   /* ── Cards: shadcn-style — border, not shadow ── */
   .bb-card {
-    @apply bg-base-100 rounded-xl border border-base-300 transition-colors duration-150;
+    @apply bg-base-100 rounded-xl border border-base-300;
+    transition: background-color 0.15s ease, border-color 0.15s ease, box-shadow 0.2s ease;
   }
 
   .bb-card--interactive {
-    @apply hover:bg-base-200/50 cursor-pointer;
+    @apply cursor-pointer;
+  }
+
+  .bb-card--interactive:hover {
+    @apply bg-base-200/50;
+    border-color: oklch(0.85 0 0);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-card--interactive:hover {
+      border-color: oklch(0.35 0 0);
+    }
   }
 
   /* ── Sidebar ── */
@@ -142,8 +214,12 @@
   .bb-sidebar-link {
     @apply flex items-center gap-3 px-3 py-1.5 rounded-lg text-sm font-medium
            text-base-content/60 no-underline
-           transition-colors duration-100
            hover:bg-base-200 hover:text-base-content;
+    transition: background-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
+  }
+
+  .bb-sidebar-link:active {
+    transform: scale(0.98);
   }
 
   .bb-sidebar-link--active {
@@ -152,6 +228,11 @@
 
   .bb-sidebar-link i, .bb-sidebar-link svg {
     @apply w-4 h-4 opacity-50;
+    transition: opacity 0.15s ease;
+  }
+
+  .bb-sidebar-link:hover i, .bb-sidebar-link:hover svg {
+    @apply opacity-70;
   }
 
   .bb-sidebar-link--active i, .bb-sidebar-link--active svg {
@@ -211,10 +292,22 @@
     @apply text-base-content;
   }
 
-  /* ── Stat cards (shadcn: clean border, no shadow, no hover lift) ── */
+  /* ── Stat cards (shadcn: clean border, subtle hover) ── */
   .bb-stat-card {
     @apply flex items-center gap-4 rounded-xl bg-base-100 px-5 py-4
            border border-base-300;
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+  }
+
+  a.bb-stat-card:hover {
+    @apply bg-base-200/50;
+    border-color: oklch(0.85 0 0);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    a.bb-stat-card:hover {
+      border-color: oklch(0.35 0 0);
+    }
   }
 
   .bb-stat-card--primary,
@@ -228,6 +321,7 @@
 
   .bb-stat-card__icon {
     @apply flex items-center justify-center w-10 h-10 rounded-lg bg-base-200 shrink-0;
+    transition: background-color 0.15s ease;
   }
 
   .bb-stat-card__body {
@@ -310,5 +404,118 @@
 
   .bb-error-message {
     @apply text-sm text-base-content/50 max-w-sm mb-6 leading-relaxed;
+  }
+
+  /* ── Page entrance animation ── */
+  .bb-page-enter {
+    animation: bb-page-enter 0.25s ease-out both;
+  }
+
+  @keyframes bb-page-enter {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* Staggered children animation */
+  .bb-stagger > * {
+    animation: bb-page-enter 0.25s ease-out both;
+  }
+  .bb-stagger > *:nth-child(1) { animation-delay: 0ms; }
+  .bb-stagger > *:nth-child(2) { animation-delay: 40ms; }
+  .bb-stagger > *:nth-child(3) { animation-delay: 80ms; }
+  .bb-stagger > *:nth-child(4) { animation-delay: 120ms; }
+  .bb-stagger > *:nth-child(5) { animation-delay: 160ms; }
+  .bb-stagger > *:nth-child(6) { animation-delay: 200ms; }
+
+  /* ── Button polish ── */
+  .btn {
+    transition: background-color 0.15s ease, color 0.15s ease,
+                border-color 0.15s ease, transform 0.1s ease,
+                box-shadow 0.15s ease, opacity 0.15s ease !important;
+  }
+
+  .btn:active:not(:disabled) {
+    transform: scale(0.97) !important;
+  }
+
+  /* ── Badge transitions ── */
+  .badge {
+    transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  }
+
+  /* ── Table row polish ── */
+  .table tbody tr {
+    transition: background-color 0.12s ease;
+  }
+
+  /* ── Toggle transitions ── */
+  .toggle {
+    transition: background-color 0.2s ease, border-color 0.2s ease !important;
+  }
+
+  /* ── Select/Input focus transitions ── */
+  .select, .input, .textarea {
+    transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease !important;
+  }
+
+  /* ── Modal backdrop smooth ── */
+  .modal-backdrop {
+    transition: opacity 0.2s ease !important;
+  }
+
+  /* ── Toast entrance ── */
+  .toast .alert {
+    animation: bb-toast-enter 0.3s ease-out both;
+  }
+
+  @keyframes bb-toast-enter {
+    from {
+      opacity: 0;
+      transform: translateX(20px) scale(0.95);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(0) scale(1);
+    }
+  }
+
+  /* ── Dropdown smooth open ── */
+  .dropdown-content {
+    animation: bb-dropdown-enter 0.15s ease-out both;
+  }
+
+  @keyframes bb-dropdown-enter {
+    from {
+      opacity: 0;
+      transform: translateY(-4px) scale(0.98);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  /* ── Category picker shake animation (reviews page) ── */
+  .bb-picker-shake {
+    animation: bb-shake 0.4s ease-in-out;
+  }
+
+  @keyframes bb-shake {
+    0%, 100% { transform: translateX(0); }
+    20% { transform: translateX(-4px); }
+    40% { transform: translateX(4px); }
+    60% { transform: translateX(-3px); }
+    80% { transform: translateX(3px); }
+  }
+
+  /* ── Smooth collapse for filter panels ── */
+  [x-collapse] {
+    transition: height 0.2s ease-out, opacity 0.15s ease !important;
   }
 }

--- a/input.css
+++ b/input.css
@@ -738,4 +738,55 @@
     @apply inline-flex items-center justify-center min-w-[1.1rem] h-4 px-0.5
            text-[0.55rem] font-medium bg-base-200 border border-base-300 rounded;
   }
+
+  /* ── Sidebar user profile ── */
+  .bb-sidebar-profile {
+    @apply flex items-center gap-2.5 px-2 py-2 rounded-lg;
+    transition: background-color 0.15s ease;
+  }
+
+  .bb-sidebar-profile-avatar {
+    @apply w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center
+           text-xs font-semibold text-primary shrink-0 uppercase;
+    transition: background-color 0.15s ease;
+  }
+
+  .bb-sidebar-profile-info {
+    @apply flex-1 min-w-0;
+  }
+
+  .bb-sidebar-profile-name {
+    @apply text-sm font-medium text-base-content truncate leading-tight;
+  }
+
+  .bb-sidebar-profile-role {
+    @apply text-[0.65rem] text-base-content/35 leading-tight mt-0.5;
+  }
+
+  .bb-sidebar-profile-logout {
+    @apply shrink-0;
+  }
+
+  .bb-sidebar-logout-btn {
+    @apply flex items-center justify-center w-7 h-7 rounded-md
+           text-base-content/30 cursor-pointer border-0 bg-transparent;
+    transition: background-color 0.15s ease, color 0.15s ease;
+  }
+
+  .bb-sidebar-logout-btn:hover {
+    @apply bg-base-200 text-base-content/60;
+  }
+
+  .bb-sidebar-logout-btn svg, .bb-sidebar-logout-btn i {
+    @apply w-3.5 h-3.5;
+  }
+
+  /* ── Sidebar version badge ── */
+  .bb-sidebar-version {
+    @apply flex items-center gap-1.5 px-3 mt-2 text-[0.6rem] text-base-content/20;
+  }
+
+  .bb-sidebar-version svg, .bb-sidebar-version i {
+    @apply opacity-50;
+  }
 }

--- a/input.css
+++ b/input.css
@@ -208,7 +208,7 @@
   }
 
   .bb-sidebar-section {
-    @apply text-[0.65rem] font-medium uppercase tracking-widest text-base-content/40 px-3 pt-5 pb-1.5;
+    @apply text-[0.65rem] font-medium text-base-content/40 px-3 pt-5 pb-1.5;
   }
 
   .bb-sidebar-link {

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"math"
 	"net/http"
+	"sort"
 	"time"
 
 	"breadbox/internal/app"
@@ -190,6 +192,96 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			totalSpending = *categorySummary.Totals.TotalAmount
 		}
 
+		// Total income (30 days) — negative amounts in our system are credits/income.
+		var totalIncome float64
+		if dailySummary != nil {
+			for _, row := range dailySummary.Summary {
+				if row.TotalAmount < 0 {
+					totalIncome += -row.TotalAmount
+				}
+			}
+		}
+
+		// Accounts with balances for the overview section.
+		accounts, err := svc.ListAccounts(ctx, nil)
+		if err != nil {
+			a.Logger.Error("list accounts for dashboard", "error", err)
+		}
+
+		// Compute net worth and group by type.
+		var netWorth float64
+		var totalAssets, totalLiabilities float64
+		type DashboardAccount struct {
+			ID              string
+			Name            string
+			InstitutionName string
+			Type            string
+			Subtype         string
+			Mask            string
+			BalanceCurrent  float64
+			IsoCurrencyCode string
+			IsLiability     bool
+		}
+		var dashAccounts []DashboardAccount
+		for _, acct := range accounts {
+			if acct.BalanceCurrent == nil {
+				continue
+			}
+			bal := *acct.BalanceCurrent
+			institution := ""
+			if acct.InstitutionName != nil {
+				institution = *acct.InstitutionName
+			}
+			subtype := ""
+			if acct.Subtype != nil {
+				subtype = *acct.Subtype
+			}
+			mask := ""
+			if acct.Mask != nil {
+				mask = *acct.Mask
+			}
+			currency := "USD"
+			if acct.IsoCurrencyCode != nil {
+				currency = *acct.IsoCurrencyCode
+			}
+
+			isLiability := acct.Type == "credit" || acct.Type == "loan"
+			if isLiability {
+				totalLiabilities += math.Abs(bal)
+				netWorth -= math.Abs(bal)
+			} else {
+				totalAssets += bal
+				netWorth += bal
+			}
+
+			dashAccounts = append(dashAccounts, DashboardAccount{
+				ID:              acct.ID,
+				Name:            acct.Name,
+				InstitutionName: institution,
+				Type:            acct.Type,
+				Subtype:         subtype,
+				Mask:            mask,
+				BalanceCurrent:  bal,
+				IsoCurrencyCode: currency,
+				IsLiability:     isLiability,
+			})
+		}
+		// Sort: depository first, then credit, then loan, then others.
+		typeOrder := map[string]int{"depository": 0, "investment": 1, "credit": 2, "loan": 3}
+		sort.Slice(dashAccounts, func(i, j int) bool {
+			oi, oj := 4, 4
+			if v, ok := typeOrder[dashAccounts[i].Type]; ok {
+				oi = v
+			}
+			if v, ok := typeOrder[dashAccounts[j].Type]; ok {
+				oj = v
+			}
+			if oi != oj {
+				return oi < oj
+			}
+			return dashAccounts[i].Name < dashAccounts[j].Name
+		})
+
 		data := map[string]any{
 			"PageTitle":              "Dashboard",
 			"CurrentPage":            "dashboard",
@@ -215,6 +307,11 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"DailyAmounts":           dailyAmountsJSON,
 			"RecentTransactions":     recentTransactions,
 			"TotalSpending":          totalSpending,
+			"TotalIncome":            totalIncome,
+			"Accounts":              dashAccounts,
+			"NetWorth":              netWorth,
+			"TotalAssets":           totalAssets,
+			"TotalLiabilities":     totalLiabilities,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -385,6 +385,7 @@ var templatePartials = []string{
 	"partials/flash.html",
 	"partials/nav.html",
 	"partials/category_picker.html",
+	"partials/skeletons.html",
 }
 
 func (tr *TemplateRenderer) parseTemplates() error {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
+	"math"
 	"net/http"
 	"path"
 	"sync"
@@ -163,6 +164,80 @@ func NewTemplateRenderer() (*TemplateRenderer, error) {
 					return fmt.Sprintf("-$%.2f", -amount)
 				}
 				return fmt.Sprintf("$%.2f", amount)
+			},
+			"formatBalance": func(amount float64) string {
+				abs := math.Abs(amount)
+				if abs >= 1_000_000 {
+					return fmt.Sprintf("$%.1fM", abs/1_000_000)
+				}
+				if abs >= 1_000 {
+					whole := int(abs)
+					cents := int((abs - float64(whole)) * 100)
+					// Format with comma separators
+					s := fmt.Sprintf("%d", whole)
+					if len(s) > 3 {
+						result := ""
+						for i, c := range s {
+							if i > 0 && (len(s)-i)%3 == 0 {
+								result += ","
+							}
+							result += string(c)
+						}
+						s = result
+					}
+					return fmt.Sprintf("$%s.%02d", s, cents)
+				}
+				return fmt.Sprintf("$%.2f", abs)
+			},
+			"accountTypeIcon": func(acctType string) string {
+				switch acctType {
+				case "depository":
+					return "landmark"
+				case "credit":
+					return "credit-card"
+				case "loan":
+					return "file-text"
+				case "investment":
+					return "trending-up"
+				default:
+					return "wallet"
+				}
+			},
+			"accountTypeLabel": func(acctType, subtype string) string {
+				if subtype != "" {
+					labels := map[string]string{
+						"checking":         "Checking",
+						"savings":          "Savings",
+						"credit card":      "Credit Card",
+						"credit_card":      "Credit Card",
+						"money market":     "Money Market",
+						"money_market":     "Money Market",
+						"cd":               "CD",
+						"paypal":           "PayPal",
+						"student":          "Student Loan",
+						"mortgage":         "Mortgage",
+						"auto":             "Auto Loan",
+						"401k":             "401(k)",
+						"ira":              "IRA",
+						"brokerage":        "Brokerage",
+						"prepaid":          "Prepaid",
+						"hsa":              "HSA",
+					}
+					if label, ok := labels[subtype]; ok {
+						return label
+					}
+					return subtype
+				}
+				labels := map[string]string{
+					"depository":  "Bank Account",
+					"credit":     "Credit Card",
+					"loan":       "Loan",
+					"investment": "Investment",
+				}
+				if label, ok := labels[acctType]; ok {
+					return label
+				}
+				return acctType
 			},
 			"formatNumeric": func(n pgtype.Numeric) string {
 				if !n.Valid {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -43,12 +43,16 @@ type TemplateRenderer struct {
 	mu        sync.RWMutex
 	templates map[string]*template.Template
 	funcMap   template.FuncMap
+	sm        *scs.SessionManager
+	version   string
 }
 
 // NewTemplateRenderer parses all embedded templates and returns a renderer.
-func NewTemplateRenderer() (*TemplateRenderer, error) {
+// sm is used to auto-inject the admin username into template data.
+func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 	tr := &TemplateRenderer{
 		templates: make(map[string]*template.Template),
+		sm:        sm,
 		funcMap: template.FuncMap{
 			"sub": func(a, b int) int { return a - b },
 			"add": func(a, b int) int { return a + b },
@@ -425,6 +429,16 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, name 
 		return
 	}
 
+	// Auto-inject common fields into map data if not already present.
+	if m, ok := data.(map[string]any); ok {
+		if _, exists := m["AdminUsername"]; !exists && tr.sm != nil {
+			m["AdminUsername"] = tr.sm.GetString(r.Context(), sessionKeyAdminUsername)
+		}
+		if _, exists := m["AppVersion"]; !exists && tr.version != "" {
+			m["AppVersion"] = tr.version
+		}
+	}
+
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	if err := t.ExecuteTemplate(w, "layout", data); err != nil {
 		http.Error(w, "template render error: "+err.Error(), http.StatusInternalServerError)
@@ -435,11 +449,22 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, name 
 // Handlers can add page-specific fields to the returned map before rendering.
 func BaseTemplateData(r *http.Request, sm *scs.SessionManager, currentPage, pageTitle string) map[string]any {
 	return map[string]any{
-		"PageTitle":   pageTitle,
-		"CurrentPage": currentPage,
-		"Flash":       GetFlash(r.Context(), sm),
-		"CSRFToken":   GetCSRFToken(r),
+		"PageTitle":     pageTitle,
+		"CurrentPage":   currentPage,
+		"Flash":         GetFlash(r.Context(), sm),
+		"CSRFToken":     GetCSRFToken(r),
+		"AdminUsername": sm.GetString(r.Context(), sessionKeyAdminUsername),
 	}
+}
+
+// SetVersion sets the application version for auto-injection into template data.
+func (tr *TemplateRenderer) SetVersion(v string) {
+	tr.version = v
+}
+
+// AdminUsername returns the admin username from the session for use in template data maps.
+func AdminUsername(r *http.Request, sm *scs.SessionManager) string {
+	return sm.GetString(r.Context(), sessionKeyAdminUsername)
 }
 
 // RenderTo writes the named template to any io.Writer.

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -239,6 +239,64 @@ func NewTemplateRenderer() (*TemplateRenderer, error) {
 				}
 				return acctType
 			},
+			"formatDateTime": func(t interface{}) string {
+				format := func(tm time.Time) string {
+					return tm.Local().Format("Jan 2, 2006 3:04 PM")
+				}
+				switch v := t.(type) {
+				case time.Time:
+					return format(v)
+				case *time.Time:
+					if v == nil {
+						return ""
+					}
+					return format(*v)
+				case string:
+					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
+						return format(parsed)
+					}
+					return v
+				case *string:
+					if v == nil {
+						return ""
+					}
+					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
+						return format(parsed)
+					}
+					return *v
+				default:
+					return ""
+				}
+			},
+			"formatDateShort": func(t interface{}) string {
+				format := func(tm time.Time) string {
+					return tm.Local().Format("Jan 2, 3:04 PM")
+				}
+				switch v := t.(type) {
+				case time.Time:
+					return format(v)
+				case *time.Time:
+					if v == nil {
+						return ""
+					}
+					return format(*v)
+				case string:
+					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
+						return format(parsed)
+					}
+					return v
+				case *string:
+					if v == nil {
+						return ""
+					}
+					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
+						return format(parsed)
+					}
+					return *v
+				default:
+					return ""
+				}
+			},
 			"formatNumeric": func(n pgtype.Numeric) string {
 				if !n.Valid {
 					return ""

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -312,6 +312,59 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return fmt.Sprintf("%.2f", f.Float64)
 			},
+			"fmtBalance": func(v interface{}) string {
+				var f float64
+				switch val := v.(type) {
+				case *float64:
+					if val == nil {
+						return ""
+					}
+					f = *val
+				case float64:
+					f = val
+				default:
+					return ""
+				}
+				neg := f < 0
+				abs := math.Abs(f)
+				whole := int(abs)
+				cents := int(math.Round((abs - float64(whole)) * 100))
+				s := fmt.Sprintf("%d", whole)
+				if len(s) > 3 {
+					result := ""
+					for i, c := range s {
+						if i > 0 && (len(s)-i)%3 == 0 {
+							result += ","
+						}
+						result += string(c)
+					}
+					s = result
+				}
+				formatted := fmt.Sprintf("$%s.%02d", s, cents)
+				if neg {
+					formatted = "-" + formatted
+				}
+				return formatted
+			},
+			"fmtFloat": func(v interface{}) string {
+				switch val := v.(type) {
+				case *float64:
+					if val == nil {
+						return ""
+					}
+					return fmt.Sprintf("%.2f", *val)
+				case float64:
+					return fmt.Sprintf("%.2f", val)
+				default:
+					return ""
+				}
+			},
+			"pgtext": func(v pgtype.Text) string {
+				if !v.Valid {
+					return ""
+				}
+				return v.String
+			},
 		},
 	}
 	if err := tr.parseTemplates(); err != nil {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -164,10 +164,13 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				return t.Before(time.Now())
 			},
 			"formatAmount": func(amount float64) string {
-				if amount < 0 {
-					return fmt.Sprintf("-$%.2f", -amount)
+				neg := amount < 0
+				abs := math.Abs(amount)
+				formatted := formatCurrency(abs)
+				if neg {
+					return "-" + formatted
 				}
-				return fmt.Sprintf("$%.2f", amount)
+				return formatted
 			},
 			"formatBalance": func(amount float64) string {
 				abs := math.Abs(amount)
@@ -301,16 +304,21 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return ""
 				}
 			},
+			"formatDate": func(s string) string {
+				if t, err := time.Parse("2006-01-02", s); err == nil {
+					return t.Format("Jan 2, 2006")
+				}
+				return s
+			},
 			"formatNumeric": func(n pgtype.Numeric) string {
 				if !n.Valid {
 					return ""
 				}
-				// Use the decimal representation from the numeric value.
 				f, err := n.Float64Value()
 				if err != nil || !f.Valid {
 					return ""
 				}
-				return fmt.Sprintf("%.2f", f.Float64)
+				return formatCurrency(math.Abs(f.Float64))
 			},
 			"fmtBalance": func(v interface{}) string {
 				var f float64
@@ -513,6 +521,24 @@ func BaseTemplateData(r *http.Request, sm *scs.SessionManager, currentPage, page
 // SetVersion sets the application version for auto-injection into template data.
 func (tr *TemplateRenderer) SetVersion(v string) {
 	tr.version = v
+}
+
+// formatCurrency formats a non-negative float as "$X,XXX.XX".
+func formatCurrency(abs float64) string {
+	whole := int(abs)
+	cents := int(math.Round((abs - float64(whole)) * 100))
+	s := fmt.Sprintf("%d", whole)
+	if len(s) > 3 {
+		result := ""
+		for i, c := range s {
+			if i > 0 && (len(s)-i)%3 == 0 {
+				result += ","
+			}
+			result += string(c)
+		}
+		s = result
+	}
+	return fmt.Sprintf("$%s.%02d", s, cents)
 }
 
 // AdminUsername returns the admin username from the session for use in template data maps.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -111,10 +111,11 @@ func NewRouter(a *app.App, version string) http.Handler {
 	// Admin dashboard: session manager + template renderer + admin router.
 	isSecure := a.Config.Environment == "production" || a.Config.Environment == "docker"
 	sm := admin.NewSessionManager(a.DB, isSecure)
-	tr, err := admin.NewTemplateRenderer()
+	tr, err := admin.NewTemplateRenderer(sm)
 	if err != nil {
 		a.Logger.Error("failed to initialize template renderer", "error", err)
 	} else {
+		tr.SetVersion(a.Config.Version)
 		adminRouter := admin.NewAdminRouter(a, sm, tr, svc, mcpServer)
 		r.Mount("/", adminRouter)
 	}

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -85,6 +85,153 @@
     </template>
   </div>
 
+  <!-- Keyboard Shortcuts Help (?-key) -->
+  <div x-data="shortcutsHelp()" x-show="open" x-cloak
+       @open-shortcuts.window="openHelp()"
+       @keydown.window.escape="if (open) { open = false; $event.stopPropagation(); }">
+    <div class="bb-shortcuts-backdrop" @click="open = false"></div>
+    <div class="bb-shortcuts-dialog">
+      <div class="bb-shortcuts-header">
+        <span class="bb-shortcuts-title">Keyboard Shortcuts</span>
+        <button class="bb-shortcuts-close" @click="open = false">
+          <i data-lucide="x"></i>
+        </button>
+      </div>
+      <div class="bb-shortcuts-body">
+        <!-- General -->
+        <div class="bb-shortcuts-group">
+          <div class="bb-shortcuts-group-label">General</div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Open command palette</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">&#8984;</kbd>
+              <kbd class="bb-shortcuts-kbd">K</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Show keyboard shortcuts</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">?</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Close dialog / cancel</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">Esc</kbd>
+            </span>
+          </div>
+        </div>
+        <!-- Go to navigation -->
+        <div class="bb-shortcuts-group">
+          <div class="bb-shortcuts-group-label">Go to</div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Dashboard</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">g</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">d</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Transactions</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">g</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">t</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Connections</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">g</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">c</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Reviews</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">g</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">r</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Rules</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">g</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">u</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Categories</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">g</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">a</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Sync Logs</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">g</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">l</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Settings</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">g</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">s</kbd>
+            </span>
+          </div>
+        </div>
+        <!-- Actions -->
+        <div class="bb-shortcuts-group">
+          <div class="bb-shortcuts-group-label">Actions</div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Connect a bank</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">n</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">c</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Import CSV</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">n</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">i</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Create API key</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">n</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">k</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Add family member</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">n</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">u</kbd>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div class="bb-shortcuts-footer">
+        Press <kbd class="bb-shortcuts-kbd" style="display:inline-flex;vertical-align:middle;">?</kbd> anytime to toggle this panel
+      </div>
+    </div>
+  </div>
+
   <!-- Command Palette (Cmd+K) -->
   <div x-data="commandPalette()" x-show="open" x-cloak
        @open-cmdk.window="openPalette()"
@@ -152,6 +299,7 @@
           <span><kbd>&uarr;</kbd> <kbd>&darr;</kbd> navigate</span>
           <span><kbd>&crarr;</kbd> open</span>
           <span><kbd>esc</kbd> close</span>
+          <span><kbd>?</kbd> shortcuts</span>
         </div>
       </div>
     </div>
@@ -302,6 +450,135 @@
         }
       };
     }
+
+    // Shortcuts Help Panel
+    function shortcutsHelp() {
+      return {
+        open: false,
+        openHelp: function() {
+          this.open = true;
+          var self = this;
+          setTimeout(function() {
+            var dialog = document.querySelector('.bb-shortcuts-dialog');
+            if (dialog) lucide.createIcons({ nodes: [dialog] });
+          }, 50);
+        }
+      };
+    }
+
+    // Global Keyboard Shortcuts (vim-style g+key navigation, ?-key help)
+    (function() {
+      var pendingPrefix = null;
+      var prefixTimeout = null;
+      var COMBO_WINDOW = 800; // ms to type second key
+
+      // Route maps for two-key combos
+      var goRoutes = {
+        d: '/',
+        t: '/transactions',
+        c: '/connections',
+        r: '/reviews',
+        u: '/rules',
+        a: '/categories',
+        l: '/sync-logs',
+        s: '/settings',
+        p: '/providers',
+        m: '/mcp-settings',
+        k: '/api-keys',
+        f: '/users'
+      };
+
+      var newRoutes = {
+        c: '/connections/new',
+        i: '/connections/import-csv',
+        k: '/api-keys/new',
+        u: '/users/new'
+      };
+
+      function isInputFocused() {
+        var el = document.activeElement;
+        if (!el) return false;
+        var tag = el.tagName.toLowerCase();
+        if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+        if (el.contentEditable === 'true') return true;
+        return false;
+      }
+
+      function isOverlayOpen() {
+        // Check if command palette or shortcuts help is open
+        var cmdkEl = document.querySelector('[x-data="commandPalette()"]');
+        var shortcutsEl = document.querySelector('[x-data="shortcutsHelp()"]');
+        if (cmdkEl && cmdkEl.style.display !== 'none' && cmdkEl.__x && cmdkEl.__x.$data && cmdkEl.__x.$data.open) return true;
+        if (shortcutsEl && shortcutsEl.style.display !== 'none' && shortcutsEl.__x && shortcutsEl.__x.$data && shortcutsEl.__x.$data.open) return true;
+        // Also check by visibility of backdrop
+        var backdrops = document.querySelectorAll('.bb-cmdk-backdrop, .bb-shortcuts-backdrop');
+        for (var i = 0; i < backdrops.length; i++) {
+          if (backdrops[i].offsetParent !== null) return true;
+        }
+        return false;
+      }
+
+      function clearPrefix() {
+        pendingPrefix = null;
+        if (prefixTimeout) {
+          clearTimeout(prefixTimeout);
+          prefixTimeout = null;
+        }
+      }
+
+      document.addEventListener('keydown', function(e) {
+        // Skip if modifier keys are held (except shift for ?)
+        if (e.ctrlKey || e.metaKey || e.altKey) return;
+        // Skip if typing in an input
+        if (isInputFocused()) return;
+        // Skip if an overlay is open
+        if (isOverlayOpen()) return;
+
+        var key = e.key;
+
+        // ? opens shortcuts help (shift + / on most keyboards)
+        if (key === '?') {
+          e.preventDefault();
+          window.dispatchEvent(new CustomEvent('open-shortcuts'));
+          clearPrefix();
+          return;
+        }
+
+        // / focuses the command palette (like GitHub)
+        if (key === '/') {
+          e.preventDefault();
+          window.dispatchEvent(new CustomEvent('open-cmdk'));
+          clearPrefix();
+          return;
+        }
+
+        // Two-key combos: g+key, n+key
+        if (pendingPrefix) {
+          var prefix = pendingPrefix;
+          clearPrefix();
+
+          var routes = null;
+          if (prefix === 'g') routes = goRoutes;
+          else if (prefix === 'n') routes = newRoutes;
+
+          if (routes && routes[key]) {
+            e.preventDefault();
+            window.location.href = routes[key];
+          }
+          return;
+        }
+
+        // Start a prefix sequence
+        if (key === 'g' || key === 'n') {
+          pendingPrefix = key;
+          prefixTimeout = setTimeout(function() {
+            pendingPrefix = null;
+            prefixTimeout = null;
+          }, COMBO_WINDOW);
+          return;
+        }
+      });
+    })();
   </script>
 </body>
 </html>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -30,6 +30,11 @@
         <div class="flex-1 min-w-0">
           <span class="text-sm font-semibold truncate">{{.PageTitle}}</span>
         </div>
+        <div class="flex-none">
+          <button class="btn btn-square btn-ghost" @click="$dispatch('open-cmdk')">
+            <i data-lucide="search" class="w-4 h-4"></i>
+          </button>
+        </div>
       </div>
       <!-- Page content -->
       <main class="p-4 sm:p-6 max-w-6xl min-h-screen bb-page-enter">
@@ -47,6 +52,14 @@
           <i data-lucide="package" class="w-5 h-5"></i>
           Breadbox
         </a>
+        <!-- Search trigger -->
+        <div class="bb-sidebar-search" @click="$dispatch('open-cmdk')" role="button" tabindex="0" @keydown.enter="$dispatch('open-cmdk')">
+          <i data-lucide="search"></i>
+          <span>Search...</span>
+          <span class="bb-sidebar-search-hint">
+            <kbd>&#8984;</kbd><kbd>K</kbd>
+          </span>
+        </div>
         {{template "nav" .}}
       </aside>
     </div>
@@ -72,6 +85,78 @@
     </template>
   </div>
 
+  <!-- Command Palette (Cmd+K) -->
+  <div x-data="commandPalette()" x-show="open" x-cloak
+       @open-cmdk.window="openPalette()"
+       @keydown.window="handleGlobalKey($event)">
+    <!-- Backdrop -->
+    <div class="bb-cmdk-backdrop" @click="closePalette()"></div>
+    <!-- Dialog -->
+    <div class="bb-cmdk-dialog" @keydown.escape.prevent="closePalette()" @keydown.arrow-down.prevent="moveDown()" @keydown.arrow-up.prevent="moveUp()" @keydown.enter.prevent="selectActive()">
+      <!-- Search input -->
+      <div class="bb-cmdk-input-wrap">
+        <i data-lucide="search"></i>
+        <input type="text"
+          class="bb-cmdk-input"
+          placeholder="Type a command or search..."
+          x-ref="cmdkInput"
+          x-model="query"
+          @input="onInput()"
+          autocomplete="off"
+          spellcheck="false">
+        <div class="bb-cmdk-kbd" style="font-size:0.6rem" @click="closePalette()">esc</div>
+      </div>
+
+      <!-- Results list -->
+      <div class="bb-cmdk-list" x-ref="cmdkList">
+        <template x-if="filteredItems.length === 0 && query.length > 0">
+          <div class="bb-cmdk-empty">
+            <i data-lucide="search-x"></i>
+            <span class="text-sm">No results found</span>
+          </div>
+        </template>
+        <template x-for="(group, gi) in filteredGroups" :key="group.label">
+          <div class="bb-cmdk-group">
+            <div class="bb-cmdk-group-label" x-text="group.label"></div>
+            <template x-for="(item, ii) in group.items" :key="item.id">
+              <div class="bb-cmdk-item"
+                   :data-active="activeIndex === item._flatIndex"
+                   :data-cmdk-idx="item._flatIndex"
+                   @click="go(item)"
+                   @mouseenter="activeIndex = item._flatIndex">
+                <div class="bb-cmdk-item-icon">
+                  <i :data-lucide="item.icon"></i>
+                </div>
+                <div class="bb-cmdk-item-label">
+                  <div class="bb-cmdk-item-title" x-text="item.title"></div>
+                  <template x-if="item.desc">
+                    <div class="bb-cmdk-item-desc" x-text="item.desc"></div>
+                  </template>
+                </div>
+                <template x-if="item.shortcut">
+                  <div class="bb-cmdk-item-shortcut">
+                    <template x-for="k in item.shortcut" :key="k">
+                      <span class="bb-cmdk-kbd" x-text="k"></span>
+                    </template>
+                  </div>
+                </template>
+              </div>
+            </template>
+          </div>
+        </template>
+      </div>
+
+      <!-- Footer hints -->
+      <div class="bb-cmdk-footer">
+        <div class="flex items-center gap-3">
+          <span><kbd>&uarr;</kbd> <kbd>&darr;</kbd> navigate</span>
+          <span><kbd>&crarr;</kbd> open</span>
+          <span><kbd>esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/lucide@0.468.0/dist/umd/lucide.min.js"></script>
   <script>
     lucide.createIcons();
@@ -89,6 +174,134 @@
         });
       });
     })();
+
+    // Command Palette Alpine component
+    function commandPalette() {
+      var allItems = [
+        // Navigation
+        { id: 'nav-dashboard', group: 'Navigation', title: 'Dashboard', desc: 'Overview and stats', icon: 'layout-dashboard', href: '/', keywords: 'home overview net worth' },
+        { id: 'nav-transactions', group: 'Navigation', title: 'Transactions', desc: 'View all transactions', icon: 'receipt', href: '/transactions', keywords: 'payments expenses spending' },
+        { id: 'nav-connections', group: 'Navigation', title: 'Connections', desc: 'Bank connections', icon: 'link', href: '/connections', keywords: 'banks accounts linked' },
+        { id: 'nav-reviews', group: 'Navigation', title: 'Reviews', desc: 'Transaction review queue', icon: 'clipboard-check', href: '/reviews', keywords: 'pending approve categorize' },
+        { id: 'nav-rules', group: 'Navigation', title: 'Rules', desc: 'Auto-categorization rules', icon: 'list-filter', href: '/rules', keywords: 'automation patterns categorize' },
+        { id: 'nav-categories', group: 'Navigation', title: 'Categories', desc: 'Category taxonomy', icon: 'tag', href: '/categories', keywords: 'tags labels organize' },
+        { id: 'nav-users', group: 'Navigation', title: 'Family Members', desc: 'Manage family members', icon: 'users', href: '/users', keywords: 'people household members' },
+        // System
+        { id: 'sys-providers', group: 'System', title: 'Providers', desc: 'Configure Plaid, Teller, CSV', icon: 'plug', href: '/providers', keywords: 'plaid teller csv bank setup' },
+        { id: 'sys-api-keys', group: 'System', title: 'API Keys', desc: 'Manage API access keys', icon: 'key', href: '/api-keys', keywords: 'tokens authentication' },
+        { id: 'sys-mcp', group: 'System', title: 'MCP Settings', desc: 'AI agent configuration', icon: 'bot', href: '/mcp-settings', keywords: 'agent tools permissions' },
+        { id: 'sys-sync-logs', group: 'System', title: 'Sync Logs', desc: 'Sync history and status', icon: 'refresh-cw', href: '/sync-logs', keywords: 'history errors status' },
+        { id: 'sys-settings', group: 'System', title: 'Settings', desc: 'Sync schedule, security, system', icon: 'settings', href: '/settings', keywords: 'schedule password encryption' },
+        { id: 'sys-review-agent', group: 'System', title: 'Review Agent', desc: 'MCP review instructions', icon: 'message-square-code', href: '/review-instructions', keywords: 'agent instructions prompts' },
+        // Actions
+        { id: 'act-connect', group: 'Quick Actions', title: 'Connect a Bank', desc: 'Add a new bank connection', icon: 'plus-circle', href: '/connections/new', keywords: 'add new link' },
+        { id: 'act-import', group: 'Quick Actions', title: 'Import CSV', desc: 'Import transactions from CSV', icon: 'upload', href: '/connections/import-csv', keywords: 'upload file' },
+        { id: 'act-api-key', group: 'Quick Actions', title: 'Create API Key', desc: 'Generate a new API key', icon: 'key-round', href: '/api-keys/new', keywords: 'new token' },
+        { id: 'act-user', group: 'Quick Actions', title: 'Add Family Member', desc: 'Add a new family member', icon: 'user-plus', href: '/users/new', keywords: 'new person' },
+      ];
+
+      return {
+        open: false,
+        query: '',
+        activeIndex: 0,
+        _allItems: allItems,
+
+        get filteredItems() {
+          if (!this.query.trim()) return this._allItems;
+          var q = this.query.toLowerCase().trim();
+          var terms = q.split(/\s+/);
+          return this._allItems.filter(function(item) {
+            var haystack = (item.title + ' ' + (item.desc || '') + ' ' + (item.keywords || '')).toLowerCase();
+            return terms.every(function(term) { return haystack.indexOf(term) !== -1; });
+          });
+        },
+
+        get filteredGroups() {
+          var items = this.filteredItems;
+          var groups = [];
+          var seen = {};
+          var flatIndex = 0;
+          items.forEach(function(item) {
+            if (!seen[item.group]) {
+              seen[item.group] = { label: item.group, items: [] };
+              groups.push(seen[item.group]);
+            }
+            var clone = Object.assign({}, item, { _flatIndex: flatIndex });
+            seen[item.group].items.push(clone);
+            flatIndex++;
+          });
+          return groups;
+        },
+
+        openPalette() {
+          this.open = true;
+          this.query = '';
+          this.activeIndex = 0;
+          var self = this;
+          setTimeout(function() {
+            if (self.$refs.cmdkInput) {
+              self.$refs.cmdkInput.focus();
+            }
+            lucide.createIcons({ nodes: [document.querySelector('.bb-cmdk-dialog')] });
+          }, 50);
+        },
+
+        closePalette() {
+          this.open = false;
+          this.query = '';
+        },
+
+        handleGlobalKey(e) {
+          if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+            e.preventDefault();
+            if (this.open) {
+              this.closePalette();
+            } else {
+              this.openPalette();
+            }
+          }
+        },
+
+        onInput() {
+          this.activeIndex = 0;
+        },
+
+        moveDown() {
+          var max = this.filteredItems.length - 1;
+          if (this.activeIndex < max) this.activeIndex++;
+          else this.activeIndex = 0;
+          this.scrollToActive();
+        },
+
+        moveUp() {
+          if (this.activeIndex > 0) this.activeIndex--;
+          else this.activeIndex = this.filteredItems.length - 1;
+          this.scrollToActive();
+        },
+
+        scrollToActive() {
+          var self = this;
+          setTimeout(function() {
+            var el = document.querySelector('[data-cmdk-idx="' + self.activeIndex + '"]');
+            if (el) el.scrollIntoView({ block: 'nearest' });
+          }, 10);
+        },
+
+        selectActive() {
+          var items = this.filteredItems;
+          if (items.length > 0 && this.activeIndex < items.length) {
+            this.go(items[this.activeIndex]);
+          }
+        },
+
+        go(item) {
+          if (item.href) {
+            window.location.href = item.href;
+          }
+          this.closePalette();
+        }
+      };
+    }
   </script>
 </body>
 </html>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -15,6 +15,11 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 </head>
 <body>
+  <!-- Navigation progress bar -->
+  <div class="bb-progress-bar" id="bb-nav-progress">
+    <div class="bb-progress-bar__fill" id="bb-nav-progress-fill"></div>
+  </div>
+
   <div class="drawer lg:drawer-open">
     <input id="bb-drawer" type="checkbox" class="drawer-toggle" />
 
@@ -444,6 +449,14 @@
 
         go(item) {
           if (item.href) {
+            if (window.bbProgress) window.bbProgress.start();
+            var main = document.querySelector('main');
+            if (main) {
+              main.style.transition = 'opacity 0.15s ease, filter 0.15s ease';
+              main.style.opacity = '0.6';
+              main.style.filter = 'blur(1px)';
+              main.style.pointerEvents = 'none';
+            }
             window.location.href = item.href;
           }
           this.closePalette();
@@ -465,6 +478,125 @@
         }
       };
     }
+
+    // Navigation Progress Bar
+    (function() {
+      var bar = document.getElementById('bb-nav-progress');
+      var fill = document.getElementById('bb-nav-progress-fill');
+      if (!bar || !fill) return;
+
+      var progress = 0;
+      var tickTimer = null;
+      var isActive = false;
+
+      function start() {
+        if (isActive) return;
+        isActive = true;
+        progress = 0;
+        fill.style.width = '0%';
+        fill.classList.remove('bb-progress-bar__fill--done');
+        bar.classList.remove('bb-progress-bar--fade');
+        bar.classList.add('bb-progress-bar--active');
+
+        // Quick initial jump
+        setTimeout(function() { setProgress(15); }, 50);
+        setTimeout(function() { setProgress(30); }, 200);
+
+        // Slow trickle
+        tickTimer = setInterval(function() {
+          if (progress < 85) {
+            progress += (85 - progress) * 0.03;
+            fill.style.width = progress + '%';
+          }
+        }, 200);
+      }
+
+      function setProgress(val) {
+        progress = val;
+        fill.style.width = val + '%';
+      }
+
+      function finish() {
+        if (tickTimer) { clearInterval(tickTimer); tickTimer = null; }
+        fill.classList.add('bb-progress-bar__fill--done');
+        isActive = false;
+
+        setTimeout(function() {
+          bar.classList.add('bb-progress-bar--fade');
+          setTimeout(function() {
+            bar.classList.remove('bb-progress-bar--active', 'bb-progress-bar--fade');
+            fill.classList.remove('bb-progress-bar__fill--done');
+            fill.style.width = '0%';
+          }, 500);
+        }, 150);
+      }
+
+      // Expose globally
+      window.bbProgress = { start: start, finish: finish, setProgress: setProgress };
+
+      // Main content area for fade effect
+      var mainContent = document.querySelector('main');
+
+      // Intercept navigation clicks (sidebar links, breadcrumbs, any internal link)
+      document.addEventListener('click', function(e) {
+        var link = e.target.closest('a[href]');
+        if (!link) return;
+
+        var href = link.getAttribute('href');
+        // Only intercept internal same-origin links
+        if (!href || href.startsWith('#') || href.startsWith('javascript:') ||
+            href.startsWith('http://') && !href.startsWith(window.location.origin) ||
+            href.startsWith('https://') && !href.startsWith(window.location.origin)) return;
+
+        // Don't intercept if modifier keys are held (new tab, etc.)
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
+        // Don't intercept if target is _blank
+        if (link.target === '_blank') return;
+
+        // Skip same-page links
+        if (href === window.location.pathname + window.location.search) return;
+
+        // Start the progress bar for this navigation
+        start();
+
+        // Subtle content fade during navigation
+        if (mainContent) {
+          mainContent.style.transition = 'opacity 0.15s ease, filter 0.15s ease';
+          mainContent.style.opacity = '0.6';
+          mainContent.style.filter = 'blur(1px)';
+          mainContent.style.pointerEvents = 'none';
+        }
+      });
+
+      // Handle form submissions
+      document.addEventListener('submit', function(e) {
+        var form = e.target;
+        if (form && form.method && form.method.toLowerCase() === 'get') {
+          start();
+        }
+      });
+
+      // Finish on page load (covers back/forward navigation via bfcache)
+      window.addEventListener('pageshow', function(e) {
+        if (isActive) finish();
+        // Restore main content if page was served from bfcache
+        if (e.persisted) {
+          var main = document.querySelector('main');
+          if (main) {
+            main.style.opacity = '';
+            main.style.filter = '';
+            main.style.pointerEvents = '';
+            main.style.transition = '';
+          }
+        }
+      });
+
+      // Before unload — ensure bar stays visible
+      window.addEventListener('beforeunload', function() {
+        if (isActive) setProgress(90);
+      });
+    })();
 
     // Global Keyboard Shortcuts (vim-style g+key navigation, ?-key help)
     (function() {
@@ -563,6 +695,14 @@
 
           if (routes && routes[key]) {
             e.preventDefault();
+            if (window.bbProgress) window.bbProgress.start();
+            var main = document.querySelector('main');
+            if (main) {
+              main.style.transition = 'opacity 0.15s ease, filter 0.15s ease';
+              main.style.opacity = '0.6';
+              main.style.filter = 'blur(1px)';
+              main.style.pointerEvents = 'none';
+            }
             window.location.href = routes[key];
           }
           return;

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -19,9 +19,9 @@
     <input id="bb-drawer" type="checkbox" class="drawer-toggle" />
 
     <!-- Main content -->
-    <div class="drawer-content bg-base-200/50">
+    <div class="drawer-content bg-base-200">
       <!-- Mobile navbar -->
-      <div class="navbar bg-base-100 lg:hidden border-b border-base-200">
+      <div class="navbar bg-base-100 lg:hidden border-b border-base-300">
         <div class="flex-none">
           <label for="bb-drawer" class="btn btn-square btn-ghost">
             <i data-lucide="menu" class="w-5 h-5"></i>
@@ -32,7 +32,7 @@
         </div>
       </div>
       <!-- Page content -->
-      <main class="p-8 max-w-6xl min-h-screen">
+      <main class="p-6 max-w-6xl min-h-screen">
         {{template "flash" .}}
         {{block "content" .}}{{end}}
       </main>
@@ -60,7 +60,7 @@
          setTimeout(() => toasts.shift(), 4000)
        ">
     <template x-for="t in toasts" :key="t.id">
-      <div class="alert shadow-lg rounded-xl"
+      <div class="alert rounded-lg border border-base-300"
            :class="{
              'alert-success': t.type === 'success',
              'alert-error': t.type === 'error',

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -32,7 +32,7 @@
         </div>
       </div>
       <!-- Page content -->
-      <main class="p-6 max-w-6xl min-h-screen">
+      <main class="p-6 max-w-6xl min-h-screen bb-page-enter">
         {{template "flash" .}}
         {{block "content" .}}{{end}}
       </main>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -21,14 +21,14 @@
     <!-- Main content -->
     <div class="drawer-content bg-base-200">
       <!-- Mobile navbar -->
-      <div class="navbar bg-base-100 lg:hidden border-b border-base-300">
+      <div class="navbar bg-base-100 lg:hidden border-b border-base-300 sticky top-0 z-30">
         <div class="flex-none">
           <label for="bb-drawer" class="btn btn-square btn-ghost">
             <i data-lucide="menu" class="w-5 h-5"></i>
           </label>
         </div>
-        <div class="flex-1">
-          <span class="text-lg font-bold">Breadbox</span>
+        <div class="flex-1 min-w-0">
+          <span class="text-sm font-semibold truncate">{{.PageTitle}}</span>
         </div>
       </div>
       <!-- Page content -->
@@ -73,7 +73,23 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/lucide@0.468.0/dist/umd/lucide.min.js"></script>
-  <script>lucide.createIcons();</script>
+  <script>
+    lucide.createIcons();
+    // Auto-close sidebar on mobile when a nav link is tapped
+    (function() {
+      var toggle = document.getElementById('bb-drawer');
+      if (!toggle) return;
+      var side = document.querySelector('.drawer-side');
+      if (!side) return;
+      side.querySelectorAll('a.bb-sidebar-link, button[type="submit"]').forEach(function(link) {
+        link.addEventListener('click', function() {
+          if (window.innerWidth < 1024) {
+            toggle.checked = false;
+          }
+        });
+      });
+    })();
+  </script>
 </body>
 </html>
 {{end}}

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -32,7 +32,7 @@
         </div>
       </div>
       <!-- Page content -->
-      <main class="p-6 max-w-6xl min-h-screen bb-page-enter">
+      <main class="p-4 sm:p-6 max-w-6xl min-h-screen bb-page-enter">
         {{template "flash" .}}
         {{block "content" .}}{{end}}
       </main>

--- a/internal/templates/layout/wizard.html
+++ b/internal/templates/layout/wizard.html
@@ -28,7 +28,7 @@
     <div class="bb-wizard-card">
       {{if .StepNumber}}
       <div class="text-center mb-6">
-        <p class="text-xs font-semibold uppercase tracking-widest text-base-content/40">Setup &mdash; Step {{.StepNumber}} of 6</p>
+        <p class="text-xs font-medium text-base-content/40">Setup — Step {{.StepNumber}} of 6</p>
       </div>
       {{end}}
       {{template "flash" .}}

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -15,7 +15,7 @@
       <i data-lucide="{{if eq .Account.Type "credit"}}credit-card{{else if eq .Account.Type "investment"}}trending-up{{else if eq .Account.Type "loan"}}landmark{{else}}wallet{{end}}" class="w-6 h-6 text-base-content/50"></i>
     </div>
     <div>
-      <h1 class="text-2xl font-bold tracking-tight">{{if .Account.DisplayName}}{{.Account.DisplayName}}{{else}}{{.Account.Name}}{{end}}</h1>
+      <h1 class="bb-page-title">{{if .Account.DisplayName}}{{.Account.DisplayName}}{{else}}{{.Account.Name}}{{end}}</h1>
       <div class="flex items-center gap-2 mt-0.5">
         <span class="text-xs text-base-content/40 capitalize">{{.Account.Type}}{{if .Account.Subtype}} &middot; {{.Account.Subtype}}{{end}}</span>
         {{if .Account.Mask}}<span class="text-xs text-base-content/30">&bull;&bull;&bull;&bull;{{.Account.Mask}}</span>{{end}}
@@ -29,25 +29,25 @@
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
   <!-- Balance Card -->
   <div class="bb-card p-6 lg:col-span-2">
-    <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider mb-5">Balances</h2>
+    <h2 class="text-sm font-semibold text-base-content/50 mb-5">Balances</h2>
     <div class="grid grid-cols-2 sm:grid-cols-3 gap-6">
       <div>
         <p class="text-xs text-base-content/40 mb-1">Current Balance</p>
-        <p class="text-2xl font-bold tabular-nums">
+        <p class="text-2xl font-semibold tabular-nums">
           {{if .Account.BalanceCurrent}}{{printf "%.2f" .Account.BalanceCurrent}}{{else}}<span class="text-base-content/20">&mdash;</span>{{end}}
         </p>
         {{if .Account.IsoCurrencyCode}}<p class="text-xs text-base-content/30 mt-0.5">{{.Account.IsoCurrencyCode}}</p>{{end}}
       </div>
       <div>
         <p class="text-xs text-base-content/40 mb-1">Available</p>
-        <p class="text-2xl font-bold tabular-nums text-base-content/60">
+        <p class="text-2xl font-semibold tabular-nums text-base-content/60">
           {{if .Account.BalanceAvailable}}{{printf "%.2f" .Account.BalanceAvailable}}{{else}}<span class="text-base-content/20">&mdash;</span>{{end}}
         </p>
       </div>
       {{if .Account.BalanceLimit}}
       <div>
         <p class="text-xs text-base-content/40 mb-1">Credit Limit</p>
-        <p class="text-2xl font-bold tabular-nums text-base-content/60">{{printf "%.2f" .Account.BalanceLimit}}</p>
+        <p class="text-2xl font-semibold tabular-nums text-base-content/60">{{printf "%.2f" .Account.BalanceLimit}}</p>
       </div>
       {{end}}
     </div>
@@ -55,7 +55,7 @@
 
   <!-- Account Settings Card -->
   <div class="bb-card p-6">
-    <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider mb-5">Settings</h2>
+    <h2 class="text-sm font-semibold text-base-content/50 mb-5">Settings</h2>
     <div class="space-y-4">
       <div>
         <label class="text-xs text-base-content/40 mb-1.5 block">Display Name</label>
@@ -91,7 +91,7 @@
 <div class="bb-card">
   <div class="px-6 pt-6 pb-4">
     <div class="flex items-center justify-between mb-4">
-      <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider">Transactions</h2>
+      <h2 class="text-sm font-semibold text-base-content/50">Transactions</h2>
       {{if .Transactions}}<span class="text-xs text-base-content/30">{{.Total}} total</span>{{end}}
     </div>
 
@@ -153,7 +153,7 @@
   <div class="overflow-x-auto">
     <table class="table table-sm">
       <thead>
-        <tr class="text-xs text-base-content/40 uppercase tracking-wider border-b border-base-300">
+        <tr class="text-xs text-base-content/50 border-b border-base-300">
           <th class="font-medium">Date</th>
           <th class="font-medium">Description</th>
           <th class="font-medium text-right">Amount</th>

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -11,7 +11,7 @@
 <!-- Header -->
 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
   <div class="flex items-center gap-4">
-    <div class="w-12 h-12 rounded-2xl bg-base-200 flex items-center justify-center">
+    <div class="w-12 h-12 rounded-xl bg-base-200 flex items-center justify-center">
       <i data-lucide="{{if eq .Account.Type "credit"}}credit-card{{else if eq .Account.Type "investment"}}trending-up{{else if eq .Account.Type "loan"}}landmark{{else}}wallet{{end}}" class="w-6 h-6 text-base-content/50"></i>
     </div>
     <div>
@@ -73,7 +73,7 @@
           </div>
         </label>
       </div>
-      <div class="pt-2 border-t border-base-200">
+      <div class="pt-2 border-t border-base-300">
         <p class="text-xs text-base-content/40 mb-1">Connection</p>
         <a href="/connections/{{.Account.ConnectionID}}" class="text-sm font-medium hover:text-primary transition-colors no-underline">{{.Account.InstitutionName}}</a>
       </div>
@@ -96,7 +96,7 @@
     </div>
 
     <!-- Filters -->
-    <form method="GET" action="/accounts/{{.AccountID}}" class="flex flex-wrap items-end gap-3 pb-4 border-b border-base-200" x-data>
+    <form method="GET" action="/accounts/{{.AccountID}}" class="flex flex-wrap items-end gap-3 pb-4 border-b border-base-300" x-data>
       <label class="flex flex-col gap-1">
         <span class="text-xs text-base-content/40">Start Date</span>
         <input type="date" name="start_date" value="{{.FilterStartDate}}" class="input input-sm input-bordered">
@@ -153,7 +153,7 @@
   <div class="overflow-x-auto">
     <table class="table table-sm">
       <thead>
-        <tr class="text-xs text-base-content/40 uppercase tracking-wider border-b border-base-200">
+        <tr class="text-xs text-base-content/40 uppercase tracking-wider border-b border-base-300">
           <th class="font-medium">Date</th>
           <th class="font-medium">Description</th>
           <th class="font-medium text-right">Amount</th>
@@ -213,7 +213,7 @@
   </div>
 
   {{if gt .TotalPages 1}}
-  <div class="px-6 py-4 flex items-center justify-between border-t border-base-200">
+  <div class="px-6 py-4 flex items-center justify-between border-t border-base-300">
     <div>
       {{if gt .Page 1}}
       <a href="/accounts/{{$.AccountID}}?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}" class="btn btn-sm btn-ghost">&larr; Previous</a>

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -34,20 +34,20 @@
       <div>
         <p class="text-xs text-base-content/40 mb-1">Current Balance</p>
         <p class="text-2xl font-semibold tabular-nums">
-          {{if .Account.BalanceCurrent}}{{printf "%.2f" .Account.BalanceCurrent}}{{else}}<span class="text-base-content/20">&mdash;</span>{{end}}
+          {{if .Account.BalanceCurrent}}{{fmtBalance .Account.BalanceCurrent}}{{else}}<span class="text-base-content/20">&mdash;</span>{{end}}
         </p>
-        {{if .Account.IsoCurrencyCode}}<p class="text-xs text-base-content/30 mt-0.5">{{.Account.IsoCurrencyCode}}</p>{{end}}
+        {{if .Account.IsoCurrencyCode}}<p class="text-xs text-base-content/30 mt-0.5">{{deref .Account.IsoCurrencyCode}}</p>{{end}}
       </div>
       <div>
         <p class="text-xs text-base-content/40 mb-1">Available</p>
         <p class="text-2xl font-semibold tabular-nums text-base-content/60">
-          {{if .Account.BalanceAvailable}}{{printf "%.2f" .Account.BalanceAvailable}}{{else}}<span class="text-base-content/20">&mdash;</span>{{end}}
+          {{if .Account.BalanceAvailable}}{{fmtBalance .Account.BalanceAvailable}}{{else}}<span class="text-base-content/20">&mdash;</span>{{end}}
         </p>
       </div>
       {{if .Account.BalanceLimit}}
       <div>
         <p class="text-xs text-base-content/40 mb-1">Credit Limit</p>
-        <p class="text-2xl font-semibold tabular-nums text-base-content/60">{{printf "%.2f" .Account.BalanceLimit}}</p>
+        <p class="text-2xl font-semibold tabular-nums text-base-content/60">{{fmtBalance .Account.BalanceLimit}}</p>
       </div>
       {{end}}
     </div>

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -202,8 +202,8 @@
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
               {{if .MerchantName}}<div><span class="text-xs text-base-content/40 block">Merchant</span>{{.MerchantName}}</div>{{end}}
               <div><span class="text-xs text-base-content/40 block">Transaction ID</span><code class="font-mono text-xs text-base-content/50">{{.ID}}</code></div>
-              <div><span class="text-xs text-base-content/40 block">Created</span>{{.CreatedAt}}</div>
-              <div><span class="text-xs text-base-content/40 block">Updated</span>{{.UpdatedAt}}</div>
+              <div><span class="text-xs text-base-content/40 block">Created</span>{{formatDateTime .CreatedAt}}</div>
+              <div><span class="text-xs text-base-content/40 block">Updated</span>{{formatDateTime .UpdatedAt}}</div>
             </div>
           </td>
         </tr>

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -142,9 +142,9 @@
         <span class="text-xs text-base-content/40">Search</span>
         <input type="text" name="search" value="{{.FilterSearch}}" placeholder="Name or merchant" class="input input-sm input-bordered">
       </label>
-      <button type="submit" class="btn btn-sm btn-primary">Filter</button>
+      <button type="submit" class="btn btn-sm btn-primary rounded-xl">Filter</button>
       {{if or .FilterStartDate .FilterEndDate .FilterCategory .FilterPending .FilterSearch}}
-      <a href="/accounts/{{.AccountID}}" class="btn btn-sm btn-ghost">Clear</a>
+      <a href="/accounts/{{.AccountID}}" class="btn btn-sm btn-ghost rounded-xl">Clear</a>
       {{end}}
     </form>
   </div>

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -164,13 +164,13 @@
       {{range .Transactions}}
       <tbody x-data="{ expanded: false }">
         <tr @click="expanded = !expanded" class="cursor-pointer hover:bg-base-200/40 transition-colors duration-150">
-          <td class="text-sm text-base-content/60 whitespace-nowrap">{{.Date}}</td>
+          <td class="text-sm text-base-content/60 whitespace-nowrap">{{formatDate .Date}}</td>
           <td>
             <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors no-underline">{{.Name}}</a>
             {{if .MerchantName}}<span class="text-xs text-base-content/40 ml-1">{{.MerchantName}}</span>{{end}}
           </td>
           <td class="text-right tabular-nums text-sm font-semibold{{if lt .Amount 0.0}} text-error{{end}}">
-            {{printf "%.2f" .Amount}}{{if .IsoCurrencyCode}} <span class="text-xs text-base-content/30 font-normal">{{.IsoCurrencyCode}}</span>{{end}}
+            {{formatAmount .Amount}}
           </td>
           <td @click.stop>
             <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">

--- a/internal/templates/pages/api_key_created.html
+++ b/internal/templates/pages/api_key_created.html
@@ -8,7 +8,7 @@
 
 <div class="bb-card p-8 max-w-lg">
   <div class="flex flex-col items-center text-center mb-6">
-    <div class="w-16 h-16 rounded-2xl bg-success/10 flex items-center justify-center mb-4">
+    <div class="w-16 h-16 rounded-xl bg-success/10 flex items-center justify-center mb-4">
       <i data-lucide="check-circle-2" class="w-8 h-8 text-success"></i>
     </div>
     <h2 class="text-lg font-semibold mb-1">Key Ready</h2>
@@ -25,7 +25,7 @@
       <label class="text-xs font-medium text-base-content/50 mb-1.5 block">API Key</label>
       <div class="relative">
         <input type="text" value="{{.PlaintextKey}}" readonly id="api-key-value"
-               class="input input-sm font-mono w-full bg-base-200/50 border-base-200 rounded-xl pr-24 text-xs">
+               class="input input-sm font-mono w-full bg-base-200/50 border-base-300 rounded-xl pr-24 text-xs">
       </div>
     </div>
   </div>
@@ -39,7 +39,7 @@
     <a href="/api-keys" class="btn btn-ghost btn-sm rounded-xl">Done</a>
   </div>
 
-  <p class="text-xs text-base-content/40 mt-6 pt-4 border-t border-base-200">
+  <p class="text-xs text-base-content/40 mt-6 pt-4 border-t border-base-300">
     Use this key in the <code class="font-mono text-primary/70 bg-primary/5 px-1.5 py-0.5 rounded">X-API-Key</code> header when making API requests.
   </p>
 </div>

--- a/internal/templates/pages/api_key_new.html
+++ b/internal/templates/pages/api_key_new.html
@@ -25,13 +25,13 @@
 
     <fieldset class="fieldset mb-5">
       <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="name">Name</label>
-      <input type="text" id="name" name="name" class="input w-full bg-base-200/50 border-base-200 focus:border-primary rounded-xl" placeholder="e.g., Claude MCP, Dashboard" required autofocus>
+      <input type="text" id="name" name="name" class="input w-full bg-base-200/50 border-base-300 focus:border-primary rounded-xl" placeholder="e.g., Claude MCP, Dashboard" required autofocus>
       <p class="text-xs text-base-content/40 mt-2">A descriptive name to identify this API key.</p>
     </fieldset>
 
     <fieldset class="fieldset mb-6">
       <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="scope">Scope</label>
-      <select id="scope" name="scope" class="select w-full bg-base-200/50 border-base-200 focus:border-primary rounded-xl">
+      <select id="scope" name="scope" class="select w-full bg-base-200/50 border-base-300 focus:border-primary rounded-xl">
         <option value="full_access">Full Access &mdash; read and write</option>
         <option value="read_only">Read Only &mdash; query data only</option>
       </select>

--- a/internal/templates/pages/api_keys.html
+++ b/internal/templates/pages/api_keys.html
@@ -4,7 +4,7 @@
     <h1 class="bb-page-title">API Keys</h1>
     <p class="text-sm text-base-content/50 mt-1">Manage keys for REST API and MCP access</p>
   </div>
-  <a href="/api-keys/new" class="btn btn-primary btn-sm">
+  <a href="/api-keys/new" class="btn btn-primary btn-sm rounded-xl">
     <i data-lucide="plus" class="w-4 h-4"></i>
     Create Key
   </a>
@@ -47,8 +47,8 @@
           Revoke
         </button>
         <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
-          <button type="submit" class="btn btn-error btn-sm btn-soft">Confirm</button>
-          <button type="button" class="btn btn-ghost btn-sm" @click="confirming = false">Cancel</button>
+          <button type="submit" class="btn btn-error btn-sm btn-soft rounded-xl">Confirm</button>
+          <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="confirming = false">Cancel</button>
         </span>
       </form>
     </div>
@@ -64,7 +64,7 @@
     </div>
     <h3 class="text-lg font-semibold mb-1">No API keys yet</h3>
     <p class="text-sm text-base-content/50 mb-5 max-w-sm">Create an API key to connect MCP agents or integrate with external tools.</p>
-    <a href="/api-keys/new" class="btn btn-primary btn-sm">
+    <a href="/api-keys/new" class="btn btn-primary btn-sm rounded-xl">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Create your first key
     </a>

--- a/internal/templates/pages/api_keys.html
+++ b/internal/templates/pages/api_keys.html
@@ -59,7 +59,7 @@
 {{else}}
 <div class="bb-card p-12 text-center">
   <div class="flex flex-col items-center">
-    <div class="w-16 h-16 rounded-2xl bg-base-200/60 flex items-center justify-center mb-4">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
       <i data-lucide="key" class="w-8 h-8 text-base-content/25"></i>
     </div>
     <h3 class="text-lg font-semibold mb-1">No API keys yet</h3>

--- a/internal/templates/pages/api_keys.html
+++ b/internal/templates/pages/api_keys.html
@@ -11,7 +11,7 @@
 </div>
 
 {{if .Keys}}
-<div class="space-y-3">
+<div class="space-y-3 bb-stagger">
   {{range .Keys}}
   <div class="bb-card p-5 flex items-center justify-between gap-4 flex-wrap" x-data="{ confirming: false }">
     <div class="flex items-center gap-4 min-w-0">

--- a/internal/templates/pages/api_keys.html
+++ b/internal/templates/pages/api_keys.html
@@ -33,8 +33,8 @@
         </div>
         <div class="flex items-center gap-3 mt-0.5 text-xs text-base-content/40">
           <code class="font-mono bg-base-200/50 px-1.5 py-0.5 rounded">{{.KeyPrefix}}...</code>
-          <span>Created {{.CreatedAt}}</span>
-          {{if .LastUsedAt}}<span>Last used {{.LastUsedAt}}</span>{{end}}
+          <span>Created {{formatDateTime .CreatedAt}}</span>
+          {{if .LastUsedAt}}<span>Last used {{relativeTime .LastUsedAt}}</span>{{end}}
         </div>
       </div>
     </div>

--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -23,7 +23,7 @@
 
 <!-- Tabs -->
 <div x-data="{ activeTab: ({'#mappings':'mappings','#bulk':'bulk'}[window.location.hash]) || 'tree' }" x-init="$watch('activeTab', v => window.location.hash = v)">
-  <div class="flex gap-1 p-1 bg-base-200/60 rounded-2xl w-fit mb-8">
+  <div class="flex gap-1 p-1 bg-base-200/60 rounded-xl w-fit mb-8">
     <button class="px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 flex items-center gap-2"
       :class="activeTab === 'tree' ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/50 hover:text-base-content/80'"
       @click="activeTab = 'tree'" data-tab="tree">
@@ -91,7 +91,7 @@
           x-transition:leave="transition ease-in duration-150"
           x-transition:leave-start="opacity-100"
           x-transition:leave-end="opacity-0"
-          class="border-t border-base-200">
+          class="border-t border-base-300">
           <div class="px-3 py-2">
             {{range .Children}}
             <div class="group flex items-center gap-3 py-2.5 px-3 rounded-xl hover:bg-base-200/40 transition-colors duration-150">
@@ -125,7 +125,7 @@
           x-transition:enter="transition ease-out duration-200"
           x-transition:enter-start="opacity-0"
           x-transition:enter-end="opacity-100"
-          class="border-t border-base-200 px-6 py-4">
+          class="border-t border-base-300 px-6 py-4">
           <p class="text-sm text-base-content/40">No subcategories</p>
         </div>
         {{end}}
@@ -136,7 +136,7 @@
     <!-- Empty state -->
     <div class="bb-card">
       <div class="flex flex-col items-center text-center py-16 px-6">
-        <div class="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mb-4">
+        <div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
           <i data-lucide="tag" class="w-8 h-8 text-primary"></i>
         </div>
         <h2 class="text-lg font-semibold mb-1">No categories yet</h2>
@@ -173,7 +173,7 @@
               <i data-lucide="chevron-down" class="w-3 h-3"></i>
             </button>
             <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-              <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+              <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
                 <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full rounded-lg">
               </div>
               <div x-ref="listbox">
@@ -224,7 +224,7 @@
                       <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
                     </button>
                     <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-                      <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+                      <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
                         <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
                       </div>
                       <div x-ref="listbox">
@@ -270,7 +270,7 @@
                 <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
               </button>
               <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
-                <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+                <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
                   <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
                 </div>
                 <div x-ref="listbox">
@@ -354,7 +354,7 @@
                         <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
                       </button>
                       <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
-                        <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+                        <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
                           <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
                         </div>
                         <div x-ref="listbox">
@@ -394,7 +394,7 @@
       </div>
       {{else}}
       <div class="flex flex-col items-center text-center py-12">
-        <div class="w-14 h-14 rounded-2xl bg-base-200/60 flex items-center justify-center mb-3">
+        <div class="w-14 h-14 rounded-xl bg-base-200/60 flex items-center justify-center mb-3">
           <i data-lucide="arrow-right-left" class="w-7 h-7 text-base-content/30"></i>
         </div>
         <p class="text-sm text-base-content/45">No mappings configured yet.</p>
@@ -543,7 +543,7 @@
 
 <!-- ═══════════ Create Modal ═══════════ -->
 <dialog id="create-modal" class="modal modal-bottom sm:modal-middle">
-  <form class="modal-box rounded-3xl max-w-lg" x-data="{displayName: '', parentId: '', icon: '', color: '#6366f1', sortOrder: 0, submitting: false, showIconPicker: false,
+  <form class="modal-box rounded-xl max-w-lg" x-data="{displayName: '', parentId: '', icon: '', color: '#6366f1', sortOrder: 0, submitting: false, showIconPicker: false,
     commonIcons: ['shopping-cart','utensils','car','home','briefcase','heart','zap','book','plane','music','gift','coffee','scissors','shirt','gamepad-2','graduation-cap','building-2','fuel','bus','train'],
     presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c']
   }" @submit.prevent="
@@ -556,7 +556,7 @@
     <p class="text-sm text-base-content/50 mt-1">Create a new category in your taxonomy</p>
     <div class="space-y-4 mt-6">
       <!-- Live preview -->
-      <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-2xl">
+      <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-xl">
         <div class="w-9 h-9 rounded-xl flex items-center justify-center" :style="'background-color:' + (color || '#6366f1') + '15'">
           <template x-if="icon"><i :data-lucide="icon" class="w-4.5 h-4.5" :style="'color:' + (color || '#6366f1')"></i></template>
           <template x-if="!icon"><span class="w-2.5 h-2.5 rounded-full" :style="'background-color:' + (color || '#6366f1')"></span></template>
@@ -577,7 +577,7 @@
             <i data-lucide="chevron-down" class="w-4 h-4 opacity-40"></i>
           </button>
           <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
-            <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+            <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
               <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
             </div>
             <div x-ref="listbox">
@@ -647,12 +647,12 @@
   commonIcons: ['shopping-cart','utensils','car','home','briefcase','heart','zap','book','plane','music','gift','coffee','scissors','shirt','gamepad-2','graduation-cap','building-2','fuel','bus','train'],
   presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c']
 }" @edit-category.window="editId = $event.detail.id; editDisplayName = $event.detail.displayName; editIcon = $event.detail.icon; editColor = $event.detail.color || '#6366f1'; editSortOrder = $event.detail.sortOrder; editHidden = $event.detail.hidden; showIconPicker = false; document.getElementById('edit-modal').showModal(); $nextTick(() => lucide.createIcons())">
-  <div class="modal-box rounded-3xl max-w-lg">
+  <div class="modal-box rounded-xl max-w-lg">
     <h3 class="text-lg font-bold">Edit Category</h3>
     <p class="text-sm text-base-content/50 mt-1">Update category appearance and settings</p>
     <div class="space-y-4 mt-6">
       <!-- Live preview -->
-      <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-2xl">
+      <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-xl">
         <div class="w-9 h-9 rounded-xl flex items-center justify-center" :style="'background-color:' + (editColor || '#6366f1') + '15'">
           <template x-if="editIcon"><i :data-lucide="editIcon" class="w-4.5 h-4.5" :style="'color:' + (editColor || '#6366f1')"></i></template>
           <template x-if="!editIcon"><span class="w-2.5 h-2.5 rounded-full" :style="'background-color:' + (editColor || '#6366f1')"></span></template>
@@ -727,7 +727,7 @@
 
 <!-- ═══════════ Delete Modal ═══════════ -->
 <dialog id="delete-modal" class="modal modal-bottom sm:modal-middle" x-data="{deleteId: '', deleteName: '', submitting: false}" @delete-category.window="deleteId = $event.detail.id; deleteName = $event.detail.name; document.getElementById('delete-modal').showModal()">
-  <div class="modal-box rounded-3xl max-w-md">
+  <div class="modal-box rounded-xl max-w-md">
     <div class="flex items-center gap-3 mb-4">
       <div class="w-10 h-10 rounded-xl bg-error/10 flex items-center justify-center">
         <i data-lucide="alert-triangle" class="w-5 h-5 text-error"></i>

--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -1,91 +1,147 @@
 {{define "content"}}
 {{template "category-picker-styles" .}}
 
-<div class="flex items-center justify-between mb-6 flex-wrap gap-3">
-  <h1 class="text-2xl font-bold">Categories {{if .Categories}}<span class="badge badge-neutral badge-sm align-middle">{{len .Categories}}</span>{{end}}</h1>
+<!-- Page Header -->
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Categories</h1>
+    <p class="text-sm text-base-content/50 mt-1">Organize transactions with a two-level category taxonomy</p>
+  </div>
   <div class="flex gap-2 flex-wrap">
     {{if gt .UnmappedCount 0}}
-    <button class="btn btn-sm btn-warning" onclick="document.querySelector('[data-tab=mappings]').click()">
+    <button class="btn btn-sm btn-warning rounded-xl gap-2" onclick="document.querySelector('[data-tab=mappings]').click()">
       <i data-lucide="alert-triangle" class="w-4 h-4"></i>
       {{.UnmappedCount}} unmapped
     </button>
     {{end}}
-    <button class="btn btn-sm btn-primary" onclick="document.getElementById('create-modal').showModal()">
+    <button class="btn btn-sm btn-primary rounded-xl gap-2" onclick="document.getElementById('create-modal').showModal()">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Add Category
     </button>
   </div>
 </div>
 
-<!-- Tabs: Tree + Mappings + Bulk Edit -->
+<!-- Tabs -->
 <div x-data="{ activeTab: ({'#mappings':'mappings','#bulk':'bulk'}[window.location.hash]) || 'tree' }" x-init="$watch('activeTab', v => window.location.hash = v)">
-  <div role="tablist" class="tabs tabs-bordered mb-6">
-    <button role="tab" class="tab" :class="activeTab === 'tree' && 'tab-active'" @click="activeTab = 'tree'" data-tab="tree">
-      <i data-lucide="list-tree" class="w-4 h-4 mr-1.5"></i> Categories
+  <div class="flex gap-1 p-1 bg-base-200/60 rounded-2xl w-fit mb-8">
+    <button class="px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 flex items-center gap-2"
+      :class="activeTab === 'tree' ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/50 hover:text-base-content/80'"
+      @click="activeTab = 'tree'" data-tab="tree">
+      <i data-lucide="list-tree" class="w-4 h-4"></i> Categories
     </button>
-    <button role="tab" class="tab" :class="activeTab === 'mappings' && 'tab-active'" @click="activeTab = 'mappings'" data-tab="mappings">
-      <i data-lucide="arrow-right-left" class="w-4 h-4 mr-1.5"></i> Mappings
-      {{if gt .UnmappedCount 0}}<span class="badge badge-warning badge-xs ml-1">{{.UnmappedCount}}</span>{{end}}
+    <button class="px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 flex items-center gap-2"
+      :class="activeTab === 'mappings' ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/50 hover:text-base-content/80'"
+      @click="activeTab = 'mappings'" data-tab="mappings">
+      <i data-lucide="arrow-right-left" class="w-4 h-4"></i> Mappings
+      {{if gt .UnmappedCount 0}}<span class="badge badge-warning badge-xs">{{.UnmappedCount}}</span>{{end}}
     </button>
-    <button role="tab" class="tab" :class="activeTab === 'bulk' && 'tab-active'" @click="activeTab = 'bulk'" data-tab="bulk">
-      <i data-lucide="file-spreadsheet" class="w-4 h-4 mr-1.5"></i> Bulk Edit
+    <button class="px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 flex items-center gap-2"
+      :class="activeTab === 'bulk' ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/50 hover:text-base-content/80'"
+      @click="activeTab = 'bulk'" data-tab="bulk">
+      <i data-lucide="file-spreadsheet" class="w-4 h-4"></i> Bulk Edit
     </button>
   </div>
 
-  <!-- Tree Tab -->
+  <!-- ═══════════ Tree Tab ═══════════ -->
   <div x-show="activeTab === 'tree'" x-cloak>
     {{if .Categories}}
-    <div class="space-y-2">
+    <div class="text-sm text-base-content/40 mb-4 px-1">{{len .Categories}} top-level categories</div>
+    <div class="space-y-3">
       {{range .Categories}}
-      <div class="collapse collapse-arrow bg-base-100 shadow-sm border border-base-300 rounded-lg" x-data="{open: false}">
-        <input type="checkbox" x-model="open" class="peer" />
-        <div class="collapse-title pr-12">
-          <div class="flex items-center gap-3 flex-wrap">
-            {{if .Color}}<span class="bb-cat-dot" style="background-color: {{.Color}}"></span>{{end}}
-            {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-5 h-5 opacity-70"></i>{{end}}
-            <span class="font-semibold text-base">{{.DisplayName}}</span>
-            <span class="text-xs text-base-content/40 hidden sm:inline font-mono">{{.Slug}}</span>
-            {{if .Hidden}}<span class="badge badge-ghost badge-xs">Hidden</span>{{end}}
-            {{if .IsSystem}}<span class="badge badge-info badge-xs">System</span>{{end}}
-            {{if .Children}}<span class="badge badge-neutral badge-xs">{{len .Children}}</span>{{end}}
-            <div class="ml-auto flex gap-1" @click.stop>
-              <button class="btn btn-ghost btn-xs" data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}" @click.prevent="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})" title="Edit"><i data-lucide="pencil" class="w-4 h-4"></i></button>
-              {{if not .IsSystem}}<button class="btn btn-ghost btn-xs text-error" data-id="{{.ID}}" data-name="{{.DisplayName}}" @click.prevent="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})" title="Delete"><i data-lucide="trash-2" class="w-4 h-4"></i></button>{{end}}
+      <div class="bb-card overflow-hidden" x-data="{open: false}">
+        <!-- Parent row -->
+        <button type="button" class="w-full flex items-center gap-4 px-6 py-4 hover:bg-base-200/30 transition-colors duration-150 text-left"
+          @click="open = !open">
+          <div class="flex items-center justify-center w-10 h-10 rounded-xl shrink-0"
+            style="{{if .Color}}background-color: {{.Color}}15{{else}}background-color: oklch(48% 0.17 265 / 0.08){{end}}">
+            {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-5 h-5" style="{{if .Color}}color: {{.Color}}{{end}}"></i>
+            {{else}}{{if .Color}}<span class="w-3 h-3 rounded-full" style="background-color: {{.Color}}"></span>
+            {{else}}<i data-lucide="tag" class="w-5 h-5 text-primary/60"></i>{{end}}{{end}}
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="font-semibold text-sm">{{.DisplayName}}</span>
+              {{if .Hidden}}<span class="badge badge-ghost badge-xs">Hidden</span>{{end}}
+              {{if .IsSystem}}<span class="badge badge-info badge-xs">System</span>{{end}}
+            </div>
+            <div class="flex items-center gap-3 mt-0.5">
+              <span class="text-xs text-base-content/35 font-mono">{{.Slug}}</span>
+              {{if .Children}}<span class="text-xs text-base-content/40">{{len .Children}} subcategories</span>{{end}}
             </div>
           </div>
-        </div>
+          <div class="flex items-center gap-2" @click.stop>
+            <button class="btn btn-ghost btn-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity"
+              data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+              @click.prevent="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+              title="Edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i></button>
+            {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error opacity-0 group-hover:opacity-100 transition-opacity"
+              data-id="{{.ID}}" data-name="{{.DisplayName}}"
+              @click.prevent="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+              title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
+          </div>
+          <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 shrink-0" :class="open ? 'rotate-180' : ''"></i>
+        </button>
+
         {{if .Children}}
-        <div class="collapse-content px-4 pb-3">
-          <div class="space-y-1 pt-1">
+        <!-- Children -->
+        <div x-show="open" x-cloak
+          x-transition:enter="transition ease-out duration-200"
+          x-transition:enter-start="opacity-0 -translate-y-1"
+          x-transition:enter-end="opacity-100 translate-y-0"
+          x-transition:leave="transition ease-in duration-150"
+          x-transition:leave-start="opacity-100"
+          x-transition:leave-end="opacity-0"
+          class="border-t border-base-200">
+          <div class="px-3 py-2">
             {{range .Children}}
-            <div class="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-base-200 transition-colors group">
-              {{if .Color}}<span class="bb-cat-dot" style="background-color: {{.Color}}"></span>{{end}}
-              {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-4 h-4 opacity-60"></i>{{end}}
-              <span class="text-sm">{{.DisplayName}}</span>
-              <span class="text-xs text-base-content/30 hidden sm:inline font-mono">{{.Slug}}</span>
-              {{if .Hidden}}<span class="badge badge-ghost badge-xs">Hidden</span>{{end}}
-              <div class="ml-auto flex gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
-                <button class="btn btn-ghost btn-xs" data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}" @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})" title="Edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i></button>
-                {{if not .IsSystem}}<button class="btn btn-ghost btn-xs text-error" data-id="{{.ID}}" data-name="{{.DisplayName}}" @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})" title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
+            <div class="group flex items-center gap-3 py-2.5 px-3 rounded-xl hover:bg-base-200/40 transition-colors duration-150">
+              <div class="w-7 h-7 rounded-lg flex items-center justify-center shrink-0"
+                style="{{if .Color}}background-color: {{.Color}}12{{end}}">
+                {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-3.5 h-3.5" style="{{if .Color}}color: {{.Color}}{{end}}"></i>
+                {{else if .Color}}<span class="w-2 h-2 rounded-full" style="background-color: {{.Color}}"></span>
+                {{else}}<span class="w-2 h-2 rounded-full bg-base-content/20"></span>{{end}}
+              </div>
+              <div class="flex-1 min-w-0">
+                <span class="text-sm">{{.DisplayName}}</span>
+                <span class="text-xs text-base-content/30 ml-2 hidden sm:inline font-mono">{{.Slug}}</span>
+                {{if .Hidden}}<span class="badge badge-ghost badge-xs ml-1">Hidden</span>{{end}}
+              </div>
+              <div class="flex gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150">
+                <button class="btn btn-ghost btn-xs rounded-lg"
+                  data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+                  @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                  title="Edit"><i data-lucide="pencil" class="w-3 h-3"></i></button>
+                {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error"
+                  data-id="{{.ID}}" data-name="{{.DisplayName}}"
+                  @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                  title="Delete"><i data-lucide="trash-2" class="w-3 h-3"></i></button>{{end}}
               </div>
             </div>
             {{end}}
           </div>
         </div>
         {{else}}
-        <div class="collapse-content px-4 pb-3">
-          <p class="text-sm text-base-content/50 pt-1">No subcategories</p>
+        <div x-show="open" x-cloak
+          x-transition:enter="transition ease-out duration-200"
+          x-transition:enter-start="opacity-0"
+          x-transition:enter-end="opacity-100"
+          class="border-t border-base-200 px-6 py-4">
+          <p class="text-sm text-base-content/40">No subcategories</p>
         </div>
         {{end}}
       </div>
       {{end}}
     </div>
     {{else}}
-    <div class="card bg-base-100 border border-base-300 text-center py-12">
-      <div class="card-body items-center">
-        <i data-lucide="tag" class="w-12 h-12 text-base-content/30 mb-2"></i>
-        <p class="text-base-content/60">No categories yet. Create your first category to get started.</p>
-        <button class="btn btn-primary btn-sm mt-4" onclick="document.getElementById('create-modal').showModal()">
+    <!-- Empty state -->
+    <div class="bb-card">
+      <div class="flex flex-col items-center text-center py-16 px-6">
+        <div class="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mb-4">
+          <i data-lucide="tag" class="w-8 h-8 text-primary"></i>
+        </div>
+        <h2 class="text-lg font-semibold mb-1">No categories yet</h2>
+        <p class="text-base-content/50 text-sm mb-6 max-w-sm">Create your first category to start organizing transactions into a clean taxonomy.</p>
+        <button class="btn btn-primary btn-sm rounded-xl gap-2" onclick="document.getElementById('create-modal').showModal()">
           <i data-lucide="plus" class="w-4 h-4"></i> Add Category
         </button>
       </div>
@@ -93,34 +149,134 @@
     {{end}}
   </div>
 
-  <!-- Mappings Tab -->
+  <!-- ═══════════ Mappings Tab ═══════════ -->
   <div x-show="activeTab === 'mappings'" x-cloak x-data="mappingsTab()">
     {{if .UnmappedCategories}}
-    <!-- Unmapped categories -->
-    <div class="card bg-base-100 shadow-sm border border-warning/30 mb-6">
-      <div class="card-body p-4">
-        <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
-          <h2 class="card-title text-base">
+    <!-- Unmapped categories alert -->
+    <div class="bb-card p-6 mb-6 border-warning/20">
+      <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div class="flex items-center gap-3">
+          <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-warning/10">
             <i data-lucide="alert-triangle" class="w-5 h-5 text-warning"></i>
-            Unmapped Categories ({{len .UnmappedCategories}})
-          </h2>
-          <div class="flex gap-2" x-show="bulkSelected.length > 0">
-            <span class="text-sm text-base-content/60" x-text="bulkSelected.length + ' selected'"></span>
-            <div class="bb-cat-picker inline-block" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'Map to...', allowEmpty: false})" @category-change.stop="bulkCategoryId = $event.detail.id; bulkCategoryLabel = $event.detail.label">
-              <button type="button" class="btn btn-sm btn-outline gap-2" @click="openPicker()">
-                <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-                <span x-text="bulkCategoryLabel || 'Map to...'" class="text-sm"></span>
-                <i data-lucide="chevron-down" class="w-3 h-3"></i>
+          </div>
+          <div>
+            <h2 class="text-sm font-semibold">{{len .UnmappedCategories}} unmapped categories</h2>
+            <p class="text-xs text-base-content/45">Map these provider categories to your taxonomy</p>
+          </div>
+        </div>
+        <div class="flex gap-2 items-center" x-show="bulkSelected.length > 0">
+          <span class="text-xs text-base-content/50" x-text="bulkSelected.length + ' selected'"></span>
+          <div class="bb-cat-picker inline-block" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'Map to...', allowEmpty: false})" @category-change.stop="bulkCategoryId = $event.detail.id; bulkCategoryLabel = $event.detail.label">
+            <button type="button" class="btn btn-sm btn-outline rounded-xl gap-2" @click="openPicker()">
+              <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+              <span x-text="bulkCategoryLabel || 'Map to...'" class="text-sm"></span>
+              <i data-lucide="chevron-down" class="w-3 h-3"></i>
+            </button>
+            <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
+              <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+                <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full rounded-lg">
+              </div>
+              <div x-ref="listbox">
+                <template x-for="(item, idx) in filteredList" :key="item.id || item.slug || idx">
+                  <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
+                    <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
+                    <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
+                    <span x-text="item.label"></span>
+                  </div>
+                </template>
+                <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
+              </div>
+            </div>
+          </div>
+          <button class="btn btn-sm btn-primary rounded-xl" :disabled="!bulkCategoryId || bulkSubmitting" @click="submitBulkMapping()">
+            <span x-show="!bulkSubmitting">Map All</span>
+            <span x-show="bulkSubmitting" class="loading loading-spinner loading-xs"></span>
+          </button>
+        </div>
+      </div>
+
+      <!-- Desktop: table layout -->
+      <div class="hidden sm:block overflow-x-auto rounded-xl">
+        <table class="table table-sm">
+          <thead>
+            <tr class="bg-base-200/40">
+              <th class="text-xs font-medium text-base-content/50 w-8"><input type="checkbox" class="checkbox checkbox-xs" @change="toggleAllUnmapped($event.target.checked)"></th>
+              <th class="text-xs font-medium text-base-content/50">Provider</th>
+              <th class="text-xs font-medium text-base-content/50">Category</th>
+              <th class="text-xs font-medium text-base-content/50 w-72">Map To</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .UnmappedCategories}}
+            <tr x-data="{submitting: false}" class="hover:bg-base-200/20 transition-colors duration-150">
+              <td><input type="checkbox" class="checkbox checkbox-xs" value="{{.Provider}}||{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}" @change="toggleBulkSelect($el)"></td>
+              <td><span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}} rounded-lg">{{.Provider}}</span></td>
+              <td>
+                <span class="font-mono text-sm">{{if .Primary}}{{.Primary}}{{end}}</span>
+                {{if .Detailed}}<span class="text-xs text-base-content/35 ml-1">&rarr; {{.Detailed}}</span>{{end}}
+              </td>
+              <td>
+                <div class="flex gap-2 items-center">
+                  <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false})">
+                    <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start rounded-xl" @click="openPicker()">
+                      <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+                      <span x-text="displayLabel" class="text-sm truncate"></span>
+                      <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
+                    </button>
+                    <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
+                      <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+                        <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
+                      </div>
+                      <div x-ref="listbox">
+                        <template x-for="(item, idx) in filteredList" :key="item.id || idx">
+                          <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
+                            <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
+                            <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
+                            <span x-text="item.label"></span>
+                          </div>
+                        </template>
+                        <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
+                      </div>
+                    </div>
+                  </div>
+                  <button class="btn btn-sm btn-primary rounded-lg" :disabled="!selectedId || submitting" @click="
+                    submitting = true;
+                    let provCat = '{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}';
+                    fetch('/-/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: selectedId})})
+                    .then(r => { if(r.ok) location.reload(); else { submitting = false; window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Failed to create mapping',type:'error'}})); } })
+                    .catch(() => { submitting = false; })
+                  ">Map</button>
+                </div>
+              </td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Mobile: card layout -->
+      <div class="sm:hidden space-y-2 mt-4">
+        {{range .UnmappedCategories}}
+        <div class="p-3 rounded-xl bg-base-200/30" x-data="{submitting: false}">
+          <div class="flex items-center gap-2 mb-2">
+            <input type="checkbox" class="checkbox checkbox-xs" value="{{.Provider}}||{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}" @change="toggleBulkSelect($el)">
+            <span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}} rounded-lg">{{.Provider}}</span>
+            <span class="font-mono text-sm truncate">{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}</span>
+          </div>
+          <div class="flex gap-2">
+            <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false})">
+              <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start rounded-xl" @click="openPicker()">
+                <span x-text="displayLabel" class="text-sm truncate"></span>
+                <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
               </button>
-              <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-                <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                  <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full">
+              <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
+                <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+                  <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
                 </div>
                 <div x-ref="listbox">
-                  <template x-for="(item, idx) in filteredList" :key="item.id || item.slug || idx">
+                  <template x-for="(item, idx) in filteredList" :key="item.id || idx">
                     <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
                       <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                      <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
                       <span x-text="item.label"></span>
                     </div>
                   </template>
@@ -128,50 +284,83 @@
                 </div>
               </div>
             </div>
-            <button class="btn btn-sm btn-primary" :disabled="!bulkCategoryId || bulkSubmitting" @click="submitBulkMapping()">
-              <span x-show="!bulkSubmitting">Map All</span>
-              <span x-show="bulkSubmitting" class="loading loading-spinner loading-xs"></span>
-            </button>
+            <button class="btn btn-sm btn-primary rounded-lg" :disabled="!selectedId || submitting" @click="
+              submitting = true;
+              let provCat = '{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}';
+              fetch('/-/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: selectedId})})
+              .then(r => { if(r.ok) location.reload(); else { submitting = false; } })
+              .catch(() => { submitting = false; })
+            ">Map</button>
           </div>
         </div>
+        {{end}}
+      </div>
+    </div>
+    {{end}}
 
-        <!-- Desktop: table layout -->
-        <div class="hidden sm:block overflow-x-auto">
-          <table class="table table-sm">
-            <thead>
-              <tr>
-                <th><input type="checkbox" class="checkbox checkbox-xs" @change="toggleAllUnmapped($event.target.checked)"></th>
-                <th>Provider</th>
-                <th>Category</th>
-                <th class="w-72">Map To</th>
-              </tr>
-            </thead>
-            <tbody>
-              {{range .UnmappedCategories}}
-              <tr x-data="{submitting: false}">
-                <td><input type="checkbox" class="checkbox checkbox-xs" value="{{.Provider}}||{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}" @change="toggleBulkSelect($el)"></td>
-                <td><span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}}">{{.Provider}}</span></td>
-                <td>
-                  <span class="font-mono text-sm">{{if .Primary}}{{.Primary}}{{end}}</span>
-                  {{if .Detailed}}<span class="text-xs text-base-content/40"> &rarr; {{.Detailed}}</span>{{end}}
-                </td>
-                <td>
+    <!-- Filter bar -->
+    <div class="bb-card px-6 py-4 mb-6">
+      <form method="GET" class="flex items-center gap-4 flex-wrap">
+        <input type="hidden" name="tab" value="mappings">
+        <div class="form-control">
+          <label class="label label-text text-xs text-base-content/50 pb-1">Provider</label>
+          <select name="provider" class="select select-bordered select-sm rounded-xl" onchange="this.form.submit()">
+            <option value="">All Providers</option>
+            <option value="plaid"{{if eq .FilterProvider "plaid"}} selected{{end}}>Plaid</option>
+            <option value="teller"{{if eq .FilterProvider "teller"}} selected{{end}}>Teller</option>
+            <option value="csv"{{if eq .FilterProvider "csv"}} selected{{end}}>CSV</option>
+          </select>
+        </div>
+        {{if .FilterProvider}}<a href="/categories#mappings" class="btn btn-sm btn-ghost rounded-xl mt-5">Clear</a>{{end}}
+        <div class="ml-auto">
+          <label class="label label-text text-xs text-base-content/50 pb-1">Search</label>
+          <input type="text" placeholder="Search mappings..." class="input input-sm input-bordered w-48 rounded-xl" @input="mappingSearch = $event.target.value">
+        </div>
+      </form>
+    </div>
+
+    <!-- Existing Mappings -->
+    <div class="bb-card p-6">
+      <h2 class="text-sm font-semibold text-base-content/70 mb-4">Mappings ({{len .Mappings}})</h2>
+      {{if .Mappings}}
+      <div class="overflow-x-auto rounded-xl">
+        <table class="table table-sm">
+          <thead>
+            <tr class="bg-base-200/40">
+              <th class="text-xs font-medium text-base-content/50">Provider</th>
+              <th class="text-xs font-medium text-base-content/50">Provider Category</th>
+              <th class="text-xs font-medium text-base-content/50">Mapped To</th>
+              <th class="text-xs font-medium text-base-content/50 w-10"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {{range .Mappings}}
+            <tr x-data="{editing: false, categoryId: '{{.CategoryID}}', submitting: false}" data-mapping-text="{{.ProviderCategory}} {{.CategoryDisplayName}}" x-show="!mappingSearch || $el.dataset.mappingText.toLowerCase().includes(mappingSearch.toLowerCase())" class="hover:bg-base-200/20 transition-colors duration-150">
+              <td><span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}} rounded-lg">{{.Provider}}</span></td>
+              <td class="font-mono text-xs text-base-content/70">{{.ProviderCategory}}</td>
+              <td>
+                <template x-if="!editing">
+                  <button class="btn btn-ghost btn-xs gap-2 justify-start rounded-lg" @click="editing = true">
+                    <span>{{.CategoryDisplayName}}</span>
+                    <i data-lucide="pencil" class="w-3 h-3 opacity-30"></i>
+                  </button>
+                </template>
+                <template x-if="editing">
                   <div class="flex gap-2 items-center">
-                    <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false})">
-                      <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start" @click="openPicker()">
+                    <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false, initial: categoryId})">
+                      <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start rounded-xl" @click="openPicker()">
                         <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
                         <span x-text="displayLabel" class="text-sm truncate"></span>
                         <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
                       </button>
-                      <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-                        <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                          <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
+                      <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
+                        <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+                          <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
                         </div>
                         <div x-ref="listbox">
                           <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                            <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
+                            <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item); categoryId = item.id">
                               <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                              <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
                               <span x-text="item.label"></span>
                             </div>
                           </template>
@@ -179,298 +368,182 @@
                         </div>
                       </div>
                     </div>
-                    <button class="btn btn-sm btn-primary" :disabled="!selectedId || submitting" @click="
+                    <button class="btn btn-sm btn-primary rounded-lg" :disabled="submitting" @click="
                       submitting = true;
-                      let provCat = '{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}';
-                      fetch('/-/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: selectedId})})
-                      .then(r => { if(r.ok) location.reload(); else { submitting = false; window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Failed to create mapping',type:'error'}})); } })
+                      fetch('/-/category-mappings/{{.ID}}', {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({category_id: categoryId})})
+                      .then(r => { if(r.ok) location.reload(); else { submitting = false; editing = false; } })
                       .catch(() => { submitting = false; })
-                    ">Map</button>
+                    ">Save</button>
+                    <button class="btn btn-sm btn-ghost rounded-lg" @click="editing = false">Cancel</button>
                   </div>
-                </td>
-              </tr>
-              {{end}}
-            </tbody>
-          </table>
-        </div>
-
-        <!-- Mobile: card layout -->
-        <div class="sm:hidden space-y-2">
-          {{range .UnmappedCategories}}
-          <div class="border border-base-300 rounded-lg p-3" x-data="{submitting: false}">
-            <div class="flex items-center gap-2 mb-2">
-              <input type="checkbox" class="checkbox checkbox-xs" value="{{.Provider}}||{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}" @change="toggleBulkSelect($el)">
-              <span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}}">{{.Provider}}</span>
-              <span class="font-mono text-sm truncate">{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}</span>
-            </div>
-            <div class="flex gap-2">
-              <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false})">
-                <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start" @click="openPicker()">
-                  <span x-text="displayLabel" class="text-sm truncate"></span>
-                  <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
-                </button>
-                <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
-                  <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                    <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
-                  </div>
-                  <div x-ref="listbox">
-                    <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                      <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                        <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                        <span x-text="item.label"></span>
-                      </div>
-                    </template>
-                    <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-                  </div>
-                </div>
-              </div>
-              <button class="btn btn-sm btn-primary" :disabled="!selectedId || submitting" @click="
-                submitting = true;
-                let provCat = '{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}';
-                fetch('/-/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: selectedId})})
-                .then(r => { if(r.ok) location.reload(); else { submitting = false; } })
-                .catch(() => { submitting = false; })
-              ">Map</button>
-            </div>
-          </div>
-          {{end}}
-        </div>
+                </template>
+              </td>
+              <td>
+                <button class="btn btn-ghost btn-xs text-error/50 hover:text-error rounded-lg transition-colors" @click="
+                  if(confirm('Delete this mapping?')) {
+                    fetch('/-/category-mappings/{{.ID}}', {method: 'DELETE'})
+                    .then(r => { if(r.ok) location.reload(); })
+                  }
+                "><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>
+              </td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
+        <p class="text-sm text-base-content/40 py-6 text-center" x-show="mappingSearch && mappingSearchEmpty" x-cloak>No mappings match your search.</p>
       </div>
-    </div>
-    {{end}}
-
-    <!-- Filter bar -->
-    <div class="bb-filter-bar mb-4">
-      <form method="GET" class="flex items-center gap-3">
-        <input type="hidden" name="tab" value="mappings">
-        <label class="form-control">
-          <select name="provider" class="select select-bordered select-sm" onchange="this.form.submit()">
-            <option value="">All Providers</option>
-            <option value="plaid"{{if eq .FilterProvider "plaid"}} selected{{end}}>Plaid</option>
-            <option value="teller"{{if eq .FilterProvider "teller"}} selected{{end}}>Teller</option>
-            <option value="csv"{{if eq .FilterProvider "csv"}} selected{{end}}>CSV</option>
-          </select>
-        </label>
-        {{if .FilterProvider}}<a href="/categories#mappings" class="btn btn-sm btn-ghost">Clear</a>{{end}}
-      </form>
-      <div class="ml-auto">
-        <input type="text" placeholder="Search mappings..." class="input input-sm input-bordered w-48" @input="mappingSearch = $event.target.value">
-      </div>
-    </div>
-
-    <!-- Existing Mappings -->
-    <div class="card bg-base-100 shadow-sm">
-      <div class="card-body p-4">
-        <h2 class="card-title text-base mb-2">Mappings ({{len .Mappings}})</h2>
-        {{if .Mappings}}
-        <div class="overflow-x-auto">
-          <table class="table table-sm">
-            <thead>
-              <tr><th>Provider</th><th>Provider Category</th><th>Mapped To</th><th></th></tr>
-            </thead>
-            <tbody>
-              {{range .Mappings}}
-              <tr x-data="{editing: false, categoryId: '{{.CategoryID}}', submitting: false}" data-mapping-text="{{.ProviderCategory}} {{.CategoryDisplayName}}" x-show="!mappingSearch || $el.dataset.mappingText.toLowerCase().includes(mappingSearch.toLowerCase())">
-                <td><span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}}">{{.Provider}}</span></td>
-                <td class="font-mono text-sm">{{.ProviderCategory}}</td>
-                <td>
-                  <template x-if="!editing">
-                    <button class="btn btn-ghost btn-xs gap-2 justify-start" @click="editing = true">
-                      <span>{{.CategoryDisplayName}}</span>
-                      <i data-lucide="pencil" class="w-3 h-3 opacity-40"></i>
-                    </button>
-                  </template>
-                  <template x-if="editing">
-                    <div class="flex gap-2 items-center">
-                      <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false, initial: categoryId})">
-                        <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start" @click="openPicker()">
-                          <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-                          <span x-text="displayLabel" class="text-sm truncate"></span>
-                          <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
-                        </button>
-                        <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
-                          <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                            <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
-                          </div>
-                          <div x-ref="listbox">
-                            <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                              <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item); categoryId = item.id">
-                                <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                                <span x-text="item.label"></span>
-                              </div>
-                            </template>
-                            <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-                          </div>
-                        </div>
-                      </div>
-                      <button class="btn btn-sm btn-primary" :disabled="submitting" @click="
-                        submitting = true;
-                        fetch('/-/category-mappings/{{.ID}}', {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({category_id: categoryId})})
-                        .then(r => { if(r.ok) location.reload(); else { submitting = false; editing = false; } })
-                        .catch(() => { submitting = false; })
-                      ">Save</button>
-                      <button class="btn btn-sm btn-ghost" @click="editing = false">Cancel</button>
-                    </div>
-                  </template>
-                </td>
-                <td>
-                  <button class="btn btn-ghost btn-xs text-error" @click="
-                    if(confirm('Delete this mapping?')) {
-                      fetch('/-/category-mappings/{{.ID}}', {method: 'DELETE'})
-                      .then(r => { if(r.ok) location.reload(); })
-                    }
-                  "><i data-lucide="trash-2" class="w-4 h-4"></i></button>
-                </td>
-              </tr>
-              {{end}}
-            </tbody>
-          </table>
-          <p class="text-sm text-base-content/50 py-4 text-center" x-show="mappingSearch && mappingSearchEmpty" x-cloak>No mappings match your search.</p>
+      {{else}}
+      <div class="flex flex-col items-center text-center py-12">
+        <div class="w-14 h-14 rounded-2xl bg-base-200/60 flex items-center justify-center mb-3">
+          <i data-lucide="arrow-right-left" class="w-7 h-7 text-base-content/30"></i>
         </div>
-        {{else}}
-        <p class="text-sm text-base-content/50 py-4 text-center">No mappings configured yet.</p>
-        {{end}}
+        <p class="text-sm text-base-content/45">No mappings configured yet.</p>
       </div>
+      {{end}}
     </div>
   </div>
 
-  <!-- Bulk Edit Tab -->
+  <!-- ═══════════ Bulk Edit Tab ═══════════ -->
   <div x-show="activeTab === 'bulk'" x-cloak x-data="bulkEditTab()">
     <div class="space-y-6">
       <!-- Categories TSV -->
-      <div class="card bg-base-100 shadow-sm border border-base-300">
-        <div class="card-body p-4">
-          <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
-            <div>
-              <h2 class="card-title text-base">
-                <i data-lucide="list-tree" class="w-5 h-5"></i>
-                Categories
-              </h2>
-              <p class="text-xs text-base-content/50 mt-0.5">TSV format: slug, display_name, parent_slug, icon, color, sort_order, hidden, merge_into</p>
+      <div class="bb-card p-6">
+        <div class="flex items-center justify-between mb-5 flex-wrap gap-3">
+          <div class="flex items-center gap-3">
+            <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
+              <i data-lucide="list-tree" class="w-5 h-5 text-primary"></i>
             </div>
-            <div class="flex gap-2">
-              <button class="btn btn-sm btn-ghost btn-square" title="Copy agent instructions" @click="copyAgentInstructions()">
-                <i data-lucide="bot" class="w-4 h-4"></i>
-              </button>
-              <button class="btn btn-sm btn-outline" :disabled="catLoading" @click="exportCategories()">
-                <i data-lucide="download" class="w-4 h-4"></i>
-                <span x-show="!catLoading">Export</span>
-                <span x-show="catLoading" class="loading loading-spinner loading-xs"></span>
-              </button>
-              <button class="btn btn-sm btn-primary" :disabled="!catText.trim() || catImporting" @click="importCategories()">
-                <i data-lucide="upload" class="w-4 h-4"></i>
-                <span x-show="!catImporting">Import</span>
-                <span x-show="catImporting" class="loading loading-spinner loading-xs"></span>
-              </button>
+            <div>
+              <h2 class="text-sm font-semibold">Categories</h2>
+              <p class="text-xs text-base-content/40 mt-0.5">TSV format: slug, display_name, parent_slug, icon, color, sort_order, hidden, merge_into</p>
             </div>
           </div>
-          <textarea x-model="catText" class="textarea textarea-bordered w-full font-mono text-xs leading-relaxed" rows="12" placeholder="Click Export to load current categories, or paste TSV data here...&#10;&#10;slug&#9;display_name&#9;parent_slug&#9;icon&#9;color&#9;sort_order&#9;hidden&#9;merge_into&#10;food_and_drink&#9;Food & Drink&#9;&#9;utensils&#9;#ef4444&#9;0&#9;false&#9;&#10;old_category&#9;&#9;&#9;&#9;&#9;&#9;&#9;food_and_drink" spellcheck="false"></textarea>
-          <!-- Import mode toggle -->
-          <label class="label cursor-pointer justify-start gap-3 mt-1">
-            <input type="checkbox" x-model="catReplace" class="toggle toggle-sm toggle-error">
-            <div>
-              <span class="label-text">Full replace</span>
-              <span class="text-xs text-base-content/50 block">Delete categories not in the import (system categories are kept). Off = only add &amp; update.</span>
-            </div>
-          </label>
-          <!-- Result -->
-          <template x-if="catResult">
-            <div class="mt-2">
-              <div class="flex flex-wrap gap-2 text-sm">
-                <span x-show="catResult.created > 0" class="badge badge-success badge-sm" x-text="catResult.created + ' created'"></span>
-                <span x-show="catResult.updated > 0" class="badge badge-info badge-sm" x-text="catResult.updated + ' updated'"></span>
-                <span x-show="catResult.unchanged > 0" class="badge badge-ghost badge-sm" x-text="catResult.unchanged + ' unchanged'"></span>
-                <span x-show="catResult.merged > 0" class="badge badge-warning badge-sm" x-text="catResult.merged + ' merged'"></span>
-                <span x-show="catResult.deleted > 0" class="badge badge-error badge-sm" x-text="catResult.deleted + ' deleted'"></span>
-              </div>
-              <template x-if="catResult.errors && catResult.errors.length > 0">
-                <div class="mt-2 text-sm text-error">
-                  <template x-for="e in catResult.errors"><p x-text="e"></p></template>
-                </div>
-              </template>
-            </div>
-          </template>
+          <div class="flex gap-2">
+            <button class="btn btn-sm btn-ghost btn-square rounded-xl" title="Copy agent instructions" @click="copyAgentInstructions()">
+              <i data-lucide="bot" class="w-4 h-4"></i>
+            </button>
+            <button class="btn btn-sm btn-outline rounded-xl" :disabled="catLoading" @click="exportCategories()">
+              <i data-lucide="download" class="w-4 h-4"></i>
+              <span x-show="!catLoading">Export</span>
+              <span x-show="catLoading" class="loading loading-spinner loading-xs"></span>
+            </button>
+            <button class="btn btn-sm btn-primary rounded-xl" :disabled="!catText.trim() || catImporting" @click="importCategories()">
+              <i data-lucide="upload" class="w-4 h-4"></i>
+              <span x-show="!catImporting">Import</span>
+              <span x-show="catImporting" class="loading loading-spinner loading-xs"></span>
+            </button>
+          </div>
         </div>
+        <textarea x-model="catText" class="textarea textarea-bordered w-full font-mono text-xs leading-relaxed rounded-xl bg-base-200/30" rows="12" placeholder="Click Export to load current categories, or paste TSV data here...&#10;&#10;slug&#9;display_name&#9;parent_slug&#9;icon&#9;color&#9;sort_order&#9;hidden&#9;merge_into&#10;food_and_drink&#9;Food & Drink&#9;&#9;utensils&#9;#ef4444&#9;0&#9;false&#9;&#10;old_category&#9;&#9;&#9;&#9;&#9;&#9;&#9;food_and_drink" spellcheck="false"></textarea>
+        <!-- Import mode toggle -->
+        <label class="label cursor-pointer justify-start gap-3 mt-2">
+          <input type="checkbox" x-model="catReplace" class="toggle toggle-sm toggle-error">
+          <div>
+            <span class="label-text text-sm">Full replace</span>
+            <span class="text-xs text-base-content/40 block">Delete categories not in the import (system categories are kept). Off = only add &amp; update.</span>
+          </div>
+        </label>
+        <!-- Result -->
+        <template x-if="catResult">
+          <div class="mt-3 p-3 bg-base-200/30 rounded-xl">
+            <div class="flex flex-wrap gap-2 text-sm">
+              <span x-show="catResult.created > 0" class="badge badge-success badge-sm rounded-lg" x-text="catResult.created + ' created'"></span>
+              <span x-show="catResult.updated > 0" class="badge badge-info badge-sm rounded-lg" x-text="catResult.updated + ' updated'"></span>
+              <span x-show="catResult.unchanged > 0" class="badge badge-ghost badge-sm rounded-lg" x-text="catResult.unchanged + ' unchanged'"></span>
+              <span x-show="catResult.merged > 0" class="badge badge-warning badge-sm rounded-lg" x-text="catResult.merged + ' merged'"></span>
+              <span x-show="catResult.deleted > 0" class="badge badge-error badge-sm rounded-lg" x-text="catResult.deleted + ' deleted'"></span>
+            </div>
+            <template x-if="catResult.errors && catResult.errors.length > 0">
+              <div class="mt-2 text-sm text-error">
+                <template x-for="e in catResult.errors"><p x-text="e"></p></template>
+              </div>
+            </template>
+          </div>
+        </template>
       </div>
 
       <!-- Mappings TSV -->
-      <div class="card bg-base-100 shadow-sm border border-base-300">
-        <div class="card-body p-4">
-          <div class="flex items-center justify-between mb-3 flex-wrap gap-2">
+      <div class="bb-card p-6">
+        <div class="flex items-center justify-between mb-5 flex-wrap gap-3">
+          <div class="flex items-center gap-3">
+            <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-secondary/8">
+              <i data-lucide="arrow-right-left" class="w-5 h-5 text-secondary"></i>
+            </div>
             <div>
-              <h2 class="card-title text-base">
-                <i data-lucide="arrow-right-left" class="w-5 h-5"></i>
-                Mappings
-              </h2>
-              <p class="text-xs text-base-content/50 mt-0.5">TSV format: provider, provider_category, category_slug</p>
-            </div>
-            <div class="flex gap-2">
-              <button class="btn btn-sm btn-outline" :disabled="mapLoading" @click="exportMappings()">
-                <i data-lucide="download" class="w-4 h-4"></i>
-                <span x-show="!mapLoading">Export</span>
-                <span x-show="mapLoading" class="loading loading-spinner loading-xs"></span>
-              </button>
-              <button class="btn btn-sm btn-primary" :disabled="!mapText.trim() || mapImporting" @click="importMappings()">
-                <i data-lucide="upload" class="w-4 h-4"></i>
-                <span x-show="!mapImporting">Import</span>
-                <span x-show="mapImporting" class="loading loading-spinner loading-xs"></span>
-              </button>
+              <h2 class="text-sm font-semibold">Mappings</h2>
+              <p class="text-xs text-base-content/40 mt-0.5">TSV format: provider, provider_category, category_slug</p>
             </div>
           </div>
-          <textarea x-model="mapText" class="textarea textarea-bordered w-full font-mono text-xs leading-relaxed" rows="12" placeholder="Click Export to load current mappings, or paste TSV data here...&#10;&#10;provider&#9;provider_category&#9;category_slug&#10;plaid&#9;FOOD_AND_DRINK_GROCERIES&#9;food_and_drink_groceries" spellcheck="false"></textarea>
-          <!-- Import options -->
-          <div class="space-y-1 mt-1">
-            <label class="label cursor-pointer justify-start gap-3">
-              <input type="checkbox" x-model="mapReplace" class="toggle toggle-sm toggle-error">
-              <div>
-                <span class="label-text">Full replace</span>
-                <span class="text-xs text-base-content/50 block">Delete mappings not in the import. Off = only add &amp; update.</span>
-              </div>
-            </label>
-            <label class="label cursor-pointer justify-start gap-3">
-              <input type="checkbox" x-model="mapRetroactive" class="toggle toggle-sm">
-              <div>
-                <span class="label-text">Apply retroactively</span>
-                <span class="text-xs text-base-content/50 block">Re-categorize existing transactions that match updated mappings</span>
-              </div>
-            </label>
+          <div class="flex gap-2">
+            <button class="btn btn-sm btn-outline rounded-xl" :disabled="mapLoading" @click="exportMappings()">
+              <i data-lucide="download" class="w-4 h-4"></i>
+              <span x-show="!mapLoading">Export</span>
+              <span x-show="mapLoading" class="loading loading-spinner loading-xs"></span>
+            </button>
+            <button class="btn btn-sm btn-primary rounded-xl" :disabled="!mapText.trim() || mapImporting" @click="importMappings()">
+              <i data-lucide="upload" class="w-4 h-4"></i>
+              <span x-show="!mapImporting">Import</span>
+              <span x-show="mapImporting" class="loading loading-spinner loading-xs"></span>
+            </button>
           </div>
-          <!-- Result -->
-          <template x-if="mapResult">
-            <div class="mt-2">
-              <div class="flex flex-wrap gap-2 text-sm">
-                <span x-show="mapResult.created > 0" class="badge badge-success badge-sm" x-text="mapResult.created + ' created'"></span>
-                <span x-show="mapResult.updated > 0" class="badge badge-info badge-sm" x-text="mapResult.updated + ' updated'"></span>
-                <span x-show="mapResult.unchanged > 0" class="badge badge-ghost badge-sm" x-text="mapResult.unchanged + ' unchanged'"></span>
-                <span x-show="mapResult.deleted > 0" class="badge badge-error badge-sm" x-text="mapResult.deleted + ' deleted'"></span>
-                <span x-show="mapResult.transactions_updated > 0" class="badge badge-warning badge-sm" x-text="mapResult.transactions_updated + ' transactions re-categorized'"></span>
-              </div>
-              <template x-if="mapResult.errors && mapResult.errors.length > 0">
-                <div class="mt-2 text-sm text-error">
-                  <template x-for="e in mapResult.errors"><p x-text="e"></p></template>
-                </div>
-              </template>
-            </div>
-          </template>
         </div>
+        <textarea x-model="mapText" class="textarea textarea-bordered w-full font-mono text-xs leading-relaxed rounded-xl bg-base-200/30" rows="12" placeholder="Click Export to load current mappings, or paste TSV data here...&#10;&#10;provider&#9;provider_category&#9;category_slug&#10;plaid&#9;FOOD_AND_DRINK_GROCERIES&#9;food_and_drink_groceries" spellcheck="false"></textarea>
+        <!-- Import options -->
+        <div class="space-y-1 mt-2">
+          <label class="label cursor-pointer justify-start gap-3">
+            <input type="checkbox" x-model="mapReplace" class="toggle toggle-sm toggle-error">
+            <div>
+              <span class="label-text text-sm">Full replace</span>
+              <span class="text-xs text-base-content/40 block">Delete mappings not in the import. Off = only add &amp; update.</span>
+            </div>
+          </label>
+          <label class="label cursor-pointer justify-start gap-3">
+            <input type="checkbox" x-model="mapRetroactive" class="toggle toggle-sm">
+            <div>
+              <span class="label-text text-sm">Apply retroactively</span>
+              <span class="text-xs text-base-content/40 block">Re-categorize existing transactions that match updated mappings</span>
+            </div>
+          </label>
+        </div>
+        <!-- Result -->
+        <template x-if="mapResult">
+          <div class="mt-3 p-3 bg-base-200/30 rounded-xl">
+            <div class="flex flex-wrap gap-2 text-sm">
+              <span x-show="mapResult.created > 0" class="badge badge-success badge-sm rounded-lg" x-text="mapResult.created + ' created'"></span>
+              <span x-show="mapResult.updated > 0" class="badge badge-info badge-sm rounded-lg" x-text="mapResult.updated + ' updated'"></span>
+              <span x-show="mapResult.unchanged > 0" class="badge badge-ghost badge-sm rounded-lg" x-text="mapResult.unchanged + ' unchanged'"></span>
+              <span x-show="mapResult.deleted > 0" class="badge badge-error badge-sm rounded-lg" x-text="mapResult.deleted + ' deleted'"></span>
+              <span x-show="mapResult.transactions_updated > 0" class="badge badge-warning badge-sm rounded-lg" x-text="mapResult.transactions_updated + ' transactions re-categorized'"></span>
+            </div>
+            <template x-if="mapResult.errors && mapResult.errors.length > 0">
+              <div class="mt-2 text-sm text-error">
+                <template x-for="e in mapResult.errors"><p x-text="e"></p></template>
+              </div>
+            </template>
+          </div>
+        </template>
       </div>
 
       <!-- Info card -->
-      <div class="alert alert-info">
-        <i data-lucide="info" class="w-5 h-5"></i>
-        <div class="text-sm">
-          <p class="font-semibold">How bulk edit works</p>
-          <p>Export loads the current data into the text area as tab-separated values. Edit the text (or paste from a spreadsheet), then click Import. By default, existing entries are updated and new ones are created — rows you remove are <strong>not</strong> deleted. Enable <strong>Full replace</strong> to also delete any entries not present in the import.</p>
-          <p class="mt-1"><strong>Merging categories:</strong> To consolidate categories, set the <code>merge_into</code> column to the target category's slug. All transactions and mappings from the source category are moved to the target, then the source is deleted. Great for simplifying a complex taxonomy. Use the <i data-lucide="bot" class="w-3 h-3 inline"></i> button to copy instructions for an AI agent to help you edit the file.</p>
+      <div class="bb-card p-6 border-info/15">
+        <div class="flex gap-4">
+          <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-info/10 shrink-0">
+            <i data-lucide="info" class="w-5 h-5 text-info"></i>
+          </div>
+          <div class="text-sm text-base-content/70 space-y-2">
+            <p class="font-semibold text-base-content">How bulk edit works</p>
+            <p>Export loads the current data into the text area as tab-separated values. Edit the text (or paste from a spreadsheet), then click Import. By default, existing entries are updated and new ones are created — rows you remove are <strong>not</strong> deleted. Enable <strong>Full replace</strong> to also delete any entries not present in the import.</p>
+            <p><strong>Merging categories:</strong> To consolidate categories, set the <code class="bg-base-200/60 px-1.5 py-0.5 rounded text-xs">merge_into</code> column to the target category's slug. All transactions and mappings are moved to the target, then the source is deleted. Use the <i data-lucide="bot" class="w-3 h-3 inline"></i> button to copy instructions for an AI agent.</p>
+          </div>
         </div>
       </div>
     </div>
   </div>
 </div>
 
-<!-- Create Modal -->
+<!-- ═══════════ Create Modal ═══════════ -->
 <dialog id="create-modal" class="modal modal-bottom sm:modal-middle">
-  <form class="modal-box" x-data="{displayName: '', parentId: '', icon: '', color: '#6366f1', sortOrder: 0, submitting: false, showIconPicker: false,
+  <form class="modal-box rounded-3xl max-w-lg" x-data="{displayName: '', parentId: '', icon: '', color: '#6366f1', sortOrder: 0, submitting: false, showIconPicker: false,
     commonIcons: ['shopping-cart','utensils','car','home','briefcase','heart','zap','book','plane','music','gift','coffee','scissors','shirt','gamepad-2','graduation-cap','building-2','fuel','bus','train'],
     presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c']
   }" @submit.prevent="
@@ -479,30 +552,33 @@
     .then(r => { if(r.ok) location.reload(); else r.json().then(d => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Error', type:'error'}})); submitting = false; }); })
     .catch(() => { submitting = false; })
   ">
-    <h3 class="font-bold text-lg">Add Category</h3>
-    <div class="space-y-4 mt-4">
+    <h3 class="text-lg font-bold">Add Category</h3>
+    <p class="text-sm text-base-content/50 mt-1">Create a new category in your taxonomy</p>
+    <div class="space-y-4 mt-6">
       <!-- Live preview -->
-      <div class="flex items-center gap-3 p-3 bg-base-200 rounded-lg">
-        <span class="bb-cat-dot" :style="'background-color:' + (color || '#6366f1')" style="width:0.75rem;height:0.75rem"></span>
-        <template x-if="icon"><i :data-lucide="icon" class="w-5 h-5 opacity-70"></i></template>
-        <span class="font-semibold" x-text="displayName || 'Category Name'"></span>
+      <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-2xl">
+        <div class="w-9 h-9 rounded-xl flex items-center justify-center" :style="'background-color:' + (color || '#6366f1') + '15'">
+          <template x-if="icon"><i :data-lucide="icon" class="w-4.5 h-4.5" :style="'color:' + (color || '#6366f1')"></i></template>
+          <template x-if="!icon"><span class="w-2.5 h-2.5 rounded-full" :style="'background-color:' + (color || '#6366f1')"></span></template>
+        </div>
+        <span class="font-semibold text-sm" x-text="displayName || 'Category Name'"></span>
       </div>
 
       <label class="form-control w-full">
-        <div class="label"><span class="label-text">Display Name</span></div>
-        <input type="text" x-model="displayName" class="input input-bordered w-full" required placeholder="e.g. Food & Drink">
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Display Name</span></div>
+        <input type="text" x-model="displayName" class="input input-bordered w-full rounded-xl" required placeholder="e.g. Food & Drink">
       </label>
 
       <label class="form-control w-full">
-        <div class="label"><span class="label-text">Parent Category</span></div>
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Parent Category</span></div>
         <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'None (top-level)', allowEmpty: true, emptyLabel: 'None (top-level)'})" @category-change="parentId = $event.detail.id">
-          <button type="button" class="select select-bordered w-full text-left flex items-center gap-2" @click="openPicker()">
+          <button type="button" class="select select-bordered w-full text-left flex items-center gap-2 rounded-xl" @click="openPicker()">
             <span x-text="displayLabel" class="flex-1 text-sm"></span>
-            <i data-lucide="chevron-down" class="w-4 h-4 opacity-50"></i>
+            <i data-lucide="chevron-down" class="w-4 h-4 opacity-40"></i>
           </button>
           <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
-            <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-              <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
+            <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+              <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
             </div>
             <div x-ref="listbox">
               <template x-for="(item, idx) in filteredList" :key="item.id || idx">
@@ -519,17 +595,17 @@
 
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div class="form-control">
-          <div class="label"><span class="label-text">Icon</span></div>
+          <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Icon</span></div>
           <div class="flex gap-2 items-center">
-            <input type="text" x-model="icon" class="input input-bordered flex-1" placeholder="e.g. shopping-cart">
-            <button type="button" class="btn btn-sm btn-ghost" @click="showIconPicker = !showIconPicker" title="Browse icons">
+            <input type="text" x-model="icon" class="input input-bordered flex-1 rounded-xl" placeholder="e.g. shopping-cart">
+            <button type="button" class="btn btn-sm btn-ghost rounded-xl" @click="showIconPicker = !showIconPicker" title="Browse icons">
               <i data-lucide="grid-3x3" class="w-4 h-4"></i>
             </button>
           </div>
-          <div x-show="showIconPicker" x-cloak class="mt-2 p-2 bg-base-200 rounded-lg">
+          <div x-show="showIconPicker" x-cloak class="mt-2 p-2.5 bg-base-200/40 rounded-xl">
             <div class="grid grid-cols-5 gap-1">
               <template x-for="ic in commonIcons">
-                <button type="button" class="btn btn-ghost btn-sm" @click="icon = ic; showIconPicker = false; $nextTick(() => lucide.createIcons())">
+                <button type="button" class="btn btn-ghost btn-sm rounded-lg" @click="icon = ic; showIconPicker = false; $nextTick(() => lucide.createIcons())">
                   <i :data-lucide="ic" class="w-4 h-4"></i>
                 </button>
               </template>
@@ -537,27 +613,27 @@
           </div>
         </div>
         <div class="form-control">
-          <div class="label"><span class="label-text">Color</span></div>
+          <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Color</span></div>
           <div class="flex flex-wrap gap-1.5">
             <template x-for="c in presetColors">
-              <button type="button" class="w-7 h-7 rounded-full border-2 transition-transform" :style="'background-color:' + c" :class="color === c ? 'border-base-content scale-110' : 'border-transparent'" @click="color = c"></button>
+              <button type="button" class="w-7 h-7 rounded-full border-2 transition-all duration-150 hover:scale-110" :style="'background-color:' + c" :class="color === c ? 'border-base-content scale-110 shadow-sm' : 'border-transparent'" @click="color = c"></button>
             </template>
-            <label class="w-7 h-7 rounded-full border-2 border-dashed border-base-content/30 cursor-pointer overflow-hidden flex items-center justify-center" title="Custom color">
+            <label class="w-7 h-7 rounded-full border-2 border-dashed border-base-content/20 cursor-pointer overflow-hidden flex items-center justify-center hover:border-base-content/40 transition-colors" title="Custom color">
               <input type="color" x-model="color" class="opacity-0 absolute w-0 h-0">
-              <i data-lucide="palette" class="w-3.5 h-3.5 opacity-50"></i>
+              <i data-lucide="palette" class="w-3.5 h-3.5 opacity-40"></i>
             </label>
           </div>
         </div>
       </div>
 
       <label class="form-control w-full">
-        <div class="label"><span class="label-text">Sort Order</span></div>
-        <input type="number" x-model.number="sortOrder" class="input input-bordered w-full" value="0">
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Sort Order</span></div>
+        <input type="number" x-model.number="sortOrder" class="input input-bordered w-full rounded-xl" value="0">
       </label>
     </div>
     <div class="modal-action">
-      <button type="button" class="btn" onclick="document.getElementById('create-modal').close()">Cancel</button>
-      <button type="submit" class="btn btn-primary" :disabled="submitting || !displayName">
+      <button type="button" class="btn btn-ghost rounded-xl" onclick="document.getElementById('create-modal').close()">Cancel</button>
+      <button type="submit" class="btn btn-primary rounded-xl" :disabled="submitting || !displayName">
         <span x-show="!submitting">Create</span>
         <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
       </button>
@@ -566,39 +642,42 @@
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
 
-<!-- Edit Modal -->
+<!-- ═══════════ Edit Modal ═══════════ -->
 <dialog id="edit-modal" class="modal modal-bottom sm:modal-middle" x-data="{editId: '', editDisplayName: '', editIcon: '', editColor: '', editSortOrder: 0, editHidden: false, submitting: false, showIconPicker: false,
   commonIcons: ['shopping-cart','utensils','car','home','briefcase','heart','zap','book','plane','music','gift','coffee','scissors','shirt','gamepad-2','graduation-cap','building-2','fuel','bus','train'],
   presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c']
 }" @edit-category.window="editId = $event.detail.id; editDisplayName = $event.detail.displayName; editIcon = $event.detail.icon; editColor = $event.detail.color || '#6366f1'; editSortOrder = $event.detail.sortOrder; editHidden = $event.detail.hidden; showIconPicker = false; document.getElementById('edit-modal').showModal(); $nextTick(() => lucide.createIcons())">
-  <div class="modal-box">
-    <h3 class="font-bold text-lg">Edit Category</h3>
-    <div class="space-y-4 mt-4">
+  <div class="modal-box rounded-3xl max-w-lg">
+    <h3 class="text-lg font-bold">Edit Category</h3>
+    <p class="text-sm text-base-content/50 mt-1">Update category appearance and settings</p>
+    <div class="space-y-4 mt-6">
       <!-- Live preview -->
-      <div class="flex items-center gap-3 p-3 bg-base-200 rounded-lg">
-        <span class="bb-cat-dot" :style="'background-color:' + (editColor || '#6366f1')" style="width:0.75rem;height:0.75rem"></span>
-        <template x-if="editIcon"><i :data-lucide="editIcon" class="w-5 h-5 opacity-70"></i></template>
-        <span class="font-semibold" x-text="editDisplayName || 'Category Name'"></span>
+      <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-2xl">
+        <div class="w-9 h-9 rounded-xl flex items-center justify-center" :style="'background-color:' + (editColor || '#6366f1') + '15'">
+          <template x-if="editIcon"><i :data-lucide="editIcon" class="w-4.5 h-4.5" :style="'color:' + (editColor || '#6366f1')"></i></template>
+          <template x-if="!editIcon"><span class="w-2.5 h-2.5 rounded-full" :style="'background-color:' + (editColor || '#6366f1')"></span></template>
+        </div>
+        <span class="font-semibold text-sm" x-text="editDisplayName || 'Category Name'"></span>
         <span x-show="editHidden" class="badge badge-ghost badge-xs">Hidden</span>
       </div>
 
       <label class="form-control w-full">
-        <div class="label"><span class="label-text">Display Name</span></div>
-        <input type="text" x-model="editDisplayName" class="input input-bordered w-full" required>
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Display Name</span></div>
+        <input type="text" x-model="editDisplayName" class="input input-bordered w-full rounded-xl" required>
       </label>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div class="form-control">
-          <div class="label"><span class="label-text">Icon</span></div>
+          <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Icon</span></div>
           <div class="flex gap-2 items-center">
-            <input type="text" x-model="editIcon" class="input input-bordered flex-1" placeholder="e.g. shopping-cart">
-            <button type="button" class="btn btn-sm btn-ghost" @click="showIconPicker = !showIconPicker">
+            <input type="text" x-model="editIcon" class="input input-bordered flex-1 rounded-xl" placeholder="e.g. shopping-cart">
+            <button type="button" class="btn btn-sm btn-ghost rounded-xl" @click="showIconPicker = !showIconPicker">
               <i data-lucide="grid-3x3" class="w-4 h-4"></i>
             </button>
           </div>
-          <div x-show="showIconPicker" x-cloak class="mt-2 p-2 bg-base-200 rounded-lg">
+          <div x-show="showIconPicker" x-cloak class="mt-2 p-2.5 bg-base-200/40 rounded-xl">
             <div class="grid grid-cols-5 gap-1">
               <template x-for="ic in commonIcons">
-                <button type="button" class="btn btn-ghost btn-sm" @click="editIcon = ic; showIconPicker = false; $nextTick(() => lucide.createIcons())">
+                <button type="button" class="btn btn-ghost btn-sm rounded-lg" @click="editIcon = ic; showIconPicker = false; $nextTick(() => lucide.createIcons())">
                   <i :data-lucide="ic" class="w-4 h-4"></i>
                 </button>
               </template>
@@ -606,30 +685,33 @@
           </div>
         </div>
         <div class="form-control">
-          <div class="label"><span class="label-text">Color</span></div>
+          <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Color</span></div>
           <div class="flex flex-wrap gap-1.5">
             <template x-for="c in presetColors">
-              <button type="button" class="w-7 h-7 rounded-full border-2 transition-transform" :style="'background-color:' + c" :class="editColor === c ? 'border-base-content scale-110' : 'border-transparent'" @click="editColor = c"></button>
+              <button type="button" class="w-7 h-7 rounded-full border-2 transition-all duration-150 hover:scale-110" :style="'background-color:' + c" :class="editColor === c ? 'border-base-content scale-110 shadow-sm' : 'border-transparent'" @click="editColor = c"></button>
             </template>
-            <label class="w-7 h-7 rounded-full border-2 border-dashed border-base-content/30 cursor-pointer overflow-hidden flex items-center justify-center" title="Custom color">
+            <label class="w-7 h-7 rounded-full border-2 border-dashed border-base-content/20 cursor-pointer overflow-hidden flex items-center justify-center hover:border-base-content/40 transition-colors" title="Custom color">
               <input type="color" x-model="editColor" class="opacity-0 absolute w-0 h-0">
-              <i data-lucide="palette" class="w-3.5 h-3.5 opacity-50"></i>
+              <i data-lucide="palette" class="w-3.5 h-3.5 opacity-40"></i>
             </label>
           </div>
         </div>
       </div>
       <label class="form-control w-full">
-        <div class="label"><span class="label-text">Sort Order</span></div>
-        <input type="number" x-model.number="editSortOrder" class="input input-bordered w-full">
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Sort Order</span></div>
+        <input type="number" x-model.number="editSortOrder" class="input input-bordered w-full rounded-xl">
       </label>
       <label class="label cursor-pointer justify-start gap-3">
         <input type="checkbox" x-model="editHidden" class="toggle toggle-sm">
-        <span class="label-text">Hidden</span>
+        <div>
+          <span class="label-text text-sm">Hidden</span>
+          <span class="text-xs text-base-content/40 block">Hidden categories still work for mapping but don't appear in dropdowns</span>
+        </div>
       </label>
     </div>
     <div class="modal-action">
-      <button type="button" class="btn" onclick="document.getElementById('edit-modal').close()">Cancel</button>
-      <button type="button" class="btn btn-primary" :disabled="submitting || !editDisplayName" @click="
+      <button type="button" class="btn btn-ghost rounded-xl" onclick="document.getElementById('edit-modal').close()">Cancel</button>
+      <button type="button" class="btn btn-primary rounded-xl" :disabled="submitting || !editDisplayName" @click="
         submitting = true;
         fetch('/-/categories/' + editId, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({display_name: editDisplayName, icon: editIcon || undefined, color: editColor || undefined, sort_order: editSortOrder, hidden: editHidden})})
         .then(r => { if(r.ok) location.reload(); else r.json().then(d => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Error', type:'error'}})); submitting = false; }); })
@@ -643,14 +725,19 @@
   <form method="dialog" class="modal-backdrop"><button>close</button></form>
 </dialog>
 
-<!-- Delete Modal -->
+<!-- ═══════════ Delete Modal ═══════════ -->
 <dialog id="delete-modal" class="modal modal-bottom sm:modal-middle" x-data="{deleteId: '', deleteName: '', submitting: false}" @delete-category.window="deleteId = $event.detail.id; deleteName = $event.detail.name; document.getElementById('delete-modal').showModal()">
-  <div class="modal-box">
-    <h3 class="font-bold text-lg text-error">Delete Category</h3>
-    <p class="py-4">Are you sure you want to delete <strong x-text="deleteName"></strong>? Affected transactions will be set to Uncategorized.</p>
+  <div class="modal-box rounded-3xl max-w-md">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="w-10 h-10 rounded-xl bg-error/10 flex items-center justify-center">
+        <i data-lucide="alert-triangle" class="w-5 h-5 text-error"></i>
+      </div>
+      <h3 class="font-bold text-lg">Delete Category</h3>
+    </div>
+    <p class="text-sm text-base-content/70">Are you sure you want to delete <strong x-text="deleteName"></strong>? Affected transactions will be set to Uncategorized.</p>
     <div class="modal-action">
-      <button type="button" class="btn" onclick="document.getElementById('delete-modal').close()">Cancel</button>
-      <button type="button" class="btn btn-error" :disabled="submitting" @click="
+      <button type="button" class="btn btn-ghost rounded-xl" onclick="document.getElementById('delete-modal').close()">Cancel</button>
+      <button type="button" class="btn btn-error rounded-xl" :disabled="submitting" @click="
         submitting = true;
         fetch('/-/categories/' + deleteId, {method: 'DELETE'})
         .then(r => { if(r.ok) location.reload(); else r.json().then(d => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Error', type:'error'}})); submitting = false; }); })

--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -48,10 +48,10 @@
     <div class="text-sm text-base-content/40 mb-4 px-1">{{len .Categories}} top-level categories</div>
     <div class="space-y-3">
       {{range .Categories}}
-      <div class="bb-card overflow-hidden" x-data="{open: false}">
+      <div class="bb-card overflow-hidden group" x-data="{open: false}">
         <!-- Parent row -->
-        <button type="button" class="w-full flex items-center gap-4 px-6 py-4 hover:bg-base-200/30 transition-colors duration-150 text-left"
-          @click="open = !open">
+        <div role="button" tabindex="0" class="w-full flex items-center gap-4 px-6 py-4 hover:bg-base-200/30 transition-colors duration-150 text-left cursor-pointer select-none"
+          @click="open = !open" @keydown.enter="open = !open" @keydown.space.prevent="open = !open">
           <div class="flex items-center justify-center w-10 h-10 rounded-xl shrink-0"
             style="{{if .Color}}background-color: {{.Color}}15{{else}}background-color: oklch(48% 0.17 265 / 0.08){{end}}">
             {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-5 h-5" style="{{if .Color}}color: {{.Color}}{{end}}"></i>
@@ -80,7 +80,7 @@
               title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
           </div>
           <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 shrink-0" :class="open ? 'rotate-180' : ''"></i>
-        </button>
+        </div>
 
         {{if .Children}}
         <!-- Children -->

--- a/internal/templates/pages/category_mappings.html
+++ b/internal/templates/pages/category_mappings.html
@@ -10,7 +10,7 @@
 </div>
 
 {{if .UnmappedCategories}}
-<div class="bb-card p-5 mb-6 border-warning/20" x-data="{show: true}" x-show="show">
+<div class="bb-card p-6 mb-6 border-warning/20" x-data="{show: true}" x-show="show">
   <div class="flex items-center gap-3 mb-4">
     <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-warning/10">
       <i data-lucide="alert-triangle" class="w-5 h-5 text-warning"></i>
@@ -21,10 +21,10 @@
     </div>
   </div>
 
-  <div class="overflow-x-auto rounded-xl border border-base-200">
+  <div class="overflow-x-auto rounded-xl">
     <table class="table table-sm">
       <thead>
-        <tr class="bg-base-200/50">
+        <tr class="bg-base-200/40">
           <th class="text-xs font-medium text-base-content/50">Provider</th>
           <th class="text-xs font-medium text-base-content/50">Primary</th>
           <th class="text-xs font-medium text-base-content/50">Detailed</th>
@@ -33,22 +33,22 @@
       </thead>
       <tbody>
         {{range .UnmappedCategories}}
-        <tr x-data="{categoryId: '', submitting: false}">
-          <td><span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}}">{{.Provider}}</span></td>
+        <tr x-data="{categoryId: '', submitting: false}" class="hover:bg-base-200/20 transition-colors duration-150">
+          <td><span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}} rounded-lg">{{.Provider}}</span></td>
           <td class="text-sm">{{if .Primary}}{{.Primary}}{{else}}&mdash;{{end}}</td>
           <td class="text-sm font-mono text-xs">{{if .Detailed}}{{.Detailed}}{{else}}&mdash;{{end}}</td>
           <td class="flex gap-2 items-center">
-            <select x-model="categoryId" class="select select-sm w-48 bg-base-200/50 border-base-200 rounded-lg">
+            <select x-model="categoryId" class="select select-sm w-48 bg-base-200/30 border-base-200 rounded-xl">
               <option value="">Select category...</option>
               {{range $.AllCategories}}
               <option value="{{.ID}}">{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
               {{end}}
             </select>
-            <button class="btn btn-sm btn-primary rounded-lg" :disabled="!categoryId || submitting" @click="
+            <button class="btn btn-sm btn-primary rounded-xl" :disabled="!categoryId || submitting" @click="
               submitting = true;
               let provCat = '{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}';
               fetch('/-/category-mappings', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({provider: '{{.Provider}}', provider_category: provCat, category_id: categoryId})})
-              .then(r => { if(r.ok) location.reload(); else { submitting = false; alert('Failed to create mapping'); } })
+              .then(r => { if(r.ok) location.reload(); else { submitting = false; window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Failed to create mapping',type:'error'}})); } })
               .catch(() => { submitting = false; })
             ">Map</button>
           </td>
@@ -78,13 +78,12 @@
 
 <!-- Mappings table -->
 <div class="bb-card p-6">
-  <div class="flex items-center justify-between mb-4">
-    <h2 class="text-sm font-semibold text-base-content/70">Mappings ({{len .Mappings}})</h2>
-  </div>
-  <div class="overflow-x-auto rounded-xl border border-base-200">
+  <h2 class="text-sm font-semibold text-base-content/70 mb-4">Mappings ({{len .Mappings}})</h2>
+  {{if .Mappings}}
+  <div class="overflow-x-auto rounded-xl">
     <table class="table table-sm">
       <thead>
-        <tr class="bg-base-200/50">
+        <tr class="bg-base-200/40">
           <th class="text-xs font-medium text-base-content/50">Provider</th>
           <th class="text-xs font-medium text-base-content/50">Provider Category</th>
           <th class="text-xs font-medium text-base-content/50">Mapped To</th>
@@ -93,43 +92,54 @@
       </thead>
       <tbody>
         {{range .Mappings}}
-        <tr x-data="{editing: false, categoryId: '{{.CategoryID}}', submitting: false}" class="hover:bg-base-200/30 transition-colors">
-          <td><span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}}">{{.Provider}}</span></td>
+        <tr x-data="{editing: false, categoryId: '{{.CategoryID}}', submitting: false}" class="hover:bg-base-200/20 transition-colors duration-150">
+          <td><span class="badge badge-sm {{if eq .Provider "plaid"}}badge-primary{{else if eq .Provider "teller"}}badge-secondary{{else}}badge-accent{{end}} rounded-lg">{{.Provider}}</span></td>
           <td class="font-mono text-xs text-base-content/70">{{.ProviderCategory}}</td>
           <td>
             <template x-if="!editing">
-              <span @click="editing = true" class="text-sm cursor-pointer hover:text-primary transition-colors">{{.CategoryDisplayName}}</span>
+              <button class="btn btn-ghost btn-xs gap-2 justify-start rounded-lg" @click="editing = true">
+                <span class="text-sm">{{.CategoryDisplayName}}</span>
+                <i data-lucide="pencil" class="w-3 h-3 opacity-30"></i>
+              </button>
             </template>
             <template x-if="editing">
               <div class="flex gap-2 items-center">
-                <select x-model="categoryId" class="select select-sm w-48 bg-base-200/50 border-base-200 rounded-lg">
+                <select x-model="categoryId" class="select select-sm w-48 bg-base-200/30 border-base-200 rounded-xl">
                   {{range $.AllCategories}}
                   <option value="{{.ID}}">{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
                   {{end}}
                 </select>
-                <button class="btn btn-sm btn-primary rounded-lg" :disabled="submitting" @click="
+                <button class="btn btn-sm btn-primary rounded-xl" :disabled="submitting" @click="
                   submitting = true;
                   fetch('/-/category-mappings/{{.ID}}', {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({category_id: categoryId})})
                   .then(r => { if(r.ok) location.reload(); else { submitting = false; editing = false; } })
                   .catch(() => { submitting = false; })
                 ">Save</button>
-                <button class="btn btn-sm btn-ghost rounded-lg" @click="editing = false">Cancel</button>
+                <button class="btn btn-sm btn-ghost rounded-xl" @click="editing = false">Cancel</button>
               </div>
             </template>
           </td>
           <td>
-            <button class="btn btn-ghost btn-xs text-error opacity-50 hover:opacity-100 transition-opacity" @click="
+            <button class="btn btn-ghost btn-xs text-error/50 hover:text-error rounded-lg transition-colors" @click="
               if(confirm('Delete this mapping?')) {
                 fetch('/-/category-mappings/{{.ID}}', {method: 'DELETE'})
                 .then(r => { if(r.ok) location.reload(); })
               }
-            "><i data-lucide="trash-2" class="w-4 h-4"></i></button>
+            "><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>
           </td>
         </tr>
         {{end}}
       </tbody>
     </table>
   </div>
+  {{else}}
+  <div class="flex flex-col items-center text-center py-12">
+    <div class="w-14 h-14 rounded-2xl bg-base-200/60 flex items-center justify-center mb-3">
+      <i data-lucide="arrow-right-left" class="w-7 h-7 text-base-content/30"></i>
+    </div>
+    <p class="text-sm text-base-content/45">No mappings configured yet.</p>
+  </div>
+  {{end}}
 </div>
 
 <script>

--- a/internal/templates/pages/category_mappings.html
+++ b/internal/templates/pages/category_mappings.html
@@ -38,7 +38,7 @@
           <td class="text-sm">{{if .Primary}}{{.Primary}}{{else}}&mdash;{{end}}</td>
           <td class="text-sm font-mono text-xs">{{if .Detailed}}{{.Detailed}}{{else}}&mdash;{{end}}</td>
           <td class="flex gap-2 items-center">
-            <select x-model="categoryId" class="select select-sm w-48 bg-base-200/30 border-base-200 rounded-xl">
+            <select x-model="categoryId" class="select select-sm w-48 bg-base-200/30 border-base-300 rounded-xl">
               <option value="">Select category...</option>
               {{range $.AllCategories}}
               <option value="{{.ID}}">{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
@@ -104,7 +104,7 @@
             </template>
             <template x-if="editing">
               <div class="flex gap-2 items-center">
-                <select x-model="categoryId" class="select select-sm w-48 bg-base-200/30 border-base-200 rounded-xl">
+                <select x-model="categoryId" class="select select-sm w-48 bg-base-200/30 border-base-300 rounded-xl">
                   {{range $.AllCategories}}
                   <option value="{{.ID}}">{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
                   {{end}}
@@ -134,7 +134,7 @@
   </div>
   {{else}}
   <div class="flex flex-col items-center text-center py-12">
-    <div class="w-14 h-14 rounded-2xl bg-base-200/60 flex items-center justify-center mb-3">
+    <div class="w-14 h-14 rounded-xl bg-base-200/60 flex items-center justify-center mb-3">
       <i data-lucide="arrow-right-left" class="w-7 h-7 text-base-content/30"></i>
     </div>
     <p class="text-sm text-base-content/45">No mappings configured yet.</p>

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -76,7 +76,7 @@
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-6">
       <div>
         <p class="text-xs text-base-content/40 mb-1">Family Member</p>
-        <p class="text-sm font-medium">{{.Connection.UserName}}</p>
+        <p class="text-sm font-medium">{{pgtext .Connection.UserName}}</p>
       </div>
       <div>
         <p class="text-xs text-base-content/40 mb-1">Provider</p>

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -15,7 +15,7 @@
     <p class="font-semibold text-sm">This connection requires re-authentication</p>
     <p class="text-sm text-base-content/60 mt-0.5">The bank may have changed its login requirements, or your session may have expired.</p>
     {{if .Connection.ErrorCode.Valid}}<p class="text-xs text-base-content/50 mt-1">{{errorMessage .Connection.ErrorCode.String}}</p>{{else if .Connection.ErrorMessage.Valid}}<p class="text-xs text-base-content/50 mt-1">{{.Connection.ErrorMessage.String}}</p>{{end}}
-    <a href="/connections/{{.ConnID}}/reauth" class="btn btn-sm btn-error mt-3">Re-authenticate</a>
+    <a href="/connections/{{.ConnID}}/reauth" class="btn btn-sm btn-error mt-3 rounded-xl">Re-authenticate</a>
   </div>
 </div>
 {{end}}
@@ -38,30 +38,30 @@
   </div>
   <div class="flex items-center gap-2 flex-wrap">
     {{if or (eq (printf "%s" .Connection.Status) "error") (eq (printf "%s" .Connection.Status) "pending_reauth")}}
-    <a href="/connections/{{.ConnID}}/reauth" class="btn btn-sm btn-outline">Re-authenticate</a>
+    <a href="/connections/{{.ConnID}}/reauth" class="btn btn-sm btn-outline rounded-xl">Re-authenticate</a>
     {{end}}
     {{if eq (printf "%s" .Connection.Provider) "csv"}}
-    <a href="/connections/import-csv?connection_id={{.ConnID}}" class="btn btn-sm btn-outline">
+    <a href="/connections/import-csv?connection_id={{.ConnID}}" class="btn btn-sm btn-outline rounded-xl">
       <i data-lucide="upload" class="w-3.5 h-3.5"></i>
       Import More
     </a>
     {{end}}
     {{if eq (printf "%s" .Connection.Status) "active"}}
-    <button class="btn btn-sm btn-primary" onclick="syncConnection()" id="sync-btn">
+    <button class="btn btn-sm btn-primary rounded-xl" onclick="syncConnection()" id="sync-btn">
       <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
       Sync Now
     </button>
     {{end}}
-    <button class="btn btn-sm btn-ghost" onclick="togglePause()" id="pause-btn">
+    <button class="btn btn-sm btn-ghost rounded-xl" onclick="togglePause()" id="pause-btn">
       <i data-lucide="{{if .Connection.Paused}}play{{else}}pause{{end}}" class="w-3.5 h-3.5"></i>
       {{if .Connection.Paused}}Resume{{else}}Pause{{end}}
     </button>
     <span x-data="{ confirming: false }">
-      <button class="btn btn-sm btn-ghost text-error/70 hover:text-error" x-show="!confirming" @click="confirming = true" id="remove-btn">
+      <button class="btn btn-sm btn-ghost text-error/70 hover:text-error rounded-xl" x-show="!confirming" @click="confirming = true" id="remove-btn">
         <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
       </button>
       <span x-show="confirming" x-cloak class="inline-flex gap-2">
-        <button class="btn btn-error btn-sm" @click="removeConnection()">Yes, Remove</button>
+        <button class="btn btn-error btn-sm rounded-xl" @click="removeConnection()">Yes, Remove</button>
         <button class="btn btn-ghost btn-sm" @click="confirming = false">Cancel</button>
       </span>
     </span>
@@ -98,7 +98,7 @@
     <h2 class="text-sm font-semibold text-base-content/50 mb-4">Sync Settings</h2>
     <div>
       <label class="text-xs text-base-content/40 mb-1.5 block">Sync Interval</label>
-      <select id="sync-interval" onchange="updateSyncInterval(this.value)" class="select select-sm select-bordered w-full">
+      <select id="sync-interval" onchange="updateSyncInterval(this.value)" class="select select-sm select-bordered w-full rounded-xl">
         <option value=""{{if not .Connection.SyncIntervalOverrideMinutes.Valid}} selected{{end}}>Use global default</option>
         <option value="15"{{if and .Connection.SyncIntervalOverrideMinutes.Valid (eq .Connection.SyncIntervalOverrideMinutes.Int32 15)}} selected{{end}}>Every 15 minutes</option>
         <option value="30"{{if and .Connection.SyncIntervalOverrideMinutes.Valid (eq .Connection.SyncIntervalOverrideMinutes.Int32 30)}} selected{{end}}>Every 30 minutes</option>

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -179,6 +179,21 @@
     <h2 class="text-sm font-semibold text-base-content/50">Sync History</h2>
     <span class="text-xs text-base-content/30">Last 10</span>
   </div>
+  <!-- Skeleton shown during sync -->
+  <div id="sync-history-skeleton" class="px-6 pb-6" style="display:none">
+    <!-- Pulsing "syncing" indicator -->
+    <div class="flex items-center gap-3 p-3 rounded-xl bg-primary/5 border border-primary/10 mb-2">
+      <div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+        <span class="loading loading-spinner loading-xs text-primary"></span>
+      </div>
+      <div>
+        <div class="text-sm font-medium">Syncing in progress</div>
+        <div class="text-xs text-base-content/40">Fetching latest transactions...</div>
+      </div>
+    </div>
+    {{template "skeleton-sync-list" .}}
+  </div>
+  <div id="sync-history-content">
   {{if .SyncLogs}}
   <div class="px-6 pb-6 space-y-2">
     {{range .SyncLogs}}
@@ -216,6 +231,7 @@
     </div>
   </div>
   {{end}}
+  </div><!-- /sync-history-content -->
 </div>
 
 <script>
@@ -227,11 +243,23 @@ function syncConnection() {
   var btn = document.getElementById('sync-btn');
   btn.disabled = true;
   btn.innerHTML = '<span class="loading loading-spinner loading-xs"></span> Syncing...';
+
+  // Show skeleton loading state in sync history
+  var syncHistory = document.getElementById('sync-history-content');
+  var syncSkeleton = document.getElementById('sync-history-skeleton');
+  if (syncHistory && syncSkeleton) {
+    syncHistory.classList.add('bb-loading-fade');
+    syncSkeleton.style.display = 'block';
+  }
+
+  if (window.bbProgress) window.bbProgress.start();
+
   fetch("/-/connections/{{.ConnID}}/sync", { method: "POST" })
   .then(function(res) {
     if (res.ok) {
       btn.innerHTML = '<i data-lucide="check" class="w-3.5 h-3.5"></i> Synced!';
       lucide.createIcons({nodes: [btn]});
+      if (window.bbProgress) window.bbProgress.finish();
       setTimeout(function() { window.location.reload(); }, 3000);
     } else {
       return res.json().then(function(data) {
@@ -239,6 +267,9 @@ function syncConnection() {
         btn.disabled = false;
         btn.innerHTML = '<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i> Sync Now';
         lucide.createIcons({nodes: [btn]});
+        if (syncHistory) syncHistory.classList.remove('bb-loading-fade');
+        if (syncSkeleton) syncSkeleton.style.display = 'none';
+        if (window.bbProgress) window.bbProgress.finish();
       });
     }
   })
@@ -247,21 +278,28 @@ function syncConnection() {
     btn.disabled = false;
     btn.innerHTML = '<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i> Sync Now';
     lucide.createIcons({nodes: [btn]});
+    if (syncHistory) syncHistory.classList.remove('bb-loading-fade');
+    if (syncSkeleton) syncSkeleton.style.display = 'none';
+    if (window.bbProgress) window.bbProgress.finish();
   });
 }
 
 function removeConnection() {
+  if (window.bbProgress) window.bbProgress.start();
   fetch("/-/connections/{{.ConnID}}", { method: "DELETE" })
   .then(function (res) {
     if (res.ok) {
+      if (window.bbProgress) window.bbProgress.finish();
       window.location.href = "/connections";
     } else {
+      if (window.bbProgress) window.bbProgress.finish();
       return res.json().then(function (data) {
         showToast(data.error || "Failed to remove connection.");
       });
     }
   })
   .catch(function () {
+    if (window.bbProgress) window.bbProgress.finish();
     showToast("Network error. Please try again.");
   });
 }

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -23,7 +23,7 @@
 <!-- Header with actions -->
 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
   <div class="flex items-center gap-4">
-    <div class="w-12 h-12 rounded-2xl bg-base-200 flex items-center justify-center">
+    <div class="w-12 h-12 rounded-xl bg-base-200 flex items-center justify-center">
       <i data-lucide="building-2" class="w-6 h-6 text-base-content/50"></i>
     </div>
     <div>
@@ -123,7 +123,7 @@
   <div class="overflow-x-auto">
     <table class="table table-sm">
       <thead>
-        <tr class="text-xs text-base-content/40 uppercase tracking-wider border-b border-base-200">
+        <tr class="text-xs text-base-content/40 uppercase tracking-wider border-b border-base-300">
           <th class="font-medium">Account</th>
           <th class="font-medium">Display Name</th>
           <th class="font-medium">Type</th>

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -27,7 +27,7 @@
       <i data-lucide="building-2" class="w-6 h-6 text-base-content/50"></i>
     </div>
     <div>
-      <h1 class="text-2xl font-bold tracking-tight">{{.Connection.InstitutionName.String}}</h1>
+      <h1 class="bb-page-title">{{.Connection.InstitutionName.String}}</h1>
       <div class="flex items-center gap-2 mt-0.5">
         {{statusBadge (printf "%s" .Connection.Status)}}
         {{if .Connection.Paused}}<span class="badge badge-ghost badge-sm">Paused</span>{{end}}
@@ -72,7 +72,7 @@
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
   <!-- Connection Details Card -->
   <div class="bb-card p-6 lg:col-span-2">
-    <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider mb-4">Connection Details</h2>
+    <h2 class="text-sm font-semibold text-base-content/50 mb-4">Connection Details</h2>
     <div class="grid grid-cols-2 sm:grid-cols-4 gap-6">
       <div>
         <p class="text-xs text-base-content/40 mb-1">Family Member</p>
@@ -95,7 +95,7 @@
 
   <!-- Sync Settings Card -->
   <div class="bb-card p-6">
-    <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider mb-4">Sync Settings</h2>
+    <h2 class="text-sm font-semibold text-base-content/50 mb-4">Sync Settings</h2>
     <div>
       <label class="text-xs text-base-content/40 mb-1.5 block">Sync Interval</label>
       <select id="sync-interval" onchange="updateSyncInterval(this.value)" class="select select-sm select-bordered w-full">
@@ -116,14 +116,14 @@
 <!-- Accounts -->
 <div class="bb-card mb-8">
   <div class="px-6 pt-6 pb-4 flex items-center justify-between">
-    <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider">Accounts</h2>
+    <h2 class="text-sm font-semibold text-base-content/50">Accounts</h2>
     {{if .Accounts}}<span class="text-xs text-base-content/30">{{len .Accounts}} total</span>{{end}}
   </div>
   {{if .Accounts}}
   <div class="overflow-x-auto">
     <table class="table table-sm">
       <thead>
-        <tr class="text-xs text-base-content/40 uppercase tracking-wider border-b border-base-300">
+        <tr class="text-xs text-base-content/50 border-b border-base-300">
           <th class="font-medium">Account</th>
           <th class="font-medium">Display Name</th>
           <th class="font-medium">Type</th>
@@ -176,7 +176,7 @@
 <!-- Sync History -->
 <div class="bb-card">
   <div class="px-6 pt-6 pb-4 flex items-center justify-between">
-    <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider">Sync History</h2>
+    <h2 class="text-sm font-semibold text-base-content/50">Sync History</h2>
     <span class="text-xs text-base-content/30">Last 10</span>
   </div>
   {{if .SyncLogs}}

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -148,7 +148,7 @@
           </td>
           <td class="text-xs text-base-content/50">{{.Type}}{{if .Subtype.Valid}} / {{.Subtype.String}}{{end}}</td>
           <td class="text-right tabular-nums text-sm font-semibold">
-            {{if .BalanceCurrent.Valid}}{{formatNumeric .BalanceCurrent}}{{if .IsoCurrencyCode.Valid}} <span class="text-xs text-base-content/40 font-normal">{{.IsoCurrencyCode.String}}</span>{{end}}{{else}}<span class="text-base-content/20">&mdash;</span>{{end}}
+            {{if .BalanceCurrent.Valid}}{{formatNumeric .BalanceCurrent}}{{else}}<span class="text-base-content/20">&mdash;</span>{{end}}
           </td>
           <td class="text-right tabular-nums text-sm text-base-content/60">
             {{if .BalanceAvailable.Valid}}{{formatNumeric .BalanceAvailable}}{{else}}<span class="text-base-content/20">&mdash;</span>{{end}}

--- a/internal/templates/pages/connection_new.html
+++ b/internal/templates/pages/connection_new.html
@@ -13,7 +13,7 @@
 <!-- No providers configured -->
 <div class="bb-card p-8 max-w-lg">
   <div class="flex flex-col items-center text-center">
-    <div class="w-16 h-16 rounded-2xl bg-warning/10 flex items-center justify-center mb-4">
+    <div class="w-16 h-16 rounded-xl bg-warning/10 flex items-center justify-center mb-4">
       <i data-lucide="plug-zap" class="w-8 h-8 text-warning"></i>
     </div>
     <h2 class="text-lg font-semibold mb-1">No Providers Configured</h2>
@@ -43,7 +43,7 @@
           {{if .HasPlaid}}
           <label class="relative cursor-pointer">
             <input type="radio" name="provider" value="plaid" class="peer sr-only" checked>
-            <div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-200 bg-base-200/30
+            <div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
                         peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300">
               <i data-lucide="building-2" class="w-6 h-6 text-base-content/60"></i>
               <span class="text-sm font-medium">Plaid</span>
@@ -53,7 +53,7 @@
           {{if .HasTeller}}
           <label class="relative cursor-pointer">
             <input type="radio" name="provider" value="teller" class="peer sr-only" {{if not .HasPlaid}}checked{{end}}>
-            <div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-200 bg-base-200/30
+            <div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
                         peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300">
               <i data-lucide="landmark" class="w-6 h-6 text-base-content/60"></i>
               <span class="text-sm font-medium">Teller</span>
@@ -62,7 +62,7 @@
           {{end}}
           <label class="relative cursor-pointer">
             <input type="radio" name="provider" value="csv" class="peer sr-only">
-            <div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-200 bg-base-200/30
+            <div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
                         peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300">
               <i data-lucide="file-spreadsheet" class="w-6 h-6 text-base-content/60"></i>
               <span class="text-sm font-medium">CSV</span>
@@ -73,7 +73,7 @@
 
       <fieldset class="fieldset">
         <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="user_id">Family Member</label>
-        <select id="user_id" name="user_id" required class="select w-full bg-base-200/50 border-base-200 focus:border-primary rounded-xl">
+        <select id="user_id" name="user_id" required class="select w-full bg-base-200/50 border-base-300 focus:border-primary rounded-xl">
           <option value="" disabled selected>Select a member...</option>
           {{range .Users}}
           <option value="{{formatUUID .ID}}">{{.Name}}</option>
@@ -93,7 +93,7 @@
 <div id="step-link" class="hidden">
   <div class="bb-card p-8 max-w-lg">
     <div class="flex flex-col items-center text-center">
-      <div class="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mb-4">
+      <div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
         <i data-lucide="link" class="w-8 h-8 text-primary"></i>
       </div>
       <h2 class="text-lg font-semibold mb-1">Connect Bank</h2>

--- a/internal/templates/pages/connection_reauth.html
+++ b/internal/templates/pages/connection_reauth.html
@@ -17,7 +17,7 @@
 
 <div class="bb-card p-8 max-w-lg">
   <div class="flex flex-col items-center text-center">
-    <div class="w-16 h-16 rounded-2xl bg-warning/10 flex items-center justify-center mb-4">
+    <div class="w-16 h-16 rounded-xl bg-warning/10 flex items-center justify-center mb-4">
       <i data-lucide="shield-alert" class="w-8 h-8 text-warning"></i>
     </div>
     <h2 class="text-lg font-semibold mb-1">{{.Connection.InstitutionName.String}}</h2>

--- a/internal/templates/pages/connection_reauth.html
+++ b/internal/templates/pages/connection_reauth.html
@@ -22,7 +22,7 @@
     </div>
     <h2 class="text-lg font-semibold mb-1">{{.Connection.InstitutionName.String}}</h2>
     <p class="text-sm text-base-content/50 mb-1">
-      Re-connecting for: <span class="font-semibold text-base-content">{{.Connection.UserName}}</span>
+      Re-connecting for: <span class="font-semibold text-base-content">{{pgtext .Connection.UserName}}</span>
     </p>
     <p id="link-status" class="text-sm text-base-content/50 mb-6">Opening re-authentication dialog...</p>
     <div class="flex items-center gap-3">

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -7,7 +7,7 @@
     <span class="badge badge-ghost badge-sm">{{len .Connections}}</span>
     {{end}}
   </div>
-  <a href="/connections/new" class="btn btn-primary btn-sm">
+  <a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">
     <i data-lucide="plus" class="w-4 h-4"></i>
     Connect Bank
   </a>
@@ -17,7 +17,7 @@
 <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 bb-stagger">
   {{range .Connections}}
   <a href="/connections/{{formatUUID .ID}}" class="bb-card bb-card--interactive no-underline group">
-    <div class="card-body p-5">
+    <div class="p-5">
       <!-- Header: Institution + Status -->
       <div class="flex items-start justify-between gap-3 mb-3">
         <div class="flex items-center gap-3 min-w-0">
@@ -78,14 +78,14 @@
 
 {{else}}
 <!-- Empty State -->
-<div class="card bg-base-100 border border-base-300">
-  <div class="card-body items-center text-center py-16">
+<div class="bb-card">
+  <div class="flex flex-col items-center text-center py-16 px-6">
     <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
       <i data-lucide="building-2" class="w-8 h-8 text-base-content/20"></i>
     </div>
     <h3 class="text-lg font-semibold mb-1">No bank connections yet</h3>
     <p class="text-sm text-base-content/60 max-w-sm mb-4">Connect your first bank to start syncing transactions and tracking your finances.</p>
-    <a href="/connections/new" class="btn btn-primary">
+    <a href="/connections/new" class="btn btn-primary rounded-xl">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Connect Your First Bank
     </a>

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -2,7 +2,7 @@
 <!-- Page Header -->
 <div class="flex items-center justify-between mb-6">
   <div class="flex items-center gap-3">
-    <h1 class="text-2xl font-bold">Connections</h1>
+    <h1 class="bb-page-title">Connections</h1>
     {{if .Connections}}
     <span class="badge badge-ghost badge-sm">{{len .Connections}}</span>
     {{end}}

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -16,7 +16,7 @@
 {{if .Connections}}
 <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
   {{range .Connections}}
-  <a href="/connections/{{formatUUID .ID}}" class="card bg-base-100 shadow-sm border border-base-300 hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 no-underline group">
+  <a href="/connections/{{formatUUID .ID}}" class="card bg-base-100 border border-base-300 hover:bg-base-200/50 transition-colors duration-150 no-underline group">
     <div class="card-body p-5">
       <!-- Header: Institution + Status -->
       <div class="flex items-start justify-between gap-3 mb-3">
@@ -78,9 +78,9 @@
 
 {{else}}
 <!-- Empty State -->
-<div class="card bg-base-100 shadow-sm border border-base-300">
+<div class="card bg-base-100 border border-base-300">
   <div class="card-body items-center text-center py-16">
-    <div class="w-16 h-16 rounded-2xl bg-base-200/60 flex items-center justify-center mb-4">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
       <i data-lucide="building-2" class="w-8 h-8 text-base-content/20"></i>
     </div>
     <h3 class="text-lg font-semibold mb-1">No bank connections yet</h3>

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -14,9 +14,9 @@
 </div>
 
 {{if .Connections}}
-<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+<div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 bb-stagger">
   {{range .Connections}}
-  <a href="/connections/{{formatUUID .ID}}" class="card bg-base-100 border border-base-300 hover:bg-base-200/50 transition-colors duration-150 no-underline group">
+  <a href="/connections/{{formatUUID .ID}}" class="bb-card bb-card--interactive no-underline group">
     <div class="card-body p-5">
       <!-- Header: Institution + Status -->
       <div class="flex items-start justify-between gap-3 mb-3">

--- a/internal/templates/pages/csv_import.html
+++ b/internal/templates/pages/csv_import.html
@@ -57,7 +57,7 @@
       {{else}}
       <fieldset class="fieldset mb-5">
         <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="csv-user-id">Family Member</label>
-        <select id="csv-user-id" class="select w-full bg-base-200/50 border-base-200 focus:border-primary rounded-xl" required>
+        <select id="csv-user-id" class="select w-full bg-base-200/50 border-base-300 focus:border-primary rounded-xl" required>
           <option value="" disabled selected>Select a member...</option>
           {{range .Users}}
           <option value="{{formatUUID .ID}}">{{.Name}}</option>
@@ -68,7 +68,7 @@
 
       <fieldset class="fieldset mb-6">
         <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="csv-file">CSV File</label>
-        <input type="file" id="csv-file" accept=".csv,.tsv,.txt" class="file-input file-input-bordered w-full bg-base-200/50 border-base-200 rounded-xl">
+        <input type="file" id="csv-file" accept=".csv,.tsv,.txt" class="file-input file-input-bordered w-full bg-base-200/50 border-base-300 rounded-xl">
         <p class="text-xs text-base-content/40 mt-2">Supported: CSV, TSV, TXT files up to 10MB. Max 50,000 rows.</p>
       </fieldset>
 
@@ -99,51 +99,51 @@
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-date">
             Date Column <span class="text-xs text-base-content/30">(required)</span>
           </label>
-          <select id="map-date" class="select w-full bg-base-200/50 border-base-200 rounded-xl"></select>
+          <select id="map-date" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
         </fieldset>
         <fieldset class="fieldset">
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-amount">
             Amount Column <span class="text-xs text-base-content/30">(required)</span>
           </label>
-          <select id="map-amount" class="select w-full bg-base-200/50 border-base-200 rounded-xl"></select>
+          <select id="map-amount" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
         </fieldset>
         <fieldset class="fieldset">
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-description">
             Description Column <span class="text-xs text-base-content/30">(required)</span>
           </label>
-          <select id="map-description" class="select w-full bg-base-200/50 border-base-200 rounded-xl"></select>
+          <select id="map-description" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
         </fieldset>
         <fieldset class="fieldset">
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-category">
             Category Column <span class="text-xs text-base-content/30">(optional)</span>
           </label>
-          <select id="map-category" class="select w-full bg-base-200/50 border-base-200 rounded-xl"></select>
+          <select id="map-category" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
         </fieldset>
         <fieldset class="fieldset">
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-merchant">
             Merchant Column <span class="text-xs text-base-content/30">(optional)</span>
           </label>
-          <select id="map-merchant" class="select w-full bg-base-200/50 border-base-200 rounded-xl"></select>
+          <select id="map-merchant" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
         </fieldset>
       </div>
 
       <div id="debit-credit-section" class="hidden mb-6">
-        <div class="rounded-xl bg-base-200/30 border border-base-200 p-5">
+        <div class="rounded-xl bg-base-200/30 border border-base-300 p-5">
           <p class="text-sm font-medium text-base-content/70 mb-4">Split Debit/Credit Columns</p>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <fieldset class="fieldset">
               <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-debit">Debit Column</label>
-              <select id="map-debit" class="select w-full bg-base-100 border-base-200 rounded-xl"></select>
+              <select id="map-debit" class="select w-full bg-base-100 border-base-300 rounded-xl"></select>
             </fieldset>
             <fieldset class="fieldset">
               <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-credit">Credit Column</label>
-              <select id="map-credit" class="select w-full bg-base-100 border-base-200 rounded-xl"></select>
+              <select id="map-credit" class="select w-full bg-base-100 border-base-300 rounded-xl"></select>
             </fieldset>
           </div>
         </div>
       </div>
 
-      <div class="rounded-xl bg-base-200/30 border border-base-200 p-5 mb-6">
+      <div class="rounded-xl bg-base-200/30 border border-base-300 p-5 mb-6">
         <p class="text-sm font-medium text-base-content/70 mb-3">Sign Convention</p>
         <div class="flex flex-col gap-2.5">
           <label class="flex items-center gap-3 cursor-pointer">
@@ -165,7 +165,7 @@
       {{if not .ConnectionID}}
       <fieldset class="fieldset mb-6">
         <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="account-name">Account Name</label>
-        <input type="text" id="account-name" class="input w-full bg-base-200/50 border-base-200 rounded-xl" value="CSV Import" placeholder="e.g., Chase Checking CSV">
+        <input type="text" id="account-name" class="input w-full bg-base-200/50 border-base-300 rounded-xl" value="CSV Import" placeholder="e.g., Chase Checking CSV">
       </fieldset>
       {{end}}
 
@@ -192,7 +192,7 @@
           </div>
           <h3 class="text-sm font-semibold">Preview (first 10 rows)</h3>
         </div>
-        <div class="overflow-x-auto rounded-xl border border-base-200">
+        <div class="overflow-x-auto rounded-xl border border-base-300">
           <table id="preview-table" class="table table-sm">
             <thead>
               <tr class="bg-base-200/50">
@@ -225,11 +225,11 @@
       </div>
 
       <div class="space-y-4 mb-8">
-        <div class="flex items-center justify-between py-3 border-b border-base-200">
+        <div class="flex items-center justify-between py-3 border-b border-base-300">
           <span class="text-sm text-base-content/50">Total Rows</span>
           <span id="summary-rows" class="text-sm font-semibold tabular-nums"></span>
         </div>
-        <div class="flex items-center justify-between py-3 border-b border-base-200">
+        <div class="flex items-center justify-between py-3 border-b border-base-300">
           <span class="text-sm text-base-content/50">Account Name</span>
           <span id="summary-account" class="text-sm font-semibold"></span>
         </div>
@@ -255,7 +255,7 @@
   <div id="step-4" x-show="step === 4" x-cloak x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0">
     <div class="bb-card p-8 max-w-lg">
       <div class="flex flex-col items-center text-center mb-8">
-        <div class="w-16 h-16 rounded-2xl bg-success/10 flex items-center justify-center mb-4">
+        <div class="w-16 h-16 rounded-xl bg-success/10 flex items-center justify-center mb-4">
           <i data-lucide="check-circle-2" class="w-8 h-8 text-success"></i>
         </div>
         <h2 class="text-lg font-semibold mb-1">Import Complete</h2>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -38,7 +38,7 @@
     {{end}}
     <div class="dropdown dropdown-end">
       <div tabindex="0" role="button" class="btn btn-sm btn-ghost">Update Command</div>
-      <div tabindex="0" class="dropdown-content card card-compact bg-base-200 shadow-lg p-3 w-80 z-10">
+      <div tabindex="0" class="dropdown-content card card-compact bg-base-200 shadow-sm p-3 w-80 z-10">
         <code class="text-xs select-all">cd /opt/breadbox && docker compose pull && docker compose up -d</code>
       </div>
     </div>
@@ -55,7 +55,7 @@
 {{end}}
 
 {{if .ShowOnboarding}}
-<div class="card bg-base-100 shadow-lg border border-base-300 mb-6">
+<div class="card bg-base-100 border border-base-300 mb-6">
   <div class="card-body">
     <h2 class="card-title">
       <i data-lucide="rocket" class="w-5 h-5 text-primary"></i>
@@ -162,7 +162,7 @@
 <!-- Charts Row -->
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
   <!-- Spending Trend Chart -->
-  <div class="card bg-base-100 shadow-sm border border-base-300 lg:col-span-2">
+  <div class="card bg-base-100 border border-base-300 lg:col-span-2">
     <div class="card-body p-5">
       <div class="flex items-center justify-between mb-2">
         <h2 class="card-title text-base">
@@ -186,7 +186,7 @@
   </div>
 
   <!-- Category Breakdown Chart -->
-  <div class="card bg-base-100 shadow-sm border border-base-300">
+  <div class="card bg-base-100 border border-base-300">
     <div class="card-body p-5">
       <div class="flex items-center justify-between mb-2">
         <h2 class="card-title text-base">
@@ -213,7 +213,7 @@
 <!-- Recent Transactions + Sync Activity -->
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
   <!-- Recent Transactions -->
-  <div class="card bg-base-100 shadow-sm border border-base-300 lg:col-span-2">
+  <div class="card bg-base-100 border border-base-300 lg:col-span-2">
     <div class="card-body p-5">
       <div class="flex items-center justify-between mb-3">
         <h2 class="card-title text-base">
@@ -271,7 +271,7 @@
   </div>
 
   <!-- Recent Sync Activity -->
-  <div class="card bg-base-100 shadow-sm border border-base-300">
+  <div class="card bg-base-100 border border-base-300">
     <div class="card-body p-5">
       <div class="flex items-center justify-between mb-3">
         <h2 class="card-title text-base">

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -1,8 +1,4 @@
 {{define "content"}}
-<div class="flex items-center justify-between mb-6">
-  <h1 class="text-2xl font-bold">Dashboard</h1>
-  <span class="text-sm text-base-content/50">Last 30 days</span>
-</div>
 
 {{if .ShowUpdateBanner}}
 <div class="alert alert-info mb-6" x-data="{ pulling: false, pulled: false, error: '' }">
@@ -96,204 +92,215 @@
 </div>
 {{end}}
 
-<!-- Stat Cards -->
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 mb-8 bb-stagger">
-  <div class="bb-stat-card bb-stat-card--primary">
-    <div class="bb-stat-card__icon text-primary">
-      <i data-lucide="building-2" class="w-6 h-6"></i>
+<!-- Financial Summary Hero -->
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-8 bb-stagger">
+  <!-- Net Worth Card -->
+  <div class="bb-card p-6">
+    <div class="flex items-center gap-2 mb-1">
+      <span class="text-xs font-medium text-base-content/50 uppercase tracking-wide">Net Worth</span>
     </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value">{{.AccountCount}}</span>
-      <span class="bb-stat-card__label">Accounts</span>
+    <div class="text-3xl font-semibold tabular-nums tracking-tight">
+      {{formatBalance .NetWorth}}
     </div>
-  </div>
-  <a href="/transactions" class="bb-stat-card bb-stat-card--secondary no-underline">
-    <div class="bb-stat-card__icon text-secondary">
-      <i data-lucide="receipt" class="w-6 h-6"></i>
-    </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value">{{.TxCount}}</span>
-      <span class="bb-stat-card__label">Transactions</span>
-    </div>
-  </a>
-  <div class="bb-stat-card bb-stat-card--accent">
-    <div class="bb-stat-card__icon text-accent">
-      <i data-lucide="clock" class="w-6 h-6"></i>
-    </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value text-lg">{{.LastSync}}</span>
-      <span class="bb-stat-card__label">Last Sync</span>
+    <div class="flex items-center gap-4 mt-3 text-xs text-base-content/50">
+      <span class="flex items-center gap-1">
+        <span class="w-1.5 h-1.5 rounded-full bg-base-content/30"></span>
+        Assets {{formatBalance .TotalAssets}}
+      </span>
+      <span class="flex items-center gap-1">
+        <span class="w-1.5 h-1.5 rounded-full bg-error/50"></span>
+        Liabilities {{formatBalance .TotalLiabilities}}
+      </span>
     </div>
   </div>
-  {{if gt .NeedsAttention 0}}
-  <a href="/connections" class="bb-stat-card bb-stat-card--warning no-underline">
-    <div class="bb-stat-card__icon text-warning">
-      <i data-lucide="alert-triangle" class="w-6 h-6"></i>
-    </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value text-warning">{{.NeedsAttention}}</span>
-      <span class="bb-stat-card__label">Needs Attention</span>
-    </div>
-  </a>
-  {{else}}
-  <div class="bb-stat-card bb-stat-card--neutral">
-    <div class="bb-stat-card__icon text-base-content/40">
-      <i data-lucide="check-circle" class="w-6 h-6"></i>
-    </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value">0</span>
-      <span class="bb-stat-card__label">Needs Attention</span>
-    </div>
-  </div>
-  {{end}}
-  {{if gt .ReviewPending 0}}
-  <a href="/reviews" class="bb-stat-card bb-stat-card--info no-underline">
-    <div class="bb-stat-card__icon text-info">
-      <i data-lucide="clipboard-check" class="w-6 h-6"></i>
-    </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value text-info">{{.ReviewPending}}</span>
-      <span class="bb-stat-card__label">Pending Reviews</span>
-    </div>
-  </a>
-  {{end}}
-</div>
 
-<!-- Charts Row -->
-<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8 bb-stagger">
-  <!-- Spending Trend Chart -->
-  <div class="card bg-base-100 border border-base-300 lg:col-span-2">
-    <div class="card-body p-5">
-      <div class="flex items-center justify-between mb-2">
-        <h2 class="card-title text-base">
-          <i data-lucide="trending-up" class="w-4 h-4 text-primary"></i>
-          Daily Spending
-        </h2>
-      </div>
-      {{if .DailyLabels}}
-      <div class="h-56">
-        <canvas id="spendingTrendChart"></canvas>
-      </div>
-      {{else}}
-      <div class="flex items-center justify-center h-56 text-base-content/40">
-        <div class="text-center">
-          <i data-lucide="bar-chart-3" class="w-10 h-10 mx-auto mb-2 opacity-40"></i>
-          <p class="text-sm">No spending data yet</p>
-        </div>
-      </div>
+  <!-- Spending Card -->
+  <div class="bb-card p-6">
+    <div class="flex items-center gap-2 mb-1">
+      <span class="text-xs font-medium text-base-content/50 uppercase tracking-wide">Spending</span>
+      <span class="text-xs text-base-content/30">30d</span>
+    </div>
+    <div class="text-3xl font-semibold tabular-nums tracking-tight">
+      {{formatBalance .TotalSpending}}
+    </div>
+    <div class="flex items-center gap-4 mt-3 text-xs text-base-content/50">
+      <a href="/transactions" class="flex items-center gap-1 hover:text-base-content transition-colors">
+        <i data-lucide="receipt" class="w-3 h-3"></i>
+        {{.TxCount}} transactions
+      </a>
+      <span class="flex items-center gap-1">
+        <i data-lucide="clock" class="w-3 h-3"></i>
+        Synced {{.LastSync}}
+      </span>
+    </div>
+  </div>
+
+  <!-- Income Card -->
+  <div class="bb-card p-6">
+    <div class="flex items-center gap-2 mb-1">
+      <span class="text-xs font-medium text-base-content/50 uppercase tracking-wide">Income</span>
+      <span class="text-xs text-base-content/30">30d</span>
+    </div>
+    <div class="text-3xl font-semibold tabular-nums tracking-tight text-success">
+      {{formatBalance .TotalIncome}}
+    </div>
+    <div class="flex items-center gap-4 mt-3 text-xs text-base-content/50">
+      {{if gt .ReviewPending 0}}
+      <a href="/reviews" class="flex items-center gap-1 hover:text-base-content transition-colors">
+        <i data-lucide="clipboard-check" class="w-3 h-3"></i>
+        {{.ReviewPending}} pending reviews
+      </a>
+      {{end}}
+      {{if gt .NeedsAttention 0}}
+      <a href="/connections" class="flex items-center gap-1 text-warning hover:text-warning/80 transition-colors">
+        <i data-lucide="alert-triangle" class="w-3 h-3"></i>
+        {{.NeedsAttention}} need attention
+      </a>
       {{end}}
     </div>
+  </div>
+</div>
+
+<!-- Accounts Overview -->
+{{if .Accounts}}
+<div class="mb-8">
+  <div class="flex items-center justify-between mb-4">
+    <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">Accounts</h2>
+    <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+  </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 bb-stagger">
+    {{range .Accounts}}
+    <a href="/accounts/{{.ID}}" class="bb-card bb-card--interactive p-4 no-underline group">
+      <div class="flex items-center gap-3">
+        <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+          <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center justify-between gap-2">
+            <div class="min-w-0">
+              <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
+              <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
+            </div>
+            <div class="text-right shrink-0">
+              <div class="text-sm font-semibold tabular-nums{{if .IsLiability}} text-error/80{{end}}">
+                {{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}
+              </div>
+              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </a>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+<!-- Charts Row -->
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-8 bb-stagger">
+  <!-- Spending Trend Chart -->
+  <div class="bb-card lg:col-span-2 p-5">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">Daily Spending</h2>
+    </div>
+    {{if .DailyLabels}}
+    <div class="h-52">
+      <canvas id="spendingTrendChart"></canvas>
+    </div>
+    {{else}}
+    <div class="flex items-center justify-center h-52 text-base-content/40">
+      <div class="text-center">
+        <i data-lucide="bar-chart-3" class="w-10 h-10 mx-auto mb-2 opacity-40"></i>
+        <p class="text-sm">No spending data yet</p>
+      </div>
+    </div>
+    {{end}}
   </div>
 
   <!-- Category Breakdown Chart -->
-  <div class="card bg-base-100 border border-base-300">
-    <div class="card-body p-5">
-      <div class="flex items-center justify-between mb-2">
-        <h2 class="card-title text-base">
-          <i data-lucide="pie-chart" class="w-4 h-4 text-secondary"></i>
-          By Category
-        </h2>
-      </div>
-      {{if .CategoryLabels}}
-      <div class="h-56 flex items-center justify-center">
-        <canvas id="categoryChart"></canvas>
-      </div>
-      {{else}}
-      <div class="flex items-center justify-center h-56 text-base-content/40">
-        <div class="text-center">
-          <i data-lucide="pie-chart" class="w-10 h-10 mx-auto mb-2 opacity-40"></i>
-          <p class="text-sm">No category data yet</p>
-        </div>
-      </div>
-      {{end}}
+  <div class="bb-card p-5">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">By Category</h2>
     </div>
+    {{if .CategoryLabels}}
+    <div class="h-52 flex items-center justify-center">
+      <canvas id="categoryChart"></canvas>
+    </div>
+    {{else}}
+    <div class="flex items-center justify-center h-52 text-base-content/40">
+      <div class="text-center">
+        <i data-lucide="pie-chart" class="w-10 h-10 mx-auto mb-2 opacity-40"></i>
+        <p class="text-sm">No category data yet</p>
+      </div>
+    </div>
+    {{end}}
   </div>
 </div>
 
 <!-- Recent Transactions + Sync Activity -->
-<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
   <!-- Recent Transactions -->
-  <div class="card bg-base-100 border border-base-300 lg:col-span-2">
-    <div class="card-body p-5">
-      <div class="flex items-center justify-between mb-3">
-        <h2 class="card-title text-base">
-          <i data-lucide="list" class="w-4 h-4 text-accent"></i>
-          Recent Transactions
-        </h2>
-        <a href="/transactions" class="btn btn-ghost btn-xs">View all</a>
-      </div>
-      {{if .RecentTransactions}}
-      <div class="overflow-x-auto -mx-5">
-        <table class="table table-sm">
-          <thead>
-            <tr class="text-xs text-base-content/50 uppercase">
-              <th>Description</th>
-              <th>Account</th>
-              <th>Category</th>
-              <th class="text-right">Amount</th>
-            </tr>
-          </thead>
-          <tbody>
-            {{range .RecentTransactions}}
-            <tr class="hover:bg-base-200/50 transition-colors duration-150">
-              <td>
-                <div class="flex flex-col">
-                  <span class="font-medium text-sm truncate max-w-48">{{.Name}}</span>
-                  <span class="text-xs text-base-content/50">{{.Date}}</span>
-                </div>
-              </td>
-              <td class="text-sm text-base-content/70">{{.AccountName}}</td>
-              <td>
-                {{if .CategoryDisplayName}}
-                <span class="badge badge-ghost badge-sm">{{if .CategoryIcon}}{{.CategoryIcon}} {{end}}{{deref .CategoryDisplayName}}</span>
-                {{else}}
-                <span class="text-base-content/30 text-xs">—</span>
-                {{end}}
-              </td>
-              <td class="text-right tabular-nums text-sm font-medium{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">
-                {{formatAmount .Amount}}
-              </td>
-            </tr>
+  <div class="bb-card lg:col-span-2 p-5">
+    <div class="flex items-center justify-between mb-3">
+      <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">Recent Transactions</h2>
+      <a href="/transactions" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+    </div>
+    {{if .RecentTransactions}}
+    <div class="space-y-0.5">
+      {{range .RecentTransactions}}
+      <div class="flex items-center justify-between py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1">
+        <div class="flex items-center gap-3 min-w-0">
+          <div class="w-8 h-8 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0">
+            {{if .CategoryIcon}}
+            <i data-lucide="{{.CategoryIcon}}" class="w-3.5 h-3.5 text-base-content/40"></i>
+            {{else}}
+            <i data-lucide="minus" class="w-3.5 h-3.5 text-base-content/20"></i>
             {{end}}
-          </tbody>
-        </table>
-      </div>
-      {{else}}
-      <div class="flex items-center justify-center py-8 text-base-content/40">
-        <div class="text-center">
-          <i data-lucide="receipt" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
-          <p class="text-sm">No transactions yet</p>
-          <a href="/connections/new" class="btn btn-primary btn-sm mt-3">Connect a bank</a>
+          </div>
+          <div class="min-w-0">
+            <div class="text-sm font-medium truncate max-w-64">{{.Name}}</div>
+            <div class="text-xs text-base-content/40">{{.AccountName}} · {{.Date}}</div>
+          </div>
+        </div>
+        <div class="text-sm font-semibold tabular-nums shrink-0 pl-3{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">
+          {{formatAmount .Amount}}
         </div>
       </div>
       {{end}}
     </div>
+    {{else}}
+    <div class="flex items-center justify-center py-8 text-base-content/40">
+      <div class="text-center">
+        <i data-lucide="receipt" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
+        <p class="text-sm">No transactions yet</p>
+        <a href="/connections/new" class="btn btn-primary btn-sm mt-3">Connect a bank</a>
+      </div>
+    </div>
+    {{end}}
   </div>
 
-  <!-- Recent Sync Activity -->
-  <div class="card bg-base-100 border border-base-300">
-    <div class="card-body p-5">
+  <!-- Right Column: Sync Activity + Quick Actions -->
+  <div class="flex flex-col gap-4">
+    <!-- Recent Sync Activity -->
+    <div class="bb-card p-5 flex-1">
       <div class="flex items-center justify-between mb-3">
-        <h2 class="card-title text-base">
-          <i data-lucide="refresh-cw" class="w-4 h-4 text-info"></i>
-          Sync Activity
-        </h2>
-        <a href="/sync-logs" class="btn btn-ghost btn-xs">View all</a>
+        <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">Sync Activity</h2>
+        <a href="/sync-logs" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
       </div>
       {{if .RecentLogs}}
-      <div class="space-y-2">
+      <div class="space-y-1">
         {{range .RecentLogs}}
-        <a href="/connections/{{formatUUID .ConnectionID}}" class="flex items-center justify-between p-2.5 rounded-lg hover:bg-base-200/60 transition-colors duration-150 no-underline group">
-          <div class="flex items-center gap-3 min-w-0">
-            <div class="w-8 h-8 rounded-lg bg-base-200 flex items-center justify-center shrink-0">
-              <i data-lucide="building-2" class="w-4 h-4 text-base-content/60"></i>
+        <a href="/connections/{{formatUUID .ConnectionID}}" class="flex items-center justify-between py-2 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 no-underline group -mx-1">
+          <div class="flex items-center gap-2.5 min-w-0">
+            <div class="w-6 h-6 rounded-md bg-base-200/50 flex items-center justify-center shrink-0">
+              <i data-lucide="building-2" class="w-3 h-3 text-base-content/40"></i>
             </div>
             <div class="min-w-0">
-              <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.InstitutionName.String}}</div>
-              <div class="text-xs text-base-content/50">{{relativeTime .StartedAt}}</div>
+              <div class="text-xs font-medium truncate group-hover:text-primary transition-colors">{{.InstitutionName.String}}</div>
+              <div class="text-xs text-base-content/30">{{relativeTime .StartedAt}}</div>
             </div>
           </div>
-          <div class="flex items-center gap-2 shrink-0">
+          <div class="flex items-center gap-1.5 shrink-0">
             {{if .AddedCount}}<span class="text-xs text-success font-medium">+{{.AddedCount}}</span>{{end}}
             {{syncBadge (printf "%s" .Status)}}
           </div>
@@ -301,27 +308,29 @@
         {{end}}
       </div>
       {{else}}
-      <div class="flex items-center justify-center py-8 text-base-content/40">
+      <div class="flex items-center justify-center py-6 text-base-content/40">
         <div class="text-center">
-          <i data-lucide="refresh-cw" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
-          <p class="text-sm">No sync activity yet</p>
+          <i data-lucide="refresh-cw" class="w-6 h-6 mx-auto mb-2 opacity-40"></i>
+          <p class="text-xs">No sync activity yet</p>
         </div>
       </div>
       {{end}}
     </div>
-  </div>
-</div>
 
-<!-- Quick Actions -->
-<div class="flex gap-3">
-  <a href="/connections/new" class="btn btn-primary btn-sm">
-    <i data-lucide="plus" class="w-4 h-4"></i>
-    Connect Bank
-  </a>
-  <a href="/reviews" class="btn btn-ghost btn-sm">
-    <i data-lucide="clipboard-check" class="w-4 h-4"></i>
-    Review Queue
-  </a>
+    <!-- Quick Actions -->
+    <div class="bb-card p-4">
+      <div class="flex gap-2">
+        <a href="/connections/new" class="btn btn-primary btn-sm flex-1">
+          <i data-lucide="plus" class="w-3.5 h-3.5"></i>
+          Connect Bank
+        </a>
+        <a href="/reviews" class="btn btn-ghost btn-sm flex-1">
+          <i data-lucide="clipboard-check" class="w-3.5 h-3.5"></i>
+          Reviews
+        </a>
+      </div>
+    </div>
+  </div>
 </div>
 
 <!-- Chart.js Initialization -->

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -259,7 +259,7 @@
           </div>
           <div class="min-w-0">
             <div class="text-sm font-medium truncate max-w-64">{{.Name}}</div>
-            <div class="text-xs text-base-content/40">{{.AccountName}} · {{.Date}}</div>
+            <div class="text-xs text-base-content/40">{{.AccountName}} · {{formatDate .Date}}</div>
           </div>
         </div>
         <div class="text-sm font-semibold tabular-nums shrink-0 pl-3{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -97,7 +97,7 @@
 {{end}}
 
 <!-- Stat Cards -->
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 mb-8">
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-5 gap-4 mb-8 bb-stagger">
   <div class="bb-stat-card bb-stat-card--primary">
     <div class="bb-stat-card__icon text-primary">
       <i data-lucide="building-2" class="w-6 h-6"></i>
@@ -160,7 +160,7 @@
 </div>
 
 <!-- Charts Row -->
-<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8 bb-stagger">
   <!-- Spending Trend Chart -->
   <div class="card bg-base-100 border border-base-300 lg:col-span-2">
     <div class="card-body p-5">
@@ -334,13 +334,26 @@ document.addEventListener('DOMContentLoaded', function() {
 
   Chart.defaults.font.family = 'Inter, system-ui, -apple-system, sans-serif';
 
+  /* shadcn-aligned tooltip style */
+  const tooltipStyle = {
+    backgroundColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
+    titleColor: isDark ? 'hsl(0 0% 93%)' : 'hsl(0 0% 9%)',
+    bodyColor: isDark ? 'hsl(0 0% 64%)' : 'hsl(0 0% 45%)',
+    borderColor: isDark ? 'hsl(0 0% 18%)' : 'hsl(0 0% 90%)',
+    borderWidth: 1,
+    padding: 10,
+    cornerRadius: 8,
+    titleFont: { size: 12, weight: '600' },
+    bodyFont: { size: 12 },
+    displayColors: false,
+  };
+
   // Spending Trend
   const trendCtx = document.getElementById('spendingTrendChart');
   if (trendCtx) {
     const dailyLabels = {{.DailyLabels}};
     const dailyData = {{.DailyAmounts}};
 
-    // Format labels to short dates
     const shortLabels = dailyLabels.map(d => {
       const date = new Date(d + 'T00:00:00');
       return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
@@ -353,15 +366,15 @@ document.addEventListener('DOMContentLoaded', function() {
         datasets: [{
           label: 'Spending',
           data: dailyData,
-          borderColor: isDark ? '#8b8cf7' : '#4338a8',
-          backgroundColor: isDark ? 'rgba(139,140,247,0.08)' : 'rgba(67,56,168,0.06)',
+          borderColor: isDark ? 'hsl(0 0% 70%)' : 'hsl(0 0% 15%)',
+          backgroundColor: isDark ? 'hsla(0,0%,70%,0.06)' : 'hsla(0,0%,15%,0.04)',
           fill: true,
-          tension: 0.35,
-          borderWidth: 2,
+          tension: 0.4,
+          borderWidth: 1.5,
           pointRadius: 0,
-          pointHoverRadius: 5,
-          pointHoverBackgroundColor: isDark ? '#8b8cf7' : '#4338a8',
-          pointHoverBorderColor: isDark ? '#1a1a2e' : '#ffffff',
+          pointHoverRadius: 4,
+          pointHoverBackgroundColor: isDark ? 'hsl(0 0% 70%)' : 'hsl(0 0% 15%)',
+          pointHoverBorderColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
           pointHoverBorderWidth: 2,
         }]
       },
@@ -372,14 +385,7 @@ document.addEventListener('DOMContentLoaded', function() {
         plugins: {
           legend: { display: false },
           tooltip: {
-            backgroundColor: isDark ? '#1a1a2e' : '#fff',
-            titleColor: isDark ? '#e0e0ec' : '#1a1a2e',
-            bodyColor: isDark ? '#a0a0b8' : '#555566',
-            borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
-            borderWidth: 1,
-            padding: 12,
-            cornerRadius: 10,
-            displayColors: false,
+            ...tooltipStyle,
             callbacks: {
               label: ctx => '$' + ctx.parsed.y.toFixed(2)
             }
@@ -388,13 +394,15 @@ document.addEventListener('DOMContentLoaded', function() {
         scales: {
           x: {
             grid: { display: false },
-            ticks: { color: textColor, font: { size: 10 }, maxTicksLimit: 8, maxRotation: 0 }
+            border: { display: false },
+            ticks: { color: textColor, font: { size: 10, weight: '500' }, maxTicksLimit: 8, maxRotation: 0 }
           },
           y: {
-            grid: { color: gridColor },
+            grid: { color: gridColor, drawBorder: false },
+            border: { display: false },
             ticks: {
               color: textColor,
-              font: { size: 10 },
+              font: { size: 10, weight: '500' },
               callback: v => '$' + v.toLocaleString()
             }
           }
@@ -410,14 +418,16 @@ document.addEventListener('DOMContentLoaded', function() {
     const categoryLabels = {{.CategoryLabels}};
     const categoryData = {{.CategoryAmounts}};
 
-    /* Refined palette: indigo core with desaturated complementary tones */
+    /* Neutral-first palette: grays + one muted accent per segment */
     const palette = isDark
-      ? ['#8b8cf7', '#a39ef5', '#7b9cf0', '#6db8c4', '#82c9a0',
-         '#c4a66d', '#d4907a', '#b88bb4', '#8a9baa', '#6e8b9e',
-         '#a08db8', '#7eaab4']
-      : ['#4338a8', '#5e4fb8', '#3b6daa', '#2d8f9a', '#3d8f6a',
-         '#9a7b3d', '#b86050', '#8f5f8a', '#5a6e80', '#4a7080',
-         '#7a6898', '#4d8a8f'];
+      ? ['hsl(0 0% 65%)', 'hsl(0 0% 50%)', 'hsl(0 0% 40%)',
+         'hsl(210 8% 55%)', 'hsl(160 10% 50%)', 'hsl(30 12% 55%)',
+         'hsl(0 0% 75%)', 'hsl(200 6% 45%)', 'hsl(140 8% 45%)',
+         'hsl(45 10% 50%)', 'hsl(0 0% 58%)', 'hsl(180 6% 48%)']
+      : ['hsl(0 0% 15%)', 'hsl(0 0% 30%)', 'hsl(0 0% 45%)',
+         'hsl(210 10% 40%)', 'hsl(160 12% 38%)', 'hsl(30 15% 42%)',
+         'hsl(0 0% 55%)', 'hsl(200 8% 50%)', 'hsl(140 10% 45%)',
+         'hsl(45 12% 48%)', 'hsl(0 0% 65%)', 'hsl(180 8% 42%)'];
 
     new Chart(catCtx, {
       type: 'doughnut',
@@ -426,34 +436,30 @@ document.addEventListener('DOMContentLoaded', function() {
         datasets: [{
           data: categoryData,
           backgroundColor: palette.slice(0, categoryData.length),
-          borderWidth: 0,
-          hoverOffset: 4
+          borderWidth: isDark ? 1 : 1,
+          borderColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
+          hoverOffset: 3
         }]
       },
       options: {
         responsive: true,
         maintainAspectRatio: false,
-        cutout: '65%',
+        cutout: '68%',
         plugins: {
           legend: {
             position: 'bottom',
             labels: {
               color: textColor,
-              font: { size: 10 },
-              boxWidth: 10,
-              padding: 8,
+              font: { size: 10, weight: '500' },
+              boxWidth: 8,
+              boxHeight: 8,
+              padding: 10,
               usePointStyle: true,
               pointStyle: 'circle'
             }
           },
           tooltip: {
-            backgroundColor: isDark ? '#1a1a2e' : '#fff',
-            titleColor: isDark ? '#e0e0ec' : '#1a1a2e',
-            bodyColor: isDark ? '#a0a0b8' : '#555566',
-            borderColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.08)',
-            borderWidth: 1,
-            padding: 12,
-            cornerRadius: 10,
+            ...tooltipStyle,
             callbacks: {
               label: ctx => ctx.label + ': $' + ctx.parsed.toFixed(2)
             }

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -97,7 +97,7 @@
   <!-- Net Worth Card -->
   <div class="bb-card p-6">
     <div class="flex items-center gap-2 mb-1">
-      <span class="text-xs font-medium text-base-content/50 uppercase tracking-wide">Net Worth</span>
+      <span class="text-xs font-medium text-base-content/50">Net Worth</span>
     </div>
     <div class="text-3xl font-semibold tabular-nums tracking-tight">
       {{formatBalance .NetWorth}}
@@ -117,7 +117,7 @@
   <!-- Spending Card -->
   <div class="bb-card p-6">
     <div class="flex items-center gap-2 mb-1">
-      <span class="text-xs font-medium text-base-content/50 uppercase tracking-wide">Spending</span>
+      <span class="text-xs font-medium text-base-content/50">Spending</span>
       <span class="text-xs text-base-content/30">30d</span>
     </div>
     <div class="text-3xl font-semibold tabular-nums tracking-tight">
@@ -138,7 +138,7 @@
   <!-- Income Card -->
   <div class="bb-card p-6">
     <div class="flex items-center gap-2 mb-1">
-      <span class="text-xs font-medium text-base-content/50 uppercase tracking-wide">Income</span>
+      <span class="text-xs font-medium text-base-content/50">Income</span>
       <span class="text-xs text-base-content/30">30d</span>
     </div>
     <div class="text-3xl font-semibold tabular-nums tracking-tight text-success">
@@ -165,7 +165,7 @@
 {{if .Accounts}}
 <div class="mb-8">
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">Accounts</h2>
+    <h2 class="text-sm font-semibold text-base-content/70">Accounts</h2>
     <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
   </div>
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 bb-stagger">
@@ -201,7 +201,7 @@
   <!-- Spending Trend Chart -->
   <div class="bb-card lg:col-span-2 p-5">
     <div class="flex items-center justify-between mb-3">
-      <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">Daily Spending</h2>
+      <h2 class="text-sm font-semibold text-base-content/70">Daily Spending</h2>
     </div>
     {{if .DailyLabels}}
     <div class="h-52">
@@ -220,7 +220,7 @@
   <!-- Category Breakdown Chart -->
   <div class="bb-card p-5">
     <div class="flex items-center justify-between mb-3">
-      <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">By Category</h2>
+      <h2 class="text-sm font-semibold text-base-content/70">By Category</h2>
     </div>
     {{if .CategoryLabels}}
     <div class="h-52 flex items-center justify-center">
@@ -242,7 +242,7 @@
   <!-- Recent Transactions -->
   <div class="bb-card lg:col-span-2 p-5">
     <div class="flex items-center justify-between mb-3">
-      <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">Recent Transactions</h2>
+      <h2 class="text-sm font-semibold text-base-content/70">Recent Transactions</h2>
       <a href="/transactions" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
     </div>
     {{if .RecentTransactions}}
@@ -284,7 +284,7 @@
     <!-- Recent Sync Activity -->
     <div class="bb-card p-5 flex-1">
       <div class="flex items-center justify-between mb-3">
-        <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wide">Sync Activity</h2>
+        <h2 class="text-sm font-semibold text-base-content/70">Sync Activity</h2>
         <a href="/sync-logs" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
       </div>
       {{if .RecentLogs}}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -19,7 +19,7 @@
   <div class="flex gap-2 items-center">
     {{if .DockerSocketAvailable}}
     <button
-      class="btn btn-sm btn-primary"
+      class="btn btn-sm btn-primary rounded-xl"
       x-show="!pulled"
       :disabled="pulling"
       @click="pulling = true; error = '';
@@ -33,7 +33,7 @@
     </button>
     {{end}}
     <div class="dropdown dropdown-end">
-      <div tabindex="0" role="button" class="btn btn-sm btn-ghost">Update Command</div>
+      <div tabindex="0" role="button" class="btn btn-sm btn-ghost rounded-xl">Update Command</div>
       <div tabindex="0" class="dropdown-content card card-compact bg-base-200 shadow-sm p-3 w-80 z-10">
         <code class="text-xs select-all">cd /opt/breadbox && docker compose pull && docker compose up -d</code>
       </div>
@@ -51,9 +51,9 @@
 {{end}}
 
 {{if .ShowOnboarding}}
-<div class="card bg-base-100 border border-base-300 mb-6">
-  <div class="card-body">
-    <h2 class="card-title">
+<div class="bb-card mb-6">
+  <div class="p-6">
+    <h2 class="flex items-center gap-2 text-lg font-semibold">
       <i data-lucide="rocket" class="w-5 h-5 text-primary"></i>
       Getting Started
     </h2>
@@ -72,10 +72,10 @@
         <span class="text-left">{{if .HasConnection}}Bank connected{{else}}<a href="/connections/new" class="link">Connect your first bank</a>{{end}}</span>
       </li>
     </ul>
-    <div class="card-actions justify-end mt-2">
+    <div class="flex justify-end mt-2">
       <form method="POST" action="/onboarding/dismiss">
         <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-        <button type="submit" class="btn btn-ghost btn-sm">Dismiss</button>
+        <button type="submit" class="btn btn-ghost btn-sm rounded-xl">Dismiss</button>
       </form>
     </div>
   </div>
@@ -273,7 +273,7 @@
       <div class="text-center">
         <i data-lucide="receipt" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
         <p class="text-sm">No transactions yet</p>
-        <a href="/connections/new" class="btn btn-primary btn-sm mt-3">Connect a bank</a>
+        <a href="/connections/new" class="btn btn-primary btn-sm mt-3 rounded-xl">Connect a bank</a>
       </div>
     </div>
     {{end}}
@@ -320,11 +320,11 @@
     <!-- Quick Actions -->
     <div class="bb-card p-4">
       <div class="flex gap-2">
-        <a href="/connections/new" class="btn btn-primary btn-sm flex-1">
+        <a href="/connections/new" class="btn btn-primary btn-sm flex-1 rounded-xl">
           <i data-lucide="plus" class="w-3.5 h-3.5"></i>
           Connect Bank
         </a>
-        <a href="/reviews" class="btn btn-ghost btn-sm flex-1">
+        <a href="/reviews" class="btn btn-ghost btn-sm flex-1 rounded-xl">
           <i data-lucide="clipboard-check" class="w-3.5 h-3.5"></i>
           Reviews
         </a>

--- a/internal/templates/pages/login.html
+++ b/internal/templates/pages/login.html
@@ -18,17 +18,17 @@
     <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="username">Username</label>
     <input type="text" id="username" name="username" value="{{.Username}}" required autocomplete="username"
            placeholder="Enter your username"
-           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-200 focus:bg-base-100 focus:border-primary/40 transition-all duration-200">
+           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200">
   </div>
 
   <div>
     <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="password">Password</label>
     <input type="password" id="password" name="password" required autocomplete="current-password"
            placeholder="Enter your password"
-           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-200 focus:bg-base-100 focus:border-primary/40 transition-all duration-200">
+           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200">
   </div>
 
-  <button type="submit" class="btn btn-primary w-full h-12 rounded-xl text-base font-semibold shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200 mt-1">
+  <button type="submit" class="btn btn-primary w-full h-12 rounded-xl text-base font-semibold transition-colors duration-150 mt-1">
     Sign In
     <i data-lucide="arrow-right" class="w-4 h-4 ml-1"></i>
   </button>

--- a/internal/templates/pages/login.html
+++ b/internal/templates/pages/login.html
@@ -1,6 +1,6 @@
 {{define "content"}}
 <div class="text-center mb-8">
-  <h1 class="text-2xl font-bold tracking-tight">Welcome back</h1>
+  <h1 class="text-xl font-semibold tracking-tight">Welcome back</h1>
   <p class="text-sm text-base-content/50 mt-1.5">Sign in to your Breadbox dashboard</p>
 </div>
 
@@ -15,14 +15,14 @@
   {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
 
   <div>
-    <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="username">Username</label>
+    <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="username">Username</label>
     <input type="text" id="username" name="username" value="{{.Username}}" required autocomplete="username"
            placeholder="Enter your username"
            class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200">
   </div>
 
   <div>
-    <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="password">Password</label>
+    <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="password">Password</label>
     <input type="password" id="password" name="password" required autocomplete="current-password"
            placeholder="Enter your password"
            class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200">

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<div class="grid gap-6">
+<div class="grid gap-6 bb-stagger">
 
   <!-- Card 1: Global Mode -->
   <div class="bb-card p-0 overflow-hidden">

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -10,7 +10,7 @@
 
   <!-- Card 1: Global Mode -->
   <div class="bb-card p-0 overflow-hidden">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center gap-3">
       <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
         <i data-lucide="shield" class="w-5 h-5 text-primary"></i>
       </div>
@@ -50,7 +50,7 @@
 
   <!-- Card 2: Tool Access -->
   <div class="bb-card p-0 overflow-hidden">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center gap-3">
       <div class="w-10 h-10 rounded-xl bg-secondary/10 flex items-center justify-center">
         <i data-lucide="wrench" class="w-5 h-5 text-secondary"></i>
       </div>
@@ -119,7 +119,7 @@
       }
     }
   }">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center gap-3">
       <div class="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center">
         <i data-lucide="file-text" class="w-5 h-5 text-accent"></i>
       </div>
@@ -167,7 +167,7 @@
 
   <!-- Card 4: API Key Scopes -->
   <div class="bb-card p-0 overflow-hidden">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center gap-3">
       <div class="w-10 h-10 rounded-xl bg-warning/10 flex items-center justify-center">
         <i data-lucide="key" class="w-5 h-5 text-warning"></i>
       </div>

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -178,7 +178,7 @@
     </div>
     <div class="px-6 py-5">
       <p class="text-sm text-base-content/50 mb-5">Read-only keys cannot invoke write tools or write REST endpoints, even when global mode is Read & Write.</p>
-      <div class="grid grid-cols-2 gap-4 mb-5">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-5">
         <div class="bb-stat-card">
           <div class="bb-stat-card__icon text-primary">
             <i data-lucide="shield-check" class="w-5 h-5"></i>

--- a/internal/templates/pages/providers.html
+++ b/internal/templates/pages/providers.html
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 bb-stagger">
 
   <!-- Plaid Card -->
   <div class="bb-card p-0 overflow-hidden">

--- a/internal/templates/pages/providers.html
+++ b/internal/templates/pages/providers.html
@@ -10,7 +10,7 @@
 
   <!-- Plaid Card -->
   <div class="bb-card p-0 overflow-hidden">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center justify-between">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center justify-between">
       <div class="flex items-center gap-3">
         <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
           <i data-lucide="building-2" class="w-5 h-5 text-primary"></i>
@@ -82,7 +82,7 @@
       {{end}}
 
       {{if .PlaidConfigured}}
-      <div class="mt-5 flex items-center gap-3 border-t border-base-200 pt-4">
+      <div class="mt-5 flex items-center gap-3 border-t border-base-300 pt-4">
         <button type="button" class="btn btn-sm btn-ghost rounded-xl" onclick="testProvider('plaid')" id="test-plaid-btn">Test Connection</button>
         <span id="test-plaid-result" class="text-sm"></span>
       </div>
@@ -92,7 +92,7 @@
 
   <!-- Teller Card -->
   <div class="bb-card p-0 overflow-hidden">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center justify-between">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center justify-between">
       <div class="flex items-center gap-3">
         <div class="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center">
           <i data-lucide="landmark" class="w-5 h-5 text-accent"></i>
@@ -140,7 +140,7 @@
         </div>
 
         {{if not .TellerCertFromEnv}}
-        <div class="border-t border-base-200 pt-4 mt-4">
+        <div class="border-t border-base-300 pt-4 mt-4">
           <h3 class="text-sm font-medium mb-3 text-base-content/60">mTLS Certificate</h3>
 
           {{if .TellerCertConfigured}}
@@ -181,7 +181,7 @@
       {{end}}
 
       {{if .TellerConfigured}}
-      <div class="mt-5 flex items-center gap-3 border-t border-base-200 pt-4">
+      <div class="mt-5 flex items-center gap-3 border-t border-base-300 pt-4">
         <button type="button" class="btn btn-sm btn-ghost rounded-xl" onclick="testProvider('teller')" id="test-teller-btn">Test Connection</button>
         <span id="test-teller-result" class="text-sm"></span>
       </div>
@@ -191,7 +191,7 @@
 
   <!-- CSV Card -->
   <div class="bb-card p-0 overflow-hidden">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center justify-between">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center justify-between">
       <div class="flex items-center gap-3">
         <div class="w-10 h-10 rounded-xl bg-success/10 flex items-center justify-center">
           <i data-lucide="file-spreadsheet" class="w-5 h-5 text-success"></i>

--- a/internal/templates/pages/review_instructions.html
+++ b/internal/templates/pages/review_instructions.html
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<div class="grid gap-6">
+<div class="grid gap-6 bb-stagger">
 
   <!-- Card 1: Initial Review Mode -->
   <div class="bb-card p-0 overflow-hidden" x-data="{ copied: false }">

--- a/internal/templates/pages/review_instructions.html
+++ b/internal/templates/pages/review_instructions.html
@@ -10,7 +10,7 @@
 
   <!-- Card 1: Initial Review Mode -->
   <div class="bb-card p-0 overflow-hidden" x-data="{ copied: false }">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center gap-3">
       <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center">
         <i data-lucide="layers" class="w-5 h-5 text-primary"></i>
       </div>
@@ -40,7 +40,7 @@
 
   <!-- Card 2: Recurring Review Mode -->
   <div class="bb-card p-0 overflow-hidden" x-data="{ copied: false }">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center gap-3">
       <div class="w-10 h-10 rounded-xl bg-secondary/10 flex items-center justify-center">
         <i data-lucide="repeat" class="w-5 h-5 text-secondary"></i>
       </div>
@@ -70,7 +70,7 @@
 
   <!-- Card 3: Connection Info -->
   <div class="bb-card p-0 overflow-hidden" x-data="{ copiedConfig: false }">
-    <div class="px-6 py-5 border-b border-base-200 flex items-center gap-3">
+    <div class="px-6 py-5 border-b border-base-300 flex items-center gap-3">
       <div class="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center">
         <i data-lucide="plug" class="w-5 h-5 text-accent"></i>
       </div>

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -13,7 +13,7 @@
       Dismiss All
     </button>
     <dialog class="modal" :class="{ 'modal-open': confirmOpen }">
-      <div class="modal-box rounded-2xl">
+      <div class="modal-box rounded-xl">
         <h3 class="text-lg font-bold">Dismiss all pending reviews?</h3>
         <p class="py-4 text-base-content/70">This will permanently remove all <strong>{{.Counts.Pending}}</strong> pending reviews from the queue. This cannot be undone.</p>
         <div class="modal-action">
@@ -101,7 +101,7 @@
     <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 transition-transform duration-200" :class="open && 'rotate-180'"></i>
   </button>
   <div x-show="open" x-cloak x-collapse x-data="{ autoEnqueue: {{.ReviewAutoEnqueue}}, threshold: '{{.ReviewConfidenceThreshold}}', saving: false }">
-    <div class="px-6 pb-6 pt-0 border-t border-base-200">
+    <div class="px-6 pb-6 pt-0 border-t border-base-300">
       <div class="flex flex-wrap gap-6 items-end pt-4">
         <div class="form-control">
           <label class="label cursor-pointer gap-3">
@@ -263,20 +263,20 @@
 
       {{if eq .Status "pending"}}
       <!-- Action bar for pending reviews -->
-      <div class="border-t border-base-200 pt-4 mt-4">
+      <div class="border-t border-base-300 pt-4 mt-4">
         <!-- Category picker -->
         <div class="form-control" :class="{ 'bb-picker-shake': pickerShake }">
           <label class="label label-text text-xs text-base-content/40 py-0.5">
             {{if .SuggestedCategoryID}}Correct category{{else}}Assign category{{end}}
           </label>
           <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', placeholder: 'Keep current', allowEmpty: true, emptyLabel: 'Keep current'})" @category-change="selectedCatId = $event.detail.id; if (selectedCatId !== suggestedCatId && suggestedCatId) { feedback = 'down'; }">
-            <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start border border-base-200 rounded-xl" @click="openPicker()">
+            <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start border border-base-300 rounded-xl" @click="openPicker()">
               <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
               <span x-text="displayLabel" class="text-sm truncate"></span>
               <svg class="w-3 h-3 ml-auto opacity-40" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
             </button>
             <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-              <div class="p-2 border-b border-base-200 sticky top-0 bg-base-100 z-10">
+              <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
                 <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full rounded-xl">
               </div>
               <div x-ref="listbox">
@@ -323,7 +323,7 @@
       </div>
       {{else if .ReviewerName}}
       <!-- Resolved info -->
-      <div class="border-t border-base-200 pt-3 mt-4 text-xs text-base-content/40">
+      <div class="border-t border-base-300 pt-3 mt-4 text-xs text-base-content/40">
         Reviewed by {{.ReviewerName}} {{if .ReviewedAt}} &middot; {{relativeTime .ReviewedAt}}{{end}}
         {{if .ReviewNote}}<br>Note: {{.ReviewNote}}{{end}}
       </div>
@@ -344,7 +344,7 @@
   {{else}}
   <div class="bb-card">
     <div class="flex flex-col items-center text-center py-16 px-6">
-      <div class="w-16 h-16 rounded-2xl bg-success/10 flex items-center justify-center mb-4">
+      <div class="w-16 h-16 rounded-xl bg-success/10 flex items-center justify-center mb-4">
         <i data-lucide="check-circle" class="w-8 h-8 text-success"></i>
       </div>
       <h2 class="text-lg font-semibold mb-1">All caught up!</h2>

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -51,7 +51,7 @@
 
 <!-- Stat Cards -->
 {{if .Counts}}
-<div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
+<div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8 bb-stagger">
   <div class="bb-stat-card">
     <div class="bb-stat-card__icon text-warning">
       <i data-lucide="clock" class="w-5 h-5"></i>

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -134,8 +134,8 @@
 </div>
 
 <!-- Filter Bar -->
-<div class="bb-card px-6 py-4 mb-6">
-  <form method="GET" action="/reviews" class="flex flex-wrap gap-4 items-end">
+<div class="bb-card px-4 sm:px-6 py-4 mb-6">
+  <form method="GET" action="/reviews" class="flex flex-col sm:flex-row sm:flex-wrap gap-3 sm:gap-4 sm:items-end">
     <div class="form-control">
       <label class="label label-text text-xs text-base-content/50 pb-1">Status</label>
       <select name="status" class="select select-bordered select-sm rounded-xl">

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -200,7 +200,7 @@
           <span class="badge badge-soft badge-neutral badge-sm rounded-lg">Manual</span>
           {{end}}
           {{if .Provider}}
-          <span class="badge badge-ghost badge-xs uppercase rounded-lg">{{.Provider}}</span>
+          <span class="badge badge-ghost badge-xs rounded-lg">{{.Provider}}</span>
           {{end}}
           {{if eq .Status "approved"}}
           <span class="badge badge-success badge-sm rounded-lg">Approved</span>

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -226,10 +226,10 @@
         </div>
         <div class="text-right flex-shrink-0">
           <div class="text-xl font-bold tabular-nums{{if lt .Transaction.Amount 0.0}} text-error{{end}}">
-            {{printf "%.2f" .Transaction.Amount}}
+            {{formatAmount .Transaction.Amount}}
           </div>
           <div class="text-xs text-base-content/40 mt-0.5">
-            {{if .Transaction.IsoCurrencyCode}}{{.Transaction.IsoCurrencyCode}} &middot; {{end}}{{.Transaction.Date}}
+            {{formatDate .Transaction.Date}}
           </div>
         </div>
       </div>

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -12,11 +12,11 @@
 </div>
 
 <!-- Filter bar -->
-<div class="bb-card px-6 py-4 mb-6">
-  <form method="GET" class="flex items-end gap-4 flex-wrap">
+<div class="bb-card px-4 sm:px-6 py-4 mb-6">
+  <form method="GET" class="flex flex-col sm:flex-row sm:items-end gap-3 sm:gap-4 sm:flex-wrap">
     <div class="form-control">
       <label class="label label-text text-xs text-base-content/50 pb-1">Search</label>
-      <input type="text" name="search" placeholder="Search by name..." value="{{.SearchFilter}}" class="input input-bordered input-sm w-48 rounded-xl" />
+      <input type="text" name="search" placeholder="Search by name..." value="{{.SearchFilter}}" class="input input-bordered input-sm w-full sm:w-48 rounded-xl" />
     </div>
     <div class="form-control">
       <label class="label label-text text-xs text-base-content/50 pb-1">Category</label>
@@ -66,7 +66,7 @@
 <div class="space-y-3">
 {{range .Rules}}
 <div class="bb-card p-0 overflow-hidden" x-data="{deleting: false}">
-  <div class="flex items-center gap-4 px-6 py-4">
+  <div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-6 py-3 sm:py-4">
     <!-- Status indicator -->
     <div class="flex-shrink-0">
       {{if .Enabled}}

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -51,7 +51,7 @@
 {{if not .Rules}}
 <div class="bb-card">
   <div class="flex flex-col items-center text-center py-16 px-6">
-    <div class="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mb-4">
+    <div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
       <i data-lucide="list-filter" class="w-8 h-8 text-primary"></i>
     </div>
     <h2 class="text-lg font-semibold mb-1">No rules yet</h2>
@@ -153,7 +153,7 @@
 
 <!-- Create/Edit Rule Modal -->
 <dialog class="modal" :class="{'modal-open': showCreateModal || showEditModal}">
-  <div class="modal-box max-w-lg rounded-2xl">
+  <div class="modal-box max-w-lg rounded-xl">
     <h3 class="font-bold text-lg mb-6" x-text="showEditModal ? 'Edit Rule' : 'Create Rule'"></h3>
     <form @submit.prevent="submitRule()">
       <div class="form-control mb-4">

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 bb-stagger">
 
   <!-- Sync & Scheduling -->
   <div class="bb-card p-6">

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -26,7 +26,7 @@
       <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="sync_interval_minutes">
         Sync Interval {{configSource .ConfigSources "sync_interval_minutes"}}
       </label>
-      <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm w-full bg-base-200/50 border-base-200 focus:border-primary">
+      <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm w-full bg-base-200/50 border-base-300 focus:border-primary">
         <option value="15"{{if eq .SyncIntervalMinutes 15}} selected{{end}}>Every 15 minutes</option>
         <option value="30"{{if eq .SyncIntervalMinutes 30}} selected{{end}}>Every 30 minutes</option>
         <option value="60"{{if eq .SyncIntervalMinutes 60}} selected{{end}}>Every hour</option>
@@ -43,7 +43,7 @@
       </p>
       {{end}}
 
-      <div class="mt-5 pt-4 border-t border-base-200">
+      <div class="mt-5 pt-4 border-t border-base-300">
         <button type="submit" class="btn btn-primary btn-sm">Save Schedule</button>
       </div>
     </form>
@@ -89,15 +89,15 @@
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
       <div>
         <label class="text-xs font-medium text-base-content/50 mb-1 block" for="current_password">Current Password</label>
-        <input type="password" id="current_password" name="current_password" required class="input input-sm w-full bg-base-200/50 border-base-200 focus:border-primary">
+        <input type="password" id="current_password" name="current_password" required class="input input-sm w-full bg-base-200/50 border-base-300 focus:border-primary">
       </div>
       <div>
         <label class="text-xs font-medium text-base-content/50 mb-1 block" for="new_password">New Password</label>
-        <input type="password" id="new_password" name="new_password" required minlength="8" class="input input-sm w-full bg-base-200/50 border-base-200 focus:border-primary">
+        <input type="password" id="new_password" name="new_password" required minlength="8" class="input input-sm w-full bg-base-200/50 border-base-300 focus:border-primary">
       </div>
       <div>
         <label class="text-xs font-medium text-base-content/50 mb-1 block" for="confirm_password">Confirm New Password</label>
-        <input type="password" id="confirm_password" name="confirm_password" required class="input input-sm w-full bg-base-200/50 border-base-200 focus:border-primary">
+        <input type="password" id="confirm_password" name="confirm_password" required class="input input-sm w-full bg-base-200/50 border-base-300 focus:border-primary">
       </div>
       <div class="pt-2">
         <button type="submit" class="btn btn-primary btn-sm">Update Password</button>

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -26,7 +26,7 @@
       <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="sync_interval_minutes">
         Sync Interval {{configSource .ConfigSources "sync_interval_minutes"}}
       </label>
-      <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm w-full bg-base-200/50 border-base-300 focus:border-primary">
+      <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm select-bordered w-full rounded-xl">
         <option value="15"{{if eq .SyncIntervalMinutes 15}} selected{{end}}>Every 15 minutes</option>
         <option value="30"{{if eq .SyncIntervalMinutes 30}} selected{{end}}>Every 30 minutes</option>
         <option value="60"{{if eq .SyncIntervalMinutes 60}} selected{{end}}>Every hour</option>
@@ -44,7 +44,7 @@
       {{end}}
 
       <div class="mt-5 pt-4 border-t border-base-300">
-        <button type="submit" class="btn btn-primary btn-sm">Save Schedule</button>
+        <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Schedule</button>
       </div>
     </form>
   </div>
@@ -89,18 +89,18 @@
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
       <div>
         <label class="text-xs font-medium text-base-content/50 mb-1 block" for="current_password">Current Password</label>
-        <input type="password" id="current_password" name="current_password" required class="input input-sm w-full bg-base-200/50 border-base-300 focus:border-primary">
+        <input type="password" id="current_password" name="current_password" required class="input input-sm input-bordered w-full rounded-xl">
       </div>
       <div>
         <label class="text-xs font-medium text-base-content/50 mb-1 block" for="new_password">New Password</label>
-        <input type="password" id="new_password" name="new_password" required minlength="8" class="input input-sm w-full bg-base-200/50 border-base-300 focus:border-primary">
+        <input type="password" id="new_password" name="new_password" required minlength="8" class="input input-sm input-bordered w-full rounded-xl">
       </div>
       <div>
         <label class="text-xs font-medium text-base-content/50 mb-1 block" for="confirm_password">Confirm New Password</label>
-        <input type="password" id="confirm_password" name="confirm_password" required class="input input-sm w-full bg-base-200/50 border-base-300 focus:border-primary">
+        <input type="password" id="confirm_password" name="confirm_password" required class="input input-sm input-bordered w-full rounded-xl">
       </div>
       <div class="pt-2">
-        <button type="submit" class="btn btn-primary btn-sm">Update Password</button>
+        <button type="submit" class="btn btn-primary btn-sm rounded-xl">Update Password</button>
       </div>
     </form>
   </div>

--- a/internal/templates/pages/setup_create_admin.html
+++ b/internal/templates/pages/setup_create_admin.html
@@ -1,6 +1,6 @@
 {{define "content"}}
 <div class="text-center mb-8">
-  <h1 class="text-2xl font-bold tracking-tight">Create your account</h1>
+  <h1 class="text-xl font-semibold tracking-tight">Create your account</h1>
   <p class="text-sm text-base-content/50 mt-1.5">Set up the admin account to get started with Breadbox</p>
 </div>
 
@@ -15,7 +15,7 @@
   {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
 
   <div>
-    <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="username">Username</label>
+    <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="username">Username</label>
     <input type="text" id="username" name="username" value="{{.Username}}" required autocomplete="username"
            placeholder="Choose a username"
            class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.Username}} input-error{{end}}">
@@ -23,7 +23,7 @@
   </div>
 
   <div>
-    <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="password">Password</label>
+    <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="password">Password</label>
     <input type="password" id="password" name="password" required autocomplete="new-password" minlength="8"
            placeholder="Create a password"
            class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.Password}} input-error{{end}}">
@@ -32,7 +32,7 @@
   </div>
 
   <div>
-    <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="confirm_password">Confirm Password</label>
+    <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="confirm_password">Confirm Password</label>
     <input type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password"
            placeholder="Confirm your password"
            class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.ConfirmPassword}} input-error{{end}}">

--- a/internal/templates/pages/setup_create_admin.html
+++ b/internal/templates/pages/setup_create_admin.html
@@ -18,7 +18,7 @@
     <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="username">Username</label>
     <input type="text" id="username" name="username" value="{{.Username}}" required autocomplete="username"
            placeholder="Choose a username"
-           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-200 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.Username}} input-error{{end}}">
+           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.Username}} input-error{{end}}">
     {{if .Errors.Username}}<p class="text-xs text-error mt-1.5">{{.Errors.Username}}</p>{{end}}
   </div>
 
@@ -26,7 +26,7 @@
     <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="password">Password</label>
     <input type="password" id="password" name="password" required autocomplete="new-password" minlength="8"
            placeholder="Create a password"
-           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-200 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.Password}} input-error{{end}}">
+           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.Password}} input-error{{end}}">
     <p class="text-xs text-base-content/40 mt-1.5">Minimum 8 characters</p>
     {{if .Errors.Password}}<p class="text-xs text-error mt-1">{{.Errors.Password}}</p>{{end}}
   </div>
@@ -35,11 +35,11 @@
     <label class="block text-xs font-semibold uppercase tracking-wider text-base-content/50 mb-1.5" for="confirm_password">Confirm Password</label>
     <input type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password"
            placeholder="Confirm your password"
-           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-200 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.ConfirmPassword}} input-error{{end}}">
+           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.ConfirmPassword}} input-error{{end}}">
     {{if .Errors.ConfirmPassword}}<p class="text-xs text-error mt-1.5">{{.Errors.ConfirmPassword}}</p>{{end}}
   </div>
 
-  <button type="submit" class="btn btn-primary w-full h-12 rounded-xl text-base font-semibold shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200 mt-1">
+  <button type="submit" class="btn btn-primary w-full h-12 rounded-xl text-base font-semibold transition-colors duration-150 mt-1">
     Create Account
     <i data-lucide="arrow-right" class="w-4 h-4 ml-1"></i>
   </button>

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -11,7 +11,7 @@
   <form method="GET" action="/sync-logs" class="flex flex-col sm:flex-row sm:flex-wrap sm:items-end gap-3">
     <div class="form-control">
       <label class="text-xs font-medium text-base-content/50 mb-1">Connection</label>
-      <select name="connection_id" class="select select-sm bg-base-200/50 border-base-300 w-full sm:w-auto sm:min-w-[10rem]">
+      <select name="connection_id" class="select select-sm select-bordered w-full sm:w-auto sm:min-w-[10rem] rounded-xl">
         <option value="">All connections</option>
         {{range .Connections}}
         <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
@@ -20,16 +20,16 @@
     </div>
     <div class="form-control">
       <label class="text-xs font-medium text-base-content/50 mb-1">Status</label>
-      <select name="status" class="select select-sm bg-base-200/50 border-base-300 w-full sm:w-auto sm:min-w-[8rem]">
+      <select name="status" class="select select-sm select-bordered w-full sm:w-auto sm:min-w-[8rem] rounded-xl">
         <option value="">All statuses</option>
         <option value="success"{{if eq .FilterStatus "success"}} selected{{end}}>Success</option>
         <option value="error"{{if eq .FilterStatus "error"}} selected{{end}}>Error</option>
         <option value="in_progress"{{if eq .FilterStatus "in_progress"}} selected{{end}}>In Progress</option>
       </select>
     </div>
-    <button type="submit" class="btn btn-primary btn-sm">Filter</button>
+    <button type="submit" class="btn btn-primary btn-sm rounded-xl">Filter</button>
     {{if or .FilterConnID .FilterStatus}}
-    <a href="/sync-logs" class="btn btn-ghost btn-sm">Clear</a>
+    <a href="/sync-logs" class="btn btn-ghost btn-sm rounded-xl">Clear</a>
     {{end}}
   </form>
 </div>
@@ -167,13 +167,13 @@
 <div class="flex items-center justify-between mt-6">
   <div>
     {{if gt .Page 1}}
-    <a href="/sync-logs?page={{sub .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost">&laquo; Previous</a>
+    <a href="/sync-logs?page={{sub .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost rounded-xl">&laquo; Previous</a>
     {{end}}
   </div>
   <span class="text-xs text-base-content/40">Page {{.Page}} of {{.TotalPages}}</span>
   <div>
     {{if lt .Page .TotalPages}}
-    <a href="/sync-logs?page={{add .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost">Next &raquo;</a>
+    <a href="/sync-logs?page={{add .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost rounded-xl">Next &raquo;</a>
     {{end}}
   </div>
 </div>
@@ -188,7 +188,7 @@
     <h3 class="text-lg font-semibold mb-1">No sync logs found</h3>
     <p class="text-sm text-base-content/50 mb-5">{{if or .FilterConnID .FilterStatus}}Try adjusting your filters.{{else}}Sync logs will appear here after your first bank sync.{{end}}</p>
     {{if or .FilterConnID .FilterStatus}}
-    <a href="/sync-logs" class="btn btn-ghost btn-sm">Clear filters</a>
+    <a href="/sync-logs" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
     {{end}}
   </div>
 </div>

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -11,7 +11,7 @@
   <form method="GET" action="/sync-logs" class="flex flex-wrap items-end gap-3">
     <div class="form-control">
       <label class="text-xs font-medium text-base-content/50 mb-1">Connection</label>
-      <select name="connection_id" class="select select-sm bg-base-200/50 border-base-200 min-w-[10rem]">
+      <select name="connection_id" class="select select-sm bg-base-200/50 border-base-300 min-w-[10rem]">
         <option value="">All connections</option>
         {{range .Connections}}
         <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
@@ -20,7 +20,7 @@
     </div>
     <div class="form-control">
       <label class="text-xs font-medium text-base-content/50 mb-1">Status</label>
-      <select name="status" class="select select-sm bg-base-200/50 border-base-200 min-w-[8rem]">
+      <select name="status" class="select select-sm bg-base-200/50 border-base-300 min-w-[8rem]">
         <option value="">All statuses</option>
         <option value="success"{{if eq .FilterStatus "success"}} selected{{end}}>Success</option>
         <option value="error"{{if eq .FilterStatus "error"}} selected{{end}}>Error</option>
@@ -85,7 +85,7 @@
         <div tabindex="0" role="button" class="btn btn-ghost btn-xs text-error">
           <i data-lucide="alert-circle" class="w-3.5 h-3.5"></i>
         </div>
-        <div tabindex="0" class="dropdown-content card card-compact bg-base-100 shadow-xl border border-base-200 p-3 w-72 z-10">
+        <div tabindex="0" class="dropdown-content card card-compact bg-base-100 shadow-sm border border-base-300 p-3 w-72 z-10">
           <p class="text-xs text-error font-mono break-all">{{.ErrorMessage}}</p>
         </div>
       </div>
@@ -115,7 +115,7 @@
 {{else}}
 <div class="bb-card p-12 text-center">
   <div class="flex flex-col items-center">
-    <div class="w-16 h-16 rounded-2xl bg-base-200/60 flex items-center justify-center mb-4">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
       <i data-lucide="refresh-cw" class="w-8 h-8 text-base-content/25"></i>
     </div>
     <h3 class="text-lg font-semibold mb-1">No sync logs found</h3>

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -38,7 +38,7 @@
 <!-- Results count -->
 <div class="text-xs text-base-content/40 mb-3 px-1">{{.Total}} sync log{{if ne .Total 1}}s{{end}}</div>
 
-<div class="space-y-2">
+<div class="space-y-2 bb-stagger">
   {{range .Logs}}
   <div class="bb-card px-5 py-3.5 flex items-center gap-4 flex-wrap">
     <!-- Institution icon + name -->

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -8,10 +8,10 @@
 
 <!-- Filter Bar -->
 <div class="bb-card p-4 mb-6">
-  <form method="GET" action="/sync-logs" class="flex flex-wrap items-end gap-3">
+  <form method="GET" action="/sync-logs" class="flex flex-col sm:flex-row sm:flex-wrap sm:items-end gap-3">
     <div class="form-control">
       <label class="text-xs font-medium text-base-content/50 mb-1">Connection</label>
-      <select name="connection_id" class="select select-sm bg-base-200/50 border-base-300 min-w-[10rem]">
+      <select name="connection_id" class="select select-sm bg-base-200/50 border-base-300 w-full sm:w-auto sm:min-w-[10rem]">
         <option value="">All connections</option>
         {{range .Connections}}
         <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
@@ -20,7 +20,7 @@
     </div>
     <div class="form-control">
       <label class="text-xs font-medium text-base-content/50 mb-1">Status</label>
-      <select name="status" class="select select-sm bg-base-200/50 border-base-300 min-w-[8rem]">
+      <select name="status" class="select select-sm bg-base-200/50 border-base-300 w-full sm:w-auto sm:min-w-[8rem]">
         <option value="">All statuses</option>
         <option value="success"{{if eq .FilterStatus "success"}} selected{{end}}>Success</option>
         <option value="error"{{if eq .FilterStatus "error"}} selected{{end}}>Error</option>

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -38,60 +38,127 @@
 <!-- Results count -->
 <div class="text-xs text-base-content/40 mb-3 px-1">{{.Total}} sync log{{if ne .Total 1}}s{{end}}</div>
 
-<div class="space-y-2 bb-stagger">
+<!-- Desktop table view (hidden on mobile) -->
+<div class="bb-card overflow-hidden mb-2 hidden md:block">
+  <table class="table table-sm w-full">
+    <thead>
+      <tr class="text-xs text-base-content/40">
+        <th class="font-medium">Connection</th>
+        <th class="font-medium">When</th>
+        <th class="font-medium">Trigger</th>
+        <th class="font-medium">Changes</th>
+        <th class="font-medium text-right">Duration</th>
+        <th class="font-medium text-right">Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      {{range .Logs}}
+      <tr class="hover:bg-base-200/30">
+        <!-- Connection -->
+        <td>
+          <div class="flex items-center gap-2.5">
+            <div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0">
+              <i data-lucide="building-2" class="w-3.5 h-3.5 text-base-content/40"></i>
+            </div>
+            <span class="text-sm font-medium">{{.InstitutionName}}</span>
+          </div>
+        </td>
+        <!-- Timestamp -->
+        <td>
+          <div class="text-sm text-base-content/70">{{relativeTime .StartedAt}}</div>
+          <div class="text-xs text-base-content/30">{{formatDateShort .StartedAt}}</div>
+        </td>
+        <!-- Trigger -->
+        <td>
+          <span class="badge badge-ghost badge-xs">{{.Trigger}}</span>
+        </td>
+        <!-- Changes -->
+        <td>
+          <div class="flex items-center gap-2.5 text-xs tabular-nums">
+            {{if .AddedCount}}
+            <span class="text-success font-medium">+{{.AddedCount}}</span>
+            {{end}}
+            {{if .ModifiedCount}}
+            <span class="text-info font-medium">~{{.ModifiedCount}}</span>
+            {{end}}
+            {{if .RemovedCount}}
+            <span class="text-error font-medium">-{{.RemovedCount}}</span>
+            {{end}}
+            {{if and (not .AddedCount) (not .ModifiedCount) (not .RemovedCount)}}
+            <span class="text-base-content/25">No changes</span>
+            {{end}}
+          </div>
+        </td>
+        <!-- Duration -->
+        <td class="text-right">
+          <span class="text-xs text-base-content/50 tabular-nums">{{if .Duration}}{{.Duration}}{{else}}&mdash;{{end}}</span>
+        </td>
+        <!-- Status -->
+        <td class="text-right">
+          <div class="flex items-center justify-end gap-1.5">
+            {{if .ErrorMessage}}
+            <div class="dropdown dropdown-end dropdown-hover">
+              <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-circle text-error/70">
+                <i data-lucide="info" class="w-3.5 h-3.5"></i>
+              </div>
+              <div tabindex="0" class="dropdown-content bg-base-100 shadow-lg border border-base-300 rounded-xl p-3 w-80 z-10">
+                <div class="text-xs font-medium text-error mb-1">Error Details</div>
+                <p class="text-xs text-base-content/60 font-mono break-all leading-relaxed">{{.ErrorMessage}}</p>
+              </div>
+            </div>
+            {{end}}
+            {{syncBadge .Status}}
+          </div>
+        </td>
+      </tr>
+      {{end}}
+    </tbody>
+  </table>
+</div>
+
+<!-- Mobile card view (hidden on desktop) -->
+<div class="space-y-2 md:hidden bb-stagger">
   {{range .Logs}}
-  <div class="bb-card px-5 py-3.5 flex items-center gap-4 flex-wrap">
-    <!-- Institution icon + name -->
-    <div class="flex items-center gap-3 min-w-0 w-44 shrink-0">
-      <div class="w-8 h-8 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0">
-        <i data-lucide="building-2" class="w-4 h-4 text-base-content/40"></i>
-      </div>
-      <div class="min-w-0">
-        <div class="text-sm font-medium truncate">{{.InstitutionName}}</div>
-        <div class="text-xs text-base-content/40">{{if .StartedAt}}{{.StartedAt}}{{end}}</div>
-      </div>
-    </div>
-
-    <!-- Trigger -->
-    <div class="w-16 shrink-0">
-      <span class="badge badge-ghost badge-xs uppercase tracking-wide">{{.Trigger}}</span>
-    </div>
-
-    <!-- Counts -->
-    <div class="flex items-center gap-3 text-xs tabular-nums flex-1">
-      {{if .AddedCount}}
-      <span class="text-success font-medium">+{{.AddedCount}}</span>
-      {{end}}
-      {{if .ModifiedCount}}
-      <span class="text-info font-medium">~{{.ModifiedCount}}</span>
-      {{end}}
-      {{if .RemovedCount}}
-      <span class="text-error font-medium">-{{.RemovedCount}}</span>
-      {{end}}
-      {{if and (not .AddedCount) (not .ModifiedCount) (not .RemovedCount)}}
-      <span class="text-base-content/25">No changes</span>
-      {{end}}
-    </div>
-
-    <!-- Duration -->
-    <div class="w-20 text-xs text-base-content/50 text-right shrink-0">
-      {{if .Duration}}{{.Duration}}{{else}}&mdash;{{end}}
-    </div>
-
-    <!-- Status + Error -->
-    <div class="w-24 shrink-0 flex items-center justify-end gap-2">
-      {{if .ErrorMessage}}
-      <div class="dropdown dropdown-end">
-        <div tabindex="0" role="button" class="btn btn-ghost btn-xs text-error">
-          <i data-lucide="alert-circle" class="w-3.5 h-3.5"></i>
+  <div class="bb-card p-4">
+    <!-- Header: connection + status -->
+    <div class="flex items-center justify-between mb-2.5">
+      <div class="flex items-center gap-2.5 min-w-0">
+        <div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0">
+          <i data-lucide="building-2" class="w-3.5 h-3.5 text-base-content/40"></i>
         </div>
-        <div tabindex="0" class="dropdown-content card card-compact bg-base-100 shadow-sm border border-base-300 p-3 w-72 z-10">
-          <p class="text-xs text-error font-mono break-all">{{.ErrorMessage}}</p>
+        <div class="min-w-0">
+          <div class="text-sm font-medium truncate">{{.InstitutionName}}</div>
+          <div class="text-xs text-base-content/40">{{relativeTime .StartedAt}}</div>
         </div>
       </div>
-      {{end}}
-      {{syncBadge .Status}}
+      <div class="flex items-center gap-1.5 shrink-0">
+        {{syncBadge .Status}}
+      </div>
     </div>
+
+    <!-- Details row -->
+    <div class="flex items-center justify-between text-xs text-base-content/50 pt-2 border-t border-base-300/50">
+      <div class="flex items-center gap-3">
+        <span class="badge badge-ghost badge-xs">{{.Trigger}}</span>
+        <div class="flex items-center gap-2 tabular-nums">
+          {{if .AddedCount}}<span class="text-success font-medium">+{{.AddedCount}}</span>{{end}}
+          {{if .ModifiedCount}}<span class="text-info font-medium">~{{.ModifiedCount}}</span>{{end}}
+          {{if .RemovedCount}}<span class="text-error font-medium">-{{.RemovedCount}}</span>{{end}}
+          {{if and (not .AddedCount) (not .ModifiedCount) (not .RemovedCount)}}
+          <span class="text-base-content/25">No changes</span>
+          {{end}}
+        </div>
+      </div>
+      <span class="tabular-nums">{{if .Duration}}{{.Duration}}{{else}}&mdash;{{end}}</span>
+    </div>
+
+    <!-- Error message if present -->
+    {{if .ErrorMessage}}
+    <div class="mt-2.5 flex items-start gap-2 text-xs text-error/80 bg-error/5 rounded-lg px-3 py-2">
+      <i data-lucide="alert-circle" class="w-3.5 h-3.5 shrink-0 mt-0.5"></i>
+      <span class="font-mono break-all leading-relaxed">{{.ErrorMessage}}</span>
+    </div>
+    {{end}}
   </div>
   {{end}}
 </div>

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -179,7 +179,7 @@
       </div>
       <div class="flex-1 flex gap-2">
         <textarea x-model="newComment" placeholder="Add a comment..." class="textarea textarea-bordered textarea-sm flex-1 min-h-[2.5rem] resize-none" rows="1" @input="$el.style.height = 'auto'; $el.style.height = $el.scrollHeight + 'px'"></textarea>
-        <button @click="addComment()" class="btn btn-sm btn-primary self-end" :disabled="!newComment.trim()">
+        <button @click="addComment()" class="btn btn-sm btn-primary self-end rounded-xl" :disabled="!newComment.trim()">
           <i data-lucide="send" class="w-3.5 h-3.5"></i>
         </button>
       </div>

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -15,7 +15,7 @@
       <i data-lucide="{{if lt .Transaction.Amount 0.0}}arrow-up-right{{else}}arrow-down-left{{end}}" class="w-6 h-6 {{if lt .Transaction.Amount 0.0}}text-error{{else}}text-success{{end}}"></i>
     </div>
     <div>
-      <h1 class="text-2xl font-bold tracking-tight">{{.Transaction.Name}}</h1>
+      <h1 class="bb-page-title">{{.Transaction.Name}}</h1>
       <div class="flex items-center gap-2 mt-0.5">
         <span class="text-xs text-base-content/40">{{.Transaction.Date}}</span>
         {{if .Transaction.MerchantName}}
@@ -27,7 +27,7 @@
     </div>
   </div>
   <div class="text-right">
-    <p class="text-3xl font-bold tabular-nums{{if lt .Transaction.Amount 0.0}} text-error{{end}}">
+    <p class="text-3xl font-semibold tabular-nums{{if lt .Transaction.Amount 0.0}} text-error{{end}}">
       {{printf "%.2f" .Transaction.Amount}}
     </p>
     {{if .Transaction.IsoCurrencyCode}}<p class="text-xs text-base-content/30 mt-0.5">{{.Transaction.IsoCurrencyCode}}</p>{{end}}
@@ -38,7 +38,7 @@
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
   <!-- Transaction Details -->
   <div class="bb-card p-6 lg:col-span-2">
-    <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider mb-5">Details</h2>
+    <h2 class="text-sm font-semibold text-base-content/50 mb-5">Details</h2>
     <div class="grid grid-cols-2 sm:grid-cols-3 gap-y-5 gap-x-6">
       <div>
         <p class="text-xs text-base-content/40 mb-1">Date</p>
@@ -101,7 +101,7 @@
 
   <!-- Category Card -->
   <div class="bb-card p-6" x-data="txCategoryEditor()">
-    <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider mb-5">Category</h2>
+    <h2 class="text-sm font-semibold text-base-content/50 mb-5">Category</h2>
 
     <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', initial: '{{if .Transaction.Category}}{{.Transaction.Category.ID}}{{end}}'})" @category-change="setCategoryFromPicker($event.detail)">
       <button type="button" class="w-full flex items-center gap-3 p-3 rounded-xl bg-base-200/50 hover:bg-base-200 transition-colors" @click="openPicker()">
@@ -141,7 +141,7 @@
 <!-- Comments Section -->
 <div class="bb-card" x-data="commentManager()">
   <div class="px-6 pt-6 pb-4 flex items-center justify-between">
-    <h2 class="text-sm font-semibold text-base-content/40 uppercase tracking-wider">Comments</h2>
+    <h2 class="text-sm font-semibold text-base-content/50">Comments</h2>
     <span class="text-xs text-base-content/30">{{len .Comments}} total</span>
   </div>
 

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -17,10 +17,10 @@
     <div>
       <h1 class="bb-page-title">{{.Transaction.Name}}</h1>
       <div class="flex items-center gap-2 mt-0.5">
-        <span class="text-xs text-base-content/40">{{.Transaction.Date}}</span>
+        <span class="text-xs text-base-content/40">{{formatDate .Transaction.Date}}</span>
         {{if .Transaction.MerchantName}}
         <span class="text-xs text-base-content/30">&middot;</span>
-        <span class="text-xs text-base-content/40">{{.Transaction.MerchantName}}</span>
+        <span class="text-xs text-base-content/40">{{deref .Transaction.MerchantName}}</span>
         {{end}}
         {{if .Transaction.Pending}}<span class="badge badge-warning badge-xs ml-1">Pending</span>{{end}}
       </div>
@@ -28,9 +28,9 @@
   </div>
   <div class="text-right">
     <p class="text-3xl font-semibold tabular-nums{{if lt .Transaction.Amount 0.0}} text-error{{end}}">
-      {{printf "%.2f" .Transaction.Amount}}
+      {{formatAmount .Transaction.Amount}}
     </p>
-    {{if .Transaction.IsoCurrencyCode}}<p class="text-xs text-base-content/30 mt-0.5">{{.Transaction.IsoCurrencyCode}}</p>{{end}}
+    {{if .Transaction.IsoCurrencyCode}}<p class="text-xs text-base-content/30 mt-0.5">{{deref .Transaction.IsoCurrencyCode}}</p>{{end}}
   </div>
 </div>
 
@@ -42,7 +42,7 @@
     <div class="grid grid-cols-2 sm:grid-cols-3 gap-y-5 gap-x-6">
       <div>
         <p class="text-xs text-base-content/40 mb-1">Date</p>
-        <p class="text-sm font-medium">{{.Transaction.Date}}</p>
+        <p class="text-sm font-medium">{{formatDate .Transaction.Date}}</p>
       </div>
       {{if .Transaction.MerchantName}}
       <div>

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -89,11 +89,11 @@
         </div>
         <div>
           <p class="text-base-content/30 mb-0.5">Created</p>
-          <p class="text-base-content/50">{{.Transaction.CreatedAt}}</p>
+          <p class="text-base-content/50">{{formatDateTime .Transaction.CreatedAt}}</p>
         </div>
         <div>
           <p class="text-base-content/30 mb-0.5">Updated</p>
-          <p class="text-base-content/50">{{.Transaction.UpdatedAt}}</p>
+          <p class="text-base-content/50">{{formatDateTime .Transaction.UpdatedAt}}</p>
         </div>
       </div>
     </div>
@@ -156,7 +156,7 @@
         <p class="text-sm whitespace-pre-wrap leading-relaxed">{{.Content}}</p>
         <div class="flex items-center gap-2 mt-2">
           <span class="text-xs font-medium text-base-content/50">{{.AuthorName}}</span>
-          <span class="text-xs text-base-content/30">{{.CreatedAt}}</span>
+          <span class="text-xs text-base-content/30">{{relativeTime .CreatedAt}}</span>
         </div>
       </div>
       <button class="btn btn-ghost btn-xs opacity-0 group-hover:opacity-100 transition-opacity text-error/50 hover:text-error" @click="deleteComment('{{.ID}}')" title="Delete">

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -11,7 +11,7 @@
 <!-- Header with amount -->
 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-8">
   <div class="flex items-center gap-4">
-    <div class="w-12 h-12 rounded-2xl {{if lt .Transaction.Amount 0.0}}bg-error/10{{else}}bg-success/10{{end}} flex items-center justify-center">
+    <div class="w-12 h-12 rounded-xl {{if lt .Transaction.Amount 0.0}}bg-error/10{{else}}bg-success/10{{end}} flex items-center justify-center">
       <i data-lucide="{{if lt .Transaction.Amount 0.0}}arrow-up-right{{else}}arrow-down-left{{end}}" class="w-6 h-6 {{if lt .Transaction.Amount 0.0}}text-error{{else}}text-success{{end}}"></i>
     </div>
     <div>
@@ -81,7 +81,7 @@
     </div>
 
     <!-- Metadata -->
-    <div class="mt-6 pt-5 border-t border-base-200">
+    <div class="mt-6 pt-5 border-t border-base-300">
       <div class="grid grid-cols-2 sm:grid-cols-3 gap-y-3 gap-x-6 text-xs">
         <div>
           <p class="text-base-content/30 mb-0.5">Transaction ID</p>
@@ -172,7 +172,7 @@
   {{end}}
 
   <!-- Add Comment -->
-  <div class="px-6 py-4 mt-2 border-t border-base-200">
+  <div class="px-6 py-4 mt-2 border-t border-base-300">
     <div class="flex gap-3">
       <div class="w-8 h-8 rounded-full bg-base-200 flex items-center justify-center shrink-0 mt-0.5">
         <i data-lucide="user" class="w-4 h-4 text-base-content/40"></i>

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -4,7 +4,7 @@
 <!-- Page Header -->
 <div class="flex items-center justify-between mb-6">
   <div class="flex items-center gap-3">
-    <h1 class="text-2xl font-bold">Transactions</h1>
+    <h1 class="bb-page-title">Transactions</h1>
     {{if .Total}}
     <span class="badge badge-ghost badge-sm tabular-nums">{{.Total}} total</span>
     {{end}}
@@ -43,15 +43,15 @@
       x-transition:leave-end="opacity-0 -translate-y-2"
       class="px-4 sm:px-5 pb-4" x-data>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-3">
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Start Date
           <input type="date" name="start_date" value="{{.FilterStartDate}}" class="input input-sm input-bordered w-full">
         </label>
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           End Date
           <input type="date" name="end_date" value="{{.FilterEndDate}}" class="input input-sm input-bordered w-full">
         </label>
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Connection
           <select name="connection_id" class="select select-sm select-bordered w-full">
             <option value="">All connections</option>
@@ -60,7 +60,7 @@
             {{end}}
           </select>
         </label>
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Account
           <select name="account_id" class="select select-sm select-bordered w-full">
             <option value="">All accounts</option>
@@ -69,7 +69,7 @@
             {{end}}
           </select>
         </label>
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Family Member
           <select name="user_id" class="select select-sm select-bordered w-full">
             <option value="">All members</option>
@@ -80,7 +80,7 @@
         </label>
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-4">
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Category
           <div class="bb-cat-picker" x-data="categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
             <input type="hidden" name="category" x-ref="catInput" value="{{.FilterCategory}}">
@@ -105,15 +105,15 @@
             </div>
           </div>
         </label>
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Min Amount
           <input type="number" name="min_amount" step="0.01" value="{{.FilterMinAmount}}" placeholder="0.00" class="input input-sm input-bordered w-full">
         </label>
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Max Amount
           <input type="number" name="max_amount" step="0.01" value="{{.FilterMaxAmount}}" placeholder="0.00" class="input input-sm input-bordered w-full">
         </label>
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Pending
           <select name="pending" class="select select-sm select-bordered w-full">
             <option value="">All</option>
@@ -121,7 +121,7 @@
             <option value="false"{{if eq .FilterPending "false"}} selected{{end}}>No</option>
           </select>
         </label>
-        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
+        <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Search
           <input type="text" name="search" value="{{.FilterSearch}}" placeholder="Name or merchant" class="input input-sm input-bordered w-full">
         </label>
@@ -144,7 +144,7 @@
     <div class="overflow-x-auto">
       <table class="table table-sm">
         <thead>
-          <tr class="text-xs text-base-content/50 uppercase tracking-wide border-b border-base-300">
+          <tr class="text-xs text-base-content/50 border-b border-base-300">
             <th class="font-medium">Date</th>
             <th class="font-medium">Description</th>
             <th class="font-medium text-right">Amount</th>

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -2,7 +2,7 @@
 {{template "category-picker-styles" .}}
 
 <!-- Page Header -->
-<div class="flex items-center justify-between mb-6">
+<div class="bb-page-header">
   <div class="flex items-center gap-3">
     <h1 class="bb-page-title">Transactions</h1>
     {{if .Total}}

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -11,7 +11,7 @@
   </div>
   <div class="flex items-center gap-2">
     {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}
-    <a href="/transactions" class="btn btn-ghost btn-sm">
+    <a href="/transactions" class="btn btn-ghost btn-sm rounded-xl">
       <i data-lucide="x" class="w-3.5 h-3.5"></i>
       <span class="hidden sm:inline">Clear filters</span>
     </a>
@@ -20,9 +20,9 @@
 </div>
 
 <!-- Filters Card -->
-<div class="card bg-base-100 border border-base-300 mb-6" x-data="{ filtersOpen: {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}true{{else}}false{{end}} }">
-  <div class="card-body p-0">
-    <button type="button" class="flex items-center justify-between w-full px-4 sm:px-5 py-3 text-sm font-medium hover:bg-base-200/50 transition-colors duration-150 rounded-t-2xl"
+<div class="bb-card mb-6" x-data="{ filtersOpen: {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}true{{else}}false{{end}} }">
+  <div class="p-0">
+    <button type="button" class="flex items-center justify-between w-full px-4 sm:px-5 py-3 text-sm font-medium hover:bg-base-200/50 transition-colors duration-150 rounded-t-xl"
       @click="filtersOpen = !filtersOpen">
       <div class="flex items-center gap-2">
         <i data-lucide="sliders-horizontal" class="w-4 h-4 text-base-content/60"></i>
@@ -127,7 +127,7 @@
         </label>
       </div>
       <div class="flex justify-end gap-2">
-        <button type="submit" class="btn btn-sm btn-primary">
+        <button type="submit" class="btn btn-sm btn-primary rounded-xl">
           <i data-lucide="search" class="w-3.5 h-3.5"></i>
           Apply Filters
         </button>
@@ -140,7 +140,7 @@
 
 <!-- ═══ Desktop Table (hidden on mobile) ═══ -->
 <div class="hidden lg:block">
-  <div class="card bg-base-100 border border-base-300">
+  <div class="bb-card overflow-hidden">
     <div class="overflow-x-auto">
       <table class="table table-sm">
         <thead>
@@ -215,7 +215,7 @@
     <div class="border-t border-base-300 px-5 py-3 flex items-center justify-between">
       <div>
         {{if gt .Page 1}}
-        <a href="/transactions?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm">
+        <a href="/transactions?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm rounded-xl">
           <i data-lucide="chevron-left" class="w-4 h-4"></i>
           Previous
         </a>
@@ -224,7 +224,7 @@
       <span class="text-xs text-base-content/50 tabular-nums">Page {{.Page}} of {{.TotalPages}}</span>
       <div>
         {{if lt .Page .TotalPages}}
-        <a href="/transactions?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm">
+        <a href="/transactions?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm rounded-xl">
           Next
           <i data-lucide="chevron-right" class="w-4 h-4"></i>
         </a>
@@ -325,7 +325,7 @@
   <div class="flex items-center justify-between mt-4 px-1">
     <div>
       {{if gt .Page 1}}
-      <a href="/transactions?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm">
+      <a href="/transactions?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm rounded-xl">
         <i data-lucide="chevron-left" class="w-4 h-4"></i>
         Prev
       </a>
@@ -334,7 +334,7 @@
     <span class="text-xs text-base-content/50 tabular-nums">{{.Page}} / {{.TotalPages}}</span>
     <div>
       {{if lt .Page .TotalPages}}
-      <a href="/transactions?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm">
+      <a href="/transactions?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm rounded-xl">
         Next
         <i data-lucide="chevron-right" class="w-4 h-4"></i>
       </a>
@@ -345,8 +345,8 @@
 </div>
 
 {{else}}
-<div class="card bg-base-100 border border-base-300">
-  <div class="card-body items-center text-center py-12">
+<div class="bb-card">
+  <div class="flex flex-col items-center text-center py-12 px-6">
     <i data-lucide="receipt" class="w-12 h-12 text-base-content/20 mb-2"></i>
     <p class="text-base-content/60">No transactions found.</p>
     {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -156,7 +156,7 @@
         {{range .Transactions}}
         <tbody x-data="{ expanded: false }">
           <tr @click="expanded = !expanded" class="cursor-pointer hover:bg-base-200/50 transition-colors duration-150">
-            <td class="text-sm text-base-content/70 whitespace-nowrap">{{.Date}}</td>
+            <td class="text-sm text-base-content/70 whitespace-nowrap">{{formatDate .Date}}</td>
             <td>
               <div class="flex flex-col">
                 <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors truncate max-w-xs">{{.Name}}</a>
@@ -249,7 +249,7 @@
             {{if .Pending}}<span class="badge badge-warning badge-xs">Pending</span>{{end}}
           </div>
           <div class="flex items-center gap-2 mt-0.5">
-            <span class="text-xs text-base-content/50">{{.Date}}</span>
+            <span class="text-xs text-base-content/50">{{formatDate .Date}}</span>
             <span class="text-xs text-base-content/30">&middot;</span>
             <span class="text-xs text-base-content/50 truncate">{{.AccountName}}</span>
           </div>

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -13,7 +13,7 @@
     {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}
     <a href="/transactions" class="btn btn-ghost btn-sm">
       <i data-lucide="x" class="w-3.5 h-3.5"></i>
-      Clear filters
+      <span class="hidden sm:inline">Clear filters</span>
     </a>
     {{end}}
   </div>
@@ -22,7 +22,7 @@
 <!-- Filters Card -->
 <div class="card bg-base-100 border border-base-300 mb-6" x-data="{ filtersOpen: {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}true{{else}}false{{end}} }">
   <div class="card-body p-0">
-    <button type="button" class="flex items-center justify-between w-full px-5 py-3 text-sm font-medium hover:bg-base-200/50 transition-colors duration-150 rounded-t-2xl"
+    <button type="button" class="flex items-center justify-between w-full px-4 sm:px-5 py-3 text-sm font-medium hover:bg-base-200/50 transition-colors duration-150 rounded-t-2xl"
       @click="filtersOpen = !filtersOpen">
       <div class="flex items-center gap-2">
         <i data-lucide="sliders-horizontal" class="w-4 h-4 text-base-content/60"></i>
@@ -41,19 +41,19 @@
       x-transition:leave="transition ease-in duration-150"
       x-transition:leave-start="opacity-100 translate-y-0"
       x-transition:leave-end="opacity-0 -translate-y-2"
-      class="px-5 pb-4" x-data>
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-3">
+      class="px-4 sm:px-5 pb-4" x-data>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-3">
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           Start Date
-          <input type="date" name="start_date" value="{{.FilterStartDate}}" class="input input-sm input-bordered">
+          <input type="date" name="start_date" value="{{.FilterStartDate}}" class="input input-sm input-bordered w-full">
         </label>
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           End Date
-          <input type="date" name="end_date" value="{{.FilterEndDate}}" class="input input-sm input-bordered">
+          <input type="date" name="end_date" value="{{.FilterEndDate}}" class="input input-sm input-bordered w-full">
         </label>
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           Connection
-          <select name="connection_id" class="select select-sm select-bordered">
+          <select name="connection_id" class="select select-sm select-bordered w-full">
             <option value="">All connections</option>
             {{range .Connections}}
             <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
@@ -62,7 +62,7 @@
         </label>
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           Account
-          <select name="account_id" class="select select-sm select-bordered">
+          <select name="account_id" class="select select-sm select-bordered w-full">
             <option value="">All accounts</option>
             {{range .Accounts}}
             <option value="{{.ID}}"{{if eq .ID $.FilterAccountID}} selected{{end}}>{{.Name}}</option>
@@ -71,7 +71,7 @@
         </label>
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           Family Member
-          <select name="user_id" class="select select-sm select-bordered">
+          <select name="user_id" class="select select-sm select-bordered w-full">
             <option value="">All members</option>
             {{range .Users}}
             <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterUserID}} selected{{end}}>{{.Name}}</option>
@@ -79,7 +79,7 @@
           </select>
         </label>
       </div>
-      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-4">
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           Category
           <div class="bb-cat-picker" x-data="categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
@@ -107,15 +107,15 @@
         </label>
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           Min Amount
-          <input type="number" name="min_amount" step="0.01" value="{{.FilterMinAmount}}" placeholder="0.00" class="input input-sm input-bordered">
+          <input type="number" name="min_amount" step="0.01" value="{{.FilterMinAmount}}" placeholder="0.00" class="input input-sm input-bordered w-full">
         </label>
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           Max Amount
-          <input type="number" name="max_amount" step="0.01" value="{{.FilterMaxAmount}}" placeholder="0.00" class="input input-sm input-bordered">
+          <input type="number" name="max_amount" step="0.01" value="{{.FilterMaxAmount}}" placeholder="0.00" class="input input-sm input-bordered w-full">
         </label>
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           Pending
-          <select name="pending" class="select select-sm select-bordered">
+          <select name="pending" class="select select-sm select-bordered w-full">
             <option value="">All</option>
             <option value="true"{{if eq .FilterPending "true"}} selected{{end}}>Yes</option>
             <option value="false"{{if eq .FilterPending "false"}} selected{{end}}>No</option>
@@ -123,7 +123,7 @@
         </label>
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60 uppercase tracking-wide">
           Search
-          <input type="text" name="search" value="{{.FilterSearch}}" placeholder="Name or merchant" class="input input-sm input-bordered">
+          <input type="text" name="search" value="{{.FilterSearch}}" placeholder="Name or merchant" class="input input-sm input-bordered w-full">
         </label>
       </div>
       <div class="flex justify-end gap-2">
@@ -136,90 +136,202 @@
   </div>
 </div>
 
-<!-- Transactions Table -->
 {{if .Transactions}}
-<div class="card bg-base-100 border border-base-300">
-  <div class="overflow-x-auto">
-    <table class="table table-sm">
-      <thead>
-        <tr class="text-xs text-base-content/50 uppercase tracking-wide border-b border-base-300">
-          <th class="font-medium">Date</th>
-          <th class="font-medium">Description</th>
-          <th class="font-medium text-right">Amount</th>
-          <th class="font-medium">Account</th>
-          <th class="font-medium">Category</th>
-          <th class="font-medium">Status</th>
-        </tr>
-      </thead>
-      {{range .Transactions}}
-      <tbody x-data="{ expanded: false }">
-        <tr @click="expanded = !expanded" class="cursor-pointer hover:bg-base-200/50 transition-colors duration-150">
-          <td class="text-sm text-base-content/70 whitespace-nowrap">{{.Date}}</td>
-          <td>
-            <div class="flex flex-col">
-              <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors truncate max-w-xs">{{.Name}}</a>
-              {{if .MerchantName}}<span class="text-xs text-base-content/50">{{deref .MerchantName}}</span>{{end}}
-            </div>
-          </td>
-          <td class="text-right tabular-nums text-sm font-medium whitespace-nowrap{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">
-            {{formatAmount .Amount}}
-          </td>
-          <td class="text-sm text-base-content/70">{{.AccountName}}</td>
-          <td @click.stop>
-            <div class="bb-cat-picker" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
-              <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
-                <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-                <span x-text="displayLabel" class="text-sm"></span>
-                {{if .CategoryOverride}}<span class="badge badge-outline badge-xs">override</span>{{end}}
-              </button>
-              <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false" style="min-width:16rem">
-                <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                  <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
-                </div>
-                <div x-ref="listbox">
-                  <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                    <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                      <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                      <span x-text="item.label"></span>
-                    </div>
-                  </template>
-                  <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
+
+<!-- ═══ Desktop Table (hidden on mobile) ═══ -->
+<div class="hidden lg:block">
+  <div class="card bg-base-100 border border-base-300">
+    <div class="overflow-x-auto">
+      <table class="table table-sm">
+        <thead>
+          <tr class="text-xs text-base-content/50 uppercase tracking-wide border-b border-base-300">
+            <th class="font-medium">Date</th>
+            <th class="font-medium">Description</th>
+            <th class="font-medium text-right">Amount</th>
+            <th class="font-medium">Account</th>
+            <th class="font-medium">Category</th>
+            <th class="font-medium">Status</th>
+          </tr>
+        </thead>
+        {{range .Transactions}}
+        <tbody x-data="{ expanded: false }">
+          <tr @click="expanded = !expanded" class="cursor-pointer hover:bg-base-200/50 transition-colors duration-150">
+            <td class="text-sm text-base-content/70 whitespace-nowrap">{{.Date}}</td>
+            <td>
+              <div class="flex flex-col">
+                <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors truncate max-w-xs">{{.Name}}</a>
+                {{if .MerchantName}}<span class="text-xs text-base-content/50">{{deref .MerchantName}}</span>{{end}}
+              </div>
+            </td>
+            <td class="text-right tabular-nums text-sm font-medium whitespace-nowrap{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">
+              {{formatAmount .Amount}}
+            </td>
+            <td class="text-sm text-base-content/70">{{.AccountName}}</td>
+            <td @click.stop>
+              <div class="bb-cat-picker" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+                <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
+                  <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+                  <span x-text="displayLabel" class="text-sm"></span>
+                  {{if .CategoryOverride}}<span class="badge badge-outline badge-xs">override</span>{{end}}
+                </button>
+                <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false" style="min-width:16rem">
+                  <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
+                    <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
+                  </div>
+                  <div x-ref="listbox">
+                    <template x-for="(item, idx) in filteredList" :key="item.id || idx">
+                      <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
+                        <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
+                        <span x-text="item.label"></span>
+                      </div>
+                    </template>
+                    <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
+                  </div>
                 </div>
               </div>
+            </td>
+            <td>
+              {{if .Pending}}<span class="badge badge-warning badge-sm">Pending</span>{{end}}
+            </td>
+          </tr>
+          <tr x-show="expanded" x-cloak>
+            <td colspan="6" class="bg-base-200/30 border-t border-base-300 px-6 py-3">
+              <dl class="bb-info-grid">
+                {{if .MerchantName}}<dt>Merchant</dt><dd>{{deref .MerchantName}}</dd>{{end}}
+                <dt>Transaction ID</dt><dd><code class="font-mono text-xs bg-base-200 px-1.5 py-0.5 rounded">{{.ID}}</code></dd>
+                <dt>Account</dt><dd>{{.AccountName}} ({{.InstitutionName}})</dd>
+                <dt>Family Member</dt><dd>{{if .UserName}}{{.UserName}}{{else}}<span class="text-base-content/30">&mdash;</span>{{end}}</dd>
+                <dt>Created</dt><dd>{{.CreatedAt}}</dd>
+                <dt>Updated</dt><dd>{{.UpdatedAt}}</dd>
+              </dl>
+            </td>
+          </tr>
+        </tbody>
+        {{end}}
+      </table>
+    </div>
+
+    {{if gt .TotalPages 1}}
+    <div class="border-t border-base-300 px-5 py-3 flex items-center justify-between">
+      <div>
+        {{if gt .Page 1}}
+        <a href="/transactions?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm">
+          <i data-lucide="chevron-left" class="w-4 h-4"></i>
+          Previous
+        </a>
+        {{end}}
+      </div>
+      <span class="text-xs text-base-content/50 tabular-nums">Page {{.Page}} of {{.TotalPages}}</span>
+      <div>
+        {{if lt .Page .TotalPages}}
+        <a href="/transactions?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm">
+          Next
+          <i data-lucide="chevron-right" class="w-4 h-4"></i>
+        </a>
+        {{end}}
+      </div>
+    </div>
+    {{end}}
+  </div>
+</div>
+
+<!-- ═══ Mobile Card List (hidden on desktop) ═══ -->
+<div class="lg:hidden">
+  <div class="space-y-2">
+    {{range .Transactions}}
+    <div class="bb-card bb-tx-card" x-data="{ expanded: false }">
+      <!-- Main row: tap to expand -->
+      <div class="flex items-center gap-3 px-4 py-3 cursor-pointer" @click="expanded = !expanded">
+        <!-- Left: name + meta -->
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2">
+            <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors truncate">{{.Name}}</a>
+            {{if .Pending}}<span class="badge badge-warning badge-xs">Pending</span>{{end}}
+          </div>
+          <div class="flex items-center gap-2 mt-0.5">
+            <span class="text-xs text-base-content/50">{{.Date}}</span>
+            <span class="text-xs text-base-content/30">&middot;</span>
+            <span class="text-xs text-base-content/50 truncate">{{.AccountName}}</span>
+          </div>
+        </div>
+        <!-- Right: amount -->
+        <div class="text-right shrink-0">
+          <span class="text-sm font-semibold tabular-nums{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">
+            {{formatAmount .Amount}}
+          </span>
+        </div>
+        <!-- Expand chevron -->
+        <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 shrink-0 transition-transform duration-200" :class="expanded ? 'rotate-180' : ''"></i>
+      </div>
+
+      <!-- Expanded details -->
+      <div x-show="expanded" x-cloak
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0"
+        x-transition:enter-end="opacity-100"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100"
+        x-transition:leave-end="opacity-0"
+        class="border-t border-base-300 px-4 py-3 bg-base-200/30">
+        <!-- Category picker -->
+        <div class="flex items-center gap-2 mb-3" @click.stop>
+          <span class="text-xs text-base-content/50 font-medium w-16 shrink-0">Category</span>
+          <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+            <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
+              <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+              <span x-text="displayLabel" class="text-sm"></span>
+              {{if .CategoryOverride}}<span class="badge badge-outline badge-xs">override</span>{{end}}
+            </button>
+            <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false" style="min-width:14rem">
+              <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
+                <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
+              </div>
+              <div x-ref="listbox">
+                <template x-for="(item, idx) in filteredList" :key="item.id || idx">
+                  <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
+                    <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
+                    <span x-text="item.label"></span>
+                  </div>
+                </template>
+                <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
+              </div>
             </div>
-          </td>
-          <td>
-            {{if .Pending}}<span class="badge badge-warning badge-sm">Pending</span>{{end}}
-          </td>
-        </tr>
-        <tr x-show="expanded" x-cloak>
-          <td colspan="6" class="bg-base-200/30 border-t border-base-300 px-6 py-3">
-            <dl class="bb-info-grid">
-              {{if .MerchantName}}<dt>Merchant</dt><dd>{{deref .MerchantName}}</dd>{{end}}
-              <dt>Transaction ID</dt><dd><code class="font-mono text-xs bg-base-200 px-1.5 py-0.5 rounded">{{.ID}}</code></dd>
-              <dt>Account</dt><dd>{{.AccountName}} ({{.InstitutionName}})</dd>
-              <dt>Family Member</dt><dd>{{if .UserName}}{{.UserName}}{{else}}<span class="text-base-content/30">&mdash;</span>{{end}}</dd>
-              <dt>Created</dt><dd>{{.CreatedAt}}</dd>
-              <dt>Updated</dt><dd>{{.UpdatedAt}}</dd>
-            </dl>
-          </td>
-        </tr>
-      </tbody>
-      {{end}}
-    </table>
+          </div>
+        </div>
+        <!-- Detail fields -->
+        <div class="space-y-1.5 text-xs">
+          {{if .MerchantName}}
+          <div class="flex items-center gap-2">
+            <span class="text-base-content/50 font-medium w-16 shrink-0">Merchant</span>
+            <span class="text-base-content/70">{{deref .MerchantName}}</span>
+          </div>
+          {{end}}
+          <div class="flex items-center gap-2">
+            <span class="text-base-content/50 font-medium w-16 shrink-0">Member</span>
+            <span class="text-base-content/70">{{if .UserName}}{{.UserName}}{{else}}&mdash;{{end}}</span>
+          </div>
+          <div class="flex items-start gap-2">
+            <span class="text-base-content/50 font-medium w-16 shrink-0">ID</span>
+            <code class="font-mono text-[0.65rem] bg-base-200 px-1.5 py-0.5 rounded break-all">{{.ID}}</code>
+          </div>
+        </div>
+      </div>
+    </div>
+    {{end}}
   </div>
 
+  <!-- Mobile Pagination -->
   {{if gt .TotalPages 1}}
-  <div class="border-t border-base-300 px-5 py-3 flex items-center justify-between">
+  <div class="flex items-center justify-between mt-4 px-1">
     <div>
       {{if gt .Page 1}}
       <a href="/transactions?page={{sub .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm">
         <i data-lucide="chevron-left" class="w-4 h-4"></i>
-        Previous
+        Prev
       </a>
       {{end}}
     </div>
-    <span class="text-xs text-base-content/50 tabular-nums">Page {{.Page}} of {{.TotalPages}}</span>
+    <span class="text-xs text-base-content/50 tabular-nums">{{.Page}} / {{.TotalPages}}</span>
     <div>
       {{if lt .Page .TotalPages}}
       <a href="/transactions?page={{add .Page 1}}{{if $.FilterStartDate}}&start_date={{$.FilterStartDate}}{{end}}{{if $.FilterEndDate}}&end_date={{$.FilterEndDate}}{{end}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterAccountID}}&account_id={{$.FilterAccountID}}{{end}}{{if $.FilterUserID}}&user_id={{$.FilterUserID}}{{end}}{{if $.FilterCategory}}&category={{$.FilterCategory}}{{end}}{{if $.FilterMinAmount}}&min_amount={{$.FilterMinAmount}}{{end}}{{if $.FilterMaxAmount}}&max_amount={{$.FilterMaxAmount}}{{end}}{{if $.FilterPending}}&pending={{$.FilterPending}}{{end}}{{if $.FilterSearch}}&search={{$.FilterSearch}}{{end}}{{if $.FilterSort}}&sort={{$.FilterSort}}{{end}}" class="btn btn-ghost btn-sm">

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -20,7 +20,7 @@
 </div>
 
 <!-- Filters Card -->
-<div class="card bg-base-100 shadow-sm border border-base-300 mb-6" x-data="{ filtersOpen: {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}true{{else}}false{{end}} }">
+<div class="card bg-base-100 border border-base-300 mb-6" x-data="{ filtersOpen: {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}true{{else}}false{{end}} }">
   <div class="card-body p-0">
     <button type="button" class="flex items-center justify-between w-full px-5 py-3 text-sm font-medium hover:bg-base-200/50 transition-colors duration-150 rounded-t-2xl"
       @click="filtersOpen = !filtersOpen">
@@ -138,7 +138,7 @@
 
 <!-- Transactions Table -->
 {{if .Transactions}}
-<div class="card bg-base-100 shadow-sm border border-base-300">
+<div class="card bg-base-100 border border-base-300">
   <div class="overflow-x-auto">
     <table class="table table-sm">
       <thead>
@@ -233,7 +233,7 @@
 </div>
 
 {{else}}
-<div class="card bg-base-100 shadow-sm border border-base-300">
+<div class="card bg-base-100 border border-base-300">
   <div class="card-body items-center text-center py-12">
     <i data-lucide="receipt" class="w-12 h-12 text-base-content/20 mb-2"></i>
     <p class="text-base-content/60">No transactions found.</p>

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -201,8 +201,8 @@
                 <dt>Transaction ID</dt><dd><code class="font-mono text-xs bg-base-200 px-1.5 py-0.5 rounded">{{.ID}}</code></dd>
                 <dt>Account</dt><dd>{{.AccountName}} ({{.InstitutionName}})</dd>
                 <dt>Family Member</dt><dd>{{if .UserName}}{{.UserName}}{{else}}<span class="text-base-content/30">&mdash;</span>{{end}}</dd>
-                <dt>Created</dt><dd>{{.CreatedAt}}</dd>
-                <dt>Updated</dt><dd>{{.UpdatedAt}}</dd>
+                <dt>Created</dt><dd>{{formatDateTime .CreatedAt}}</dd>
+                <dt>Updated</dt><dd>{{formatDateTime .UpdatedAt}}</dd>
               </dl>
             </td>
           </tr>

--- a/internal/templates/pages/user_form.html
+++ b/internal/templates/pages/user_form.html
@@ -25,7 +25,7 @@
       <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="name">
         Name <span class="text-error text-xs">*</span>
       </label>
-      <input type="text" id="name" name="name" class="input w-full bg-base-200/50 border-base-200 focus:border-primary rounded-xl" required maxlength="128"
+      <input type="text" id="name" name="name" class="input w-full bg-base-200/50 border-base-300 focus:border-primary rounded-xl" required maxlength="128"
         value="{{if .IsEdit}}{{.User.Name}}{{end}}"
         placeholder="e.g., Alex Canales">
     </fieldset>
@@ -34,7 +34,7 @@
       <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="email">
         Email <span class="text-xs text-base-content/30">(optional)</span>
       </label>
-      <input type="email" id="email" name="email" class="input w-full bg-base-200/50 border-base-200 focus:border-primary rounded-xl"
+      <input type="email" id="email" name="email" class="input w-full bg-base-200/50 border-base-300 focus:border-primary rounded-xl"
         value="{{if and .IsEdit .User.Email.Valid}}{{.User.Email.String}}{{end}}"
         placeholder="e.g., alex@example.com">
     </fieldset>

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -11,7 +11,7 @@
 </div>
 
 {{if .Created}}
-<div class="alert alert-success mb-6 rounded-2xl">
+<div class="alert alert-success mb-6 rounded-xl">
   <i data-lucide="check-circle" class="w-5 h-5"></i>
   <span>Member created. <a href="/connections/new" class="link font-medium">Connect a bank for them</a></span>
 </div>
@@ -40,7 +40,7 @@
       </a>
     </div>
 
-    <div class="flex items-center gap-4 pt-3 border-t border-base-200">
+    <div class="flex items-center gap-4 pt-3 border-t border-base-300">
       <div class="flex items-center gap-1.5 text-xs text-base-content/50">
         <i data-lucide="link" class="w-3.5 h-3.5"></i>
         <span class="font-medium text-base-content/70">{{index $.ConnectionCounts (formatUUID .ID)}}</span> connections
@@ -58,7 +58,7 @@
 {{else}}
 <div class="bb-card p-12 text-center">
   <div class="flex flex-col items-center">
-    <div class="w-16 h-16 rounded-2xl bg-base-200/60 flex items-center justify-center mb-4">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
       <i data-lucide="users" class="w-8 h-8 text-base-content/25"></i>
     </div>
     <h3 class="text-lg font-semibold mb-1">No family members yet</h3>

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -4,7 +4,7 @@
     <h1 class="bb-page-title">Family Members</h1>
     <p class="text-sm text-base-content/50 mt-1">Manage who has bank connections in Breadbox</p>
   </div>
-  <a href="/users/new" class="btn btn-primary btn-sm">
+  <a href="/users/new" class="btn btn-primary btn-sm rounded-xl">
     <i data-lucide="plus" class="w-4 h-4"></i>
     Add Member
   </a>
@@ -63,7 +63,7 @@
     </div>
     <h3 class="text-lg font-semibold mb-1">No family members yet</h3>
     <p class="text-sm text-base-content/50 mb-5 max-w-sm">Add family members to connect their bank accounts and track spending across the household.</p>
-    <a href="/users/new" class="btn btn-primary btn-sm">
+    <a href="/users/new" class="btn btn-primary btn-sm rounded-xl">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Add your first member
     </a>

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -18,7 +18,7 @@
 {{end}}
 
 {{if .Users}}
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 bb-stagger">
   {{range .Users}}
   <div class="bb-card bb-card--interactive p-6 group">
     <div class="flex items-start justify-between mb-4">

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -45,7 +45,7 @@
 </nav>
 
 <!-- Sign out -->
-<form method="POST" action="/logout" class="mt-auto pt-4 border-t border-base-200">
+<form method="POST" action="/logout" class="mt-auto pt-4 border-t border-base-300">
   {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
   <button type="submit" class="bb-sidebar-link w-full justify-start">
     <i data-lucide="log-out"></i> Sign Out

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -44,11 +44,28 @@
   </a>
 </nav>
 
-<!-- Sign out -->
-<form method="POST" action="/logout" class="mt-auto pt-4 border-t border-base-300">
-  {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
-  <button type="submit" class="bb-sidebar-link w-full justify-start">
-    <i data-lucide="log-out"></i> Sign Out
-  </button>
-</form>
+<!-- User profile + Sign out -->
+<div class="mt-auto pt-4 border-t border-base-300">
+  <div class="bb-sidebar-profile">
+    <div class="bb-sidebar-profile-avatar">
+      {{if .AdminUsername}}{{slice .AdminUsername 0 1}}{{else}}A{{end}}
+    </div>
+    <div class="bb-sidebar-profile-info">
+      <div class="bb-sidebar-profile-name">{{if .AdminUsername}}{{.AdminUsername}}{{else}}Admin{{end}}</div>
+      <div class="bb-sidebar-profile-role">Administrator</div>
+    </div>
+    <form method="POST" action="/logout" class="bb-sidebar-profile-logout">
+      {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
+      <button type="submit" class="bb-sidebar-logout-btn" title="Sign out">
+        <i data-lucide="log-out"></i>
+      </button>
+    </form>
+  </div>
+  {{if .AppVersion}}
+  <div class="bb-sidebar-version">
+    <i data-lucide="package" class="w-3 h-3"></i>
+    <span>Breadbox v{{.AppVersion}}</span>
+  </div>
+  {{end}}
+</div>
 {{end}}

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -61,11 +61,17 @@
       </button>
     </form>
   </div>
-  {{if .AppVersion}}
   <div class="bb-sidebar-version">
+    {{if .AppVersion}}
     <i data-lucide="package" class="w-3 h-3"></i>
     <span>Breadbox v{{.AppVersion}}</span>
+    {{else}}
+    <i data-lucide="package" class="w-3 h-3"></i>
+    <span>Breadbox vdev</span>
+    {{end}}
+    <span class="ml-auto" style="cursor:pointer;opacity:0.5" @click="$dispatch('open-shortcuts')" title="Keyboard shortcuts">
+      <kbd class="bb-shortcuts-kbd" style="font-size:0.5rem;min-width:1rem;height:1rem;padding:0 0.25rem">?</kbd>
+    </span>
   </div>
-  {{end}}
 </div>
 {{end}}

--- a/internal/templates/partials/skeletons.html
+++ b/internal/templates/partials/skeletons.html
@@ -1,0 +1,217 @@
+{{define "skeleton-stat-cards"}}
+<!-- Skeleton: Three stat cards -->
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-8">
+  <div class="bb-card p-6">
+    <div class="bb-skeleton bb-skeleton--text-xs mb-3" style="width:5rem"></div>
+    <div class="bb-skeleton bb-skeleton--amount mb-3"></div>
+    <div class="flex gap-4">
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width:6rem"></div>
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width:5rem"></div>
+    </div>
+  </div>
+  <div class="bb-card p-6">
+    <div class="bb-skeleton bb-skeleton--text-xs mb-3" style="width:4rem"></div>
+    <div class="bb-skeleton bb-skeleton--amount mb-3"></div>
+    <div class="flex gap-4">
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width:7rem"></div>
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width:5rem"></div>
+    </div>
+  </div>
+  <div class="bb-card p-6">
+    <div class="bb-skeleton bb-skeleton--text-xs mb-3" style="width:3.5rem"></div>
+    <div class="bb-skeleton bb-skeleton--amount mb-3"></div>
+    <div class="flex gap-4">
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width:8rem"></div>
+    </div>
+  </div>
+</div>
+{{end}}
+
+{{define "skeleton-account-grid"}}
+<!-- Skeleton: Account grid cards -->
+<div class="mb-8">
+  <div class="flex items-center justify-between mb-4">
+    <div class="bb-skeleton bb-skeleton--text-sm" style="width:5rem"></div>
+    <div class="bb-skeleton bb-skeleton--text-xs" style="width:3rem"></div>
+  </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+    <div class="bb-card p-4">
+      <div class="flex items-center gap-3">
+        <div class="bb-skeleton bb-skeleton--circle-sm"></div>
+        <div class="flex-1">
+          <div class="flex items-center justify-between gap-2">
+            <div class="min-w-0 flex-1">
+              <div class="bb-skeleton bb-skeleton--text mb-1.5" style="width:70%"></div>
+              <div class="bb-skeleton bb-skeleton--text-xs" style="width:50%"></div>
+            </div>
+            <div class="bb-skeleton" style="width:4.5rem;height:1rem;border-radius:0.25rem"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="bb-card p-4">
+      <div class="flex items-center gap-3">
+        <div class="bb-skeleton bb-skeleton--circle-sm"></div>
+        <div class="flex-1">
+          <div class="flex items-center justify-between gap-2">
+            <div class="min-w-0 flex-1">
+              <div class="bb-skeleton bb-skeleton--text mb-1.5" style="width:60%"></div>
+              <div class="bb-skeleton bb-skeleton--text-xs" style="width:45%"></div>
+            </div>
+            <div class="bb-skeleton" style="width:5rem;height:1rem;border-radius:0.25rem"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="bb-card p-4">
+      <div class="flex items-center gap-3">
+        <div class="bb-skeleton bb-skeleton--circle-sm"></div>
+        <div class="flex-1">
+          <div class="flex items-center justify-between gap-2">
+            <div class="min-w-0 flex-1">
+              <div class="bb-skeleton bb-skeleton--text mb-1.5" style="width:80%"></div>
+              <div class="bb-skeleton bb-skeleton--text-xs" style="width:55%"></div>
+            </div>
+            <div class="bb-skeleton" style="width:4rem;height:1rem;border-radius:0.25rem"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
+{{define "skeleton-table-rows"}}
+<!-- Skeleton: Table rows -->
+<div class="bb-skeleton-table-row">
+  <div class="bb-skeleton bb-skeleton--text-sm" style="width:5rem"></div>
+  <div class="bb-skeleton bb-skeleton--text" style="width:14rem"></div>
+  <div class="bb-skeleton" style="width:4rem;height:0.875rem;border-radius:0.25rem"></div>
+  <div class="bb-skeleton bb-skeleton--badge"></div>
+</div>
+<div class="bb-skeleton-table-row">
+  <div class="bb-skeleton bb-skeleton--text-sm" style="width:5rem"></div>
+  <div class="bb-skeleton bb-skeleton--text" style="width:10rem"></div>
+  <div class="bb-skeleton" style="width:3.5rem;height:0.875rem;border-radius:0.25rem"></div>
+  <div class="bb-skeleton bb-skeleton--badge"></div>
+</div>
+<div class="bb-skeleton-table-row">
+  <div class="bb-skeleton bb-skeleton--text-sm" style="width:5rem"></div>
+  <div class="bb-skeleton bb-skeleton--text" style="width:12rem"></div>
+  <div class="bb-skeleton" style="width:4.5rem;height:0.875rem;border-radius:0.25rem"></div>
+  <div class="bb-skeleton bb-skeleton--badge"></div>
+</div>
+<div class="bb-skeleton-table-row">
+  <div class="bb-skeleton bb-skeleton--text-sm" style="width:5rem"></div>
+  <div class="bb-skeleton bb-skeleton--text" style="width:11rem"></div>
+  <div class="bb-skeleton" style="width:3rem;height:0.875rem;border-radius:0.25rem"></div>
+  <div class="bb-skeleton bb-skeleton--badge"></div>
+</div>
+<div class="bb-skeleton-table-row">
+  <div class="bb-skeleton bb-skeleton--text-sm" style="width:5rem"></div>
+  <div class="bb-skeleton bb-skeleton--text" style="width:13rem"></div>
+  <div class="bb-skeleton" style="width:4rem;height:0.875rem;border-radius:0.25rem"></div>
+  <div class="bb-skeleton bb-skeleton--badge"></div>
+</div>
+{{end}}
+
+{{define "skeleton-transaction-list"}}
+<!-- Skeleton: Transaction list items (dashboard style) -->
+<div class="space-y-0.5">
+  <div class="flex items-center justify-between py-2.5 px-1 -mx-1">
+    <div class="flex items-center gap-3 min-w-0">
+      <div class="bb-skeleton" style="width:2rem;height:2rem;border-radius:0.5rem"></div>
+      <div class="space-y-1.5">
+        <div class="bb-skeleton bb-skeleton--text" style="width:10rem"></div>
+        <div class="bb-skeleton bb-skeleton--text-xs" style="width:8rem"></div>
+      </div>
+    </div>
+    <div class="bb-skeleton" style="width:3.5rem;height:0.875rem;border-radius:0.25rem"></div>
+  </div>
+  <div class="flex items-center justify-between py-2.5 px-1 -mx-1">
+    <div class="flex items-center gap-3 min-w-0">
+      <div class="bb-skeleton" style="width:2rem;height:2rem;border-radius:0.5rem"></div>
+      <div class="space-y-1.5">
+        <div class="bb-skeleton bb-skeleton--text" style="width:8rem"></div>
+        <div class="bb-skeleton bb-skeleton--text-xs" style="width:10rem"></div>
+      </div>
+    </div>
+    <div class="bb-skeleton" style="width:4rem;height:0.875rem;border-radius:0.25rem"></div>
+  </div>
+  <div class="flex items-center justify-between py-2.5 px-1 -mx-1">
+    <div class="flex items-center gap-3 min-w-0">
+      <div class="bb-skeleton" style="width:2rem;height:2rem;border-radius:0.5rem"></div>
+      <div class="space-y-1.5">
+        <div class="bb-skeleton bb-skeleton--text" style="width:12rem"></div>
+        <div class="bb-skeleton bb-skeleton--text-xs" style="width:7rem"></div>
+      </div>
+    </div>
+    <div class="bb-skeleton" style="width:3rem;height:0.875rem;border-radius:0.25rem"></div>
+  </div>
+  <div class="flex items-center justify-between py-2.5 px-1 -mx-1">
+    <div class="flex items-center gap-3 min-w-0">
+      <div class="bb-skeleton" style="width:2rem;height:2rem;border-radius:0.5rem"></div>
+      <div class="space-y-1.5">
+        <div class="bb-skeleton bb-skeleton--text" style="width:9rem"></div>
+        <div class="bb-skeleton bb-skeleton--text-xs" style="width:9rem"></div>
+      </div>
+    </div>
+    <div class="bb-skeleton" style="width:4.5rem;height:0.875rem;border-radius:0.25rem"></div>
+  </div>
+  <div class="flex items-center justify-between py-2.5 px-1 -mx-1">
+    <div class="flex items-center gap-3 min-w-0">
+      <div class="bb-skeleton" style="width:2rem;height:2rem;border-radius:0.5rem"></div>
+      <div class="space-y-1.5">
+        <div class="bb-skeleton bb-skeleton--text" style="width:11rem"></div>
+        <div class="bb-skeleton bb-skeleton--text-xs" style="width:6rem"></div>
+      </div>
+    </div>
+    <div class="bb-skeleton" style="width:3.5rem;height:0.875rem;border-radius:0.25rem"></div>
+  </div>
+</div>
+{{end}}
+
+{{define "skeleton-sync-list"}}
+<!-- Skeleton: Sync activity items -->
+<div class="space-y-1">
+  <div class="flex items-center justify-between py-2 px-1 -mx-1">
+    <div class="flex items-center gap-2.5">
+      <div class="bb-skeleton" style="width:1.5rem;height:1.5rem;border-radius:0.375rem"></div>
+      <div class="space-y-1">
+        <div class="bb-skeleton bb-skeleton--text-sm" style="width:4rem"></div>
+        <div class="bb-skeleton bb-skeleton--text-xs" style="width:5rem"></div>
+      </div>
+    </div>
+    <div class="flex items-center gap-1.5">
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width:2rem"></div>
+      <div class="bb-skeleton bb-skeleton--badge"></div>
+    </div>
+  </div>
+  <div class="flex items-center justify-between py-2 px-1 -mx-1">
+    <div class="flex items-center gap-2.5">
+      <div class="bb-skeleton" style="width:1.5rem;height:1.5rem;border-radius:0.375rem"></div>
+      <div class="space-y-1">
+        <div class="bb-skeleton bb-skeleton--text-sm" style="width:5rem"></div>
+        <div class="bb-skeleton bb-skeleton--text-xs" style="width:4rem"></div>
+      </div>
+    </div>
+    <div class="flex items-center gap-1.5">
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width:2.5rem"></div>
+      <div class="bb-skeleton bb-skeleton--badge"></div>
+    </div>
+  </div>
+  <div class="flex items-center justify-between py-2 px-1 -mx-1">
+    <div class="flex items-center gap-2.5">
+      <div class="bb-skeleton" style="width:1.5rem;height:1.5rem;border-radius:0.375rem"></div>
+      <div class="space-y-1">
+        <div class="bb-skeleton bb-skeleton--text-sm" style="width:4.5rem"></div>
+        <div class="bb-skeleton bb-skeleton--text-xs" style="width:3.5rem"></div>
+      </div>
+    </div>
+    <div class="flex items-center gap-1.5">
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width:2rem"></div>
+      <div class="bb-skeleton bb-skeleton--badge"></div>
+    </div>
+  </div>
+</div>
+{{end}}


### PR DESCRIPTION
## Summary
- **Navigation progress bar** (YouTube/GitHub style): thin animated bar at the top of the viewport fires on every internal navigation — sidebar clicks, command palette, keyboard shortcuts (`g+d`, etc.), and form submissions. Smoothly animates from 0% to completion with cubic-bezier easing.
- **Shimmer skeleton CSS system**: reusable `.bb-skeleton` classes with shimmer animation (`bb-skeleton--text`, `bb-skeleton--amount`, `bb-skeleton--circle`, `bb-skeleton--badge`, etc.) plus pre-built composite patterns (`skeleton-stat-cards`, `skeleton-table-rows`, `skeleton-transaction-list`, `skeleton-sync-list`). Works in both light and dark mode.
- **Page transition effects**: content fades to 60% opacity with subtle blur during navigation, creating the perception of instant responsiveness. Properly handles bfcache restoration on back/forward nav.
- **Connection detail sync skeleton**: when "Sync Now" is clicked, the sync history section shows a shimmer skeleton with "Syncing in progress" indicator while the existing content fades, then reloads with fresh data.

## Screenshots
**Sync skeleton loading state on connection detail:**
![sync-skeleton](https://i.img402.dev/ucnixmkq6a.png)

**Navigation progress bar + content fade during transition:**
![progress-bar](https://i.img402.dev/0dfcfx8ltt.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent