### PR TITLE
Refactor category picker to global overlay

### DIFF
--- a/input.css
+++ b/input.css
@@ -924,6 +924,125 @@
     @apply px-6 py-3 border-t border-base-300 text-[0.6rem] text-base-content/25 text-center;
   }
 
+  /* ─── Global Category Picker Overlay ─── */
+  .bb-catpicker-backdrop {
+    @apply fixed inset-0 z-50;
+    background: oklch(0 0 0 / 0.4);
+    backdrop-filter: blur(4px);
+    animation: bb-catpicker-backdrop-in 0.15s ease-out;
+  }
+
+  @keyframes bb-catpicker-backdrop-in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+  }
+
+  .bb-catpicker-dialog {
+    @apply fixed z-50 bg-base-100 border border-base-300 rounded-xl overflow-hidden;
+    top: min(20%, 140px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: min(95vw, 420px);
+    max-height: min(70vh, 460px);
+    box-shadow: 0 16px 70px oklch(0 0 0 / 0.15), 0 0 0 1px oklch(0 0 0 / 0.04);
+    animation: bb-catpicker-dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-catpicker-dialog {
+      box-shadow: 0 16px 70px oklch(0 0 0 / 0.5), 0 0 0 1px oklch(1 0 0 / 0.06);
+    }
+  }
+
+  @keyframes bb-catpicker-dialog-in {
+    from {
+      opacity: 0;
+      transform: translateX(-50%) scale(0.96) translateY(-8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateX(-50%) scale(1) translateY(0);
+    }
+  }
+
+  .bb-catpicker-input-wrap {
+    @apply flex items-center gap-3 px-4 border-b border-base-300;
+  }
+
+  .bb-catpicker-input-wrap svg,
+  .bb-catpicker-input-wrap i {
+    @apply w-4 h-4 text-base-content/30 shrink-0;
+  }
+
+  .bb-catpicker-input {
+    @apply w-full py-3.5 text-sm bg-transparent border-none outline-none placeholder:text-base-content/30;
+  }
+
+  .bb-catpicker-input:focus {
+    outline: none;
+    box-shadow: none;
+  }
+
+  .bb-catpicker-list {
+    @apply overflow-y-auto;
+    max-height: min(55vh, 370px);
+    scrollbar-width: thin;
+  }
+
+  .bb-catpicker-item {
+    @apply flex items-center gap-3 px-4 py-2 mx-2 rounded-lg text-sm cursor-pointer;
+    transition: background-color 0.1s ease, color 0.1s ease;
+  }
+
+  .bb-catpicker-item:hover,
+  .bb-catpicker-item[data-active="true"] {
+    @apply bg-base-200 text-base-content;
+  }
+
+  .bb-catpicker-item[data-active="true"] {
+    @apply bg-primary/8;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-catpicker-item[data-active="true"] {
+      @apply bg-primary/12;
+    }
+  }
+
+  .bb-catpicker-item--indent {
+    @apply pl-9;
+  }
+
+  .bb-catpicker-item--parent {
+    @apply font-semibold;
+  }
+
+  .bb-catpicker-dot {
+    @apply w-2.5 h-2.5 rounded-full shrink-0;
+  }
+
+  .bb-catpicker-icon {
+    @apply w-4 h-4 shrink-0 opacity-60;
+  }
+
+  .bb-catpicker-empty {
+    @apply flex flex-col items-center justify-center py-12 text-base-content/30;
+  }
+
+  .bb-catpicker-empty svg,
+  .bb-catpicker-empty i {
+    @apply w-8 h-8 mb-2 opacity-40;
+  }
+
+  .bb-catpicker-footer {
+    @apply flex items-center justify-between px-4 py-2.5 border-t border-base-300 text-[0.65rem] text-base-content/30;
+  }
+
+  .bb-catpicker-footer kbd {
+    @apply inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1
+           text-[0.6rem] font-medium text-base-content/40 bg-base-200 border border-base-300 rounded mx-0.5;
+  }
+
   /* ─── Navigation Progress Bar (YouTube/GitHub style) ─── */
   .bb-progress-bar {
     @apply fixed top-0 left-0 right-0 z-[100] h-[2.5px] pointer-events-none;

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -268,6 +268,75 @@
     </div>
   </div>
 
+  <!-- Global Category Picker Overlay -->
+  <div x-data="globalCategoryPicker()" x-show="open" x-cloak
+       @open-category-picker.window="openPicker($event.detail)"
+       @keydown.window.escape="if (open) { closePicker(); $event.stopPropagation(); }">
+    <!-- Backdrop -->
+    <div class="bb-catpicker-backdrop" @click="closePicker()"></div>
+    <!-- Dialog -->
+    <div class="bb-catpicker-dialog"
+         @click.stop
+         @keydown.escape.prevent="closePicker()"
+         @keydown.arrow-down.prevent="moveDown()"
+         @keydown.arrow-up.prevent="moveUp()"
+         @keydown.enter.prevent="selectActive()">
+      <!-- Search input -->
+      <div class="bb-catpicker-input-wrap">
+        <i data-lucide="tag"></i>
+        <input type="text"
+          class="bb-catpicker-input"
+          placeholder="Search categories..."
+          x-ref="catPickerInput"
+          x-model="search"
+          @input="activeIndex = 0"
+          autocomplete="off"
+          spellcheck="false">
+        <div class="bb-cmdk-kbd" style="font-size:0.6rem" @click="closePicker()">esc</div>
+      </div>
+
+      <!-- Results list -->
+      <div class="bb-catpicker-list" x-ref="catPickerList">
+        <div class="py-1">
+          <template x-for="(item, idx) in filteredList" :key="item.slug + '-' + idx">
+            <div class="bb-catpicker-item"
+                 :class="{'bb-catpicker-item--indent': item.indent, 'bb-catpicker-item--parent': item.isParent}"
+                 :data-active="activeIndex === idx"
+                 :data-catpicker-idx="idx"
+                 @click="selectItem(item)"
+                 @mouseenter="activeIndex = idx">
+              <template x-if="item.color">
+                <span class="bb-catpicker-dot" :style="'background-color:' + item.color"></span>
+              </template>
+              <template x-if="item.icon">
+                <i :data-lucide="item.icon" class="bb-catpicker-icon"></i>
+              </template>
+              <span x-text="item.label" class="truncate"></span>
+              <template x-if="item.indent && item.parentLabel">
+                <span class="text-xs text-base-content/30 ml-auto truncate" x-text="item.parentLabel"></span>
+              </template>
+            </div>
+          </template>
+        </div>
+        <template x-if="search && filteredList.length === 0">
+          <div class="bb-catpicker-empty">
+            <i data-lucide="search-x"></i>
+            <span class="text-sm">No categories found</span>
+          </div>
+        </template>
+      </div>
+
+      <!-- Footer -->
+      <div class="bb-catpicker-footer">
+        <div class="flex items-center gap-3">
+          <span><kbd>&uarr;</kbd> <kbd>&darr;</kbd> navigate</span>
+          <span><kbd>&crarr;</kbd> select</span>
+          <span><kbd>esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- Command Palette (Cmd+K) -->
   <div x-data="commandPalette()" x-show="open" x-cloak
        @open-cmdk.window="openPalette()"
@@ -408,6 +477,110 @@
         }));
       });
     };
+
+    // Global Category Picker component
+    function globalCategoryPicker() {
+      return {
+        open: false,
+        search: '',
+        activeIndex: 0,
+        mode: 'assign',
+        allowEmpty: true,
+        emptyLabel: 'Uncategorized',
+        sourceId: '',
+        categories: [],
+        _resolve: null,
+
+        get flatList() {
+          var items = [];
+          if (this.allowEmpty) {
+            items.push({ id: '', slug: '', label: this.emptyLabel, isParent: false, indent: false, icon: null, color: null, hidden: false });
+          }
+          for (var i = 0; i < this.categories.length; i++) {
+            var cat = this.categories[i];
+            items.push({ id: cat.id, slug: cat.slug, label: cat.display_name, isParent: true, indent: false, icon: cat.icon, color: cat.color, hidden: cat.hidden || false });
+            if (cat.children) {
+              for (var j = 0; j < cat.children.length; j++) {
+                var child = cat.children[j];
+                items.push({ id: child.id, slug: child.slug, label: child.display_name, isParent: false, indent: true, icon: child.icon, color: child.color, hidden: child.hidden || false, parentLabel: cat.display_name });
+              }
+            }
+          }
+          return items;
+        },
+
+        get filteredList() {
+          var list = this.flatList;
+          if (!this.search) return list.filter(function(i) { return !i.hidden || i.id === ''; });
+          var q = this.search.toLowerCase();
+          return list.filter(function(i) {
+            if (i.hidden && i.id !== '') return false;
+            return i.label.toLowerCase().indexOf(q) !== -1 ||
+              (i.parentLabel && i.parentLabel.toLowerCase().indexOf(q) !== -1) ||
+              (i.slug && i.slug.toLowerCase().indexOf(q) !== -1);
+          });
+        },
+
+        openPicker(detail) {
+          this.mode = detail.mode || 'assign';
+          this.allowEmpty = detail.allowEmpty !== false;
+          this.emptyLabel = detail.emptyLabel || 'Uncategorized';
+          this.sourceId = detail.sourceId || '';
+          this.categories = detail.categories || window.__bbCategories || [];
+          this.search = '';
+          this.activeIndex = 0;
+          this.open = true;
+
+          var self = this;
+          setTimeout(function() {
+            if (self.$refs.catPickerInput) self.$refs.catPickerInput.focus();
+            var dialog = document.querySelector('.bb-catpicker-dialog');
+            if (dialog) lucide.createIcons({ nodes: [dialog] });
+          }, 50);
+        },
+
+        closePicker() {
+          this.open = false;
+          this.search = '';
+        },
+
+        moveDown() {
+          var max = this.filteredList.length - 1;
+          if (this.activeIndex < max) this.activeIndex++;
+          else this.activeIndex = 0;
+          this.scrollToActive();
+        },
+
+        moveUp() {
+          if (this.activeIndex > 0) this.activeIndex--;
+          else this.activeIndex = this.filteredList.length - 1;
+          this.scrollToActive();
+        },
+
+        scrollToActive() {
+          var self = this;
+          setTimeout(function() {
+            var el = document.querySelector('[data-catpicker-idx="' + self.activeIndex + '"]');
+            if (el) el.scrollIntoView({ block: 'nearest' });
+          }, 10);
+        },
+
+        selectActive() {
+          var items = this.filteredList;
+          if (items.length > 0 && this.activeIndex < items.length) {
+            this.selectItem(items[this.activeIndex]);
+          }
+        },
+
+        selectItem(item) {
+          var value = this.mode === 'filter' ? item.slug : item.id;
+          window.dispatchEvent(new CustomEvent('category-picked', {
+            detail: { id: item.id, slug: item.slug, label: item.label, value: value, sourceId: this.sourceId }
+          }));
+          this.closePicker();
+        }
+      };
+    }
 
     // Command Palette Alpine component
     function commandPalette() {

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -102,27 +102,12 @@
       </label>
       <label class="flex flex-col gap-1">
         <span class="text-xs text-base-content/40">Category</span>
-        <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
+        <div class="bb-cat-picker" data-picker-source="acct-filter-cat" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
           <input type="hidden" name="category" x-ref="catInput" value="{{.FilterCategory}}">
           <button type="button" class="select select-sm select-bordered w-auto min-w-[8rem] text-left flex items-center gap-2" @click="openPicker()">
             <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
             <span x-text="displayLabel" class="text-sm truncate"></span>
           </button>
-          <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-            <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-              <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full">
-            </div>
-            <div x-ref="listbox">
-              <template x-for="(item, idx) in filteredList" :key="item.slug || idx">
-                <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item); $refs.catInput.value = item.slug">
-                  <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                  <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
-                  <span x-text="item.label"></span>
-                </div>
-              </template>
-              <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-            </div>
-          </div>
         </div>
       </label>
       <label class="flex flex-col gap-1">
@@ -168,26 +153,12 @@
             {{formatAmount .Amount}}
           </td>
           <td @click.stop>
-            <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+            <div class="bb-cat-picker" data-picker-source="acct-tx-{{.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
               <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
                 <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
                 <span x-text="displayLabel" class="text-sm"></span>
                 {{if .CategoryOverride}}<span class="badge badge-outline badge-xs">override</span>{{end}}
               </button>
-              <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false" style="min-width:16rem">
-                <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                  <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
-                </div>
-                <div x-ref="listbox">
-                  <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                    <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                      <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                      <span x-text="item.label"></span>
-                    </div>
-                  </template>
-                  <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-                </div>
-              </div>
             </div>
           </td>
           <td>{{if .Pending}}<span class="badge badge-warning badge-xs">Pending</span>{{end}}</td>

--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -166,27 +166,12 @@
         </div>
         <div class="flex gap-2 items-center" x-show="bulkSelected.length > 0">
           <span class="text-xs text-base-content/50" x-text="bulkSelected.length + ' selected'"></span>
-          <div class="bb-cat-picker inline-block" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'Map to...', allowEmpty: false})" @category-change.stop="bulkCategoryId = $event.detail.id; bulkCategoryLabel = $event.detail.label">
+          <div class="bb-cat-picker inline-block" data-picker-source="bulk-map-cat" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'Map to...', allowEmpty: false})" @category-change.stop="bulkCategoryId = $event.detail.id; bulkCategoryLabel = $event.detail.label">
             <button type="button" class="btn btn-sm btn-outline rounded-xl gap-2" @click="openPicker()">
               <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
               <span x-text="bulkCategoryLabel || 'Map to...'" class="text-sm"></span>
               <i data-lucide="chevron-down" class="w-3 h-3"></i>
             </button>
-            <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-              <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full rounded-lg">
-              </div>
-              <div x-ref="listbox">
-                <template x-for="(item, idx) in filteredList" :key="item.id || item.slug || idx">
-                  <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                    <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                    <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
-                    <span x-text="item.label"></span>
-                  </div>
-                </template>
-                <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-              </div>
-            </div>
           </div>
           <button class="btn btn-sm btn-primary rounded-xl" :disabled="!bulkCategoryId || bulkSubmitting" @click="submitBulkMapping()">
             <span x-show="!bulkSubmitting">Map All</span>
@@ -217,27 +202,12 @@
               </td>
               <td>
                 <div class="flex gap-2 items-center">
-                  <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false})">
+                  <div class="bb-cat-picker flex-1" data-picker-source="unmap-d-{{.Provider}}-{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false})">
                     <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start rounded-xl" @click="openPicker()">
                       <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
                       <span x-text="displayLabel" class="text-sm truncate"></span>
                       <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
                     </button>
-                    <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-                      <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                        <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
-                      </div>
-                      <div x-ref="listbox">
-                        <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                          <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                            <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                            <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
-                            <span x-text="item.label"></span>
-                          </div>
-                        </template>
-                        <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-                      </div>
-                    </div>
                   </div>
                   <button class="btn btn-sm btn-primary rounded-lg" :disabled="!selectedId || submitting" @click="
                     submitting = true;
@@ -264,25 +234,11 @@
             <span class="font-mono text-sm truncate">{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}</span>
           </div>
           <div class="flex gap-2">
-            <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false})">
+            <div class="bb-cat-picker flex-1" data-picker-source="unmap-m-{{.Provider}}-{{if .Detailed}}{{.Detailed}}{{else}}{{.Primary}}{{end}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false})">
               <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start rounded-xl" @click="openPicker()">
                 <span x-text="displayLabel" class="text-sm truncate"></span>
                 <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
               </button>
-              <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
-                <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                  <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
-                </div>
-                <div x-ref="listbox">
-                  <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                    <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                      <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                      <span x-text="item.label"></span>
-                    </div>
-                  </template>
-                  <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-                </div>
-              </div>
             </div>
             <button class="btn btn-sm btn-primary rounded-lg" :disabled="!selectedId || submitting" @click="
               submitting = true;
@@ -347,26 +303,12 @@
                 </template>
                 <template x-if="editing">
                   <div class="flex gap-2 items-center">
-                    <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false, initial: categoryId})">
+                    <div class="bb-cat-picker flex-1" data-picker-source="map-edit-{{.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', placeholder: 'Select...', allowEmpty: false, initial: categoryId})" @category-change="categoryId = $event.detail.id">
                       <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start rounded-xl" @click="openPicker()">
                         <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
                         <span x-text="displayLabel" class="text-sm truncate"></span>
                         <i data-lucide="chevron-down" class="w-3 h-3 ml-auto"></i>
                       </button>
-                      <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
-                        <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                          <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
-                        </div>
-                        <div x-ref="listbox">
-                          <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                            <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item); categoryId = item.id">
-                              <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                              <span x-text="item.label"></span>
-                            </div>
-                          </template>
-                          <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-                        </div>
-                      </div>
                     </div>
                     <button class="btn btn-sm btn-primary rounded-lg" :disabled="submitting" @click="
                       submitting = true;
@@ -572,25 +514,11 @@
 
       <label class="form-control w-full">
         <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Parent Category</span></div>
-        <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'None (top-level)', allowEmpty: true, emptyLabel: 'None (top-level)'})" @category-change="parentId = $event.detail.id">
+        <div class="bb-cat-picker" data-picker-source="cat-create-parent" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'None (top-level)', allowEmpty: true, emptyLabel: 'None (top-level)'})" @category-change="parentId = $event.detail.id">
           <button type="button" class="select select-bordered w-full text-left flex items-center gap-2 rounded-xl" @click="openPicker()">
             <span x-text="displayLabel" class="flex-1 text-sm"></span>
             <i data-lucide="chevron-down" class="w-4 h-4 opacity-40"></i>
           </button>
-          <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false">
-            <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-              <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full rounded-lg">
-            </div>
-            <div x-ref="listbox">
-              <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                  <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                  <span x-text="item.label"></span>
-                </div>
-              </template>
-              <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-            </div>
-          </div>
         </div>
       </label>
 

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -269,27 +269,12 @@
           <label class="label label-text text-xs text-base-content/40 py-0.5">
             {{if .SuggestedCategoryID}}Correct category{{else}}Assign category{{end}}
           </label>
-          <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', placeholder: 'Keep current', allowEmpty: true, emptyLabel: 'Keep current'})" @category-change="selectedCatId = $event.detail.id; if (selectedCatId !== suggestedCatId && suggestedCatId) { feedback = 'down'; }">
+          <div class="bb-cat-picker" data-picker-source="review-{{.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', placeholder: 'Keep current', allowEmpty: true, emptyLabel: 'Keep current'})" @category-change="selectedCatId = $event.detail.id; if (selectedCatId !== suggestedCatId && suggestedCatId) { feedback = 'down'; }">
             <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start border border-base-300 rounded-xl" @click="openPicker()">
               <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
               <span x-text="displayLabel" class="text-sm truncate"></span>
               <svg class="w-3 h-3 ml-auto opacity-40" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
             </button>
-            <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-              <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full rounded-xl">
-              </div>
-              <div x-ref="listbox">
-                <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                  <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                    <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                    <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
-                    <span x-text="item.label"></span>
-                  </div>
-                </template>
-                <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-              </div>
-            </div>
           </div>
         </div>
         <!-- Note -->

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -98,27 +98,12 @@
   <div class="bb-card p-6" x-data="txCategoryEditor()">
     <h2 class="text-sm font-semibold text-base-content/50 mb-5">Category</h2>
 
-    <div class="bb-cat-picker" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', initial: '{{if .Transaction.Category}}{{.Transaction.Category.ID}}{{end}}'})" @category-change="setCategoryFromPicker($event.detail)">
+    <div class="bb-cat-picker" data-picker-source="txd-cat" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', initial: '{{if .Transaction.Category}}{{.Transaction.Category.ID}}{{end}}'})" @category-change="setCategoryFromPicker($event.detail)">
       <button type="button" class="w-full flex items-center gap-3 p-3 rounded-xl bg-base-200/50 hover:bg-base-200 transition-colors" @click="openPicker()">
         <template x-if="displayColor"><span class="w-3 h-3 rounded-full shrink-0" :style="'background-color:' + displayColor"></span></template>
         <span x-text="displayLabel" class="text-sm font-medium flex-1 text-left"></span>
         <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30"></i>
       </button>
-      <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-        <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-          <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full">
-        </div>
-        <div x-ref="listbox">
-          <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-            <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-              <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-              <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
-              <span x-text="item.label"></span>
-            </div>
-          </template>
-          <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-        </div>
-      </div>
     </div>
 
     <div class="flex items-center gap-2 mt-3">

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -82,27 +82,12 @@
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-4">
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
           Category
-          <div class="bb-cat-picker" x-data="categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
+          <div class="bb-cat-picker" data-picker-source="tx-filter-cat" x-data="categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
             <input type="hidden" name="category" x-ref="catInput" value="{{.FilterCategory}}">
             <button type="button" class="select select-sm select-bordered w-full text-left flex items-center gap-2" @click="openPicker()">
               <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
               <span x-text="displayLabel" class="text-sm truncate"></span>
             </button>
-            <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false">
-              <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search categories..." class="input input-sm input-bordered w-full">
-              </div>
-              <div x-ref="listbox">
-                <template x-for="(item, idx) in filteredList" :key="item.slug || idx">
-                  <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item); $refs.catInput.value = item.slug">
-                    <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                    <template x-if="item.icon"><i :data-lucide="item.icon" class="bb-cat-icon"></i></template>
-                    <span x-text="item.label"></span>
-                  </div>
-                </template>
-                <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-              </div>
-            </div>
           </div>
         </label>
         <label class="flex flex-col gap-1 text-xs font-medium text-base-content/60">
@@ -168,26 +153,12 @@
             </td>
             <td class="text-sm text-base-content/70">{{.AccountName}}</td>
             <td @click.stop>
-              <div class="bb-cat-picker" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+              <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
                 <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
                   <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
                   <span x-text="displayLabel" class="text-sm"></span>
                   {{if .CategoryOverride}}<span class="badge badge-outline badge-xs">override</span>{{end}}
                 </button>
-                <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false" style="min-width:16rem">
-                  <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                    <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
-                  </div>
-                  <div x-ref="listbox">
-                    <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                      <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                        <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                        <span x-text="item.label"></span>
-                      </div>
-                    </template>
-                    <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-                  </div>
-                </div>
               </div>
             </td>
             <td>
@@ -276,26 +247,12 @@
         <!-- Category picker -->
         <div class="flex items-center gap-2 mb-3" @click.stop>
           <span class="text-xs text-base-content/50 font-medium w-16 shrink-0">Category</span>
-          <div class="bb-cat-picker flex-1" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+          <div class="bb-cat-picker flex-1" data-picker-source="tx-cat-m-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
             <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
               <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
               <span x-text="displayLabel" class="text-sm"></span>
               {{if .CategoryOverride}}<span class="badge badge-outline badge-xs">override</span>{{end}}
             </button>
-            <div class="bb-cat-picker-dropdown" x-show="open" x-cloak @click.outside="open = false" @keydown.window.escape="open = false" style="min-width:14rem">
-              <div class="p-2 border-b border-base-300 sticky top-0 bg-base-100 z-10">
-                <input type="text" x-model="search" x-ref="searchInput" @keydown="handleKeydown($event)" placeholder="Search..." class="input input-sm input-bordered w-full">
-              </div>
-              <div x-ref="listbox">
-                <template x-for="(item, idx) in filteredList" :key="item.id || idx">
-                  <div class="bb-cat-item" :class="{'bb-cat-item--indent': item.indent, 'bb-cat-item--parent': item.isParent}" :data-highlighted="idx === highlightIndex" @click="select(item)">
-                    <template x-if="item.color"><span class="bb-cat-dot" :style="'background-color:' + item.color"></span></template>
-                    <span x-text="item.label"></span>
-                  </div>
-                </template>
-                <div class="bb-cat-empty" x-show="search && !hasResults" x-cloak>No results found</div>
-              </div>
-            </div>
           </div>
         </div>
         <!-- Detail fields -->

--- a/internal/templates/partials/category_picker.html
+++ b/internal/templates/partials/category_picker.html
@@ -115,16 +115,37 @@ function categoryPicker(config) {
     },
 
     openPicker() {
-      this.open = true;
-      this.search = '';
-      this.highlightIndex = -1;
-      this.$nextTick(() => {
-        this.$refs.searchInput?.focus();
-        if (typeof lucide !== 'undefined') lucide.createIcons({ nameAttr: 'data-lucide' });
+      this.open = false;
+      var self = this;
+      this.$dispatch('open-category-picker', {
+        mode: this.mode,
+        allowEmpty: this.allowEmpty,
+        emptyLabel: this.emptyLabel,
+        categories: this.categories,
+        sourceId: this._bbSourceId || this.$el.closest('[data-picker-source]')?.dataset.pickerSource || ('picker-' + Math.random().toString(36).slice(2, 8))
       });
+      // Store the sourceId so we can match the response
+      if (!this._bbSourceId) {
+        this._bbSourceId = this.$el.closest('[data-picker-source]')?.dataset.pickerSource || ('picker-' + Math.random().toString(36).slice(2, 8));
+      }
     },
 
     init() {
+      // Generate a stable sourceId
+      this._bbSourceId = this.$el.closest('[data-picker-source]')?.dataset.pickerSource || ('picker-' + Math.random().toString(36).slice(2, 8));
+
+      // Listen for category-picked responses
+      var self = this;
+      window.addEventListener('category-picked', function(e) {
+        if (e.detail.sourceId === self._bbSourceId) {
+          self.selectedId = self.mode === 'filter' ? e.detail.slug : e.detail.id;
+          self.$dispatch('category-change', { id: e.detail.id, slug: e.detail.slug, label: e.detail.label });
+          self.$nextTick(function() {
+            if (typeof lucide !== 'undefined') lucide.createIcons({ nameAttr: 'data-lucide' });
+          });
+        }
+      });
+
       this.$nextTick(() => {
         if (typeof lucide !== 'undefined') lucide.createIcons({ nameAttr: 'data-lucide' });
       });
@@ -136,34 +157,10 @@ function categoryPicker(config) {
 
 {{define "category-picker-styles"}}
 <style>
+  /* Legacy inline picker styles removed — using global overlay via base.html */
   .bb-cat-picker { position: relative; }
-  .bb-cat-picker-dropdown {
-    position: absolute; z-index: 50; left: 0; right: 0; top: 100%;
-    margin-top: 0.25rem; max-height: 18rem; overflow-y: auto;
-    background: var(--color-base-100); border: 1px solid var(--color-base-300); border-radius: var(--rounded-btn, 0.5rem);
-    box-shadow: 0 4px 6px -1px rgba(0,0,0,.1), 0 2px 4px -2px rgba(0,0,0,.1);
-  }
-  .bb-cat-item {
-    display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0.75rem;
-    cursor: pointer; min-height: 2.5rem; font-size: 0.875rem; transition: background 0.1s;
-    color: var(--color-base-content);
-  }
-  .bb-cat-item:hover, .bb-cat-item[data-highlighted="true"] { background: var(--color-base-200); }
-  .bb-cat-item--indent { padding-left: 2rem; }
-  .bb-cat-item--parent { font-weight: 600; }
   .bb-cat-dot { width: 0.625rem; height: 0.625rem; border-radius: 9999px; flex-shrink: 0; }
   .bb-cat-icon { width: 1rem; height: 1rem; flex-shrink: 0; opacity: 0.7; }
-  .bb-cat-empty { padding: 1rem; text-align: center; font-size: 0.875rem; color: color-mix(in oklch, var(--color-base-content) 50%, transparent); }
-  @media (max-width: 640px) {
-    .bb-cat-picker-dropdown {
-      position: fixed; left: 0.5rem; right: 0.5rem; top: 0.5rem; bottom: auto;
-      max-height: 70vh; border-radius: var(--rounded-btn, 0.5rem);
-    }
-    .bb-cat-picker-dropdown::before {
-      content: ''; position: fixed; inset: 0; z-index: -1;
-      background: rgba(0,0,0,.4);
-    }
-  }
   @keyframes bb-shake {
     0%, 100% { transform: translateX(0); }
     20%, 60% { transform: translateX(-4px); }


### PR DESCRIPTION
## Summary
- Replaced 13 inline `bb-cat-picker-dropdown` instances across 5 pages (transactions, account_detail, transaction_detail, reviews, categories) with a single global overlay component in `base.html`
- The overlay follows the same pattern as the existing Cmd+K command palette: frosted backdrop, centered dialog, search input, keyboard navigation (arrows/enter/escape)
- Communication uses Alpine.js events: `open-category-picker` (with `sourceId`) triggers the overlay, `category-picked` (with matching `sourceId`) routes the selection back to the correct caller
- This fixes overflow clipping issues that occurred when inline dropdowns were inside cards, table cells, or modals

## Test plan
- [ ] Transactions page: filter bar category picker works, inline table row pickers auto-save on selection
- [ ] Transactions page (mobile): card category pickers work in expanded view
- [ ] Account detail page: filter bar picker and inline table row pickers work
- [ ] Transaction detail page: category card picker updates and saves
- [ ] Reviews page: picker sets selectedCatId, thumbs-down feedback triggers when changing from suggested
- [ ] Categories page: bulk mapping picker, individual mapping pickers (desktop + mobile), existing mapping edit picker, create modal parent picker all work
- [ ] Keyboard navigation: arrow keys, enter to select, escape to close
- [ ] Dark mode: overlay renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)