### PR TITLE
Add sync error indicators and inline category badges

### DIFF
--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -391,13 +391,14 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 	selectPrefix := "SELECT t.id, t.account_id, COALESCE(a.display_name, a.name, ''), " +
 		"COALESCE(bc.institution_name, ''), COALESCE(u.name, ''), " +
 		"t.date, t.name, t.merchant_name, t.amount, t.iso_currency_code, " +
-		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, " +
+		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, t.created_at, t.updated_at "
 	fromClause := "FROM transactions t " +
 		"LEFT JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
 		"LEFT JOIN users u ON bc.user_id = u.id " +
-		"LEFT JOIN categories c ON t.category_id = c.id "
+		"LEFT JOIN categories c ON t.category_id = c.id " +
+		"LEFT JOIN categories pc ON c.parent_id = pc.id "
 	query := selectPrefix + fromClause + "WHERE t.deleted_at IS NULL"
 
 	// Track which JOINs are needed for the WHERE clause (used by the count query).
@@ -579,6 +580,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			catDisplayName   pgtype.Text
 			catSlug          pgtype.Text
 			catIcon          pgtype.Text
+			catColor         pgtype.Text
 			categoryOverride bool
 			pending          bool
 			createdAt        pgtype.Timestamptz
@@ -589,7 +591,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			&id, &accountID, &accountName,
 			&institutionName, &userName,
 			&date, &name, &merchantName, &amount, &isoCurrencyCode,
-			&categoryID, &catDisplayName, &catSlug, &catIcon,
+			&categoryID, &catDisplayName, &catSlug, &catIcon, &catColor,
 			&categoryOverride, &pending, &createdAt, &updatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan admin transaction: %w", err)
@@ -626,6 +628,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			CategoryDisplayName: textPtr(catDisplayName),
 			CategorySlug:        textPtr(catSlug),
 			CategoryIcon:        textPtr(catIcon),
+			CategoryColor:       textPtr(catColor),
 			CategoryOverride:    categoryOverride,
 			Pending:             pending,
 			CreatedAt:           createdAt.Time.UTC().Format(time.RFC3339),

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -213,6 +213,7 @@ type AdminTransactionRow struct {
 	CategoryDisplayName *string
 	CategorySlug        *string
 	CategoryIcon        *string
+	CategoryColor       *string
 	CategoryOverride    bool
 	Pending             bool
 	CreatedAt           string

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -252,14 +252,23 @@
         <div class="flex items-center gap-3 min-w-0">
           <div class="w-8 h-8 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0">
             {{if .CategoryIcon}}
-            <i data-lucide="{{.CategoryIcon}}" class="w-3.5 h-3.5 text-base-content/40"></i>
+            <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5 text-base-content/40"></i>
             {{else}}
             <i data-lucide="minus" class="w-3.5 h-3.5 text-base-content/20"></i>
             {{end}}
           </div>
           <div class="min-w-0">
             <div class="text-sm font-medium truncate max-w-64">{{.Name}}</div>
-            <div class="text-xs text-base-content/40">{{.AccountName}} · {{formatDate .Date}}</div>
+            <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40">
+              <span>{{.AccountName}} · {{formatDate .Date}}</span>
+              {{if .CategoryDisplayName}}
+              <span class="text-base-content/20">&middot;</span>
+              <span class="inline-flex items-center gap-1">
+                <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{deref .CategoryColor}}{{else}}oklch(0.65 0 0){{end}}"></span>
+                <span class="text-base-content/50">{{deref .CategoryDisplayName}}</span>
+              </span>
+              {{end}}
+            </div>
           </div>
         </div>
         <div class="text-sm font-semibold tabular-nums shrink-0 pl-3{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">
@@ -290,21 +299,37 @@
       {{if .RecentLogs}}
       <div class="space-y-1">
         {{range .RecentLogs}}
-        <a href="/connections/{{formatUUID .ConnectionID}}" class="flex items-center justify-between py-2 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 no-underline group -mx-1">
-          <div class="flex items-center gap-2.5 min-w-0">
-            <div class="w-6 h-6 rounded-md bg-base-200/50 flex items-center justify-center shrink-0">
-              <i data-lucide="building-2" class="w-3 h-3 text-base-content/40"></i>
+        <div class="rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1{{if eq (printf "%s" .Status) "error"}} bg-error/4{{end}}">
+          <a href="/connections/{{formatUUID .ConnectionID}}" class="flex items-center justify-between py-2 px-1 no-underline group">
+            <div class="flex items-center gap-2.5 min-w-0">
+              <div class="w-6 h-6 rounded-md flex items-center justify-center shrink-0{{if eq (printf "%s" .Status) "error"}} bg-error/10{{else}} bg-base-200/50{{end}}">
+                {{if eq (printf "%s" .Status) "error"}}
+                <i data-lucide="alert-circle" class="w-3 h-3 text-error/70"></i>
+                {{else if eq (printf "%s" .Status) "in_progress"}}
+                <i data-lucide="loader" class="w-3 h-3 text-base-content/40 animate-spin"></i>
+                {{else}}
+                <i data-lucide="building-2" class="w-3 h-3 text-base-content/40"></i>
+                {{end}}
+              </div>
+              <div class="min-w-0">
+                <div class="text-xs font-medium truncate group-hover:text-primary transition-colors">{{.InstitutionName.String}}</div>
+                <div class="text-xs text-base-content/30">{{relativeTime .StartedAt}}</div>
+              </div>
             </div>
-            <div class="min-w-0">
-              <div class="text-xs font-medium truncate group-hover:text-primary transition-colors">{{.InstitutionName.String}}</div>
-              <div class="text-xs text-base-content/30">{{relativeTime .StartedAt}}</div>
+            <div class="flex items-center gap-1.5 shrink-0">
+              {{if .AddedCount}}<span class="text-xs text-success font-medium">+{{.AddedCount}}</span>{{end}}
+              {{syncBadge (printf "%s" .Status)}}
+            </div>
+          </a>
+          {{if and .ErrorMessage.Valid (eq (printf "%s" .Status) "error")}}
+          <div class="flex items-start gap-1.5 px-1 pb-2 -mt-0.5">
+            <div class="w-6 shrink-0"></div>
+            <div class="text-[0.65rem] text-error/70 leading-relaxed font-mono truncate" title="{{.ErrorMessage.String}}">
+              {{.ErrorMessage.String}}
             </div>
           </div>
-          <div class="flex items-center gap-1.5 shrink-0">
-            {{if .AddedCount}}<span class="text-xs text-success font-medium">+{{.AddedCount}}</span>{{end}}
-            {{syncBadge (printf "%s" .Status)}}
-          </div>
-        </a>
+          {{end}}
+        </div>
         {{end}}
       </div>
       {{else}}

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -155,8 +155,11 @@
             <td @click.stop>
               <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
                 <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
+                  {{if .CategoryColor}}
+                  <span class="bb-cat-dot" x-show="!displayColor" style="background-color: {{deref .CategoryColor}}"></span>
+                  {{end}}
                   <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-                  <span x-text="displayLabel" class="text-sm"></span>
+                  <span x-text="displayLabel" class="text-sm">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}&mdash;{{end}}</span>
                   {{if .CategoryOverride}}<span class="badge badge-outline badge-xs">override</span>{{end}}
                 </button>
               </div>
@@ -219,10 +222,17 @@
             <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors truncate">{{.Name}}</a>
             {{if .Pending}}<span class="badge badge-warning badge-xs">Pending</span>{{end}}
           </div>
-          <div class="flex items-center gap-2 mt-0.5">
-            <span class="text-xs text-base-content/50">{{formatDate .Date}}</span>
-            <span class="text-xs text-base-content/30">&middot;</span>
-            <span class="text-xs text-base-content/50 truncate">{{.AccountName}}</span>
+          <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/50 flex-wrap">
+            <span>{{formatDate .Date}}</span>
+            <span class="text-base-content/30">&middot;</span>
+            <span class="truncate">{{.AccountName}}</span>
+            {{if .CategoryDisplayName}}
+            <span class="text-base-content/20">&middot;</span>
+            <span class="inline-flex items-center gap-1">
+              <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{deref .CategoryColor}}{{else}}oklch(0.65 0 0){{end}}"></span>
+              <span class="text-base-content/50">{{deref .CategoryDisplayName}}</span>
+            </span>
+            {{end}}
           </div>
         </div>
         <!-- Right: amount -->


### PR DESCRIPTION
## Summary
- **Dashboard sync error indicators**: Failed syncs now show a red-tinted background, alert icon, and the actual error message inline (truncated with full text on hover). In-progress syncs show a spinner. Previously, errors only showed a generic "error" badge with no detail.
- **Inline category badges on transaction rows**: Both the dashboard recent transactions and the full transactions page now display a colored dot + category name inline. Colors are inherited from parent categories when subcategories don't have their own color (`COALESCE(c.color, pc.color)`).
- **Server-rendered category dots**: Transaction table category cells now show a server-rendered colored dot before Alpine.js hydrates, eliminating the flash of unstyled content. The dot gracefully hands off to Alpine's dynamic dot when available.

## Screenshots

### Dashboard — sync errors + category badges
![Dashboard](https://i.img402.dev/p3g23fdz3s.png)

### Transactions — inline category dots
![Transactions](https://i.img402.dev/65a6jld785.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent