### PR TITLE
Add spending comparison and top categories to dashboard

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"sort"
+	"strings"
 	"time"
 
 	"breadbox/internal/app"
@@ -68,6 +69,13 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			a.Logger.Error("category summary", "error", err)
 		}
 		var categoryLabelsJSON, categoryAmountsJSON template.JS
+		// Top spending categories for the breakdown list.
+		type CategorySpend struct {
+			Name   string
+			Amount float64
+		}
+		var topCategories []CategorySpend
+		var maxCategorySpend float64
 		if categorySummary != nil && len(categorySummary.Summary) > 0 {
 			labels := make([]string, 0, len(categorySummary.Summary))
 			amounts := make([]float64, 0, len(categorySummary.Summary))
@@ -80,6 +88,13 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				if row.TotalAmount > 0 {
 					labels = append(labels, label)
 					amounts = append(amounts, row.TotalAmount)
+					// Title-case the label for the top categories display.
+					displayLabel := strings.ReplaceAll(label, "_", " ")
+					displayLabel = strings.Title(displayLabel) //nolint:staticcheck // simple title case
+					topCategories = append(topCategories, CategorySpend{Name: displayLabel, Amount: row.TotalAmount})
+					if row.TotalAmount > maxCategorySpend {
+						maxCategorySpend = row.TotalAmount
+					}
 				}
 			}
 			if lb, err := json.Marshal(labels); err == nil {
@@ -89,6 +104,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				categoryAmountsJSON = template.JS(ab)
 			}
 		}
+		// Limit to top 8 categories.
+		if len(topCategories) > 8 {
+			topCategories = topCategories[:8]
+		}
 
 		// Daily spending trend (last 30 days).
 		dailySummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
@@ -97,6 +116,30 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		if err != nil {
 			a.Logger.Error("daily summary", "error", err)
 		}
+
+		// Previous 30-day period spending for comparison.
+		prevStart := time.Now().AddDate(0, 0, -60)
+		prevEnd := time.Now().AddDate(0, 0, -30)
+		prevSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:   "category",
+			StartDate: &prevStart,
+			EndDate:   &prevEnd,
+		})
+		if err != nil {
+			a.Logger.Error("previous period summary", "error", err)
+		}
+		var prevTotalSpending float64
+		if prevSummary != nil {
+			for _, row := range prevSummary.Summary {
+				if row.TotalAmount > 0 {
+					prevTotalSpending += row.TotalAmount
+				}
+			}
+		}
+		// Calculate spending change percentage.
+		var spendingChangePercent float64
+		var hasSpendingChange bool
+		// We compute these after totalSpending is calculated below.
 		var dailyLabelsJSON, dailyAmountsJSON template.JS
 		if dailySummary != nil && len(dailySummary.Summary) > 0 {
 			// Reverse so oldest is first (API returns DESC).
@@ -190,6 +233,12 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		var totalSpending float64
 		if categorySummary != nil && categorySummary.Totals.TotalAmount != nil {
 			totalSpending = *categorySummary.Totals.TotalAmount
+		}
+
+		// Compute spending change vs previous period.
+		if prevTotalSpending > 0 {
+			hasSpendingChange = true
+			spendingChangePercent = ((totalSpending - prevTotalSpending) / prevTotalSpending) * 100
 		}
 
 		// Total income (30 days) — negative amounts in our system are credits/income.
@@ -312,6 +361,11 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"NetWorth":              netWorth,
 			"TotalAssets":           totalAssets,
 			"TotalLiabilities":     totalLiabilities,
+			"TopCategories":        topCategories,
+			"MaxCategorySpend":     maxCategorySpend,
+			"PrevTotalSpending":    prevTotalSpending,
+			"SpendingChangePercent": spendingChangePercent,
+			"HasSpendingChange":    hasSpendingChange,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -170,6 +170,12 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return t.Before(time.Now())
 			},
+			"percent": func(value, max float64) float64 {
+				if max <= 0 {
+					return 0
+				}
+				return (value / max) * 100
+			},
 			"formatAmount": func(amount float64) string {
 				neg := amount < 0
 				abs := math.Abs(amount)

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -120,8 +120,16 @@
       <span class="text-xs font-medium text-base-content/50">Spending</span>
       <span class="text-xs text-base-content/30">30d</span>
     </div>
-    <div class="text-3xl font-semibold tabular-nums tracking-tight">
-      {{formatBalance .TotalSpending}}
+    <div class="flex items-baseline gap-3">
+      <div class="text-3xl font-semibold tabular-nums tracking-tight">
+        {{formatBalance .TotalSpending}}
+      </div>
+      {{if .HasSpendingChange}}
+      <div class="flex items-center gap-1 text-xs font-medium {{if gt .SpendingChangePercent 0.0}}text-error/70{{else}}text-success/70{{end}}">
+        <i data-lucide="{{if gt .SpendingChangePercent 0.0}}trending-up{{else}}trending-down{{end}}" class="w-3 h-3"></i>
+        {{if gt .SpendingChangePercent 0.0}}+{{end}}{{printf "%.0f" .SpendingChangePercent}}%
+      </div>
+      {{end}}
     </div>
     <div class="flex items-center gap-4 mt-3 text-xs text-base-content/50">
       <a href="/transactions" class="flex items-center gap-1 hover:text-base-content transition-colors">
@@ -201,7 +209,18 @@
   <!-- Spending Trend Chart -->
   <div class="bb-card lg:col-span-2 p-5">
     <div class="flex items-center justify-between mb-3">
-      <h2 class="text-sm font-semibold text-base-content/70">Daily Spending</h2>
+      <div class="flex items-center gap-2">
+        <h2 class="text-sm font-semibold text-base-content/70">Daily Spending</h2>
+        <span class="text-xs text-base-content/30">Last 30 days</span>
+      </div>
+      {{if .HasSpendingChange}}
+      <div class="flex items-center gap-1.5 text-xs text-base-content/40">
+        <span>vs prev 30d:</span>
+        <span class="font-medium {{if gt .SpendingChangePercent 0.0}}text-error/70{{else}}text-success/70{{end}}">
+          {{if gt .SpendingChangePercent 0.0}}+{{end}}{{printf "%.0f" .SpendingChangePercent}}%
+        </span>
+      </div>
+      {{end}}
     </div>
     {{if .DailyLabels}}
     <div class="h-52">
@@ -217,19 +236,30 @@
     {{end}}
   </div>
 
-  <!-- Category Breakdown Chart -->
+  <!-- Top Spending Categories -->
   <div class="bb-card p-5">
-    <div class="flex items-center justify-between mb-3">
-      <h2 class="text-sm font-semibold text-base-content/70">By Category</h2>
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-sm font-semibold text-base-content/70">Top Categories</h2>
+      <a href="/categories" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
     </div>
-    {{if .CategoryLabels}}
-    <div class="h-52 flex items-center justify-center">
-      <canvas id="categoryChart"></canvas>
+    {{if .TopCategories}}
+    <div class="space-y-3">
+      {{range .TopCategories}}
+      <div class="group">
+        <div class="flex items-center justify-between mb-1">
+          <span class="text-sm text-base-content/70 group-hover:text-base-content transition-colors">{{.Name}}</span>
+          <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatAmount .Amount}}</span>
+        </div>
+        <div class="w-full h-1.5 bg-base-200 rounded-full overflow-hidden">
+          <div class="h-full bg-base-content/20 rounded-full transition-all duration-500" style="width: {{printf "%.0f" (percent .Amount $.MaxCategorySpend)}}%"></div>
+        </div>
+      </div>
+      {{end}}
     </div>
     {{else}}
-    <div class="flex items-center justify-center h-52 text-base-content/40">
+    <div class="flex items-center justify-center h-40 text-base-content/40">
       <div class="text-center">
-        <i data-lucide="pie-chart" class="w-10 h-10 mx-auto mb-2 opacity-40"></i>
+        <i data-lucide="pie-chart" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
         <p class="text-sm">No category data yet</p>
       </div>
     </div>
@@ -382,7 +412,7 @@ document.addEventListener('DOMContentLoaded', function() {
     displayColors: false,
   };
 
-  // Spending Trend
+  // Spending Trend — bar chart with rounded tops
   const trendCtx = document.getElementById('spendingTrendChart');
   if (trendCtx) {
     const dailyLabels = {{.DailyLabels}};
@@ -394,22 +424,18 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 
     new Chart(trendCtx, {
-      type: 'line',
+      type: 'bar',
       data: {
         labels: shortLabels,
         datasets: [{
-          label: 'Spending',
+          label: 'Daily Spending',
           data: dailyData,
-          borderColor: isDark ? 'hsl(0 0% 70%)' : 'hsl(0 0% 15%)',
-          backgroundColor: isDark ? 'hsla(0,0%,70%,0.06)' : 'hsla(0,0%,15%,0.04)',
-          fill: true,
-          tension: 0.4,
-          borderWidth: 1.5,
-          pointRadius: 0,
-          pointHoverRadius: 4,
-          pointHoverBackgroundColor: isDark ? 'hsl(0 0% 70%)' : 'hsl(0 0% 15%)',
-          pointHoverBorderColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
-          pointHoverBorderWidth: 2,
+          backgroundColor: isDark ? 'hsl(0 0% 55% / 0.4)' : 'hsl(0 0% 15% / 0.15)',
+          hoverBackgroundColor: isDark ? 'hsl(0 0% 65% / 0.6)' : 'hsl(0 0% 15% / 0.3)',
+          borderRadius: 4,
+          borderSkipped: false,
+          barPercentage: 0.7,
+          categoryPercentage: 0.85,
         }]
       },
       options: {
@@ -444,65 +470,6 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   }
-
-  // Category Doughnut
-  {{if .CategoryLabels}}
-  const catCtx = document.getElementById('categoryChart');
-  if (catCtx) {
-    const categoryLabels = {{.CategoryLabels}};
-    const categoryData = {{.CategoryAmounts}};
-
-    /* Neutral-first palette: grays + one muted accent per segment */
-    const palette = isDark
-      ? ['hsl(0 0% 65%)', 'hsl(0 0% 50%)', 'hsl(0 0% 40%)',
-         'hsl(210 8% 55%)', 'hsl(160 10% 50%)', 'hsl(30 12% 55%)',
-         'hsl(0 0% 75%)', 'hsl(200 6% 45%)', 'hsl(140 8% 45%)',
-         'hsl(45 10% 50%)', 'hsl(0 0% 58%)', 'hsl(180 6% 48%)']
-      : ['hsl(0 0% 15%)', 'hsl(0 0% 30%)', 'hsl(0 0% 45%)',
-         'hsl(210 10% 40%)', 'hsl(160 12% 38%)', 'hsl(30 15% 42%)',
-         'hsl(0 0% 55%)', 'hsl(200 8% 50%)', 'hsl(140 10% 45%)',
-         'hsl(45 12% 48%)', 'hsl(0 0% 65%)', 'hsl(180 8% 42%)'];
-
-    new Chart(catCtx, {
-      type: 'doughnut',
-      data: {
-        labels: categoryLabels,
-        datasets: [{
-          data: categoryData,
-          backgroundColor: palette.slice(0, categoryData.length),
-          borderWidth: isDark ? 1 : 1,
-          borderColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
-          hoverOffset: 3
-        }]
-      },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        cutout: '68%',
-        plugins: {
-          legend: {
-            position: 'bottom',
-            labels: {
-              color: textColor,
-              font: { size: 10, weight: '500' },
-              boxWidth: 8,
-              boxHeight: 8,
-              padding: 10,
-              usePointStyle: true,
-              pointStyle: 'circle'
-            }
-          },
-          tooltip: {
-            ...tooltipStyle,
-            callbacks: {
-              label: ctx => ctx.label + ': $' + ctx.parsed.toFixed(2)
-            }
-          }
-        }
-      }
-    });
-  }
-  {{end}}
 });
 </script>
 {{end}}


### PR DESCRIPTION
## Summary
- Replace the doughnut chart with a **top 8 spending categories list** using progress bars — more readable, shows exact amounts, proportional widths
- Add **30-day period-over-period spending comparison** (+51% vs previous period) shown as a trend indicator on the spending card and chart header
- Switch daily spending chart from line to **bar chart** with rounded tops for a cleaner, more modern look
- Category names are now title-cased (e.g., "Service" instead of "service")

## Screenshots

### Dashboard hero cards with spending comparison indicator
![Dashboard](https://i.img402.dev/qjcxwt8y2z.png)

### Charts section: bar chart + top categories with progress bars
![Charts](https://i.img402.dev/tysw0ibi8o.png)

## Changes
- `internal/admin/dashboard.go` — Fetch previous 30-day period data, compute spending change %, build top categories list with title-cased names
- `internal/admin/templates.go` — Add `percent` template function for progress bar width calculation
- `internal/templates/pages/dashboard.html` — Replace doughnut with categories list, add comparison indicators, switch to bar chart

Relates to #55

🤖 Generated by autonomous UX improvement agent