### PR TITLE
Add CSV export for transactions

### DIFF
--- a/internal/admin/csv_export.go
+++ b/internal/admin/csv_export.go
@@ -1,0 +1,143 @@
+package admin
+
+import (
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/service"
+)
+
+// ExportTransactionsCSVHandler serves GET /admin/-/transactions/export-csv.
+// It streams all transactions matching the current filters as a CSV download.
+func ExportTransactionsCSVHandler(a *app.App, svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		params := service.AdminTransactionListParams{
+			Page:     1,
+			PageSize: -1, // Export all matching rows (no pagination).
+		}
+
+		if v := r.URL.Query().Get("start_date"); v != "" {
+			if t, err := time.Parse("2006-01-02", v); err == nil {
+				params.StartDate = &t
+			}
+		}
+		if v := r.URL.Query().Get("end_date"); v != "" {
+			if t, err := time.Parse("2006-01-02", v); err == nil {
+				t = t.AddDate(0, 0, 1)
+				params.EndDate = &t
+			}
+		}
+		if v := r.URL.Query().Get("account_id"); v != "" {
+			params.AccountID = &v
+		}
+		if v := r.URL.Query().Get("user_id"); v != "" {
+			params.UserID = &v
+		}
+		if v := r.URL.Query().Get("connection_id"); v != "" {
+			params.ConnectionID = &v
+		}
+		if v := r.URL.Query().Get("category"); v != "" {
+			params.CategorySlug = &v
+		}
+		if v := r.URL.Query().Get("min_amount"); v != "" {
+			if f, err := strconv.ParseFloat(v, 64); err == nil {
+				params.MinAmount = &f
+			}
+		}
+		if v := r.URL.Query().Get("max_amount"); v != "" {
+			if f, err := strconv.ParseFloat(v, 64); err == nil {
+				params.MaxAmount = &f
+			}
+		}
+		if v := r.URL.Query().Get("pending"); v != "" {
+			b := v == "true"
+			params.Pending = &b
+		}
+		if v := r.URL.Query().Get("search"); v != "" {
+			params.Search = &v
+		}
+		if v := r.URL.Query().Get("sort"); v == "asc" {
+			params.SortOrder = "asc"
+		}
+
+		result, err := svc.ListTransactionsAdmin(ctx, params)
+		if err != nil {
+			a.Logger.Error("export transactions csv", "error", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		// Generate filename with date range or current date.
+		filename := "breadbox-transactions"
+		if sd := r.URL.Query().Get("start_date"); sd != "" {
+			filename += "-from-" + sd
+		}
+		if ed := r.URL.Query().Get("end_date"); ed != "" {
+			filename += "-to-" + ed
+		}
+		if filename == "breadbox-transactions" {
+			filename += "-" + time.Now().Format("2006-01-02")
+		}
+		filename += ".csv"
+
+		w.Header().Set("Content-Type", "text/csv; charset=utf-8")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+
+		writer := csv.NewWriter(w)
+		defer writer.Flush()
+
+		// Write header row.
+		header := []string{
+			"Date",
+			"Name",
+			"Merchant",
+			"Amount",
+			"Currency",
+			"Account",
+			"Institution",
+			"Family Member",
+			"Category",
+			"Pending",
+			"Transaction ID",
+		}
+		if err := writer.Write(header); err != nil {
+			a.Logger.Error("write csv header", "error", err)
+			return
+		}
+
+		// Write data rows.
+		for _, tx := range result.Transactions {
+			row := []string{
+				tx.Date,
+				tx.Name,
+				derefStr(tx.MerchantName),
+				strconv.FormatFloat(tx.Amount, 'f', 2, 64),
+				derefStr(tx.IsoCurrencyCode),
+				tx.AccountName,
+				tx.InstitutionName,
+				tx.UserName,
+				derefStr(tx.CategoryDisplayName),
+				strconv.FormatBool(tx.Pending),
+				tx.ID,
+			}
+			if err := writer.Write(row); err != nil {
+				a.Logger.Error("write csv row", "error", err)
+				return
+			}
+		}
+	}
+}
+
+// derefStr safely dereferences a string pointer, returning empty string if nil.
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -139,6 +139,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/category-mappings/export-tsv", ExportMappingsTSVAdminHandler(svc))
 		r.Post("/category-mappings/import-tsv", ImportMappingsTSVAdminHandler(svc))
 
+		// Transaction CSV export
+		r.Get("/transactions/export-csv", ExportTransactionsCSVHandler(a, svc))
+
 		// Transaction category override
 		r.Post("/transactions/{id}/category", SetTransactionCategoryAdminHandler(svc))
 		r.Delete("/transactions/{id}/category", ResetTransactionCategoryAdminHandler(svc))

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -128,30 +128,34 @@ func TransactionListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRend
 		}()
 		wg.Wait()
 
+		// Build export URL from active filters (excludes page param).
+		exportURL := buildExportURL(r)
+
 		data := map[string]any{
-			"PageTitle":        "Transactions",
-			"CurrentPage":     "transactions",
-			"CSRFToken":       GetCSRFToken(r),
-			"Flash":           GetFlash(ctx, sm),
-			"Transactions":    result.Transactions,
-			"Accounts":        accounts,
-			"Users":           users,
-			"Categories":      categoryTree,
-			"Connections":     connections,
-			"Page":            result.Page,
-			"TotalPages":      result.TotalPages,
-			"Total":           result.Total,
-			"FilterStartDate": stringOrEmpty(dateParamPtr(r, "start_date")),
-			"FilterEndDate":   stringOrEmpty(dateParamPtr(r, "end_date")),
-			"FilterAccountID": stringOrEmpty(params.AccountID),
-			"FilterUserID":    stringOrEmpty(params.UserID),
-			"FilterConnID":    stringOrEmpty(params.ConnectionID),
-			"FilterCategory":  stringOrEmpty(params.CategorySlug),
-			"FilterMinAmount": stringOrEmpty(floatParamPtr(r, "min_amount")),
-			"FilterMaxAmount": stringOrEmpty(floatParamPtr(r, "max_amount")),
-			"FilterPending":   r.URL.Query().Get("pending"),
-			"FilterSearch":    r.URL.Query().Get("search"),
-			"FilterSort":      r.URL.Query().Get("sort"),
+			"PageTitle":         "Transactions",
+			"CurrentPage":      "transactions",
+			"CSRFToken":        GetCSRFToken(r),
+			"Flash":            GetFlash(ctx, sm),
+			"Transactions":     result.Transactions,
+			"Accounts":         accounts,
+			"Users":            users,
+			"Categories":       categoryTree,
+			"Connections":      connections,
+			"Page":             result.Page,
+			"TotalPages":       result.TotalPages,
+			"Total":            result.Total,
+			"ExportURL":         exportURL,
+			"FilterStartDate":  stringOrEmpty(dateParamPtr(r, "start_date")),
+			"FilterEndDate":    stringOrEmpty(dateParamPtr(r, "end_date")),
+			"FilterAccountID":  stringOrEmpty(params.AccountID),
+			"FilterUserID":     stringOrEmpty(params.UserID),
+			"FilterConnID":     stringOrEmpty(params.ConnectionID),
+			"FilterCategory":   stringOrEmpty(params.CategorySlug),
+			"FilterMinAmount":  stringOrEmpty(floatParamPtr(r, "min_amount")),
+			"FilterMaxAmount":  stringOrEmpty(floatParamPtr(r, "max_amount")),
+			"FilterPending":    r.URL.Query().Get("pending"),
+			"FilterSearch":     r.URL.Query().Get("search"),
+			"FilterSort":       r.URL.Query().Get("sort"),
 		}
 		tr.Render(w, r, "transactions.html", data)
 	}
@@ -220,6 +224,21 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 			a.Logger.Error("list categories for account detail", "error", err)
 		}
 
+		// Build export URL for this account's transactions.
+		acctExportURL := "/-/transactions/export-csv?account_id=" + idStr
+		if sd := r.URL.Query().Get("start_date"); sd != "" {
+			acctExportURL += "&start_date=" + sd
+		}
+		if ed := r.URL.Query().Get("end_date"); ed != "" {
+			acctExportURL += "&end_date=" + ed
+		}
+		if cat := r.URL.Query().Get("category"); cat != "" {
+			acctExportURL += "&category=" + cat
+		}
+		if search := r.URL.Query().Get("search"); search != "" {
+			acctExportURL += "&search=" + search
+		}
+
 		data := map[string]any{
 			"PageTitle":       detail.InstitutionName + " — " + accountDisplayName(detail),
 			"CurrentPage":    "transactions",
@@ -232,6 +251,7 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 			"Page":           txResult.Page,
 			"TotalPages":     txResult.TotalPages,
 			"Total":          txResult.Total,
+			"ExportURL":      acctExportURL,
 			"FilterStartDate": stringOrEmpty(dateParamPtr(r, "start_date")),
 			"FilterEndDate":   stringOrEmpty(dateParamPtr(r, "end_date")),
 			"FilterCategory":  r.URL.Query().Get("category"),
@@ -396,4 +416,25 @@ func DeleteTransactionCommentHandler(a *app.App, sm *scs.SessionManager, svc *se
 
 		w.WriteHeader(http.StatusNoContent)
 	}
+}
+
+// buildExportURL returns the full CSV export URL with the current filter params.
+func buildExportURL(r *http.Request) string {
+	exportParams := []string{
+		"start_date", "end_date", "account_id", "user_id",
+		"connection_id", "category", "min_amount", "max_amount",
+		"pending", "search", "sort",
+	}
+	q := r.URL.Query()
+	qs := make([]string, 0, len(exportParams))
+	for _, key := range exportParams {
+		if v := q.Get(key); v != "" {
+			qs = append(qs, key+"="+v)
+		}
+	}
+	url := "/-/transactions/export-csv"
+	if len(qs) > 0 {
+		url += "?" + strings.Join(qs, "&")
+	}
+	return url
 }

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -546,7 +546,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 	query += fmt.Sprintf(" ORDER BY t.date %s, t.id %s", sortOrder, sortOrder)
 
 	pageSize := params.PageSize
-	if pageSize <= 0 {
+	if pageSize == 0 {
 		pageSize = 50
 	}
 	page := params.Page
@@ -554,8 +554,11 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		page = 1
 	}
 
-	query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argN, argN+1)
-	args = append(args, pageSize, (page-1)*pageSize)
+	// PageSize -1 means export all (no pagination).
+	if pageSize > 0 {
+		query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argN, argN+1)
+		args = append(args, pageSize, (page-1)*pageSize)
+	}
 
 	rows, err := s.Pool.Query(ctx, query, args...)
 	if err != nil {
@@ -639,7 +642,10 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		return nil, fmt.Errorf("iterate admin transactions: %w", err)
 	}
 
-	totalPages := int(math.Ceil(float64(total) / float64(pageSize)))
+	totalPages := 1
+	if pageSize > 0 {
+		totalPages = int(math.Ceil(float64(total) / float64(pageSize)))
+	}
 
 	return &AdminTransactionListResult{
 		Transactions: transactions,

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -87,7 +87,13 @@
   <div class="px-6 pt-6 pb-4">
     <div class="flex items-center justify-between mb-4">
       <h2 class="text-sm font-semibold text-base-content/50">Transactions</h2>
-      {{if .Transactions}}<span class="text-xs text-base-content/30">{{.Total}} total</span>{{end}}
+      <div class="flex items-center gap-2">
+        {{if .Transactions}}<span class="text-xs text-base-content/30">{{.Total}} total</span>
+        <a href="{{.ExportURL}}" class="btn btn-ghost btn-xs rounded-lg" title="Export as CSV">
+          <i data-lucide="download" class="w-3 h-3"></i>
+          CSV
+        </a>{{end}}
+      </div>
     </div>
 
     <!-- Filters -->

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -16,6 +16,12 @@
       <span class="hidden sm:inline">Clear filters</span>
     </a>
     {{end}}
+    {{if .Transactions}}
+    <a href="{{.ExportURL}}" class="btn btn-ghost btn-sm rounded-xl" title="Export as CSV">
+      <i data-lucide="download" class="w-3.5 h-3.5"></i>
+      <span class="hidden sm:inline">Export CSV</span>
+    </a>
+    {{end}}
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Added a new **CSV Export** button to the transactions page that downloads all matching transactions as a `.csv` file
- Export respects all active filters (date range, account, category, search, etc.) so users export exactly what they see
- Also added a compact CSV export button to the **account detail** page for per-account exports
- New Go handler (`ExportTransactionsCSVHandler`) streams CSV with proper `Content-Disposition` header and dynamic filename
- Service layer updated to support unbounded queries (`PageSize=-1`) for full dataset export

## Screenshots
### Transactions page with Export CSV button
![transactions-export](https://i.img402.dev/4xln9gpiws.png)

### Account detail with CSV export
![account-export](https://i.img402.dev/vtw6wzca8c.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent