### PR TITLE
Fix dashboard spending inversion and category display

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"net/http"
 	"sort"
-	"strings"
 	"time"
 
 	"breadbox/internal/app"
@@ -61,9 +60,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			lastSyncText = relativeTime(lastSync.Time)
 		}
 
-		// Spending by category (last 30 days).
+		// Spending by category (last 30 days) — only positive amounts (debits).
 		categorySummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
-			GroupBy: "category",
+			GroupBy:      "category",
+			SpendingOnly: true,
 		})
 		if err != nil {
 			a.Logger.Error("category summary", "error", err)
@@ -72,6 +72,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		// Top spending categories for the breakdown list.
 		type CategorySpend struct {
 			Name   string
+			Color  string
 			Amount float64
 		}
 		var topCategories []CategorySpend
@@ -84,17 +85,15 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				if row.Category != nil && *row.Category != "" {
 					label = *row.Category
 				}
-				// Only include positive amounts (spending)
-				if row.TotalAmount > 0 {
-					labels = append(labels, label)
-					amounts = append(amounts, row.TotalAmount)
-					// Title-case the label for the top categories display.
-					displayLabel := strings.ReplaceAll(label, "_", " ")
-					displayLabel = strings.Title(displayLabel) //nolint:staticcheck // simple title case
-					topCategories = append(topCategories, CategorySpend{Name: displayLabel, Amount: row.TotalAmount})
-					if row.TotalAmount > maxCategorySpend {
-						maxCategorySpend = row.TotalAmount
-					}
+				labels = append(labels, label)
+				amounts = append(amounts, row.TotalAmount)
+				color := ""
+				if row.CategoryColor != nil {
+					color = *row.CategoryColor
+				}
+				topCategories = append(topCategories, CategorySpend{Name: label, Color: color, Amount: row.TotalAmount})
+				if row.TotalAmount > maxCategorySpend {
+					maxCategorySpend = row.TotalAmount
 				}
 			}
 			if lb, err := json.Marshal(labels); err == nil {
@@ -109,9 +108,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			topCategories = topCategories[:8]
 		}
 
-		// Daily spending trend (last 30 days).
+		// Daily spending trend (last 30 days) — only positive amounts (debits).
 		dailySummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
-			GroupBy: "day",
+			GroupBy:      "day",
+			SpendingOnly: true,
 		})
 		if err != nil {
 			a.Logger.Error("daily summary", "error", err)
@@ -121,9 +121,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		prevStart := time.Now().AddDate(0, 0, -60)
 		prevEnd := time.Now().AddDate(0, 0, -30)
 		prevSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
-			GroupBy:   "category",
-			StartDate: &prevStart,
-			EndDate:   &prevEnd,
+			GroupBy:      "category",
+			StartDate:    &prevStart,
+			EndDate:      &prevEnd,
+			SpendingOnly: true,
 		})
 		if err != nil {
 			a.Logger.Error("previous period summary", "error", err)
@@ -131,9 +132,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		var prevTotalSpending float64
 		if prevSummary != nil {
 			for _, row := range prevSummary.Summary {
-				if row.TotalAmount > 0 {
-					prevTotalSpending += row.TotalAmount
-				}
+				prevTotalSpending += row.TotalAmount
 			}
 		}
 		// Calculate spending change percentage.
@@ -153,12 +152,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 					label = *row.Period
 				}
 				labels = append(labels, label)
-				// Use absolute value for spending trend
-				amt := row.TotalAmount
-				if amt < 0 {
-					amt = -amt
-				}
-				amounts = append(amounts, amt)
+				amounts = append(amounts, row.TotalAmount)
 			}
 			if lb, err := json.Marshal(labels); err == nil {
 				dailyLabelsJSON = template.JS(lb)
@@ -242,9 +236,16 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		}
 
 		// Total income (30 days) — negative amounts in our system are credits/income.
+		// Use a separate summary query without SpendingOnly to get income totals.
 		var totalIncome float64
-		if dailySummary != nil {
-			for _, row := range dailySummary.Summary {
+		incomeSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy: "day",
+		})
+		if err != nil {
+			a.Logger.Error("income summary", "error", err)
+		}
+		if incomeSummary != nil {
+			for _, row := range incomeSummary.Summary {
 				if row.TotalAmount < 0 {
 					totalIncome += -row.TotalAmount
 				}

--- a/internal/service/transaction_summary.go
+++ b/internal/service/transaction_summary.go
@@ -15,6 +15,7 @@ type TransactionSummaryParams struct {
 	UserID         *string
 	Category       *string
 	IncludePending bool
+	SpendingOnly   bool // Only include positive amounts (debits/spending)
 }
 
 // TransactionSummaryResult is the response for a transaction summary query.
@@ -27,6 +28,8 @@ type TransactionSummaryResult struct {
 // TransactionSummaryRow is a single aggregated row.
 type TransactionSummaryRow struct {
 	Category         *string `json:"category,omitempty"`
+	CategoryIcon     *string `json:"category_icon,omitempty"`
+	CategoryColor    *string `json:"category_color,omitempty"`
 	Period           *string `json:"period,omitempty"`
 	TotalAmount      float64 `json:"total_amount"`
 	TransactionCount int64   `json:"transaction_count"`
@@ -74,11 +77,13 @@ func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionS
 
 	// Build SELECT clause based on group_by.
 	var selectCols, groupCols, orderCols string
+	joinCategories := false
 	switch params.GroupBy {
 	case "category":
-		selectCols = "t.category_primary AS category, t.iso_currency_code"
-		groupCols = "t.category_primary, t.iso_currency_code"
+		selectCols = "COALESCE(cat.display_name, t.category_primary) AS category, cat.icon AS category_icon, cat.color AS category_color, t.iso_currency_code"
+		groupCols = "COALESCE(cat.display_name, t.category_primary), cat.icon, cat.color, t.iso_currency_code"
 		orderCols = "SUM(t.amount) DESC"
+		joinCategories = true
 	case "month":
 		selectCols = "to_char(date_trunc('month', t.date), 'YYYY-MM') AS period, t.iso_currency_code"
 		groupCols = "date_trunc('month', t.date), t.iso_currency_code"
@@ -92,22 +97,30 @@ func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionS
 		groupCols = "t.date, t.iso_currency_code"
 		orderCols = "t.date DESC"
 	case "category_month":
-		selectCols = "t.category_primary AS category, to_char(date_trunc('month', t.date), 'YYYY-MM') AS period, t.iso_currency_code"
-		groupCols = "t.category_primary, date_trunc('month', t.date), t.iso_currency_code"
+		selectCols = "COALESCE(cat.display_name, t.category_primary) AS category, cat.icon AS category_icon, cat.color AS category_color, to_char(date_trunc('month', t.date), 'YYYY-MM') AS period, t.iso_currency_code"
+		groupCols = "COALESCE(cat.display_name, t.category_primary), cat.icon, cat.color, date_trunc('month', t.date), t.iso_currency_code"
 		orderCols = "date_trunc('month', t.date) DESC, SUM(t.amount) DESC"
+		joinCategories = true
 	}
 
 	query := fmt.Sprintf(`SELECT %s, SUM(t.amount) AS total_amount, COUNT(*) AS transaction_count
 FROM transactions t
 JOIN accounts a ON t.account_id = a.id
-LEFT JOIN bank_connections bc ON a.connection_id = bc.id
-WHERE t.deleted_at IS NULL`, selectCols)
+LEFT JOIN bank_connections bc ON a.connection_id = bc.id`, selectCols)
+	if joinCategories {
+		query += "\nLEFT JOIN categories cat ON t.category_id = cat.id"
+	}
+	query += "\nWHERE t.deleted_at IS NULL"
 
 	args := []any{}
 	argN := 1
 
 	if !params.IncludePending {
 		query += " AND t.pending = false"
+	}
+
+	if params.SpendingOnly {
+		query += " AND t.amount > 0"
 	}
 
 	query += fmt.Sprintf(" AND t.date >= $%d", argN)
@@ -153,11 +166,11 @@ WHERE t.deleted_at IS NULL`, selectCols)
 		var row TransactionSummaryRow
 		switch params.GroupBy {
 		case "category":
-			err = rows.Scan(&row.Category, &row.IsoCurrencyCode, &row.TotalAmount, &row.TransactionCount)
+			err = rows.Scan(&row.Category, &row.CategoryIcon, &row.CategoryColor, &row.IsoCurrencyCode, &row.TotalAmount, &row.TransactionCount)
 		case "month", "week", "day":
 			err = rows.Scan(&row.Period, &row.IsoCurrencyCode, &row.TotalAmount, &row.TransactionCount)
 		case "category_month":
-			err = rows.Scan(&row.Category, &row.Period, &row.IsoCurrencyCode, &row.TotalAmount, &row.TransactionCount)
+			err = rows.Scan(&row.Category, &row.CategoryIcon, &row.CategoryColor, &row.Period, &row.IsoCurrencyCode, &row.TotalAmount, &row.TransactionCount)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("scan summary row: %w", err)

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -247,11 +247,14 @@
       {{range .TopCategories}}
       <div class="group">
         <div class="flex items-center justify-between mb-1">
-          <span class="text-sm text-base-content/70 group-hover:text-base-content transition-colors">{{.Name}}</span>
+          <span class="flex items-center gap-1.5 text-sm text-base-content/70 group-hover:text-base-content transition-colors">
+            {{if .Color}}<span class="w-2 h-2 rounded-full shrink-0" style="background-color: {{.Color}}"></span>{{end}}
+            {{.Name}}
+          </span>
           <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatAmount .Amount}}</span>
         </div>
         <div class="w-full h-1.5 bg-base-200 rounded-full overflow-hidden">
-          <div class="h-full bg-base-content/20 rounded-full transition-all duration-500" style="width: {{printf "%.0f" (percent .Amount $.MaxCategorySpend)}}%"></div>
+          <div class="h-full rounded-full transition-all duration-500" style="width: {{printf "%.0f" (percent .Amount $.MaxCategorySpend)}}%;{{if .Color}} background-color: {{.Color}}{{else}} background-color: oklch(0.65 0 0){{end}}"></div>
         </div>
       </div>
       {{end}}


### PR DESCRIPTION
## Summary
- **Spending inversion fix**: Dashboard spending stat card, daily bar chart, and period-over-period comparison were mixing income (negative amounts) with spending (positive amounts). Added `SpendingOnly` parameter to `TransactionSummaryParams` that adds `AND t.amount > 0` at the SQL level. Daily chart no longer uses `abs()` on net totals.
- **Category display names**: Top categories breakdown was showing raw provider strings (e.g., "FOOD_AND_DRINK") instead of proper category names. Summary query now JOINs the `categories` table via `t.category_id` and uses `COALESCE(cat.display_name, t.category_primary)` as fallback. Category colors from the DB are now shown in the progress bars.

## Test plan
- [ ] Verify dashboard spending card shows only debit totals (positive amounts)
- [ ] Verify daily spending chart bars represent actual spending, not net or absolute values
- [ ] Verify top categories show human-readable names (e.g., "Restaurants" not "FOOD_AND_DRINK")
- [ ] Verify category color dots appear next to category names
- [ ] Verify income card still shows correct income total
- [ ] Verify period-over-period comparison percentage is accurate
- [ ] Run `go test ./...` — all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)