### PR TITLE
Add per-account spending sparklines to dashboard

### DIFF
--- a/input.css
+++ b/input.css
@@ -357,6 +357,15 @@
     @apply text-right tabular-nums text-success;
   }
 
+  /* ── Sparkline (inline mini charts) ── */
+  .bb-sparkline {
+    @apply h-8 w-full;
+  }
+
+  .bb-sparkline svg {
+    display: block;
+  }
+
   /* ── Info grid (detail pages) ── */
   .bb-info-grid {
     @apply grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm;

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -292,6 +292,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			BalanceCurrent  float64
 			IsoCurrencyCode string
 			IsLiability     bool
+			SparklineData   template.JS // JSON array of daily spending amounts (30 days)
+			SpendingTotal   float64     // Total spending in last 30 days for this account
 		}
 		var dashAccounts []DashboardAccount
 		for _, acct := range accounts {
@@ -325,6 +327,36 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				netWorth += bal
 			}
 
+			// Fetch per-account daily spending for sparkline.
+			acctID := acct.ID
+			acctDailySummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+				GroupBy:      "day",
+				AccountID:    &acctID,
+				SpendingOnly: true,
+			})
+			var sparklineJSON template.JS
+			var acctSpendTotal float64
+			if err == nil && acctDailySummary != nil && len(acctDailySummary.Summary) > 0 {
+				// Build a map of date->amount, then fill in 30 days.
+				dayMap := make(map[string]float64, len(acctDailySummary.Summary))
+				for _, row := range acctDailySummary.Summary {
+					if row.Period != nil {
+						dayMap[*row.Period] = row.TotalAmount
+						acctSpendTotal += row.TotalAmount
+					}
+				}
+				// Build array for last 30 days (oldest first).
+				now := time.Now()
+				sparkData := make([]float64, 30)
+				for i := 29; i >= 0; i-- {
+					day := now.AddDate(0, 0, -i).Format("2006-01-02")
+					sparkData[29-i] = dayMap[day]
+				}
+				if sb, err := json.Marshal(sparkData); err == nil {
+					sparklineJSON = template.JS(sb)
+				}
+			}
+
 			dashAccounts = append(dashAccounts, DashboardAccount{
 				ID:              acct.ID,
 				Name:            acct.Name,
@@ -335,6 +367,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				BalanceCurrent:  bal,
 				IsoCurrencyCode: currency,
 				IsLiability:     isLiability,
+				SparklineData:   sparklineJSON,
+				SpendingTotal:   acctSpendTotal,
 			})
 		}
 		// Sort: depository first, then credit, then loan, then others.

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -179,23 +179,32 @@
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 bb-stagger">
     {{range .Accounts}}
     <a href="/accounts/{{.ID}}" class="bb-card bb-card--interactive p-4 no-underline group">
-      <div class="flex items-center gap-3">
+      <div class="flex items-center gap-3 mb-2">
         <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
           <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
         </div>
         <div class="flex-1 min-w-0">
-          <div class="flex items-center justify-between gap-2">
-            <div class="min-w-0">
-              <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
-              <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
-            </div>
-            <div class="text-right shrink-0">
-              <div class="text-sm font-semibold tabular-nums{{if .IsLiability}} text-error/80{{end}}">
-                {{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}
-              </div>
-              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
-            </div>
+          <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
+          <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
+        </div>
+      </div>
+      <div class="flex items-end justify-between gap-3">
+        <div class="flex-1 min-w-0">
+          {{if .SparklineData}}
+          <div class="bb-sparkline" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+          {{else}}
+          <div class="h-8"></div>
+          {{end}}
+        </div>
+        <div class="text-right shrink-0">
+          <div class="text-sm font-semibold tabular-nums{{if .IsLiability}} text-error/80{{end}}">
+            {{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}
           </div>
+          {{if gt .SpendingTotal 0.0}}
+          <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+          {{else}}
+          <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
+          {{end}}
         </div>
       </div>
     </a>
@@ -396,6 +405,58 @@
     </div>
   </div>
 </div>
+
+<!-- Sparkline Rendering -->
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+  document.querySelectorAll('.bb-sparkline').forEach(function(el) {
+    try {
+      const values = JSON.parse(el.dataset.values);
+      const isLiability = el.dataset.liability === 'true';
+      if (!values || values.length === 0) return;
+
+      const w = 120, h = 32, padding = 1;
+      const max = Math.max.apply(null, values);
+      const hasData = max > 0;
+      if (!hasData) return;
+
+      // Normalize values to fit in the chart area.
+      const points = values.map(function(v, i) {
+        var x = padding + (i / (values.length - 1)) * (w - padding * 2);
+        var y = h - padding - ((v / max) * (h - padding * 2));
+        return x + ',' + y;
+      });
+
+      // Build SVG polyline path.
+      var pathD = 'M' + points.join(' L');
+
+      // Build fill area (closed path from line down to bottom).
+      var fillD = pathD + ' L' + (w - padding) + ',' + h + ' L' + padding + ',' + h + ' Z';
+
+      // Colors: liability accounts get a warm tone, regular accounts get a cool neutral.
+      var strokeColor, fillColor;
+      if (isLiability) {
+        strokeColor = isDark ? 'oklch(0.65 0.15 25)' : 'oklch(0.55 0.15 25)';
+        fillColor = isDark ? 'oklch(0.65 0.15 25 / 0.12)' : 'oklch(0.55 0.15 25 / 0.08)';
+      } else {
+        strokeColor = isDark ? 'oklch(0.65 0.02 250)' : 'oklch(0.45 0.02 250)';
+        fillColor = isDark ? 'oklch(0.65 0.02 250 / 0.12)' : 'oklch(0.45 0.02 250 / 0.08)';
+      }
+
+      var svg = '<svg viewBox="0 0 ' + w + ' ' + h + '" preserveAspectRatio="none" class="w-full h-8">' +
+        '<path d="' + fillD + '" fill="' + fillColor + '" />' +
+        '<polyline points="' + points.join(' ') + '" fill="none" stroke="' + strokeColor + '" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />' +
+        '</svg>';
+
+      el.innerHTML = svg;
+    } catch(e) {
+      // Silently ignore malformed data.
+    }
+  });
+});
+</script>
 
 <!-- Chart.js Initialization -->
 {{if or .DailyLabels .CategoryLabels}}


### PR DESCRIPTION
## Summary
- Each dashboard account card now displays a **30-day spending sparkline** — a tiny inline SVG chart showing daily spending patterns per account
- Adds per-account **spending total** (e.g. "$2,161.14 spent") below the balance, replacing the generic type label when spending data exists
- Go handler queries the transaction summary API per-account to build sparkline data arrays; SVG rendering is pure client-side JavaScript with dark/light mode support
- Liability accounts (credit cards) use a warm tone; depository accounts use a cool neutral — both with subtle area fills

## Screenshots
### Dashboard with sparklines
![Dashboard](https://i.img402.dev/rubcy6htp0.png)

### Accounts section close-up
![Accounts close-up](https://i.img402.dev/3ehdii9bxj.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent