### PR TITLE
Add net worth trend chart to dashboard hero

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -446,6 +446,51 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			return dashAccounts[i].Name < dashAccounts[j].Name
 		})
 
+		// Net worth trend: compute daily net worth by working backwards from current balance.
+		// Query all daily transaction totals (net: spending positive, income negative) for chart period.
+		netWorthTrendStart := time.Now().AddDate(0, 0, -chartDays)
+		dailyNetSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:   "day",
+			StartDate: &netWorthTrendStart,
+		})
+		if err != nil {
+			a.Logger.Error("daily net summary for net worth trend", "error", err)
+		}
+		// Build map of date -> net amount (positive = money out, negative = money in).
+		dailyNetMap := make(map[string]float64)
+		if dailyNetSummary != nil {
+			for _, row := range dailyNetSummary.Summary {
+				if row.Period != nil {
+					dailyNetMap[*row.Period] = row.TotalAmount
+				}
+			}
+		}
+		// Build net worth series: start from today's net worth, walk backwards.
+		now := time.Now()
+		nwDays := chartDays
+		if nwDays > 90 {
+			nwDays = 90 // Cap at 90 days for readability
+		}
+		nwLabels := make([]string, nwDays+1)
+		nwValues := make([]float64, nwDays+1)
+		nwValues[nwDays] = netWorth
+		nwLabels[nwDays] = now.Format("2006-01-02")
+		for i := nwDays - 1; i >= 0; i-- {
+			day := now.AddDate(0, 0, -(nwDays - i))
+			dayStr := day.Format("2006-01-02")
+			nwLabels[i] = dayStr
+			// Net worth on day[i] = net worth on day[i+1] - net_transactions on day[i+1].
+			nextDayStr := now.AddDate(0, 0, -(nwDays - i - 1)).Format("2006-01-02")
+			nwValues[i] = nwValues[i+1] - dailyNetMap[nextDayStr]
+		}
+		var netWorthLabelsJSON, netWorthValuesJSON template.JS
+		if lb, err := json.Marshal(nwLabels); err == nil {
+			netWorthLabelsJSON = template.JS(lb)
+		}
+		if vb, err := json.Marshal(nwValues); err == nil {
+			netWorthValuesJSON = template.JS(vb)
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Dashboard",
 			"CurrentPage":            "dashboard",
@@ -484,6 +529,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"PrevTotalSpending":      prevTotalSpending,
 			"SpendingChangePercent":  spendingChangePercent,
 			"HasSpendingChange":      hasSpendingChange,
+			"NetWorthLabels":         netWorthLabelsJSON,
+			"NetWorthValues":         netWorthValuesJSON,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -92,80 +92,78 @@
 </div>
 {{end}}
 
-<!-- Financial Summary Hero -->
-<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-8 bb-stagger">
-  <!-- Net Worth Card -->
-  <div class="bb-card p-6">
-    <div class="flex items-center gap-2 mb-1">
-      <span class="text-xs font-medium text-base-content/50">Net Worth</span>
-    </div>
-    <div class="text-3xl font-semibold tabular-nums tracking-tight">
-      {{formatBalance .NetWorth}}
-    </div>
-    <div class="flex items-center gap-4 mt-3 text-xs text-base-content/50">
-      <span class="flex items-center gap-1">
-        <span class="w-1.5 h-1.5 rounded-full bg-base-content/30"></span>
-        Assets {{formatBalance .TotalAssets}}
-      </span>
-      <span class="flex items-center gap-1">
-        <span class="w-1.5 h-1.5 rounded-full bg-error/50"></span>
-        Liabilities {{formatBalance .TotalLiabilities}}
-      </span>
+<!-- Net Worth Hero with Trend Chart -->
+<div class="bb-card mb-6 bb-stagger">
+  <div class="p-6 pb-0">
+    <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+      <!-- Left: Net Worth -->
+      <div>
+        <div class="text-xs font-medium text-base-content/50 mb-1">Net Worth</div>
+        <div class="text-4xl font-semibold tabular-nums tracking-tight leading-none">
+          {{formatBalance .NetWorth}}
+        </div>
+        <div class="flex items-center gap-4 mt-3 text-xs text-base-content/50">
+          <span class="flex items-center gap-1.5">
+            <span class="w-1.5 h-1.5 rounded-full bg-base-content/30"></span>
+            Assets {{formatBalance .TotalAssets}}
+          </span>
+          <span class="flex items-center gap-1.5">
+            <span class="w-1.5 h-1.5 rounded-full bg-error/50"></span>
+            Liabilities {{formatBalance .TotalLiabilities}}
+          </span>
+        </div>
+      </div>
+      <!-- Right: Spending + Income summary pills -->
+      <div class="flex items-center gap-3 sm:gap-4">
+        <div class="flex flex-col items-end">
+          <div class="text-xs text-base-content/40 mb-0.5">Spending <span class="text-base-content/25">30d</span></div>
+          <div class="flex items-baseline gap-1.5">
+            <span class="text-lg font-semibold tabular-nums">{{formatBalance .TotalSpending}}</span>
+            {{if .HasSpendingChange}}
+            <span class="text-[0.65rem] font-medium {{if gt .SpendingChangePercent 0.0}}text-error/70{{else}}text-success/70{{end}}">
+              {{if gt .SpendingChangePercent 0.0}}+{{end}}{{printf "%.0f" .SpendingChangePercent}}%
+            </span>
+            {{end}}
+          </div>
+        </div>
+        <div class="w-px h-8 bg-base-300"></div>
+        <div class="flex flex-col items-end">
+          <div class="text-xs text-base-content/40 mb-0.5">Income <span class="text-base-content/25">30d</span></div>
+          <span class="text-lg font-semibold tabular-nums text-success">{{formatBalance .TotalIncome}}</span>
+        </div>
+      </div>
     </div>
   </div>
-
-  <!-- Spending Card -->
-  <div class="bb-card p-6">
-    <div class="flex items-center gap-2 mb-1">
-      <span class="text-xs font-medium text-base-content/50">Spending</span>
-      <span class="text-xs text-base-content/30">30d</span>
-    </div>
-    <div class="flex items-baseline gap-3">
-      <div class="text-3xl font-semibold tabular-nums tracking-tight">
-        {{formatBalance .TotalSpending}}
-      </div>
-      {{if .HasSpendingChange}}
-      <div class="flex items-center gap-1 text-xs font-medium {{if gt .SpendingChangePercent 0.0}}text-error/70{{else}}text-success/70{{end}}">
-        <i data-lucide="{{if gt .SpendingChangePercent 0.0}}trending-up{{else}}trending-down{{end}}" class="w-3 h-3"></i>
-        {{if gt .SpendingChangePercent 0.0}}+{{end}}{{printf "%.0f" .SpendingChangePercent}}%
-      </div>
-      {{end}}
-    </div>
-    <div class="flex items-center gap-4 mt-3 text-xs text-base-content/50">
-      <a href="/transactions" class="flex items-center gap-1 hover:text-base-content transition-colors">
-        <i data-lucide="receipt" class="w-3 h-3"></i>
-        {{.TxCount}} transactions
-      </a>
-      <span class="flex items-center gap-1">
-        <i data-lucide="clock" class="w-3 h-3"></i>
-        Synced {{.LastSync}}
-      </span>
+  <!-- Net Worth Trend Chart -->
+  {{if .NetWorthLabels}}
+  <div class="px-2 pt-2 pb-2">
+    <div class="h-40">
+      <canvas id="netWorthTrendChart"></canvas>
     </div>
   </div>
-
-  <!-- Income Card -->
-  <div class="bb-card p-6">
-    <div class="flex items-center gap-2 mb-1">
-      <span class="text-xs font-medium text-base-content/50">Income</span>
-      <span class="text-xs text-base-content/30">30d</span>
-    </div>
-    <div class="text-3xl font-semibold tabular-nums tracking-tight text-success">
-      {{formatBalance .TotalIncome}}
-    </div>
-    <div class="flex items-center gap-4 mt-3 text-xs text-base-content/50">
-      {{if gt .ReviewPending 0}}
-      <a href="/reviews" class="flex items-center gap-1 hover:text-base-content transition-colors">
-        <i data-lucide="clipboard-check" class="w-3 h-3"></i>
-        {{.ReviewPending}} pending reviews
-      </a>
-      {{end}}
-      {{if gt .NeedsAttention 0}}
-      <a href="/connections" class="flex items-center gap-1 text-warning hover:text-warning/80 transition-colors">
-        <i data-lucide="alert-triangle" class="w-3 h-3"></i>
-        {{.NeedsAttention}} need attention
-      </a>
-      {{end}}
-    </div>
+  {{end}}
+  <!-- Footer row with quick stats -->
+  <div class="px-6 py-3 border-t border-base-200 flex items-center gap-6 text-xs text-base-content/50">
+    <a href="/transactions" class="flex items-center gap-1.5 hover:text-base-content transition-colors">
+      <i data-lucide="receipt" class="w-3 h-3"></i>
+      {{.TxCount}} transactions
+    </a>
+    <span class="flex items-center gap-1.5">
+      <i data-lucide="clock" class="w-3 h-3"></i>
+      Synced {{.LastSync}}
+    </span>
+    {{if gt .ReviewPending 0}}
+    <a href="/reviews" class="flex items-center gap-1.5 hover:text-base-content transition-colors">
+      <i data-lucide="clipboard-check" class="w-3 h-3"></i>
+      {{.ReviewPending}} pending reviews
+    </a>
+    {{end}}
+    {{if gt .NeedsAttention 0}}
+    <a href="/connections" class="flex items-center gap-1.5 text-warning hover:text-warning/80 transition-colors">
+      <i data-lucide="alert-triangle" class="w-3 h-3"></i>
+      {{.NeedsAttention}} need attention
+    </a>
+    {{end}}
   </div>
 </div>
 
@@ -417,6 +415,133 @@
     </div>
   </div>
 </div>
+
+<!-- Net Worth Trend Chart -->
+{{if .NetWorthLabels}}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var nwCtx = document.getElementById('netWorthTrendChart');
+  if (!nwCtx) return;
+
+  var labels = {{.NetWorthLabels}};
+  var values = {{.NetWorthValues}};
+  var chartDays = {{.ChartDays}};
+
+  Chart.defaults.font.family = 'Inter, system-ui, -apple-system, sans-serif';
+
+  // Determine color: green if trend is up, red if down, neutral if flat.
+  var first = values[0], last = values[values.length - 1];
+  var trendUp = last >= first;
+  var lineColor, gradTop, gradBot;
+  if (trendUp) {
+    lineColor = isDark ? 'oklch(0.70 0.14 155)' : 'oklch(0.55 0.14 155)';
+    gradTop = isDark ? 'oklch(0.70 0.14 155 / 0.15)' : 'oklch(0.55 0.14 155 / 0.12)';
+    gradBot = isDark ? 'oklch(0.70 0.14 155 / 0.01)' : 'oklch(0.55 0.14 155 / 0.01)';
+  } else {
+    lineColor = isDark ? 'oklch(0.70 0.15 25)' : 'oklch(0.55 0.15 25)';
+    gradTop = isDark ? 'oklch(0.70 0.15 25 / 0.15)' : 'oklch(0.55 0.15 25 / 0.12)';
+    gradBot = isDark ? 'oklch(0.70 0.15 25 / 0.01)' : 'oklch(0.55 0.15 25 / 0.01)';
+  }
+
+  var shortLabels = labels.map(function(d) {
+    var date = new Date(d + 'T00:00:00');
+    if (chartDays <= 7) return date.toLocaleDateString('en-US', { weekday: 'short' });
+    if (chartDays <= 30) return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  });
+
+  /* shadcn tooltip */
+  var tooltipStyle = {
+    backgroundColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
+    titleColor: isDark ? 'hsl(0 0% 93%)' : 'hsl(0 0% 9%)',
+    bodyColor: isDark ? 'hsl(0 0% 64%)' : 'hsl(0 0% 45%)',
+    borderColor: isDark ? 'hsl(0 0% 18%)' : 'hsl(0 0% 90%)',
+    borderWidth: 1,
+    padding: { top: 8, bottom: 8, left: 12, right: 12 },
+    cornerRadius: 8,
+    titleFont: { size: 11, weight: '600' },
+    bodyFont: { size: 13, weight: '600' },
+    displayColors: false,
+    titleMarginBottom: 4,
+  };
+
+  new Chart(nwCtx, {
+    type: 'line',
+    data: {
+      labels: shortLabels,
+      datasets: [{
+        data: values,
+        borderColor: lineColor,
+        borderWidth: 2,
+        pointRadius: 0,
+        pointHoverRadius: 4,
+        pointHoverBackgroundColor: lineColor,
+        pointHoverBorderColor: isDark ? 'hsl(0 0% 15%)' : 'hsl(0 0% 100%)',
+        pointHoverBorderWidth: 2,
+        tension: 0.35,
+        fill: true,
+        backgroundColor: function(context) {
+          var chart = context.chart;
+          var ctx2 = chart.ctx;
+          var area = chart.chartArea;
+          if (!area) return gradTop;
+          var gradient = ctx2.createLinearGradient(0, area.top, 0, area.bottom);
+          gradient.addColorStop(0, gradTop);
+          gradient.addColorStop(1, gradBot);
+          return gradient;
+        },
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: { display: false },
+        tooltip: Object.assign({}, tooltipStyle, {
+          callbacks: {
+            title: function(items) {
+              var idx = items[0].dataIndex;
+              var d = labels[idx];
+              var tdate = new Date(d + 'T00:00:00');
+              return tdate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+            },
+            label: function(ctx) {
+              return '$' + ctx.parsed.y.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+            }
+          }
+        })
+      },
+      scales: {
+        x: {
+          grid: { display: false },
+          border: { display: false },
+          ticks: {
+            color: isDark ? 'rgba(255,255,255,0.25)' : 'rgba(0,0,0,0.25)',
+            font: { size: 10, weight: '500' },
+            maxTicksLimit: chartDays <= 7 ? 7 : chartDays <= 30 ? 6 : 8,
+            maxRotation: 0,
+          }
+        },
+        y: {
+          grid: { display: false },
+          border: { display: false },
+          ticks: { display: false },
+        }
+      },
+      layout: {
+        padding: { left: 8, right: 8, top: 4, bottom: 0 }
+      },
+      animation: {
+        duration: 600,
+        easing: 'easeOutQuart',
+      }
+    }
+  });
+});
+</script>
+{{end}}
 
 <!-- Sparkline Rendering -->
 <script>


### PR DESCRIPTION
## Summary
- Transform the static Net Worth card into a Mercury-style hero section with a Chart.js area chart showing net worth over time
- Compute daily historical balance by walking backwards from current net worth using aggregated transaction deltas
- Consolidate spending/income stats into a compact header row, with the trend chart as the visual centerpiece
- Chart adapts to the existing date range selector (7d/30d/90d/12m), capped at 90 daily data points for readability
- Trend color is dynamic: green gradient when net worth is rising, red when falling

## Screenshots

### 30-day view (default)
![Dashboard 30d](https://i.img402.dev/nxyg4rkkem.png)

### 90-day view
![Dashboard 90d](https://i.img402.dev/ji9qo9lfci.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent