### PR TITLE
Transform Family Members into rich financial profiles

### DIFF
--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/mail"
 	"strings"
@@ -13,6 +14,30 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// UserAccountSummary holds a single account's display info for the users page.
+type UserAccountSummary struct {
+	ID              string
+	Name            string
+	Type            string
+	Subtype         string
+	Mask            string
+	InstitutionName string
+	BalanceCurrent  float64
+	IsoCurrencyCode string
+	IsLiability     bool
+}
+
+// EnrichedUser holds a user plus their computed financial summary.
+type EnrichedUser struct {
+	db.User
+	Accounts         []UserAccountSummary
+	ConnectionCount  int64
+	AccountCount     int
+	TotalAssets      float64
+	TotalLiabilities float64
+	NetWorth         float64
+}
 
 // UsersListHandler serves GET /admin/users.
 func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
@@ -35,13 +60,77 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			}
 		}
 
+		// Enrich each user with account data and financial summary.
+		enrichedUsers := make([]EnrichedUser, 0, len(users))
+		for _, u := range users {
+			eu := EnrichedUser{
+				User:            u,
+				ConnectionCount: connectionCounts[formatUUID(u.ID)],
+			}
+
+			accounts, err := a.Queries.ListAccountsByUser(ctx, u.ID)
+			if err != nil {
+				a.Logger.Error("list accounts for user", "error", err, "user_id", formatUUID(u.ID))
+			} else {
+				eu.AccountCount = len(accounts)
+				for _, acct := range accounts {
+					bal, err := numericToFloat(acct.BalanceCurrent)
+					if err != nil {
+						continue
+					}
+					subtype := ""
+					if acct.Subtype.Valid {
+						subtype = acct.Subtype.String
+					}
+					mask := ""
+					if acct.Mask.Valid {
+						mask = acct.Mask.String
+					}
+					institution := ""
+					if acct.InstitutionName.Valid {
+						institution = acct.InstitutionName.String
+					}
+					currency := "USD"
+					if acct.IsoCurrencyCode.Valid {
+						currency = acct.IsoCurrencyCode.String
+					}
+					displayName := acct.Name
+					if acct.DisplayName.Valid {
+						displayName = acct.DisplayName.String
+					}
+
+					isLiability := acct.Type == "credit" || acct.Type == "loan"
+					if isLiability {
+						eu.TotalLiabilities += math.Abs(bal)
+						eu.NetWorth -= math.Abs(bal)
+					} else {
+						eu.TotalAssets += bal
+						eu.NetWorth += bal
+					}
+
+					eu.Accounts = append(eu.Accounts, UserAccountSummary{
+						ID:              formatUUID(acct.ID),
+						Name:            displayName,
+						Type:            acct.Type,
+						Subtype:         subtype,
+						Mask:            mask,
+						InstitutionName: institution,
+						BalanceCurrent:  bal,
+						IsoCurrencyCode: currency,
+						IsLiability:     isLiability,
+					})
+				}
+			}
+
+			enrichedUsers = append(enrichedUsers, eu)
+		}
+
 		data := map[string]any{
-			"PageTitle":        "Family Members",
-			"CurrentPage":      "users",
-			"Users":            users,
-			"ConnectionCounts": connectionCounts,
-			"CSRFToken":        GetCSRFToken(r),
-			"Created":          r.URL.Query().Get("created") == "1",
+			"PageTitle":     "Family Members",
+			"CurrentPage":   "users",
+			"EnrichedUsers": enrichedUsers,
+			"CSRFToken":     GetCSRFToken(r),
+			"Created":       r.URL.Query().Get("created") == "1",
 		}
 		tr.Render(w, r, "users.html", data)
 	}

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -26,6 +26,7 @@ type UserAccountSummary struct {
 	BalanceCurrent  float64
 	IsoCurrencyCode string
 	IsLiability     bool
+	HasBalance      bool
 }
 
 // EnrichedUser holds a user plus their computed financial summary.
@@ -75,12 +76,11 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 				eu.AccountCount = len(accounts)
 				for _, acct := range accounts {
 					bal, err := numericToFloat(acct.BalanceCurrent)
-					if err != nil {
-						continue
-					}
+					hasBal := err == nil
 					subtype := ""
 					if acct.Subtype.Valid {
-						subtype = acct.Subtype.String
+						// Clean up subtype for display (e.g. "credit_card" -> "Credit Card")
+						subtype = strings.ReplaceAll(acct.Subtype.String, "_", " ")
 					}
 					mask := ""
 					if acct.Mask.Valid {
@@ -100,12 +100,17 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 					}
 
 					isLiability := acct.Type == "credit" || acct.Type == "loan"
-					if isLiability {
-						eu.TotalLiabilities += math.Abs(bal)
-						eu.NetWorth -= math.Abs(bal)
-					} else {
-						eu.TotalAssets += bal
-						eu.NetWorth += bal
+					displayBal := bal
+					if hasBal {
+						if isLiability {
+							eu.TotalLiabilities += math.Abs(bal)
+							eu.NetWorth -= math.Abs(bal)
+							// Show liabilities as negative in the UI
+							displayBal = -math.Abs(bal)
+						} else {
+							eu.TotalAssets += bal
+							eu.NetWorth += bal
+						}
 					}
 
 					eu.Accounts = append(eu.Accounts, UserAccountSummary{
@@ -115,9 +120,10 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 						Subtype:         subtype,
 						Mask:            mask,
 						InstitutionName: institution,
-						BalanceCurrent:  bal,
+						BalanceCurrent:  displayBal,
 						IsoCurrencyCode: currency,
 						IsLiability:     isLiability,
+						HasBalance:      hasBal,
 					})
 				}
 			}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -92,6 +92,19 @@
 </div>
 {{end}}
 
+<!-- Dashboard Page Header with Global Date Range Picker -->
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Dashboard</h1>
+  </div>
+  <div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5">
+    <a href="/?days=7" class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 7}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">7d</a>
+    <a href="/?days=30" class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 30}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">30d</a>
+    <a href="/?days=90" class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 90}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">90d</a>
+    <a href="/?days=365" class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 365}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">12m</a>
+  </div>
+</div>
+
 <!-- Net Worth Hero with Trend Chart -->
 <div class="bb-card mb-6 bb-stagger">
   <div class="p-6 pb-0">
@@ -116,7 +129,7 @@
       <!-- Right: Spending + Income summary pills -->
       <div class="flex items-center gap-3 sm:gap-4">
         <div class="flex flex-col items-end">
-          <div class="text-xs text-base-content/40 mb-0.5">Spending <span class="text-base-content/25">30d</span></div>
+          <div class="text-xs text-base-content/40 mb-0.5">Spending <span class="text-base-content/25">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}}</span></div>
           <div class="flex items-baseline gap-1.5">
             <span class="text-lg font-semibold tabular-nums">{{formatBalance .TotalSpending}}</span>
             {{if .HasSpendingChange}}
@@ -128,7 +141,7 @@
         </div>
         <div class="w-px h-8 bg-base-300"></div>
         <div class="flex flex-col items-end">
-          <div class="text-xs text-base-content/40 mb-0.5">Income <span class="text-base-content/25">30d</span></div>
+          <div class="text-xs text-base-content/40 mb-0.5">Income <span class="text-base-content/25">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}}</span></div>
           <span class="text-lg font-semibold tabular-nums text-success">{{formatBalance .TotalIncome}}</span>
         </div>
       </div>
@@ -223,12 +236,6 @@
           {{if gt .SpendingChangePercent 0.0}}+{{end}}{{printf "%.0f" .SpendingChangePercent}}% vs prev
         </span>
         {{end}}
-      </div>
-      <div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5">
-        <a href="/?days=7" class="px-2.5 py-1 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 7}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">7d</a>
-        <a href="/?days=30" class="px-2.5 py-1 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 30}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">30d</a>
-        <a href="/?days=90" class="px-2.5 py-1 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 90}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">90d</a>
-        <a href="/?days=365" class="px-2.5 py-1 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 365}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">12m</a>
       </div>
     </div>
     {{if .DailyLabels}}

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -17,42 +17,123 @@
 </div>
 {{end}}
 
-{{if .Users}}
-<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 bb-stagger">
-  {{range .Users}}
-  <a href="/users/{{formatUUID .ID}}/edit" class="bb-card bb-card--interactive p-6 group no-underline">
-    <div class="flex items-start justify-between mb-4">
-      <div class="flex items-center gap-3">
-        <div class="w-11 h-11 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold text-base">
-          {{slice .Name 0 1}}
+{{if .EnrichedUsers}}
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-5 bb-stagger">
+  {{range .EnrichedUsers}}
+  <div class="bb-card overflow-hidden">
+    <!-- Member Header -->
+    <div class="p-6 pb-4">
+      <div class="flex items-start justify-between">
+        <div class="flex items-center gap-4">
+          <div class="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold text-lg shrink-0">
+            {{slice .Name 0 1}}
+          </div>
+          <div>
+            <div class="flex items-center gap-2">
+              <h3 class="font-semibold text-base">{{.Name}}</h3>
+              <a href="/users/{{formatUUID .ID}}/edit" class="btn btn-ghost btn-xs rounded-lg opacity-40 hover:opacity-100 transition-opacity" title="Edit member">
+                <i data-lucide="pencil" class="w-3 h-3"></i>
+              </a>
+            </div>
+            {{if .Email.Valid}}
+            <p class="text-xs text-base-content/45 mt-0.5">{{.Email.String}}</p>
+            {{else}}
+            <p class="text-xs text-base-content/30 italic mt-0.5">No email</p>
+            {{end}}
+          </div>
+        </div>
+      </div>
+
+      <!-- Financial Summary -->
+      {{if gt .AccountCount 0}}
+      <div class="grid grid-cols-3 gap-4 mt-5 pt-4 border-t border-base-300">
+        <div>
+          <p class="text-xs text-base-content/40 mb-1">Net Worth</p>
+          <p class="text-lg font-semibold tabular-nums{{if lt .NetWorth 0.0}} text-error{{end}}">
+            {{formatAmount .NetWorth}}
+          </p>
         </div>
         <div>
-          <h3 class="font-semibold text-base group-hover:text-primary transition-colors">{{.Name}}</h3>
-          {{if .Email.Valid}}
-          <p class="text-xs text-base-content/45">{{.Email.String}}</p>
-          {{else}}
-          <p class="text-xs text-base-content/30 italic">No email</p>
-          {{end}}
+          <p class="text-xs text-base-content/40 mb-1">Assets</p>
+          <p class="text-sm font-medium tabular-nums text-base-content/70">{{formatAmount .TotalAssets}}</p>
         </div>
-      </div>
-      <span class="btn btn-ghost btn-xs opacity-0 group-hover:opacity-100 transition-opacity">
-        <i data-lucide="pencil" class="w-3.5 h-3.5"></i>
-      </span>
-    </div>
-
-    <div class="flex items-center gap-4 pt-3 border-t border-base-300">
-      <div class="flex items-center gap-1.5 text-xs text-base-content/50">
-        <i data-lucide="link" class="w-3.5 h-3.5"></i>
-        <span class="font-medium text-base-content/70">{{index $.ConnectionCounts (formatUUID .ID)}}</span> connections
-      </div>
-      {{if .CreatedAt.Valid}}
-      <div class="flex items-center gap-1.5 text-xs text-base-content/40">
-        <i data-lucide="calendar" class="w-3.5 h-3.5"></i>
-        {{.CreatedAt.Time.Format "Jan 2, 2006"}}
+        <div>
+          <p class="text-xs text-base-content/40 mb-1">Liabilities</p>
+          <p class="text-sm font-medium tabular-nums text-error/70">{{formatAmount .TotalLiabilities}}</p>
+        </div>
       </div>
       {{end}}
     </div>
-  </a>
+
+    <!-- Accounts List -->
+    {{if .Accounts}}
+    <div class="border-t border-base-300">
+      <div class="px-6 py-2.5 flex items-center justify-between bg-base-200/30">
+        <span class="text-xs font-medium text-base-content/40">{{.AccountCount}} account{{if gt .AccountCount 1}}s{{end}} across {{.ConnectionCount}} connection{{if gt .ConnectionCount 1}}s{{end}}</span>
+      </div>
+      <div class="divide-y divide-base-300/50">
+        {{range .Accounts}}
+        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-6 py-3 hover:bg-base-200/40 transition-colors no-underline group">
+          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+            {{if eq .Type "depository"}}
+            <i data-lucide="landmark" class="w-3.5 h-3.5 text-base-content/40"></i>
+            {{else if eq .Type "credit"}}
+            <i data-lucide="credit-card" class="w-3.5 h-3.5 text-base-content/40"></i>
+            {{else if eq .Type "loan"}}
+            <i data-lucide="banknote" class="w-3.5 h-3.5 text-base-content/40"></i>
+            {{else if eq .Type "investment"}}
+            <i data-lucide="trending-up" class="w-3.5 h-3.5 text-base-content/40"></i>
+            {{else}}
+            <i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content/40"></i>
+            {{end}}
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-medium group-hover:text-primary transition-colors truncate">{{.Name}}</div>
+            <div class="text-xs text-base-content/40 flex items-center gap-1.5">
+              <span>{{.InstitutionName}}</span>
+              {{if .Mask}}
+              <span class="text-base-content/20">&middot;</span>
+              <span>{{.Mask}}</span>
+              {{end}}
+              {{if .Subtype}}
+              <span class="text-base-content/20">&middot;</span>
+              <span class="capitalize">{{.Subtype}}</span>
+              {{end}}
+            </div>
+          </div>
+          <div class="text-right shrink-0">
+            {{if .HasBalance}}
+            <span class="text-sm font-semibold tabular-nums{{if .IsLiability}} text-error{{end}}">
+              {{formatAmount .BalanceCurrent}}
+            </span>
+            <div class="text-[0.65rem] text-base-content/30 mt-0.5">{{.IsoCurrencyCode}}</div>
+            {{else}}
+            <span class="text-xs text-base-content/30">&mdash;</span>
+            {{end}}
+          </div>
+        </a>
+        {{end}}
+      </div>
+    </div>
+    {{else}}
+    <!-- No accounts state -->
+    <div class="border-t border-base-300 px-6 py-5 bg-base-200/20">
+      <div class="flex items-center gap-3 text-sm text-base-content/40">
+        <i data-lucide="link" class="w-4 h-4 shrink-0"></i>
+        <span>No bank accounts connected</span>
+        <a href="/connections/new" class="btn btn-ghost btn-xs rounded-lg ml-auto">Connect</a>
+      </div>
+    </div>
+    {{end}}
+
+    <!-- Footer -->
+    <div class="px-6 py-2.5 border-t border-base-300 flex items-center justify-between text-xs text-base-content/30 bg-base-200/20">
+      {{if .CreatedAt.Valid}}
+      <span>Member since {{.CreatedAt.Time.Format "Jan 2006"}}</span>
+      {{end}}
+      <a href="/users/{{formatUUID .ID}}/edit" class="text-base-content/40 hover:text-primary transition-colors no-underline">Edit profile</a>
+    </div>
+  </div>
   {{end}}
 </div>
 {{else}}


### PR DESCRIPTION
## Summary
- Enriched the Family Members page handler to fetch per-user accounts, compute net worth (assets vs liabilities), and pass rich data to the template
- Redesigned member cards from simple name/email display into full financial profile cards showing net worth breakdown, account list with type-specific icons, balances, and institution details
- Accounts with no balance (e.g., CSV imports) show gracefully with a dash; credit card balances display as negative

## Screenshots
![Family Members - Rich Profiles](https://i.img402.dev/rvns541rk8.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent