### PR TITLE
Fix income date range bug and add cash flow card

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -315,11 +315,12 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			spendingChangePercent = ((totalSpending - prevTotalSpending) / prevTotalSpending) * 100
 		}
 
-		// Total income (30 days) — negative amounts in our system are credits/income.
+		// Total income for the selected date range — negative amounts in our system are credits/income.
 		// Use a separate summary query without SpendingOnly to get income totals.
 		var totalIncome float64
 		incomeSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
-			GroupBy: "day",
+			GroupBy:   "day",
+			StartDate: &chartStart,
 		})
 		if err != nil {
 			a.Logger.Error("income summary", "error", err)
@@ -329,6 +330,27 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				if row.TotalAmount < 0 {
 					totalIncome += -row.TotalAmount
 				}
+			}
+		}
+
+		// Cash flow: net = income - spending, savings rate = net/income * 100.
+		var cashFlowNet float64
+		var savingsRate float64
+		var hasCashFlow bool
+		if totalIncome > 0 || totalSpending > 0 {
+			hasCashFlow = true
+			cashFlowNet = totalIncome - totalSpending
+			if totalIncome > 0 {
+				savingsRate = (cashFlowNet / totalIncome) * 100
+			}
+		}
+
+		// Spending vs income ratio for the visual bar (spending as % of income).
+		var spendingRatio float64
+		if totalIncome > 0 {
+			spendingRatio = (totalSpending / totalIncome) * 100
+			if spendingRatio > 100 {
+				spendingRatio = 100
 			}
 		}
 
@@ -531,6 +553,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"HasSpendingChange":      hasSpendingChange,
 			"NetWorthLabels":         netWorthLabelsJSON,
 			"NetWorthValues":         netWorthValuesJSON,
+			"CashFlowNet":            cashFlowNet,
+			"SavingsRate":            savingsRate,
+			"HasCashFlow":            hasCashFlow,
+			"SpendingRatio":          spendingRatio,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -296,6 +296,83 @@
   </div>
 </div>
 
+<!-- Cash Flow Summary -->
+{{if .HasCashFlow}}
+<div class="bb-card mb-8 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <h2 class="text-sm font-semibold text-base-content/70">Cash Flow</h2>
+    <span class="text-xs text-base-content/40">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}} period</span>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <!-- Income vs Spending Bars -->
+    <div class="md:col-span-2 space-y-3">
+      <!-- Income bar -->
+      <div class="group">
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0" style="background: oklch(0.62 0.14 155)"></span>
+            Income
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-success">{{formatBalance .TotalIncome}}</span>
+        </div>
+        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
+          <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: 100%; background: oklch(0.62 0.14 155); opacity: 0.6;"></div>
+        </div>
+      </div>
+
+      <!-- Spending bar (relative to income) -->
+      <div class="group">
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0 bg-base-content/20"></span>
+            Spending
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatBalance .TotalSpending}}</span>
+        </div>
+        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
+          {{if gt .TotalIncome 0.0}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out {{if gt .SpendingRatio 90.0}}bg-error/50{{else if gt .SpendingRatio 70.0}}bg-warning/50{{else}}bg-base-content/15{{end}}" style="width: {{printf "%.1f" .SpendingRatio}}%;"></div>
+          {{else}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15" style="width: 100%;"></div>
+          {{end}}
+        </div>
+      </div>
+    </div>
+
+    <!-- Net Cash Flow + Savings Rate -->
+    <div class="flex flex-col items-center justify-center text-center border-t md:border-t-0 md:border-l border-base-200/80 pt-4 md:pt-0 md:pl-6">
+      <div class="text-xs font-medium text-base-content/40 mb-1">Net Cash Flow</div>
+      <div class="text-2xl font-semibold tabular-nums {{if gt .CashFlowNet 0.0}}text-success{{else if lt .CashFlowNet 0.0}}text-error{{else}}text-base-content{{end}}">
+        {{if gt .CashFlowNet 0.0}}+{{end}}{{if lt .CashFlowNet 0.0}}-{{end}}{{formatBalance .CashFlowNet}}
+      </div>
+      {{if gt .TotalIncome 0.0}}
+      <div class="mt-2 flex items-center gap-1.5">
+        <div class="w-8 h-8 rounded-full flex items-center justify-center {{if gt .SavingsRate 20.0}}bg-success/10{{else if gt .SavingsRate 0.0}}bg-warning/10{{else}}bg-error/10{{end}}">
+          {{if gt .SavingsRate 20.0}}
+          <i data-lucide="trending-up" class="w-3.5 h-3.5 text-success"></i>
+          {{else if gt .SavingsRate 0.0}}
+          <i data-lucide="minus" class="w-3.5 h-3.5 text-warning"></i>
+          {{else}}
+          <i data-lucide="trending-down" class="w-3.5 h-3.5 text-error"></i>
+          {{end}}
+        </div>
+        <div class="text-left">
+          {{if lt .SavingsRate -200.0}}
+          <div class="text-xs font-semibold text-error/80">Over budget</div>
+          <div class="text-[0.6rem] text-base-content/30">spending > income</div>
+          {{else}}
+          <div class="text-xs font-semibold tabular-nums {{if gt .SavingsRate 0.0}}text-success/80{{else}}text-error/80{{end}}">{{printf "%.0f" .SavingsRate}}%</div>
+          <div class="text-[0.6rem] text-base-content/30">savings rate</div>
+          {{end}}
+        </div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+</div>
+{{end}}
+
 <!-- Recent Transactions + Sync Activity -->
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
   <!-- Recent Transactions -->


### PR DESCRIPTION
## Summary
- **Bug fix**: Dashboard income summary was querying all-time data instead of respecting the date range picker (7d/30d/90d/12m). Now correctly scoped to the selected period via `StartDate` parameter.
- **New feature**: Added a "Cash Flow" summary card between the charts row and recent transactions, showing income vs spending as comparative horizontal bars, net cash flow amount, and a savings rate indicator with visual feedback (trending up/down icons, "over budget" state).
- **Edge cases**: Handles zero income, spending >> income (shows "Over budget" instead of extreme negative percentages), and responsive layout (border switches from left to top on mobile).

## Screenshots

### Cash Flow card (30d view)
![Cash Flow Card](https://i.img402.dev/n52zak587b.png)

### Dashboard hero with corrected income
![Dashboard Top](https://i.img402.dev/7o5bvw6wxr.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent