### PR TITLE
Replace Sync Activity with Connection Health + Insights

### DIFF
--- a/input.css
+++ b/input.css
@@ -610,6 +610,59 @@
     @apply bg-base-200/40;
   }
 
+  /* ── Transaction category avatar ── */
+  .bb-tx-avatar {
+    @apply w-9 h-9 rounded-xl flex items-center justify-center shrink-0;
+    --avatar-color: oklch(0.65 0 0);
+    background: color-mix(in oklch, var(--avatar-color) 12%, transparent);
+    color: var(--avatar-color);
+  }
+
+  .bb-tx-avatar i, .bb-tx-avatar svg {
+    color: inherit;
+    opacity: 0.85;
+  }
+
+  .bb-tx-avatar--sm {
+    @apply w-8 h-8 rounded-lg;
+  }
+
+  .bb-tx-avatar--sm i, .bb-tx-avatar--sm svg {
+    @apply w-3.5 h-3.5;
+  }
+
+  .bb-tx-avatar--letter {
+    @apply text-xs font-semibold;
+    --avatar-color: oklch(0.205 0 0);
+    background: oklch(0.205 0 0 / 0.06);
+    color: oklch(0.205 0 0 / 0.45);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-tx-avatar {
+      background: color-mix(in oklch, var(--avatar-color) 18%, transparent);
+    }
+    .bb-tx-avatar--letter {
+      background: oklch(0.985 0 0 / 0.08);
+      color: oklch(0.985 0 0 / 0.45);
+    }
+  }
+
+  /* ── Transaction amount styling ── */
+  .bb-tx-amount {
+    @apply text-sm font-semibold tabular-nums text-base-content;
+  }
+
+  .bb-tx-amount--income {
+    color: oklch(0.62 0.14 155);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-tx-amount--income {
+      color: oklch(0.70 0.14 155);
+    }
+  }
+
   /* ── Mobile transaction cards ── */
   .bb-tx-card {
     @apply overflow-hidden;

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -579,6 +579,100 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			return dashAccounts[i].Name < dashAccounts[j].Name
 		})
 
+		// Group accounts by asset vs liability for the dashboard layout.
+		type AccountGroup struct {
+			Label    string // "Cash & Savings", "Investments", "Credit Cards", "Loans"
+			Icon     string // Lucide icon name
+			Type     string // "asset" or "liability"
+			Total    float64
+			Accounts []DashboardAccount
+		}
+		accountGroupOrder := []string{"depository", "investment", "credit", "loan"}
+		accountGroupMeta := map[string]struct {
+			Label string
+			Icon  string
+			Type  string
+		}{
+			"depository": {Label: "Cash & Savings", Icon: "landmark", Type: "asset"},
+			"investment": {Label: "Investments", Icon: "trending-up", Type: "asset"},
+			"credit":     {Label: "Credit Cards", Icon: "credit-card", Type: "liability"},
+			"loan":       {Label: "Loans", Icon: "banknote", Type: "liability"},
+		}
+		groupMap := make(map[string]*AccountGroup)
+		for _, acct := range dashAccounts {
+			key := acct.Type
+			if _, ok := accountGroupMeta[key]; !ok {
+				key = "depository" // fallback for unknown types
+			}
+			if g, ok := groupMap[key]; ok {
+				g.Accounts = append(g.Accounts, acct)
+				if acct.IsLiability {
+					g.Total += math.Abs(acct.BalanceCurrent)
+				} else {
+					g.Total += acct.BalanceCurrent
+				}
+			} else {
+				meta := accountGroupMeta[key]
+				bal := acct.BalanceCurrent
+				if acct.IsLiability {
+					bal = math.Abs(bal)
+				}
+				groupMap[key] = &AccountGroup{
+					Label:    meta.Label,
+					Icon:     meta.Icon,
+					Type:     meta.Type,
+					Total:    bal,
+					Accounts: []DashboardAccount{acct},
+				}
+			}
+		}
+		var assetGroups, liabilityGroups []AccountGroup
+		for _, key := range accountGroupOrder {
+			if g, ok := groupMap[key]; ok {
+				if g.Type == "asset" {
+					assetGroups = append(assetGroups, *g)
+				} else {
+					liabilityGroups = append(liabilityGroups, *g)
+				}
+			}
+		}
+
+		// Allocation bar: proportion of total assets in each asset type.
+		type AllocationSlice struct {
+			Label   string
+			Amount  float64
+			Percent float64
+			Color   string // OKLCH color for the bar segment
+		}
+		allocationColors := map[string]string{
+			"depository": "oklch(0.55 0.14 155)", // green
+			"investment": "oklch(0.55 0.12 250)", // blue
+			"credit":     "oklch(0.58 0.12 35)",  // amber
+			"loan":       "oklch(0.55 0.15 25)",  // red-ish
+		}
+		var allocationSlices []AllocationSlice
+		grossTotal := totalAssets + totalLiabilities
+		if grossTotal > 0 {
+			for _, key := range accountGroupOrder {
+				if g, ok := groupMap[key]; ok {
+					pct := (g.Total / grossTotal) * 100
+					if pct < 0.5 {
+						continue // skip tiny slices
+					}
+					color := allocationColors[key]
+					if color == "" {
+						color = "oklch(0.45 0 0)"
+					}
+					allocationSlices = append(allocationSlices, AllocationSlice{
+						Label:   g.Label,
+						Amount:  g.Total,
+						Percent: pct,
+						Color:   color,
+					})
+				}
+			}
+		}
+
 		// Net worth trend: compute daily net worth by working backwards from current balance.
 		// Query all daily transaction totals (net: spending positive, income negative) for chart period.
 		netWorthTrendStart := time.Now().AddDate(0, 0, -chartDays)
@@ -684,6 +778,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"MonthProgress":          monthProgress,
 			"CurrentMonthName":       today.Format("January"),
 			"LastMonthName":          lastMonthStart.Format("January"),
+			// Grouped accounts.
+			"AssetGroups":            assetGroups,
+			"LiabilityGroups":       liabilityGroups,
+			"AllocationSlices":       allocationSlices,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -354,6 +354,117 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			}
 		}
 
+		// ── Spending Pace: current month vs last month ──────────────────────
+		// Always computed regardless of date picker selection.
+		today := time.Now()
+		monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, today.Location())
+		daysElapsed := today.Day()
+		daysInMonth := time.Date(today.Year(), today.Month()+1, 0, 0, 0, 0, 0, today.Location()).Day()
+		daysRemaining := daysInMonth - daysElapsed
+
+		// Current month spending (1st → today).
+		var currentMonthSpending float64
+		currentMonthSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      "day",
+			StartDate:    &monthStart,
+			SpendingOnly: true,
+		})
+		if err != nil {
+			a.Logger.Error("current month spending", "error", err)
+		}
+		if currentMonthSummary != nil {
+			for _, row := range currentMonthSummary.Summary {
+				currentMonthSpending += row.TotalAmount
+			}
+		}
+
+		// Current month income.
+		var currentMonthIncome float64
+		currentMonthIncomeSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:   "day",
+			StartDate: &monthStart,
+		})
+		if err != nil {
+			a.Logger.Error("current month income", "error", err)
+		}
+		if currentMonthIncomeSummary != nil {
+			for _, row := range currentMonthIncomeSummary.Summary {
+				if row.TotalAmount < 0 {
+					currentMonthIncome += -row.TotalAmount
+				}
+			}
+		}
+
+		// Last month total spending.
+		lastMonthStart := time.Date(today.Year(), today.Month()-1, 1, 0, 0, 0, 0, today.Location())
+		lastMonthEnd := monthStart // first of current month
+		var lastMonthSpending float64
+		lastMonthSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      "day",
+			StartDate:    &lastMonthStart,
+			EndDate:      &lastMonthEnd,
+			SpendingOnly: true,
+		})
+		if err != nil {
+			a.Logger.Error("last month spending", "error", err)
+		}
+		if lastMonthSummary != nil {
+			for _, row := range lastMonthSummary.Summary {
+				lastMonthSpending += row.TotalAmount
+			}
+		}
+
+		// Last month spending at the same point (1st → same day of last month).
+		lastMonthSameDay := time.Date(today.Year(), today.Month()-1, 1, 0, 0, 0, 0, today.Location())
+		lastMonthDaysInMonth := time.Date(lastMonthSameDay.Year(), lastMonthSameDay.Month()+1, 0, 0, 0, 0, 0, today.Location()).Day()
+		sameDayOfLastMonth := daysElapsed
+		if sameDayOfLastMonth > lastMonthDaysInMonth {
+			sameDayOfLastMonth = lastMonthDaysInMonth
+		}
+		lastMonthSameDayEnd := time.Date(lastMonthSameDay.Year(), lastMonthSameDay.Month(), sameDayOfLastMonth+1, 0, 0, 0, 0, today.Location())
+		var lastMonthPaceSpending float64
+		lastMonthPaceSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      "day",
+			StartDate:    &lastMonthSameDay,
+			EndDate:      &lastMonthSameDayEnd,
+			SpendingOnly: true,
+		})
+		if err != nil {
+			a.Logger.Error("last month pace spending", "error", err)
+		}
+		if lastMonthPaceSummary != nil {
+			for _, row := range lastMonthPaceSummary.Summary {
+				lastMonthPaceSpending += row.TotalAmount
+			}
+		}
+
+		// Compute pace metrics.
+		var dailyAvgSpending float64
+		var projectedMonthly float64
+		var pacePercent float64    // How current month compares to last month at same point
+		var hasPaceData bool
+		var paceVsLastMonth string // "ahead", "behind", "same"
+
+		if daysElapsed > 0 && currentMonthSpending > 0 {
+			hasPaceData = true
+			dailyAvgSpending = currentMonthSpending / float64(daysElapsed)
+			projectedMonthly = dailyAvgSpending * float64(daysInMonth)
+
+			if lastMonthPaceSpending > 0 {
+				pacePercent = ((currentMonthSpending - lastMonthPaceSpending) / lastMonthPaceSpending) * 100
+				if pacePercent > 2.0 {
+					paceVsLastMonth = "ahead"
+				} else if pacePercent < -2.0 {
+					paceVsLastMonth = "behind"
+				} else {
+					paceVsLastMonth = "same"
+				}
+			}
+		}
+
+		// Progress through the month (percent).
+		monthProgress := float64(daysElapsed) / float64(daysInMonth) * 100
+
 		// Accounts with balances for the overview section.
 		accounts, err := svc.ListAccounts(ctx, nil)
 		if err != nil {
@@ -557,6 +668,22 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"SavingsRate":            savingsRate,
 			"HasCashFlow":            hasCashFlow,
 			"SpendingRatio":          spendingRatio,
+			// Spending pace data.
+			"HasPaceData":            hasPaceData,
+			"CurrentMonthSpending":   currentMonthSpending,
+			"CurrentMonthIncome":     currentMonthIncome,
+			"LastMonthSpending":      lastMonthSpending,
+			"LastMonthPaceSpending":  lastMonthPaceSpending,
+			"DailyAvgSpending":       dailyAvgSpending,
+			"ProjectedMonthly":       projectedMonthly,
+			"PacePercent":            pacePercent,
+			"PaceVsLastMonth":        paceVsLastMonth,
+			"DaysElapsed":            daysElapsed,
+			"DaysInMonth":            daysInMonth,
+			"DaysRemaining":          daysRemaining,
+			"MonthProgress":          monthProgress,
+			"CurrentMonthName":       today.Format("January"),
+			"LastMonthName":          lastMonthStart.Format("January"),
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -315,11 +315,12 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			spendingChangePercent = ((totalSpending - prevTotalSpending) / prevTotalSpending) * 100
 		}
 
-		// Total income (30 days) — negative amounts in our system are credits/income.
+		// Total income for the selected date range — negative amounts in our system are credits/income.
 		// Use a separate summary query without SpendingOnly to get income totals.
 		var totalIncome float64
 		incomeSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
-			GroupBy: "day",
+			GroupBy:   "day",
+			StartDate: &chartStart,
 		})
 		if err != nil {
 			a.Logger.Error("income summary", "error", err)
@@ -329,6 +330,27 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				if row.TotalAmount < 0 {
 					totalIncome += -row.TotalAmount
 				}
+			}
+		}
+
+		// Cash flow: net = income - spending, savings rate = net/income * 100.
+		var cashFlowNet float64
+		var savingsRate float64
+		var hasCashFlow bool
+		if totalIncome > 0 || totalSpending > 0 {
+			hasCashFlow = true
+			cashFlowNet = totalIncome - totalSpending
+			if totalIncome > 0 {
+				savingsRate = (cashFlowNet / totalIncome) * 100
+			}
+		}
+
+		// Spending vs income ratio for the visual bar (spending as % of income).
+		var spendingRatio float64
+		if totalIncome > 0 {
+			spendingRatio = (totalSpending / totalIncome) * 100
+			if spendingRatio > 100 {
+				spendingRatio = 100
 			}
 		}
 
@@ -531,6 +553,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"HasSpendingChange":      hasSpendingChange,
 			"NetWorthLabels":         netWorthLabelsJSON,
 			"NetWorthValues":         netWorthValuesJSON,
+			"CashFlowNet":            cashFlowNet,
+			"SavingsRate":            savingsRate,
+			"HasCashFlow":            hasCashFlow,
+			"SpendingRatio":          spendingRatio,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -718,6 +718,140 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			netWorthValuesJSON = template.JS(vb)
 		}
 
+		// ── Connection Health: per-connection status for dashboard panel ──
+		type ConnectionHealthRow struct {
+			ID              string
+			Name            string // Institution name
+			Provider        string
+			Status          string // active, error, pending_reauth, disconnected
+			ErrorMessage    string
+			LastSyncedAt    string // relative time string
+			AccountCount    int64
+			Paused          bool
+			IsStale         bool // hasn't synced in 24+ hours
+		}
+		var connectionHealth []ConnectionHealthRow
+		var healthyCount, errorCount, staleCount int
+
+		bankConnections, err := a.Queries.ListBankConnections(ctx)
+		if err != nil {
+			a.Logger.Error("list bank connections for health", "error", err)
+		}
+		for _, conn := range bankConnections {
+			if string(conn.Status) == "disconnected" {
+				continue
+			}
+			name := "Unknown"
+			if conn.InstitutionName.Valid {
+				name = conn.InstitutionName.String
+			}
+			errMsg := ""
+			if conn.ErrorMessage.Valid {
+				errMsg = conn.ErrorMessage.String
+			}
+			lastSync := "Never"
+			isStale := false
+			if conn.LastSyncedAt.Valid {
+				lastSync = relativeTime(conn.LastSyncedAt.Time)
+				if time.Since(conn.LastSyncedAt.Time) > 24*time.Hour {
+					isStale = true
+				}
+			} else {
+				isStale = true
+			}
+
+			status := string(conn.Status)
+			switch status {
+			case "active":
+				if isStale {
+					staleCount++
+				} else {
+					healthyCount++
+				}
+			case "error", "pending_reauth":
+				errorCount++
+			}
+
+			connID := formatUUID(conn.ID)
+
+			connectionHealth = append(connectionHealth, ConnectionHealthRow{
+				ID:           connID,
+				Name:         name,
+				Provider:     string(conn.Provider),
+				Status:       status,
+				ErrorMessage: errMsg,
+				LastSyncedAt: lastSync,
+				AccountCount: conn.AccountCount,
+				Paused:       conn.Paused,
+				IsStale:      isStale,
+			})
+		}
+
+		// ── Insights: useful aggregate data for the insights card ──
+		type InsightItem struct {
+			Icon    string // Lucide icon name
+			Label   string
+			Value   string
+			Link    string // optional href
+			Color   string // optional: "success", "warning", "error"
+		}
+		var insights []InsightItem
+
+		// Pending reviews insight
+		if reviewPending > 0 {
+			insights = append(insights, InsightItem{
+				Icon:  "clipboard-check",
+				Label: "Pending reviews",
+				Value: fmt.Sprintf("%d", reviewPending),
+				Link:  "/reviews",
+				Color: "warning",
+			})
+		}
+
+		// Active rules count
+		var activeRuleCountVal int64
+		err = a.DB.QueryRow(ctx, "SELECT COUNT(*) FROM transaction_rules WHERE enabled = true AND (expires_at IS NULL OR expires_at > NOW())").Scan(&activeRuleCountVal)
+		if err == nil && activeRuleCountVal > 0 {
+			insights = append(insights, InsightItem{
+				Icon:  "list-filter",
+				Label: "Active rules",
+				Value: fmt.Sprintf("%d", activeRuleCountVal),
+				Link:  "/rules",
+			})
+		}
+
+		// Uncategorized transactions count
+		var uncatCount int64
+		err = a.DB.QueryRow(ctx, "SELECT COUNT(*) FROM transactions WHERE deleted_at IS NULL AND category_id IS NULL AND pending = false").Scan(&uncatCount)
+		if err == nil && uncatCount > 0 {
+			insights = append(insights, InsightItem{
+				Icon:  "help-circle",
+				Label: "Uncategorized",
+				Value: fmt.Sprintf("%d", uncatCount),
+				Link:  "/transactions",
+				Color: "warning",
+			})
+		}
+
+		// Top merchant this month (most frequent)
+		var topMerchant string
+		var topMerchantCount int64
+		err = a.DB.QueryRow(ctx, `
+			SELECT COALESCE(merchant_name, name), COUNT(*) as cnt
+			FROM transactions
+			WHERE deleted_at IS NULL AND date >= $1 AND amount > 0
+			GROUP BY COALESCE(merchant_name, name)
+			ORDER BY cnt DESC
+			LIMIT 1
+		`, monthStart).Scan(&topMerchant, &topMerchantCount)
+		if err == nil && topMerchantCount >= 2 {
+			insights = append(insights, InsightItem{
+				Icon:  "store",
+				Label: "Top merchant",
+				Value: fmt.Sprintf("%s (%dx)", topMerchant, topMerchantCount),
+			})
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Dashboard",
 			"CurrentPage":            "dashboard",
@@ -782,6 +916,13 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"AssetGroups":            assetGroups,
 			"LiabilityGroups":       liabilityGroups,
 			"AllocationSlices":       allocationSlices,
+			// Connection health.
+			"ConnectionHealth":       connectionHealth,
+			"HealthyCount":          healthyCount,
+			"ErrorCount":            errorCount,
+			"StaleCount":            staleCount,
+			// Insights.
+			"Insights":              insights,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -50,18 +50,45 @@ func SyncLogsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, s
 		filterConnID := stringOrEmpty(params.ConnectionID)
 		filterStatus := stringOrEmpty(params.Status)
 
+		// Compute summary stats (unfiltered by status for overview).
+		statsParams := service.SyncLogListParams{}
+		if params.ConnectionID != nil {
+			statsParams.ConnectionID = params.ConnectionID
+		}
+		stats, err := svc.SyncLogStats(ctx, statsParams)
+		if err != nil {
+			a.Logger.Error("sync log stats", "error", err)
+			stats = &service.SyncLogStats{} // graceful fallback
+		}
+
+		// Also count per-status for the tab badges.
+		successStatus := "success"
+		errorStatus := "error"
+		inProgressStatus := "in_progress"
+		successParams := service.SyncLogListParams{ConnectionID: params.ConnectionID, Status: &successStatus}
+		errorParams := service.SyncLogListParams{ConnectionID: params.ConnectionID, Status: &errorStatus}
+		inProgressParams := service.SyncLogListParams{ConnectionID: params.ConnectionID, Status: &inProgressStatus}
+
+		successCount, _ := svc.CountSyncLogsFiltered(ctx, successParams)
+		errorCount, _ := svc.CountSyncLogsFiltered(ctx, errorParams)
+		inProgressCount, _ := svc.CountSyncLogsFiltered(ctx, inProgressParams)
+
 		data := map[string]any{
-			"PageTitle":      "Sync Logs",
-			"CurrentPage":    "sync-logs",
-			"CSRFToken":      GetCSRFToken(r),
-			"Flash":          GetFlash(ctx, sm),
-			"Logs":           result.Logs,
-			"Connections":    connections,
-			"FilterConnID":   filterConnID,
-			"FilterStatus":   filterStatus,
-			"Page":           result.Page,
-			"TotalPages":     result.TotalPages,
-			"Total":          result.Total,
+			"PageTitle":        "Sync Logs",
+			"CurrentPage":      "sync-logs",
+			"CSRFToken":        GetCSRFToken(r),
+			"Flash":            GetFlash(ctx, sm),
+			"Logs":             result.Logs,
+			"Connections":      connections,
+			"FilterConnID":     filterConnID,
+			"FilterStatus":     filterStatus,
+			"Page":             result.Page,
+			"TotalPages":       result.TotalPages,
+			"Total":            result.Total,
+			"Stats":            stats,
+			"SuccessCount":     successCount,
+			"ErrorCount":       errorCount,
+			"InProgressCount":  inProgressCount,
 		}
 		tr.Render(w, r, "sync_logs.html", data)
 	}

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -82,6 +82,26 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			"intToFloat": func(a int) float64 {
 				return float64(a)
 			},
+			"subf": func(a, b float64) float64 { return a - b },
+			"mulf": func(a, b float64) float64 { return a * b },
+			"divf": func(a, b float64) float64 {
+				if b == 0 {
+					return 0
+				}
+				return a / b
+			},
+			"minf": func(a, b float64) float64 {
+				if a < b {
+					return a
+				}
+				return b
+			},
+			"absf": func(a float64) float64 {
+				if a < 0 {
+					return -a
+				}
+				return a
+			},
 			"syncDuration": func(start, end time.Time) string {
 				d := end.Sub(start)
 				if d < time.Second {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -238,6 +238,21 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return result
 			},
+			"firstChar": func(s string) string {
+				if s == "" {
+					return "?"
+				}
+				for _, r := range s {
+					c := strings.ToUpper(string(r))
+					if c >= "A" && c <= "Z" {
+						return c
+					}
+					if c >= "0" && c <= "9" {
+						return c
+					}
+				}
+				return strings.ToUpper(string([]rune(s)[0]))
+			},
 			"expired": func(s *string) bool {
 				if s == nil {
 					return false

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -199,3 +199,56 @@ func (s *Service) CountSyncLogsFiltered(ctx context.Context, params SyncLogListP
 	}
 	return count, nil
 }
+
+// SyncLogStats returns aggregate statistics about sync logs, optionally filtered.
+func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*SyncLogStats, error) {
+	query := `SELECT
+		COUNT(*) AS total,
+		COUNT(*) FILTER (WHERE sl.status = 'success') AS success_count,
+		COUNT(*) FILTER (WHERE sl.status = 'error') AS error_count,
+		COALESCE(AVG(EXTRACT(MILLISECONDS FROM (sl.completed_at - sl.started_at))) FILTER (WHERE sl.completed_at IS NOT NULL), 0) AS avg_duration_ms,
+		COALESCE(SUM(sl.added_count), 0) AS total_added,
+		COALESCE(SUM(sl.modified_count), 0) AS total_modified,
+		COALESCE(SUM(sl.removed_count), 0) AS total_removed
+	FROM sync_logs sl
+	JOIN bank_connections bc ON sl.connection_id = bc.id
+	WHERE 1=1`
+	args := []any{}
+	argN := 1
+
+	if params.ConnectionID != nil {
+		uid, err := parseUUID(*params.ConnectionID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid connection id: %w", err)
+		}
+		query += fmt.Sprintf(" AND sl.connection_id = $%d", argN)
+		args = append(args, uid)
+		argN++
+	}
+
+	if params.Status != nil {
+		query += fmt.Sprintf(" AND sl.status = $%d::sync_status", argN)
+		args = append(args, *params.Status)
+		argN++
+	}
+
+	var stats SyncLogStats
+	err := s.Pool.QueryRow(ctx, query, args...).Scan(
+		&stats.TotalSyncs,
+		&stats.SuccessCount,
+		&stats.ErrorCount,
+		&stats.AvgDurationMs,
+		&stats.TotalAdded,
+		&stats.TotalModified,
+		&stats.TotalRemoved,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sync log stats: %w", err)
+	}
+
+	if stats.TotalSyncs > 0 {
+		stats.SuccessRate = float64(stats.SuccessCount) / float64(stats.TotalSyncs) * 100
+	}
+
+	return &stats, nil
+}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -182,6 +182,18 @@ type SyncLogRow struct {
 	Duration        *string
 }
 
+// SyncLogStats contains aggregate statistics about sync logs.
+type SyncLogStats struct {
+	TotalSyncs    int64
+	SuccessCount  int64
+	ErrorCount    int64
+	SuccessRate   float64 // 0-100 percentage
+	AvgDurationMs float64 // average duration in milliseconds
+	TotalAdded    int64
+	TotalModified int64
+	TotalRemoved  int64
+}
+
 type AdminTransactionListParams struct {
 	Page         int
 	PageSize     int

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -187,40 +187,112 @@
     <h2 class="text-sm font-semibold text-base-content/70">Accounts</h2>
     <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
   </div>
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 bb-stagger">
-    {{range .Accounts}}
-    <a href="/accounts/{{.ID}}" class="bb-card bb-card--interactive p-4 no-underline group">
-      <div class="flex items-center gap-3 mb-2">
-        <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-          <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
+
+  <!-- Allocation Bar -->
+  {{if .AllocationSlices}}
+  <div class="bb-card p-4 mb-4">
+    <div class="flex h-3 rounded-full overflow-hidden gap-0.5">
+      {{range .AllocationSlices}}
+      <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: {{printf "%.1f" .Percent}}%; background: {{safeCSS .Color}}; opacity: 0.7;" title="{{.Label}}: {{formatBalance .Amount}}"></div>
+      {{end}}
+    </div>
+    <div class="flex items-center gap-4 mt-3 flex-wrap">
+      {{range .AllocationSlices}}
+      <span class="flex items-center gap-1.5 text-xs text-base-content/50">
+        <span class="w-2 h-2 rounded-full shrink-0" style="background: {{safeCSS .Color}}; opacity: 0.7;"></span>
+        {{.Label}}
+        <span class="tabular-nums font-medium text-base-content/70">{{formatBalance .Amount}}</span>
+      </span>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+
+  <!-- Asset Groups -->
+  {{if .AssetGroups}}
+  <div class="space-y-3 mb-4 bb-stagger">
+    {{range .AssetGroups}}
+    <div class="bb-card p-0 overflow-hidden">
+      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
+        <div class="flex items-center gap-2.5">
+          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
+          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
         </div>
-        <div class="flex-1 min-w-0">
-          <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
-          <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
-        </div>
+        <span class="text-sm font-semibold tabular-nums text-base-content">{{formatBalance .Total}}</span>
       </div>
-      <div class="flex items-end justify-between gap-3">
-        <div class="flex-1 min-w-0">
-          {{if .SparklineData}}
-          <div class="bb-sparkline" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
-          {{else}}
-          <div class="h-8"></div>
-          {{end}}
-        </div>
-        <div class="text-right shrink-0">
-          <div class="text-sm font-semibold tabular-nums{{if .IsLiability}} text-error/80{{end}}">
-            {{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}
+      <div class="divide-y divide-base-300/40">
+        {{range .Accounts}}
+        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
+          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
           </div>
-          {{if gt .SpendingTotal 0.0}}
-          <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-          {{else}}
-          <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
-          {{end}}
-        </div>
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
+            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
+          </div>
+          <div class="flex items-center gap-3 shrink-0">
+            {{if .SparklineData}}
+            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+            {{end}}
+            <div class="text-right">
+              <div class="text-sm font-semibold tabular-nums">{{formatBalance .BalanceCurrent}}</div>
+              {{if gt .SpendingTotal 0.0}}
+              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+              {{else}}
+              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
+              {{end}}
+            </div>
+          </div>
+        </a>
+        {{end}}
       </div>
-    </a>
+    </div>
     {{end}}
   </div>
+  {{end}}
+
+  <!-- Liability Groups -->
+  {{if .LiabilityGroups}}
+  <div class="space-y-3 bb-stagger">
+    {{range .LiabilityGroups}}
+    <div class="bb-card p-0 overflow-hidden">
+      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
+        <div class="flex items-center gap-2.5">
+          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
+          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
+        </div>
+        <span class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .Total}}</span>
+      </div>
+      <div class="divide-y divide-base-300/40">
+        {{range .Accounts}}
+        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
+          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
+            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
+          </div>
+          <div class="flex items-center gap-3 shrink-0">
+            {{if .SparklineData}}
+            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+            {{end}}
+            <div class="text-right">
+              <div class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .BalanceCurrent}}</div>
+              {{if gt .SpendingTotal 0.0}}
+              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+              {{else}}
+              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
+              {{end}}
+            </div>
+          </div>
+        </a>
+        {{end}}
+      </div>
+    </div>
+    {{end}}
+  </div>
+  {{end}}
 </div>
 {{end}}
 

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -373,6 +373,187 @@
 </div>
 {{end}}
 
+<!-- Monthly Spending Pace -->
+{{if .HasPaceData}}
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-8 bb-stagger">
+  <!-- Spending Pace Card -->
+  <div class="bb-card p-5">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-sm font-semibold text-base-content/70">{{.CurrentMonthName}} Spending Pace</h2>
+      <span class="text-xs text-base-content/30">Day {{.DaysElapsed}} of {{.DaysInMonth}}</span>
+    </div>
+
+    <!-- Month progress bar with pace marker -->
+    <div class="mb-5">
+      <div class="relative">
+        <!-- Background track -->
+        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
+          <!-- Spending progress (how much of projected has been spent) -->
+          {{if gt .LastMonthSpending 0.0}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out {{if gt .PacePercent 10.0}}bg-error/50{{else if lt .PacePercent -10.0}}bg-success/50{{else}}bg-primary/40{{end}}"
+            style="width: {{printf "%.1f" .MonthProgress}}%;"></div>
+          {{else}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out bg-primary/40"
+            style="width: {{printf "%.1f" .MonthProgress}}%;"></div>
+          {{end}}
+        </div>
+        <!-- Time marker: where we are in the month -->
+        <div class="absolute top-0 h-3 w-0.5 bg-base-content/30 rounded-full" style="left: {{printf "%.1f" .MonthProgress}}%;">
+          <div class="absolute -top-5 left-1/2 -translate-x-1/2 text-[0.6rem] text-base-content/40 whitespace-nowrap font-medium">today</div>
+        </div>
+      </div>
+      <div class="flex justify-between mt-1.5 text-[0.6rem] text-base-content/30">
+        <span>{{.CurrentMonthName}} 1</span>
+        <span>{{.DaysRemaining}} days left</span>
+      </div>
+    </div>
+
+    <!-- Pace metrics grid -->
+    <div class="grid grid-cols-3 gap-4">
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Spent so far</div>
+        <div class="text-lg font-semibold tabular-nums">{{formatBalance .CurrentMonthSpending}}</div>
+      </div>
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Daily avg</div>
+        <div class="text-lg font-semibold tabular-nums">{{formatBalance .DailyAvgSpending}}</div>
+      </div>
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Projected</div>
+        <div class="flex items-baseline gap-1.5">
+          <span class="text-lg font-semibold tabular-nums">{{formatBalance .ProjectedMonthly}}</span>
+          {{if and (gt .LastMonthSpending 0.0) (ne .PaceVsLastMonth "same")}}
+          <i data-lucide="{{if eq .PaceVsLastMonth "ahead"}}arrow-up-right{{else}}arrow-down-right{{end}}" class="w-3 h-3 {{if eq .PaceVsLastMonth "ahead"}}text-error/60{{else}}text-success/60{{end}}"></i>
+          {{end}}
+        </div>
+      </div>
+    </div>
+
+    <!-- Last month comparison -->
+    {{if gt .LastMonthSpending 0.0}}
+    <div class="mt-4 pt-4 border-t border-base-200/60">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <span class="text-xs text-base-content/40">vs {{.LastMonthName}}</span>
+          <span class="text-xs font-medium tabular-nums text-base-content/50">{{formatBalance .LastMonthSpending}} total</span>
+        </div>
+        <div class="flex items-center gap-1.5">
+          {{if ne .PaceVsLastMonth ""}}
+          <div class="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
+            {{if eq .PaceVsLastMonth "ahead"}}bg-error/8 text-error/70
+            {{else if eq .PaceVsLastMonth "behind"}}bg-success/8 text-success/70
+            {{else}}bg-base-200 text-base-content/50{{end}}">
+            {{if eq .PaceVsLastMonth "ahead"}}
+            <i data-lucide="trending-up" class="w-3 h-3"></i>
+            Spending {{printf "%.0f" (absf .PacePercent)}}% more
+            {{else if eq .PaceVsLastMonth "behind"}}
+            <i data-lucide="trending-down" class="w-3 h-3"></i>
+            Spending {{printf "%.0f" (absf .PacePercent)}}% less
+            {{else}}
+            <i data-lucide="minus" class="w-3 h-3"></i>
+            On pace
+            {{end}}
+          </div>
+          {{end}}
+        </div>
+      </div>
+      <!-- Visual comparison bar -->
+      <div class="mt-3 space-y-1.5">
+        <div class="flex items-center gap-3">
+          <span class="text-[0.65rem] text-base-content/35 w-20 shrink-0 text-right">This month</span>
+          <div class="flex-1 h-2 bg-base-200/50 rounded-full overflow-hidden">
+            <div class="h-full rounded-full transition-all duration-700 ease-out bg-primary/40"
+              style="width: {{if gt .LastMonthSpending 0.0}}{{printf "%.1f" (minf (mulf (divf .CurrentMonthSpending .LastMonthSpending) 100.0) 100.0)}}%{{else}}0%{{end}};"></div>
+          </div>
+          <span class="text-[0.65rem] tabular-nums text-base-content/40 w-16 shrink-0">{{formatBalance .CurrentMonthSpending}}</span>
+        </div>
+        <div class="flex items-center gap-3">
+          <span class="text-[0.65rem] text-base-content/35 w-20 shrink-0 text-right">{{.LastMonthName}}</span>
+          <div class="flex-1 h-2 bg-base-200/50 rounded-full overflow-hidden">
+            <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/12" style="width: 100%;"></div>
+          </div>
+          <span class="text-[0.65rem] tabular-nums text-base-content/40 w-16 shrink-0">{{formatBalance .LastMonthSpending}}</span>
+        </div>
+      </div>
+    </div>
+    {{end}}
+  </div>
+
+  <!-- Monthly Income vs Spending Summary -->
+  <div class="bb-card p-5">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-sm font-semibold text-base-content/70">{{.CurrentMonthName}} Summary</h2>
+    </div>
+
+    <!-- Big number: net for the month -->
+    <div class="text-center mb-5">
+      <div class="text-xs text-base-content/40 mb-1">Month-to-date net</div>
+      <div class="text-3xl font-semibold tabular-nums {{if gt .CurrentMonthIncome .CurrentMonthSpending}}text-success{{else}}text-error{{end}}">
+        {{if gt .CurrentMonthIncome .CurrentMonthSpending}}+{{end}}{{if lt (subf .CurrentMonthIncome .CurrentMonthSpending) 0.0}}-{{end}}{{formatBalance (absf (subf .CurrentMonthIncome .CurrentMonthSpending))}}
+      </div>
+      <div class="text-[0.65rem] text-base-content/30 mt-1">
+        {{if gt .CurrentMonthIncome .CurrentMonthSpending}}saving money{{else}}spending more than earning{{end}}
+      </div>
+    </div>
+
+    <!-- Income vs Spending mini breakdown -->
+    <div class="space-y-3">
+      <div>
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0" style="background: oklch(0.62 0.14 155)"></span>
+            Income
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-success">{{formatBalance .CurrentMonthIncome}}</span>
+        </div>
+        <div class="w-full h-2.5 bg-base-200/50 rounded-full overflow-hidden">
+          <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: 100%; background: oklch(0.62 0.14 155); opacity: 0.5;"></div>
+        </div>
+      </div>
+      <div>
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0 bg-base-content/20"></span>
+            Spending
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatBalance .CurrentMonthSpending}}</span>
+        </div>
+        <div class="w-full h-2.5 bg-base-200/50 rounded-full overflow-hidden">
+          {{if gt .CurrentMonthIncome 0.0}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15"
+            style="width: {{printf "%.1f" (minf (mulf (divf .CurrentMonthSpending .CurrentMonthIncome) 100.0) 100.0)}}%;"></div>
+          {{else}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15" style="width: 100%;"></div>
+          {{end}}
+        </div>
+      </div>
+    </div>
+
+    <!-- Key stats row -->
+    <div class="mt-5 pt-4 border-t border-base-200/60 grid grid-cols-2 gap-4">
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Burn rate</div>
+        {{if gt .CurrentMonthIncome 0.0}}
+          {{if gt .CurrentMonthSpending (mulf .CurrentMonthIncome 2.0)}}
+          <div class="text-sm font-semibold text-error/80">High</div>
+          {{else if gt .CurrentMonthSpending .CurrentMonthIncome}}
+          <div class="text-sm font-semibold text-warning">{{printf "%.0f" (mulf (divf .CurrentMonthSpending .CurrentMonthIncome) 100.0)}}% of income</div>
+          {{else}}
+          <div class="text-sm font-semibold text-success/80">{{printf "%.0f" (mulf (divf .CurrentMonthSpending .CurrentMonthIncome) 100.0)}}% of income</div>
+          {{end}}
+        {{else}}
+        <div class="text-sm text-base-content/30">&mdash;</div>
+        {{end}}
+      </div>
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Days remaining</div>
+        <div class="text-sm font-semibold tabular-nums text-base-content/70">{{.DaysRemaining}}</div>
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
 <!-- Recent Transactions + Sync Activity -->
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
   <!-- Recent Transactions -->

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -386,13 +386,15 @@
       {{range .RecentTransactions}}
       <a href="/transactions/{{.ID}}" class="flex items-center justify-between py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
         <div class="flex items-center gap-3 min-w-0">
-          <div class="w-8 h-8 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0">
-            {{if .CategoryIcon}}
-            <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5 text-base-content/40"></i>
-            {{else}}
-            <i data-lucide="minus" class="w-3.5 h-3.5 text-base-content/20"></i>
-            {{end}}
+          {{if .CategoryIcon}}
+          <div class="bb-tx-avatar bb-tx-avatar--sm" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
+            <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5"></i>
           </div>
+          {{else}}
+          <div class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
+            <span>{{firstChar .Name}}</span>
+          </div>
+          {{end}}
           <div class="min-w-0">
             <div class="text-sm font-medium truncate max-w-64">{{.Name}}</div>
             <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40">
@@ -413,9 +415,9 @@
             </div>
           </div>
         </div>
-        <div class="text-sm font-semibold tabular-nums shrink-0 pl-3{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">
+        <span class="bb-tx-amount{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
           {{formatAmount .Amount}}
-        </div>
+        </span>
       </a>
       {{end}}
     </div>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -685,72 +685,162 @@
     {{end}}
   </div>
 
-  <!-- Right Column: Sync Activity + Quick Actions -->
+  <!-- Right Column: Connection Health + Insights -->
   <div class="flex flex-col gap-4">
-    <!-- Recent Sync Activity -->
+    <!-- Connection Health -->
     <div class="bb-card p-5 flex-1">
       <div class="flex items-center justify-between mb-3">
-        <h2 class="text-sm font-semibold text-base-content/70">Sync Activity</h2>
-        <a href="/sync-logs" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
-      </div>
-      {{if .RecentLogs}}
-      <div class="space-y-1">
-        {{range .RecentLogs}}
-        <div class="rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1{{if eq (printf "%s" .Status) "error"}} bg-error/4{{end}}">
-          <a href="/connections/{{formatUUID .ConnectionID}}" class="flex items-center justify-between py-2 px-1 no-underline group">
-            <div class="flex items-center gap-2.5 min-w-0">
-              <div class="w-6 h-6 rounded-md flex items-center justify-center shrink-0{{if eq (printf "%s" .Status) "error"}} bg-error/10{{else}} bg-base-200/50{{end}}">
-                {{if eq (printf "%s" .Status) "error"}}
-                <i data-lucide="alert-circle" class="w-3 h-3 text-error/70"></i>
-                {{else if eq (printf "%s" .Status) "in_progress"}}
-                <i data-lucide="loader" class="w-3 h-3 text-base-content/40 animate-spin"></i>
-                {{else}}
-                <i data-lucide="building-2" class="w-3 h-3 text-base-content/40"></i>
-                {{end}}
-              </div>
-              <div class="min-w-0">
-                <div class="text-xs font-medium truncate group-hover:text-primary transition-colors">{{.InstitutionName.String}}</div>
-                <div class="text-xs text-base-content/30">{{relativeTime .StartedAt}}</div>
-              </div>
-            </div>
-            <div class="flex items-center gap-1.5 shrink-0">
-              {{if .AddedCount}}<span class="text-xs text-success font-medium">+{{.AddedCount}}</span>{{end}}
-              {{syncBadge (printf "%s" .Status)}}
-            </div>
-          </a>
-          {{if and .ErrorMessage.Valid (eq (printf "%s" .Status) "error")}}
-          <div class="flex items-start gap-1.5 px-1 pb-2 -mt-0.5">
-            <div class="w-6 shrink-0"></div>
-            <div class="text-[0.65rem] text-error/70 leading-relaxed font-mono truncate" title="{{.ErrorMessage.String}}">
-              {{.ErrorMessage.String}}
-            </div>
-          </div>
+        <div class="flex items-center gap-2">
+          <h2 class="text-sm font-semibold text-base-content/70">Connection Health</h2>
+          {{if gt .ErrorCount 0}}
+          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-error/8 text-error/80">
+            {{.ErrorCount}} issue{{if gt .ErrorCount 1}}s{{end}}
+          </span>
           {{end}}
         </div>
+        <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Manage</a>
+      </div>
+      {{if .ConnectionHealth}}
+      <!-- Health summary bar -->
+      <div class="flex items-center gap-3 mb-3 pb-3 border-b border-base-200/60">
+        {{if gt .HealthyCount 0}}
+        <span class="flex items-center gap-1.5 text-xs text-base-content/50">
+          <span class="w-2 h-2 rounded-full bg-success/60"></span>
+          {{.HealthyCount}} healthy
+        </span>
+        {{end}}
+        {{if gt .ErrorCount 0}}
+        <span class="flex items-center gap-1.5 text-xs text-error/70">
+          <span class="w-2 h-2 rounded-full bg-error/60"></span>
+          {{.ErrorCount}} error{{if gt .ErrorCount 1}}s{{end}}
+        </span>
+        {{end}}
+        {{if gt .StaleCount 0}}
+        <span class="flex items-center gap-1.5 text-xs text-warning">
+          <span class="w-2 h-2 rounded-full bg-warning/60"></span>
+          {{.StaleCount}} stale
+        </span>
+        {{end}}
+      </div>
+
+      <!-- Per-connection rows -->
+      <div class="space-y-1">
+        {{range .ConnectionHealth}}
+        <a href="/connections/{{.ID}}" class="flex items-center gap-2.5 py-2 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline group">
+          <!-- Status indicator -->
+          <div class="relative shrink-0">
+            <div class="w-7 h-7 rounded-lg flex items-center justify-center
+              {{if eq .Status "error"}}bg-error/10
+              {{else if eq .Status "pending_reauth"}}bg-warning/10
+              {{else if .IsStale}}bg-warning/8
+              {{else}}bg-success/8{{end}}">
+              {{if eq .Status "error"}}
+              <i data-lucide="alert-circle" class="w-3.5 h-3.5 text-error/70"></i>
+              {{else if eq .Status "pending_reauth"}}
+              <i data-lucide="key" class="w-3.5 h-3.5 text-warning"></i>
+              {{else if .IsStale}}
+              <i data-lucide="clock" class="w-3.5 h-3.5 text-warning/70"></i>
+              {{else}}
+              <i data-lucide="check-circle-2" class="w-3.5 h-3.5 text-success/70"></i>
+              {{end}}
+            </div>
+            {{if .Paused}}
+            <div class="absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full bg-base-100 flex items-center justify-center">
+              <i data-lucide="pause" class="w-2 h-2 text-base-content/40"></i>
+            </div>
+            {{end}}
+          </div>
+
+          <!-- Connection info -->
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-1.5">
+              <span class="text-xs font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+              <span class="text-[0.6rem] text-base-content/25 shrink-0">{{.Provider}}</span>
+            </div>
+            {{if and (ne .Status "active") (ne .ErrorMessage "")}}
+            <div class="text-[0.6rem] text-error/60 truncate mt-0.5 font-mono max-w-full" title="{{.ErrorMessage}}">{{.ErrorMessage}}</div>
+            {{else}}
+            <div class="text-[0.6rem] text-base-content/30 mt-0.5">
+              {{.AccountCount}} account{{if ne .AccountCount 1}}s{{end}} · synced {{.LastSyncedAt}}
+            </div>
+            {{end}}
+          </div>
+
+          <!-- Status badge -->
+          <div class="shrink-0">
+            {{if eq .Status "active"}}
+              {{if .IsStale}}
+              <span class="text-[0.6rem] font-medium text-warning/70 bg-warning/8 px-1.5 py-0.5 rounded-full">stale</span>
+              {{else}}
+              <span class="w-1.5 h-1.5 rounded-full bg-success/50"></span>
+              {{end}}
+            {{else if eq .Status "error"}}
+            <span class="text-[0.6rem] font-medium text-error/70 bg-error/8 px-1.5 py-0.5 rounded-full">error</span>
+            {{else if eq .Status "pending_reauth"}}
+            <span class="text-[0.6rem] font-medium text-warning bg-warning/8 px-1.5 py-0.5 rounded-full">reauth</span>
+            {{end}}
+          </div>
+        </a>
         {{end}}
       </div>
       {{else}}
       <div class="flex items-center justify-center py-6 text-base-content/40">
         <div class="text-center">
-          <i data-lucide="refresh-cw" class="w-6 h-6 mx-auto mb-2 opacity-40"></i>
-          <p class="text-xs">No sync activity yet</p>
+          <i data-lucide="plug" class="w-6 h-6 mx-auto mb-2 opacity-40"></i>
+          <p class="text-xs">No connections yet</p>
+          <a href="/connections/new" class="btn btn-primary btn-xs mt-2 rounded-lg">Connect a bank</a>
         </div>
       </div>
       {{end}}
     </div>
 
-    <!-- Quick Actions -->
+    <!-- Insights + Quick Actions -->
     <div class="bb-card p-4">
-      <div class="flex gap-2">
-        <a href="/connections/new" class="btn btn-primary btn-sm flex-1 rounded-xl">
-          <i data-lucide="plus" class="w-3.5 h-3.5"></i>
-          Connect Bank
+      {{if .Insights}}
+      <div class="space-y-1 mb-3">
+        {{range .Insights}}
+        {{if .Link}}
+        <a href="{{.Link}}" class="flex items-center gap-2.5 py-1.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 no-underline -mx-1">
+        {{else}}
+        <div class="flex items-center gap-2.5 py-1.5 px-1 rounded-lg -mx-1">
+        {{end}}
+          <div class="w-6 h-6 rounded-md flex items-center justify-center shrink-0
+            {{if eq .Color "warning"}}bg-warning/10
+            {{else if eq .Color "error"}}bg-error/10
+            {{else if eq .Color "success"}}bg-success/10
+            {{else}}bg-base-200/50{{end}}">
+            <i data-lucide="{{.Icon}}" class="w-3 h-3
+              {{if eq .Color "warning"}}text-warning
+              {{else if eq .Color "error"}}text-error/70
+              {{else if eq .Color "success"}}text-success/70
+              {{else}}text-base-content/40{{end}}"></i>
+          </div>
+          <div class="flex-1 min-w-0">
+            <span class="text-xs text-base-content/50">{{.Label}}</span>
+          </div>
+          <span class="text-xs font-semibold tabular-nums text-base-content/70 shrink-0 truncate max-w-[10rem]">{{.Value}}</span>
+        {{if .Link}}
         </a>
-        <a href="/reviews" class="btn btn-ghost btn-sm flex-1 rounded-xl">
-          <i data-lucide="clipboard-check" class="w-3.5 h-3.5"></i>
-          Reviews
-        </a>
+        {{else}}
+        </div>
+        {{end}}
+        {{end}}
       </div>
+      <div class="border-t border-base-200/60 pt-3">
+      {{end}}
+        <div class="flex gap-2">
+          <a href="/connections/new" class="btn btn-primary btn-sm flex-1 rounded-xl">
+            <i data-lucide="plus" class="w-3.5 h-3.5"></i>
+            Connect Bank
+          </a>
+          <a href="/reviews" class="btn btn-ghost btn-sm flex-1 rounded-xl">
+            <i data-lucide="clipboard-check" class="w-3.5 h-3.5"></i>
+            Reviews
+          </a>
+        </div>
+      {{if .Insights}}
+      </div>
+      {{end}}
     </div>
   </div>
 </div>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -296,6 +296,83 @@
   </div>
 </div>
 
+<!-- Cash Flow Summary -->
+{{if .HasCashFlow}}
+<div class="bb-card mb-8 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <h2 class="text-sm font-semibold text-base-content/70">Cash Flow</h2>
+    <span class="text-xs text-base-content/40">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}} period</span>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <!-- Income vs Spending Bars -->
+    <div class="md:col-span-2 space-y-3">
+      <!-- Income bar -->
+      <div class="group">
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0" style="background: oklch(0.62 0.14 155)"></span>
+            Income
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-success">{{formatBalance .TotalIncome}}</span>
+        </div>
+        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
+          <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: 100%; background: oklch(0.62 0.14 155); opacity: 0.6;"></div>
+        </div>
+      </div>
+
+      <!-- Spending bar (relative to income) -->
+      <div class="group">
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0 bg-base-content/20"></span>
+            Spending
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatBalance .TotalSpending}}</span>
+        </div>
+        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
+          {{if gt .TotalIncome 0.0}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out {{if gt .SpendingRatio 90.0}}bg-error/50{{else if gt .SpendingRatio 70.0}}bg-warning/50{{else}}bg-base-content/15{{end}}" style="width: {{printf "%.1f" .SpendingRatio}}%;"></div>
+          {{else}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15" style="width: 100%;"></div>
+          {{end}}
+        </div>
+      </div>
+    </div>
+
+    <!-- Net Cash Flow + Savings Rate -->
+    <div class="flex flex-col items-center justify-center text-center border-t md:border-t-0 md:border-l border-base-200/80 pt-4 md:pt-0 md:pl-6">
+      <div class="text-xs font-medium text-base-content/40 mb-1">Net Cash Flow</div>
+      <div class="text-2xl font-semibold tabular-nums {{if gt .CashFlowNet 0.0}}text-success{{else if lt .CashFlowNet 0.0}}text-error{{else}}text-base-content{{end}}">
+        {{if gt .CashFlowNet 0.0}}+{{end}}{{if lt .CashFlowNet 0.0}}-{{end}}{{formatBalance .CashFlowNet}}
+      </div>
+      {{if gt .TotalIncome 0.0}}
+      <div class="mt-2 flex items-center gap-1.5">
+        <div class="w-8 h-8 rounded-full flex items-center justify-center {{if gt .SavingsRate 20.0}}bg-success/10{{else if gt .SavingsRate 0.0}}bg-warning/10{{else}}bg-error/10{{end}}">
+          {{if gt .SavingsRate 20.0}}
+          <i data-lucide="trending-up" class="w-3.5 h-3.5 text-success"></i>
+          {{else if gt .SavingsRate 0.0}}
+          <i data-lucide="minus" class="w-3.5 h-3.5 text-warning"></i>
+          {{else}}
+          <i data-lucide="trending-down" class="w-3.5 h-3.5 text-error"></i>
+          {{end}}
+        </div>
+        <div class="text-left">
+          {{if lt .SavingsRate -200.0}}
+          <div class="text-xs font-semibold text-error/80">Over budget</div>
+          <div class="text-[0.6rem] text-base-content/30">spending > income</div>
+          {{else}}
+          <div class="text-xs font-semibold tabular-nums {{if gt .SavingsRate 0.0}}text-success/80{{else}}text-error/80{{end}}">{{printf "%.0f" .SavingsRate}}%</div>
+          <div class="text-[0.6rem] text-base-content/30">savings rate</div>
+          {{end}}
+        </div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+</div>
+{{end}}
+
 <!-- Recent Transactions + Sync Activity -->
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
   <!-- Recent Transactions -->

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -6,157 +6,197 @@
   </div>
 </div>
 
-<!-- Filter Bar -->
-<div class="bb-card p-4 mb-6">
-  <form method="GET" action="/sync-logs" class="flex flex-col sm:flex-row sm:flex-wrap sm:items-end gap-3">
-    <div class="form-control">
-      <label class="text-xs font-medium text-base-content/50 mb-1">Connection</label>
-      <select name="connection_id" class="select select-sm select-bordered w-full sm:w-auto sm:min-w-[10rem] rounded-xl">
-        <option value="">All connections</option>
-        {{range .Connections}}
-        <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
+<!-- Summary Stats Cards -->
+{{if .Stats}}
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6 bb-stagger">
+  <!-- Total Syncs -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+        <i data-lucide="refresh-cw" class="w-4 h-4 text-base-content/40"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none">{{.Stats.TotalSyncs}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Total syncs</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Success Rate -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .Stats.SuccessRate 80.0}}bg-success/10{{else if gt .Stats.SuccessRate 50.0}}bg-warning/10{{else}}bg-error/10{{end}}">
+        {{if gt .Stats.SuccessRate 80.0}}
+        <i data-lucide="check-circle-2" class="w-4 h-4 text-success"></i>
+        {{else if gt .Stats.SuccessRate 50.0}}
+        <i data-lucide="alert-triangle" class="w-4 h-4 text-warning"></i>
+        {{else}}
+        <i data-lucide="x-circle" class="w-4 h-4 text-error"></i>
         {{end}}
-      </select>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.SuccessRate 80.0}}text-success{{else if gt .Stats.SuccessRate 50.0}}text-warning{{else}}text-error{{end}}">{{printf "%.0f" .Stats.SuccessRate}}%</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Success rate</div>
+      </div>
     </div>
-    <div class="form-control">
-      <label class="text-xs font-medium text-base-content/50 mb-1">Status</label>
-      <select name="status" class="select select-sm select-bordered w-full sm:w-auto sm:min-w-[8rem] rounded-xl">
-        <option value="">All statuses</option>
-        <option value="success"{{if eq .FilterStatus "success"}} selected{{end}}>Success</option>
-        <option value="error"{{if eq .FilterStatus "error"}} selected{{end}}>Error</option>
-        <option value="in_progress"{{if eq .FilterStatus "in_progress"}} selected{{end}}>In Progress</option>
-      </select>
+  </div>
+
+  <!-- Errors -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .Stats.ErrorCount 0}}bg-error/10{{else}}bg-base-200/60{{end}}">
+        <i data-lucide="alert-circle" class="w-4 h-4 {{if gt .Stats.ErrorCount 0}}text-error/70{{else}}text-base-content/40{{end}}"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.ErrorCount 0}}text-error{{end}}">{{.Stats.ErrorCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Errors</div>
+      </div>
     </div>
-    <button type="submit" class="btn btn-primary btn-sm rounded-xl">Filter</button>
-    {{if or .FilterConnID .FilterStatus}}
-    <a href="/sync-logs" class="btn btn-ghost btn-sm rounded-xl">Clear</a>
+  </div>
+
+  <!-- Avg Duration -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+        <i data-lucide="timer" class="w-4 h-4 text-base-content/40"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none">
+          {{if gt .Stats.AvgDurationMs 999.0}}{{printf "%.1f" (divFloat .Stats.AvgDurationMs 1000.0)}}s{{else}}{{printf "%.0f" .Stats.AvgDurationMs}}ms{{end}}
+        </div>
+        <div class="text-xs text-base-content/40 mt-0.5">Avg duration</div>
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
+<!-- Status Filter Tabs + Connection Dropdown -->
+<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
+  <!-- Status pill tabs -->
+  <div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5">
+    <a href="/sync-logs{{if .FilterConnID}}?connection_id={{.FilterConnID}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if not .FilterStatus}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      All
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.Stats.TotalSyncs}}</span>
+    </a>
+    <a href="/sync-logs?status=success{{if .FilterConnID}}&connection_id={{.FilterConnID}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if eq .FilterStatus "success"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-success"></span>
+      Success
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.SuccessCount}}</span>
+    </a>
+    <a href="/sync-logs?status=error{{if .FilterConnID}}&connection_id={{.FilterConnID}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if eq .FilterStatus "error"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-error"></span>
+      Errors
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.ErrorCount}}</span>
+    </a>
+    <a href="/sync-logs?status=in_progress{{if .FilterConnID}}&connection_id={{.FilterConnID}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if eq .FilterStatus "in_progress"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-warning"></span>
+      In Progress
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.InProgressCount}}</span>
+    </a>
+  </div>
+
+  <!-- Connection filter dropdown -->
+  <form method="GET" action="/sync-logs" class="flex items-center gap-2">
+    {{if .FilterStatus}}<input type="hidden" name="status" value="{{.FilterStatus}}">{{end}}
+    <select name="connection_id" class="select select-sm select-bordered rounded-xl text-xs min-w-[10rem]"
+            onchange="this.form.submit()">
+      <option value="">All connections</option>
+      {{range .Connections}}
+      <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
+      {{end}}
+    </select>
+    {{if .FilterConnID}}
+    <a href="/sync-logs{{if $.FilterStatus}}?status={{$.FilterStatus}}{{end}}" class="btn btn-ghost btn-xs rounded-lg">
+      <i data-lucide="x" class="w-3 h-3"></i>
+    </a>
     {{end}}
   </form>
 </div>
 
 {{if .Logs}}
+
 <!-- Results count -->
 <div class="text-xs text-base-content/40 mb-3 px-1">{{.Total}} sync log{{if ne .Total 1}}s{{end}}</div>
 
-<!-- Desktop table view (hidden on mobile) -->
-<div class="bb-card overflow-hidden mb-2 hidden md:block">
-  <table class="table table-sm w-full">
-    <thead>
-      <tr class="text-xs text-base-content/40">
-        <th class="font-medium">Connection</th>
-        <th class="font-medium">When</th>
-        <th class="font-medium">Trigger</th>
-        <th class="font-medium">Changes</th>
-        <th class="font-medium text-right">Duration</th>
-        <th class="font-medium text-right">Status</th>
-      </tr>
-    </thead>
-    <tbody>
-      {{range .Logs}}
-      <tr class="hover:bg-base-200/30">
-        <!-- Connection -->
-        <td>
-          <div class="flex items-center gap-2.5">
-            <div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0">
-              <i data-lucide="building-2" class="w-3.5 h-3.5 text-base-content/40"></i>
-            </div>
-            <span class="text-sm font-medium">{{.InstitutionName}}</span>
-          </div>
-        </td>
-        <!-- Timestamp -->
-        <td>
-          <div class="text-sm text-base-content/70">{{relativeTime .StartedAt}}</div>
-          <div class="text-xs text-base-content/30">{{formatDateShort .StartedAt}}</div>
-        </td>
-        <!-- Trigger -->
-        <td>
-          <span class="badge badge-ghost badge-xs">{{.Trigger}}</span>
-        </td>
-        <!-- Changes -->
-        <td>
-          <div class="flex items-center gap-2.5 text-xs tabular-nums">
-            {{if .AddedCount}}
-            <span class="text-success font-medium">+{{.AddedCount}}</span>
-            {{end}}
-            {{if .ModifiedCount}}
-            <span class="text-info font-medium">~{{.ModifiedCount}}</span>
-            {{end}}
-            {{if .RemovedCount}}
-            <span class="text-error font-medium">-{{.RemovedCount}}</span>
-            {{end}}
-            {{if and (not .AddedCount) (not .ModifiedCount) (not .RemovedCount)}}
-            <span class="text-base-content/25">No changes</span>
-            {{end}}
-          </div>
-        </td>
-        <!-- Duration -->
-        <td class="text-right">
-          <span class="text-xs text-base-content/50 tabular-nums">{{if .Duration}}{{.Duration}}{{else}}&mdash;{{end}}</span>
-        </td>
-        <!-- Status -->
-        <td class="text-right">
-          <div class="flex items-center justify-end gap-1.5">
-            {{if .ErrorMessage}}
-            <div class="dropdown dropdown-end dropdown-hover">
-              <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-circle text-error/70">
-                <i data-lucide="info" class="w-3.5 h-3.5"></i>
-              </div>
-              <div tabindex="0" class="dropdown-content bg-base-100 shadow-lg border border-base-300 rounded-xl p-3 w-80 z-10">
-                <div class="text-xs font-medium text-error mb-1">Error Details</div>
-                <p class="text-xs text-base-content/60 font-mono break-all leading-relaxed">{{.ErrorMessage}}</p>
-              </div>
-            </div>
-            {{end}}
-            {{syncBadge .Status}}
-          </div>
-        </td>
-      </tr>
-      {{end}}
-    </tbody>
-  </table>
-</div>
-
-<!-- Mobile card view (hidden on desktop) -->
-<div class="space-y-2 md:hidden bb-stagger">
+<!-- Timeline view -->
+<div class="space-y-1 bb-stagger">
   {{range .Logs}}
-  <div class="bb-card p-4">
-    <!-- Header: connection + status -->
-    <div class="flex items-center justify-between mb-2.5">
-      <div class="flex items-center gap-2.5 min-w-0">
-        <div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0">
-          <i data-lucide="building-2" class="w-3.5 h-3.5 text-base-content/40"></i>
-        </div>
-        <div class="min-w-0">
-          <div class="text-sm font-medium truncate">{{.InstitutionName}}</div>
-          <div class="text-xs text-base-content/40">{{relativeTime .StartedAt}}</div>
+  <div class="bb-card bb-card--interactive group transition-all duration-150 {{if eq .Status "error"}}border-error/20 hover:border-error/30{{end}}" x-data="{ open: false }">
+    <a href="/connections/{{.ConnectionID}}" class="flex items-center gap-4 py-3 px-4 no-underline">
+      <!-- Status indicator -->
+      <div class="relative shrink-0">
+        <div class="w-8 h-8 rounded-lg flex items-center justify-center
+                    {{if eq .Status "success"}}bg-success/10{{else if eq .Status "error"}}bg-error/10{{else if eq .Status "in_progress"}}bg-warning/10{{else}}bg-base-200/50{{end}}">
+          {{if eq .Status "success"}}
+          <i data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
+          {{else if eq .Status "error"}}
+          <i data-lucide="x" class="w-3.5 h-3.5 text-error"></i>
+          {{else if eq .Status "in_progress"}}
+          <i data-lucide="loader" class="w-3.5 h-3.5 text-warning animate-spin"></i>
+          {{else}}
+          <i data-lucide="minus" class="w-3.5 h-3.5 text-base-content/30"></i>
+          {{end}}
         </div>
       </div>
-      <div class="flex items-center gap-1.5 shrink-0">
-        {{syncBadge .Status}}
-      </div>
-    </div>
 
-    <!-- Details row -->
-    <div class="flex items-center justify-between text-xs text-base-content/50 pt-2 border-t border-base-300/50">
-      <div class="flex items-center gap-3">
-        <span class="badge badge-ghost badge-xs">{{.Trigger}}</span>
-        <div class="flex items-center gap-2 tabular-nums">
+      <!-- Main content -->
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium group-hover:text-primary transition-colors">{{.InstitutionName}}</span>
+          <span class="badge badge-ghost badge-xs opacity-60">{{.Trigger}}</span>
+        </div>
+        <div class="flex items-center gap-3 mt-0.5 text-xs text-base-content/40">
+          <span>{{relativeTime .StartedAt}}</span>
+          {{if .Duration}}
+          <span class="text-base-content/25">&middot;</span>
+          <span class="tabular-nums">{{.Duration}}</span>
+          {{end}}
+        </div>
+      </div>
+
+      <!-- Changes + Status -->
+      <div class="flex items-center gap-4 shrink-0">
+        <!-- Transaction changes -->
+        <div class="flex items-center gap-2 text-xs tabular-nums">
           {{if .AddedCount}}<span class="text-success font-medium">+{{.AddedCount}}</span>{{end}}
           {{if .ModifiedCount}}<span class="text-info font-medium">~{{.ModifiedCount}}</span>{{end}}
           {{if .RemovedCount}}<span class="text-error font-medium">-{{.RemovedCount}}</span>{{end}}
           {{if and (not .AddedCount) (not .ModifiedCount) (not .RemovedCount)}}
-          <span class="text-base-content/25">No changes</span>
+          <span class="text-base-content/20 text-xs">No changes</span>
           {{end}}
         </div>
-      </div>
-      <span class="tabular-nums">{{if .Duration}}{{.Duration}}{{else}}&mdash;{{end}}</span>
-    </div>
 
-    <!-- Error message if present -->
+        <!-- Status badge -->
+        {{syncBadge .Status}}
+
+        <!-- Error expand button -->
+        {{if .ErrorMessage}}
+        <button @click.prevent="open = !open" class="btn btn-ghost btn-xs btn-circle text-error/50 hover:text-error hover:bg-error/10 transition-colors">
+          <i data-lucide="chevron-down" class="w-3.5 h-3.5 transition-transform duration-200" :class="open ? 'rotate-180' : ''"></i>
+        </button>
+        {{end}}
+      </div>
+    </a>
+
+    <!-- Expandable error detail -->
     {{if .ErrorMessage}}
-    <div class="mt-2.5 flex items-start gap-2 text-xs text-error/80 bg-error/5 rounded-lg px-3 py-2">
-      <i data-lucide="alert-circle" class="w-3.5 h-3.5 shrink-0 mt-0.5"></i>
-      <span class="font-mono break-all leading-relaxed">{{.ErrorMessage}}</span>
+    <div x-show="open" x-cloak x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="border-t border-base-200">
+      <div class="flex items-start gap-2.5 px-4 py-3 ml-12">
+        <i data-lucide="alert-circle" class="w-3.5 h-3.5 text-error/60 shrink-0 mt-0.5"></i>
+        <div class="min-w-0">
+          <div class="text-xs font-medium text-error/80 mb-0.5">Error Details</div>
+          <p class="text-xs text-base-content/50 font-mono break-all leading-relaxed">{{deref .ErrorMessage}}</p>
+        </div>
+      </div>
     </div>
     {{end}}
   </div>

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -503,14 +503,16 @@ function quickSetCategory(txId, categoryId) {
         @change="$store.bulk.toggle('{{.ID}}')">
     </label>
 
-    <!-- Category Icon -->
-    <div class="w-9 h-9 rounded-xl bg-base-200/60 flex items-center justify-center shrink-0">
-      {{if .CategoryIcon}}
-      <i data-lucide="{{deref .CategoryIcon}}" class="w-4 h-4 text-base-content/40"></i>
-      {{else}}
-      <i data-lucide="minus" class="w-4 h-4 text-base-content/20"></i>
-      {{end}}
+    <!-- Category Icon / Merchant Avatar -->
+    {{if .CategoryIcon}}
+    <div class="bb-tx-avatar" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
+      <i data-lucide="{{deref .CategoryIcon}}" class="w-4 h-4"></i>
     </div>
+    {{else}}
+    <div class="bb-tx-avatar bb-tx-avatar--letter">
+      <span>{{firstChar .Name}}</span>
+    </div>
+    {{end}}
 
     <!-- Description + Details -->
     <div class="flex-1 min-w-0">
@@ -547,7 +549,7 @@ function quickSetCategory(txId, categoryId) {
 
     <!-- Amount -->
     <div class="text-right shrink-0 pl-3">
-      <span class="text-sm font-semibold tabular-nums{{if gt .Amount 0.0}} text-base-content{{else}} text-success{{end}}">
+      <span class="bb-tx-amount{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
         {{formatAmount .Amount}}
       </span>
     </div>


### PR DESCRIPTION
## Summary
- **Connection Health panel** replaces the old Sync Activity section that showed redundant repeated error logs. Now shows one row per connection with health status (healthy/error/stale/reauth), account count, last sync time, and inline error messages. Includes a summary bar with healthy/error/stale counts at a glance.
- **Insights card** surfaces actionable aggregate data: pending review count, active rules count, uncategorized transaction count, and top merchant this month. Each item links to its respective page.
- **Go handler changes**: queries `ListBankConnections` for health data plus inline SQL for active rules, uncategorized count, and top merchant aggregation.

## Screenshots
![Connection Health and Insights](https://i.img402.dev/3oiu3eeknb.png)
![Close-up](https://i.img402.dev/i6pw8csu5l.png)

Relates to #55

🤖 Generated by autonomous UX improvement agent