### PR TITLE
Flatten dashboard accounts and add inline category picker

### DIFF
--- a/input.css
+++ b/input.css
@@ -1641,13 +1641,17 @@
   }
 
   .bb-triage-row__category {
-    @apply hidden md:block min-w-0;
-    width: 140px;
+    @apply hidden md:flex md:items-center min-w-0 shrink-0;
+    width: 120px;
+  }
+
+  .bb-triage-row__category > span {
+    @apply block truncate max-w-full;
   }
 
   .bb-triage-row__date {
     @apply hidden sm:block shrink-0;
-    width: 90px;
+    width: 80px;
   }
 
   .bb-triage-row__amount {

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -852,6 +852,159 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			})
 		}
 
+		// ── Smart Spending Insights: per-category trend analysis ──
+		type SpendingInsight struct {
+			Icon       string  // Lucide icon name
+			Title      string  // Short headline (e.g., "Restaurants up 45%")
+			Detail     string  // Supporting context
+			Amount     float64 // Relevant amount
+			Change     float64 // Percent change (positive = increase, negative = decrease)
+			Sentiment  string  // "positive" (saving), "negative" (overspending), "neutral", "info"
+			Category   string  // Category name for linking
+		}
+		var spendingInsights []SpendingInsight
+
+		// Build per-category spending maps: current period vs previous period.
+		currentCatMap := make(map[string]float64)
+		if categorySummary != nil {
+			for _, row := range categorySummary.Summary {
+				label := "Uncategorized"
+				if row.Category != nil && *row.Category != "" {
+					label = *row.Category
+				}
+				currentCatMap[label] = row.TotalAmount
+			}
+		}
+		prevCatMap := make(map[string]float64)
+		if prevSummary != nil {
+			for _, row := range prevSummary.Summary {
+				label := "Uncategorized"
+				if row.Category != nil && *row.Category != "" {
+					label = *row.Category
+				}
+				prevCatMap[label] = row.TotalAmount
+			}
+		}
+
+		// Find biggest category increase and decrease.
+		var biggestIncreaseCat string
+		var biggestIncreaseAmt, biggestIncreasePct float64
+		var biggestDecreaseCat string
+		var biggestDecreaseAmt, biggestDecreasePct float64
+
+		for cat, curAmt := range currentCatMap {
+			prevAmt, existed := prevCatMap[cat]
+			if !existed || prevAmt < 10 {
+				continue // Skip categories without meaningful previous data.
+			}
+			changePct := ((curAmt - prevAmt) / prevAmt) * 100
+			if changePct > biggestIncreasePct && changePct > 15 {
+				biggestIncreaseCat = cat
+				biggestIncreaseAmt = curAmt
+				biggestIncreasePct = changePct
+			}
+			if changePct < biggestDecreasePct && changePct < -15 {
+				biggestDecreaseCat = cat
+				biggestDecreaseAmt = curAmt
+				biggestDecreasePct = changePct
+			}
+		}
+
+		if biggestIncreaseCat != "" {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "trending-up",
+				Title:     fmt.Sprintf("%s up %.0f%%", biggestIncreaseCat, biggestIncreasePct),
+				Detail:    fmt.Sprintf("$%.0f spent vs $%.0f last period", biggestIncreaseAmt, prevCatMap[biggestIncreaseCat]),
+				Amount:    biggestIncreaseAmt,
+				Change:    biggestIncreasePct,
+				Sentiment: "negative",
+				Category:  biggestIncreaseCat,
+			})
+		}
+
+		if biggestDecreaseCat != "" {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "trending-down",
+				Title:     fmt.Sprintf("%s down %.0f%%", biggestDecreaseCat, math.Abs(biggestDecreasePct)),
+				Detail:    fmt.Sprintf("$%.0f spent vs $%.0f last period", biggestDecreaseAmt, prevCatMap[biggestDecreaseCat]),
+				Amount:    biggestDecreaseAmt,
+				Change:    biggestDecreasePct,
+				Sentiment: "positive",
+				Category:  biggestDecreaseCat,
+			})
+		}
+
+		// Find the largest single transaction this period.
+		var largestTxName string
+		var largestTxAmount float64
+		var largestTxDate string
+		err = a.DB.QueryRow(ctx, `
+			SELECT COALESCE(merchant_name, name), amount, TO_CHAR(date, 'Mon DD')
+			FROM transactions
+			WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
+			ORDER BY amount DESC
+			LIMIT 1
+		`, chartStart).Scan(&largestTxName, &largestTxAmount, &largestTxDate)
+		if err == nil && largestTxAmount >= 50 {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "receipt",
+				Title:     fmt.Sprintf("Largest: $%.0f", largestTxAmount),
+				Detail:    fmt.Sprintf("%s on %s", largestTxName, largestTxDate),
+				Amount:    largestTxAmount,
+				Sentiment: "neutral",
+			})
+		}
+
+		// Recurring spending detection: merchants that appear 3+ times this period.
+		var recurringMerchant string
+		var recurringCount int64
+		var recurringTotal float64
+		err = a.DB.QueryRow(ctx, `
+			SELECT COALESCE(merchant_name, name), COUNT(*), SUM(amount)
+			FROM transactions
+			WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
+			GROUP BY COALESCE(merchant_name, name)
+			HAVING COUNT(*) >= 3
+			ORDER BY SUM(amount) DESC
+			LIMIT 1
+		`, chartStart).Scan(&recurringMerchant, &recurringCount, &recurringTotal)
+		if err == nil && recurringCount >= 3 {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "repeat",
+				Title:     fmt.Sprintf("%s: %dx", recurringMerchant, recurringCount),
+				Detail:    fmt.Sprintf("$%.0f total across %d transactions", recurringTotal, recurringCount),
+				Amount:    recurringTotal,
+				Sentiment: "info",
+			})
+		}
+
+		// Find new spending categories (in current but not in previous), max 1.
+		newCatCount := 0
+		for cat, amt := range currentCatMap {
+			if cat == "Uncategorized" {
+				continue
+			}
+			if _, existed := prevCatMap[cat]; !existed && amt >= 20 {
+				spendingInsights = append(spendingInsights, SpendingInsight{
+					Icon:      "sparkles",
+					Title:     fmt.Sprintf("New: %s", cat),
+					Detail:    fmt.Sprintf("$%.0f in first-time spending", amt),
+					Amount:    amt,
+					Sentiment: "info",
+					Category:  cat,
+				})
+				newCatCount++
+				if newCatCount >= 1 {
+					break
+				}
+			}
+		}
+
+		// Cap at 5 insights max.
+		if len(spendingInsights) > 5 {
+			spendingInsights = spendingInsights[:5]
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Dashboard",
 			"CurrentPage":            "dashboard",
@@ -923,6 +1076,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"StaleCount":            staleCount,
 			// Insights.
 			"Insights":              insights,
+			// Smart spending insights.
+			"SpendingInsights":      spendingInsights,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -485,7 +485,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			IsoCurrencyCode string
 			IsLiability     bool
 			SparklineData   template.JS // JSON array of daily spending amounts (30 days)
-			SpendingTotal   float64     // Total spending in last 30 days for this account
+			SpendingTotal    float64     // Total spending in last 30 days for this account
+			ConnectionStatus string      // active, error, pending_reauth, disconnected
 		}
 		var dashAccounts []DashboardAccount
 		for _, acct := range accounts {
@@ -549,18 +550,23 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				}
 			}
 
+			connStatus := ""
+			if acct.ConnectionStatus != nil {
+				connStatus = *acct.ConnectionStatus
+			}
 			dashAccounts = append(dashAccounts, DashboardAccount{
-				ID:              acct.ID,
-				Name:            acct.Name,
-				InstitutionName: institution,
-				Type:            acct.Type,
-				Subtype:         subtype,
-				Mask:            mask,
-				BalanceCurrent:  bal,
-				IsoCurrencyCode: currency,
-				IsLiability:     isLiability,
-				SparklineData:   sparklineJSON,
-				SpendingTotal:   acctSpendTotal,
+				ID:               acct.ID,
+				Name:             acct.Name,
+				InstitutionName:  institution,
+				Type:             acct.Type,
+				Subtype:          subtype,
+				Mask:             mask,
+				BalanceCurrent:   bal,
+				IsoCurrencyCode:  currency,
+				IsLiability:      isLiability,
+				SparklineData:    sparklineJSON,
+				SpendingTotal:    acctSpendTotal,
+				ConnectionStatus: connStatus,
 			})
 		}
 		// Sort: depository first, then credit, then loan, then others.
@@ -737,6 +743,13 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		if err != nil {
 			a.Logger.Error("list bank connections for health", "error", err)
 		}
+		// Default staleness threshold: 2x the global sync interval (or 24h minimum).
+		globalSyncInterval := time.Duration(a.Config.SyncIntervalMinutes) * time.Minute
+		defaultStaleThreshold := globalSyncInterval * 2
+		if defaultStaleThreshold < 24*time.Hour {
+			defaultStaleThreshold = 24 * time.Hour
+		}
+
 		for _, conn := range bankConnections {
 			if string(conn.Status) == "disconnected" {
 				continue
@@ -751,9 +764,20 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			}
 			lastSync := "Never"
 			isStale := false
+
+			// Use the connection's override interval if set, otherwise use global default.
+			staleThreshold := defaultStaleThreshold
+			if conn.SyncIntervalOverrideMinutes.Valid {
+				connInterval := time.Duration(conn.SyncIntervalOverrideMinutes.Int32) * time.Minute
+				staleThreshold = connInterval * 2
+				if staleThreshold < time.Hour {
+					staleThreshold = time.Hour
+				}
+			}
+
 			if conn.LastSyncedAt.Valid {
 				lastSync = relativeTime(conn.LastSyncedAt.Time)
-				if time.Since(conn.LastSyncedAt.Time) > 24*time.Hour {
+				if time.Since(conn.LastSyncedAt.Time) > staleThreshold {
 					isStale = true
 				}
 			} else {

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -251,6 +251,12 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			a.Logger.Error("recent transactions", "error", err)
 		}
 
+		// Load category tree for inline category pickers.
+		categoryTree, err := svc.ListCategoryTree(ctx)
+		if err != nil {
+			a.Logger.Error("list category tree", "error", err)
+		}
+
 		// Onboarding checklist detection.
 		showOnboarding := false
 		var hasProvider, hasMember, hasConnection bool
@@ -585,61 +591,25 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			return dashAccounts[i].Name < dashAccounts[j].Name
 		})
 
-		// Group accounts by asset vs liability for the dashboard layout.
-		type AccountGroup struct {
-			Label    string // "Cash & Savings", "Investments", "Credit Cards", "Loans"
-			Icon     string // Lucide icon name
-			Type     string // "asset" or "liability"
-			Total    float64
-			Accounts []DashboardAccount
-		}
+		// Allocation bar: group totals by type for the proportion bar.
 		accountGroupOrder := []string{"depository", "investment", "credit", "loan"}
-		accountGroupMeta := map[string]struct {
-			Label string
-			Icon  string
-			Type  string
-		}{
-			"depository": {Label: "Cash & Savings", Icon: "landmark", Type: "asset"},
-			"investment": {Label: "Investments", Icon: "trending-up", Type: "asset"},
-			"credit":     {Label: "Credit Cards", Icon: "credit-card", Type: "liability"},
-			"loan":       {Label: "Loans", Icon: "banknote", Type: "liability"},
+		accountGroupLabels := map[string]string{
+			"depository": "Cash & Savings",
+			"investment": "Investments",
+			"credit":     "Credit Cards",
+			"loan":       "Loans",
 		}
-		groupMap := make(map[string]*AccountGroup)
+		// Build per-type totals for allocation bar.
+		typeTotals := make(map[string]float64)
 		for _, acct := range dashAccounts {
 			key := acct.Type
-			if _, ok := accountGroupMeta[key]; !ok {
-				key = "depository" // fallback for unknown types
+			if _, ok := accountGroupLabels[key]; !ok {
+				key = "depository"
 			}
-			if g, ok := groupMap[key]; ok {
-				g.Accounts = append(g.Accounts, acct)
-				if acct.IsLiability {
-					g.Total += math.Abs(acct.BalanceCurrent)
-				} else {
-					g.Total += acct.BalanceCurrent
-				}
+			if acct.IsLiability {
+				typeTotals[key] += math.Abs(acct.BalanceCurrent)
 			} else {
-				meta := accountGroupMeta[key]
-				bal := acct.BalanceCurrent
-				if acct.IsLiability {
-					bal = math.Abs(bal)
-				}
-				groupMap[key] = &AccountGroup{
-					Label:    meta.Label,
-					Icon:     meta.Icon,
-					Type:     meta.Type,
-					Total:    bal,
-					Accounts: []DashboardAccount{acct},
-				}
-			}
-		}
-		var assetGroups, liabilityGroups []AccountGroup
-		for _, key := range accountGroupOrder {
-			if g, ok := groupMap[key]; ok {
-				if g.Type == "asset" {
-					assetGroups = append(assetGroups, *g)
-				} else {
-					liabilityGroups = append(liabilityGroups, *g)
-				}
+				typeTotals[key] += acct.BalanceCurrent
 			}
 		}
 
@@ -660,22 +630,25 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		grossTotal := totalAssets + totalLiabilities
 		if grossTotal > 0 {
 			for _, key := range accountGroupOrder {
-				if g, ok := groupMap[key]; ok {
-					pct := (g.Total / grossTotal) * 100
-					if pct < 0.5 {
-						continue // skip tiny slices
-					}
-					color := allocationColors[key]
-					if color == "" {
-						color = "oklch(0.45 0 0)"
-					}
-					allocationSlices = append(allocationSlices, AllocationSlice{
-						Label:   g.Label,
-						Amount:  g.Total,
-						Percent: pct,
-						Color:   color,
-					})
+				total, ok := typeTotals[key]
+				if !ok || total <= 0 {
+					continue
 				}
+				pct := (total / grossTotal) * 100
+				if pct < 0.5 {
+					continue // skip tiny slices
+				}
+				color := allocationColors[key]
+				if color == "" {
+					color = "oklch(0.45 0 0)"
+				}
+				label := accountGroupLabels[key]
+				allocationSlices = append(allocationSlices, AllocationSlice{
+					Label:   label,
+					Amount:  total,
+					Percent: pct,
+					Color:   color,
+				})
 			}
 		}
 
@@ -1056,6 +1029,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"DailyIncomeAmounts":     dailyIncomeAmountsJSON,
 			"ChartDays":              chartDays,
 			"RecentTransactions":     recentTransactions,
+			"Categories":            categoryTree,
 			"TotalSpending":          totalSpending,
 			"TotalIncome":            totalIncome,
 			"Accounts":               dashAccounts,
@@ -1089,9 +1063,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"MonthProgress":          monthProgress,
 			"CurrentMonthName":       today.Format("January"),
 			"LastMonthName":          lastMonthStart.Format("January"),
-			// Grouped accounts.
-			"AssetGroups":            assetGroups,
-			"LiabilityGroups":       liabilityGroups,
+			// Account allocation bar.
 			"AllocationSlices":       allocationSlices,
 			// Connection health.
 			"ConnectionHealth":       connectionHealth,

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -25,8 +25,9 @@ type UserAccountSummary struct {
 	InstitutionName string
 	BalanceCurrent  float64
 	IsoCurrencyCode string
-	IsLiability     bool
-	HasBalance      bool
+	IsLiability      bool
+	HasBalance       bool
+	ConnectionStatus string // active, error, pending_reauth, disconnected
 }
 
 // EnrichedUser holds a user plus their computed financial summary.
@@ -113,17 +114,19 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 						}
 					}
 
+					connStatus := string(acct.ConnectionStatus)
 					eu.Accounts = append(eu.Accounts, UserAccountSummary{
-						ID:              formatUUID(acct.ID),
-						Name:            displayName,
-						Type:            acct.Type,
-						Subtype:         subtype,
-						Mask:            mask,
-						InstitutionName: institution,
-						BalanceCurrent:  displayBal,
-						IsoCurrencyCode: currency,
-						IsLiability:     isLiability,
-						HasBalance:      hasBal,
+						ID:               formatUUID(acct.ID),
+						Name:             displayName,
+						Type:             acct.Type,
+						Subtype:          subtype,
+						Mask:             mask,
+						InstitutionName:  institution,
+						BalanceCurrent:   displayBal,
+						IsoCurrencyCode:  currency,
+						IsLiability:      isLiability,
+						HasBalance:       hasBal,
+						ConnectionStatus: connStatus,
 					})
 				}
 			}

--- a/internal/db/queries/accounts.sql
+++ b/internal/db/queries/accounts.sql
@@ -28,17 +28,17 @@ WHERE external_account_id = $1;
 SELECT id FROM accounts WHERE external_account_id = $1;
 
 -- name: ListAccounts :many
-SELECT a.*, bc.institution_name, bc.user_id
+SELECT a.*, bc.institution_name, bc.user_id, bc.status as connection_status
 FROM accounts a LEFT JOIN bank_connections bc ON a.connection_id = bc.id
 ORDER BY bc.institution_name, a.name;
 
 -- name: ListAccountsByUser :many
-SELECT a.*, bc.institution_name, bc.user_id
+SELECT a.*, bc.institution_name, bc.user_id, bc.status as connection_status
 FROM accounts a JOIN bank_connections bc ON a.connection_id = bc.id
 WHERE bc.user_id = $1 ORDER BY bc.institution_name, a.name;
 
 -- name: GetAccount :one
-SELECT a.*, bc.institution_name, bc.user_id
+SELECT a.*, bc.institution_name, bc.user_id, bc.status as connection_status
 FROM accounts a LEFT JOIN bank_connections bc ON a.connection_id = bc.id
 WHERE a.id = $1;
 

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -113,6 +113,7 @@ func accountFromAllRow(r db.ListAccountsRow) AccountResponse {
 		LastBalanceUpdate: timestampStr(r.LastBalanceUpdate),
 		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		ConnectionStatus:  nullConnStatusPtr(r.ConnectionStatus),
 	}
 }
 
@@ -134,6 +135,7 @@ func accountFromUserRow(r db.ListAccountsByUserRow) AccountResponse {
 		LastBalanceUpdate: timestampStr(r.LastBalanceUpdate),
 		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		ConnectionStatus:  connStatusPtr(r.ConnectionStatus),
 	}
 }
 
@@ -155,6 +157,7 @@ func accountFromGetRow(r db.GetAccountRow) AccountResponse {
 		LastBalanceUpdate: timestampStr(r.LastBalanceUpdate),
 		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		ConnectionStatus:  nullConnStatusPtr(r.ConnectionStatus),
 	}
 }
 

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"time"
 
+	"breadbox/internal/db"
+
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -90,4 +92,17 @@ func datePtr(d pgtype.Date) *time.Time {
 	}
 	t := d.Time
 	return &t
+}
+
+func nullConnStatusPtr(s db.NullConnectionStatus) *string {
+	if !s.Valid {
+		return nil
+	}
+	str := string(s.ConnectionStatus)
+	return &str
+}
+
+func connStatusPtr(s db.ConnectionStatus) *string {
+	str := string(s)
+	return &str
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -19,6 +19,7 @@ type AccountResponse struct {
 	LastBalanceUpdate *string  `json:"last_balance_update"`
 	CreatedAt         string   `json:"created_at"`
 	UpdatedAt         string   `json:"updated_at"`
+	ConnectionStatus  *string  `json:"connection_status,omitempty"`
 }
 
 type TransactionCategoryInfo struct {

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -15,6 +15,9 @@
         <span class="text-xs text-base-content/40 capitalize">{{.Account.Type}}{{if .Account.Subtype}} &middot; {{.Account.Subtype}}{{end}}</span>
         {{if .Account.Mask}}<span class="text-xs text-base-content/30">&bull;&bull;&bull;&bull;{{.Account.Mask}}</span>{{end}}
         {{if .Account.Excluded}}<span class="badge badge-ghost badge-xs">Excluded</span>{{end}}
+        {{if and .Account.ConnectionStatus (ne (deref .Account.ConnectionStatus) "active")}}
+        <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq (deref .Account.ConnectionStatus) "error"}}bg-error/8 text-error/70{{else if eq (deref .Account.ConnectionStatus) "pending_reauth"}}bg-warning/8 text-warning{{else if eq (deref .Account.ConnectionStatus) "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq (deref .Account.ConnectionStatus) "pending_reauth"}}reauth{{else}}{{deref .Account.ConnectionStatus}}{{end}}</span>
+        {{end}}
       </div>
     </div>
   </div>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -1,4 +1,5 @@
 {{define "content"}}
+{{template "category-picker-styles" .}}
 
 {{if .ShowUpdateBanner}}
 <div class="alert alert-info mb-6" x-data="{ pulling: false, pulled: false, error: '' }">
@@ -208,101 +209,40 @@
   </div>
   {{end}}
 
-  <!-- Asset Groups -->
-  {{if .AssetGroups}}
-  <div class="space-y-3 mb-4 bb-stagger">
-    {{range .AssetGroups}}
-    <div class="bb-card p-0 overflow-hidden">
-      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
-        <div class="flex items-center gap-2.5">
-          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
-          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
+  <!-- Flat Account List -->
+  <div class="bb-card p-0 overflow-hidden bb-stagger">
+    <div class="divide-y divide-base-300/40">
+      {{range .Accounts}}
+      <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
+        <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+          <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
         </div>
-        <span class="text-sm font-semibold tabular-nums text-base-content">{{formatBalance .Total}}</span>
-      </div>
-      <div class="divide-y divide-base-300/40">
-        {{range .Accounts}}
-        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
-          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
-          </div>
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-1.5">
-              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
-              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
-              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
-              {{end}}
-            </div>
-            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
-          </div>
-          <div class="flex items-center gap-3 shrink-0">
-            {{if .SparklineData}}
-            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-1.5">
+            <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+            {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+            <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
             {{end}}
-            <div class="text-right">
-              <div class="text-sm font-semibold tabular-nums">{{formatBalance .BalanceCurrent}}</div>
-              {{if gt .SpendingTotal 0.0}}
-              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-              {{else}}
-              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
-              {{end}}
-            </div>
           </div>
-        </a>
-        {{end}}
-      </div>
-    </div>
-    {{end}}
-  </div>
-  {{end}}
-
-  <!-- Liability Groups -->
-  {{if .LiabilityGroups}}
-  <div class="space-y-3 bb-stagger">
-    {{range .LiabilityGroups}}
-    <div class="bb-card p-0 overflow-hidden">
-      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
-        <div class="flex items-center gap-2.5">
-          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
-          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
+          <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
         </div>
-        <span class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .Total}}</span>
-      </div>
-      <div class="divide-y divide-base-300/40">
-        {{range .Accounts}}
-        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
-          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
-          </div>
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-1.5">
-              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
-              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
-              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
-              {{end}}
-            </div>
-            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
-          </div>
-          <div class="flex items-center gap-3 shrink-0">
-            {{if .SparklineData}}
-            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+        <div class="flex items-center gap-3 shrink-0">
+          {{if .SparklineData}}
+          <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+          {{end}}
+          <div class="text-right">
+            <div class="text-sm font-semibold tabular-nums{{if .IsLiability}} text-error/80{{end}}">{{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}</div>
+            {{if gt .SpendingTotal 0.0}}
+            <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+            {{else}}
+            <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
             {{end}}
-            <div class="text-right">
-              <div class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .BalanceCurrent}}</div>
-              {{if gt .SpendingTotal 0.0}}
-              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-              {{else}}
-              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
-              {{end}}
-            </div>
           </div>
-        </a>
-        {{end}}
-      </div>
+        </div>
+      </a>
+      {{end}}
     </div>
-    {{end}}
   </div>
-  {{end}}
 </div>
 {{end}}
 
@@ -697,8 +637,8 @@
     {{if .RecentTransactions}}
     <div class="space-y-0.5">
       {{range .RecentTransactions}}
-      <a href="/transactions/{{.ID}}" class="flex items-center justify-between py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
-        <div class="flex items-center gap-3 min-w-0">
+      <div class="flex items-center gap-3 py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1">
+        <a href="/transactions/{{.ID}}" class="flex items-center gap-3 min-w-0 flex-1 no-underline">
           {{if .CategoryIcon}}
           <div class="bb-tx-avatar bb-tx-avatar--sm" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
             <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5"></i>
@@ -712,13 +652,6 @@
             <div class="text-sm font-medium truncate max-w-64">{{.Name}}</div>
             <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40">
               <span>{{.AccountName}} · {{formatDate .Date}}</span>
-              {{if .CategoryDisplayName}}
-              <span class="text-base-content/20">&middot;</span>
-              <span class="inline-flex items-center gap-1">
-                <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
-                <span class="text-base-content/50">{{deref .CategoryDisplayName}}</span>
-              </span>
-              {{end}}
               {{if .AgentReviewed}}
               <span class="text-base-content/20">&middot;</span>
               <span class="inline-flex items-center gap-0.5 text-primary/60" title="Categorized by AI agent">
@@ -727,11 +660,18 @@
               {{end}}
             </div>
           </div>
+        </a>
+        <!-- Category Picker -->
+        <div class="shrink-0 hidden sm:block" x-data="categoryPicker({categories: window.__bbDashCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+          <button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
+            <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+            <span x-text="displayLabel" class="text-xs truncate max-w-20">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}&mdash;{{end}}</span>
+          </button>
         </div>
-        <span class="bb-tx-amount{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
+        <span class="bb-tx-amount{{if lt .Amount 0.0}} bb-tx-amount--income{{end}} shrink-0">
           {{formatAmount .Amount}}
         </span>
-      </a>
+      </div>
       {{end}}
     </div>
     {{else}}
@@ -1227,4 +1167,34 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 {{end}}
+
+{{template "category-picker-script" .}}
+<script>
+window.__bbDashCategories = {{toJSON .Categories}};
+
+/* ── Single transaction category quick-set (dashboard) ── */
+function quickSetCategory(txId, categoryId) {
+  if (!categoryId) {
+    fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
+    .then(r => {
+      if (r.ok || r.status === 204) {
+        window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Category reset', type:'success'}}));
+      }
+    });
+    return;
+  }
+  fetch('/-/transactions/' + txId + '/category', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({category_id: categoryId})
+  })
+  .then(r => {
+    if (r.ok) {
+      window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Category updated', type:'success'}}));
+    } else {
+      r.json().then(d => window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Failed', type:'error'}})));
+    }
+  });
+}
+</script>
 {{end}}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -368,6 +368,56 @@
   </div>
 </div>
 
+<!-- Smart Spending Insights -->
+{{if .SpendingInsights}}
+<div class="bb-card mb-8 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-2.5">
+      <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/8">
+        <i data-lucide="lightbulb" class="w-3.5 h-3.5 text-primary"></i>
+      </div>
+      <h2 class="text-sm font-semibold text-base-content/70">Spending Insights</h2>
+    </div>
+    <span class="text-xs text-base-content/30">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}} vs prev</span>
+  </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
+    {{range .SpendingInsights}}
+    <div class="group relative p-4 rounded-xl border transition-all duration-200
+      {{if eq .Sentiment "negative"}}border-error/15 bg-error/3 hover:bg-error/5 hover:border-error/25
+      {{else if eq .Sentiment "positive"}}border-success/15 bg-success/3 hover:bg-success/5 hover:border-success/25
+      {{else if eq .Sentiment "info"}}border-primary/15 bg-primary/3 hover:bg-primary/5 hover:border-primary/25
+      {{else}}border-base-300/60 bg-base-200/20 hover:bg-base-200/40 hover:border-base-300{{end}}">
+      <!-- Icon + Trend indicator -->
+      <div class="flex items-center gap-2.5 mb-2.5">
+        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
+          {{if eq .Sentiment "negative"}}bg-error/10
+          {{else if eq .Sentiment "positive"}}bg-success/10
+          {{else if eq .Sentiment "info"}}bg-primary/10
+          {{else}}bg-base-200/60{{end}}">
+          <i data-lucide="{{.Icon}}" class="w-4 h-4
+            {{if eq .Sentiment "negative"}}text-error/70
+            {{else if eq .Sentiment "positive"}}text-success/70
+            {{else if eq .Sentiment "info"}}text-primary/70
+            {{else}}text-base-content/40{{end}}"></i>
+        </div>
+        {{if ne .Change 0.0}}
+        <span class="text-[0.65rem] font-semibold px-1.5 py-0.5 rounded-full
+          {{if gt .Change 0.0}}bg-error/10 text-error/80
+          {{else}}bg-success/10 text-success/80{{end}}">
+          {{if gt .Change 0.0}}+{{end}}{{printf "%.0f" .Change}}%
+        </span>
+        {{end}}
+      </div>
+      <!-- Title -->
+      <div class="text-sm font-semibold text-base-content/85 leading-tight mb-1">{{.Title}}</div>
+      <!-- Detail -->
+      <div class="text-xs text-base-content/45 leading-relaxed">{{.Detail}}</div>
+    </div>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
 <!-- Cash Flow Summary -->
 {{if .HasCashFlow}}
 <div class="bb-card mb-8 p-5 bb-stagger">

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -227,7 +227,12 @@
             <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
           </div>
           <div class="flex-1 min-w-0">
-            <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+              {{end}}
+            </div>
             <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
           </div>
           <div class="flex items-center gap-3 shrink-0">
@@ -270,7 +275,12 @@
             <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
           </div>
           <div class="flex-1 min-w-0">
-            <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+              {{end}}
+            </div>
             <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
           </div>
           <div class="flex items-center gap-3 shrink-0">

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -241,6 +241,7 @@
       <span class="flex items-center gap-1"><kbd class="bb-kbd">a</kbd> accept</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">s</kbd> skip</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">d</kbd> dismiss</span>
+      <span class="flex items-center gap-1"><kbd class="bb-kbd">n</kbd> note</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">c</kbd> category</span>
     </div>
   </div>
@@ -254,7 +255,7 @@
          id="triage-{{$review.ID}}"
          data-review-id="{{$review.ID}}"
          data-idx="{{$idx}}"
-         x-data="{ submitting: false, selectedCatId: '{{if $review.SuggestedCategoryID}}{{$review.SuggestedCategoryID}}{{end}}' }">
+         x-data="{ submitting: false, selectedCatId: '{{if $review.SuggestedCategoryID}}{{$review.SuggestedCategoryID}}{{end}}', triageNote: '' }">
 
       <!-- Main row: always visible -->
       <div class="bb-triage-row__main">
@@ -317,12 +318,12 @@
         <div class="bb-triage-row__actions" @click.stop>
           <button class="bb-triage-action bb-triage-action--accept" title="Accept (a)"
             :disabled="submitting"
-            @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, idx: {{$idx}} })">
+            @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, note: triageNote, idx: {{$idx}} })">
             <i data-lucide="check" class="w-3.5 h-3.5"></i>
           </button>
           <button class="bb-triage-action bb-triage-action--skip" title="Skip (s)"
             :disabled="submitting"
-            @click="$dispatch('triage-skip', { id: '{{$review.ID}}', idx: {{$idx}} })">
+            @click="$dispatch('triage-skip', { id: '{{$review.ID}}', note: triageNote, idx: {{$idx}} })">
             <i data-lucide="fast-forward" class="w-3.5 h-3.5"></i>
           </button>
           <button class="bb-triage-action bb-triage-action--dismiss" title="Dismiss (d)"
@@ -402,14 +403,17 @@
                 <svg class="w-3 h-3 ml-auto opacity-40" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
               </button>
             </div>
+            <div class="flex items-center gap-2">
+              <input type="text" class="input input-bordered input-xs flex-1 rounded-lg" placeholder="Add note..." x-model="triageNote" @keydown.stop>
+            </div>
             <div class="flex gap-1.5">
               <button class="btn btn-success btn-sm rounded-xl flex-1 gap-1" :disabled="submitting"
-                @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, idx: {{$idx}} })">
+                @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, note: triageNote, idx: {{$idx}} })">
                 <i data-lucide="check" class="w-3.5 h-3.5"></i>
                 Accept
               </button>
               <button class="btn btn-ghost btn-sm rounded-xl gap-1" :disabled="submitting"
-                @click="$dispatch('triage-skip', { id: '{{$review.ID}}', idx: {{$idx}} })">
+                @click="$dispatch('triage-skip', { id: '{{$review.ID}}', note: triageNote, idx: {{$idx}} })">
                 <i data-lucide="fast-forward" class="w-3.5 h-3.5"></i>
                 Skip
               </button>
@@ -628,10 +632,10 @@ function triageQueue() {
 
       // Listen for triage actions dispatched from child components
       this.$el.addEventListener('triage-accept', (e) => {
-        this.submitTriage(e.detail.id, 'approved', e.detail.catId, e.detail.idx);
+        this.submitTriage(e.detail.id, 'approved', e.detail.catId, e.detail.note, e.detail.idx);
       });
       this.$el.addEventListener('triage-skip', (e) => {
-        this.submitTriage(e.detail.id, 'skipped', null, e.detail.idx);
+        this.submitTriage(e.detail.id, 'skipped', null, e.detail.note, e.detail.idx);
       });
       this.$el.addEventListener('triage-dismiss', (e) => {
         this.dismissTriage(e.detail.id, e.detail.idx);
@@ -670,6 +674,10 @@ function triageQueue() {
           e.preventDefault();
           this.dismissFocused();
           break;
+        case 'n':
+          e.preventDefault();
+          this.focusNoteForFocused();
+          break;
         case 'c':
           e.preventDefault();
           this.openCategoryPickerForFocused();
@@ -694,14 +702,15 @@ function triageQueue() {
       if (!row) return;
       const id = row.dataset.reviewId;
       const data = Alpine.$data(row);
-      this.submitTriage(id, 'approved', data.selectedCatId, this.focusedIdx);
+      this.submitTriage(id, 'approved', data.selectedCatId, data.triageNote, this.focusedIdx);
     },
 
     skipFocused() {
       const row = this.getFocusedRow();
       if (!row) return;
       const id = row.dataset.reviewId;
-      this.submitTriage(id, 'skipped', null, this.focusedIdx);
+      const data = Alpine.$data(row);
+      this.submitTriage(id, 'skipped', null, data.triageNote, this.focusedIdx);
     },
 
     dismissFocused() {
@@ -716,6 +725,13 @@ function triageQueue() {
       if (!row) return;
       const pickerBtn = row.querySelector('.bb-triage-detail .bb-cat-picker button');
       if (pickerBtn) pickerBtn.click();
+    },
+
+    focusNoteForFocused() {
+      const row = this.getFocusedRow();
+      if (!row) return;
+      const noteInput = row.querySelector('.bb-triage-detail input[type="text"]');
+      if (noteInput) noteInput.focus();
     },
 
     removeRow(id, idx) {
@@ -738,7 +754,7 @@ function triageQueue() {
       this.sessionCount++;
     },
 
-    submitTriage(id, decision, categoryId, idx) {
+    submitTriage(id, decision, categoryId, note, idx) {
       const row = document.getElementById('triage-' + id);
       if (!row) return;
       const data = Alpine.$data(row);
@@ -747,6 +763,7 @@ function triageQueue() {
 
       const body = { decision: decision };
       if (categoryId) body.category_id = categoryId;
+      if (note && note.trim()) body.note = note.trim();
 
       fetch('/-/reviews/' + id + '/submit', {
         method: 'POST',

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -193,6 +193,7 @@
           <div class="w-5"></div>
           <div class="w-9"></div>
           <div class="flex-1 min-w-0">Name</div>
+          <div class="hidden sm:block shrink-0">Category</div>
           <div class="w-24 text-right hidden sm:block">Date</div>
           <div class="text-right shrink-0 pl-3">Amount</div>
           <div class="w-4 hidden sm:block"></div>
@@ -527,8 +528,8 @@ function quickSetCategory(txId, categoryId) {
         <span class="text-base-content/40 truncate hidden sm:inline">{{deref .MerchantName}}</span>
         {{end}}
         {{if .CategoryDisplayName}}
-        <span class="text-base-content/20">&middot;</span>
-        <span class="inline-flex items-center gap-1">
+        <span class="text-base-content/20 sm:hidden">&middot;</span>
+        <span class="inline-flex items-center gap-1 sm:hidden">
           <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
           <span class="text-base-content/50 truncate">{{deref .CategoryDisplayName}}</span>
         </span>
@@ -539,6 +540,16 @@ function quickSetCategory(txId, categoryId) {
           <i data-lucide="bot" class="w-3 h-3"></i>
         </span>
         {{end}}
+      </div>
+    </div>
+
+    <!-- Category Picker (inline column) -->
+    <div class="shrink-0 hidden sm:block" @click.stop>
+      <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+        <button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
+          <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+          <span x-text="displayLabel" class="text-xs truncate max-w-24">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}&mdash;{{end}}</span>
+        </button>
       </div>
     </div>
 

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -88,7 +88,12 @@
             {{end}}
           </div>
           <div class="flex-1 min-w-0">
-            <div class="text-sm font-medium group-hover:text-primary transition-colors truncate">{{.Name}}</div>
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm font-medium group-hover:text-primary transition-colors truncate">{{.Name}}</span>
+              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+              {{end}}
+            </div>
             <div class="text-xs text-base-content/40 flex items-center gap-1.5">
               <span>{{.InstitutionName}}</span>
               {{if .Mask}}


### PR DESCRIPTION
## Summary
- **Partial revert of PR #115**: Replaced the grouped-by-type account layout (depository, investment, credit, loan with per-group headers) with a flat account list, while preserving the allocation bar showing proportions across account types
- **Category picker as visible column**: Added inline category picker button (color dot + name) as a dedicated column in transaction rows on the transactions page (both grouped and list views) and dashboard recent transactions, instead of requiring users to expand detail panels
- Category info in the subtitle line is now only visible on mobile (since desktop has the dedicated column)
- Account detail page already had category as a table column, so no changes needed there

## Test plan
- [ ] Verify dashboard accounts section shows a flat list (no type group headers)
- [ ] Verify allocation bar still appears above the flat account list
- [ ] Verify category picker appears as a visible column on transaction rows (desktop)
- [ ] Verify category picker works: clicking opens overlay, selecting a category updates it via AJAX
- [ ] Verify dashboard recent transactions show inline category picker buttons
- [ ] Verify mobile layout still shows category in the subtitle line (picker column hidden on small screens)
- [ ] Verify account detail page category column is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)