### PR TITLE
Add Insights page and reorganize dashboard

### DIFF
--- a/input.css
+++ b/input.css
@@ -1641,13 +1641,17 @@
   }
 
   .bb-triage-row__category {
-    @apply hidden md:block min-w-0;
-    width: 140px;
+    @apply hidden md:flex md:items-center min-w-0 shrink-0;
+    width: 120px;
+  }
+
+  .bb-triage-row__category > span {
+    @apply block truncate max-w-full;
   }
 
   .bb-triage-row__date {
     @apply hidden sm:block shrink-0;
-    width: 90px;
+    width: 80px;
   }
 
   .bb-triage-row__amount {

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -852,6 +852,159 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			})
 		}
 
+		// ── Smart Spending Insights: per-category trend analysis ──
+		type SpendingInsight struct {
+			Icon       string  // Lucide icon name
+			Title      string  // Short headline (e.g., "Restaurants up 45%")
+			Detail     string  // Supporting context
+			Amount     float64 // Relevant amount
+			Change     float64 // Percent change (positive = increase, negative = decrease)
+			Sentiment  string  // "positive" (saving), "negative" (overspending), "neutral", "info"
+			Category   string  // Category name for linking
+		}
+		var spendingInsights []SpendingInsight
+
+		// Build per-category spending maps: current period vs previous period.
+		currentCatMap := make(map[string]float64)
+		if categorySummary != nil {
+			for _, row := range categorySummary.Summary {
+				label := "Uncategorized"
+				if row.Category != nil && *row.Category != "" {
+					label = *row.Category
+				}
+				currentCatMap[label] = row.TotalAmount
+			}
+		}
+		prevCatMap := make(map[string]float64)
+		if prevSummary != nil {
+			for _, row := range prevSummary.Summary {
+				label := "Uncategorized"
+				if row.Category != nil && *row.Category != "" {
+					label = *row.Category
+				}
+				prevCatMap[label] = row.TotalAmount
+			}
+		}
+
+		// Find biggest category increase and decrease.
+		var biggestIncreaseCat string
+		var biggestIncreaseAmt, biggestIncreasePct float64
+		var biggestDecreaseCat string
+		var biggestDecreaseAmt, biggestDecreasePct float64
+
+		for cat, curAmt := range currentCatMap {
+			prevAmt, existed := prevCatMap[cat]
+			if !existed || prevAmt < 10 {
+				continue // Skip categories without meaningful previous data.
+			}
+			changePct := ((curAmt - prevAmt) / prevAmt) * 100
+			if changePct > biggestIncreasePct && changePct > 15 {
+				biggestIncreaseCat = cat
+				biggestIncreaseAmt = curAmt
+				biggestIncreasePct = changePct
+			}
+			if changePct < biggestDecreasePct && changePct < -15 {
+				biggestDecreaseCat = cat
+				biggestDecreaseAmt = curAmt
+				biggestDecreasePct = changePct
+			}
+		}
+
+		if biggestIncreaseCat != "" {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "trending-up",
+				Title:     fmt.Sprintf("%s up %.0f%%", biggestIncreaseCat, biggestIncreasePct),
+				Detail:    fmt.Sprintf("$%.0f spent vs $%.0f last period", biggestIncreaseAmt, prevCatMap[biggestIncreaseCat]),
+				Amount:    biggestIncreaseAmt,
+				Change:    biggestIncreasePct,
+				Sentiment: "negative",
+				Category:  biggestIncreaseCat,
+			})
+		}
+
+		if biggestDecreaseCat != "" {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "trending-down",
+				Title:     fmt.Sprintf("%s down %.0f%%", biggestDecreaseCat, math.Abs(biggestDecreasePct)),
+				Detail:    fmt.Sprintf("$%.0f spent vs $%.0f last period", biggestDecreaseAmt, prevCatMap[biggestDecreaseCat]),
+				Amount:    biggestDecreaseAmt,
+				Change:    biggestDecreasePct,
+				Sentiment: "positive",
+				Category:  biggestDecreaseCat,
+			})
+		}
+
+		// Find the largest single transaction this period.
+		var largestTxName string
+		var largestTxAmount float64
+		var largestTxDate string
+		err = a.DB.QueryRow(ctx, `
+			SELECT COALESCE(merchant_name, name), amount, TO_CHAR(date, 'Mon DD')
+			FROM transactions
+			WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
+			ORDER BY amount DESC
+			LIMIT 1
+		`, chartStart).Scan(&largestTxName, &largestTxAmount, &largestTxDate)
+		if err == nil && largestTxAmount >= 50 {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "receipt",
+				Title:     fmt.Sprintf("Largest: $%.0f", largestTxAmount),
+				Detail:    fmt.Sprintf("%s on %s", largestTxName, largestTxDate),
+				Amount:    largestTxAmount,
+				Sentiment: "neutral",
+			})
+		}
+
+		// Recurring spending detection: merchants that appear 3+ times this period.
+		var recurringMerchant string
+		var recurringCount int64
+		var recurringTotal float64
+		err = a.DB.QueryRow(ctx, `
+			SELECT COALESCE(merchant_name, name), COUNT(*), SUM(amount)
+			FROM transactions
+			WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
+			GROUP BY COALESCE(merchant_name, name)
+			HAVING COUNT(*) >= 3
+			ORDER BY SUM(amount) DESC
+			LIMIT 1
+		`, chartStart).Scan(&recurringMerchant, &recurringCount, &recurringTotal)
+		if err == nil && recurringCount >= 3 {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "repeat",
+				Title:     fmt.Sprintf("%s: %dx", recurringMerchant, recurringCount),
+				Detail:    fmt.Sprintf("$%.0f total across %d transactions", recurringTotal, recurringCount),
+				Amount:    recurringTotal,
+				Sentiment: "info",
+			})
+		}
+
+		// Find new spending categories (in current but not in previous), max 1.
+		newCatCount := 0
+		for cat, amt := range currentCatMap {
+			if cat == "Uncategorized" {
+				continue
+			}
+			if _, existed := prevCatMap[cat]; !existed && amt >= 20 {
+				spendingInsights = append(spendingInsights, SpendingInsight{
+					Icon:      "sparkles",
+					Title:     fmt.Sprintf("New: %s", cat),
+					Detail:    fmt.Sprintf("$%.0f in first-time spending", amt),
+					Amount:    amt,
+					Sentiment: "info",
+					Category:  cat,
+				})
+				newCatCount++
+				if newCatCount >= 1 {
+					break
+				}
+			}
+		}
+
+		// Cap at 5 insights max.
+		if len(spendingInsights) > 5 {
+			spendingInsights = spendingInsights[:5]
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Dashboard",
 			"CurrentPage":            "dashboard",
@@ -923,6 +1076,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"StaleCount":            staleCount,
 			// Insights.
 			"Insights":              insights,
+			// Smart spending insights.
+			"SpendingInsights":      spendingInsights,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -485,7 +485,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			IsoCurrencyCode string
 			IsLiability     bool
 			SparklineData   template.JS // JSON array of daily spending amounts (30 days)
-			SpendingTotal   float64     // Total spending in last 30 days for this account
+			SpendingTotal    float64     // Total spending in last 30 days for this account
+			ConnectionStatus string      // active, error, pending_reauth, disconnected
 		}
 		var dashAccounts []DashboardAccount
 		for _, acct := range accounts {
@@ -549,18 +550,23 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				}
 			}
 
+			connStatus := ""
+			if acct.ConnectionStatus != nil {
+				connStatus = *acct.ConnectionStatus
+			}
 			dashAccounts = append(dashAccounts, DashboardAccount{
-				ID:              acct.ID,
-				Name:            acct.Name,
-				InstitutionName: institution,
-				Type:            acct.Type,
-				Subtype:         subtype,
-				Mask:            mask,
-				BalanceCurrent:  bal,
-				IsoCurrencyCode: currency,
-				IsLiability:     isLiability,
-				SparklineData:   sparklineJSON,
-				SpendingTotal:   acctSpendTotal,
+				ID:               acct.ID,
+				Name:             acct.Name,
+				InstitutionName:  institution,
+				Type:             acct.Type,
+				Subtype:          subtype,
+				Mask:             mask,
+				BalanceCurrent:   bal,
+				IsoCurrencyCode:  currency,
+				IsLiability:      isLiability,
+				SparklineData:    sparklineJSON,
+				SpendingTotal:    acctSpendTotal,
+				ConnectionStatus: connStatus,
 			})
 		}
 		// Sort: depository first, then credit, then loan, then others.
@@ -737,6 +743,13 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		if err != nil {
 			a.Logger.Error("list bank connections for health", "error", err)
 		}
+		// Default staleness threshold: 2x the global sync interval (or 24h minimum).
+		globalSyncInterval := time.Duration(a.Config.SyncIntervalMinutes) * time.Minute
+		defaultStaleThreshold := globalSyncInterval * 2
+		if defaultStaleThreshold < 24*time.Hour {
+			defaultStaleThreshold = 24 * time.Hour
+		}
+
 		for _, conn := range bankConnections {
 			if string(conn.Status) == "disconnected" {
 				continue
@@ -751,9 +764,20 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			}
 			lastSync := "Never"
 			isStale := false
+
+			// Use the connection's override interval if set, otherwise use global default.
+			staleThreshold := defaultStaleThreshold
+			if conn.SyncIntervalOverrideMinutes.Valid {
+				connInterval := time.Duration(conn.SyncIntervalOverrideMinutes.Int32) * time.Minute
+				staleThreshold = connInterval * 2
+				if staleThreshold < time.Hour {
+					staleThreshold = time.Hour
+				}
+			}
+
 			if conn.LastSyncedAt.Valid {
 				lastSync = relativeTime(conn.LastSyncedAt.Time)
-				if time.Since(conn.LastSyncedAt.Time) > 24*time.Hour {
+				if time.Since(conn.LastSyncedAt.Time) > staleThreshold {
 					isStale = true
 				}
 			} else {

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -251,6 +251,12 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			a.Logger.Error("recent transactions", "error", err)
 		}
 
+		// Load category tree for inline category pickers.
+		categoryTree, err := svc.ListCategoryTree(ctx)
+		if err != nil {
+			a.Logger.Error("list category tree", "error", err)
+		}
+
 		// Onboarding checklist detection.
 		showOnboarding := false
 		var hasProvider, hasMember, hasConnection bool
@@ -585,61 +591,25 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			return dashAccounts[i].Name < dashAccounts[j].Name
 		})
 
-		// Group accounts by asset vs liability for the dashboard layout.
-		type AccountGroup struct {
-			Label    string // "Cash & Savings", "Investments", "Credit Cards", "Loans"
-			Icon     string // Lucide icon name
-			Type     string // "asset" or "liability"
-			Total    float64
-			Accounts []DashboardAccount
-		}
+		// Allocation bar: group totals by type for the proportion bar.
 		accountGroupOrder := []string{"depository", "investment", "credit", "loan"}
-		accountGroupMeta := map[string]struct {
-			Label string
-			Icon  string
-			Type  string
-		}{
-			"depository": {Label: "Cash & Savings", Icon: "landmark", Type: "asset"},
-			"investment": {Label: "Investments", Icon: "trending-up", Type: "asset"},
-			"credit":     {Label: "Credit Cards", Icon: "credit-card", Type: "liability"},
-			"loan":       {Label: "Loans", Icon: "banknote", Type: "liability"},
+		accountGroupLabels := map[string]string{
+			"depository": "Cash & Savings",
+			"investment": "Investments",
+			"credit":     "Credit Cards",
+			"loan":       "Loans",
 		}
-		groupMap := make(map[string]*AccountGroup)
+		// Build per-type totals for allocation bar.
+		typeTotals := make(map[string]float64)
 		for _, acct := range dashAccounts {
 			key := acct.Type
-			if _, ok := accountGroupMeta[key]; !ok {
-				key = "depository" // fallback for unknown types
+			if _, ok := accountGroupLabels[key]; !ok {
+				key = "depository"
 			}
-			if g, ok := groupMap[key]; ok {
-				g.Accounts = append(g.Accounts, acct)
-				if acct.IsLiability {
-					g.Total += math.Abs(acct.BalanceCurrent)
-				} else {
-					g.Total += acct.BalanceCurrent
-				}
+			if acct.IsLiability {
+				typeTotals[key] += math.Abs(acct.BalanceCurrent)
 			} else {
-				meta := accountGroupMeta[key]
-				bal := acct.BalanceCurrent
-				if acct.IsLiability {
-					bal = math.Abs(bal)
-				}
-				groupMap[key] = &AccountGroup{
-					Label:    meta.Label,
-					Icon:     meta.Icon,
-					Type:     meta.Type,
-					Total:    bal,
-					Accounts: []DashboardAccount{acct},
-				}
-			}
-		}
-		var assetGroups, liabilityGroups []AccountGroup
-		for _, key := range accountGroupOrder {
-			if g, ok := groupMap[key]; ok {
-				if g.Type == "asset" {
-					assetGroups = append(assetGroups, *g)
-				} else {
-					liabilityGroups = append(liabilityGroups, *g)
-				}
+				typeTotals[key] += acct.BalanceCurrent
 			}
 		}
 
@@ -660,22 +630,25 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		grossTotal := totalAssets + totalLiabilities
 		if grossTotal > 0 {
 			for _, key := range accountGroupOrder {
-				if g, ok := groupMap[key]; ok {
-					pct := (g.Total / grossTotal) * 100
-					if pct < 0.5 {
-						continue // skip tiny slices
-					}
-					color := allocationColors[key]
-					if color == "" {
-						color = "oklch(0.45 0 0)"
-					}
-					allocationSlices = append(allocationSlices, AllocationSlice{
-						Label:   g.Label,
-						Amount:  g.Total,
-						Percent: pct,
-						Color:   color,
-					})
+				total, ok := typeTotals[key]
+				if !ok || total <= 0 {
+					continue
 				}
+				pct := (total / grossTotal) * 100
+				if pct < 0.5 {
+					continue // skip tiny slices
+				}
+				color := allocationColors[key]
+				if color == "" {
+					color = "oklch(0.45 0 0)"
+				}
+				label := accountGroupLabels[key]
+				allocationSlices = append(allocationSlices, AllocationSlice{
+					Label:   label,
+					Amount:  total,
+					Percent: pct,
+					Color:   color,
+				})
 			}
 		}
 
@@ -1056,6 +1029,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"DailyIncomeAmounts":     dailyIncomeAmountsJSON,
 			"ChartDays":              chartDays,
 			"RecentTransactions":     recentTransactions,
+			"Categories":            categoryTree,
 			"TotalSpending":          totalSpending,
 			"TotalIncome":            totalIncome,
 			"Accounts":               dashAccounts,
@@ -1089,9 +1063,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"MonthProgress":          monthProgress,
 			"CurrentMonthName":       today.Format("January"),
 			"LastMonthName":          lastMonthStart.Format("January"),
-			// Grouped accounts.
-			"AssetGroups":            assetGroups,
-			"LiabilityGroups":       liabilityGroups,
+			// Account allocation bar.
 			"AllocationSlices":       allocationSlices,
 			// Connection health.
 			"ConnectionHealth":       connectionHealth,

--- a/internal/admin/insights.go
+++ b/internal/admin/insights.go
@@ -1,0 +1,547 @@
+package admin
+
+import (
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"math"
+	"net/http"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/service"
+)
+
+// InsightsHandler serves GET /admin/insights — the spending insights page.
+func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		// Parse date range from query param (default 30 days).
+		chartDays := 30
+		if d := r.URL.Query().Get("days"); d != "" {
+			switch d {
+			case "7":
+				chartDays = 7
+			case "30":
+				chartDays = 30
+			case "90":
+				chartDays = 90
+			case "365":
+				chartDays = 365
+			}
+		}
+		chartStart := time.Now().AddDate(0, 0, -chartDays)
+
+		// ── Spending by category for the selected date range ──
+		categorySummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      "category",
+			StartDate:    &chartStart,
+			SpendingOnly: true,
+		})
+		if err != nil {
+			a.Logger.Error("category summary", "error", err)
+		}
+
+		var categoryLabelsJSON, categoryAmountsJSON, categoryColorsJSON template.JS
+
+		type CategorySpend struct {
+			Name    string
+			Color   string
+			Amount  float64
+			Percent float64
+		}
+
+		categoryPalette := []string{
+			"oklch(0.55 0.12 250)", // blue
+			"oklch(0.55 0.14 160)", // teal
+			"oklch(0.58 0.12 35)",  // warm amber
+			"oklch(0.52 0.14 300)", // purple
+			"oklch(0.58 0.10 80)",  // olive
+			"oklch(0.50 0.12 200)", // slate blue
+			"oklch(0.55 0.12 120)", // green
+			"oklch(0.48 0.10 350)", // rose
+			"oklch(0.45 0 0)",      // gray (for "Other")
+		}
+
+		var topCategories []CategorySpend
+		var maxCategorySpend float64
+		if categorySummary != nil && len(categorySummary.Summary) > 0 {
+			labels := make([]string, 0, len(categorySummary.Summary))
+			amounts := make([]float64, 0, len(categorySummary.Summary))
+			colors := make([]string, 0, len(categorySummary.Summary))
+			for i, row := range categorySummary.Summary {
+				label := "Uncategorized"
+				if row.Category != nil && *row.Category != "" {
+					label = *row.Category
+				}
+				labels = append(labels, label)
+				amounts = append(amounts, row.TotalAmount)
+				color := ""
+				if row.CategoryColor != nil && *row.CategoryColor != "" {
+					color = *row.CategoryColor
+				} else {
+					color = categoryPalette[i%len(categoryPalette)]
+				}
+				colors = append(colors, color)
+				topCategories = append(topCategories, CategorySpend{Name: label, Color: color, Amount: row.TotalAmount})
+				if row.TotalAmount > maxCategorySpend {
+					maxCategorySpend = row.TotalAmount
+				}
+			}
+			if lb, err := json.Marshal(labels); err == nil {
+				categoryLabelsJSON = template.JS(lb)
+			}
+			if ab, err := json.Marshal(amounts); err == nil {
+				categoryAmountsJSON = template.JS(ab)
+			}
+			if cb, err := json.Marshal(colors); err == nil {
+				categoryColorsJSON = template.JS(cb)
+			}
+		}
+		if len(topCategories) > 8 {
+			topCategories = topCategories[:8]
+		}
+		if catTotal := func() float64 {
+			var t float64
+			for _, c := range topCategories {
+				t += c.Amount
+			}
+			return t
+		}(); catTotal > 0 {
+			for i := range topCategories {
+				topCategories[i].Percent = (topCategories[i].Amount / catTotal) * 100
+			}
+		}
+
+		// ── Daily spending trend ──
+		chartGroupBy := "day"
+		if chartDays == 365 {
+			chartGroupBy = "month"
+		}
+		dailySummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      chartGroupBy,
+			StartDate:    &chartStart,
+			SpendingOnly: true,
+		})
+		if err != nil {
+			a.Logger.Error("daily summary", "error", err)
+		}
+
+		// Daily income for the same period.
+		dailyIncomeSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:   chartGroupBy,
+			StartDate: &chartStart,
+		})
+		if err != nil {
+			a.Logger.Error("daily income summary", "error", err)
+		}
+		incomeByPeriod := make(map[string]float64)
+		if dailyIncomeSummary != nil {
+			for _, row := range dailyIncomeSummary.Summary {
+				if row.TotalAmount < 0 && row.Period != nil {
+					incomeByPeriod[*row.Period] = -row.TotalAmount
+				}
+			}
+		}
+
+		// Previous period spending for comparison.
+		prevStart := time.Now().AddDate(0, 0, -chartDays*2)
+		prevEnd := time.Now().AddDate(0, 0, -chartDays)
+		prevSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      "category",
+			StartDate:    &prevStart,
+			EndDate:      &prevEnd,
+			SpendingOnly: true,
+		})
+		if err != nil {
+			a.Logger.Error("previous period summary", "error", err)
+		}
+		var prevTotalSpending float64
+		if prevSummary != nil {
+			for _, row := range prevSummary.Summary {
+				prevTotalSpending += row.TotalAmount
+			}
+		}
+
+		var spendingChangePercent float64
+		var hasSpendingChange bool
+
+		var dailyLabelsJSON, dailyAmountsJSON, dailyIncomeAmountsJSON template.JS
+		if dailySummary != nil && len(dailySummary.Summary) > 0 {
+			rows := dailySummary.Summary
+			labels := make([]string, 0, len(rows))
+			amounts := make([]float64, 0, len(rows))
+			incomeAmounts := make([]float64, 0, len(rows))
+			for i := len(rows) - 1; i >= 0; i-- {
+				row := rows[i]
+				label := ""
+				if row.Period != nil {
+					label = *row.Period
+				}
+				labels = append(labels, label)
+				amounts = append(amounts, row.TotalAmount)
+				incomeAmounts = append(incomeAmounts, incomeByPeriod[label])
+			}
+			if lb, err := json.Marshal(labels); err == nil {
+				dailyLabelsJSON = template.JS(lb)
+			}
+			if ab, err := json.Marshal(amounts); err == nil {
+				dailyAmountsJSON = template.JS(ab)
+			}
+			if ib, err := json.Marshal(incomeAmounts); err == nil {
+				dailyIncomeAmountsJSON = template.JS(ib)
+			}
+		}
+
+		// Total spending for the selected period.
+		var totalSpending float64
+		if categorySummary != nil && categorySummary.Totals.TotalAmount != nil {
+			totalSpending = *categorySummary.Totals.TotalAmount
+		}
+
+		// Compute spending change vs previous period.
+		if prevTotalSpending > 0 {
+			hasSpendingChange = true
+			spendingChangePercent = ((totalSpending - prevTotalSpending) / prevTotalSpending) * 100
+		}
+
+		// Total income for the selected date range.
+		var totalIncome float64
+		incomeSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:   "day",
+			StartDate: &chartStart,
+		})
+		if err != nil {
+			a.Logger.Error("income summary", "error", err)
+		}
+		if incomeSummary != nil {
+			for _, row := range incomeSummary.Summary {
+				if row.TotalAmount < 0 {
+					totalIncome += -row.TotalAmount
+				}
+			}
+		}
+
+		// Cash flow: net = income - spending, savings rate = net/income * 100.
+		var cashFlowNet float64
+		var savingsRate float64
+		var hasCashFlow bool
+		if totalIncome > 0 || totalSpending > 0 {
+			hasCashFlow = true
+			cashFlowNet = totalIncome - totalSpending
+			if totalIncome > 0 {
+				savingsRate = (cashFlowNet / totalIncome) * 100
+			}
+		}
+
+		var spendingRatio float64
+		if totalIncome > 0 {
+			spendingRatio = (totalSpending / totalIncome) * 100
+			if spendingRatio > 100 {
+				spendingRatio = 100
+			}
+		}
+
+		// ── Spending Pace ──
+		today := time.Now()
+		monthStart := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, today.Location())
+		daysElapsed := today.Day()
+		daysInMonth := time.Date(today.Year(), today.Month()+1, 0, 0, 0, 0, 0, today.Location()).Day()
+		daysRemaining := daysInMonth - daysElapsed
+
+		var currentMonthSpending float64
+		currentMonthSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      "day",
+			StartDate:    &monthStart,
+			SpendingOnly: true,
+		})
+		if err != nil {
+			a.Logger.Error("current month spending", "error", err)
+		}
+		if currentMonthSummary != nil {
+			for _, row := range currentMonthSummary.Summary {
+				currentMonthSpending += row.TotalAmount
+			}
+		}
+
+		var currentMonthIncome float64
+		currentMonthIncomeSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:   "day",
+			StartDate: &monthStart,
+		})
+		if err != nil {
+			a.Logger.Error("current month income", "error", err)
+		}
+		if currentMonthIncomeSummary != nil {
+			for _, row := range currentMonthIncomeSummary.Summary {
+				if row.TotalAmount < 0 {
+					currentMonthIncome += -row.TotalAmount
+				}
+			}
+		}
+
+		lastMonthStart := time.Date(today.Year(), today.Month()-1, 1, 0, 0, 0, 0, today.Location())
+		lastMonthEnd := monthStart
+		var lastMonthSpending float64
+		lastMonthSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      "day",
+			StartDate:    &lastMonthStart,
+			EndDate:      &lastMonthEnd,
+			SpendingOnly: true,
+		})
+		if err != nil {
+			a.Logger.Error("last month spending", "error", err)
+		}
+		if lastMonthSummary != nil {
+			for _, row := range lastMonthSummary.Summary {
+				lastMonthSpending += row.TotalAmount
+			}
+		}
+
+		// Last month spending at the same point.
+		lastMonthSameDay := time.Date(today.Year(), today.Month()-1, 1, 0, 0, 0, 0, today.Location())
+		lastMonthDaysInMonth := time.Date(lastMonthSameDay.Year(), lastMonthSameDay.Month()+1, 0, 0, 0, 0, 0, today.Location()).Day()
+		sameDayOfLastMonth := daysElapsed
+		if sameDayOfLastMonth > lastMonthDaysInMonth {
+			sameDayOfLastMonth = lastMonthDaysInMonth
+		}
+		lastMonthSameDayEnd := time.Date(lastMonthSameDay.Year(), lastMonthSameDay.Month(), sameDayOfLastMonth+1, 0, 0, 0, 0, today.Location())
+		var lastMonthPaceSpending float64
+		lastMonthPaceSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      "day",
+			StartDate:    &lastMonthSameDay,
+			EndDate:      &lastMonthSameDayEnd,
+			SpendingOnly: true,
+		})
+		if err != nil {
+			a.Logger.Error("last month pace spending", "error", err)
+		}
+		if lastMonthPaceSummary != nil {
+			for _, row := range lastMonthPaceSummary.Summary {
+				lastMonthPaceSpending += row.TotalAmount
+			}
+		}
+
+		var dailyAvgSpending float64
+		var projectedMonthly float64
+		var pacePercent float64
+		var hasPaceData bool
+		var paceVsLastMonth string
+
+		if daysElapsed > 0 && currentMonthSpending > 0 {
+			hasPaceData = true
+			dailyAvgSpending = currentMonthSpending / float64(daysElapsed)
+			projectedMonthly = dailyAvgSpending * float64(daysInMonth)
+
+			if lastMonthPaceSpending > 0 {
+				pacePercent = ((currentMonthSpending - lastMonthPaceSpending) / lastMonthPaceSpending) * 100
+				if pacePercent > 2.0 {
+					paceVsLastMonth = "ahead"
+				} else if pacePercent < -2.0 {
+					paceVsLastMonth = "behind"
+				} else {
+					paceVsLastMonth = "same"
+				}
+			}
+		}
+
+		monthProgress := float64(daysElapsed) / float64(daysInMonth) * 100
+
+		// ── Smart Spending Insights ──
+		type SpendingInsight struct {
+			Icon      string
+			Title     string
+			Detail    string
+			Amount    float64
+			Change    float64
+			Sentiment string
+			Category  string
+		}
+		var spendingInsights []SpendingInsight
+
+		currentCatMap := make(map[string]float64)
+		if categorySummary != nil {
+			for _, row := range categorySummary.Summary {
+				label := "Uncategorized"
+				if row.Category != nil && *row.Category != "" {
+					label = *row.Category
+				}
+				currentCatMap[label] = row.TotalAmount
+			}
+		}
+		prevCatMap := make(map[string]float64)
+		if prevSummary != nil {
+			for _, row := range prevSummary.Summary {
+				label := "Uncategorized"
+				if row.Category != nil && *row.Category != "" {
+					label = *row.Category
+				}
+				prevCatMap[label] = row.TotalAmount
+			}
+		}
+
+		var biggestIncreaseCat string
+		var biggestIncreaseAmt, biggestIncreasePct float64
+		var biggestDecreaseCat string
+		var biggestDecreaseAmt, biggestDecreasePct float64
+
+		for cat, curAmt := range currentCatMap {
+			prevAmt, existed := prevCatMap[cat]
+			if !existed || prevAmt < 10 {
+				continue
+			}
+			changePct := ((curAmt - prevAmt) / prevAmt) * 100
+			if changePct > biggestIncreasePct && changePct > 15 {
+				biggestIncreaseCat = cat
+				biggestIncreaseAmt = curAmt
+				biggestIncreasePct = changePct
+			}
+			if changePct < biggestDecreasePct && changePct < -15 {
+				biggestDecreaseCat = cat
+				biggestDecreaseAmt = curAmt
+				biggestDecreasePct = changePct
+			}
+		}
+
+		if biggestIncreaseCat != "" {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "trending-up",
+				Title:     fmt.Sprintf("%s up %.0f%%", biggestIncreaseCat, biggestIncreasePct),
+				Detail:    fmt.Sprintf("$%.0f spent vs $%.0f last period", biggestIncreaseAmt, prevCatMap[biggestIncreaseCat]),
+				Amount:    biggestIncreaseAmt,
+				Change:    biggestIncreasePct,
+				Sentiment: "negative",
+				Category:  biggestIncreaseCat,
+			})
+		}
+
+		if biggestDecreaseCat != "" {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "trending-down",
+				Title:     fmt.Sprintf("%s down %.0f%%", biggestDecreaseCat, math.Abs(biggestDecreasePct)),
+				Detail:    fmt.Sprintf("$%.0f spent vs $%.0f last period", biggestDecreaseAmt, prevCatMap[biggestDecreaseCat]),
+				Amount:    biggestDecreaseAmt,
+				Change:    biggestDecreasePct,
+				Sentiment: "positive",
+				Category:  biggestDecreaseCat,
+			})
+		}
+
+		// Largest single transaction this period.
+		var largestTxName string
+		var largestTxAmount float64
+		var largestTxDate string
+		err = a.DB.QueryRow(ctx, `
+			SELECT COALESCE(merchant_name, name), amount, TO_CHAR(date, 'Mon DD')
+			FROM transactions
+			WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
+			ORDER BY amount DESC
+			LIMIT 1
+		`, chartStart).Scan(&largestTxName, &largestTxAmount, &largestTxDate)
+		if err == nil && largestTxAmount >= 50 {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "receipt",
+				Title:     fmt.Sprintf("Largest: $%.0f", largestTxAmount),
+				Detail:    fmt.Sprintf("%s on %s", largestTxName, largestTxDate),
+				Amount:    largestTxAmount,
+				Sentiment: "neutral",
+			})
+		}
+
+		// Recurring spending detection.
+		var recurringMerchant string
+		var recurringCount int64
+		var recurringTotal float64
+		err = a.DB.QueryRow(ctx, `
+			SELECT COALESCE(merchant_name, name), COUNT(*), SUM(amount)
+			FROM transactions
+			WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
+			GROUP BY COALESCE(merchant_name, name)
+			HAVING COUNT(*) >= 3
+			ORDER BY SUM(amount) DESC
+			LIMIT 1
+		`, chartStart).Scan(&recurringMerchant, &recurringCount, &recurringTotal)
+		if err == nil && recurringCount >= 3 {
+			spendingInsights = append(spendingInsights, SpendingInsight{
+				Icon:      "repeat",
+				Title:     fmt.Sprintf("%s: %dx", recurringMerchant, recurringCount),
+				Detail:    fmt.Sprintf("$%.0f total across %d transactions", recurringTotal, recurringCount),
+				Amount:    recurringTotal,
+				Sentiment: "info",
+			})
+		}
+
+		// New spending categories.
+		newCatCount := 0
+		for cat, amt := range currentCatMap {
+			if cat == "Uncategorized" {
+				continue
+			}
+			if _, existed := prevCatMap[cat]; !existed && amt >= 20 {
+				spendingInsights = append(spendingInsights, SpendingInsight{
+					Icon:      "sparkles",
+					Title:     fmt.Sprintf("New: %s", cat),
+					Detail:    fmt.Sprintf("$%.0f in first-time spending", amt),
+					Amount:    amt,
+					Sentiment: "info",
+					Category:  cat,
+				})
+				newCatCount++
+				if newCatCount >= 1 {
+					break
+				}
+			}
+		}
+
+		if len(spendingInsights) > 5 {
+			spendingInsights = spendingInsights[:5]
+		}
+
+		data := map[string]any{
+			"PageTitle":              "Insights",
+			"CurrentPage":            "insights",
+			"CSRFToken":              GetCSRFToken(r),
+			"ChartDays":              chartDays,
+			// Spending chart data.
+			"CategoryLabels":         categoryLabelsJSON,
+			"CategoryAmounts":        categoryAmountsJSON,
+			"CategoryColors":         categoryColorsJSON,
+			"DailyLabels":            dailyLabelsJSON,
+			"DailyAmounts":           dailyAmountsJSON,
+			"DailyIncomeAmounts":     dailyIncomeAmountsJSON,
+			"TopCategories":          topCategories,
+			"MaxCategorySpend":       maxCategorySpend,
+			// Totals.
+			"TotalSpending":          totalSpending,
+			"TotalIncome":            totalIncome,
+			"PrevTotalSpending":      prevTotalSpending,
+			"SpendingChangePercent":  spendingChangePercent,
+			"HasSpendingChange":      hasSpendingChange,
+			// Cash flow.
+			"CashFlowNet":            cashFlowNet,
+			"SavingsRate":            savingsRate,
+			"HasCashFlow":            hasCashFlow,
+			"SpendingRatio":          spendingRatio,
+			// Spending pace.
+			"HasPaceData":            hasPaceData,
+			"CurrentMonthSpending":   currentMonthSpending,
+			"CurrentMonthIncome":     currentMonthIncome,
+			"LastMonthSpending":      lastMonthSpending,
+			"LastMonthPaceSpending":  lastMonthPaceSpending,
+			"DailyAvgSpending":       dailyAvgSpending,
+			"ProjectedMonthly":       projectedMonthly,
+			"PacePercent":            pacePercent,
+			"PaceVsLastMonth":        paceVsLastMonth,
+			"DaysElapsed":            daysElapsed,
+			"DaysInMonth":            daysInMonth,
+			"DaysRemaining":          daysRemaining,
+			"MonthProgress":          monthProgress,
+			"CurrentMonthName":       today.Format("January"),
+			"LastMonthName":          lastMonthStart.Format("January"),
+			// Smart spending insights.
+			"SpendingInsights":       spendingInsights,
+		}
+		tr.Render(w, r, "insights.html", data)
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -40,6 +40,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Use(NavBadgesMiddleware(a.Queries, a.Logger))
 
 		r.Get("/", DashboardHandler(a, svc, tr))
+		r.Get("/insights", InsightsHandler(a, svc, tr))
 		r.Post("/onboarding/dismiss", DismissOnboardingHandler(a))
 
 		r.Route("/connections", func(r chi.Router) {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -549,6 +549,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/reviews.html",
 		"pages/rules.html",
 		"pages/review_instructions.html",
+		"pages/insights.html",
 	}
 
 	// Pages using the wizard layout (login + first-run admin creation).

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -25,8 +25,9 @@ type UserAccountSummary struct {
 	InstitutionName string
 	BalanceCurrent  float64
 	IsoCurrencyCode string
-	IsLiability     bool
-	HasBalance      bool
+	IsLiability      bool
+	HasBalance       bool
+	ConnectionStatus string // active, error, pending_reauth, disconnected
 }
 
 // EnrichedUser holds a user plus their computed financial summary.
@@ -113,17 +114,19 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 						}
 					}
 
+					connStatus := string(acct.ConnectionStatus)
 					eu.Accounts = append(eu.Accounts, UserAccountSummary{
-						ID:              formatUUID(acct.ID),
-						Name:            displayName,
-						Type:            acct.Type,
-						Subtype:         subtype,
-						Mask:            mask,
-						InstitutionName: institution,
-						BalanceCurrent:  displayBal,
-						IsoCurrencyCode: currency,
-						IsLiability:     isLiability,
-						HasBalance:      hasBal,
+						ID:               formatUUID(acct.ID),
+						Name:             displayName,
+						Type:             acct.Type,
+						Subtype:          subtype,
+						Mask:             mask,
+						InstitutionName:  institution,
+						BalanceCurrent:   displayBal,
+						IsoCurrencyCode:  currency,
+						IsLiability:      isLiability,
+						HasBalance:       hasBal,
+						ConnectionStatus: connStatus,
 					})
 				}
 			}

--- a/internal/db/queries/accounts.sql
+++ b/internal/db/queries/accounts.sql
@@ -28,17 +28,17 @@ WHERE external_account_id = $1;
 SELECT id FROM accounts WHERE external_account_id = $1;
 
 -- name: ListAccounts :many
-SELECT a.*, bc.institution_name, bc.user_id
+SELECT a.*, bc.institution_name, bc.user_id, bc.status as connection_status
 FROM accounts a LEFT JOIN bank_connections bc ON a.connection_id = bc.id
 ORDER BY bc.institution_name, a.name;
 
 -- name: ListAccountsByUser :many
-SELECT a.*, bc.institution_name, bc.user_id
+SELECT a.*, bc.institution_name, bc.user_id, bc.status as connection_status
 FROM accounts a JOIN bank_connections bc ON a.connection_id = bc.id
 WHERE bc.user_id = $1 ORDER BY bc.institution_name, a.name;
 
 -- name: GetAccount :one
-SELECT a.*, bc.institution_name, bc.user_id
+SELECT a.*, bc.institution_name, bc.user_id, bc.status as connection_status
 FROM accounts a LEFT JOIN bank_connections bc ON a.connection_id = bc.id
 WHERE a.id = $1;
 

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -113,6 +113,7 @@ func accountFromAllRow(r db.ListAccountsRow) AccountResponse {
 		LastBalanceUpdate: timestampStr(r.LastBalanceUpdate),
 		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		ConnectionStatus:  nullConnStatusPtr(r.ConnectionStatus),
 	}
 }
 
@@ -134,6 +135,7 @@ func accountFromUserRow(r db.ListAccountsByUserRow) AccountResponse {
 		LastBalanceUpdate: timestampStr(r.LastBalanceUpdate),
 		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		ConnectionStatus:  connStatusPtr(r.ConnectionStatus),
 	}
 }
 
@@ -155,6 +157,7 @@ func accountFromGetRow(r db.GetAccountRow) AccountResponse {
 		LastBalanceUpdate: timestampStr(r.LastBalanceUpdate),
 		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		ConnectionStatus:  nullConnStatusPtr(r.ConnectionStatus),
 	}
 }
 

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"time"
 
+	"breadbox/internal/db"
+
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -90,4 +92,17 @@ func datePtr(d pgtype.Date) *time.Time {
 	}
 	t := d.Time
 	return &t
+}
+
+func nullConnStatusPtr(s db.NullConnectionStatus) *string {
+	if !s.Valid {
+		return nil
+	}
+	str := string(s.ConnectionStatus)
+	return &str
+}
+
+func connStatusPtr(s db.ConnectionStatus) *string {
+	str := string(s)
+	return &str
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -19,6 +19,7 @@ type AccountResponse struct {
 	LastBalanceUpdate *string  `json:"last_balance_update"`
 	CreatedAt         string   `json:"created_at"`
 	UpdatedAt         string   `json:"updated_at"`
+	ConnectionStatus  *string  `json:"connection_status,omitempty"`
 }
 
 type TransactionCategoryInfo struct {

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -15,6 +15,9 @@
         <span class="text-xs text-base-content/40 capitalize">{{.Account.Type}}{{if .Account.Subtype}} &middot; {{.Account.Subtype}}{{end}}</span>
         {{if .Account.Mask}}<span class="text-xs text-base-content/30">&bull;&bull;&bull;&bull;{{.Account.Mask}}</span>{{end}}
         {{if .Account.Excluded}}<span class="badge badge-ghost badge-xs">Excluded</span>{{end}}
+        {{if and .Account.ConnectionStatus (ne (deref .Account.ConnectionStatus) "active")}}
+        <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq (deref .Account.ConnectionStatus) "error"}}bg-error/8 text-error/70{{else if eq (deref .Account.ConnectionStatus) "pending_reauth"}}bg-warning/8 text-warning{{else if eq (deref .Account.ConnectionStatus) "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq (deref .Account.ConnectionStatus) "pending_reauth"}}reauth{{else}}{{deref .Account.ConnectionStatus}}{{end}}</span>
+        {{end}}
       </div>
     </div>
   </div>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -1,4 +1,5 @@
 {{define "content"}}
+{{template "category-picker-styles" .}}
 
 {{if .ShowUpdateBanner}}
 <div class="alert alert-info mb-6" x-data="{ pulling: false, pulled: false, error: '' }">
@@ -208,101 +209,40 @@
   </div>
   {{end}}
 
-  <!-- Asset Groups -->
-  {{if .AssetGroups}}
-  <div class="space-y-3 mb-4 bb-stagger">
-    {{range .AssetGroups}}
-    <div class="bb-card p-0 overflow-hidden">
-      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
-        <div class="flex items-center gap-2.5">
-          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
-          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
+  <!-- Flat Account List -->
+  <div class="bb-card p-0 overflow-hidden bb-stagger">
+    <div class="divide-y divide-base-300/40">
+      {{range .Accounts}}
+      <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
+        <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+          <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
         </div>
-        <span class="text-sm font-semibold tabular-nums text-base-content">{{formatBalance .Total}}</span>
-      </div>
-      <div class="divide-y divide-base-300/40">
-        {{range .Accounts}}
-        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
-          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
-          </div>
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-1.5">
-              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
-              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
-              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
-              {{end}}
-            </div>
-            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
-          </div>
-          <div class="flex items-center gap-3 shrink-0">
-            {{if .SparklineData}}
-            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-1.5">
+            <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+            {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+            <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
             {{end}}
-            <div class="text-right">
-              <div class="text-sm font-semibold tabular-nums">{{formatBalance .BalanceCurrent}}</div>
-              {{if gt .SpendingTotal 0.0}}
-              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-              {{else}}
-              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
-              {{end}}
-            </div>
           </div>
-        </a>
-        {{end}}
-      </div>
-    </div>
-    {{end}}
-  </div>
-  {{end}}
-
-  <!-- Liability Groups -->
-  {{if .LiabilityGroups}}
-  <div class="space-y-3 bb-stagger">
-    {{range .LiabilityGroups}}
-    <div class="bb-card p-0 overflow-hidden">
-      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
-        <div class="flex items-center gap-2.5">
-          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
-          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
+          <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
         </div>
-        <span class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .Total}}</span>
-      </div>
-      <div class="divide-y divide-base-300/40">
-        {{range .Accounts}}
-        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
-          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
-          </div>
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-1.5">
-              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
-              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
-              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
-              {{end}}
-            </div>
-            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
-          </div>
-          <div class="flex items-center gap-3 shrink-0">
-            {{if .SparklineData}}
-            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+        <div class="flex items-center gap-3 shrink-0">
+          {{if .SparklineData}}
+          <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+          {{end}}
+          <div class="text-right">
+            <div class="text-sm font-semibold tabular-nums{{if .IsLiability}} text-error/80{{end}}">{{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}</div>
+            {{if gt .SpendingTotal 0.0}}
+            <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+            {{else}}
+            <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
             {{end}}
-            <div class="text-right">
-              <div class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .BalanceCurrent}}</div>
-              {{if gt .SpendingTotal 0.0}}
-              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-              {{else}}
-              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
-              {{end}}
-            </div>
           </div>
-        </a>
-        {{end}}
-      </div>
+        </div>
+      </a>
+      {{end}}
     </div>
-    {{end}}
   </div>
-  {{end}}
 </div>
 {{end}}
 
@@ -697,8 +637,8 @@
     {{if .RecentTransactions}}
     <div class="space-y-0.5">
       {{range .RecentTransactions}}
-      <a href="/transactions/{{.ID}}" class="flex items-center justify-between py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
-        <div class="flex items-center gap-3 min-w-0">
+      <div class="flex items-center gap-3 py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1">
+        <a href="/transactions/{{.ID}}" class="flex items-center gap-3 min-w-0 flex-1 no-underline">
           {{if .CategoryIcon}}
           <div class="bb-tx-avatar bb-tx-avatar--sm" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
             <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5"></i>
@@ -712,13 +652,6 @@
             <div class="text-sm font-medium truncate max-w-64">{{.Name}}</div>
             <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40">
               <span>{{.AccountName}} · {{formatDate .Date}}</span>
-              {{if .CategoryDisplayName}}
-              <span class="text-base-content/20">&middot;</span>
-              <span class="inline-flex items-center gap-1">
-                <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
-                <span class="text-base-content/50">{{deref .CategoryDisplayName}}</span>
-              </span>
-              {{end}}
               {{if .AgentReviewed}}
               <span class="text-base-content/20">&middot;</span>
               <span class="inline-flex items-center gap-0.5 text-primary/60" title="Categorized by AI agent">
@@ -727,11 +660,18 @@
               {{end}}
             </div>
           </div>
+        </a>
+        <!-- Category Picker -->
+        <div class="shrink-0 hidden sm:block" x-data="categoryPicker({categories: window.__bbDashCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+          <button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
+            <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+            <span x-text="displayLabel" class="text-xs truncate max-w-20">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}&mdash;{{end}}</span>
+          </button>
         </div>
-        <span class="bb-tx-amount{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
+        <span class="bb-tx-amount{{if lt .Amount 0.0}} bb-tx-amount--income{{end}} shrink-0">
           {{formatAmount .Amount}}
         </span>
-      </a>
+      </div>
       {{end}}
     </div>
     {{else}}
@@ -1227,4 +1167,34 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 {{end}}
+
+{{template "category-picker-script" .}}
+<script>
+window.__bbDashCategories = {{toJSON .Categories}};
+
+/* ── Single transaction category quick-set (dashboard) ── */
+function quickSetCategory(txId, categoryId) {
+  if (!categoryId) {
+    fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
+    .then(r => {
+      if (r.ok || r.status === 204) {
+        window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Category reset', type:'success'}}));
+      }
+    });
+    return;
+  }
+  fetch('/-/transactions/' + txId + '/category', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({category_id: categoryId})
+  })
+  .then(r => {
+    if (r.ok) {
+      window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Category updated', type:'success'}}));
+    } else {
+      r.json().then(d => window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Failed', type:'error'}})));
+    }
+  });
+}
+</script>
 {{end}}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -1,5 +1,4 @@
 {{define "content"}}
-{{template "category-picker-styles" .}}
 
 {{if .ShowUpdateBanner}}
 <div class="alert alert-info mb-6" x-data="{ pulling: false, pulled: false, error: '' }">
@@ -209,424 +208,105 @@
   </div>
   {{end}}
 
-  <!-- Flat Account List -->
-  <div class="bb-card p-0 overflow-hidden bb-stagger">
-    <div class="divide-y divide-base-300/40">
-      {{range .Accounts}}
-      <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
-        <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-          <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
+  <!-- Asset Groups -->
+  {{if .AssetGroups}}
+  <div class="space-y-3 mb-4 bb-stagger">
+    {{range .AssetGroups}}
+    <div class="bb-card p-0 overflow-hidden">
+      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
+        <div class="flex items-center gap-2.5">
+          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
+          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
         </div>
-        <div class="flex-1 min-w-0">
-          <div class="flex items-center gap-1.5">
-            <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
-            {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
-            <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
-            {{end}}
+        <span class="text-sm font-semibold tabular-nums text-base-content">{{formatBalance .Total}}</span>
+      </div>
+      <div class="divide-y divide-base-300/40">
+        {{range .Accounts}}
+        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
+          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
           </div>
-          <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
-        </div>
-        <div class="flex items-center gap-3 shrink-0">
-          {{if .SparklineData}}
-          <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
-          {{end}}
-          <div class="text-right">
-            <div class="text-sm font-semibold tabular-nums{{if .IsLiability}} text-error/80{{end}}">{{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}</div>
-            {{if gt .SpendingTotal 0.0}}
-            <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-            {{else}}
-            <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
-            {{end}}
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+              {{end}}
+            </div>
+            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
           </div>
-        </div>
-      </a>
-      {{end}}
-    </div>
-  </div>
-</div>
-{{end}}
-
-<!-- Charts Row -->
-<div class="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-8 bb-stagger">
-  <!-- Spending & Income Chart -->
-  <div class="bb-card lg:col-span-3 p-5">
-    <div class="flex items-center justify-between mb-4">
-      <div class="flex items-center gap-3">
-        <h2 class="text-sm font-semibold text-base-content/70">Spending</h2>
-        {{if .HasSpendingChange}}
-        <span class="text-xs font-medium {{if gt .SpendingChangePercent 0.0}}text-error/70{{else}}text-success/70{{end}}">
-          {{if gt .SpendingChangePercent 0.0}}+{{end}}{{printf "%.0f" .SpendingChangePercent}}% vs prev
-        </span>
+          <div class="flex items-center gap-3 shrink-0">
+            {{if .SparklineData}}
+            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+            {{end}}
+            <div class="text-right">
+              <div class="text-sm font-semibold tabular-nums">{{formatBalance .BalanceCurrent}}</div>
+              {{if gt .SpendingTotal 0.0}}
+              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+              {{else}}
+              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
+              {{end}}
+            </div>
+          </div>
+        </a>
         {{end}}
       </div>
     </div>
-    {{if .DailyLabels}}
-    <div class="h-56">
-      <canvas id="spendingTrendChart"></canvas>
-    </div>
-    <div class="flex items-center gap-5 mt-3 pt-3 border-t border-base-200">
-      <span class="flex items-center gap-1.5 text-xs text-base-content/50">
-        <span class="w-2.5 h-1.5 rounded-sm bg-base-content/15"></span>
-        Spending
-      </span>
-      <span class="flex items-center gap-1.5 text-xs text-base-content/50">
-        <span class="w-2.5 h-1.5 rounded-sm" style="background: oklch(0.62 0.14 155 / 0.35)"></span>
-        Income
-      </span>
-    </div>
-    {{else}}
-    <div class="flex items-center justify-center h-56 text-base-content/40">
-      <div class="text-center">
-        <i data-lucide="bar-chart-3" class="w-10 h-10 mx-auto mb-2 opacity-40"></i>
-        <p class="text-sm">No spending data yet</p>
-      </div>
-    </div>
     {{end}}
   </div>
+  {{end}}
 
-  <!-- Top Spending Categories — Horizontal Bar Chart -->
-  <div class="bb-card lg:col-span-2 p-5">
-    <div class="flex items-center justify-between mb-4">
-      <h2 class="text-sm font-semibold text-base-content/70">Top Categories</h2>
-      <a href="/categories" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
-    </div>
-    {{if .TopCategories}}
-    <div class="space-y-3">
-      {{range .TopCategories}}
-      <div class="group">
-        <div class="flex items-center justify-between mb-1">
-          <span class="flex items-center gap-2 text-xs font-medium text-base-content/70 group-hover:text-base-content transition-colors truncate">
-            <span class="w-2 h-2 rounded-full shrink-0" style="background-color: {{safeCSS .Color}}"></span>
-            <span class="truncate">{{.Name}}</span>
-          </span>
-          <span class="text-xs font-semibold tabular-nums text-base-content/80 shrink-0 ml-3">{{formatAmount .Amount}}</span>
+  <!-- Liability Groups -->
+  {{if .LiabilityGroups}}
+  <div class="space-y-3 bb-stagger">
+    {{range .LiabilityGroups}}
+    <div class="bb-card p-0 overflow-hidden">
+      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
+        <div class="flex items-center gap-2.5">
+          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
+          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
         </div>
-        <div class="w-full h-2 bg-base-200/80 rounded-full overflow-hidden">
-          <div class="h-full rounded-full transition-all duration-500 ease-out" style="width: {{printf "%.1f" .Percent}}%; background-color: {{safeCSS .Color}}; opacity: 0.7;"></div>
-        </div>
+        <span class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .Total}}</span>
       </div>
-      {{end}}
-    </div>
-    {{else}}
-    <div class="flex items-center justify-center h-48 text-base-content/40">
-      <div class="text-center">
-        <i data-lucide="bar-chart-2" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
-        <p class="text-sm">No category data yet</p>
-      </div>
-    </div>
-    {{end}}
-  </div>
-</div>
-
-<!-- Smart Spending Insights -->
-{{if .SpendingInsights}}
-<div class="bb-card mb-8 p-5 bb-stagger">
-  <div class="flex items-center justify-between mb-4">
-    <div class="flex items-center gap-2.5">
-      <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/8">
-        <i data-lucide="lightbulb" class="w-3.5 h-3.5 text-primary"></i>
-      </div>
-      <h2 class="text-sm font-semibold text-base-content/70">Spending Insights</h2>
-    </div>
-    <span class="text-xs text-base-content/30">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}} vs prev</span>
-  </div>
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
-    {{range .SpendingInsights}}
-    <div class="group relative p-4 rounded-xl border transition-all duration-200
-      {{if eq .Sentiment "negative"}}border-error/15 bg-error/3 hover:bg-error/5 hover:border-error/25
-      {{else if eq .Sentiment "positive"}}border-success/15 bg-success/3 hover:bg-success/5 hover:border-success/25
-      {{else if eq .Sentiment "info"}}border-primary/15 bg-primary/3 hover:bg-primary/5 hover:border-primary/25
-      {{else}}border-base-300/60 bg-base-200/20 hover:bg-base-200/40 hover:border-base-300{{end}}">
-      <!-- Icon + Trend indicator -->
-      <div class="flex items-center gap-2.5 mb-2.5">
-        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
-          {{if eq .Sentiment "negative"}}bg-error/10
-          {{else if eq .Sentiment "positive"}}bg-success/10
-          {{else if eq .Sentiment "info"}}bg-primary/10
-          {{else}}bg-base-200/60{{end}}">
-          <i data-lucide="{{.Icon}}" class="w-4 h-4
-            {{if eq .Sentiment "negative"}}text-error/70
-            {{else if eq .Sentiment "positive"}}text-success/70
-            {{else if eq .Sentiment "info"}}text-primary/70
-            {{else}}text-base-content/40{{end}}"></i>
-        </div>
-        {{if ne .Change 0.0}}
-        <span class="text-[0.65rem] font-semibold px-1.5 py-0.5 rounded-full
-          {{if gt .Change 0.0}}bg-error/10 text-error/80
-          {{else}}bg-success/10 text-success/80{{end}}">
-          {{if gt .Change 0.0}}+{{end}}{{printf "%.0f" .Change}}%
-        </span>
-        {{end}}
-      </div>
-      <!-- Title -->
-      <div class="text-sm font-semibold text-base-content/85 leading-tight mb-1">{{.Title}}</div>
-      <!-- Detail -->
-      <div class="text-xs text-base-content/45 leading-relaxed">{{.Detail}}</div>
-    </div>
-    {{end}}
-  </div>
-</div>
-{{end}}
-
-<!-- Cash Flow Summary -->
-{{if .HasCashFlow}}
-<div class="bb-card mb-8 p-5 bb-stagger">
-  <div class="flex items-center justify-between mb-4">
-    <h2 class="text-sm font-semibold text-base-content/70">Cash Flow</h2>
-    <span class="text-xs text-base-content/40">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}} period</span>
-  </div>
-
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-    <!-- Income vs Spending Bars -->
-    <div class="md:col-span-2 space-y-3">
-      <!-- Income bar -->
-      <div class="group">
-        <div class="flex items-center justify-between mb-1.5">
-          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
-            <span class="w-2 h-2 rounded-full shrink-0" style="background: oklch(0.62 0.14 155)"></span>
-            Income
-          </span>
-          <span class="text-sm font-semibold tabular-nums text-success">{{formatBalance .TotalIncome}}</span>
-        </div>
-        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
-          <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: 100%; background: oklch(0.62 0.14 155); opacity: 0.6;"></div>
-        </div>
-      </div>
-
-      <!-- Spending bar (relative to income) -->
-      <div class="group">
-        <div class="flex items-center justify-between mb-1.5">
-          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
-            <span class="w-2 h-2 rounded-full shrink-0 bg-base-content/20"></span>
-            Spending
-          </span>
-          <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatBalance .TotalSpending}}</span>
-        </div>
-        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
-          {{if gt .TotalIncome 0.0}}
-          <div class="h-full rounded-full transition-all duration-700 ease-out {{if gt .SpendingRatio 90.0}}bg-error/50{{else if gt .SpendingRatio 70.0}}bg-warning/50{{else}}bg-base-content/15{{end}}" style="width: {{printf "%.1f" .SpendingRatio}}%;"></div>
-          {{else}}
-          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15" style="width: 100%;"></div>
-          {{end}}
-        </div>
-      </div>
-    </div>
-
-    <!-- Net Cash Flow + Savings Rate -->
-    <div class="flex flex-col items-center justify-center text-center border-t md:border-t-0 md:border-l border-base-200/80 pt-4 md:pt-0 md:pl-6">
-      <div class="text-xs font-medium text-base-content/40 mb-1">Net Cash Flow</div>
-      <div class="text-2xl font-semibold tabular-nums {{if gt .CashFlowNet 0.0}}text-success{{else if lt .CashFlowNet 0.0}}text-error{{else}}text-base-content{{end}}">
-        {{if gt .CashFlowNet 0.0}}+{{end}}{{if lt .CashFlowNet 0.0}}-{{end}}{{formatBalance .CashFlowNet}}
-      </div>
-      {{if gt .TotalIncome 0.0}}
-      <div class="mt-2 flex items-center gap-1.5">
-        <div class="w-8 h-8 rounded-full flex items-center justify-center {{if gt .SavingsRate 20.0}}bg-success/10{{else if gt .SavingsRate 0.0}}bg-warning/10{{else}}bg-error/10{{end}}">
-          {{if gt .SavingsRate 20.0}}
-          <i data-lucide="trending-up" class="w-3.5 h-3.5 text-success"></i>
-          {{else if gt .SavingsRate 0.0}}
-          <i data-lucide="minus" class="w-3.5 h-3.5 text-warning"></i>
-          {{else}}
-          <i data-lucide="trending-down" class="w-3.5 h-3.5 text-error"></i>
-          {{end}}
-        </div>
-        <div class="text-left">
-          {{if lt .SavingsRate -200.0}}
-          <div class="text-xs font-semibold text-error/80">Over budget</div>
-          <div class="text-[0.6rem] text-base-content/30">spending > income</div>
-          {{else}}
-          <div class="text-xs font-semibold tabular-nums {{if gt .SavingsRate 0.0}}text-success/80{{else}}text-error/80{{end}}">{{printf "%.0f" .SavingsRate}}%</div>
-          <div class="text-[0.6rem] text-base-content/30">savings rate</div>
-          {{end}}
-        </div>
-      </div>
-      {{end}}
-    </div>
-  </div>
-</div>
-{{end}}
-
-<!-- Monthly Spending Pace -->
-{{if .HasPaceData}}
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-8 bb-stagger">
-  <!-- Spending Pace Card -->
-  <div class="bb-card p-5">
-    <div class="flex items-center justify-between mb-4">
-      <h2 class="text-sm font-semibold text-base-content/70">{{.CurrentMonthName}} Spending Pace</h2>
-      <span class="text-xs text-base-content/30">Day {{.DaysElapsed}} of {{.DaysInMonth}}</span>
-    </div>
-
-    <!-- Month progress bar with pace marker -->
-    <div class="mb-5">
-      <div class="relative">
-        <!-- Background track -->
-        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
-          <!-- Spending progress (how much of projected has been spent) -->
-          {{if gt .LastMonthSpending 0.0}}
-          <div class="h-full rounded-full transition-all duration-700 ease-out {{if gt .PacePercent 10.0}}bg-error/50{{else if lt .PacePercent -10.0}}bg-success/50{{else}}bg-primary/40{{end}}"
-            style="width: {{printf "%.1f" .MonthProgress}}%;"></div>
-          {{else}}
-          <div class="h-full rounded-full transition-all duration-700 ease-out bg-primary/40"
-            style="width: {{printf "%.1f" .MonthProgress}}%;"></div>
-          {{end}}
-        </div>
-        <!-- Time marker: where we are in the month -->
-        <div class="absolute top-0 h-3 w-0.5 bg-base-content/30 rounded-full" style="left: {{printf "%.1f" .MonthProgress}}%;">
-          <div class="absolute -top-5 left-1/2 -translate-x-1/2 text-[0.6rem] text-base-content/40 whitespace-nowrap font-medium">today</div>
-        </div>
-      </div>
-      <div class="flex justify-between mt-1.5 text-[0.6rem] text-base-content/30">
-        <span>{{.CurrentMonthName}} 1</span>
-        <span>{{.DaysRemaining}} days left</span>
-      </div>
-    </div>
-
-    <!-- Pace metrics grid -->
-    <div class="grid grid-cols-3 gap-4">
-      <div>
-        <div class="text-xs text-base-content/40 mb-0.5">Spent so far</div>
-        <div class="text-lg font-semibold tabular-nums">{{formatBalance .CurrentMonthSpending}}</div>
-      </div>
-      <div>
-        <div class="text-xs text-base-content/40 mb-0.5">Daily avg</div>
-        <div class="text-lg font-semibold tabular-nums">{{formatBalance .DailyAvgSpending}}</div>
-      </div>
-      <div>
-        <div class="text-xs text-base-content/40 mb-0.5">Projected</div>
-        <div class="flex items-baseline gap-1.5">
-          <span class="text-lg font-semibold tabular-nums">{{formatBalance .ProjectedMonthly}}</span>
-          {{if and (gt .LastMonthSpending 0.0) (ne .PaceVsLastMonth "same")}}
-          <i data-lucide="{{if eq .PaceVsLastMonth "ahead"}}arrow-up-right{{else}}arrow-down-right{{end}}" class="w-3 h-3 {{if eq .PaceVsLastMonth "ahead"}}text-error/60{{else}}text-success/60{{end}}"></i>
-          {{end}}
-        </div>
-      </div>
-    </div>
-
-    <!-- Last month comparison -->
-    {{if gt .LastMonthSpending 0.0}}
-    <div class="mt-4 pt-4 border-t border-base-200/60">
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-2">
-          <span class="text-xs text-base-content/40">vs {{.LastMonthName}}</span>
-          <span class="text-xs font-medium tabular-nums text-base-content/50">{{formatBalance .LastMonthSpending}} total</span>
-        </div>
-        <div class="flex items-center gap-1.5">
-          {{if ne .PaceVsLastMonth ""}}
-          <div class="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
-            {{if eq .PaceVsLastMonth "ahead"}}bg-error/8 text-error/70
-            {{else if eq .PaceVsLastMonth "behind"}}bg-success/8 text-success/70
-            {{else}}bg-base-200 text-base-content/50{{end}}">
-            {{if eq .PaceVsLastMonth "ahead"}}
-            <i data-lucide="trending-up" class="w-3 h-3"></i>
-            Spending {{printf "%.0f" (absf .PacePercent)}}% more
-            {{else if eq .PaceVsLastMonth "behind"}}
-            <i data-lucide="trending-down" class="w-3 h-3"></i>
-            Spending {{printf "%.0f" (absf .PacePercent)}}% less
-            {{else}}
-            <i data-lucide="minus" class="w-3 h-3"></i>
-            On pace
+      <div class="divide-y divide-base-300/40">
+        {{range .Accounts}}
+        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
+          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+              {{end}}
+            </div>
+            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
+          </div>
+          <div class="flex items-center gap-3 shrink-0">
+            {{if .SparklineData}}
+            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
             {{end}}
+            <div class="text-right">
+              <div class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .BalanceCurrent}}</div>
+              {{if gt .SpendingTotal 0.0}}
+              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+              {{else}}
+              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
+              {{end}}
+            </div>
           </div>
-          {{end}}
-        </div>
-      </div>
-      <!-- Visual comparison bar -->
-      <div class="mt-3 space-y-1.5">
-        <div class="flex items-center gap-3">
-          <span class="text-[0.65rem] text-base-content/35 w-20 shrink-0 text-right">This month</span>
-          <div class="flex-1 h-2 bg-base-200/50 rounded-full overflow-hidden">
-            <div class="h-full rounded-full transition-all duration-700 ease-out bg-primary/40"
-              style="width: {{if gt .LastMonthSpending 0.0}}{{printf "%.1f" (minf (mulf (divf .CurrentMonthSpending .LastMonthSpending) 100.0) 100.0)}}%{{else}}0%{{end}};"></div>
-          </div>
-          <span class="text-[0.65rem] tabular-nums text-base-content/40 w-16 shrink-0">{{formatBalance .CurrentMonthSpending}}</span>
-        </div>
-        <div class="flex items-center gap-3">
-          <span class="text-[0.65rem] text-base-content/35 w-20 shrink-0 text-right">{{.LastMonthName}}</span>
-          <div class="flex-1 h-2 bg-base-200/50 rounded-full overflow-hidden">
-            <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/12" style="width: 100%;"></div>
-          </div>
-          <span class="text-[0.65rem] tabular-nums text-base-content/40 w-16 shrink-0">{{formatBalance .LastMonthSpending}}</span>
-        </div>
+        </a>
+        {{end}}
       </div>
     </div>
     {{end}}
   </div>
-
-  <!-- Monthly Income vs Spending Summary -->
-  <div class="bb-card p-5">
-    <div class="flex items-center justify-between mb-4">
-      <h2 class="text-sm font-semibold text-base-content/70">{{.CurrentMonthName}} Summary</h2>
-    </div>
-
-    <!-- Big number: net for the month -->
-    <div class="text-center mb-5">
-      <div class="text-xs text-base-content/40 mb-1">Month-to-date net</div>
-      <div class="text-3xl font-semibold tabular-nums {{if gt .CurrentMonthIncome .CurrentMonthSpending}}text-success{{else}}text-error{{end}}">
-        {{if gt .CurrentMonthIncome .CurrentMonthSpending}}+{{end}}{{if lt (subf .CurrentMonthIncome .CurrentMonthSpending) 0.0}}-{{end}}{{formatBalance (absf (subf .CurrentMonthIncome .CurrentMonthSpending))}}
-      </div>
-      <div class="text-[0.65rem] text-base-content/30 mt-1">
-        {{if gt .CurrentMonthIncome .CurrentMonthSpending}}saving money{{else}}spending more than earning{{end}}
-      </div>
-    </div>
-
-    <!-- Income vs Spending mini breakdown -->
-    <div class="space-y-3">
-      <div>
-        <div class="flex items-center justify-between mb-1.5">
-          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
-            <span class="w-2 h-2 rounded-full shrink-0" style="background: oklch(0.62 0.14 155)"></span>
-            Income
-          </span>
-          <span class="text-sm font-semibold tabular-nums text-success">{{formatBalance .CurrentMonthIncome}}</span>
-        </div>
-        <div class="w-full h-2.5 bg-base-200/50 rounded-full overflow-hidden">
-          <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: 100%; background: oklch(0.62 0.14 155); opacity: 0.5;"></div>
-        </div>
-      </div>
-      <div>
-        <div class="flex items-center justify-between mb-1.5">
-          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
-            <span class="w-2 h-2 rounded-full shrink-0 bg-base-content/20"></span>
-            Spending
-          </span>
-          <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatBalance .CurrentMonthSpending}}</span>
-        </div>
-        <div class="w-full h-2.5 bg-base-200/50 rounded-full overflow-hidden">
-          {{if gt .CurrentMonthIncome 0.0}}
-          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15"
-            style="width: {{printf "%.1f" (minf (mulf (divf .CurrentMonthSpending .CurrentMonthIncome) 100.0) 100.0)}}%;"></div>
-          {{else}}
-          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15" style="width: 100%;"></div>
-          {{end}}
-        </div>
-      </div>
-    </div>
-
-    <!-- Key stats row -->
-    <div class="mt-5 pt-4 border-t border-base-200/60 grid grid-cols-2 gap-4">
-      <div>
-        <div class="text-xs text-base-content/40 mb-0.5">Burn rate</div>
-        {{if gt .CurrentMonthIncome 0.0}}
-          {{if gt .CurrentMonthSpending (mulf .CurrentMonthIncome 2.0)}}
-          <div class="text-sm font-semibold text-error/80">High</div>
-          {{else if gt .CurrentMonthSpending .CurrentMonthIncome}}
-          <div class="text-sm font-semibold text-warning">{{printf "%.0f" (mulf (divf .CurrentMonthSpending .CurrentMonthIncome) 100.0)}}% of income</div>
-          {{else}}
-          <div class="text-sm font-semibold text-success/80">{{printf "%.0f" (mulf (divf .CurrentMonthSpending .CurrentMonthIncome) 100.0)}}% of income</div>
-          {{end}}
-        {{else}}
-        <div class="text-sm text-base-content/30">&mdash;</div>
-        {{end}}
-      </div>
-      <div>
-        <div class="text-xs text-base-content/40 mb-0.5">Days remaining</div>
-        <div class="text-sm font-semibold tabular-nums text-base-content/70">{{.DaysRemaining}}</div>
-      </div>
-    </div>
-  </div>
+  {{end}}
 </div>
 {{end}}
 
-<!-- Recent Transactions + Sync Activity -->
+<!-- Recent Transactions + Connection Health -->
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
   <!-- Recent Transactions -->
   <div class="bb-card lg:col-span-2 p-5">
@@ -637,8 +317,8 @@
     {{if .RecentTransactions}}
     <div class="space-y-0.5">
       {{range .RecentTransactions}}
-      <div class="flex items-center gap-3 py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1">
-        <a href="/transactions/{{.ID}}" class="flex items-center gap-3 min-w-0 flex-1 no-underline">
+      <a href="/transactions/{{.ID}}" class="flex items-center justify-between py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
+        <div class="flex items-center gap-3 min-w-0">
           {{if .CategoryIcon}}
           <div class="bb-tx-avatar bb-tx-avatar--sm" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
             <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5"></i>
@@ -652,6 +332,13 @@
             <div class="text-sm font-medium truncate max-w-64">{{.Name}}</div>
             <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40">
               <span>{{.AccountName}} · {{formatDate .Date}}</span>
+              {{if .CategoryDisplayName}}
+              <span class="text-base-content/20">&middot;</span>
+              <span class="inline-flex items-center gap-1">
+                <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
+                <span class="text-base-content/50">{{deref .CategoryDisplayName}}</span>
+              </span>
+              {{end}}
               {{if .AgentReviewed}}
               <span class="text-base-content/20">&middot;</span>
               <span class="inline-flex items-center gap-0.5 text-primary/60" title="Categorized by AI agent">
@@ -660,18 +347,11 @@
               {{end}}
             </div>
           </div>
-        </a>
-        <!-- Category Picker -->
-        <div class="shrink-0 hidden sm:block" x-data="categoryPicker({categories: window.__bbDashCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
-          <button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
-            <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-            <span x-text="displayLabel" class="text-xs truncate max-w-20">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}&mdash;{{end}}</span>
-          </button>
         </div>
-        <span class="bb-tx-amount{{if lt .Amount 0.0}} bb-tx-amount--income{{end}} shrink-0">
+        <span class="bb-tx-amount{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
           {{formatAmount .Amount}}
         </span>
-      </div>
+      </a>
       {{end}}
     </div>
     {{else}}
@@ -685,7 +365,7 @@
     {{end}}
   </div>
 
-  <!-- Right Column: Connection Health + Insights -->
+  <!-- Right Column: Connection Health + Quick Actions -->
   <div class="flex flex-col gap-4">
     <!-- Connection Health -->
     <div class="bb-card p-5 flex-1">
@@ -727,7 +407,6 @@
       <div class="space-y-1">
         {{range .ConnectionHealth}}
         <a href="/connections/{{.ID}}" class="flex items-center gap-2.5 py-2 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline group">
-          <!-- Status indicator -->
           <div class="relative shrink-0">
             <div class="w-7 h-7 rounded-lg flex items-center justify-center
               {{if eq .Status "error"}}bg-error/10
@@ -750,8 +429,6 @@
             </div>
             {{end}}
           </div>
-
-          <!-- Connection info -->
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-1.5">
               <span class="text-xs font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
@@ -765,8 +442,6 @@
             </div>
             {{end}}
           </div>
-
-          <!-- Status badge -->
           <div class="shrink-0">
             {{if eq .Status "active"}}
               {{if .IsStale}}
@@ -794,53 +469,18 @@
       {{end}}
     </div>
 
-    <!-- Insights + Quick Actions -->
+    <!-- Quick Actions -->
     <div class="bb-card p-4">
-      {{if .Insights}}
-      <div class="space-y-1 mb-3">
-        {{range .Insights}}
-        {{if .Link}}
-        <a href="{{.Link}}" class="flex items-center gap-2.5 py-1.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 no-underline -mx-1">
-        {{else}}
-        <div class="flex items-center gap-2.5 py-1.5 px-1 rounded-lg -mx-1">
-        {{end}}
-          <div class="w-6 h-6 rounded-md flex items-center justify-center shrink-0
-            {{if eq .Color "warning"}}bg-warning/10
-            {{else if eq .Color "error"}}bg-error/10
-            {{else if eq .Color "success"}}bg-success/10
-            {{else}}bg-base-200/50{{end}}">
-            <i data-lucide="{{.Icon}}" class="w-3 h-3
-              {{if eq .Color "warning"}}text-warning
-              {{else if eq .Color "error"}}text-error/70
-              {{else if eq .Color "success"}}text-success/70
-              {{else}}text-base-content/40{{end}}"></i>
-          </div>
-          <div class="flex-1 min-w-0">
-            <span class="text-xs text-base-content/50">{{.Label}}</span>
-          </div>
-          <span class="text-xs font-semibold tabular-nums text-base-content/70 shrink-0 truncate max-w-[10rem]">{{.Value}}</span>
-        {{if .Link}}
+      <div class="flex gap-2">
+        <a href="/connections/new" class="btn btn-primary btn-sm flex-1 rounded-xl">
+          <i data-lucide="plus" class="w-3.5 h-3.5"></i>
+          Connect Bank
         </a>
-        {{else}}
-        </div>
-        {{end}}
-        {{end}}
+        <a href="/insights" class="btn btn-ghost btn-sm flex-1 rounded-xl">
+          <i data-lucide="lightbulb" class="w-3.5 h-3.5"></i>
+          Insights
+        </a>
       </div>
-      <div class="border-t border-base-200/60 pt-3">
-      {{end}}
-        <div class="flex gap-2">
-          <a href="/connections/new" class="btn btn-primary btn-sm flex-1 rounded-xl">
-            <i data-lucide="plus" class="w-3.5 h-3.5"></i>
-            Connect Bank
-          </a>
-          <a href="/reviews" class="btn btn-ghost btn-sm flex-1 rounded-xl">
-            <i data-lucide="clipboard-check" class="w-3.5 h-3.5"></i>
-            Reviews
-          </a>
-        </div>
-      {{if .Insights}}
-      </div>
-      {{end}}
     </div>
   </div>
 </div>
@@ -859,7 +499,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
   Chart.defaults.font.family = 'Inter, system-ui, -apple-system, sans-serif';
 
-  // Determine color: green if trend is up, red if down, neutral if flat.
   var first = values[0], last = values[values.length - 1];
   var trendUp = last >= first;
   var lineColor, gradTop, gradBot;
@@ -880,7 +519,6 @@ document.addEventListener('DOMContentLoaded', function() {
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   });
 
-  /* shadcn tooltip */
   var tooltipStyle = {
     backgroundColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
     titleColor: isDark ? 'hsl(0 0% 93%)' : 'hsl(0 0% 9%)',
@@ -1017,184 +655,5 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 });
-</script>
-
-<!-- Chart.js Initialization -->
-{{if .DailyLabels}}
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-  var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-  var gridColor = isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.04)';
-  var textColor = isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)';
-
-  Chart.defaults.font.family = 'Inter, system-ui, -apple-system, sans-serif';
-
-  /* shadcn-aligned tooltip */
-  var tooltipStyle = {
-    backgroundColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
-    titleColor: isDark ? 'hsl(0 0% 93%)' : 'hsl(0 0% 9%)',
-    bodyColor: isDark ? 'hsl(0 0% 64%)' : 'hsl(0 0% 45%)',
-    borderColor: isDark ? 'hsl(0 0% 18%)' : 'hsl(0 0% 90%)',
-    borderWidth: 1,
-    padding: { top: 8, bottom: 8, left: 12, right: 12 },
-    cornerRadius: 8,
-    titleFont: { size: 11, weight: '600' },
-    bodyFont: { size: 12 },
-    displayColors: false,
-    titleMarginBottom: 4,
-  };
-
-  // Spending + Income chart
-  var trendCtx = document.getElementById('spendingTrendChart');
-  if (trendCtx) {
-    var dailyLabels = {{.DailyLabels}};
-    var dailyData = {{.DailyAmounts}};
-    var incomeData = {{.DailyIncomeAmounts}};
-    var chartDays = {{.ChartDays}};
-
-    var shortLabels = dailyLabels.map(function(d) {
-      if (chartDays === 365) {
-        var parts = d.split('-');
-        var mdate = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, 1);
-        return mdate.toLocaleDateString('en-US', { month: 'short' });
-      }
-      var date = new Date(d + 'T00:00:00');
-      if (chartDays <= 7) {
-        return date.toLocaleDateString('en-US', { weekday: 'short' });
-      }
-      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-    });
-
-    // Bar width based on data density
-    var barPct = chartDays <= 7 ? 0.6 : chartDays <= 30 ? 0.65 : 0.75;
-    var catPct = chartDays <= 7 ? 0.7 : chartDays <= 30 ? 0.8 : 0.9;
-
-    // Colors
-    var spendBg = isDark ? 'oklch(0.65 0 0 / 0.3)' : 'oklch(0.15 0 0 / 0.12)';
-    var spendHover = isDark ? 'oklch(0.65 0 0 / 0.5)' : 'oklch(0.15 0 0 / 0.22)';
-    var incomeBg = isDark ? 'oklch(0.70 0.14 155 / 0.3)' : 'oklch(0.62 0.14 155 / 0.25)';
-    var incomeHover = isDark ? 'oklch(0.70 0.14 155 / 0.5)' : 'oklch(0.62 0.14 155 / 0.4)';
-
-    var hasIncome = incomeData && incomeData.some(function(v) { return v > 0; });
-
-    var datasets = [{
-      label: 'Spending',
-      data: dailyData,
-      backgroundColor: spendBg,
-      hoverBackgroundColor: spendHover,
-      borderRadius: { topLeft: 4, topRight: 4 },
-      borderSkipped: false,
-      barPercentage: barPct,
-      categoryPercentage: catPct,
-      order: 1,
-    }];
-
-    if (hasIncome) {
-      datasets.push({
-        label: 'Income',
-        data: incomeData,
-        backgroundColor: incomeBg,
-        hoverBackgroundColor: incomeHover,
-        borderRadius: { topLeft: 4, topRight: 4 },
-        borderSkipped: false,
-        barPercentage: barPct,
-        categoryPercentage: catPct,
-        order: 2,
-      });
-    }
-
-    var maxTicks = chartDays <= 7 ? 7 : chartDays <= 30 ? 8 : chartDays <= 90 ? 10 : 12;
-
-    new Chart(trendCtx, {
-      type: 'bar',
-      data: { labels: shortLabels, datasets: datasets },
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-        interaction: { mode: 'index', intersect: false },
-        plugins: {
-          legend: { display: false },
-          tooltip: Object.assign({}, tooltipStyle, {
-            callbacks: {
-              title: function(items) {
-                var idx = items[0].dataIndex;
-                var d = dailyLabels[idx];
-                if (chartDays === 365) {
-                  var parts = d.split('-');
-                  var mdate = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, 1);
-                  return mdate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
-                }
-                var tdate = new Date(d + 'T00:00:00');
-                return tdate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
-              },
-              label: function(ctx) {
-                var prefix = ctx.dataset.label === 'Income' ? '+ ' : '';
-                return prefix + '$' + ctx.parsed.y.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
-              }
-            }
-          })
-        },
-        scales: {
-          x: {
-            grid: { display: false },
-            border: { display: false },
-            ticks: {
-              color: textColor,
-              font: { size: 10, weight: '500' },
-              maxTicksLimit: maxTicks,
-              maxRotation: 0,
-            }
-          },
-          y: {
-            grid: { color: gridColor, drawBorder: false },
-            border: { display: false },
-            ticks: {
-              color: textColor,
-              font: { size: 10, weight: '500' },
-              maxTicksLimit: 5,
-              callback: function(v) { return '$' + v.toLocaleString(); }
-            },
-            beginAtZero: true,
-          }
-        },
-        animation: {
-          duration: 400,
-          easing: 'easeOutQuart',
-        }
-      }
-    });
-  }
-});
-</script>
-{{end}}
-
-{{template "category-picker-script" .}}
-<script>
-window.__bbDashCategories = {{toJSON .Categories}};
-
-/* ── Single transaction category quick-set (dashboard) ── */
-function quickSetCategory(txId, categoryId) {
-  if (!categoryId) {
-    fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
-    .then(r => {
-      if (r.ok || r.status === 204) {
-        window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Category reset', type:'success'}}));
-      }
-    });
-    return;
-  }
-  fetch('/-/transactions/' + txId + '/category', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({category_id: categoryId})
-  })
-  .then(r => {
-    if (r.ok) {
-      window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Category updated', type:'success'}}));
-    } else {
-      r.json().then(d => window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Failed', type:'error'}})));
-    }
-  });
-}
 </script>
 {{end}}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -368,6 +368,56 @@
   </div>
 </div>
 
+<!-- Smart Spending Insights -->
+{{if .SpendingInsights}}
+<div class="bb-card mb-8 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-2.5">
+      <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/8">
+        <i data-lucide="lightbulb" class="w-3.5 h-3.5 text-primary"></i>
+      </div>
+      <h2 class="text-sm font-semibold text-base-content/70">Spending Insights</h2>
+    </div>
+    <span class="text-xs text-base-content/30">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}} vs prev</span>
+  </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
+    {{range .SpendingInsights}}
+    <div class="group relative p-4 rounded-xl border transition-all duration-200
+      {{if eq .Sentiment "negative"}}border-error/15 bg-error/3 hover:bg-error/5 hover:border-error/25
+      {{else if eq .Sentiment "positive"}}border-success/15 bg-success/3 hover:bg-success/5 hover:border-success/25
+      {{else if eq .Sentiment "info"}}border-primary/15 bg-primary/3 hover:bg-primary/5 hover:border-primary/25
+      {{else}}border-base-300/60 bg-base-200/20 hover:bg-base-200/40 hover:border-base-300{{end}}">
+      <!-- Icon + Trend indicator -->
+      <div class="flex items-center gap-2.5 mb-2.5">
+        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
+          {{if eq .Sentiment "negative"}}bg-error/10
+          {{else if eq .Sentiment "positive"}}bg-success/10
+          {{else if eq .Sentiment "info"}}bg-primary/10
+          {{else}}bg-base-200/60{{end}}">
+          <i data-lucide="{{.Icon}}" class="w-4 h-4
+            {{if eq .Sentiment "negative"}}text-error/70
+            {{else if eq .Sentiment "positive"}}text-success/70
+            {{else if eq .Sentiment "info"}}text-primary/70
+            {{else}}text-base-content/40{{end}}"></i>
+        </div>
+        {{if ne .Change 0.0}}
+        <span class="text-[0.65rem] font-semibold px-1.5 py-0.5 rounded-full
+          {{if gt .Change 0.0}}bg-error/10 text-error/80
+          {{else}}bg-success/10 text-success/80{{end}}">
+          {{if gt .Change 0.0}}+{{end}}{{printf "%.0f" .Change}}%
+        </span>
+        {{end}}
+      </div>
+      <!-- Title -->
+      <div class="text-sm font-semibold text-base-content/85 leading-tight mb-1">{{.Title}}</div>
+      <!-- Detail -->
+      <div class="text-xs text-base-content/45 leading-relaxed">{{.Detail}}</div>
+    </div>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
 <!-- Cash Flow Summary -->
 {{if .HasCashFlow}}
 <div class="bb-card mb-8 p-5 bb-stagger">

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -227,7 +227,12 @@
             <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
           </div>
           <div class="flex-1 min-w-0">
-            <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+              {{end}}
+            </div>
             <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
           </div>
           <div class="flex items-center gap-3 shrink-0">
@@ -270,7 +275,12 @@
             <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
           </div>
           <div class="flex-1 min-w-0">
-            <div class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</div>
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+              {{end}}
+            </div>
             <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
           </div>
           <div class="flex items-center gap-3 shrink-0">

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -1,0 +1,566 @@
+{{define "content"}}
+
+<!-- Insights Page Header with Date Range Picker -->
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Insights</h1>
+    <p class="text-sm text-base-content/50 mt-0.5">Spending trends, pace, and cash flow analysis</p>
+  </div>
+  <div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5">
+    <a href="/insights?days=7" class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 7}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">7d</a>
+    <a href="/insights?days=30" class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 30}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">30d</a>
+    <a href="/insights?days=90" class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 90}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">90d</a>
+    <a href="/insights?days=365" class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline {{if eq .ChartDays 365}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">12m</a>
+  </div>
+</div>
+
+<!-- Summary Pills -->
+<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+  <div class="bb-card p-4">
+    <div class="text-xs text-base-content/40 mb-1">Spending</div>
+    <div class="text-xl font-semibold tabular-nums">{{formatBalance .TotalSpending}}</div>
+    {{if .HasSpendingChange}}
+    <div class="text-[0.65rem] font-medium mt-1 {{if gt .SpendingChangePercent 0.0}}text-error/70{{else}}text-success/70{{end}}">
+      {{if gt .SpendingChangePercent 0.0}}+{{end}}{{printf "%.0f" .SpendingChangePercent}}% vs prev
+    </div>
+    {{end}}
+  </div>
+  <div class="bb-card p-4">
+    <div class="text-xs text-base-content/40 mb-1">Income</div>
+    <div class="text-xl font-semibold tabular-nums text-success">{{formatBalance .TotalIncome}}</div>
+  </div>
+  {{if .HasCashFlow}}
+  <div class="bb-card p-4">
+    <div class="text-xs text-base-content/40 mb-1">Net Cash Flow</div>
+    <div class="text-xl font-semibold tabular-nums {{if gt .CashFlowNet 0.0}}text-success{{else if lt .CashFlowNet 0.0}}text-error{{end}}">
+      {{if gt .CashFlowNet 0.0}}+{{end}}{{if lt .CashFlowNet 0.0}}-{{end}}{{formatBalance .CashFlowNet}}
+    </div>
+  </div>
+  <div class="bb-card p-4">
+    <div class="text-xs text-base-content/40 mb-1">Savings Rate</div>
+    {{if gt .TotalIncome 0.0}}
+    <div class="text-xl font-semibold tabular-nums {{if gt .SavingsRate 0.0}}text-success{{else}}text-error{{end}}">{{printf "%.0f" .SavingsRate}}%</div>
+    {{else}}
+    <div class="text-xl text-base-content/30">&mdash;</div>
+    {{end}}
+  </div>
+  {{end}}
+</div>
+
+<!-- Monthly Spending Pace -->
+{{if .HasPaceData}}
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6 bb-stagger">
+  <!-- Spending Pace Card -->
+  <div class="bb-card p-5">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-sm font-semibold text-base-content/70">{{.CurrentMonthName}} Spending Pace</h2>
+      <span class="text-xs text-base-content/30">Day {{.DaysElapsed}} of {{.DaysInMonth}}</span>
+    </div>
+
+    <!-- Month progress bar with pace marker -->
+    <div class="mb-5">
+      <div class="relative">
+        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
+          {{if gt .LastMonthSpending 0.0}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out {{if gt .PacePercent 10.0}}bg-error/50{{else if lt .PacePercent -10.0}}bg-success/50{{else}}bg-primary/40{{end}}"
+            style="width: {{printf "%.1f" .MonthProgress}}%;"></div>
+          {{else}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out bg-primary/40"
+            style="width: {{printf "%.1f" .MonthProgress}}%;"></div>
+          {{end}}
+        </div>
+        <div class="absolute top-0 h-3 w-0.5 bg-base-content/30 rounded-full" style="left: {{printf "%.1f" .MonthProgress}}%;">
+          <div class="absolute -top-5 left-1/2 -translate-x-1/2 text-[0.6rem] text-base-content/40 whitespace-nowrap font-medium">today</div>
+        </div>
+      </div>
+      <div class="flex justify-between mt-1.5 text-[0.6rem] text-base-content/30">
+        <span>{{.CurrentMonthName}} 1</span>
+        <span>{{.DaysRemaining}} days left</span>
+      </div>
+    </div>
+
+    <!-- Pace metrics grid -->
+    <div class="grid grid-cols-3 gap-4">
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Spent so far</div>
+        <div class="text-lg font-semibold tabular-nums">{{formatBalance .CurrentMonthSpending}}</div>
+      </div>
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Daily avg</div>
+        <div class="text-lg font-semibold tabular-nums">{{formatBalance .DailyAvgSpending}}</div>
+      </div>
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Projected</div>
+        <div class="flex items-baseline gap-1.5">
+          <span class="text-lg font-semibold tabular-nums">{{formatBalance .ProjectedMonthly}}</span>
+          {{if and (gt .LastMonthSpending 0.0) (ne .PaceVsLastMonth "same")}}
+          <i data-lucide="{{if eq .PaceVsLastMonth "ahead"}}arrow-up-right{{else}}arrow-down-right{{end}}" class="w-3 h-3 {{if eq .PaceVsLastMonth "ahead"}}text-error/60{{else}}text-success/60{{end}}"></i>
+          {{end}}
+        </div>
+      </div>
+    </div>
+
+    <!-- Last month comparison -->
+    {{if gt .LastMonthSpending 0.0}}
+    <div class="mt-4 pt-4 border-t border-base-200/60">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <span class="text-xs text-base-content/40">vs {{.LastMonthName}}</span>
+          <span class="text-xs font-medium tabular-nums text-base-content/50">{{formatBalance .LastMonthSpending}} total</span>
+        </div>
+        <div class="flex items-center gap-1.5">
+          {{if ne .PaceVsLastMonth ""}}
+          <div class="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium
+            {{if eq .PaceVsLastMonth "ahead"}}bg-error/8 text-error/70
+            {{else if eq .PaceVsLastMonth "behind"}}bg-success/8 text-success/70
+            {{else}}bg-base-200 text-base-content/50{{end}}">
+            {{if eq .PaceVsLastMonth "ahead"}}
+            <i data-lucide="trending-up" class="w-3 h-3"></i>
+            Spending {{printf "%.0f" (absf .PacePercent)}}% more
+            {{else if eq .PaceVsLastMonth "behind"}}
+            <i data-lucide="trending-down" class="w-3 h-3"></i>
+            Spending {{printf "%.0f" (absf .PacePercent)}}% less
+            {{else}}
+            <i data-lucide="minus" class="w-3 h-3"></i>
+            On pace
+            {{end}}
+          </div>
+          {{end}}
+        </div>
+      </div>
+      <!-- Visual comparison bar -->
+      <div class="mt-3 space-y-1.5">
+        <div class="flex items-center gap-3">
+          <span class="text-[0.65rem] text-base-content/35 w-20 shrink-0 text-right">This month</span>
+          <div class="flex-1 h-2 bg-base-200/50 rounded-full overflow-hidden">
+            <div class="h-full rounded-full transition-all duration-700 ease-out bg-primary/40"
+              style="width: {{if gt .LastMonthSpending 0.0}}{{printf "%.1f" (minf (mulf (divf .CurrentMonthSpending .LastMonthSpending) 100.0) 100.0)}}%{{else}}0%{{end}};"></div>
+          </div>
+          <span class="text-[0.65rem] tabular-nums text-base-content/40 w-16 shrink-0">{{formatBalance .CurrentMonthSpending}}</span>
+        </div>
+        <div class="flex items-center gap-3">
+          <span class="text-[0.65rem] text-base-content/35 w-20 shrink-0 text-right">{{.LastMonthName}}</span>
+          <div class="flex-1 h-2 bg-base-200/50 rounded-full overflow-hidden">
+            <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/12" style="width: 100%;"></div>
+          </div>
+          <span class="text-[0.65rem] tabular-nums text-base-content/40 w-16 shrink-0">{{formatBalance .LastMonthSpending}}</span>
+        </div>
+      </div>
+    </div>
+    {{end}}
+  </div>
+
+  <!-- Monthly Income vs Spending Summary -->
+  <div class="bb-card p-5">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-sm font-semibold text-base-content/70">{{.CurrentMonthName}} Summary</h2>
+    </div>
+
+    <!-- Big number: net for the month -->
+    <div class="text-center mb-5">
+      <div class="text-xs text-base-content/40 mb-1">Month-to-date net</div>
+      <div class="text-3xl font-semibold tabular-nums {{if gt .CurrentMonthIncome .CurrentMonthSpending}}text-success{{else}}text-error{{end}}">
+        {{if gt .CurrentMonthIncome .CurrentMonthSpending}}+{{end}}{{if lt (subf .CurrentMonthIncome .CurrentMonthSpending) 0.0}}-{{end}}{{formatBalance (absf (subf .CurrentMonthIncome .CurrentMonthSpending))}}
+      </div>
+      <div class="text-[0.65rem] text-base-content/30 mt-1">
+        {{if gt .CurrentMonthIncome .CurrentMonthSpending}}saving money{{else}}spending more than earning{{end}}
+      </div>
+    </div>
+
+    <!-- Income vs Spending mini breakdown -->
+    <div class="space-y-3">
+      <div>
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0" style="background: oklch(0.62 0.14 155)"></span>
+            Income
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-success">{{formatBalance .CurrentMonthIncome}}</span>
+        </div>
+        <div class="w-full h-2.5 bg-base-200/50 rounded-full overflow-hidden">
+          <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: 100%; background: oklch(0.62 0.14 155); opacity: 0.5;"></div>
+        </div>
+      </div>
+      <div>
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0 bg-base-content/20"></span>
+            Spending
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatBalance .CurrentMonthSpending}}</span>
+        </div>
+        <div class="w-full h-2.5 bg-base-200/50 rounded-full overflow-hidden">
+          {{if gt .CurrentMonthIncome 0.0}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15"
+            style="width: {{printf "%.1f" (minf (mulf (divf .CurrentMonthSpending .CurrentMonthIncome) 100.0) 100.0)}}%;"></div>
+          {{else}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15" style="width: 100%;"></div>
+          {{end}}
+        </div>
+      </div>
+    </div>
+
+    <!-- Key stats row -->
+    <div class="mt-5 pt-4 border-t border-base-200/60 grid grid-cols-2 gap-4">
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Burn rate</div>
+        {{if gt .CurrentMonthIncome 0.0}}
+          {{if gt .CurrentMonthSpending (mulf .CurrentMonthIncome 2.0)}}
+          <div class="text-sm font-semibold text-error/80">High</div>
+          {{else if gt .CurrentMonthSpending .CurrentMonthIncome}}
+          <div class="text-sm font-semibold text-warning">{{printf "%.0f" (mulf (divf .CurrentMonthSpending .CurrentMonthIncome) 100.0)}}% of income</div>
+          {{else}}
+          <div class="text-sm font-semibold text-success/80">{{printf "%.0f" (mulf (divf .CurrentMonthSpending .CurrentMonthIncome) 100.0)}}% of income</div>
+          {{end}}
+        {{else}}
+        <div class="text-sm text-base-content/30">&mdash;</div>
+        {{end}}
+      </div>
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Days remaining</div>
+        <div class="text-sm font-semibold tabular-nums text-base-content/70">{{.DaysRemaining}}</div>
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
+<!-- Cash Flow Summary -->
+{{if .HasCashFlow}}
+<div class="bb-card mb-6 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <h2 class="text-sm font-semibold text-base-content/70">Cash Flow</h2>
+    <span class="text-xs text-base-content/40">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}} period</span>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <!-- Income vs Spending Bars -->
+    <div class="md:col-span-2 space-y-3">
+      <div class="group">
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0" style="background: oklch(0.62 0.14 155)"></span>
+            Income
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-success">{{formatBalance .TotalIncome}}</span>
+        </div>
+        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
+          <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: 100%; background: oklch(0.62 0.14 155); opacity: 0.6;"></div>
+        </div>
+      </div>
+
+      <div class="group">
+        <div class="flex items-center justify-between mb-1.5">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/60">
+            <span class="w-2 h-2 rounded-full shrink-0 bg-base-content/20"></span>
+            Spending
+          </span>
+          <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatBalance .TotalSpending}}</span>
+        </div>
+        <div class="w-full h-3 bg-base-200/60 rounded-full overflow-hidden">
+          {{if gt .TotalIncome 0.0}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out {{if gt .SpendingRatio 90.0}}bg-error/50{{else if gt .SpendingRatio 70.0}}bg-warning/50{{else}}bg-base-content/15{{end}}" style="width: {{printf "%.1f" .SpendingRatio}}%;"></div>
+          {{else}}
+          <div class="h-full rounded-full transition-all duration-700 ease-out bg-base-content/15" style="width: 100%;"></div>
+          {{end}}
+        </div>
+      </div>
+    </div>
+
+    <!-- Net Cash Flow + Savings Rate -->
+    <div class="flex flex-col items-center justify-center text-center border-t md:border-t-0 md:border-l border-base-200/80 pt-4 md:pt-0 md:pl-6">
+      <div class="text-xs font-medium text-base-content/40 mb-1">Net Cash Flow</div>
+      <div class="text-2xl font-semibold tabular-nums {{if gt .CashFlowNet 0.0}}text-success{{else if lt .CashFlowNet 0.0}}text-error{{else}}text-base-content{{end}}">
+        {{if gt .CashFlowNet 0.0}}+{{end}}{{if lt .CashFlowNet 0.0}}-{{end}}{{formatBalance .CashFlowNet}}
+      </div>
+      {{if gt .TotalIncome 0.0}}
+      <div class="mt-2 flex items-center gap-1.5">
+        <div class="w-8 h-8 rounded-full flex items-center justify-center {{if gt .SavingsRate 20.0}}bg-success/10{{else if gt .SavingsRate 0.0}}bg-warning/10{{else}}bg-error/10{{end}}">
+          {{if gt .SavingsRate 20.0}}
+          <i data-lucide="trending-up" class="w-3.5 h-3.5 text-success"></i>
+          {{else if gt .SavingsRate 0.0}}
+          <i data-lucide="minus" class="w-3.5 h-3.5 text-warning"></i>
+          {{else}}
+          <i data-lucide="trending-down" class="w-3.5 h-3.5 text-error"></i>
+          {{end}}
+        </div>
+        <div class="text-left">
+          {{if lt .SavingsRate -200.0}}
+          <div class="text-xs font-semibold text-error/80">Over budget</div>
+          <div class="text-[0.6rem] text-base-content/30">spending > income</div>
+          {{else}}
+          <div class="text-xs font-semibold tabular-nums {{if gt .SavingsRate 0.0}}text-success/80{{else}}text-error/80{{end}}">{{printf "%.0f" .SavingsRate}}%</div>
+          <div class="text-[0.6rem] text-base-content/30">savings rate</div>
+          {{end}}
+        </div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+</div>
+{{end}}
+
+<!-- Charts Row: Spending Chart + Top Categories -->
+<div class="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-6 bb-stagger">
+  <!-- Spending & Income Chart -->
+  <div class="bb-card lg:col-span-3 p-5">
+    <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center gap-3">
+        <h2 class="text-sm font-semibold text-base-content/70">Spending</h2>
+        {{if .HasSpendingChange}}
+        <span class="text-xs font-medium {{if gt .SpendingChangePercent 0.0}}text-error/70{{else}}text-success/70{{end}}">
+          {{if gt .SpendingChangePercent 0.0}}+{{end}}{{printf "%.0f" .SpendingChangePercent}}% vs prev
+        </span>
+        {{end}}
+      </div>
+    </div>
+    {{if .DailyLabels}}
+    <div class="h-56">
+      <canvas id="spendingTrendChart"></canvas>
+    </div>
+    <div class="flex items-center gap-5 mt-3 pt-3 border-t border-base-200">
+      <span class="flex items-center gap-1.5 text-xs text-base-content/50">
+        <span class="w-2.5 h-1.5 rounded-sm bg-base-content/15"></span>
+        Spending
+      </span>
+      <span class="flex items-center gap-1.5 text-xs text-base-content/50">
+        <span class="w-2.5 h-1.5 rounded-sm" style="background: oklch(0.62 0.14 155 / 0.35)"></span>
+        Income
+      </span>
+    </div>
+    {{else}}
+    <div class="flex items-center justify-center h-56 text-base-content/40">
+      <div class="text-center">
+        <i data-lucide="bar-chart-3" class="w-10 h-10 mx-auto mb-2 opacity-40"></i>
+        <p class="text-sm">No spending data yet</p>
+      </div>
+    </div>
+    {{end}}
+  </div>
+
+  <!-- Top Spending Categories -->
+  <div class="bb-card lg:col-span-2 p-5">
+    <div class="flex items-center justify-between mb-4">
+      <h2 class="text-sm font-semibold text-base-content/70">Top Categories</h2>
+      <a href="/categories" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+    </div>
+    {{if .TopCategories}}
+    <div class="space-y-3">
+      {{range .TopCategories}}
+      <div class="group">
+        <div class="flex items-center justify-between mb-1">
+          <span class="flex items-center gap-2 text-xs font-medium text-base-content/70 group-hover:text-base-content transition-colors truncate">
+            <span class="w-2 h-2 rounded-full shrink-0" style="background-color: {{safeCSS .Color}}"></span>
+            <span class="truncate">{{.Name}}</span>
+          </span>
+          <span class="text-xs font-semibold tabular-nums text-base-content/80 shrink-0 ml-3">{{formatAmount .Amount}}</span>
+        </div>
+        <div class="w-full h-2 bg-base-200/80 rounded-full overflow-hidden">
+          <div class="h-full rounded-full transition-all duration-500 ease-out" style="width: {{printf "%.1f" .Percent}}%; background-color: {{safeCSS .Color}}; opacity: 0.7;"></div>
+        </div>
+      </div>
+      {{end}}
+    </div>
+    {{else}}
+    <div class="flex items-center justify-center h-48 text-base-content/40">
+      <div class="text-center">
+        <i data-lucide="bar-chart-2" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
+        <p class="text-sm">No category data yet</p>
+      </div>
+    </div>
+    {{end}}
+  </div>
+</div>
+
+<!-- Smart Spending Insights -->
+{{if .SpendingInsights}}
+<div class="bb-card mb-6 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-2.5">
+      <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/8">
+        <i data-lucide="lightbulb" class="w-3.5 h-3.5 text-primary"></i>
+      </div>
+      <h2 class="text-sm font-semibold text-base-content/70">Spending Insights</h2>
+    </div>
+    <span class="text-xs text-base-content/30">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}} vs prev</span>
+  </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
+    {{range .SpendingInsights}}
+    <div class="group relative p-4 rounded-xl border transition-all duration-200
+      {{if eq .Sentiment "negative"}}border-error/15 bg-error/3 hover:bg-error/5 hover:border-error/25
+      {{else if eq .Sentiment "positive"}}border-success/15 bg-success/3 hover:bg-success/5 hover:border-success/25
+      {{else if eq .Sentiment "info"}}border-primary/15 bg-primary/3 hover:bg-primary/5 hover:border-primary/25
+      {{else}}border-base-300/60 bg-base-200/20 hover:bg-base-200/40 hover:border-base-300{{end}}">
+      <div class="flex items-center gap-2.5 mb-2.5">
+        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
+          {{if eq .Sentiment "negative"}}bg-error/10
+          {{else if eq .Sentiment "positive"}}bg-success/10
+          {{else if eq .Sentiment "info"}}bg-primary/10
+          {{else}}bg-base-200/60{{end}}">
+          <i data-lucide="{{.Icon}}" class="w-4 h-4
+            {{if eq .Sentiment "negative"}}text-error/70
+            {{else if eq .Sentiment "positive"}}text-success/70
+            {{else if eq .Sentiment "info"}}text-primary/70
+            {{else}}text-base-content/40{{end}}"></i>
+        </div>
+        {{if ne .Change 0.0}}
+        <span class="text-[0.65rem] font-semibold px-1.5 py-0.5 rounded-full
+          {{if gt .Change 0.0}}bg-error/10 text-error/80
+          {{else}}bg-success/10 text-success/80{{end}}">
+          {{if gt .Change 0.0}}+{{end}}{{printf "%.0f" .Change}}%
+        </span>
+        {{end}}
+      </div>
+      <div class="text-sm font-semibold text-base-content/85 leading-tight mb-1">{{.Title}}</div>
+      <div class="text-xs text-base-content/45 leading-relaxed">{{.Detail}}</div>
+    </div>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+<!-- Chart.js Initialization -->
+{{if .DailyLabels}}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var gridColor = isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.04)';
+  var textColor = isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)';
+
+  Chart.defaults.font.family = 'Inter, system-ui, -apple-system, sans-serif';
+
+  var tooltipStyle = {
+    backgroundColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
+    titleColor: isDark ? 'hsl(0 0% 93%)' : 'hsl(0 0% 9%)',
+    bodyColor: isDark ? 'hsl(0 0% 64%)' : 'hsl(0 0% 45%)',
+    borderColor: isDark ? 'hsl(0 0% 18%)' : 'hsl(0 0% 90%)',
+    borderWidth: 1,
+    padding: { top: 8, bottom: 8, left: 12, right: 12 },
+    cornerRadius: 8,
+    titleFont: { size: 11, weight: '600' },
+    bodyFont: { size: 12 },
+    displayColors: false,
+    titleMarginBottom: 4,
+  };
+
+  var trendCtx = document.getElementById('spendingTrendChart');
+  if (trendCtx) {
+    var dailyLabels = {{.DailyLabels}};
+    var dailyData = {{.DailyAmounts}};
+    var incomeData = {{.DailyIncomeAmounts}};
+    var chartDays = {{.ChartDays}};
+
+    var shortLabels = dailyLabels.map(function(d) {
+      if (chartDays === 365) {
+        var parts = d.split('-');
+        var mdate = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, 1);
+        return mdate.toLocaleDateString('en-US', { month: 'short' });
+      }
+      var date = new Date(d + 'T00:00:00');
+      if (chartDays <= 7) {
+        return date.toLocaleDateString('en-US', { weekday: 'short' });
+      }
+      return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    });
+
+    var barPct = chartDays <= 7 ? 0.6 : chartDays <= 30 ? 0.65 : 0.75;
+    var catPct = chartDays <= 7 ? 0.7 : chartDays <= 30 ? 0.8 : 0.9;
+
+    var spendBg = isDark ? 'oklch(0.65 0 0 / 0.3)' : 'oklch(0.15 0 0 / 0.12)';
+    var spendHover = isDark ? 'oklch(0.65 0 0 / 0.5)' : 'oklch(0.15 0 0 / 0.22)';
+    var incomeBg = isDark ? 'oklch(0.70 0.14 155 / 0.3)' : 'oklch(0.62 0.14 155 / 0.25)';
+    var incomeHover = isDark ? 'oklch(0.70 0.14 155 / 0.5)' : 'oklch(0.62 0.14 155 / 0.4)';
+
+    var hasIncome = incomeData && incomeData.some(function(v) { return v > 0; });
+
+    var datasets = [{
+      label: 'Spending',
+      data: dailyData,
+      backgroundColor: spendBg,
+      hoverBackgroundColor: spendHover,
+      borderRadius: { topLeft: 4, topRight: 4 },
+      borderSkipped: false,
+      barPercentage: barPct,
+      categoryPercentage: catPct,
+      order: 1,
+    }];
+
+    if (hasIncome) {
+      datasets.push({
+        label: 'Income',
+        data: incomeData,
+        backgroundColor: incomeBg,
+        hoverBackgroundColor: incomeHover,
+        borderRadius: { topLeft: 4, topRight: 4 },
+        borderSkipped: false,
+        barPercentage: barPct,
+        categoryPercentage: catPct,
+        order: 2,
+      });
+    }
+
+    var maxTicks = chartDays <= 7 ? 7 : chartDays <= 30 ? 8 : chartDays <= 90 ? 10 : 12;
+
+    new Chart(trendCtx, {
+      type: 'bar',
+      data: { labels: shortLabels, datasets: datasets },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: { mode: 'index', intersect: false },
+        plugins: {
+          legend: { display: false },
+          tooltip: Object.assign({}, tooltipStyle, {
+            callbacks: {
+              title: function(items) {
+                var idx = items[0].dataIndex;
+                var d = dailyLabels[idx];
+                if (chartDays === 365) {
+                  var parts = d.split('-');
+                  var mdate = new Date(parseInt(parts[0]), parseInt(parts[1]) - 1, 1);
+                  return mdate.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+                }
+                var tdate = new Date(d + 'T00:00:00');
+                return tdate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+              },
+              label: function(ctx) {
+                var prefix = ctx.dataset.label === 'Income' ? '+ ' : '';
+                return prefix + '$' + ctx.parsed.y.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+              }
+            }
+          })
+        },
+        scales: {
+          x: {
+            grid: { display: false },
+            border: { display: false },
+            ticks: {
+              color: textColor,
+              font: { size: 10, weight: '500' },
+              maxTicksLimit: maxTicks,
+              maxRotation: 0,
+            }
+          },
+          y: {
+            grid: { color: gridColor, drawBorder: false },
+            border: { display: false },
+            ticks: {
+              color: textColor,
+              font: { size: 10, weight: '500' },
+              maxTicksLimit: 5,
+              callback: function(v) { return '$' + v.toLocaleString(); }
+            },
+            beginAtZero: true,
+          }
+        },
+        animation: {
+          duration: 400,
+          easing: 'easeOutQuart',
+        }
+      }
+    });
+  }
+});
+</script>
+{{end}}
+{{end}}

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -241,6 +241,7 @@
       <span class="flex items-center gap-1"><kbd class="bb-kbd">a</kbd> accept</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">s</kbd> skip</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">d</kbd> dismiss</span>
+      <span class="flex items-center gap-1"><kbd class="bb-kbd">n</kbd> note</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">c</kbd> category</span>
     </div>
   </div>
@@ -254,7 +255,7 @@
          id="triage-{{$review.ID}}"
          data-review-id="{{$review.ID}}"
          data-idx="{{$idx}}"
-         x-data="{ submitting: false, selectedCatId: '{{if $review.SuggestedCategoryID}}{{$review.SuggestedCategoryID}}{{end}}' }">
+         x-data="{ submitting: false, selectedCatId: '{{if $review.SuggestedCategoryID}}{{$review.SuggestedCategoryID}}{{end}}', triageNote: '' }">
 
       <!-- Main row: always visible -->
       <div class="bb-triage-row__main">
@@ -317,12 +318,12 @@
         <div class="bb-triage-row__actions" @click.stop>
           <button class="bb-triage-action bb-triage-action--accept" title="Accept (a)"
             :disabled="submitting"
-            @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, idx: {{$idx}} })">
+            @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, note: triageNote, idx: {{$idx}} })">
             <i data-lucide="check" class="w-3.5 h-3.5"></i>
           </button>
           <button class="bb-triage-action bb-triage-action--skip" title="Skip (s)"
             :disabled="submitting"
-            @click="$dispatch('triage-skip', { id: '{{$review.ID}}', idx: {{$idx}} })">
+            @click="$dispatch('triage-skip', { id: '{{$review.ID}}', note: triageNote, idx: {{$idx}} })">
             <i data-lucide="fast-forward" class="w-3.5 h-3.5"></i>
           </button>
           <button class="bb-triage-action bb-triage-action--dismiss" title="Dismiss (d)"
@@ -402,14 +403,17 @@
                 <svg class="w-3 h-3 ml-auto opacity-40" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
               </button>
             </div>
+            <div class="flex items-center gap-2">
+              <input type="text" class="input input-bordered input-xs flex-1 rounded-lg" placeholder="Add note..." x-model="triageNote" @keydown.stop>
+            </div>
             <div class="flex gap-1.5">
               <button class="btn btn-success btn-sm rounded-xl flex-1 gap-1" :disabled="submitting"
-                @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, idx: {{$idx}} })">
+                @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, note: triageNote, idx: {{$idx}} })">
                 <i data-lucide="check" class="w-3.5 h-3.5"></i>
                 Accept
               </button>
               <button class="btn btn-ghost btn-sm rounded-xl gap-1" :disabled="submitting"
-                @click="$dispatch('triage-skip', { id: '{{$review.ID}}', idx: {{$idx}} })">
+                @click="$dispatch('triage-skip', { id: '{{$review.ID}}', note: triageNote, idx: {{$idx}} })">
                 <i data-lucide="fast-forward" class="w-3.5 h-3.5"></i>
                 Skip
               </button>
@@ -628,10 +632,10 @@ function triageQueue() {
 
       // Listen for triage actions dispatched from child components
       this.$el.addEventListener('triage-accept', (e) => {
-        this.submitTriage(e.detail.id, 'approved', e.detail.catId, e.detail.idx);
+        this.submitTriage(e.detail.id, 'approved', e.detail.catId, e.detail.note, e.detail.idx);
       });
       this.$el.addEventListener('triage-skip', (e) => {
-        this.submitTriage(e.detail.id, 'skipped', null, e.detail.idx);
+        this.submitTriage(e.detail.id, 'skipped', null, e.detail.note, e.detail.idx);
       });
       this.$el.addEventListener('triage-dismiss', (e) => {
         this.dismissTriage(e.detail.id, e.detail.idx);
@@ -670,6 +674,10 @@ function triageQueue() {
           e.preventDefault();
           this.dismissFocused();
           break;
+        case 'n':
+          e.preventDefault();
+          this.focusNoteForFocused();
+          break;
         case 'c':
           e.preventDefault();
           this.openCategoryPickerForFocused();
@@ -694,14 +702,15 @@ function triageQueue() {
       if (!row) return;
       const id = row.dataset.reviewId;
       const data = Alpine.$data(row);
-      this.submitTriage(id, 'approved', data.selectedCatId, this.focusedIdx);
+      this.submitTriage(id, 'approved', data.selectedCatId, data.triageNote, this.focusedIdx);
     },
 
     skipFocused() {
       const row = this.getFocusedRow();
       if (!row) return;
       const id = row.dataset.reviewId;
-      this.submitTriage(id, 'skipped', null, this.focusedIdx);
+      const data = Alpine.$data(row);
+      this.submitTriage(id, 'skipped', null, data.triageNote, this.focusedIdx);
     },
 
     dismissFocused() {
@@ -716,6 +725,13 @@ function triageQueue() {
       if (!row) return;
       const pickerBtn = row.querySelector('.bb-triage-detail .bb-cat-picker button');
       if (pickerBtn) pickerBtn.click();
+    },
+
+    focusNoteForFocused() {
+      const row = this.getFocusedRow();
+      if (!row) return;
+      const noteInput = row.querySelector('.bb-triage-detail input[type="text"]');
+      if (noteInput) noteInput.focus();
     },
 
     removeRow(id, idx) {
@@ -738,7 +754,7 @@ function triageQueue() {
       this.sessionCount++;
     },
 
-    submitTriage(id, decision, categoryId, idx) {
+    submitTriage(id, decision, categoryId, note, idx) {
       const row = document.getElementById('triage-' + id);
       if (!row) return;
       const data = Alpine.$data(row);
@@ -747,6 +763,7 @@ function triageQueue() {
 
       const body = { decision: decision };
       if (categoryId) body.category_id = categoryId;
+      if (note && note.trim()) body.note = note.trim();
 
       fetch('/-/reviews/' + id + '/submit', {
         method: 'POST',

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -193,6 +193,7 @@
           <div class="w-5"></div>
           <div class="w-9"></div>
           <div class="flex-1 min-w-0">Name</div>
+          <div class="hidden sm:block shrink-0">Category</div>
           <div class="w-24 text-right hidden sm:block">Date</div>
           <div class="text-right shrink-0 pl-3">Amount</div>
           <div class="w-4 hidden sm:block"></div>
@@ -527,8 +528,8 @@ function quickSetCategory(txId, categoryId) {
         <span class="text-base-content/40 truncate hidden sm:inline">{{deref .MerchantName}}</span>
         {{end}}
         {{if .CategoryDisplayName}}
-        <span class="text-base-content/20">&middot;</span>
-        <span class="inline-flex items-center gap-1">
+        <span class="text-base-content/20 sm:hidden">&middot;</span>
+        <span class="inline-flex items-center gap-1 sm:hidden">
           <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
           <span class="text-base-content/50 truncate">{{deref .CategoryDisplayName}}</span>
         </span>
@@ -539,6 +540,16 @@ function quickSetCategory(txId, categoryId) {
           <i data-lucide="bot" class="w-3 h-3"></i>
         </span>
         {{end}}
+      </div>
+    </div>
+
+    <!-- Category Picker (inline column) -->
+    <div class="shrink-0 hidden sm:block" @click.stop>
+      <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+        <button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
+          <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+          <span x-text="displayLabel" class="text-xs truncate max-w-24">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}&mdash;{{end}}</span>
+        </button>
       </div>
     </div>
 

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -88,7 +88,12 @@
             {{end}}
           </div>
           <div class="flex-1 min-w-0">
-            <div class="text-sm font-medium group-hover:text-primary transition-colors truncate">{{.Name}}</div>
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm font-medium group-hover:text-primary transition-colors truncate">{{.Name}}</span>
+              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+              {{end}}
+            </div>
             <div class="text-xs text-base-content/40 flex items-center gap-1.5">
               <span>{{.InstitutionName}}</span>
               {{if .Mask}}

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -4,6 +4,9 @@
   <a href="/" class="bb-sidebar-link{{if eq .CurrentPage "dashboard"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="layout-dashboard"></i> Dashboard
   </a>
+  <a href="/insights" class="bb-sidebar-link{{if eq .CurrentPage "insights"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="lightbulb"></i> Insights
+  </a>
   <a href="/connections" class="bb-sidebar-link{{if eq .CurrentPage "connections"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="link"></i>
     <span class="flex-1">Connections</span>


### PR DESCRIPTION
## Summary
- Move spending-focused widgets (Spending Pace, Monthly Summary, Cash Flow, Spending Insights, Top Categories, Spending chart) from dashboard to a new `/insights` page
- Dashboard is now a clean overview: net worth hero with trend chart, account list with allocation bar, spending/income pills, recent transactions, and connection health
- New nav entry with `lightbulb` icon between Dashboard and Connections

## Changes
- `internal/admin/insights.go` — new `InsightsHandler` with all spending analysis data fetching
- `internal/templates/pages/insights.html` — insights page template with date range picker (7d/30d/90d/12m)
- `internal/admin/dashboard.go` — removed moved data fetching, kept overview-only data
- `internal/templates/pages/dashboard.html` — removed moved widgets, added quick-action link to Insights
- `internal/admin/router.go` — registered `GET /insights` route
- `internal/admin/templates.go` — registered `insights.html` template
- `internal/templates/partials/nav.html` — added Insights nav entry

## Test plan
- [ ] Verify dashboard loads cleanly with net worth, accounts, recent transactions, connection health
- [ ] Verify `/insights` page loads with spending pace, monthly summary, cash flow, spending chart, top categories, spending insights
- [ ] Verify date range picker works on both pages
- [ ] Verify nav highlighting works for both Dashboard and Insights
- [ ] Run `go build ./...` and `go test ./...` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)