### PR TITLE
Fix net worth trend chart sign inversion

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -653,7 +653,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		}
 
 		// Net worth trend: compute daily net worth by working backwards from current balance.
-		// Query all daily transaction totals (net: spending positive, income negative) for chart period.
+		// Query all daily transaction totals (spending=positive, income=negative) for chart period.
+		// Going backwards: past_nw = current_nw + daily_net (positive spending means higher past balance).
 		netWorthTrendStart := time.Now().AddDate(0, 0, -chartDays)
 		dailyNetSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
 			GroupBy:   "day",
@@ -685,9 +686,13 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			day := now.AddDate(0, 0, -(nwDays - i))
 			dayStr := day.Format("2006-01-02")
 			nwLabels[i] = dayStr
-			// Net worth on day[i] = net worth on day[i+1] - net_transactions on day[i+1].
+			// Net worth on day[i] = net worth on day[i+1] + net_transactions on day[i+1].
+			// Positive transactions = spending (reduce net worth going forward),
+			// so going backwards: previous day = current day + spending that day.
+			// Negative transactions = income (increase net worth going forward),
+			// so going backwards: previous day = current day + (negative income) = lower.
 			nextDayStr := now.AddDate(0, 0, -(nwDays - i - 1)).Format("2006-01-02")
-			nwValues[i] = nwValues[i+1] - dailyNetMap[nextDayStr]
+			nwValues[i] = nwValues[i+1] + dailyNetMap[nextDayStr]
 		}
 		var netWorthLabelsJSON, netWorthValuesJSON template.JS
 		if lb, err := json.Marshal(nwLabels); err == nil {


### PR DESCRIPTION
## Summary
- Fixed the backwards-walk formula in the net worth trend chart calculation
- The formula was subtracting daily transaction totals instead of adding them, which inverted the chart: income showed as drops, spending showed as increases
- Root cause: `past_nw = current_nw - daily_net` should be `past_nw = current_nw + daily_net` because positive amounts (spending) mean higher past balance when walking backwards

## Details
In Breadbox's sign convention, positive transaction amounts = spending/debits (money out) and negative amounts = income/credits (money in). When reconstructing past net worth by walking backwards from today's known balance:

- If $5000 was spent on a day (positive), the day before must have been $5000 **higher** → add
- If $5000 income arrived on a day (negative), the day before must have been $5000 **lower** → add (negative value)

The old formula subtracted, which flipped both cases. This caused a large bonus deposit (~March 20th) to show as a sharp drop instead of an increase.

## Test plan
- [ ] Verify chart shows upward trend around March 20th (bonus deposit date)
- [ ] Verify spending days show downward trend
- [ ] Check 7-day, 30-day, and 90-day chart views

🤖 Generated with [Claude Code](https://claude.com/claude-code)