### PR TITLE
Fix transaction category width and reviews page polish

### DIFF
--- a/input.css
+++ b/input.css
@@ -1632,17 +1632,16 @@
 
   .bb-triage-row__name {
     @apply flex flex-col min-w-0 flex-1;
-    max-width: 220px;
   }
 
   .bb-triage-row__account {
-    @apply hidden lg:block min-w-0;
-    width: 130px;
+    @apply hidden lg:block min-w-0 shrink-0;
+    width: 160px;
   }
 
   .bb-triage-row__category {
     @apply hidden md:flex md:items-center min-w-0 shrink-0;
-    width: 120px;
+    width: 160px;
   }
 
   .bb-triage-row__category > span {

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -236,6 +236,7 @@
       <span class="text-xs text-base-content/40 tabular-nums">{{.Counts.Pending}} remaining</span>
       {{end}}
     </div>
+    {{if eq .StatusFilter "pending"}}
     <div class="flex items-center gap-2 text-xs text-base-content/30">
       <span class="flex items-center gap-1"><kbd class="bb-kbd">j</kbd><kbd class="bb-kbd">k</kbd> navigate</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">a</kbd> accept</span>
@@ -244,6 +245,7 @@
       <span class="flex items-center gap-1"><kbd class="bb-kbd">n</kbd> note</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">c</kbd> category</span>
     </div>
+    {{end}}
   </div>
 
   <!-- Triage list -->
@@ -404,7 +406,7 @@
               </button>
             </div>
             <div class="flex items-center gap-2">
-              <input type="text" class="input input-bordered input-xs flex-1 rounded-lg" placeholder="Add note..." x-model="triageNote" @keydown.stop>
+              <input type="text" class="input input-bordered input-xs flex-1 rounded-lg" placeholder="Add note..." x-model="triageNote" @keydown.stop @keydown.escape.prevent="$el.blur()">
             </div>
             <div class="flex gap-1.5">
               <button class="btn btn-success btn-sm rounded-xl flex-1 gap-1" :disabled="submitting"

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -548,7 +548,7 @@ function quickSetCategory(txId, categoryId) {
       <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
         <button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
           <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-          <span x-text="displayLabel" class="text-xs truncate max-w-24">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}&mdash;{{end}}</span>
+          <span x-text="displayLabel" class="text-xs truncate max-w-48">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}&mdash;{{end}}</span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **Transaction category column**: Widened truncation limit from `max-w-24` (96px) to `max-w-48` (192px) so full category names like "Food & Drink > Restaurants" are readable in the inline picker
- **Reviews keyboard shortcuts**: Only show shortcut hints (j/k/a/s/d/n/c) when filtering by pending status — they don't apply to resolved reviews
- **Triage row width**: Removed `max-width: 220px` cap on transaction name column and widened account/category columns (130px/120px to 160px each) so rows use available horizontal space
- **Note input escape**: Added `Escape` key handler on triage note input to blur the field and return keyboard focus to the triage row

## Test plan
- [ ] Visit `/transactions` and confirm category names in the inline picker column are no longer truncated at ~6 characters
- [ ] Visit `/reviews?view=triage&status=pending` and confirm keyboard shortcut hints appear
- [ ] Visit `/reviews?view=triage&status=approved` and confirm keyboard shortcut hints are hidden
- [ ] In triage view, verify rows expand to use full width — name column should be wider
- [ ] In triage view, focus a row, press `n` to enter note field, then press `Escape` to exit back to row navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)