### PR TITLE
Add account linking for transaction deduplication and attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,12 @@ One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), M
 - Batch categorize: `batch_categorize_transactions` MCP tool (ToolWrite, max 200 items) and `POST /api/v1/transactions/batch-categorize`. Takes array of `{transaction_id, category_slug}` pairs. Pre-resolves slugs with cache.
 - Bulk recategorize: `bulk_recategorize` MCP tool (ToolWrite) and `POST /api/v1/transactions/bulk-recategorize`. Server-side UPDATE with dynamic WHERE clause (same filter params as query_transactions) + target category. Requires at least one filter (safety). Sets `category_override=TRUE`.
 - Review field selection: `list_pending_reviews` supports `fields` param. Aliases: `triage` (review id/type/status + transaction name/amount/date/category_primary_raw/account_name/user_name/merchant_name), `review_core` (review metadata only), `transaction_core` (key transaction fields). Implemented in `internal/service/fields.go` via `ParseReviewFields`/`FilterReviewFields`.
+- Account linking: `account_links` table links dependent (authorized user) accounts to primary (cardholder) accounts for cross-connection transaction deduplication. `transaction_matches` table stores matched pairs. `transactions.attributed_user_id` overrides user attribution. `accounts.is_dependent_linked` flag excludes dependent transactions from totals at query time.
+- Account link matching: `internal/sync/matcher.go` matches by date + exact amount. Runs post-sync via `Engine.matcher.ReconcileForConnection()`. Single candidate → auto-match. Multiple candidates → name similarity tiebreaker. Ambiguous → skip for manual review.
+- Attribution-aware filtering: transaction queries use `COALESCE(t.attributed_user_id, bc.user_id)` for user filtering. "Ricardo's transactions" includes his own plus those attributed to him on shared cards. Dependent account transactions excluded from totals via `AND a.is_dependent_linked = FALSE`.
+- Account link MCP tools: `list_account_links`, `create_account_link` (ToolWrite, auto-runs initial reconciliation), `delete_account_link`, `reconcile_account_link`, `list_transaction_matches`, `confirm_match`, `reject_match`.
+- Account link REST API: `/api/v1/account-links` CRUD + `/reconcile` + `/matches`. `/api/v1/transaction-matches/{id}/confirm|reject`. `POST /api/v1/transaction-matches/manual`.
+- Account link admin: `/admin/account-links` page with link list, create modal, match detail view. Nav item with `link-2` Lucide icon between Categories and Family Members.
 
 ## Canonical Enums
 
@@ -140,6 +146,8 @@ One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), M
 - Condition operators (string): `eq`, `neq`, `contains`, `not_contains`, `matches`, `in`
 - Condition operators (numeric): `eq`, `neq`, `gt`, `gte`, `lt`, `lte`
 - Condition operators (bool): `eq`, `neq`
+- Match confidence: `auto`, `confirmed`, `rejected`
+- Match strategy: `date_amount_name`
 
 ## Spec Documents
 

--- a/internal/admin/account_links.go
+++ b/internal/admin/account_links.go
@@ -1,0 +1,205 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+
+	"breadbox/internal/app"
+	"breadbox/internal/service"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// AccountForLink is a simplified account for the link creation form.
+type AccountForLink struct {
+	ID              string
+	DisplayName     string
+	UserName        string
+	InstitutionName string
+}
+
+// AccountLinksPageHandler serves GET /admin/account-links.
+func AccountLinksPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		links, err := svc.ListAccountLinks(ctx)
+		if err != nil {
+			a.Logger.Error("list account links", "error", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		// Load accounts for the creation form.
+		accounts, err := svc.ListAccounts(ctx, nil)
+		if err != nil {
+			a.Logger.Error("list accounts", "error", err)
+		}
+
+		var acctList []AccountForLink
+		for _, acct := range accounts {
+			name := acct.Name
+			if acct.OfficialName != nil && *acct.OfficialName != "" {
+				name = *acct.OfficialName
+			}
+			userName := ""
+			if acct.UserID != nil {
+				detail, err := svc.GetAccountDetail(ctx, *acct.ConnectionID)
+				if err == nil {
+					userName = detail.UserName
+				}
+			}
+			instName := ""
+			if acct.InstitutionName != nil {
+				instName = *acct.InstitutionName
+			}
+			acctList = append(acctList, AccountForLink{
+				ID:              acct.ID,
+				DisplayName:     name,
+				UserName:        userName,
+				InstitutionName: instName,
+			})
+		}
+
+		data := BaseTemplateData(r, sm, "account-links", "Account Links")
+		data["Links"] = links
+		data["Accounts"] = acctList
+
+		tr.Render(w, r, "account_links.html", data)
+	}
+}
+
+// AccountLinkDetailHandler serves GET /admin/account-links/{id}.
+func AccountLinkDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		link, err := svc.GetAccountLink(r.Context(), id)
+		if err != nil {
+			http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+			return
+		}
+
+		matches, err := svc.ListTransactionMatches(r.Context(), id)
+		if err != nil {
+			a.Logger.Error("list matches", "error", err)
+		}
+
+		data := BaseTemplateData(r, sm, "account-links", "Transaction Matches")
+		data["Link"] = link
+		data["Matches"] = matches
+
+		tr.Render(w, r, "account_link_detail.html", data)
+	}
+}
+
+// CreateAccountLinkAdminHandler handles POST /-/account-links.
+func CreateAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		primaryID := r.FormValue("primary_account_id")
+		dependentID := r.FormValue("dependent_account_id")
+
+		if primaryID == "" || dependentID == "" {
+			SetFlash(r.Context(), sm, "error", "Both accounts must be selected.")
+			http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+			return
+		}
+
+		link, err := svc.CreateAccountLink(r.Context(), service.CreateAccountLinkParams{
+			PrimaryAccountID:   primaryID,
+			DependentAccountID: dependentID,
+		})
+		if err != nil {
+			SetFlash(r.Context(), sm, "error", "Failed to create link: "+err.Error())
+			http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+			return
+		}
+
+		// Run initial reconciliation.
+		result, err := svc.RunMatchReconciliation(r.Context(), link.ID)
+		if err != nil {
+			SetFlash(r.Context(), sm, "info", "Link created. Reconciliation failed: "+err.Error())
+		} else {
+			SetFlash(r.Context(), sm, "success", formatReconciliationFlash(result))
+		}
+
+		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+	}
+}
+
+// DeleteAccountLinkAdminHandler handles POST /-/account-links/{id}/delete.
+func DeleteAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.DeleteAccountLink(r.Context(), id); err != nil {
+			SetFlash(r.Context(), sm, "error", "Failed to delete link: "+err.Error())
+		} else {
+			SetFlash(r.Context(), sm, "success", "Account link deleted. Attribution cleared.")
+		}
+		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+	}
+}
+
+// ReconcileAccountLinkAdminHandler handles POST /-/account-links/{id}/reconcile.
+func ReconcileAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		result, err := svc.RunMatchReconciliation(r.Context(), id)
+		if err != nil {
+			SetFlash(r.Context(), sm, "error", "Reconciliation failed: "+err.Error())
+		} else {
+			SetFlash(r.Context(), sm, "success", formatReconciliationFlash(result))
+		}
+
+		// Redirect back to the detail page if we came from there.
+		referer := r.Header.Get("Referer")
+		if referer != "" {
+			http.Redirect(w, r, referer, http.StatusSeeOther)
+			return
+		}
+		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+	}
+}
+
+// ConfirmMatchAdminHandler handles POST /-/transaction-matches/{id}/confirm.
+func ConfirmMatchAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.ConfirmMatch(r.Context(), id); err != nil {
+			SetFlash(r.Context(), sm, "error", "Failed to confirm match.")
+		}
+		referer := r.Header.Get("Referer")
+		if referer != "" {
+			http.Redirect(w, r, referer, http.StatusSeeOther)
+			return
+		}
+		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+	}
+}
+
+// RejectMatchAdminHandler handles POST /-/transaction-matches/{id}/reject.
+func RejectMatchAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.RejectMatch(r.Context(), id); err != nil {
+			SetFlash(r.Context(), sm, "error", "Failed to reject match.")
+		} else {
+			SetFlash(r.Context(), sm, "success", "Match rejected. Attribution cleared.")
+		}
+		referer := r.Header.Get("Referer")
+		if referer != "" {
+			http.Redirect(w, r, referer, http.StatusSeeOther)
+			return
+		}
+		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+	}
+}
+
+func formatReconciliationFlash(result *service.MatchReconciliationResult) string {
+	if result.NewMatches == 0 {
+		return "Reconciliation complete. No new matches found."
+	}
+	return fmt.Sprintf("Reconciliation complete. %d new matches, %d total matched, %d unmatched.",
+		result.NewMatches, result.TotalMatched, result.Unmatched)
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -70,6 +70,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/accounts/{id}", AccountDetailHandler(a, sm, tr, svc))
 		r.Get("/sync-logs", SyncLogsHandler(a, sm, tr, svc))
 
+		r.Get("/account-links", AccountLinksPageHandler(a, svc, sm, tr))
+		r.Get("/account-links/{id}", AccountLinkDetailHandler(a, svc, sm, tr))
+
 		r.Get("/reviews", ReviewsPageHandler(a, sm, tr, svc))
 		r.Get("/review-instructions", ReviewInstructionsPageHandler(sm, tr))
 		r.Get("/rules", RulesPageHandler(svc, sm, tr, a.Config.Version))
@@ -167,6 +170,13 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Put("/rules/{id}", UpdateRuleAdminHandler(svc, sm))
 		r.Delete("/rules/{id}", DeleteRuleAdminHandler(svc))
 		r.Post("/rules/{id}/toggle", ToggleRuleAdminHandler(svc))
+
+		// Account links
+		r.Post("/account-links", CreateAccountLinkAdminHandler(svc, sm))
+		r.Post("/account-links/{id}/delete", DeleteAccountLinkAdminHandler(svc, sm))
+		r.Post("/account-links/{id}/reconcile", ReconcileAccountLinkAdminHandler(svc, sm))
+		r.Post("/transaction-matches/{id}/confirm", ConfirmMatchAdminHandler(svc, sm))
+		r.Post("/transaction-matches/{id}/reject", RejectMatchAdminHandler(svc, sm))
 	})
 
 	return r

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -550,6 +550,8 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/rules.html",
 		"pages/review_instructions.html",
 		"pages/insights.html",
+		"pages/account_links.html",
+		"pages/account_link_detail.html",
 	}
 
 	// Pages using the wizard layout (login + first-run admin creation).

--- a/internal/api/account_links.go
+++ b/internal/api/account_links.go
@@ -1,0 +1,235 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ListAccountLinksHandler returns all account links.
+func ListAccountLinksHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		links, err := svc.ListAccountLinks(r.Context())
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list account links")
+			return
+		}
+		writeData(w, links)
+	}
+}
+
+// CreateAccountLinkHandler creates a new account link.
+func CreateAccountLinkHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var input struct {
+			PrimaryAccountID   string `json:"primary_account_id"`
+			DependentAccountID string `json:"dependent_account_id"`
+			MatchStrategy      string `json:"match_strategy"`
+			MatchToleranceDays int    `json:"match_tolerance_days"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			return
+		}
+
+		if input.PrimaryAccountID == "" || input.DependentAccountID == "" {
+			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "primary_account_id and dependent_account_id are required")
+			return
+		}
+
+		link, err := svc.CreateAccountLink(r.Context(), service.CreateAccountLinkParams{
+			PrimaryAccountID:   input.PrimaryAccountID,
+			DependentAccountID: input.DependentAccountID,
+			MatchStrategy:      input.MatchStrategy,
+			MatchToleranceDays: input.MatchToleranceDays,
+		})
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+				return
+			}
+			if errors.Is(err, service.ErrInvalidParameter) {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create account link")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, link)
+	}
+}
+
+// GetAccountLinkHandler returns a single account link.
+func GetAccountLinkHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		link, err := svc.GetAccountLink(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get account link")
+			return
+		}
+		writeData(w, link)
+	}
+}
+
+// UpdateAccountLinkHandler updates an account link.
+func UpdateAccountLinkHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		var input struct {
+			MatchStrategy      *string `json:"match_strategy"`
+			MatchToleranceDays *int    `json:"match_tolerance_days"`
+			Enabled            *bool   `json:"enabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			return
+		}
+
+		link, err := svc.UpdateAccountLink(r.Context(), id, service.UpdateAccountLinkParams{
+			MatchStrategy:      input.MatchStrategy,
+			MatchToleranceDays: input.MatchToleranceDays,
+			Enabled:            input.Enabled,
+		})
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update account link")
+			return
+		}
+		writeData(w, link)
+	}
+}
+
+// DeleteAccountLinkHandler deletes an account link.
+func DeleteAccountLinkHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.DeleteAccountLink(r.Context(), id); err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete account link")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// ReconcileAccountLinkHandler triggers match reconciliation for a link.
+func ReconcileAccountLinkHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		result, err := svc.RunMatchReconciliation(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reconcile")
+			return
+		}
+		writeData(w, result)
+	}
+}
+
+// ListTransactionMatchesHandler returns matches for a link.
+func ListTransactionMatchesHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		_ = r.URL.Query().Get("limit") // unused for now, matches are unbounded per link
+
+		matches, err := svc.ListTransactionMatches(r.Context(), id)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list matches")
+			return
+		}
+		writeData(w, matches)
+	}
+}
+
+// ConfirmMatchHandler confirms an auto-match.
+func ConfirmMatchHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.ConfirmMatch(r.Context(), id); err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Match not found")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to confirm match")
+			return
+		}
+		writeData(w, map[string]string{"status": "confirmed"})
+	}
+}
+
+// RejectMatchHandler rejects a match and clears attribution.
+func RejectMatchHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.RejectMatch(r.Context(), id); err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Match not found")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reject match")
+			return
+		}
+		writeData(w, map[string]string{"status": "rejected"})
+	}
+}
+
+// ManualMatchHandler creates a manual match between two transactions.
+func ManualMatchHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var input struct {
+			LinkID              string `json:"link_id"`
+			PrimaryTransactionID   string `json:"primary_transaction_id"`
+			DependentTransactionID string `json:"dependent_transaction_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			return
+		}
+
+		if input.LinkID == "" || input.PrimaryTransactionID == "" || input.DependentTransactionID == "" {
+			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "link_id, primary_transaction_id, and dependent_transaction_id are required")
+			return
+		}
+
+		match, err := svc.ManualMatch(r.Context(), input.LinkID, input.PrimaryTransactionID, input.DependentTransactionID)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+				return
+			}
+			if errors.Is(err, service.ErrInvalidParameter) {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create match")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, match)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -63,6 +63,9 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/reviews/{id}", GetReviewHandler(svc))
 		r.Get("/rules", ListRulesHandler(svc))
 		r.Get("/rules/{id}", GetRuleHandler(svc))
+		r.Get("/account-links", ListAccountLinksHandler(svc))
+		r.Get("/account-links/{id}", GetAccountLinkHandler(svc))
+		r.Get("/account-links/{id}/matches", ListTransactionMatchesHandler(svc))
 
 		// Write endpoints — full_access API keys only.
 		r.Group(func(r chi.Router) {
@@ -93,6 +96,13 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/rules/preview", PreviewRuleHandler(svc))
 			r.Post("/transactions/batch-categorize", BatchCategorizeHandler(svc))
 			r.Post("/transactions/bulk-recategorize", BulkRecategorizeHandler(svc))
+			r.Post("/account-links", CreateAccountLinkHandler(svc))
+			r.Put("/account-links/{id}", UpdateAccountLinkHandler(svc))
+			r.Delete("/account-links/{id}", DeleteAccountLinkHandler(svc))
+			r.Post("/account-links/{id}/reconcile", ReconcileAccountLinkHandler(svc))
+			r.Post("/transaction-matches/{id}/confirm", ConfirmMatchHandler(svc))
+			r.Post("/transaction-matches/{id}/reject", RejectMatchHandler(svc))
+			r.Post("/transaction-matches/manual", ManualMatchHandler(svc))
 		})
 	})
 

--- a/internal/db/migrations/00027_account_links.sql
+++ b/internal/db/migrations/00027_account_links.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+
+-- Account links: connects dependent (authorized user) accounts to primary accounts
+-- for cross-connection transaction deduplication and attribution.
+CREATE TABLE account_links (
+    id                     UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    primary_account_id     UUID          NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    dependent_account_id   UUID          NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+    match_strategy         TEXT          NOT NULL DEFAULT 'date_amount_name',
+    match_tolerance_days   INTEGER       NOT NULL DEFAULT 0,
+    enabled                BOOLEAN       NOT NULL DEFAULT TRUE,
+    created_at             TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ   NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_account_link UNIQUE (primary_account_id, dependent_account_id),
+    CONSTRAINT no_self_link CHECK (primary_account_id != dependent_account_id)
+);
+
+CREATE INDEX account_links_primary_idx ON account_links(primary_account_id) WHERE enabled = TRUE;
+CREATE INDEX account_links_dependent_idx ON account_links(dependent_account_id) WHERE enabled = TRUE;
+
+-- Transaction matches: pairs of matched transactions across linked accounts.
+CREATE TABLE transaction_matches (
+    id                       UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_link_id          UUID        NOT NULL REFERENCES account_links(id) ON DELETE CASCADE,
+    primary_transaction_id   UUID        NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
+    dependent_transaction_id UUID        NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
+    match_confidence         TEXT        NOT NULL DEFAULT 'auto',
+    matched_on               TEXT[]      NOT NULL,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_primary_match UNIQUE (primary_transaction_id),
+    CONSTRAINT uq_dependent_match UNIQUE (dependent_transaction_id)
+);
+
+CREATE INDEX transaction_matches_link_idx ON transaction_matches(account_link_id);
+CREATE INDEX transaction_matches_primary_idx ON transaction_matches(primary_transaction_id);
+CREATE INDEX transaction_matches_dependent_idx ON transaction_matches(dependent_transaction_id);
+
+-- Transaction attribution: override who a transaction is attributed to.
+ALTER TABLE transactions ADD COLUMN attributed_user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL;
+CREATE INDEX transactions_attributed_user_idx ON transactions(attributed_user_id) WHERE attributed_user_id IS NOT NULL;
+
+-- Fast query-time filter for dependent-linked accounts.
+ALTER TABLE accounts ADD COLUMN is_dependent_linked BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- +goose Down
+ALTER TABLE accounts DROP COLUMN IF EXISTS is_dependent_linked;
+DROP INDEX IF EXISTS transactions_attributed_user_idx;
+ALTER TABLE transactions DROP COLUMN IF EXISTS attributed_user_id;
+DROP TABLE IF EXISTS transaction_matches;
+DROP TABLE IF EXISTS account_links;

--- a/internal/db/queries/account_links.sql
+++ b/internal/db/queries/account_links.sql
@@ -1,0 +1,68 @@
+-- name: CreateAccountLink :one
+INSERT INTO account_links (primary_account_id, dependent_account_id, match_strategy, match_tolerance_days)
+VALUES ($1, $2, $3, $4)
+RETURNING *;
+
+-- name: GetAccountLink :one
+SELECT al.*,
+       pa.name AS primary_account_name,
+       COALESCE(pa.display_name, pa.name) AS primary_account_display_name,
+       da.name AS dependent_account_name,
+       COALESCE(da.display_name, da.name) AS dependent_account_display_name,
+       pu.name AS primary_user_name,
+       du.name AS dependent_user_name
+FROM account_links al
+JOIN accounts pa ON al.primary_account_id = pa.id
+JOIN accounts da ON al.dependent_account_id = da.id
+LEFT JOIN bank_connections pbc ON pa.connection_id = pbc.id
+LEFT JOIN users pu ON pbc.user_id = pu.id
+LEFT JOIN bank_connections dbc ON da.connection_id = dbc.id
+LEFT JOIN users du ON dbc.user_id = du.id
+WHERE al.id = $1;
+
+-- name: ListAccountLinks :many
+SELECT al.*,
+       pa.name AS primary_account_name,
+       COALESCE(pa.display_name, pa.name) AS primary_account_display_name,
+       da.name AS dependent_account_name,
+       COALESCE(da.display_name, da.name) AS dependent_account_display_name,
+       pu.name AS primary_user_name,
+       du.name AS dependent_user_name
+FROM account_links al
+JOIN accounts pa ON al.primary_account_id = pa.id
+JOIN accounts da ON al.dependent_account_id = da.id
+LEFT JOIN bank_connections pbc ON pa.connection_id = pbc.id
+LEFT JOIN users pu ON pbc.user_id = pu.id
+LEFT JOIN bank_connections dbc ON da.connection_id = dbc.id
+LEFT JOIN users du ON dbc.user_id = du.id
+ORDER BY al.created_at DESC;
+
+-- name: UpdateAccountLink :one
+UPDATE account_links
+SET match_strategy = $2,
+    match_tolerance_days = $3,
+    enabled = $4,
+    updated_at = NOW()
+WHERE id = $1
+RETURNING *;
+
+-- name: DeleteAccountLink :exec
+DELETE FROM account_links WHERE id = $1;
+
+-- name: ListAccountLinksByAccountID :many
+SELECT * FROM account_links
+WHERE (primary_account_id = $1 OR dependent_account_id = $1) AND enabled = TRUE;
+
+-- name: ListAccountLinksByConnectionID :many
+SELECT al.* FROM account_links al
+JOIN accounts a ON a.id = al.primary_account_id OR a.id = al.dependent_account_id
+WHERE a.connection_id = $1 AND al.enabled = TRUE;
+
+-- name: UpdateAccountDependentLinked :exec
+UPDATE accounts SET is_dependent_linked = $2, updated_at = NOW() WHERE id = $1;
+
+-- name: GetDependentUserID :one
+SELECT u.id FROM accounts a
+JOIN bank_connections bc ON a.connection_id = bc.id
+JOIN users u ON bc.user_id = u.id
+WHERE a.id = $1;

--- a/internal/db/queries/transaction_matches.sql
+++ b/internal/db/queries/transaction_matches.sql
@@ -1,0 +1,51 @@
+-- name: CreateTransactionMatch :one
+INSERT INTO transaction_matches (account_link_id, primary_transaction_id, dependent_transaction_id, match_confidence, matched_on)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT DO NOTHING
+RETURNING *;
+
+-- name: GetTransactionMatch :one
+SELECT * FROM transaction_matches WHERE id = $1;
+
+-- name: GetTransactionMatchByPrimaryTxn :one
+SELECT * FROM transaction_matches WHERE primary_transaction_id = $1;
+
+-- name: GetTransactionMatchByDependentTxn :one
+SELECT * FROM transaction_matches WHERE dependent_transaction_id = $1;
+
+-- name: ListTransactionMatchesByLink :many
+SELECT tm.*,
+       pt.name AS primary_txn_name, pt.amount AS primary_txn_amount, pt.date AS primary_txn_date, pt.merchant_name AS primary_txn_merchant,
+       dt.name AS dependent_txn_name, dt.amount AS dependent_txn_amount, dt.date AS dependent_txn_date, dt.merchant_name AS dependent_txn_merchant
+FROM transaction_matches tm
+JOIN transactions pt ON tm.primary_transaction_id = pt.id
+JOIN transactions dt ON tm.dependent_transaction_id = dt.id
+WHERE tm.account_link_id = $1
+ORDER BY pt.date DESC, tm.created_at DESC;
+
+-- name: CountTransactionMatchesByLink :one
+SELECT COUNT(*) FROM transaction_matches WHERE account_link_id = $1;
+
+-- name: CountUnmatchedDependentTransactions :one
+SELECT COUNT(*) FROM transactions t
+JOIN accounts a ON t.account_id = a.id
+WHERE a.id = $1
+  AND t.deleted_at IS NULL
+  AND NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id);
+
+-- name: UpdateTransactionMatchConfidence :one
+UPDATE transaction_matches SET match_confidence = $2 WHERE id = $1 RETURNING *;
+
+-- name: DeleteTransactionMatch :exec
+DELETE FROM transaction_matches WHERE id = $1;
+
+-- name: DeleteTransactionMatchesByLink :exec
+DELETE FROM transaction_matches WHERE account_link_id = $1;
+
+-- name: SetTransactionAttributedUser :exec
+UPDATE transactions SET attributed_user_id = $2, updated_at = NOW() WHERE id = $1;
+
+-- name: ClearTransactionAttributedUserByLink :exec
+UPDATE transactions t SET attributed_user_id = NULL, updated_at = NOW()
+FROM transaction_matches tm
+WHERE tm.primary_transaction_id = t.id AND tm.account_link_id = $1;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -72,6 +72,15 @@ TRANSACTION RULES:
 - Use preview_rule to test a condition before creating — shows match count and sample transactions
 - Teller's "general" category is a catch-all — do NOT create a category_primary rule for it, use name patterns instead
 
+ACCOUNT LINKING (Deduplication & Attribution):
+- When two family members connect the same credit card (e.g., primary cardholder + authorized user), transactions appear in both feeds with different IDs
+- Use create_account_link to link the dependent account to the primary account
+- The system auto-matches transactions by date + exact amount, attributes matched primary-side transactions to the dependent user
+- Dependent account transactions are excluded from totals and summaries by default
+- When filtering by user_id, attributed transactions are included — "Ricardo's transactions" includes his own plus those attributed to him on the shared card
+- Use reconcile_account_link to re-run matching after new syncs
+- Use list_transaction_matches to review matched pairs, confirm_match/reject_match to correct errors
+
 RULE CREATION STRATEGY — follow this order:
 1. FIRST, create category_primary rules (highest impact). Look at the category_primary field on transactions — these are raw provider categories like "dining", "groceries", "phone", "accommodation", "fuel", "entertainment". One rule per category_primary covers ALL transactions with that label. Example: {"and": [{"field": "provider", "op": "eq", "value": "teller"}, {"field": "category_primary", "op": "eq", "value": "dining"}]} → food_and_drink_restaurant. This single rule handles every dining transaction from Teller.
 2. THEN, create name-pattern rules for transaction types that span merchants: "ATM Withdrawal" → withdrawals, "Wire Transfer" → transfer_out, "Service Charge" → bank_fees, "Cash Deposit" → deposits. Use contains on the name field.
@@ -224,6 +233,27 @@ func (s *MCPServer) buildToolRegistry() {
 		makeToolDef("bulk_recategorize", ToolWrite,
 			"Recategorize all transactions matching a filter to a new category. Requires target_category_slug and at least one filter (safety requirement). Sets category_override=true since this is an explicit action. Use this for bulk corrections — e.g., recategorize all transactions currently tagged 'general_merchandise' in a date range to 'groceries'. Returns matched/updated counts.",
 			s.handleBulkRecategorize),
+		makeToolDef("list_account_links", ToolRead,
+			"List account links between primary and dependent/authorized-user accounts. Account links deduplicate transactions that appear in both a primary cardholder and authorized user's bank feeds. Returns link details, match counts, and unmatched transaction counts.",
+			s.handleListAccountLinks),
+		makeToolDef("create_account_link", ToolWrite,
+			"Link a dependent account to a primary account for cross-connection deduplication. When two family members connect the same credit card (e.g., primary cardholder and authorized user), transactions appear in both feeds. This link pairs matching transactions by date+amount, excludes the dependent's copies from totals, and attributes matched primary-side transactions to the dependent user. Automatically runs initial reconciliation after creation.",
+			s.handleCreateAccountLink),
+		makeToolDef("delete_account_link", ToolWrite,
+			"Remove an account link and clear all transaction attribution set by it. Transactions from the dependent account will be included in totals again.",
+			s.handleDeleteAccountLink),
+		makeToolDef("reconcile_account_link", ToolWrite,
+			"Manually trigger match reconciliation for an account link. Finds unmatched dependent transactions and attempts to pair them with primary account transactions by date and exact amount. Sets attributed_user_id on matched primary transactions.",
+			s.handleReconcileAccountLink),
+		makeToolDef("list_transaction_matches", ToolRead,
+			"List matched transaction pairs for an account link. Shows which primary-side transactions have been matched to dependent-side transactions, with match confidence and the fields that matched.",
+			s.handleListTransactionMatches),
+		makeToolDef("confirm_match", ToolWrite,
+			"Confirm an auto-matched transaction pair as correct. Changes match confidence from 'auto' to 'confirmed'.",
+			s.handleConfirmMatch),
+		makeToolDef("reject_match", ToolWrite,
+			"Reject a false auto-match between two transactions. Removes the match record and clears the attributed_user_id on the primary transaction.",
+			s.handleRejectMatch),
 	}
 }
 

--- a/internal/mcp/tools_account_links.go
+++ b/internal/mcp/tools_account_links.go
@@ -1,0 +1,121 @@
+package mcp
+
+import (
+	"context"
+
+	"breadbox/internal/service"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// --- Input types ---
+
+type listAccountLinksInput struct{}
+
+type createAccountLinkInput struct {
+	PrimaryAccountID   string `json:"primary_account_id" jsonschema:"The primary cardholder's account ID"`
+	DependentAccountID string `json:"dependent_account_id" jsonschema:"The authorized/dependent user's account ID"`
+	MatchStrategy      string `json:"match_strategy,omitempty" jsonschema:"Matching strategy: date_amount_name (default)"`
+	MatchToleranceDays int    `json:"match_tolerance_days,omitempty" jsonschema:"Date tolerance in days for matching (default 0 = same day)"`
+}
+
+type deleteAccountLinkInput struct {
+	LinkID string `json:"link_id" jsonschema:"The account link ID to delete"`
+}
+
+type reconcileAccountLinkInput struct {
+	LinkID string `json:"link_id" jsonschema:"The account link ID to reconcile"`
+}
+
+type listTransactionMatchesInput struct {
+	LinkID string `json:"link_id" jsonschema:"The account link ID to list matches for"`
+}
+
+type confirmMatchInput struct {
+	MatchID string `json:"match_id" jsonschema:"The transaction match ID to confirm"`
+}
+
+type rejectMatchInput struct {
+	MatchID string `json:"match_id" jsonschema:"The transaction match ID to reject"`
+}
+
+// --- Handlers ---
+
+func (s *MCPServer) handleListAccountLinks(_ context.Context, _ *mcpsdk.CallToolRequest, _ listAccountLinksInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	links, err := s.svc.ListAccountLinks(ctx)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(links)
+}
+
+func (s *MCPServer) handleCreateAccountLink(_ context.Context, _ *mcpsdk.CallToolRequest, input createAccountLinkInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	link, err := s.svc.CreateAccountLink(ctx, service.CreateAccountLinkParams{
+		PrimaryAccountID:   input.PrimaryAccountID,
+		DependentAccountID: input.DependentAccountID,
+		MatchStrategy:      input.MatchStrategy,
+		MatchToleranceDays: input.MatchToleranceDays,
+	})
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+
+	// Auto-run initial reconciliation after creating a link.
+	result, reconcileErr := s.svc.RunMatchReconciliation(ctx, link.ID)
+	if reconcileErr != nil {
+		// Non-fatal — return the link anyway.
+		return jsonResult(map[string]any{
+			"link":                link,
+			"reconciliation_note": "Link created but initial reconciliation failed: " + reconcileErr.Error(),
+		})
+	}
+
+	return jsonResult(map[string]any{
+		"link":           link,
+		"reconciliation": result,
+	})
+}
+
+func (s *MCPServer) handleDeleteAccountLink(_ context.Context, _ *mcpsdk.CallToolRequest, input deleteAccountLinkInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	if err := s.svc.DeleteAccountLink(ctx, input.LinkID); err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(map[string]string{"status": "deleted"})
+}
+
+func (s *MCPServer) handleReconcileAccountLink(_ context.Context, _ *mcpsdk.CallToolRequest, input reconcileAccountLinkInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	result, err := s.svc.RunMatchReconciliation(ctx, input.LinkID)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(result)
+}
+
+func (s *MCPServer) handleListTransactionMatches(_ context.Context, _ *mcpsdk.CallToolRequest, input listTransactionMatchesInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	matches, err := s.svc.ListTransactionMatches(ctx, input.LinkID)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(matches)
+}
+
+func (s *MCPServer) handleConfirmMatch(_ context.Context, _ *mcpsdk.CallToolRequest, input confirmMatchInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	if err := s.svc.ConfirmMatch(ctx, input.MatchID); err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(map[string]string{"status": "confirmed"})
+}
+
+func (s *MCPServer) handleRejectMatch(_ context.Context, _ *mcpsdk.CallToolRequest, input rejectMatchInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	if err := s.svc.RejectMatch(ctx, input.MatchID); err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(map[string]string{"status": "rejected"})
+}

--- a/internal/service/account_links.go
+++ b/internal/service/account_links.go
@@ -1,0 +1,486 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// AccountLinkResponse is the API response for an account link.
+type AccountLinkResponse struct {
+	ID                       string `json:"id"`
+	PrimaryAccountID         string `json:"primary_account_id"`
+	PrimaryAccountName       string `json:"primary_account_name"`
+	PrimaryUserName          string `json:"primary_user_name"`
+	DependentAccountID       string `json:"dependent_account_id"`
+	DependentAccountName     string `json:"dependent_account_name"`
+	DependentUserName        string `json:"dependent_user_name"`
+	MatchStrategy            string `json:"match_strategy"`
+	MatchToleranceDays       int    `json:"match_tolerance_days"`
+	Enabled                  bool   `json:"enabled"`
+	MatchCount               int64  `json:"match_count"`
+	UnmatchedDependentCount  int64  `json:"unmatched_dependent_count"`
+	CreatedAt                string `json:"created_at"`
+	UpdatedAt                string `json:"updated_at"`
+}
+
+// TransactionMatchResponse is the API response for a transaction match.
+type TransactionMatchResponse struct {
+	ID                     string   `json:"id"`
+	AccountLinkID          string   `json:"account_link_id"`
+	PrimaryTransactionID   string   `json:"primary_transaction_id"`
+	DependentTransactionID string   `json:"dependent_transaction_id"`
+	MatchConfidence        string   `json:"match_confidence"`
+	MatchedOn              []string `json:"matched_on"`
+	CreatedAt              string   `json:"created_at"`
+	PrimaryTxnName         string   `json:"primary_txn_name"`
+	PrimaryTxnMerchant     *string  `json:"primary_txn_merchant"`
+	DependentTxnName       string   `json:"dependent_txn_name"`
+	DependentTxnMerchant   *string  `json:"dependent_txn_merchant"`
+	Amount                 float64  `json:"amount"`
+	Date                   string   `json:"date"`
+}
+
+// CreateAccountLinkParams defines the params for creating an account link.
+type CreateAccountLinkParams struct {
+	PrimaryAccountID   string
+	DependentAccountID string
+	MatchStrategy      string
+	MatchToleranceDays int
+}
+
+// UpdateAccountLinkParams defines the params for updating an account link.
+type UpdateAccountLinkParams struct {
+	MatchStrategy      *string
+	MatchToleranceDays *int
+	Enabled            *bool
+}
+
+// MatchReconciliationResult is the result of a reconciliation run.
+type MatchReconciliationResult struct {
+	NewMatches   int   `json:"new_matches"`
+	TotalMatched int64 `json:"total_matched"`
+	Unmatched    int64 `json:"unmatched"`
+}
+
+// CreateAccountLink establishes a link between a primary and dependent account.
+func (s *Service) CreateAccountLink(ctx context.Context, params CreateAccountLinkParams) (*AccountLinkResponse, error) {
+	primaryID, err := parseUUID(params.PrimaryAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid primary account id", ErrInvalidParameter)
+	}
+	dependentID, err := parseUUID(params.DependentAccountID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid dependent account id", ErrInvalidParameter)
+	}
+
+	// Verify both accounts exist.
+	if _, err := s.Queries.GetAccount(ctx, primaryID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: primary account not found", ErrNotFound)
+		}
+		return nil, fmt.Errorf("get primary account: %w", err)
+	}
+	if _, err := s.Queries.GetAccount(ctx, dependentID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("%w: dependent account not found", ErrNotFound)
+		}
+		return nil, fmt.Errorf("get dependent account: %w", err)
+	}
+
+	strategy := params.MatchStrategy
+	if strategy == "" {
+		strategy = "date_amount_name"
+	}
+
+	link, err := s.Queries.CreateAccountLink(ctx, db.CreateAccountLinkParams{
+		PrimaryAccountID:   primaryID,
+		DependentAccountID: dependentID,
+		MatchStrategy:      strategy,
+		MatchToleranceDays: int32(params.MatchToleranceDays),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create account link: %w", err)
+	}
+
+	// Mark the dependent account as linked.
+	if err := s.Queries.UpdateAccountDependentLinked(ctx, db.UpdateAccountDependentLinkedParams{
+		ID:                dependentID,
+		IsDependentLinked: true,
+	}); err != nil {
+		return nil, fmt.Errorf("mark dependent account: %w", err)
+	}
+
+	// Return the full response.
+	return s.GetAccountLink(ctx, formatUUID(link.ID))
+}
+
+// GetAccountLink returns a single account link by ID with denormalized info.
+func (s *Service) GetAccountLink(ctx context.Context, id string) (*AccountLinkResponse, error) {
+	uid, err := parseUUID(id)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+	row, err := s.Queries.GetAccountLink(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get account link: %w", err)
+	}
+
+	matchCount, _ := s.Queries.CountTransactionMatchesByLink(ctx, uid)
+	unmatchedCount, _ := s.Queries.CountUnmatchedDependentTransactions(ctx, row.DependentAccountID)
+
+	return &AccountLinkResponse{
+		ID:                      formatUUID(row.ID),
+		PrimaryAccountID:        formatUUID(row.PrimaryAccountID),
+		PrimaryAccountName:      row.PrimaryAccountDisplayName,
+		PrimaryUserName:         textPtrVal(row.PrimaryUserName),
+		DependentAccountID:      formatUUID(row.DependentAccountID),
+		DependentAccountName:    row.DependentAccountDisplayName,
+		DependentUserName:       textPtrVal(row.DependentUserName),
+		MatchStrategy:           row.MatchStrategy,
+		MatchToleranceDays:      int(row.MatchToleranceDays),
+		Enabled:                 row.Enabled,
+		MatchCount:              matchCount,
+		UnmatchedDependentCount: unmatchedCount,
+		CreatedAt:               row.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:               row.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}, nil
+}
+
+// ListAccountLinks returns all account links.
+func (s *Service) ListAccountLinks(ctx context.Context) ([]AccountLinkResponse, error) {
+	rows, err := s.Queries.ListAccountLinks(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list account links: %w", err)
+	}
+
+	result := make([]AccountLinkResponse, 0, len(rows))
+	for _, row := range rows {
+		matchCount, _ := s.Queries.CountTransactionMatchesByLink(ctx, row.ID)
+		unmatchedCount, _ := s.Queries.CountUnmatchedDependentTransactions(ctx, row.DependentAccountID)
+
+		result = append(result, AccountLinkResponse{
+			ID:                      formatUUID(row.ID),
+			PrimaryAccountID:        formatUUID(row.PrimaryAccountID),
+			PrimaryAccountName:      row.PrimaryAccountDisplayName,
+			PrimaryUserName:         textPtrVal(row.PrimaryUserName),
+			DependentAccountID:      formatUUID(row.DependentAccountID),
+			DependentAccountName:    row.DependentAccountDisplayName,
+			DependentUserName:       textPtrVal(row.DependentUserName),
+			MatchStrategy:           row.MatchStrategy,
+			MatchToleranceDays:      int(row.MatchToleranceDays),
+			Enabled:                 row.Enabled,
+			MatchCount:              matchCount,
+			UnmatchedDependentCount: unmatchedCount,
+			CreatedAt:               row.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			UpdatedAt:               row.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		})
+	}
+	return result, nil
+}
+
+// UpdateAccountLink updates match strategy, tolerance, or enabled status.
+func (s *Service) UpdateAccountLink(ctx context.Context, id string, params UpdateAccountLinkParams) (*AccountLinkResponse, error) {
+	uid, err := parseUUID(id)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	// Load current values.
+	row, err := s.Queries.GetAccountLink(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get account link: %w", err)
+	}
+
+	strategy := row.MatchStrategy
+	tolerance := row.MatchToleranceDays
+	enabled := row.Enabled
+
+	if params.MatchStrategy != nil {
+		strategy = *params.MatchStrategy
+	}
+	if params.MatchToleranceDays != nil {
+		tolerance = int32(*params.MatchToleranceDays)
+	}
+	if params.Enabled != nil {
+		enabled = *params.Enabled
+	}
+
+	if _, err := s.Queries.UpdateAccountLink(ctx, db.UpdateAccountLinkParams{
+		ID:                 uid,
+		MatchStrategy:      strategy,
+		MatchToleranceDays: tolerance,
+		Enabled:            enabled,
+	}); err != nil {
+		return nil, fmt.Errorf("update account link: %w", err)
+	}
+
+	// If disabling, unmark the dependent account.
+	if params.Enabled != nil && !*params.Enabled {
+		// Check if the dependent is still linked by another enabled link.
+		links, _ := s.Queries.ListAccountLinksByAccountID(ctx, row.DependentAccountID)
+		stillLinked := false
+		for _, l := range links {
+			if formatUUID(l.ID) != id && l.Enabled {
+				stillLinked = true
+				break
+			}
+		}
+		if !stillLinked {
+			_ = s.Queries.UpdateAccountDependentLinked(ctx, db.UpdateAccountDependentLinkedParams{
+				ID:                row.DependentAccountID,
+				IsDependentLinked: false,
+			})
+		}
+	}
+
+	// If re-enabling, mark the dependent account.
+	if params.Enabled != nil && *params.Enabled {
+		_ = s.Queries.UpdateAccountDependentLinked(ctx, db.UpdateAccountDependentLinkedParams{
+			ID:                row.DependentAccountID,
+			IsDependentLinked: true,
+		})
+	}
+
+	return s.GetAccountLink(ctx, id)
+}
+
+// DeleteAccountLink removes a link, clears attribution, and unmarks the dependent.
+func (s *Service) DeleteAccountLink(ctx context.Context, id string) error {
+	uid, err := parseUUID(id)
+	if err != nil {
+		return ErrNotFound
+	}
+
+	row, err := s.Queries.GetAccountLink(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("get account link: %w", err)
+	}
+
+	// Clear attributed_user_id on transactions matched via this link.
+	if err := s.Queries.ClearTransactionAttributedUserByLink(ctx, uid); err != nil {
+		return fmt.Errorf("clear attribution: %w", err)
+	}
+
+	// Delete the link (CASCADE deletes transaction_matches).
+	if err := s.Queries.DeleteAccountLink(ctx, uid); err != nil {
+		return fmt.Errorf("delete account link: %w", err)
+	}
+
+	// Check if the dependent is still linked by another enabled link.
+	links, _ := s.Queries.ListAccountLinksByAccountID(ctx, row.DependentAccountID)
+	if len(links) == 0 {
+		_ = s.Queries.UpdateAccountDependentLinked(ctx, db.UpdateAccountDependentLinkedParams{
+			ID:                row.DependentAccountID,
+			IsDependentLinked: false,
+		})
+	}
+
+	return nil
+}
+
+// ListTransactionMatches returns all matches for a given link.
+func (s *Service) ListTransactionMatches(ctx context.Context, linkID string) ([]TransactionMatchResponse, error) {
+	uid, err := parseUUID(linkID)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	rows, err := s.Queries.ListTransactionMatchesByLink(ctx, uid)
+	if err != nil {
+		return nil, fmt.Errorf("list matches: %w", err)
+	}
+
+	result := make([]TransactionMatchResponse, 0, len(rows))
+	for _, row := range rows {
+		amountVal := 0.0
+		if f := numericFloat(row.PrimaryTxnAmount); f != nil {
+			amountVal = *f
+		}
+		var dateVal string
+		if d := dateStr(row.PrimaryTxnDate); d != nil {
+			dateVal = *d
+		}
+
+		result = append(result, TransactionMatchResponse{
+			ID:                     formatUUID(row.ID),
+			AccountLinkID:          formatUUID(row.AccountLinkID),
+			PrimaryTransactionID:   formatUUID(row.PrimaryTransactionID),
+			DependentTransactionID: formatUUID(row.DependentTransactionID),
+			MatchConfidence:        row.MatchConfidence,
+			MatchedOn:              row.MatchedOn,
+			CreatedAt:              row.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			PrimaryTxnName:         row.PrimaryTxnName,
+			PrimaryTxnMerchant:     textPtr(row.PrimaryTxnMerchant),
+			DependentTxnName:       row.DependentTxnName,
+			DependentTxnMerchant:   textPtr(row.DependentTxnMerchant),
+			Amount:                 amountVal,
+			Date:                   dateVal,
+		})
+	}
+	return result, nil
+}
+
+// ConfirmMatch marks an auto-match as confirmed.
+func (s *Service) ConfirmMatch(ctx context.Context, matchID string) error {
+	uid, err := parseUUID(matchID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if _, err := s.Queries.UpdateTransactionMatchConfidence(ctx, db.UpdateTransactionMatchConfidenceParams{
+		ID:              uid,
+		MatchConfidence: "confirmed",
+	}); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("confirm match: %w", err)
+	}
+	return nil
+}
+
+// RejectMatch removes a match and clears the attribution on the primary transaction.
+func (s *Service) RejectMatch(ctx context.Context, matchID string) error {
+	uid, err := parseUUID(matchID)
+	if err != nil {
+		return ErrNotFound
+	}
+
+	match, err := s.Queries.GetTransactionMatch(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("get match: %w", err)
+	}
+
+	// Clear attribution on the primary transaction.
+	if err := s.Queries.SetTransactionAttributedUser(ctx, db.SetTransactionAttributedUserParams{
+		ID:               match.PrimaryTransactionID,
+		AttributedUserID: pgtype.UUID{}, // NULL
+	}); err != nil {
+		return fmt.Errorf("clear attribution: %w", err)
+	}
+
+	if err := s.Queries.DeleteTransactionMatch(ctx, uid); err != nil {
+		return fmt.Errorf("delete match: %w", err)
+	}
+	return nil
+}
+
+// ManualMatch creates a match between two specific transactions.
+func (s *Service) ManualMatch(ctx context.Context, linkID, primaryTxnID, dependentTxnID string) (*TransactionMatchResponse, error) {
+	linkUUID, err := parseUUID(linkID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid link id", ErrInvalidParameter)
+	}
+	primaryUUID, err := parseUUID(primaryTxnID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid primary transaction id", ErrInvalidParameter)
+	}
+	dependentUUID, err := parseUUID(dependentTxnID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid dependent transaction id", ErrInvalidParameter)
+	}
+
+	// Verify the link exists.
+	link, err := s.Queries.GetAccountLink(ctx, linkUUID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get link: %w", err)
+	}
+
+	match, err := s.Queries.CreateTransactionMatch(ctx, db.CreateTransactionMatchParams{
+		AccountLinkID:          linkUUID,
+		PrimaryTransactionID:   primaryUUID,
+		DependentTransactionID: dependentUUID,
+		MatchConfidence:        "confirmed",
+		MatchedOn:              []string{"manual"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create match: %w", err)
+	}
+
+	// Set attribution on the primary transaction.
+	depUserID, err := s.Queries.GetDependentUserID(ctx, link.DependentAccountID)
+	if err == nil {
+		_ = s.Queries.SetTransactionAttributedUser(ctx, db.SetTransactionAttributedUserParams{
+			ID:               primaryUUID,
+			AttributedUserID: depUserID,
+		})
+	}
+
+	return &TransactionMatchResponse{
+		ID:                     formatUUID(match.ID),
+		AccountLinkID:          formatUUID(match.AccountLinkID),
+		PrimaryTransactionID:   formatUUID(match.PrimaryTransactionID),
+		DependentTransactionID: formatUUID(match.DependentTransactionID),
+		MatchConfidence:        match.MatchConfidence,
+		MatchedOn:              match.MatchedOn,
+		CreatedAt:              match.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}, nil
+}
+
+// RunMatchReconciliation triggers matching for a specific link.
+func (s *Service) RunMatchReconciliation(ctx context.Context, linkID string) (*MatchReconciliationResult, error) {
+	uid, err := parseUUID(linkID)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	row, err := s.Queries.GetAccountLink(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get account link: %w", err)
+	}
+
+	// Build a db.AccountLink from the row.
+	link := db.AccountLink{
+		ID:                 row.ID,
+		PrimaryAccountID:   row.PrimaryAccountID,
+		DependentAccountID: row.DependentAccountID,
+		MatchStrategy:      row.MatchStrategy,
+		MatchToleranceDays: row.MatchToleranceDays,
+		Enabled:            row.Enabled,
+	}
+
+	newMatches, err := s.SyncEngine.Matcher().ReconcileLink(ctx, link)
+	if err != nil {
+		return nil, fmt.Errorf("reconcile: %w", err)
+	}
+
+	totalMatched, _ := s.Queries.CountTransactionMatchesByLink(ctx, uid)
+	unmatched, _ := s.Queries.CountUnmatchedDependentTransactions(ctx, row.DependentAccountID)
+
+	return &MatchReconciliationResult{
+		NewMatches:   newMatches,
+		TotalMatched: totalMatched,
+		Unmatched:    unmatched,
+	}, nil
+}
+
+// textPtrVal returns the string value of a pgtype.Text, or empty string if null.
+func textPtrVal(t pgtype.Text) string {
+	if !t.Valid {
+		return ""
+	}
+	return t.String
+}

--- a/internal/service/overview.go
+++ b/internal/service/overview.go
@@ -76,14 +76,14 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 	}
 
 	err = s.Pool.QueryRow(ctx,
-		"SELECT COUNT(*), COALESCE(MIN(date)::text, ''), COALESCE(MAX(date)::text, '') FROM transactions WHERE deleted_at IS NULL").
+		"SELECT COUNT(*), COALESCE(MIN(date)::text, ''), COALESCE(MAX(date)::text, '') FROM transactions t JOIN accounts a ON t.account_id = a.id WHERE t.deleted_at IS NULL AND a.is_dependent_linked = FALSE").
 		Scan(&stats.TransactionCount, &stats.EarliestDate, &stats.LatestDate)
 	if err != nil {
 		return nil, fmt.Errorf("count transactions: %w", err)
 	}
 
 	err = s.Pool.QueryRow(ctx,
-		"SELECT COUNT(*) FROM transactions WHERE deleted_at IS NULL AND pending = true").
+		"SELECT COUNT(*) FROM transactions t JOIN accounts a ON t.account_id = a.id WHERE t.deleted_at IS NULL AND t.pending = true AND a.is_dependent_linked = FALSE").
 		Scan(&stats.PendingTransactionCount)
 	if err != nil {
 		return nil, fmt.Errorf("count pending: %w", err)
@@ -95,7 +95,7 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 	}
 
 	err = s.Pool.QueryRow(ctx,
-		"SELECT COUNT(*) FROM transactions WHERE category_id IS NULL AND deleted_at IS NULL").
+		"SELECT COUNT(*) FROM transactions t JOIN accounts a ON t.account_id = a.id WHERE t.category_id IS NULL AND t.deleted_at IS NULL AND a.is_dependent_linked = FALSE").
 		Scan(&stats.UnmappedCount)
 	if err != nil {
 		return nil, fmt.Errorf("count unmapped: %w", err)
@@ -179,9 +179,10 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 	var spendCurrency *string
 	var currencyCount int
 	err = s.Pool.QueryRow(ctx, `
-		SELECT COALESCE(SUM(amount), 0), COUNT(*), COUNT(DISTINCT iso_currency_code)
-		FROM transactions
-		WHERE deleted_at IS NULL AND pending = false AND date >= $1 AND amount > 0`,
+		SELECT COALESCE(SUM(t.amount), 0), COUNT(*), COUNT(DISTINCT t.iso_currency_code)
+		FROM transactions t
+		JOIN accounts a ON t.account_id = a.id
+		WHERE t.deleted_at IS NULL AND t.pending = false AND t.date >= $1 AND t.amount > 0 AND a.is_dependent_linked = FALSE`,
 		thirtyDaysAgo).Scan(&spendTotal, &spendCount, &currencyCount)
 	if err != nil {
 		return nil, fmt.Errorf("spending summary: %w", err)
@@ -189,8 +190,9 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 
 	if spendCount > 0 && currencyCount == 1 {
 		err = s.Pool.QueryRow(ctx, `
-			SELECT iso_currency_code FROM transactions
-			WHERE deleted_at IS NULL AND pending = false AND date >= $1 AND amount > 0 LIMIT 1`,
+			SELECT t.iso_currency_code FROM transactions t
+			JOIN accounts a ON t.account_id = a.id
+			WHERE t.deleted_at IS NULL AND t.pending = false AND t.date >= $1 AND t.amount > 0 AND a.is_dependent_linked = FALSE LIMIT 1`,
 			thirtyDaysAgo).Scan(&spendCurrency)
 		if err != nil {
 			return nil, fmt.Errorf("spending currency: %w", err)
@@ -204,11 +206,12 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		}
 
 		catRows, err := s.Pool.Query(ctx, `
-			SELECT COALESCE(category_primary, 'UNCATEGORIZED'), SUM(amount), COUNT(*)
-			FROM transactions
-			WHERE deleted_at IS NULL AND pending = false AND date >= $1 AND amount > 0
-			GROUP BY category_primary
-			ORDER BY SUM(amount) DESC
+			SELECT COALESCE(t.category_primary, 'UNCATEGORIZED'), SUM(t.amount), COUNT(*)
+			FROM transactions t
+			JOIN accounts a ON t.account_id = a.id
+			WHERE t.deleted_at IS NULL AND t.pending = false AND t.date >= $1 AND t.amount > 0 AND a.is_dependent_linked = FALSE
+			GROUP BY t.category_primary
+			ORDER BY SUM(t.amount) DESC
 			LIMIT 5`, thirtyDaysAgo)
 		if err != nil {
 			return nil, fmt.Errorf("top categories: %w", err)

--- a/internal/service/transaction_summary.go
+++ b/internal/service/transaction_summary.go
@@ -111,6 +111,7 @@ LEFT JOIN bank_connections bc ON a.connection_id = bc.id`, selectCols)
 		query += "\nLEFT JOIN categories cat ON t.category_id = cat.id"
 	}
 	query += "\nWHERE t.deleted_at IS NULL"
+	query += " AND a.is_dependent_linked = FALSE"
 
 	args := []any{}
 	argN := 1
@@ -138,7 +139,7 @@ LEFT JOIN bank_connections bc ON a.connection_id = bc.id`, selectCols)
 	}
 
 	if params.UserID != nil {
-		query += fmt.Sprintf(" AND bc.user_id = $%d", argN)
+		query += fmt.Sprintf(" AND COALESCE(t.attributed_user_id, bc.user_id) = $%d", argN)
 		args = append(args, *params.UserID)
 		argN++
 	}

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -22,11 +22,13 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		"u.name AS user_name, " +
 		"t.category_id, t.category_override, " +
 		"c.slug AS cat_slug, c.display_name AS cat_display_name, c.icon AS cat_icon, c.color AS cat_color, " +
-		"pc.slug AS cat_primary_slug, pc.display_name AS cat_primary_display_name " +
+		"pc.slug AS cat_primary_slug, pc.display_name AS cat_primary_display_name, " +
+		"t.attributed_user_id, au.name AS attributed_user_name " +
 		"FROM transactions t " +
 		"JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
 		"LEFT JOIN users u ON bc.user_id = u.id " +
+		"LEFT JOIN users au ON t.attributed_user_id = au.id " +
 		"LEFT JOIN categories c ON t.category_id = c.id " +
 		"LEFT JOIN categories pc ON c.parent_id = pc.id"
 
@@ -43,12 +45,18 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 
 	query += " WHERE t.deleted_at IS NULL"
 
+	// Exclude dependent-linked accounts by default.
+	if !params.IncludeDependent {
+		query += " AND a.is_dependent_linked = FALSE"
+	}
+
 	if params.UserID != nil {
 		uid, err := parseUUID(*params.UserID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid user id: %w", err)
 		}
-		query += fmt.Sprintf(" AND bc.user_id = $%d", argN)
+		// Attribution-aware: use attributed_user_id if set, otherwise connection user.
+		query += fmt.Sprintf(" AND COALESCE(t.attributed_user_id, bc.user_id) = $%d", argN)
 		args = append(args, uid)
 		argN++
 	}
@@ -196,6 +204,8 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			catColor               pgtype.Text
 			catPrimarySlug         pgtype.Text
 			catPrimaryDisplayName  pgtype.Text
+			attributedUserID       pgtype.UUID
+			attributedUserName     pgtype.Text
 		)
 
 		if err := rows.Scan(
@@ -209,6 +219,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			&categoryID, &categoryOverride,
 			&catSlug, &catDisplayName, &catIcon, &catColor,
 			&catPrimarySlug, &catPrimaryDisplayName,
+			&attributedUserID, &attributedUserName,
 		); err != nil {
 			return nil, fmt.Errorf("scan transaction: %w", err)
 		}
@@ -244,6 +255,8 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			AccountID:           uuidPtr(accountID),
 			AccountName:         &accountName,
 			UserName:            textPtr(userName),
+			AttributedUserID:    uuidPtr(attributedUserID),
+			AttributedUserName:  textPtr(attributedUserName),
 			Amount:              amountVal,
 			IsoCurrencyCode:     textPtr(isoCurrencyCode),
 			Date:                dateVal,
@@ -304,12 +317,16 @@ func (s *Service) CountTransactionsFiltered(ctx context.Context, params Transact
 
 	query += " WHERE t.deleted_at IS NULL"
 
+	if !params.IncludeDependent {
+		query += " AND a.is_dependent_linked = FALSE"
+	}
+
 	if params.UserID != nil {
 		uid, err := parseUUID(*params.UserID)
 		if err != nil {
 			return 0, fmt.Errorf("invalid user id: %w", err)
 		}
-		query += fmt.Sprintf(" AND bc.user_id = $%d", argN)
+		query += fmt.Sprintf(" AND COALESCE(t.attributed_user_id, bc.user_id) = $%d", argN)
 		args = append(args, uid)
 		argN++
 	}
@@ -410,12 +427,18 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 	argN := 1
 	whereClauses := ""
 
+	// Exclude dependent-linked accounts by default.
+	depClause := " AND a.is_dependent_linked = FALSE"
+	query += depClause
+	whereClauses += depClause
+	needAccountJoin = true
+
 	if params.UserID != nil {
 		uid, err := parseUUID(*params.UserID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid user id: %w", err)
 		}
-		clause := fmt.Sprintf(" AND bc.user_id = $%d", argN)
+		clause := fmt.Sprintf(" AND COALESCE(t.attributed_user_id, bc.user_id) = $%d", argN)
 		query += clause
 		whereClauses += clause
 		args = append(args, uid)

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -33,27 +33,29 @@ type TransactionCategoryInfo struct {
 }
 
 type TransactionResponse struct {
-	ID                 string                   `json:"id"`
-	AccountID          *string                  `json:"account_id"`
-	AccountName        *string                  `json:"account_name"`
-	UserName           *string                  `json:"user_name"`
-	Amount             float64                  `json:"amount"`
-	IsoCurrencyCode    *string                  `json:"iso_currency_code"`
-	Date               string                   `json:"date"`
-	AuthorizedDate     *string                  `json:"authorized_date"`
-	Datetime           *string                  `json:"datetime"`
-	AuthorizedDatetime *string                  `json:"authorized_datetime"`
-	Name               string                   `json:"name"`
-	MerchantName       *string                  `json:"merchant_name"`
-	Category           *TransactionCategoryInfo `json:"category"`
-	CategoryOverride   bool                     `json:"category_override"`
-	CategoryPrimaryRaw *string                  `json:"category_primary_raw"`
-	CategoryDetailedRaw *string                 `json:"category_detailed_raw"`
-	CategoryConfidence *string                  `json:"category_confidence"`
-	PaymentChannel     *string                  `json:"payment_channel"`
-	Pending            bool                     `json:"pending"`
-	CreatedAt          string                   `json:"created_at"`
-	UpdatedAt          string                   `json:"updated_at"`
+	ID                  string                   `json:"id"`
+	AccountID           *string                  `json:"account_id"`
+	AccountName         *string                  `json:"account_name"`
+	UserName            *string                  `json:"user_name"`
+	AttributedUserID    *string                  `json:"attributed_user_id,omitempty"`
+	AttributedUserName  *string                  `json:"attributed_user_name,omitempty"`
+	Amount              float64                  `json:"amount"`
+	IsoCurrencyCode     *string                  `json:"iso_currency_code"`
+	Date                string                   `json:"date"`
+	AuthorizedDate      *string                  `json:"authorized_date"`
+	Datetime            *string                  `json:"datetime"`
+	AuthorizedDatetime  *string                  `json:"authorized_datetime"`
+	Name                string                   `json:"name"`
+	MerchantName        *string                  `json:"merchant_name"`
+	Category            *TransactionCategoryInfo `json:"category"`
+	CategoryOverride    bool                     `json:"category_override"`
+	CategoryPrimaryRaw  *string                  `json:"category_primary_raw"`
+	CategoryDetailedRaw *string                  `json:"category_detailed_raw"`
+	CategoryConfidence  *string                  `json:"category_confidence"`
+	PaymentChannel      *string                  `json:"payment_channel"`
+	Pending             bool                     `json:"pending"`
+	CreatedAt           string                   `json:"created_at"`
+	UpdatedAt           string                   `json:"updated_at"`
 }
 
 type TransactionListResult struct {
@@ -64,31 +66,33 @@ type TransactionListResult struct {
 }
 
 type TransactionListParams struct {
-	Cursor       string
-	Limit        int
-	StartDate    *time.Time
-	EndDate      *time.Time
-	AccountID    *string
-	UserID       *string
-	CategorySlug *string
-	MinAmount    *float64
-	MaxAmount    *float64
-	Pending      *bool
-	Search       *string
-	SortBy       *string
-	SortOrder    *string
+	Cursor           string
+	Limit            int
+	StartDate        *time.Time
+	EndDate          *time.Time
+	AccountID        *string
+	UserID           *string
+	CategorySlug     *string
+	MinAmount        *float64
+	MaxAmount        *float64
+	Pending          *bool
+	Search           *string
+	SortBy           *string
+	SortOrder        *string
+	IncludeDependent bool
 }
 
 type TransactionCountParams struct {
-	StartDate    *time.Time
-	EndDate      *time.Time
-	AccountID    *string
-	UserID       *string
-	CategorySlug *string
-	MinAmount    *float64
-	MaxAmount    *float64
-	Pending      *bool
-	Search       *string
+	StartDate        *time.Time
+	EndDate          *time.Time
+	AccountID        *string
+	UserID           *string
+	CategorySlug     *string
+	MinAmount        *float64
+	MaxAmount        *float64
+	Pending          *bool
+	Search           *string
+	IncludeDependent bool
 }
 
 type CategoryPair struct {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -25,6 +25,7 @@ type Engine struct {
 	providers map[string]provider.Provider
 	logger    *slog.Logger
 	locks     gosync.Map // connection ID string -> *gosync.Mutex
+	matcher   *Matcher
 }
 
 // NewEngine creates a new sync engine.
@@ -34,6 +35,7 @@ func NewEngine(queries *db.Queries, pool *pgxpool.Pool, providers map[string]pro
 		pool:      pool,
 		providers: providers,
 		logger:    logger,
+		matcher:   NewMatcher(queries, pool, logger.With("component", "matcher")),
 	}
 }
 
@@ -303,6 +305,9 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 			}
 		}
 
+		// Reconcile linked account matches (best-effort, non-fatal).
+		e.matcher.ReconcileForConnection(ctx, connectionID)
+
 		// Update connection status to active (clear any previous errors).
 		// Kept outside the transaction as an independent status update.
 		_ = e.db.UpdateBankConnectionStatus(ctx, db.UpdateBankConnectionStatusParams{
@@ -503,6 +508,11 @@ func (e *Engine) SyncAll(ctx context.Context, trigger db.SyncTrigger) error {
 
 	wg.Wait()
 	return nil
+}
+
+// Matcher returns the engine's matcher for external use (e.g., manual reconciliation).
+func (e *Engine) Matcher() *Matcher {
+	return e.matcher
 }
 
 // --- helpers ---

--- a/internal/sync/matcher.go
+++ b/internal/sync/matcher.go
@@ -1,0 +1,296 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"strings"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Matcher reconciles transactions between linked accounts (primary + dependent).
+// It finds unmatched dependent transactions and pairs them with primary transactions
+// based on date + exact amount matching.
+type Matcher struct {
+	queries *db.Queries
+	pool    *pgxpool.Pool
+	logger  *slog.Logger
+}
+
+// NewMatcher creates a new Matcher.
+func NewMatcher(queries *db.Queries, pool *pgxpool.Pool, logger *slog.Logger) *Matcher {
+	return &Matcher{queries: queries, pool: pool, logger: logger}
+}
+
+// matchCandidate holds a primary transaction that could match a dependent one.
+type matchCandidate struct {
+	ID           pgtype.UUID
+	Name         string
+	MerchantName string
+}
+
+// ReconcileLink runs the matching algorithm for a single account link.
+// Returns the number of new matches created.
+func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, error) {
+	if !link.Enabled {
+		return 0, nil
+	}
+
+	logger := m.logger.With("link_id", formatUUID(link.ID))
+
+	// Resolve the dependent account's user ID for attribution.
+	depUserID, err := m.queries.GetDependentUserID(ctx, link.DependentAccountID)
+	if err != nil {
+		return 0, fmt.Errorf("get dependent user id: %w", err)
+	}
+
+	// Find unmatched dependent transactions.
+	unmatchedQuery := `
+		SELECT t.id, t.date, t.amount, t.name, COALESCE(t.merchant_name, '') AS merchant_name
+		FROM transactions t
+		WHERE t.account_id = $1
+		  AND t.deleted_at IS NULL
+		  AND NOT EXISTS (
+			SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id
+		  )
+		ORDER BY t.date DESC`
+
+	unmatchedRows, err := m.pool.Query(ctx, unmatchedQuery, link.DependentAccountID)
+	if err != nil {
+		return 0, fmt.Errorf("query unmatched dependent txns: %w", err)
+	}
+	defer unmatchedRows.Close()
+
+	type depTxn struct {
+		ID           pgtype.UUID
+		Date         pgtype.Date
+		Amount       pgtype.Numeric
+		Name         string
+		MerchantName string
+	}
+
+	var unmatched []depTxn
+	for unmatchedRows.Next() {
+		var t depTxn
+		if err := unmatchedRows.Scan(&t.ID, &t.Date, &t.Amount, &t.Name, &t.MerchantName); err != nil {
+			return 0, fmt.Errorf("scan unmatched txn: %w", err)
+		}
+		unmatched = append(unmatched, t)
+	}
+	if err := unmatchedRows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate unmatched txns: %w", err)
+	}
+
+	if len(unmatched) == 0 {
+		return 0, nil
+	}
+
+	newMatches := 0
+	tolerance := int(link.MatchToleranceDays)
+
+	for _, dep := range unmatched {
+		// Find candidate primary transactions: same amount, date within tolerance, not already matched.
+		candidateQuery := `
+			SELECT t.id, t.name, COALESCE(t.merchant_name, '') AS merchant_name
+			FROM transactions t
+			WHERE t.account_id = $1
+			  AND t.deleted_at IS NULL
+			  AND t.amount = $2
+			  AND t.date BETWEEN ($3::date - $4::integer) AND ($3::date + $4::integer)
+			  AND NOT EXISTS (
+				SELECT 1 FROM transaction_matches tm WHERE tm.primary_transaction_id = t.id
+			  )`
+
+		candidateRows, err := m.pool.Query(ctx, candidateQuery,
+			link.PrimaryAccountID, dep.Amount, dep.Date, tolerance)
+		if err != nil {
+			logger.Error("query candidates", "dep_id", formatUUID(dep.ID), "error", err)
+			continue
+		}
+
+		var candidates []matchCandidate
+		for candidateRows.Next() {
+			var c matchCandidate
+			if err := candidateRows.Scan(&c.ID, &c.Name, &c.MerchantName); err != nil {
+				logger.Error("scan candidate", "error", err)
+				continue
+			}
+			candidates = append(candidates, c)
+		}
+		candidateRows.Close()
+
+		if len(candidates) == 0 {
+			continue
+		}
+
+		// Single candidate → auto-match.
+		var bestCandidate *matchCandidate
+		var matchedFields []string
+
+		if len(candidates) == 1 {
+			bestCandidate = &candidates[0]
+			matchedFields = buildMatchedOn(dep.Name, dep.MerchantName, bestCandidate.Name, bestCandidate.MerchantName)
+		} else {
+			// Multiple candidates — use name similarity as tiebreaker.
+			bestCandidate, matchedFields = pickBestCandidate(dep.Name, dep.MerchantName, candidates)
+		}
+
+		if bestCandidate == nil {
+			logger.Debug("ambiguous match, skipping",
+				"dep_id", formatUUID(dep.ID),
+				"candidates", len(candidates))
+			continue
+		}
+
+		// Always include date and amount in matched_on.
+		matchedFields = append([]string{"date", "amount"}, matchedFields...)
+
+		// Create the match record.
+		_, err = m.queries.CreateTransactionMatch(ctx, db.CreateTransactionMatchParams{
+			AccountLinkID:          link.ID,
+			PrimaryTransactionID:   bestCandidate.ID,
+			DependentTransactionID: dep.ID,
+			MatchConfidence:        "auto",
+			MatchedOn:              matchedFields,
+		})
+		if err != nil {
+			// ON CONFLICT DO NOTHING — already matched.
+			logger.Debug("match insert skipped (conflict)", "dep_id", formatUUID(dep.ID))
+			continue
+		}
+
+		// Set attribution on the primary transaction.
+		if err := m.queries.SetTransactionAttributedUser(ctx, db.SetTransactionAttributedUserParams{
+			ID:               bestCandidate.ID,
+			AttributedUserID: depUserID,
+		}); err != nil {
+			logger.Error("set attribution", "primary_id", formatUUID(bestCandidate.ID), "error", err)
+		}
+
+		newMatches++
+	}
+
+	if newMatches > 0 {
+		logger.Info("reconciliation complete", "new_matches", newMatches)
+	}
+
+	return newMatches, nil
+}
+
+// ReconcileForConnection runs matching for all account links involving accounts
+// under the given connection. Called post-sync.
+func (m *Matcher) ReconcileForConnection(ctx context.Context, connectionID pgtype.UUID) {
+	links, err := m.queries.ListAccountLinksByConnectionID(ctx, connectionID)
+	if err != nil {
+		m.logger.Error("list account links for reconciliation", "error", err)
+		return
+	}
+
+	for _, link := range links {
+		if _, err := m.ReconcileLink(ctx, link); err != nil {
+			m.logger.Error("reconcile link", "link_id", formatUUID(link.ID), "error", err)
+		}
+	}
+}
+
+// pickBestCandidate selects the best matching candidate when there are multiple
+// with the same date+amount. Returns nil if ambiguous.
+func pickBestCandidate(depName, depMerchant string, candidates []matchCandidate) (*matchCandidate, []string) {
+	type scored struct {
+		idx      int
+		score    int
+		fields   []string
+	}
+
+	var best []scored
+
+	for i, c := range candidates {
+		s, fields := nameSimilarityScore(depName, depMerchant, c.Name, c.MerchantName)
+		if len(best) == 0 || s > best[0].score {
+			best = []scored{{idx: i, score: s, fields: fields}}
+		} else if s == best[0].score {
+			best = append(best, scored{idx: i, score: s, fields: fields})
+		}
+	}
+
+	// If exactly one best candidate, return it.
+	if len(best) == 1 {
+		return &candidates[best[0].idx], best[0].fields
+	}
+
+	return nil, nil
+}
+
+// nameSimilarityScore computes how similar two transactions' names are.
+// Returns score (0-3) and which fields matched.
+func nameSimilarityScore(depName, depMerchant, priName, priMerchant string) (int, []string) {
+	var fields []string
+
+	// Exact merchant_name match (highest signal).
+	if depMerchant != "" && priMerchant != "" &&
+		strings.EqualFold(depMerchant, priMerchant) {
+		return 3, []string{"merchant_name"}
+	}
+
+	// Merchant name contains or is contained.
+	if depMerchant != "" && priMerchant != "" {
+		dl := strings.ToLower(depMerchant)
+		pl := strings.ToLower(priMerchant)
+		if strings.Contains(dl, pl) || strings.Contains(pl, dl) {
+			return 2, []string{"merchant_name"}
+		}
+	}
+
+	// Exact name match.
+	if strings.EqualFold(depName, priName) {
+		return 2, []string{"name"}
+	}
+
+	// Name contains or is contained.
+	dl := strings.ToLower(depName)
+	pl := strings.ToLower(priName)
+	if strings.Contains(dl, pl) || strings.Contains(pl, dl) {
+		fields = append(fields, "name")
+		return 1, fields
+	}
+
+	// No name similarity — still valid (date + amount matched).
+	return 0, nil
+}
+
+// buildMatchedOn returns which name fields matched between two transactions.
+func buildMatchedOn(depName, depMerchant, priName, priMerchant string) []string {
+	_, fields := nameSimilarityScore(depName, depMerchant, priName, priMerchant)
+	return fields
+}
+
+// numericToFloat64 converts a pgtype.Numeric to float64.
+func numericToFloat64(n pgtype.Numeric) float64 {
+	if !n.Valid || n.Int == nil {
+		return 0
+	}
+	f := new(big.Float).SetInt(n.Int)
+	if n.Exp != 0 {
+		exp := new(big.Float).SetFloat64(1)
+		base := new(big.Float).SetFloat64(10)
+		e := int(n.Exp)
+		if e > 0 {
+			for i := 0; i < e; i++ {
+				exp.Mul(exp, base)
+			}
+		} else {
+			for i := 0; i < -e; i++ {
+				exp.Mul(exp, base)
+			}
+			exp = new(big.Float).Quo(new(big.Float).SetFloat64(1), exp)
+		}
+		f.Mul(f, exp)
+	}
+	result, _ := f.Float64()
+	return result
+}

--- a/internal/templates/pages/account_link_detail.html
+++ b/internal/templates/pages/account_link_detail.html
@@ -1,0 +1,92 @@
+{{template "base" .}}
+
+{{define "content"}}
+<div class="bb-page-header">
+  <div>
+    <div class="breadcrumbs text-sm mb-1">
+      <ul><li><a href="/account-links">Account Links</a></li><li>{{.Link.PrimaryAccountName}} &rarr; {{.Link.DependentAccountName}}</li></ul>
+    </div>
+    <h1 class="bb-page-title">Transaction Matches</h1>
+    <p class="text-base-content/60 text-sm mt-1">
+      <span class="font-medium">{{.Link.MatchCount}}</span> matched,
+      <span class="font-medium">{{.Link.UnmatchedDependentCount}}</span> unmatched
+    </p>
+  </div>
+  <form method="POST" action="/-/account-links/{{.Link.ID}}/reconcile" class="inline">
+    <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+    <button type="submit" class="btn btn-primary btn-sm">
+      <i data-lucide="refresh-cw" class="w-4 h-4"></i> Reconcile Now
+    </button>
+  </form>
+</div>
+
+{{if .Matches}}
+<div class="overflow-x-auto mt-6">
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Amount</th>
+        <th>Primary Transaction</th>
+        <th>Dependent Transaction</th>
+        <th>Confidence</th>
+        <th>Matched On</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {{range .Matches}}
+      <tr>
+        <td class="whitespace-nowrap">{{.Date}}</td>
+        <td class="whitespace-nowrap bb-amount">{{printf "%.2f" .Amount}}</td>
+        <td>
+          <a href="/transactions/{{.PrimaryTransactionID}}" class="link link-hover">{{.PrimaryTxnName}}</a>
+          {{if .PrimaryTxnMerchant}}<div class="text-xs text-base-content/50">{{.PrimaryTxnMerchant}}</div>{{end}}
+        </td>
+        <td>
+          <a href="/transactions/{{.DependentTransactionID}}" class="link link-hover">{{.DependentTxnName}}</a>
+          {{if .DependentTxnMerchant}}<div class="text-xs text-base-content/50">{{.DependentTxnMerchant}}</div>{{end}}
+        </td>
+        <td>
+          {{if eq .MatchConfidence "confirmed"}}
+          <span class="badge badge-success badge-xs">Confirmed</span>
+          {{else if eq .MatchConfidence "auto"}}
+          <span class="badge badge-info badge-xs">Auto</span>
+          {{else}}
+          <span class="badge badge-ghost badge-xs">{{.MatchConfidence}}</span>
+          {{end}}
+        </td>
+        <td class="text-xs text-base-content/60">{{range .MatchedOn}}{{.}} {{end}}</td>
+        <td>
+          {{if eq .MatchConfidence "auto"}}
+          <div class="flex gap-1">
+            <form method="POST" action="/-/transaction-matches/{{.ID}}/confirm" class="inline">
+              <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+              <button type="submit" class="btn btn-ghost btn-xs text-success" title="Confirm match">
+                <i data-lucide="check" class="w-3.5 h-3.5"></i>
+              </button>
+            </form>
+            <form method="POST" action="/-/transaction-matches/{{.ID}}/reject" class="inline">
+              <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+              <button type="submit" class="btn btn-ghost btn-xs text-error" title="Reject match">
+                <i data-lucide="x" class="w-3.5 h-3.5"></i>
+              </button>
+            </form>
+          </div>
+          {{end}}
+        </td>
+      </tr>
+      {{end}}
+    </tbody>
+  </table>
+</div>
+{{else}}
+<div class="card bg-base-100 shadow-sm border border-base-300 mt-6">
+  <div class="card-body items-center text-center py-12">
+    <i data-lucide="check-circle-2" class="w-12 h-12 text-base-content/20 mb-4"></i>
+    <h3 class="font-semibold text-lg">No Matches Yet</h3>
+    <p class="text-base-content/60">Run reconciliation to find matching transactions between the linked accounts.</p>
+  </div>
+</div>
+{{end}}
+{{end}}

--- a/internal/templates/pages/account_links.html
+++ b/internal/templates/pages/account_links.html
@@ -1,0 +1,116 @@
+{{template "base" .}}
+
+{{define "content"}}
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Account Links</h1>
+    <p class="text-base-content/60 text-sm mt-1">Link dependent (authorized user) accounts to primary accounts for transaction deduplication and attribution.</p>
+  </div>
+  <button class="btn btn-primary btn-sm" onclick="document.getElementById('create-modal').showModal()">
+    <i data-lucide="plus" class="w-4 h-4"></i> New Link
+  </button>
+</div>
+
+{{if .Links}}
+<div class="space-y-4 mt-6">
+  {{range .Links}}
+  <div class="card bg-base-100 shadow-sm border border-base-300">
+    <div class="card-body p-4">
+      <div class="flex items-start justify-between gap-4">
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="font-semibold">{{.PrimaryAccountName}}</span>
+            <span class="text-base-content/40">({{.PrimaryUserName}})</span>
+            <i data-lucide="arrow-right" class="w-4 h-4 text-base-content/40 shrink-0"></i>
+            <span class="font-semibold">{{.DependentAccountName}}</span>
+            <span class="text-base-content/40">({{.DependentUserName}})</span>
+            {{if not .Enabled}}<span class="badge badge-ghost badge-sm">Disabled</span>{{end}}
+          </div>
+          <div class="flex items-center gap-4 mt-2 text-sm text-base-content/60">
+            <span class="flex items-center gap-1">
+              <i data-lucide="check-circle-2" class="w-3.5 h-3.5 text-success"></i>
+              {{.MatchCount}} matched
+            </span>
+            {{if gt .UnmatchedDependentCount 0}}
+            <span class="flex items-center gap-1">
+              <i data-lucide="help-circle" class="w-3.5 h-3.5 text-warning"></i>
+              {{.UnmatchedDependentCount}} unmatched
+            </span>
+            {{end}}
+            <span>Strategy: {{.MatchStrategy}}</span>
+            {{if gt .MatchToleranceDays 0}}<span>Tolerance: {{.MatchToleranceDays}}d</span>{{end}}
+          </div>
+        </div>
+        <div class="flex items-center gap-1 shrink-0">
+          <form method="POST" action="/-/account-links/{{.ID}}/reconcile" class="inline">
+            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+            <button type="submit" class="btn btn-ghost btn-xs" title="Run reconciliation">
+              <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
+            </button>
+          </form>
+          <a href="/account-links/{{.ID}}" class="btn btn-ghost btn-xs" title="View matches">
+            <i data-lucide="list" class="w-3.5 h-3.5"></i>
+          </a>
+          <form method="POST" action="/-/account-links/{{.ID}}/delete" class="inline"
+                x-data @submit.prevent="if(confirm('Delete this account link? All attribution will be cleared.')) $el.submit()">
+            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+            <button type="submit" class="btn btn-ghost btn-xs text-error" title="Delete link">
+              <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+  {{end}}
+</div>
+{{else}}
+<div class="card bg-base-100 shadow-sm border border-base-300 mt-6">
+  <div class="card-body items-center text-center py-12">
+    <i data-lucide="link-2" class="w-12 h-12 text-base-content/20 mb-4"></i>
+    <h3 class="font-semibold text-lg">No Account Links</h3>
+    <p class="text-base-content/60 max-w-md">
+      Account links connect authorized user accounts to primary accounts for deduplication.
+      If two family members connect the same credit card, linking prevents double-counting.
+    </p>
+    <button class="btn btn-primary btn-sm mt-4" onclick="document.getElementById('create-modal').showModal()">
+      <i data-lucide="plus" class="w-4 h-4"></i> Create First Link
+    </button>
+  </div>
+</div>
+{{end}}
+
+<!-- Create Link Modal -->
+<dialog id="create-modal" class="modal">
+  <div class="modal-box">
+    <h3 class="font-bold text-lg">Create Account Link</h3>
+    <p class="text-sm text-base-content/60 mt-1">Link a dependent (authorized user) account to the primary cardholder's account.</p>
+    <form method="POST" action="/-/account-links" class="mt-4 space-y-4" x-data="{ loading: false }" @submit="loading = true">
+      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+      <div class="form-control">
+        <label class="label"><span class="label-text">Primary Account</span></label>
+        <select name="primary_account_id" class="select select-bordered select-sm w-full" required>
+          <option value="">Select the primary cardholder's account...</option>
+          {{range .Accounts}}
+          <option value="{{.ID}}">{{.DisplayName}} ({{.UserName}} - {{.InstitutionName}})</option>
+          {{end}}
+        </select>
+      </div>
+      <div class="form-control">
+        <label class="label"><span class="label-text">Dependent Account</span></label>
+        <select name="dependent_account_id" class="select select-bordered select-sm w-full" required>
+          <option value="">Select the authorized user's account...</option>
+          {{range .Accounts}}
+          <option value="{{.ID}}">{{.DisplayName}} ({{.UserName}} - {{.InstitutionName}})</option>
+          {{end}}
+        </select>
+      </div>
+      <div class="modal-action">
+        <button type="button" class="btn btn-ghost btn-sm" onclick="document.getElementById('create-modal').close()">Cancel</button>
+        <button type="submit" class="btn btn-primary btn-sm" :class="{ 'loading': loading }" :disabled="loading">Create Link</button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+{{end}}

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -33,6 +33,9 @@
   <a href="/categories" class="bb-sidebar-link{{if eq .CurrentPage "categories"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="tag"></i> Categories
   </a>
+  <a href="/account-links" class="bb-sidebar-link{{if eq .CurrentPage "account-links"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="link-2"></i> Account Links
+  </a>
   <a href="/users" class="bb-sidebar-link{{if eq .CurrentPage "users"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="users"></i> Family Members
   </a>


### PR DESCRIPTION
## Summary

- Adds **account linking** to solve the authorized-user duplicate transaction problem: when two family members connect the same credit card, transactions appear in both feeds
- Links a dependent (authorized user) account to a primary (cardholder) account
- Auto-matches transactions post-sync by **date + exact amount**, sets `attributed_user_id` on the primary side
- Dependent account transactions **excluded from all totals/summaries** via `is_dependent_linked` flag
- **Attribution-aware filtering**: querying by user includes transactions attributed to them on shared cards (`COALESCE(t.attributed_user_id, bc.user_id)`)

### What's included
- **Schema**: `account_links`, `transaction_matches` tables, `attributed_user_id` on transactions, `is_dependent_linked` on accounts (migration 00027)
- **Matching engine**: `internal/sync/matcher.go` — runs post-sync, single candidate auto-match, name similarity tiebreaker for ambiguous cases
- **Query-time changes**: `ListTransactions`, `CountTransactionsFiltered`, `ListTransactionsAdmin`, `GetTransactionSummary`, `GetOverviewStats` all updated
- **REST API**: `/api/v1/account-links` CRUD + `/reconcile` + `/matches`, confirm/reject/manual match
- **MCP tools**: `list_account_links`, `create_account_link`, `delete_account_link`, `reconcile_account_link`, `list_transaction_matches`, `confirm_match`, `reject_match`
- **Admin dashboard**: `/account-links` page with link list, create modal, match detail view with confirm/reject actions

## Test plan
- [ ] Run migration on dev database (`go run ./cmd/breadbox migrate`)
- [ ] Verify account links page loads at `/account-links`
- [ ] Create an account link between two accounts sharing the same card
- [ ] Verify auto-matching runs and pairs transactions correctly
- [ ] Verify dependent account transactions are excluded from dashboard totals
- [ ] Verify filtering by user includes attributed transactions
- [ ] Test confirm/reject match actions on the detail page
- [ ] Run `go test ./...` — all unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)