### PR TITLE
Add 49 category service integration tests

### DIFF
--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -1,0 +1,1669 @@
+//go:build integration
+
+// Integration tests for REST API handlers. Require a running PostgreSQL with breadbox_test database.
+// Run with: DATABASE_URL="postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable" go test -tags integration -count=1 -p 1 -v ./internal/api/...
+//
+// IMPORTANT: Do NOT use t.Parallel() — tests share a database and truncate between runs.
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestMain(m *testing.M) {
+	testutil.RunWithDB(m)
+}
+
+// testEnv holds the test server and helpers for making authenticated requests.
+type testEnv struct {
+	Server  *httptest.Server
+	APIKey  string // plaintext API key for X-API-Key header
+	Service *service.Service
+	Queries *db.Queries
+	Pool    *pgxpool.Pool
+}
+
+// setupTestEnv creates a service, wires up a chi router with API key auth middleware,
+// and returns a running httptest.Server.
+func setupTestEnv(t *testing.T) *testEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "test-key", "full_access")
+	if err != nil {
+		t.Fatalf("create API key: %v", err)
+	}
+
+	r := buildTestRouter(svc)
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &testEnv{
+		Server:  server,
+		APIKey:  keyResult.PlaintextKey,
+		Service: svc,
+		Queries: queries,
+		Pool:    pool,
+	}
+}
+
+// setupReadOnlyEnv creates a test env with a read_only API key.
+func setupReadOnlyEnv(t *testing.T) *testEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "readonly-key", "read_only")
+	if err != nil {
+		t.Fatalf("create API key: %v", err)
+	}
+
+	r := buildTestRouter(svc)
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &testEnv{
+		Server:  server,
+		APIKey:  keyResult.PlaintextKey,
+		Service: svc,
+		Queries: queries,
+		Pool:    pool,
+	}
+}
+
+// buildTestRouter creates a chi router mirroring the production API routes.
+func buildTestRouter(svc *service.Service) http.Handler {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+
+		// Read endpoints
+		r.Get("/accounts", ListAccountsHandler(svc))
+		r.Get("/transactions", ListTransactionsHandler(svc))
+		r.Get("/transactions/count", CountTransactionsHandler(svc))
+		r.Get("/transactions/summary", TransactionSummaryHandler(svc))
+		r.Get("/transactions/{id}", GetTransactionHandler(svc))
+		r.Get("/categories", ListCategoriesHandler(svc))
+		r.Get("/categories/{id}", GetCategoryHandler(svc))
+		r.Get("/users", ListUsersHandler(svc))
+		r.Get("/connections", ListConnectionsHandler(svc))
+		r.Get("/reviews", ListReviewsHandler(svc))
+		r.Get("/reviews/counts", ReviewCountsHandler(svc))
+		r.Get("/reviews/{id}", GetReviewHandler(svc))
+		r.Get("/rules", ListRulesHandler(svc))
+		r.Get("/rules/{id}", GetRuleHandler(svc))
+		r.Get("/transactions/{transaction_id}/comments", ListCommentsHandler(svc))
+
+		// Write endpoints — require full_access scope
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Patch("/transactions/{id}/category", SetTransactionCategoryHandler(svc))
+			r.Delete("/transactions/{id}/category", ResetTransactionCategoryHandler(svc))
+			r.Post("/categories", CreateCategoryHandler(svc))
+			r.Put("/categories/{id}", UpdateCategoryHandler(svc))
+			r.Delete("/categories/{id}", DeleteCategoryHandler(svc))
+			r.Post("/categories/{id}/merge", MergeCategoriesHandler(svc))
+			r.Post("/rules", CreateRuleHandler(svc))
+			r.Put("/rules/{id}", UpdateRuleHandler(svc))
+			r.Delete("/rules/{id}", DeleteRuleHandler(svc))
+			r.Post("/rules/preview", PreviewRuleHandler(svc))
+			r.Post("/transactions/{transaction_id}/comments", CreateCommentHandler(svc))
+			r.Put("/transactions/{transaction_id}/comments/{id}", UpdateCommentHandler(svc))
+			r.Delete("/transactions/{transaction_id}/comments/{id}", DeleteCommentHandler(svc))
+			r.Post("/reviews/{id}/submit", SubmitReviewHandler(svc))
+			r.Post("/reviews/enqueue", EnqueueReviewHandler(svc))
+			r.Delete("/reviews/{id}", DismissReviewHandler(svc))
+			r.Post("/transactions/batch-categorize", BatchCategorizeHandler(svc))
+		})
+	})
+	return r
+}
+
+// --- HTTP helper methods ---
+
+func (e *testEnv) doGet(t *testing.T, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("GET", e.Server.URL+path, nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("X-API-Key", e.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+func (e *testEnv) doJSON(t *testing.T, method, path string, body any) *http.Response {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest(method, e.Server.URL+path, bodyReader)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("X-API-Key", e.APIKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+func (e *testEnv) doPost(t *testing.T, path string, body any) *http.Response {
+	t.Helper()
+	return e.doJSON(t, "POST", path, body)
+}
+
+func (e *testEnv) doPut(t *testing.T, path string, body any) *http.Response {
+	t.Helper()
+	return e.doJSON(t, "PUT", path, body)
+}
+
+func (e *testEnv) doPatch(t *testing.T, path string, body any) *http.Response {
+	t.Helper()
+	return e.doJSON(t, "PATCH", path, body)
+}
+
+func (e *testEnv) doDelete(t *testing.T, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("DELETE", e.Server.URL+path, nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("X-API-Key", e.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// --- Response helpers ---
+
+func parseJSON(t *testing.T, resp *http.Response, v any) {
+	t.Helper()
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		t.Fatalf("unmarshal body: %v\nbody: %s", err, string(data))
+	}
+}
+
+func assertStatus(t *testing.T, resp *http.Response, want int) {
+	t.Helper()
+	if resp.StatusCode != want {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("want status %d, got %d, body: %s", want, resp.StatusCode, string(body))
+	}
+}
+
+func readErrorCode(t *testing.T, resp *http.Response, wantStatus int, wantCode string) {
+	t.Helper()
+	if resp.StatusCode != wantStatus {
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		t.Fatalf("want status %d, got %d, body: %s", wantStatus, resp.StatusCode, string(body))
+	}
+	var errResp mw.ErrorResponse
+	parseJSON(t, resp, &errResp)
+	if errResp.Error.Code != wantCode {
+		t.Fatalf("want error code %q, got %q (message: %s)", wantCode, errResp.Error.Code, errResp.Error.Message)
+	}
+}
+
+// --- Fixture helpers ---
+
+func seedFixture(t *testing.T, q *db.Queries) (user db.User, acct db.Account, txn db.Transaction) {
+	t.Helper()
+	user = testutil.MustCreateUser(t, q, "Alice")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "item_1")
+	acct = testutil.MustCreateAccount(t, q, conn.ID, "ext_acct_1", "Checking")
+	txn = testutil.MustCreateTransaction(t, q, acct.ID, "ext_txn_1", "Coffee Shop", 450, "2025-03-15")
+	return
+}
+
+// seedUncategorized creates the "uncategorized" system category needed by category operations.
+func seedUncategorized(t *testing.T, q *db.Queries) db.Category {
+	t.Helper()
+	cat, err := q.InsertCategory(context.Background(), db.InsertCategoryParams{
+		Slug:        "uncategorized",
+		DisplayName: "Uncategorized",
+		IsSystem:    true,
+	})
+	if err != nil {
+		t.Fatalf("seed uncategorized category: %v", err)
+	}
+	return cat
+}
+
+func fmtUUID(u pgtype.UUID) string {
+	if !u.Valid {
+		return ""
+	}
+	b := u.Bytes
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// ============================================================
+// Authentication & Scope Tests
+// ============================================================
+
+func TestAPI_MissingAPIKey(t *testing.T) {
+	env := setupTestEnv(t)
+
+	req, _ := http.NewRequest("GET", env.Server.URL+"/api/v1/users", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readErrorCode(t, resp, http.StatusUnauthorized, "MISSING_API_KEY")
+}
+
+func TestAPI_InvalidAPIKey(t *testing.T) {
+	env := setupTestEnv(t)
+
+	req, _ := http.NewRequest("GET", env.Server.URL+"/api/v1/users", nil)
+	req.Header.Set("X-API-Key", "bb_invalidkey123")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readErrorCode(t, resp, http.StatusUnauthorized, "INVALID_API_KEY")
+}
+
+func TestAPI_ReadOnlyKeyBlocksWrite(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+
+	resp := env.doPost(t, "/api/v1/categories", map[string]string{
+		"display_name": "Test Category",
+	})
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+func TestAPI_ReadOnlyKeyAllowsRead(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+
+	resp := env.doGet(t, "/api/v1/users")
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+}
+
+func TestAPI_RevokedAPIKey(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Create a second key, then revoke it
+	result2, err := env.Service.CreateAPIKey(t.Context(), "revocable", "full_access")
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, _ := env.Service.ListAPIKeys(t.Context())
+	for _, k := range keys {
+		if k.Name == "revocable" {
+			_ = env.Service.RevokeAPIKey(t.Context(), k.ID)
+		}
+	}
+
+	req, _ := http.NewRequest("GET", env.Server.URL+"/api/v1/users", nil)
+	req.Header.Set("X-API-Key", result2.PlaintextKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	readErrorCode(t, resp, http.StatusUnauthorized, "REVOKED_API_KEY")
+}
+
+// ============================================================
+// Transaction List Handler Tests
+// ============================================================
+
+func TestAPI_ListTransactions_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result struct {
+		Transactions []any  `json:"transactions"`
+		NextCursor   string `json:"next_cursor"`
+		HasMore      bool   `json:"has_more"`
+	}
+	parseJSON(t, resp, &result)
+	if len(result.Transactions) != 0 {
+		t.Errorf("expected 0 transactions, got %d", len(result.Transactions))
+	}
+	if result.HasMore {
+		t.Error("expected has_more=false")
+	}
+}
+
+func TestAPI_ListTransactions_WithData(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, _ = seedFixture(t, env.Queries)
+
+	resp := env.doGet(t, "/api/v1/transactions")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result struct {
+		Transactions []map[string]any `json:"transactions"`
+	}
+	parseJSON(t, resp, &result)
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(result.Transactions))
+	}
+	if result.Transactions[0]["name"] != "Coffee Shop" {
+		t.Errorf("expected name 'Coffee Shop', got %v", result.Transactions[0]["name"])
+	}
+	// Verify denormalized fields exist
+	if result.Transactions[0]["account_name"] == nil {
+		t.Error("expected account_name to be present")
+	}
+}
+
+func TestAPI_ListTransactions_InvalidLimit(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?limit=0")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListTransactions_LimitTooHigh(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?limit=501")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListTransactions_InvalidStartDate(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?start_date=not-a-date")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListTransactions_StartAfterEnd(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?start_date=2025-03-20&end_date=2025-03-10")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListTransactions_DateFilter(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, _ = seedFixture(t, env.Queries) // txn on 2025-03-15
+
+	// Range that includes the transaction
+	resp := env.doGet(t, "/api/v1/transactions?start_date=2025-03-01&end_date=2025-03-31")
+	assertStatus(t, resp, http.StatusOK)
+	var incl struct{ Transactions []any }
+	parseJSON(t, resp, &incl)
+	if len(incl.Transactions) != 1 {
+		t.Errorf("expected 1 transaction in range, got %d", len(incl.Transactions))
+	}
+
+	// Range that excludes the transaction
+	resp = env.doGet(t, "/api/v1/transactions?start_date=2025-04-01&end_date=2025-04-30")
+	assertStatus(t, resp, http.StatusOK)
+	var excl struct{ Transactions []any }
+	parseJSON(t, resp, &excl)
+	if len(excl.Transactions) != 0 {
+		t.Errorf("expected 0 transactions outside range, got %d", len(excl.Transactions))
+	}
+}
+
+func TestAPI_ListTransactions_AmountFilter(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, _ = seedFixture(t, env.Queries) // txn amount = 4.50
+
+	resp := env.doGet(t, "/api/v1/transactions?min_amount=4&max_amount=5")
+	assertStatus(t, resp, http.StatusOK)
+	var result struct{ Transactions []any }
+	parseJSON(t, resp, &result)
+	if len(result.Transactions) != 1 {
+		t.Errorf("expected 1 transaction, got %d", len(result.Transactions))
+	}
+
+	resp = env.doGet(t, "/api/v1/transactions?min_amount=10")
+	assertStatus(t, resp, http.StatusOK)
+	var empty struct{ Transactions []any }
+	parseJSON(t, resp, &empty)
+	if len(empty.Transactions) != 0 {
+		t.Errorf("expected 0 transactions, got %d", len(empty.Transactions))
+	}
+}
+
+func TestAPI_ListTransactions_MinAmountGtMaxAmount(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?min_amount=100&max_amount=50")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListTransactions_InvalidPending(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?pending=maybe")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListTransactions_SearchTooShort(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?search=a")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListTransactions_InvalidSortBy(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?sort_by=invalid")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListTransactions_InvalidSortOrder(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?sort_order=up")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListTransactions_SearchFilter(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Bob")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "item_2")
+	acct := testutil.MustCreateAccount(t, env.Queries, conn.ID, "ext_2", "Savings")
+	testutil.MustCreateTransaction(t, env.Queries, acct.ID, "tx_1", "Starbucks Coffee", 550, "2025-03-10")
+	testutil.MustCreateTransaction(t, env.Queries, acct.ID, "tx_2", "Gas Station", 3500, "2025-03-11")
+
+	resp := env.doGet(t, "/api/v1/transactions?search=coffee")
+	assertStatus(t, resp, http.StatusOK)
+	var result struct{ Transactions []map[string]any }
+	parseJSON(t, resp, &result)
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 transaction matching 'coffee', got %d", len(result.Transactions))
+	}
+	if result.Transactions[0]["name"] != "Starbucks Coffee" {
+		t.Errorf("expected 'Starbucks Coffee', got %v", result.Transactions[0]["name"])
+	}
+}
+
+func TestAPI_ListTransactions_Pagination(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "item_p")
+	acct := testutil.MustCreateAccount(t, env.Queries, conn.ID, "ext_p", "Checking")
+	for i := 0; i < 3; i++ {
+		testutil.MustCreateTransaction(t, env.Queries, acct.ID,
+			fmt.Sprintf("tx_p_%d", i), fmt.Sprintf("Store %d", i), int64(100*(i+1)), "2025-03-15")
+	}
+
+	// Get page 1 with limit 2
+	resp := env.doGet(t, "/api/v1/transactions?limit=2")
+	assertStatus(t, resp, http.StatusOK)
+	var page1 struct {
+		Transactions []any  `json:"transactions"`
+		NextCursor   string `json:"next_cursor"`
+		HasMore      bool   `json:"has_more"`
+	}
+	parseJSON(t, resp, &page1)
+	if len(page1.Transactions) != 2 {
+		t.Fatalf("expected 2 transactions on page 1, got %d", len(page1.Transactions))
+	}
+	if !page1.HasMore {
+		t.Error("expected has_more=true on page 1")
+	}
+	if page1.NextCursor == "" {
+		t.Error("expected non-empty next_cursor on page 1")
+	}
+
+	// Get page 2
+	resp = env.doGet(t, "/api/v1/transactions?limit=2&cursor="+page1.NextCursor)
+	assertStatus(t, resp, http.StatusOK)
+	var page2 struct {
+		Transactions []any `json:"transactions"`
+		HasMore      bool  `json:"has_more"`
+	}
+	parseJSON(t, resp, &page2)
+	if len(page2.Transactions) != 1 {
+		t.Fatalf("expected 1 transaction on page 2, got %d", len(page2.Transactions))
+	}
+	if page2.HasMore {
+		t.Error("expected has_more=false on page 2")
+	}
+}
+
+// ============================================================
+// Transaction Count Handler Tests
+// ============================================================
+
+func TestAPI_CountTransactions_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions/count")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result struct {
+		Count int64 `json:"count"`
+	}
+	parseJSON(t, resp, &result)
+	if result.Count != 0 {
+		t.Errorf("expected count 0, got %d", result.Count)
+	}
+}
+
+func TestAPI_CountTransactions_WithData(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, _ = seedFixture(t, env.Queries)
+
+	resp := env.doGet(t, "/api/v1/transactions/count")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result struct {
+		Count int64 `json:"count"`
+	}
+	parseJSON(t, resp, &result)
+	if result.Count != 1 {
+		t.Errorf("expected count 1, got %d", result.Count)
+	}
+}
+
+// ============================================================
+// Get Transaction Handler Tests
+// ============================================================
+
+func TestAPI_GetTransaction_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_GetTransaction_Found(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doGet(t, "/api/v1/transactions/"+txnID)
+	assertStatus(t, resp, http.StatusOK)
+
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	if result["name"] != "Coffee Shop" {
+		t.Errorf("expected name 'Coffee Shop', got %v", result["name"])
+	}
+}
+
+func TestAPI_GetTransaction_InvalidID(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions/not-a-uuid")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// ============================================================
+// Transaction Summary Handler Tests
+// ============================================================
+
+func TestAPI_TransactionSummary_MissingGroupBy(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions/summary")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_TransactionSummary_ValidGroupBy(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, _ = seedFixture(t, env.Queries)
+
+	resp := env.doGet(t, "/api/v1/transactions/summary?group_by=month")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	// Response uses "summary" key for aggregated rows
+	if result["summary"] == nil {
+		t.Error("expected 'summary' in response")
+	}
+	if result["totals"] == nil {
+		t.Error("expected 'totals' in response")
+	}
+}
+
+func TestAPI_TransactionSummary_InvalidGroupBy(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions/summary?group_by=invalid")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// ============================================================
+// Category CRUD Handler Tests
+// ============================================================
+
+func TestAPI_CreateCategory_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Food & Drink",
+		"slug":         "food_and_drink",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+
+	var cat map[string]any
+	parseJSON(t, resp, &cat)
+	if cat["display_name"] != "Food & Drink" {
+		t.Errorf("expected display_name 'Food & Drink', got %v", cat["display_name"])
+	}
+	if cat["slug"] != "food_and_drink" {
+		t.Errorf("expected slug 'food_and_drink', got %v", cat["slug"])
+	}
+}
+
+func TestAPI_CreateCategory_MissingName(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"slug": "no_name",
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "VALIDATION_ERROR")
+}
+
+func TestAPI_CreateCategory_AutoSlug(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Create without explicit slug — service should auto-generate from display_name
+	resp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "My Custom Category",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+
+	var cat map[string]any
+	parseJSON(t, resp, &cat)
+	slug, ok := cat["slug"].(string)
+	if !ok || slug == "" {
+		t.Fatal("expected auto-generated slug")
+	}
+}
+
+func TestAPI_CreateCategory_DuplicateSlugAutoDedup(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// First
+	resp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Food",
+		"slug":         "food",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	// Second with same slug — service auto-appends _2
+	resp = env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Food Again",
+		"slug":         "food",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	var cat map[string]any
+	parseJSON(t, resp, &cat)
+	if cat["slug"] == "food" {
+		t.Error("expected deduplicated slug, got 'food'")
+	}
+}
+
+func TestAPI_GetCategory_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/categories/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_UpdateCategory_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Old Name",
+		"slug":         "old_name",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	var cat map[string]any
+	parseJSON(t, resp, &cat)
+	catID := cat["id"].(string)
+
+	resp = env.doPut(t, "/api/v1/categories/"+catID, map[string]any{
+		"display_name": "New Name",
+	})
+	assertStatus(t, resp, http.StatusOK)
+	var updated map[string]any
+	parseJSON(t, resp, &updated)
+	if updated["display_name"] != "New Name" {
+		t.Errorf("expected 'New Name', got %v", updated["display_name"])
+	}
+}
+
+func TestAPI_DeleteCategory_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doDelete(t, "/api/v1/categories/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_DeleteCategory_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	// DeleteCategory reassigns orphaned transactions to "uncategorized", so it must exist
+	seedUncategorized(t, env.Queries)
+
+	resp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Deletable",
+		"slug":         "deletable",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	var cat map[string]any
+	parseJSON(t, resp, &cat)
+	catID := cat["id"].(string)
+
+	resp = env.doDelete(t, "/api/v1/categories/"+catID)
+	assertStatus(t, resp, http.StatusOK)
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	if result["affected_transactions"] == nil {
+		t.Error("expected affected_transactions in response")
+	}
+}
+
+func TestAPI_DeleteCategory_UndeletableSystem(t *testing.T) {
+	env := setupTestEnv(t)
+	uncat := seedUncategorized(t, env.Queries)
+	uncatID := fmtUUID(uncat.ID)
+
+	resp := env.doDelete(t, "/api/v1/categories/"+uncatID)
+	readErrorCode(t, resp, http.StatusConflict, "CATEGORY_UNDELETABLE")
+}
+
+// ============================================================
+// Category Set/Reset on Transaction Tests
+// ============================================================
+
+func TestAPI_SetTransactionCategory_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	seedUncategorized(t, env.Queries)
+
+	// Create a category so category_id is valid
+	catResp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Valid", "slug": "valid",
+	})
+	var cat map[string]any
+	parseJSON(t, catResp, &cat)
+
+	resp := env.doPatch(t, "/api/v1/transactions/00000000-0000-0000-0000-000000000000/category", map[string]string{
+		"category_id": cat["id"].(string),
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_SetTransactionCategory_MissingCategoryID(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPatch(t, "/api/v1/transactions/"+txnID+"/category", map[string]string{})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_SetTransactionCategory_CategoryNotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPatch(t, "/api/v1/transactions/"+txnID+"/category", map[string]string{
+		"category_id": "00000000-0000-0000-0000-000000000099",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "CATEGORY_NOT_FOUND")
+}
+
+func TestAPI_SetTransactionCategory_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	catResp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Coffee",
+		"slug":         "coffee",
+	})
+	assertStatus(t, catResp, http.StatusCreated)
+	var cat map[string]any
+	parseJSON(t, catResp, &cat)
+	catID := cat["id"].(string)
+
+	resp := env.doPatch(t, "/api/v1/transactions/"+txnID+"/category", map[string]string{
+		"category_id": catID,
+	})
+	assertStatus(t, resp, http.StatusNoContent)
+	resp.Body.Close()
+
+	// Verify via GET
+	getResp := env.doGet(t, "/api/v1/transactions/"+txnID)
+	assertStatus(t, getResp, http.StatusOK)
+	var txnData map[string]any
+	parseJSON(t, getResp, &txnData)
+	if txnData["category_override"] != true {
+		t.Error("expected category_override=true after manual set")
+	}
+}
+
+func TestAPI_ResetTransactionCategory_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	seedUncategorized(t, env.Queries)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	// Create and set category
+	catResp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Temp",
+		"slug":         "temp",
+	})
+	var cat map[string]any
+	parseJSON(t, catResp, &cat)
+	env.doPatch(t, "/api/v1/transactions/"+txnID+"/category", map[string]string{
+		"category_id": cat["id"].(string),
+	}).Body.Close()
+
+	// Reset
+	resp := env.doDelete(t, "/api/v1/transactions/"+txnID+"/category")
+	assertStatus(t, resp, http.StatusNoContent)
+	resp.Body.Close()
+
+	// Verify override is cleared
+	getResp := env.doGet(t, "/api/v1/transactions/"+txnID)
+	var txnData map[string]any
+	parseJSON(t, getResp, &txnData)
+	if txnData["category_override"] == true {
+		t.Error("expected category_override=false after reset")
+	}
+}
+
+func TestAPI_ResetTransactionCategory_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doDelete(t, "/api/v1/transactions/00000000-0000-0000-0000-000000000000/category")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// ============================================================
+// Transaction Rules Handler Tests
+// ============================================================
+
+func TestAPI_CreateRule_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Groceries",
+		"slug":         "groceries",
+	}).Body.Close()
+
+	resp := env.doPost(t, "/api/v1/rules", map[string]any{
+		"name":          "Grocery Rule",
+		"category_slug": "groceries",
+		"priority":      10,
+		"conditions": map[string]any{
+			"field": "name",
+			"op":    "contains",
+			"value": "grocery",
+		},
+	})
+	assertStatus(t, resp, http.StatusCreated)
+
+	var rule map[string]any
+	parseJSON(t, resp, &rule)
+	if rule["name"] != "Grocery Rule" {
+		t.Errorf("expected name 'Grocery Rule', got %v", rule["name"])
+	}
+	if rule["enabled"] != true {
+		t.Error("expected rule to be enabled by default")
+	}
+}
+
+func TestAPI_CreateRule_MissingName(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/rules", map[string]any{
+		"category_slug": "food",
+		"conditions": map[string]any{
+			"field": "name",
+			"op":    "eq",
+			"value": "test",
+		},
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "VALIDATION_ERROR")
+}
+
+func TestAPI_CreateRule_MissingCategorySlug(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/rules", map[string]any{
+		"name": "Test Rule",
+		"conditions": map[string]any{
+			"field": "name",
+			"op":    "eq",
+			"value": "test",
+		},
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "VALIDATION_ERROR")
+}
+
+func TestAPI_CreateRule_InvalidCategory(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/rules", map[string]any{
+		"name":          "Bad Category Rule",
+		"category_slug": "nonexistent_category_slug",
+		"conditions": map[string]any{
+			"field": "name",
+			"op":    "eq",
+			"value": "test",
+		},
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "VALIDATION_ERROR")
+}
+
+func TestAPI_GetRule_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/rules/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_ListRules_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/rules")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result struct{ Rules []any }
+	parseJSON(t, resp, &result)
+	if len(result.Rules) != 0 {
+		t.Errorf("expected 0 rules, got %d", len(result.Rules))
+	}
+}
+
+func TestAPI_ListRules_InvalidLimit(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/rules?limit=0")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ListRules_LimitTooHigh(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/rules?limit=201")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_UpdateRule_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Food",
+		"slug":         "food",
+	}).Body.Close()
+
+	resp := env.doPost(t, "/api/v1/rules", map[string]any{
+		"name":          "Food Rule",
+		"category_slug": "food",
+		"priority":      5,
+		"conditions":    map[string]any{"field": "name", "op": "contains", "value": "food"},
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	var rule map[string]any
+	parseJSON(t, resp, &rule)
+	ruleID := rule["id"].(string)
+
+	newName := "Updated Food Rule"
+	resp = env.doPut(t, "/api/v1/rules/"+ruleID, map[string]any{
+		"name": &newName,
+	})
+	assertStatus(t, resp, http.StatusOK)
+	var updated map[string]any
+	parseJSON(t, resp, &updated)
+	if updated["name"] != "Updated Food Rule" {
+		t.Errorf("expected 'Updated Food Rule', got %v", updated["name"])
+	}
+}
+
+func TestAPI_UpdateRule_Disable(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Misc",
+		"slug":         "misc",
+	}).Body.Close()
+
+	resp := env.doPost(t, "/api/v1/rules", map[string]any{
+		"name":          "Disable Me",
+		"category_slug": "misc",
+		"conditions":    map[string]any{"field": "name", "op": "eq", "value": "x"},
+	})
+	var rule map[string]any
+	parseJSON(t, resp, &rule)
+	ruleID := rule["id"].(string)
+
+	disabled := false
+	resp = env.doPut(t, "/api/v1/rules/"+ruleID, map[string]any{
+		"enabled": &disabled,
+	})
+	assertStatus(t, resp, http.StatusOK)
+	var updated map[string]any
+	parseJSON(t, resp, &updated)
+	if updated["enabled"] != false {
+		t.Error("expected rule to be disabled")
+	}
+}
+
+func TestAPI_DeleteRule_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doDelete(t, "/api/v1/rules/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_DeleteRule_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Transport",
+		"slug":         "transport",
+	}).Body.Close()
+
+	resp := env.doPost(t, "/api/v1/rules", map[string]any{
+		"name":          "Transport Rule",
+		"category_slug": "transport",
+		"priority":      1,
+		"conditions":    map[string]any{"field": "name", "op": "contains", "value": "uber"},
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	var rule map[string]any
+	parseJSON(t, resp, &rule)
+	ruleID, ok := rule["id"].(string)
+	if !ok || ruleID == "" {
+		t.Fatalf("expected rule id in response, got %v", rule)
+	}
+
+	resp = env.doDelete(t, "/api/v1/rules/"+ruleID)
+	assertStatus(t, resp, http.StatusNoContent)
+	resp.Body.Close()
+
+	// Confirm it's gone
+	resp = env.doGet(t, "/api/v1/rules/"+ruleID)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_PreviewRule_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, _ = seedFixture(t, env.Queries) // "Coffee Shop" transaction
+
+	resp := env.doPost(t, "/api/v1/rules/preview", map[string]any{
+		"conditions": map[string]any{
+			"field": "name",
+			"op":    "contains",
+			"value": "Coffee",
+		},
+		"sample_size": 10,
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	matchCount, ok := result["match_count"].(float64)
+	if !ok {
+		t.Fatal("expected match_count in response")
+	}
+	if matchCount != 1 {
+		t.Errorf("expected 1 match, got %v", matchCount)
+	}
+}
+
+func TestAPI_PreviewRule_NoMatches(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, _ = seedFixture(t, env.Queries)
+
+	resp := env.doPost(t, "/api/v1/rules/preview", map[string]any{
+		"conditions": map[string]any{
+			"field": "name",
+			"op":    "eq",
+			"value": "NONEXISTENT",
+		},
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	if result["match_count"].(float64) != 0 {
+		t.Errorf("expected 0 matches, got %v", result["match_count"])
+	}
+}
+
+// ============================================================
+// Review Handler Tests
+// ============================================================
+
+func TestAPI_ListReviews_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/reviews")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result struct{ Reviews []any }
+	parseJSON(t, resp, &result)
+	if len(result.Reviews) != 0 {
+		t.Errorf("expected 0 reviews, got %d", len(result.Reviews))
+	}
+}
+
+func TestAPI_ListReviews_InvalidLimit(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/reviews?limit=201")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_ReviewCounts_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/reviews/counts")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	if result["pending"] == nil {
+		t.Error("expected 'pending' field in review counts")
+	}
+}
+
+func TestAPI_GetReview_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/reviews/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_EnqueueReview_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": txnID,
+	})
+	assertStatus(t, resp, http.StatusCreated)
+
+	var review map[string]any
+	parseJSON(t, resp, &review)
+	if review["review_type"] != "manual" {
+		t.Errorf("expected review_type 'manual', got %v", review["review_type"])
+	}
+	if review["status"] != "pending" {
+		t.Errorf("expected status 'pending', got %v", review["status"])
+	}
+}
+
+func TestAPI_EnqueueReview_TransactionNotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": "00000000-0000-0000-0000-000000000000",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_EnqueueReview_DuplicatePending(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": txnID,
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	resp = env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": txnID,
+	})
+	readErrorCode(t, resp, http.StatusConflict, "REVIEW_ALREADY_PENDING")
+}
+
+func TestAPI_SubmitReview_Approve(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": txnID,
+	})
+	var review map[string]any
+	parseJSON(t, resp, &review)
+	reviewID := review["id"].(string)
+
+	resp = env.doPost(t, "/api/v1/reviews/"+reviewID+"/submit", map[string]any{
+		"decision": "approved",
+	})
+	assertStatus(t, resp, http.StatusOK)
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	if result["status"] != "approved" {
+		t.Errorf("expected status 'approved', got %v", result["status"])
+	}
+}
+
+func TestAPI_SubmitReview_Reject(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": txnID,
+	})
+	var review map[string]any
+	parseJSON(t, resp, &review)
+	reviewID := review["id"].(string)
+
+	resp = env.doPost(t, "/api/v1/reviews/"+reviewID+"/submit", map[string]any{
+		"decision": "rejected",
+	})
+	assertStatus(t, resp, http.StatusOK)
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	if result["status"] != "rejected" {
+		t.Errorf("expected status 'rejected', got %v", result["status"])
+	}
+}
+
+func TestAPI_SubmitReview_Skip(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": txnID,
+	})
+	var review map[string]any
+	parseJSON(t, resp, &review)
+	reviewID := review["id"].(string)
+
+	resp = env.doPost(t, "/api/v1/reviews/"+reviewID+"/submit", map[string]any{
+		"decision": "skipped",
+	})
+	assertStatus(t, resp, http.StatusOK)
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	if result["status"] != "skipped" {
+		t.Errorf("expected status 'skipped', got %v", result["status"])
+	}
+}
+
+func TestAPI_SubmitReview_InvalidDecision(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": txnID,
+	})
+	var review map[string]any
+	parseJSON(t, resp, &review)
+	reviewID := review["id"].(string)
+
+	resp = env.doPost(t, "/api/v1/reviews/"+reviewID+"/submit", map[string]any{
+		"decision": "invalid_decision",
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestAPI_SubmitReview_AlreadyResolved(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": txnID,
+	})
+	var review map[string]any
+	parseJSON(t, resp, &review)
+	reviewID := review["id"].(string)
+
+	env.doPost(t, "/api/v1/reviews/"+reviewID+"/submit", map[string]any{
+		"decision": "approved",
+	}).Body.Close()
+
+	resp = env.doPost(t, "/api/v1/reviews/"+reviewID+"/submit", map[string]any{
+		"decision": "rejected",
+	})
+	readErrorCode(t, resp, http.StatusConflict, "REVIEW_ALREADY_RESOLVED")
+}
+
+func TestAPI_DismissReview_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
+		"transaction_id": txnID,
+	})
+	var review map[string]any
+	parseJSON(t, resp, &review)
+	reviewID := review["id"].(string)
+
+	resp = env.doDelete(t, "/api/v1/reviews/"+reviewID)
+	assertStatus(t, resp, http.StatusNoContent)
+	resp.Body.Close()
+}
+
+func TestAPI_DismissReview_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doDelete(t, "/api/v1/reviews/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// ============================================================
+// Comment Handler Tests
+// ============================================================
+
+func TestAPI_CreateComment_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/comments", map[string]string{
+		"content": "This is a test comment",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+
+	var comment map[string]any
+	parseJSON(t, resp, &comment)
+	if comment["content"] != "This is a test comment" {
+		t.Errorf("expected content 'This is a test comment', got %v", comment["content"])
+	}
+}
+
+func TestAPI_CreateComment_TransactionNotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/transactions/00000000-0000-0000-0000-000000000000/comments", map[string]string{
+		"content": "Comment on nonexistent",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_ListComments_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	resp := env.doGet(t, "/api/v1/transactions/"+txnID+"/comments")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result struct{ Comments []any }
+	parseJSON(t, resp, &result)
+	if len(result.Comments) != 0 {
+		t.Errorf("expected 0 comments, got %d", len(result.Comments))
+	}
+}
+
+func TestAPI_ListComments_WithData(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	env.doPost(t, "/api/v1/transactions/"+txnID+"/comments", map[string]string{
+		"content": "First comment",
+	}).Body.Close()
+	env.doPost(t, "/api/v1/transactions/"+txnID+"/comments", map[string]string{
+		"content": "Second comment",
+	}).Body.Close()
+
+	resp := env.doGet(t, "/api/v1/transactions/"+txnID+"/comments")
+	assertStatus(t, resp, http.StatusOK)
+
+	var result struct{ Comments []any }
+	parseJSON(t, resp, &result)
+	if len(result.Comments) != 2 {
+		t.Errorf("expected 2 comments, got %d", len(result.Comments))
+	}
+}
+
+// ============================================================
+// Users & Accounts & Connections Handler Tests
+// ============================================================
+
+func TestAPI_ListUsers_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/users")
+	assertStatus(t, resp, http.StatusOK)
+
+	var users []any
+	parseJSON(t, resp, &users)
+	if len(users) != 0 {
+		t.Errorf("expected 0 users, got %d", len(users))
+	}
+}
+
+func TestAPI_ListUsers_WithData(t *testing.T) {
+	env := setupTestEnv(t)
+	testutil.MustCreateUser(t, env.Queries, "Alice")
+	testutil.MustCreateUser(t, env.Queries, "Bob")
+
+	resp := env.doGet(t, "/api/v1/users")
+	assertStatus(t, resp, http.StatusOK)
+
+	var users []map[string]any
+	parseJSON(t, resp, &users)
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+}
+
+func TestAPI_ListAccounts_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/accounts")
+	assertStatus(t, resp, http.StatusOK)
+
+	var accounts []any
+	parseJSON(t, resp, &accounts)
+	if len(accounts) != 0 {
+		t.Errorf("expected 0 accounts, got %d", len(accounts))
+	}
+}
+
+func TestAPI_ListAccounts_WithData(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, _ = seedFixture(t, env.Queries)
+
+	resp := env.doGet(t, "/api/v1/accounts")
+	assertStatus(t, resp, http.StatusOK)
+
+	var accounts []map[string]any
+	parseJSON(t, resp, &accounts)
+	if len(accounts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accounts))
+	}
+	if accounts[0]["name"] != "Checking" {
+		t.Errorf("expected name 'Checking', got %v", accounts[0]["name"])
+	}
+}
+
+func TestAPI_ListConnections_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/connections")
+	assertStatus(t, resp, http.StatusOK)
+
+	var conns []any
+	parseJSON(t, resp, &conns)
+	if len(conns) != 0 {
+		t.Errorf("expected 0 connections, got %d", len(conns))
+	}
+}
+
+func TestAPI_ListConnections_WithData(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, _ = seedFixture(t, env.Queries)
+
+	resp := env.doGet(t, "/api/v1/connections")
+	assertStatus(t, resp, http.StatusOK)
+
+	var conns []map[string]any
+	parseJSON(t, resp, &conns)
+	if len(conns) != 1 {
+		t.Fatalf("expected 1 connection, got %d", len(conns))
+	}
+}
+
+// ============================================================
+// Category Merge Test
+// ============================================================
+
+func TestAPI_MergeCategories_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	seedUncategorized(t, env.Queries)
+
+	resp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Source",
+		"slug":         "source",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	var src map[string]any
+	parseJSON(t, resp, &src)
+
+	resp = env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Target",
+		"slug":         "target",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	var tgt map[string]any
+	parseJSON(t, resp, &tgt)
+
+	resp = env.doPost(t, "/api/v1/categories/"+src["id"].(string)+"/merge", map[string]string{
+		"target_id": tgt["id"].(string),
+	})
+	assertStatus(t, resp, http.StatusNoContent)
+	resp.Body.Close()
+
+	// Source should be gone
+	resp = env.doGet(t, "/api/v1/categories/"+src["id"].(string))
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestAPI_MergeCategories_MissingTargetID(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Src",
+		"slug":         "src",
+	})
+	var src map[string]any
+	parseJSON(t, resp, &src)
+
+	resp = env.doPost(t, "/api/v1/categories/"+src["id"].(string)+"/merge", map[string]string{})
+	readErrorCode(t, resp, http.StatusBadRequest, "VALIDATION_ERROR")
+}
+
+// ============================================================
+// Batch Categorize Test
+// ============================================================
+
+func TestAPI_BatchCategorize_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := fmtUUID(txn.ID)
+
+	env.doPost(t, "/api/v1/categories", map[string]any{
+		"display_name": "Dining",
+		"slug":         "dining",
+	}).Body.Close()
+
+	resp := env.doPost(t, "/api/v1/transactions/batch-categorize", map[string]any{
+		"items": []map[string]string{
+			{"transaction_id": txnID, "category_slug": "dining"},
+		},
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var result map[string]any
+	parseJSON(t, resp, &result)
+	if result["succeeded"] == nil {
+		t.Error("expected 'succeeded' field in batch result")
+	}
+	if result["succeeded"].(float64) != 1 {
+		t.Errorf("expected succeeded=1, got %v", result["succeeded"])
+	}
+}
+
+func TestAPI_BatchCategorize_EmptyItems(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/transactions/batch-categorize", map[string]any{
+		"items": []map[string]string{},
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// ============================================================
+// JSON Error Envelope Tests
+// ============================================================
+
+func TestAPI_ErrorEnvelope_HasCorrectStructure(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions?limit=999")
+	if resp.StatusCode != http.StatusBadRequest {
+		resp.Body.Close()
+		t.Skip("limit 999 might be valid, skipping")
+	}
+
+	var envelope map[string]any
+	parseJSON(t, resp, &envelope)
+	errorObj, ok := envelope["error"].(map[string]any)
+	if !ok {
+		t.Fatal("expected 'error' object in response")
+	}
+	if errorObj["code"] == nil {
+		t.Error("expected 'code' in error object")
+	}
+	if errorObj["message"] == nil {
+		t.Error("expected 'message' in error object")
+	}
+}

--- a/internal/db/queries/categories.sql
+++ b/internal/db/queries/categories.sql
@@ -51,12 +51,12 @@ UPDATE category_mappings
 SET category_id = $2, updated_at = NOW()
 WHERE category_id = $1;
 
--- name: SetTransactionCategoryOverride :exec
+-- name: SetTransactionCategoryOverride :execrows
 UPDATE transactions
 SET category_id = $2, category_override = TRUE, updated_at = NOW()
 WHERE id = $1;
 
--- name: ClearTransactionCategoryOverride :exec
+-- name: ClearTransactionCategoryOverride :execrows
 UPDATE transactions
 SET category_override = FALSE, updated_at = NOW()
 WHERE id = $1;

--- a/internal/service/account_link_integration_test.go
+++ b/internal/service/account_link_integration_test.go
@@ -1,0 +1,790 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+
+// formatUUIDForTest converts a pgtype.UUID to a string for test assertions.
+func formatUUIDForTest(u pgtype.UUID) string {
+	if !u.Valid {
+		return ""
+	}
+	b := u.Bytes
+	return bytesToUUIDString(b)
+}
+
+func bytesToUUIDString(b [16]byte) string {
+	return hexEncode(b[0:4]) + "-" + hexEncode(b[4:6]) + "-" + hexEncode(b[6:8]) + "-" + hexEncode(b[8:10]) + "-" + hexEncode(b[10:16])
+}
+
+func hexEncode(b []byte) string {
+	const hex = "0123456789abcdef"
+	result := make([]byte, len(b)*2)
+	for i, v := range b {
+		result[i*2] = hex[v>>4]
+		result[i*2+1] = hex[v&0x0f]
+	}
+	return string(result)
+}
+
+// --- CreateAccountLink ---
+
+func TestCreateAccountLink_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "Cardholder")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_primary")
+	primaryAcct := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_primary", "Primary Card")
+
+	user2 := testutil.MustCreateUser(t, queries, "Authorized User")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_dependent")
+	dependentAcct := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
+
+	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(primaryAcct.ID),
+		DependentAccountID: formatUUIDForTest(dependentAcct.ID),
+		MatchStrategy:      "date_amount_name",
+		MatchToleranceDays: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	if link.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if link.PrimaryAccountID != formatUUIDForTest(primaryAcct.ID) {
+		t.Errorf("primary account mismatch: got %s, want %s", link.PrimaryAccountID, formatUUIDForTest(primaryAcct.ID))
+	}
+	if link.DependentAccountID != formatUUIDForTest(dependentAcct.ID) {
+		t.Errorf("dependent account mismatch")
+	}
+	if link.MatchStrategy != "date_amount_name" {
+		t.Errorf("strategy: got %s, want date_amount_name", link.MatchStrategy)
+	}
+	if link.MatchToleranceDays != 1 {
+		t.Errorf("tolerance: got %d, want 1", link.MatchToleranceDays)
+	}
+	if !link.Enabled {
+		t.Error("expected link to be enabled by default")
+	}
+
+	// Verify dependent account is marked as linked.
+	acct, err := queries.GetAccount(context.Background(), dependentAcct.ID)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if !acct.IsDependentLinked {
+		t.Error("expected dependent account to be marked as linked")
+	}
+}
+
+func TestCreateAccountLink_DefaultStrategy(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "Cardholder")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_primary")
+	primaryAcct := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_primary", "Primary Card")
+
+	user2 := testutil.MustCreateUser(t, queries, "Authorized User")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_dependent")
+	dependentAcct := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
+
+	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(primaryAcct.ID),
+		DependentAccountID: formatUUIDForTest(dependentAcct.ID),
+		// No strategy specified — should default to "date_amount_name"
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+	if link.MatchStrategy != "date_amount_name" {
+		t.Errorf("expected default strategy, got %q", link.MatchStrategy)
+	}
+}
+
+func TestCreateAccountLink_InvalidPrimaryAccount(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user := testutil.MustCreateUser(t, queries, "User")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_1", "Real Account")
+
+	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   "00000000-0000-0000-0000-000000000001",
+		DependentAccountID: formatUUIDForTest(acct.ID),
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent primary account")
+	}
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestCreateAccountLink_InvalidDependentAccount(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user := testutil.MustCreateUser(t, queries, "User")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_1", "Real Account")
+
+	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct.ID),
+		DependentAccountID: "00000000-0000-0000-0000-000000000001",
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent dependent account")
+	}
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestCreateAccountLink_BadUUID(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   "not-a-uuid",
+		DependentAccountID: "also-not-a-uuid",
+	})
+	if err == nil {
+		t.Fatal("expected error for bad UUID")
+	}
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got: %v", err)
+	}
+}
+
+func TestCreateAccountLink_DuplicateLink(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "Cardholder")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_primary")
+	primaryAcct := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_primary", "Primary Card")
+
+	user2 := testutil.MustCreateUser(t, queries, "Authorized User")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_dependent")
+	dependentAcct := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
+
+	params := service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(primaryAcct.ID),
+		DependentAccountID: formatUUIDForTest(dependentAcct.ID),
+	}
+
+	_, err := svc.CreateAccountLink(context.Background(), params)
+	if err != nil {
+		t.Fatalf("first CreateAccountLink: %v", err)
+	}
+
+	// Creating the same link again should fail (unique constraint).
+	_, err = svc.CreateAccountLink(context.Background(), params)
+	if err == nil {
+		t.Fatal("expected error for duplicate link")
+	}
+}
+
+// --- GetAccountLink ---
+
+func TestGetAccountLink_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "Cardholder")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_primary")
+	primaryAcct := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_primary", "Primary Card")
+
+	user2 := testutil.MustCreateUser(t, queries, "Authorized User")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_dependent")
+	dependentAcct := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
+
+	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(primaryAcct.ID),
+		DependentAccountID: formatUUIDForTest(dependentAcct.ID),
+		MatchToleranceDays: 2,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	got, err := svc.GetAccountLink(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetAccountLink: %v", err)
+	}
+
+	if got.ID != created.ID {
+		t.Errorf("ID mismatch: got %s, want %s", got.ID, created.ID)
+	}
+	if got.PrimaryAccountName != "Primary Card" {
+		t.Errorf("primary name: got %q, want %q", got.PrimaryAccountName, "Primary Card")
+	}
+	if got.DependentAccountName != "Dependent Card" {
+		t.Errorf("dependent name: got %q, want %q", got.DependentAccountName, "Dependent Card")
+	}
+	if got.PrimaryUserName != "Cardholder" {
+		t.Errorf("primary user name: got %q, want %q", got.PrimaryUserName, "Cardholder")
+	}
+	if got.DependentUserName != "Authorized User" {
+		t.Errorf("dependent user name: got %q, want %q", got.DependentUserName, "Authorized User")
+	}
+	if got.MatchToleranceDays != 2 {
+		t.Errorf("tolerance: got %d, want 2", got.MatchToleranceDays)
+	}
+}
+
+func TestGetAccountLink_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	_, err := svc.GetAccountLink(context.Background(), "00000000-0000-0000-0000-000000000001")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestGetAccountLink_BadUUID(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	_, err := svc.GetAccountLink(context.Background(), "not-a-uuid")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound for bad UUID, got: %v", err)
+	}
+}
+
+// --- ListAccountLinks ---
+
+func TestListAccountLinks_Empty(t *testing.T) {
+	svc, _, _ := newService(t)
+	links, err := svc.ListAccountLinks(context.Background())
+	if err != nil {
+		t.Fatalf("ListAccountLinks: %v", err)
+	}
+	if len(links) != 0 {
+		t.Errorf("expected 0 links, got %d", len(links))
+	}
+}
+
+func TestListAccountLinks_WithData(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Acct1")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
+
+	user3 := testutil.MustCreateUser(t, queries, "User3")
+	conn3 := testutil.MustCreateConnection(t, queries, user3.ID, "item_3")
+	acct3 := testutil.MustCreateAccount(t, queries, conn3.ID, "ext_3", "Acct3")
+
+	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink 1: %v", err)
+	}
+	_, err = svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct3.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink 2: %v", err)
+	}
+
+	links, err := svc.ListAccountLinks(context.Background())
+	if err != nil {
+		t.Fatalf("ListAccountLinks: %v", err)
+	}
+	if len(links) != 2 {
+		t.Errorf("expected 2 links, got %d", len(links))
+	}
+}
+
+// --- UpdateAccountLink ---
+
+func TestUpdateAccountLink_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Acct1")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
+
+	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+		MatchToleranceDays: 0,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	newTolerance := 3
+	updated, err := svc.UpdateAccountLink(context.Background(), created.ID, service.UpdateAccountLinkParams{
+		MatchToleranceDays: &newTolerance,
+	})
+	if err != nil {
+		t.Fatalf("UpdateAccountLink: %v", err)
+	}
+	if updated.MatchToleranceDays != 3 {
+		t.Errorf("tolerance: got %d, want 3", updated.MatchToleranceDays)
+	}
+	// Other fields should be unchanged.
+	if updated.MatchStrategy != "date_amount_name" {
+		t.Errorf("strategy changed unexpectedly: %s", updated.MatchStrategy)
+	}
+	if !updated.Enabled {
+		t.Error("enabled changed unexpectedly")
+	}
+}
+
+func TestUpdateAccountLink_Disable(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Acct1")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
+
+	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	disabled := false
+	updated, err := svc.UpdateAccountLink(context.Background(), created.ID, service.UpdateAccountLinkParams{
+		Enabled: &disabled,
+	})
+	if err != nil {
+		t.Fatalf("UpdateAccountLink: %v", err)
+	}
+	if updated.Enabled {
+		t.Error("expected link to be disabled")
+	}
+
+	// Dependent account should be unmarked (no other enabled links).
+	acct, err := queries.GetAccount(context.Background(), acct2.ID)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if acct.IsDependentLinked {
+		t.Error("expected dependent account to be unmarked when only link is disabled")
+	}
+}
+
+func TestUpdateAccountLink_ReEnable(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Acct1")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
+
+	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	// Disable then re-enable.
+	disabled := false
+	_, err = svc.UpdateAccountLink(context.Background(), created.ID, service.UpdateAccountLinkParams{
+		Enabled: &disabled,
+	})
+	if err != nil {
+		t.Fatalf("Disable: %v", err)
+	}
+
+	enabled := true
+	_, err = svc.UpdateAccountLink(context.Background(), created.ID, service.UpdateAccountLinkParams{
+		Enabled: &enabled,
+	})
+	if err != nil {
+		t.Fatalf("Re-enable: %v", err)
+	}
+
+	// Dependent account should be marked as linked again.
+	acct, err := queries.GetAccount(context.Background(), acct2.ID)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if !acct.IsDependentLinked {
+		t.Error("expected dependent account to be re-marked as linked")
+	}
+}
+
+func TestUpdateAccountLink_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	newTol := 1
+	_, err := svc.UpdateAccountLink(context.Background(), "00000000-0000-0000-0000-000000000001", service.UpdateAccountLinkParams{
+		MatchToleranceDays: &newTol,
+	})
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+// --- DeleteAccountLink ---
+
+func TestDeleteAccountLink_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Acct1")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
+
+	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	err = svc.DeleteAccountLink(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("DeleteAccountLink: %v", err)
+	}
+
+	// Should be gone.
+	_, err = svc.GetAccountLink(context.Background(), created.ID)
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound after delete, got: %v", err)
+	}
+
+	// Dependent account should be unmarked.
+	acct, err := queries.GetAccount(context.Background(), acct2.ID)
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	if acct.IsDependentLinked {
+		t.Error("expected dependent account to be unmarked after link deletion")
+	}
+}
+
+func TestDeleteAccountLink_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	err := svc.DeleteAccountLink(context.Background(), "00000000-0000-0000-0000-000000000001")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+// --- ManualMatch ---
+
+func TestManualMatch_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "Cardholder")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_primary")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_primary", "Primary Card")
+
+	user2 := testutil.MustCreateUser(t, queries, "Authorized User")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_dependent")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
+
+	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_p1", "Coffee Shop", 550, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_d1", "Coffee Shop", 550, "2025-01-15")
+
+	match, err := svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	if err != nil {
+		t.Fatalf("ManualMatch: %v", err)
+	}
+
+	if match.ID == "" {
+		t.Error("expected non-empty match ID")
+	}
+	if match.MatchConfidence != "confirmed" {
+		t.Errorf("confidence: got %q, want %q", match.MatchConfidence, "confirmed")
+	}
+	if len(match.MatchedOn) != 1 || match.MatchedOn[0] != "manual" {
+		t.Errorf("matched_on: got %v, want [manual]", match.MatchedOn)
+	}
+	if match.PrimaryTransactionID != formatUUIDForTest(txn1.ID) {
+		t.Error("primary transaction ID mismatch")
+	}
+	if match.DependentTransactionID != formatUUIDForTest(txn2.ID) {
+		t.Error("dependent transaction ID mismatch")
+	}
+}
+
+func TestManualMatch_InvalidLinkID(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	_, err := svc.ManualMatch(context.Background(), "not-a-uuid", "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002")
+	if err == nil {
+		t.Fatal("expected error for bad link UUID")
+	}
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got: %v", err)
+	}
+}
+
+func TestManualMatch_NonexistentLink(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	_, err := svc.ManualMatch(context.Background(), "00000000-0000-0000-0000-000000000001", "00000000-0000-0000-0000-000000000002", "00000000-0000-0000-0000-000000000003")
+	if err == nil {
+		t.Fatal("expected error for nonexistent link")
+	}
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+// --- ConfirmMatch & RejectMatch ---
+
+func TestConfirmMatch_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Acct1")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
+
+	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_1", "Store", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_2", "Store", 1000, "2025-01-15")
+
+	match, err := svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	if err != nil {
+		t.Fatalf("ManualMatch: %v", err)
+	}
+
+	// ManualMatch already creates as confirmed, but let's test the ConfirmMatch method works.
+	err = svc.ConfirmMatch(context.Background(), match.ID)
+	if err != nil {
+		t.Fatalf("ConfirmMatch: %v", err)
+	}
+}
+
+func TestConfirmMatch_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	err := svc.ConfirmMatch(context.Background(), "00000000-0000-0000-0000-000000000001")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestRejectMatch_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Acct1")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
+
+	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_1", "Store", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_2", "Store", 1000, "2025-01-15")
+
+	match, err := svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	if err != nil {
+		t.Fatalf("ManualMatch: %v", err)
+	}
+
+	err = svc.RejectMatch(context.Background(), match.ID)
+	if err != nil {
+		t.Fatalf("RejectMatch: %v", err)
+	}
+
+	// Match should be gone after rejection.
+	matches, err := svc.ListTransactionMatches(context.Background(), link.ID)
+	if err != nil {
+		t.Fatalf("ListTransactionMatches: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches after reject, got %d", len(matches))
+	}
+}
+
+func TestRejectMatch_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	err := svc.RejectMatch(context.Background(), "00000000-0000-0000-0000-000000000001")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+// --- ListTransactionMatches ---
+
+func TestListTransactionMatches_Empty(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Acct1")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
+
+	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	matches, err := svc.ListTransactionMatches(context.Background(), link.ID)
+	if err != nil {
+		t.Fatalf("ListTransactionMatches: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches, got %d", len(matches))
+	}
+}
+
+func TestListTransactionMatches_WithData(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Acct1")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
+
+	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_1", "Store A", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_2", "Store A", 1000, "2025-01-15")
+
+	_, err = svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	if err != nil {
+		t.Fatalf("ManualMatch: %v", err)
+	}
+
+	matches, err := svc.ListTransactionMatches(context.Background(), link.ID)
+	if err != nil {
+		t.Fatalf("ListTransactionMatches: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].PrimaryTxnName != "Store A" {
+		t.Errorf("primary txn name: got %q, want %q", matches[0].PrimaryTxnName, "Store A")
+	}
+	if matches[0].DependentTxnName != "Store A" {
+		t.Errorf("dependent txn name: got %q, want %q", matches[0].DependentTxnName, "Store A")
+	}
+	if matches[0].Amount != 10.00 {
+		t.Errorf("amount: got %f, want 10.00", matches[0].Amount)
+	}
+}
+
+func TestListTransactionMatches_InvalidLinkID(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	_, err := svc.ListTransactionMatches(context.Background(), "not-a-uuid")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound for bad UUID, got: %v", err)
+	}
+}
+
+// --- DeleteAccountLink clears attribution ---
+
+func TestDeleteAccountLink_ClearsAttribution(t *testing.T) {
+	svc, queries, pool := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "Cardholder")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Primary Card")
+
+	user2 := testutil.MustCreateUser(t, queries, "Auth User")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Dependent Card")
+
+	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_p1", "Coffee", 550, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_d1", "Coffee", 550, "2025-01-15")
+
+	_, err = svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	if err != nil {
+		t.Fatalf("ManualMatch: %v", err)
+	}
+
+	// Verify attribution was set on primary transaction.
+	var attrUserID pgtype.UUID
+	err = pool.QueryRow(context.Background(), "SELECT attributed_user_id FROM transactions WHERE id = $1", txn1.ID).Scan(&attrUserID)
+	if err != nil {
+		t.Fatalf("query attributed_user_id: %v", err)
+	}
+	if !attrUserID.Valid {
+		t.Fatal("expected attributed_user_id to be set after ManualMatch")
+	}
+
+	// Now delete the link.
+	err = svc.DeleteAccountLink(context.Background(), link.ID)
+	if err != nil {
+		t.Fatalf("DeleteAccountLink: %v", err)
+	}
+
+	// Attribution should be cleared.
+	err = pool.QueryRow(context.Background(), "SELECT attributed_user_id FROM transactions WHERE id = $1", txn1.ID).Scan(&attrUserID)
+	if err != nil {
+		t.Fatalf("query attributed_user_id after delete: %v", err)
+	}
+	if attrUserID.Valid {
+		t.Error("expected attributed_user_id to be NULL after link deletion")
+	}
+}

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -13,6 +13,7 @@ import (
 	bsync "breadbox/internal/sync"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -389,10 +390,22 @@ func (s *Service) SetTransactionCategory(ctx context.Context, txnID, categoryID 
 		return ErrCategoryNotFound
 	}
 
-	return s.Queries.SetTransactionCategoryOverride(ctx, db.SetTransactionCategoryOverrideParams{
+	rowsAffected, err := s.Queries.SetTransactionCategoryOverride(ctx, db.SetTransactionCategoryOverrideParams{
 		ID:         txnUID,
 		CategoryID: catUID,
 	})
+	if err != nil {
+		// Check for FK violation on category_id (nonexistent category)
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23503" {
+			return ErrCategoryNotFound
+		}
+		return fmt.Errorf("set category override: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // ResetTransactionCategory clears the manual override and re-resolves category from mappings.
@@ -403,8 +416,12 @@ func (s *Service) ResetTransactionCategory(ctx context.Context, txnID string) er
 	}
 
 	// Clear the override flag
-	if err := s.Queries.ClearTransactionCategoryOverride(ctx, txnUID); err != nil {
+	rowsAffected, err := s.Queries.ClearTransactionCategoryOverride(ctx, txnUID)
+	if err != nil {
 		return fmt.Errorf("clear override: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
 	}
 
 	// Re-resolve: look up the transaction's raw categories and resolve through mappings

--- a/internal/service/category_integration_test.go
+++ b/internal/service/category_integration_test.go
@@ -1,0 +1,1082 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+
+	"breadbox/internal/db"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// --- Helper ---
+
+// mustCreateCategoryViaService creates a category via the service layer and returns the response.
+func mustCreateCategoryViaService(t *testing.T, svc *service.Service, slug, displayName string, parentID *string) *service.CategoryResponse {
+	t.Helper()
+	cat, err := svc.CreateCategory(context.Background(), service.CreateCategoryParams{
+		Slug:        slug,
+		DisplayName: displayName,
+		ParentID:    parentID,
+	})
+	if err != nil {
+		t.Fatalf("mustCreateCategoryViaService(%q): %v", slug, err)
+	}
+	return cat
+}
+
+// mustSeedUncategorized creates the system "uncategorized" category directly in DB.
+func mustSeedUncategorized(t *testing.T, q *db.Queries) db.Category {
+	t.Helper()
+	cat, err := q.InsertCategory(context.Background(), db.InsertCategoryParams{
+		Slug: "uncategorized", DisplayName: "Uncategorized", IsSystem: true,
+	})
+	if err != nil {
+		t.Fatalf("seed uncategorized: %v", err)
+	}
+	return cat
+}
+
+// mustCreateTransactionWithCategory creates a transaction linked to a specific category.
+func mustCreateTransactionWithCategory(t *testing.T, q *db.Queries, acctID, catID pgtype.UUID, extID, name string, amountCents int64, date string) db.Transaction {
+	t.Helper()
+	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
+		AccountID:             acctID,
+		ExternalTransactionID: extID,
+		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
+		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
+		Name:                  name,
+		CategoryID:            catID,
+	})
+	if err != nil {
+		t.Fatalf("mustCreateTransactionWithCategory(%q): %v", name, err)
+	}
+	return txn
+}
+
+// --- ListCategories ---
+
+func TestListCategories_Empty(t *testing.T) {
+	svc, _, _ := newService(t)
+	cats, err := svc.ListCategories(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cats) != 0 {
+		t.Errorf("expected 0 categories, got %d", len(cats))
+	}
+}
+
+func TestListCategories_ReturnsAll(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	parent := mustCreateCategoryViaService(t, svc, "food_and_drink", "Food & Drink", nil)
+	mustCreateCategoryViaService(t, svc, "food_groceries", "Groceries", &parent.ID)
+	mustCreateCategoryViaService(t, svc, "transportation", "Transportation", nil)
+
+	cats, err := svc.ListCategories(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cats) != 3 {
+		t.Fatalf("expected 3 categories, got %d", len(cats))
+	}
+
+	// Verify child has parent info
+	var child *service.CategoryResponse
+	for i := range cats {
+		if cats[i].Slug == "food_groceries" {
+			child = &cats[i]
+			break
+		}
+	}
+	if child == nil {
+		t.Fatal("child category not found")
+	}
+	if child.ParentID == nil || *child.ParentID != parent.ID {
+		t.Errorf("child parent ID mismatch")
+	}
+	if child.ParentSlug == nil || *child.ParentSlug != "food_and_drink" {
+		t.Errorf("child parent slug mismatch: got %v", child.ParentSlug)
+	}
+}
+
+// --- ListCategoryTree ---
+
+func TestListCategoryTree_GroupsChildren(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	parent := mustCreateCategoryViaService(t, svc, "food_and_drink", "Food & Drink", nil)
+	mustCreateCategoryViaService(t, svc, "food_groceries", "Groceries", &parent.ID)
+	mustCreateCategoryViaService(t, svc, "food_restaurants", "Restaurants", &parent.ID)
+	mustCreateCategoryViaService(t, svc, "transportation", "Transportation", nil)
+
+	tree, err := svc.ListCategoryTree(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Tree should only have root-level categories
+	if len(tree) != 2 {
+		t.Fatalf("expected 2 root categories, got %d", len(tree))
+	}
+
+	var foodNode *service.CategoryResponse
+	for i := range tree {
+		if tree[i].Slug == "food_and_drink" {
+			foodNode = &tree[i]
+			break
+		}
+	}
+	if foodNode == nil {
+		t.Fatal("food_and_drink not found in tree roots")
+	}
+	if len(foodNode.Children) != 2 {
+		t.Errorf("expected 2 children, got %d", len(foodNode.Children))
+	}
+}
+
+// --- GetCategory ---
+
+func TestGetCategory_Found(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	created := mustCreateCategoryViaService(t, svc, "test_cat", "Test Category", nil)
+
+	got, err := svc.GetCategory(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Slug != "test_cat" {
+		t.Errorf("slug mismatch: got %s", got.Slug)
+	}
+	if got.DisplayName != "Test Category" {
+		t.Errorf("display name mismatch: got %s", got.DisplayName)
+	}
+}
+
+func TestGetCategory_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	_, err := svc.GetCategory(context.Background(), "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("expected ErrCategoryNotFound, got: %v", err)
+	}
+}
+
+func TestGetCategory_InvalidID(t *testing.T) {
+	svc, _, _ := newService(t)
+	_, err := svc.GetCategory(context.Background(), "not-a-uuid")
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("expected ErrCategoryNotFound for invalid ID, got: %v", err)
+	}
+}
+
+// --- CreateCategory ---
+
+func TestCreateCategory_AutoGeneratesSlug(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	cat, err := svc.CreateCategory(ctx, service.CreateCategoryParams{
+		DisplayName: "Food & Drink",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cat.Slug != "food__drink" && cat.Slug != "food_drink" {
+		// GenerateSlug converts "Food & Drink" → "food_&_drink" → strips & → "food__drink" → collapses → "food_drink"
+		// Let's just check it's non-empty and lowercase
+		if cat.Slug == "" {
+			t.Errorf("expected auto-generated slug, got empty")
+		}
+	}
+	if cat.DisplayName != "Food & Drink" {
+		t.Errorf("display name mismatch: got %s", cat.DisplayName)
+	}
+	if cat.IsSystem {
+		t.Errorf("new category should not be system")
+	}
+}
+
+func TestCreateCategory_DuplicateSlugAppendsSuffix(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	cat1 := mustCreateCategoryViaService(t, svc, "my_cat", "My Category", nil)
+	cat2, err := svc.CreateCategory(ctx, service.CreateCategoryParams{
+		Slug:        "my_cat",
+		DisplayName: "My Category Dupe",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cat2.Slug != "my_cat_2" {
+		t.Errorf("expected slug my_cat_2, got %s", cat2.Slug)
+	}
+	if cat1.ID == cat2.ID {
+		t.Errorf("categories should have different IDs")
+	}
+}
+
+func TestCreateCategory_WithParent(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	parent := mustCreateCategoryViaService(t, svc, "parent_cat", "Parent", nil)
+	child := mustCreateCategoryViaService(t, svc, "child_cat", "Child", &parent.ID)
+
+	if child.ParentID == nil || *child.ParentID != parent.ID {
+		t.Errorf("child parent ID mismatch")
+	}
+}
+
+func TestCreateCategory_WithIconAndColor(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	icon := "shopping-cart"
+	color := "#ff0000"
+	cat, err := svc.CreateCategory(ctx, service.CreateCategoryParams{
+		Slug:        "styled_cat",
+		DisplayName: "Styled",
+		Icon:        &icon,
+		Color:       &color,
+		SortOrder:   5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cat.Icon == nil || *cat.Icon != "shopping-cart" {
+		t.Errorf("icon mismatch: got %v", cat.Icon)
+	}
+	if cat.Color == nil || *cat.Color != "#ff0000" {
+		t.Errorf("color mismatch: got %v", cat.Color)
+	}
+	if cat.SortOrder != 5 {
+		t.Errorf("sort order mismatch: got %d", cat.SortOrder)
+	}
+}
+
+// --- UpdateCategory ---
+
+func TestUpdateCategory_Success(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	cat := mustCreateCategoryViaService(t, svc, "update_me", "Before", nil)
+
+	icon := "new-icon"
+	updated, err := svc.UpdateCategory(ctx, cat.ID, service.UpdateCategoryParams{
+		DisplayName: "After",
+		Icon:        &icon,
+		SortOrder:   10,
+		Hidden:      true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if updated.DisplayName != "After" {
+		t.Errorf("display name not updated: got %s", updated.DisplayName)
+	}
+	if updated.Icon == nil || *updated.Icon != "new-icon" {
+		t.Errorf("icon not updated")
+	}
+	if updated.SortOrder != 10 {
+		t.Errorf("sort order not updated: got %d", updated.SortOrder)
+	}
+	if !updated.Hidden {
+		t.Errorf("hidden not updated")
+	}
+	// Slug should NOT change
+	if updated.Slug != "update_me" {
+		t.Errorf("slug should be immutable, got %s", updated.Slug)
+	}
+}
+
+func TestUpdateCategory_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	_, err := svc.UpdateCategory(context.Background(), "00000000-0000-0000-0000-000000000000", service.UpdateCategoryParams{
+		DisplayName: "Nope",
+	})
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("expected ErrCategoryNotFound, got: %v", err)
+	}
+}
+
+// --- DeleteCategory ---
+
+func TestDeleteCategory_Success(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	mustSeedUncategorized(t, q)
+	cat := mustCreateCategoryViaService(t, svc, "delete_me", "Delete Me", nil)
+
+	count, err := svc.DeleteCategory(ctx, cat.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 affected transactions, got %d", count)
+	}
+
+	// Verify it's gone
+	_, err = svc.GetCategory(ctx, cat.ID)
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("expected not found after delete, got: %v", err)
+	}
+}
+
+func TestDeleteCategory_CannotDeleteUncategorized(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	_, err := svc.DeleteCategory(ctx, formatUUID(uncat.ID))
+	if !errors.Is(err, service.ErrCategoryUndeletable) {
+		t.Errorf("expected ErrCategoryUndeletable, got: %v", err)
+	}
+}
+
+func TestDeleteCategory_ReassignsTransactionsToUncategorized(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	cat := mustCreateCategoryViaService(t, svc, "doomed", "Doomed", nil)
+
+	acctID := seedTxnFixture(t, q)
+	catUID, _ := parseUUIDForTest(cat.ID)
+	mustCreateTransactionWithCategory(t, q, acctID, catUID, "txn_doomed", "Doomed Txn", 1000, "2025-01-15")
+
+	count, err := svc.DeleteCategory(ctx, cat.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 affected transaction, got %d", count)
+	}
+
+	// Transaction should now be uncategorized
+	var gotCatID pgtype.UUID
+	err = pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_doomed'").Scan(&gotCatID)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if gotCatID != uncat.ID {
+		t.Errorf("expected transaction reassigned to uncategorized")
+	}
+}
+
+func TestDeleteCategory_DeletesChildrenToo(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	mustSeedUncategorized(t, q)
+	parent := mustCreateCategoryViaService(t, svc, "parent_del", "Parent", nil)
+	child := mustCreateCategoryViaService(t, svc, "child_del", "Child", &parent.ID)
+
+	_, err := svc.DeleteCategory(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both parent and child should be gone
+	_, err = svc.GetCategory(ctx, parent.ID)
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("parent should be deleted")
+	}
+	_, err = svc.GetCategory(ctx, child.ID)
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("child should be cascade-deleted")
+	}
+}
+
+func TestDeleteCategory_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	_, err := svc.DeleteCategory(context.Background(), "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("expected ErrCategoryNotFound, got: %v", err)
+	}
+}
+
+// --- MergeCategories ---
+
+func TestMergeCategories_Success(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	source := mustCreateCategoryViaService(t, svc, "merge_source", "Source", nil)
+	target := mustCreateCategoryViaService(t, svc, "merge_target", "Target", nil)
+
+	// Create a transaction in source category
+	acctID := seedTxnFixture(t, q)
+	srcUID, _ := parseUUIDForTest(source.ID)
+	mustCreateTransactionWithCategory(t, q, acctID, srcUID, "txn_merge", "Merge Txn", 2000, "2025-01-15")
+
+	// Create a mapping pointing to source
+	_, err := svc.CreateMapping(ctx, "plaid", "MERGE_TEST", source.ID)
+	if err != nil {
+		t.Fatalf("create mapping: %v", err)
+	}
+
+	err = svc.MergeCategories(ctx, source.ID, target.ID)
+	if err != nil {
+		t.Fatalf("MergeCategories: %v", err)
+	}
+
+	// Source should be deleted
+	_, err = svc.GetCategory(ctx, source.ID)
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("source category should be deleted after merge")
+	}
+
+	// Transaction should be in target
+	tgtUID, _ := parseUUIDForTest(target.ID)
+	var gotCatID pgtype.UUID
+	err = pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_merge'").Scan(&gotCatID)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if gotCatID != tgtUID {
+		t.Errorf("transaction should be reassigned to target category")
+	}
+
+	// Mapping should point to target
+	mappings, err := svc.ListMappings(ctx, nil)
+	if err != nil {
+		t.Fatalf("list mappings: %v", err)
+	}
+	if len(mappings) != 1 {
+		t.Fatalf("expected 1 mapping, got %d", len(mappings))
+	}
+	if mappings[0].CategoryID != target.ID {
+		t.Errorf("mapping should point to target category, got %s", mappings[0].CategoryID)
+	}
+}
+
+func TestMergeCategories_SourceNotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	target := mustCreateCategoryViaService(t, svc, "merge_tgt2", "Target", nil)
+	err := svc.MergeCategories(context.Background(), "00000000-0000-0000-0000-000000000000", target.ID)
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("expected ErrCategoryNotFound, got: %v", err)
+	}
+}
+
+func TestMergeCategories_TargetNotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	source := mustCreateCategoryViaService(t, svc, "merge_src2", "Source", nil)
+	err := svc.MergeCategories(context.Background(), source.ID, "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("expected ErrCategoryNotFound, got: %v", err)
+	}
+}
+
+// --- SetTransactionCategory ---
+
+func TestSetTransactionCategory_Success(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	target := mustCreateCategoryViaService(t, svc, "manual_cat", "Manual", nil)
+
+	acctID := seedTxnFixture(t, q)
+	txn := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "txn_manual", "Manual Txn", 500, "2025-02-01")
+
+	err := svc.SetTransactionCategory(ctx, formatUUID(txn.ID), target.ID)
+	if err != nil {
+		t.Fatalf("SetTransactionCategory: %v", err)
+	}
+
+	// Verify category changed and override is set
+	var gotCatID pgtype.UUID
+	var override bool
+	err = pool.QueryRow(ctx,
+		"SELECT category_id, category_override FROM transactions WHERE id = $1", txn.ID,
+	).Scan(&gotCatID, &override)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	tgtUID, _ := parseUUIDForTest(target.ID)
+	if gotCatID != tgtUID {
+		t.Errorf("category not set correctly")
+	}
+	if !override {
+		t.Errorf("category_override should be true")
+	}
+}
+
+func TestSetTransactionCategory_InvalidTransaction(t *testing.T) {
+	svc, _, _ := newService(t)
+	cat := mustCreateCategoryViaService(t, svc, "cat_for_invalid", "Cat", nil)
+	err := svc.SetTransactionCategory(context.Background(), "00000000-0000-0000-0000-000000000000", cat.ID)
+	if err == nil {
+		t.Error("expected error for nonexistent transaction")
+	}
+}
+
+func TestSetTransactionCategory_InvalidCategory(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	acctID := seedTxnFixture(t, q)
+	txn := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "txn_badcat", "Bad Cat", 100, "2025-02-01")
+
+	err := svc.SetTransactionCategory(ctx, formatUUID(txn.ID), "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, service.ErrCategoryNotFound) {
+		t.Errorf("expected ErrCategoryNotFound, got: %v", err)
+	}
+}
+
+// --- ResetTransactionCategory ---
+
+func TestResetTransactionCategory_ResolvesFromMappings(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	groceries := mustCreateCategoryViaService(t, svc, "groceries_reset", "Groceries", nil)
+
+	acctID := seedTxnFixture(t, q)
+
+	// Create a transaction with a detailed category, manually overridden to uncategorized
+	_, err := q.UpsertTransaction(ctx, db.UpsertTransactionParams{
+		AccountID:             acctID,
+		ExternalTransactionID: "txn_reset",
+		Amount:                pgtype.Numeric{Int: big.NewInt(2000), Exp: -2, Valid: true},
+		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
+		Date:                  pgtype.Date{Time: testutil.MustParseDate("2025-02-01"), Valid: true},
+		Name:                  "Reset Txn",
+		CategoryPrimary:       pgtype.Text{String: "FOOD_AND_DRINK", Valid: true},
+		CategoryDetailed:      pgtype.Text{String: "FOOD_AND_DRINK_GROCERIES", Valid: true},
+		CategoryID:            uncat.ID,
+	})
+	if err != nil {
+		t.Fatalf("create transaction: %v", err)
+	}
+
+	// Set manual override
+	pool.Exec(ctx, "UPDATE transactions SET category_override = TRUE WHERE external_transaction_id = 'txn_reset'")
+
+	// Create mapping so reset can resolve
+	_, err = svc.CreateMapping(ctx, "plaid", "FOOD_AND_DRINK_GROCERIES", groceries.ID)
+	if err != nil {
+		t.Fatalf("create mapping: %v", err)
+	}
+
+	// Get the transaction ID
+	var txnID pgtype.UUID
+	pool.QueryRow(ctx, "SELECT id FROM transactions WHERE external_transaction_id = 'txn_reset'").Scan(&txnID)
+
+	err = svc.ResetTransactionCategory(ctx, formatUUID(txnID))
+	if err != nil {
+		t.Fatalf("ResetTransactionCategory: %v", err)
+	}
+
+	// Should be resolved to groceries now via mapping
+	var gotCatID pgtype.UUID
+	var override bool
+	pool.QueryRow(ctx, "SELECT category_id, category_override FROM transactions WHERE id = $1", txnID).Scan(&gotCatID, &override)
+
+	grocUID, _ := parseUUIDForTest(groceries.ID)
+	if gotCatID != grocUID {
+		t.Errorf("expected resolved to groceries, got %v", gotCatID)
+	}
+	if override {
+		t.Errorf("category_override should be false after reset")
+	}
+}
+
+func TestResetTransactionCategory_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	err := svc.ResetTransactionCategory(context.Background(), "00000000-0000-0000-0000-000000000000")
+	if err == nil {
+		t.Error("expected error for nonexistent transaction")
+	}
+}
+
+// --- BatchSetTransactionCategory ---
+
+func TestBatchSetTransactionCategory_SetsOverrideFlag(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	mustCreateCategoryViaService(t, svc, "batch_groceries", "Groceries", nil)
+
+	acctID := seedTxnFixture(t, q)
+	txn1 := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "batch_txn_1", "Txn 1", 100, "2025-01-10")
+
+	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
+		{TransactionID: formatUUID(txn1.ID), CategorySlug: "batch_groceries"},
+	})
+	if err != nil {
+		t.Fatalf("BatchSetTransactionCategory: %v", err)
+	}
+	if result.Succeeded != 1 {
+		t.Errorf("expected 1 succeeded, got %d", result.Succeeded)
+	}
+
+	// Verify category_override is set to TRUE
+	var override bool
+	err = pool.QueryRow(ctx, "SELECT category_override FROM transactions WHERE id = $1", txn1.ID).Scan(&override)
+	if err != nil {
+		t.Fatalf("query override: %v", err)
+	}
+	if !override {
+		t.Errorf("category_override should be true after batch categorize")
+	}
+}
+
+func TestBatchSetTransactionCategory_PartialFailure(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	mustCreateCategoryViaService(t, svc, "batch_good", "Good", nil)
+
+	acctID := seedTxnFixture(t, q)
+	txn := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "batch_partial", "Partial", 100, "2025-01-10")
+
+	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
+		{TransactionID: formatUUID(txn.ID), CategorySlug: "batch_good"},
+		{TransactionID: formatUUID(txn.ID), CategorySlug: "nonexistent_slug"},
+	})
+	if err != nil {
+		t.Fatalf("BatchSetTransactionCategory: %v", err)
+	}
+	if result.Succeeded != 1 {
+		t.Errorf("expected 1 succeeded, got %d", result.Succeeded)
+	}
+	if len(result.Failed) != 1 {
+		t.Errorf("expected 1 failed, got %d", len(result.Failed))
+	}
+}
+
+func TestBatchSetTransactionCategory_EmptyItems(t *testing.T) {
+	svc, _, _ := newService(t)
+	_, err := svc.BatchSetTransactionCategory(context.Background(), []service.BatchCategorizeItem{})
+	if err == nil {
+		t.Error("expected error for empty items")
+	}
+}
+
+func TestBatchSetTransactionCategory_TooManyItems(t *testing.T) {
+	svc, _, _ := newService(t)
+	items := make([]service.BatchCategorizeItem, 201)
+	for i := range items {
+		items[i] = service.BatchCategorizeItem{TransactionID: "x", CategorySlug: "y"}
+	}
+	_, err := svc.BatchSetTransactionCategory(context.Background(), items)
+	if err == nil {
+		t.Error("expected error for >200 items")
+	}
+}
+
+// --- BulkRecategorizeByFilter ---
+
+func TestBulkRecategorizeByFilter_ByNameSearch(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	mustCreateCategoryViaService(t, svc, "bulk_target", "Target", nil)
+
+	acctID := seedTxnFixture(t, q)
+	mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "bulk_txn_1", "Starbucks Coffee", 500, "2025-01-10")
+	mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "bulk_txn_2", "Starbucks Tea", 300, "2025-01-11")
+	mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "bulk_txn_3", "Walmart", 2000, "2025-01-12")
+
+	search := "Starbucks"
+	result, err := svc.BulkRecategorizeByFilter(ctx, service.BulkRecategorizeParams{
+		TargetCategorySlug: "bulk_target",
+		Search:             &search,
+	})
+	if err != nil {
+		t.Fatalf("BulkRecategorizeByFilter: %v", err)
+	}
+	if result.UpdatedCount != 2 {
+		t.Errorf("expected 2 updated, got %d", result.UpdatedCount)
+	}
+
+	// Walmart should be unchanged
+	var walmartCatID pgtype.UUID
+	pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE external_transaction_id = 'bulk_txn_3'").Scan(&walmartCatID)
+	if walmartCatID != uncat.ID {
+		t.Errorf("Walmart should still be uncategorized")
+	}
+}
+
+func TestBulkRecategorizeByFilter_RequiresFilter(t *testing.T) {
+	svc, q, _ := newService(t)
+	mustSeedUncategorized(t, q)
+	mustCreateCategoryViaService(t, svc, "bulk_nofilter", "NoFilter", nil)
+
+	_, err := svc.BulkRecategorizeByFilter(context.Background(), service.BulkRecategorizeParams{
+		TargetCategorySlug: "bulk_nofilter",
+	})
+	if err == nil {
+		t.Error("expected error when no filter provided")
+	}
+	if !strings.Contains(err.Error(), "at least one filter") {
+		t.Errorf("error should mention filter requirement, got: %v", err)
+	}
+}
+
+func TestBulkRecategorizeByFilter_InvalidTargetCategory(t *testing.T) {
+	svc, _, _ := newService(t)
+	search := "anything"
+	_, err := svc.BulkRecategorizeByFilter(context.Background(), service.BulkRecategorizeParams{
+		TargetCategorySlug: "nonexistent_target",
+		Search:             &search,
+	})
+	if err == nil {
+		t.Error("expected error for invalid target category")
+	}
+}
+
+// --- Mapping CRUD ---
+
+func TestListMappings_Empty(t *testing.T) {
+	svc, _, _ := newService(t)
+	mappings, err := svc.ListMappings(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(mappings) != 0 {
+		t.Errorf("expected 0 mappings, got %d", len(mappings))
+	}
+}
+
+func TestListMappings_FilterByProvider(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	cat := mustCreateCategoryViaService(t, svc, "map_filter_cat", "Cat", nil)
+	_, err := svc.CreateMapping(ctx, "plaid", "FOOD_AND_DRINK", cat.ID)
+	if err != nil {
+		t.Fatalf("create plaid mapping: %v", err)
+	}
+	_, err = svc.CreateMapping(ctx, "teller", "dining", cat.ID)
+	if err != nil {
+		t.Fatalf("create teller mapping: %v", err)
+	}
+
+	plaid := "plaid"
+	mappings, err := svc.ListMappings(ctx, &plaid)
+	if err != nil {
+		t.Fatalf("list mappings: %v", err)
+	}
+	if len(mappings) != 1 {
+		t.Fatalf("expected 1 plaid mapping, got %d", len(mappings))
+	}
+	if mappings[0].Provider != "plaid" {
+		t.Errorf("expected provider plaid, got %s", mappings[0].Provider)
+	}
+}
+
+func TestCreateMappingBySlug_Success(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	mustCreateCategoryViaService(t, svc, "slug_map_cat", "SlugCat", nil)
+
+	mapping, err := svc.CreateMappingBySlug(ctx, "plaid", "FOOD_AND_DRINK_GROCERIES", "slug_map_cat")
+	if err != nil {
+		t.Fatalf("CreateMappingBySlug: %v", err)
+	}
+	if mapping.Provider != "plaid" {
+		t.Errorf("provider mismatch: got %s", mapping.Provider)
+	}
+	if mapping.ProviderCategory != "FOOD_AND_DRINK_GROCERIES" {
+		t.Errorf("provider category mismatch")
+	}
+	if mapping.CategorySlug != "slug_map_cat" {
+		t.Errorf("category slug mismatch: got %s", mapping.CategorySlug)
+	}
+}
+
+func TestCreateMappingBySlug_InvalidSlug(t *testing.T) {
+	svc, _, _ := newService(t)
+	_, err := svc.CreateMappingBySlug(context.Background(), "plaid", "TEST", "nonexistent_slug")
+	if err == nil {
+		t.Error("expected error for invalid slug")
+	}
+}
+
+func TestCreateMappingBySlug_DuplicateMapping(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	mustCreateCategoryViaService(t, svc, "dup_map_cat", "DupCat", nil)
+
+	_, err := svc.CreateMappingBySlug(ctx, "plaid", "DUP_TEST", "dup_map_cat")
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+
+	_, err = svc.CreateMappingBySlug(ctx, "plaid", "DUP_TEST", "dup_map_cat")
+	if err == nil {
+		t.Error("expected error for duplicate mapping")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention 'already exists', got: %v", err)
+	}
+}
+
+func TestUpdateMappingBySlug_ByID(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	mustCreateCategoryViaService(t, svc, "upd_map_cat1", "Cat1", nil)
+	mustCreateCategoryViaService(t, svc, "upd_map_cat2", "Cat2", nil)
+
+	mapping, err := svc.CreateMappingBySlug(ctx, "plaid", "UPD_TEST", "upd_map_cat1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if mapping.CategorySlug != "upd_map_cat1" {
+		t.Fatalf("initial slug mismatch")
+	}
+
+	updated, err := svc.UpdateMappingBySlug(ctx, &mapping.ID, nil, nil, "upd_map_cat2")
+	if err != nil {
+		t.Fatalf("UpdateMappingBySlug: %v", err)
+	}
+	if updated.CategorySlug != "upd_map_cat2" {
+		t.Errorf("expected updated slug upd_map_cat2, got %s", updated.CategorySlug)
+	}
+}
+
+func TestUpdateMappingBySlug_ByProviderCategory(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	mustCreateCategoryViaService(t, svc, "upd_map_pc1", "PC1", nil)
+	mustCreateCategoryViaService(t, svc, "upd_map_pc2", "PC2", nil)
+
+	_, err := svc.CreateMappingBySlug(ctx, "teller", "groceries_update", "upd_map_pc1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	prov := "teller"
+	provCat := "groceries_update"
+	updated, err := svc.UpdateMappingBySlug(ctx, nil, &prov, &provCat, "upd_map_pc2")
+	if err != nil {
+		t.Fatalf("UpdateMappingBySlug: %v", err)
+	}
+	if updated.CategorySlug != "upd_map_pc2" {
+		t.Errorf("expected slug upd_map_pc2, got %s", updated.CategorySlug)
+	}
+}
+
+func TestUpdateMappingBySlug_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	mustCreateCategoryViaService(t, svc, "upd_map_nf", "NF", nil)
+
+	badID := "00000000-0000-0000-0000-000000000000"
+	_, err := svc.UpdateMappingBySlug(context.Background(), &badID, nil, nil, "upd_map_nf")
+	if !errors.Is(err, service.ErrMappingNotFound) {
+		t.Errorf("expected ErrMappingNotFound, got: %v", err)
+	}
+}
+
+func TestDeleteMappingByLookup_ByID(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	mustCreateCategoryViaService(t, svc, "del_map_cat", "Cat", nil)
+	mapping, err := svc.CreateMappingBySlug(ctx, "plaid", "DEL_BY_ID", "del_map_cat")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	prov, provCat, err := svc.DeleteMappingByLookup(ctx, &mapping.ID, nil, nil)
+	if err != nil {
+		t.Fatalf("DeleteMappingByLookup: %v", err)
+	}
+	if prov != "plaid" || provCat != "DEL_BY_ID" {
+		t.Errorf("returned provider info mismatch: %s/%s", prov, provCat)
+	}
+
+	// Verify it's deleted
+	mappings, err := svc.ListMappings(ctx, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(mappings) != 0 {
+		t.Errorf("expected 0 mappings after delete, got %d", len(mappings))
+	}
+}
+
+func TestDeleteMappingByLookup_ByProviderCategory(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	mustCreateCategoryViaService(t, svc, "del_map_pc", "Cat", nil)
+	_, err := svc.CreateMappingBySlug(ctx, "teller", "del_by_pc", "del_map_pc")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	prov := "teller"
+	provCat := "del_by_pc"
+	_, _, err = svc.DeleteMappingByLookup(ctx, nil, &prov, &provCat)
+	if err != nil {
+		t.Fatalf("DeleteMappingByLookup: %v", err)
+	}
+}
+
+func TestDeleteMappingByLookup_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	badID := "00000000-0000-0000-0000-000000000000"
+	_, _, err := svc.DeleteMappingByLookup(context.Background(), &badID, nil, nil)
+	if !errors.Is(err, service.ErrMappingNotFound) {
+		t.Errorf("expected ErrMappingNotFound, got: %v", err)
+	}
+}
+
+func TestDeleteMappingByLookup_NoIdentifier(t *testing.T) {
+	svc, _, _ := newService(t)
+	_, _, err := svc.DeleteMappingByLookup(context.Background(), nil, nil, nil)
+	if err == nil {
+		t.Error("expected error when no identifier provided")
+	}
+}
+
+// --- BulkUpsertMappings ---
+
+func TestBulkUpsertMappings_CreatesNew(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	cat := mustCreateCategoryViaService(t, svc, "bulk_upsert_cat", "BulkCat", nil)
+
+	count, err := svc.BulkUpsertMappings(ctx, []service.BulkMappingEntry{
+		{Provider: "plaid", ProviderCategory: "BULK_1", CategoryID: cat.ID},
+		{Provider: "plaid", ProviderCategory: "BULK_2", CategoryID: cat.ID},
+	})
+	if err != nil {
+		t.Fatalf("BulkUpsertMappings: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2, got %d", count)
+	}
+
+	mappings, err := svc.ListMappings(ctx, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(mappings) != 2 {
+		t.Errorf("expected 2 mappings, got %d", len(mappings))
+	}
+}
+
+func TestBulkUpsertMappings_UpdatesExisting(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	cat1 := mustCreateCategoryViaService(t, svc, "bulk_upsert_1", "Cat1", nil)
+	cat2 := mustCreateCategoryViaService(t, svc, "bulk_upsert_2", "Cat2", nil)
+
+	// Create initial mapping
+	_, err := svc.BulkUpsertMappings(ctx, []service.BulkMappingEntry{
+		{Provider: "plaid", ProviderCategory: "UPSERT_TEST", CategoryID: cat1.ID},
+	})
+	if err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+
+	// Upsert with different category
+	count, err := svc.BulkUpsertMappings(ctx, []service.BulkMappingEntry{
+		{Provider: "plaid", ProviderCategory: "UPSERT_TEST", CategoryID: cat2.ID},
+	})
+	if err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1, got %d", count)
+	}
+
+	// Should still be 1 mapping total, not 2
+	mappings, err := svc.ListMappings(ctx, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(mappings) != 1 {
+		t.Errorf("expected 1 mapping after upsert, got %d", len(mappings))
+	}
+	if mappings[0].CategoryID != cat2.ID {
+		t.Errorf("mapping should point to cat2")
+	}
+}
+
+// --- GetCategoryBySlug ---
+
+func TestGetCategoryBySlug_Found(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	mustCreateCategoryViaService(t, svc, "slug_test", "Slug Test", nil)
+
+	cat, err := svc.GetCategoryBySlug(ctx, "slug_test")
+	if err != nil {
+		t.Fatalf("GetCategoryBySlug: %v", err)
+	}
+	if cat.Slug != "slug_test" {
+		t.Errorf("slug mismatch: got %s", cat.Slug)
+	}
+}
+
+func TestGetCategoryBySlug_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	_, err := svc.GetCategoryBySlug(context.Background(), "nonexistent_slug")
+	if err == nil {
+		t.Error("expected error for nonexistent slug")
+	}
+}
+
+// --- GenerateSlug ---
+
+func TestGenerateSlug_Variants(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Food & Drink", "food_drink"},
+		{"  Travel  ", "travel"},
+		{"General Merchandise", "general_merchandise"},
+		{"123 Numbers", "123_numbers"},
+		{"Already_valid", "already_valid"},
+	}
+	for _, tc := range tests {
+		got := service.GenerateSlug(tc.input)
+		if got != tc.expected {
+			t.Errorf("GenerateSlug(%q) = %q, want %q", tc.input, got, tc.expected)
+		}
+	}
+}
+
+// --- parseUUIDForTest helper (internal to these tests) ---
+
+func parseUUIDForTest(s string) (pgtype.UUID, error) {
+	var u pgtype.UUID
+	if err := u.Scan(s); err != nil {
+		return pgtype.UUID{}, err
+	}
+	return u, nil
+}

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -1603,8 +1603,7 @@ func TestBatchSetTransactionCategory_InvalidTxnID(t *testing.T) {
 		t.Fatalf("create category: %v", err)
 	}
 
-	// Note: nonexistent transaction ID doesn't error — UPDATE WHERE id=$1 affects 0 rows silently.
-	// Both calls succeed from the service's perspective.
+	// Nonexistent transaction ID now correctly reports as failed (ErrNotFound).
 	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
 		{TransactionID: formatUUID(txn1.ID), CategorySlug: "food_and_drink"},
 		{TransactionID: "00000000-0000-0000-0000-000000000099", CategorySlug: "food_and_drink"},
@@ -1612,11 +1611,11 @@ func TestBatchSetTransactionCategory_InvalidTxnID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BatchSetTransactionCategory: %v", err)
 	}
-	if result.Succeeded != 2 {
-		t.Errorf("expected succeeded=2, got %d", result.Succeeded)
+	if result.Succeeded != 1 {
+		t.Errorf("expected succeeded=1, got %d", result.Succeeded)
 	}
-	if len(result.Failed) != 0 {
-		t.Errorf("expected 0 failed, got %d", len(result.Failed))
+	if len(result.Failed) != 1 {
+		t.Errorf("expected 1 failed, got %d", len(result.Failed))
 	}
 }
 

--- a/internal/service/review_integration_test.go
+++ b/internal/service/review_integration_test.go
@@ -1,0 +1,868 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"breadbox/internal/db"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// mustCreateCategory creates a category and fatals on error.
+func mustCreateCategory(t *testing.T, q *db.Queries, slug, displayName string) db.Category {
+	t.Helper()
+	cat, err := q.InsertCategory(context.Background(), db.InsertCategoryParams{
+		Slug:        slug,
+		DisplayName: displayName,
+	})
+	if err != nil {
+		t.Fatalf("mustCreateCategory(%q): %v", slug, err)
+	}
+	return cat
+}
+
+// mustEnqueueReview directly enqueues a review via DB for test setup.
+func mustEnqueueReview(t *testing.T, q *db.Queries, txnID pgtype.UUID, reviewType string) db.ReviewQueue {
+	t.Helper()
+	review, err := q.EnqueueReview(context.Background(), db.EnqueueReviewParams{
+		TransactionID: txnID,
+		ReviewType:    reviewType,
+	})
+	if err != nil {
+		t.Fatalf("mustEnqueueReview: %v", err)
+	}
+	return review
+}
+
+// reviewTestFixture creates user → connection → account → transaction and returns the transaction.
+func reviewTestFixture(t *testing.T, q *db.Queries) db.Transaction {
+	t.Helper()
+	user := testutil.MustCreateUser(t, q, "Alice")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "item_review_1")
+	acct := testutil.MustCreateAccount(t, q, conn.ID, "ext_review_1", "Checking")
+	txn := testutil.MustCreateTransaction(t, q, acct.ID, "txn_review_1", "Coffee Shop", 550, "2025-01-15")
+	return txn
+}
+
+var testActor = service.Actor{Type: "user", ID: "admin-1", Name: "Test Admin"}
+
+// --- EnqueueManualReview ---
+
+func TestEnqueueManualReview_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	txnID := formatUUID(txn.ID)
+
+	review, err := svc.EnqueueManualReview(ctx, txnID, testActor)
+	if err != nil {
+		t.Fatalf("EnqueueManualReview: %v", err)
+	}
+
+	if review.TransactionID != txnID {
+		t.Errorf("expected transaction_id=%s, got %s", txnID, review.TransactionID)
+	}
+	if review.ReviewType != "manual" {
+		t.Errorf("expected review_type=manual, got %s", review.ReviewType)
+	}
+	if review.Status != "pending" {
+		t.Errorf("expected status=pending, got %s", review.Status)
+	}
+}
+
+func TestEnqueueManualReview_DuplicatePending(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	txnID := formatUUID(txn.ID)
+
+	// First enqueue succeeds
+	_, err := svc.EnqueueManualReview(ctx, txnID, testActor)
+	if err != nil {
+		t.Fatalf("first EnqueueManualReview: %v", err)
+	}
+
+	// Second enqueue should fail with ErrReviewAlreadyPending
+	_, err = svc.EnqueueManualReview(ctx, txnID, testActor)
+	if !errors.Is(err, service.ErrReviewAlreadyPending) {
+		t.Errorf("expected ErrReviewAlreadyPending, got %v", err)
+	}
+}
+
+func TestEnqueueManualReview_SoftDeletedTransaction(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	txnID := formatUUID(txn.ID)
+
+	// Soft-delete the transaction
+	_, err := pool.Exec(ctx, "UPDATE transactions SET deleted_at = NOW() WHERE id = $1", txn.ID)
+	if err != nil {
+		t.Fatalf("soft-delete txn: %v", err)
+	}
+
+	_, err = svc.EnqueueManualReview(ctx, txnID, testActor)
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound for soft-deleted transaction, got %v", err)
+	}
+}
+
+func TestEnqueueManualReview_NonexistentTransaction(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	_, err := svc.EnqueueManualReview(ctx, "00000000-0000-0000-0000-000000000000", testActor)
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- GetReview ---
+
+func TestGetReview_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	result, err := svc.GetReview(ctx, formatUUID(review.ID))
+	if err != nil {
+		t.Fatalf("GetReview: %v", err)
+	}
+
+	if result.ID != formatUUID(review.ID) {
+		t.Errorf("expected id=%s, got %s", formatUUID(review.ID), result.ID)
+	}
+	if result.ReviewType != "new_transaction" {
+		t.Errorf("expected review_type=new_transaction, got %s", result.ReviewType)
+	}
+	if result.Status != "pending" {
+		t.Errorf("expected status=pending, got %s", result.Status)
+	}
+	if result.Transaction == nil {
+		t.Error("expected transaction to be populated")
+	} else if result.Transaction.Name != "Coffee Shop" {
+		t.Errorf("expected transaction name=Coffee Shop, got %s", result.Transaction.Name)
+	}
+}
+
+func TestGetReview_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	_, err := svc.GetReview(ctx, "00000000-0000-0000-0000-000000000000")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- ListReviews ---
+
+func TestListReviews_Empty(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	result, err := svc.ListReviews(ctx, service.ReviewListParams{})
+	if err != nil {
+		t.Fatalf("ListReviews: %v", err)
+	}
+	if len(result.Reviews) != 0 {
+		t.Errorf("expected 0 reviews, got %d", len(result.Reviews))
+	}
+	if result.Total != 0 {
+		t.Errorf("expected total=0, got %d", result.Total)
+	}
+}
+
+func TestListReviews_DefaultsPending(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Create two transactions with reviews in different states
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_lr1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_lr1", "Checking")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_lr1", "Pending Review", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_lr2", "Resolved Review", 2000, "2025-01-16")
+
+	mustEnqueueReview(t, queries, txn1.ID, "new_transaction")
+	review2 := mustEnqueueReview(t, queries, txn2.ID, "uncategorized")
+
+	// Resolve review2
+	_, err := queries.UpdateReviewDecision(ctx, db.UpdateReviewDecisionParams{
+		ID:     review2.ID,
+		Status: "approved",
+		ReviewerType: pgtype.Text{String: "user", Valid: true},
+		ReviewerName: pgtype.Text{String: "Admin", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("resolve review: %v", err)
+	}
+
+	// Default listing should only return pending
+	result, err := svc.ListReviews(ctx, service.ReviewListParams{})
+	if err != nil {
+		t.Fatalf("ListReviews: %v", err)
+	}
+	if len(result.Reviews) != 1 {
+		t.Fatalf("expected 1 pending review, got %d", len(result.Reviews))
+	}
+	if result.Reviews[0].Transaction.Name != "Pending Review" {
+		t.Errorf("expected Pending Review, got %s", result.Reviews[0].Transaction.Name)
+	}
+}
+
+func TestListReviews_FilterByType(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_ft1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_ft1", "Checking")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_ft1", "New Txn", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_ft2", "Uncat Txn", 2000, "2025-01-16")
+
+	mustEnqueueReview(t, queries, txn1.ID, "new_transaction")
+	mustEnqueueReview(t, queries, txn2.ID, "uncategorized")
+
+	reviewType := "uncategorized"
+	result, err := svc.ListReviews(ctx, service.ReviewListParams{
+		ReviewType: &reviewType,
+	})
+	if err != nil {
+		t.Fatalf("ListReviews: %v", err)
+	}
+	if len(result.Reviews) != 1 {
+		t.Fatalf("expected 1 uncategorized review, got %d", len(result.Reviews))
+	}
+	if result.Reviews[0].ReviewType != "uncategorized" {
+		t.Errorf("expected uncategorized, got %s", result.Reviews[0].ReviewType)
+	}
+}
+
+func TestListReviews_InvalidStatus(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	invalid := "invalid_status"
+	_, err := svc.ListReviews(ctx, service.ReviewListParams{Status: &invalid})
+	if err == nil {
+		t.Error("expected error for invalid status")
+	}
+}
+
+func TestListReviews_StatusAll(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_sa1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_sa1", "Checking")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_sa1", "Txn1", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_sa2", "Txn2", 2000, "2025-01-16")
+
+	mustEnqueueReview(t, queries, txn1.ID, "new_transaction")
+	review2 := mustEnqueueReview(t, queries, txn2.ID, "uncategorized")
+
+	// Resolve one
+	_, err := queries.UpdateReviewDecision(ctx, db.UpdateReviewDecisionParams{
+		ID:           review2.ID,
+		Status:       "rejected",
+		ReviewerType: pgtype.Text{String: "user", Valid: true},
+		ReviewerName: pgtype.Text{String: "Admin", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("resolve review: %v", err)
+	}
+
+	all := "all"
+	result, err := svc.ListReviews(ctx, service.ReviewListParams{Status: &all})
+	if err != nil {
+		t.Fatalf("ListReviews: %v", err)
+	}
+	if len(result.Reviews) != 2 {
+		t.Errorf("expected 2 reviews with status=all, got %d", len(result.Reviews))
+	}
+}
+
+// --- SubmitReview ---
+
+func TestSubmitReview_Approve(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: formatUUID(review.ID),
+		Decision: "approved",
+		Actor:    testActor,
+	})
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+	if result.Status != "approved" {
+		t.Errorf("expected status=approved, got %s", result.Status)
+	}
+	if result.ReviewerName == nil || *result.ReviewerName != "Test Admin" {
+		t.Error("expected reviewer_name to be Test Admin")
+	}
+	if result.ReviewedAt == nil {
+		t.Error("expected reviewed_at to be set")
+	}
+}
+
+func TestSubmitReview_Reject(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: formatUUID(review.ID),
+		Decision: "rejected",
+		Actor:    testActor,
+	})
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+	if result.Status != "rejected" {
+		t.Errorf("expected status=rejected, got %s", result.Status)
+	}
+}
+
+func TestSubmitReview_Skip(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: formatUUID(review.ID),
+		Decision: "skipped",
+		Actor:    testActor,
+	})
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Errorf("expected status=skipped, got %s", result.Status)
+	}
+}
+
+func TestSubmitReview_InvalidDecision(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	_, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: formatUUID(review.ID),
+		Decision: "invalid",
+		Actor:    testActor,
+	})
+	if !errors.Is(err, service.ErrInvalidDecision) {
+		t.Errorf("expected ErrInvalidDecision, got %v", err)
+	}
+}
+
+func TestSubmitReview_AlreadyResolved(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	// First submit succeeds
+	_, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: formatUUID(review.ID),
+		Decision: "approved",
+		Actor:    testActor,
+	})
+	if err != nil {
+		t.Fatalf("first SubmitReview: %v", err)
+	}
+
+	// Second submit should fail
+	_, err = svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: formatUUID(review.ID),
+		Decision: "rejected",
+		Actor:    testActor,
+	})
+	if !errors.Is(err, service.ErrReviewAlreadyResolved) {
+		t.Errorf("expected ErrReviewAlreadyResolved, got %v", err)
+	}
+}
+
+func TestSubmitReview_WithCategoryOverride(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "uncategorized")
+
+	// Create a category
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+	catID := formatUUID(cat.ID)
+
+	// Approve with explicit category
+	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID:   formatUUID(review.ID),
+		Decision:   "approved",
+		CategoryID: &catID,
+		Actor:      testActor,
+	})
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+	if result.ResolvedCategoryID == nil || *result.ResolvedCategoryID != catID {
+		t.Error("expected resolved_category_id to match the provided category")
+	}
+
+	// Verify the transaction was updated with the category and override flag
+	var txnCatID pgtype.UUID
+	var catOverride bool
+	err = pool.QueryRow(ctx, "SELECT category_id, category_override FROM transactions WHERE id = $1", txn.ID).Scan(&txnCatID, &catOverride)
+	if err != nil {
+		t.Fatalf("query transaction: %v", err)
+	}
+	if !txnCatID.Valid {
+		t.Error("expected transaction category_id to be set")
+	}
+	if formatUUID(txnCatID) != catID {
+		t.Errorf("expected transaction category_id=%s, got %s", catID, formatUUID(txnCatID))
+	}
+	if !catOverride {
+		t.Error("expected category_override=true after review approval with category")
+	}
+}
+
+func TestSubmitReview_WithNote(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	note := "This looks like a duplicate charge"
+	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: formatUUID(review.ID),
+		Decision: "rejected",
+		Note:     &note,
+		Actor:    testActor,
+	})
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+	if result.ReviewNote == nil || *result.ReviewNote != note {
+		t.Error("expected review_note to be set")
+	}
+}
+
+func TestSubmitReview_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	_, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: "00000000-0000-0000-0000-000000000000",
+		Decision: "approved",
+		Actor:    testActor,
+	})
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- BulkSubmitReviews ---
+
+func TestBulkSubmitReviews_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_bulk1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_bulk1", "Checking")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_b1", "Txn1", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_b2", "Txn2", 2000, "2025-01-16")
+
+	r1 := mustEnqueueReview(t, queries, txn1.ID, "new_transaction")
+	r2 := mustEnqueueReview(t, queries, txn2.ID, "new_transaction")
+
+	result, err := svc.BulkSubmitReviews(ctx, service.BulkSubmitReviewParams{
+		Reviews: []service.BulkReviewItem{
+			{ReviewID: formatUUID(r1.ID), Decision: "approved"},
+			{ReviewID: formatUUID(r2.ID), Decision: "rejected"},
+		},
+		Actor: testActor,
+	})
+	if err != nil {
+		t.Fatalf("BulkSubmitReviews: %v", err)
+	}
+	if result.Succeeded != 2 {
+		t.Errorf("expected 2 succeeded, got %d", result.Succeeded)
+	}
+	if len(result.Failed) != 0 {
+		t.Errorf("expected 0 failed, got %d", len(result.Failed))
+	}
+}
+
+func TestBulkSubmitReviews_PartialFailure(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	result, err := svc.BulkSubmitReviews(ctx, service.BulkSubmitReviewParams{
+		Reviews: []service.BulkReviewItem{
+			{ReviewID: formatUUID(review.ID), Decision: "approved"},
+			{ReviewID: "00000000-0000-0000-0000-000000000000", Decision: "approved"}, // nonexistent
+		},
+		Actor: testActor,
+	})
+	if err != nil {
+		t.Fatalf("BulkSubmitReviews: %v", err)
+	}
+	if result.Succeeded != 1 {
+		t.Errorf("expected 1 succeeded, got %d", result.Succeeded)
+	}
+	if len(result.Failed) != 1 {
+		t.Errorf("expected 1 failed, got %d", len(result.Failed))
+	}
+}
+
+func TestBulkSubmitReviews_EmptyArray(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	_, err := svc.BulkSubmitReviews(ctx, service.BulkSubmitReviewParams{
+		Reviews: []service.BulkReviewItem{},
+		Actor:   testActor,
+	})
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter for empty reviews, got %v", err)
+	}
+}
+
+// --- DismissReview ---
+
+func TestDismissReview_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	err := svc.DismissReview(ctx, formatUUID(review.ID), testActor)
+	if err != nil {
+		t.Fatalf("DismissReview: %v", err)
+	}
+
+	// Verify it's gone
+	_, err = svc.GetReview(ctx, formatUUID(review.ID))
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound after dismiss, got %v", err)
+	}
+}
+
+func TestDismissReview_AlreadyResolved(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	// Resolve it first
+	_, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: formatUUID(review.ID),
+		Decision: "approved",
+		Actor:    testActor,
+	})
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+
+	// Now try to dismiss
+	err = svc.DismissReview(ctx, formatUUID(review.ID), testActor)
+	if !errors.Is(err, service.ErrReviewAlreadyResolved) {
+		t.Errorf("expected ErrReviewAlreadyResolved, got %v", err)
+	}
+}
+
+func TestDismissReview_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	err := svc.DismissReview(ctx, "00000000-0000-0000-0000-000000000000", testActor)
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got %v", err)
+	}
+}
+
+// --- DismissAllPendingReviews ---
+
+func TestDismissAllPendingReviews(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_dap1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_dap1", "Checking")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_dap1", "Txn1", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_dap2", "Txn2", 2000, "2025-01-16")
+	txn3 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_dap3", "Txn3", 3000, "2025-01-17")
+
+	mustEnqueueReview(t, queries, txn1.ID, "new_transaction")
+	mustEnqueueReview(t, queries, txn2.ID, "uncategorized")
+	r3 := mustEnqueueReview(t, queries, txn3.ID, "new_transaction")
+
+	// Resolve one so it should NOT be dismissed
+	_, err := queries.UpdateReviewDecision(ctx, db.UpdateReviewDecisionParams{
+		ID:           r3.ID,
+		Status:       "approved",
+		ReviewerType: pgtype.Text{String: "user", Valid: true},
+		ReviewerName: pgtype.Text{String: "Admin", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("resolve review: %v", err)
+	}
+
+	count, err := svc.DismissAllPendingReviews(ctx, testActor)
+	if err != nil {
+		t.Fatalf("DismissAllPendingReviews: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 dismissed, got %d", count)
+	}
+
+	// Verify: pending count should be 0
+	all := "all"
+	result, err := svc.ListReviews(ctx, service.ReviewListParams{Status: &all})
+	if err != nil {
+		t.Fatalf("ListReviews: %v", err)
+	}
+	// Only the resolved one should remain
+	if len(result.Reviews) != 1 {
+		t.Errorf("expected 1 remaining review (resolved), got %d", len(result.Reviews))
+	}
+}
+
+// --- GetReviewCounts ---
+
+func TestGetReviewCounts_Empty(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	counts, err := svc.GetReviewCounts(ctx)
+	if err != nil {
+		t.Fatalf("GetReviewCounts: %v", err)
+	}
+	if counts.Pending != 0 {
+		t.Errorf("expected pending=0, got %d", counts.Pending)
+	}
+}
+
+func TestGetReviewCounts_WithData(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_rc1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_rc1", "Checking")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_rc1", "Txn1", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_rc2", "Txn2", 2000, "2025-01-16")
+	txn3 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_rc3", "Txn3", 3000, "2025-01-17")
+
+	mustEnqueueReview(t, queries, txn1.ID, "new_transaction")
+	mustEnqueueReview(t, queries, txn2.ID, "uncategorized")
+	r3 := mustEnqueueReview(t, queries, txn3.ID, "new_transaction")
+
+	// Approve r3 (this makes it approved today)
+	_, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: formatUUID(r3.ID),
+		Decision: "approved",
+		Actor:    testActor,
+	})
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+
+	counts, err := svc.GetReviewCounts(ctx)
+	if err != nil {
+		t.Fatalf("GetReviewCounts: %v", err)
+	}
+	if counts.Pending != 2 {
+		t.Errorf("expected pending=2, got %d", counts.Pending)
+	}
+	if counts.ApprovedToday != 1 {
+		t.Errorf("expected approved_today=1, got %d", counts.ApprovedToday)
+	}
+}
+
+// --- GetReviewSummary ---
+
+func TestGetReviewSummary_Empty(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	summary, err := svc.GetReviewSummary(ctx)
+	if err != nil {
+		t.Fatalf("GetReviewSummary: %v", err)
+	}
+	if summary.TotalPending != 0 {
+		t.Errorf("expected total_pending=0, got %d", summary.TotalPending)
+	}
+	if len(summary.Groups) != 0 {
+		t.Errorf("expected 0 groups, got %d", len(summary.Groups))
+	}
+}
+
+func TestGetReviewSummary_GroupsByCategory(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_rs1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_rs1", "Checking")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_rs1", "Coffee", 500, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_rs2", "Lunch", 1200, "2025-01-16")
+	txn3 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_rs3", "Dinner", 2500, "2025-01-17")
+
+	// Set category_primary on txns
+	_, err := pool.Exec(ctx, "UPDATE transactions SET category_primary = 'FOOD_AND_DRINK' WHERE id = $1", txn1.ID)
+	if err != nil {
+		t.Fatalf("update txn1: %v", err)
+	}
+	_, err = pool.Exec(ctx, "UPDATE transactions SET category_primary = 'FOOD_AND_DRINK' WHERE id = $1", txn2.ID)
+	if err != nil {
+		t.Fatalf("update txn2: %v", err)
+	}
+	_, err = pool.Exec(ctx, "UPDATE transactions SET category_primary = 'SHOPPING' WHERE id = $1", txn3.ID)
+	if err != nil {
+		t.Fatalf("update txn3: %v", err)
+	}
+
+	mustEnqueueReview(t, queries, txn1.ID, "new_transaction")
+	mustEnqueueReview(t, queries, txn2.ID, "new_transaction")
+	mustEnqueueReview(t, queries, txn3.ID, "new_transaction")
+
+	summary, err := svc.GetReviewSummary(ctx)
+	if err != nil {
+		t.Fatalf("GetReviewSummary: %v", err)
+	}
+	if summary.TotalPending != 3 {
+		t.Errorf("expected total_pending=3, got %d", summary.TotalPending)
+	}
+	if len(summary.Groups) != 2 {
+		t.Errorf("expected 2 groups, got %d", len(summary.Groups))
+	}
+	// FOOD_AND_DRINK group should come first (count=2 > count=1)
+	if len(summary.Groups) >= 1 && summary.Groups[0].CategoryPrimaryRaw != "FOOD_AND_DRINK" {
+		t.Errorf("expected first group=FOOD_AND_DRINK, got %s", summary.Groups[0].CategoryPrimaryRaw)
+	}
+	if len(summary.Groups) >= 1 && summary.Groups[0].Count != 2 {
+		t.Errorf("expected first group count=2, got %d", summary.Groups[0].Count)
+	}
+}
+
+// --- AutoApproveCategorizedReviews ---
+
+func TestAutoApproveCategorizedReviews_ApprovesWhenCategorized(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_aa1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_aa1", "Checking")
+
+	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_aa1", "Categorized Txn", 1000, "2025-01-15")
+	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_aa2", "Uncategorized Txn", 2000, "2025-01-16")
+
+	// Create a category and assign it to txn1
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+	_, err := pool.Exec(ctx, "UPDATE transactions SET category_id = $1 WHERE id = $2", cat.ID, txn1.ID)
+	if err != nil {
+		t.Fatalf("set category: %v", err)
+	}
+
+	mustEnqueueReview(t, queries, txn1.ID, "new_transaction")
+	mustEnqueueReview(t, queries, txn2.ID, "new_transaction")
+
+	result, err := svc.AutoApproveCategorizedReviews(ctx, testActor)
+	if err != nil {
+		t.Fatalf("AutoApproveCategorizedReviews: %v", err)
+	}
+	if result.Approved != 1 {
+		t.Errorf("expected approved=1, got %d", result.Approved)
+	}
+	if result.Remaining != 1 {
+		t.Errorf("expected remaining=1, got %d", result.Remaining)
+	}
+}
+
+func TestAutoApproveCategorizedReviews_SkipsCategoryOverride(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_aa2")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_aa2", "Checking")
+
+	txn := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_aa_co", "Override Txn", 1000, "2025-01-15")
+
+	// Set category AND category_override=true (auto-approve should skip these)
+	cat := mustCreateCategory(t, queries, "transport", "Transportation")
+	_, err := pool.Exec(ctx, "UPDATE transactions SET category_id = $1, category_override = TRUE WHERE id = $2", cat.ID, txn.ID)
+	if err != nil {
+		t.Fatalf("set category with override: %v", err)
+	}
+
+	mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	result, err := svc.AutoApproveCategorizedReviews(ctx, testActor)
+	if err != nil {
+		t.Fatalf("AutoApproveCategorizedReviews: %v", err)
+	}
+	// category_override=true means the query condition `category_override = FALSE` excludes it
+	if result.Approved != 0 {
+		t.Errorf("expected approved=0 (category_override=true should be skipped), got %d", result.Approved)
+	}
+}
+
+func TestAutoApproveCategorizedReviews_NoneEligible(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	// No category assigned — should not be auto-approved
+	mustEnqueueReview(t, queries, txn.ID, "new_transaction")
+
+	result, err := svc.AutoApproveCategorizedReviews(ctx, testActor)
+	if err != nil {
+		t.Fatalf("AutoApproveCategorizedReviews: %v", err)
+	}
+	if result.Approved != 0 {
+		t.Errorf("expected approved=0, got %d", result.Approved)
+	}
+}

--- a/internal/service/reviews.go
+++ b/internal/service/reviews.go
@@ -495,6 +495,14 @@ func (s *Service) GetReview(ctx context.Context, id string) (*ReviewResponse, er
 	}
 
 	resp := s.reviewFromRow(ctx, review)
+
+	// Enrich with full transaction context
+	txnID := formatUUID(review.TransactionID)
+	txn, err := s.GetTransaction(ctx, txnID)
+	if err == nil {
+		resp.Transaction = txn
+	}
+
 	return &resp, nil
 }
 

--- a/internal/service/rules_integration_test.go
+++ b/internal/service/rules_integration_test.go
@@ -1,0 +1,796 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"breadbox/internal/db"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// mustCreateCategoryForRule creates a category for use in rule tests.
+// Re-uses the mustCreateCategory helper from review_integration_test.go (same package).
+
+// --- CreateTransactionRule ---
+
+func TestCreateTransactionRule_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	rule, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Coffee shops",
+		CategorySlug: cat.Slug,
+		Conditions: service.Condition{
+			Field: "name",
+			Op:    "contains",
+			Value: "coffee",
+		},
+		Priority: 10,
+		Actor:    service.Actor{Type: "user", ID: "admin-1", Name: "Test Admin"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	if rule.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if rule.Name != "Coffee shops" {
+		t.Errorf("name: got %q, want %q", rule.Name, "Coffee shops")
+	}
+	if rule.CategorySlug == nil || *rule.CategorySlug != "food_and_drink" {
+		t.Errorf("category slug mismatch")
+	}
+	if rule.CategoryName == nil || *rule.CategoryName != "Food & Drink" {
+		t.Errorf("category name mismatch")
+	}
+	if rule.Priority != 10 {
+		t.Errorf("priority: got %d, want 10", rule.Priority)
+	}
+	if !rule.Enabled {
+		t.Error("expected rule to be enabled by default")
+	}
+	if rule.CreatedByType != "user" {
+		t.Errorf("created_by_type: got %q, want %q", rule.CreatedByType, "user")
+	}
+	if rule.CreatedByName != "Test Admin" {
+		t.Errorf("created_by_name: got %q, want %q", rule.CreatedByName, "Test Admin")
+	}
+	if rule.HitCount != 0 {
+		t.Errorf("hit_count: got %d, want 0", rule.HitCount)
+	}
+}
+
+func TestCreateTransactionRule_DefaultPriority(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	rule, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Default priority rule",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+		// No priority — should default to 10.
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+	if rule.Priority != 10 {
+		t.Errorf("expected default priority 10, got %d", rule.Priority)
+	}
+}
+
+func TestCreateTransactionRule_WithExpiry(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	rule, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Temporary rule",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+		ExpiresIn:    "24h",
+		Actor:        service.Actor{Type: "agent", Name: "AI Agent"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+	if rule.ExpiresAt == nil {
+		t.Error("expected expires_at to be set")
+	}
+	if rule.CreatedByType != "agent" {
+		t.Errorf("created_by_type: got %q, want %q", rule.CreatedByType, "agent")
+	}
+}
+
+func TestCreateTransactionRule_InvalidExpiresIn(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	_, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Bad expiry",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+		ExpiresIn:    "invalid",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid expires_in")
+	}
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got: %v", err)
+	}
+}
+
+func TestCreateTransactionRule_InvalidCategorySlug(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	_, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Bad category",
+		CategorySlug: "nonexistent_category",
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid category slug")
+	}
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got: %v", err)
+	}
+}
+
+func TestCreateTransactionRule_InvalidCondition(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	_, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Bad condition",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "unknown_field", Op: "eq", Value: "test"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid condition field")
+	}
+}
+
+func TestCreateTransactionRule_ANDCondition(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	rule, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "AND condition",
+		CategorySlug: cat.Slug,
+		Conditions: service.Condition{
+			And: []service.Condition{
+				{Field: "name", Op: "contains", Value: "coffee"},
+				{Field: "amount", Op: "gte", Value: float64(5)},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule with AND: %v", err)
+	}
+	if rule.Conditions.And == nil || len(rule.Conditions.And) != 2 {
+		t.Errorf("expected 2 AND conditions, got: %+v", rule.Conditions)
+	}
+}
+
+// --- GetTransactionRule ---
+
+func TestGetTransactionRule_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	created, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Test rule",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+		Priority:     5,
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	got, err := svc.GetTransactionRule(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetTransactionRule: %v", err)
+	}
+
+	if got.ID != created.ID {
+		t.Errorf("ID mismatch")
+	}
+	if got.Name != "Test rule" {
+		t.Errorf("name: got %q, want %q", got.Name, "Test rule")
+	}
+	if got.Priority != 5 {
+		t.Errorf("priority: got %d, want 5", got.Priority)
+	}
+	if got.CategorySlug == nil || *got.CategorySlug != "food_and_drink" {
+		t.Error("category slug not resolved in Get response")
+	}
+}
+
+func TestGetTransactionRule_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	_, err := svc.GetTransactionRule(context.Background(), "00000000-0000-0000-0000-000000000001")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestGetTransactionRule_BadUUID(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	_, err := svc.GetTransactionRule(context.Background(), "not-a-uuid")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound for bad UUID, got: %v", err)
+	}
+}
+
+// --- ListTransactionRules ---
+
+func TestListTransactionRules_Empty(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	result, err := svc.ListTransactionRules(context.Background(), service.TransactionRuleListParams{})
+	if err != nil {
+		t.Fatalf("ListTransactionRules: %v", err)
+	}
+	if len(result.Rules) != 0 {
+		t.Errorf("expected 0 rules, got %d", len(result.Rules))
+	}
+	if result.Total != 0 {
+		t.Errorf("expected total 0, got %d", result.Total)
+	}
+	if result.HasMore {
+		t.Error("expected HasMore=false")
+	}
+}
+
+func TestListTransactionRules_WithData(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	for i := 0; i < 3; i++ {
+		_, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+			Name:         "Rule " + string(rune('A'+i)),
+			CategorySlug: cat.Slug,
+			Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+		})
+		if err != nil {
+			t.Fatalf("CreateTransactionRule %d: %v", i, err)
+		}
+	}
+
+	result, err := svc.ListTransactionRules(context.Background(), service.TransactionRuleListParams{})
+	if err != nil {
+		t.Fatalf("ListTransactionRules: %v", err)
+	}
+	if len(result.Rules) != 3 {
+		t.Errorf("expected 3 rules, got %d", len(result.Rules))
+	}
+	if result.Total != 3 {
+		t.Errorf("expected total 3, got %d", result.Total)
+	}
+}
+
+func TestListTransactionRules_FilterByEnabled(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	created, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Enabled rule",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Disable the rule.
+	disabled := false
+	_, err = svc.UpdateTransactionRule(context.Background(), created.ID, service.UpdateTransactionRuleParams{
+		Enabled: &disabled,
+	})
+	if err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	// Create another enabled rule.
+	_, err = svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Still enabled",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test2"},
+	})
+	if err != nil {
+		t.Fatalf("create 2: %v", err)
+	}
+
+	enabledFilter := true
+	result, err := svc.ListTransactionRules(context.Background(), service.TransactionRuleListParams{
+		Enabled: &enabledFilter,
+	})
+	if err != nil {
+		t.Fatalf("ListTransactionRules: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected 1 enabled rule, got %d", result.Total)
+	}
+}
+
+func TestListTransactionRules_FilterByCategory(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat1 := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+	cat2 := mustCreateCategory(t, queries, "transportation", "Transportation")
+
+	_, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Food rule",
+		CategorySlug: cat1.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "pizza"},
+	})
+	if err != nil {
+		t.Fatalf("create 1: %v", err)
+	}
+
+	_, err = svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Transport rule",
+		CategorySlug: cat2.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "uber"},
+	})
+	if err != nil {
+		t.Fatalf("create 2: %v", err)
+	}
+
+	slug := "food_and_drink"
+	result, err := svc.ListTransactionRules(context.Background(), service.TransactionRuleListParams{
+		CategorySlug: &slug,
+	})
+	if err != nil {
+		t.Fatalf("ListTransactionRules: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected 1 food rule, got %d", result.Total)
+	}
+	if len(result.Rules) != 1 || result.Rules[0].Name != "Food rule" {
+		t.Errorf("expected Food rule, got: %+v", result.Rules)
+	}
+}
+
+func TestListTransactionRules_FilterBySearch(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	_, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Coffee shops",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "contains", Value: "coffee"},
+	})
+	if err != nil {
+		t.Fatalf("create 1: %v", err)
+	}
+
+	_, err = svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Grocery stores",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "contains", Value: "grocery"},
+	})
+	if err != nil {
+		t.Fatalf("create 2: %v", err)
+	}
+
+	search := "coffee"
+	result, err := svc.ListTransactionRules(context.Background(), service.TransactionRuleListParams{
+		Search: &search,
+	})
+	if err != nil {
+		t.Fatalf("ListTransactionRules: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected 1 matching rule, got %d", result.Total)
+	}
+}
+
+func TestListTransactionRules_Pagination(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	// Create 5 rules.
+	for i := 0; i < 5; i++ {
+		_, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+			Name:         "Rule " + string(rune('A'+i)),
+			CategorySlug: cat.Slug,
+			Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+		})
+		if err != nil {
+			t.Fatalf("create %d: %v", i, err)
+		}
+	}
+
+	// First page: limit 2.
+	result, err := svc.ListTransactionRules(context.Background(), service.TransactionRuleListParams{
+		Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("page 1: %v", err)
+	}
+	if len(result.Rules) != 2 {
+		t.Errorf("page 1: expected 2 rules, got %d", len(result.Rules))
+	}
+	if !result.HasMore {
+		t.Error("page 1: expected HasMore=true")
+	}
+	if result.NextCursor == "" {
+		t.Error("page 1: expected non-empty cursor")
+	}
+	if result.Total != 5 {
+		t.Errorf("page 1: expected total 5, got %d", result.Total)
+	}
+
+	// Second page using cursor.
+	result2, err := svc.ListTransactionRules(context.Background(), service.TransactionRuleListParams{
+		Limit:  2,
+		Cursor: result.NextCursor,
+	})
+	if err != nil {
+		t.Fatalf("page 2: %v", err)
+	}
+	if len(result2.Rules) != 2 {
+		t.Errorf("page 2: expected 2 rules, got %d", len(result2.Rules))
+	}
+	if !result2.HasMore {
+		t.Error("page 2: expected HasMore=true")
+	}
+
+	// Ensure no overlap between pages.
+	for _, r1 := range result.Rules {
+		for _, r2 := range result2.Rules {
+			if r1.ID == r2.ID {
+				t.Errorf("duplicate rule across pages: %s", r1.ID)
+			}
+		}
+	}
+}
+
+// --- UpdateTransactionRule ---
+
+func TestUpdateTransactionRule_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat1 := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+	cat2 := mustCreateCategory(t, queries, "transportation", "Transportation")
+
+	created, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Original name",
+		CategorySlug: cat1.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+		Priority:     5,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	newName := "Updated name"
+	newPriority := 20
+	newSlug := cat2.Slug
+	updated, err := svc.UpdateTransactionRule(context.Background(), created.ID, service.UpdateTransactionRuleParams{
+		Name:         &newName,
+		Priority:     &newPriority,
+		CategorySlug: &newSlug,
+	})
+	if err != nil {
+		t.Fatalf("UpdateTransactionRule: %v", err)
+	}
+	if updated.Name != "Updated name" {
+		t.Errorf("name: got %q, want %q", updated.Name, "Updated name")
+	}
+	if updated.Priority != 20 {
+		t.Errorf("priority: got %d, want 20", updated.Priority)
+	}
+	if updated.CategorySlug == nil || *updated.CategorySlug != "transportation" {
+		t.Errorf("category slug not updated")
+	}
+}
+
+func TestUpdateTransactionRule_PartialUpdate(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	created, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Original",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+		Priority:     5,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	// Only update name, leave everything else unchanged.
+	newName := "New Name"
+	updated, err := svc.UpdateTransactionRule(context.Background(), created.ID, service.UpdateTransactionRuleParams{
+		Name: &newName,
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Name != "New Name" {
+		t.Errorf("name not updated: %q", updated.Name)
+	}
+	if updated.Priority != 5 {
+		t.Errorf("priority changed unexpectedly: got %d, want 5", updated.Priority)
+	}
+	if updated.CategorySlug == nil || *updated.CategorySlug != "food_and_drink" {
+		t.Error("category slug changed unexpectedly")
+	}
+}
+
+func TestUpdateTransactionRule_Disable(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	created, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Rule",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	disabled := false
+	updated, err := svc.UpdateTransactionRule(context.Background(), created.ID, service.UpdateTransactionRuleParams{
+		Enabled: &disabled,
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Enabled {
+		t.Error("expected rule to be disabled")
+	}
+}
+
+func TestUpdateTransactionRule_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	newName := "test"
+	_, err := svc.UpdateTransactionRule(context.Background(), "00000000-0000-0000-0000-000000000001", service.UpdateTransactionRuleParams{
+		Name: &newName,
+	})
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestUpdateTransactionRule_InvalidCategorySlug(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	created, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Rule",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	badSlug := "nonexistent_slug"
+	_, err = svc.UpdateTransactionRule(context.Background(), created.ID, service.UpdateTransactionRuleParams{
+		CategorySlug: &badSlug,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid category slug")
+	}
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got: %v", err)
+	}
+}
+
+// --- DeleteTransactionRule ---
+
+func TestDeleteTransactionRule_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	created, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "To be deleted",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	err = svc.DeleteTransactionRule(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("DeleteTransactionRule: %v", err)
+	}
+
+	_, err = svc.GetTransactionRule(context.Background(), created.ID)
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound after delete, got: %v", err)
+	}
+}
+
+func TestDeleteTransactionRule_NotFound(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	err := svc.DeleteTransactionRule(context.Background(), "00000000-0000-0000-0000-000000000001")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestDeleteTransactionRule_BadUUID(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	err := svc.DeleteTransactionRule(context.Background(), "not-a-uuid")
+	if !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound for bad UUID, got: %v", err)
+	}
+}
+
+// --- ListActiveRulesForSync ---
+
+func TestListActiveRulesForSync_FiltersExpiredAndDisabled(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	// Create an active rule.
+	_, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Active rule",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "active"},
+	})
+	if err != nil {
+		t.Fatalf("create active: %v", err)
+	}
+
+	// Create a disabled rule.
+	created2, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Disabled rule",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "disabled"},
+	})
+	if err != nil {
+		t.Fatalf("create disabled: %v", err)
+	}
+	disabled := false
+	_, err = svc.UpdateTransactionRule(context.Background(), created2.ID, service.UpdateTransactionRuleParams{
+		Enabled: &disabled,
+	})
+	if err != nil {
+		t.Fatalf("disable: %v", err)
+	}
+
+	rules, err := svc.ListActiveRulesForSync(context.Background())
+	if err != nil {
+		t.Fatalf("ListActiveRulesForSync: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Errorf("expected 1 active rule, got %d", len(rules))
+	}
+	if rules[0].Name != "Active rule" {
+		t.Errorf("expected 'Active rule', got %q", rules[0].Name)
+	}
+}
+
+// --- BatchIncrementHitCounts ---
+
+func TestBatchIncrementHitCounts_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	rule, err := svc.CreateTransactionRule(context.Background(), service.CreateTransactionRuleParams{
+		Name:         "Hit counter test",
+		CategorySlug: cat.Slug,
+		Conditions:   service.Condition{Field: "name", Op: "eq", Value: "test"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	err = svc.BatchIncrementHitCounts(context.Background(), map[string]int{
+		rule.ID: 5,
+	})
+	if err != nil {
+		t.Fatalf("BatchIncrementHitCounts: %v", err)
+	}
+
+	got, err := svc.GetTransactionRule(context.Background(), rule.ID)
+	if err != nil {
+		t.Fatalf("GetTransactionRule: %v", err)
+	}
+	if got.HitCount != 5 {
+		t.Errorf("hit_count: got %d, want 5", got.HitCount)
+	}
+	if got.LastHitAt == nil {
+		t.Error("expected last_hit_at to be set")
+	}
+
+	// Increment again.
+	err = svc.BatchIncrementHitCounts(context.Background(), map[string]int{
+		rule.ID: 3,
+	})
+	if err != nil {
+		t.Fatalf("BatchIncrementHitCounts 2: %v", err)
+	}
+
+	got, _ = svc.GetTransactionRule(context.Background(), rule.ID)
+	if got.HitCount != 8 {
+		t.Errorf("hit_count after second increment: got %d, want 8", got.HitCount)
+	}
+}
+
+// --- SelfLink prevention (DB constraint) ---
+
+func TestCreateAccountLink_SelfLinkRejected(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user := testutil.MustCreateUser(t, queries, "User")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_1", "Acct")
+
+	acctID := formatUUIDForTest(acct.ID)
+	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   acctID,
+		DependentAccountID: acctID,
+	})
+	if err == nil {
+		t.Fatal("expected error for self-link (primary == dependent)")
+	}
+}
+
+// --- MatchCount and UnmatchedDependentCount in GetAccountLink ---
+
+func TestGetAccountLink_MatchCounts(t *testing.T) {
+	svc, queries, _ := newService(t)
+	user1 := testutil.MustCreateUser(t, queries, "User1")
+	conn1 := testutil.MustCreateConnection(t, queries, user1.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn1.ID, "ext_1", "Primary")
+
+	user2 := testutil.MustCreateUser(t, queries, "User2")
+	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_2")
+	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Dependent")
+
+	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
+		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
+		DependentAccountID: formatUUIDForTest(acct2.ID),
+	})
+	if err != nil {
+		t.Fatalf("create link: %v", err)
+	}
+
+	// Create 3 transactions in each account, match 2 of them.
+	txnP1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "p1", "Store A", 1000, "2025-01-15")
+	txnP2 := testutil.MustCreateTransaction(t, queries, acct1.ID, "p2", "Store B", 2000, "2025-01-16")
+	_ = testutil.MustCreateTransaction(t, queries, acct1.ID, "p3", "Store C", 3000, "2025-01-17")
+
+	txnD1 := testutil.MustCreateTransaction(t, queries, acct2.ID, "d1", "Store A", 1000, "2025-01-15")
+	txnD2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "d2", "Store B", 2000, "2025-01-16")
+	_ = testutil.MustCreateTransaction(t, queries, acct2.ID, "d3", "Store C", 3000, "2025-01-17")
+
+	_, err = svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txnP1.ID), formatUUIDForTest(txnD1.ID))
+	if err != nil {
+		t.Fatalf("match 1: %v", err)
+	}
+	_, err = svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txnP2.ID), formatUUIDForTest(txnD2.ID))
+	if err != nil {
+		t.Fatalf("match 2: %v", err)
+	}
+
+	got, err := svc.GetAccountLink(context.Background(), link.ID)
+	if err != nil {
+		t.Fatalf("GetAccountLink: %v", err)
+	}
+	if got.MatchCount != 2 {
+		t.Errorf("match_count: got %d, want 2", got.MatchCount)
+	}
+	if got.UnmatchedDependentCount != 1 {
+		t.Errorf("unmatched_dependent_count: got %d, want 1", got.UnmatchedDependentCount)
+	}
+}
+
+// Verify that InsertCategoryParams works as expected (used by mustCreateCategory).
+func init() {
+	_ = db.InsertCategoryParams{}
+}

--- a/internal/service/transaction_query_integration_test.go
+++ b/internal/service/transaction_query_integration_test.go
@@ -1,0 +1,1078 @@
+//go:build integration
+
+// Integration tests for transaction query builder, filters, summary, and count.
+// Run with: make test-integration
+//
+// IMPORTANT: Do NOT use t.Parallel() — tests share a database and truncate between runs.
+package service_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// --- Transaction Summary: group_by=category ---
+
+func TestGetTransactionSummary_GroupByCategory(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	// Create category
+	groceries, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "groceries", DisplayName: "Groceries",
+	})
+	if err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+
+	// Create transactions: 2 with category, 1 without
+	upsertTxnWithCategory(t, queries, acctID, "txn_g1", "Whole Foods", 2500, "2025-01-10", groceries.ID)
+	upsertTxnWithCategory(t, queries, acctID, "txn_g2", "Trader Joes", 3500, "2025-01-11", groceries.ID)
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_nocat", "Random Store", 1000, "2025-01-12")
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-02-01")
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "category",
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Summary) == 0 {
+		t.Fatal("expected at least one summary row")
+	}
+
+	// Should have at least a groceries row
+	var foundGroceries bool
+	for _, row := range result.Summary {
+		if row.Category != nil && *row.Category == "Groceries" {
+			foundGroceries = true
+			if row.TransactionCount != 2 {
+				t.Errorf("expected 2 grocery transactions, got %d", row.TransactionCount)
+			}
+			if row.TotalAmount != 60.0 { // 25 + 35
+				t.Errorf("expected total 60.0, got %f", row.TotalAmount)
+			}
+		}
+	}
+	if !foundGroceries {
+		t.Error("expected to find Groceries in summary")
+	}
+
+	// Totals
+	if result.Totals.TransactionCount != 3 {
+		t.Errorf("expected total count 3, got %d", result.Totals.TransactionCount)
+	}
+	if result.Totals.TotalAmount == nil {
+		t.Error("expected total amount to be set (single currency)")
+	}
+}
+
+// --- Transaction Summary: group_by=month ---
+
+func TestGetTransactionSummary_GroupByMonth(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	// Create transactions in different months
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_jan1", "Jan Purchase 1", 1000, "2025-01-10")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_jan2", "Jan Purchase 2", 2000, "2025-01-20")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_feb1", "Feb Purchase", 3000, "2025-02-15")
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-03-01")
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "month",
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Summary) != 2 {
+		t.Fatalf("expected 2 month rows, got %d", len(result.Summary))
+	}
+
+	// Newest month first (DESC)
+	if result.Summary[0].Period == nil || *result.Summary[0].Period != "2025-02" {
+		t.Errorf("expected first row period=2025-02, got %v", result.Summary[0].Period)
+	}
+	if result.Summary[0].TransactionCount != 1 {
+		t.Errorf("expected 1 Feb txn, got %d", result.Summary[0].TransactionCount)
+	}
+	if result.Summary[1].Period == nil || *result.Summary[1].Period != "2025-01" {
+		t.Errorf("expected second row period=2025-01, got %v", result.Summary[1].Period)
+	}
+	if result.Summary[1].TransactionCount != 2 {
+		t.Errorf("expected 2 Jan txns, got %d", result.Summary[1].TransactionCount)
+	}
+}
+
+// --- Transaction Summary: group_by=day ---
+
+func TestGetTransactionSummary_GroupByDay(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_d1", "Purchase A", 1000, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_d2", "Purchase B", 2000, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_d3", "Purchase C", 3000, "2025-01-16")
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-02-01")
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "day",
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Summary) != 2 {
+		t.Fatalf("expected 2 day rows, got %d", len(result.Summary))
+	}
+
+	// Newest day first (DESC)
+	if result.Summary[0].Period == nil || *result.Summary[0].Period != "2025-01-16" {
+		t.Errorf("expected first row 2025-01-16, got %v", result.Summary[0].Period)
+	}
+	if result.Summary[0].TotalAmount != 30.0 {
+		t.Errorf("expected 30.0 for Jan 16, got %f", result.Summary[0].TotalAmount)
+	}
+	if result.Summary[1].Period == nil || *result.Summary[1].Period != "2025-01-15" {
+		t.Errorf("expected second row 2025-01-15, got %v", result.Summary[1].Period)
+	}
+	if result.Summary[1].TotalAmount != 30.0 { // 10 + 20
+		t.Errorf("expected 30.0 for Jan 15, got %f", result.Summary[1].TotalAmount)
+	}
+}
+
+// --- Transaction Summary: SpendingOnly filter ---
+
+func TestGetTransactionSummary_SpendingOnly(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	// Positive amount = debit/spending, negative = credit/income
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_spend", "Starbucks", 1500, "2025-01-15")
+	upsertTxnWithAmount(t, queries, acctID, "txn_income", "Payroll", -500000, "2025-01-15")
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-02-01")
+
+	// With SpendingOnly=true, should only see positive amounts
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:      "day",
+		StartDate:    &start,
+		EndDate:      &end,
+		SpendingOnly: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Totals.TransactionCount != 1 {
+		t.Errorf("expected 1 spending transaction, got %d", result.Totals.TransactionCount)
+	}
+	if result.Totals.TotalAmount == nil || *result.Totals.TotalAmount != 15.0 {
+		t.Errorf("expected total 15.0, got %v", result.Totals.TotalAmount)
+	}
+
+	// Without SpendingOnly, should see both
+	result2, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "day",
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result2.Totals.TransactionCount != 2 {
+		t.Errorf("expected 2 total transactions, got %d", result2.Totals.TransactionCount)
+	}
+}
+
+// --- Transaction Summary: pending filter ---
+
+func TestGetTransactionSummary_ExcludesPendingByDefault(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_posted", "Posted Purchase", 1500, "2025-01-15")
+	upsertTxnPending(t, queries, acctID, "txn_pending", "Pending Purchase", 2000, "2025-01-15")
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-02-01")
+
+	// Default: exclude pending
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "day",
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Totals.TransactionCount != 1 {
+		t.Errorf("expected 1 (posted only), got %d", result.Totals.TransactionCount)
+	}
+
+	// Include pending
+	result2, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:        "day",
+		StartDate:      &start,
+		EndDate:        &end,
+		IncludePending: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result2.Totals.TransactionCount != 2 {
+		t.Errorf("expected 2 (including pending), got %d", result2.Totals.TransactionCount)
+	}
+}
+
+// --- Transaction Summary: AccountID filter ---
+
+func TestGetTransactionSummary_AccountFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn.ID, "ext_1", "Checking")
+	acct2 := testutil.MustCreateAccount(t, queries, conn.ID, "ext_2", "Savings")
+
+	testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_c1", "Checking Purchase", 1000, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_s1", "Savings Purchase", 2000, "2025-01-15")
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-02-01")
+	acct1ID := formatUUID(acct1.ID)
+
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "day",
+		StartDate: &start,
+		EndDate:   &end,
+		AccountID: &acct1ID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Totals.TransactionCount != 1 {
+		t.Errorf("expected 1 (checking only), got %d", result.Totals.TransactionCount)
+	}
+}
+
+// --- Transaction Summary: UserID filter ---
+
+func TestGetTransactionSummary_UserFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	alice := testutil.MustCreateUser(t, queries, "Alice")
+	bob := testutil.MustCreateUser(t, queries, "Bob")
+	connA := testutil.MustCreateConnection(t, queries, alice.ID, "item_a")
+	connB := testutil.MustCreateConnection(t, queries, bob.ID, "item_b")
+	acctA := testutil.MustCreateAccount(t, queries, connA.ID, "ext_a", "Alice Checking")
+	acctB := testutil.MustCreateAccount(t, queries, connB.ID, "ext_b", "Bob Checking")
+
+	testutil.MustCreateTransaction(t, queries, acctA.ID, "txn_alice", "Alice Purchase", 1000, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctB.ID, "txn_bob", "Bob Purchase", 2000, "2025-01-15")
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-02-01")
+	aliceID := formatUUID(alice.ID)
+
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "day",
+		StartDate: &start,
+		EndDate:   &end,
+		UserID:    &aliceID,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Totals.TransactionCount != 1 {
+		t.Errorf("expected 1 (Alice only), got %d", result.Totals.TransactionCount)
+	}
+}
+
+// --- Transaction Summary: empty result ---
+
+func TestGetTransactionSummary_EmptyResult(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-02-01")
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "category",
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Summary) != 0 {
+		t.Errorf("expected empty summary, got %d rows", len(result.Summary))
+	}
+	if result.Totals.TransactionCount != 0 {
+		t.Errorf("expected 0 total count, got %d", result.Totals.TransactionCount)
+	}
+}
+
+// --- Transaction Summary: group_by=category_month ---
+
+func TestGetTransactionSummary_GroupByCategoryMonth(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	groceries, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "groceries", DisplayName: "Groceries",
+	})
+	if err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+
+	upsertTxnWithCategory(t, queries, acctID, "txn_g_jan", "Jan Groceries", 2000, "2025-01-15", groceries.ID)
+	upsertTxnWithCategory(t, queries, acctID, "txn_g_feb", "Feb Groceries", 3000, "2025-02-15", groceries.ID)
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-03-01")
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "category_month",
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Summary) < 2 {
+		t.Fatalf("expected at least 2 category_month rows, got %d", len(result.Summary))
+	}
+
+	// Verify both rows have category and period set
+	for _, row := range result.Summary {
+		if row.Category == nil {
+			continue // uncategorized rows
+		}
+		if *row.Category == "Groceries" {
+			if row.Period == nil {
+				t.Error("expected period to be set on category_month row")
+			}
+		}
+	}
+}
+
+// --- Transaction Summary: group_by=week ---
+
+func TestGetTransactionSummary_GroupByWeek(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	// Two transactions in same ISO week, one in different week
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_w1", "Monday Purchase", 1000, "2025-01-13") // Monday
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_w2", "Tuesday Purchase", 2000, "2025-01-14")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_w3", "Next Week", 3000, "2025-01-20") // next Monday
+
+	start := testutil.MustParseDate("2025-01-01")
+	end := testutil.MustParseDate("2025-02-01")
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy:   "week",
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Summary) != 2 {
+		t.Fatalf("expected 2 week rows, got %d", len(result.Summary))
+	}
+	if result.Totals.TransactionCount != 3 {
+		t.Errorf("expected 3 total transactions, got %d", result.Totals.TransactionCount)
+	}
+}
+
+// --- Transaction Summary: default date range ---
+
+func TestGetTransactionSummary_DefaultDateRange(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	// Create a transaction within the last 30 days
+	recentDate := time.Now().AddDate(0, 0, -5).Format("2006-01-02")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_recent", "Recent Purchase", 1500, recentDate)
+
+	// Create a transaction 60 days ago (outside default range)
+	oldDate := time.Now().AddDate(0, 0, -60).Format("2006-01-02")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_old", "Old Purchase", 2500, oldDate)
+
+	// No date params — should use default 30-day range
+	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+		GroupBy: "day",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Totals.TransactionCount != 1 {
+		t.Errorf("expected 1 transaction in default 30-day range, got %d", result.Totals.TransactionCount)
+	}
+}
+
+// --- ListTransactions: date range filter ---
+
+func TestListTransactions_DateRangeFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_early", "Early", 100, "2025-01-05")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_mid", "Mid", 200, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_late", "Late", 300, "2025-01-25")
+
+	start := testutil.MustParseDate("2025-01-10")
+	end := testutil.MustParseDate("2025-01-20")
+
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 transaction in date range, got %d", len(result.Transactions))
+	}
+	if result.Transactions[0].Name != "Mid" {
+		t.Errorf("expected Mid, got %s", result.Transactions[0].Name)
+	}
+}
+
+// --- ListTransactions: pending filter ---
+
+func TestListTransactions_PendingFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_posted", "Posted", 100, "2025-01-15")
+	upsertTxnPending(t, queries, acctID, "txn_pending", "Pending", 200, "2025-01-15")
+
+	// Filter for pending=true
+	pendingTrue := true
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{Pending: &pendingTrue})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 pending, got %d", len(result.Transactions))
+	}
+	if result.Transactions[0].Name != "Pending" {
+		t.Errorf("expected Pending, got %s", result.Transactions[0].Name)
+	}
+
+	// Filter for pending=false
+	pendingFalse := false
+	result2, err := svc.ListTransactions(ctx, service.TransactionListParams{Pending: &pendingFalse})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result2.Transactions) != 1 {
+		t.Fatalf("expected 1 posted, got %d", len(result2.Transactions))
+	}
+	if result2.Transactions[0].Name != "Posted" {
+		t.Errorf("expected Posted, got %s", result2.Transactions[0].Name)
+	}
+}
+
+// --- ListTransactions: user filter ---
+
+func TestListTransactions_UserFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	alice := testutil.MustCreateUser(t, queries, "Alice")
+	bob := testutil.MustCreateUser(t, queries, "Bob")
+	connA := testutil.MustCreateConnection(t, queries, alice.ID, "item_a")
+	connB := testutil.MustCreateConnection(t, queries, bob.ID, "item_b")
+	acctA := testutil.MustCreateAccount(t, queries, connA.ID, "ext_a", "Alice Checking")
+	acctB := testutil.MustCreateAccount(t, queries, connB.ID, "ext_b", "Bob Checking")
+
+	testutil.MustCreateTransaction(t, queries, acctA.ID, "txn_alice", "Alice Purchase", 1000, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctB.ID, "txn_bob", "Bob Purchase", 2000, "2025-01-15")
+
+	aliceID := formatUUID(alice.ID)
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{UserID: &aliceID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 transaction for Alice, got %d", len(result.Transactions))
+	}
+	if result.Transactions[0].Name != "Alice Purchase" {
+		t.Errorf("expected Alice Purchase, got %s", result.Transactions[0].Name)
+	}
+}
+
+// --- ListTransactions: account filter ---
+
+func TestListTransactions_AccountFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	acct1 := testutil.MustCreateAccount(t, queries, conn.ID, "ext_1", "Checking")
+	acct2 := testutil.MustCreateAccount(t, queries, conn.ID, "ext_2", "Savings")
+
+	testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_c", "Checking Txn", 1000, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_s", "Savings Txn", 2000, "2025-01-15")
+
+	acct1ID := formatUUID(acct1.ID)
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{AccountID: &acct1ID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 for checking account, got %d", len(result.Transactions))
+	}
+	if result.Transactions[0].Name != "Checking Txn" {
+		t.Errorf("expected Checking Txn, got %s", result.Transactions[0].Name)
+	}
+}
+
+// --- ListTransactions: category_slug filter ---
+
+func TestListTransactions_CategorySlugFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	groceries, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "groceries", DisplayName: "Groceries",
+	})
+	if err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+
+	upsertTxnWithCategory(t, queries, acctID, "txn_g1", "Whole Foods", 2500, "2025-01-15", groceries.ID)
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_none", "Other Store", 1000, "2025-01-15")
+
+	slug := "groceries"
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{CategorySlug: &slug})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 groceries transaction, got %d", len(result.Transactions))
+	}
+	if result.Transactions[0].Name != "Whole Foods" {
+		t.Errorf("expected Whole Foods, got %s", result.Transactions[0].Name)
+	}
+}
+
+// --- ListTransactions: parent category slug includes children ---
+
+func TestListTransactions_ParentCategorySlugIncludesChildren(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	// Create parent category
+	foodDrink, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "food_and_drink", DisplayName: "Food & Drink",
+	})
+	if err != nil {
+		t.Fatalf("create parent category: %v", err)
+	}
+
+	// Create child category
+	groceries, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug:        "food_and_drink_groceries",
+		DisplayName: "Groceries",
+		ParentID:    foodDrink.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child category: %v", err)
+	}
+
+	// One with parent, one with child, one uncategorized
+	upsertTxnWithCategory(t, queries, acctID, "txn_parent", "Restaurant", 3000, "2025-01-15", foodDrink.ID)
+	upsertTxnWithCategory(t, queries, acctID, "txn_child", "Whole Foods", 2500, "2025-01-14", groceries.ID)
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_other", "Gas Station", 4000, "2025-01-13")
+
+	// Filter by parent slug — should include both parent and child
+	slug := "food_and_drink"
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{CategorySlug: &slug})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 2 {
+		t.Fatalf("expected 2 transactions (parent + child), got %d", len(result.Transactions))
+	}
+}
+
+// --- ListTransactions: unknown category slug returns empty ---
+
+func TestListTransactions_UnknownCategorySlugReturnsEmpty(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_1", "Purchase", 1000, "2025-01-15")
+
+	slug := "nonexistent_category"
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{CategorySlug: &slug})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 0 {
+		t.Errorf("expected 0 results for unknown slug, got %d", len(result.Transactions))
+	}
+}
+
+// --- ListTransactions: sort by amount ---
+
+func TestListTransactions_SortByAmount(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_small", "Small", 500, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_big", "Big", 10000, "2025-01-14")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_mid", "Mid", 3000, "2025-01-13")
+
+	sortBy := "amount"
+	sortOrder := "desc"
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{
+		SortBy:    &sortBy,
+		SortOrder: &sortOrder,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 3 {
+		t.Fatalf("expected 3, got %d", len(result.Transactions))
+	}
+	if result.Transactions[0].Name != "Big" {
+		t.Errorf("expected Big first (highest amount), got %s", result.Transactions[0].Name)
+	}
+	if result.Transactions[2].Name != "Small" {
+		t.Errorf("expected Small last (lowest amount), got %s", result.Transactions[2].Name)
+	}
+
+	// No cursor when sorting by non-date
+	if result.NextCursor != "" {
+		t.Error("expected empty cursor when sorting by amount")
+	}
+}
+
+// --- ListTransactions: sort by name ---
+
+func TestListTransactions_SortByName(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_c", "Charlie", 100, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_a", "Alice", 200, "2025-01-14")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_b", "Bob", 300, "2025-01-13")
+
+	sortBy := "name"
+	sortOrder := "asc"
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{
+		SortBy:    &sortBy,
+		SortOrder: &sortOrder,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Transactions[0].Name != "Alice" {
+		t.Errorf("expected Alice first, got %s", result.Transactions[0].Name)
+	}
+	if result.Transactions[1].Name != "Bob" {
+		t.Errorf("expected Bob second, got %s", result.Transactions[1].Name)
+	}
+	if result.Transactions[2].Name != "Charlie" {
+		t.Errorf("expected Charlie third, got %s", result.Transactions[2].Name)
+	}
+}
+
+// --- ListTransactions: sort asc ---
+
+func TestListTransactions_SortDateAsc(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_new", "New", 100, "2025-01-20")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_old", "Old", 200, "2025-01-10")
+
+	sortOrder := "asc"
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{SortOrder: &sortOrder})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Transactions[0].Name != "Old" {
+		t.Errorf("expected Old first (asc), got %s", result.Transactions[0].Name)
+	}
+}
+
+// --- ListTransactions: max_amount filter ---
+
+func TestListTransactions_MaxAmountFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_small", "Small", 500, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_big", "Big", 10000, "2025-01-14")
+
+	max := 10.0
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{MaxAmount: &max})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 (amount <= 10), got %d", len(result.Transactions))
+	}
+	if result.Transactions[0].Name != "Small" {
+		t.Errorf("expected Small, got %s", result.Transactions[0].Name)
+	}
+}
+
+// --- ListTransactions: combined min+max amount ---
+
+func TestListTransactions_MinMaxAmountRange(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_1", "Tiny", 100, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_2", "Mid", 2000, "2025-01-14")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_3", "Big", 10000, "2025-01-13")
+
+	min := 5.0
+	max := 50.0
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{
+		MinAmount: &min,
+		MaxAmount: &max,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1 (5 <= amount <= 50), got %d", len(result.Transactions))
+	}
+	if result.Transactions[0].Name != "Mid" {
+		t.Errorf("expected Mid, got %s", result.Transactions[0].Name)
+	}
+}
+
+// --- CountTransactionsFiltered: with filters ---
+
+func TestCountTransactionsFiltered_DateRange(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_1", "Old", 100, "2025-01-05")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_2", "Mid", 200, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_3", "New", 300, "2025-01-25")
+
+	start := testutil.MustParseDate("2025-01-10")
+	end := testutil.MustParseDate("2025-01-20")
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{
+		StartDate: &start,
+		EndDate:   &end,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 in range, got %d", count)
+	}
+}
+
+func TestCountTransactionsFiltered_SearchFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_a", "Starbucks", 500, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_b", "Shell", 3000, "2025-01-14")
+
+	search := "starbucks"
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Search: &search})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 matching 'starbucks', got %d", count)
+	}
+}
+
+func TestCountTransactionsFiltered_UserFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	alice := testutil.MustCreateUser(t, queries, "Alice")
+	bob := testutil.MustCreateUser(t, queries, "Bob")
+	connA := testutil.MustCreateConnection(t, queries, alice.ID, "item_a")
+	connB := testutil.MustCreateConnection(t, queries, bob.ID, "item_b")
+	acctA := testutil.MustCreateAccount(t, queries, connA.ID, "ext_a", "Alice Checking")
+	acctB := testutil.MustCreateAccount(t, queries, connB.ID, "ext_b", "Bob Checking")
+
+	testutil.MustCreateTransaction(t, queries, acctA.ID, "txn_a", "Alice Txn", 100, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctB.ID, "txn_b", "Bob Txn", 200, "2025-01-15")
+
+	aliceID := formatUUID(alice.ID)
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{UserID: &aliceID})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 for Alice, got %d", count)
+	}
+}
+
+func TestCountTransactionsFiltered_CategorySlug(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	groceries, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "groceries", DisplayName: "Groceries",
+	})
+	if err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+
+	upsertTxnWithCategory(t, queries, acctID, "txn_g", "Groceries Txn", 2500, "2025-01-15", groceries.ID)
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_o", "Other Txn", 1000, "2025-01-15")
+
+	slug := "groceries"
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{CategorySlug: &slug})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 groceries, got %d", count)
+	}
+}
+
+func TestCountTransactionsFiltered_PendingFilter(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_posted", "Posted", 100, "2025-01-15")
+	upsertTxnPending(t, queries, acctID, "txn_pending", "Pending", 200, "2025-01-15")
+
+	pendingTrue := true
+	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{Pending: &pendingTrue})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 pending, got %d", count)
+	}
+}
+
+// --- ListTransactions: limit clamping ---
+
+func TestListTransactions_LimitClamping(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_1", "Test", 100, "2025-01-15")
+
+	// Limit 0 should default to 50
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{Limit: 0})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Limit != 50 {
+		t.Errorf("expected default limit 50, got %d", result.Limit)
+	}
+
+	// Limit > 500 should clamp to 500
+	result2, err := svc.ListTransactions(ctx, service.TransactionListParams{Limit: 999})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result2.Limit != 500 {
+		t.Errorf("expected clamped limit 500, got %d", result2.Limit)
+	}
+}
+
+// --- ListTransactions: invalid cursor ---
+
+func TestListTransactions_InvalidCursor(t *testing.T) {
+	svc, _, _ := newService(t)
+	_, err := svc.ListTransactions(context.Background(), service.TransactionListParams{
+		Cursor: "not-a-valid-cursor",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid cursor")
+	}
+}
+
+// --- ListTransactions: transaction response has category info ---
+
+func TestListTransactions_CategoryInfoInResponse(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	parent, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "food_and_drink", DisplayName: "Food & Drink",
+	})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	child, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "food_and_drink_groceries", DisplayName: "Groceries", ParentID: parent.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	upsertTxnWithCategory(t, queries, acctID, "txn_cat", "Whole Foods", 2500, "2025-01-15", child.ID)
+
+	result, err := svc.ListTransactions(ctx, service.TransactionListParams{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Transactions) != 1 {
+		t.Fatalf("expected 1, got %d", len(result.Transactions))
+	}
+
+	txn := result.Transactions[0]
+	if txn.Category == nil {
+		t.Fatal("expected category info to be set")
+	}
+	if txn.Category.Slug == nil || *txn.Category.Slug != "food_and_drink_groceries" {
+		t.Errorf("expected slug food_and_drink_groceries, got %v", txn.Category.Slug)
+	}
+	if txn.Category.PrimarySlug == nil || *txn.Category.PrimarySlug != "food_and_drink" {
+		t.Errorf("expected primary slug food_and_drink, got %v", txn.Category.PrimarySlug)
+	}
+	if txn.Category.DisplayName == nil || *txn.Category.DisplayName != "Groceries" {
+		t.Errorf("expected display name Groceries, got %v", txn.Category.DisplayName)
+	}
+}
+
+// --- GetTransaction: returns full details including category ---
+
+func TestGetTransaction_WithCategory(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+
+	parent, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "food_and_drink", DisplayName: "Food & Drink",
+	})
+	if err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+	child, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "food_and_drink_groceries", DisplayName: "Groceries", ParentID: parent.ID,
+	})
+	if err != nil {
+		t.Fatalf("create child: %v", err)
+	}
+
+	txn := upsertTxnWithCategory(t, queries, acctID, "txn_get", "Whole Foods", 2500, "2025-01-15", child.ID)
+
+	resp, err := svc.GetTransaction(ctx, formatUUID(txn.ID))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Category == nil {
+		t.Fatal("expected category info")
+	}
+	if resp.Category.Slug == nil || *resp.Category.Slug != "food_and_drink_groceries" {
+		t.Errorf("expected slug food_and_drink_groceries, got %v", resp.Category.Slug)
+	}
+	if resp.Category.PrimarySlug == nil || *resp.Category.PrimarySlug != "food_and_drink" {
+		t.Errorf("expected primary slug, got %v", resp.Category.PrimarySlug)
+	}
+}
+
+// --- Helpers ---
+
+func upsertTxnWithCategory(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID, name string, amountCents int64, date string, categoryID pgtype.UUID) db.Transaction {
+	t.Helper()
+	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
+		AccountID:             acctID,
+		ExternalTransactionID: extID,
+		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
+		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
+		Name:                  name,
+		CategoryID:            categoryID,
+	})
+	if err != nil {
+		t.Fatalf("upsertTxnWithCategory(%q): %v", name, err)
+	}
+	return txn
+}
+
+func upsertTxnPending(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID, name string, amountCents int64, date string) db.Transaction {
+	t.Helper()
+	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
+		AccountID:             acctID,
+		ExternalTransactionID: extID,
+		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
+		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
+		Name:                  name,
+		Pending:               true,
+	})
+	if err != nil {
+		t.Fatalf("upsertTxnPending(%q): %v", name, err)
+	}
+	return txn
+}
+
+func upsertTxnWithAmount(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID, name string, amountCents int64, date string) db.Transaction {
+	t.Helper()
+	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
+		AccountID:             acctID,
+		ExternalTransactionID: extID,
+		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
+		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
+		Name:                  name,
+	})
+	if err != nil {
+		t.Fatalf("upsertTxnWithAmount(%q): %v", name, err)
+	}
+	return txn
+}

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -11,6 +11,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>body { font-family: 'Inter', system-ui, -apple-system, sans-serif; }</style>
+  <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3/dist/cdn.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- Adds 49 new integration tests for the category service layer, which previously had zero dedicated test coverage
- Covers full CRUD lifecycle for categories and category mappings, plus bulk operations (batch categorize, bulk recategorize, bulk upsert mappings)
- Tests edge cases: uncategorized deletion protection, cascade delete, transaction reassignment, slug auto-generation/dedup, mapping duplicate detection, reset-to-mapping resolution

## Test Details
**Categories CRUD (17 tests):** ListCategories, ListCategoryTree, GetCategory (found/not-found/invalid-ID), CreateCategory (auto-slug, duplicate-slug suffix, parent, icon+color), UpdateCategory (success/not-found), DeleteCategory (success, uncategorized-protection, reassignment, cascade, not-found)

**Merge (3 tests):** Success (verifies transaction + mapping reassignment), source not found, target not found

**Transaction categorization (9 tests):** SetTransactionCategory (success, invalid-txn, invalid-cat), ResetTransactionCategory (resolves from mappings, not-found), BatchSetTransactionCategory (override flag, partial failure, empty, too-many)

**Bulk recategorize (3 tests):** By name search, requires-filter safety check, invalid target category

**Mapping CRUD (12 tests):** ListMappings (empty, filter-by-provider), CreateMappingBySlug (success, invalid-slug, duplicate), UpdateMappingBySlug (by-ID, by-provider-category, not-found), DeleteMappingByLookup (by-ID, by-provider-category, not-found, no-identifier), BulkUpsertMappings (create, update-existing)

**Slug/lookup (3 tests + 1 unit):** GetCategoryBySlug (found/not-found), GenerateSlug variants

Relates to #125

🤖 Generated by autonomous QA agent