### PR TITLE
Fix rejected/skipped reviews applying category override

### DIFF
--- a/internal/service/review_integration_test.go
+++ b/internal/service/review_integration_test.go
@@ -850,6 +850,94 @@ func TestAutoApproveCategorizedReviews_SkipsCategoryOverride(t *testing.T) {
 	}
 }
 
+func TestSubmitReview_RejectWithCategoryDoesNotModifyTransaction(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_reject_cat")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_reject_cat", "Checking")
+	txn := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_reject_cat", "Coffee Shop", 550, "2025-01-15")
+
+	review := mustEnqueueReview(t, queries, txn.ID, "uncategorized")
+
+	// Create a category
+	cat := mustCreateCategory(t, queries, "reject_test_cat", "Reject Test Category")
+	catID := formatUUID(cat.ID)
+
+	// Reject with an explicit category — the category should NOT be applied
+	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID:   formatUUID(review.ID),
+		Decision:   "rejected",
+		CategoryID: &catID,
+		Actor:      testActor,
+	})
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+	if result.Status != "rejected" {
+		t.Errorf("expected status=rejected, got %s", result.Status)
+	}
+
+	// Verify the transaction was NOT modified — category_id should still be NULL
+	// and category_override should still be FALSE
+	var txnCatID pgtype.UUID
+	var catOverride bool
+	err = pool.QueryRow(ctx, "SELECT category_id, category_override FROM transactions WHERE id = $1", txn.ID).Scan(&txnCatID, &catOverride)
+	if err != nil {
+		t.Fatalf("query transaction: %v", err)
+	}
+	if txnCatID.Valid {
+		t.Errorf("expected transaction category_id to remain NULL after rejection, got %s", formatUUID(txnCatID))
+	}
+	if catOverride {
+		t.Error("expected category_override=false after rejection, but got true")
+	}
+}
+
+func TestSubmitReview_SkipWithCategoryDoesNotModifyTransaction(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_skip_cat")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_skip_cat", "Checking")
+	txn := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_skip_cat", "Restaurant", 2000, "2025-01-20")
+
+	review := mustEnqueueReview(t, queries, txn.ID, "uncategorized")
+
+	cat := mustCreateCategory(t, queries, "skip_test_cat", "Skip Test Category")
+	catID := formatUUID(cat.ID)
+
+	// Skip with an explicit category — the category should NOT be applied
+	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID:   formatUUID(review.ID),
+		Decision:   "skipped",
+		CategoryID: &catID,
+		Actor:      testActor,
+	})
+	if err != nil {
+		t.Fatalf("SubmitReview: %v", err)
+	}
+	if result.Status != "skipped" {
+		t.Errorf("expected status=skipped, got %s", result.Status)
+	}
+
+	// Verify the transaction was NOT modified
+	var txnCatID pgtype.UUID
+	var catOverride bool
+	err = pool.QueryRow(ctx, "SELECT category_id, category_override FROM transactions WHERE id = $1", txn.ID).Scan(&txnCatID, &catOverride)
+	if err != nil {
+		t.Fatalf("query transaction: %v", err)
+	}
+	if txnCatID.Valid {
+		t.Errorf("expected transaction category_id to remain NULL after skip, got %s", formatUUID(txnCatID))
+	}
+	if catOverride {
+		t.Error("expected category_override=false after skip, but got true")
+	}
+}
+
 func TestAutoApproveCategorizedReviews_NoneEligible(t *testing.T) {
 	svc, queries, _ := newService(t)
 	ctx := context.Background()

--- a/internal/service/reviews.go
+++ b/internal/service/reviews.go
@@ -600,9 +600,10 @@ func (s *Service) SubmitReview(ctx context.Context, params SubmitReviewParams) (
 		return nil, fmt.Errorf("update review: %w", err)
 	}
 
-	// Apply category override to transaction if applicable
+	// Apply category override to transaction only when approving.
+	// Rejected/skipped reviews should never modify the transaction's category.
 	txnID := formatUUID(existing.TransactionID)
-	if categoryToApply != nil && (params.Decision == "approved" || params.CategoryID != nil) {
+	if categoryToApply != nil && params.Decision == "approved" {
 		if err := s.SetTransactionCategory(ctx, txnID, *categoryToApply); err != nil {
 			s.Logger.Warn("failed to set transaction category from review", "error", err, "transaction_id", txnID)
 		}


### PR DESCRIPTION
## Summary
- Fixed a bug where rejecting or skipping a review with a `category_id` parameter would still apply the category override to the transaction
- The condition `params.CategoryID != nil` bypassed the decision check, setting `category_override=TRUE` even on rejected/skipped reviews
- Added 2 integration tests that verify rejected and skipped reviews do not modify transaction categories

## Bug Details
**Found via**: Code review of `internal/service/reviews.go` SubmitReview method
**Steps to reproduce**: Call `POST /api/v1/reviews/{id}/submit` with `{"decision": "rejected", "category_id": "some-uuid"}` — the transaction's category would be overridden despite the rejection
**Root cause**: Line 605 had `(params.Decision == "approved" || params.CategoryID != nil)` — the second condition meant any non-nil category_id would trigger the override regardless of decision
**Fix**: Changed to `params.Decision == "approved"` — only approved reviews apply category changes

Relates to #125

🤖 Generated by autonomous QA agent