### PR TITLE
Add agent reports: MCP tool, dashboard widget, and REST API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,8 @@ One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), M
 - Account link MCP tools: `list_account_links`, `create_account_link` (ToolWrite, auto-runs initial reconciliation), `delete_account_link`, `reconcile_account_link`, `list_transaction_matches`, `confirm_match`, `reject_match`.
 - Account link REST API: `/api/v1/account-links` CRUD + `/reconcile` + `/matches`. `/api/v1/transaction-matches/{id}/confirm|reject`. `POST /api/v1/transaction-matches/manual`.
 - Account link admin: `/admin/account-links` page with link list, create modal, match detail view. Nav item with `link-2` Lucide icon between Categories and Family Members.
+- Agent reports: `agent_reports` table for agents to submit summaries and flag transactions. `submit_report` MCP tool (ToolWrite) with title + markdown body. Dashboard widget shows unread reports with markdown rendering (marked.js CDN). Transaction deep-links via `[Name](/transactions/ID)` in markdown. Mark read/dismiss via admin API. Nav badge shows unread count.
+- Agent report REST API: `GET /api/v1/reports`, `POST /api/v1/reports`, `GET /api/v1/reports/unread-count`, `PATCH /api/v1/reports/{id}/read`. Admin API: `POST /-/reports/{id}/read`, `POST /-/reports/read-all`.
 
 ## Canonical Enums
 

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -1007,6 +1007,30 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			spendingInsights = spendingInsights[:5]
 		}
 
+		// Agent reports: load recent unread reports for the dashboard widget.
+		type DashboardReport struct {
+			ID            string
+			Title         string
+			Body          string
+			CreatedByName string
+			CreatedAt     string // relative time
+		}
+		var agentReports []DashboardReport
+		rawReports, err := svc.ListUnreadAgentReports(ctx, 5)
+		if err != nil {
+			a.Logger.Error("list unread agent reports", "error", err)
+		}
+		for _, r := range rawReports {
+			t, _ := time.Parse(time.RFC3339, r.CreatedAt)
+			agentReports = append(agentReports, DashboardReport{
+				ID:            r.ID,
+				Title:         r.Title,
+				Body:          r.Body,
+				CreatedByName: r.CreatedByName,
+				CreatedAt:     relativeTime(t),
+			})
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Dashboard",
 			"CurrentPage":            "dashboard",
@@ -1079,6 +1103,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"Insights":              insights,
 			// Smart spending insights.
 			"SpendingInsights":      spendingInsights,
+			// Agent reports.
+			"AgentReports":          agentReports,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -16,6 +16,7 @@ const navBadgesKey contextKey = "navBadges"
 type NavBadges struct {
 	PendingReviews       int64
 	ConnectionsAttention int64
+	UnreadReports        int64
 }
 
 // NavBadgesMiddleware fetches sidebar notification badge counts and stores them
@@ -36,6 +37,12 @@ func NavBadgesMiddleware(queries *db.Queries, logger *slog.Logger) func(http.Han
 				badges.ConnectionsAttention = attn
 			} else {
 				logger.Debug("nav badges: count connections needing attention", "error", err)
+			}
+
+			if unread, err := queries.CountUnreadAgentReports(ctx); err == nil {
+				badges.UnreadReports = unread
+			} else {
+				logger.Debug("nav badges: count unread agent reports", "error", err)
 			}
 
 			ctx = context.WithValue(ctx, navBadgesKey, badges)

--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -1,0 +1,37 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// MarkReportReadAdminHandler handles POST /-/reports/{id}/read.
+func MarkReportReadAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.MarkAgentReportRead(r.Context(), id); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}
+}
+
+// MarkAllReportsReadAdminHandler handles POST /-/reports/read-all.
+func MarkAllReportsReadAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := svc.MarkAllAgentReportsRead(r.Context()); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -177,6 +177,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/account-links/{id}/reconcile", ReconcileAccountLinkAdminHandler(svc, sm))
 		r.Post("/transaction-matches/{id}/confirm", ConfirmMatchAdminHandler(svc, sm))
 		r.Post("/transaction-matches/{id}/reject", RejectMatchAdminHandler(svc, sm))
+
+		// Agent reports
+		r.Post("/reports/{id}/read", MarkReportReadAdminHandler(svc))
+		r.Post("/reports/read-all", MarkAllReportsReadAdminHandler(svc))
 	})
 
 	return r

--- a/internal/api/reports.go
+++ b/internal/api/reports.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ListReportsHandler handles GET /api/v1/reports.
+func ListReportsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		reports, err := svc.ListAgentReports(r.Context(), 50)
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list reports")
+			return
+		}
+		writeData(w, reports)
+	}
+}
+
+// UnreadReportCountHandler handles GET /api/v1/reports/unread-count.
+func UnreadReportCountHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		count, err := svc.CountUnreadAgentReports(r.Context())
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to count unread reports")
+			return
+		}
+		writeData(w, map[string]int64{"unread_count": count})
+	}
+}
+
+// CreateReportHandler handles POST /api/v1/reports.
+func CreateReportHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Title string `json:"title"`
+			Body  string `json:"body"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid JSON body")
+			return
+		}
+
+		actor := service.ActorFromContext(r.Context())
+		report, err := svc.CreateAgentReport(r.Context(), req.Title, req.Body, actor)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusCreated)
+		writeData(w, report)
+	}
+}
+
+// MarkReportReadHandler handles PATCH /api/v1/reports/{id}/read.
+func MarkReportReadHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.MarkAgentReportRead(r.Context(), id); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+		writeData(w, map[string]bool{"ok": true})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -67,6 +67,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/account-links", ListAccountLinksHandler(svc))
 		r.Get("/account-links/{id}", GetAccountLinkHandler(svc))
 		r.Get("/account-links/{id}/matches", ListTransactionMatchesHandler(svc))
+		r.Get("/reports", ListReportsHandler(svc))
+		r.Get("/reports/unread-count", UnreadReportCountHandler(svc))
 
 		// Write endpoints — full_access API keys only.
 		r.Group(func(r chi.Router) {
@@ -105,6 +107,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/transaction-matches/{id}/confirm", ConfirmMatchHandler(svc))
 			r.Post("/transaction-matches/{id}/reject", RejectMatchHandler(svc))
 			r.Post("/transaction-matches/manual", ManualMatchHandler(svc))
+			r.Post("/reports", CreateReportHandler(svc))
+			r.Patch("/reports/{id}/read", MarkReportReadHandler(svc))
 		})
 	})
 

--- a/internal/db/migrations/00028_agent_reports.sql
+++ b/internal/db/migrations/00028_agent_reports.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+CREATE TABLE agent_reports (
+    id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    title             TEXT        NOT NULL,
+    body              TEXT        NOT NULL,
+    created_by_type   TEXT        NOT NULL DEFAULT 'agent',
+    created_by_id     TEXT        NULL,
+    created_by_name   TEXT        NOT NULL DEFAULT 'Unknown',
+    read_at           TIMESTAMPTZ NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX agent_reports_unread_idx ON agent_reports (created_at DESC) WHERE read_at IS NULL;
+CREATE INDEX agent_reports_created_at_idx ON agent_reports (created_at DESC);
+
+-- +goose Down
+DROP TABLE IF EXISTS agent_reports;

--- a/internal/db/queries/agent_reports.sql
+++ b/internal/db/queries/agent_reports.sql
@@ -1,0 +1,22 @@
+-- name: CreateAgentReport :one
+INSERT INTO agent_reports (title, body, created_by_type, created_by_id, created_by_name)
+VALUES ($1, $2, $3, $4, $5)
+RETURNING *;
+
+-- name: GetAgentReport :one
+SELECT * FROM agent_reports WHERE id = $1;
+
+-- name: ListAgentReports :many
+SELECT * FROM agent_reports ORDER BY created_at DESC LIMIT $1;
+
+-- name: ListUnreadAgentReports :many
+SELECT * FROM agent_reports WHERE read_at IS NULL ORDER BY created_at DESC LIMIT $1;
+
+-- name: CountUnreadAgentReports :one
+SELECT COUNT(*) FROM agent_reports WHERE read_at IS NULL;
+
+-- name: MarkAgentReportRead :exec
+UPDATE agent_reports SET read_at = NOW() WHERE id = $1 AND read_at IS NULL;
+
+-- name: MarkAllAgentReportsRead :exec
+UPDATE agent_reports SET read_at = NOW() WHERE read_at IS NULL;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -91,7 +91,13 @@ RULE CREATION STRATEGY — follow this order:
 
 - ALWAYS check list_transaction_rules before creating to avoid duplicates
 - Use batch_create_rules to create multiple rules efficiently
-- Before creating rules, query some transactions to see what category_primary values exist — use query_transactions with fields=core,category`
+- Before creating rules, query some transactions to see what category_primary values exist — use query_transactions with fields=core,category
+
+AGENT REPORTS:
+- Use submit_report at the end of a review session to summarize what you did and flag anything needing human attention
+- The report title should be a short summary (e.g., "Weekly Review: 45 transactions categorized")
+- The body supports markdown. Reference specific transactions with links: [Transaction Name](/transactions/TRANSACTION_ID)
+- Reports appear on the family's dashboard — use them to communicate findings, flag suspicious transactions, or suggest actions`
 
 // ToolClassification indicates whether a tool is read-only or performs writes.
 type ToolClassification string
@@ -263,6 +269,9 @@ func (s *MCPServer) buildToolRegistry() {
 		makeToolDef("auto_approve_categorized_reviews", ToolWrite,
 			"Bulk-approve all pending reviews whose transactions already have a category (e.g., from rules). This bridges the gap between rules and reviews — after creating rules with apply_retroactively=true, call this to clear the review queue of transactions that rules already handled. Returns count of approved reviews and remaining pending count.",
 			s.handleAutoApproveCategorized),
+		makeToolDef("submit_report", ToolWrite,
+			"Submit a report to the family dashboard summarizing your work, flagging transactions, or raising issues. Reports appear in the dashboard for the family to review. Use this at the end of a review session to summarize what you did, what you found, and any items needing human attention. The body supports markdown — reference specific transactions with [Transaction Name](/transactions/TRANSACTION_ID) links so the family can click through to see details.",
+			s.handleSubmitReport),
 	}
 }
 

--- a/internal/mcp/templates.go
+++ b/internal/mcp/templates.go
@@ -36,7 +36,14 @@ Always use fields=triage on list_pending_reviews — it returns only the fields 
 categorization decisions and dramatically reduces response size.
 
 Focus on COVERAGE — your goal is to reduce future review work as much as possible.
-Prioritize rules that match the most transactions. Check list_transaction_rules before creating to avoid duplicates.`
+Prioritize rules that match the most transactions. Check list_transaction_rules before creating to avoid duplicates.
+
+WRAP-UP:
+When finished, call submit_report with a summary of what you did. Include:
+- How many transactions/reviews you processed
+- Rules you created and their expected coverage
+- Any transactions or patterns that need human attention (link them: [Name](/transactions/ID))
+- Remaining items you skipped or couldn't categorize`
 
 // RecurringReviewInstructions provides guidance for routine daily/weekly reviews.
 const RecurringReviewInstructions = `You are performing a routine review of recent transactions. Review pending transactions, categorize them, and create rules for any new patterns you notice.
@@ -50,7 +57,14 @@ STRATEGY:
 
 Focus on ACCURACY — take time to categorize correctly since there are fewer transactions.
 Create specific rules for new recurring merchants you encounter. Prefer contains over exact match for merchant names.
-Do NOT use apply_rules during routine reviews — rules are designed to match future transactions during sync. Retroactive application is a separate, deliberate action.`
+Do NOT use apply_rules during routine reviews — rules are designed to match future transactions during sync. Retroactive application is a separate, deliberate action.
+
+WRAP-UP:
+When finished, call submit_report with a brief summary. Include:
+- Number of reviews processed (approved/skipped)
+- Any new rules created
+- Transactions flagged for human attention (link them: [Name](/transactions/ID))
+- Anything unusual or noteworthy`
 
 // InstructionTemplate represents a pre-built instruction set.
 type InstructionTemplate struct {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1145,6 +1145,28 @@ func (s *MCPServer) handleBulkRecategorize(ctx context.Context, _ *mcpsdk.CallTo
 	return jsonResult(result)
 }
 
+// --- Agent Reports ---
+
+type submitReportInput struct {
+	Title string `json:"title" jsonschema:"required,Short title summarizing the report (e.g. 'Weekly Review Complete' or 'Suspicious Transactions Found')"`
+	Body  string `json:"body" jsonschema:"required,Detailed report content in markdown format. To reference specific transactions use markdown links: [Transaction Name](/transactions/TRANSACTION_ID). These will be rendered as clickable deep-links in the dashboard."`
+}
+
+func (s *MCPServer) handleSubmitReport(reqCtx context.Context, _ *mcpsdk.CallToolRequest, input submitReportInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+
+	if err := s.checkWritePermission(reqCtx); err != nil {
+		return errorResult(err), nil, nil
+	}
+
+	actor := service.ActorFromContext(reqCtx)
+	report, err := s.svc.CreateAgentReport(ctx, input.Title, input.Body, actor)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(report)
+}
+
 // --- Helpers ---
 
 // parseConditions converts a map[string]any (from MCP input) to a service.Condition.

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -1,0 +1,109 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// AgentReportResponse is the API response type for agent reports.
+type AgentReportResponse struct {
+	ID            string  `json:"id"`
+	Title         string  `json:"title"`
+	Body          string  `json:"body"`
+	CreatedByType string  `json:"created_by_type"`
+	CreatedByID   *string `json:"created_by_id"`
+	CreatedByName string  `json:"created_by_name"`
+	ReadAt        *string `json:"read_at"`
+	CreatedAt     string  `json:"created_at"`
+}
+
+func agentReportFromRow(r db.AgentReport) AgentReportResponse {
+	return AgentReportResponse{
+		ID:            formatUUID(r.ID),
+		Title:         r.Title,
+		Body:          r.Body,
+		CreatedByType: r.CreatedByType,
+		CreatedByID:   textPtr(r.CreatedByID),
+		CreatedByName: r.CreatedByName,
+		ReadAt:        timestampStr(r.ReadAt),
+		CreatedAt:     r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+// CreateAgentReport creates a new agent report.
+func (s *Service) CreateAgentReport(ctx context.Context, title, body string, actor Actor) (AgentReportResponse, error) {
+	if title == "" {
+		return AgentReportResponse{}, fmt.Errorf("%w: title is required", ErrInvalidParameter)
+	}
+	if body == "" {
+		return AgentReportResponse{}, fmt.Errorf("%w: body is required", ErrInvalidParameter)
+	}
+
+	report, err := s.Queries.CreateAgentReport(ctx, db.CreateAgentReportParams{
+		Title:         title,
+		Body:          body,
+		CreatedByType: actor.Type,
+		CreatedByID:   pgtype.Text{String: actor.ID, Valid: actor.ID != ""},
+		CreatedByName: actor.Name,
+	})
+	if err != nil {
+		return AgentReportResponse{}, fmt.Errorf("create agent report: %w", err)
+	}
+
+	return agentReportFromRow(report), nil
+}
+
+// ListAgentReports returns the most recent reports.
+func (s *Service) ListAgentReports(ctx context.Context, limit int) ([]AgentReportResponse, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	rows, err := s.Queries.ListAgentReports(ctx, int32(limit))
+	if err != nil {
+		return nil, fmt.Errorf("list agent reports: %w", err)
+	}
+	result := make([]AgentReportResponse, len(rows))
+	for i, r := range rows {
+		result[i] = agentReportFromRow(r)
+	}
+	return result, nil
+}
+
+// ListUnreadAgentReports returns unread reports.
+func (s *Service) ListUnreadAgentReports(ctx context.Context, limit int) ([]AgentReportResponse, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 10
+	}
+	rows, err := s.Queries.ListUnreadAgentReports(ctx, int32(limit))
+	if err != nil {
+		return nil, fmt.Errorf("list unread agent reports: %w", err)
+	}
+	result := make([]AgentReportResponse, len(rows))
+	for i, r := range rows {
+		result[i] = agentReportFromRow(r)
+	}
+	return result, nil
+}
+
+// CountUnreadAgentReports returns the count of unread reports.
+func (s *Service) CountUnreadAgentReports(ctx context.Context) (int64, error) {
+	return s.Queries.CountUnreadAgentReports(ctx)
+}
+
+// MarkAgentReportRead marks a single report as read.
+func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) error {
+	uid, err := parseUUID(reportID)
+	if err != nil {
+		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
+	}
+	return s.Queries.MarkAgentReportRead(ctx, uid)
+}
+
+// MarkAllAgentReportsRead marks all unread reports as read.
+func (s *Service) MarkAllAgentReportsRead(ctx context.Context) error {
+	return s.Queries.MarkAllAgentReportsRead(ctx)
+}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -306,6 +306,49 @@
 </div>
 {{end}}
 
+<!-- Agent Reports -->
+{{if .AgentReports}}
+<div class="bb-card mb-6 bb-stagger" x-data="agentReports()">
+  <div class="p-5">
+    <div class="flex items-center justify-between mb-3">
+      <div class="flex items-center gap-2">
+        <i data-lucide="bot" class="w-4 h-4 text-primary"></i>
+        <h2 class="text-sm font-semibold text-base-content/70">Agent Reports</h2>
+        <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary">{{len .AgentReports}} new</span>
+      </div>
+      <button class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors"
+        @click="markAllRead()">
+        Mark all read
+      </button>
+    </div>
+    <div class="space-y-3">
+      {{range .AgentReports}}
+      <div class="rounded-xl border border-base-300/60 p-4 transition-all duration-300"
+        :class="dismissed.has('{{.ID}}') ? 'opacity-0 scale-95 h-0 !p-0 !m-0 overflow-hidden border-0' : ''"
+        id="report-{{.ID}}">
+        <div class="flex items-start justify-between gap-3">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-1">
+              <span class="text-sm font-semibold">{{.Title}}</span>
+            </div>
+            <div class="flex items-center gap-2 text-xs text-base-content/40 mb-2">
+              <span>{{.CreatedByName}}</span>
+              <span>&middot;</span>
+              <span>{{.CreatedAt}}</span>
+            </div>
+            <div class="bb-report-body text-sm text-base-content/70 leading-relaxed" data-markdown="{{.Body}}"></div>
+          </div>
+          <button class="btn btn-ghost btn-xs shrink-0 rounded-lg" @click="markRead('{{.ID}}')" title="Dismiss">
+            <i data-lucide="check" class="w-3.5 h-3.5"></i>
+          </button>
+        </div>
+      </div>
+      {{end}}
+    </div>
+  </div>
+</div>
+{{end}}
+
 <!-- Recent Transactions + Connection Health -->
 <div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
   <!-- Recent Transactions -->
@@ -608,6 +651,58 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   });
 });
+</script>
+{{end}}
+
+<!-- Agent Reports: markdown rendering + dismiss logic -->
+{{if .AgentReports}}
+<script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  // Render markdown in report bodies.
+  document.querySelectorAll('.bb-report-body').forEach(function(el) {
+    var md = el.getAttribute('data-markdown');
+    if (md) {
+      el.innerHTML = marked.parse(md);
+      // Style rendered content.
+      el.querySelectorAll('a').forEach(function(a) {
+        a.classList.add('link', 'link-primary');
+        // Open external links in new tab, keep internal links in same tab.
+        if (a.href && !a.href.startsWith(window.location.origin) && !a.getAttribute('href').startsWith('/')) {
+          a.setAttribute('target', '_blank');
+          a.setAttribute('rel', 'noopener');
+        }
+      });
+      el.querySelectorAll('ul, ol').forEach(function(list) {
+        list.classList.add('list-disc', 'pl-4', 'space-y-0.5');
+      });
+      el.querySelectorAll('p').forEach(function(p) {
+        p.classList.add('mb-1');
+      });
+      el.querySelectorAll('strong').forEach(function(s) {
+        s.classList.add('text-base-content');
+      });
+    }
+  });
+});
+
+function agentReports() {
+  return {
+    dismissed: new Set(),
+    markRead(id) {
+      this.dismissed.add(id);
+      fetch('/-/reports/' + id + '/read', { method: 'POST' });
+    },
+    markAllRead() {
+      var self = this;
+      document.querySelectorAll('[id^="report-"]').forEach(function(el) {
+        var id = el.id.replace('report-', '');
+        self.dismissed.add(id);
+      });
+      fetch('/-/reports/read-all', { method: 'POST' });
+    }
+  };
+}
 </script>
 {{end}}
 

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -2,7 +2,11 @@
 <nav class="bb-sidebar-nav">
   <div class="bb-sidebar-section">Data</div>
   <a href="/" class="bb-sidebar-link{{if eq .CurrentPage "dashboard"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="layout-dashboard"></i> Dashboard
+    <i data-lucide="layout-dashboard"></i>
+    <span class="flex-1">Dashboard</span>
+    {{if and .NavBadges (gt .NavBadges.UnreadReports 0)}}
+    <span class="bb-nav-badge">{{.NavBadges.UnreadReports}}</span>
+    {{end}}
   </a>
   <a href="/insights" class="bb-sidebar-link{{if eq .CurrentPage "insights"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="lightbulb"></i> Insights


### PR DESCRIPTION
## Summary

- Agents can submit reports via `submit_report` MCP tool after review sessions — summarizing work done, flagging transactions, or raising issues
- Reports appear as a card on the admin dashboard with full markdown rendering (marked.js CDN) and clickable transaction deep-links (`[Name](/transactions/ID)`)
- Nav badge shows unread report count; dismiss individual reports or mark all read

## Changes

**Database:**
- New `agent_reports` table (migration 00028) with title, markdown body, actor tracking, read_at

**MCP:**
- `submit_report` tool (ToolWrite) with title + markdown body
- Added `AGENT REPORTS` section to built-in instructions
- Updated `InitialReviewInstructions` and `RecurringReviewInstructions` with wrap-up guidance

**REST API:**
- `GET /api/v1/reports` — list recent reports
- `POST /api/v1/reports` — create a report
- `GET /api/v1/reports/unread-count` — unread count
- `PATCH /api/v1/reports/{id}/read` — mark as read

**Dashboard:**
- Agent Reports card showing unread reports with markdown body
- Fade-out animation on dismiss via Alpine.js
- Transaction links rendered as clickable deep-links

**Admin API:**
- `POST /-/reports/{id}/read` — mark single report read
- `POST /-/reports/read-all` — mark all reports read

## Test plan

- [ ] Run `sqlc generate` and `go build ./...` — clean
- [ ] Run `go test ./...` — all pass
- [ ] Verify migration applies cleanly on fresh DB
- [ ] Create a report via MCP tool, confirm it appears on dashboard
- [ ] Click transaction links in report body, confirm navigation
- [ ] Mark report read, confirm it disappears from widget
- [ ] Check nav badge updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)