### PR TITLE
Fix income amounts showing red instead of green

### DIFF
--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -279,7 +279,7 @@
             <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors no-underline">{{.Name}}</a>
             {{if .MerchantName}}<span class="text-xs text-base-content/40 ml-1">{{.MerchantName}}</span>{{end}}
           </td>
-          <td class="text-right tabular-nums text-sm font-semibold{{if lt .Amount 0.0}} text-error{{end}}">
+          <td class="text-right tabular-nums text-sm font-semibold{{if lt .Amount 0.0}} text-success{{end}}">
             {{formatAmount .Amount}}
           </td>
           <td @click.stop>

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -309,7 +309,7 @@
 
         <!-- Amount -->
         <div class="bb-triage-row__amount">
-          <span class="text-sm font-semibold tabular-nums{{if lt $review.Transaction.Amount 0.0}} text-error{{end}}">
+          <span class="text-sm font-semibold tabular-nums{{if lt $review.Transaction.Amount 0.0}} text-success{{end}}">
             {{formatAmount $review.Transaction.Amount}}
           </span>
         </div>
@@ -385,7 +385,7 @@
               </div>
               <div>
                 <span class="text-base-content/40">Amount</span>
-                <div class="font-medium tabular-nums{{if lt $review.Transaction.Amount 0.0}} text-error{{end}}">{{formatAmount $review.Transaction.Amount}}</div>
+                <div class="font-medium tabular-nums{{if lt $review.Transaction.Amount 0.0}} text-success{{end}}">{{formatAmount $review.Transaction.Amount}}</div>
               </div>
             </div>
             {{if $review.Transaction.CategoryPrimaryRaw}}

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -6,8 +6,8 @@
 <!-- Hero: Transaction name + amount -->
 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
   <div class="flex items-center gap-4">
-    <div class="w-12 h-12 rounded-xl {{if lt .Transaction.Amount 0.0}}bg-error/10{{else}}bg-success/10{{end}} flex items-center justify-center shrink-0">
-      <i data-lucide="{{if lt .Transaction.Amount 0.0}}arrow-up-right{{else}}arrow-down-left{{end}}" class="w-6 h-6 {{if lt .Transaction.Amount 0.0}}text-error{{else}}text-success{{end}}"></i>
+    <div class="w-12 h-12 rounded-xl {{if lt .Transaction.Amount 0.0}}bg-success/10{{else}}bg-error/10{{end}} flex items-center justify-center shrink-0">
+      <i data-lucide="{{if lt .Transaction.Amount 0.0}}arrow-down-left{{else}}arrow-up-right{{end}}" class="w-6 h-6 {{if lt .Transaction.Amount 0.0}}text-success{{else}}text-error{{end}}"></i>
     </div>
     <div>
       <h1 class="bb-page-title">{{.Transaction.Name}}</h1>
@@ -22,7 +22,7 @@
     </div>
   </div>
   <div class="text-right sm:text-right">
-    <p class="text-3xl font-semibold tabular-nums{{if lt .Transaction.Amount 0.0}} text-error{{end}}">
+    <p class="text-3xl font-semibold tabular-nums{{if lt .Transaction.Amount 0.0}} text-success{{end}}">
       {{formatAmount .Transaction.Amount}}
     </p>
     {{if .Transaction.IsoCurrencyCode}}<p class="text-xs text-base-content/30 mt-0.5">{{deref .Transaction.IsoCurrencyCode}}</p>{{end}}


### PR DESCRIPTION
## Summary
- Fixed negative/income amounts displaying in red (`text-error`) instead of green (`text-success`) across transaction detail, reviews, and account detail pages
- Swapped the transaction detail icon and background colors which were inverted (income showed error styling, expenses showed success styling)

## Test plan
- [ ] Open a transaction detail page for an income transaction — amount should be green, icon should be `arrow-down-left` with green background
- [ ] Open a transaction detail page for an expense — amount should be default color, icon should be `arrow-up-right` with red background
- [ ] Check review queue triage view — income amounts should be green
- [ ] Check account detail transactions table — income amounts should be green

🤖 Generated with [Claude Code](https://claude.com/claude-code)