### PR TITLE
Add pending review indicator dot to transaction rows

### DIFF
--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -411,6 +411,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, " +
 		"EXISTS(SELECT 1 FROM review_queue rq WHERE rq.transaction_id = t.id AND rq.reviewer_type = 'agent' AND rq.status IN ('approved', 'rejected')) AS agent_reviewed, " +
+		"EXISTS(SELECT 1 FROM review_queue rq WHERE rq.transaction_id = t.id AND rq.status = 'pending') AS has_pending_review, " +
 		"t.created_at, t.updated_at "
 	fromClause := "FROM transactions t " +
 		"LEFT JOIN accounts a ON t.account_id = a.id " +
@@ -612,6 +613,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			categoryOverride bool
 			pending          bool
 			agentReviewed    bool
+			hasPendingReview bool
 			createdAt        pgtype.Timestamptz
 			updatedAt        pgtype.Timestamptz
 		)
@@ -621,7 +623,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			&institutionName, &userName,
 			&date, &name, &merchantName, &amount, &isoCurrencyCode,
 			&categoryID, &catDisplayName, &catSlug, &catIcon, &catColor,
-			&categoryOverride, &pending, &agentReviewed, &createdAt, &updatedAt,
+			&categoryOverride, &pending, &agentReviewed, &hasPendingReview, &createdAt, &updatedAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan admin transaction: %w", err)
 		}
@@ -661,6 +663,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			CategoryOverride:    categoryOverride,
 			Pending:             pending,
 			AgentReviewed:       agentReviewed,
+			HasPendingReview:    hasPendingReview,
 			CreatedAt:           createdAt.Time.UTC().Format(time.RFC3339),
 			UpdatedAt:           updatedAt.Time.UTC().Format(time.RFC3339),
 		})

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -234,6 +234,7 @@ type AdminTransactionRow struct {
 	CategoryOverride    bool
 	Pending             bool
 	AgentReviewed       bool
+	HasPendingReview    bool
 	CreatedAt           string
 	UpdatedAt           string
 }

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -276,8 +276,13 @@
         <tr @click="expanded = !expanded" class="cursor-pointer hover:bg-base-200/40 transition-colors duration-150">
           <td class="text-sm text-base-content/60 whitespace-nowrap">{{formatDate .Date}}</td>
           <td>
-            <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors no-underline">{{.Name}}</a>
-            {{if .MerchantName}}<span class="text-xs text-base-content/40 ml-1">{{.MerchantName}}</span>{{end}}
+            <div class="flex items-center gap-2">
+              {{if .HasPendingReview}}<span class="inline-block w-2 h-2 rounded-full bg-info shrink-0" title="Pending review"></span>{{end}}
+              <span>
+                <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors no-underline">{{.Name}}</a>
+                {{if .MerchantName}}<span class="text-xs text-base-content/40 ml-1">{{.MerchantName}}</span>{{end}}
+              </span>
+            </div>
           </td>
           <td class="text-right tabular-nums text-sm font-semibold{{if lt .Amount 0.0}} text-error{{end}}">
             {{formatAmount .Amount}}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -319,6 +319,7 @@
       {{range .RecentTransactions}}
       <a href="/transactions/{{.ID}}" class="flex items-center justify-between py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
         <div class="flex items-center gap-3 min-w-0">
+          {{if .HasPendingReview}}<span class="inline-block w-2 h-2 rounded-full bg-info shrink-0" title="Pending review"></span>{{end}}
           {{if .CategoryIcon}}
           <div class="bb-tx-avatar bb-tx-avatar--sm" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
             <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5"></i>

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -504,6 +504,9 @@ function quickSetCategory(txId, categoryId) {
         @change="$store.bulk.toggle('{{.ID}}')">
     </label>
 
+    <!-- Pending Review Indicator -->
+    {{if .HasPendingReview}}<span class="inline-block w-2 h-2 rounded-full bg-info shrink-0" title="Pending review"></span>{{end}}
+
     <!-- Category Icon / Merchant Avatar -->
     {{if .CategoryIcon}}
     <div class="bb-tx-avatar" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">


### PR DESCRIPTION
## Summary
- Added a small blue dot (`bg-info`, 8px) to the left of transaction rows that have a pending review in the queue
- Added `has_pending_review` EXISTS subquery to `ListTransactionsAdmin` (mirrors the existing `agent_reviewed` pattern)
- Indicator appears on transactions list, dashboard recent transactions, and account detail pages

## Test plan
- [ ] Ensure some transactions have pending reviews in the queue
- [ ] Check the transactions list page — those transactions should show a small blue dot on the left
- [ ] Check the dashboard recent transactions — same blue dot
- [ ] Check account detail page — same blue dot
- [ ] Transactions without pending reviews should NOT have the dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)