### PR TITLE
Add merchant analysis and day-of-week spending to Insights

### DIFF
--- a/internal/admin/insights.go
+++ b/internal/admin/insights.go
@@ -498,6 +498,137 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			spendingInsights = spendingInsights[:5]
 		}
 
+		// ── Top Merchants Analysis ──
+		type MerchantSpend struct {
+			Name      string
+			Category  string
+			Total     float64
+			Count     int
+			AvgAmount float64
+			Percent   float64
+		}
+		var topMerchants []MerchantSpend
+		var maxMerchantSpend float64
+
+		merchantRows, err := a.DB.Query(ctx, `
+			SELECT
+				COALESCE(NULLIF(merchant_name, ''), name) AS merchant,
+				COUNT(*)::int AS tx_count,
+				SUM(amount) AS total,
+				AVG(amount) AS avg_amount,
+				MODE() WITHIN GROUP (ORDER BY COALESCE(category_primary, '')) AS top_category
+			FROM transactions
+			WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
+			GROUP BY COALESCE(NULLIF(merchant_name, ''), name)
+			ORDER BY SUM(amount) DESC
+			LIMIT 10
+		`, chartStart)
+		if err != nil {
+			a.Logger.Error("top merchants query", "error", err)
+		} else {
+			defer merchantRows.Close()
+			for merchantRows.Next() {
+				var m MerchantSpend
+				var cat *string
+				if err := merchantRows.Scan(&m.Name, &m.Count, &m.Total, &m.AvgAmount, &cat); err != nil {
+					a.Logger.Error("top merchants scan", "error", err)
+					continue
+				}
+				if cat != nil && *cat != "" {
+					m.Category = *cat
+				}
+				topMerchants = append(topMerchants, m)
+				if m.Total > maxMerchantSpend {
+					maxMerchantSpend = m.Total
+				}
+			}
+			merchantRows.Close()
+		}
+
+		// Compute merchant bar percentages relative to max.
+		if len(topMerchants) > 0 && maxMerchantSpend > 0 {
+			for i := range topMerchants {
+				topMerchants[i].Percent = (topMerchants[i].Total / maxMerchantSpend) * 100
+			}
+		}
+
+		// ── Day-of-Week Spending Pattern ──
+		type DayOfWeekSpend struct {
+			DayShort  string  // "Mon", "Tue", etc.
+			DayFull   string  // "Monday", "Tuesday", etc.
+			Total     float64
+			Count     int
+			Intensity float64 // 0-1 for heatmap coloring
+		}
+		dowSpending := make([]DayOfWeekSpend, 7)
+		dayNames := []string{"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"}
+		dayFullNames := []string{"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"}
+		for i := range dowSpending {
+			dowSpending[i].DayShort = dayNames[i]
+			dowSpending[i].DayFull = dayFullNames[i]
+		}
+
+		var maxDaySpend float64
+		dowRows, err := a.DB.Query(ctx, `
+			SELECT
+				EXTRACT(ISODOW FROM date)::int AS dow,
+				SUM(amount) AS total,
+				COUNT(*)::int AS tx_count
+			FROM transactions
+			WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
+			GROUP BY EXTRACT(ISODOW FROM date)::int
+			ORDER BY dow
+		`, chartStart)
+		if err != nil {
+			a.Logger.Error("day-of-week query", "error", err)
+		} else {
+			defer dowRows.Close()
+			for dowRows.Next() {
+				var dow int
+				var total float64
+				var count int
+				if err := dowRows.Scan(&dow, &total, &count); err != nil {
+					continue
+				}
+				// ISODOW: 1=Mon, 7=Sun
+				idx := dow - 1
+				if idx >= 0 && idx < 7 {
+					dowSpending[idx].Total = total
+					dowSpending[idx].Count = count
+					if total > maxDaySpend {
+						maxDaySpend = total
+					}
+				}
+			}
+			dowRows.Close()
+		}
+		hasDOWData := maxDaySpend > 0
+		if hasDOWData {
+			for i := range dowSpending {
+				if dowSpending[i].Total > 0 {
+					dowSpending[i].Intensity = dowSpending[i].Total / maxDaySpend
+				}
+			}
+		}
+
+		// Find highest and lowest spending days.
+		var highSpendDay, lowSpendDay string
+		var highSpendDayAmt float64
+		lowSpendDayAmt := math.MaxFloat64
+		for _, d := range dowSpending {
+			if d.Total > highSpendDayAmt {
+				highSpendDayAmt = d.Total
+				highSpendDay = d.DayFull
+			}
+			if d.Total > 0 && d.Total < lowSpendDayAmt {
+				lowSpendDayAmt = d.Total
+				lowSpendDay = d.DayFull
+			}
+		}
+		if lowSpendDayAmt == math.MaxFloat64 {
+			lowSpendDayAmt = 0
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Insights",
 			"CurrentPage":            "insights",
@@ -541,6 +672,15 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			"LastMonthName":          lastMonthStart.Format("January"),
 			// Smart spending insights.
 			"SpendingInsights":       spendingInsights,
+			// Merchant analysis.
+			"TopMerchants":           topMerchants,
+			// Day-of-week spending.
+			"DOWSpending":            dowSpending,
+			"HasDOWData":             hasDOWData,
+			"HighSpendDay":           highSpendDay,
+			"LowSpendDay":            lowSpendDay,
+			"HighSpendDayAmt":        highSpendDayAmt,
+			"LowSpendDayAmt":         lowSpendDayAmt,
 		}
 		tr.Render(w, r, "insights.html", data)
 	}

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -372,6 +372,126 @@
   </div>
 </div>
 
+<!-- Merchant Analysis + Day-of-Week Heatmap -->
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6 bb-stagger">
+  <!-- Top Merchants -->
+  {{if .TopMerchants}}
+  <div class="bb-card lg:col-span-2 p-5">
+    <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center gap-2.5">
+        <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-base-200/60">
+          <i data-lucide="store" class="w-3.5 h-3.5 text-base-content/50"></i>
+        </div>
+        <h2 class="text-sm font-semibold text-base-content/70">Top Merchants</h2>
+      </div>
+      <span class="text-xs text-base-content/30">by total spend</span>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="w-full">
+        <thead>
+          <tr class="text-[0.65rem] uppercase tracking-wider text-base-content/30 border-b border-base-200/60">
+            <th class="text-left py-2 font-medium">Merchant</th>
+            <th class="text-right py-2 font-medium w-20">Total</th>
+            <th class="text-right py-2 font-medium w-12 hidden sm:table-cell">Txns</th>
+            <th class="text-right py-2 font-medium w-16 hidden sm:table-cell">Avg</th>
+            <th class="text-left py-2 font-medium w-28 pl-3 hidden md:table-cell"></th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-base-200/40">
+          {{range $i, $m := .TopMerchants}}
+          <tr class="group hover:bg-base-200/20 transition-colors">
+            <td class="py-2.5 pr-3">
+              <div class="flex items-center gap-2.5">
+                <span class="flex items-center justify-center w-6 h-6 rounded-md bg-base-200/50 text-[0.6rem] font-semibold text-base-content/35 shrink-0 tabular-nums">{{add $i 1}}</span>
+                <div class="min-w-0">
+                  <div class="text-sm font-medium text-base-content/80 truncate group-hover:text-base-content transition-colors">{{$m.Name}}</div>
+                  {{if $m.Category}}<div class="text-[0.6rem] text-base-content/30 truncate">{{$m.Category}}</div>{{end}}
+                </div>
+              </div>
+            </td>
+            <td class="py-2.5 text-right">
+              <span class="text-sm font-semibold tabular-nums text-base-content/80">{{formatAmount $m.Total}}</span>
+            </td>
+            <td class="py-2.5 text-right hidden sm:table-cell">
+              <span class="text-xs tabular-nums text-base-content/40">{{$m.Count}}</span>
+            </td>
+            <td class="py-2.5 text-right hidden sm:table-cell">
+              <span class="text-xs tabular-nums text-base-content/40">{{formatAmount $m.AvgAmount}}</span>
+            </td>
+            <td class="py-2.5 pl-3 hidden md:table-cell">
+              <div class="w-full h-1.5 bg-base-200/50 rounded-full overflow-hidden">
+                <div class="h-full rounded-full transition-all duration-500 ease-out bg-base-content/12 group-hover:bg-base-content/20"
+                  style="width: {{printf "%.1f" $m.Percent}}%;"></div>
+              </div>
+            </td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {{end}}
+
+  <!-- Day-of-Week Spending Heatmap -->
+  {{if .HasDOWData}}
+  <div class="bb-card p-5">
+    <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center gap-2.5">
+        <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-base-200/60">
+          <i data-lucide="calendar-days" class="w-3.5 h-3.5 text-base-content/50"></i>
+        </div>
+        <h2 class="text-sm font-semibold text-base-content/70">Spending by Day</h2>
+      </div>
+    </div>
+    <div class="space-y-2">
+      {{range .DOWSpending}}
+      <div class="group flex items-center gap-3">
+        <span class="text-[0.65rem] font-medium text-base-content/40 w-7 shrink-0">{{.DayShort}}</span>
+        <div class="flex-1 relative">
+          <div class="w-full h-7 rounded-md transition-all duration-300 flex items-center"
+            style="background-color: oklch(0.55 0.12 250 / {{if gt .Intensity 0.0}}{{printf "%.2f" (mulf .Intensity 0.45)}}{{else}}0.03{{end}});">
+            {{if gt .Total 0.0}}
+            <span class="text-[0.6rem] font-semibold tabular-nums text-base-content/60 pl-2.5 opacity-0 group-hover:opacity-100 transition-opacity">
+              {{formatAmount .Total}}
+            </span>
+            {{end}}
+          </div>
+        </div>
+        <div class="text-right shrink-0 w-12">
+          {{if gt .Count 0}}
+          <div class="text-xs font-semibold tabular-nums text-base-content/50">{{.Count}}</div>
+          <div class="text-[0.55rem] text-base-content/25">txns</div>
+          {{else}}
+          <div class="text-xs text-base-content/20">&mdash;</div>
+          {{end}}
+        </div>
+      </div>
+      {{end}}
+    </div>
+    <!-- Insight text -->
+    {{if .HighSpendDay}}
+    <div class="mt-4 pt-3 border-t border-base-200/60">
+      <p class="text-[0.65rem] text-base-content/35 leading-relaxed">
+        You spend the most on <span class="font-semibold text-base-content/50">{{.HighSpendDay}}s</span> ({{formatAmount .HighSpendDayAmt}}){{if .LowSpendDay}} and least on <span class="font-semibold text-base-content/50">{{.LowSpendDay}}s</span> ({{formatAmount .LowSpendDayAmt}}){{end}}.
+      </p>
+    </div>
+    {{end}}
+    <!-- Legend -->
+    <div class="mt-3 pt-3 border-t border-base-200/60 flex items-center justify-between">
+      <span class="text-[0.6rem] text-base-content/25">Less</span>
+      <div class="flex items-center gap-1">
+        <div class="w-4 h-3 rounded-sm" style="background-color: oklch(0.55 0.12 250 / 0.05);"></div>
+        <div class="w-4 h-3 rounded-sm" style="background-color: oklch(0.55 0.12 250 / 0.12);"></div>
+        <div class="w-4 h-3 rounded-sm" style="background-color: oklch(0.55 0.12 250 / 0.22);"></div>
+        <div class="w-4 h-3 rounded-sm" style="background-color: oklch(0.55 0.12 250 / 0.33);"></div>
+        <div class="w-4 h-3 rounded-sm" style="background-color: oklch(0.55 0.12 250 / 0.45);"></div>
+      </div>
+      <span class="text-[0.6rem] text-base-content/25">More</span>
+    </div>
+  </div>
+  {{end}}
+</div>
+
 <!-- Smart Spending Insights -->
 {{if .SpendingInsights}}
 <div class="bb-card mb-6 p-5 bb-stagger">


### PR DESCRIPTION
## Summary
- Adds **Top Merchants** table to the Insights page showing the top 10 merchants by total spend, with category name, transaction count, average transaction size, and relative spend bar
- Adds **Spending by Day** heatmap showing spending intensity by day of week (Mon-Sun) with transaction counts, a color-intensity legend, and natural language insight text ("You spend the most on Saturdays...")
- Both sections respond to the existing date range picker (7d/30d/90d/12m)

## Screenshots

![insights-merchants-overview](https://i.img402.dev/s74y6aozeu.png)

![insights-merchants-detail](https://i.img402.dev/chtemuuefi.png)

## Files changed
- `internal/admin/insights.go` — Added two new DB queries (top merchants with MODE() category, day-of-week ISODOW aggregation) and high/low spend day analysis
- `internal/templates/pages/insights.html` — Added merchant table and DOW heatmap sections with insight text

## Test plan
- [x] Page loads without template errors on all date ranges (7d, 30d, 90d, 12m)
- [x] Merchant table shows rank, name, category, total, count, avg, progress bar
- [x] DOW heatmap shows correct day ordering (Mon-Sun) with intensity coloring
- [x] Insight text shows highest/lowest spend days with amounts
- [x] `go build ./...` passes
- [x] Chrome MCP verified all sections render with real data

Refs #150

🤖 Generated by autonomous UX improvement agent