### PR TITLE
Add recurring subscriptions tracker to Insights

### DIFF
--- a/internal/admin/insights.go
+++ b/internal/admin/insights.go
@@ -629,6 +629,109 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			lowSpendDayAmt = 0
 		}
 
+		// ── Recurring / Subscription Detection ──
+		// Find merchants with 2+ transactions at consistent amounts over 90 days.
+		type RecurringCharge struct {
+			Name           string
+			Category       string
+			Amount         float64
+			Frequency      string
+			TxCount        int
+			TotalSpent     float64
+			LastChargeDate string
+			MonthlyEst     float64
+		}
+		var recurringCharges []RecurringCharge
+		var totalRecurringMonthly float64
+		var hasRecurringData bool
+
+		recurringLookback := time.Now().AddDate(0, 0, -90)
+		recurringRows, err := a.DB.Query(ctx, `
+			WITH merchant_stats AS (
+				SELECT
+					COALESCE(NULLIF(merchant_name, ''), name) AS merchant,
+					MODE() WITHIN GROUP (ORDER BY amount) AS typical_amount,
+					MODE() WITHIN GROUP (ORDER BY COALESCE(category_primary, '')) AS top_category,
+					COUNT(*) AS tx_count,
+					SUM(amount) AS total_spent,
+					MAX(date) AS last_date,
+					MIN(date) AS first_date,
+					CASE WHEN AVG(amount) > 0 THEN COALESCE(STDDEV(amount), 0) / AVG(amount) ELSE 1 END AS cv
+				FROM transactions
+				WHERE deleted_at IS NULL
+					AND date >= $1
+					AND amount > 0
+					AND pending = false
+				GROUP BY COALESCE(NULLIF(merchant_name, ''), name)
+				HAVING COUNT(*) >= 2
+			)
+			SELECT
+				merchant,
+				typical_amount,
+				top_category,
+				tx_count,
+				total_spent,
+				TO_CHAR(last_date, 'Mon DD') AS last_charge,
+				(last_date - first_date)::float / NULLIF(tx_count - 1, 0) AS avg_days_between,
+				cv
+			FROM merchant_stats
+			WHERE cv < 0.3
+				AND typical_amount >= 3
+			ORDER BY total_spent DESC
+			LIMIT 12
+		`, recurringLookback)
+		if err != nil {
+			a.Logger.Error("recurring charges query", "error", err)
+		} else {
+			defer recurringRows.Close()
+			for recurringRows.Next() {
+				var rc RecurringCharge
+				var cat *string
+				var avgDaysBetween *float64
+				var cv float64
+				if err := recurringRows.Scan(&rc.Name, &rc.Amount, &cat, &rc.TxCount, &rc.TotalSpent, &rc.LastChargeDate, &avgDaysBetween, &cv); err != nil {
+					a.Logger.Error("recurring charges scan", "error", err)
+					continue
+				}
+				if cat != nil && *cat != "" {
+					rc.Category = *cat
+				}
+				if avgDaysBetween != nil && *avgDaysBetween > 0 {
+					days := *avgDaysBetween
+					switch {
+					case days >= 25 && days <= 35:
+						rc.Frequency = "monthly"
+						rc.MonthlyEst = rc.Amount
+					case days >= 12 && days <= 18:
+						rc.Frequency = "biweekly"
+						rc.MonthlyEst = rc.Amount * 2
+					case days >= 5 && days <= 9:
+						rc.Frequency = "weekly"
+						rc.MonthlyEst = rc.Amount * 4.33
+					case days >= 55 && days <= 65:
+						rc.Frequency = "bimonthly"
+						rc.MonthlyEst = rc.Amount / 2
+					case days >= 80 && days <= 100:
+						rc.Frequency = "quarterly"
+						rc.MonthlyEst = rc.Amount / 3
+					case days >= 350 && days <= 380:
+						rc.Frequency = "yearly"
+						rc.MonthlyEst = rc.Amount / 12
+					default:
+						rc.Frequency = "recurring"
+						rc.MonthlyEst = rc.TotalSpent / 3
+					}
+				} else {
+					rc.Frequency = "recurring"
+					rc.MonthlyEst = rc.TotalSpent / 3
+				}
+				totalRecurringMonthly += rc.MonthlyEst
+				recurringCharges = append(recurringCharges, rc)
+			}
+			recurringRows.Close()
+			hasRecurringData = len(recurringCharges) > 0
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Insights",
 			"CurrentPage":            "insights",
@@ -681,6 +784,10 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			"LowSpendDay":            lowSpendDay,
 			"HighSpendDayAmt":        highSpendDayAmt,
 			"LowSpendDayAmt":         lowSpendDayAmt,
+			// Recurring charges.
+			"RecurringCharges":       recurringCharges,
+			"HasRecurringData":       hasRecurringData,
+			"TotalRecurringMonthly":  totalRecurringMonthly,
 		}
 		tr.Render(w, r, "insights.html", data)
 	}

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -492,6 +492,89 @@
   {{end}}
 </div>
 
+<!-- Recurring & Subscriptions -->
+{{if .HasRecurringData}}
+<div class="bb-card mb-6 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-2.5">
+      <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-warning/8">
+        <i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-warning"></i>
+      </div>
+      <div>
+        <h2 class="text-sm font-semibold text-base-content/70">Recurring & Subscriptions</h2>
+        <p class="text-[0.6rem] text-base-content/30 mt-0.5">Detected from 90-day transaction patterns</p>
+      </div>
+    </div>
+    <div class="text-right">
+      <div class="text-xs text-base-content/35">Est. monthly</div>
+      <div class="text-lg font-semibold tabular-nums text-base-content/80">{{formatBalance .TotalRecurringMonthly}}</div>
+    </div>
+  </div>
+
+  <!-- Recurring charges grid -->
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2.5">
+    {{range .RecurringCharges}}
+    <div class="group flex items-center gap-3 p-3 rounded-xl border border-base-200/60 bg-base-200/10 hover:bg-base-200/30 hover:border-base-300/60 transition-all duration-200">
+      <!-- Frequency icon -->
+      <div class="flex items-center justify-center w-9 h-9 rounded-lg shrink-0
+        {{if eq .Frequency "monthly"}}bg-primary/8
+        {{else if eq .Frequency "weekly"}}bg-warning/8
+        {{else if eq .Frequency "biweekly"}}bg-info/8
+        {{else}}bg-base-200/60{{end}}">
+        <i data-lucide="{{if eq .Frequency "monthly"}}calendar{{else if eq .Frequency "weekly"}}calendar-clock{{else if eq .Frequency "biweekly"}}calendar-range{{else if eq .Frequency "quarterly"}}calendar-check{{else if eq .Frequency "yearly"}}calendar-heart{{else}}repeat{{end}}"
+          class="w-4 h-4
+          {{if eq .Frequency "monthly"}}text-primary/60
+          {{else if eq .Frequency "weekly"}}text-warning/60
+          {{else if eq .Frequency "biweekly"}}text-info/60
+          {{else}}text-base-content/35{{end}}"></i>
+      </div>
+      <!-- Details -->
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center justify-between gap-2">
+          <span class="text-sm font-medium text-base-content/80 truncate group-hover:text-base-content transition-colors">{{.Name}}</span>
+          <span class="text-sm font-semibold tabular-nums text-base-content/80 shrink-0">{{formatAmount .Amount}}</span>
+        </div>
+        <div class="flex items-center justify-between gap-2 mt-0.5">
+          <div class="flex items-center gap-1.5">
+            <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full
+              {{if eq .Frequency "monthly"}}bg-primary/8 text-primary/70
+              {{else if eq .Frequency "weekly"}}bg-warning/8 text-warning/70
+              {{else if eq .Frequency "biweekly"}}bg-info/8 text-info/70
+              {{else}}bg-base-200/80 text-base-content/40{{end}}">{{.Frequency}}</span>
+            {{if .Category}}<span class="text-[0.6rem] text-base-content/25 truncate">{{.Category}}</span>{{end}}
+          </div>
+          <span class="text-[0.6rem] text-base-content/30">{{.TxCount}}x &middot; last {{.LastChargeDate}}</span>
+        </div>
+      </div>
+    </div>
+    {{end}}
+  </div>
+
+  <!-- Summary footer -->
+  <div class="mt-4 pt-3 border-t border-base-200/60 flex items-center justify-between">
+    <div class="flex items-center gap-4">
+      <div class="flex items-center gap-1.5">
+        <span class="w-2 h-2 rounded-full bg-primary/40"></span>
+        <span class="text-[0.6rem] text-base-content/30">monthly</span>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <span class="w-2 h-2 rounded-full bg-warning/40"></span>
+        <span class="text-[0.6rem] text-base-content/30">weekly</span>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <span class="w-2 h-2 rounded-full bg-info/40"></span>
+        <span class="text-[0.6rem] text-base-content/30">biweekly</span>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <span class="w-2 h-2 rounded-full bg-base-content/20"></span>
+        <span class="text-[0.6rem] text-base-content/30">other</span>
+      </div>
+    </div>
+    <span class="text-[0.6rem] text-base-content/25">{{len .RecurringCharges}} recurring charges detected</span>
+  </div>
+</div>
+{{end}}
+
 <!-- Smart Spending Insights -->
 {{if .SpendingInsights}}
 <div class="bb-card mb-6 p-5 bb-stagger">


### PR DESCRIPTION
## Summary
- Adds a **Recurring & Subscriptions** section to the Insights page that automatically detects likely recurring charges from 90-day transaction patterns
- Uses coefficient of variation (< 0.3) to find merchants with consistent payment amounts, then classifies frequency (weekly, biweekly, monthly, quarterly, yearly)
- Shows each recurring charge with merchant name, amount, frequency badge, category, transaction count, last charge date, and an estimated total monthly recurring cost

## How it works
- Queries transactions over 90 days (independent of date range picker) for better pattern detection
- Groups by merchant, computes amount consistency via stddev/avg ratio
- Calculates average days between charges to determine frequency
- Estimates monthly cost based on detected frequency (e.g., weekly x 4.33, quarterly / 3)

## Screenshots
![Recurring subscriptions section](https://i.img402.dev/5elsox3jfw.png)
![Centered view](https://i.img402.dev/ns1ny6dlp4.png)

Relates to #150

🤖 Generated by autonomous UX improvement agent