### PR TITLE
Add monthly category comparison table to Insights

### DIFF
--- a/internal/admin/insights.go
+++ b/internal/admin/insights.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"math"
 	"net/http"
+	"sort"
 	"time"
 
 	"breadbox/internal/app"
@@ -732,6 +733,143 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			hasRecurringData = len(recurringCharges) > 0
 		}
 
+		// ── Monthly Category Comparison Table ──
+		// Fetch category_month data for last 4 months to build a comparison grid.
+		type MonthlyCompRow struct {
+			Category      string
+			CategoryColor string
+			Amounts       []float64 // one per month column, aligned with MonthHeaders
+			Total         float64
+			Change        float64 // % change newest vs prior month
+			HasChange     bool
+		}
+		var monthHeaders []string // e.g. ["Dec", "Jan", "Feb", "Mar"]
+		var monthlyCompRows []MonthlyCompRow
+		var monthlyTotals []float64
+		var hasMonthlyComp bool
+
+		compStart := time.Date(today.Year(), today.Month()-3, 1, 0, 0, 0, 0, today.Location())
+		compEnd := time.Now().AddDate(0, 0, 1)
+		compSummary, compErr := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+			GroupBy:      "category_month",
+			StartDate:    &compStart,
+			EndDate:      &compEnd,
+			SpendingOnly: true,
+		})
+		if compErr != nil {
+			a.Logger.Error("monthly comparison summary", "error", compErr)
+		}
+		if compSummary != nil && len(compSummary.Summary) > 0 {
+			// Collect unique months (sorted) and categories.
+			monthSet := make(map[string]bool)
+			catColorMap := make(map[string]string)
+			// Map: category -> month -> amount
+			catMonthMap := make(map[string]map[string]float64)
+
+			for _, row := range compSummary.Summary {
+				cat := "Uncategorized"
+				if row.Category != nil && *row.Category != "" {
+					cat = *row.Category
+				}
+				period := ""
+				if row.Period != nil {
+					period = *row.Period
+				}
+				if period == "" {
+					continue
+				}
+				monthSet[period] = true
+				if row.CategoryColor != nil && *row.CategoryColor != "" {
+					catColorMap[cat] = *row.CategoryColor
+				}
+				if catMonthMap[cat] == nil {
+					catMonthMap[cat] = make(map[string]float64)
+				}
+				catMonthMap[cat][period] += row.TotalAmount
+			}
+
+			// Sort months chronologically.
+			sortedMonths := make([]string, 0, len(monthSet))
+			for m := range monthSet {
+				sortedMonths = append(sortedMonths, m)
+			}
+			sort.Strings(sortedMonths)
+			// Limit to last 4 months.
+			if len(sortedMonths) > 4 {
+				sortedMonths = sortedMonths[len(sortedMonths)-4:]
+			}
+
+			// Build month headers as short names (e.g. "Jan", "Feb").
+			for _, m := range sortedMonths {
+				t, parseErr := time.Parse("2006-01", m)
+				if parseErr == nil {
+					monthHeaders = append(monthHeaders, t.Format("Jan"))
+				} else {
+					monthHeaders = append(monthHeaders, m)
+				}
+			}
+
+			// Build rows: collect total per category across all months, sort by total desc.
+			type catEntry struct {
+				Name  string
+				Color string
+				Total float64
+			}
+			var catEntries []catEntry
+			for cat, months := range catMonthMap {
+				var total float64
+				for _, amt := range months {
+					total += amt
+				}
+				color := catColorMap[cat]
+				if color == "" {
+					color = categoryPalette[len(catEntries)%len(categoryPalette)]
+				}
+				catEntries = append(catEntries, catEntry{Name: cat, Color: color, Total: total})
+			}
+			sort.Slice(catEntries, func(i, j int) bool {
+				return catEntries[i].Total > catEntries[j].Total
+			})
+
+			// Limit to top 10 categories.
+			if len(catEntries) > 10 {
+				catEntries = catEntries[:10]
+			}
+
+			monthlyTotals = make([]float64, len(sortedMonths))
+			for _, ce := range catEntries {
+				row := MonthlyCompRow{
+					Category:      ce.Name,
+					CategoryColor: ce.Color,
+					Amounts:       make([]float64, len(sortedMonths)),
+					Total:         ce.Total,
+				}
+				for j, m := range sortedMonths {
+					amt := catMonthMap[ce.Name][m]
+					row.Amounts[j] = amt
+					monthlyTotals[j] += amt
+				}
+				// Compute % change between the two most recent months.
+				if len(sortedMonths) >= 2 {
+					prev := row.Amounts[len(sortedMonths)-2]
+					curr := row.Amounts[len(sortedMonths)-1]
+					if prev > 10 {
+						row.HasChange = true
+						row.Change = ((curr - prev) / prev) * 100
+					}
+				}
+				monthlyCompRows = append(monthlyCompRows, row)
+			}
+			hasMonthlyComp = len(monthlyCompRows) > 0
+		}
+
+		var maxMonthlyTotal float64
+		for _, t := range monthlyTotals {
+			if t > maxMonthlyTotal {
+				maxMonthlyTotal = t
+			}
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Insights",
 			"CurrentPage":            "insights",
@@ -788,6 +926,12 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			"RecurringCharges":       recurringCharges,
 			"HasRecurringData":       hasRecurringData,
 			"TotalRecurringMonthly":  totalRecurringMonthly,
+			// Monthly category comparison.
+			"HasMonthlyComp":         hasMonthlyComp,
+			"MonthHeaders":           monthHeaders,
+			"MonthlyCompRows":        monthlyCompRows,
+			"MonthlyTotals":          monthlyTotals,
+			"MaxMonthlyTotal":        maxMonthlyTotal,
 		}
 		tr.Render(w, r, "insights.html", data)
 	}

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -622,6 +622,122 @@
 </div>
 {{end}}
 
+<!-- Monthly Category Comparison -->
+{{if .HasMonthlyComp}}
+<div class="bb-card mb-6 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-2.5">
+      <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-base-200/60">
+        <i data-lucide="columns-3" class="w-3.5 h-3.5 text-base-content/50"></i>
+      </div>
+      <div>
+        <h2 class="text-sm font-semibold text-base-content/70">Monthly Comparison</h2>
+        <p class="text-[0.6rem] text-base-content/30 mt-0.5">Category spending across recent months</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="overflow-x-auto -mx-1">
+    <table class="w-full min-w-[480px]">
+      <thead>
+        <tr class="text-[0.65rem] uppercase tracking-wider text-base-content/30 border-b border-base-200/80">
+          <th class="text-left py-2.5 font-medium pl-1 w-[30%]">Category</th>
+          {{range .MonthHeaders}}
+          <th class="text-right py-2.5 font-medium w-[15%] px-2">{{.}}</th>
+          {{end}}
+          <th class="text-right py-2.5 font-medium w-[10%] pr-1">Trend</th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-base-200/30">
+        {{range $row := .MonthlyCompRows}}
+        <tr class="group hover:bg-base-200/20 transition-colors">
+          <td class="py-2.5 pl-1 pr-2">
+            <div class="flex items-center gap-2">
+              <span class="w-2 h-2 rounded-full shrink-0" style="background-color: {{safeCSS $row.CategoryColor}}"></span>
+              <span class="text-xs font-medium text-base-content/70 truncate group-hover:text-base-content transition-colors">{{$row.Category}}</span>
+            </div>
+          </td>
+          {{range $j, $amt := $row.Amounts}}
+          <td class="py-2.5 text-right px-2">
+            {{if gt $amt 0.0}}
+            <span class="text-xs tabular-nums font-medium text-base-content/65">{{formatAmount $amt}}</span>
+            {{else}}
+            <span class="text-xs text-base-content/15">&mdash;</span>
+            {{end}}
+          </td>
+          {{end}}
+          <td class="py-2.5 text-right pr-1">
+            {{if $row.HasChange}}
+            <span class="inline-flex items-center gap-0.5 text-[0.65rem] font-semibold tabular-nums
+              {{if gt $row.Change 15.0}}text-error/70
+              {{else if lt $row.Change -15.0}}text-success/70
+              {{else}}text-base-content/35{{end}}">
+              {{if gt $row.Change 0.0}}
+              <i data-lucide="trending-up" class="w-3 h-3"></i>
+              +{{printf "%.0f" $row.Change}}%
+              {{else if lt $row.Change 0.0}}
+              <i data-lucide="trending-down" class="w-3 h-3"></i>
+              {{printf "%.0f" $row.Change}}%
+              {{else}}
+              <i data-lucide="minus" class="w-2.5 h-2.5"></i>
+              {{end}}
+            </span>
+            {{else}}
+            <span class="text-xs text-base-content/15">&mdash;</span>
+            {{end}}
+          </td>
+        </tr>
+        {{end}}
+      </tbody>
+      <tfoot>
+        <tr class="border-t border-base-200/80">
+          <td class="py-2.5 pl-1">
+            <span class="text-xs font-semibold text-base-content/50">Total</span>
+          </td>
+          {{range .MonthlyTotals}}
+          <td class="py-2.5 text-right px-2">
+            <span class="text-xs font-semibold tabular-nums text-base-content/70">{{formatAmount .}}</span>
+          </td>
+          {{end}}
+          <td class="py-2.5 text-right pr-1">
+            {{if ge (len $.MonthlyTotals) 2}}
+            {{$prev := index $.MonthlyTotals (sub (len $.MonthlyTotals) 2)}}
+            {{$curr := index $.MonthlyTotals (sub (len $.MonthlyTotals) 1)}}
+            {{if gt $prev 0.0}}
+            {{$pct := mulf (divf (subf $curr $prev) $prev) 100.0}}
+            <span class="inline-flex items-center gap-0.5 text-[0.65rem] font-semibold tabular-nums
+              {{if gt $pct 5.0}}text-error/70
+              {{else if lt $pct -5.0}}text-success/70
+              {{else}}text-base-content/35{{end}}">
+              {{if gt $pct 0.0}}+{{end}}{{printf "%.0f" $pct}}%
+            </span>
+            {{end}}
+            {{end}}
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+
+  <!-- Mini bar chart showing month-over-month totals -->
+  {{if ge (len .MonthlyTotals) 2}}
+  <div class="mt-4 pt-3 border-t border-base-200/60">
+    <div class="flex items-end gap-1.5 h-12">
+      {{range $i, $total := $.MonthlyTotals}}
+      <div class="flex-1 flex flex-col items-center gap-1">
+        <div class="w-full rounded-t-sm transition-all duration-500 ease-out
+          {{if eq $i (sub (len $.MonthlyTotals) 1)}}bg-primary/30{{else}}bg-base-content/8{{end}}"
+          style="height: {{if gt $.MaxMonthlyTotal 0.0}}{{printf "%.0f" (mulf (divf $total $.MaxMonthlyTotal) 100.0)}}%{{else}}0%{{end}}; min-height: 2px;">
+        </div>
+        <span class="text-[0.55rem] text-base-content/30 font-medium">{{index $.MonthHeaders $i}}</span>
+      </div>
+      {{end}}
+    </div>
+  </div>
+  {{end}}
+</div>
+{{end}}
+
 <!-- Chart.js Initialization -->
 {{if .DailyLabels}}
 <script>


### PR DESCRIPTION
## Summary
- Adds a **Monthly Comparison** table showing category-by-category spending across the last 4 months (e.g., Dec, Jan, Feb, Mar)
- Each row shows a category with its spending amount per month, plus a trend indicator (% change between the two most recent months)
- Includes a totals row with month-over-month change and a mini bar chart visualizing total spending per month
- Uses the existing `category_month` group_by in `GetTransactionSummary` — no schema changes needed

## Screenshot
![Monthly Comparison Table](https://i.img402.dev/qvcuzyztkx.png)

## Test plan
- [x] `go build ./...` compiles successfully
- [x] `go test ./...` unit tests pass
- [x] Verified with real data on 7d, 30d, 90d, and 12m date ranges
- [x] Table renders correctly with 4 month columns, 10 categories, trend arrows
- [x] Empty months show dash, trend only shows when prior month > $10

Relates to #150

🤖 Generated by autonomous UX improvement agent