### PR TITLE
Add spending velocity chart and family breakdown to Insights

### DIFF
--- a/internal/admin/insights.go
+++ b/internal/admin/insights.go
@@ -870,6 +870,185 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			}
 		}
 
+		// ── Spending Velocity: cumulative daily spending for last 3 months ──
+		type VelocityMonth struct {
+			Label      string    // "March 2026"
+			ShortLabel string    // "Mar"
+			IsCurrent  bool
+			Days       []float64 // cumulative amount per day (index 0 = day 1)
+			FinalTotal float64
+		}
+		var velocityMonths []VelocityMonth
+		var hasVelocityData bool
+		var velocityMaxDays int
+
+		// Build 3 months: current, previous, two months ago.
+		for mi := 2; mi >= 0; mi-- {
+			mStart := time.Date(today.Year(), today.Month()-time.Month(mi), 1, 0, 0, 0, 0, today.Location())
+			mEnd := time.Date(mStart.Year(), mStart.Month()+1, 1, 0, 0, 0, 0, today.Location())
+			mDaysInMonth := time.Date(mStart.Year(), mStart.Month()+1, 0, 0, 0, 0, 0, today.Location()).Day()
+
+			// For current month, only up to today.
+			maxDay := mDaysInMonth
+			if mi == 0 && daysElapsed < mDaysInMonth {
+				maxDay = daysElapsed
+			}
+
+			vm := VelocityMonth{
+				Label:      mStart.Format("January 2006"),
+				ShortLabel: mStart.Format("Jan"),
+				IsCurrent:  mi == 0,
+				Days:       make([]float64, mDaysInMonth),
+			}
+
+			velocityRows, vErr := a.DB.Query(ctx, `
+				SELECT EXTRACT(DAY FROM date)::int AS day_num, SUM(amount)
+				FROM transactions
+				WHERE deleted_at IS NULL AND date >= $1 AND date < $2 AND amount > 0 AND pending = false
+				GROUP BY EXTRACT(DAY FROM date)::int
+				ORDER BY day_num
+			`, mStart, mEnd)
+			if vErr != nil {
+				a.Logger.Error("velocity query", "error", vErr)
+			} else {
+				for velocityRows.Next() {
+					var dayNum int
+					var dayTotal float64
+					if err := velocityRows.Scan(&dayNum, &dayTotal); err != nil {
+						continue
+					}
+					if dayNum >= 1 && dayNum <= mDaysInMonth {
+						vm.Days[dayNum-1] = dayTotal
+					}
+				}
+				velocityRows.Close()
+			}
+
+			// Convert to cumulative.
+			var cumulative float64
+			for d := 0; d < mDaysInMonth; d++ {
+				cumulative += vm.Days[d]
+				vm.Days[d] = cumulative
+				// For current month, zero out future days.
+				if mi == 0 && d >= maxDay {
+					vm.Days[d] = 0
+				}
+			}
+			vm.FinalTotal = cumulative
+
+			if mDaysInMonth > velocityMaxDays {
+				velocityMaxDays = mDaysInMonth
+			}
+			if cumulative > 0 {
+				hasVelocityData = true
+			}
+			velocityMonths = append(velocityMonths, vm)
+		}
+
+		// JSON-encode velocity data for Chart.js.
+		type velocityDS struct {
+			Label string    `json:"label"`
+			Data  []float64 `json:"data"`
+		}
+		type velocityChartData struct {
+			Labels   []int        `json:"labels"`
+			Datasets []velocityDS `json:"datasets"`
+		}
+		var velocityJSON template.JS
+		if hasVelocityData {
+			vLabels := make([]int, velocityMaxDays)
+			for i := range vLabels {
+				vLabels[i] = i + 1
+			}
+			vData := velocityChartData{Labels: vLabels}
+			for _, vm := range velocityMonths {
+				ds := velocityDS{Label: vm.ShortLabel}
+				// Pad to max days.
+				padded := make([]float64, velocityMaxDays)
+				for i := 0; i < len(vm.Days) && i < velocityMaxDays; i++ {
+					padded[i] = vm.Days[i]
+				}
+				ds.Data = padded
+				vData.Datasets = append(vData.Datasets, ds)
+			}
+			if vb, err := json.Marshal(vData); err == nil {
+				velocityJSON = template.JS(vb)
+			}
+		}
+
+		// ── Family Spending Breakdown ──
+		type FamilyMemberSpend struct {
+			UserID   string
+			UserName string
+			Total    float64
+			Percent  float64
+			TxCount  int
+			TopCat   string
+			Color    string
+		}
+		var familySpending []FamilyMemberSpend
+		var hasFamilyData bool
+		var maxFamilySpend float64
+
+		familyColors := []string{
+			"oklch(0.60 0.15 250)", // blue
+			"oklch(0.58 0.14 160)", // teal
+			"oklch(0.60 0.14 35)",  // amber
+			"oklch(0.55 0.14 300)", // purple
+			"oklch(0.58 0.12 80)",  // olive
+		}
+
+		familyRows, fErr := a.DB.Query(ctx, `
+			SELECT
+				COALESCE(bc.user_id::text, 'unknown') AS uid,
+				COALESCE(u.display_name, u.username, 'Unknown') AS user_name,
+				SUM(t.amount) AS total,
+				COUNT(*)::int AS tx_count,
+				MODE() WITHIN GROUP (ORDER BY COALESCE(t.category_primary, '')) AS top_cat
+			FROM transactions t
+			JOIN accounts a ON t.account_id = a.id
+			LEFT JOIN bank_connections bc ON a.connection_id = bc.id
+			LEFT JOIN users u ON bc.user_id = u.id
+			WHERE t.deleted_at IS NULL AND t.date >= $1 AND t.amount > 0 AND t.pending = false
+				AND COALESCE(a.is_dependent_linked, false) = false
+			GROUP BY bc.user_id, u.display_name, u.username
+			ORDER BY SUM(t.amount) DESC
+		`, chartStart)
+		if fErr != nil {
+			a.Logger.Error("family spending query", "error", fErr)
+		} else {
+			for familyRows.Next() {
+				var fs FamilyMemberSpend
+				var topCat *string
+				if err := familyRows.Scan(&fs.UserID, &fs.UserName, &fs.Total, &fs.TxCount, &topCat); err != nil {
+					a.Logger.Error("family spending scan", "error", err)
+					continue
+				}
+				if topCat != nil && *topCat != "" {
+					fs.TopCat = *topCat
+				}
+				fs.Color = familyColors[len(familySpending)%len(familyColors)]
+				familySpending = append(familySpending, fs)
+				if fs.Total > maxFamilySpend {
+					maxFamilySpend = fs.Total
+				}
+			}
+			familyRows.Close()
+			hasFamilyData = len(familySpending) > 1 // Only show if there are multiple users
+		}
+		// Compute percentages for family spending.
+		if len(familySpending) > 0 {
+			var familyTotal float64
+			for _, fs := range familySpending {
+				familyTotal += fs.Total
+			}
+			if familyTotal > 0 {
+				for i := range familySpending {
+					familySpending[i].Percent = (familySpending[i].Total / familyTotal) * 100
+				}
+			}
+		}
+
 		data := map[string]any{
 			"PageTitle":              "Insights",
 			"CurrentPage":            "insights",
@@ -932,6 +1111,14 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			"MonthlyCompRows":        monthlyCompRows,
 			"MonthlyTotals":          monthlyTotals,
 			"MaxMonthlyTotal":        maxMonthlyTotal,
+			// Spending velocity.
+			"HasVelocityData":        hasVelocityData,
+			"VelocityJSON":           velocityJSON,
+			"VelocityMonths":         velocityMonths,
+			"VelocityMaxDays":        velocityMaxDays,
+			// Family spending breakdown.
+			"HasFamilyData":          hasFamilyData,
+			"FamilySpending":         familySpending,
 		}
 		tr.Render(w, r, "insights.html", data)
 	}

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -738,6 +738,96 @@
 </div>
 {{end}}
 
+<!-- Spending Velocity: Cumulative daily curves for last 3 months -->
+{{if .HasVelocityData}}
+<div class="bb-card mb-6 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-2.5">
+      <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/8">
+        <i data-lucide="activity" class="w-3.5 h-3.5 text-primary/60"></i>
+      </div>
+      <div>
+        <h2 class="text-sm font-semibold text-base-content/70">Spending Velocity</h2>
+        <p class="text-[0.6rem] text-base-content/30 mt-0.5">Cumulative daily spending across months</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="h-64">
+    <canvas id="velocityChart"></canvas>
+  </div>
+
+  <!-- Legend -->
+  <div class="flex items-center gap-5 mt-3 pt-3 border-t border-base-200/60">
+    {{range .VelocityMonths}}
+    <span class="flex items-center gap-1.5 text-xs text-base-content/50">
+      <span class="w-2.5 h-1.5 rounded-sm {{if .IsCurrent}}bg-primary/60{{else}}bg-base-content/15{{end}}"></span>
+      {{.Label}}
+      <span class="text-[0.6rem] text-base-content/30 tabular-nums">{{formatBalance .FinalTotal}}</span>
+    </span>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+<!-- Family Spending Breakdown -->
+{{if .HasFamilyData}}
+<div class="bb-card mb-6 p-5 bb-stagger">
+  <div class="flex items-center justify-between mb-4">
+    <div class="flex items-center gap-2.5">
+      <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-base-200/60">
+        <i data-lucide="users" class="w-3.5 h-3.5 text-base-content/50"></i>
+      </div>
+      <div>
+        <h2 class="text-sm font-semibold text-base-content/70">Family Spending</h2>
+        <p class="text-[0.6rem] text-base-content/30 mt-0.5">Per-member breakdown for selected period</p>
+      </div>
+    </div>
+    <span class="text-xs text-base-content/30">{{if eq .ChartDays 365}}12m{{else}}{{.ChartDays}}d{{end}} period</span>
+  </div>
+
+  <!-- Stacked proportion bar -->
+  <div class="w-full h-4 rounded-full overflow-hidden flex mb-5">
+    {{range .FamilySpending}}
+    <div class="h-full transition-all duration-700 ease-out first:rounded-l-full last:rounded-r-full"
+      style="width: {{printf "%.1f" .Percent}}%; background-color: {{safeCSS .Color}}; opacity: 0.6;"
+      title="{{.UserName}}: {{printf "%.0f" .Percent}}%"></div>
+    {{end}}
+  </div>
+
+  <!-- Member cards -->
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-{{if le (len .FamilySpending) 3}}{{len .FamilySpending}}{{else}}3{{end}} gap-3">
+    {{range $i, $fs := .FamilySpending}}
+    <div class="group flex items-center gap-3.5 p-4 rounded-xl border border-base-200/60 bg-base-200/10 hover:bg-base-200/30 hover:border-base-300/60 transition-all duration-200">
+      <!-- Avatar circle with initial -->
+      <div class="flex items-center justify-center w-10 h-10 rounded-full shrink-0 text-sm font-bold text-white/90"
+        style="background-color: {{safeCSS $fs.Color}};">
+        {{slice $fs.UserName 0 1}}
+      </div>
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center justify-between gap-2 mb-1">
+          <span class="text-sm font-semibold text-base-content/80 truncate group-hover:text-base-content transition-colors">{{$fs.UserName}}</span>
+          <span class="text-sm font-semibold tabular-nums text-base-content/80 shrink-0">{{formatAmount $fs.Total}}</span>
+        </div>
+        <!-- Progress bar relative to max -->
+        <div class="w-full h-1.5 bg-base-200/50 rounded-full overflow-hidden mb-1.5">
+          <div class="h-full rounded-full transition-all duration-500 ease-out"
+            style="width: {{printf "%.1f" $fs.Percent}}%; background-color: {{safeCSS $fs.Color}}; opacity: 0.5;"></div>
+        </div>
+        <div class="flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full bg-base-200/60 text-base-content/40">{{printf "%.0f" $fs.Percent}}%</span>
+            {{if $fs.TopCat}}<span class="text-[0.6rem] text-base-content/25 truncate">{{$fs.TopCat}}</span>{{end}}
+          </div>
+          <span class="text-[0.6rem] text-base-content/30 tabular-nums">{{$fs.TxCount}} txns</span>
+        </div>
+      </div>
+    </div>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
 <!-- Chart.js Initialization -->
 {{if .DailyLabels}}
 <script>
@@ -879,6 +969,135 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
   }
+});
+</script>
+{{end}}
+
+<!-- Velocity Chart Script -->
+{{if .HasVelocityData}}
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var gridColor = isDark ? 'rgba(255,255,255,0.04)' : 'rgba(0,0,0,0.04)';
+  var textColor = isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)';
+
+  var velocityEl = document.getElementById('velocityChart');
+  if (!velocityEl) return;
+
+  var vData = {{.VelocityJSON}};
+  var numMonths = vData.datasets.length;
+
+  // Color palette: older months are more muted, current month is vivid.
+  var lineColors = isDark
+    ? ['rgba(255,255,255,0.08)', 'rgba(255,255,255,0.15)', 'oklch(0.70 0.15 250)']
+    : ['rgba(0,0,0,0.06)', 'rgba(0,0,0,0.12)', 'oklch(0.55 0.15 250)'];
+  var fillColors = isDark
+    ? ['transparent', 'transparent', 'oklch(0.70 0.15 250 / 0.08)']
+    : ['transparent', 'transparent', 'oklch(0.55 0.15 250 / 0.06)'];
+  var borderWidths = [1.5, 1.5, 2.5];
+  var borderDashes = [[4, 3], [4, 3], []];
+
+  var datasets = vData.datasets.map(function(ds, i) {
+    var colorIdx = numMonths - 1 - (numMonths - 1 - i);
+    // Filter out trailing zeros for current month (incomplete).
+    var data = ds.data.slice();
+    if (i === numMonths - 1) {
+      // Find last non-zero value and truncate.
+      var lastNonZero = data.length - 1;
+      while (lastNonZero > 0 && data[lastNonZero] === 0) lastNonZero--;
+      data = data.slice(0, lastNonZero + 1);
+    }
+    return {
+      label: ds.label,
+      data: data,
+      borderColor: lineColors[i] || lineColors[lineColors.length - 1],
+      backgroundColor: fillColors[i] || 'transparent',
+      fill: i === numMonths - 1,
+      borderWidth: borderWidths[i] || 2,
+      borderDash: borderDashes[i] || [],
+      pointRadius: 0,
+      pointHoverRadius: i === numMonths - 1 ? 4 : 2,
+      pointHoverBackgroundColor: lineColors[i] || lineColors[lineColors.length - 1],
+      tension: 0.3,
+      order: numMonths - i,
+    };
+  });
+
+  var tooltipStyle = {
+    backgroundColor: isDark ? 'hsl(0 0% 12%)' : 'hsl(0 0% 100%)',
+    titleColor: isDark ? 'hsl(0 0% 93%)' : 'hsl(0 0% 9%)',
+    bodyColor: isDark ? 'hsl(0 0% 64%)' : 'hsl(0 0% 45%)',
+    borderColor: isDark ? 'hsl(0 0% 18%)' : 'hsl(0 0% 90%)',
+    borderWidth: 1,
+    padding: { top: 8, bottom: 8, left: 12, right: 12 },
+    cornerRadius: 8,
+    titleFont: { size: 11, weight: '600' },
+    bodyFont: { size: 12 },
+    displayColors: true,
+    boxWidth: 8,
+    boxHeight: 8,
+    boxPadding: 4,
+    titleMarginBottom: 4,
+  };
+
+  new Chart(velocityEl, {
+    type: 'line',
+    data: {
+      labels: vData.labels,
+      datasets: datasets
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: 'index', intersect: false },
+      plugins: {
+        legend: { display: false },
+        tooltip: Object.assign({}, tooltipStyle, {
+          callbacks: {
+            title: function(items) {
+              return 'Day ' + items[0].label;
+            },
+            label: function(ctx) {
+              return ctx.dataset.label + ': $' + ctx.parsed.y.toLocaleString('en-US', {minimumFractionDigits: 0, maximumFractionDigits: 0});
+            }
+          }
+        })
+      },
+      scales: {
+        x: {
+          grid: { display: false },
+          border: { display: false },
+          ticks: {
+            color: textColor,
+            font: { size: 10, weight: '500' },
+            maxTicksLimit: 10,
+            callback: function(v, i) { return (i + 1) % 5 === 0 || i === 0 ? (i + 1) : ''; }
+          },
+          title: {
+            display: true,
+            text: 'Day of month',
+            color: textColor,
+            font: { size: 10, weight: '500' },
+          }
+        },
+        y: {
+          grid: { color: gridColor, drawBorder: false },
+          border: { display: false },
+          ticks: {
+            color: textColor,
+            font: { size: 10, weight: '500' },
+            maxTicksLimit: 5,
+            callback: function(v) { return '$' + v.toLocaleString(); }
+          },
+          beginAtZero: true,
+        }
+      },
+      animation: {
+        duration: 600,
+        easing: 'easeOutQuart',
+      }
+    }
+  });
 });
 </script>
 {{end}}


### PR DESCRIPTION
## Summary
- **Spending Velocity Chart**: Cumulative daily spending curves for the last 3 months overlaid on a single line chart. Shows how spending accumulates day-by-day so you can instantly see if this month is tracking higher or lower than previous months at every point. Current month is a vivid blue line with fill, previous months are dashed/muted. Tooltips compare all 3 months at any given day.
- **Family Spending Breakdown**: Per-user spending with a stacked proportion bar, avatar cards with initials, top spending category, and transaction counts. Only appears when there are 2+ family members (relevant for the family finance use case).

## What it looks like

The velocity chart overlays Jan/Feb/Mar cumulative spending curves. At Day 26, March ($3,477) is tracking below February ($3,915) and January ($4,786).

## Test plan
- [x] Go builds clean (`go build ./...`)
- [x] Unit tests pass (`go test ./...`)
- [x] CSS builds clean (`make css`)
- [x] Page renders correctly in dark mode
- [x] Chart tooltips work on hover
- [x] Legend shows month labels with totals
- [x] Family section hidden when only 1 user (correct behavior)
- [ ] Verify on light mode

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)