### PR TITLE
Insights: interactive category drill-down on donut chart

### DIFF
--- a/internal/admin/insights.go
+++ b/internal/admin/insights.go
@@ -128,14 +128,15 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 		drilldownRows, drilldownErr := a.DB.Query(ctx, `
 			WITH ranked AS (
 				SELECT
-					COALESCE(category_primary, 'Uncategorized') AS cat,
-					COALESCE(NULLIF(merchant_name, ''), name) AS merchant,
-					SUM(amount) AS total,
+					COALESCE(cat.display_name, t.category_primary, 'Uncategorized') AS cat,
+					COALESCE(NULLIF(t.merchant_name, ''), t.name) AS merchant,
+					SUM(t.amount) AS total,
 					COUNT(*)::int AS tx_count,
-					ROW_NUMBER() OVER (PARTITION BY COALESCE(category_primary, 'Uncategorized') ORDER BY SUM(amount) DESC) AS rn
-				FROM transactions
-				WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
-				GROUP BY COALESCE(category_primary, 'Uncategorized'), COALESCE(NULLIF(merchant_name, ''), name)
+					ROW_NUMBER() OVER (PARTITION BY COALESCE(cat.display_name, t.category_primary, 'Uncategorized') ORDER BY SUM(t.amount) DESC) AS rn
+				FROM transactions t
+				LEFT JOIN categories cat ON t.category_id = cat.id
+				WHERE t.deleted_at IS NULL AND t.date >= $1 AND t.amount > 0 AND t.pending = false
+				GROUP BY COALESCE(cat.display_name, t.category_primary, 'Uncategorized'), COALESCE(NULLIF(t.merchant_name, ''), t.name)
 			)
 			SELECT cat, merchant, total, tx_count
 			FROM ranked

--- a/internal/admin/insights.go
+++ b/internal/admin/insights.go
@@ -115,6 +115,57 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			}
 		}
 
+		// ── Category Drill-Down Data ──
+		// Query top merchants per category for interactive donut drill-down.
+		type CategoryMerchant struct {
+			Name   string  `json:"name"`
+			Amount float64 `json:"amount"`
+			Count  int     `json:"count"`
+		}
+		categoryDrilldown := make(map[string][]CategoryMerchant)
+		var categoryDrilldownJSON template.JS
+
+		drilldownRows, drilldownErr := a.DB.Query(ctx, `
+			WITH ranked AS (
+				SELECT
+					COALESCE(category_primary, 'Uncategorized') AS cat,
+					COALESCE(NULLIF(merchant_name, ''), name) AS merchant,
+					SUM(amount) AS total,
+					COUNT(*)::int AS tx_count,
+					ROW_NUMBER() OVER (PARTITION BY COALESCE(category_primary, 'Uncategorized') ORDER BY SUM(amount) DESC) AS rn
+				FROM transactions
+				WHERE deleted_at IS NULL AND date >= $1 AND amount > 0 AND pending = false
+				GROUP BY COALESCE(category_primary, 'Uncategorized'), COALESCE(NULLIF(merchant_name, ''), name)
+			)
+			SELECT cat, merchant, total, tx_count
+			FROM ranked
+			WHERE rn <= 8
+			ORDER BY cat, total DESC
+		`, chartStart)
+		if drilldownErr != nil {
+			a.Logger.Error("category drilldown query", "error", drilldownErr)
+		} else {
+			for drilldownRows.Next() {
+				var cat, merchant string
+				var total float64
+				var count int
+				if err := drilldownRows.Scan(&cat, &merchant, &total, &count); err != nil {
+					continue
+				}
+				categoryDrilldown[cat] = append(categoryDrilldown[cat], CategoryMerchant{
+					Name:   merchant,
+					Amount: total,
+					Count:  count,
+				})
+			}
+			drilldownRows.Close()
+		}
+		if len(categoryDrilldown) > 0 {
+			if db, err := json.Marshal(categoryDrilldown); err == nil {
+				categoryDrilldownJSON = template.JS(db)
+			}
+		}
+
 		// ── Daily spending trend ──
 		chartGroupBy := "day"
 		if chartDays == 365 {
@@ -1448,6 +1499,7 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			"DailyIncomeAmounts":     dailyIncomeAmountsJSON,
 			"TopCategories":          topCategories,
 			"MaxCategorySpend":       maxCategorySpend,
+			"CategoryDrilldownJSON":  categoryDrilldownJSON,
 			// Totals.
 			"TotalSpending":          totalSpending,
 			"TotalIncome":            totalIncome,

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -399,25 +399,68 @@
     {{end}}
   </div>
 
-  <!-- Category Donut Chart -->
-  <div class="bb-card lg:col-span-2 p-5">
+  <!-- Category Donut Chart with Drill-Down -->
+  <div class="bb-card lg:col-span-2 p-5" x-data="categoryDrilldown()">
     <div class="flex items-center justify-between mb-4">
-      <h2 class="text-sm font-semibold text-base-content/70">Top Categories</h2>
-      <a href="/categories" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+      <div class="flex items-center gap-2">
+        <button x-show="isDrilledDown" @click="drillUp()" x-transition
+          class="flex items-center justify-center w-6 h-6 rounded-md bg-base-200/60 hover:bg-base-200 transition-colors cursor-pointer">
+          <i data-lucide="arrow-left" class="w-3.5 h-3.5 text-base-content/50"></i>
+        </button>
+        <h2 class="text-sm font-semibold text-base-content/70">
+          <span x-show="!isDrilledDown">Top Categories</span>
+          <span x-show="isDrilledDown" x-text="'Top Merchants in ' + activeCategoryName" x-cloak></span>
+        </h2>
+      </div>
+      <div class="flex items-center gap-2">
+        <span x-show="isDrilledDown" x-cloak class="text-[0.6rem] text-base-content/30">click chart or</span>
+        <a x-show="!isDrilledDown" href="/categories" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+        <button x-show="isDrilledDown" @click="drillUp()" x-cloak
+          class="text-xs text-primary/60 hover:text-primary/80 transition-colors cursor-pointer bg-transparent">back to categories</button>
+      </div>
     </div>
     {{if .TopCategories}}
     <div id="echartsCategoryDonut" style="width: 100%; height: 240px;"></div>
-    <!-- Category list below donut -->
+    <!-- Category/merchant list below donut -->
     <div class="mt-3 pt-3 border-t border-base-200/60 space-y-1.5">
-      {{range .TopCategories}}
-      <div class="flex items-center justify-between">
-        <span class="flex items-center gap-2 text-xs text-base-content/60 truncate">
-          <span class="w-2 h-2 rounded-full shrink-0" style="background-color: {{safeCSS .Color}}"></span>
-          <span class="truncate">{{.Name}}</span>
-        </span>
-        <span class="text-xs font-semibold tabular-nums text-base-content/70 shrink-0 ml-2">{{formatAmount .Amount}}</span>
-      </div>
-      {{end}}
+      <!-- Category view -->
+      <template x-if="!isDrilledDown">
+        <div class="space-y-1.5">
+          {{range .TopCategories}}
+          <div class="flex items-center justify-between group cursor-pointer hover:bg-base-200/30 -mx-2 px-2 py-0.5 rounded-md transition-colors"
+            @click="drillInto('{{.Name}}', '{{safeCSS .Color}}')">
+            <span class="flex items-center gap-2 text-xs text-base-content/60 truncate">
+              <span class="w-2 h-2 rounded-full shrink-0" style="background-color: {{safeCSS .Color}}"></span>
+              <span class="truncate group-hover:text-base-content/80 transition-colors">{{.Name}}</span>
+            </span>
+            <span class="flex items-center gap-1.5">
+              <span class="text-xs font-semibold tabular-nums text-base-content/70 shrink-0">{{formatAmount .Amount}}</span>
+              <i data-lucide="chevron-right" class="w-3 h-3 text-base-content/20 opacity-0 group-hover:opacity-100 transition-opacity"></i>
+            </span>
+          </div>
+          {{end}}
+        </div>
+      </template>
+      <!-- Merchant drill-down view -->
+      <template x-if="isDrilledDown">
+        <div class="space-y-1.5">
+          <template x-for="(m, i) in activeMerchants" :key="i">
+            <div class="flex items-center justify-between -mx-2 px-2 py-0.5">
+              <span class="flex items-center gap-2 text-xs text-base-content/60 truncate">
+                <span class="w-5 h-5 rounded-md flex items-center justify-center text-[0.55rem] font-semibold tabular-nums shrink-0"
+                  :style="'background-color: ' + merchantColors[i % merchantColors.length] + '; opacity: 0.15; color: ' + merchantColors[i % merchantColors.length]"
+                  x-text="i + 1"></span>
+                <span class="truncate" x-text="m.name"></span>
+              </span>
+              <span class="flex items-center gap-2">
+                <span class="text-[0.6rem] text-base-content/30 tabular-nums" x-text="m.count + ' txns'"></span>
+                <span class="text-xs font-semibold tabular-nums text-base-content/70 shrink-0"
+                  x-text="'$' + m.amount.toLocaleString('en-US', {minimumFractionDigits: 2, maximumFractionDigits: 2})"></span>
+              </span>
+            </div>
+          </template>
+        </div>
+      </template>
     </div>
     {{else}}
     <div class="flex items-center justify-center h-60 text-base-content/40">
@@ -1268,7 +1311,7 @@ document.addEventListener('DOMContentLoaded', function() {
   })();
   {{end}}
 
-  // ── Category Donut Chart ──
+  // ── Category Donut Chart with Drill-Down ──
   {{if .CategoryLabels}}
   (function() {
     var el = document.getElementById('echartsCategoryDonut');
@@ -1279,77 +1322,173 @@ document.addEventListener('DOMContentLoaded', function() {
     var amounts = {{.CategoryAmounts}};
     var colors = {{.CategoryColors}};
     var totalSpending = {{printf "%.2f" .TotalSpending}};
+    var drilldownData = {{if .CategoryDrilldownJSON}}{{.CategoryDrilldownJSON}}{{else}}{}{{end}};
 
-    var data = labels.map(function(name, i) {
+    // Merchant sub-colors: generate shades from parent color
+    var merchantPalette = [
+      'oklch(0.55 0.12 250)', 'oklch(0.60 0.10 250)', 'oklch(0.50 0.14 250)',
+      'oklch(0.58 0.08 250)', 'oklch(0.52 0.11 250)', 'oklch(0.63 0.07 250)',
+      'oklch(0.48 0.13 250)', 'oklch(0.65 0.06 250)'
+    ];
+
+    var categoryData = labels.map(function(name, i) {
       return { value: amounts[i], name: name, itemStyle: { color: colors[i] } };
     });
 
-    var option = {
-      animation: true,
-      animationDuration: 800,
-      animationEasing: 'cubicOut',
-      tooltip: {
-        trigger: 'item',
-        backgroundColor: tooltipBg,
-        borderColor: tooltipBorder,
-        borderWidth: 1,
-        padding: [10, 14],
-        extraCssText: 'border-radius: 10px; box-shadow: 0 8px 24px rgba(0,0,0,0.12);',
-        formatter: function(params) {
-          var pct = (params.value / totalSpending * 100).toFixed(1);
-          var val = '$' + params.value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
-          return '<div style="font-family:Inter,system-ui,sans-serif">' +
-            '<div style="font-weight:600;font-size:12px;margin-bottom:4px;color:' + tooltipText + '">' + params.name + '</div>' +
-            '<div style="display:flex;justify-content:space-between;gap:16px;align-items:center;">' +
-            '<span style="color:' + tooltipSubtext + ';font-size:12px">' + pct + '% of total</span>' +
-            '<span style="font-weight:600;font-size:13px;font-variant-numeric:tabular-nums;color:' + tooltipText + '">' + val + '</span></div></div>';
-        }
-      },
-      series: [{
-        type: 'pie',
-        radius: ['52%', '78%'],
-        center: ['50%', '50%'],
-        avoidLabelOverlap: false,
-        padAngle: 2,
-        itemStyle: {
-          borderRadius: 4,
-          borderColor: isDark ? '#1a1a1a' : '#ffffff',
-          borderWidth: 2
-        },
-        label: {
-          show: true,
-          position: 'center',
-          formatter: function() {
-            return '{total|$' + totalSpending.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }) + '}\n{label|total spending}';
-          },
-          rich: {
-            total: {
-              fontSize: 20,
-              fontWeight: 700,
-              fontFamily: 'Inter, system-ui, sans-serif',
-              color: isDark ? '#e5e5e5' : '#1a1a1a',
-              padding: [0, 0, 4, 0]
-            },
-            label: {
-              fontSize: 10,
-              fontFamily: 'Inter, system-ui, sans-serif',
-              color: textColor
-            }
+    function buildCategoryOption() {
+      return {
+        animation: true,
+        animationDuration: 800,
+        animationEasing: 'cubicOut',
+        tooltip: {
+          trigger: 'item',
+          backgroundColor: tooltipBg,
+          borderColor: tooltipBorder,
+          borderWidth: 1,
+          padding: [10, 14],
+          extraCssText: 'border-radius: 10px; box-shadow: 0 8px 24px rgba(0,0,0,0.12);',
+          formatter: function(params) {
+            var pct = (params.value / totalSpending * 100).toFixed(1);
+            var val = '$' + params.value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+            return '<div style="font-family:Inter,system-ui,sans-serif">' +
+              '<div style="font-weight:600;font-size:12px;margin-bottom:4px;color:' + tooltipText + '">' + params.name + '</div>' +
+              '<div style="display:flex;justify-content:space-between;gap:16px;align-items:center;">' +
+              '<span style="color:' + tooltipSubtext + ';font-size:12px">' + pct + '% of total</span>' +
+              '<span style="font-weight:600;font-size:13px;font-variant-numeric:tabular-nums;color:' + tooltipText + '">' + val + '</span></div></div>';
           }
         },
-        emphasis: {
+        series: [{
+          type: 'pie',
+          radius: ['52%', '78%'],
+          center: ['50%', '50%'],
+          avoidLabelOverlap: false,
+          padAngle: 2,
           itemStyle: {
-            shadowBlur: 12,
-            shadowOffsetX: 0,
-            shadowColor: 'rgba(0, 0, 0, 0.15)'
+            borderRadius: 4,
+            borderColor: isDark ? '#1a1a1a' : '#ffffff',
+            borderWidth: 2
           },
-          label: { show: true }
-        },
-        data: data
-      }]
-    };
+          label: {
+            show: true,
+            position: 'center',
+            formatter: function() {
+              return '{total|$' + totalSpending.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }) + '}\n{label|total spending}';
+            },
+            rich: {
+              total: { fontSize: 20, fontWeight: 700, fontFamily: 'Inter, system-ui, sans-serif', color: isDark ? '#e5e5e5' : '#1a1a1a', padding: [0, 0, 4, 0] },
+              label: { fontSize: 10, fontFamily: 'Inter, system-ui, sans-serif', color: textColor }
+            }
+          },
+          emphasis: {
+            itemStyle: { shadowBlur: 12, shadowOffsetX: 0, shadowColor: 'rgba(0, 0, 0, 0.15)' },
+            label: { show: true }
+          },
+          data: categoryData
+        }]
+      };
+    }
 
-    chart.setOption(option);
+    function buildMerchantOption(categoryName, parentColor, merchants) {
+      var catTotal = 0;
+      merchants.forEach(function(m) { catTotal += m.amount; });
+      // Generate color shades from parent
+      var hueMatch = parentColor.match(/oklch\([\d.]+ [\d.]+ ([\d.]+)\)/);
+      var baseHue = hueMatch ? parseFloat(hueMatch[1]) : 250;
+      var mColors = merchants.map(function(_, i) {
+        var l = 0.58 - (i * 0.03);
+        var c = 0.12 - (i * 0.008);
+        if (l < 0.38) l = 0.38;
+        if (c < 0.04) c = 0.04;
+        return 'oklch(' + l.toFixed(2) + ' ' + c.toFixed(2) + ' ' + baseHue.toFixed(0) + ')';
+      });
+      var mData = merchants.map(function(m, i) {
+        return { value: m.amount, name: m.name, itemStyle: { color: mColors[i] } };
+      });
+      return {
+        animation: true,
+        animationDuration: 600,
+        animationEasing: 'cubicOut',
+        tooltip: {
+          trigger: 'item',
+          backgroundColor: tooltipBg,
+          borderColor: tooltipBorder,
+          borderWidth: 1,
+          padding: [10, 14],
+          extraCssText: 'border-radius: 10px; box-shadow: 0 8px 24px rgba(0,0,0,0.12);',
+          formatter: function(params) {
+            var pct = (params.value / catTotal * 100).toFixed(1);
+            var val = '$' + params.value.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+            return '<div style="font-family:Inter,system-ui,sans-serif">' +
+              '<div style="font-weight:600;font-size:12px;margin-bottom:4px;color:' + tooltipText + '">' + params.name + '</div>' +
+              '<div style="display:flex;justify-content:space-between;gap:16px;align-items:center;">' +
+              '<span style="color:' + tooltipSubtext + ';font-size:12px">' + pct + '% of ' + categoryName + '</span>' +
+              '<span style="font-weight:600;font-size:13px;font-variant-numeric:tabular-nums;color:' + tooltipText + '">' + val + '</span></div></div>';
+          }
+        },
+        series: [{
+          type: 'pie',
+          radius: ['52%', '78%'],
+          center: ['50%', '50%'],
+          avoidLabelOverlap: false,
+          padAngle: 2,
+          itemStyle: {
+            borderRadius: 4,
+            borderColor: isDark ? '#1a1a1a' : '#ffffff',
+            borderWidth: 2
+          },
+          label: {
+            show: true,
+            position: 'center',
+            formatter: function() {
+              return '{total|$' + catTotal.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }) + '}\n{label|' + categoryName + '}';
+            },
+            rich: {
+              total: { fontSize: 20, fontWeight: 700, fontFamily: 'Inter, system-ui, sans-serif', color: isDark ? '#e5e5e5' : '#1a1a1a', padding: [0, 0, 4, 0] },
+              label: { fontSize: 10, fontFamily: 'Inter, system-ui, sans-serif', color: textColor }
+            }
+          },
+          emphasis: {
+            itemStyle: { shadowBlur: 12, shadowOffsetX: 0, shadowColor: 'rgba(0, 0, 0, 0.15)' },
+            label: { show: true }
+          },
+          data: mData
+        }]
+      };
+    }
+
+    chart.setOption(buildCategoryOption());
+
+    // Click handler: drill into category
+    chart.on('click', function(params) {
+      if (params.componentType !== 'series') return;
+      var categoryName = params.name;
+      var parentColor = params.color || 'oklch(0.55 0.12 250)';
+      var merchants = drilldownData[categoryName];
+      if (!merchants || merchants.length === 0) return;
+
+      // Update Alpine state
+      var alpineEl = el.closest('[x-data]');
+      if (alpineEl && alpineEl.__x) {
+        alpineEl.__x.$data.isDrilledDown = true;
+        alpineEl.__x.$data.activeCategoryName = categoryName;
+        alpineEl.__x.$data.activeCategoryColor = parentColor;
+        alpineEl.__x.$data.activeMerchants = merchants;
+      } else if (alpineEl && window.Alpine) {
+        Alpine.evaluate(alpineEl, '$data').isDrilledDown = true;
+        Alpine.evaluate(alpineEl, '$data').activeCategoryName = categoryName;
+        Alpine.evaluate(alpineEl, '$data').activeCategoryColor = parentColor;
+        Alpine.evaluate(alpineEl, '$data').activeMerchants = merchants;
+      }
+
+      chart.setOption(buildMerchantOption(categoryName, parentColor, merchants), true);
+    });
+
+    // Expose chart for Alpine drill-up
+    window._categoryDonutChart = chart;
+    window._categoryDonutCategoryOption = buildCategoryOption;
+    window._categoryDonutMerchantOption = buildMerchantOption;
+    window._categoryDrilldownData = drilldownData;
+
     window.addEventListener('resize', function() { chart.resize(); });
   })();
   {{end}}
@@ -1861,6 +2000,62 @@ document.addEventListener('DOMContentLoaded', function() {
   })();
   {{end}}
 });
+</script>
+
+<!-- Alpine: Category Drill-Down Component -->
+<script>
+function categoryDrilldown() {
+  return {
+    isDrilledDown: false,
+    activeCategoryName: '',
+    activeCategoryColor: '',
+    activeMerchants: [],
+    merchantColors: [
+      'oklch(0.55 0.12 250)', 'oklch(0.60 0.10 250)', 'oklch(0.50 0.14 250)',
+      'oklch(0.58 0.08 250)', 'oklch(0.52 0.11 250)', 'oklch(0.63 0.07 250)',
+      'oklch(0.48 0.13 250)', 'oklch(0.65 0.06 250)'
+    ],
+    drillInto: function(categoryName, parentColor) {
+      var drilldownData = window._categoryDrilldownData || {};
+      var merchants = drilldownData[categoryName];
+      if (!merchants || merchants.length === 0) return;
+
+      this.isDrilledDown = true;
+      this.activeCategoryName = categoryName;
+      this.activeCategoryColor = parentColor;
+      this.activeMerchants = merchants;
+
+      // Update chart
+      var chart = window._categoryDonutChart;
+      var buildMerchant = window._categoryDonutMerchantOption;
+      if (chart && buildMerchant) {
+        chart.setOption(buildMerchant(categoryName, parentColor, merchants), true);
+      }
+
+      // Re-render lucide icons
+      this.$nextTick(function() {
+        if (typeof lucide !== 'undefined') lucide.createIcons();
+      });
+    },
+    drillUp: function() {
+      this.isDrilledDown = false;
+      this.activeCategoryName = '';
+      this.activeMerchants = [];
+
+      // Reset chart
+      var chart = window._categoryDonutChart;
+      var buildCategory = window._categoryDonutCategoryOption;
+      if (chart && buildCategory) {
+        chart.setOption(buildCategory(), true);
+      }
+
+      // Re-render lucide icons
+      this.$nextTick(function() {
+        if (typeof lucide !== 'undefined') lucide.createIcons();
+      });
+    }
+  };
+}
 </script>
 
 <!-- Re-init Lucide icons on tab switch (icons in initially hidden tabs need rendering) -->


### PR DESCRIPTION
## Summary
- **Category drill-down**: Click any segment in the category donut chart (or the category list below it) to drill into a merchant-level breakdown within that category
- **Smooth chart transitions**: The donut animates to show top merchants with proportional color shading derived from the parent category's hue
- **Back navigation**: Header shows a back arrow and "back to categories" link to return to the category overview
- **Server-side data**: New SQL query fetches top 8 merchants per category (ranked by spending), passed as JSON for instant client-side drill-down with no extra network requests
- **Merchant details**: Drill-down list shows merchant rank, name, transaction count, and amount

## Details
- New `CategoryMerchant` struct and SQL CTE query with `ROW_NUMBER()` window function
- Alpine.js `categoryDrilldown()` component manages drill state
- ECharts click handler bridges chart interactions to Alpine state
- Merchant donut colors are generated algorithmically from the parent category color's hue

References #150

## Test plan
- [ ] Navigate to /admin/insights, verify the category donut chart renders normally
- [ ] Click a donut segment -- chart should animate to show merchants within that category
- [ ] Verify the list below the chart updates to show merchant names, counts, and amounts
- [ ] Click the back arrow or "back to categories" link -- chart should return to category view
- [ ] Click a category name in the list (not the chart) -- should also drill down
- [ ] Verify tooltip shows category-relative percentage in drill-down mode
- [ ] Test with different date ranges (7d, 30d, 90d, 12m)
- [ ] Verify dark mode renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)