### PR TITLE
Insights: Add Financial Health Score composite gauge

### DIFF
--- a/input.css
+++ b/input.css
@@ -609,6 +609,12 @@
     }
   }
 
+  /* ── Financial Health Score ring ── */
+  .bb-health-ring {
+    stroke: currentColor;
+    transition: stroke-dasharray 1.2s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
   /* ── Button polish ── */
   .btn {
     transition: background-color 0.15s ease, color 0.15s ease,

--- a/internal/admin/insights.go
+++ b/internal/admin/insights.go
@@ -1687,6 +1687,207 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 		}
 		hasBudgetTargets = len(budgetTargets) > 0
 
+		// ── Financial Health Score (composite 0-100) ──
+		// Five dimensions, each scored 0-20 points:
+		//   1. Savings Rate: higher savings = higher score
+		//   2. Budget Adherence: % of categories on-track
+		//   3. Spending Trend: spending down vs previous period
+		//   4. Cash Flow: positive net = good, negative = bad
+		//   5. Spending Pace: on-track for month vs overshooting
+		type HealthDimension struct {
+			Name        string
+			Score       int
+			MaxScore    int
+			Description string
+			Icon        string
+			Color       string
+		}
+
+		var healthScore int
+		var healthDimensions []HealthDimension
+		var hasHealthScore bool
+
+		// Only compute if we have meaningful data.
+		if totalSpending > 0 || totalIncome > 0 {
+			hasHealthScore = true
+
+			// Dimension 1: Savings Rate (0-20)
+			savingsScore := 0
+			savingsDesc := "No income data"
+			if totalIncome > 0 {
+				sr := savingsRate
+				switch {
+				case sr >= 30:
+					savingsScore = 20
+					savingsDesc = "Excellent savings rate"
+				case sr >= 20:
+					savingsScore = 17
+					savingsDesc = "Strong savings rate"
+				case sr >= 10:
+					savingsScore = 14
+					savingsDesc = "Good savings rate"
+				case sr >= 0:
+					savingsScore = 10
+					savingsDesc = "Break-even or minimal savings"
+				case sr >= -20:
+					savingsScore = 6
+					savingsDesc = "Spending slightly exceeds income"
+				case sr >= -50:
+					savingsScore = 3
+					savingsDesc = "Spending significantly exceeds income"
+				default:
+					savingsScore = 0
+					savingsDesc = "Spending far exceeds income"
+				}
+			}
+			healthDimensions = append(healthDimensions, HealthDimension{
+				Name: "Savings Rate", Score: savingsScore, MaxScore: 20,
+				Description: savingsDesc, Icon: "piggy-bank", Color: "oklch(0.65 0.17 155)",
+			})
+
+			// Dimension 2: Budget Adherence (0-20)
+			budgetScore := 10 // Default if no budget data
+			budgetDesc := "No budget data yet"
+			if len(budgetTargets) > 0 {
+				total := budgetOnTrackCount + budgetOverCount
+				if total > 0 {
+					onTrackRatio := float64(budgetOnTrackCount) / float64(total)
+					budgetScore = int(math.Round(onTrackRatio * 20))
+					switch {
+					case onTrackRatio >= 0.8:
+						budgetDesc = fmt.Sprintf("%d of %d categories on track", budgetOnTrackCount, total)
+					case onTrackRatio >= 0.5:
+						budgetDesc = fmt.Sprintf("%d of %d categories over budget", budgetOverCount, total)
+					default:
+						budgetDesc = fmt.Sprintf("Most categories (%d/%d) over budget", budgetOverCount, total)
+					}
+				}
+			}
+			healthDimensions = append(healthDimensions, HealthDimension{
+				Name: "Budget Adherence", Score: budgetScore, MaxScore: 20,
+				Description: budgetDesc, Icon: "target", Color: "oklch(0.62 0.15 250)",
+			})
+
+			// Dimension 3: Spending Trend (0-20)
+			trendScore := 10 // Default if no comparison data
+			trendDesc := "Not enough history"
+			if hasSpendingChange {
+				pct := spendingChangePercent
+				switch {
+				case pct <= -20:
+					trendScore = 20
+					trendDesc = fmt.Sprintf("Spending down %.0f%% vs previous period", math.Abs(pct))
+				case pct <= -10:
+					trendScore = 17
+					trendDesc = fmt.Sprintf("Spending down %.0f%%", math.Abs(pct))
+				case pct <= -2:
+					trendScore = 14
+					trendDesc = fmt.Sprintf("Spending slightly down %.0f%%", math.Abs(pct))
+				case pct <= 2:
+					trendScore = 12
+					trendDesc = "Spending roughly flat"
+				case pct <= 10:
+					trendScore = 8
+					trendDesc = fmt.Sprintf("Spending up %.0f%%", pct)
+				case pct <= 25:
+					trendScore = 4
+					trendDesc = fmt.Sprintf("Spending up %.0f%%", pct)
+				default:
+					trendScore = 0
+					trendDesc = fmt.Sprintf("Spending up %.0f%% vs previous period", pct)
+				}
+			}
+			healthDimensions = append(healthDimensions, HealthDimension{
+				Name: "Spending Trend", Score: trendScore, MaxScore: 20,
+				Description: trendDesc, Icon: "trending-down", Color: "oklch(0.64 0.16 160)",
+			})
+
+			// Dimension 4: Cash Flow (0-20)
+			cashFlowScore := 10
+			cashFlowDesc := "No cash flow data"
+			if hasCashFlow && totalIncome > 0 {
+				ratio := cashFlowNet / totalIncome
+				switch {
+				case ratio >= 0.3:
+					cashFlowScore = 20
+					cashFlowDesc = "Strong positive cash flow"
+				case ratio >= 0.1:
+					cashFlowScore = 16
+					cashFlowDesc = "Positive cash flow"
+				case ratio >= 0:
+					cashFlowScore = 12
+					cashFlowDesc = "Near break-even"
+				case ratio >= -0.2:
+					cashFlowScore = 6
+					cashFlowDesc = "Negative cash flow"
+				default:
+					cashFlowScore = 0
+					cashFlowDesc = "Significant negative cash flow"
+				}
+			}
+			healthDimensions = append(healthDimensions, HealthDimension{
+				Name: "Cash Flow", Score: cashFlowScore, MaxScore: 20,
+				Description: cashFlowDesc, Icon: "wallet", Color: "oklch(0.66 0.14 35)",
+			})
+
+			// Dimension 5: Spending Pace (0-20)
+			paceScore := 10 // Default
+			paceDesc := "No pace data"
+			if hasPaceData && lastMonthSpending > 0 {
+				switch paceVsLastMonth {
+				case "behind":
+					paceScore = 18
+					paceDesc = fmt.Sprintf("Spending %.0f%% less than last month's pace", math.Abs(pacePercent))
+				case "same":
+					paceScore = 12
+					paceDesc = "On pace with last month"
+				case "ahead":
+					if pacePercent <= 10 {
+						paceScore = 8
+						paceDesc = fmt.Sprintf("Slightly ahead of last month (+%.0f%%)", pacePercent)
+					} else if pacePercent <= 25 {
+						paceScore = 4
+						paceDesc = fmt.Sprintf("Spending faster than last month (+%.0f%%)", pacePercent)
+					} else {
+						paceScore = 0
+						paceDesc = fmt.Sprintf("Spending much faster than last month (+%.0f%%)", pacePercent)
+					}
+				}
+			}
+			healthDimensions = append(healthDimensions, HealthDimension{
+				Name: "Monthly Pace", Score: paceScore, MaxScore: 20,
+				Description: paceDesc, Icon: "gauge", Color: "oklch(0.60 0.16 300)",
+			})
+
+			// Sum up total health score
+			for _, d := range healthDimensions {
+				healthScore += d.Score
+			}
+		}
+
+		// Health score label and color
+		healthLabel := "N/A"
+		healthColorClass := "text-base-content/50"
+		if hasHealthScore {
+			switch {
+			case healthScore >= 80:
+				healthLabel = "Excellent"
+				healthColorClass = "text-success"
+			case healthScore >= 65:
+				healthLabel = "Good"
+				healthColorClass = "text-success/70"
+			case healthScore >= 50:
+				healthLabel = "Fair"
+				healthColorClass = "text-warning"
+			case healthScore >= 35:
+				healthLabel = "Needs Attention"
+				healthColorClass = "text-warning/70"
+			default:
+				healthLabel = "Critical"
+				healthColorClass = "text-error"
+			}
+		}
+
 		// ── CSV Export data (JSON blob for client-side CSV generation) ──
 		type csvExportData struct {
 			PeriodLabel string `json:"periodLabel"`
@@ -1978,6 +2179,12 @@ func InsightsHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) htt
 			"SparkIncome":               sparkIncomeJSON,
 			"SparkNet":                  sparkNetJSON,
 			"SparkSavings":              sparkSavingsJSON,
+			// Financial health score.
+			"HasHealthScore":            hasHealthScore,
+			"HealthScore":               healthScore,
+			"HealthLabel":               healthLabel,
+			"HealthColorClass":          healthColorClass,
+			"HealthDimensions":          healthDimensions,
 		}
 		tr.Render(w, r, "insights.html", data)
 	}

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -102,6 +102,9 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return a
 			},
+			"itof": func(a int) float64 {
+				return float64(a)
+			},
 			"syncDuration": func(start, end time.Time) string {
 				d := end.Sub(start)
 				if d < time.Second {

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -172,6 +172,72 @@
 <!-- ═══════════════════════════════════════════════ -->
 <div x-show="tab === 'overview'" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-1" x-transition:enter-end="opacity-100 translate-y-0">
 
+<!-- Financial Health Score -->
+{{if .HasHealthScore}}
+<div class="bb-card mb-6 p-5 bb-stagger">
+  <div class="flex flex-col lg:flex-row items-start lg:items-center gap-6">
+    <!-- Score Ring -->
+    <div class="flex items-center gap-5 shrink-0">
+      <div class="relative w-24 h-24 sm:w-28 sm:h-28">
+        <svg viewBox="0 0 120 120" class="w-full h-full -rotate-90">
+          <!-- Background ring -->
+          <circle cx="60" cy="60" r="52" fill="none" stroke="currentColor" stroke-width="8"
+            class="text-base-200/60" />
+          <!-- Score arc -->
+          <circle cx="60" cy="60" r="52" fill="none" stroke-width="8" stroke-linecap="round"
+            class="bb-health-ring {{.HealthColorClass}}"
+            stroke-dasharray="{{printf "%.1f" (mulf (divf (itof .HealthScore) 100.0) 326.7)}} 326.7"
+            style="transition: stroke-dasharray 1.2s cubic-bezier(0.4, 0, 0.2, 1);" />
+        </svg>
+        <div class="absolute inset-0 flex flex-col items-center justify-center">
+          <span class="text-2xl sm:text-3xl font-bold tabular-nums {{.HealthColorClass}}"
+            data-countup="{{.HealthScore}}" data-decimals="0" data-duration="1200">{{.HealthScore}}</span>
+          <span class="text-[0.55rem] text-base-content/30 font-medium -mt-0.5">/ 100</span>
+        </div>
+      </div>
+      <div class="lg:hidden">
+        <div class="text-sm font-semibold {{.HealthColorClass}}">{{.HealthLabel}}</div>
+        <div class="text-[0.65rem] text-base-content/35 mt-0.5">Financial Health Score</div>
+      </div>
+    </div>
+
+    <!-- Dimension Breakdown -->
+    <div class="flex-1 w-full">
+      <div class="hidden lg:flex items-center gap-2.5 mb-4">
+        <h2 class="text-sm font-semibold text-base-content/70">Financial Health</h2>
+        <span class="text-xs font-semibold {{.HealthColorClass}}">{{.HealthLabel}}</span>
+        <span class="text-[0.6rem] text-base-content/25 ml-auto">Based on 5 dimensions, scored 0-20 each</span>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-5 gap-2 sm:gap-3">
+        {{range .HealthDimensions}}
+        <div class="group flex sm:flex-col items-center sm:items-start gap-3 sm:gap-0 p-2.5 sm:p-3 rounded-xl border border-base-200/50 bg-base-200/[0.03] hover:bg-base-200/20 hover:border-base-300/50 transition-all duration-200">
+          <div class="flex items-center gap-2 sm:mb-2 shrink-0">
+            <div class="flex items-center justify-center w-6 h-6 rounded-md" style="background-color: {{safeCSS .Color}}; opacity: 0.12;">
+              <i data-lucide="{{.Icon}}" class="w-3 h-3" style="color: {{safeCSS .Color}};"></i>
+            </div>
+            <span class="text-[0.65rem] font-medium text-base-content/50 sm:hidden">{{.Name}}</span>
+          </div>
+          <div class="flex-1 sm:flex-initial w-full min-w-0">
+            <div class="hidden sm:block text-[0.6rem] font-medium text-base-content/45 mb-1.5 truncate">{{.Name}}</div>
+            <!-- Score bar -->
+            <div class="w-full h-1.5 bg-base-200/60 rounded-full overflow-hidden mb-1.5">
+              <div class="h-full rounded-full transition-all duration-700 ease-out"
+                style="width: {{printf "%.0f" (mulf (divf (itof .Score) (itof .MaxScore)) 100.0)}}%; background-color: {{safeCSS .Color}}; opacity: 0.6;"></div>
+            </div>
+            <div class="flex items-center justify-between gap-1">
+              <span class="text-[0.55rem] text-base-content/30 truncate hidden sm:inline">{{.Description}}</span>
+              <span class="text-[0.6rem] font-semibold tabular-nums text-base-content/50 shrink-0">{{.Score}}/{{.MaxScore}}</span>
+            </div>
+            <span class="text-[0.55rem] text-base-content/30 sm:hidden">{{.Description}}</span>
+          </div>
+        </div>
+        {{end}}
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
 <!-- Monthly Spending Pace -->
 {{if .HasPaceData}}
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6 bb-stagger">

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -191,7 +191,7 @@
         </svg>
         <div class="absolute inset-0 flex flex-col items-center justify-center">
           <span class="text-2xl sm:text-3xl font-bold tabular-nums {{.HealthColorClass}}"
-            data-countup="{{.HealthScore}}" data-decimals="0" data-duration="1200">{{.HealthScore}}</span>
+            data-countup="{{.HealthScore}}" data-prefix="" data-decimals="0" data-duration="1200">{{.HealthScore}}</span>
           <span class="text-[0.55rem] text-base-content/30 font-medium -mt-0.5">/ 100</span>
         </div>
       </div>
@@ -1485,7 +1485,7 @@ document.addEventListener('DOMContentLoaded', function() {
       observer.unobserve(el);
 
       var target = parseFloat(el.getAttribute('data-countup'));
-      var prefix = el.getAttribute('data-prefix') || '$';
+      var prefix = el.hasAttribute('data-prefix') ? el.getAttribute('data-prefix') : '$';
       var suffix = el.getAttribute('data-suffix') || '';
       var decimals = parseInt(el.getAttribute('data-decimals') || '2', 10);
       var duration = 800;


### PR DESCRIPTION
## Summary
- Adds a **Financial Health Score** (0-100) to the top of the Insights Overview tab, computed from 5 weighted dimensions: savings rate, budget adherence, spending trend, cash flow, and monthly pace
- Displays an animated SVG ring chart with the total score, a label (Excellent/Good/Fair/Needs Attention/Critical), and 5 dimension breakdown cards showing individual score bars with descriptions
- Each dimension scores 0-20 points with contextual descriptions explaining the rating

## Files Changed
- `internal/admin/insights.go` — Health score computation (5 dimensions with scoring logic)
- `internal/templates/pages/insights.html` — Score ring + dimension cards UI
- `internal/admin/templates.go` — Added `itof` template function (int to float64)
- `input.css` — Health ring animation class

## Screenshots
_Will be added via comment_

Relates to #150

🤖 Generated by autonomous UX improvement agent