### PR TITLE
Insights: Add skeleton loading state

### DIFF
--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -1,8 +1,11 @@
 {{define "content"}}
 
 <!-- Insights Page with Tabbed Layout -->
-<div x-data="{ tab: (new URLSearchParams(window.location.search).get('tab')) || 'overview', highlightedCategory: '' }"
-     x-init="$watch('tab', v => { const u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); if (window._onInsightsTabSwitch) window._onInsightsTabSwitch(v); })"
+<div x-data="{ tab: (new URLSearchParams(window.location.search).get('tab')) || 'overview', highlightedCategory: '', insightsReady: false }"
+     x-init="
+       $watch('tab', v => { const u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); if (window._onInsightsTabSwitch) window._onInsightsTabSwitch(v); });
+       window._setInsightsReady = () => { insightsReady = true; };
+     "
      @keydown.window="
        if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA' || event.target.isContentEditable) return;
        const tabs = ['overview', 'analysis', 'trends'];
@@ -76,6 +79,142 @@
     </div>
   </div>
 </div>
+
+<!-- ═══════════════════════════════════════════════ -->
+<!-- SKELETON LOADING STATE                        -->
+<!-- ═══════════════════════════════════════════════ -->
+<div x-show="!insightsReady" x-transition:leave="transition ease-in duration-300" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="bb-page-skeleton" aria-hidden="true" role="presentation">
+  <!-- Skeleton Summary Pills -->
+  <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3 mb-6">
+    <div class="bb-skeleton--card !p-3 sm:!p-4 min-h-[4.5rem]">
+      <div class="bb-skeleton bb-skeleton--text-xs mb-3" style="width: 55px;"></div>
+      <div class="bb-skeleton bb-skeleton--amount mb-1.5"></div>
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width: 65px;"></div>
+    </div>
+    <div class="bb-skeleton--card !p-3 sm:!p-4 min-h-[4.5rem]">
+      <div class="bb-skeleton bb-skeleton--text-xs mb-3" style="width: 48px;"></div>
+      <div class="bb-skeleton bb-skeleton--amount mb-1.5"></div>
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width: 0;"></div>
+    </div>
+    <div class="bb-skeleton--card !p-3 sm:!p-4 min-h-[4.5rem]">
+      <div class="bb-skeleton bb-skeleton--text-xs mb-3" style="width: 80px;"></div>
+      <div class="bb-skeleton bb-skeleton--amount mb-1.5"></div>
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width: 0;"></div>
+    </div>
+    <div class="bb-skeleton--card !p-3 sm:!p-4 min-h-[4.5rem]">
+      <div class="bb-skeleton bb-skeleton--text-xs mb-3" style="width: 72px;"></div>
+      <div class="bb-skeleton bb-skeleton--amount mb-1.5"></div>
+      <div class="bb-skeleton bb-skeleton--text-xs" style="width: 0;"></div>
+    </div>
+  </div>
+
+  <!-- Skeleton Tab Bar -->
+  <div class="flex items-center gap-1 border-b border-base-200/80 mb-6">
+    <div class="px-4 py-2.5 border-b-2 border-primary/30">
+      <div class="bb-skeleton" style="width: 64px; height: 14px;"></div>
+    </div>
+    <div class="px-4 py-2.5">
+      <div class="bb-skeleton" style="width: 56px; height: 14px;"></div>
+    </div>
+    <div class="px-4 py-2.5">
+      <div class="bb-skeleton" style="width: 48px; height: 14px;"></div>
+    </div>
+  </div>
+
+  <!-- Skeleton Health Score Card -->
+  <div class="bb-skeleton--card mb-6 !p-5">
+    <div class="flex flex-col lg:flex-row items-start lg:items-center gap-6">
+      <div class="flex items-center gap-5 shrink-0">
+        <div class="bb-skeleton rounded-full" style="width: 112px; height: 112px;"></div>
+        <div class="lg:hidden">
+          <div class="bb-skeleton" style="width: 100px; height: 16px; margin-bottom: 6px;"></div>
+          <div class="bb-skeleton bb-skeleton--text-xs" style="width: 120px;"></div>
+        </div>
+      </div>
+      <div class="flex-1 w-full">
+        <div class="hidden lg:flex items-center gap-2.5 mb-4">
+          <div class="bb-skeleton" style="width: 120px; height: 16px;"></div>
+          <div class="bb-skeleton bb-skeleton--badge"></div>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-5 gap-2 sm:gap-3">
+          <div class="bb-skeleton--card !p-3"><div class="bb-skeleton bb-skeleton--circle-sm mb-2"></div><div class="bb-skeleton bb-skeleton--text-xs mb-1.5"></div><div class="bb-skeleton" style="width: 100%; height: 6px;"></div></div>
+          <div class="bb-skeleton--card !p-3"><div class="bb-skeleton bb-skeleton--circle-sm mb-2"></div><div class="bb-skeleton bb-skeleton--text-xs mb-1.5"></div><div class="bb-skeleton" style="width: 100%; height: 6px;"></div></div>
+          <div class="bb-skeleton--card !p-3"><div class="bb-skeleton bb-skeleton--circle-sm mb-2"></div><div class="bb-skeleton bb-skeleton--text-xs mb-1.5"></div><div class="bb-skeleton" style="width: 100%; height: 6px;"></div></div>
+          <div class="bb-skeleton--card !p-3"><div class="bb-skeleton bb-skeleton--circle-sm mb-2"></div><div class="bb-skeleton bb-skeleton--text-xs mb-1.5"></div><div class="bb-skeleton" style="width: 100%; height: 6px;"></div></div>
+          <div class="bb-skeleton--card !p-3"><div class="bb-skeleton bb-skeleton--circle-sm mb-2"></div><div class="bb-skeleton bb-skeleton--text-xs mb-1.5"></div><div class="bb-skeleton" style="width: 100%; height: 6px;"></div></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Skeleton Pace + Summary Row -->
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+    <div class="bb-skeleton--card !p-5">
+      <div class="flex items-center justify-between mb-4">
+        <div class="bb-skeleton" style="width: 160px; height: 16px;"></div>
+        <div class="bb-skeleton bb-skeleton--text-xs" style="width: 72px;"></div>
+      </div>
+      <div class="bb-skeleton mb-5" style="width: 100%; height: 12px; border-radius: 9999px;"></div>
+      <div class="grid grid-cols-3 gap-4">
+        <div><div class="bb-skeleton bb-skeleton--text-xs mb-2" style="width: 60px;"></div><div class="bb-skeleton bb-skeleton--amount"></div></div>
+        <div><div class="bb-skeleton bb-skeleton--text-xs mb-2" style="width: 50px;"></div><div class="bb-skeleton bb-skeleton--amount"></div></div>
+        <div><div class="bb-skeleton bb-skeleton--text-xs mb-2" style="width: 56px;"></div><div class="bb-skeleton bb-skeleton--amount"></div></div>
+      </div>
+    </div>
+    <div class="bb-skeleton--card !p-5">
+      <div class="flex items-center justify-between mb-4">
+        <div class="bb-skeleton" style="width: 130px; height: 16px;"></div>
+      </div>
+      <div class="flex flex-col items-center mb-5">
+        <div class="bb-skeleton bb-skeleton--text-xs mb-2" style="width: 90px;"></div>
+        <div class="bb-skeleton" style="width: 140px; height: 28px;"></div>
+      </div>
+      <div class="space-y-3">
+        <div class="bb-skeleton" style="width: 100%; height: 10px; border-radius: 9999px;"></div>
+        <div class="bb-skeleton" style="width: 100%; height: 10px; border-radius: 9999px;"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Skeleton Charts Row -->
+  <div class="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-6">
+    <div class="bb-skeleton--card lg:col-span-3 !p-5">
+      <div class="flex items-center justify-between mb-4">
+        <div class="bb-skeleton" style="width: 140px; height: 16px;"></div>
+        <div class="bb-skeleton bb-skeleton--badge"></div>
+      </div>
+      <div class="bb-skeleton" style="width: 100%; height: 240px; border-radius: 8px;"></div>
+    </div>
+    <div class="bb-skeleton--card lg:col-span-2 !p-5">
+      <div class="flex items-center justify-between mb-4">
+        <div class="bb-skeleton" style="width: 110px; height: 16px;"></div>
+      </div>
+      <div class="flex items-center justify-center" style="height: 240px;">
+        <div class="bb-skeleton rounded-full" style="width: 180px; height: 180px;"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Skeleton Budget Targets -->
+  <div class="bb-skeleton--card !p-5">
+    <div class="flex items-center justify-between mb-4">
+      <div class="flex items-center gap-2.5">
+        <div class="bb-skeleton" style="width: 28px; height: 28px; border-radius: 8px;"></div>
+        <div class="bb-skeleton" style="width: 120px; height: 16px;"></div>
+      </div>
+    </div>
+    <div class="space-y-3">
+      <div><div class="flex items-center justify-between mb-1.5"><div class="bb-skeleton bb-skeleton--text-xs" style="width: 100px;"></div><div class="bb-skeleton bb-skeleton--text-xs" style="width: 80px;"></div></div><div class="bb-skeleton" style="width: 100%; height: 10px; border-radius: 9999px;"></div></div>
+      <div><div class="flex items-center justify-between mb-1.5"><div class="bb-skeleton bb-skeleton--text-xs" style="width: 90px;"></div><div class="bb-skeleton bb-skeleton--text-xs" style="width: 75px;"></div></div><div class="bb-skeleton" style="width: 100%; height: 10px; border-radius: 9999px;"></div></div>
+      <div><div class="flex items-center justify-between mb-1.5"><div class="bb-skeleton bb-skeleton--text-xs" style="width: 110px;"></div><div class="bb-skeleton bb-skeleton--text-xs" style="width: 70px;"></div></div><div class="bb-skeleton" style="width: 100%; height: 10px; border-radius: 9999px;"></div></div>
+      <div><div class="flex items-center justify-between mb-1.5"><div class="bb-skeleton bb-skeleton--text-xs" style="width: 85px;"></div><div class="bb-skeleton bb-skeleton--text-xs" style="width: 65px;"></div></div><div class="bb-skeleton" style="width: 100%; height: 10px; border-radius: 9999px;"></div></div>
+      <div><div class="flex items-center justify-between mb-1.5"><div class="bb-skeleton bb-skeleton--text-xs" style="width: 95px;"></div><div class="bb-skeleton bb-skeleton--text-xs" style="width: 82px;"></div></div><div class="bb-skeleton" style="width: 100%; height: 10px; border-radius: 9999px;"></div></div>
+    </div>
+  </div>
+</div>
+
+<!-- Real Insights Content (hidden until ready) -->
+<div x-show="insightsReady" x-transition:enter="transition ease-out duration-400" x-transition:enter-start="opacity-0 translate-y-1" x-transition:enter-end="opacity-100 translate-y-0" x-cloak>
 
 <!-- Summary Pills (always visible) with sparklines + count-up animation -->
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3 mb-6">
@@ -1378,6 +1517,8 @@
 
 </div><!-- /tab: trends -->
 
+</div><!-- /x-show insightsReady wrapper -->
+
 </div><!-- /alpine x-data tabs -->
 
 <!-- ECharts CDN (loaded only on Insights page) -->
@@ -2436,6 +2577,14 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     }, 250);
   };
+
+  // ── Signal to Alpine that insights content is ready ──
+  // Dismiss the skeleton loading state after charts are initialized.
+  requestAnimationFrame(function() {
+    setTimeout(function() {
+      if (window._setInsightsReady) window._setInsightsReady();
+    }, 80);
+  });
 });
 </script>
 


### PR DESCRIPTION
## Summary
- Adds animated skeleton loading placeholders that mirror the real Insights layout (summary pills, health score ring, pace cards, charts, budget targets)
- Skeleton shows immediately on page load with shimmer animation, then smoothly fades out (300ms) once ECharts and content are initialized
- Real content fades in with a subtle translate-y entrance animation (400ms) for a premium feel

## How it works
- Alpine.js `insightsReady` flag starts as `false`, showing the skeleton
- After ECharts DOMContentLoaded handler completes chart initialization, it calls `window._setInsightsReady()` which flips the flag to `true`
- Uses existing `bb-skeleton` CSS primitives from `input.css` — no new CSS needed
- Only `insights.html` was modified (no Go handler or CSS changes)

## Screenshots

### Skeleton loading state
![skeleton-loading](https://github.com/user-attachments/assets/placeholder-skeleton)

The skeleton matches the Overview tab layout: 4 summary pill cards, tab navigation bar, health score card with circular ring placeholder, spending pace + summary grid, charts row (bar chart + donut), and budget targets with progress bars.

### After content loads
The skeleton fades out and real content fades in with all charts, data, and interactive elements.

Relates to #150

🤖 Generated by autonomous UX improvement agent