### PR TITLE
Add Agents section to sidebar navigation

### DIFF
--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -21,16 +21,6 @@
   <a href="/transactions" class="bb-sidebar-link{{if eq .CurrentPage "transactions"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="receipt"></i> Transactions
   </a>
-  <a href="/reviews" class="bb-sidebar-link{{if eq .CurrentPage "reviews"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="clipboard-check"></i>
-    <span class="flex-1">Reviews</span>
-    {{if and .NavBadges (gt .NavBadges.PendingReviews 0)}}
-    <span class="bb-nav-badge">{{.NavBadges.PendingReviews}}</span>
-    {{end}}
-  </a>
-  <a href="/review-instructions" class="bb-sidebar-link{{if eq .CurrentPage "review-instructions"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="message-square-code"></i> Review Agent
-  </a>
   <a href="/rules" class="bb-sidebar-link{{if eq .CurrentPage "rules"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="list-filter"></i> Rules
   </a>
@@ -42,6 +32,18 @@
   </a>
   <a href="/users" class="bb-sidebar-link{{if eq .CurrentPage "users"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="users"></i> Family Members
+  </a>
+
+  <div class="bb-sidebar-section">Agents</div>
+  <a href="/reviews" class="bb-sidebar-link{{if eq .CurrentPage "reviews"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="clipboard-check"></i>
+    <span class="flex-1">Review Queue</span>
+    {{if and .NavBadges (gt .NavBadges.PendingReviews 0)}}
+    <span class="bb-nav-badge">{{.NavBadges.PendingReviews}}</span>
+    {{end}}
+  </a>
+  <a href="/review-instructions" class="bb-sidebar-link{{if eq .CurrentPage "review-instructions"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="message-square-code"></i> Review Agent
   </a>
 
   <div class="bb-sidebar-section">System</div>


### PR DESCRIPTION
## Summary
- Add new "Agents" section to the sidebar between Data and System
- Move Review Queue and Review Agent under the Agents section
- Rename "Reviews" to "Review Queue" for clarity

## Test plan
- [ ] Verify sidebar shows three sections: Data, Agents, System
- [ ] Verify Review Queue and Review Agent appear under Agents
- [ ] Verify active states work correctly on all moved items

🤖 Generated with [Claude Code](https://claude.com/claude-code)