### PR TITLE
Add sync duration tracking and display

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -383,13 +383,19 @@ func ConnectionDetailHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc 
 				errorSyncs++
 			}
 
-			// Calculate duration.
-			if log.StartedAt.Valid && log.CompletedAt.Valid {
-				dur := log.CompletedAt.Time.Sub(log.StartedAt.Time).Seconds()
-				if dur >= 0 && dur < 600 { // sanity check: under 10 min
-					avgDurationSec += dur
-					durationCount++
-				}
+			// Calculate duration (prefer stored duration_ms, fall back to timestamps).
+			var durSec float64
+			var hasDur bool
+			if log.DurationMs.Valid {
+				durSec = float64(log.DurationMs.Int32) / 1000.0
+				hasDur = true
+			} else if log.StartedAt.Valid && log.CompletedAt.Valid {
+				durSec = log.CompletedAt.Time.Sub(log.StartedAt.Time).Seconds()
+				hasDur = true
+			}
+			if hasDur && durSec >= 0 && durSec < 600 { // sanity check: under 10 min
+				avgDurationSec += durSec
+				durationCount++
 			}
 
 			// Populate day map.

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -115,6 +115,20 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return fmt.Sprintf("%.0fm", d.Minutes())
 			},
+			"formatDurationMs": func(ms int32) string {
+				if ms < 1000 {
+					return fmt.Sprintf("%dms", ms)
+				}
+				if ms < 60000 {
+					return fmt.Sprintf("%.1fs", float64(ms)/1000)
+				}
+				mins := ms / 60000
+				secs := (ms % 60000) / 1000
+				if secs == 0 {
+					return fmt.Sprintf("%dm", mins)
+				}
+				return fmt.Sprintf("%dm %ds", mins, secs)
+			},
 			"relativeTime": func(t interface{}) string {
 				switch v := t.(type) {
 				case time.Time:

--- a/internal/db/migrations/20260327171429_add_sync_duration_ms.sql
+++ b/internal/db/migrations/20260327171429_add_sync_duration_ms.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+ALTER TABLE sync_logs ADD COLUMN duration_ms INTEGER NULL;
+
+-- Backfill duration_ms for existing completed sync logs.
+UPDATE sync_logs
+SET duration_ms = EXTRACT(MILLISECONDS FROM (completed_at - started_at))::INTEGER
+WHERE completed_at IS NOT NULL AND started_at IS NOT NULL;
+
+-- +goose Down
+ALTER TABLE sync_logs DROP COLUMN IF EXISTS duration_ms;

--- a/internal/db/queries/sync_logs.sql
+++ b/internal/db/queries/sync_logs.sql
@@ -23,7 +23,7 @@ LIMIT $2 OFFSET $3;
 
 -- name: UpdateSyncLog :exec
 UPDATE sync_logs
-SET status = $2, completed_at = $3, added_count = $4, modified_count = $5, removed_count = $6, error_message = $7
+SET status = $2, completed_at = $3, added_count = $4, modified_count = $5, removed_count = $6, error_message = $7, duration_ms = $8
 WHERE id = $1;
 
 -- name: GetMostRecentSyncLog :one

--- a/internal/service/connections.go
+++ b/internal/service/connections.go
@@ -101,7 +101,7 @@ func (s *Service) GetConnectionStatus(ctx context.Context, id string) (*Connecti
 		// No sync log found, that's fine
 	} else {
 		resp.LastAttemptedSyncAt = timestampStr(syncLog.StartedAt)
-		resp.LastSyncLog = &SyncLogResponse{
+		slResp := SyncLogResponse{
 			ID:            formatUUID(syncLog.ID),
 			ConnectionID:  formatUUID(syncLog.ConnectionID),
 			Trigger:       string(syncLog.Trigger),
@@ -113,6 +113,17 @@ func (s *Service) GetConnectionStatus(ctx context.Context, id string) (*Connecti
 			StartedAt:     timestampStr(syncLog.StartedAt),
 			CompletedAt:   timestampStr(syncLog.CompletedAt),
 		}
+		if syncLog.DurationMs.Valid {
+			slResp.DurationMs = &syncLog.DurationMs.Int32
+			d := formatDurationMs(int64(syncLog.DurationMs.Int32))
+			slResp.Duration = &d
+		} else if syncLog.StartedAt.Valid && syncLog.CompletedAt.Valid {
+			ms := int32(syncLog.CompletedAt.Time.Sub(syncLog.StartedAt.Time).Milliseconds())
+			slResp.DurationMs = &ms
+			d := formatDurationMs(int64(ms))
+			slResp.Duration = &d
+		}
+		resp.LastSyncLog = &slResp
 	}
 
 	return resp, nil

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -106,3 +106,20 @@ func connStatusPtr(s db.ConnectionStatus) *string {
 	str := string(s)
 	return &str
 }
+
+// formatDurationMs converts milliseconds to a human-readable duration string.
+// Examples: 42ms, 1.2s, 2m 15s
+func formatDurationMs(ms int64) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	if ms < 60000 {
+		return fmt.Sprintf("%.1fs", float64(ms)/1000)
+	}
+	mins := ms / 60000
+	secs := (ms % 60000) / 1000
+	if secs == 0 {
+		return fmt.Sprintf("%dm", mins)
+	}
+	return fmt.Sprintf("%dm %ds", mins, secs)
+}

--- a/internal/service/convert_test.go
+++ b/internal/service/convert_test.go
@@ -165,6 +165,35 @@ func TestDateStrInvalid(t *testing.T) {
 	}
 }
 
+func TestFormatDurationMs(t *testing.T) {
+	tests := []struct {
+		ms   int64
+		want string
+	}{
+		{0, "0ms"},
+		{42, "42ms"},
+		{999, "999ms"},
+		{1000, "1.0s"},
+		{1500, "1.5s"},
+		{5250, "5.2s"},
+		{59999, "60.0s"},
+		{60000, "1m"},
+		{90000, "1m 30s"},
+		{120000, "2m"},
+		{125000, "2m 5s"},
+		{300000, "5m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := formatDurationMs(tt.ms)
+			if got != tt.want {
+				t.Errorf("formatDurationMs(%d) = %q, want %q", tt.ms, got, tt.want)
+			}
+		})
+	}
+}
+
 func ptrFloat(f float64) *float64 {
 	return &f
 }

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"time"
 
 	"breadbox/internal/db"
 
@@ -49,7 +48,7 @@ func (s *Service) TriggerSync(ctx context.Context, connectionID *string) error {
 func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListParams) (*SyncLogListResult, error) {
 	query := "SELECT sl.id, sl.connection_id, bc.institution_name, sl.trigger, sl.status, " +
 		"sl.added_count, sl.modified_count, sl.removed_count, sl.error_message, " +
-		"sl.started_at, sl.completed_at " +
+		"sl.started_at, sl.completed_at, sl.duration_ms " +
 		"FROM sync_logs sl " +
 		"JOIN bank_connections bc ON sl.connection_id = bc.id " +
 		"WHERE 1=1"
@@ -119,20 +118,33 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 			errorMessage    pgtype.Text
 			startedAt       pgtype.Timestamptz
 			completedAt     pgtype.Timestamptz
+			durationMs      pgtype.Int4
 		)
 
 		if err := rows.Scan(
 			&id, &connectionID, &institutionName, &trigger, &status,
 			&addedCount, &modifiedCount, &removedCount, &errorMessage,
-			&startedAt, &completedAt,
+			&startedAt, &completedAt, &durationMs,
 		); err != nil {
 			return nil, fmt.Errorf("scan sync log: %w", err)
 		}
 
 		var duration *string
-		if startedAt.Valid && completedAt.Valid {
-			d := completedAt.Time.Sub(startedAt.Time).Round(time.Millisecond).String()
+		if durationMs.Valid {
+			d := formatDurationMs(int64(durationMs.Int32))
 			duration = &d
+		} else if startedAt.Valid && completedAt.Valid {
+			// Fallback for logs before the duration_ms column was backfilled.
+			d := formatDurationMs(completedAt.Time.Sub(startedAt.Time).Milliseconds())
+			duration = &d
+		}
+
+		var durationMsPtr *int32
+		if durationMs.Valid {
+			durationMsPtr = &durationMs.Int32
+		} else if startedAt.Valid && completedAt.Valid {
+			ms := int32(completedAt.Time.Sub(startedAt.Time).Milliseconds())
+			durationMsPtr = &ms
 		}
 
 		instName := ""
@@ -153,6 +165,7 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 			StartedAt:       timestampStr(startedAt),
 			CompletedAt:     timestampStr(completedAt),
 			Duration:        duration,
+			DurationMs:      durationMsPtr,
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -206,7 +219,7 @@ func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*
 		COUNT(*) AS total,
 		COUNT(*) FILTER (WHERE sl.status = 'success') AS success_count,
 		COUNT(*) FILTER (WHERE sl.status = 'error') AS error_count,
-		COALESCE(AVG(EXTRACT(MILLISECONDS FROM (sl.completed_at - sl.started_at))) FILTER (WHERE sl.completed_at IS NOT NULL), 0) AS avg_duration_ms,
+		COALESCE(AVG(COALESCE(sl.duration_ms, EXTRACT(MILLISECONDS FROM (sl.completed_at - sl.started_at))::INTEGER)) FILTER (WHERE sl.completed_at IS NOT NULL), 0) AS avg_duration_ms,
 		COALESCE(SUM(sl.added_count), 0) AS total_added,
 		COALESCE(SUM(sl.modified_count), 0) AS total_modified,
 		COALESCE(SUM(sl.removed_count), 0) AS total_removed

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -144,6 +144,8 @@ type SyncLogResponse struct {
 	ErrorMessage  *string `json:"error_message"`
 	StartedAt     *string `json:"started_at"`
 	CompletedAt   *string `json:"completed_at"`
+	DurationMs    *int32  `json:"duration_ms,omitempty"`
+	Duration      *string `json:"duration,omitempty"`
 }
 
 type APIKeyResponse struct {
@@ -189,6 +191,7 @@ type SyncLogRow struct {
 	StartedAt       *string
 	CompletedAt     *string
 	Duration        *string
+	DurationMs      *int32
 }
 
 // SyncLogStats contains aggregate statistics about sync logs.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -67,12 +67,20 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	added, modified, removed, syncErr := e.runSync(ctx, connectionID, logger)
 
 	// Update sync_log with final status.
-	now := pgtype.Timestamptz{Time: time.Now(), Valid: true}
+	completedAt := time.Now()
+	now := pgtype.Timestamptz{Time: completedAt, Valid: true}
 	status := db.SyncStatusSuccess
 	var errMsg pgtype.Text
 	if syncErr != nil {
 		status = db.SyncStatusError
 		errMsg = pgtype.Text{String: syncErr.Error(), Valid: true}
+	}
+
+	// Compute duration in milliseconds from started_at.
+	var durationMs pgtype.Int4
+	if syncLog.StartedAt.Valid {
+		ms := completedAt.Sub(syncLog.StartedAt.Time).Milliseconds()
+		durationMs = pgtype.Int4{Int32: int32(ms), Valid: true}
 	}
 
 	if err := e.db.UpdateSyncLog(ctx, db.UpdateSyncLogParams{
@@ -83,6 +91,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 		ModifiedCount: int32(modified),
 		RemovedCount:  int32(removed),
 		ErrorMessage:  errMsg,
+		DurationMs:    durationMs,
 	}); err != nil {
 		logger.Error("failed to update sync log", "error", err)
 	}

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -295,7 +295,9 @@
           <div class="flex items-center gap-2 flex-wrap">
             <span class="text-sm font-medium capitalize">{{.Trigger}}</span>
             <span class="text-xs text-base-content/40">{{relativeTime .StartedAt}}</span>
-            {{if and .StartedAt.Valid .CompletedAt.Valid}}
+            {{if .DurationMs.Valid}}
+            <span class="text-[0.65rem] text-base-content/25 tabular-nums">{{formatDurationMs .DurationMs.Int32}}</span>
+            {{else if and .StartedAt.Valid .CompletedAt.Valid}}
             <span class="text-[0.65rem] text-base-content/25 tabular-nums">{{syncDuration .StartedAt.Time .CompletedAt.Time}}</span>
             {{end}}
           </div>


### PR DESCRIPTION
## Summary
- Add `duration_ms` INTEGER column to `sync_logs` table via migration (with backfill of existing rows)
- Compute and store duration when completing a sync log in the engine
- Display human-readable duration in sync log list page and connection detail page
- Expose `duration_ms` and `duration` in REST API `SyncLogResponse`

## Changes

### Migration
- `internal/db/migrations/20260327171429_add_sync_duration_ms.sql` -- adds `duration_ms INTEGER NULL` column and backfills from `completed_at - started_at`

### Sync Engine
- `internal/sync/engine.go` -- computes `duration_ms` from `started_at` when completing a sync and passes it to `UpdateSyncLog`

### sqlc Queries
- `internal/db/queries/sync_logs.sql` -- `UpdateSyncLog` now includes `duration_ms = $8`

### Service Layer
- `internal/service/sync.go` -- `ListSyncLogsPaginated` reads `duration_ms` from DB (falls back to timestamp diff); `SyncLogStats` uses `COALESCE(duration_ms, ...)` for avg calculation
- `internal/service/types.go` -- adds `DurationMs *int32` to `SyncLogRow` and `DurationMs`/`Duration` to `SyncLogResponse`
- `internal/service/connections.go` -- populates `DurationMs` and `Duration` on `SyncLogResponse` for connection status
- `internal/service/convert.go` -- adds `formatDurationMs()` helper (0ms, 1.2s, 2m 15s format)

### Admin UI
- `internal/admin/connections.go` -- connection detail handler uses stored `DurationMs` for avg duration (falls back to timestamp diff)
- `internal/admin/templates.go` -- adds `formatDurationMs` template function
- `internal/templates/pages/connection_detail.html` -- sync history entries prefer stored `DurationMs` over computed timestamp diff

### Tests
- `internal/service/convert_test.go` -- unit tests for `formatDurationMs` covering ms, seconds, and minutes ranges

## Testing
- `go build ./...` passes
- `go test breadbox/internal/service breadbox/internal/admin` passes
- Migration verified against local PostgreSQL (column created, backfill correct)
- Dev server starts and `/health/ready` returns 200

🤖 Generated by autonomous sync improvement agent