### PR TITLE
Add sync health dashboard widget

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -728,6 +728,23 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			})
 		}
 
+		// ── Sync Health Summary ──────────────────────────────────────
+		syncHealth, err := svc.GetSyncHealthSummary(ctx)
+		if err != nil {
+			a.Logger.Error("sync health summary", "error", err)
+		}
+		// Enrich with connection-level errors (already computed above) and next sync time.
+		if syncHealth != nil {
+			syncHealth.ConnectionErrors = int64(errorCount)
+			if a.Scheduler != nil {
+				syncHealth.NextSyncTime = formatNextSync(a.Scheduler.NextRun())
+			}
+			// Override health if connections have errors.
+			if errorCount > 0 && syncHealth.OverallHealth == "healthy" {
+				syncHealth.OverallHealth = "degraded"
+			}
+		}
+
 		// ── Insights: useful aggregate data for the insights card ──
 		type InsightItem struct {
 			Icon    string // Lucide icon name
@@ -1042,6 +1059,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"HealthyCount":          healthyCount,
 			"ErrorCount":            errorCount,
 			"StaleCount":            staleCount,
+			// Sync health summary.
+			"SyncHealth":            syncHealth,
 			// Insights.
 			"Insights":              insights,
 			// Smart spending insights.

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -252,3 +252,99 @@ func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*
 
 	return &stats, nil
 }
+
+// GetSyncHealthSummary returns a dashboard-oriented summary of recent sync health.
+// It queries the last 24 hours of sync activity.
+func (s *Service) GetSyncHealthSummary(ctx context.Context) (*SyncHealthSummary, error) {
+	query := `SELECT
+		COUNT(*) AS total_syncs,
+		COUNT(*) FILTER (WHERE status = 'success') AS success_count,
+		COUNT(*) FILTER (WHERE status = 'error') AS error_count,
+		MAX(COALESCE(completed_at, started_at)) AS last_sync_time,
+		(SELECT status FROM sync_logs ORDER BY started_at DESC LIMIT 1) AS last_status
+	FROM sync_logs
+	WHERE started_at >= NOW() - INTERVAL '24 hours'`
+
+	var (
+		totalSyncs   int64
+		successCount int64
+		errorCount   int64
+		lastSyncTime pgtype.Timestamptz
+		lastStatus   pgtype.Text
+	)
+
+	err := s.Pool.QueryRow(ctx, query).Scan(
+		&totalSyncs,
+		&successCount,
+		&errorCount,
+		&lastSyncTime,
+		&lastStatus,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("sync health summary: %w", err)
+	}
+
+	summary := &SyncHealthSummary{
+		RecentSyncCount:  totalSyncs,
+		RecentErrorCount: errorCount,
+	}
+
+	if totalSyncs > 0 {
+		summary.RecentSuccessRate = float64(successCount) / float64(totalSyncs) * 100
+	}
+
+	if lastSyncTime.Valid {
+		t := relativeTimeStr(lastSyncTime.Time)
+		summary.LastSyncTime = &t
+	}
+
+	if lastStatus.Valid {
+		summary.LastSyncStatus = lastStatus.String
+	}
+
+	// Determine overall health: healthy, degraded, or unhealthy.
+	// - unhealthy: success rate < 50% with 2+ syncs, or all recent syncs failed
+	// - degraded: success rate < 100% or no syncs in 24h
+	// - healthy: everything ok
+	switch {
+	case totalSyncs == 0:
+		summary.OverallHealth = "degraded" // no recent syncs
+	case summary.RecentSuccessRate < 50 && totalSyncs >= 2:
+		summary.OverallHealth = "unhealthy"
+	case errorCount == totalSyncs && totalSyncs > 0:
+		summary.OverallHealth = "unhealthy"
+	case errorCount > 0:
+		summary.OverallHealth = "degraded"
+	default:
+		summary.OverallHealth = "healthy"
+	}
+
+	return summary, nil
+}
+
+// relativeTimeStr converts a time to a human-readable relative string.
+func relativeTimeStr(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		mins := int(d.Minutes())
+		if mins == 1 {
+			return "1 minute ago"
+		}
+		return fmt.Sprintf("%d minutes ago", mins)
+	case d < 24*time.Hour:
+		hours := int(d.Hours())
+		if hours == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", hours)
+	default:
+		days := int(d.Hours() / 24)
+		if days == 1 {
+			return "1 day ago"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	}
+}

--- a/internal/service/sync_health_test.go
+++ b/internal/service/sync_health_test.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRelativeTimeStr(t *testing.T) {
+	tests := []struct {
+		name string
+		t    time.Time
+		want string
+	}{
+		{"just now", time.Now().Add(-10 * time.Second), "just now"},
+		{"1 minute ago", time.Now().Add(-90 * time.Second), "1 minute ago"},
+		{"5 minutes ago", time.Now().Add(-5 * time.Minute), "5 minutes ago"},
+		{"1 hour ago", time.Now().Add(-90 * time.Minute), "1 hour ago"},
+		{"3 hours ago", time.Now().Add(-3 * time.Hour), "3 hours ago"},
+		{"1 day ago", time.Now().Add(-36 * time.Hour), "1 day ago"},
+		{"5 days ago", time.Now().Add(-5 * 24 * time.Hour), "5 days ago"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := relativeTimeStr(tt.t)
+			if got != tt.want {
+				t.Errorf("relativeTimeStr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSyncHealthSummaryOverallHealth(t *testing.T) {
+	// Test the health determination logic by constructing summaries
+	// and verifying the OverallHealth field.
+	tests := []struct {
+		name         string
+		syncCount    int64
+		successRate  float64
+		errorCount   int64
+		connErrors   int64
+		wantHealth   string
+	}{
+		{
+			name:        "no syncs is degraded",
+			syncCount:   0,
+			successRate: 0,
+			errorCount:  0,
+			connErrors:  0,
+			wantHealth:  "degraded",
+		},
+		{
+			name:        "all success is healthy",
+			syncCount:   10,
+			successRate: 100,
+			errorCount:  0,
+			connErrors:  0,
+			wantHealth:  "healthy",
+		},
+		{
+			name:        "some errors is degraded",
+			syncCount:   10,
+			successRate: 80,
+			errorCount:  2,
+			connErrors:  0,
+			wantHealth:  "degraded",
+		},
+		{
+			name:        "low success rate is unhealthy",
+			syncCount:   10,
+			successRate: 40,
+			errorCount:  6,
+			connErrors:  0,
+			wantHealth:  "unhealthy",
+		},
+		{
+			name:        "all errors is unhealthy",
+			syncCount:   5,
+			successRate: 0,
+			errorCount:  5,
+			connErrors:  0,
+			wantHealth:  "unhealthy",
+		},
+		{
+			name:        "healthy syncs but connection errors is degraded",
+			syncCount:   10,
+			successRate: 100,
+			errorCount:  0,
+			connErrors:  1,
+			wantHealth:  "degraded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reproduce the health logic from GetSyncHealthSummary.
+			var health string
+			switch {
+			case tt.syncCount == 0:
+				health = "degraded"
+			case tt.successRate < 50 && tt.syncCount >= 2:
+				health = "unhealthy"
+			case tt.errorCount == tt.syncCount && tt.syncCount > 0:
+				health = "unhealthy"
+			case tt.errorCount > 0:
+				health = "degraded"
+			default:
+				health = "healthy"
+			}
+			// Apply connection error override (same as dashboard handler).
+			if tt.connErrors > 0 && health == "healthy" {
+				health = "degraded"
+			}
+			if health != tt.wantHealth {
+				t.Errorf("health = %q, want %q", health, tt.wantHealth)
+			}
+		})
+	}
+}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -203,6 +203,18 @@ type SyncLogStats struct {
 	TotalRemoved  int64
 }
 
+// SyncHealthSummary contains a dashboard-oriented overview of sync health.
+type SyncHealthSummary struct {
+	LastSyncTime      *string // relative time of most recent completed sync (any status)
+	LastSyncStatus    string  // status of the most recent sync: "success", "error", or ""
+	RecentSyncCount   int64   // total syncs in the last 24h
+	RecentSuccessRate float64 // 0-100 success rate over last 24h
+	RecentErrorCount  int64   // error syncs in the last 24h
+	ConnectionErrors  int64   // count of connections currently in error/pending_reauth status
+	NextSyncTime      string  // human-readable time until next scheduled sync
+	OverallHealth     string  // "healthy", "degraded", or "unhealthy"
+}
+
 type AdminTransactionListParams struct {
 	Page          int
 	PageSize      int

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -389,6 +389,107 @@
       {{end}}
     </div>
 
+    <!-- Sync Health Summary -->
+    {{if .SyncHealth}}
+    <div class="bb-card p-5">
+      <div class="flex items-center justify-between mb-3">
+        <div class="flex items-center gap-2">
+          <h2 class="text-sm font-semibold text-base-content/70">Sync Health</h2>
+          {{if eq .SyncHealth.OverallHealth "healthy"}}
+          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-success/10 text-success">
+            <span class="w-1.5 h-1.5 rounded-full bg-success animate-pulse"></span>
+            Healthy
+          </span>
+          {{else if eq .SyncHealth.OverallHealth "degraded"}}
+          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-warning/10 text-warning">
+            <span class="w-1.5 h-1.5 rounded-full bg-warning animate-pulse"></span>
+            Degraded
+          </span>
+          {{else if eq .SyncHealth.OverallHealth "unhealthy"}}
+          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-error/10 text-error">
+            <span class="w-1.5 h-1.5 rounded-full bg-error animate-pulse"></span>
+            Unhealthy
+          </span>
+          {{end}}
+        </div>
+        <a href="/sync-logs" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Logs</a>
+      </div>
+
+      <div class="space-y-2.5">
+        <!-- Last Sync -->
+        <div class="flex items-center justify-between">
+          <span class="flex items-center gap-2 text-xs text-base-content/50">
+            <i data-lucide="clock" class="w-3.5 h-3.5"></i>
+            Last sync
+          </span>
+          <span class="text-xs font-medium tabular-nums {{if .SyncHealth.LastSyncTime}}{{if eq .SyncHealth.LastSyncStatus "error"}}text-error/80{{else}}text-base-content/70{{end}}{{else}}text-base-content/40{{end}}">
+            {{if .SyncHealth.LastSyncTime}}{{deref .SyncHealth.LastSyncTime}}{{else}}Never{{end}}
+          </span>
+        </div>
+
+        <!-- Success Rate (24h) -->
+        <div class="flex items-center justify-between">
+          <span class="flex items-center gap-2 text-xs text-base-content/50">
+            <i data-lucide="bar-chart-3" class="w-3.5 h-3.5"></i>
+            24h success rate
+          </span>
+          {{if gt .SyncHealth.RecentSyncCount 0}}
+          <span class="text-xs font-medium tabular-nums {{if ge .SyncHealth.RecentSuccessRate 90.0}}text-success{{else if ge .SyncHealth.RecentSuccessRate 50.0}}text-warning{{else}}text-error/80{{end}}">
+            {{printf "%.0f" .SyncHealth.RecentSuccessRate}}%
+            <span class="text-base-content/30 font-normal">({{.SyncHealth.RecentSyncCount}} syncs)</span>
+          </span>
+          {{else}}
+          <span class="text-xs text-base-content/40">No syncs</span>
+          {{end}}
+        </div>
+
+        <!-- Errors (24h) -->
+        {{if gt .SyncHealth.RecentErrorCount 0}}
+        <div class="flex items-center justify-between">
+          <span class="flex items-center gap-2 text-xs text-base-content/50">
+            <i data-lucide="alert-triangle" class="w-3.5 h-3.5 text-error/60"></i>
+            Failed syncs (24h)
+          </span>
+          <span class="text-xs font-medium tabular-nums text-error/80">{{.SyncHealth.RecentErrorCount}}</span>
+        </div>
+        {{end}}
+
+        <!-- Connection Errors -->
+        {{if gt .SyncHealth.ConnectionErrors 0}}
+        <div class="flex items-center justify-between">
+          <span class="flex items-center gap-2 text-xs text-base-content/50">
+            <i data-lucide="unplug" class="w-3.5 h-3.5 text-error/60"></i>
+            Connections with issues
+          </span>
+          <a href="/connections" class="text-xs font-medium tabular-nums text-error/80 hover:text-error transition-colors">{{.SyncHealth.ConnectionErrors}}</a>
+        </div>
+        {{end}}
+
+        <!-- Next Sync -->
+        {{if .SyncHealth.NextSyncTime}}
+        <div class="flex items-center justify-between">
+          <span class="flex items-center gap-2 text-xs text-base-content/50">
+            <i data-lucide="timer" class="w-3.5 h-3.5"></i>
+            Next sync
+          </span>
+          <span class="text-xs font-medium text-base-content/60">{{.SyncHealth.NextSyncTime}}</span>
+        </div>
+        {{end}}
+      </div>
+
+      <!-- Success rate mini bar -->
+      {{if gt .SyncHealth.RecentSyncCount 0}}
+      <div class="mt-3 pt-3 border-t border-base-200/60">
+        <div class="flex h-1.5 rounded-full overflow-hidden bg-base-200/60">
+          {{if gt .SyncHealth.RecentSuccessRate 0.0}}
+          <div class="h-full rounded-full {{if ge .SyncHealth.RecentSuccessRate 90.0}}bg-success/60{{else if ge .SyncHealth.RecentSuccessRate 50.0}}bg-warning/60{{else}}bg-error/60{{end}} transition-all duration-700" style="width: {{printf "%.0f" .SyncHealth.RecentSuccessRate}}%;"></div>
+          {{end}}
+        </div>
+      </div>
+      {{end}}
+    </div>
+    {{end}}
+
     <!-- Quick Actions -->
     <div class="bb-card p-4">
       <div class="flex gap-2">


### PR DESCRIPTION
## Summary
- Adds a "Sync Health" card to the dashboard right column (between Connection Health and Quick Actions)
- Shows overall sync health status at a glance with color-coded indicator (healthy/degraded/unhealthy)
- Displays last sync time, 24h success rate, error counts, connection issues, and next scheduled sync

## Changes
- **`internal/service/types.go`**: New `SyncHealthSummary` struct with health fields
- **`internal/service/sync.go`**: New `GetSyncHealthSummary()` service method that queries last 24h of sync logs with a single SQL query (total syncs, success/error counts, last sync time, last status). Includes health determination logic
- **`internal/admin/dashboard.go`**: Wire up sync health data, enrich with connection error count and next sync time from scheduler
- **`internal/templates/pages/dashboard.html`**: New sync health card widget with DaisyUI styling
- **`internal/service/sync_health_test.go`**: Unit tests for `relativeTimeStr` helper and health determination logic

## Health Determination
- **Healthy** (green): All recent syncs succeeded, no connection issues
- **Degraded** (yellow): Some sync errors, no recent syncs in 24h, or connections need attention  
- **Unhealthy** (red): Success rate below 50% with 2+ syncs, or all syncs failing

## Testing
- Unit tests: `go test ./internal/service/ -run "TestRelativeTimeStr|TestSyncHealthSummaryOverallHealth"` (7 test cases)
- Build: `go build ./...` passes
- Full test suite: `go test ./...` passes
- No schema changes needed - uses existing `sync_logs` and `bank_connections` tables

🤖 Generated by autonomous sync improvement agent