### PR TITLE
Add sync log retention with automatic cleanup

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -116,6 +116,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 		r.Get("/settings", SettingsGetHandler(a, sm, tr))
 		r.Post("/settings/sync", SettingsSyncPostHandler(a, sm))
+		r.Post("/settings/retention", SettingsRetentionPostHandler(a, sm))
 		r.Post("/settings/password", ChangePasswordHandler(a, sm))
 	})
 

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -36,12 +36,19 @@ func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 		var pgVersion string
 		_ = a.DB.QueryRow(ctx, "SELECT version()").Scan(&pgVersion)
 
+		// Sync log retention.
+		retentionDays, _ := a.Service.GetSyncLogRetentionDays(ctx)
+		syncLogCount, _ := a.Service.CountSyncLogs(ctx)
+
 		data := map[string]any{
 			"PageTitle":           "Settings",
 			"CurrentPage":         "settings",
 			"CSRFToken":           GetCSRFToken(r),
 			"Flash":               GetFlash(ctx, sm),
 			"SyncIntervalMinutes": a.Config.SyncIntervalMinutes,
+			// Sync log retention
+			"SyncLogRetentionDays": retentionDays,
+			"SyncLogCount":         syncLogCount,
 			// System info
 			"Version":         a.Config.Version,
 			"GoVersion":       runtime.Version(),
@@ -159,6 +166,38 @@ func ChangePasswordHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc 
 		}
 
 		SetFlash(ctx, sm, "success", "Password updated successfully.")
+		http.Redirect(w, r, "/settings", http.StatusSeeOther)
+	}
+}
+
+// SettingsRetentionPostHandler serves POST /admin/settings/retention.
+func SettingsRetentionPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		retentionStr := r.FormValue("sync_log_retention_days")
+		retentionDays, err := strconv.Atoi(retentionStr)
+		if err != nil || retentionDays < 0 || retentionDays > 3650 {
+			SetFlash(ctx, sm, "error", "Invalid retention period. Must be 0-3650 days.")
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
+			return
+		}
+
+		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+			Key:   "sync_log_retention_days",
+			Value: pgtype.Text{String: fmt.Sprintf("%d", retentionDays), Valid: true},
+		}); err != nil {
+			a.Logger.Error("save sync log retention", "error", err)
+			SetFlash(ctx, sm, "error", "Failed to save retention setting.")
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
+			return
+		}
+
+		if retentionDays == 0 {
+			SetFlash(ctx, sm, "success", "Sync log cleanup disabled.")
+		} else {
+			SetFlash(ctx, sm, "success", fmt.Sprintf("Sync log retention set to %d days.", retentionDays))
+		}
 		http.Redirect(w, r, "/settings", http.StatusSeeOther)
 	}
 }

--- a/internal/db/queries/sync_logs.sql
+++ b/internal/db/queries/sync_logs.sql
@@ -32,3 +32,11 @@ SELECT * FROM sync_logs WHERE connection_id = $1 ORDER BY started_at DESC LIMIT 
 -- name: CleanupOrphanedSyncLogs :execresult
 UPDATE sync_logs SET status = 'error', error_message = 'interrupted by server restart', completed_at = NOW()
 WHERE status = 'in_progress';
+
+-- name: DeleteSyncLogsOlderThan :execresult
+DELETE FROM sync_logs
+WHERE started_at < $1
+  AND status != 'in_progress';
+
+-- name: CountSyncLogs :one
+SELECT COUNT(*) FROM sync_logs;

--- a/internal/service/mcp_synclog_csv_integration_test.go
+++ b/internal/service/mcp_synclog_csv_integration_test.go
@@ -1074,6 +1074,175 @@ func TestGetOverviewStats_WithConnections(t *testing.T) {
 	}
 }
 
+// ===================== Sync Log Retention Tests =====================
+
+func TestCountSyncLogs(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Count should be 0 with no logs.
+	count, err := svc.CountSyncLogs(ctx)
+	if err != nil {
+		t.Fatalf("CountSyncLogs failed: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count = %d, want 0", count)
+	}
+
+	// Create a sync log.
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "conn_count_test")
+	now := time.Now()
+	_, err = queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerManual,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: now.Add(-time.Minute), Valid: true},
+		CompletedAt:  pgtype.Timestamptz{Time: now, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateSyncLog failed: %v", err)
+	}
+
+	count, err = svc.CountSyncLogs(ctx)
+	if err != nil {
+		t.Fatalf("CountSyncLogs failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+}
+
+func TestCleanupSyncLogs_DeletesOldLogs(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "conn_cleanup_test")
+
+	// Create an old log (100 days ago).
+	oldTime := time.Now().AddDate(0, 0, -100)
+	_, err := queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerCron,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: oldTime, Valid: true},
+		CompletedAt:  pgtype.Timestamptz{Time: oldTime.Add(time.Second), Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateSyncLog (old) failed: %v", err)
+	}
+
+	// Create a recent log (1 day ago).
+	recentTime := time.Now().AddDate(0, 0, -1)
+	_, err = queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerManual,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: recentTime, Valid: true},
+		CompletedAt:  pgtype.Timestamptz{Time: recentTime.Add(time.Second), Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateSyncLog (recent) failed: %v", err)
+	}
+
+	// Cleanup with 90-day retention should delete the old log.
+	deleted, err := svc.CleanupSyncLogs(ctx, 90)
+	if err != nil {
+		t.Fatalf("CleanupSyncLogs failed: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+
+	// Should have 1 log remaining.
+	count, err := svc.CountSyncLogs(ctx)
+	if err != nil {
+		t.Fatalf("CountSyncLogs failed: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("remaining count = %d, want 1", count)
+	}
+}
+
+func TestCleanupSyncLogs_SkipsInProgress(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "conn_cleanup_inprog")
+
+	// Create an old in_progress log (should not be deleted).
+	oldTime := time.Now().AddDate(0, 0, -100)
+	_, err := queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerCron,
+		Status:       db.SyncStatusInProgress,
+		StartedAt:    pgtype.Timestamptz{Time: oldTime, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("CreateSyncLog (in_progress) failed: %v", err)
+	}
+
+	deleted, err := svc.CleanupSyncLogs(ctx, 90)
+	if err != nil {
+		t.Fatalf("CleanupSyncLogs failed: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted = %d, want 0 (in_progress should be skipped)", deleted)
+	}
+}
+
+func TestCleanupSyncLogs_InvalidRetention(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	_, err := svc.CleanupSyncLogs(ctx, 0)
+	if err == nil {
+		t.Fatal("expected error for retention_days=0, got nil")
+	}
+
+	_, err = svc.CleanupSyncLogs(ctx, -5)
+	if err == nil {
+		t.Fatal("expected error for negative retention_days, got nil")
+	}
+}
+
+func TestGetSyncLogRetentionDays_Default(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	days, err := svc.GetSyncLogRetentionDays(ctx)
+	if err != nil {
+		t.Fatalf("GetSyncLogRetentionDays failed: %v", err)
+	}
+	if days != 90 {
+		t.Errorf("retention_days = %d, want 90 (default)", days)
+	}
+}
+
+func TestGetSyncLogRetentionDays_Configured(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Set a custom retention period.
+	err := queries.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   "sync_log_retention_days",
+		Value: pgtype.Text{String: "30", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("SetAppConfig failed: %v", err)
+	}
+
+	days, err := svc.GetSyncLogRetentionDays(ctx)
+	if err != nil {
+		t.Fatalf("GetSyncLogRetentionDays failed: %v", err)
+	}
+	if days != 30 {
+		t.Errorf("retention_days = %d, want 30", days)
+	}
+}
+
 // ===================== Helpers =====================
 
 func parseUUIDForCSVTest(s string) (pgtype.UUID, error) {

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"time"
 
 	"breadbox/internal/db"
@@ -251,4 +252,46 @@ func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*
 	}
 
 	return &stats, nil
+}
+
+// CountSyncLogs returns the total number of sync log entries.
+func (s *Service) CountSyncLogs(ctx context.Context) (int64, error) {
+	return s.Queries.CountSyncLogs(ctx)
+}
+
+// CleanupSyncLogs deletes sync logs older than the given number of days.
+// It skips in_progress logs for safety. Returns the number of deleted rows.
+func (s *Service) CleanupSyncLogs(ctx context.Context, retentionDays int) (int64, error) {
+	if retentionDays <= 0 {
+		return 0, fmt.Errorf("retention days must be positive, got %d", retentionDays)
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	result, err := s.Queries.DeleteSyncLogsOlderThan(ctx, pgtype.Timestamptz{
+		Time:  cutoff,
+		Valid: true,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("delete old sync logs: %w", err)
+	}
+
+	return result.RowsAffected(), nil
+}
+
+// GetSyncLogRetentionDays reads the sync_log_retention_days setting from app_config.
+// Returns 90 (default) if not set.
+func (s *Service) GetSyncLogRetentionDays(ctx context.Context) (int, error) {
+	row, err := s.Queries.GetAppConfig(ctx, "sync_log_retention_days")
+	if err != nil {
+		return 90, nil // default if not found
+	}
+	if !row.Value.Valid || row.Value.String == "" {
+		return 90, nil
+	}
+
+	days, err := strconv.Atoi(row.Value.String)
+	if err != nil || days <= 0 {
+		return 90, nil
+	}
+	return days, nil
 }

--- a/internal/sync/scheduler.go
+++ b/internal/sync/scheduler.go
@@ -3,10 +3,12 @@ package sync
 import (
 	"context"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"breadbox/internal/db"
 
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/robfig/cron/v3"
 )
 
@@ -32,6 +34,7 @@ func NewScheduler(engine *Engine, queries *db.Queries, logger *slog.Logger, sync
 
 // Start begins the cron scheduler. Cron fires every 15 minutes (the minimum
 // supported interval) and checks each connection's staleness individually.
+// It also schedules a daily sync log cleanup job.
 func (s *Scheduler) Start(globalIntervalMinutes int) {
 	_, err := s.cron.AddFunc("@every 15m", func() {
 		ctx := context.Background()
@@ -43,6 +46,16 @@ func (s *Scheduler) Start(globalIntervalMinutes int) {
 		s.logger.Error("failed to add cron job", "error", err)
 		return
 	}
+
+	// Daily sync log cleanup at 3:00 AM.
+	_, err = s.cron.AddFunc("0 3 * * *", func() {
+		ctx := context.Background()
+		s.cleanupSyncLogs(ctx)
+	})
+	if err != nil {
+		s.logger.Error("failed to add sync log cleanup job", "error", err)
+	}
+
 	s.cron.Start()
 	s.logger.Info("scheduler started", "check_interval", "15m", "global_sync_interval_minutes", globalIntervalMinutes)
 }
@@ -170,4 +183,43 @@ func (s *Scheduler) RunStartupSync(ctx context.Context, globalIntervalMinutes in
 	}
 
 	s.logger.Info("startup sync completed", "total", len(connections), "stale_synced", staleCount)
+}
+
+// defaultRetentionDays is used when sync_log_retention_days is not configured.
+const defaultRetentionDays = 90
+
+// cleanupSyncLogs deletes sync logs older than the configured retention period.
+// Reads sync_log_retention_days from app_config (default: 90 days).
+// A value of 0 disables cleanup.
+func (s *Scheduler) cleanupSyncLogs(ctx context.Context) {
+	retentionDays := defaultRetentionDays
+
+	row, err := s.queries.GetAppConfig(ctx, "sync_log_retention_days")
+	if err == nil && row.Value.Valid && row.Value.String != "" {
+		if days, parseErr := strconv.Atoi(row.Value.String); parseErr == nil && days >= 0 {
+			retentionDays = days
+		}
+	}
+
+	if retentionDays == 0 {
+		s.logger.Debug("sync log cleanup disabled (retention_days=0)")
+		return
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	result, err := s.queries.DeleteSyncLogsOlderThan(ctx, pgtype.Timestamptz{
+		Time:  cutoff,
+		Valid: true,
+	})
+	if err != nil {
+		s.logger.Error("sync log cleanup failed", "error", err)
+		return
+	}
+
+	deleted := result.RowsAffected()
+	if deleted > 0 {
+		s.logger.Info("sync log cleanup completed", "deleted", deleted, "retention_days", retentionDays)
+	} else {
+		s.logger.Debug("sync log cleanup completed, no old logs to delete", "retention_days", retentionDays)
+	}
 }

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -49,6 +49,54 @@
     </form>
   </div>
 
+  <!-- Sync Log Retention -->
+  <div class="bb-card p-6">
+    <div class="flex items-center gap-3 mb-5">
+      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-warning/8">
+        <i data-lucide="archive" class="w-5 h-5 text-warning"></i>
+      </div>
+      <div>
+        <h2 class="text-base font-semibold">Sync Log Retention</h2>
+        <p class="text-xs text-base-content/45">Auto-delete old sync logs to save storage</p>
+      </div>
+    </div>
+
+    <div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40 mb-5">
+      <div class="flex items-center gap-2.5">
+        <i data-lucide="database" class="w-4 h-4 text-base-content/50"></i>
+        <span class="text-sm font-medium">Total Sync Logs</span>
+      </div>
+      <span class="text-sm font-semibold tabular-nums">{{.SyncLogCount}}</span>
+    </div>
+
+    <form method="POST" action="/settings/retention">
+      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+
+      <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="sync_log_retention_days">
+        Retention Period
+      </label>
+      <select id="sync_log_retention_days" name="sync_log_retention_days" class="select select-sm select-bordered w-full rounded-xl">
+        <option value="7"{{if eq .SyncLogRetentionDays 7}} selected{{end}}>7 days</option>
+        <option value="14"{{if eq .SyncLogRetentionDays 14}} selected{{end}}>14 days</option>
+        <option value="30"{{if eq .SyncLogRetentionDays 30}} selected{{end}}>30 days</option>
+        <option value="60"{{if eq .SyncLogRetentionDays 60}} selected{{end}}>60 days</option>
+        <option value="90"{{if eq .SyncLogRetentionDays 90}} selected{{end}}>90 days (default)</option>
+        <option value="180"{{if eq .SyncLogRetentionDays 180}} selected{{end}}>180 days</option>
+        <option value="365"{{if eq .SyncLogRetentionDays 365}} selected{{end}}>1 year</option>
+        <option value="0"{{if eq .SyncLogRetentionDays 0}} selected{{end}}>Keep forever</option>
+      </select>
+
+      <p class="text-xs text-base-content/40 mt-3 flex items-center gap-1.5">
+        <i data-lucide="clock" class="w-3.5 h-3.5"></i>
+        Cleanup runs daily at 3:00 AM
+      </p>
+
+      <div class="mt-5 pt-4 border-t border-base-300">
+        <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Retention</button>
+      </div>
+    </form>
+  </div>
+
   <!-- Security -->
   <div class="bb-card p-6">
     <div class="flex items-center gap-3 mb-5">


### PR DESCRIPTION
## Summary
- Sync logs accumulate indefinitely with no cleanup, degrading query performance and wasting storage over time
- Adds a configurable `sync_log_retention_days` setting (default: 90 days, set to 0 to disable cleanup)
- Scheduler runs cleanup daily at 3:00 AM, deleting completed sync logs older than the retention period
- Settings page shows total sync log count and a retention period selector

## Changes
- **`internal/db/queries/sync_logs.sql`** -- Added `DeleteSyncLogsOlderThan` (skips in_progress logs) and `CountSyncLogs` queries
- **`internal/service/sync.go`** -- Added `CleanupSyncLogs`, `CountSyncLogs`, and `GetSyncLogRetentionDays` service methods
- **`internal/sync/scheduler.go`** -- Added daily cron job (`0 3 * * *`) that reads retention config from `app_config` and deletes old logs
- **`internal/admin/settings.go`** -- Added `SettingsRetentionPostHandler` for saving retention setting; updated GET handler to pass retention days and log count
- **`internal/admin/router.go`** -- Wired `POST /settings/retention` route
- **`internal/templates/pages/settings.html`** -- Added "Sync Log Retention" card with log count display, period dropdown (7d to forever), and save button
- **`internal/service/mcp_synclog_csv_integration_test.go`** -- Added 6 integration tests covering cleanup, count, in_progress safety, invalid input, and config read

## Design decisions
- Cleanup skips `in_progress` logs to avoid deleting logs for syncs that are actively running
- Retention of 0 disables cleanup entirely ("Keep forever" option)
- Cleanup runs at 3:00 AM to avoid interfering with normal sync operations
- Uses `app_config` table (same as other settings) -- no migration needed
- Upper bound of 3650 days (10 years) in the handler for validation safety

## Testing
- [x] `go build ./...` passes
- [x] `go test ./...` passes (unit tests)
- [x] `go vet ./...` clean
- [x] Dev server starts and health check passes
- [x] 6 new integration tests: count, cleanup deletes old, skips in_progress, rejects invalid retention, default config, custom config

🤖 Generated by autonomous sync improvement agent