### PR TITLE
Fix sync engine counting upserted transactions as new

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -229,6 +229,10 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		removed = len(pendingRemovals)
 
 		// Process added transactions (skip excluded accounts).
+		// Note: providers like Teller return ALL transactions as "Added" on every
+		// sync (date-range polling). The upsert handles this correctly (ON CONFLICT
+		// DO UPDATE), but we need to count accurately: only truly new rows count as
+		// "added"; existing rows that got upserted count as "modified".
 		var skipped int
 		for i := range pendingAdded {
 			accountID, err := e.resolveAccountID(ctx, pendingAdded[i].AccountExternalID, accountIDCache)
@@ -245,11 +249,18 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				logger.Error("upsert added transaction", "external_id", pendingAdded[i].ExternalID, "error", err)
 				continue
 			}
+			// Determine if this was truly new or an upsert of an existing row.
+			// The DB sets created_at on INSERT and updated_at=NOW() on both INSERT
+			// and UPDATE. If they're equal (within 1s tolerance), it's a new row.
+			isNew := txnResult.CreatedAt.Time.Sub(txnResult.UpdatedAt.Time).Abs() < time.Second
+			if isNew {
+				added++
+			} else {
+				modified++
+			}
 			if reviewAutoEnqueue {
-				isNew := txnResult.CreatedAt.Time.Equal(txnResult.UpdatedAt.Time)
 				e.enqueueForReview(ctx, txQueries, txnResult, isNew, confidenceThreshold, resolver)
 			}
-			added++
 		}
 
 		// Process modified transactions (skip excluded accounts).
@@ -268,10 +279,10 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				logger.Error("upsert modified transaction", "external_id", pendingModified[i].ExternalID, "error", err)
 				continue
 			}
+			modified++
 			if reviewAutoEnqueue {
 				e.enqueueForReview(ctx, txQueries, txnResult, false, confidenceThreshold, resolver)
 			}
-			modified++
 		}
 
 		if skipped > 0 {


### PR DESCRIPTION
## Summary
- Teller returns ALL transactions as "Added" on every sync (date-range polling, not cursor-based)
- The upsert (`ON CONFLICT DO UPDATE`) handles this correctly at the DB level — no duplicate data
- But the engine always counted them as `added++`, inflating sync log numbers (e.g., "314 added" on every sync when nothing is new)

## Root Cause
Teller's sync model is fundamentally different from Plaid's:
- **Plaid**: Cursor-based incremental — only returns new/modified/removed since last cursor
- **Teller**: Date-range polling with 10-day overlap — returns ALL transactions in the window every time

The engine trusted the provider's classification (`result.Added`) for counting, but Teller puts everything in Added regardless.

## Fix
Uses the `created_at` vs `updated_at` timestamps from the `UpsertTransaction` result to determine if a row was truly inserted (new) or updated (existing):
- `created_at ≈ updated_at` (within 1s) → genuinely new → count as **added**
- `created_at < updated_at` → already existed, got upserted → count as **modified**

This is a 1-file, 14-line change in `internal/sync/engine.go`. The `isNew` logic already existed at line 249 for the review queue — now it's also used for sync log counting.

## Impact
After this fix, clicking "Sync Now" on a Teller connection will show:
- **First sync**: "314 added" (correct — all new)
- **Subsequent syncs**: "0 added, 314 modified" (correct — all upserted)
- If new transactions appear: "2 added, 312 modified" (correct)

## Testing
- All unit tests pass (`go test ./...`)
- App compiles and starts successfully

🤖 Generated with Claude Opus 4.6