### PR TITLE
Add trigger and date range filters to sync log list page

### DIFF
--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -33,6 +34,21 @@ func SyncLogsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, s
 		if status := r.URL.Query().Get("status"); status != "" {
 			params.Status = &status
 		}
+		if trigger := r.URL.Query().Get("trigger"); trigger != "" {
+			params.Trigger = &trigger
+		}
+		if v := r.URL.Query().Get("date_from"); v != "" {
+			if t, err := time.Parse("2006-01-02", v); err == nil {
+				params.DateFrom = &t
+			}
+		}
+		if v := r.URL.Query().Get("date_to"); v != "" {
+			if t, err := time.Parse("2006-01-02", v); err == nil {
+				// Add one day so the end date is inclusive.
+				t = t.AddDate(0, 0, 1)
+				params.DateTo = &t
+			}
+		}
 
 		// Fetch paginated sync logs.
 		result, err := svc.ListSyncLogsPaginated(ctx, params)
@@ -50,46 +66,62 @@ func SyncLogsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, s
 
 		filterConnID := stringOrEmpty(params.ConnectionID)
 		filterStatus := stringOrEmpty(params.Status)
+		filterTrigger := stringOrEmpty(params.Trigger)
+		filterDateFrom := r.URL.Query().Get("date_from")
+		filterDateTo := r.URL.Query().Get("date_to")
 
-		// Compute summary stats (unfiltered by status for overview).
-		statsParams := service.SyncLogListParams{}
-		if params.ConnectionID != nil {
-			statsParams.ConnectionID = params.ConnectionID
+		// Build base params for stats/counts (non-status filters apply, status does not).
+		baseParams := service.SyncLogListParams{
+			ConnectionID: params.ConnectionID,
+			Trigger:      params.Trigger,
+			DateFrom:     params.DateFrom,
+			DateTo:       params.DateTo,
 		}
-		stats, err := svc.SyncLogStats(ctx, statsParams)
+
+		stats, err := svc.SyncLogStats(ctx, baseParams)
 		if err != nil {
 			a.Logger.Error("sync log stats", "error", err)
 			stats = &service.SyncLogStats{} // graceful fallback
 		}
 
-		// Also count per-status for the tab badges.
+		// Count per-status for the tab badges (include trigger+date but not status).
 		successStatus := "success"
 		errorStatus := "error"
 		inProgressStatus := "in_progress"
-		successParams := service.SyncLogListParams{ConnectionID: params.ConnectionID, Status: &successStatus}
-		errorParams := service.SyncLogListParams{ConnectionID: params.ConnectionID, Status: &errorStatus}
-		inProgressParams := service.SyncLogListParams{ConnectionID: params.ConnectionID, Status: &inProgressStatus}
+		successParams := baseParams
+		successParams.Status = &successStatus
+		errorParams := baseParams
+		errorParams.Status = &errorStatus
+		inProgressParams := baseParams
+		inProgressParams.Status = &inProgressStatus
 
 		successCount, _ := svc.CountSyncLogsFiltered(ctx, successParams)
 		errorCount, _ := svc.CountSyncLogsFiltered(ctx, errorParams)
 		inProgressCount, _ := svc.CountSyncLogsFiltered(ctx, inProgressParams)
 
+		// Determine whether the advanced filter panel has active filters.
+		hasAdvancedFilters := filterConnID != "" || filterTrigger != "" || filterDateFrom != "" || filterDateTo != ""
+
 		data := map[string]any{
-			"PageTitle":        "Sync Logs",
-			"CurrentPage":      "sync-logs",
-			"CSRFToken":        GetCSRFToken(r),
-			"Flash":            GetFlash(ctx, sm),
-			"Logs":             result.Logs,
-			"Connections":      connections,
-			"FilterConnID":     filterConnID,
-			"FilterStatus":     filterStatus,
-			"Page":             result.Page,
-			"TotalPages":       result.TotalPages,
-			"Total":            result.Total,
-			"Stats":            stats,
-			"SuccessCount":     successCount,
-			"ErrorCount":       errorCount,
-			"InProgressCount":  inProgressCount,
+			"PageTitle":          "Sync Logs",
+			"CurrentPage":        "sync-logs",
+			"CSRFToken":          GetCSRFToken(r),
+			"Flash":              GetFlash(ctx, sm),
+			"Logs":               result.Logs,
+			"Connections":        connections,
+			"FilterConnID":       filterConnID,
+			"FilterStatus":       filterStatus,
+			"FilterTrigger":      filterTrigger,
+			"FilterDateFrom":     filterDateFrom,
+			"FilterDateTo":       filterDateTo,
+			"HasAdvancedFilters": hasAdvancedFilters,
+			"Page":               result.Page,
+			"TotalPages":         result.TotalPages,
+			"Total":              result.Total,
+			"Stats":              stats,
+			"SuccessCount":       successCount,
+			"ErrorCount":         errorCount,
+			"InProgressCount":    inProgressCount,
 		}
 		tr.Render(w, r, "sync_logs.html", data)
 	}

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 	"sync"
@@ -247,6 +248,25 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return ""
 				}
 				return *s
+			},
+			"syncLogFilterQuery": func(status, connID, trigger, dateFrom, dateTo string) template.URL {
+				params := url.Values{}
+				if status != "" {
+					params.Set("status", status)
+				}
+				if connID != "" {
+					params.Set("connection_id", connID)
+				}
+				if trigger != "" {
+					params.Set("trigger", trigger)
+				}
+				if dateFrom != "" {
+					params.Set("date_from", dateFrom)
+				}
+				if dateTo != "" {
+					params.Set("date_to", dateTo)
+				}
+				return template.URL(params.Encode())
 			},
 			"derefFloat": func(f *float64) float64 {
 				if f == nil {

--- a/internal/service/mcp_synclog_csv_integration_test.go
+++ b/internal/service/mcp_synclog_csv_integration_test.go
@@ -514,6 +514,289 @@ func TestSyncLogStats_FilterByConnection(t *testing.T) {
 	}
 }
 
+// ===================== Sync Log Filter by Trigger Tests =====================
+
+func TestListSyncLogsPaginated_FilterByTrigger(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_trig_f1")
+
+	now := time.Now().UTC()
+	// Create logs with different triggers.
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerManual,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+	})
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerCron,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: now.Add(time.Minute), Valid: true},
+	})
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerCron,
+		Status:       db.SyncStatusError,
+		StartedAt:    pgtype.Timestamptz{Time: now.Add(2 * time.Minute), Valid: true},
+	})
+
+	// Filter by manual trigger.
+	trigger := "manual"
+	result, err := svc.ListSyncLogsPaginated(ctx, service.SyncLogListParams{
+		Page:     1,
+		PageSize: 10,
+		Trigger:  &trigger,
+	})
+	if err != nil {
+		t.Fatalf("ListSyncLogsPaginated(trigger=manual): %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("total = %d, want 1", result.Total)
+	}
+	if len(result.Logs) != 1 || result.Logs[0].Trigger != "manual" {
+		t.Errorf("expected 1 manual log, got %d logs", len(result.Logs))
+	}
+
+	// Filter by cron trigger.
+	trigger = "cron"
+	result, err = svc.ListSyncLogsPaginated(ctx, service.SyncLogListParams{
+		Page:     1,
+		PageSize: 10,
+		Trigger:  &trigger,
+	})
+	if err != nil {
+		t.Fatalf("ListSyncLogsPaginated(trigger=cron): %v", err)
+	}
+	if result.Total != 2 {
+		t.Errorf("total = %d, want 2", result.Total)
+	}
+}
+
+func TestCountSyncLogsFiltered_ByTrigger(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_trig_c1")
+
+	now := time.Now().UTC()
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerManual,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+	})
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerWebhook,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: now.Add(time.Minute), Valid: true},
+	})
+
+	trigger := "webhook"
+	count, err := svc.CountSyncLogsFiltered(ctx, service.SyncLogListParams{
+		Trigger: &trigger,
+	})
+	if err != nil {
+		t.Fatalf("CountSyncLogsFiltered(trigger=webhook): %v", err)
+	}
+	if count != 1 {
+		t.Errorf("count = %d, want 1", count)
+	}
+}
+
+// ===================== Sync Log Filter by Date Range Tests =====================
+
+func TestListSyncLogsPaginated_FilterByDateRange(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_date_f1")
+
+	// Create logs at specific dates.
+	day1 := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	day2 := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+	day3 := time.Date(2025, 3, 25, 10, 0, 0, 0, time.UTC)
+
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerManual,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: day1, Valid: true},
+	})
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerCron,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: day2, Valid: true},
+	})
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerManual,
+		Status:       db.SyncStatusError,
+		StartedAt:    pgtype.Timestamptz{Time: day3, Valid: true},
+	})
+
+	// Filter: from March 10 onward — should return day2 and day3.
+	dateFrom := time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC)
+	result, err := svc.ListSyncLogsPaginated(ctx, service.SyncLogListParams{
+		Page:     1,
+		PageSize: 10,
+		DateFrom: &dateFrom,
+	})
+	if err != nil {
+		t.Fatalf("ListSyncLogsPaginated(date_from): %v", err)
+	}
+	if result.Total != 2 {
+		t.Errorf("total = %d, want 2 (from March 10 onward)", result.Total)
+	}
+
+	// Filter: up to March 20 — should return day1 and day2.
+	dateTo := time.Date(2025, 3, 20, 0, 0, 0, 0, time.UTC)
+	result, err = svc.ListSyncLogsPaginated(ctx, service.SyncLogListParams{
+		Page:     1,
+		PageSize: 10,
+		DateTo:   &dateTo,
+	})
+	if err != nil {
+		t.Fatalf("ListSyncLogsPaginated(date_to): %v", err)
+	}
+	if result.Total != 2 {
+		t.Errorf("total = %d, want 2 (before March 20)", result.Total)
+	}
+
+	// Filter: March 10 to March 20 — should return only day2.
+	result, err = svc.ListSyncLogsPaginated(ctx, service.SyncLogListParams{
+		Page:     1,
+		PageSize: 10,
+		DateFrom: &dateFrom,
+		DateTo:   &dateTo,
+	})
+	if err != nil {
+		t.Fatalf("ListSyncLogsPaginated(date range): %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("total = %d, want 1 (March 10-20)", result.Total)
+	}
+}
+
+func TestListSyncLogsPaginated_CombinedFilters(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_combo_f1")
+
+	day1 := time.Date(2025, 6, 1, 10, 0, 0, 0, time.UTC)
+	day2 := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	// Manual success on day1.
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerManual,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: day1, Valid: true},
+	})
+	// Cron success on day1.
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerCron,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: day1.Add(time.Hour), Valid: true},
+	})
+	// Manual error on day2.
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerManual,
+		Status:       db.SyncStatusError,
+		StartedAt:    pgtype.Timestamptz{Time: day2, Valid: true},
+	})
+
+	// Filter: manual + success + day1 range — should return 1.
+	trigger := "manual"
+	status := "success"
+	dateFrom := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)
+
+	result, err := svc.ListSyncLogsPaginated(ctx, service.SyncLogListParams{
+		Page:     1,
+		PageSize: 10,
+		Status:   &status,
+		Trigger:  &trigger,
+		DateFrom: &dateFrom,
+		DateTo:   &dateTo,
+	})
+	if err != nil {
+		t.Fatalf("ListSyncLogsPaginated(combined): %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("total = %d, want 1 (manual + success + day1)", result.Total)
+	}
+	if len(result.Logs) == 1 {
+		if result.Logs[0].Trigger != "manual" {
+			t.Errorf("trigger = %q, want manual", result.Logs[0].Trigger)
+		}
+		if result.Logs[0].Status != "success" {
+			t.Errorf("status = %q, want success", result.Logs[0].Status)
+		}
+	}
+}
+
+func TestSyncLogStats_FilterByTriggerAndDate(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_stats_td")
+
+	day1 := time.Date(2025, 4, 1, 10, 0, 0, 0, time.UTC)
+	day2 := time.Date(2025, 4, 15, 10, 0, 0, 0, time.UTC)
+
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerManual,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: day1, Valid: true},
+	})
+	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+		ConnectionID: conn.ID,
+		Trigger:      db.SyncTriggerCron,
+		Status:       db.SyncStatusSuccess,
+		StartedAt:    pgtype.Timestamptz{Time: day2, Valid: true},
+	})
+
+	// Stats for manual trigger only.
+	trigger := "manual"
+	stats, err := svc.SyncLogStats(ctx, service.SyncLogListParams{
+		Trigger: &trigger,
+	})
+	if err != nil {
+		t.Fatalf("SyncLogStats(trigger=manual): %v", err)
+	}
+	if stats.TotalSyncs != 1 {
+		t.Errorf("total_syncs = %d, want 1", stats.TotalSyncs)
+	}
+
+	// Stats for date range covering only day1.
+	dateFrom := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+	dateTo := time.Date(2025, 4, 2, 0, 0, 0, 0, time.UTC)
+	stats, err = svc.SyncLogStats(ctx, service.SyncLogListParams{
+		DateFrom: &dateFrom,
+		DateTo:   &dateTo,
+	})
+	if err != nil {
+		t.Fatalf("SyncLogStats(date range): %v", err)
+	}
+	if stats.TotalSyncs != 1 {
+		t.Errorf("total_syncs = %d, want 1 (day1 only)", stats.TotalSyncs)
+	}
+}
+
 // ===================== Connection/Account Edge Cases =====================
 
 func TestGetConnectionStatus_WithSyncLog(t *testing.T) {

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -119,52 +119,25 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 }
 
 func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListParams) (*SyncLogListResult, error) {
+	whereClause, args, argN, err := s.buildSyncLogWhereClause(params)
+	if err != nil {
+		return nil, err
+	}
+
 	query := "SELECT sl.id, sl.connection_id, bc.institution_name, sl.trigger, sl.status, " +
 		"sl.added_count, sl.modified_count, sl.removed_count, sl.error_message, " +
 		"sl.started_at, sl.completed_at, sl.duration_ms " +
 		"FROM sync_logs sl " +
 		"JOIN bank_connections bc ON sl.connection_id = bc.id " +
-		"WHERE 1=1"
-	args := []any{}
-	argN := 1
-
-	if params.ConnectionID != nil {
-		uid, err := parseUUID(*params.ConnectionID)
-		if err != nil {
-			return nil, fmt.Errorf("invalid connection id: %w", err)
-		}
-		query += fmt.Sprintf(" AND sl.connection_id = $%d", argN)
-		args = append(args, uid)
-		argN++
-	}
-
-	if params.Status != nil {
-		query += fmt.Sprintf(" AND sl.status = $%d::sync_status", argN)
-		args = append(args, *params.Status)
-		argN++
-	}
+		whereClause
 
 	// Get total count with same filters.
 	countQuery := "SELECT COUNT(*) FROM sync_logs sl " +
 		"JOIN bank_connections bc ON sl.connection_id = bc.id " +
-		"WHERE 1=1"
-	countArgs := []any{}
-	countArgN := 1
-
-	if params.ConnectionID != nil {
-		uid, _ := parseUUID(*params.ConnectionID) // already validated above
-		countQuery += fmt.Sprintf(" AND sl.connection_id = $%d", countArgN)
-		countArgs = append(countArgs, uid)
-		countArgN++
-	}
-	if params.Status != nil {
-		countQuery += fmt.Sprintf(" AND sl.status = $%d::sync_status", countArgN)
-		countArgs = append(countArgs, *params.Status)
-		countArgN++
-	}
+		whereClause
 
 	var total int64
-	if err := s.Pool.QueryRow(ctx, countQuery, countArgs...).Scan(&total); err != nil {
+	if err := s.Pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
 		return nil, fmt.Errorf("count sync logs: %w", err)
 	}
 
@@ -286,27 +259,14 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 }
 
 func (s *Service) CountSyncLogsFiltered(ctx context.Context, params SyncLogListParams) (int64, error) {
+	whereClause, args, _, err := s.buildSyncLogWhereClause(params)
+	if err != nil {
+		return 0, err
+	}
+
 	query := "SELECT COUNT(*) FROM sync_logs sl " +
 		"JOIN bank_connections bc ON sl.connection_id = bc.id " +
-		"WHERE 1=1"
-	args := []any{}
-	argN := 1
-
-	if params.ConnectionID != nil {
-		uid, err := parseUUID(*params.ConnectionID)
-		if err != nil {
-			return 0, fmt.Errorf("invalid connection id: %w", err)
-		}
-		query += fmt.Sprintf(" AND sl.connection_id = $%d", argN)
-		args = append(args, uid)
-		argN++
-	}
-
-	if params.Status != nil {
-		query += fmt.Sprintf(" AND sl.status = $%d::sync_status", argN)
-		args = append(args, *params.Status)
-		argN++
-	}
+		whereClause
 
 	var count int64
 	if err := s.Pool.QueryRow(ctx, query, args...).Scan(&count); err != nil {
@@ -317,6 +277,11 @@ func (s *Service) CountSyncLogsFiltered(ctx context.Context, params SyncLogListP
 
 // SyncLogStats returns aggregate statistics about sync logs, optionally filtered.
 func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*SyncLogStats, error) {
+	whereClause, args, _, err := s.buildSyncLogWhereClause(params)
+	if err != nil {
+		return nil, err
+	}
+
 	query := `SELECT
 		COUNT(*) AS total,
 		COUNT(*) FILTER (WHERE sl.status = 'success') AS success_count,
@@ -327,28 +292,10 @@ func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*
 		COALESCE(SUM(sl.removed_count), 0) AS total_removed
 	FROM sync_logs sl
 	JOIN bank_connections bc ON sl.connection_id = bc.id
-	WHERE 1=1`
-	args := []any{}
-	argN := 1
-
-	if params.ConnectionID != nil {
-		uid, err := parseUUID(*params.ConnectionID)
-		if err != nil {
-			return nil, fmt.Errorf("invalid connection id: %w", err)
-		}
-		query += fmt.Sprintf(" AND sl.connection_id = $%d", argN)
-		args = append(args, uid)
-		argN++
-	}
-
-	if params.Status != nil {
-		query += fmt.Sprintf(" AND sl.status = $%d::sync_status", argN)
-		args = append(args, *params.Status)
-		argN++
-	}
+	` + whereClause
 
 	var stats SyncLogStats
-	err := s.Pool.QueryRow(ctx, query, args...).Scan(
+	err = s.Pool.QueryRow(ctx, query, args...).Scan(
 		&stats.TotalSyncs,
 		&stats.SuccessCount,
 		&stats.ErrorCount,
@@ -535,4 +482,48 @@ func (s *Service) ListSyncLogAccounts(ctx context.Context, syncLogID string) ([]
 		result = append(result, r)
 	}
 	return result, nil
+}
+
+// buildSyncLogWhereClause constructs a WHERE clause and args from SyncLogListParams.
+// Returns the clause string (starting with "WHERE 1=1"), the args slice, and the next argN.
+func (s *Service) buildSyncLogWhereClause(params SyncLogListParams) (string, []any, int, error) {
+	where := "WHERE 1=1"
+	args := []any{}
+	argN := 1
+
+	if params.ConnectionID != nil {
+		uid, err := parseUUID(*params.ConnectionID)
+		if err != nil {
+			return "", nil, 0, fmt.Errorf("invalid connection id: %w", err)
+		}
+		where += fmt.Sprintf(" AND sl.connection_id = $%d", argN)
+		args = append(args, uid)
+		argN++
+	}
+
+	if params.Status != nil {
+		where += fmt.Sprintf(" AND sl.status = $%d::sync_status", argN)
+		args = append(args, *params.Status)
+		argN++
+	}
+
+	if params.Trigger != nil {
+		where += fmt.Sprintf(" AND sl.trigger = $%d::sync_trigger", argN)
+		args = append(args, *params.Trigger)
+		argN++
+	}
+
+	if params.DateFrom != nil {
+		where += fmt.Sprintf(" AND sl.started_at >= $%d", argN)
+		args = append(args, *params.DateFrom)
+		argN++
+	}
+
+	if params.DateTo != nil {
+		where += fmt.Sprintf(" AND sl.started_at < $%d", argN)
+		args = append(args, *params.DateTo)
+		argN++
+	}
+
+	return where, args, argN, nil
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -168,6 +168,9 @@ type SyncLogListParams struct {
 	PageSize     int
 	ConnectionID *string
 	Status       *string
+	Trigger      *string
+	DateFrom     *time.Time
+	DateTo       *time.Time
 }
 
 type SyncLogListResult struct {

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -71,31 +71,94 @@
 </div>
 {{end}}
 
-<!-- Status Filter Tabs + Connection Dropdown -->
+<!-- Collapsible Filter Bar -->
+<div class="bb-card mb-5" x-data="{ filtersOpen: {{if .HasAdvancedFilters}}true{{else}}false{{end}} }">
+  <div class="p-0">
+    <button type="button" class="bb-filter-toggle" @click="filtersOpen = !filtersOpen">
+      <div class="flex items-center gap-2">
+        <i data-lucide="sliders-horizontal" class="w-4 h-4 text-base-content/60"></i>
+        <span>Filters</span>
+        {{if .HasAdvancedFilters}}
+        <span class="badge badge-primary badge-xs">Active</span>
+        {{end}}
+      </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 transition-transform duration-200" :class="filtersOpen ? 'rotate-180' : ''"></i>
+    </button>
+
+    <form method="GET" action="/sync-logs" x-show="filtersOpen" x-cloak
+      x-transition:enter="transition ease-out duration-200"
+      x-transition:enter-start="opacity-0 -translate-y-2"
+      x-transition:enter-end="opacity-100 translate-y-0"
+      x-transition:leave="transition ease-in duration-150"
+      x-transition:leave-start="opacity-100 translate-y-0"
+      x-transition:leave-end="opacity-0 -translate-y-2"
+      class="bb-filter-form">
+      {{if .FilterStatus}}<input type="hidden" name="status" value="{{.FilterStatus}}">{{end}}
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-3">
+        <label class="bb-filter-label">
+          Connection
+          <select name="connection_id" class="select select-sm select-bordered w-full">
+            <option value="">All connections</option>
+            {{range .Connections}}
+            <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
+            {{end}}
+          </select>
+        </label>
+        <label class="bb-filter-label">
+          Trigger
+          <select name="trigger" class="select select-sm select-bordered w-full">
+            <option value="">All triggers</option>
+            <option value="cron"{{if eq .FilterTrigger "cron"}} selected{{end}}>Cron</option>
+            <option value="manual"{{if eq .FilterTrigger "manual"}} selected{{end}}>Manual</option>
+            <option value="webhook"{{if eq .FilterTrigger "webhook"}} selected{{end}}>Webhook</option>
+            <option value="initial"{{if eq .FilterTrigger "initial"}} selected{{end}}>Initial</option>
+          </select>
+        </label>
+        <label class="bb-filter-label">
+          From Date
+          <input type="date" name="date_from" value="{{.FilterDateFrom}}" class="input input-sm input-bordered w-full">
+        </label>
+        <label class="bb-filter-label">
+          To Date
+          <input type="date" name="date_to" value="{{.FilterDateTo}}" class="input input-sm input-bordered w-full">
+        </label>
+      </div>
+      <div class="bb-filter-actions">
+        <a href="/sync-logs" class="btn btn-sm btn-ghost rounded-xl">Reset</a>
+        <button type="submit" class="btn btn-sm btn-primary rounded-xl">
+          <i data-lucide="search" class="w-3.5 h-3.5"></i>
+          Apply Filters
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Status Filter Tabs -->
 <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
   <!-- Status pill tabs -->
   <div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5">
-    <a href="/sync-logs{{if .FilterConnID}}?connection_id={{.FilterConnID}}{{end}}"
+    <a href="/sync-logs?{{syncLogFilterQuery "" .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}"
        class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
               {{if not .FilterStatus}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
       All
       <span class="text-[0.6rem] tabular-nums opacity-60">{{.Stats.TotalSyncs}}</span>
     </a>
-    <a href="/sync-logs?status=success{{if .FilterConnID}}&connection_id={{.FilterConnID}}{{end}}"
+    <a href="/sync-logs?{{syncLogFilterQuery "success" .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}"
        class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
               {{if eq .FilterStatus "success"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
       <span class="w-1.5 h-1.5 rounded-full bg-success"></span>
       Success
       <span class="text-[0.6rem] tabular-nums opacity-60">{{.SuccessCount}}</span>
     </a>
-    <a href="/sync-logs?status=error{{if .FilterConnID}}&connection_id={{.FilterConnID}}{{end}}"
+    <a href="/sync-logs?{{syncLogFilterQuery "error" .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}"
        class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
               {{if eq .FilterStatus "error"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
       <span class="w-1.5 h-1.5 rounded-full bg-error"></span>
       Errors
       <span class="text-[0.6rem] tabular-nums opacity-60">{{.ErrorCount}}</span>
     </a>
-    <a href="/sync-logs?status=in_progress{{if .FilterConnID}}&connection_id={{.FilterConnID}}{{end}}"
+    <a href="/sync-logs?{{syncLogFilterQuery "in_progress" .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}"
        class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
               {{if eq .FilterStatus "in_progress"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
       <span class="w-1.5 h-1.5 rounded-full bg-warning"></span>
@@ -104,22 +167,12 @@
     </a>
   </div>
 
-  <!-- Connection filter dropdown -->
-  <form method="GET" action="/sync-logs" class="flex items-center gap-2">
-    {{if .FilterStatus}}<input type="hidden" name="status" value="{{.FilterStatus}}">{{end}}
-    <select name="connection_id" class="select select-sm select-bordered rounded-xl text-xs min-w-[10rem]"
-            onchange="this.form.submit()">
-      <option value="">All connections</option>
-      {{range .Connections}}
-      <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
-      {{end}}
-    </select>
-    {{if .FilterConnID}}
-    <a href="/sync-logs{{if $.FilterStatus}}?status={{$.FilterStatus}}{{end}}" class="btn btn-ghost btn-xs rounded-lg">
-      <i data-lucide="x" class="w-3 h-3"></i>
-    </a>
-    {{end}}
-  </form>
+  {{if or .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo .FilterStatus}}
+  <a href="/sync-logs" class="btn btn-ghost btn-xs rounded-lg gap-1 text-base-content/50 hover:text-base-content/80">
+    <i data-lucide="x" class="w-3 h-3"></i>
+    Clear all filters
+  </a>
+  {{end}}
 </div>
 
 {{if .Logs}}
@@ -219,13 +272,13 @@
 <div class="flex items-center justify-between mt-6">
   <div>
     {{if gt .Page 1}}
-    <a href="/sync-logs?page={{sub .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost rounded-xl">&laquo; Previous</a>
+    <a href="/sync-logs?page={{sub .Page 1}}&{{syncLogFilterQuery .FilterStatus .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}" class="btn btn-sm btn-ghost rounded-xl">&laquo; Previous</a>
     {{end}}
   </div>
   <span class="text-xs text-base-content/40">Page {{.Page}} of {{.TotalPages}}</span>
   <div>
     {{if lt .Page .TotalPages}}
-    <a href="/sync-logs?page={{add .Page 1}}{{if $.FilterConnID}}&connection_id={{$.FilterConnID}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost rounded-xl">Next &raquo;</a>
+    <a href="/sync-logs?page={{add .Page 1}}&{{syncLogFilterQuery .FilterStatus .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}" class="btn btn-sm btn-ghost rounded-xl">Next &raquo;</a>
     {{end}}
   </div>
 </div>
@@ -238,8 +291,8 @@
       <i data-lucide="refresh-cw" class="w-8 h-8 text-base-content/25"></i>
     </div>
     <h3 class="text-lg font-semibold mb-1">No sync logs found</h3>
-    <p class="text-sm text-base-content/50 mb-5">{{if or .FilterConnID .FilterStatus}}Try adjusting your filters.{{else}}Sync logs will appear here after your first bank sync.{{end}}</p>
-    {{if or .FilterConnID .FilterStatus}}
+    <p class="text-sm text-base-content/50 mb-5">{{if or .FilterConnID .FilterStatus .FilterTrigger .FilterDateFrom .FilterDateTo}}Try adjusting your filters.{{else}}Sync logs will appear here after your first bank sync.{{end}}</p>
+    {{if or .FilterConnID .FilterStatus .FilterTrigger .FilterDateFrom .FilterDateTo}}
     <a href="/sync-logs" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
     {{end}}
   </div>


### PR DESCRIPTION
## Summary
- Add trigger type filter (cron/manual/webhook/initial) and date range filter to the sync logs page
- Refactor WHERE clause building into shared `buildSyncLogWhereClause` helper, eliminating duplicated filter logic across `ListSyncLogsPaginated`, `CountSyncLogsFiltered`, and `SyncLogStats`
- Add collapsible filter bar matching the design pattern from the transactions page
- Status tab badges and summary stats correctly reflect trigger + date filters
- All filter state preserved across pagination and status tab navigation via `syncLogFilterQuery` template function
- "Clear all filters" link shown when any filter is active

## Changes
- `internal/service/types.go` — Added `Trigger`, `DateFrom`, `DateTo` fields to `SyncLogListParams`
- `internal/service/sync.go` — Extracted `buildSyncLogWhereClause` shared helper; updated all three query functions to use it
- `internal/admin/synclogs.go` — Parse new `trigger`, `date_from`, `date_to` query params; pass `HasAdvancedFilters` and filter values to template; use base params (non-status) for stats/counts
- `internal/admin/templates.go` — Added `syncLogFilterQuery` template function and `net/url` import
- `internal/templates/pages/sync_logs.html` — Replaced inline connection dropdown with full collapsible filter bar; updated status tabs and pagination to preserve all filters
- `internal/service/mcp_synclog_csv_integration_test.go` — Added 5 new integration tests covering trigger filter, date range filter, combined filters, and stats with trigger+date

## Testing
- All unit tests pass (`go test ./...`)
- 5 new integration tests pass covering:
  - `TestListSyncLogsPaginated_FilterByTrigger` — filter by manual/cron trigger
  - `TestCountSyncLogsFiltered_ByTrigger` — count with trigger filter
  - `TestListSyncLogsPaginated_FilterByDateRange` — date_from, date_to, and combined range
  - `TestListSyncLogsPaginated_CombinedFilters` — trigger + status + date range together
  - `TestSyncLogStats_FilterByTriggerAndDate` — stats aggregation with new filters
- All existing sync log integration tests still pass (no regressions)
- Dev server starts cleanly with no template errors

🤖 Generated by autonomous sync improvement agent