### PR TITLE
Show sync health info on connection cards

### DIFF
--- a/internal/db/queries/bank_connections.sql
+++ b/internal/db/queries/bank_connections.sql
@@ -11,9 +11,24 @@ WHERE bc.id = $1;
 
 -- name: ListBankConnections :many
 SELECT bc.*, u.name as user_name,
-  (SELECT COUNT(*) FROM accounts a WHERE a.connection_id = bc.id) as account_count
+  (SELECT COUNT(*) FROM accounts a WHERE a.connection_id = bc.id) as account_count,
+  COALESCE(ls.status::text, '')::text as last_sync_status,
+  COALESCE(ls.trigger::text, '')::text as last_sync_trigger,
+  COALESCE(ls.duration_ms, 0) as last_sync_duration_ms,
+  ls.started_at as last_sync_started_at,
+  COALESCE(ls.added_count, 0) as last_sync_added,
+  COALESCE(ls.modified_count, 0) as last_sync_modified,
+  COALESCE(ls.removed_count, 0) as last_sync_removed
 FROM bank_connections bc
 LEFT JOIN users u ON bc.user_id = u.id
+LEFT JOIN LATERAL (
+  SELECT sl.status, sl.trigger, sl.duration_ms, sl.started_at,
+         sl.added_count, sl.modified_count, sl.removed_count
+  FROM sync_logs sl
+  WHERE sl.connection_id = bc.id
+  ORDER BY sl.started_at DESC
+  LIMIT 1
+) ls ON true
 ORDER BY bc.created_at DESC;
 
 -- name: UpdateBankConnectionStatus :exec

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -64,12 +64,33 @@
               </span>
               {{end}}
             </div>
-            <div class="flex items-center gap-3 text-xs text-base-content/50 mt-0.5">
+            <div class="flex items-center gap-3 text-xs text-base-content/50 mt-0.5 flex-wrap">
               <span>{{.UserName.String}}</span>
               <span class="text-base-content/20">&middot;</span>
               <span class="capitalize">{{printf "%s" .Provider}}</span>
               <span class="text-base-content/20">&middot;</span>
-              <span>{{if .LastSyncedAt.Valid}}Synced {{relativeTime .LastSyncedAt.Time}}{{else}}Never synced{{end}}</span>
+              {{if .LastSyncedAt.Valid}}
+              <span class="inline-flex items-center gap-1.5">
+                {{if eq .LastSyncStatus "success"}}<i data-lucide="check-circle" class="w-3 h-3 text-success"></i>
+                {{else if eq .LastSyncStatus "error"}}<i data-lucide="x-circle" class="w-3 h-3 text-error"></i>
+                {{else if eq .LastSyncStatus "in_progress"}}<i data-lucide="loader" class="w-3 h-3 text-warning animate-spin"></i>
+                {{end}}
+                <span>Synced {{relativeTime .LastSyncedAt.Time}}</span>
+                {{if and (ne .LastSyncStatus "in_progress") (gt .LastSyncDurationMs 0)}}
+                <span class="text-base-content/30">({{formatDurationMs .LastSyncDurationMs}})</span>
+                {{end}}
+              </span>
+              {{if and (ne .LastSyncStatus "") (or (gt .LastSyncAdded 0) (gt .LastSyncModified 0) (gt .LastSyncRemoved 0))}}
+              <span class="text-base-content/20">&middot;</span>
+              <span class="inline-flex items-center gap-1">
+                {{if gt .LastSyncAdded 0}}<span class="text-success/70">+{{.LastSyncAdded}}</span>{{end}}
+                {{if gt .LastSyncModified 0}}<span class="text-info/70">~{{.LastSyncModified}}</span>{{end}}
+                {{if gt .LastSyncRemoved 0}}<span class="text-error/70">-{{.LastSyncRemoved}}</span>{{end}}
+              </span>
+              {{end}}
+              {{else}}
+              <span>Never synced</span>
+              {{end}}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Display last sync status, duration, and transaction change counts directly on connection cards
- Eliminates the need to navigate to connection detail page to check sync health
- Uses efficient LATERAL JOIN to fetch latest sync log per connection in a single query

## Changes
- **`internal/db/queries/bank_connections.sql`**: Enhanced `ListBankConnections` query with a `LEFT JOIN LATERAL` on `sync_logs` to fetch the most recent sync log per connection. Returns `last_sync_status`, `last_sync_trigger`, `last_sync_duration_ms`, `last_sync_started_at`, `last_sync_added`, `last_sync_modified`, `last_sync_removed`. Uses `COALESCE` for NULL safety on connections with no sync history.

- **`internal/templates/pages/connections.html`**: Updated the connection card metadata line to show:
  - Status icon: green check (success), red X (error), or spinning loader (in_progress)
  - Relative time since last sync (existing) with duration in parentheses
  - Transaction change summary: `+N` added (green), `~N` modified (blue), `-N` removed (red) -- only shown when there were changes
  - Added `flex-wrap` to handle graceful wrapping on narrow screens

## Testing
- `go build ./...` passes
- `go test ./...` passes (all unit tests)
- Dev server starts and serves connections page without template errors
- The LATERAL JOIN uses the existing `sync_logs_connection_id_started_at_idx` index for efficient lookup

🤖 Generated by autonomous sync improvement agent