### PR TITLE
Pre-fetch account IDs at sync start

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -198,9 +198,27 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		}
 	}
 
-	// Account ID + name caches to avoid repeated lookups.
+	// Pre-fetch all account IDs and display names for this connection in one query.
+	// This eliminates per-transaction DB lookups during the sync loop. The caches
+	// still work as lazy fallbacks if a new account appears mid-sync.
 	accountIDCache := make(map[string]pgtype.UUID)
 	accountNameCache := make(map[string]string) // account UUID string -> display name
+
+	connAccounts, err := e.db.ListAccountsByConnection(ctx, connectionID)
+	if err != nil {
+		logger.Warn("failed to pre-fetch accounts, will resolve lazily", "error", err)
+	} else {
+		for _, acct := range connAccounts {
+			accountIDCache[acct.ExternalAccountID] = acct.ID
+			key := formatUUID(acct.ID)
+			if acct.DisplayName.Valid && acct.DisplayName.String != "" {
+				accountNameCache[key] = acct.DisplayName.String
+			} else {
+				accountNameCache[key] = acct.Name
+			}
+		}
+		logger.Debug("pre-fetched account caches", "accounts", len(connAccounts))
+	}
 
 	// Buffer writes so we can discard them on ErrMutationDuringPagination.
 	var pendingRemovals []string


### PR DESCRIPTION
## Summary
- Pre-fetches all account IDs and display names for a connection in one query before the sync loop starts
- Eliminates N per-transaction DB cache-miss queries (one per unique account) during sync
- Gracefully degrades: if the pre-fetch fails, the existing lazy `resolveAccountID` fallback still works

## Changes
- **`internal/sync/engine.go`**: Added a `ListAccountsByConnection` call in `runSync()` between the config loading and the pagination loop. Populates both `accountIDCache` (external_account_id -> UUID) and `accountNameCache` (UUID string -> display name) from the result, so all subsequent `resolveAccountID` and `trackAccountCount` calls are cache hits.

## Why this matters
For a typical connection with 5 accounts and 314 transactions, the old code made 5 individual `GetAccountIDByExternalAccountID` queries (one per first encounter of each account's external ID) plus 5 individual `GetAccountDisplayNameByID` queries. Now it's a single `ListAccountsByConnection` query that pre-warms both caches.

## Testing
- `go build ./...` passes
- `go test ./...` passes (all unit tests)
- Dev server starts and `/health/ready` returns 200
- Existing integration tests in `internal/sync/engine_integration_test.go` cover the sync flow end-to-end and continue to pass (the pre-fetch is transparent to them since the caches are still populated correctly)

🤖 Generated by autonomous sync improvement agent