### PR TITLE
Track rule hits per sync in sync_logs

### DIFF
--- a/internal/db/migrations/20260327220424_sync_log_rule_hits.sql
+++ b/internal/db/migrations/20260327220424_sync_log_rule_hits.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+ALTER TABLE sync_logs ADD COLUMN rule_hits JSONB NULL;
+COMMENT ON COLUMN sync_logs.rule_hits IS 'Map of transaction rule UUID -> hit count for this sync run';
+
+-- +goose Down
+ALTER TABLE sync_logs DROP COLUMN IF EXISTS rule_hits;

--- a/internal/db/queries/sync_logs.sql
+++ b/internal/db/queries/sync_logs.sql
@@ -23,7 +23,7 @@ LIMIT $2 OFFSET $3;
 
 -- name: UpdateSyncLog :exec
 UPDATE sync_logs
-SET status = $2, completed_at = $3, added_count = $4, modified_count = $5, removed_count = $6, error_message = $7, duration_ms = $8
+SET status = $2, completed_at = $3, added_count = $4, modified_count = $5, removed_count = $6, error_message = $7, duration_ms = $8, rule_hits = $9
 WHERE id = $1;
 
 -- name: GetMostRecentSyncLog :one

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strconv"
 	"time"
 
@@ -57,7 +59,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 
 	query := "SELECT sl.id, sl.connection_id, bc.institution_name, sl.trigger, sl.status, " +
 		"sl.added_count, sl.modified_count, sl.removed_count, sl.error_message, " +
-		"sl.started_at, sl.completed_at " +
+		"sl.started_at, sl.completed_at, sl.rule_hits " +
 		"FROM sync_logs sl " +
 		"JOIN bank_connections bc ON sl.connection_id = bc.id " +
 		"WHERE sl.id = $1"
@@ -74,12 +76,13 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		errorMessage    pgtype.Text
 		startedAt       pgtype.Timestamptz
 		completedAt     pgtype.Timestamptz
+		ruleHitsJSON    []byte
 	)
 
 	if err := s.Pool.QueryRow(ctx, query, uid).Scan(
 		&id, &connectionID, &institutionName, &trigger, &status,
 		&addedCount, &modifiedCount, &removedCount, &errorMessage,
-		&startedAt, &completedAt,
+		&startedAt, &completedAt, &ruleHitsJSON,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -101,7 +104,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 	// Get account count.
 	accountCount, _ := s.Queries.CountAffectedAccountsBySyncLog(ctx, uid)
 
-	return &SyncLogRow{
+	row := &SyncLogRow{
 		ID:               formatUUID(id),
 		ConnectionID:     formatUUID(connectionID),
 		InstitutionName:  instName,
@@ -115,7 +118,12 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		CompletedAt:      timestampStr(completedAt),
 		Duration:         duration,
 		AccountsAffected: accountCount,
-	}, nil
+	}
+
+	// Parse and resolve rule hits.
+	row.RuleHits, row.TotalRuleHits = s.parseRuleHits(ctx, ruleHitsJSON)
+
+	return row, nil
 }
 
 func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListParams) (*SyncLogListResult, error) {
@@ -535,4 +543,59 @@ func (s *Service) ListSyncLogAccounts(ctx context.Context, syncLogID string) ([]
 		result = append(result, r)
 	}
 	return result, nil
+}
+
+// parseRuleHits parses the JSONB rule_hits column and resolves rule names.
+// Returns the entries sorted by hit count descending, and the total hit count.
+func (s *Service) parseRuleHits(ctx context.Context, ruleHitsJSON []byte) ([]RuleHitEntry, int) {
+	if len(ruleHitsJSON) == 0 {
+		return nil, 0
+	}
+
+	var hitMap map[string]int
+	if err := json.Unmarshal(ruleHitsJSON, &hitMap); err != nil {
+		s.Logger.Warn("failed to parse rule_hits JSON", "error", err)
+		return nil, 0
+	}
+
+	if len(hitMap) == 0 {
+		return nil, 0
+	}
+
+	// Batch-fetch rule names for all rule IDs.
+	ruleNames := make(map[string]string, len(hitMap))
+	for ruleID := range hitMap {
+		uid, err := parseUUID(ruleID)
+		if err != nil {
+			continue
+		}
+		var name string
+		err = s.Pool.QueryRow(ctx, "SELECT name FROM transaction_rules WHERE id = $1", uid).Scan(&name)
+		if err != nil {
+			name = "Deleted rule"
+		}
+		ruleNames[ruleID] = name
+	}
+
+	entries := make([]RuleHitEntry, 0, len(hitMap))
+	total := 0
+	for ruleID, count := range hitMap {
+		name := ruleNames[ruleID]
+		entries = append(entries, RuleHitEntry{
+			RuleID:   ruleID,
+			RuleName: name,
+			Count:    count,
+		})
+		total += count
+	}
+
+	// Sort by hit count descending, then by rule name for stability.
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Count != entries[j].Count {
+			return entries[i].Count > entries[j].Count
+		}
+		return entries[i].RuleName < entries[j].RuleName
+	})
+
+	return entries, total
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -193,7 +193,16 @@ type SyncLogRow struct {
 	CompletedAt          *string
 	Duration             *string
 	DurationMs           *int32
-	AccountsAffected     int64 // number of accounts with activity in this sync
+	AccountsAffected     int64          // number of accounts with activity in this sync
+	RuleHits             []RuleHitEntry // per-rule hit counts from this sync run
+	TotalRuleHits        int            // sum of all rule hits
+}
+
+// RuleHitEntry represents a single rule's hit count within a sync run.
+type RuleHitEntry struct {
+	RuleID   string
+	RuleName string
+	Count    int
 }
 
 // SyncLogAccountRow represents a per-account breakdown within a sync log.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -73,7 +73,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	}
 
 	// Run the sync and capture results.
-	added, modified, removed, perAccount, syncErr := e.runSync(ctx, connectionID, logger)
+	added, modified, removed, perAccount, ruleHits, syncErr := e.runSync(ctx, connectionID, logger)
 
 	// Update sync_log with final status.
 	completedAt := time.Now()
@@ -101,6 +101,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 		RemovedCount:  int32(removed),
 		ErrorMessage:  errMsg,
 		DurationMs:    durationMs,
+		RuleHits:      ruleHits,
 	}); err != nil {
 		logger.Error("failed to update sync log", "error", err)
 	}
@@ -124,27 +125,27 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	return nil
 }
 
-// runSync performs the actual sync loop for a connection. Returns counts, per-account breakdown, and any error.
-func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *slog.Logger) (added, modified, removed int, perAccount map[string]*accountSyncCounts, err error) {
+// runSync performs the actual sync loop for a connection. Returns counts, per-account breakdown, rule hit counts JSON, and any error.
+func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *slog.Logger) (added, modified, removed int, perAccount map[string]*accountSyncCounts, ruleHits []byte, err error) {
 	// Initialize per-account tracking map.
 	perAccount = make(map[string]*accountSyncCounts)
 
 	// Load connection from DB.
 	conn, err := e.db.GetBankConnectionForSync(ctx, connectionID)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf("load connection: %w", err)
+		return 0, 0, 0, nil, nil, fmt.Errorf("load connection: %w", err)
 	}
 
 	// Look up the provider.
 	prov, ok := e.providers[string(conn.Provider)]
 	if !ok {
-		return 0, 0, 0, nil, fmt.Errorf("unknown provider: %s", conn.Provider)
+		return 0, 0, 0, nil, nil, fmt.Errorf("unknown provider: %s", conn.Provider)
 	}
 
 	// Fetch excluded account IDs for this connection.
 	excludedIDs, err := e.db.ListExcludedAccountIDsByConnection(ctx, connectionID)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf("list excluded accounts: %w", err)
+		return 0, 0, 0, nil, nil, fmt.Errorf("list excluded accounts: %w", err)
 	}
 	excludedSet := make(map[pgtype.UUID]bool, len(excludedIDs))
 	for _, id := range excludedIDs {
@@ -227,9 +228,9 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 					ErrorCode:    pgtype.Text{String: "ITEM_LOGIN_REQUIRED", Valid: true},
 					ErrorMessage: pgtype.Text{String: "Re-authentication required by institution", Valid: true},
 				})
-				return 0, 0, 0, nil, syncErr
+				return 0, 0, 0, nil, nil, syncErr
 			}
-			return 0, 0, 0, nil, syncErr
+			return 0, 0, 0, nil, nil, syncErr
 		}
 
 		// Buffer results — don't write to DB until pagination is complete.
@@ -247,7 +248,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		// Start transaction for all data writes.
 		tx, err := e.pool.Begin(ctx)
 		if err != nil {
-			return 0, 0, 0, nil, fmt.Errorf("begin transaction: %w", err)
+			return 0, 0, 0, nil, nil, fmt.Errorf("begin transaction: %w", err)
 		}
 		defer tx.Rollback(ctx)
 
@@ -339,7 +340,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 			ID:         connectionID,
 			SyncCursor: pgtype.Text{String: result.Cursor, Valid: true},
 		}); err != nil {
-			return added, modified, removed, perAccount, fmt.Errorf("update cursor: %w", err)
+			return added, modified, removed, perAccount, nil, fmt.Errorf("update cursor: %w", err)
 		}
 
 		// Fetch and update balances.
@@ -349,7 +350,12 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		}
 
 		if err := tx.Commit(ctx); err != nil {
-			return 0, 0, 0, nil, fmt.Errorf("commit transaction: %w", err)
+			return 0, 0, 0, nil, nil, fmt.Errorf("commit transaction: %w", err)
+		}
+
+		// Capture rule hit counts for the sync log before flushing.
+		if resolver != nil {
+			ruleHits = resolver.HitCountsJSON()
 		}
 
 		// Flush rule hit counts after commit (best-effort, non-fatal).
@@ -372,7 +378,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		break
 	}
 
-	return added, modified, removed, perAccount, nil
+	return added, modified, removed, perAccount, ruleHits, nil
 }
 
 // upsertTransaction resolves the account ID and upserts a single transaction.

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -303,6 +303,27 @@ func (r *RuleResolver) resolveMappings(provider, detailed, primary string) pgtyp
 	return r.uncategorizedID
 }
 
+// HitCountsJSON returns the per-rule hit counts from this sync run as JSON bytes
+// suitable for storing in the sync_logs.rule_hits JSONB column.
+// Returns nil if no rules matched.
+func (r *RuleResolver) HitCountsJSON() []byte {
+	if len(r.hitCounts) == 0 {
+		return nil
+	}
+
+	result := make(map[string]int, len(r.hitCounts))
+	for uuidBytes, count := range r.hitCounts {
+		id := pgtype.UUID{Bytes: uuidBytes, Valid: true}
+		result[formatUUID(id)] = count
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
 // FlushHitCounts updates hit_count and last_hit_at for all rules that matched
 // during this sync run. Should be called after the sync transaction commits.
 func (r *RuleResolver) FlushHitCounts(ctx context.Context, pool *pgxpool.Pool) error {

--- a/internal/sync/rule_resolver_test.go
+++ b/internal/sync/rule_resolver_test.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -743,5 +744,91 @@ func TestStringInList(t *testing.T) {
 	// Single value (not a list)
 	if !stringInList("hello", "Hello") {
 		t.Error("expected single value match")
+	}
+}
+
+func TestHitCountsJSON_Empty(t *testing.T) {
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+	}
+
+	result := r.HitCountsJSON()
+	if result != nil {
+		t.Errorf("expected nil for empty hit counts, got %s", string(result))
+	}
+}
+
+func TestHitCountsJSON_WithHits(t *testing.T) {
+	ruleA := testUUID(10)
+	ruleB := testUUID(20)
+
+	r := &RuleResolver{
+		hitCounts: map[[16]byte]int{
+			ruleA.Bytes: 5,
+			ruleB.Bytes: 3,
+		},
+	}
+
+	result := r.HitCountsJSON()
+	if result == nil {
+		t.Fatal("expected non-nil JSON, got nil")
+	}
+
+	var parsed map[string]int
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal hit counts JSON: %v", err)
+	}
+
+	if len(parsed) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(parsed))
+	}
+
+	ruleAID := formatUUID(ruleA)
+	ruleBID := formatUUID(ruleB)
+
+	if parsed[ruleAID] != 5 {
+		t.Errorf("expected 5 hits for rule A, got %d", parsed[ruleAID])
+	}
+	if parsed[ruleBID] != 3 {
+		t.Errorf("expected 3 hits for rule B, got %d", parsed[ruleBID])
+	}
+}
+
+func TestHitCountsJSON_IntegrationWithResolveWithContext(t *testing.T) {
+	ruleID := testUUID(10)
+	catA := testUUID(1)
+
+	r := &RuleResolver{
+		mappings:  make(map[string]pgtype.UUID),
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:         ruleID,
+				categoryID: catA,
+				condition:  mustCompile(t, &Condition{Field: "name", Op: "contains", Value: "coffee"}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	// Trigger hits.
+	tctx := TransactionContext{Name: "Coffee Shop", Provider: "plaid"}
+	r.ResolveWithContext("plaid", tctx)
+	r.ResolveWithContext("plaid", tctx)
+	r.ResolveWithContext("plaid", tctx)
+
+	result := r.HitCountsJSON()
+	if result == nil {
+		t.Fatal("expected non-nil JSON after resolving")
+	}
+
+	var parsed map[string]int
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	ruleIDStr := formatUUID(ruleID)
+	if parsed[ruleIDStr] != 3 {
+		t.Errorf("expected 3 hits, got %d", parsed[ruleIDStr])
 	}
 }

--- a/internal/templates/pages/sync_log_detail.html
+++ b/internal/templates/pages/sync_log_detail.html
@@ -28,7 +28,7 @@
 </div>
 
 <!-- Summary Stats -->
-<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+<div class="grid grid-cols-2 sm:grid-cols-4 {{if .Log.RuleHits}}lg:grid-cols-5{{end}} gap-3 mb-6">
   <div class="bb-card p-4">
     <div class="flex items-center gap-3">
       <div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center shrink-0">
@@ -73,6 +73,19 @@
       </div>
     </div>
   </div>
+  {{if .Log.RuleHits}}
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+        <i data-lucide="list-filter" class="w-4 h-4 text-primary"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none text-primary">{{.Log.TotalRuleHits}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Rule Hit{{if ne .Log.TotalRuleHits 1}}s{{end}}</div>
+      </div>
+    </div>
+  </div>
+  {{end}}
 </div>
 
 <!-- Details Card -->
@@ -115,6 +128,37 @@
   </div>
   <div class="px-5 py-4">
     <p class="text-sm text-base-content/60 font-mono break-all leading-relaxed">{{deref .Log.ErrorMessage}}</p>
+  </div>
+</div>
+{{end}}
+
+<!-- Rule Hits -->
+{{if .Log.RuleHits}}
+<div class="bb-card p-0 mb-6">
+  <div class="px-5 py-3.5 border-b border-base-200">
+    <div class="flex items-center justify-between">
+      <div>
+        <h2 class="text-sm font-semibold">Rule Hits</h2>
+        <p class="text-xs text-base-content/40 mt-0.5">Transaction rules that matched during this sync</p>
+      </div>
+      <span class="badge badge-primary badge-sm tabular-nums">{{.Log.TotalRuleHits}} total</span>
+    </div>
+  </div>
+  <div class="divide-y divide-base-200">
+    {{range .Log.RuleHits}}
+    <div class="flex items-center gap-4 px-5 py-3">
+      <div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+        <i data-lucide="list-filter" class="w-3.5 h-3.5 text-primary"></i>
+      </div>
+      <div class="flex-1 min-w-0">
+        <span class="text-sm font-medium truncate block">{{.RuleName}}</span>
+        <span class="text-xs text-base-content/30 font-mono">{{.RuleID}}</span>
+      </div>
+      <div class="flex items-center gap-1.5 shrink-0">
+        <span class="badge badge-ghost badge-sm tabular-nums font-semibold">{{.Count}} hit{{if ne .Count 1}}s{{end}}</span>
+      </div>
+    </div>
+    {{end}}
   </div>
 </div>
 {{end}}


### PR DESCRIPTION
## Summary

- Store per-rule hit counts as JSONB on `sync_logs` after each sync run
- Surface rule hit data on the sync log detail page with a dedicated card
- Answers "which rules fired and how often?" for each sync

## Changes

**Migration**: `20260327220424_sync_log_rule_hits.sql` adds `rule_hits JSONB NULL` column to `sync_logs`

**RuleResolver** (`internal/sync/rule_resolver.go`):
- New `HitCountsJSON()` method exports the internal `hitCounts` map as `{"rule-uuid": count}` JSON bytes

**Engine** (`internal/sync/engine.go`):
- `runSync` now returns `ruleHits []byte` alongside existing counts
- Rule hits captured after tx commit, before `FlushHitCounts`
- Passed to `UpdateSyncLog` for storage

**Service** (`internal/service/sync.go`, `types.go`):
- `GetSyncLog` reads and parses `rule_hits` JSONB
- Resolves rule UUIDs to rule names (graceful "Deleted rule" fallback)
- New `RuleHitEntry` type and `parseRuleHits` helper
- Sorted by hit count descending

**Template** (`sync_log_detail.html`):
- New "Rule Hits" stat card in summary row (conditional, only shown when rules fired)
- New "Rule Hits" detail card listing each rule with name, UUID, and hit count

**sqlc** (`queries/sync_logs.sql`):
- `UpdateSyncLog` now includes `rule_hits = $9`

## Testing

- 3 new unit tests for `HitCountsJSON`: empty, with direct hits, integration with `ResolveWithContext`
- All existing unit tests pass (`go test ./...`)
- Server starts cleanly with migration applied
- Backward compatible: existing sync logs show `NULL` rule_hits (no UI card shown)

Generated by autonomous sync improvement agent