### PR TITLE
Add unchanged count to sync logs

### DIFF
--- a/internal/db/migrations/20260327223550_add_unchanged_count.sql
+++ b/internal/db/migrations/20260327223550_add_unchanged_count.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE sync_logs ADD COLUMN unchanged_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE sync_log_accounts ADD COLUMN unchanged_count INTEGER NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE sync_log_accounts DROP COLUMN IF EXISTS unchanged_count;
+ALTER TABLE sync_logs DROP COLUMN IF EXISTS unchanged_count;

--- a/internal/db/queries/sync_log_accounts.sql
+++ b/internal/db/queries/sync_log_accounts.sql
@@ -1,14 +1,15 @@
 -- name: InsertSyncLogAccount :exec
-INSERT INTO sync_log_accounts (sync_log_id, account_id, account_name, added_count, modified_count, removed_count)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO sync_log_accounts (sync_log_id, account_id, account_name, added_count, modified_count, removed_count, unchanged_count)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (sync_log_id, account_id) DO UPDATE SET
     added_count = sync_log_accounts.added_count + EXCLUDED.added_count,
     modified_count = sync_log_accounts.modified_count + EXCLUDED.modified_count,
-    removed_count = sync_log_accounts.removed_count + EXCLUDED.removed_count;
+    removed_count = sync_log_accounts.removed_count + EXCLUDED.removed_count,
+    unchanged_count = sync_log_accounts.unchanged_count + EXCLUDED.unchanged_count;
 
 -- name: ListSyncLogAccounts :many
 SELECT sla.id, sla.sync_log_id, sla.account_id, sla.account_name,
-       sla.added_count, sla.modified_count, sla.removed_count
+       sla.added_count, sla.modified_count, sla.removed_count, sla.unchanged_count
 FROM sync_log_accounts sla
 WHERE sla.sync_log_id = $1
 ORDER BY (sla.added_count + sla.modified_count + sla.removed_count) DESC, sla.account_name;

--- a/internal/db/queries/sync_logs.sql
+++ b/internal/db/queries/sync_logs.sql
@@ -23,7 +23,7 @@ LIMIT $2 OFFSET $3;
 
 -- name: UpdateSyncLog :exec
 UPDATE sync_logs
-SET status = $2, completed_at = $3, added_count = $4, modified_count = $5, removed_count = $6, error_message = $7, duration_ms = $8
+SET status = $2, completed_at = $3, added_count = $4, modified_count = $5, removed_count = $6, error_message = $7, duration_ms = $8, unchanged_count = $9
 WHERE id = $1;
 
 -- name: GetMostRecentSyncLog :one

--- a/internal/db/queries/transactions.sql
+++ b/internal/db/queries/transactions.sql
@@ -29,7 +29,17 @@ ON CONFLICT (external_transaction_id) DO UPDATE SET
   pending = EXCLUDED.pending,
   category_id = CASE WHEN transactions.category_override THEN transactions.category_id ELSE EXCLUDED.category_id END,
   deleted_at = NULL,
-  updated_at = NOW()
+  updated_at = CASE
+    WHEN transactions.amount IS DISTINCT FROM EXCLUDED.amount
+      OR transactions.name IS DISTINCT FROM EXCLUDED.name
+      OR transactions.pending IS DISTINCT FROM EXCLUDED.pending
+      OR transactions.merchant_name IS DISTINCT FROM EXCLUDED.merchant_name
+      OR transactions.category_primary IS DISTINCT FROM EXCLUDED.category_primary
+      OR transactions.category_detailed IS DISTINCT FROM EXCLUDED.category_detailed
+      OR transactions.deleted_at IS NOT NULL
+    THEN NOW()
+    ELSE transactions.updated_at
+  END
 RETURNING *;
 
 -- name: SoftDeleteTransactionByExternalID :exec

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -56,7 +56,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 	}
 
 	query := "SELECT sl.id, sl.connection_id, bc.institution_name, sl.trigger, sl.status, " +
-		"sl.added_count, sl.modified_count, sl.removed_count, sl.error_message, " +
+		"sl.added_count, sl.modified_count, sl.removed_count, sl.unchanged_count, sl.error_message, " +
 		"sl.started_at, sl.completed_at " +
 		"FROM sync_logs sl " +
 		"JOIN bank_connections bc ON sl.connection_id = bc.id " +
@@ -71,6 +71,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		addedCount      int32
 		modifiedCount   int32
 		removedCount    int32
+		unchangedCount  int32
 		errorMessage    pgtype.Text
 		startedAt       pgtype.Timestamptz
 		completedAt     pgtype.Timestamptz
@@ -78,7 +79,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 
 	if err := s.Pool.QueryRow(ctx, query, uid).Scan(
 		&id, &connectionID, &institutionName, &trigger, &status,
-		&addedCount, &modifiedCount, &removedCount, &errorMessage,
+		&addedCount, &modifiedCount, &removedCount, &unchangedCount, &errorMessage,
 		&startedAt, &completedAt,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -110,6 +111,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		AddedCount:       addedCount,
 		ModifiedCount:    modifiedCount,
 		RemovedCount:     removedCount,
+		UnchangedCount:   unchangedCount,
 		ErrorMessage:     textPtr(errorMessage),
 		StartedAt:        timestampStr(startedAt),
 		CompletedAt:      timestampStr(completedAt),
@@ -120,7 +122,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 
 func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListParams) (*SyncLogListResult, error) {
 	query := "SELECT sl.id, sl.connection_id, bc.institution_name, sl.trigger, sl.status, " +
-		"sl.added_count, sl.modified_count, sl.removed_count, sl.error_message, " +
+		"sl.added_count, sl.modified_count, sl.removed_count, sl.unchanged_count, sl.error_message, " +
 		"sl.started_at, sl.completed_at, sl.duration_ms " +
 		"FROM sync_logs sl " +
 		"JOIN bank_connections bc ON sl.connection_id = bc.id " +
@@ -188,6 +190,7 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 			addedCount      int32
 			modifiedCount   int32
 			removedCount    int32
+			unchangedCount  int32
 			errorMessage    pgtype.Text
 			startedAt       pgtype.Timestamptz
 			completedAt     pgtype.Timestamptz
@@ -196,7 +199,7 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 
 		if err := rows.Scan(
 			&id, &connectionID, &institutionName, &trigger, &status,
-			&addedCount, &modifiedCount, &removedCount, &errorMessage,
+			&addedCount, &modifiedCount, &removedCount, &unchangedCount, &errorMessage,
 			&startedAt, &completedAt, &durationMs,
 		); err != nil {
 			return nil, fmt.Errorf("scan sync log: %w", err)
@@ -234,6 +237,7 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 			AddedCount:      addedCount,
 			ModifiedCount:   modifiedCount,
 			RemovedCount:    removedCount,
+			UnchangedCount:  unchangedCount,
 			ErrorMessage:    textPtr(errorMessage),
 			StartedAt:       timestampStr(startedAt),
 			CompletedAt:     timestampStr(completedAt),
@@ -324,7 +328,8 @@ func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*
 		COALESCE(AVG(COALESCE(sl.duration_ms, EXTRACT(MILLISECONDS FROM (sl.completed_at - sl.started_at))::INTEGER)) FILTER (WHERE sl.completed_at IS NOT NULL), 0) AS avg_duration_ms,
 		COALESCE(SUM(sl.added_count), 0) AS total_added,
 		COALESCE(SUM(sl.modified_count), 0) AS total_modified,
-		COALESCE(SUM(sl.removed_count), 0) AS total_removed
+		COALESCE(SUM(sl.removed_count), 0) AS total_removed,
+		COALESCE(SUM(sl.unchanged_count), 0) AS total_unchanged
 	FROM sync_logs sl
 	JOIN bank_connections bc ON sl.connection_id = bc.id
 	WHERE 1=1`
@@ -356,6 +361,7 @@ func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*
 		&stats.TotalAdded,
 		&stats.TotalModified,
 		&stats.TotalRemoved,
+		&stats.TotalUnchanged,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("sync log stats: %w", err)
@@ -521,12 +527,13 @@ func (s *Service) ListSyncLogAccounts(ctx context.Context, syncLogID string) ([]
 	result := make([]SyncLogAccountRow, 0, len(rows))
 	for _, row := range rows {
 		r := SyncLogAccountRow{
-			ID:            formatUUID(row.ID),
-			SyncLogID:     formatUUID(row.SyncLogID),
-			AccountName:   row.AccountName,
-			AddedCount:    row.AddedCount,
-			ModifiedCount: row.ModifiedCount,
-			RemovedCount:  row.RemovedCount,
+			ID:             formatUUID(row.ID),
+			SyncLogID:      formatUUID(row.SyncLogID),
+			AccountName:    row.AccountName,
+			AddedCount:     row.AddedCount,
+			ModifiedCount:  row.ModifiedCount,
+			RemovedCount:   row.RemovedCount,
+			UnchangedCount: row.UnchangedCount,
 		}
 		if row.AccountID.Valid {
 			id := formatUUID(row.AccountID)

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -187,6 +187,7 @@ type SyncLogRow struct {
 	AddedCount           int32
 	ModifiedCount        int32
 	RemovedCount         int32
+	UnchangedCount       int32
 	ErrorMessage         *string // raw technical error for debugging
 	FriendlyErrorMessage *string // human-friendly error for display
 	StartedAt            *string
@@ -198,25 +199,27 @@ type SyncLogRow struct {
 
 // SyncLogAccountRow represents a per-account breakdown within a sync log.
 type SyncLogAccountRow struct {
-	ID            string
-	SyncLogID     string
-	AccountID     *string
-	AccountName   string
-	AddedCount    int32
-	ModifiedCount int32
-	RemovedCount  int32
+	ID             string
+	SyncLogID      string
+	AccountID      *string
+	AccountName    string
+	AddedCount     int32
+	ModifiedCount  int32
+	RemovedCount   int32
+	UnchangedCount int32
 }
 
 // SyncLogStats contains aggregate statistics about sync logs.
 type SyncLogStats struct {
-	TotalSyncs    int64
-	SuccessCount  int64
-	ErrorCount    int64
-	SuccessRate   float64 // 0-100 percentage
-	AvgDurationMs float64 // average duration in milliseconds
-	TotalAdded    int64
-	TotalModified int64
-	TotalRemoved  int64
+	TotalSyncs      int64
+	SuccessCount    int64
+	ErrorCount      int64
+	SuccessRate     float64 // 0-100 percentage
+	AvgDurationMs   float64 // average duration in milliseconds
+	TotalAdded      int64
+	TotalModified   int64
+	TotalRemoved    int64
+	TotalUnchanged  int64
 }
 
 // SyncHealthSummary contains a dashboard-oriented overview of sync health.

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -25,6 +25,7 @@ type accountSyncCounts struct {
 	Added       int
 	Modified    int
 	Removed     int
+	Unchanged   int
 }
 
 // Engine orchestrates transaction syncing across all bank connections.
@@ -73,7 +74,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	}
 
 	// Run the sync and capture results.
-	added, modified, removed, perAccount, syncErr := e.runSync(ctx, connectionID, logger)
+	added, modified, removed, unchanged, perAccount, syncErr := e.runSync(ctx, connectionID, logger)
 
 	// Update sync_log with final status.
 	completedAt := time.Now()
@@ -93,14 +94,15 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	}
 
 	if err := e.db.UpdateSyncLog(ctx, db.UpdateSyncLogParams{
-		ID:            syncLog.ID,
-		Status:        status,
-		CompletedAt:   now,
-		AddedCount:    int32(added),
-		ModifiedCount: int32(modified),
-		RemovedCount:  int32(removed),
-		ErrorMessage:  errMsg,
-		DurationMs:    durationMs,
+		ID:             syncLog.ID,
+		Status:         status,
+		CompletedAt:    now,
+		AddedCount:     int32(added),
+		ModifiedCount:  int32(modified),
+		RemovedCount:   int32(removed),
+		UnchangedCount: int32(unchanged),
+		ErrorMessage:   errMsg,
+		DurationMs:     durationMs,
 	}); err != nil {
 		logger.Error("failed to update sync log", "error", err)
 	}
@@ -120,31 +122,31 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 		logger.Error("failed to reset consecutive failures", "error", err)
 	}
 
-	logger.Info("sync completed", "added", added, "modified", modified, "removed", removed)
+	logger.Info("sync completed", "added", added, "modified", modified, "removed", removed, "unchanged", unchanged)
 	return nil
 }
 
 // runSync performs the actual sync loop for a connection. Returns counts, per-account breakdown, and any error.
-func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *slog.Logger) (added, modified, removed int, perAccount map[string]*accountSyncCounts, err error) {
+func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *slog.Logger) (added, modified, removed, unchanged int, perAccount map[string]*accountSyncCounts, err error) {
 	// Initialize per-account tracking map.
 	perAccount = make(map[string]*accountSyncCounts)
 
 	// Load connection from DB.
 	conn, err := e.db.GetBankConnectionForSync(ctx, connectionID)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf("load connection: %w", err)
+		return 0, 0, 0, 0, nil, fmt.Errorf("load connection: %w", err)
 	}
 
 	// Look up the provider.
 	prov, ok := e.providers[string(conn.Provider)]
 	if !ok {
-		return 0, 0, 0, nil, fmt.Errorf("unknown provider: %s", conn.Provider)
+		return 0, 0, 0, 0, nil, fmt.Errorf("unknown provider: %s", conn.Provider)
 	}
 
 	// Fetch excluded account IDs for this connection.
 	excludedIDs, err := e.db.ListExcludedAccountIDsByConnection(ctx, connectionID)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf("list excluded accounts: %w", err)
+		return 0, 0, 0, 0, nil, fmt.Errorf("list excluded accounts: %w", err)
 	}
 	excludedSet := make(map[pgtype.UUID]bool, len(excludedIDs))
 	for _, id := range excludedIDs {
@@ -227,9 +229,9 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 					ErrorCode:    pgtype.Text{String: "ITEM_LOGIN_REQUIRED", Valid: true},
 					ErrorMessage: pgtype.Text{String: "Re-authentication required by institution", Valid: true},
 				})
-				return 0, 0, 0, nil, syncErr
+				return 0, 0, 0, 0, nil, syncErr
 			}
-			return 0, 0, 0, nil, syncErr
+			return 0, 0, 0, 0, nil, syncErr
 		}
 
 		// Buffer results — don't write to DB until pagination is complete.
@@ -247,7 +249,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		// Start transaction for all data writes.
 		tx, err := e.pool.Begin(ctx)
 		if err != nil {
-			return 0, 0, 0, nil, fmt.Errorf("begin transaction: %w", err)
+			return 0, 0, 0, 0, nil, fmt.Errorf("begin transaction: %w", err)
 		}
 		defer tx.Rollback(ctx)
 
@@ -265,7 +267,15 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		// Note: providers like Teller return ALL transactions as "Added" on every
 		// sync (date-range polling). The upsert handles this correctly (ON CONFLICT
 		// DO UPDATE), but we need to count accurately: only truly new rows count as
-		// "added"; existing rows that got upserted count as "modified".
+		// "added"; existing rows that got upserted count as "modified" or "unchanged".
+		//
+		// Classification logic uses timestamps from the upserted row:
+		// - New: created_at ~= updated_at (within 1s) — row was just inserted.
+		// - Modified: existing row where updated_at was bumped to NOW() by the
+		//   conditional CASE in the upsert (key fields actually changed).
+		// - Unchanged: existing row where updated_at was NOT bumped (all key
+		//   fields identical to what was already stored).
+		upsertStart := time.Now()
 		var skipped int
 		for i := range pendingAdded {
 			accountID, err := e.resolveAccountID(ctx, pendingAdded[i].AccountExternalID, accountIDCache)
@@ -282,22 +292,23 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				logger.Error("upsert added transaction", "external_id", pendingAdded[i].ExternalID, "error", err)
 				continue
 			}
-			// Determine if this was truly new or an upsert of an existing row.
-			// The DB sets created_at on INSERT and updated_at=NOW() on both INSERT
-			// and UPDATE. If they're equal (within 1s tolerance), it's a new row.
-			isNew := txnResult.CreatedAt.Time.Sub(txnResult.UpdatedAt.Time).Abs() < time.Second
+			isNew, isChanged := classifyUpsertResult(txnResult, upsertStart)
 			if isNew {
 				added++
-			} else {
+			} else if isChanged {
 				modified++
+			} else {
+				unchanged++
 			}
 			if reviewAutoEnqueue {
 				e.enqueueForReview(ctx, txQueries, txnResult, isNew, confidenceThreshold, resolver)
 			}
 			if isNew {
 				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "added")
-			} else {
+			} else if isChanged {
 				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "modified")
+			} else {
+				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "unchanged")
 			}
 		}
 
@@ -317,11 +328,17 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				logger.Error("upsert modified transaction", "external_id", pendingModified[i].ExternalID, "error", err)
 				continue
 			}
-			modified++
+			_, isChanged := classifyUpsertResult(txnResult, upsertStart)
+			if isChanged {
+				modified++
+				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "modified")
+			} else {
+				unchanged++
+				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "unchanged")
+			}
 			if reviewAutoEnqueue {
 				e.enqueueForReview(ctx, txQueries, txnResult, false, confidenceThreshold, resolver)
 			}
-			e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "modified")
 		}
 
 		if skipped > 0 {
@@ -339,7 +356,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 			ID:         connectionID,
 			SyncCursor: pgtype.Text{String: result.Cursor, Valid: true},
 		}); err != nil {
-			return added, modified, removed, perAccount, fmt.Errorf("update cursor: %w", err)
+			return added, modified, removed, unchanged, perAccount, fmt.Errorf("update cursor: %w", err)
 		}
 
 		// Fetch and update balances.
@@ -349,7 +366,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		}
 
 		if err := tx.Commit(ctx); err != nil {
-			return 0, 0, 0, nil, fmt.Errorf("commit transaction: %w", err)
+			return 0, 0, 0, 0, nil, fmt.Errorf("commit transaction: %w", err)
 		}
 
 		// Flush rule hit counts after commit (best-effort, non-fatal).
@@ -372,7 +389,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		break
 	}
 
-	return added, modified, removed, perAccount, nil
+	return added, modified, removed, unchanged, perAccount, nil
 }
 
 // upsertTransaction resolves the account ID and upserts a single transaction.
@@ -603,6 +620,8 @@ func (e *Engine) trackAccountCount(ctx context.Context, perAccount map[string]*a
 		counts.Modified++
 	case "removed":
 		counts.Removed++
+	case "unchanged":
+		counts.Unchanged++
 	}
 }
 
@@ -614,12 +633,13 @@ func (e *Engine) saveSyncLogAccounts(ctx context.Context, syncLogID pgtype.UUID,
 
 	for _, counts := range perAccount {
 		if err := e.db.InsertSyncLogAccount(ctx, db.InsertSyncLogAccountParams{
-			SyncLogID:     syncLogID,
-			AccountID:     counts.AccountID,
-			AccountName:   counts.AccountName,
-			AddedCount:    int32(counts.Added),
-			ModifiedCount: int32(counts.Modified),
-			RemovedCount:  int32(counts.Removed),
+			SyncLogID:      syncLogID,
+			AccountID:      counts.AccountID,
+			AccountName:    counts.AccountName,
+			AddedCount:     int32(counts.Added),
+			ModifiedCount:  int32(counts.Modified),
+			RemovedCount:   int32(counts.Removed),
+			UnchangedCount: int32(counts.Unchanged),
 		}); err != nil {
 			logger.Warn("failed to insert sync log account breakdown",
 				"account_name", counts.AccountName,
@@ -628,6 +648,27 @@ func (e *Engine) saveSyncLogAccounts(ctx context.Context, syncLogID pgtype.UUID,
 	}
 
 	logger.Debug("saved per-account sync breakdown", "accounts", len(perAccount))
+}
+
+// classifyUpsertResult determines whether an upserted transaction row is new,
+// actually modified, or unchanged. It relies on the conditional updated_at in
+// the UpsertTransaction SQL: updated_at is only set to NOW() when key fields
+// actually changed. For new rows, created_at and updated_at are both set to
+// NOW() by the INSERT.
+//
+// Returns (isNew, isChanged):
+//   - (true, true):   newly inserted row
+//   - (false, true):  existing row with changed values
+//   - (false, false): existing row with identical values (unchanged)
+func classifyUpsertResult(txn db.Transaction, upsertStart time.Time) (isNew bool, isChanged bool) {
+	// New row: created_at ~= updated_at (both set to NOW() on INSERT).
+	if txn.CreatedAt.Time.Sub(txn.UpdatedAt.Time).Abs() < time.Second {
+		return true, true
+	}
+	// Existing row: if updated_at was bumped to NOW() (>= upsertStart with
+	// some tolerance), values actually changed. Otherwise unchanged.
+	isChanged = txn.UpdatedAt.Time.After(upsertStart.Add(-2 * time.Second))
+	return false, isChanged
 }
 
 // --- helpers ---

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -1,0 +1,82 @@
+package sync
+
+import (
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestClassifyUpsertResult(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name          string
+		createdAt     time.Time
+		updatedAt     time.Time
+		upsertStart   time.Time
+		wantNew       bool
+		wantChanged   bool
+	}{
+		{
+			name:        "new row: created_at == updated_at (both NOW)",
+			createdAt:   now,
+			updatedAt:   now,
+			upsertStart: now.Add(-100 * time.Millisecond),
+			wantNew:     true,
+			wantChanged: true,
+		},
+		{
+			name:        "new row: created_at and updated_at within 1s tolerance",
+			createdAt:   now,
+			updatedAt:   now.Add(500 * time.Millisecond),
+			upsertStart: now.Add(-100 * time.Millisecond),
+			wantNew:     true,
+			wantChanged: true,
+		},
+		{
+			name:        "modified: updated_at just bumped (within sync window)",
+			createdAt:   now.Add(-24 * time.Hour),
+			updatedAt:   now,
+			upsertStart: now.Add(-100 * time.Millisecond),
+			wantNew:     false,
+			wantChanged: true,
+		},
+		{
+			name:        "unchanged: updated_at is old (not bumped)",
+			createdAt:   now.Add(-24 * time.Hour),
+			updatedAt:   now.Add(-12 * time.Hour),
+			upsertStart: now.Add(-100 * time.Millisecond),
+			wantNew:     false,
+			wantChanged: false,
+		},
+		{
+			name:        "unchanged: updated_at is minutes before upsert start",
+			createdAt:   now.Add(-48 * time.Hour),
+			updatedAt:   now.Add(-5 * time.Minute),
+			upsertStart: now.Add(-100 * time.Millisecond),
+			wantNew:     false,
+			wantChanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			txn := db.Transaction{
+				CreatedAt: pgtype.Timestamptz{Time: tt.createdAt, Valid: true},
+				UpdatedAt: pgtype.Timestamptz{Time: tt.updatedAt, Valid: true},
+			}
+
+			gotNew, gotChanged := classifyUpsertResult(txn, tt.upsertStart)
+
+			if gotNew != tt.wantNew {
+				t.Errorf("isNew = %v, want %v", gotNew, tt.wantNew)
+			}
+			if gotChanged != tt.wantChanged {
+				t.Errorf("isChanged = %v, want %v", gotChanged, tt.wantChanged)
+			}
+		})
+	}
+}

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -337,6 +337,7 @@
         {{if .AddedCount}}<span class="text-success font-medium">+{{.AddedCount}}</span>{{end}}
         {{if .ModifiedCount}}<span class="text-info font-medium">~{{.ModifiedCount}}</span>{{end}}
         {{if .RemovedCount}}<span class="text-error font-medium">-{{.RemovedCount}}</span>{{end}}
+        {{if .UnchangedCount}}<span class="text-base-content/30 font-medium" title="{{.UnchangedCount}} unchanged">={{.UnchangedCount}}</span>{{end}}
         {{syncBadge (printf "%s" .Status)}}
       </div>
     </div>

--- a/internal/templates/pages/sync_log_detail.html
+++ b/internal/templates/pages/sync_log_detail.html
@@ -28,7 +28,7 @@
 </div>
 
 <!-- Summary Stats -->
-<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+<div class="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6">
   <div class="bb-card p-4">
     <div class="flex items-center gap-3">
       <div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center shrink-0">
@@ -59,6 +59,17 @@
       <div>
         <div class="text-2xl font-semibold tabular-nums leading-none text-error">{{.Log.RemovedCount}}</div>
         <div class="text-xs text-base-content/40 mt-0.5">Removed</div>
+      </div>
+    </div>
+  </div>
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+        <i data-lucide="equal" class="w-4 h-4 text-base-content/30"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none text-base-content/40">{{.Log.UnchangedCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Unchanged</div>
       </div>
     </div>
   </div>
@@ -149,6 +160,11 @@
         {{if .RemovedCount}}
         <span class="text-error font-medium flex items-center gap-1">
           <i data-lucide="minus" class="w-3 h-3"></i>{{.RemovedCount}}
+        </span>
+        {{end}}
+        {{if .UnchangedCount}}
+        <span class="text-base-content/30 font-medium flex items-center gap-1" title="Unchanged">
+          <i data-lucide="equal" class="w-3 h-3"></i>{{.UnchangedCount}}
         </span>
         {{end}}
       </div>

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -174,7 +174,8 @@
           {{if .AddedCount}}<span class="text-success font-medium">+{{.AddedCount}}</span>{{end}}
           {{if .ModifiedCount}}<span class="text-info font-medium">~{{.ModifiedCount}}</span>{{end}}
           {{if .RemovedCount}}<span class="text-error font-medium">-{{.RemovedCount}}</span>{{end}}
-          {{if and (not .AddedCount) (not .ModifiedCount) (not .RemovedCount)}}
+          {{if .UnchangedCount}}<span class="text-base-content/30 font-medium" title="{{.UnchangedCount}} unchanged transactions">={{.UnchangedCount}}</span>{{end}}
+          {{if and (not .AddedCount) (not .ModifiedCount) (not .RemovedCount) (not .UnchangedCount)}}
           <span class="text-base-content/20 text-xs">No changes</span>
           {{end}}
         </div>


### PR DESCRIPTION
## Summary
- Adds `unchanged_count` column to `sync_logs` and `sync_log_accounts` tables to distinguish truly-modified transactions from no-op upserts
- Modifies the `UpsertTransaction` SQL to use conditional `updated_at` -- only bumps the timestamp when key fields (amount, name, pending, merchant_name, category_primary, category_detailed) actually differ or when restoring a soft-deleted row
- Adds `classifyUpsertResult()` helper in the sync engine that compares `updated_at` against the sync start time to classify each upsert as new/modified/unchanged
- Displays unchanged count in sync log list, sync log detail, connection detail, and per-account breakdown views

## Changes
- **Migration**: `20260327223550_add_unchanged_count.sql` -- adds `unchanged_count INTEGER NOT NULL DEFAULT 0` to both `sync_logs` and `sync_log_accounts`
- **SQL**: `UpsertTransaction` now uses `IS DISTINCT FROM` checks for key fields in a CASE expression to conditionally set `updated_at`
- **SQL**: `UpdateSyncLog` and `InsertSyncLogAccount` updated to include `unchanged_count`
- **Engine**: `runSync()` returns 4 counts (added, modified, removed, unchanged); `classifyUpsertResult()` uses timestamp comparison to determine classification; `accountSyncCounts` tracks per-account unchanged count
- **Service**: `SyncLogRow`, `SyncLogAccountRow`, and `SyncLogStats` types include `UnchangedCount`/`TotalUnchanged`; all queries updated to select/aggregate the new column
- **UI**: Sync log list shows `=N` in muted style for unchanged count; sync log detail page adds an "Unchanged" stat card with `equal` icon; per-account breakdown shows unchanged count; connection detail sync history shows unchanged count

## Testing
- Unit test for `classifyUpsertResult` covering new, modified, and unchanged scenarios
- All existing unit tests pass (`go test ./...`)
- Server starts cleanly with migration applied; sync logs page renders correctly
- Backward compatible: existing sync logs show 0 for unchanged count (correct default)

🤖 Generated by autonomous sync improvement agent