### PR TITLE
Add webhook event logging

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -92,6 +92,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/accounts/{id}", AccountDetailHandler(a, sm, tr, svc))
 		r.Get("/sync-logs", SyncLogsHandler(a, sm, tr, svc))
 		r.Get("/sync-logs/{id}", SyncLogDetailHandler(a, sm, tr, svc))
+		r.Get("/webhook-events", WebhookEventsHandler(a, sm, tr, svc))
 
 		r.Get("/account-links", AccountLinksPageHandler(a, svc, sm, tr))
 		r.Get("/account-links/{id}", AccountLinkDetailHandler(a, svc, sm, tr))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -595,6 +595,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/account_links.html",
 		"pages/account_link_detail.html",
 		"pages/reports.html",
+		"pages/webhook_events.html",
 		"pages/oauth_clients.html",
 		"pages/oauth_client_new.html",
 		"pages/oauth_client_created.html",

--- a/internal/admin/webhook_events.go
+++ b/internal/admin/webhook_events.go
@@ -1,0 +1,72 @@
+package admin
+
+import (
+	"net/http"
+	"strconv"
+
+	"breadbox/internal/app"
+	"breadbox/internal/service"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+// WebhookEventsHandler serves GET /admin/webhook-events.
+func WebhookEventsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page < 1 {
+			page = 1
+		}
+
+		params := service.WebhookEventListParams{
+			Page:     page,
+			PageSize: 25,
+		}
+
+		if prov := r.URL.Query().Get("provider"); prov != "" {
+			params.Provider = &prov
+		}
+		if status := r.URL.Query().Get("status"); status != "" {
+			params.Status = &status
+		}
+
+		result, err := svc.ListWebhookEventsPaginated(ctx, params)
+		if err != nil {
+			a.Logger.Error("list webhook events", "error", err)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		stats, err := svc.WebhookEventCounts(ctx)
+		if err != nil {
+			a.Logger.Error("webhook event counts", "error", err)
+			stats = &service.WebhookEventStats{}
+		}
+
+		filterProvider := ""
+		if params.Provider != nil {
+			filterProvider = *params.Provider
+		}
+		filterStatus := ""
+		if params.Status != nil {
+			filterStatus = *params.Status
+		}
+
+		data := map[string]any{
+			"PageTitle":      "Webhook Events",
+			"CurrentPage":    "webhook-events",
+			"CSRFToken":      GetCSRFToken(r),
+			"Flash":          GetFlash(ctx, sm),
+			"Events":         result.Events,
+			"Page":           result.Page,
+			"TotalPages":     result.TotalPages,
+			"Total":          result.Total,
+			"Stats":          stats,
+			"FilterProvider": filterProvider,
+			"FilterStatus":   filterStatus,
+		}
+		tr.Render(w, r, "webhook_events.html", data)
+	}
+}

--- a/internal/db/migrations/20260327230533_webhook_events.sql
+++ b/internal/db/migrations/20260327230533_webhook_events.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+
+CREATE TABLE webhook_events (
+    id               UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    provider         provider_type NOT NULL,
+    event_type       TEXT          NOT NULL,
+    connection_id    UUID          NULL REFERENCES bank_connections(id) ON DELETE SET NULL,
+    raw_payload_hash TEXT          NOT NULL,
+    status           TEXT          NOT NULL DEFAULT 'received',
+    error_message    TEXT          NULL,
+    created_at       TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX webhook_events_created_at_idx ON webhook_events(created_at DESC);
+CREATE INDEX webhook_events_provider_idx ON webhook_events(provider);
+CREATE INDEX webhook_events_connection_id_idx ON webhook_events(connection_id) WHERE connection_id IS NOT NULL;
+CREATE INDEX webhook_events_status_idx ON webhook_events(status);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS webhook_events;

--- a/internal/db/queries/webhook_events.sql
+++ b/internal/db/queries/webhook_events.sql
@@ -1,0 +1,10 @@
+-- name: CreateWebhookEvent :one
+INSERT INTO webhook_events (provider, event_type, connection_id, raw_payload_hash, status, error_message)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING *;
+
+-- name: UpdateWebhookEventStatus :exec
+UPDATE webhook_events SET status = $2, error_message = $3 WHERE id = $1;
+
+-- name: CountWebhookEvents :one
+SELECT COUNT(*) FROM webhook_events;

--- a/internal/service/webhook_events.go
+++ b/internal/service/webhook_events.go
@@ -1,0 +1,168 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"math"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// WebhookEventRow is the service-layer representation of a webhook event.
+type WebhookEventRow struct {
+	ID              string  `json:"id"`
+	Provider        string  `json:"provider"`
+	EventType       string  `json:"event_type"`
+	ConnectionID    *string `json:"connection_id,omitempty"`
+	InstitutionName *string `json:"institution_name,omitempty"`
+	PayloadHash     string  `json:"raw_payload_hash"`
+	Status          string  `json:"status"`
+	ErrorMessage    *string `json:"error_message,omitempty"`
+	CreatedAt       *string `json:"created_at"`
+}
+
+// WebhookEventListParams controls filtering and pagination.
+type WebhookEventListParams struct {
+	Page     int
+	PageSize int
+	Provider *string
+	Status   *string
+}
+
+// WebhookEventListResult is a paginated list of webhook events.
+type WebhookEventListResult struct {
+	Events     []WebhookEventRow
+	Total      int64
+	Page       int
+	PageSize   int
+	TotalPages int
+}
+
+// WebhookEventStats holds aggregate counts for the dashboard header.
+type WebhookEventStats struct {
+	TotalEvents    int64
+	ReceivedCount  int64
+	ProcessedCount int64
+	ErrorCount     int64
+}
+
+// ListWebhookEventsPaginated returns a filtered, paginated list of webhook events.
+func (s *Service) ListWebhookEventsPaginated(ctx context.Context, params WebhookEventListParams) (*WebhookEventListResult, error) {
+	if params.PageSize <= 0 {
+		params.PageSize = 25
+	}
+	if params.Page <= 0 {
+		params.Page = 1
+	}
+
+	// Build the filtered query.
+	baseWhere := "WHERE 1=1"
+	args := []any{}
+	argN := 1
+
+	if params.Provider != nil && *params.Provider != "" {
+		baseWhere += fmt.Sprintf(" AND we.provider = $%d::provider_type", argN)
+		args = append(args, *params.Provider)
+		argN++
+	}
+	if params.Status != nil && *params.Status != "" {
+		baseWhere += fmt.Sprintf(" AND we.status = $%d", argN)
+		args = append(args, *params.Status)
+		argN++
+	}
+
+	// Count query.
+	countQuery := "SELECT COUNT(*) FROM webhook_events we " + baseWhere
+	var total int64
+	if err := s.Pool.QueryRow(ctx, countQuery, args...).Scan(&total); err != nil {
+		return nil, fmt.Errorf("count webhook events: %w", err)
+	}
+
+	// Data query with LEFT JOIN to bank_connections for institution name.
+	dataQuery := `SELECT we.id, we.provider, we.event_type, we.connection_id,
+		bc.institution_name, we.raw_payload_hash, we.status, we.error_message, we.created_at
+		FROM webhook_events we
+		LEFT JOIN bank_connections bc ON we.connection_id = bc.id ` +
+		baseWhere +
+		fmt.Sprintf(" ORDER BY we.created_at DESC LIMIT $%d OFFSET $%d", argN, argN+1)
+	args = append(args, params.PageSize, (params.Page-1)*params.PageSize)
+
+	rows, err := s.Pool.Query(ctx, dataQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query webhook events: %w", err)
+	}
+	defer rows.Close()
+
+	var events []WebhookEventRow
+	for rows.Next() {
+		var (
+			id              pgtype.UUID
+			provider        string
+			eventType       string
+			connectionID    pgtype.UUID
+			institutionName pgtype.Text
+			payloadHash     string
+			status          string
+			errorMessage    pgtype.Text
+			createdAt       pgtype.Timestamptz
+		)
+		if err := rows.Scan(&id, &provider, &eventType, &connectionID,
+			&institutionName, &payloadHash, &status, &errorMessage, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan webhook event: %w", err)
+		}
+		row := WebhookEventRow{
+			ID:          formatUUID(id),
+			Provider:    provider,
+			EventType:   eventType,
+			PayloadHash: payloadHash,
+			Status:      status,
+			CreatedAt:   timestampStr(createdAt),
+		}
+		if connectionID.Valid {
+			cid := formatUUID(connectionID)
+			row.ConnectionID = &cid
+		}
+		if institutionName.Valid {
+			row.InstitutionName = &institutionName.String
+		}
+		if errorMessage.Valid {
+			row.ErrorMessage = &errorMessage.String
+		}
+		events = append(events, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate webhook events: %w", err)
+	}
+
+	totalPages := int(math.Ceil(float64(total) / float64(params.PageSize)))
+
+	return &WebhookEventListResult{
+		Events:     events,
+		Total:      total,
+		Page:       params.Page,
+		PageSize:   params.PageSize,
+		TotalPages: totalPages,
+	}, nil
+}
+
+// WebhookEventCounts returns aggregate status counts.
+func (s *Service) WebhookEventCounts(ctx context.Context) (*WebhookEventStats, error) {
+	query := `SELECT
+		COUNT(*) AS total,
+		COUNT(*) FILTER (WHERE status = 'received') AS received_count,
+		COUNT(*) FILTER (WHERE status = 'processed') AS processed_count,
+		COUNT(*) FILTER (WHERE status = 'error') AS error_count
+	FROM webhook_events`
+
+	var stats WebhookEventStats
+	if err := s.Pool.QueryRow(ctx, query).Scan(
+		&stats.TotalEvents,
+		&stats.ReceivedCount,
+		&stats.ProcessedCount,
+		&stats.ErrorCount,
+	); err != nil {
+		return nil, fmt.Errorf("webhook event counts: %w", err)
+	}
+	return &stats, nil
+}
+

--- a/internal/service/webhook_events_integration_test.go
+++ b/internal/service/webhook_events_integration_test.go
@@ -1,0 +1,253 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/db"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestListWebhookEventsPaginated_Empty(t *testing.T) {
+	svc, _, _ := newService(t)
+	result, err := svc.ListWebhookEventsPaginated(context.Background(), service.WebhookEventListParams{
+		Page:     1,
+		PageSize: 25,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Total != 0 {
+		t.Errorf("expected 0 total, got %d", result.Total)
+	}
+	if len(result.Events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(result.Events))
+	}
+}
+
+func TestListWebhookEventsPaginated_WithData(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_wh_1")
+
+	// Create several webhook events.
+	for i := 0; i < 3; i++ {
+		_, err := queries.CreateWebhookEvent(ctx, db.CreateWebhookEventParams{
+			Provider:       db.ProviderTypePlaid,
+			EventType:      "sync_available",
+			ConnectionID:   conn.ID,
+			RawPayloadHash: "abc123",
+			Status:         "processed",
+		})
+		if err != nil {
+			t.Fatalf("create webhook event: %v", err)
+		}
+	}
+	// Create an error event without connection.
+	_, err := queries.CreateWebhookEvent(ctx, db.CreateWebhookEventParams{
+		Provider:       db.ProviderTypeTeller,
+		EventType:      "verification_failed",
+		ConnectionID:   pgtype.UUID{},
+		RawPayloadHash: "def456",
+		Status:         "error",
+		ErrorMessage:   pgtype.Text{String: "bad signature", Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("create error event: %v", err)
+	}
+
+	// List all.
+	result, err := svc.ListWebhookEventsPaginated(ctx, service.WebhookEventListParams{
+		Page:     1,
+		PageSize: 25,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Total != 4 {
+		t.Errorf("expected 4 total, got %d", result.Total)
+	}
+
+	// Filter by provider.
+	plaid := "plaid"
+	result, err = svc.ListWebhookEventsPaginated(ctx, service.WebhookEventListParams{
+		Page:     1,
+		PageSize: 25,
+		Provider: &plaid,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Total != 3 {
+		t.Errorf("expected 3 plaid events, got %d", result.Total)
+	}
+
+	// Filter by status.
+	errorStatus := "error"
+	result, err = svc.ListWebhookEventsPaginated(ctx, service.WebhookEventListParams{
+		Page:     1,
+		PageSize: 25,
+		Status:   &errorStatus,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("expected 1 error event, got %d", result.Total)
+	}
+	if result.Events[0].ErrorMessage == nil || *result.Events[0].ErrorMessage != "bad signature" {
+		t.Errorf("expected error message 'bad signature', got %v", result.Events[0].ErrorMessage)
+	}
+}
+
+func TestWebhookEventCounts(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Empty state.
+	stats, err := svc.WebhookEventCounts(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalEvents != 0 {
+		t.Errorf("expected 0 total, got %d", stats.TotalEvents)
+	}
+
+	// Add events with different statuses.
+	user := testutil.MustCreateUser(t, queries, "Bob")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_wh_2")
+
+	for _, status := range []string{"processed", "processed", "received", "error"} {
+		_, err := queries.CreateWebhookEvent(ctx, db.CreateWebhookEventParams{
+			Provider:       db.ProviderTypePlaid,
+			EventType:      "sync_available",
+			ConnectionID:   conn.ID,
+			RawPayloadHash: "hash",
+			Status:         status,
+		})
+		if err != nil {
+			t.Fatalf("create event: %v", err)
+		}
+	}
+
+	stats, err = svc.WebhookEventCounts(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalEvents != 4 {
+		t.Errorf("expected 4 total, got %d", stats.TotalEvents)
+	}
+	if stats.ProcessedCount != 2 {
+		t.Errorf("expected 2 processed, got %d", stats.ProcessedCount)
+	}
+	if stats.ReceivedCount != 1 {
+		t.Errorf("expected 1 received, got %d", stats.ReceivedCount)
+	}
+	if stats.ErrorCount != 1 {
+		t.Errorf("expected 1 error, got %d", stats.ErrorCount)
+	}
+}
+
+func TestListWebhookEventsPaginated_Pagination(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Charlie")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_wh_3")
+
+	// Create 7 events.
+	for i := 0; i < 7; i++ {
+		_, err := queries.CreateWebhookEvent(ctx, db.CreateWebhookEventParams{
+			Provider:       db.ProviderTypePlaid,
+			EventType:      "sync_available",
+			ConnectionID:   conn.ID,
+			RawPayloadHash: "hash",
+			Status:         "processed",
+		})
+		if err != nil {
+			t.Fatalf("create event: %v", err)
+		}
+	}
+
+	// Page 1 of 3 (page size 3).
+	result, err := svc.ListWebhookEventsPaginated(ctx, service.WebhookEventListParams{
+		Page:     1,
+		PageSize: 3,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Total != 7 {
+		t.Errorf("expected 7 total, got %d", result.Total)
+	}
+	if result.TotalPages != 3 {
+		t.Errorf("expected 3 total pages, got %d", result.TotalPages)
+	}
+	if len(result.Events) != 3 {
+		t.Errorf("expected 3 events on page 1, got %d", len(result.Events))
+	}
+
+	// Page 3 should have 1 event.
+	result, err = svc.ListWebhookEventsPaginated(ctx, service.WebhookEventListParams{
+		Page:     3,
+		PageSize: 3,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Errorf("expected 1 event on page 3, got %d", len(result.Events))
+	}
+}
+
+func TestListWebhookEventsPaginated_JoinsInstitutionName(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Diana")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_wh_4")
+
+	_, err := queries.CreateWebhookEvent(ctx, db.CreateWebhookEventParams{
+		Provider:       db.ProviderTypePlaid,
+		EventType:      "connection_error",
+		ConnectionID:   conn.ID,
+		RawPayloadHash: "hash",
+		Status:         "processed",
+	})
+	if err != nil {
+		t.Fatalf("create event: %v", err)
+	}
+
+	result, err := svc.ListWebhookEventsPaginated(ctx, service.WebhookEventListParams{
+		Page:     1,
+		PageSize: 25,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result.Events))
+	}
+	evt := result.Events[0]
+	if evt.ConnectionID == nil {
+		t.Error("expected connection ID to be set")
+	}
+	// MustCreateConnection does not set institution_name, so it will be NULL.
+	// This test verifies that the LEFT JOIN works without error and the field is nil.
+	if evt.InstitutionName != nil {
+		t.Errorf("expected institution name to be nil (not set in fixture), got %q", *evt.InstitutionName)
+	}
+	if evt.EventType != "connection_error" {
+		t.Errorf("expected event_type 'connection_error', got %q", evt.EventType)
+	}
+	if evt.Provider != "plaid" {
+		t.Errorf("expected provider 'plaid', got %q", evt.Provider)
+	}
+}

--- a/internal/templates/pages/webhook_events.html
+++ b/internal/templates/pages/webhook_events.html
@@ -1,0 +1,232 @@
+{{define "content"}}
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Webhook Events</h1>
+    <p class="text-sm text-base-content/50 mt-1">Inbound webhook events from bank data providers</p>
+  </div>
+</div>
+
+<!-- Summary Stats Cards -->
+{{if .Stats}}
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6 bb-stagger">
+  <!-- Total Events -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+        <i data-lucide="webhook" class="w-4 h-4 text-base-content/40"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none">{{.Stats.TotalEvents}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Total events</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Processed -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center shrink-0">
+        <i data-lucide="check-circle-2" class="w-4 h-4 text-success"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none text-success">{{.Stats.ProcessedCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Processed</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Received (in-flight) -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-warning/10 flex items-center justify-center shrink-0">
+        <i data-lucide="clock" class="w-4 h-4 text-warning"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.ReceivedCount 0}}text-warning{{end}}">{{.Stats.ReceivedCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">In-flight</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Errors -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .Stats.ErrorCount 0}}bg-error/10{{else}}bg-base-200/60{{end}}">
+        <i data-lucide="alert-circle" class="w-4 h-4 {{if gt .Stats.ErrorCount 0}}text-error/70{{else}}text-base-content/40{{end}}"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.ErrorCount 0}}text-error{{end}}">{{.Stats.ErrorCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Errors</div>
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
+<!-- Status Filter Tabs + Provider Dropdown -->
+<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
+  <!-- Status pill tabs -->
+  <div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5">
+    <a href="/webhook-events{{if .FilterProvider}}?provider={{.FilterProvider}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if not .FilterStatus}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      All
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.Stats.TotalEvents}}</span>
+    </a>
+    <a href="/webhook-events?status=processed{{if .FilterProvider}}&provider={{.FilterProvider}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if eq .FilterStatus "processed"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-success"></span>
+      Processed
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.Stats.ProcessedCount}}</span>
+    </a>
+    <a href="/webhook-events?status=received{{if .FilterProvider}}&provider={{.FilterProvider}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if eq .FilterStatus "received"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-warning"></span>
+      In-flight
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.Stats.ReceivedCount}}</span>
+    </a>
+    <a href="/webhook-events?status=error{{if .FilterProvider}}&provider={{.FilterProvider}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if eq .FilterStatus "error"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-error"></span>
+      Errors
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.Stats.ErrorCount}}</span>
+    </a>
+  </div>
+
+  <!-- Provider filter dropdown -->
+  <form method="GET" action="/webhook-events" class="flex items-center gap-2">
+    {{if .FilterStatus}}<input type="hidden" name="status" value="{{.FilterStatus}}">{{end}}
+    <select name="provider" class="select select-sm select-bordered rounded-xl text-xs min-w-[10rem]"
+            onchange="this.form.submit()">
+      <option value="">All providers</option>
+      <option value="plaid"{{if eq .FilterProvider "plaid"}} selected{{end}}>Plaid</option>
+      <option value="teller"{{if eq .FilterProvider "teller"}} selected{{end}}>Teller</option>
+    </select>
+    {{if .FilterProvider}}
+    <a href="/webhook-events{{if $.FilterStatus}}?status={{$.FilterStatus}}{{end}}" class="btn btn-ghost btn-xs rounded-lg">
+      <i data-lucide="x" class="w-3 h-3"></i>
+    </a>
+    {{end}}
+  </form>
+</div>
+
+{{if .Events}}
+
+<!-- Results count -->
+<div class="text-xs text-base-content/40 mb-3 px-1">{{.Total}} webhook event{{if ne .Total 1}}s{{end}}</div>
+
+<!-- Event list -->
+<div class="space-y-1 bb-stagger">
+  {{range .Events}}
+  <div class="bb-card group transition-all duration-150 {{if eq .Status "error"}}border-error/20{{end}}" x-data="{ open: false }">
+    <div class="flex items-center gap-4 py-3 px-4 cursor-pointer" @click="open = !open">
+      <!-- Status indicator -->
+      <div class="relative shrink-0">
+        <div class="w-8 h-8 rounded-lg flex items-center justify-center
+                    {{if eq .Status "processed"}}bg-success/10{{else if eq .Status "error"}}bg-error/10{{else}}bg-warning/10{{end}}">
+          {{if eq .Status "processed"}}
+          <i data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
+          {{else if eq .Status "error"}}
+          <i data-lucide="x" class="w-3.5 h-3.5 text-error"></i>
+          {{else}}
+          <i data-lucide="clock" class="w-3.5 h-3.5 text-warning"></i>
+          {{end}}
+        </div>
+      </div>
+
+      <!-- Main content -->
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium">{{.EventType}}</span>
+          <span class="badge badge-ghost badge-xs opacity-60">{{.Provider}}</span>
+        </div>
+        <div class="flex items-center gap-3 mt-0.5 text-xs text-base-content/40">
+          <span>{{relativeTime .CreatedAt}}</span>
+          {{if .InstitutionName}}
+          <span class="text-base-content/25">&middot;</span>
+          <span>{{deref .InstitutionName}}</span>
+          {{end}}
+        </div>
+      </div>
+
+      <!-- Status badge + expand -->
+      <div class="flex items-center gap-3 shrink-0">
+        {{if eq .Status "processed"}}
+        <span class="badge badge-success badge-sm">processed</span>
+        {{else if eq .Status "error"}}
+        <span class="badge badge-error badge-sm">error</span>
+        {{else}}
+        <span class="badge badge-warning badge-sm">{{.Status}}</span>
+        {{end}}
+
+        <button class="btn btn-ghost btn-xs btn-circle text-base-content/30 hover:text-base-content/60 transition-colors">
+          <i data-lucide="chevron-down" class="w-3.5 h-3.5 transition-transform duration-200" :class="open ? 'rotate-180' : ''"></i>
+        </button>
+      </div>
+    </div>
+
+    <!-- Expandable detail -->
+    <div x-show="open" x-cloak x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="border-t border-base-200">
+      <div class="px-4 py-3 ml-12 space-y-2">
+        {{if .ConnectionID}}
+        <div class="flex items-center gap-2 text-xs">
+          <span class="text-base-content/40 w-24 shrink-0">Connection</span>
+          <a href="/connections/{{deref .ConnectionID}}" class="font-medium hover:text-primary transition-colors font-mono text-xs">
+            {{if .InstitutionName}}{{deref .InstitutionName}}{{else}}{{deref .ConnectionID}}{{end}}
+          </a>
+        </div>
+        {{end}}
+        <div class="flex items-center gap-2 text-xs">
+          <span class="text-base-content/40 w-24 shrink-0">Payload hash</span>
+          <span class="font-mono text-base-content/50 text-[0.65rem] break-all select-all">{{.PayloadHash}}</span>
+        </div>
+        <div class="flex items-center gap-2 text-xs">
+          <span class="text-base-content/40 w-24 shrink-0">Received at</span>
+          <span class="font-medium">{{formatDateTime .CreatedAt}}</span>
+        </div>
+        {{if .ErrorMessage}}
+        <div class="flex items-start gap-2 text-xs mt-2">
+          <i data-lucide="alert-circle" class="w-3.5 h-3.5 text-error/60 shrink-0 mt-0.5"></i>
+          <p class="text-error/80 font-mono break-all leading-relaxed">{{deref .ErrorMessage}}</p>
+        </div>
+        {{end}}
+      </div>
+    </div>
+  </div>
+  {{end}}
+</div>
+
+{{if gt .TotalPages 1}}
+<div class="flex items-center justify-between mt-6">
+  <div>
+    {{if gt .Page 1}}
+    <a href="/webhook-events?page={{sub .Page 1}}{{if $.FilterProvider}}&provider={{$.FilterProvider}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost rounded-xl">&laquo; Previous</a>
+    {{end}}
+  </div>
+  <span class="text-xs text-base-content/40">Page {{.Page}} of {{.TotalPages}}</span>
+  <div>
+    {{if lt .Page .TotalPages}}
+    <a href="/webhook-events?page={{add .Page 1}}{{if $.FilterProvider}}&provider={{$.FilterProvider}}{{end}}{{if $.FilterStatus}}&status={{$.FilterStatus}}{{end}}" class="btn btn-sm btn-ghost rounded-xl">Next &raquo;</a>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+{{else}}
+<div class="bb-card p-12 text-center">
+  <div class="flex flex-col items-center">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
+      <i data-lucide="webhook" class="w-8 h-8 text-base-content/25"></i>
+    </div>
+    <h3 class="text-lg font-semibold mb-1">No webhook events</h3>
+    <p class="text-sm text-base-content/50 mb-5">{{if or .FilterProvider .FilterStatus}}Try adjusting your filters.{{else}}Webhook events will appear here when providers send notifications.{{end}}</p>
+    {{if or .FilterProvider .FilterStatus}}
+    <a href="/webhook-events" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
+    {{end}}
+  </div>
+</div>
+{{end}}
+{{end}}

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -66,6 +66,9 @@
   <a href="/sync-logs" class="bb-sidebar-link{{if eq .CurrentPage "sync-logs"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="refresh-cw"></i> Sync Logs
   </a>
+  <a href="/webhook-events" class="bb-sidebar-link{{if eq .CurrentPage "webhook-events"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="webhook"></i> Webhooks
+  </a>
   <a href="/settings" class="bb-sidebar-link{{if eq .CurrentPage "settings"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="settings"></i> Settings
   </a>

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -2,7 +2,10 @@ package webhook
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -25,6 +28,8 @@ func NewHandler(providers map[string]provider.Provider, engine *sync.Engine, que
 		prov, ok := providers[providerName]
 		if !ok {
 			logger.Warn("webhook received for unknown provider")
+			// Log even for unknown providers so we can see unexpected traffic.
+			logWebhookEvent(r.Context(), queries, logger, db.ProviderType(providerName), "unknown", pgtype.UUID{}, nil, "error", strPtr("unknown provider: "+providerName))
 			writeOK(w)
 			return
 		}
@@ -35,6 +40,9 @@ func NewHandler(providers map[string]provider.Provider, engine *sync.Engine, que
 			writeOK(w)
 			return
 		}
+
+		// Compute SHA-256 hash of the raw payload for dedup and auditing.
+		payloadHash := sha256Hex(body)
 
 		headers := make(map[string]string)
 		for key, vals := range r.Header {
@@ -49,6 +57,7 @@ func NewHandler(providers map[string]provider.Provider, engine *sync.Engine, que
 		})
 		if err != nil {
 			logger.Error("webhook verification failed", "error", err)
+			logWebhookEvent(r.Context(), queries, logger, db.ProviderType(providerName), "verification_failed", pgtype.UUID{}, &payloadHash, "error", strPtr("verification failed: "+err.Error()))
 			writeOK(w)
 			return
 		}
@@ -62,17 +71,29 @@ func NewHandler(providers map[string]provider.Provider, engine *sync.Engine, que
 		})
 		if err != nil {
 			logger.Error("failed to look up connection", "error", err)
+			logWebhookEvent(r.Context(), queries, logger, db.ProviderType(providerName), event.Type, pgtype.UUID{}, &payloadHash, "error", strPtr("connection lookup failed: "+err.Error()))
 			writeOK(w)
 			return
 		}
 
+		// Create the webhook event log entry before processing.
+		webhookEvent := logWebhookEvent(r.Context(), queries, logger, db.ProviderType(providerName), event.Type, conn.ID, &payloadHash, "received", nil)
+
+		var processErr error
 		switch event.Type {
 		case "sync_available":
 			go func() {
 				if err := engine.Sync(context.Background(), conn.ID, db.SyncTriggerWebhook); err != nil {
 					logger.Error("webhook-triggered sync failed", "error", err)
+					// Update event status asynchronously on failure.
+					updateWebhookEventStatus(context.Background(), queries, logger, webhookEvent, "error", strPtr("sync failed: "+err.Error()))
+				} else {
+					updateWebhookEventStatus(context.Background(), queries, logger, webhookEvent, "processed", nil)
 				}
 			}()
+			// Don't mark as processed here since sync runs in background.
+			writeOK(w)
+			return
 
 		case "connection_error":
 			status := db.ConnectionStatusError
@@ -86,13 +107,14 @@ func NewHandler(providers map[string]provider.Provider, engine *sync.Engine, que
 			if event.ErrorMessage != nil {
 				errMsg = pgtype.Text{String: *event.ErrorMessage, Valid: true}
 			}
-			if err := queries.UpdateBankConnectionStatus(r.Context(), db.UpdateBankConnectionStatusParams{
+			processErr = queries.UpdateBankConnectionStatus(r.Context(), db.UpdateBankConnectionStatusParams{
 				ID:           conn.ID,
 				Status:       status,
 				ErrorCode:    errCode,
 				ErrorMessage: errMsg,
-			}); err != nil {
-				logger.Error("failed to update connection status", "error", err)
+			})
+			if processErr != nil {
+				logger.Error("failed to update connection status", "error", processErr)
 			}
 
 		case "pending_expiration":
@@ -102,27 +124,89 @@ func NewHandler(providers map[string]provider.Provider, engine *sync.Engine, que
 					expTime = pgtype.Timestamptz{Time: t, Valid: true}
 				}
 			}
-			if err := queries.UpdateConnectionConsentExpiration(r.Context(), db.UpdateConnectionConsentExpirationParams{
+			processErr = queries.UpdateConnectionConsentExpiration(r.Context(), db.UpdateConnectionConsentExpirationParams{
 				ID:                    conn.ID,
 				ConsentExpirationTime: expTime,
-			}); err != nil {
-				logger.Error("failed to update consent expiration", "error", err)
+			})
+			if processErr != nil {
+				logger.Error("failed to update consent expiration", "error", processErr)
 			}
 
 		case "new_accounts":
-			if err := queries.UpdateConnectionNewAccounts(r.Context(), db.UpdateConnectionNewAccountsParams{
+			processErr = queries.UpdateConnectionNewAccounts(r.Context(), db.UpdateConnectionNewAccountsParams{
 				ID:                   conn.ID,
 				NewAccountsAvailable: true,
-			}); err != nil {
-				logger.Error("failed to update new accounts flag", "error", err)
+			})
+			if processErr != nil {
+				logger.Error("failed to update new accounts flag", "error", processErr)
 			}
 
 		case "unknown":
 			logger.Info("received unknown webhook type, acknowledging")
 		}
 
+		// Update the webhook event status based on processing outcome.
+		if processErr != nil {
+			updateWebhookEventStatus(r.Context(), queries, logger, webhookEvent, "error", strPtr(processErr.Error()))
+		} else {
+			updateWebhookEventStatus(r.Context(), queries, logger, webhookEvent, "processed", nil)
+		}
+
 		writeOK(w)
 	}
+}
+
+// logWebhookEvent creates a webhook_events record. Returns the event ID (zero-value UUID if logging fails).
+func logWebhookEvent(ctx context.Context, queries *db.Queries, logger *slog.Logger, providerType db.ProviderType, eventType string, connectionID pgtype.UUID, payloadHash *string, status string, errMsg *string) pgtype.UUID {
+	hash := ""
+	if payloadHash != nil {
+		hash = *payloadHash
+	}
+	var errText pgtype.Text
+	if errMsg != nil {
+		errText = pgtype.Text{String: *errMsg, Valid: true}
+	}
+	evt, err := queries.CreateWebhookEvent(ctx, db.CreateWebhookEventParams{
+		Provider:       providerType,
+		EventType:      eventType,
+		ConnectionID:   connectionID,
+		RawPayloadHash: hash,
+		Status:         status,
+		ErrorMessage:   errText,
+	})
+	if err != nil {
+		// Don't fail the webhook handler if event logging fails.
+		logger.Warn("failed to log webhook event", "error", err)
+		return pgtype.UUID{}
+	}
+	return evt.ID
+}
+
+// updateWebhookEventStatus updates the status of a previously logged webhook event.
+func updateWebhookEventStatus(ctx context.Context, queries *db.Queries, logger *slog.Logger, eventID pgtype.UUID, status string, errMsg *string) {
+	if !eventID.Valid {
+		return // Event logging failed earlier, skip update.
+	}
+	var errText pgtype.Text
+	if errMsg != nil {
+		errText = pgtype.Text{String: *errMsg, Valid: true}
+	}
+	if err := queries.UpdateWebhookEventStatus(ctx, db.UpdateWebhookEventStatusParams{
+		ID:           eventID,
+		Status:       status,
+		ErrorMessage: errText,
+	}); err != nil {
+		logger.Warn("failed to update webhook event status", "event_id", fmt.Sprintf("%x", eventID.Bytes), "error", err)
+	}
+}
+
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+func strPtr(s string) *string {
+	return &s
 }
 
 func writeOK(w http.ResponseWriter) {


### PR DESCRIPTION
## Summary
- Log every inbound webhook event to a new `webhook_events` table before processing
- Track provider, event type, connection, SHA-256 payload hash, status (received/processed/error), and error messages
- New `/webhook-events` admin page with filterable list view, status tabs, and summary stats

## Changes

### Database
- New migration `20260327230533_webhook_events.sql`: `webhook_events` table with indexes on `created_at`, `provider`, `connection_id`, and `status`
- New sqlc queries: `CreateWebhookEvent`, `UpdateWebhookEventStatus`, `CountWebhookEvents`

### Webhook handler (`internal/webhook/handler.go`)
- Logs events at every decision point: unknown provider, verification failure, connection lookup failure, and processing outcome
- SHA-256 hashes the raw payload for dedup/auditing (no raw payload stored)
- For `sync_available` events, status is updated asynchronously after the background sync completes or fails
- Event logging failures are gracefully handled (logged as warnings, never block webhook processing)

### Service layer (`internal/service/webhook_events.go`)
- `ListWebhookEventsPaginated`: filtered, paginated list with LEFT JOIN to `bank_connections` for institution names
- `WebhookEventCounts`: aggregate stats (total, processed, received, error)

### Admin UI
- New `webhook_events.html` page with DaisyUI components matching existing sync logs design
- Status filter tabs (All / Processed / In-flight / Errors) with counts
- Provider dropdown filter (Plaid / Teller)
- Expandable event rows showing connection link, payload hash, timestamp, and error details
- Nav entry with `webhook` Lucide icon in System section

### Integration tests
- 5 tests covering: empty state, filtered listing, status counts, pagination, and JOIN behavior

## Testing
- `go build ./...` -- clean
- `go test ./...` -- all unit tests pass
- `go vet ./...` -- clean
- Integration tests pass against PostgreSQL (`TestListWebhookEventsPaginated_*`, `TestWebhookEventCounts`)
- Server starts cleanly with new migration, no template errors

🤖 Generated by autonomous sync improvement agent