### PR TITLE
Sync: balance fetch retry with warning message

### DIFF
--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -90,6 +90,7 @@ func SyncLogsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, s
 			"SuccessCount":     successCount,
 			"ErrorCount":       errorCount,
 			"InProgressCount":  inProgressCount,
+			"WarningCount":     stats.WarningCount,
 		}
 		tr.Render(w, r, "sync_logs.html", data)
 	}

--- a/internal/db/migrations/20260327233333_add_sync_log_warning_message.sql
+++ b/internal/db/migrations/20260327233333_add_sync_log_warning_message.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE sync_logs ADD COLUMN warning_message TEXT NULL;
+
+-- +goose Down
+ALTER TABLE sync_logs DROP COLUMN IF EXISTS warning_message;

--- a/internal/db/queries/sync_logs.sql
+++ b/internal/db/queries/sync_logs.sql
@@ -23,7 +23,7 @@ LIMIT $2 OFFSET $3;
 
 -- name: UpdateSyncLog :exec
 UPDATE sync_logs
-SET status = $2, completed_at = $3, added_count = $4, modified_count = $5, removed_count = $6, error_message = $7, duration_ms = $8
+SET status = $2, completed_at = $3, added_count = $4, modified_count = $5, removed_count = $6, error_message = $7, duration_ms = $8, warning_message = $9
 WHERE id = $1;
 
 -- name: GetMostRecentSyncLog :one

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -57,7 +57,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 
 	query := "SELECT sl.id, sl.connection_id, bc.institution_name, sl.trigger, sl.status, " +
 		"sl.added_count, sl.modified_count, sl.removed_count, sl.error_message, " +
-		"sl.started_at, sl.completed_at " +
+		"sl.started_at, sl.completed_at, sl.warning_message " +
 		"FROM sync_logs sl " +
 		"JOIN bank_connections bc ON sl.connection_id = bc.id " +
 		"WHERE sl.id = $1"
@@ -74,12 +74,13 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		errorMessage    pgtype.Text
 		startedAt       pgtype.Timestamptz
 		completedAt     pgtype.Timestamptz
+		warningMessage  pgtype.Text
 	)
 
 	if err := s.Pool.QueryRow(ctx, query, uid).Scan(
 		&id, &connectionID, &institutionName, &trigger, &status,
 		&addedCount, &modifiedCount, &removedCount, &errorMessage,
-		&startedAt, &completedAt,
+		&startedAt, &completedAt, &warningMessage,
 	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
@@ -111,6 +112,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		ModifiedCount:    modifiedCount,
 		RemovedCount:     removedCount,
 		ErrorMessage:     textPtr(errorMessage),
+		WarningMessage:   textPtr(warningMessage),
 		StartedAt:        timestampStr(startedAt),
 		CompletedAt:      timestampStr(completedAt),
 		Duration:         duration,
@@ -121,7 +123,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListParams) (*SyncLogListResult, error) {
 	query := "SELECT sl.id, sl.connection_id, bc.institution_name, sl.trigger, sl.status, " +
 		"sl.added_count, sl.modified_count, sl.removed_count, sl.error_message, " +
-		"sl.started_at, sl.completed_at, sl.duration_ms " +
+		"sl.started_at, sl.completed_at, sl.duration_ms, sl.warning_message " +
 		"FROM sync_logs sl " +
 		"JOIN bank_connections bc ON sl.connection_id = bc.id " +
 		"WHERE 1=1"
@@ -192,12 +194,13 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 			startedAt       pgtype.Timestamptz
 			completedAt     pgtype.Timestamptz
 			durationMs      pgtype.Int4
+			warningMessage  pgtype.Text
 		)
 
 		if err := rows.Scan(
 			&id, &connectionID, &institutionName, &trigger, &status,
 			&addedCount, &modifiedCount, &removedCount, &errorMessage,
-			&startedAt, &completedAt, &durationMs,
+			&startedAt, &completedAt, &durationMs, &warningMessage,
 		); err != nil {
 			return nil, fmt.Errorf("scan sync log: %w", err)
 		}
@@ -235,6 +238,7 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 			ModifiedCount:   modifiedCount,
 			RemovedCount:    removedCount,
 			ErrorMessage:    textPtr(errorMessage),
+			WarningMessage:  textPtr(warningMessage),
 			StartedAt:       timestampStr(startedAt),
 			CompletedAt:     timestampStr(completedAt),
 			Duration:        duration,
@@ -321,6 +325,7 @@ func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*
 		COUNT(*) AS total,
 		COUNT(*) FILTER (WHERE sl.status = 'success') AS success_count,
 		COUNT(*) FILTER (WHERE sl.status = 'error') AS error_count,
+		COUNT(*) FILTER (WHERE sl.warning_message IS NOT NULL AND sl.warning_message != '') AS warning_count,
 		COALESCE(AVG(COALESCE(sl.duration_ms, EXTRACT(MILLISECONDS FROM (sl.completed_at - sl.started_at))::INTEGER)) FILTER (WHERE sl.completed_at IS NOT NULL), 0) AS avg_duration_ms,
 		COALESCE(SUM(sl.added_count), 0) AS total_added,
 		COALESCE(SUM(sl.modified_count), 0) AS total_modified,
@@ -352,6 +357,7 @@ func (s *Service) SyncLogStats(ctx context.Context, params SyncLogListParams) (*
 		&stats.TotalSyncs,
 		&stats.SuccessCount,
 		&stats.ErrorCount,
+		&stats.WarningCount,
 		&stats.AvgDurationMs,
 		&stats.TotalAdded,
 		&stats.TotalModified,

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -189,6 +189,7 @@ type SyncLogRow struct {
 	RemovedCount         int32
 	ErrorMessage         *string // raw technical error for debugging
 	FriendlyErrorMessage *string // human-friendly error for display
+	WarningMessage       *string // non-fatal warning (e.g., balance fetch issues)
 	StartedAt            *string
 	CompletedAt          *string
 	Duration             *string
@@ -212,6 +213,7 @@ type SyncLogStats struct {
 	TotalSyncs    int64
 	SuccessCount  int64
 	ErrorCount    int64
+	WarningCount  int64   // syncs that succeeded with warnings
 	SuccessRate   float64 // 0-100 percentage
 	AvgDurationMs float64 // average duration in milliseconds
 	TotalAdded    int64

--- a/internal/sync/balance_retry_test.go
+++ b/internal/sync/balance_retry_test.go
@@ -1,0 +1,101 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"breadbox/internal/provider"
+)
+
+// mockBalanceProvider implements provider.Provider with controllable GetBalances behavior.
+type mockBalanceProvider struct {
+	provider.Provider // embed interface for methods we don't care about
+	balanceCalls      int
+	balanceErrors     []error // error to return on each call (index = call number)
+	balanceResults    [][]provider.AccountBalance
+}
+
+func (m *mockBalanceProvider) GetBalances(ctx context.Context, conn provider.Connection) ([]provider.AccountBalance, error) {
+	call := m.balanceCalls
+	m.balanceCalls++
+	if call < len(m.balanceErrors) && m.balanceErrors[call] != nil {
+		return nil, m.balanceErrors[call]
+	}
+	if call < len(m.balanceResults) {
+		return m.balanceResults[call], nil
+	}
+	return nil, nil
+}
+
+func TestUpdateBalancesWithRetry_Success(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	e := &Engine{logger: logger, balanceRetryDelay: 1 * time.Millisecond}
+
+	mock := &mockBalanceProvider{
+		balanceErrors:  []error{nil},
+		balanceResults: [][]provider.AccountBalance{{}},
+	}
+
+	warning := e.updateBalancesWithRetry(context.Background(), nil, mock, provider.Connection{}, logger)
+	if warning != "" {
+		t.Errorf("expected no warning on success, got: %s", warning)
+	}
+	if mock.balanceCalls != 1 {
+		t.Errorf("expected 1 call, got %d", mock.balanceCalls)
+	}
+}
+
+func TestUpdateBalancesWithRetry_FailThenSuccess(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	e := &Engine{logger: logger, balanceRetryDelay: 1 * time.Millisecond}
+
+	mock := &mockBalanceProvider{
+		balanceErrors:  []error{errors.New("connection timeout"), nil},
+		balanceResults: [][]provider.AccountBalance{nil, {}},
+	}
+
+	warning := e.updateBalancesWithRetry(context.Background(), nil, mock, provider.Connection{}, logger)
+	if warning == "" {
+		t.Error("expected warning when first attempt fails but retry succeeds")
+	}
+	if !strings.Contains(warning, "succeeded on retry") {
+		t.Errorf("warning should mention retry success, got: %s", warning)
+	}
+	if !strings.Contains(warning, "connection timeout") {
+		t.Errorf("warning should include original error, got: %s", warning)
+	}
+	if mock.balanceCalls != 2 {
+		t.Errorf("expected 2 calls (original + retry), got %d", mock.balanceCalls)
+	}
+}
+
+func TestUpdateBalancesWithRetry_BothFail(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	e := &Engine{logger: logger, balanceRetryDelay: 1 * time.Millisecond}
+
+	mock := &mockBalanceProvider{
+		balanceErrors: []error{
+			errors.New("first failure"),
+			errors.New("second failure"),
+		},
+	}
+
+	warning := e.updateBalancesWithRetry(context.Background(), nil, mock, provider.Connection{}, logger)
+	if warning == "" {
+		t.Error("expected warning when both attempts fail")
+	}
+	if !strings.Contains(warning, "failed after retry") {
+		t.Errorf("warning should mention retry failure, got: %s", warning)
+	}
+	if !strings.Contains(warning, "second failure") {
+		t.Errorf("warning should include retry error, got: %s", warning)
+	}
+	if mock.balanceCalls != 2 {
+		t.Errorf("expected 2 calls, got %d", mock.balanceCalls)
+	}
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -29,22 +29,24 @@ type accountSyncCounts struct {
 
 // Engine orchestrates transaction syncing across all bank connections.
 type Engine struct {
-	db        *db.Queries
-	pool      *pgxpool.Pool
-	providers map[string]provider.Provider
-	logger    *slog.Logger
-	locks     gosync.Map // connection ID string -> *gosync.Mutex
-	matcher   *Matcher
+	db                *db.Queries
+	pool              *pgxpool.Pool
+	providers         map[string]provider.Provider
+	logger            *slog.Logger
+	locks             gosync.Map // connection ID string -> *gosync.Mutex
+	matcher           *Matcher
+	balanceRetryDelay time.Duration // delay between balance fetch retries (default 2s)
 }
 
 // NewEngine creates a new sync engine.
 func NewEngine(queries *db.Queries, pool *pgxpool.Pool, providers map[string]provider.Provider, logger *slog.Logger) *Engine {
 	return &Engine{
-		db:        queries,
-		pool:      pool,
-		providers: providers,
-		logger:    logger,
-		matcher:   NewMatcher(queries, pool, logger.With("component", "matcher")),
+		db:                queries,
+		pool:              pool,
+		providers:         providers,
+		logger:            logger,
+		matcher:           NewMatcher(queries, pool, logger.With("component", "matcher")),
+		balanceRetryDelay: 2 * time.Second,
 	}
 }
 
@@ -73,7 +75,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	}
 
 	// Run the sync and capture results.
-	added, modified, removed, perAccount, syncErr := e.runSync(ctx, connectionID, logger)
+	added, modified, removed, perAccount, warningMsg, syncErr := e.runSync(ctx, connectionID, logger)
 
 	// Update sync_log with final status.
 	completedAt := time.Now()
@@ -85,6 +87,11 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 		errMsg = pgtype.Text{String: syncErr.Error(), Valid: true}
 	}
 
+	var warnMsg pgtype.Text
+	if warningMsg != "" {
+		warnMsg = pgtype.Text{String: warningMsg, Valid: true}
+	}
+
 	// Compute duration in milliseconds from started_at.
 	var durationMs pgtype.Int4
 	if syncLog.StartedAt.Valid {
@@ -93,14 +100,15 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	}
 
 	if err := e.db.UpdateSyncLog(ctx, db.UpdateSyncLogParams{
-		ID:            syncLog.ID,
-		Status:        status,
-		CompletedAt:   now,
-		AddedCount:    int32(added),
-		ModifiedCount: int32(modified),
-		RemovedCount:  int32(removed),
-		ErrorMessage:  errMsg,
-		DurationMs:    durationMs,
+		ID:             syncLog.ID,
+		Status:         status,
+		CompletedAt:    now,
+		AddedCount:     int32(added),
+		ModifiedCount:  int32(modified),
+		RemovedCount:   int32(removed),
+		ErrorMessage:   errMsg,
+		DurationMs:     durationMs,
+		WarningMessage: warnMsg,
 	}); err != nil {
 		logger.Error("failed to update sync log", "error", err)
 	}
@@ -124,27 +132,27 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	return nil
 }
 
-// runSync performs the actual sync loop for a connection. Returns counts, per-account breakdown, and any error.
-func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *slog.Logger) (added, modified, removed int, perAccount map[string]*accountSyncCounts, err error) {
+// runSync performs the actual sync loop for a connection. Returns counts, per-account breakdown, warning message, and any error.
+func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *slog.Logger) (added, modified, removed int, perAccount map[string]*accountSyncCounts, warning string, err error) {
 	// Initialize per-account tracking map.
 	perAccount = make(map[string]*accountSyncCounts)
 
 	// Load connection from DB.
 	conn, err := e.db.GetBankConnectionForSync(ctx, connectionID)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf("load connection: %w", err)
+		return 0, 0, 0, nil, "", fmt.Errorf("load connection: %w", err)
 	}
 
 	// Look up the provider.
 	prov, ok := e.providers[string(conn.Provider)]
 	if !ok {
-		return 0, 0, 0, nil, fmt.Errorf("unknown provider: %s", conn.Provider)
+		return 0, 0, 0, nil, "", fmt.Errorf("unknown provider: %s", conn.Provider)
 	}
 
 	// Fetch excluded account IDs for this connection.
 	excludedIDs, err := e.db.ListExcludedAccountIDsByConnection(ctx, connectionID)
 	if err != nil {
-		return 0, 0, 0, nil, fmt.Errorf("list excluded accounts: %w", err)
+		return 0, 0, 0, nil, "", fmt.Errorf("list excluded accounts: %w", err)
 	}
 	excludedSet := make(map[pgtype.UUID]bool, len(excludedIDs))
 	for _, id := range excludedIDs {
@@ -227,9 +235,9 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 					ErrorCode:    pgtype.Text{String: "ITEM_LOGIN_REQUIRED", Valid: true},
 					ErrorMessage: pgtype.Text{String: "Re-authentication required by institution", Valid: true},
 				})
-				return 0, 0, 0, nil, syncErr
+				return 0, 0, 0, nil, "", syncErr
 			}
-			return 0, 0, 0, nil, syncErr
+			return 0, 0, 0, nil, "", syncErr
 		}
 
 		// Buffer results — don't write to DB until pagination is complete.
@@ -247,7 +255,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		// Start transaction for all data writes.
 		tx, err := e.pool.Begin(ctx)
 		if err != nil {
-			return 0, 0, 0, nil, fmt.Errorf("begin transaction: %w", err)
+			return 0, 0, 0, nil, "", fmt.Errorf("begin transaction: %w", err)
 		}
 		defer tx.Rollback(ctx)
 
@@ -339,17 +347,16 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 			ID:         connectionID,
 			SyncCursor: pgtype.Text{String: result.Cursor, Valid: true},
 		}); err != nil {
-			return added, modified, removed, perAccount, fmt.Errorf("update cursor: %w", err)
+			return added, modified, removed, perAccount, "", fmt.Errorf("update cursor: %w", err)
 		}
 
-		// Fetch and update balances.
-		if err := e.updateBalances(ctx, txQueries, prov, provConn, logger); err != nil {
-			logger.Error("update balances failed", "error", err)
-			// Non-fatal: balances are best-effort.
+		// Fetch and update balances with retry.
+		if balanceWarn := e.updateBalancesWithRetry(ctx, txQueries, prov, provConn, logger); balanceWarn != "" {
+			warning = balanceWarn
 		}
 
 		if err := tx.Commit(ctx); err != nil {
-			return 0, 0, 0, nil, fmt.Errorf("commit transaction: %w", err)
+			return 0, 0, 0, nil, "", fmt.Errorf("commit transaction: %w", err)
 		}
 
 		// Flush rule hit counts after commit (best-effort, non-fatal).
@@ -372,7 +379,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		break
 	}
 
-	return added, modified, removed, perAccount, nil
+	return added, modified, removed, perAccount, warning, nil
 }
 
 // upsertTransaction resolves the account ID and upserts a single transaction.
@@ -427,6 +434,37 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 	}
 
 	return q.UpsertTransaction(ctx, params)
+}
+
+// updateBalancesWithRetry fetches balances with 1 retry on transient errors.
+// Returns a warning message if the retry succeeded (partial success) or if
+// all attempts failed (non-fatal warning). Returns empty string on clean success.
+func (e *Engine) updateBalancesWithRetry(ctx context.Context, q *db.Queries, prov provider.Provider, conn provider.Connection, logger *slog.Logger) string {
+	err := e.updateBalances(ctx, q, prov, conn, logger)
+	if err == nil {
+		return ""
+	}
+
+	// First attempt failed. Log and retry once after a short delay.
+	delay := e.balanceRetryDelay
+	if delay <= 0 {
+		delay = 2 * time.Second
+	}
+	logger.Warn("balance fetch failed, retrying", "error", err, "retry_delay", delay)
+	time.Sleep(delay)
+
+	retryErr := e.updateBalances(ctx, q, prov, conn, logger)
+	if retryErr == nil {
+		// Retry succeeded — record a warning that the first attempt failed.
+		msg := fmt.Sprintf("Balance fetch succeeded on retry (first attempt: %s)", err.Error())
+		logger.Info("balance fetch retry succeeded", "original_error", err)
+		return msg
+	}
+
+	// Both attempts failed. Non-fatal: transaction sync data is still committed.
+	msg := fmt.Sprintf("Balance fetch failed after retry: %s", retryErr.Error())
+	logger.Error("balance fetch failed after retry", "original_error", err, "retry_error", retryErr)
+	return msg
 }
 
 // updateBalances fetches current balances from the provider and updates the DB.

--- a/internal/templates/pages/sync_log_detail.html
+++ b/internal/templates/pages/sync_log_detail.html
@@ -22,6 +22,11 @@
       <div class="flex items-center gap-2 mt-0.5 flex-wrap">
         <span class="badge badge-ghost badge-xs">{{.Log.Trigger}}</span>
         {{syncBadge .Log.Status}}
+        {{if .Log.WarningMessage}}
+        <span class="badge badge-warning badge-sm gap-1">
+          <i data-lucide="alert-triangle" class="w-3 h-3"></i>warning
+        </span>
+        {{end}}
       </div>
     </div>
   </div>
@@ -103,6 +108,21 @@
     {{end}}
   </div>
 </div>
+
+<!-- Warning Card -->
+{{if .Log.WarningMessage}}
+<div class="bb-card p-0 mb-6 border-warning/20">
+  <div class="px-5 py-3.5 border-b border-warning/10 bg-warning/5">
+    <div class="flex items-center gap-2">
+      <i data-lucide="alert-triangle" class="w-4 h-4 text-warning/70"></i>
+      <h2 class="text-sm font-semibold text-warning/90">Warning</h2>
+    </div>
+  </div>
+  <div class="px-5 py-4">
+    <p class="text-sm text-base-content/60 leading-relaxed">{{deref .Log.WarningMessage}}</p>
+  </div>
+</div>
+{{end}}
 
 <!-- Error Card -->
 {{if .Log.ErrorMessage}}

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -8,7 +8,7 @@
 
 <!-- Summary Stats Cards -->
 {{if .Stats}}
-<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6 bb-stagger">
+<div class="grid grid-cols-2 lg:grid-cols-5 gap-3 mb-6 bb-stagger">
   <!-- Total Syncs -->
   <div class="bb-card p-4">
     <div class="flex items-center gap-3">
@@ -37,6 +37,19 @@
       <div>
         <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.SuccessRate 80.0}}text-success{{else if gt .Stats.SuccessRate 50.0}}text-warning{{else}}text-error{{end}}">{{printf "%.0f" .Stats.SuccessRate}}%</div>
         <div class="text-xs text-base-content/40 mt-0.5">Success rate</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Warnings -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .Stats.WarningCount 0}}bg-warning/10{{else}}bg-base-200/60{{end}}">
+        <i data-lucide="alert-triangle" class="w-4 h-4 {{if gt .Stats.WarningCount 0}}text-warning/70{{else}}text-base-content/40{{end}}"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.WarningCount 0}}text-warning{{end}}">{{.Stats.WarningCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Warnings</div>
       </div>
     </div>
   </div>
@@ -182,9 +195,16 @@
         <!-- Status badge -->
         {{syncBadge .Status}}
 
-        <!-- Error expand button -->
-        {{if .ErrorMessage}}
-        <button @click.prevent="open = !open" class="btn btn-ghost btn-xs btn-circle text-error/50 hover:text-error hover:bg-error/10 transition-colors">
+        <!-- Warning badge -->
+        {{if .WarningMessage}}
+        <span class="badge badge-warning badge-sm gap-1">
+          <i data-lucide="alert-triangle" class="w-3 h-3"></i>warning
+        </span>
+        {{end}}
+
+        <!-- Error/Warning expand button -->
+        {{if or .ErrorMessage .WarningMessage}}
+        <button @click.prevent="open = !open" class="btn btn-ghost btn-xs btn-circle {{if .ErrorMessage}}text-error/50 hover:text-error hover:bg-error/10{{else}}text-warning/50 hover:text-warning hover:bg-warning/10{{end}} transition-colors">
           <i data-lucide="chevron-down" class="w-3.5 h-3.5 transition-transform duration-200" :class="open ? 'rotate-180' : ''"></i>
         </button>
         {{end}}
@@ -207,6 +227,19 @@
           <div class="text-xs font-medium text-error/80 mb-0.5">Error Details</div>
           <p class="text-xs text-base-content/50 font-mono break-all leading-relaxed">{{deref .ErrorMessage}}</p>
           {{end}}
+        </div>
+      </div>
+    </div>
+    {{end}}
+
+    <!-- Expandable warning detail -->
+    {{if and .WarningMessage (not .ErrorMessage)}}
+    <div x-show="open" x-cloak x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="border-t border-base-200">
+      <div class="flex items-start gap-2.5 px-4 py-3 ml-12">
+        <i data-lucide="alert-triangle" class="w-3.5 h-3.5 text-warning/60 shrink-0 mt-0.5"></i>
+        <div class="min-w-0">
+          <div class="text-xs font-medium text-warning/80 mb-0.5">Warning</div>
+          <p class="text-xs text-base-content/50 leading-relaxed">{{deref .WarningMessage}}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Balance fetch failures during sync were silently logged and discarded. Now the engine retries once with a 2s delay for transient errors.
- Introduces a `warning_message` column on `sync_logs` to distinguish partial-success states (transactions synced, balances failed) from full errors.
- Warning messages are surfaced in the sync log UI with yellow warning badges and expandable detail sections.

## Changes
- **Migration**: `20260327233333_add_sync_log_warning_message.sql` adds `warning_message TEXT NULL` to `sync_logs`
- **Sync engine** (`internal/sync/engine.go`):
  - New `updateBalancesWithRetry()` method replaces direct `updateBalances()` call
  - Retries once on failure with configurable delay (default 2s, testable via `balanceRetryDelay` field)
  - Returns warning string instead of silently swallowing the error
  - `runSync()` now returns 6 values (added warning string)
  - `Sync()` stores warning in `UpdateSyncLog` params
- **SQL queries** (`internal/db/queries/sync_logs.sql`): `UpdateSyncLog` includes `warning_message = $9`
- **Service layer** (`internal/service/sync.go`, `internal/service/types.go`):
  - `SyncLogRow` gains `WarningMessage *string`
  - `SyncLogStats` gains `WarningCount int64`
  - `GetSyncLog` and `ListSyncLogsPaginated` select and scan `warning_message`
  - `SyncLogStats` query counts rows with non-null `warning_message`
- **Admin handler** (`internal/admin/synclogs.go`): passes `WarningCount` to template
- **Templates**:
  - `sync_logs.html`: warning badge next to status badge, expandable warning detail, warnings stats card, 5-column grid
  - `sync_log_detail.html`: warning card above error card, warning badge in header

## Testing
- 3 unit tests in `internal/sync/balance_retry_test.go`:
  - `TestUpdateBalancesWithRetry_Success` -- clean success, no retry, no warning
  - `TestUpdateBalancesWithRetry_FailThenSuccess` -- first attempt fails, retry succeeds, warning includes original error
  - `TestUpdateBalancesWithRetry_BothFail` -- both attempts fail, warning includes retry error
- All existing unit tests pass (`go test ./...`)
- Build verified (`go build ./...`)
- Migration applied and server starts cleanly

🤖 Generated by autonomous sync improvement agent