### PR TITLE
Show next sync schedule on connections page

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -25,12 +25,29 @@ type ConnectionAccount struct {
 	HasBalance   bool
 }
 
+// NextSyncInfo holds computed next-sync schedule information for a connection.
+type NextSyncInfo struct {
+	// NextSyncAt is when the connection will next be eligible for cron sync.
+	NextSyncAt time.Time
+	// Label is a human-readable string like "in 2h 15m" or "overdue".
+	Label string
+	// IsOverdue is true when the connection is past its scheduled sync time.
+	IsOverdue bool
+	// IsPaused is true when the connection is paused (no scheduled sync).
+	IsPaused bool
+	// IsDisconnected is true when the connection is disconnected or CSV.
+	IsDisconnected bool
+	// EffectiveIntervalMinutes is the sync interval including backoff.
+	EffectiveIntervalMinutes int
+}
+
 // ConnectionWithAccounts pairs a connection row with its accounts and computed totals.
 type ConnectionWithAccounts struct {
 	db.ListBankConnectionsRow
 	Accounts     []ConnectionAccount
 	TotalBalance float64
 	HasBalance   bool
+	NextSync     NextSyncInfo
 }
 
 // ConnectionsListHandler serves GET /admin/connections.
@@ -85,7 +102,10 @@ func ConnectionsListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 
 		netWorth := totalAssets - totalLiabilities
 
-		// Compute per-connection display total from display-ready balances.
+		// Compute per-connection display total from display-ready balances
+		// and next-sync schedule.
+		now := time.Now()
+		globalInterval := a.Config.SyncIntervalMinutes
 		for i := range enriched {
 			if enriched[i].HasBalance {
 				total := 0.0
@@ -96,6 +116,14 @@ func ConnectionsListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 				}
 				enriched[i].TotalBalance = total
 			}
+			enriched[i].NextSync = computeNextSync(syncScheduleParams{
+				Status:                      enriched[i].Status,
+				Provider:                    enriched[i].Provider,
+				Paused:                      enriched[i].Paused,
+				SyncIntervalOverrideMinutes: enriched[i].SyncIntervalOverrideMinutes,
+				ConsecutiveFailures:         enriched[i].ConsecutiveFailures,
+				LastSyncedAt:                enriched[i].LastSyncedAt,
+			}, globalInterval, now)
 		}
 
 		data := map[string]any{
@@ -444,6 +472,16 @@ func ConnectionDetailHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc 
 			}
 		}
 
+		// Compute next sync schedule.
+		nextSync := computeNextSync(syncScheduleParams{
+			Status:                      conn.Status,
+			Provider:                    conn.Provider,
+			Paused:                      conn.Paused,
+			SyncIntervalOverrideMinutes: conn.SyncIntervalOverrideMinutes,
+			ConsecutiveFailures:         conn.ConsecutiveFailures,
+			LastSyncedAt:                conn.LastSyncedAt,
+		}, a.Config.SyncIntervalMinutes, now)
+
 		data := map[string]any{
 			"PageTitle":            conn.InstitutionName.String,
 			"CurrentPage":         "connections",
@@ -471,6 +509,8 @@ func ConnectionDetailHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc 
 			// Account totals
 			"TotalBalance":        totalBalance,
 			"HasBalance":          hasBalance,
+			// Next sync schedule
+			"NextSync":            nextSync,
 		}
 		tr.Render(w, r, "connection_detail.html", data)
 	}
@@ -831,6 +871,103 @@ func UpdateConnectionSyncIntervalHandler(a *app.App, sm *scs.SessionManager) htt
 		}
 
 		writeJSON(w, http.StatusOK, conn)
+	}
+}
+
+// syncScheduleParams holds the fields needed to compute next-sync info.
+// Works with both ListBankConnectionsRow and GetBankConnectionRow.
+type syncScheduleParams struct {
+	Status                      db.ConnectionStatus
+	Provider                    db.ProviderType
+	Paused                      bool
+	SyncIntervalOverrideMinutes pgtype.Int4
+	ConsecutiveFailures         int32
+	LastSyncedAt                pgtype.Timestamptz
+}
+
+// computeNextSync calculates when a connection will next be eligible for cron
+// sync, using the same staleness logic as the scheduler. This mirrors the logic
+// in internal/sync/scheduler.go syncAllScheduled.
+func computeNextSync(p syncScheduleParams, globalIntervalMinutes int, now time.Time) NextSyncInfo {
+	// Disconnected or CSV connections don't sync on a schedule.
+	if string(p.Status) == "disconnected" || string(p.Provider) == "csv" {
+		return NextSyncInfo{IsDisconnected: true, Label: "No schedule"}
+	}
+
+	// Paused connections don't sync on a schedule.
+	if p.Paused {
+		return NextSyncInfo{IsPaused: true, Label: "Paused"}
+	}
+
+	// Compute effective interval with backoff (mirrors scheduler.go backoffInterval).
+	baseMinutes := globalIntervalMinutes
+	if p.SyncIntervalOverrideMinutes.Valid {
+		baseMinutes = int(p.SyncIntervalOverrideMinutes.Int32)
+	}
+	effectiveMinutes := syncBackoffInterval(baseMinutes, p.ConsecutiveFailures)
+
+	info := NextSyncInfo{
+		EffectiveIntervalMinutes: effectiveMinutes,
+	}
+
+	// Never synced — eligible immediately on next cron tick.
+	if !p.LastSyncedAt.Valid {
+		info.IsOverdue = true
+		info.Label = "Pending first sync"
+		return info
+	}
+
+	nextSyncAt := p.LastSyncedAt.Time.Add(time.Duration(effectiveMinutes) * time.Minute)
+	info.NextSyncAt = nextSyncAt
+
+	if nextSyncAt.Before(now) || nextSyncAt.Equal(now) {
+		info.IsOverdue = true
+		info.Label = "Due now"
+		return info
+	}
+
+	info.Label = relativeTimeUntil(nextSyncAt, now)
+	return info
+}
+
+// syncBackoffInterval returns an adjusted sync interval in minutes based on
+// consecutive failures. Mirrors internal/sync/scheduler.go backoffInterval.
+func syncBackoffInterval(baseMinutes int, consecutiveFailures int32) int {
+	if consecutiveFailures <= 0 {
+		return baseMinutes
+	}
+	exp := int(consecutiveFailures)
+	if exp > 4 {
+		exp = 4
+	}
+	return baseMinutes * (1 << exp)
+}
+
+// relativeTimeUntil formats a future time as a human-readable duration string
+// like "in 2h 15m", "in 45m", "in 3d".
+func relativeTimeUntil(target, now time.Time) string {
+	d := target.Sub(now)
+	if d <= 0 {
+		return "now"
+	}
+
+	days := int(d.Hours() / 24)
+	hours := int(d.Hours()) % 24
+	mins := int(d.Minutes()) % 60
+
+	switch {
+	case days > 0 && hours > 0:
+		return fmt.Sprintf("in %dd %dh", days, hours)
+	case days > 0:
+		return fmt.Sprintf("in %dd", days)
+	case hours > 0 && mins > 0:
+		return fmt.Sprintf("in %dh %dm", hours, mins)
+	case hours > 0:
+		return fmt.Sprintf("in %dh", hours)
+	case mins > 1:
+		return fmt.Sprintf("in %dm", mins)
+	default:
+		return "in <1m"
 	}
 }
 

--- a/internal/admin/connections_test.go
+++ b/internal/admin/connections_test.go
@@ -1,0 +1,217 @@
+package admin
+
+import (
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestSyncBackoffInterval(t *testing.T) {
+	tests := []struct {
+		name                string
+		baseMinutes         int
+		consecutiveFailures int32
+		want                int
+	}{
+		{"no failures", 720, 0, 720},
+		{"1 failure doubles", 720, 1, 1440},
+		{"2 failures 4x", 720, 2, 2880},
+		{"3 failures 8x", 60, 3, 480},
+		{"4 failures 16x", 60, 4, 960},
+		{"5 failures capped at 16x", 60, 5, 960},
+		{"10 failures capped at 16x", 60, 10, 960},
+		{"negative failures treated as zero", 720, -1, 720},
+		{"15 min base no failures", 15, 0, 15},
+		{"15 min base 2 failures", 15, 2, 60},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := syncBackoffInterval(tt.baseMinutes, tt.consecutiveFailures)
+			if got != tt.want {
+				t.Errorf("syncBackoffInterval(%d, %d) = %d, want %d", tt.baseMinutes, tt.consecutiveFailures, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRelativeTimeUntil(t *testing.T) {
+	now := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		target time.Time
+		want   string
+	}{
+		{"in the past", now.Add(-1 * time.Minute), "now"},
+		{"exactly now", now, "now"},
+		{"less than 1 minute", now.Add(30 * time.Second), "in <1m"},
+		{"5 minutes", now.Add(5 * time.Minute), "in 5m"},
+		{"1 hour", now.Add(1 * time.Hour), "in 1h"},
+		{"1 hour 30 minutes", now.Add(90 * time.Minute), "in 1h 30m"},
+		{"2 hours", now.Add(2 * time.Hour), "in 2h"},
+		{"2 hours 15 minutes", now.Add(135 * time.Minute), "in 2h 15m"},
+		{"1 day", now.Add(24 * time.Hour), "in 1d"},
+		{"1 day 3 hours", now.Add(27 * time.Hour), "in 1d 3h"},
+		{"3 days", now.Add(72 * time.Hour), "in 3d"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := relativeTimeUntil(tt.target, now)
+			if got != tt.want {
+				t.Errorf("relativeTimeUntil(%v, %v) = %q, want %q", tt.target, now, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComputeNextSync(t *testing.T) {
+	now := time.Date(2026, 3, 26, 12, 0, 0, 0, time.UTC)
+	globalInterval := 720 // 12 hours
+
+	t.Run("disconnected connection", func(t *testing.T) {
+		p := syncScheduleParams{
+			Status:   db.ConnectionStatusDisconnected,
+			Provider: db.ProviderTypePlaid,
+		}
+		info := computeNextSync(p, globalInterval, now)
+		if !info.IsDisconnected {
+			t.Error("expected IsDisconnected=true")
+		}
+		if info.Label != "No schedule" {
+			t.Errorf("expected label 'No schedule', got %q", info.Label)
+		}
+	})
+
+	t.Run("CSV provider", func(t *testing.T) {
+		p := syncScheduleParams{
+			Status:   db.ConnectionStatusActive,
+			Provider: db.ProviderTypeCsv,
+		}
+		info := computeNextSync(p, globalInterval, now)
+		if !info.IsDisconnected {
+			t.Error("expected IsDisconnected=true for CSV")
+		}
+	})
+
+	t.Run("paused connection", func(t *testing.T) {
+		p := syncScheduleParams{
+			Status:   db.ConnectionStatusActive,
+			Provider: db.ProviderTypePlaid,
+			Paused:   true,
+		}
+		info := computeNextSync(p, globalInterval, now)
+		if !info.IsPaused {
+			t.Error("expected IsPaused=true")
+		}
+		if info.Label != "Paused" {
+			t.Errorf("expected label 'Paused', got %q", info.Label)
+		}
+	})
+
+	t.Run("never synced", func(t *testing.T) {
+		p := syncScheduleParams{
+			Status:   db.ConnectionStatusActive,
+			Provider: db.ProviderTypePlaid,
+		}
+		info := computeNextSync(p, globalInterval, now)
+		if !info.IsOverdue {
+			t.Error("expected IsOverdue=true for never-synced connection")
+		}
+		if info.Label != "Pending first sync" {
+			t.Errorf("expected label 'Pending first sync', got %q", info.Label)
+		}
+	})
+
+	t.Run("recently synced - next sync in future", func(t *testing.T) {
+		lastSynced := now.Add(-6 * time.Hour) // 6h ago, interval is 12h => 6h remaining
+		p := syncScheduleParams{
+			Status:   db.ConnectionStatusActive,
+			Provider: db.ProviderTypePlaid,
+			LastSyncedAt: pgtype.Timestamptz{
+				Time:  lastSynced,
+				Valid: true,
+			},
+		}
+		info := computeNextSync(p, globalInterval, now)
+		if info.IsOverdue {
+			t.Error("expected IsOverdue=false")
+		}
+		if info.Label != "in 6h" {
+			t.Errorf("expected label 'in 6h', got %q", info.Label)
+		}
+		if info.EffectiveIntervalMinutes != 720 {
+			t.Errorf("expected EffectiveIntervalMinutes=720, got %d", info.EffectiveIntervalMinutes)
+		}
+	})
+
+	t.Run("overdue - last synced long ago", func(t *testing.T) {
+		lastSynced := now.Add(-24 * time.Hour) // 24h ago, interval is 12h => overdue
+		p := syncScheduleParams{
+			Status:   db.ConnectionStatusActive,
+			Provider: db.ProviderTypePlaid,
+			LastSyncedAt: pgtype.Timestamptz{
+				Time:  lastSynced,
+				Valid: true,
+			},
+		}
+		info := computeNextSync(p, globalInterval, now)
+		if !info.IsOverdue {
+			t.Error("expected IsOverdue=true")
+		}
+		if info.Label != "Due now" {
+			t.Errorf("expected label 'Due now', got %q", info.Label)
+		}
+	})
+
+	t.Run("per-connection override interval", func(t *testing.T) {
+		lastSynced := now.Add(-10 * time.Minute) // 10m ago, override is 30m => 20m remaining
+		p := syncScheduleParams{
+			Status:   db.ConnectionStatusActive,
+			Provider: db.ProviderTypeTeller,
+			LastSyncedAt: pgtype.Timestamptz{
+				Time:  lastSynced,
+				Valid: true,
+			},
+			SyncIntervalOverrideMinutes: pgtype.Int4{Int32: 30, Valid: true},
+		}
+		info := computeNextSync(p, globalInterval, now)
+		if info.IsOverdue {
+			t.Error("expected IsOverdue=false")
+		}
+		if info.EffectiveIntervalMinutes != 30 {
+			t.Errorf("expected EffectiveIntervalMinutes=30, got %d", info.EffectiveIntervalMinutes)
+		}
+		if info.Label != "in 20m" {
+			t.Errorf("expected label 'in 20m', got %q", info.Label)
+		}
+	})
+
+	t.Run("backoff doubles interval on failures", func(t *testing.T) {
+		lastSynced := now.Add(-30 * time.Minute) // 30m ago, base=60m, 1 failure => effective=120m, remaining=90m
+		p := syncScheduleParams{
+			Status:              db.ConnectionStatusActive,
+			Provider:            db.ProviderTypePlaid,
+			ConsecutiveFailures: 1,
+			LastSyncedAt: pgtype.Timestamptz{
+				Time:  lastSynced,
+				Valid: true,
+			},
+			SyncIntervalOverrideMinutes: pgtype.Int4{Int32: 60, Valid: true},
+		}
+		info := computeNextSync(p, globalInterval, now)
+		if info.IsOverdue {
+			t.Error("expected IsOverdue=false")
+		}
+		if info.EffectiveIntervalMinutes != 120 {
+			t.Errorf("expected EffectiveIntervalMinutes=120, got %d", info.EffectiveIntervalMinutes)
+		}
+		if info.Label != "in 1h 30m" {
+			t.Errorf("expected label 'in 1h 30m', got %q", info.Label)
+		}
+	})
+}

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -159,6 +159,26 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			"formatUUID": func(u pgtype.UUID) string {
 				return formatUUID(u)
 			},
+			"formatIntervalMinutes": func(minutes int) string {
+				// Render a sync interval in human-readable form (e.g., "12h", "4h", "30m", "1d").
+				if minutes <= 0 {
+					return "N/A"
+				}
+				if minutes >= 1440 && minutes%1440 == 0 {
+					d := minutes / 1440
+					if d == 1 {
+						return "24h"
+					}
+					return fmt.Sprintf("%dd", d)
+				}
+				if minutes >= 60 && minutes%60 == 0 {
+					return fmt.Sprintf("%dh", minutes/60)
+				}
+				if minutes >= 60 {
+					return fmt.Sprintf("%dh %dm", minutes/60, minutes%60)
+				}
+				return fmt.Sprintf("%dm", minutes)
+			},
 			"accountLabel": func(name string, mask interface{}) string {
 				// Format an account name with optional last-4 digits for disambiguation.
 				// mask can be *string, string, or pgtype.Text.

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -87,7 +87,7 @@
 
 <!-- Sync Health Stats -->
 {{if gt .TotalSyncs 0}}
-<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6 bb-stagger">
+<div class="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-6 bb-stagger">
   <div class="bb-card p-4">
     <div class="text-xs font-medium text-base-content/40 mb-1">Success Rate</div>
     <div class="flex items-baseline gap-1.5">
@@ -99,6 +99,17 @@
     <div class="text-xs font-medium text-base-content/40 mb-1">Last Successful</div>
     <div class="text-sm font-semibold truncate">{{if .LastSuccessRelative}}{{.LastSuccessRelative}}{{else}}<span class="text-base-content/30">Never</span>{{end}}</div>
     {{if .LastSuccessTime}}<div class="text-[0.65rem] text-base-content/30 mt-1 truncate" title="{{.LastSuccessTime}}">{{.LastSuccessTime}}</div>{{end}}
+  </div>
+  <div class="bb-card p-4">
+    <div class="text-xs font-medium text-base-content/40 mb-1">Next Sync</div>
+    <div class="text-sm font-semibold truncate {{if .NextSync.IsOverdue}}text-info{{end}}">
+      {{if .NextSync.IsDisconnected}}<span class="text-base-content/30">N/A</span>
+      {{else if .NextSync.IsPaused}}<span class="text-base-content/30">Paused</span>
+      {{else}}{{.NextSync.Label}}{{end}}
+    </div>
+    {{if and (not .NextSync.IsDisconnected) (not .NextSync.IsPaused)}}
+    <div class="text-[0.65rem] text-base-content/30 mt-1 tabular-nums">every {{formatIntervalMinutes .NextSync.EffectiveIntervalMinutes}}</div>
+    {{end}}
   </div>
   <div class="bb-card p-4">
     <div class="text-xs font-medium text-base-content/40 mb-1">Transactions Synced</div>

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -64,12 +64,18 @@
               </span>
               {{end}}
             </div>
-            <div class="flex items-center gap-3 text-xs text-base-content/50 mt-0.5">
+            <div class="flex items-center gap-3 text-xs text-base-content/50 mt-0.5 flex-wrap">
               <span>{{.UserName.String}}</span>
               <span class="text-base-content/20">&middot;</span>
               <span class="capitalize">{{printf "%s" .Provider}}</span>
               <span class="text-base-content/20">&middot;</span>
               <span>{{if .LastSyncedAt.Valid}}Synced {{relativeTime .LastSyncedAt.Time}}{{else}}Never synced{{end}}</span>
+              {{if and (not .NextSync.IsDisconnected) (not .NextSync.IsPaused)}}
+              <span class="text-base-content/20">&middot;</span>
+              <span class="{{if .NextSync.IsOverdue}}text-info{{end}}" title="Sync interval: {{formatIntervalMinutes .NextSync.EffectiveIntervalMinutes}}">
+                <i data-lucide="clock" class="w-3 h-3 inline-block align-[-2px] mr-0.5"></i>Next {{.NextSync.Label}}
+              </span>
+              {{end}}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Display "Next in 2h 15m" on each connection card in the connections list
- Add a "Next Sync" stat card on the connection detail page showing countdown and effective interval
- Compute schedule using the same staleness logic as the cron scheduler (base interval + per-connection override + exponential backoff on failures)

## Changes
- **`internal/admin/connections.go`**: Added `NextSyncInfo` struct, `syncScheduleParams` adapter, `computeNextSync()` that mirrors `scheduler.go` logic, `syncBackoffInterval()`, and `relativeTimeUntil()` for future-time formatting. Both `ConnectionsListHandler` and `ConnectionDetailHandler` now compute and pass next-sync data.
- **`internal/admin/templates.go`**: Added `formatIntervalMinutes` template function for human-readable interval display (e.g., "12h", "4h", "30m").
- **`internal/templates/pages/connections.html`**: Shows "Next in Xh Ym" with clock icon in the connection metadata line. Handles paused/disconnected/CSV by hiding the schedule. Overdue connections highlighted with `text-info`. Tooltip shows effective interval.
- **`internal/templates/pages/connection_detail.html`**: Added "Next Sync" stat card in the health stats grid (now 5 columns). Shows countdown, overdue state, and effective interval.
- **`internal/admin/connections_test.go`**: 29 unit tests covering `syncBackoffInterval`, `relativeTimeUntil`, and `computeNextSync` including all edge cases (disconnected, CSV, paused, never-synced, overdue, per-connection override, backoff).

## Testing
- `go build ./...` passes
- `go test ./...` passes (29 new tests, all green)
- Dev server starts cleanly with no template parsing errors
- Edge cases tested: disconnected, CSV, paused, never-synced, overdue, per-connection override interval, exponential backoff on failures

🤖 Generated by autonomous sync improvement agent