### PR TITLE
Fix MCP server panic from invalid jsonschema enum tag

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,0 +1,23 @@
+package mcp
+
+import (
+	"testing"
+)
+
+// TestBuildServerAllTools verifies that all MCP tool input schemas are valid.
+// This catches invalid jsonschema struct tags (e.g., "enum=..." syntax) that
+// cause panics in google/jsonschema-go when AddTool infers the schema.
+func TestBuildServerAllTools(t *testing.T) {
+	// NewMCPServer with nil service — we only need tool registration, not execution.
+	s := NewMCPServer(nil, "test")
+
+	// BuildServer with read_write + full_access so ALL tools (read + write) are registered.
+	// If any tool's input struct has an invalid jsonschema tag, AddTool will panic.
+	server := s.BuildServer(MCPServerConfig{
+		Mode:        "read_write",
+		APIKeyScope: "full_access",
+	})
+	if server == nil {
+		t.Fatal("BuildServer returned nil")
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1254,7 +1254,7 @@ func (s *MCPServer) handleBulkRecategorize(ctx context.Context, _ *mcpsdk.CallTo
 type submitReportInput struct {
 	Title    string   `json:"title" jsonschema:"required,A concise 1-2 sentence summary that reads like a notification or message. This is the primary thing the family sees on their dashboard — make it informative and self-contained. Good: 'Reviewed 47 transactions this week — 3 recategorized and no suspicious activity found.' Bad: 'Weekly Review Complete' (too vague to be useful without opening the full report)."`
 	Body     string   `json:"body" jsonschema:"required,Detailed breakdown in markdown format with supporting data. This is shown when the user expands the report for more detail. Use headers and bullet points and transaction links: [Transaction Name](/transactions/TRANSACTION_ID)."`
-	Priority string   `json:"priority" jsonschema:"enum=info,enum=warning,enum=critical,default=info,Severity level: info (routine updates and summaries), warning (needs attention soon), critical (urgent action required)"`
+	Priority string   `json:"priority" jsonschema:"Severity level. Valid values: info (default — routine updates and summaries), warning (needs attention soon), critical (urgent action required)"`
 	Tags     []string `json:"tags" jsonschema:"Short labels for categorizing reports (e.g. 'weekly-review' or 'anomaly'). Max 10 tags."`
 	Author   string   `json:"author" jsonschema:"Custom author name to sign this report with. Overrides the API key name for display (e.g. 'Review Agent' or 'Budget Monitor')."`
 }


### PR DESCRIPTION
## Summary
- The `submit_report` MCP tool's `Priority` field used `enum=info,enum=warning,...` syntax in its `jsonschema` struct tag, but `google/jsonschema-go` treats the tag as a plain description and panics on `WORD=...` prefixes
- Every MCP request was returning 500, which broke OAuth authorization for cloud agents
- Moved enum values into the description text (service layer already validates/defaults priority)
- Added `TestBuildServerAllTools` unit test that registers all MCP tools — catches schema tag panics without needing a database

## Test plan
- [x] `go test ./internal/mcp/` passes
- [x] Verified test catches the original bug (reverted fix, test panics, restored fix)
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)