### PR TITLE
Agent Wizard and Prompt Builder

### DIFF
--- a/internal/admin/agent_wizard.go
+++ b/internal/admin/agent_wizard.go
@@ -1,0 +1,15 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+// AgentWizardHandler serves GET /admin/agent-wizard.
+func AgentWizardHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data := BaseTemplateData(r, sm, "agent-wizard", "Agent Wizard")
+		tr.Render(w, r, "agent_wizard.html", data)
+	}
+}

--- a/internal/admin/prompt_builder.go
+++ b/internal/admin/prompt_builder.go
@@ -1,0 +1,42 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"breadbox/internal/prompts"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// PromptBuilderHandler serves GET /admin/agent-wizard/{type}.
+func PromptBuilderHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		agentType := chi.URLParam(r, "type")
+
+		cfg, ok := prompts.GetAgentConfig(agentType)
+		if !ok {
+			tr.Render(w, r, "404.html", BaseTemplateData(r, sm, "", "Not Found"))
+			return
+		}
+
+		blocks, err := prompts.LoadAgentBlocks(agentType)
+		if err != nil {
+			http.Error(w, "Failed to load blocks", http.StatusInternalServerError)
+			return
+		}
+
+		blocksJSON, _ := json.Marshal(blocks)
+
+		data := BaseTemplateData(r, sm, "agent-wizard", cfg.Label+" — Agent Wizard")
+		data["AgentType"] = agentType
+		data["AgentLabel"] = cfg.Label
+		data["AgentDescription"] = cfg.Description
+		data["AgentIcon"] = cfg.Icon
+		data["AgentColor"] = cfg.Color
+		data["BlocksJSON"] = string(blocksJSON)
+
+		tr.Render(w, r, "prompt_builder.html", data)
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -101,6 +101,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/reports", ReportsPageHandler(a, svc, sm, tr))
 		r.Get("/reviews", ReviewsPageHandler(a, sm, tr, svc))
 		r.Get("/review-instructions", ReviewInstructionsPageHandler(sm, tr))
+		r.Get("/agent-wizard", AgentWizardHandler(sm, tr))
 		r.Get("/rules", RulesPageHandler(svc, sm, tr, a.Config.Version))
 
 		r.Get("/categories", CategoriesPageHandler(svc, sm, tr))

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -102,6 +102,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/reviews", ReviewsPageHandler(a, sm, tr, svc))
 		r.Get("/review-instructions", ReviewInstructionsPageHandler(sm, tr))
 		r.Get("/agent-wizard", AgentWizardHandler(sm, tr))
+		r.Get("/agent-wizard/{type}", PromptBuilderHandler(sm, tr))
 		r.Get("/rules", RulesPageHandler(svc, sm, tr, a.Config.Version))
 
 		r.Get("/categories", CategoriesPageHandler(svc, sm, tr))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -642,6 +642,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/oauth_client_new.html",
 		"pages/oauth_client_created.html",
 		"pages/agent_wizard.html",
+		"pages/prompt_builder.html",
 	}
 
 	// Pages using the wizard layout (login + first-run admin creation + OAuth consent).

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -641,6 +641,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/oauth_clients.html",
 		"pages/oauth_client_new.html",
 		"pages/oauth_client_created.html",
+		"pages/agent_wizard.html",
 	}
 
 	// Pages using the wizard layout (login + first-run admin creation + OAuth consent).

--- a/internal/prompts/blocks/account-linking.md
+++ b/internal/prompts/blocks/account-linking.md
@@ -1,0 +1,11 @@
+# Account Linking
+> Deduplication for shared credit cards across family members
+
+ACCOUNT LINKING (Deduplication & Attribution):
+- When two family members connect the same credit card (e.g., primary cardholder + authorized user), transactions appear in both feeds with different IDs
+- Use create_account_link to link the dependent account to the primary account
+- The system auto-matches transactions by date + exact amount, attributes matched primary-side transactions to the dependent user
+- Dependent account transactions are excluded from totals and summaries by default
+- When filtering by user_id, attributed transactions are included — "Ricardo's transactions" includes his own plus those attributed to him on the shared card
+- Use reconcile_account_link to re-run matching after new syncs
+- Use list_transaction_matches to review matched pairs, confirm_match/reject_match to correct errors

--- a/internal/prompts/blocks/base-context.md
+++ b/internal/prompts/blocks/base-context.md
@@ -1,0 +1,15 @@
+# Breadbox Context
+> Core data model and amount conventions
+
+Breadbox is a self-hosted financial data aggregation server for families. It syncs bank data from Plaid, Teller, and CSV imports into a unified PostgreSQL database.
+
+DATA MODEL:
+- Users: family members who own bank connections
+- Connections: linked bank accounts via Plaid, Teller, or CSV import (status: active, error, pending_reauth, disconnected)
+- Accounts: individual bank accounts (checking, savings, credit card, etc.) belonging to a connection
+- Transactions: individual financial transactions belonging to an account
+
+AMOUNT CONVENTION:
+- Positive amounts = money out (debits, purchases, payments)
+- Negative amounts = money in (credits, deposits, refunds)
+- All amounts include iso_currency_code — never sum across different currencies

--- a/internal/prompts/blocks/category-system.md
+++ b/internal/prompts/blocks/category-system.md
@@ -1,0 +1,15 @@
+# Category System
+> Category hierarchy, slugs, merging, and bulk editing
+
+CATEGORY SYSTEM:
+- Categories are organized in a 2-level hierarchy (primary → detailed subcategories)
+- Each category has: id (UUID), slug (stable identifier), display_name (human label), icon, color
+- Use list_categories to get the full taxonomy tree with IDs and slugs
+- Filter transactions with category_slug param (parent slug includes all children)
+- Use categorize_transaction to manually override a single transaction's category
+- For bulk category changes: use batch_categorize_transactions (multiple transactions, one category) or bulk_recategorize (change all transactions from one category to another)
+- Use reset_transaction_category to undo a manual override
+- Use list_unmapped_categories to find raw provider categories without mappings
+- Use transaction rules to automatically categorize transactions based on conditions (name, amount, provider, etc). Rules are evaluated during sync in priority order.
+- For bulk editing categories: use export_categories / import_categories to export TSV text, edit it, and re-import
+- To simplify/consolidate categories: export categories, then set the merge_into column to a target slug for categories you want to merge. All transactions and mappings from the source are moved to the target.

--- a/internal/prompts/blocks/gmail-integration.md
+++ b/internal/prompts/blocks/gmail-integration.md
@@ -1,0 +1,11 @@
+# Gmail Integration
+> Cross-reference transactions with email receipts
+
+GMAIL CROSS-REFERENCE:
+You have access to a Gmail connector in addition to Breadbox. Use it to cross-reference transactions with email receipts for improved accuracy:
+- When reviewing transactions, search Gmail for receipts matching the merchant name and approximate date
+- Email receipts can confirm exact amounts, itemized breakdowns, and merchant details that bank feeds often mangle
+- Particularly useful for online purchases where the bank feed shows a generic payment processor name instead of the actual merchant
+- Search Gmail with queries like: "from:receipts subject:order" or merchant-specific patterns
+- If a receipt confirms a transaction's purpose, use that information to categorize more accurately
+- Add a transaction comment noting the receipt source when it helps clarify ambiguous transactions

--- a/internal/prompts/blocks/merchant-analysis.md
+++ b/internal/prompts/blocks/merchant-analysis.md
@@ -1,0 +1,11 @@
+# Merchant Analysis
+> Use merchant summaries to identify patterns and recurring charges
+
+MERCHANT ANALYSIS:
+- Use merchant_summary to get a compact index of all merchants with transaction counts, totals, averages, and date ranges
+- Set min_count=2 to find recurring charges, min_count=3 for likely subscriptions
+- Use spending_only=true to focus on debits and filter out income/refunds
+- Compare merchant totals across months to spot spending changes
+- Look for merchants with high transaction counts but small amounts (subscriptions, recurring fees)
+- Look for merchants with single large transactions (one-time purchases, annual renewals)
+- Use the search parameter to find specific merchants across mangled bank feed names

--- a/internal/prompts/blocks/report-submission.md
+++ b/internal/prompts/blocks/report-submission.md
@@ -1,0 +1,16 @@
+# Report Submission
+> How to submit reports to the family dashboard when done
+
+AGENT REPORTS:
+- Use submit_report to communicate with the family — think of the title as a notification message they'll read on their dashboard
+- The title should be a concise 1-2 sentence summary that's self-contained and informative (e.g., "Reviewed 47 transactions this week — 3 recategorized, no suspicious activity found.")
+- The body is the detailed breakdown shown when they tap to expand — use markdown with headers, bullets, and transaction links: [Name](/transactions/ID)
+- Set priority to 'warning' or 'critical' when something needs attention, 'info' for routine updates
+- Sign reports with an author name that identifies your role (e.g., "Review Agent", "Budget Monitor")
+
+WRAP-UP:
+When finished, call submit_report with a summary of what you did. Include:
+- How many transactions/reviews you processed
+- Rules you created and their expected coverage
+- Any transactions or patterns that need human attention (link them: [Name](/transactions/ID))
+- Remaining items you skipped or couldn't categorize

--- a/internal/prompts/blocks/rule-creation.md
+++ b/internal/prompts/blocks/rule-creation.md
@@ -1,0 +1,20 @@
+# Rule Creation
+> Strategy for creating transaction categorization rules
+
+TRANSACTION RULES:
+- Rules auto-categorize future transactions during sync. Good rules dramatically reduce future review work.
+- Conditions use a flexible JSON tree with AND/OR/NOT logic and operators: eq, contains, matches (regex), gt, gte, lt, lte, in
+- Available fields: name, merchant_name, amount, category_primary (raw provider category), category_detailed, pending, provider, account_id, user_id, user_name (family member name)
+- Rules apply automatically to new transactions during sync — no manual application needed
+- Set apply_retroactively=true on create_transaction_rule ONLY during initial bulk categorization (first-time setup). For routine work, just create the rule and let it match future syncs.
+- Use preview_rule to test a condition before creating — shows match count and sample transactions
+- Do NOT call apply_rules during routine reviews. It scans ALL transactions and its impact is hard to predict. Rules are forward-looking by design.
+
+RULE CREATION STRATEGY — follow this order:
+1. FIRST, create category_primary rules (highest impact). Look at the category_primary field on transactions — these are raw provider categories like "dining", "groceries", "phone", "accommodation", "fuel", "entertainment". One rule per category_primary covers ALL transactions with that label. Example: {"and": [{"field": "provider", "op": "eq", "value": "teller"}, {"field": "category_primary", "op": "eq", "value": "dining"}]} → food_and_drink_restaurant. This single rule handles every dining transaction from Teller.
+2. THEN, create name-pattern rules for transaction types that span merchants: "ATM Withdrawal" → withdrawals, "Wire Transfer" → transfer_out, "Service Charge" → bank_fees, "Cash Deposit" → deposits. Use contains on the name field.
+3. LAST, create per-merchant rules only for specific merchants that get miscategorized or need a different category than their category_primary suggests (e.g., Walmart categorized as "shopping" but you want it under "groceries").
+
+- ALWAYS check list_transaction_rules before creating to avoid duplicates
+- Use batch_create_rules to create multiple rules efficiently
+- Before creating rules, query some transactions to see what category_primary values exist — use query_transactions with fields=core,category

--- a/internal/prompts/blocks/scale-guidance.md
+++ b/internal/prompts/blocks/scale-guidance.md
@@ -1,0 +1,9 @@
+# Scale Guidance
+> Handling large transaction queues efficiently
+
+SCALE:
+For queues >200 transactions, consider splitting work by account_id or provider using parallel sub-agents. Each sub-agent handles one account's transactions independently, creating rules and submitting reviews for their slice.
+
+Always use fields=triage on list_pending_reviews — it returns only the fields needed for categorization decisions and dramatically reduces response size.
+
+Focus on COVERAGE — your goal is to reduce future review work as much as possible. Prioritize rules that match the most transactions. Check list_transaction_rules before creating to avoid duplicates.

--- a/internal/prompts/blocks/strategy-anomaly-detection.md
+++ b/internal/prompts/blocks/strategy-anomaly-detection.md
@@ -1,0 +1,24 @@
+# Anomaly Detection Strategy
+> Monitor for unusual charges, duplicates, and spending spikes
+
+You are monitoring transactions for anomalies that need human attention. Flag anything suspicious but avoid false alarms.
+
+STRATEGY:
+1. Read breadbox://overview for baseline context
+2. Use merchant_summary for the last 30 days and compare against the previous 30 days — look for:
+   - New merchants not seen before (first_date within last 30 days)
+   - Merchants with unusual totals compared to their historical average
+   - Unexpected recurring charges (min_count=2 in recent period but not in prior)
+3. Use query_transactions with sort_by=amount&sort_order=desc to find the largest recent transactions
+4. Look for potential duplicates: same amount + same day + different transaction IDs on the same account
+5. Check for transactions at unusual merchants or in unusual categories for each family member
+6. If account links exist, use list_transaction_matches to verify deduplication is working correctly
+
+FLAG CRITERIA (submit_report with priority='warning'):
+- Single transactions over a threshold relative to typical spending
+- Duplicate charges (same merchant + same amount within 1-2 days)
+- New subscriptions or recurring charges the family may not be aware of
+- Transactions in unexpected categories (e.g., cash advances, wire transfers)
+- Spending spikes: category total significantly above the 3-month average
+
+Do NOT flag routine variance in spending. Focus on genuinely unusual patterns.

--- a/internal/prompts/blocks/strategy-bulk-review.md
+++ b/internal/prompts/blocks/strategy-bulk-review.md
@@ -1,0 +1,17 @@
+# Bulk Review Strategy
+> Thorough review of a large pending queue
+
+You are reviewing a large queue of pending transactions. Rules may already exist from previous sessions, so focus on what's still uncategorized.
+
+STRATEGY:
+1. Start with review_summary to see pending reviews grouped by raw provider category with counts
+2. Check list_transaction_rules to understand what rules already exist — avoid creating duplicates
+3. Use list_pending_reviews with category_primary_raw filter to process one provider category at a time (fields=triage, limit up to 500)
+4. For each group:
+   a. If a clear pattern exists, create a rule with apply_retroactively=true to handle the entire group
+   b. Call auto_approve_categorized_reviews to clear reviews handled by the new rule
+   c. For remaining items, use batch_submit_reviews to approve individually with the correct category_slug
+5. Review any items with category_primary="general" last — these need name-pattern rules, not category_primary rules
+6. After processing all groups, create per-merchant rules for recurring merchants you noticed
+
+Focus on ACCURACY while maintaining efficiency. Take time to categorize correctly since these are being permanently categorized. Use preview_rule before creating rules to verify they match the expected transactions.

--- a/internal/prompts/blocks/strategy-initial-setup.md
+++ b/internal/prompts/blocks/strategy-initial-setup.md
@@ -1,0 +1,16 @@
+# Initial Setup Strategy
+> First-time bulk categorization after connecting a new account
+
+You are reviewing a batch of transactions for initial categorization. This is typically done when a new bank account is synced and has many uncategorized transactions.
+
+STRATEGY:
+1. Start with review_summary to see the review queue grouped by raw provider category
+2. Create broad category_primary rules with apply_retroactively=true — one rule per raw provider category covers hundreds of transactions at once. SKIP "general" (see Teller Categories if applicable).
+   Example: {"and": [{"field": "provider", "op": "eq", "value": "teller"}, {"field": "category_primary", "op": "eq", "value": "dining"}]} → food_and_drink_restaurant
+3. Create name-pattern rules (also with apply_retroactively=true) for transaction types that span merchants: "ATM Withdrawal" → withdrawals, "Wire Transfer" → transfer_out, "Service Charge" → bank_fees, "Cash Deposit" → deposits
+4. Call auto_approve_categorized_reviews to clear reviews that rules already handled
+5. Use review_summary again to see what remains, then list_pending_reviews with category_primary_raw filter to process one group at a time (fields=triage)
+6. Use batch_submit_reviews (up to 500) or bulk_recategorize for bulk actions on remaining items
+7. Create per-merchant rules only for merchants that get miscategorized by the broad rules
+
+Focus on COVERAGE — your goal is to reduce future review work as much as possible. Prioritize rules that match the most transactions.

--- a/internal/prompts/blocks/strategy-quick-review.md
+++ b/internal/prompts/blocks/strategy-quick-review.md
@@ -1,0 +1,20 @@
+# Quick Review Strategy
+> Rapidly clear a large queue with batch operations
+
+You are clearing a large review queue as quickly and efficiently as possible. Prioritize speed and broad coverage over individual accuracy.
+
+STRATEGY:
+1. Call auto_approve_categorized_reviews first — this clears any reviews where rules have already assigned a category
+2. Check review_summary to see what remains
+3. For each remaining category group with >10 items:
+   a. Create a category_primary rule with apply_retroactively=true
+   b. Call auto_approve_categorized_reviews again
+4. Use batch_submit_reviews (up to 500) to approve remaining obvious items in bulk
+5. Skip uncertain transactions rather than guessing — they can be handled in a future routine review
+6. Do NOT create per-merchant rules during quick review — save that for thorough reviews
+
+EFFICIENCY TIPS:
+- Always use fields=triage on list_pending_reviews
+- Process by category_primary_raw groups, largest groups first
+- Use batch operations (batch_submit_reviews, bulk_recategorize) over individual submit_review calls
+- Aim for 80% coverage, not 100% — leave edge cases for later

--- a/internal/prompts/blocks/strategy-routine-review.md
+++ b/internal/prompts/blocks/strategy-routine-review.md
@@ -1,0 +1,15 @@
+# Routine Review Strategy
+> Daily or weekly review of recent transactions
+
+You are performing a routine review of recent transactions. Review pending transactions, categorize them, and create rules for any new patterns you notice.
+
+STRATEGY:
+1. List pending reviews with fields=triage (limit 15-30)
+2. Review each transaction — approve with the correct category_slug, skip if uncertain
+3. Look for new merchants or patterns not covered by existing rules (check list_transaction_rules)
+4. For recurring merchants (seen 2+ times), create a specific rule (rules apply to future syncs automatically)
+5. Use batch_submit_reviews (up to 500) for efficiency
+
+Focus on ACCURACY — take time to categorize correctly since there are fewer transactions. Create specific rules for new recurring merchants you encounter. Prefer contains over exact match for merchant names.
+
+Do NOT use apply_rules during routine reviews — rules are designed to match future transactions during sync. Retroactive application is a separate, deliberate action.

--- a/internal/prompts/blocks/strategy-spending-report.md
+++ b/internal/prompts/blocks/strategy-spending-report.md
@@ -1,0 +1,31 @@
+# Spending Report Strategy
+> Generate a periodic spending summary with trends
+
+You are preparing a spending report for the family. Analyze transaction data and produce a clear, actionable summary.
+
+STRATEGY:
+1. Read breadbox://overview first to understand the dataset scope (users, accounts, date range)
+2. Use transaction_summary with group_by=category for the target period (default: last 30 days)
+3. Use transaction_summary with group_by=category_month to compare against previous periods
+4. Use merchant_summary with spending_only=true to identify top merchants
+5. Use merchant_summary with min_count=2 to identify recurring charges
+6. Query individual transactions for any anomalies worth highlighting (fields=core,category)
+
+REPORT STRUCTURE:
+## Spending Summary ({period})
+- Total Spending: ${amount}
+- vs Previous Period: +/- ${change} ({percent}%)
+
+## Top Categories
+(table: category, amount, % of total, change vs previous)
+
+## Notable Transactions
+(list: large purchases, new merchants, unusual patterns)
+
+## Recurring Charges
+(list: subscriptions and recurring merchants with monthly cost)
+
+## Observations
+(any trends, anomalies, or recommendations)
+
+Always note which date range you analyzed and the currency. If data seems incomplete, check get_sync_status and note any stale connections.

--- a/internal/prompts/blocks/sync-management.md
+++ b/internal/prompts/blocks/sync-management.md
@@ -1,0 +1,9 @@
+# Sync Management
+> Check data freshness and trigger syncs when needed
+
+SYNC MANAGEMENT:
+- Before starting work, call get_sync_status to check when each connection was last synced
+- If data is stale (last sync > 24 hours ago for active connections), use trigger_sync to refresh before reviewing
+- After triggering a sync, wait briefly and check get_sync_status again to confirm it completed successfully
+- If a connection shows status "error" or "pending_reauth", note it in your report — these connections need human intervention
+- Do not trigger syncs on paused or disconnected connections

--- a/internal/prompts/blocks/teller-categories.md
+++ b/internal/prompts/blocks/teller-categories.md
@@ -1,0 +1,7 @@
+# Teller Categories
+> Special handling for Teller provider's raw category labels
+
+TELLER CATEGORIES:
+Teller's "general" category is a useless catch-all covering 30%+ of transactions. Do NOT create a category_primary rule for "general" — it will miscategorize everything. Instead, use name-pattern rules (contains on the name field) for transactions with category_primary="general".
+
+Known Teller raw categories: accommodation, advertising, bar, charity, clothing, dining, education, electronics, entertainment, fuel, general, groceries, health, home, income, insurance, investment, loan, office, phone, service, shopping, software, sport, tax, transport, utilities

--- a/internal/prompts/blocks/token-efficiency.md
+++ b/internal/prompts/blocks/token-efficiency.md
@@ -1,0 +1,10 @@
+# Token Efficiency
+> Reduce token usage with field selection and summary endpoints
+
+TOKEN EFFICIENCY:
+- Use the fields parameter on query_transactions to request only needed fields. Supports individual field names (e.g., fields=name,amount,date,account_name) and aliases: minimal (name,amount,date — smallest useful set), core (id,date,amount,name,iso_currency_code), category (category,category_primary_raw,category_detailed_raw), timestamps (created_at,updated_at,datetime,authorized_datetime). id is always included.
+- Use fields=triage on list_pending_reviews to get only fields needed for categorization decisions — dramatically reduces response size
+- Use transaction_summary for aggregated spending analysis instead of paginating through individual transactions. Supports group_by: category, month, week, day, category_month
+- Use merchant_summary to get a compact index of all merchants with transaction counts, totals, and date ranges — much more efficient than paginating through raw transactions to identify spending patterns or recurring charges
+- Transaction responses include account_name and user_name — no need to cross-reference list_accounts for "which card?" questions
+- The breadbox://overview resource includes users, connections, accounts by type, and 30-day spending summary — often eliminates the need for separate list_users + list_accounts calls

--- a/internal/prompts/blocks/tool-reference.md
+++ b/internal/prompts/blocks/tool-reference.md
@@ -1,0 +1,28 @@
+# Tool Reference
+> Recommended query patterns, search modes, and efficient tool usage
+
+RECOMMENDED QUERY PATTERNS:
+1. Read breadbox://overview first for dataset context (users, connections, accounts, spending)
+2. Use transaction_summary for spending analysis (group by category, month, etc.)
+3. Use merchant_summary to scan for recurring charges or spending patterns (set min_count=2 for recurring, min_count=3 for subscriptions)
+4. Use query_transactions with fields=core,category for browsing individual transactions
+5. Use list_categories to understand the category taxonomy
+6. Use count_transactions to get totals before paginating
+7. Check get_sync_status to verify data freshness
+8. Use list_unmapped_categories to identify categorization gaps
+- Use exclude_search on query_transactions to filter out known merchants when hunting for unknown charges
+
+SEARCH MODES:
+- The search parameter supports three modes via search_mode: contains (default, substring match), words (all words must match — good for multi-word names like "Century Link" matching "CenturyLink"), fuzzy (typo-tolerant via trigram similarity — "starbuks" matches "Starbucks")
+- Comma-separated values in search are automatically ORed in all modes: search=starbucks,amazon matches either merchant
+- Available on: query_transactions, count_transactions, merchant_summary, list_transaction_rules
+- Use search_mode=words when you know the merchant name but not the exact formatting
+- Use search_mode=fuzzy when dealing with mangled bank feed names or uncertain spellings
+
+REVIEW QUEUE:
+- Start with review_summary to see pending reviews grouped by raw provider category with counts — much more efficient than listing all reviews
+- Use list_pending_reviews with category_primary_raw filter to process one group at a time. Use fields=triage to reduce response size. Supports limit up to 500.
+- Use submit_review (or batch_submit_reviews, up to 500 at once) to approve with the correct category_slug, or skip if uncertain
+- For bulk category work: batch_categorize_transactions assigns one category to many transactions; bulk_recategorize moves all transactions from one category to another
+- After creating rules with apply_retroactively=true, call auto_approve_categorized_reviews to clear reviews that rules already handled
+- After reviewing, create transaction rules for patterns you noticed so future transactions are auto-categorized

--- a/internal/prompts/blocks/transaction-comments.md
+++ b/internal/prompts/blocks/transaction-comments.md
@@ -1,0 +1,9 @@
+# Transaction Comments
+> Annotate transactions with reasoning and context
+
+COMMENTS:
+- Use add_transaction_comment to explain your reasoning when recategorizing transactions
+- Check list_transaction_comments before modifying a transaction to see prior context from other agents or users
+- Comments are especially valuable for ambiguous transactions where the categorization isn't obvious
+- Keep comments concise — explain why a category was chosen, not what tools you used
+- If you flag a transaction for human attention, add a comment explaining what looks suspicious

--- a/internal/prompts/config.go
+++ b/internal/prompts/config.go
@@ -1,0 +1,203 @@
+package prompts
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BlockRole determines how a block appears in the editor.
+type BlockRole string
+
+const (
+	BlockCore     BlockRole = "core"     // always included, editable, not removable
+	BlockDefault  BlockRole = "default"  // optional, enabled by default
+	BlockOptional BlockRole = "optional" // optional, disabled by default (shown as pill to add)
+)
+
+// Block is a prompt section loaded from a .md file.
+type Block struct {
+	ID              string `json:"id"`
+	Title           string `json:"title"`
+	Description     string `json:"description"`
+	Content         string `json:"content"`
+	OriginalContent string `json:"originalContent"`
+	Role            string `json:"role"`    // "core", "default", "optional"
+	Enabled         bool   `json:"enabled"` // true for core and default, false for optional
+}
+
+// AgentTypeConfig defines the block composition for one agent type.
+type AgentTypeConfig struct {
+	Type        string
+	Label       string
+	Description string
+	Icon        string
+	Color       string
+	Core        []string // block IDs always included
+	Default     []string // block IDs enabled by default
+	Optional    []string // block IDs available but off by default
+}
+
+// agentConfigs maps URL slug to agent config.
+var agentConfigs = map[string]AgentTypeConfig{
+	"initial-setup": {
+		Type:        "initial-setup",
+		Label:       "Initial Setup",
+		Description: "First-time bulk categorization after connecting a new account",
+		Icon:        "sparkles",
+		Color:       "primary",
+		Core:        []string{"base-context", "tool-reference", "strategy-initial-setup"},
+		Default:     []string{"teller-categories", "rule-creation", "scale-guidance", "report-submission"},
+		Optional:    []string{"gmail-integration", "account-linking", "token-efficiency", "category-system", "sync-management", "transaction-comments", "merchant-analysis"},
+	},
+	"bulk-review": {
+		Type:        "bulk-review",
+		Label:       "Bulk Review",
+		Description: "Thorough review of a large pending queue",
+		Icon:        "layers",
+		Color:       "primary",
+		Core:        []string{"base-context", "tool-reference", "strategy-bulk-review"},
+		Default:     []string{"teller-categories", "rule-creation", "report-submission"},
+		Optional:    []string{"gmail-integration", "account-linking", "token-efficiency", "scale-guidance", "category-system", "sync-management", "transaction-comments", "merchant-analysis"},
+	},
+	"quick-review": {
+		Type:        "quick-review",
+		Label:       "Quick Review",
+		Description: "Rapidly clear a large queue with batch operations",
+		Icon:        "zap",
+		Color:       "primary",
+		Core:        []string{"base-context", "tool-reference", "strategy-quick-review"},
+		Default:     []string{"token-efficiency", "report-submission"},
+		Optional:    []string{"teller-categories", "rule-creation", "gmail-integration", "account-linking", "scale-guidance", "category-system", "sync-management", "transaction-comments", "merchant-analysis"},
+	},
+	"routine-review": {
+		Type:        "routine-review",
+		Label:       "Routine Review",
+		Description: "Daily or weekly review of recent transactions",
+		Icon:        "repeat",
+		Color:       "success",
+		Core:        []string{"base-context", "tool-reference", "strategy-routine-review"},
+		Default:     []string{"rule-creation", "report-submission", "transaction-comments"},
+		Optional:    []string{"teller-categories", "gmail-integration", "account-linking", "token-efficiency", "category-system", "sync-management", "merchant-analysis"},
+	},
+	"spending-report": {
+		Type:        "spending-report",
+		Label:       "Spending Report",
+		Description: "Weekly or monthly spending summary with trends",
+		Icon:        "bar-chart-3",
+		Color:       "violet",
+		Core:        []string{"base-context", "tool-reference", "strategy-spending-report"},
+		Default:     []string{"report-submission", "category-system", "merchant-analysis"},
+		Optional:    []string{"gmail-integration", "token-efficiency", "account-linking", "sync-management", "transaction-comments"},
+	},
+	"anomaly-detection": {
+		Type:        "anomaly-detection",
+		Label:       "Anomaly Detection",
+		Description: "Monitor for unusual charges, duplicates, and spending spikes",
+		Icon:        "shield-alert",
+		Color:       "warning",
+		Core:        []string{"base-context", "tool-reference", "strategy-anomaly-detection"},
+		Default:     []string{"report-submission", "merchant-analysis", "account-linking"},
+		Optional:    []string{"gmail-integration", "token-efficiency", "teller-categories", "category-system", "sync-management", "transaction-comments"},
+	},
+	"custom": {
+		Type:        "custom",
+		Label:       "Custom Agent",
+		Description: "Start from scratch with your own goals and instructions",
+		Icon:        "plus",
+		Color:       "base",
+		Core:        []string{"base-context"},
+		Default:     []string{"tool-reference"},
+		Optional: []string{
+			"category-system", "rule-creation", "report-submission", "account-linking",
+			"teller-categories", "token-efficiency", "scale-guidance", "gmail-integration",
+			"sync-management", "transaction-comments", "merchant-analysis",
+		},
+	},
+}
+
+// GetAgentConfig returns the config for an agent type.
+func GetAgentConfig(agentType string) (AgentTypeConfig, bool) {
+	cfg, ok := agentConfigs[agentType]
+	return cfg, ok
+}
+
+// AllAgentTypes returns all registered agent type slugs.
+func AllAgentTypes() []string {
+	types := make([]string, 0, len(agentConfigs))
+	for k := range agentConfigs {
+		types = append(types, k)
+	}
+	return types
+}
+
+// LoadBlock reads a block .md file, parsing title and description from the first lines.
+func LoadBlock(id string) (Block, error) {
+	data, err := blocksFS.ReadFile("blocks/" + id + ".md")
+	if err != nil {
+		return Block{}, fmt.Errorf("read block %q: %w", id, err)
+	}
+
+	content := string(data)
+	lines := strings.SplitN(content, "\n", 4)
+
+	var title, description, body string
+
+	if len(lines) >= 1 {
+		title = strings.TrimPrefix(strings.TrimSpace(lines[0]), "# ")
+	}
+	if len(lines) >= 2 {
+		description = strings.TrimPrefix(strings.TrimSpace(lines[1]), "> ")
+	}
+	// Skip blank line between description and body.
+	if len(lines) >= 4 {
+		body = strings.TrimSpace(lines[3])
+	}
+
+	return Block{
+		ID:              id,
+		Title:           title,
+		Description:     description,
+		Content:         body,
+		OriginalContent: body,
+	}, nil
+}
+
+// LoadAgentBlocks loads all blocks for an agent type with roles and enabled state set.
+func LoadAgentBlocks(agentType string) ([]Block, error) {
+	cfg, ok := agentConfigs[agentType]
+	if !ok {
+		return nil, fmt.Errorf("unknown agent type: %s", agentType)
+	}
+
+	// Build role map.
+	roles := make(map[string]BlockRole)
+	for _, id := range cfg.Core {
+		roles[id] = BlockCore
+	}
+	for _, id := range cfg.Default {
+		roles[id] = BlockDefault
+	}
+	for _, id := range cfg.Optional {
+		roles[id] = BlockOptional
+	}
+
+	// Load blocks in order: core, default, optional.
+	var blocks []Block
+	allIDs := make([]string, 0, len(cfg.Core)+len(cfg.Default)+len(cfg.Optional))
+	allIDs = append(allIDs, cfg.Core...)
+	allIDs = append(allIDs, cfg.Default...)
+	allIDs = append(allIDs, cfg.Optional...)
+
+	for _, id := range allIDs {
+		block, err := LoadBlock(id)
+		if err != nil {
+			return nil, err
+		}
+		role := roles[id]
+		block.Role = string(role)
+		block.Enabled = role == BlockCore || role == BlockDefault
+		blocks = append(blocks, block)
+	}
+
+	return blocks, nil
+}

--- a/internal/prompts/embed.go
+++ b/internal/prompts/embed.go
@@ -1,0 +1,6 @@
+package prompts
+
+import "embed"
+
+//go:embed blocks/*.md
+var blocksFS embed.FS

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -626,6 +626,7 @@
         { id: 'nav-account-links', group: 'Data', title: 'Account Links', desc: 'Cross-account deduplication', icon: 'link-2', href: '/account-links', keywords: 'linked accounts dedup matching' },
         { id: 'nav-users', group: 'Data', title: 'Family Members', desc: 'Manage family members', icon: 'users', href: '/users', keywords: 'people household members' },
         // Agents
+        { id: 'agent-wizard', group: 'Agents', title: 'Agent Wizard', desc: 'Create agent prompts', icon: 'wand-sparkles', href: '/agent-wizard', keywords: 'wizard setup prompt create agent flow' },
         { id: 'agent-reviews', group: 'Agents', title: 'Review Queue', desc: 'Transaction review queue', icon: 'clipboard-check', href: '/reviews', keywords: 'pending approve categorize' },
         { id: 'agent-review-instructions', group: 'Agents', title: 'Review Agent', desc: 'Review agent instructions', icon: 'message-square-code', href: '/review-instructions', keywords: 'agent instructions prompts' },
         { id: 'agent-reports', group: 'Agents', title: 'Reports', desc: 'Agent reports and findings', icon: 'file-text', href: '/reports', keywords: 'agent summaries notifications' },

--- a/internal/templates/pages/agent_wizard.html
+++ b/internal/templates/pages/agent_wizard.html
@@ -1,0 +1,178 @@
+{{define "content"}}
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Agent Wizard</h1>
+    <p class="text-sm text-base-content/50 mt-1">Create agent prompts for automating financial tasks</p>
+  </div>
+</div>
+
+<div class="space-y-8 bb-stagger">
+
+  <!-- Section: Essential -->
+  <div>
+    <div class="flex items-center gap-2 mb-3">
+      <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wider">Bulk Reviews</h2>
+    </div>
+    <div class="space-y-2">
+      <a href="/agent-wizard/initial-setup" class="bb-card p-0 overflow-hidden hover:bg-base-200/50 transition-colors duration-150 cursor-pointer group no-underline flex items-center">
+        <div class="px-5 py-4 flex items-center gap-4 flex-1 min-w-0">
+          <div class="relative flex-shrink-0">
+            <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/15 transition-colors">
+              <i data-lucide="sparkles" class="w-5 h-5 text-primary"></i>
+            </div>
+            <div class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-base-100 border border-base-300 flex items-center justify-center">
+              <i data-lucide="bot" class="w-2.5 h-2.5 text-base-content/50"></i>
+            </div>
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <h3 class="font-semibold text-sm text-base-content group-hover:text-primary transition-colors">Initial Setup</h3>
+              <span class="badge badge-soft badge-primary badge-xs rounded-lg">First run</span>
+            </div>
+            <p class="text-xs text-base-content/50 mt-0.5">Establish rules and categories after connecting a new account or importing a CSV</p>
+          </div>
+          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 flex-shrink-0 group-hover:text-base-content/40 group-hover:translate-x-0.5 transition-all"></i>
+        </div>
+      </a>
+      <a href="/agent-wizard/bulk-review" class="bb-card p-0 overflow-hidden hover:bg-base-200/50 transition-colors duration-150 cursor-pointer group no-underline flex items-center">
+        <div class="px-5 py-4 flex items-center gap-4 flex-1 min-w-0">
+          <div class="relative flex-shrink-0">
+            <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/15 transition-colors">
+              <i data-lucide="layers" class="w-5 h-5 text-primary"></i>
+            </div>
+            <div class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-base-100 border border-base-300 flex items-center justify-center">
+              <i data-lucide="bot" class="w-2.5 h-2.5 text-base-content/50"></i>
+            </div>
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <h3 class="font-semibold text-sm text-base-content group-hover:text-primary transition-colors">Bulk Review</h3>
+              <span class="badge badge-soft badge-primary badge-xs rounded-lg">Thorough</span>
+            </div>
+            <p class="text-xs text-base-content/50 mt-0.5">Review a large queue of pending transactions with careful categorization and rule creation</p>
+          </div>
+          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 flex-shrink-0 group-hover:text-base-content/40 group-hover:translate-x-0.5 transition-all"></i>
+        </div>
+      </a>
+      <a href="/agent-wizard/quick-review" class="bb-card p-0 overflow-hidden hover:bg-base-200/50 transition-colors duration-150 cursor-pointer group no-underline flex items-center">
+        <div class="px-5 py-4 flex items-center gap-4 flex-1 min-w-0">
+          <div class="relative flex-shrink-0">
+            <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center group-hover:bg-primary/15 transition-colors">
+              <i data-lucide="zap" class="w-5 h-5 text-primary"></i>
+            </div>
+            <div class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-base-100 border border-base-300 flex items-center justify-center">
+              <i data-lucide="bot" class="w-2.5 h-2.5 text-base-content/50"></i>
+            </div>
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <h3 class="font-semibold text-sm text-base-content group-hover:text-primary transition-colors">Quick Review</h3>
+              <span class="badge badge-soft badge-primary badge-xs rounded-lg">Fast</span>
+            </div>
+            <p class="text-xs text-base-content/50 mt-0.5">Rapidly clear a large queue using broad rules and batch actions for maximum efficiency</p>
+          </div>
+          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 flex-shrink-0 group-hover:text-base-content/40 group-hover:translate-x-0.5 transition-all"></i>
+        </div>
+      </a>
+    </div>
+  </div>
+
+  <!-- Section: Routine -->
+  <div>
+    <div class="flex items-center gap-2 mb-3">
+      <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wider">Routine</h2>
+    </div>
+    <div class="space-y-2">
+      <a href="/agent-wizard/routine-review" class="bb-card p-0 overflow-hidden hover:bg-base-200/50 transition-colors duration-150 cursor-pointer group no-underline flex items-center">
+        <div class="px-5 py-4 flex items-center gap-4 flex-1 min-w-0">
+          <div class="relative flex-shrink-0">
+            <div class="w-10 h-10 rounded-xl bg-success/10 flex items-center justify-center group-hover:bg-success/15 transition-colors">
+              <i data-lucide="repeat" class="w-5 h-5 text-success"></i>
+            </div>
+            <div class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-base-100 border border-base-300 flex items-center justify-center">
+              <i data-lucide="bot" class="w-2.5 h-2.5 text-base-content/50"></i>
+            </div>
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <h3 class="font-semibold text-sm text-base-content group-hover:text-success transition-colors">Routine Review</h3>
+              <span class="badge badge-soft badge-success badge-xs rounded-lg">Recurring</span>
+            </div>
+            <p class="text-xs text-base-content/50 mt-0.5">Review and categorize new transactions on a daily or weekly schedule</p>
+          </div>
+          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 flex-shrink-0 group-hover:text-base-content/40 group-hover:translate-x-0.5 transition-all"></i>
+        </div>
+      </a>
+      <a href="/agent-wizard/spending-report" class="bb-card p-0 overflow-hidden hover:bg-base-200/50 transition-colors duration-150 cursor-pointer group no-underline flex items-center">
+        <div class="px-5 py-4 flex items-center gap-4 flex-1 min-w-0">
+          <div class="relative flex-shrink-0">
+            <div class="w-10 h-10 rounded-xl bg-violet-500/10 flex items-center justify-center group-hover:bg-violet-500/15 transition-colors">
+              <i data-lucide="bar-chart-3" class="w-5 h-5 text-violet-500"></i>
+            </div>
+            <div class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-base-100 border border-base-300 flex items-center justify-center">
+              <i data-lucide="bot" class="w-2.5 h-2.5 text-base-content/50"></i>
+            </div>
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <h3 class="font-semibold text-sm text-base-content group-hover:text-violet-500 transition-colors">Spending Report</h3>
+              <span class="badge badge-xs rounded-lg bg-violet-500/15 text-violet-600 border-0">Recurring</span>
+            </div>
+            <p class="text-xs text-base-content/50 mt-0.5">Weekly or monthly summary of spending by category with trend analysis</p>
+          </div>
+          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 flex-shrink-0 group-hover:text-base-content/40 group-hover:translate-x-0.5 transition-all"></i>
+        </div>
+      </a>
+    </div>
+  </div>
+
+  <!-- Section: Recommended -->
+  <div>
+    <div class="flex items-center gap-2 mb-3">
+      <h2 class="text-sm font-semibold text-base-content/70 uppercase tracking-wider">Recommended</h2>
+    </div>
+    <div class="space-y-2">
+      <a href="/agent-wizard/anomaly-detection" class="bb-card p-0 overflow-hidden hover:bg-base-200/50 transition-colors duration-150 cursor-pointer group no-underline flex items-center">
+        <div class="px-5 py-4 flex items-center gap-4 flex-1 min-w-0">
+          <div class="relative flex-shrink-0">
+            <div class="w-10 h-10 rounded-xl bg-warning/10 flex items-center justify-center group-hover:bg-warning/15 transition-colors">
+              <i data-lucide="shield-alert" class="w-5 h-5 text-warning"></i>
+            </div>
+            <div class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-base-100 border border-base-300 flex items-center justify-center">
+              <i data-lucide="bot" class="w-2.5 h-2.5 text-base-content/50"></i>
+            </div>
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <h3 class="font-semibold text-sm text-base-content group-hover:text-warning transition-colors">Anomaly Detection</h3>
+              <span class="badge badge-soft badge-warning badge-xs rounded-lg">Monitoring</span>
+            </div>
+            <p class="text-xs text-base-content/50 mt-0.5">Watch for unusual charges, duplicate transactions, or unexpected spending spikes</p>
+          </div>
+          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 flex-shrink-0 group-hover:text-base-content/40 group-hover:translate-x-0.5 transition-all"></i>
+        </div>
+      </a>
+      <a href="/agent-wizard/custom" class="bb-card p-0 overflow-hidden hover:bg-base-200/50 transition-colors duration-150 cursor-pointer group no-underline flex items-center border-dashed border-2">
+        <div class="px-5 py-4 flex items-center gap-4 flex-1 min-w-0">
+          <div class="relative flex-shrink-0">
+            <div class="w-10 h-10 rounded-xl bg-base-300/50 flex items-center justify-center group-hover:bg-base-300/70 transition-colors">
+              <i data-lucide="plus" class="w-5 h-5 text-base-content/40"></i>
+            </div>
+            <div class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full bg-base-100 border border-base-300 flex items-center justify-center">
+              <i data-lucide="bot" class="w-2.5 h-2.5 text-base-content/50"></i>
+            </div>
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <h3 class="font-semibold text-sm text-base-content/70 group-hover:text-base-content transition-colors">Custom Agent</h3>
+            </div>
+            <p class="text-xs text-base-content/50 mt-0.5">Start from scratch with your own goals, filters, and output format</p>
+          </div>
+          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 flex-shrink-0 group-hover:text-base-content/40 group-hover:translate-x-0.5 transition-all"></i>
+        </div>
+      </a>
+    </div>
+  </div>
+
+</div>
+{{end}}

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -51,7 +51,7 @@
   </div>
 
   <!-- Card 2: Server Instructions -->
-  <div class="bb-card p-0 overflow-hidden" x-data="{
+  <div id="instructions" class="bb-card p-0 overflow-hidden" x-data="{
     instructions: {{.Instructions | printf `%q`}},
     defaultInstructions: {{.DefaultInstructions | printf `%q`}},
     async resetToDefaults() {

--- a/internal/templates/pages/prompt_builder.html
+++ b/internal/templates/pages/prompt_builder.html
@@ -4,7 +4,7 @@
     <div class="flex items-center gap-2 text-sm text-base-content/50 mb-1">
       <a href="/agent-wizard" class="hover:text-base-content transition-colors">Agent Wizard</a>
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
-      <span class="text-base-content/70">{{.AgentLabel}}</span>
+      <span class="text-base-content/70">Prompt Builder</span>
     </div>
     <h1 class="bb-page-title">{{.AgentLabel}}</h1>
     <p class="text-sm text-base-content/50 mt-1">{{.AgentDescription}}</p>
@@ -21,17 +21,19 @@
                 ? 'bg-primary/10 text-primary border border-primary/30 hover:bg-primary/15'
                 : 'bg-base-200/50 text-base-content/40 border border-base-300 hover:text-base-content/60 hover:border-base-content/20'"
               @click="toggleBlock(block.id)">
-        <!-- Checkmark when enabled -->
-        <svg x-show="block.enabled" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
-        <!-- Plus when disabled -->
-        <svg x-show="!block.enabled" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
+        <!-- Left icon (block type) -->
+        <span x-html="getBlockIcon(block.id)" class="flex-shrink-0 flex items-center"></span>
         <span x-text="block.title"></span>
+        <!-- Right icon (state) -->
+        <svg x-show="block.enabled" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0"><path d="M20 6 9 17l-5-5"/></svg>
+        <svg x-show="!block.enabled" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
       </button>
     </template>
     <button class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-base-200/50 text-base-content/40 border border-dashed border-base-300 hover:text-base-content/60 hover:border-base-content/20 transition-all duration-150"
             @click="addCustomBlock()">
-      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
+      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z"/></svg>
       Custom Instructions
+      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
     </button>
   </div>
 
@@ -43,14 +45,11 @@
            @drop.prevent="handleDrop()"
            :data-block-id="block.id"
            class="group/block relative"
-           :style="focusedBlock === block.id ? 'box-shadow: inset 3px 0 0 oklch(var(--p))' : ''">
+>
 
         <!-- Block header -->
         <div class="flex items-center gap-2 px-3 py-2.5 select-none cursor-pointer transition-colors duration-100"
-             :class="[
-               draggingId === block.id ? 'opacity-30' : '',
-               focusedBlock === block.id ? 'bg-primary/8' : 'bg-base-200/50 hover:bg-base-200/80'
-             ]"
+             :class="draggingId ? (draggingId === block.id ? 'opacity-30 bg-base-200/50' : 'bg-base-200/50') : 'bg-base-200/50 hover:bg-base-300/70'"
              draggable="true"
              @dragstart="handleDragStart($event, index, block.id)"
              @dragend="handleDragEnd()"
@@ -66,6 +65,7 @@
                  class="text-base-content/30 flex-shrink-0 transition-transform duration-200"
                  :style="isCollapsed(block.id) ? '' : 'transform:rotate(90deg)'"><path d="m9 18 6-6-6-6"/></svg>
             <span class="text-sm font-semibold text-base-content/60 truncate" x-text="block.title"></span>
+            <span x-show="block.content !== block.originalContent && !block.isCustom" class="badge badge-soft badge-warning badge-xs rounded-lg flex-shrink-0">Modified</span>
           </div>
 
           <!-- Actions -->
@@ -95,14 +95,14 @@
         </div>
 
         <!-- Block content -->
-        <div class="relative overflow-hidden transition-[max-height,background-color] duration-300 ease-in-out"
-             :style="(isCollapsed(block.id) || draggingId) ? (draggingId ? 'max-height:2.5rem' : 'max-height:3.5rem') : 'max-height:' + getBlockHeight(block.id) + 'px'"
+        <div class="relative overflow-hidden transition-[max-height] duration-300 ease-in-out group/content"
+             :style="(isCollapsed(block.id) || draggingId) ? (draggingId ? 'max-height:2rem' : 'max-height:3rem') : 'max-height:' + getBlockHeight(block.id) + 'px'"
              @click="(isCollapsed(block.id) || draggingId) && !draggingId ? toggleCollapse(block.id) : null"
-             :class="(isCollapsed(block.id) || draggingId) ? 'cursor-pointer hover:bg-base-200/30' : ''">
+             :class="(isCollapsed(block.id) || draggingId) ? 'cursor-pointer' : ''">
           <div class="px-4 py-2.5">
             <textarea
               class="w-full bg-transparent font-mono text-xs leading-relaxed resize-none outline-none transition-colors duration-200"
-              :class="(isCollapsed(block.id) || draggingId) ? 'text-base-content/40 pointer-events-none' : 'text-base-content/70'"
+              :class="(isCollapsed(block.id) || draggingId) ? 'text-base-content/30 pointer-events-none' : 'text-base-content/70'"
               x-model="block.content"
               @input="autoResize($el); updateBlockHeight(block.id, $el)"
               @focus="focusedBlock = block.id"
@@ -115,10 +115,18 @@
               :tabindex="(isCollapsed(block.id) || draggingId) ? -1 : 0"
             ></textarea>
           </div>
-          <!-- Fade overlay when collapsed -->
-          <div class="absolute bottom-0 left-0 right-0 h-8 pointer-events-none transition-opacity duration-300"
+          <!-- Fade + expand hint overlay when collapsed -->
+          <div class="absolute inset-x-0 bottom-0 pointer-events-none transition-opacity duration-300 flex flex-col items-center justify-end"
                :class="(isCollapsed(block.id) || draggingId) ? 'opacity-100' : 'opacity-0'"
-               style="background: linear-gradient(to bottom, transparent, var(--color-base-100))"></div>
+               style="height: 1.25rem; background: linear-gradient(to bottom, transparent, var(--color-base-100))">
+            <div class="pb-1 transition-opacity duration-200"
+                 :class="(isCollapsed(block.id) && !draggingId) ? 'opacity-0 group-hover/content:opacity-100' : 'opacity-0'">
+              <span class="text-[10px] text-base-content/40 flex items-center gap-1">
+                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+                Click to expand
+              </span>
+            </div>
+          </div>
         </div>
       </div>
     </template>
@@ -156,8 +164,10 @@
   <!-- Floating bottom bar -->
   <div class="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
     <div class="flex items-center gap-3 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-5 py-3">
+      <span class="text-xs font-medium text-base-content/60">{{.AgentLabel}}</span>
+      <div class="w-px h-4 bg-base-300"></div>
       <span class="text-xs text-base-content/40 tabular-nums" x-text="activeBlocks.length + ' blocks · ' + preview.length.toLocaleString() + ' chars'"></span>
-      <div class="w-px h-6 bg-base-300"></div>
+      <div class="w-px h-4 bg-base-300"></div>
       <button class="btn btn-ghost btn-sm rounded-xl gap-1.5 text-xs" @click="openPreview()">
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
         Preview
@@ -209,11 +219,12 @@
           <span class="text-xs text-base-content/40 tabular-nums" x-text="preview.length.toLocaleString() + ' chars'"></span>
         </div>
         <div class="flex items-center gap-2">
-          <button class="btn btn-sm btn-primary rounded-xl gap-1.5 text-xs relative overflow-hidden" style="min-width:5.5rem" @click="copyPrompt()">
+          <button class="btn btn-sm btn-primary rounded-xl gap-1.5 text-xs relative overflow-hidden" style="min-width:6.5rem" @click="copyPrompt()">
             <span class="flex items-center gap-1.5 transition-all duration-200"
                   :class="copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'">
               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
               Copy
+              <span class="ml-0.5 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
             </span>
             <span class="absolute inset-0 flex items-center justify-center gap-1.5 transition-all duration-200"
                   :class="copied ? 'opacity-100 scale-100' : 'opacity-0 scale-75'">
@@ -319,6 +330,24 @@ function promptBuilder(initialBlocks) {
         .join('\n\n');
     },
 
+    getBlockIcon: function(id) {
+      var icons = {
+        'tool-reference': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>',
+        'category-system': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"/><circle cx="7.5" cy="7.5" r=".5" fill="currentColor"/></svg>',
+        'rule-creation': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M7 12h10"/><path d="M10 18h4"/></svg>',
+        'report-submission': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/></svg>',
+        'account-linking': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 16 4-4-4-4"/><path d="m6 8-4 4 4 4"/><path d="m14.5 4-5 16"/></svg>',
+        'teller-categories': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" x2="21" y1="22" y2="22"/><line x1="6" x2="6" y1="18" y2="11"/><line x1="10" x2="10" y1="18" y2="11"/><line x1="14" x2="14" y1="18" y2="11"/><line x1="18" x2="18" y1="18" y2="11"/><polygon points="12 2 20 7 4 7"/></svg>',
+        'token-efficiency': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/></svg>',
+        'scale-guidance': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21 16-4 4-4-4"/><path d="M17 20V4"/><path d="m3 8 4-4 4 4"/><path d="M7 4v16"/></svg>',
+        'gmail-integration': '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="12" viewBox="0 0 256 193"><path fill="#4285F4" d="M58.182 192.05V93.14L27.507 65.077 0 49.504v125.091c0 9.658 7.825 17.455 17.455 17.455z"/><path fill="#34A853" d="M197.818 192.05h40.727c9.659 0 17.455-7.826 17.455-17.455V49.505l-31.156 17.837-27.026 25.798z"/><path fill="#EA4335" d="m58.182 93.14-4.174-38.647 4.174-36.989L128 69.868l69.818-52.364 4.669 34.992-4.669 40.644L128 145.504z"/><path fill="#FBBC04" d="M197.818 17.504V93.14L256 49.504V26.231c0-21.585-24.64-33.89-41.89-20.945z"/><path fill="#C5221F" d="M0 49.504l26.759 20.07L58.182 93.14V17.504L41.89 5.286C24.61-7.66 0 4.646 0 26.23z"/></svg>',
+        'sync-management': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/></svg>',
+        'transaction-comments': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7.9 20A9 9 0 1 0 4 16.1L2 22z"/></svg>',
+        'merchant-analysis': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m2 7 4.41-4.41A2 2 0 0 1 7.83 2h8.34a2 2 0 0 1 1.42.59L22 7"/><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><path d="M15 22v-4a2 2 0 0 0-2-2h-2a2 2 0 0 0-2 2v4"/><path d="M2 7h20"/><path d="M22 7v3a2 2 0 0 1-2 2a2.7 2.7 0 0 1-1.59-.63.7.7 0 0 0-.82 0A2.7 2.7 0 0 1 16 12a2.7 2.7 0 0 1-1.59-.63.7.7 0 0 0-.82 0A2.7 2.7 0 0 1 12 12a2.7 2.7 0 0 1-1.59-.63.7.7 0 0 0-.82 0A2.7 2.7 0 0 1 8 12a2.7 2.7 0 0 1-1.59-.63.7.7 0 0 0-.82 0A2.7 2.7 0 0 1 4 12a2 2 0 0 1-2-2V7"/></svg>'
+      };
+      return icons[id] || '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/></svg>';
+    },
+
     autoResize: function(el) {
       el.style.height = '0';
       el.style.height = el.scrollHeight + 'px';
@@ -327,6 +356,11 @@ function promptBuilder(initialBlocks) {
     // --- Drag & drop ---
     handleDragStart: function(e, index, id) {
       this.draggingId = id;
+      this.focusedBlock = null;
+      // Blur any focused textarea
+      if (document.activeElement && document.activeElement.tagName === 'TEXTAREA') {
+        document.activeElement.blur();
+      }
       e.dataTransfer.effectAllowed = 'move';
       e.dataTransfer.setData('text/plain', id);
       var el = e.currentTarget;

--- a/internal/templates/pages/prompt_builder.html
+++ b/internal/templates/pages/prompt_builder.html
@@ -1,0 +1,513 @@
+{{define "content"}}
+<div class="bb-page-header">
+  <div>
+    <div class="flex items-center gap-2 text-sm text-base-content/50 mb-1">
+      <a href="/agent-wizard" class="hover:text-base-content transition-colors">Agent Wizard</a>
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+      <span class="text-base-content/70">{{.AgentLabel}}</span>
+    </div>
+    <h1 class="bb-page-title">{{.AgentLabel}}</h1>
+    <p class="text-sm text-base-content/50 mt-1">{{.AgentDescription}}</p>
+  </div>
+</div>
+
+<div x-data="promptBuilder({{.BlocksJSON}})" @keydown.window="handleKeyboard($event)" class="space-y-5">
+
+  <!-- Block pills (top) — shows all toggleable blocks with selected state -->
+  <div class="flex flex-wrap gap-1.5">
+    <template x-for="block in allToggleableBlocks" :key="block.id">
+      <button class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-150"
+              :class="block.enabled
+                ? 'bg-primary/10 text-primary border border-primary/30 hover:bg-primary/15'
+                : 'bg-base-200/50 text-base-content/40 border border-base-300 hover:text-base-content/60 hover:border-base-content/20'"
+              @click="toggleBlock(block.id)">
+        <!-- Checkmark when enabled -->
+        <svg x-show="block.enabled" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+        <!-- Plus when disabled -->
+        <svg x-show="!block.enabled" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
+        <span x-text="block.title"></span>
+      </button>
+    </template>
+    <button class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-base-200/50 text-base-content/40 border border-dashed border-base-300 hover:text-base-content/60 hover:border-base-content/20 transition-all duration-150"
+            @click="addCustomBlock()">
+      <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
+      Custom Instructions
+    </button>
+  </div>
+
+  <!-- Unified block editor -->
+  <div class="rounded-xl border border-base-300 overflow-hidden bg-base-100">
+    <template x-for="(block, index) in activeBlocks" :key="block.id">
+      <div :class="{ 'border-t border-base-300': index > 0 }"
+           @dragover.prevent="handleDragOver($event, index)"
+           @drop.prevent="handleDrop()"
+           :data-block-id="block.id"
+           class="group/block relative"
+           :style="focusedBlock === block.id ? 'box-shadow: inset 3px 0 0 oklch(var(--p))' : ''">
+
+        <!-- Block header -->
+        <div class="flex items-center gap-2 px-3 py-2.5 select-none cursor-pointer transition-colors duration-100"
+             :class="[
+               draggingId === block.id ? 'opacity-30' : '',
+               focusedBlock === block.id ? 'bg-primary/8' : 'bg-base-200/50 hover:bg-base-200/80'
+             ]"
+             draggable="true"
+             @dragstart="handleDragStart($event, index, block.id)"
+             @dragend="handleDragEnd()"
+             @click="toggleCollapse(block.id)"
+             :style="draggingId ? 'cursor:grabbing' : ''">
+
+          <!-- Drag handle -->
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-base-content/25 flex-shrink-0"><circle cx="9" cy="5" r="1"/><circle cx="9" cy="12" r="1"/><circle cx="9" cy="19" r="1"/><circle cx="15" cy="5" r="1"/><circle cx="15" cy="12" r="1"/><circle cx="15" cy="19" r="1"/></svg>
+
+          <!-- Collapse toggle + Title -->
+          <div class="flex items-center gap-1.5 flex-1 min-w-0">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+                 class="text-base-content/30 flex-shrink-0 transition-transform duration-200"
+                 :style="isCollapsed(block.id) ? '' : 'transform:rotate(90deg)'"><path d="m9 18 6-6-6-6"/></svg>
+            <span class="text-sm font-semibold text-base-content/60 truncate" x-text="block.title"></span>
+          </div>
+
+          <!-- Actions -->
+          <div class="flex items-center gap-0.5 flex-shrink-0">
+            <!-- Copy block -->
+            <button class="p-1.5 rounded-lg text-base-content/25 hover:text-base-content/60 hover:bg-base-300/50 transition-colors opacity-0 group-hover/block:opacity-100"
+                    @click.stop="copyBlock(block.id)" :title="copiedBlockId === block.id ? 'Copied!' : 'Copy block'">
+              <svg x-show="copiedBlockId !== block.id" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+              <svg x-show="copiedBlockId === block.id" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-success"><path d="M20 6 9 17l-5-5"/></svg>
+            </button>
+            <!-- Reset -->
+            <template x-if="block.content !== block.originalContent && !block.isCustom">
+              <button class="p-1.5 rounded-lg text-base-content/25 hover:text-warning hover:bg-warning/10 transition-colors"
+                      @click.stop="resetBlock(block.id)" title="Reset to default">
+                <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
+              </button>
+            </template>
+            <!-- Remove -->
+            <template x-if="block.role !== 'core'">
+              <button class="p-1.5 rounded-lg text-base-content/25 hover:text-error hover:bg-error/10 transition-colors"
+                      @click.stop="block.isCustom ? removeCustomBlock(block.id) : toggleBlock(block.id)"
+                      title="Remove block">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+              </button>
+            </template>
+          </div>
+        </div>
+
+        <!-- Block content -->
+        <div class="relative overflow-hidden transition-[max-height,background-color] duration-300 ease-in-out"
+             :style="(isCollapsed(block.id) || draggingId) ? (draggingId ? 'max-height:2.5rem' : 'max-height:3.5rem') : 'max-height:' + getBlockHeight(block.id) + 'px'"
+             @click="(isCollapsed(block.id) || draggingId) && !draggingId ? toggleCollapse(block.id) : null"
+             :class="(isCollapsed(block.id) || draggingId) ? 'cursor-pointer hover:bg-base-200/30' : ''">
+          <div class="px-4 py-2.5">
+            <textarea
+              class="w-full bg-transparent font-mono text-xs leading-relaxed resize-none outline-none transition-colors duration-200"
+              :class="(isCollapsed(block.id) || draggingId) ? 'text-base-content/40 pointer-events-none' : 'text-base-content/70'"
+              x-model="block.content"
+              @input="autoResize($el); updateBlockHeight(block.id, $el)"
+              @focus="focusedBlock = block.id"
+              @blur="focusedBlock = null"
+              @keydown.escape="$el.blur()"
+              x-init="$nextTick(() => { autoResize($el); updateBlockHeight(block.id, $el); })"
+              :placeholder="block.isCustom ? 'Add your custom instructions here...' : ''"
+              spellcheck="false"
+              rows="1"
+              :tabindex="(isCollapsed(block.id) || draggingId) ? -1 : 0"
+            ></textarea>
+          </div>
+          <!-- Fade overlay when collapsed -->
+          <div class="absolute bottom-0 left-0 right-0 h-8 pointer-events-none transition-opacity duration-300"
+               :class="(isCollapsed(block.id) || draggingId) ? 'opacity-100' : 'opacity-0'"
+               style="background: linear-gradient(to bottom, transparent, var(--color-base-100))"></div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Empty state -->
+    <template x-if="activeBlocks.length === 0">
+      <div class="px-6 py-12 text-center text-base-content/40">
+        <p class="text-sm">No blocks enabled. Toggle blocks above to start building your prompt.</p>
+      </div>
+    </template>
+  </div>
+
+  <!-- Spacer for floating bar -->
+  <div class="h-20"></div>
+
+  <!-- Teleport floating elements to body to avoid drawer transform breaking position:fixed -->
+  <template x-teleport="body">
+  <div>
+
+  <!-- Toast notification -->
+  <div x-show="toast" x-cloak
+       x-transition:enter="transition ease-out duration-200"
+       x-transition:enter-start="opacity-0 translate-y-2"
+       x-transition:enter-end="opacity-100 translate-y-0"
+       x-transition:leave="transition ease-in duration-150"
+       x-transition:leave-start="opacity-100"
+       x-transition:leave-end="opacity-0 translate-y-2"
+       class="fixed bottom-24 left-1/2 z-50 -translate-x-1/2">
+    <div class="bg-base-100 border border-base-300 rounded-xl shadow-lg px-4 py-2.5 flex items-center gap-2">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-success"><path d="M20 6 9 17l-5-5"/></svg>
+      <span class="text-sm font-medium" x-text="toast"></span>
+    </div>
+  </div>
+
+  <!-- Floating bottom bar -->
+  <div class="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
+    <div class="flex items-center gap-3 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-5 py-3">
+      <span class="text-xs text-base-content/40 tabular-nums" x-text="activeBlocks.length + ' blocks · ' + preview.length.toLocaleString() + ' chars'"></span>
+      <div class="w-px h-6 bg-base-300"></div>
+      <button class="btn btn-ghost btn-sm rounded-xl gap-1.5 text-xs" @click="openPreview()">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+        Preview
+        <span class="ml-1 text-[10px] opacity-50 border border-current/30 rounded px-1 leading-none py-0.5">P</span>
+      </button>
+      <button class="btn btn-primary btn-sm rounded-xl gap-1.5 text-xs relative overflow-hidden" style="min-width:8rem" @click="copyPrompt()">
+        <span class="flex items-center gap-1.5 transition-all duration-200"
+              :class="copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+          Copy Prompt
+          <span class="ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
+        </span>
+        <span class="absolute inset-0 flex items-center justify-center gap-1.5 transition-all duration-200"
+              :class="copied ? 'opacity-100 scale-100' : 'opacity-0 scale-75'">
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+          Copied!
+        </span>
+      </button>
+    </div>
+  </div>
+
+  <!-- Preview modal (full screen) -->
+  <div x-show="showPreview" x-cloak
+       class="fixed inset-0 z-50 flex items-center justify-center"
+       @keydown.escape.window="showPreview = false">
+    <!-- Backdrop -->
+    <div class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+         @click="showPreview = false"
+         x-show="showPreview"
+         x-transition:enter="transition ease-out duration-200"
+         x-transition:enter-start="opacity-0"
+         x-transition:enter-end="opacity-100"
+         x-transition:leave="transition ease-in duration-150"
+         x-transition:leave-start="opacity-100"
+         x-transition:leave-end="opacity-0"></div>
+    <!-- Modal -->
+    <div class="relative bg-base-100 rounded-2xl shadow-2xl border border-base-300 w-full max-w-5xl max-h-[90vh] mx-4 flex flex-col"
+         x-show="showPreview"
+         x-transition:enter="transition ease-out duration-200"
+         x-transition:enter-start="opacity-0 scale-95 translate-y-4"
+         x-transition:enter-end="opacity-100 scale-100 translate-y-0"
+         x-transition:leave="transition ease-in duration-150"
+         x-transition:leave-start="opacity-100 scale-100"
+         x-transition:leave-end="opacity-0 scale-95 translate-y-4">
+      <!-- Header -->
+      <div class="flex items-center justify-between px-6 py-4 border-b border-base-300 flex-shrink-0">
+        <div class="flex items-center gap-3">
+          <h3 class="font-semibold">Prompt Preview</h3>
+          <span class="text-xs text-base-content/40 tabular-nums" x-text="preview.length.toLocaleString() + ' chars'"></span>
+        </div>
+        <div class="flex items-center gap-2">
+          <button class="btn btn-sm btn-primary rounded-xl gap-1.5 text-xs relative overflow-hidden" style="min-width:5.5rem" @click="copyPrompt()">
+            <span class="flex items-center gap-1.5 transition-all duration-200"
+                  :class="copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+              Copy
+            </span>
+            <span class="absolute inset-0 flex items-center justify-center gap-1.5 transition-all duration-200"
+                  :class="copied ? 'opacity-100 scale-100' : 'opacity-0 scale-75'">
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+              Copied!
+            </span>
+          </button>
+          <button class="btn btn-ghost btn-sm btn-square rounded-xl" @click="showPreview = false">
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </button>
+        </div>
+      </div>
+      <!-- Rendered markdown content -->
+      <div class="overflow-auto flex-1 px-6 py-5">
+        <div class="bb-markdown" x-html="renderMarkdown(preview)"></div>
+      </div>
+      <style>
+        .bb-markdown { font-size: 0.875rem; line-height: 1.7; color: var(--color-base-content); }
+        .bb-markdown h1 { font-size: 1.5rem; font-weight: 700; margin: 1.5rem 0 0.75rem; border-bottom: 1px solid oklch(var(--bc) / 0.1); padding-bottom: 0.5rem; }
+        .bb-markdown h2 { font-size: 1.15rem; font-weight: 700; margin: 1.5rem 0 0.5rem; color: oklch(var(--bc) / 0.8); }
+        .bb-markdown h3 { font-size: 1rem; font-weight: 600; margin: 1.25rem 0 0.5rem; }
+        .bb-markdown p { margin: 0.5rem 0; }
+        .bb-markdown ul { list-style-type: disc; padding-left: 1.5rem; margin: 0.5rem 0; }
+        .bb-markdown ol { list-style-type: decimal; padding-left: 1.5rem; margin: 0.5rem 0; }
+        .bb-markdown li { margin: 0.25rem 0; }
+        .bb-markdown li > p { margin: 0; display: inline; }
+        .bb-markdown code { font-size: 0.8em; background: oklch(var(--bc) / 0.06); padding: 0.15rem 0.35rem; border-radius: 0.25rem; font-family: ui-monospace, monospace; }
+        .bb-markdown pre { background: oklch(var(--bc) / 0.04); border: 1px solid oklch(var(--bc) / 0.08); border-radius: 0.5rem; padding: 0.75rem 1rem; overflow-x: auto; margin: 0.75rem 0; }
+        .bb-markdown pre code { background: none; padding: 0; font-size: 0.8rem; }
+        .bb-markdown strong { font-weight: 600; }
+        .bb-markdown hr { border: none; border-top: 1px solid oklch(var(--bc) / 0.1); margin: 1.5rem 0; }
+        .bb-markdown blockquote { border-left: 3px solid oklch(var(--p)); padding-left: 1rem; margin: 0.75rem 0; color: oklch(var(--bc) / 0.6); }
+        .bb-markdown ul ul, .bb-markdown ol ul { margin: 0.15rem 0; }
+      </style>
+    </div>
+  </div>
+
+  </div>
+  </template><!-- /x-teleport -->
+
+</div>
+
+<script>
+function promptBuilder(initialBlocks) {
+  var customCounter = 0;
+
+  return {
+    blocks: initialBlocks.map(function(b) {
+      b.isCustom = false;
+      return b;
+    }),
+    copied: false,
+    copiedBlockId: null,
+    showPreview: false,
+    toast: null,
+    draggingId: null,
+    focusedBlock: null,
+    collapsedBlocks: {},
+    blockHeights: {},
+
+    getBlockHeight: function(id) {
+      return this.blockHeights[id] || 2000;
+    },
+
+    updateBlockHeight: function(id, el) {
+      var wrapper = el.closest('.px-4');
+      if (wrapper) {
+        this.blockHeights[id] = wrapper.scrollHeight + 20;
+      }
+    },
+
+    isCollapsed: function(id) {
+      return !!this.collapsedBlocks[id];
+    },
+
+    toggleCollapse: function(id) {
+      this.collapsedBlocks[id] = !this.collapsedBlocks[id];
+      if (!this.collapsedBlocks[id]) {
+        var self = this;
+        this.$nextTick(function() {
+          var el = self.$el.querySelector('[data-block-id="' + id + '"] textarea');
+          if (el) {
+            self.autoResize(el);
+            self.updateBlockHeight(id, el);
+          }
+        });
+      }
+    },
+
+    get activeBlocks() {
+      return this.blocks.filter(function(b) { return b.enabled; });
+    },
+
+    // All non-core, non-custom blocks (for the pill toggles at top)
+    get allToggleableBlocks() {
+      return this.blocks.filter(function(b) { return b.role !== 'core' && !b.isCustom; });
+    },
+
+    get preview() {
+      return this.blocks
+        .filter(function(b) { return b.enabled; })
+        .map(function(b) { return b.content; })
+        .join('\n\n');
+    },
+
+    autoResize: function(el) {
+      el.style.height = '0';
+      el.style.height = el.scrollHeight + 'px';
+    },
+
+    // --- Drag & drop ---
+    handleDragStart: function(e, index, id) {
+      this.draggingId = id;
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', id);
+      var el = e.currentTarget;
+      if (el) {
+        var rect = el.getBoundingClientRect();
+        var offsetX = e.clientX - rect.left;
+        var offsetY = e.clientY - rect.top;
+        e.dataTransfer.setDragImage(el, offsetX, offsetY);
+      }
+    },
+
+    handleDragOver: function(e, toIndex) {
+      if (this.draggingId === null) return;
+
+      var activeIds = this.activeBlocks.map(function(b) { return b.id; });
+      var fromActiveIdx = activeIds.indexOf(this.draggingId);
+      if (fromActiveIdx === -1 || fromActiveIdx === toIndex) return;
+
+      var el = e.currentTarget;
+      var rect = el.getBoundingClientRect();
+      var midY = rect.top + rect.height / 2;
+      var insertBefore = e.clientY < midY;
+
+      var targetActiveIdx = insertBefore ? toIndex : toIndex + 1;
+      if (targetActiveIdx === fromActiveIdx || targetActiveIdx === fromActiveIdx + 1) return;
+
+      var enabled = [];
+      for (var i = 0; i < this.blocks.length; i++) {
+        if (this.blocks[i].enabled) enabled.push(i);
+      }
+
+      var fromBlockIdx = enabled[fromActiveIdx];
+      var toBlockIdx = targetActiveIdx < enabled.length ? enabled[targetActiveIdx] : this.blocks.length;
+
+      var item = this.blocks.splice(fromBlockIdx, 1)[0];
+      if (fromBlockIdx < toBlockIdx) toBlockIdx--;
+      this.blocks.splice(toBlockIdx, 0, item);
+    },
+
+    handleDragEnd: function() {
+      this.draggingId = null;
+      this.resizeAllTextareas();
+    },
+
+    handleDrop: function() {
+      this.draggingId = null;
+      this.resizeAllTextareas();
+    },
+
+    resizeAllTextareas: function() {
+      var self = this;
+      this.$nextTick(function() {
+        setTimeout(function() {
+          self.$el.querySelectorAll('textarea').forEach(function(ta) {
+            self.autoResize(ta);
+            var blockEl = ta.closest('[data-block-id]');
+            if (blockEl) {
+              self.updateBlockHeight(blockEl.dataset.blockId, ta);
+            }
+          });
+        }, 50);
+      });
+    },
+
+    toggleBlock: function(id) {
+      var block = this.blocks.find(function(b) { return b.id === id; });
+      if (block && block.role !== 'core') {
+        block.enabled = !block.enabled;
+        if (block.enabled) {
+          delete this.collapsedBlocks[id];
+          this.resizeAllTextareas();
+        }
+      }
+    },
+
+    addCustomBlock: function() {
+      customCounter++;
+      var id = 'custom-' + customCounter;
+      this.blocks.push({
+        id: id,
+        title: 'Custom Instructions',
+        description: 'Your own instructions — edit freely',
+        content: '',
+        originalContent: '',
+        role: 'optional',
+        enabled: true,
+        isCustom: true
+      });
+      var self = this;
+      this.$nextTick(function() {
+        var el = self.$el.querySelector('[data-block-id="' + id + '"] textarea');
+        if (el) el.focus();
+      });
+    },
+
+    removeCustomBlock: function(id) {
+      this.blocks = this.blocks.filter(function(b) { return b.id !== id; });
+      delete this.collapsedBlocks[id];
+    },
+
+    resetBlock: function(id) {
+      var block = this.blocks.find(function(b) { return b.id === id; });
+      if (block) {
+        block.content = block.originalContent;
+        // Reset stored height so it recalculates
+        delete this.blockHeights[id];
+        var self = this;
+        this.$nextTick(function() {
+          var el = self.$el.querySelector('[data-block-id="' + id + '"] textarea');
+          if (el) {
+            self.autoResize(el);
+            // Double-nextTick to ensure DOM has updated with new content
+            self.$nextTick(function() {
+              self.autoResize(el);
+              self.updateBlockHeight(id, el);
+            });
+          }
+        });
+      }
+    },
+
+    copyBlock: function(id) {
+      var block = this.blocks.find(function(b) { return b.id === id; });
+      if (!block) return;
+      var self = this;
+      navigator.clipboard.writeText(block.content).then(function() {
+        self.copiedBlockId = id;
+        setTimeout(function() { self.copiedBlockId = null; }, 2000);
+      });
+    },
+
+    openPreview: function() {
+      this.showPreview = true;
+    },
+
+    renderMarkdown: function(text) {
+      if (typeof marked === 'undefined') {
+        return '<pre style="white-space:pre-wrap">' + text.replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</pre>';
+      }
+      // Preprocess: convert "ALL CAPS HEADER:" lines to markdown ## headers
+      var processed = text.replace(/^([A-Z][A-Z _&\/()\-\u2014]+):[ ]*$/gm, function(match, header) {
+        var clean = header.trim();
+        var titled = clean.toLowerCase().replace(/\b\w/g, function(c) { return c.toUpperCase(); });
+        return '\n## ' + titled + '\n';
+      });
+      // Ensure blank lines before list items (marked requires them)
+      processed = processed.replace(/([^\n])\n(- )/g, '$1\n\n$2');
+      // Ensure blank lines before numbered list items
+      processed = processed.replace(/([^\n])\n(\d+\. )/g, '$1\n\n$2');
+      return marked.parse(processed);
+    },
+
+    showToast: function(msg) {
+      this.toast = msg;
+      var self = this;
+      setTimeout(function() { self.toast = null; }, 2000);
+    },
+
+    copyPrompt: function() {
+      var self = this;
+      navigator.clipboard.writeText(this.preview).then(function() {
+        self.copied = true;
+        self.showToast('Prompt copied to clipboard');
+        setTimeout(function() { self.copied = false; }, 2000);
+      });
+    },
+
+    handleKeyboard: function(e) {
+      // Don't trigger shortcuts when typing in a textarea or input
+      if (e.target.tagName === 'TEXTAREA' || e.target.tagName === 'INPUT') return;
+      // Don't trigger if modal is open (except Escape which is handled separately)
+      if (e.key === 'c' && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        this.copyPrompt();
+      } else if (e.key === 'p' && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        this.showPreview ? (this.showPreview = false) : this.openPreview();
+      }
+    }
+  };
+}
+</script>
+<script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
+{{end}}

--- a/internal/templates/pages/prompt_builder.html
+++ b/internal/templates/pages/prompt_builder.html
@@ -13,22 +13,50 @@
 
 <div x-data="promptBuilder({{.BlocksJSON}})" @keydown.window="handleKeyboard($event)" class="space-y-5">
 
-  <!-- Block pills (top) — shows all toggleable blocks with selected state -->
+  <!-- How it works -->
+  <div class="rounded-xl bg-base-100 border border-base-300 px-5 py-4 shadow-sm">
+    <h3 class="text-xs font-semibold text-base-content/70 uppercase tracking-wider mb-2.5">How it works</h3>
+    <ul class="space-y-1.5 text-xs text-base-content/50 leading-relaxed list-none">
+      <li class="flex items-start gap-2">
+        <span class="text-base-content/25 mt-px">1.</span>
+        <span>Make sure your agent is connected to the Breadbox MCP server</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span class="text-base-content/25 mt-px">2.</span>
+        <span>Toggle, reorder, and edit blocks to build your prompt</span>
+      </li>
+      <li class="flex items-start gap-2">
+        <span class="text-base-content/25 mt-px">3.</span>
+        <span>Preview the result, then copy and paste into your agent</span>
+      </li>
+    </ul>
+    <p class="text-[11px] text-base-content/35 mt-3 leading-relaxed"><span class="font-semibold text-base-content/45">Note:</span> Agents connected via MCP automatically receive the <a href="/mcp-settings#instructions" class="text-primary hover:underline">server instructions</a> — this prompt is in addition to those.</p>
+  </div>
+
+  <!-- Block pills (top) -->
   <div class="flex flex-wrap gap-1.5">
+    <!-- Core blocks (locked) -->
+    <template x-for="block in coreBlocks" :key="block.id">
+      <span class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-primary/5 text-primary/50 border border-primary/20 cursor-default">
+        <span x-html="getBlockIcon(block.id)" class="flex-shrink-0 flex items-center"></span>
+        <span x-text="block.title"></span>
+        <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 opacity-50"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+      </span>
+    </template>
+    <!-- Toggleable blocks -->
     <template x-for="block in allToggleableBlocks" :key="block.id">
       <button class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-150"
               :class="block.enabled
                 ? 'bg-primary/10 text-primary border border-primary/30 hover:bg-primary/15'
                 : 'bg-base-200/50 text-base-content/40 border border-base-300 hover:text-base-content/60 hover:border-base-content/20'"
               @click="toggleBlock(block.id)">
-        <!-- Left icon (block type) -->
         <span x-html="getBlockIcon(block.id)" class="flex-shrink-0 flex items-center"></span>
         <span x-text="block.title"></span>
-        <!-- Right icon (state) -->
         <svg x-show="block.enabled" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0"><path d="M20 6 9 17l-5-5"/></svg>
         <svg x-show="!block.enabled" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0"><path d="M5 12h14"/><path d="M12 5v14"/></svg>
       </button>
     </template>
+    <!-- Custom instructions -->
     <button class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-base-200/50 text-base-content/40 border border-dashed border-base-300 hover:text-base-content/60 hover:border-base-content/20 transition-all duration-150"
             @click="addCustomBlock()">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z"/></svg>
@@ -139,6 +167,9 @@
     </template>
   </div>
 
+  <!-- Markdown format note -->
+  <p class="text-[11px] text-base-content/30 leading-relaxed text-center">Prompts use <a href="https://www.markdownguide.org/cheat-sheet/" target="_blank" rel="noopener" class="text-primary hover:underline">Markdown format</a> — headers, lists, and emphasis are all supported.</p>
+
   <!-- Spacer for floating bar -->
   <div class="h-20"></div>
 
@@ -192,10 +223,10 @@
   <!-- Preview modal (full screen) -->
   <div x-show="showPreview" x-cloak
        class="fixed inset-0 z-50 flex items-center justify-center"
-       @keydown.escape.window="showPreview = false">
+       @keydown.escape.window="closePreview()">
     <!-- Backdrop -->
     <div class="absolute inset-0 bg-black/50 backdrop-blur-sm"
-         @click="showPreview = false"
+         @click="closePreview()"
          x-show="showPreview"
          x-transition:enter="transition ease-out duration-200"
          x-transition:enter-start="opacity-0"
@@ -232,7 +263,7 @@
               Copied!
             </span>
           </button>
-          <button class="btn btn-ghost btn-sm btn-square rounded-xl" @click="showPreview = false">
+          <button class="btn btn-ghost btn-sm btn-square rounded-xl" @click="closePreview()">
             <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
           </button>
         </div>
@@ -319,6 +350,10 @@ function promptBuilder(initialBlocks) {
     },
 
     // All non-core, non-custom blocks (for the pill toggles at top)
+    get coreBlocks() {
+      return this.blocks.filter(function(b) { return b.role === 'core'; });
+    },
+
     get allToggleableBlocks() {
       return this.blocks.filter(function(b) { return b.role !== 'core' && !b.isCustom; });
     },
@@ -332,6 +367,13 @@ function promptBuilder(initialBlocks) {
 
     getBlockIcon: function(id) {
       var icons = {
+        'base-context': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H6.5a1 1 0 0 1 0-5H20"/></svg>',
+        'strategy-initial-setup': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.9 5.8a2 2 0 0 1-1.287 1.288L3 12l5.8 1.9a2 2 0 0 1 1.288 1.288L12 21l1.9-5.8a2 2 0 0 1 1.287-1.288L21 12l-5.8-1.9a2 2 0 0 1-1.288-1.288Z"/></svg>',
+        'strategy-bulk-review': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 3h5v5"/><path d="M8 3H3v5"/><path d="M12 22v-8.3a4 4 0 0 0-1.172-2.872L3 3"/><path d="m15 9 6-6"/></svg>',
+        'strategy-quick-review': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/></svg>',
+        'strategy-routine-review': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 2.1l4 4-4 4"/><path d="M3 12.2v-2.1a4 4 0 0 1 4-4h12.8M7 21.9l-4-4 4-4"/><path d="M21 11.8v2.1a4 4 0 0 1-4 4H4.2"/></svg>',
+        'strategy-spending-report': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="m19 9-5 5-4-4-3 3"/></svg>',
+        'strategy-anomaly-detection': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="M12 8v4"/><path d="M12 16h.01"/></svg>',
         'tool-reference': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>',
         'category-system': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"/><circle cx="7.5" cy="7.5" r=".5" fill="currentColor"/></svg>',
         'rule-creation': '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M7 12h10"/><path d="M10 18h4"/></svg>',
@@ -494,6 +536,12 @@ function promptBuilder(initialBlocks) {
 
     openPreview: function() {
       this.showPreview = true;
+      document.body.style.overflow = 'hidden';
+    },
+
+    closePreview: function() {
+      this.showPreview = false;
+      document.body.style.overflow = '';
     },
 
     renderMarkdown: function(text) {
@@ -537,7 +585,7 @@ function promptBuilder(initialBlocks) {
         this.copyPrompt();
       } else if (e.key === 'p' && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
-        this.showPreview ? (this.showPreview = false) : this.openPreview();
+        this.showPreview ? this.closePreview() : this.openPreview();
       }
     }
   };

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -32,6 +32,9 @@
   </a>
 
   <div class="bb-sidebar-section">Agents</div>
+  <a href="/agent-wizard" class="bb-sidebar-link{{if eq .CurrentPage "agent-wizard"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="wand-sparkles"></i> Agent Wizard
+  </a>
   <a href="/reviews" class="bb-sidebar-link{{if eq .CurrentPage "reviews"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="clipboard-check"></i>
     <span class="flex-1">Review Queue</span>


### PR DESCRIPTION
## Summary
- Simplify MCP settings: remove global mode toggle (default to read_write), unify server instructions into single editable textarea, remove API Key Scopes card
- Add Agent Wizard landing page with categorized workflow options (Bulk Reviews, Routine, Recommended)
- Add Prompt Builder page with block-based editor for composing agent prompts
- Align sidebar and command palette navigation groups (Data, Agents, System)

### Prompt Builder Features
- 19 composable markdown blocks decomposed from existing MCP instructions
- 7 agent type configs (initial-setup, bulk-review, quick-review, routine-review, spending-report, anomaly-detection, custom)
- Drag-to-reorder with auto-collapse during drag
- Toggle pills with block-type icons (including multicolor Gmail logo)
- Collapse/expand with content preview fade and "Click to expand" hint
- Full-screen markdown preview modal with rendered output
- Floating bottom bar with agent name, block/char count, preview and copy buttons
- Keyboard shortcuts: C to copy, P to preview, Escape to close/blur
- Per-block copy, reset-to-default, and "Modified" indicator

## Test plan
- [ ] MCP Settings page loads with Tools Enabled + Server Instructions cards only
- [ ] Agent Wizard page shows 7 workflow options in 3 sections
- [ ] Click each workflow → Prompt Builder loads with correct blocks
- [ ] Toggle pills on/off → blocks appear/disappear in editor
- [ ] Drag blocks to reorder → all collapse during drag, expand on drop
- [ ] Edit block content → "Modified" badge appears, reset button works
- [ ] Preview modal renders markdown with headers, bullet lists, etc.
- [ ] Copy Prompt → clipboard contains full concatenated markdown
- [ ] Keyboard shortcuts work (C, P, Escape)
- [ ] Command palette and sidebar reflect new navigation structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)