### PR TITLE
Polish transactions: selection mode, search/filter layout, keyboard nav

### DIFF
--- a/input.css
+++ b/input.css
@@ -711,13 +711,25 @@
     80% { transform: translateX(3px); }
   }
 
-  /* ── Transaction row hover (date-grouped list) ── */
+  /* ── Transaction row hover + keyboard focus ── */
   .bb-tx-row {
     transition: background-color 0.12s ease;
   }
 
   .bb-tx-row:hover {
     @apply bg-base-200/40;
+  }
+
+  .bb-tx-row--focused {
+    @apply bg-primary/5;
+    box-shadow: inset 3px 0 0 oklch(0.55 0.15 250);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-tx-row--focused {
+      @apply bg-primary/10;
+      box-shadow: inset 3px 0 0 oklch(0.65 0.15 250);
+    }
   }
 
   /* ── Transaction category avatar ── */

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -171,15 +171,24 @@
 {{if .Transactions}}
 
 <div x-data class="space-y-1">
-  <!-- Select all + quick search header -->
+  <!-- Selection toggle + quick search header -->
   <div class="flex items-center gap-3 px-2 pb-2">
-    <label class="flex items-center cursor-pointer" @click.stop>
+    <!-- Selection mode toggle -->
+    <button type="button" @click="$store.bulk.toggleMode()"
+      class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-xs"
+      :class="$store.bulk.selecting && 'bg-primary/10 text-primary'"
+      title="Toggle selection mode">
+      <i data-lucide="list-checks" class="w-3.5 h-3.5"></i>
+      <span class="hidden sm:inline" x-text="$store.bulk.selecting ? 'Done' : 'Select'"></span>
+    </button>
+    <!-- Select all (visible in selection mode) -->
+    <label x-show="$store.bulk.selecting" x-cloak class="flex items-center gap-2 cursor-pointer" @click.stop>
       <input type="checkbox" class="checkbox checkbox-sm checkbox-primary"
         :checked="$store.bulk.sel.length === window.__bbTxMeta.length && window.__bbTxMeta.length > 0"
         :indeterminate="$store.bulk.sel.length > 0 && $store.bulk.sel.length < window.__bbTxMeta.length"
         @change="$store.bulk.toggleAll()">
+      <span class="text-xs text-base-content/40">Select all</span>
     </label>
-    <span class="text-xs text-base-content/40">Select all</span>
     <div class="flex-1"></div>
     <div class="relative" x-data="quickSearch()">
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
@@ -250,15 +259,19 @@ function quickSearch() {
       }
 
       // Phase 1: Instant client-side filter on visible rows (no debounce)
+      // Match server strategy: search name + merchant only (not account), all words must match
       var terms = val.toLowerCase().trim().split(/\s+/);
       document.querySelectorAll('.bb-tx-row').forEach(function(row) {
-        var hay = (row.dataset.txName || '') + ' ' + (row.dataset.txMerchant || '') + ' ' + (row.dataset.txAccount || '');
+        var hay = (row.dataset.txName || '') + ' ' + (row.dataset.txMerchant || '');
         row.style.display = terms.every(function(t) { return hay.includes(t); }) ? '' : 'none';
+        row.style.borderBottom = ''; // reset divide-y fix
       });
       document.querySelectorAll('[data-date-group]').forEach(function(group) {
         var visible = group.querySelectorAll('.bb-tx-row:not([style*="display: none"])');
         var count = visible.length;
         group.style.display = count ? '' : 'none';
+        // Fix divide-y: last visible row gets a spurious border-bottom when hidden siblings follow
+        if (count > 0) visible[count - 1].style.borderBottom = '0px';
         // Update transaction count
         var countEl = group.querySelector('[data-txn-count]');
         if (countEl) countEl.textContent = count + ' txn' + (count !== 1 ? 's' : '');
@@ -349,6 +362,7 @@ function quickSearch() {
             var hasResults = html.indexOf('bb-tx-row') !== -1;
             if (hasResults) {
               results.innerHTML = html.replace(/bb-stagger/g, '');
+              results.querySelectorAll('script').forEach(function(s) { eval(s.textContent); });
               Alpine.initTree(results);
               if (window.lucide) lucide.createIcons();
             } else {
@@ -392,7 +406,7 @@ function quickSearch() {
       var pag = document.getElementById('bb-tx-paginator');
       if (pag) pag.style.display = '';
       // Show all client-side hidden rows and restore counts
-      document.querySelectorAll('.bb-tx-row').forEach(function(r) { r.style.display = ''; });
+      document.querySelectorAll('.bb-tx-row').forEach(function(r) { r.style.display = ''; r.style.borderBottom = ''; });
       document.querySelectorAll('[data-date-group]').forEach(function(g) {
         g.style.display = '';
         var countEl = g.querySelector('[data-txn-count]');
@@ -428,6 +442,7 @@ function quickSearch() {
             var results = document.getElementById('bb-tx-results');
             if (results) {
               results.innerHTML = html.replace(/bb-stagger/g, '');
+              results.querySelectorAll('script').forEach(function(s) { eval(s.textContent); });
               Alpine.initTree(results);
               if (window.lucide) lucide.createIcons();
             }
@@ -521,7 +536,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }));
   });
   document.getElementById('bb-bulk-clear').addEventListener('click', function() {
-    Alpine.store('bulk').clear();
+    Alpine.store('bulk').toggleMode();
   });
 
   // Listen for category-picked from bulk picker
@@ -536,12 +551,21 @@ document.addEventListener('DOMContentLoaded', function() {
 document.addEventListener('alpine:init', function() {
   Alpine.store('bulk', {
     sel: [],
+    selecting: false,
     processing: false,
+
+    toggleMode() {
+      this.selecting = !this.selecting;
+      if (!this.selecting) {
+        this.sel = [];
+      }
+      this._updateBar();
+    },
 
     _updateBar() {
       var bar = document.getElementById('bb-bulk-bar');
       if (!bar) return;
-      var show = this.sel.length > 0;
+      var show = this.selecting;
       bar.style.opacity = show ? '1' : '0';
       bar.style.transform = 'translateX(-50%) translateY(' + (show ? '0' : '1rem') + ')';
       bar.style.pointerEvents = show ? 'auto' : 'none';

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -21,6 +21,14 @@
         <span class="hidden sm:inline">List</span>
       </button>
     </div>
+    <!-- Selection mode toggle -->
+    <button type="button" x-data @click="$store.bulk.toggleMode()"
+      class="btn btn-ghost btn-sm rounded-xl gap-1.5"
+      :class="$store.bulk.selecting && 'bg-primary/10 text-primary'"
+      title="Toggle selection mode">
+      <i data-lucide="list-checks" class="w-3.5 h-3.5"></i>
+      <span class="hidden sm:inline" x-text="$store.bulk.selecting ? 'Done' : 'Select'"></span>
+    </button>
     {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}
     <a href="/transactions" class="btn btn-ghost btn-sm rounded-xl">
       <i data-lucide="x" class="w-3.5 h-3.5"></i>
@@ -36,168 +44,33 @@
   </div>
 </div>
 
-<!-- Filters Card -->
-<div class="bb-card mb-6" x-data="{ filtersOpen: localStorage.getItem('bb-tx-filters-open') === 'true' || {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending}}true{{else}}false{{end}} }" x-init="$watch('filtersOpen', v => localStorage.setItem('bb-tx-filters-open', v))">
-  <div class="p-0">
-    <button type="button" class="bb-filter-toggle" @click="filtersOpen = !filtersOpen">
-      <div class="flex items-center gap-2">
-        <i data-lucide="sliders-horizontal" class="w-4 h-4 text-base-content/60"></i>
-        <span>Filters</span>
-        {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}
-        <span class="badge badge-primary badge-xs">Active</span>
-        {{end}}
-      </div>
-      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 transition-transform duration-200" :class="filtersOpen ? 'rotate-180' : ''"></i>
-    </button>
-
-    <form method="GET" action="/transactions" x-show="filtersOpen" x-cloak
+<!-- Search + Filters -->
+<div class="mb-6" x-data="{ filtersOpen: localStorage.getItem('bb-tx-filters-open') === 'true' || {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending}}true{{else}}false{{end}} }" x-init="$watch('filtersOpen', v => {
+  localStorage.setItem('bb-tx-filters-open', v);
+  if (v) {
+    var qs = document.getElementById('bb-quick-search');
+    var adv = document.querySelector('input[name=&quot;search&quot;]');
+    if (qs && adv && qs.value.trim()) adv.value = qs.value.trim();
+  }
+})">
+  <!-- Search bar + filter toggle row -->
+  <div class="flex items-center gap-3">
+    <!-- Quick search (collapses when filters open) -->
+    <div x-show="!filtersOpen" x-data="quickSearch()"
       x-transition:enter="transition ease-out duration-200"
-      x-transition:enter-start="opacity-0 -translate-y-2"
-      x-transition:enter-end="opacity-100 translate-y-0"
+      x-transition:enter-start="opacity-0 -translate-x-4"
+      x-transition:enter-end="opacity-100 translate-x-0"
       x-transition:leave="transition ease-in duration-150"
-      x-transition:leave-start="opacity-100 translate-y-0"
-      x-transition:leave-end="opacity-0 -translate-y-2"
-      class="bb-filter-form px-4 pb-4 pt-2" x-data>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-3">
-        <label class="bb-filter-label">
-          Start Date
-          <input type="date" name="start_date" value="{{.FilterStartDate}}" class="input input-sm input-bordered w-full">
-        </label>
-        <label class="bb-filter-label">
-          End Date
-          <input type="date" name="end_date" value="{{.FilterEndDate}}" class="input input-sm input-bordered w-full">
-        </label>
-        <label class="bb-filter-label">
-          Connection
-          <select name="connection_id" class="select select-sm select-bordered w-full">
-            <option value="">All connections</option>
-            {{range .Connections}}
-            <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
-            {{end}}
-          </select>
-        </label>
-        <label class="bb-filter-label">
-          Account
-          <select name="account_id" class="select select-sm select-bordered w-full">
-            <option value="">All accounts</option>
-            {{range .Accounts}}
-            <option value="{{.ID}}"{{if eq .ID $.FilterAccountID}} selected{{end}}>{{accountLabel .Name .Mask}}</option>
-            {{end}}
-          </select>
-        </label>
-        <label class="bb-filter-label">
-          Family Member
-          <select name="user_id" class="select select-sm select-bordered w-full">
-            <option value="">All members</option>
-            {{range .Users}}
-            <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterUserID}} selected{{end}}>{{.Name}}</option>
-            {{end}}
-          </select>
-        </label>
-      </div>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
-        <label class="bb-filter-label">
-          Category
-          <div class="bb-cat-picker" data-picker-source="tx-filter-cat" x-data="categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
-            <input type="hidden" name="category" x-ref="catInput" value="{{.FilterCategory}}">
-            <button type="button" class="select select-sm select-bordered w-full text-left flex items-center gap-2" @click="openPicker()">
-              <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-              <span x-text="displayLabel" class="text-sm truncate"></span>
-            </button>
-          </div>
-        </label>
-        <label class="bb-filter-label">
-          Min Amount
-          <input type="number" name="min_amount" step="0.01" value="{{.FilterMinAmount}}" placeholder="0.00" class="input input-sm input-bordered w-full">
-        </label>
-        <label class="bb-filter-label">
-          Max Amount
-          <input type="number" name="max_amount" step="0.01" value="{{.FilterMaxAmount}}" placeholder="0.00" class="input input-sm input-bordered w-full">
-        </label>
-        <label class="bb-filter-label">
-          Pending
-          <select name="pending" class="select select-sm select-bordered w-full">
-            <option value="">All</option>
-            <option value="true"{{if eq .FilterPending "true"}} selected{{end}}>Yes</option>
-            <option value="false"{{if eq .FilterPending "false"}} selected{{end}}>No</option>
-          </select>
-        </label>
-      </div>
-
-      <!-- Advanced Search -->
-      <div class="border-t border-base-200 pt-4 mb-4" x-data="{ mode: '{{if .FilterSearchMode}}{{.FilterSearchMode}}{{else}}contains{{end}}' }">
-        <div class="grid grid-cols-1 sm:grid-cols-[1fr_auto_auto] gap-x-3 gap-y-1">
-          <!-- Labels row -->
-          <div class="text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2 hidden sm:flex">
-            <i data-lucide="search" class="w-3.5 h-3.5 text-base-content/40"></i>
-            Advanced Search
-          </div>
-          <div class="text-[0.65rem] text-base-content/40 hidden sm:block">Search in</div>
-          <div class="text-[0.65rem] text-base-content/40 hidden sm:block">Match type</div>
-          <!-- Mobile label -->
-          <div class="text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2 sm:hidden mb-1">
-            <i data-lucide="search" class="w-3.5 h-3.5 text-base-content/40"></i>
-            Advanced Search
-          </div>
-          <!-- Inputs row -->
-          <input type="text" name="search" value="{{.FilterSearch}}" placeholder="Search transactions..." class="input input-sm input-bordered w-full">
-          <select name="search_field" class="select select-sm select-bordered">
-            <option value="all"{{if or (eq .FilterSearchField "all") (not .FilterSearchField)}} selected{{end}}>Name &amp; Merchant</option>
-            <option value="name"{{if eq .FilterSearchField "name"}} selected{{end}}>Name only</option>
-            <option value="merchant"{{if eq .FilterSearchField "merchant"}} selected{{end}}>Merchant only</option>
-          </select>
-          <select name="search_mode" class="select select-sm select-bordered" x-model="mode">
-            <option value="contains">Contains</option>
-            <option value="words">All words</option>
-            <option value="fuzzy">Fuzzy match</option>
-          </select>
-        </div>
-        <p class="text-[0.65rem] text-base-content/30 mt-2" x-show="mode === 'contains'" x-cloak>Substring match — finds transactions containing the exact text</p>
-        <p class="text-[0.65rem] text-base-content/30 mt-2" x-show="mode === 'words'" x-cloak>Matches each word independently — "Century Link" finds "CenturyLink"</p>
-        <p class="text-[0.65rem] text-base-content/30 mt-2" x-show="mode === 'fuzzy'" x-cloak>Typo-tolerant similarity — finds close matches even with misspellings</p>
-      </div>
-
-      <div class="bb-filter-actions">
-        <a href="/transactions" class="btn btn-sm btn-ghost rounded-xl">Reset</a>
-        <button type="submit" class="btn btn-sm btn-primary rounded-xl">
-          <i data-lucide="search" class="w-3.5 h-3.5"></i>
-          Apply Filters
-        </button>
-      </div>
-    </form>
-  </div>
-</div>
-
-{{if .Transactions}}
-
-<div x-data class="space-y-1">
-  <!-- Selection toggle + quick search header -->
-  <div class="flex items-center gap-3 px-2 pb-2">
-    <!-- Selection mode toggle -->
-    <button type="button" @click="$store.bulk.toggleMode()"
-      class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-xs"
-      :class="$store.bulk.selecting && 'bg-primary/10 text-primary'"
-      title="Toggle selection mode">
-      <i data-lucide="list-checks" class="w-3.5 h-3.5"></i>
-      <span class="hidden sm:inline" x-text="$store.bulk.selecting ? 'Done' : 'Select'"></span>
-    </button>
-    <!-- Select all (visible in selection mode) -->
-    <label x-show="$store.bulk.selecting" x-cloak class="flex items-center gap-2 cursor-pointer" @click.stop>
-      <input type="checkbox" class="checkbox checkbox-sm checkbox-primary"
-        :checked="$store.bulk.sel.length === window.__bbTxMeta.length && window.__bbTxMeta.length > 0"
-        :indeterminate="$store.bulk.sel.length > 0 && $store.bulk.sel.length < window.__bbTxMeta.length"
-        @change="$store.bulk.toggleAll()">
-      <span class="text-xs text-base-content/40">Select all</span>
-    </label>
-    <div class="flex-1"></div>
-    <div class="relative" x-data="quickSearch()">
-      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
+      x-transition:leave-start="opacity-100 translate-x-0"
+      x-transition:leave-end="opacity-0 -translate-x-4"
+      class="flex-1 relative">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
         class="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none z-10 transition-colors duration-150"
         :class="searching ? 'text-primary/50' : 'text-base-content/30'">
         <circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>
       </svg>
-      <input type="text" placeholder="Search all transactions..."
-        class="input input-sm input-bordered pl-9 pr-9 w-56 sm:w-64 rounded-xl text-xs bg-base-100 border-base-300 focus:border-primary/40 transition-all duration-200"
+      <input type="text" id="bb-quick-search" placeholder="Search transactions..."
+        class="input input-sm input-bordered pl-9 pr-9 w-full rounded-xl text-sm bg-base-100 border-base-300 focus:border-primary/40 transition-all duration-200"
         x-ref="searchInput"
         :value="query"
         @input="doSearch($event.target.value)"
@@ -212,6 +85,147 @@
         </button>
       </div>
     </div>
+
+    <!-- Filter toggle button (always pinned right) -->
+    <button type="button" class="btn btn-sm rounded-xl gap-2 shrink-0 ml-auto"
+      :class="filtersOpen ? 'btn-primary' : 'btn-ghost'"
+      @click="filtersOpen = !filtersOpen">
+      <i data-lucide="sliders-horizontal" class="w-3.5 h-3.5"></i>
+      <span>Filters</span>
+      {{if or .FilterStartDate .FilterEndDate .FilterAccountID .FilterUserID .FilterConnID .FilterCategory .FilterMinAmount .FilterMaxAmount .FilterPending .FilterSearch}}
+      <span class="badge badge-xs" :class="filtersOpen ? 'badge-primary-content' : 'badge-primary'">Active</span>
+      {{end}}
+      <i data-lucide="chevron-down" class="w-3.5 h-3.5 transition-transform duration-200" :class="filtersOpen && 'rotate-180'"></i>
+    </button>
+  </div>
+
+  <!-- Filter panel -->
+  <form method="GET" action="/transactions" x-show="filtersOpen" x-cloak
+    x-transition:enter="transition ease-out duration-200"
+    x-transition:enter-start="opacity-0 -translate-y-2"
+    x-transition:enter-end="opacity-100 translate-y-0"
+    x-transition:leave="transition ease-in duration-150"
+    x-transition:leave-start="opacity-100 translate-y-0"
+    x-transition:leave-end="opacity-0 -translate-y-2"
+    class="bb-card mt-3 p-4" x-data>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-3">
+      <label class="bb-filter-label">
+        Start Date
+        <input type="date" name="start_date" value="{{.FilterStartDate}}" class="input input-sm input-bordered w-full">
+      </label>
+      <label class="bb-filter-label">
+        End Date
+        <input type="date" name="end_date" value="{{.FilterEndDate}}" class="input input-sm input-bordered w-full">
+      </label>
+      <label class="bb-filter-label">
+        Connection
+        <select name="connection_id" class="select select-sm select-bordered w-full">
+          <option value="">All connections</option>
+          {{range .Connections}}
+          <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
+          {{end}}
+        </select>
+      </label>
+      <label class="bb-filter-label">
+        Account
+        <select name="account_id" class="select select-sm select-bordered w-full">
+          <option value="">All accounts</option>
+          {{range .Accounts}}
+          <option value="{{.ID}}"{{if eq .ID $.FilterAccountID}} selected{{end}}>{{accountLabel .Name .Mask}}</option>
+          {{end}}
+        </select>
+      </label>
+      <label class="bb-filter-label">
+        Family Member
+        <select name="user_id" class="select select-sm select-bordered w-full">
+          <option value="">All members</option>
+          {{range .Users}}
+          <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterUserID}} selected{{end}}>{{.Name}}</option>
+          {{end}}
+        </select>
+      </label>
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
+      <label class="bb-filter-label">
+        Category
+        <div class="bb-cat-picker" data-picker-source="tx-filter-cat" x-data="categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
+          <input type="hidden" name="category" x-ref="catInput" value="{{.FilterCategory}}">
+          <button type="button" class="select select-sm select-bordered w-full text-left flex items-center gap-2" @click="openPicker()">
+            <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+            <span x-text="displayLabel" class="text-sm truncate"></span>
+          </button>
+        </div>
+      </label>
+      <label class="bb-filter-label">
+        Min Amount
+        <input type="number" name="min_amount" step="0.01" value="{{.FilterMinAmount}}" placeholder="0.00" class="input input-sm input-bordered w-full">
+      </label>
+      <label class="bb-filter-label">
+        Max Amount
+        <input type="number" name="max_amount" step="0.01" value="{{.FilterMaxAmount}}" placeholder="0.00" class="input input-sm input-bordered w-full">
+      </label>
+      <label class="bb-filter-label">
+        Pending
+        <select name="pending" class="select select-sm select-bordered w-full">
+          <option value="">All</option>
+          <option value="true"{{if eq .FilterPending "true"}} selected{{end}}>Yes</option>
+          <option value="false"{{if eq .FilterPending "false"}} selected{{end}}>No</option>
+        </select>
+      </label>
+    </div>
+
+    <!-- Search within filters -->
+    <div class="border-t border-base-200 pt-4 mb-4" x-data="{ mode: '{{if .FilterSearchMode}}{{.FilterSearchMode}}{{else}}contains{{end}}' }">
+      <div class="grid grid-cols-1 sm:grid-cols-[1fr_auto_auto] gap-x-3 gap-y-1">
+        <div class="text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2 hidden sm:flex">
+          <i data-lucide="search" class="w-3.5 h-3.5 text-base-content/40"></i>
+          Search
+        </div>
+        <div class="text-[0.65rem] text-base-content/40 hidden sm:block">Search in</div>
+        <div class="text-[0.65rem] text-base-content/40 hidden sm:block">Match type</div>
+        <div class="text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2 sm:hidden mb-1">
+          <i data-lucide="search" class="w-3.5 h-3.5 text-base-content/40"></i>
+          Search
+        </div>
+        <input type="text" name="search" value="{{.FilterSearch}}" placeholder="Search transactions..." class="input input-sm input-bordered w-full">
+        <select name="search_field" class="select select-sm select-bordered">
+          <option value="all"{{if or (eq .FilterSearchField "all") (not .FilterSearchField)}} selected{{end}}>Name &amp; Merchant</option>
+          <option value="name"{{if eq .FilterSearchField "name"}} selected{{end}}>Name only</option>
+          <option value="merchant"{{if eq .FilterSearchField "merchant"}} selected{{end}}>Merchant only</option>
+        </select>
+        <select name="search_mode" class="select select-sm select-bordered" x-model="mode">
+          <option value="contains">Contains</option>
+          <option value="words">All words</option>
+          <option value="fuzzy">Fuzzy match</option>
+        </select>
+      </div>
+      <p class="text-[0.65rem] text-base-content/30 mt-2" x-show="mode === 'contains'" x-cloak>Substring match — finds transactions containing the exact text</p>
+      <p class="text-[0.65rem] text-base-content/30 mt-2" x-show="mode === 'words'" x-cloak>Matches each word independently — "Century Link" finds "CenturyLink"</p>
+      <p class="text-[0.65rem] text-base-content/30 mt-2" x-show="mode === 'fuzzy'" x-cloak>Typo-tolerant similarity — finds close matches even with misspellings</p>
+    </div>
+
+    <div class="bb-filter-actions">
+      <a href="/transactions" class="btn btn-sm btn-ghost rounded-xl">Reset</a>
+      <button type="submit" class="btn btn-sm btn-primary rounded-xl">
+        <i data-lucide="search" class="w-3.5 h-3.5"></i>
+        Apply Filters
+      </button>
+    </div>
+  </form>
+</div>
+
+{{if .Transactions}}
+
+<div x-data class="space-y-1">
+  <!-- Select all (visible in selection mode) -->
+  <div x-show="$store.bulk.selecting" x-cloak class="flex items-center gap-3 px-2 pb-2">
+    <label class="flex items-center gap-2 cursor-pointer" @click.stop>
+      <input type="checkbox" class="checkbox checkbox-sm checkbox-primary"
+        :checked="$store.bulk.sel.length === window.__bbTxMeta.length && window.__bbTxMeta.length > 0"
+        :indeterminate="$store.bulk.sel.length > 0 && $store.bulk.sel.length < window.__bbTxMeta.length"
+        @change="$store.bulk.toggleAll()">
+      <span class="text-xs text-base-content/40">Select all</span>
+    </label>
   </div>
 
   <div id="bb-tx-results">

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -63,14 +63,14 @@
       x-transition:leave="transition ease-in duration-150"
       x-transition:leave-start="opacity-100 translate-x-0"
       x-transition:leave-end="opacity-0 -translate-x-4"
-      class="flex-1 relative">
+      class="relative flex-1">
       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
         class="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none z-10 transition-colors duration-150"
         :class="searching ? 'text-primary/50' : 'text-base-content/30'">
         <circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/>
       </svg>
       <input type="text" id="bb-quick-search" placeholder="Search transactions..."
-        class="input input-sm input-bordered pl-9 pr-9 w-full rounded-xl text-sm bg-base-100 border-base-300 focus:border-primary/40 transition-all duration-200"
+        class="input input-bordered pl-9 pr-9 w-full rounded-xl text-sm bg-base-100 border-base-300 focus:border-primary/40 transition-all duration-200 h-10"
         x-ref="searchInput"
         :value="query"
         @input="doSearch($event.target.value)"
@@ -87,7 +87,7 @@
     </div>
 
     <!-- Filter toggle button (always pinned right) -->
-    <button type="button" class="btn btn-sm rounded-xl gap-2 shrink-0 ml-auto"
+    <button type="button" class="btn rounded-xl gap-2 shrink-0 ml-auto h-10 min-h-0 px-4"
       :class="filtersOpen ? 'btn-primary' : 'btn-ghost'"
       @click="filtersOpen = !filtersOpen">
       <i data-lucide="sliders-horizontal" class="w-3.5 h-3.5"></i>
@@ -217,15 +217,27 @@
 {{if .Transactions}}
 
 <div x-data class="space-y-1">
-  <!-- Select all (visible in selection mode) -->
-  <div x-show="$store.bulk.selecting" x-cloak class="flex items-center gap-3 px-2 pb-2">
-    <label class="flex items-center gap-2 cursor-pointer" @click.stop>
-      <input type="checkbox" class="checkbox checkbox-sm checkbox-primary"
-        :checked="$store.bulk.sel.length === window.__bbTxMeta.length && window.__bbTxMeta.length > 0"
-        :indeterminate="$store.bulk.sel.length > 0 && $store.bulk.sel.length < window.__bbTxMeta.length"
-        @change="$store.bulk.toggleAll()">
-      <span class="text-xs text-base-content/40">Select all</span>
-    </label>
+  <!-- Toolbar: select-all + keyboard hints -->
+  <div class="flex items-center gap-3 px-2 pb-2">
+    <!-- Select all (visible in selection mode) -->
+    <div x-show="$store.bulk.selecting" x-cloak>
+      <label class="flex items-center gap-2 cursor-pointer" @click.stop>
+        <input type="checkbox" class="checkbox checkbox-sm checkbox-primary"
+          :checked="$store.bulk.sel.length === window.__bbTxMeta.length && window.__bbTxMeta.length > 0"
+          :indeterminate="$store.bulk.sel.length > 0 && $store.bulk.sel.length < window.__bbTxMeta.length"
+          @change="$store.bulk.toggleAll()">
+        <span class="text-xs text-base-content/40">Select all</span>
+      </label>
+    </div>
+    <div class="flex-1"></div>
+    <!-- Keyboard shortcuts (desktop only) -->
+    <div class="hidden sm:flex items-center gap-2 text-xs text-base-content/30">
+      <span class="flex items-center gap-1"><kbd class="bb-kbd">j</kbd><kbd class="bb-kbd">k</kbd> navigate</span>
+      <span class="flex items-center gap-1"><kbd class="bb-kbd">Enter</kbd> open</span>
+      <span class="flex items-center gap-1"><kbd class="bb-kbd">c</kbd> category</span>
+      <span class="flex items-center gap-1"><kbd class="bb-kbd">e</kbd> expand</span>
+      <span class="flex items-center gap-1"><kbd class="bb-kbd">x</kbd> select</span>
+    </div>
   </div>
 
   <div id="bb-tx-results">
@@ -660,6 +672,99 @@ document.addEventListener('alpine:init', function() {
         self.processing = false;
         window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Network error', type:'error'}}));
       });
+    }
+  });
+
+  /* ── Alpine Store: Keyboard Navigation ── */
+  Alpine.store('txNav', {
+    focusedIdx: -1,
+
+    _getRows() {
+      return Array.from(document.querySelectorAll('.bb-tx-row:not([style*="display: none"])'));
+    },
+
+    _updateFocus(oldIdx) {
+      var rows = this._getRows();
+      if (oldIdx >= 0 && rows[oldIdx]) rows[oldIdx].classList.remove('bb-tx-row--focused');
+      if (this.focusedIdx >= 0 && rows[this.focusedIdx]) {
+        rows[this.focusedIdx].classList.add('bb-tx-row--focused');
+        rows[this.focusedIdx].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      }
+    },
+
+    next() {
+      var rows = this._getRows();
+      if (!rows.length) return;
+      var old = this.focusedIdx;
+      this.focusedIdx = Math.min(this.focusedIdx + 1, rows.length - 1);
+      this._updateFocus(old);
+    },
+
+    prev() {
+      var rows = this._getRows();
+      if (!rows.length) return;
+      var old = this.focusedIdx;
+      this.focusedIdx = Math.max(this.focusedIdx - 1, 0);
+      this._updateFocus(old);
+    },
+
+    openDetail() {
+      var row = this._getRows()[this.focusedIdx];
+      if (!row) return;
+      var link = row.querySelector('a[href*="/transactions/"]');
+      if (link) window.location.href = link.href;
+    },
+
+    openCategorize() {
+      var row = this._getRows()[this.focusedIdx];
+      if (!row) return;
+      var btn = row.querySelector('.bb-cat-picker button');
+      if (btn) btn.click();
+    },
+
+    toggleExpand() {
+      var row = this._getRows()[this.focusedIdx];
+      if (!row) return;
+      var main = row.querySelector('.cursor-pointer');
+      if (main) main.click();
+    },
+
+    toggleSelect() {
+      var row = this._getRows()[this.focusedIdx];
+      if (!row) return;
+      var link = row.querySelector('a[href*="/transactions/"]');
+      if (!link) return;
+      var id = link.href.split('/').pop();
+      if (!Alpine.store('bulk').selecting) Alpine.store('bulk').toggleMode();
+      Alpine.store('bulk').toggle(id);
+    },
+
+    clearFocus() {
+      var rows = this._getRows();
+      if (this.focusedIdx >= 0 && rows[this.focusedIdx]) {
+        rows[this.focusedIdx].classList.remove('bb-tx-row--focused');
+      }
+      this.focusedIdx = -1;
+    }
+  });
+
+  // Keyboard handler
+  document.addEventListener('keydown', function(e) {
+    if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.tagName === 'SELECT') return;
+    if (document.querySelector('.bb-cat-overlay[style*="block"]')) return;
+
+    var nav = Alpine.store('txNav');
+    switch(e.key) {
+      case 'j': e.preventDefault(); nav.next(); break;
+      case 'k': e.preventDefault(); nav.prev(); break;
+      case 'Enter': if (nav.focusedIdx >= 0) { e.preventDefault(); nav.openDetail(); } break;
+      case 'c': if (nav.focusedIdx >= 0) { e.preventDefault(); nav.openCategorize(); } break;
+      case 'e': if (nav.focusedIdx >= 0) { e.preventDefault(); nav.toggleExpand(); } break;
+      case 'x': if (nav.focusedIdx >= 0) { e.preventDefault(); nav.toggleSelect(); } break;
+      case 'Escape':
+        if (nav.focusedIdx >= 0) { nav.clearFocus(); }
+        else if (Alpine.store('bulk').selecting) { Alpine.store('bulk').toggleMode(); }
+        break;
     }
   });
 });

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -7,8 +7,8 @@
   :class="$store.bulk.isIn('{{.ID}}') && 'bg-primary/5'">
   <!-- Main Row -->
   <div class="flex items-center gap-3 px-4 py-3 cursor-pointer" @click="expanded = !expanded">
-    <!-- Checkbox -->
-    <label class="flex items-center shrink-0 cursor-pointer" @click.stop>
+    <!-- Checkbox (selection mode only) -->
+    <label x-show="$store.bulk.selecting" x-cloak class="flex items-center shrink-0 cursor-pointer" @click.stop>
       <input type="checkbox" class="checkbox checkbox-sm checkbox-primary"
         :checked="$store.bulk.isIn('{{.ID}}')"
         @change="$store.bulk.toggle('{{.ID}}')">


### PR DESCRIPTION
## Summary
- **Selection mode toggle**: Replace always-visible checkboxes with a Select/Done button in page header. Floating bulk bar stays visible throughout selection mode. Checkboxes only appear when toggled on.
- **Search + filters unification**: Quick search bar and Filters button sit side-by-side. Opening filters collapses the search bar and transfers the search term. Prevents both being active simultaneously.
- **Keyboard navigation**: j/k to navigate rows, Enter to open, c for category, e to expand, x to select. Focused row gets a left accent highlight. Escape layers: clear focus → exit selection mode.
- **Hybrid search fix**: Align client-side matching to server (name + merchant only). Fix divide-y border artifact on locally-filtered rows. Execute inline scripts after innerHTML swap for correct select-all behavior.
- **Shortcut hints**: Desktop-only keyboard shortcut bar above results using `bb-kbd` styling.

## Test plan
- [ ] Toggle selection mode via header button, verify checkboxes appear/disappear
- [ ] Use j/k to navigate rows, verify focus highlight moves correctly
- [ ] Press Enter on focused row to navigate to detail page
- [ ] Press c on focused row to open category picker
- [ ] Press e to expand/collapse row detail
- [ ] Press x to select (auto-enters selection mode)
- [ ] Escape clears focus first, then exits selection mode on second press
- [ ] Quick search filters locally, server results match without pixel jumping
- [ ] Opening filters collapses search bar, term transfers to advanced search
- [ ] Keyboard hints visible on desktop, hidden on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)