### PR TITLE
Fix sync engine overwriting reviewed categories and re-firing reviews

### DIFF
--- a/internal/db/queries/reviews.sql
+++ b/internal/db/queries/reviews.sql
@@ -1,6 +1,9 @@
 -- name: EnqueueReview :one
 INSERT INTO review_queue (transaction_id, review_type, suggested_category_id, confidence_score)
-VALUES ($1, $2, $3, $4)
+SELECT $1, $2, $3, $4
+WHERE NOT EXISTS (
+  SELECT 1 FROM review_queue WHERE transaction_id = $1
+)
 ON CONFLICT (transaction_id) WHERE status = 'pending' DO NOTHING
 RETURNING *;
 

--- a/internal/db/queries/transactions.sql
+++ b/internal/db/queries/transactions.sql
@@ -27,7 +27,11 @@ ON CONFLICT (external_transaction_id) DO UPDATE SET
   category_confidence = EXCLUDED.category_confidence,
   payment_channel = EXCLUDED.payment_channel,
   pending = EXCLUDED.pending,
-  category_id = CASE WHEN transactions.category_override THEN transactions.category_id ELSE EXCLUDED.category_id END,
+  category_id = CASE
+    WHEN transactions.category_override THEN transactions.category_id
+    WHEN EXCLUDED.category_id IS NOT NULL THEN EXCLUDED.category_id
+    ELSE transactions.category_id
+  END,
   deleted_at = NULL,
   updated_at = CASE
     WHEN transactions.amount IS DISTINCT FROM EXCLUDED.amount

--- a/internal/db/reviews.sql.go
+++ b/internal/db/reviews.sql.go
@@ -83,7 +83,10 @@ func (q *Queries) DeleteReview(ctx context.Context, id pgtype.UUID) error {
 
 const enqueueReview = `-- name: EnqueueReview :one
 INSERT INTO review_queue (transaction_id, review_type, suggested_category_id, confidence_score)
-VALUES ($1, $2, $3, $4)
+SELECT $1, $2, $3, $4
+WHERE NOT EXISTS (
+  SELECT 1 FROM review_queue WHERE transaction_id = $1
+)
 ON CONFLICT (transaction_id) WHERE status = 'pending' DO NOTHING
 RETURNING id, transaction_id, review_type, status, suggested_category_id, confidence_score, reviewer_type, reviewer_id, reviewer_name, review_note, resolved_category_id, created_at, reviewed_at
 `

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -327,7 +327,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 			} else {
 				unchanged++
 			}
-			if reviewAutoEnqueue {
+			if reviewAutoEnqueue && (isNew || isChanged) {
 				e.enqueueForReview(ctx, txQueries, txnResult, isNew, confidenceThreshold, resolver)
 			}
 			if isNew {
@@ -363,7 +363,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				unchanged++
 				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "unchanged")
 			}
-			if reviewAutoEnqueue {
+			if reviewAutoEnqueue && isChanged {
 				e.enqueueForReview(ctx, txQueries, txnResult, false, confidenceThreshold, resolver)
 			}
 		}
@@ -451,7 +451,16 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 		if txn.CategoryDetailed != nil {
 			tctx.CategoryDetailed = *txn.CategoryDetailed
 		}
-		categoryID = resolver.ResolveWithContext(providerName, tctx)
+		resolved := resolver.ResolveWithContext(providerName, tctx)
+		// Only pass the category_id when a rule explicitly matched.
+		// When no rule matches, the resolver returns uncategorizedID — pass nil
+		// instead so the upsert SQL preserves the existing category for
+		// existing rows (avoids overwriting categories set by reviews/agents).
+		// New rows will get NULL category_id, which enqueueForReview catches
+		// and flags as "uncategorized" for review.
+		if resolved != resolver.UncategorizedID() {
+			categoryID = resolved
+		}
 	}
 
 	params := db.UpsertTransactionParams{


### PR DESCRIPTION
## Summary
- After PR #214 removed category mappings, transactions categorized via mappings (without `category_override`) were silently overwritten to "uncategorized" on every sync
- The partial unique index on `review_queue` only prevented duplicate *pending* reviews — resolved reviews didn't block new ones, causing every sync to re-create reviews for already-reviewed transactions
- Unchanged Teller transactions (returned every sync via date-range polling) were needlessly re-evaluated for review enqueue

## Changes
- **Upsert SQL**: Preserve existing `category_id` when the resolver passes NULL (no rule matched), only overwrite when a rule explicitly matches
- **Engine**: Pass nil `category_id` instead of the uncategorized fallback UUID so existing rows keep their category
- **Engine**: Guard `enqueueForReview` calls with `isNew || isChanged` to skip unchanged transactions
- **EnqueueReview SQL**: Add `NOT EXISTS` check to prevent creating reviews for transactions that already have any review (pending or resolved)

## Test plan
- [x] Unit tests pass (`go test ./...`)
- [x] Integration tests pass (`make test-integration`)
- [ ] Deploy to dev and verify sync no longer re-fires reviews for existing transactions
- [ ] Verify transactions previously categorized by mappings retain their categories after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)