### PR TITLE
Fix command palette icons disappearing after search

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -709,6 +709,11 @@
 
         onInput() {
           this.activeIndex = 0;
+          var self = this;
+          setTimeout(function() {
+            var dialog = document.querySelector('.bb-cmdk-dialog');
+            if (dialog) lucide.createIcons({ nodes: [dialog] });
+          }, 10);
         },
 
         moveDown() {


### PR DESCRIPTION
## Summary
- Command palette (Cmd+K) icons disappeared when typing a search query and then clearing it
- Root cause: Alpine re-renders the `x-for` template with fresh `<i data-lucide>` elements on each filter change, but `lucide.createIcons()` was only called once on palette open
- Fix: call `lucide.createIcons()` in `onInput()` after a short delay for Alpine to finish re-rendering

## Test plan
- [x] Open command palette, verify icons show
- [x] Type a search term, verify filtered results still have icons
- [x] Clear the search, verify all icons reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)