### PR TITLE
Fix mobile triage queue truncated transaction names

### DIFF
--- a/input.css
+++ b/input.css
@@ -1675,7 +1675,7 @@
   }
 
   .bb-triage-row__main {
-    @apply flex items-center gap-3 px-4 py-2.5;
+    @apply flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2.5;
     min-height: 2.75rem;
   }
 
@@ -1764,11 +1764,17 @@
 
   .bb-triage-row__amount {
     @apply shrink-0 text-right;
-    width: 90px;
+    width: 80px;
+  }
+
+  @media (min-width: 640px) {
+    .bb-triage-row__amount {
+      width: 90px;
+    }
   }
 
   .bb-triage-row__actions {
-    @apply flex items-center gap-1 shrink-0 ml-2;
+    @apply hidden sm:flex items-center gap-1 shrink-0 ml-2;
     opacity: 0;
     transition: opacity 0.15s ease;
   }
@@ -1845,7 +1851,7 @@
 
   /* Triage detail panel */
   .bb-triage-detail {
-    @apply px-6 py-4 border-t;
+    @apply px-3 sm:px-6 py-4 border-t;
     border-color: oklch(0.94 0 0);
     background: oklch(0.985 0 0);
   }

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -237,7 +237,7 @@
       {{end}}
     </div>
     {{if eq .StatusFilter "pending"}}
-    <div class="flex items-center gap-2 text-xs text-base-content/30">
+    <div class="hidden sm:flex items-center gap-2 text-xs text-base-content/30">
       <span class="flex items-center gap-1"><kbd class="bb-kbd">j</kbd><kbd class="bb-kbd">k</kbd> navigate</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">a</kbd> accept</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">s</kbd> skip</span>


### PR DESCRIPTION
## Summary
- **Root cause:** The inline action buttons (accept/skip/dismiss) in triage rows were hidden via `opacity: 0` but still consumed 92px of layout space. On a 390px mobile screen, this left only ~46px for transaction names, causing severe truncation ("Dollar Tree" -> "Doll...", "Purchase Return" -> "Purc...")
- **Fix:** Hide inline actions entirely on mobile (`hidden sm:flex`) since the expanded detail panel already provides full action buttons. Also reduced amount column width (90px -> 80px), tightened row padding/gaps, and hid keyboard shortcut hints (not useful on touch devices)
- **Result:** Transaction names now display in full on mobile (e.g., "Purchase Return" / "WALMART" instead of "Purc..." / "WAL...")

## Screenshots

### After fix — focused card with full names
![Mobile triage after](https://i.img402.dev/srgz68quw9.png)

### After fix — queue items showing full names
![Mobile triage queue](https://i.img402.dev/s781qyj6wp.png)

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent