### PR TITLE
Fix dashboard mobile: hide wrapping category text

### DIFF
--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -263,15 +263,15 @@
               {{end}}
               <span>{{.AccountName}} · {{formatDate .Date}}</span>
               {{if .CategoryDisplayName}}
-              <span class="text-base-content/20">&middot;</span>
-              <span class="inline-flex items-center gap-1">
+              <span class="hidden sm:inline text-base-content/20">&middot;</span>
+              <span class="hidden sm:inline-flex items-center gap-1">
                 <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
                 <span class="text-base-content/50">{{deref .CategoryDisplayName}}</span>
               </span>
               {{end}}
               {{if .AgentReviewed}}
-              <span class="text-base-content/20">&middot;</span>
-              <span class="inline-flex items-center gap-0.5 text-primary/60" title="Categorized by AI agent">
+              <span class="hidden sm:inline text-base-content/20">&middot;</span>
+              <span class="hidden sm:inline-flex items-center gap-0.5 text-primary/60" title="Categorized by AI agent">
                 <i data-lucide="bot" class="w-3 h-3"></i>
               </span>
               {{end}}


### PR DESCRIPTION
## Summary
- Hide category name and agent-reviewed indicator in dashboard Recent Transactions on mobile (below 640px breakpoint)
- Category text like "Other Transfer Out" was wrapping to 2-3 lines on narrow screens, causing inconsistent row heights and visual clutter
- Desktop view is unchanged — category dot + name still visible on sm+ screens

## Screenshots

### Mobile (after — clean single-line rows)
![mobile after](https://i.img402.dev/ffoufhsz6v.png)

### Desktop (unchanged — categories still visible)
![desktop after](https://i.img402.dev/of7t7ogfvl.png)

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent