### PR TITLE
Fix connections mobile: invisible bank names

### DIFF
--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -41,97 +41,102 @@
   <div class="bb-card overflow-hidden">
     <!-- Connection Header — clickable -->
     <a href="/connections/{{formatUUID .ID}}" class="block no-underline group">
-      <div class="px-6 py-5 flex items-center justify-between gap-4">
-        <div class="flex items-center gap-4 min-w-0">
-          <div class="w-10 h-10 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-            {{if eq (printf "%s" .Provider) "plaid"}}
-            <i data-lucide="building-2" class="w-5 h-5 text-info"></i>
-            {{else if eq (printf "%s" .Provider) "teller"}}
-            <i data-lucide="landmark" class="w-5 h-5 text-success"></i>
+      <div class="px-6 py-5">
+        <!-- Mobile: stacked layout / Desktop: side-by-side -->
+        <div class="flex items-start sm:items-center justify-between gap-4">
+          <div class="flex items-start sm:items-center gap-3 sm:gap-4 min-w-0">
+            <div class="w-10 h-10 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+              {{if eq (printf "%s" .Provider) "plaid"}}
+              <i data-lucide="building-2" class="w-5 h-5 text-info"></i>
+              {{else if eq (printf "%s" .Provider) "teller"}}
+              <i data-lucide="landmark" class="w-5 h-5 text-success"></i>
+              {{else}}
+              <i data-lucide="file-spreadsheet" class="w-5 h-5 text-warning"></i>
+              {{end}}
+            </div>
+            <div class="min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <h3 class="font-semibold text-base group-hover:text-primary transition-colors">{{.InstitutionName.String}}</h3>
+                <div class="flex items-center gap-1.5 shrink-0">
+                  {{statusBadge (printf "%s" .Status)}}
+                  {{if .Paused}}<span class="badge badge-ghost badge-xs">Paused</span>{{end}}
+                  {{if gt .ConsecutiveFailures 0}}
+                  <span class="badge badge-warning badge-xs gap-1" title="{{.ConsecutiveFailures}} consecutive sync failure{{if ne .ConsecutiveFailures 1}}s{{end}}{{if .LastErrorAt.Valid}} — last error {{relativeTime .LastErrorAt.Time}}{{end}}">
+                    <i data-lucide="alert-triangle" class="w-2.5 h-2.5"></i>
+                    {{.ConsecutiveFailures}} fail{{if ne .ConsecutiveFailures 1}}s{{end}}
+                  </span>
+                  {{end}}
+                </div>
+              </div>
+              <div class="flex items-center gap-3 text-xs text-base-content/50 mt-0.5 flex-wrap">
+                <span>{{.UserName.String}}</span>
+                <span class="text-base-content/20">&middot;</span>
+                <span class="capitalize">{{printf "%s" .Provider}}</span>
+                <span class="text-base-content/20">&middot;</span>
+                {{if .LastSyncedAt.Valid}}
+                <span class="inline-flex items-center gap-1.5">
+                  {{if eq .LastSyncStatus "success"}}<i data-lucide="check-circle" class="w-3 h-3 text-success"></i>
+                  {{else if eq .LastSyncStatus "error"}}<i data-lucide="x-circle" class="w-3 h-3 text-error"></i>
+                  {{else if eq .LastSyncStatus "in_progress"}}<i data-lucide="loader" class="w-3 h-3 text-warning animate-spin"></i>
+                  {{end}}
+                  <span>Synced {{relativeTime .LastSyncedAt.Time}}</span>
+                  {{if and (ne .LastSyncStatus "in_progress") (gt .LastSyncDurationMs 0)}}
+                  <span class="text-base-content/30">({{formatDurationMs .LastSyncDurationMs}})</span>
+                  {{end}}
+                </span>
+                {{if and (ne .LastSyncStatus "") (or (gt .LastSyncAdded 0) (gt .LastSyncModified 0) (gt .LastSyncRemoved 0))}}
+                <span class="text-base-content/20">&middot;</span>
+                <span class="inline-flex items-center gap-1">
+                  {{if gt .LastSyncAdded 0}}<span class="text-success/70">+{{.LastSyncAdded}}</span>{{end}}
+                  {{if gt .LastSyncModified 0}}<span class="text-info/70">~{{.LastSyncModified}}</span>{{end}}
+                  {{if gt .LastSyncRemoved 0}}<span class="text-error/70">-{{.LastSyncRemoved}}</span>{{end}}
+                </span>
+                {{end}}
+                {{if and (not .NextSync.IsDisconnected) (not .NextSync.IsPaused)}}
+                <span class="text-base-content/20">&middot;</span>
+                <span class="{{if .NextSync.IsOverdue}}text-info{{end}}" title="Sync interval: {{formatIntervalMinutes .NextSync.EffectiveIntervalMinutes}}">
+                  <i data-lucide="clock" class="w-3 h-3 inline-block align-[-2px] mr-0.5"></i>Next {{.NextSync.Label}}
+                </span>
+                {{end}}
+                {{else}}
+                <span>Never synced</span>
+                {{end}}
+              </div>
+            </div>
+          </div>
+          <div class="flex items-center gap-3 shrink-0">
+            <!-- Sync Now button (non-CSV active connections only) -->
+            {{if and (ne (printf "%s" .Provider) "csv") (eq (printf "%s" .Status) "active")}}
+            <div x-data="syncBtn('{{formatUUID .ID}}')" @click.prevent.stop>
+              <button class="btn btn-ghost btn-xs rounded-lg gap-1 text-base-content/40 hover:text-primary"
+                      :disabled="state !== 'idle'"
+                      @click="triggerSync()"
+                      :title="state === 'syncing' ? 'Syncing...' : 'Sync Now'">
+                <template x-if="state === 'idle'">
+                  <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
+                </template>
+                <template x-if="state === 'syncing'">
+                  <span class="loading loading-spinner loading-xs"></span>
+                </template>
+                <template x-if="state === 'done'">
+                  <i data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
+                </template>
+                <span class="hidden sm:inline text-xs" x-text="state === 'syncing' ? 'Syncing...' : state === 'done' ? 'Synced!' : 'Sync'"></span>
+              </button>
+            </div>
+            {{end}}
+            <!-- Connection total balance -->
+            {{if .HasBalance}}
+            <div class="text-right">
+              <div class="text-lg font-semibold tabular-nums tracking-tight">{{formatAmount .TotalBalance}}</div>
+              <div class="text-xs text-base-content/40">{{.AccountCount}} account{{if ne .AccountCount 1}}s{{end}}</div>
+            </div>
             {{else}}
-            <i data-lucide="file-spreadsheet" class="w-5 h-5 text-warning"></i>
+            <div class="text-right">
+              <div class="text-xs text-base-content/40">{{.AccountCount}} account{{if ne .AccountCount 1}}s{{end}}</div>
+            </div>
             {{end}}
           </div>
-          <div class="min-w-0">
-            <div class="flex items-center gap-2">
-              <h3 class="font-semibold text-base group-hover:text-primary transition-colors truncate">{{.InstitutionName.String}}</h3>
-              {{statusBadge (printf "%s" .Status)}}
-              {{if .Paused}}<span class="badge badge-ghost badge-xs">Paused</span>{{end}}
-              {{if gt .ConsecutiveFailures 0}}
-              <span class="badge badge-warning badge-xs gap-1" title="{{.ConsecutiveFailures}} consecutive sync failure{{if ne .ConsecutiveFailures 1}}s{{end}}{{if .LastErrorAt.Valid}} — last error {{relativeTime .LastErrorAt.Time}}{{end}}">
-                <i data-lucide="alert-triangle" class="w-2.5 h-2.5"></i>
-                {{.ConsecutiveFailures}} fail{{if ne .ConsecutiveFailures 1}}s{{end}}
-              </span>
-              {{end}}
-            </div>
-            <div class="flex items-center gap-3 text-xs text-base-content/50 mt-0.5 flex-wrap">
-              <span>{{.UserName.String}}</span>
-              <span class="text-base-content/20">&middot;</span>
-              <span class="capitalize">{{printf "%s" .Provider}}</span>
-              <span class="text-base-content/20">&middot;</span>
-              {{if .LastSyncedAt.Valid}}
-              <span class="inline-flex items-center gap-1.5">
-                {{if eq .LastSyncStatus "success"}}<i data-lucide="check-circle" class="w-3 h-3 text-success"></i>
-                {{else if eq .LastSyncStatus "error"}}<i data-lucide="x-circle" class="w-3 h-3 text-error"></i>
-                {{else if eq .LastSyncStatus "in_progress"}}<i data-lucide="loader" class="w-3 h-3 text-warning animate-spin"></i>
-                {{end}}
-                <span>Synced {{relativeTime .LastSyncedAt.Time}}</span>
-                {{if and (ne .LastSyncStatus "in_progress") (gt .LastSyncDurationMs 0)}}
-                <span class="text-base-content/30">({{formatDurationMs .LastSyncDurationMs}})</span>
-                {{end}}
-              </span>
-              {{if and (ne .LastSyncStatus "") (or (gt .LastSyncAdded 0) (gt .LastSyncModified 0) (gt .LastSyncRemoved 0))}}
-              <span class="text-base-content/20">&middot;</span>
-              <span class="inline-flex items-center gap-1">
-                {{if gt .LastSyncAdded 0}}<span class="text-success/70">+{{.LastSyncAdded}}</span>{{end}}
-                {{if gt .LastSyncModified 0}}<span class="text-info/70">~{{.LastSyncModified}}</span>{{end}}
-                {{if gt .LastSyncRemoved 0}}<span class="text-error/70">-{{.LastSyncRemoved}}</span>{{end}}
-              </span>
-              {{end}}
-              {{if and (not .NextSync.IsDisconnected) (not .NextSync.IsPaused)}}
-              <span class="text-base-content/20">&middot;</span>
-              <span class="{{if .NextSync.IsOverdue}}text-info{{end}}" title="Sync interval: {{formatIntervalMinutes .NextSync.EffectiveIntervalMinutes}}">
-                <i data-lucide="clock" class="w-3 h-3 inline-block align-[-2px] mr-0.5"></i>Next {{.NextSync.Label}}
-              </span>
-              {{end}}
-              {{else}}
-              <span>Never synced</span>
-              {{end}}
-            </div>
-          </div>
-        </div>
-        <div class="flex items-center gap-3 shrink-0">
-          <!-- Sync Now button (non-CSV active connections only) -->
-          {{if and (ne (printf "%s" .Provider) "csv") (eq (printf "%s" .Status) "active")}}
-          <div x-data="syncBtn('{{formatUUID .ID}}')" @click.prevent.stop>
-            <button class="btn btn-ghost btn-xs rounded-lg gap-1 text-base-content/40 hover:text-primary"
-                    :disabled="state !== 'idle'"
-                    @click="triggerSync()"
-                    :title="state === 'syncing' ? 'Syncing...' : 'Sync Now'">
-              <template x-if="state === 'idle'">
-                <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
-              </template>
-              <template x-if="state === 'syncing'">
-                <span class="loading loading-spinner loading-xs"></span>
-              </template>
-              <template x-if="state === 'done'">
-                <i data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
-              </template>
-              <span class="hidden sm:inline text-xs" x-text="state === 'syncing' ? 'Syncing...' : state === 'done' ? 'Synced!' : 'Sync'"></span>
-            </button>
-          </div>
-          {{end}}
-          <!-- Connection total balance -->
-          {{if .HasBalance}}
-          <div class="text-right">
-            <div class="text-lg font-semibold tabular-nums tracking-tight">{{formatAmount .TotalBalance}}</div>
-            <div class="text-xs text-base-content/40">{{.AccountCount}} account{{if ne .AccountCount 1}}s{{end}}</div>
-          </div>
-          {{else}}
-          <div class="text-right">
-            <div class="text-xs text-base-content/40">{{.AccountCount}} account{{if ne .AccountCount 1}}s{{end}}</div>
-          </div>
-          {{end}}
         </div>
       </div>
     </a>


### PR DESCRIPTION
## Summary
- Connection card headers on mobile had bank names (e.g., "Wells Fargo", "Chase") completely invisible due to CSS `truncate` shrinking the name to zero width when badges and the balance column consumed all horizontal space
- Replaced `truncate` with `flex-wrap` on the name+badge row so the institution name wraps naturally on narrow screens
- Grouped status badges into a `shrink-0` container and aligned items to `items-start` on mobile for clean vertical stacking

## Screenshots

**Desktop (no regression):**
![Desktop connections](https://i.img402.dev/7gij5jx4zv.png)

**Mobile after fix** - bank names now visible:
The fix makes "Wells Fargo", "AMEX Platinum", "CapitalOne", and "Chase" all visible on mobile, where previously they were truncated to nothing. Badges wrap below the name instead of pushing it off-screen.

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent