### PR TITLE
Fix agent reports expand/collapse reactivity bug

### DIFF
--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -538,7 +538,7 @@
   <div class="divide-y divide-base-200/60">
     {{range .AgentReports}}
     <div class="transition-all duration-300"
-      :class="dismissed.has('{{.ID}}') ? 'opacity-0 h-0 overflow-hidden' : ''"
+      :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden' : ''"
       id="report-{{.ID}}">
       <!-- Message card -->
       <div class="px-5 py-3.5 hover:bg-base-200/20 transition-colors cursor-pointer" @click="toggle('{{.ID}}')">
@@ -560,14 +560,14 @@
           <!-- Actions -->
           <div class="flex items-center gap-1.5 shrink-0">
             <i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/25 transition-transform duration-200"
-              :class="expanded.has('{{.ID}}') ? 'rotate-180' : ''"></i>
+              :class="expanded['{{.ID}}'] ? 'rotate-180' : ''"></i>
             <button @click.stop="markRead('{{.ID}}')" class="btn btn-success btn-ghost btn-xs rounded-lg cursor-pointer" title="Mark as read">
               <i data-lucide="check" class="w-4 h-4"></i>
             </button>
           </div>
         </div>
         <!-- Expanded detail -->
-        <div x-show="expanded.has('{{.ID}}')" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
+        <div x-show="expanded['{{.ID}}']" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
           x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
           x-cloak class="mt-3 ml-5 pl-3 border-l-2 border-base-200/60">
           <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
@@ -611,24 +611,24 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function agentReports() {
   return {
-    dismissed: new Set(),
-    expanded: new Set(),
+    dismissed: {},
+    expanded: {},
     toggle(id) {
-      if (this.expanded.has(id)) {
-        this.expanded.delete(id);
+      if (this.expanded[id]) {
+        delete this.expanded[id];
       } else {
-        this.expanded.add(id);
+        this.expanded[id] = true;
       }
     },
     markRead(id) {
-      this.dismissed.add(id);
+      this.dismissed[id] = true;
       fetch('/-/reports/' + id + '/read', { method: 'POST' });
     },
     markAllRead() {
       var self = this;
       document.querySelectorAll('[id^="report-"]').forEach(function(el) {
         var id = el.id.replace('report-', '');
-        self.dismissed.add(id);
+        self.dismissed[id] = true;
       });
       fetch('/-/reports/read-all', { method: 'POST' });
     }

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -26,7 +26,7 @@
 <div class="space-y-4 bb-stagger" x-data="reportsPage()">
   {{range .Reports}}
   <div class="bb-card transition-all duration-300 {{if not .IsRead}}border-l-2 border-l-primary/40{{end}}"
-    :class="dismissed.has('{{.ID}}') ? 'opacity-0 h-0 overflow-hidden !p-0 !m-0 !border-0' : ''"
+    :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !p-0 !m-0 !border-0' : ''"
     id="report-{{.ID}}">
     <!-- Message -->
     <div class="px-5 py-3.5 hover:bg-base-200/20 transition-colors cursor-pointer" @click="toggle('{{.ID}}')">
@@ -59,11 +59,11 @@
           </button>
           {{end}}
           <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/25 transition-transform duration-200"
-            :class="expanded.has('{{.ID}}') ? 'rotate-180' : ''"></i>
+            :class="expanded['{{.ID}}'] ? 'rotate-180' : ''"></i>
         </div>
       </div>
       <!-- Expanded detail -->
-      <div x-show="expanded.has('{{.ID}}')" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
+      <div x-show="expanded['{{.ID}}']" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
         x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
         x-cloak @click.stop class="mt-3 ml-5 pl-3 border-l-2 border-base-200/60">
         <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
@@ -112,17 +112,17 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function reportsPage() {
   return {
-    dismissed: new Set(),
-    expanded: new Set(),
+    dismissed: {},
+    expanded: {},
     toggle(id) {
-      if (this.expanded.has(id)) {
-        this.expanded.delete(id);
+      if (this.expanded[id]) {
+        delete this.expanded[id];
       } else {
-        this.expanded.add(id);
+        this.expanded[id] = true;
       }
     },
     markRead(id) {
-      this.dismissed.add(id);
+      this.dismissed[id] = true;
       fetch('/-/reports/' + id + '/read', { method: 'POST' });
     }
   };


### PR DESCRIPTION
## Summary
- **Bug**: Agent report expand/collapse and mark-as-read dismiss animations were broken on both the dashboard widget and the `/reports` page
- **Root cause**: Alpine.js v3 uses proxy-based reactivity that cannot track `Set` mutations (`.add()`, `.delete()`, `.has()`). The `expanded` and `dismissed` state was stored as `new Set()`, so Alpine never detected changes and never re-rendered the UI
- **Fix**: Replace `Set` with plain objects (`{}`), using `obj[id] = true` / `delete obj[id]` / `obj[id]` which Alpine's proxy system correctly intercepts

## Screenshots
![Reports page with working expand/collapse](https://i.img402.dev/2uo5xk365x.png)

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent