### PR TITLE
Fix transactions mobile: readable names and accounts

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -356,6 +356,13 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return strings.ToUpper(string([]rune(s)[0]))
 			},
+			"firstWord": func(s string) string {
+				if s == "" {
+					return ""
+				}
+				parts := strings.Fields(s)
+				return parts[0]
+			},
 			"expired": func(s *string) bool {
 				if s == nil {
 					return false

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -36,21 +36,17 @@
       </div>
       <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40">
         {{if .UserName}}
-        <span class="w-4 h-4 rounded-full bg-primary/10 inline-flex items-center justify-center shrink-0" title="{{.UserName}}">
+        <!-- Mobile: show short name; Desktop: show initial avatar -->
+        <span class="sm:hidden text-base-content/50 shrink-0">{{firstWord .UserName}}</span>
+        <span class="hidden sm:inline-flex w-4 h-4 rounded-full bg-primary/10 items-center justify-center shrink-0" title="{{.UserName}}">
           <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
         </span>
+        <span class="text-base-content/20">&middot;</span>
         {{end}}
         <span class="truncate">{{.AccountName}}</span>
         {{if .MerchantName}}
         <span class="text-base-content/20 hidden sm:inline">&middot;</span>
         <span class="text-base-content/40 truncate hidden sm:inline">{{deref .MerchantName}}</span>
-        {{end}}
-        {{if .CategoryDisplayName}}
-        <span class="text-base-content/20 sm:hidden">&middot;</span>
-        <span class="inline-flex items-center gap-1 sm:hidden">
-          <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
-          <span class="text-base-content/50 truncate">{{deref .CategoryDisplayName}}</span>
-        </span>
         {{end}}
         {{if .AgentReviewed}}
         <span class="text-base-content/20">&middot;</span>
@@ -77,7 +73,7 @@
     </div>
 
     <!-- Amount -->
-    <div class="w-24 text-right shrink-0 pl-3">
+    <div class="w-20 sm:w-24 text-right shrink-0 pl-2 sm:pl-3">
       <span class="bb-tx-amount tabular-nums{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
         {{formatAmount .Amount}}
       </span>


### PR DESCRIPTION
## Summary
- On mobile, transaction rows showed only a single-letter initial avatar for the family member and heavily truncated account names (e.g., "Pl...", "M...", "Es..."), making it impossible to identify who a transaction belonged to or which account it was from
- Replaced the initial avatar with the member's first name ("Isabela", "Ricardo") on mobile, adding a `firstWord` template function
- Removed redundant inline category text from the mobile detail line (category is already visible via the colored avatar icon), freeing space for account names to display fully
- Narrowed the amount column slightly on mobile (w-20 vs w-24) to give more room to the description area

## Screenshots
### After (mobile 400px)
![Mobile transactions after](https://i.img402.dev/vc0hn2bsth.png)

### Changes
- `"Isabela · Platinum Card"` instead of `"I · Pl... · Other Transfer Out"`
- Account names like "My Checking", "Essential Savings" are now fully readable
- Desktop layout unchanged (still shows initial avatar + account + merchant + category picker)

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent