### PR TITLE
Polish account links: mobile layout, design system, bbConfirm

### DIFF
--- a/internal/templates/pages/account_link_detail.html
+++ b/internal/templates/pages/account_link_detail.html
@@ -14,14 +14,15 @@
   </div>
   <form method="POST" action="/-/account-links/{{.Link.ID}}/reconcile" class="inline">
     <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-    <button type="submit" class="btn btn-primary btn-sm">
-      <i data-lucide="refresh-cw" class="w-4 h-4"></i> Reconcile Now
+    <button type="submit" class="btn btn-primary btn-sm rounded-xl">
+      <i data-lucide="refresh-cw" class="w-4 h-4"></i> <span class="hidden sm:inline">Reconcile Now</span><span class="sm:hidden">Reconcile</span>
     </button>
   </form>
 </div>
 
 {{if .Matches}}
-<div class="overflow-x-auto mt-6">
+<!-- Desktop table -->
+<div class="hidden md:block overflow-x-auto mt-6">
   <table class="table table-sm">
     <thead>
       <tr>
@@ -49,11 +50,11 @@
         </td>
         <td>
           {{if eq .MatchConfidence "confirmed"}}
-          <span class="badge badge-success badge-xs">Confirmed</span>
+          <span class="badge badge-success badge-xs rounded-lg">Confirmed</span>
           {{else if eq .MatchConfidence "auto"}}
-          <span class="badge badge-info badge-xs">Auto</span>
+          <span class="badge badge-info badge-xs rounded-lg">Auto</span>
           {{else}}
-          <span class="badge badge-ghost badge-xs">{{.MatchConfidence}}</span>
+          <span class="badge badge-ghost badge-xs rounded-lg">{{.MatchConfidence}}</span>
           {{end}}
         </td>
         <td class="text-xs text-base-content/60">{{range .MatchedOn}}{{.}} {{end}}</td>
@@ -62,13 +63,13 @@
           <div class="flex gap-1">
             <form method="POST" action="/-/transaction-matches/{{.ID}}/confirm" class="inline">
               <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
-              <button type="submit" class="btn btn-ghost btn-xs text-success" title="Confirm match">
+              <button type="submit" class="btn btn-ghost btn-xs text-success rounded-lg" title="Confirm match">
                 <i data-lucide="check" class="w-3.5 h-3.5"></i>
               </button>
             </form>
             <form method="POST" action="/-/transaction-matches/{{.ID}}/reject" class="inline">
               <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
-              <button type="submit" class="btn btn-ghost btn-xs text-error" title="Reject match">
+              <button type="submit" class="btn btn-ghost btn-xs text-error rounded-lg" title="Reject match">
                 <i data-lucide="x" class="w-3.5 h-3.5"></i>
               </button>
             </form>
@@ -80,12 +81,71 @@
     </tbody>
   </table>
 </div>
+
+<!-- Mobile card list -->
+<div class="md:hidden space-y-3 mt-4 bb-stagger">
+  {{range .Matches}}
+  <div class="bb-card p-4">
+    <div class="flex items-start justify-between gap-2 mb-3">
+      <div class="flex items-center gap-2">
+        <span class="text-xs text-base-content/40">{{.Date}}</span>
+        {{if eq .MatchConfidence "confirmed"}}
+        <span class="badge badge-success badge-xs rounded-lg">Confirmed</span>
+        {{else if eq .MatchConfidence "auto"}}
+        <span class="badge badge-info badge-xs rounded-lg">Auto</span>
+        {{else}}
+        <span class="badge badge-ghost badge-xs rounded-lg">{{.MatchConfidence}}</span>
+        {{end}}
+      </div>
+      <span class="text-sm font-semibold tabular-nums bb-amount">{{printf "%.2f" .Amount}}</span>
+    </div>
+    <div class="space-y-2">
+      <div class="flex items-center gap-2">
+        <div class="w-5 h-5 rounded bg-primary/10 flex items-center justify-center shrink-0">
+          <i data-lucide="credit-card" class="w-3 h-3 text-primary"></i>
+        </div>
+        <div class="min-w-0">
+          <a href="/transactions/{{.PrimaryTransactionID}}" class="link link-hover text-sm truncate block">{{.PrimaryTxnName}}</a>
+          {{if .PrimaryTxnMerchant}}<div class="text-xs text-base-content/40 truncate">{{.PrimaryTxnMerchant}}</div>{{end}}
+        </div>
+      </div>
+      <div class="flex items-center gap-2">
+        <div class="w-5 h-5 rounded bg-secondary/10 flex items-center justify-center shrink-0">
+          <i data-lucide="credit-card" class="w-3 h-3 text-secondary"></i>
+        </div>
+        <div class="min-w-0">
+          <a href="/transactions/{{.DependentTransactionID}}" class="link link-hover text-sm truncate block">{{.DependentTxnName}}</a>
+          {{if .DependentTxnMerchant}}<div class="text-xs text-base-content/40 truncate">{{.DependentTxnMerchant}}</div>{{end}}
+        </div>
+      </div>
+    </div>
+    {{if eq .MatchConfidence "auto"}}
+    <div class="flex gap-2 mt-3 pt-3 border-t border-base-200">
+      <form method="POST" action="/-/transaction-matches/{{.ID}}/confirm" class="inline">
+        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+        <button type="submit" class="btn btn-success btn-xs btn-soft rounded-lg">
+          <i data-lucide="check" class="w-3.5 h-3.5"></i> Confirm
+        </button>
+      </form>
+      <form method="POST" action="/-/transaction-matches/{{.ID}}/reject" class="inline">
+        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+        <button type="submit" class="btn btn-error btn-xs btn-soft rounded-lg">
+          <i data-lucide="x" class="w-3.5 h-3.5"></i> Reject
+        </button>
+      </form>
+    </div>
+    {{end}}
+  </div>
+  {{end}}
+</div>
 {{else}}
-<div class="card bg-base-100 shadow-sm border border-base-300 mt-6">
-  <div class="card-body items-center text-center py-12">
-    <i data-lucide="check-circle-2" class="w-12 h-12 text-base-content/20 mb-4"></i>
-    <h3 class="font-semibold text-lg">No Matches Yet</h3>
-    <p class="text-base-content/60">Run reconciliation to find matching transactions between the linked accounts.</p>
+<div class="bb-card p-12 text-center">
+  <div class="flex flex-col items-center">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
+      <i data-lucide="check-circle-2" class="w-8 h-8 text-base-content/25"></i>
+    </div>
+    <h3 class="text-lg font-semibold mb-1">No Matches Yet</h3>
+    <p class="text-sm text-base-content/50 max-w-sm">Run reconciliation to find matching transactions between the linked accounts.</p>
   </div>
 </div>
 {{end}}

--- a/internal/templates/pages/account_links.html
+++ b/internal/templates/pages/account_links.html
@@ -6,74 +6,92 @@
     <h1 class="bb-page-title">Account Links</h1>
     <p class="text-base-content/60 text-sm mt-1">Link dependent (authorized user) accounts to primary accounts for transaction deduplication and attribution.</p>
   </div>
-  <button class="btn btn-primary btn-sm" onclick="document.getElementById('create-modal').showModal()">
+  <button class="btn btn-primary btn-sm rounded-xl" onclick="document.getElementById('create-modal').showModal()">
     <i data-lucide="plus" class="w-4 h-4"></i> New Link
   </button>
 </div>
 
 {{if .Links}}
-<div class="space-y-4 mt-6">
+<div class="space-y-3 bb-stagger">
   {{range .Links}}
-  <div class="card bg-base-100 shadow-sm border border-base-300">
-    <div class="card-body p-4">
-      <div class="flex items-start justify-between gap-4">
-        <div class="flex-1 min-w-0">
-          <div class="flex items-center gap-2 flex-wrap">
-            <span class="font-semibold">{{.PrimaryAccountName}}</span>
-            <span class="text-base-content/40">({{.PrimaryUserName}})</span>
-            <i data-lucide="arrow-right" class="w-4 h-4 text-base-content/40 shrink-0"></i>
-            <span class="font-semibold">{{.DependentAccountName}}</span>
-            <span class="text-base-content/40">({{.DependentUserName}})</span>
-            {{if not .Enabled}}<span class="badge badge-ghost badge-sm">Disabled</span>{{end}}
+  <div class="bb-card p-5">
+    <div class="flex flex-col sm:flex-row sm:items-start justify-between gap-3">
+      <div class="flex-1 min-w-0">
+        <!-- Account link: stacked on mobile, inline on desktop -->
+        <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+          <div class="flex items-center gap-2 min-w-0">
+            <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-primary/8 shrink-0">
+              <i data-lucide="credit-card" class="w-4 h-4 text-primary"></i>
+            </div>
+            <div class="min-w-0">
+              <span class="font-semibold text-sm truncate block">{{.PrimaryAccountName}}</span>
+              <span class="text-xs text-base-content/40">{{.PrimaryUserName}}</span>
+            </div>
           </div>
-          <div class="flex items-center gap-4 mt-2 text-sm text-base-content/60">
-            <span class="flex items-center gap-1">
-              <i data-lucide="check-circle-2" class="w-3.5 h-3.5 text-success"></i>
-              {{.MatchCount}} matched
-            </span>
-            {{if gt .UnmatchedDependentCount 0}}
-            <span class="flex items-center gap-1">
-              <i data-lucide="help-circle" class="w-3.5 h-3.5 text-warning"></i>
-              {{.UnmatchedDependentCount}} unmatched
-            </span>
-            {{end}}
-            <span>Strategy: {{.MatchStrategy}}</span>
-            {{if gt .MatchToleranceDays 0}}<span>Tolerance: {{.MatchToleranceDays}}d</span>{{end}}
+          <i data-lucide="arrow-right" class="w-4 h-4 text-base-content/30 shrink-0 hidden sm:block"></i>
+          <i data-lucide="arrow-down" class="w-4 h-4 text-base-content/30 shrink-0 sm:hidden ml-3"></i>
+          <div class="flex items-center gap-2 min-w-0 sm:ml-0 ml-3">
+            <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-secondary/8 shrink-0">
+              <i data-lucide="credit-card" class="w-4 h-4 text-secondary"></i>
+            </div>
+            <div class="min-w-0">
+              <span class="font-semibold text-sm truncate block">{{.DependentAccountName}}</span>
+              <span class="text-xs text-base-content/40">{{.DependentUserName}}</span>
+            </div>
           </div>
+          {{if not .Enabled}}<span class="badge badge-ghost badge-sm rounded-lg">Disabled</span>{{end}}
         </div>
-        <div class="flex items-center gap-1 shrink-0">
-          <form method="POST" action="/-/account-links/{{.ID}}/reconcile" class="inline">
-            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
-            <button type="submit" class="btn btn-ghost btn-xs" title="Run reconciliation">
-              <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
-            </button>
-          </form>
-          <a href="/account-links/{{.ID}}" class="btn btn-ghost btn-xs" title="View matches">
-            <i data-lucide="list" class="w-3.5 h-3.5"></i>
-          </a>
-          <form method="POST" action="/-/account-links/{{.ID}}/delete" class="inline"
-                x-data @submit.prevent="if(confirm('Delete this account link? All attribution will be cleared.')) $el.submit()">
-            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
-            <button type="submit" class="btn btn-ghost btn-xs text-error" title="Delete link">
-              <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
-            </button>
-          </form>
+        <!-- Stats row -->
+        <div class="flex items-center gap-3 sm:gap-4 mt-3 text-xs text-base-content/50 flex-wrap">
+          <span class="flex items-center gap-1">
+            <i data-lucide="check-circle-2" class="w-3.5 h-3.5 text-success"></i>
+            {{.MatchCount}} matched
+          </span>
+          {{if gt .UnmatchedDependentCount 0}}
+          <span class="flex items-center gap-1">
+            <i data-lucide="help-circle" class="w-3.5 h-3.5 text-warning"></i>
+            {{.UnmatchedDependentCount}} unmatched
+          </span>
+          {{end}}
+          <span class="hidden sm:inline">Strategy: {{.MatchStrategy}}</span>
+          {{if gt .MatchToleranceDays 0}}<span class="hidden sm:inline">Tolerance: {{.MatchToleranceDays}}d</span>{{end}}
         </div>
+      </div>
+      <!-- Actions -->
+      <div class="flex items-center gap-1 shrink-0 sm:self-start self-end">
+        <form method="POST" action="/-/account-links/{{.ID}}/reconcile" class="inline">
+          <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+          <button type="submit" class="btn btn-ghost btn-xs rounded-lg" title="Run reconciliation">
+            <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
+          </button>
+        </form>
+        <a href="/account-links/{{.ID}}" class="btn btn-ghost btn-xs rounded-lg" title="View matches">
+          <i data-lucide="list" class="w-3.5 h-3.5"></i>
+        </a>
+        <form method="POST" action="/-/account-links/{{.ID}}/delete" class="inline"
+              x-data @submit.prevent="bbConfirm({title:'Delete account link?',message:'All transaction attribution from this link will be cleared. This cannot be undone.',confirmLabel:'Delete',variant:'danger'}).then(ok => { if(ok) $el.submit(); })">
+          <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+          <button type="submit" class="btn btn-ghost btn-xs text-error rounded-lg" title="Delete link">
+            <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+          </button>
+        </form>
       </div>
     </div>
   </div>
   {{end}}
 </div>
 {{else}}
-<div class="card bg-base-100 shadow-sm border border-base-300 mt-6">
-  <div class="card-body items-center text-center py-12">
-    <i data-lucide="link-2" class="w-12 h-12 text-base-content/20 mb-4"></i>
-    <h3 class="font-semibold text-lg">No Account Links</h3>
-    <p class="text-base-content/60 max-w-md">
+<div class="bb-card p-12 text-center">
+  <div class="flex flex-col items-center">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
+      <i data-lucide="link-2" class="w-8 h-8 text-base-content/25"></i>
+    </div>
+    <h3 class="text-lg font-semibold mb-1">No Account Links</h3>
+    <p class="text-sm text-base-content/50 mb-5 max-w-sm">
       Account links connect authorized user accounts to primary accounts for deduplication.
       If two family members connect the same credit card, linking prevents double-counting.
     </p>
-    <button class="btn btn-primary btn-sm mt-4" onclick="document.getElementById('create-modal').showModal()">
+    <button class="btn btn-primary btn-sm rounded-xl" onclick="document.getElementById('create-modal').showModal()">
       <i data-lucide="plus" class="w-4 h-4"></i> Create First Link
     </button>
   </div>
@@ -82,14 +100,14 @@
 
 <!-- Create Link Modal -->
 <dialog id="create-modal" class="modal">
-  <div class="modal-box">
+  <div class="modal-box rounded-2xl">
     <h3 class="font-bold text-lg">Create Account Link</h3>
-    <p class="text-sm text-base-content/60 mt-1">Link a dependent (authorized user) account to the primary cardholder's account.</p>
+    <p class="text-sm text-base-content/50 mt-1">Link a dependent (authorized user) account to the primary cardholder's account.</p>
     <form method="POST" action="/-/account-links" class="mt-4 space-y-4" x-data="{ loading: false }" @submit="loading = true">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
       <div class="form-control">
-        <label class="label"><span class="label-text">Primary Account</span></label>
-        <select name="primary_account_id" class="select select-bordered select-sm w-full" required>
+        <label class="label label-text text-sm font-medium">Primary Account</label>
+        <select name="primary_account_id" class="select select-bordered select-sm w-full rounded-xl" required>
           <option value="">Select the primary cardholder's account...</option>
           {{range .Accounts}}
           <option value="{{.ID}}">{{.DisplayName}}{{if .Mask}} ••{{.Mask}}{{end}} ({{.UserName}} - {{.InstitutionName}})</option>
@@ -97,8 +115,8 @@
         </select>
       </div>
       <div class="form-control">
-        <label class="label"><span class="label-text">Dependent Account</span></label>
-        <select name="dependent_account_id" class="select select-bordered select-sm w-full" required>
+        <label class="label label-text text-sm font-medium">Dependent Account</label>
+        <select name="dependent_account_id" class="select select-bordered select-sm w-full rounded-xl" required>
           <option value="">Select the authorized user's account...</option>
           {{range .Accounts}}
           <option value="{{.ID}}">{{.DisplayName}}{{if .Mask}} ••{{.Mask}}{{end}} ({{.UserName}} - {{.InstitutionName}})</option>
@@ -106,8 +124,8 @@
         </select>
       </div>
       <div class="modal-action">
-        <button type="button" class="btn btn-ghost btn-sm" onclick="document.getElementById('create-modal').close()">Cancel</button>
-        <button type="submit" class="btn btn-primary btn-sm" :class="{ 'loading': loading }" :disabled="loading">Create Link</button>
+        <button type="button" class="btn btn-ghost btn-sm rounded-xl" onclick="document.getElementById('create-modal').close()">Cancel</button>
+        <button type="submit" class="btn btn-primary btn-sm rounded-xl" :class="{ 'loading': loading }" :disabled="loading">Create Link</button>
       </div>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- Replace native `confirm()` with `bbConfirm` modal for delete actions (consistency with rules, MCP settings, etc.)
- Migrate card styles from old `card bg-base-100 shadow-sm border` to standard `bb-card` class with `bb-stagger` animation
- Add responsive mobile layout: stack primary/dependent accounts vertically with arrow-down icon, hide strategy/tolerance metadata on small screens
- Add card-based mobile layout for transaction matches detail page (replaces table on `md:` breakpoint)
- Update buttons, badges, modal to use `rounded-xl`/`rounded-lg` design tokens

## Screenshots
![account-links-empty](https://i.img402.dev/8cjmo1rlx8.png)

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent