### PR TITLE
Fix API keys page mobile layout

### DIFF
--- a/internal/templates/pages/api_keys.html
+++ b/internal/templates/pages/api_keys.html
@@ -13,46 +13,63 @@
 {{if .Keys}}
 <div class="space-y-3 bb-stagger">
   {{range .Keys}}
-  <div class="bb-card p-5 flex items-center justify-between gap-4 flex-wrap" x-data="{ confirming: false }">
-    <div class="flex items-center gap-4 min-w-0">
-      <div class="flex items-center justify-center w-10 h-10 rounded-xl shrink-0
+  <div class="bb-card p-5" x-data="{ confirming: false }">
+    <div class="flex items-start gap-4">
+      <div class="flex items-center justify-center w-10 h-10 rounded-xl shrink-0 mt-0.5
         {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-primary/8{{end}}">
         <i data-lucide="key" class="w-5 h-5 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-primary{{end}}"></i>
       </div>
-      <div class="min-w-0">
-        <div class="flex items-center gap-2 flex-wrap">
-          <span class="font-semibold text-sm {{if .RevokedAt}}text-base-content/40 line-through{{end}}">{{.Name}}</span>
-          {{if eq .Scope "read_only"}}
-          <span class="badge badge-soft badge-warning badge-xs">Read Only</span>
-          {{else}}
-          <span class="badge badge-soft badge-primary badge-xs">Full Access</span>
-          {{end}}
-          {{if .RevokedAt}}
-          <span class="badge badge-soft badge-error badge-xs">Revoked</span>
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center justify-between gap-2">
+          <div class="flex items-center gap-2 flex-wrap min-w-0">
+            <span class="font-semibold text-sm {{if .RevokedAt}}text-base-content/40 line-through{{end}}">{{.Name}}</span>
+            {{if eq .Scope "read_only"}}
+            <span class="badge badge-soft badge-warning badge-xs">Read Only</span>
+            {{else}}
+            <span class="badge badge-soft badge-primary badge-xs">Full Access</span>
+            {{end}}
+            {{if .RevokedAt}}
+            <span class="badge badge-soft badge-error badge-xs">Revoked</span>
+            {{end}}
+          </div>
+          {{if not .RevokedAt}}
+          <div class="shrink-0 hidden sm:block">
+            <form method="POST" action="/api-keys/{{.ID}}/revoke" class="inline">
+              <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+              <button type="button" class="btn btn-ghost btn-sm text-base-content/50 hover:text-error" x-show="!confirming" @click="confirming = true">
+                Revoke
+              </button>
+              <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
+                <button type="submit" class="btn btn-error btn-sm btn-soft rounded-xl">Confirm</button>
+                <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="confirming = false">Cancel</button>
+              </span>
+            </form>
+          </div>
           {{end}}
         </div>
-        <div class="flex items-center gap-3 mt-0.5 text-xs text-base-content/40">
-          <code class="font-mono bg-base-200/50 px-1.5 py-0.5 rounded">{{.KeyPrefix}}...</code>
-          <span>Created {{formatDateTime .CreatedAt}}</span>
+        <div class="mt-1.5">
+          <code class="font-mono text-xs bg-base-200/50 px-1.5 py-0.5 rounded text-base-content/40">{{.KeyPrefix}}...</code>
+        </div>
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-1.5 text-xs text-base-content/40">
+          <span>Created {{formatDateShort .CreatedAt}}</span>
           {{if .LastUsedAt}}<span>Last used {{relativeTime .LastUsedAt}}</span>{{end}}
         </div>
+        {{if not .RevokedAt}}
+        <div class="mt-3 pt-3 border-t border-base-300 sm:hidden">
+          <form method="POST" action="/api-keys/{{.ID}}/revoke" class="inline">
+            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+            <button type="button" class="btn btn-ghost btn-sm text-base-content/50 hover:text-error" x-show="!confirming" @click="confirming = true">
+              Revoke
+            </button>
+            <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
+              <button type="submit" class="btn btn-error btn-sm btn-soft rounded-xl">Confirm</button>
+              <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="confirming = false">Cancel</button>
+            </span>
+          </form>
+        </div>
+        {{end}}
       </div>
     </div>
-
-    {{if not .RevokedAt}}
-    <div class="shrink-0">
-      <form method="POST" action="/api-keys/{{.ID}}/revoke" class="inline">
-        <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
-        <button type="button" class="btn btn-ghost btn-sm text-base-content/50 hover:text-error" x-show="!confirming" @click="confirming = true">
-          Revoke
-        </button>
-        <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
-          <button type="submit" class="btn btn-error btn-sm btn-soft rounded-xl">Confirm</button>
-          <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="confirming = false">Cancel</button>
-        </span>
-      </form>
-    </div>
-    {{end}}
   </div>
   {{end}}
 </div>


### PR DESCRIPTION
## Summary
- Restructured API keys card layout for mobile: key prefix now on its own line, created date and last-used time wrap cleanly below
- Revoke button moves to a separated section below card content on mobile (`sm:hidden`), appears inline at top-right on desktop (`hidden sm:block`)
- Switched from `formatDateTime` to `formatDateShort` for more compact date display

## Screenshots
![API keys mobile](https://i.img402.dev/kaa7mfkqbl.png)

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent