### PR TITLE
Fix Alpine.js console errors on rules and reviews pages

### DIFF
--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -629,7 +629,7 @@ function triageQueue() {
 
     init() {
       this.$nextTick(() => {
-        if (typeof lucide !== 'undefined') lucide.createIcons();
+        if (typeof lucide !== 'undefined') lucide.createIcons({ nodes: [this.$el] });
       });
 
       // Listen for triage actions dispatched from child components

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -1,5 +1,5 @@
 {{define "content"}}
-<div x-data="rulesPage()" x-init="init()">
+<div x-data="rulesPage()">
 
 <div class="bb-page-header">
   <div>
@@ -252,9 +252,6 @@ function rulesPage() {
       priority: 10,
       conditions_json: '',
       expires_in: ''
-    },
-    init() {
-      lucide.createIcons();
     },
     editRule(rule) {
       this.editingId = rule.id;


### PR DESCRIPTION
## Summary
- Fixed `filtersOpen is not defined` Alpine.js errors thrown on every rules page load, caused by `rulesPage().init()` redundantly calling `lucide.createIcons()` which re-processed SVG icons already bound by Alpine, breaking their reactive scope
- Scoped the reviews page triage queue's `lucide.createIcons()` call to only process icons within its own element (`this.$el`), preventing the same error on the reviews page in triage mode
- Root cause: Lucide's `createIcons()` replaces `<svg data-lucide>` elements with new SVGs, which Alpine's MutationObserver then tries to re-initialize outside their original `x-data` scope

## Screenshots
![Rules page with filters open, no console errors](https://i.img402.dev/oonzr2hykz.png)

**Before**: 2 Alpine expression errors (`filtersOpen is not defined`) thrown on every rules page load
**After**: Zero console errors, filter toggle works correctly

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent