### PR TITLE
Fix settings page system info mobile layout

### DIFF
--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"breadbox/internal/app"
@@ -35,6 +36,7 @@ func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 		// System info.
 		var pgVersion string
 		_ = a.DB.QueryRow(ctx, "SELECT version()").Scan(&pgVersion)
+		pgVersion = strings.TrimPrefix(pgVersion, "PostgreSQL ")
 
 		// Sync log retention.
 		retentionDays, _ := a.Service.GetSyncLogRetentionDays(ctx)

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -165,25 +165,25 @@
       </div>
     </div>
 
-    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4">
-      <div class="p-3.5 rounded-xl bg-base-200/40">
-        <div class="text-xs font-medium text-base-content/40 mb-1">Version</div>
+    <div class="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
+        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Version</div>
         <div class="text-sm font-semibold tabular-nums">{{.Version}}</div>
       </div>
-      <div class="p-3.5 rounded-xl bg-base-200/40">
-        <div class="text-xs font-medium text-base-content/40 mb-1">Go Runtime</div>
+      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
+        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Go Runtime</div>
         <div class="text-sm font-semibold">{{.GoVersion}}</div>
       </div>
-      <div class="p-3.5 rounded-xl bg-base-200/40">
-        <div class="text-xs font-medium text-base-content/40 mb-1">PostgreSQL</div>
-        <div class="text-sm font-semibold truncate" title="{{.PostgresVersion}}">{{.PostgresVersion}}</div>
+      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40 min-w-0">
+        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">PostgreSQL</div>
+        <div class="text-sm font-semibold truncate min-w-0" title="{{.PostgresVersion}}">{{.PostgresVersion}}</div>
       </div>
-      <div class="p-3.5 rounded-xl bg-base-200/40">
-        <div class="text-xs font-medium text-base-content/40 mb-1">Uptime</div>
+      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
+        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Uptime</div>
         <div class="text-sm font-semibold">{{.Uptime}}</div>
       </div>
-      <div class="p-3.5 rounded-xl bg-base-200/40">
-        <div class="text-xs font-medium text-base-content/40 mb-1">Providers</div>
+      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
+        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Providers</div>
         <div class="text-sm font-semibold">{{.ProviderCount}} configured</div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **System info stat grid**: Changed from 2-column grid (which orphaned the 5th "Providers" card) to single-column stacked rows on mobile. Each row displays the label on the left and value on the right using flex layout.
- **PostgreSQL version**: Stripped the redundant "PostgreSQL " prefix from the version string so the actual version number (e.g., "16.13 on aarch64-...") is visible on mobile instead of being pushed out of view.
- **Flex layout polish**: Added `gap-3` for proper spacing, `shrink-0` on labels, and `min-w-0` on the PostgreSQL value for correct text truncation in flex containers.
- Desktop layout (sm: 3-col, lg: 5-col) is preserved via `sm:block` which overrides the mobile flex.

## Screenshots
Mobile (500px viewport) -- System info section now stacks cleanly:

| Before | After |
|--------|-------|
| 2-col grid, orphaned Providers card, "PostgreSQL" label runs into value text | Single-column rows, label-left/value-right, clean spacing, version number visible |

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent