### PR TITLE
Hide reviews triage keyboard shortcuts on mobile

### DIFF
--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -237,7 +237,7 @@
       {{end}}
     </div>
     {{if eq .StatusFilter "pending"}}
-    <div class="flex items-center gap-2 text-xs text-base-content/30">
+    <div class="hidden sm:flex items-center gap-2 text-xs text-base-content/30">
       <span class="flex items-center gap-1"><kbd class="bb-kbd">j</kbd><kbd class="bb-kbd">k</kbd> navigate</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">a</kbd> accept</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">s</kbd> skip</span>


### PR DESCRIPTION
## Summary
- Hide the keyboard shortcuts bar (j/k navigate, a accept, s skip, d dismiss, n note, c category) on mobile viewports in the reviews triage mode
- These shortcuts caused horizontal overflow on narrow screens and are useless on touch devices without physical keyboards
- Matches the existing pattern in the transactions page which already uses `hidden sm:flex` for its shortcuts bar

## Screenshots
![Reviews mobile after fix](https://i.img402.dev/y0cz5g3015.png)

Relates to #225

🤖 Generated by autonomous UX/QA/mobile agent