### PR TITLE
Fix transaction detail page mobile layout

### DIFF
--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -21,7 +21,7 @@
       </div>
     </div>
   </div>
-  <div class="text-right sm:text-right">
+  <div class="sm:text-right">
     <p class="text-3xl font-semibold tabular-nums{{if lt .Transaction.Amount 0.0}} text-success{{end}}">
       {{formatAmount .Transaction.Amount}}
     </p>
@@ -41,16 +41,16 @@
         <a href="/accounts/{{.AccountID}}" class="text-sm font-semibold hover:text-primary transition-colors no-underline truncate">{{.AccountName}}</a>
         {{if .AccountMask}}<span class="text-xs text-base-content/30 font-mono">&middot;&middot;&middot;&middot;{{.AccountMask}}</span>{{end}}
       </div>
-      <div class="flex items-center gap-2 mt-0.5">
+      <div class="flex items-center gap-2 mt-0.5 flex-wrap">
         {{if .InstitutionName}}
         <span class="text-xs text-base-content/40">{{.InstitutionName}}</span>
         {{end}}
         {{if .AccountType}}
-        <span class="text-xs text-base-content/30">&middot;</span>
+        <span class="text-xs text-base-content/30 hidden sm:inline">&middot;</span>
         <span class="text-xs text-base-content/40">{{accountTypeLabel .AccountType ""}}</span>
         {{end}}
         {{if .UserName}}
-        <span class="text-xs text-base-content/30">&middot;</span>
+        <span class="text-xs text-base-content/30 hidden sm:inline">&middot;</span>
         <span class="text-xs text-base-content/40">{{.UserName}}</span>
         {{end}}
       </div>
@@ -134,7 +134,7 @@
 
     <!-- Metadata -->
     <div class="mt-6 pt-5 border-t border-base-300">
-      <div class="grid grid-cols-2 sm:grid-cols-3 gap-y-3 gap-x-6 text-xs">
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-y-3 gap-x-6 text-xs">
         <div>
           <p class="text-base-content/30 mb-0.5">Transaction ID</p>
           <code class="font-mono text-base-content/50 break-all">{{.Transaction.ID}}</code>
@@ -261,7 +261,7 @@
             <span class="text-xs text-base-content/30">{{relativeTime .CreatedAt}}</span>
           </div>
         </div>
-        <button class="btn btn-ghost btn-xs opacity-0 group-hover:opacity-100 transition-opacity text-error/50 hover:text-error" @click="deleteComment('{{.ID}}')" title="Delete">
+        <button class="btn btn-ghost btn-xs sm:opacity-0 sm:group-hover:opacity-100 transition-opacity text-error/50 hover:text-error" @click="deleteComment('{{.ID}}')" title="Delete">
           <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
         </button>
       </div>


### PR DESCRIPTION
## Summary
- Left-align the transaction amount on mobile (was `text-right` in column layout, looked disconnected from the name)
- Stack metadata grid (Transaction ID, Created, Updated) into a single column on mobile so the UUID is not crammed into a half-width cell with `break-all`
- Add `flex-wrap` to account context banner info line and hide middot separators on mobile for cleaner wrapping when institution, type, and user name overflow
- Make comment delete button always visible on mobile since `opacity-0 group-hover:opacity-100` doesn't work on touch devices

## Test plan
- [ ] View a transaction detail page on mobile (375px width)
- [ ] Verify the amount is left-aligned below the transaction name
- [ ] Verify the metadata section (ID, Created, Updated) stacks vertically
- [ ] Verify the account banner info wraps cleanly without middot orphans
- [ ] Verify comment delete buttons are visible on mobile
- [ ] Verify desktop layout is unchanged (amount right-aligned, metadata in 3 cols, middots visible)

Tracking issue: #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)