### PR TITLE
Polish dashboard tx row subtitles for mobile

### DIFF
--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -236,49 +236,47 @@
     {{if .RecentTransactions}}
     <div class="space-y-0.5">
       {{range .RecentTransactions}}
-      <a href="/transactions/{{.ID}}" class="flex items-center justify-between py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
-        <div class="flex items-center gap-3 min-w-0">
-          <div class="relative shrink-0">
-            {{if .CategoryIcon}}
-            <div class="bb-tx-avatar bb-tx-avatar--sm" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
-              <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5"></i>
-            </div>
-            {{else}}
-            <div class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
-              <span>{{firstChar .Name}}</span>
-            </div>
-            {{end}}
-            {{if .HasPendingReview}}<span class="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-info ring-2 ring-base-100 group-hover:ring-base-200/40" title="Pending review"></span>{{end}}
+      <a href="/transactions/{{.ID}}" class="flex items-center gap-3 py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
+        <div class="relative shrink-0">
+          {{if .CategoryIcon}}
+          <div class="bb-tx-avatar bb-tx-avatar--sm" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
+            <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5"></i>
           </div>
-          <div class="min-w-0">
-            <div class="flex items-center gap-1.5">
-              <span class="text-sm font-medium truncate max-w-64">{{.Name}}</span>
-              {{if .Pending}}<span class="text-[0.6rem] font-medium text-warning/80 bg-warning/10 px-1.5 py-0.5 rounded-full leading-none">Pending</span>{{end}}
-            </div>
-            <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40">
-              {{if .UserName}}
-              <span class="w-4 h-4 rounded-full bg-primary/10 inline-flex items-center justify-center shrink-0" title="{{.UserName}}">
-                <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
-              </span>
-              {{end}}
-              <span>{{.AccountName}} · {{formatDate .Date}}</span>
-              {{if .CategoryDisplayName}}
-              <span class="hidden sm:inline text-base-content/20">&middot;</span>
-              <span class="hidden sm:inline-flex items-center gap-1">
-                <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
-                <span class="text-base-content/50">{{deref .CategoryDisplayName}}</span>
-              </span>
-              {{end}}
-              {{if .AgentReviewed}}
-              <span class="hidden sm:inline text-base-content/20">&middot;</span>
-              <span class="hidden sm:inline-flex items-center gap-0.5 text-primary/60" title="Categorized by AI agent">
-                <i data-lucide="bot" class="w-3 h-3"></i>
-              </span>
-              {{end}}
-            </div>
+          {{else}}
+          <div class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
+            <span>{{firstChar .Name}}</span>
+          </div>
+          {{end}}
+          {{if .HasPendingReview}}<span class="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-info ring-2 ring-base-100 group-hover:ring-base-200/40" title="Pending review"></span>{{end}}
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-1.5 min-w-0">
+            <span class="text-sm font-medium truncate">{{.Name}}</span>
+            {{if .Pending}}<span class="text-[0.6rem] font-medium text-warning/80 bg-warning/10 px-1.5 py-0.5 rounded-full leading-none shrink-0">Pending</span>{{end}}
+          </div>
+          <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 overflow-hidden">
+            {{if .UserName}}
+            <span class="w-4 h-4 rounded-full bg-primary/10 inline-flex items-center justify-center shrink-0" title="{{.UserName}}">
+              <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
+            </span>
+            {{end}}
+            <span class="truncate shrink min-w-0">{{.AccountName}} · {{formatDate .Date}}</span>
+            {{if .CategoryDisplayName}}
+            <span class="text-base-content/20 shrink-0 hidden sm:inline">&middot;</span>
+            <span class="items-center gap-1 shrink-0 hidden sm:inline-flex">
+              <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
+              <span class="text-base-content/50 truncate max-w-24 lg:max-w-40">{{deref .CategoryDisplayName}}</span>
+            </span>
+            {{end}}
+            {{if .AgentReviewed}}
+            <span class="text-base-content/20 shrink-0">&middot;</span>
+            <span class="inline-flex items-center gap-0.5 text-primary/60 shrink-0" title="Categorized by AI agent">
+              <i data-lucide="bot" class="w-3 h-3"></i>
+            </span>
+            {{end}}
           </div>
         </div>
-        <span class="bb-tx-amount{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
+        <span class="bb-tx-amount shrink-0{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
           {{formatAmount .Amount}}
         </span>
       </a>


### PR DESCRIPTION
## Summary
- Add proper truncation to the dashboard transaction row subtitle line (account name + date) so it clips cleanly on mobile instead of overflowing
- Hide category display name on mobile (`hidden sm:inline-flex`), matching the transactions page `tx_row.html` pattern where category is only shown on narrow screens
- Cap category text width with `max-w-24` / `lg:max-w-40` to prevent long names from pushing the amount off-screen
- Add `overflow-hidden` to subtitle container and `shrink-0` to amount/badges to prevent layout compression
- Remove fixed `max-w-64` from transaction name; let it flex naturally within available space

## Changes
- `internal/templates/pages/dashboard.html` — Recent Transactions row layout polish

## Screenshot (desktop, no regression)
![dashboard desktop](https://i.img402.dev/0qnqunzwc1.png)

## Test plan
- [ ] Verify dashboard loads without errors on desktop
- [ ] Verify transaction row subtitles truncate on mobile (<640px) — account + date should clip with ellipsis
- [ ] Verify category text is hidden on mobile, shown on desktop with colored dot
- [ ] Verify amount column stays right-aligned and never gets compressed
- [ ] Verify pending badge stays visible and doesn't get truncated
- [ ] Compare with `/transactions` page — layout should feel consistent

Tracking: #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)