### PR TITLE
Polish MCP settings page layout and icon contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ static/css/styles.css
 
 # Environment files
 .local.env
+
+# Dev server port marker (written by make dev)
+.breadbox-port
 .docker.env
 
 # Go

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ dev: generate
 		echo "  - Or kill the existing process:  kill $$(lsof -ti:$(PORT))"; \
 		exit 1; \
 	fi
-	SERVER_PORT=$(PORT) go run ./cmd/breadbox serve
+	@echo $(PORT) > .breadbox-port
+	SERVER_PORT=$(PORT) go run ./cmd/breadbox serve; rm -f .breadbox-port
 
 dev-stop:
 	@pids=$$(pgrep -f 'go run ./cmd/breadbox serve' 2>/dev/null || true); \

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -8,7 +8,53 @@
 
 <div class="grid gap-6 bb-stagger">
 
-  <!-- Card 1: Tools Enabled -->
+  <!-- Card 1: Server Instructions (most frequently edited) -->
+  <div id="instructions" class="bb-card p-0 overflow-hidden" x-data="{
+    instructions: {{.Instructions | printf `%q`}},
+    defaultInstructions: {{.DefaultInstructions | printf `%q`}},
+    async resetToDefaults() {
+      const ok = await bbConfirm({title:'Reset to defaults?',message:'Your current instructions will be replaced with the default server instructions.',confirmLabel:'Reset',variant:'warning'});
+      if (ok) {
+        this.instructions = this.defaultInstructions;
+      }
+    }
+  }">
+    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
+      <!-- NOTE: Avoid bg-secondary/10 + text-secondary for card header icons —
+           the secondary color has almost no contrast against the light background,
+           making the icon look transparent/ghostly. Use info or primary instead. -->
+      <div class="w-10 h-10 rounded-xl bg-info/10 flex items-center justify-center flex-shrink-0">
+        <i data-lucide="scroll-text" class="w-5 h-5 text-info"></i>
+      </div>
+      <div class="min-w-0">
+        <h2 class="font-semibold">Server Instructions</h2>
+        <p class="text-xs text-base-content/40">Instructions sent to agents when they connect via MCP</p>
+      </div>
+    </div>
+    <div class="px-4 sm:px-6 py-5">
+      <div class="alert alert-warning alert-soft mb-4 text-xs rounded-xl">
+        <i data-lucide="triangle-alert" class="w-4 h-4"></i>
+        <span>These instructions guide how agents understand your data model, query patterns, and available tools. Editing may cause agents to misuse tools or produce incorrect results.</span>
+      </div>
+      <form method="POST" action="/mcp-settings/instructions">
+        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+
+        <div class="form-control mb-4">
+          <textarea name="instructions" class="textarea textarea-bordered font-mono text-xs leading-relaxed w-full rounded-xl" style="min-height: 24rem" maxlength="20000" x-model="instructions" placeholder="Server instructions for MCP agents..."></textarea>
+          <label class="label">
+            <span class="label-text-alt text-base-content/40" x-text="instructions.length + '/20000'"></span>
+          </label>
+        </div>
+
+        <div class="flex flex-wrap gap-2 items-center">
+          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Instructions</button>
+          <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="resetToDefaults()">Reset to Defaults</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Card 2: Tools Enabled -->
   <div class="bb-card p-0 overflow-hidden">
     <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
       <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center flex-shrink-0">
@@ -43,49 +89,6 @@
         </div>
         <div class="mt-5">
           <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Tools</button>
-        </div>
-      </form>
-    </div>
-  </div>
-
-  <!-- Card 2: Server Instructions -->
-  <div id="instructions" class="bb-card p-0 overflow-hidden" x-data="{
-    instructions: {{.Instructions | printf `%q`}},
-    defaultInstructions: {{.DefaultInstructions | printf `%q`}},
-    async resetToDefaults() {
-      const ok = await bbConfirm({title:'Reset to defaults?',message:'Your current instructions will be replaced with the default server instructions.',confirmLabel:'Reset',variant:'warning'});
-      if (ok) {
-        this.instructions = this.defaultInstructions;
-      }
-    }
-  }">
-    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
-      <div class="w-10 h-10 rounded-xl bg-secondary/10 flex items-center justify-center flex-shrink-0">
-        <i data-lucide="scroll-text" class="w-5 h-5 text-secondary"></i>
-      </div>
-      <div class="min-w-0">
-        <h2 class="font-semibold">Server Instructions</h2>
-        <p class="text-xs text-base-content/40">Instructions sent to agents when they connect via MCP</p>
-      </div>
-    </div>
-    <div class="px-4 sm:px-6 py-5">
-      <div class="alert alert-warning alert-soft mb-4 text-xs rounded-xl">
-        <i data-lucide="triangle-alert" class="w-4 h-4"></i>
-        <span>These instructions guide how agents understand your data model, query patterns, and available tools. Editing may cause agents to misuse tools or produce incorrect results.</span>
-      </div>
-      <form method="POST" action="/mcp-settings/instructions">
-        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-
-        <div class="form-control mb-4">
-          <textarea name="instructions" class="textarea textarea-bordered font-mono text-xs leading-relaxed w-full rounded-xl" style="min-height: 24rem" maxlength="20000" x-model="instructions" placeholder="Server instructions for MCP agents..."></textarea>
-          <label class="label">
-            <span class="label-text-alt text-base-content/40" x-text="instructions.length + '/20000'"></span>
-          </label>
-        </div>
-
-        <div class="flex flex-wrap gap-2 items-center">
-          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Instructions</button>
-          <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="resetToDefaults()">Reset to Defaults</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- Move Server Instructions card to the top (most frequently edited)
- Fix ghostly icon: change from `bg-secondary/10 + text-secondary` to `bg-info/10 + text-info` for proper contrast
- Added code comment warning against using secondary color for card header icons

## Test plan
- [ ] MCP Settings page shows Instructions card first, Tools below
- [ ] Instructions icon is clearly visible (blue tint, not transparent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)