### PR TITLE
Pin sidebar profile to bottom with scrollable nav

### DIFF
--- a/input.css
+++ b/input.css
@@ -272,7 +272,7 @@
 
   /* ── Sidebar ── */
   .bb-sidebar {
-    @apply bg-base-100 min-h-full w-64 px-3 py-5 flex flex-col border-r border-base-300;
+    @apply bg-base-100 h-full w-64 px-3 py-5 flex flex-col border-r border-base-300;
   }
 
   .bb-sidebar-brand {
@@ -280,7 +280,13 @@
   }
 
   .bb-sidebar-nav {
-    @apply flex flex-col gap-0.5 flex-1;
+    @apply flex flex-col gap-0.5 flex-1 overflow-y-auto;
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+  }
+
+  .bb-sidebar-nav:hover {
+    scrollbar-color: oklch(var(--bc) / 0.15) transparent;
   }
 
   .bb-sidebar-section {


### PR DESCRIPTION
## Summary
- Sidebar profile + version badge now stays pinned at the bottom regardless of viewport height
- Nav section scrolls independently when items overflow
- Scrollbar is thin and only appears on hover

## Test plan
- [ ] Resize browser to short height — profile stays visible, nav scrolls
- [ ] At normal height, sidebar looks unchanged
- [ ] Mobile drawer still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)