### PR TITLE
Move Review Agent instructions into MCP Settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), M
 - Alpine.js v3 for admin UI interactivity (CDN, no build step). Replaces `alert()`/`confirm()` with inline patterns.
 - Dark mode: DaisyUI `light`/`dark` themes with `prefers-color-scheme` auto-switch (no hardcoded `data-theme`). Badge/flash colors use DaisyUI semantic classes.
 - Badge rendering: `statusBadge()` and `syncBadge()` template functions replace copy-pasted if-chains.
+- **Select element backgrounds**: Never use `bg-base-200/50` (or any `/opacity` modifier) on `<select>` elements — the alpha transparency renders as fully transparent in browsers. Use solid `bg-base-200` instead. `<input>` elements handle `bg-base-200/50` fine; `<select>` does not.
 - CSS spacing tokens: `--bb-gap-xs` (0.25rem) through `--bb-gap-xl` (2rem) in `:root`. Use these instead of hardcoded spacing values.
 - Template data helper: `BaseTemplateData(r, sm, currentPage, pageTitle)` returns `map[string]any` with common fields. Handlers can extend the returned map.
 - First-run: `CountAdminAccounts == 0` → redirect to `/admin/setup` (single-page admin creation form). No `setup_complete` flag. Wizard layout, no step indicator.

--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -69,22 +69,28 @@ func RevokeAPIKeyHandler(svc *service.Service) http.HandlerFunc {
 
 // --- HTML page handlers (admin dashboard) ---
 
-// APIKeysListPageHandler serves GET /admin/api-keys.
-func APIKeysListPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+// AccessPageHandler serves GET /admin/access — combined API Keys + OAuth Clients page.
+func AccessPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		keys, err := svc.ListAPIKeys(r.Context())
 		if err != nil {
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
+		clients, err := svc.ListOAuthClients(r.Context())
+		if err != nil {
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
 		data := map[string]any{
-			"PageTitle":   "API Keys",
-			"CurrentPage": "api-keys",
+			"PageTitle":   "Access",
+			"CurrentPage": "access",
 			"Keys":        keys,
+			"Clients":     clients,
 			"Flash":       GetFlash(r.Context(), sm),
 			"CSRFToken":   GetCSRFToken(r),
 		}
-		tr.Render(w, r, "api_keys.html", data)
+		tr.Render(w, r, "access.html", data)
 	}
 }
 
@@ -93,11 +99,11 @@ func APIKeyNewPageHandler(tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data := map[string]any{
 			"PageTitle":   "Create API Key",
-			"CurrentPage": "api-keys",
+			"CurrentPage": "access",
 			"CSRFToken":   GetCSRFToken(r),
 			"Breadcrumbs": []Breadcrumb{
-				{Label: "API Keys", Href: "/api-keys"},
-				{Label: "Create"},
+				{Label: "Access", Href: "/access"},
+				{Label: "Create API Key"},
 			},
 		}
 		tr.Render(w, r, "api_key_new.html", data)
@@ -139,17 +145,17 @@ func APIKeyCreatedPageHandler(sm *scs.SessionManager, tr *TemplateRenderer) http
 		name := sm.PopString(r.Context(), "created_api_key_name")
 		if key == "" {
 			// Key already shown or session expired — redirect to list.
-			http.Redirect(w, r, "/api-keys", http.StatusSeeOther)
+			http.Redirect(w, r, "/access", http.StatusSeeOther)
 			return
 		}
 		data := map[string]any{
 			"PageTitle":    "API Key Created",
-			"CurrentPage":  "api-keys",
+			"CurrentPage":  "access",
 			"PlaintextKey": key,
 			"KeyName":      name,
 			"CSRFToken":    GetCSRFToken(r),
 			"Breadcrumbs": []Breadcrumb{
-				{Label: "API Keys", Href: "/api-keys"},
+				{Label: "Access", Href: "/access"},
 				{Label: "Key Created"},
 			},
 		}
@@ -166,6 +172,6 @@ func APIKeyRevokePageHandler(svc *service.Service, sm *scs.SessionManager) http.
 		} else {
 			SetFlash(r.Context(), sm, "success", "API key revoked successfully")
 		}
-		http.Redirect(w, r, "/api-keys", http.StatusSeeOther)
+		http.Redirect(w, r, "/access", http.StatusSeeOther)
 	}
 }

--- a/internal/admin/mcp.go
+++ b/internal/admin/mcp.go
@@ -48,9 +48,19 @@ func MCPSettingsGetHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServe
 			instructions = breadboxmcp.DefaultInstructions
 		}
 
+		enabledCount := 0
+		for _, t := range tools {
+			if t.Enabled {
+				enabledCount++
+			}
+		}
+
 		data := BaseTemplateData(r, sm, "mcp", "MCP Settings")
 		data["MCPConfig"] = cfg
 		data["Tools"] = tools
+		data["ToolsEnabledCount"] = enabledCount
+		data["ToolsDisabledCount"] = len(tools) - enabledCount
+		data["ToolsTotalCount"] = len(tools)
 		data["Instructions"] = instructions
 		data["DefaultInstructions"] = breadboxmcp.DefaultInstructions
 		data["InitialReviewInstructions"] = breadboxmcp.InitialReviewInstructions

--- a/internal/admin/mcp.go
+++ b/internal/admin/mcp.go
@@ -53,6 +53,8 @@ func MCPSettingsGetHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServe
 		data["Tools"] = tools
 		data["Instructions"] = instructions
 		data["DefaultInstructions"] = breadboxmcp.DefaultInstructions
+		data["InitialReviewInstructions"] = breadboxmcp.InitialReviewInstructions
+		data["RecurringReviewInstructions"] = breadboxmcp.RecurringReviewInstructions
 
 		tr.Render(w, r, "mcp_settings.html", data)
 	}

--- a/internal/admin/oauth.go
+++ b/internal/admin/oauth.go
@@ -350,35 +350,17 @@ func (rw *oauthRedirectInterceptor) WriteHeader(code int) {
 
 // --- Admin handlers for OAuth client management ---
 
-// OAuthClientsListPageHandler serves GET /admin/oauth-clients.
-func OAuthClientsListPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		clients, err := svc.ListOAuthClients(r.Context())
-		if err != nil {
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
-		}
-		data := map[string]any{
-			"PageTitle":   "OAuth Clients",
-			"CurrentPage": "oauth-clients",
-			"Clients":     clients,
-			"Flash":       GetFlash(r.Context(), sm),
-			"CSRFToken":   GetCSRFToken(r),
-		}
-		tr.Render(w, r, "oauth_clients.html", data)
-	}
-}
 
 // OAuthClientNewPageHandler serves GET /admin/oauth-clients/new.
 func OAuthClientNewPageHandler(tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data := map[string]any{
 			"PageTitle":   "Create OAuth Client",
-			"CurrentPage": "oauth-clients",
+			"CurrentPage": "access",
 			"CSRFToken":   GetCSRFToken(r),
 			"Breadcrumbs": []Breadcrumb{
-				{Label: "OAuth Clients", Href: "/oauth-clients"},
-				{Label: "Create"},
+				{Label: "Access", Href: "/access"},
+				{Label: "Create OAuth Client"},
 			},
 		}
 		tr.Render(w, r, "oauth_client_new.html", data)
@@ -418,18 +400,18 @@ func OAuthClientCreatedPageHandler(sm *scs.SessionManager, tr *TemplateRenderer)
 		clientSecret := sm.PopString(r.Context(), "created_oauth_client_secret")
 		name := sm.PopString(r.Context(), "created_oauth_client_name")
 		if clientID == "" {
-			http.Redirect(w, r, "/oauth-clients", http.StatusSeeOther)
+			http.Redirect(w, r, "/access", http.StatusSeeOther)
 			return
 		}
 		data := map[string]any{
 			"PageTitle":    "OAuth Client Created",
-			"CurrentPage":  "oauth-clients",
+			"CurrentPage":  "access",
 			"ClientID":     clientID,
 			"ClientSecret": clientSecret,
 			"ClientName":   name,
 			"CSRFToken":    GetCSRFToken(r),
 			"Breadcrumbs": []Breadcrumb{
-				{Label: "OAuth Clients", Href: "/oauth-clients"},
+				{Label: "Access", Href: "/access"},
 				{Label: "Client Created"},
 			},
 		}
@@ -446,7 +428,7 @@ func OAuthClientRevokePageHandler(svc *service.Service, sm *scs.SessionManager) 
 		} else {
 			SetFlash(r.Context(), sm, "success", "OAuth client revoked successfully")
 		}
-		http.Redirect(w, r, "/oauth-clients", http.StatusSeeOther)
+		http.Redirect(w, r, "/access", http.StatusSeeOther)
 	}
 }
 

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -107,7 +107,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 		r.Get("/reports", ReportsPageHandler(a, svc, sm, tr))
 		r.Get("/reviews", ReviewsPageHandler(a, sm, tr, svc))
-		r.Get("/review-instructions", ReviewInstructionsPageHandler(sm, tr))
+		r.Get("/review-instructions", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/mcp-settings", http.StatusMovedPermanently)
+		})
 		r.Get("/agent-wizard", AgentWizardHandler(sm, tr))
 		r.Get("/agent-wizard/{type}", PromptBuilderHandler(sm, tr))
 		r.Get("/rules", RulesPageHandler(svc, sm, tr, a.Config.Version))

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -71,8 +71,13 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Get("/{id}/edit", EditUserHandler(a, tr))
 		})
 
+		// Combined Access page (API Keys + OAuth Clients)
+		r.Get("/access", AccessPageHandler(svc, sm, tr))
+
 		r.Route("/api-keys", func(r chi.Router) {
-			r.Get("/", APIKeysListPageHandler(svc, sm, tr))
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, "/access", http.StatusMovedPermanently)
+			})
 			r.Get("/new", APIKeyNewPageHandler(tr))
 			r.Post("/new", APIKeyCreatePageHandler(svc, sm, tr))
 			r.Get("/{id}/created", APIKeyCreatedPageHandler(sm, tr))
@@ -80,7 +85,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		})
 
 		r.Route("/oauth-clients", func(r chi.Router) {
-			r.Get("/", OAuthClientsListPageHandler(svc, sm, tr))
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, "/access", http.StatusMovedPermanently)
+			})
 			r.Get("/new", OAuthClientNewPageHandler(tr))
 			r.Post("/new", OAuthClientCreatePageHandler(svc, sm, tr))
 			r.Get("/{id}/created", OAuthClientCreatedPageHandler(sm, tr))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -260,8 +260,18 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			"safeCSS": func(s string) template.CSS {
 				return template.CSS(s)
 			},
-			"conditionSummary": func(c service.Condition) string {
-				return service.ConditionSummary(c)
+			"conditionSummary": func(c any) string {
+				switch v := c.(type) {
+				case service.Condition:
+					return service.ConditionSummary(v)
+				case *service.Condition:
+					if v == nil {
+						return ""
+					}
+					return service.ConditionSummary(*v)
+				default:
+					return ""
+				}
 			},
 			"deref": func(s *string) string {
 				if s == nil {
@@ -625,6 +635,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/connection_reauth.html",
 		"pages/users.html",
 		"pages/user_form.html",
+		"pages/access.html",
 		"pages/api_keys.html",
 		"pages/api_key_new.html",
 		"pages/api_key_created.html",

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -57,7 +57,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		return nil, fmt.Errorf("invalid sync log id: %w", err)
 	}
 
-	query := "SELECT sl.id, sl.connection_id, bc.institution_name, sl.trigger, sl.status, " +
+	query := "SELECT sl.id, sl.connection_id, bc.institution_name, bc.provider, sl.trigger, sl.status, " +
 		"sl.added_count, sl.modified_count, sl.removed_count, sl.unchanged_count, sl.error_message, " +
 		"sl.started_at, sl.completed_at, sl.rule_hits, sl.warning_message " +
 		"FROM sync_logs sl " +
@@ -68,6 +68,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		id              pgtype.UUID
 		connectionID    pgtype.UUID
 		institutionName pgtype.Text
+		providerType    string
 		trigger         string
 		status          string
 		addedCount      int32
@@ -82,7 +83,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 	)
 
 	if err := s.Pool.QueryRow(ctx, query, uid).Scan(
-		&id, &connectionID, &institutionName, &trigger, &status,
+		&id, &connectionID, &institutionName, &providerType, &trigger, &status,
 		&addedCount, &modifiedCount, &removedCount, &unchangedCount, &errorMessage,
 		&startedAt, &completedAt, &ruleHitsJSON, &warningMessage,
 	); err != nil {
@@ -110,6 +111,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		ID:               formatUUID(id),
 		ConnectionID:     formatUUID(connectionID),
 		InstitutionName:  instName,
+		Provider:         providerType,
 		Trigger:          trigger,
 		Status:           status,
 		AddedCount:       addedCount,
@@ -522,29 +524,43 @@ func (s *Service) parseRuleHits(ctx context.Context, ruleHitsJSON []byte) ([]Rul
 		return nil, 0
 	}
 
-	// Batch-fetch rule names for all rule IDs.
-	ruleNames := make(map[string]string, len(hitMap))
+	// Batch-fetch rule names and conditions for all rule IDs.
+	type ruleInfo struct {
+		name       string
+		conditions *Condition
+	}
+	ruleInfoMap := make(map[string]ruleInfo, len(hitMap))
 	for ruleID := range hitMap {
 		uid, err := parseUUID(ruleID)
 		if err != nil {
 			continue
 		}
 		var name string
-		err = s.Pool.QueryRow(ctx, "SELECT name FROM transaction_rules WHERE id = $1", uid).Scan(&name)
+		var condJSON []byte
+		err = s.Pool.QueryRow(ctx, "SELECT name, conditions FROM transaction_rules WHERE id = $1", uid).Scan(&name, &condJSON)
 		if err != nil {
-			name = "Deleted rule"
+			ruleInfoMap[ruleID] = ruleInfo{name: "Deleted rule"}
+			continue
 		}
-		ruleNames[ruleID] = name
+		info := ruleInfo{name: name}
+		if len(condJSON) > 0 {
+			var cond Condition
+			if json.Unmarshal(condJSON, &cond) == nil {
+				info.conditions = &cond
+			}
+		}
+		ruleInfoMap[ruleID] = info
 	}
 
 	entries := make([]RuleHitEntry, 0, len(hitMap))
 	total := 0
 	for ruleID, count := range hitMap {
-		name := ruleNames[ruleID]
+		info := ruleInfoMap[ruleID]
 		entries = append(entries, RuleHitEntry{
-			RuleID:   ruleID,
-			RuleName: name,
-			Count:    count,
+			RuleID:     ruleID,
+			RuleName:   info.name,
+			Count:      count,
+			Conditions: info.conditions,
 		})
 		total += count
 	}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -185,6 +185,7 @@ type SyncLogRow struct {
 	ID                   string
 	ConnectionID         string
 	InstitutionName      string
+	Provider             string
 	Trigger              string
 	Status               string
 	AddedCount           int32
@@ -205,9 +206,10 @@ type SyncLogRow struct {
 
 // RuleHitEntry represents a single rule's hit count within a sync run.
 type RuleHitEntry struct {
-	RuleID   string
-	RuleName string
-	Count    int
+	RuleID     string
+	RuleName   string
+	Count      int
+	Conditions *Condition
 }
 
 // SyncLogAccountRow represents a per-account breakdown within a sync log.

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -646,7 +646,7 @@
         // Agents
         { id: 'agent-wizard', group: 'Agents', title: 'Agent Wizard', desc: 'Create agent prompts', icon: 'wand-sparkles', href: '/agent-wizard', keywords: 'wizard setup prompt create agent flow' },
         { id: 'agent-reviews', group: 'Agents', title: 'Review Queue', desc: 'Transaction review queue', icon: 'clipboard-check', href: '/reviews', keywords: 'pending approve categorize' },
-        { id: 'agent-review-instructions', group: 'Agents', title: 'Review Agent', desc: 'Review agent instructions', icon: 'message-square-code', href: '/review-instructions', keywords: 'agent instructions prompts' },
+        { id: 'agent-review-instructions', group: 'Agents', title: 'Review Agent Instructions', desc: 'Pre-built prompts for transaction review', icon: 'clipboard-check', href: '/mcp-settings', keywords: 'agent instructions prompts review' },
         { id: 'agent-reports', group: 'Agents', title: 'Reports', desc: 'Agent reports and findings', icon: 'file-text', href: '/reports', keywords: 'agent summaries notifications' },
         { id: 'agent-mcp', group: 'Agents', title: 'MCP Settings', desc: 'Tools and server instructions', icon: 'bot', href: '/mcp-settings', keywords: 'mcp tools permissions instructions' },
         // System

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -651,8 +651,7 @@
         { id: 'agent-mcp', group: 'Agents', title: 'MCP Settings', desc: 'Tools and server instructions', icon: 'bot', href: '/mcp-settings', keywords: 'mcp tools permissions instructions' },
         // System
         { id: 'sys-providers', group: 'System', title: 'Providers', desc: 'Configure Plaid, Teller, CSV', icon: 'plug', href: '/providers', keywords: 'plaid teller csv bank setup' },
-        { id: 'sys-api-keys', group: 'System', title: 'API Keys', desc: 'Manage API access keys', icon: 'key', href: '/api-keys', keywords: 'tokens authentication' },
-        { id: 'sys-oauth-clients', group: 'System', title: 'OAuth Clients', desc: 'External connector access', icon: 'fingerprint', href: '/oauth-clients', keywords: 'oauth connector claude' },
+        { id: 'sys-access', group: 'System', title: 'Access', desc: 'API keys and OAuth clients', icon: 'shield-check', href: '/access', keywords: 'tokens authentication api keys oauth connector claude' },
         { id: 'sys-sync-logs', group: 'System', title: 'Sync Logs', desc: 'Sync history and status', icon: 'refresh-cw', href: '/sync-logs', keywords: 'history errors status' },
         { id: 'sys-webhooks', group: 'System', title: 'Webhooks', desc: 'Webhook event history', icon: 'webhook', href: '/webhook-events', keywords: 'events plaid teller notifications' },
         { id: 'sys-settings', group: 'System', title: 'Settings', desc: 'Sync schedule, security, system', icon: 'settings', href: '/settings', keywords: 'schedule password encryption' },
@@ -702,6 +701,7 @@
             seen[item.group].items.push(clone);
             flatIndex++;
           });
+          // Add skeleton group while loading
           if (this._txLoading && !seen['Transactions']) {
             groups.push({ label: 'Transactions', items: [], _loading: true });
           }
@@ -751,6 +751,7 @@
             if (dialog) lucide.createIcons({ nodes: [dialog] });
           }, 10);
 
+          // Debounced transaction search
           if (this._txTimer) clearTimeout(this._txTimer);
           if (this._txAbort) this._txAbort.abort();
 
@@ -1002,7 +1003,7 @@
         s: '/settings',
         p: '/providers',
         m: '/mcp-settings',
-        k: '/api-keys',
+        k: '/access',
         f: '/users'
       };
 

--- a/internal/templates/pages/access.html
+++ b/internal/templates/pages/access.html
@@ -1,0 +1,147 @@
+{{define "content"}}
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Access</h1>
+    <p class="text-sm text-base-content/50 mt-1">Manage API keys and OAuth clients for external access</p>
+  </div>
+</div>
+
+<!-- API Keys Section -->
+<div class="mb-8">
+  <div class="flex items-center justify-between mb-3">
+    <div class="flex items-center gap-2">
+      <i data-lucide="key" class="w-4 h-4 text-primary"></i>
+      <h2 class="text-sm font-semibold">API Keys</h2>
+      <span class="text-xs text-base-content/40">Direct REST API and MCP access</span>
+    </div>
+    <a href="/api-keys/new" class="btn btn-primary btn-sm btn-soft rounded-xl">
+      <i data-lucide="plus" class="w-4 h-4"></i>
+      Create Key
+    </a>
+  </div>
+
+  {{if .Keys}}
+  <div class="space-y-2">
+    {{range .Keys}}
+    <div class="bb-card px-5 py-3.5" x-data="{ confirming: false }">
+      <div class="flex items-center gap-3">
+        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
+          {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-primary/8{{end}}">
+          <i data-lucide="key" class="w-4 h-4 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-primary{{end}}"></i>
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="font-semibold text-sm {{if .RevokedAt}}text-base-content/40 line-through{{end}}">{{.Name}}</span>
+            {{if eq .Scope "read_only"}}
+            <span class="badge badge-soft badge-warning badge-xs">Read Only</span>
+            {{else}}
+            <span class="badge badge-soft badge-primary badge-xs">Full Access</span>
+            {{end}}
+            {{if .RevokedAt}}
+            <span class="badge badge-soft badge-error badge-xs">Revoked</span>
+            {{end}}
+          </div>
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs text-base-content/40">
+            <code class="font-mono bg-base-200/50 px-1 py-0.5 rounded text-[0.65rem]">{{.KeyPrefix}}...</code>
+            <span>Created {{formatDateShort .CreatedAt}}</span>
+            {{if .LastUsedAt}}<span>Last used {{relativeTime .LastUsedAt}}</span>{{end}}
+          </div>
+        </div>
+        {{if not .RevokedAt}}
+        <div class="shrink-0">
+          <form method="POST" action="/api-keys/{{.ID}}/revoke" class="inline">
+            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+            <button type="button" class="btn btn-ghost btn-xs text-base-content/40 hover:text-error" x-show="!confirming" @click="confirming = true">
+              Revoke
+            </button>
+            <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
+              <button type="submit" class="btn btn-error btn-xs btn-soft rounded-xl">Confirm</button>
+              <button type="button" class="btn btn-ghost btn-xs rounded-xl" @click="confirming = false">Cancel</button>
+            </span>
+          </form>
+        </div>
+        {{end}}
+      </div>
+    </div>
+    {{end}}
+  </div>
+  {{else}}
+  <div class="bb-card px-5 py-8 text-center">
+    <p class="text-sm text-base-content/40 mb-3">No API keys yet</p>
+    <a href="/api-keys/new" class="btn btn-primary btn-sm btn-soft rounded-xl">
+      <i data-lucide="plus" class="w-4 h-4"></i>
+      Create your first key
+    </a>
+  </div>
+  {{end}}
+</div>
+
+<!-- OAuth Clients Section -->
+<div>
+  <div class="flex items-center justify-between mb-3">
+    <div class="flex items-center gap-2">
+      <i data-lucide="fingerprint" class="w-4 h-4 text-base-content/50"></i>
+      <h2 class="text-sm font-semibold">OAuth Clients</h2>
+      <span class="text-xs text-base-content/40">External connector access (e.g., Claude)</span>
+    </div>
+    <a href="/oauth-clients/new" class="btn btn-neutral btn-sm btn-soft rounded-xl">
+      <i data-lucide="plus" class="w-4 h-4"></i>
+      Create Client
+    </a>
+  </div>
+
+  {{if .Clients}}
+  <div class="space-y-2">
+    {{range .Clients}}
+    <div class="bb-card px-5 py-3.5" x-data="{ confirming: false }">
+      <div class="flex items-center gap-3">
+        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
+          {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-base-200/60{{end}}">
+          <i data-lucide="fingerprint" class="w-4 h-4 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-base-content/50{{end}}"></i>
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="font-semibold text-sm {{if .RevokedAt}}text-base-content/40 line-through{{end}}">{{.Name}}</span>
+            {{if eq .Scope "read_only"}}
+            <span class="badge badge-soft badge-warning badge-xs">Read Only</span>
+            {{else}}
+            <span class="badge badge-soft badge-primary badge-xs">Full Access</span>
+            {{end}}
+            {{if .RevokedAt}}
+            <span class="badge badge-soft badge-error badge-xs">Revoked</span>
+            {{end}}
+          </div>
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs text-base-content/40">
+            <code class="font-mono bg-base-200/50 px-1 py-0.5 rounded text-[0.65rem]">{{.ClientIDPrefix}}...</code>
+            <span>Created {{formatDateShort .CreatedAt}}</span>
+          </div>
+        </div>
+        {{if not .RevokedAt}}
+        <div class="shrink-0">
+          <form method="POST" action="/oauth-clients/{{.ID}}/revoke" class="inline">
+            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+            <button type="button" class="btn btn-ghost btn-xs text-base-content/40 hover:text-error" x-show="!confirming" @click="confirming = true">
+              Revoke
+            </button>
+            <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
+              <button type="submit" class="btn btn-error btn-xs btn-soft rounded-xl">Confirm</button>
+              <button type="button" class="btn btn-ghost btn-xs rounded-xl" @click="confirming = false">Cancel</button>
+            </span>
+          </form>
+        </div>
+        {{end}}
+      </div>
+    </div>
+    {{end}}
+  </div>
+  {{else}}
+  <div class="bb-card px-5 py-8 text-center">
+    <p class="text-sm text-base-content/40 mb-3">No OAuth clients yet</p>
+    <a href="/oauth-clients/new" class="btn btn-neutral btn-sm btn-soft rounded-xl">
+      <i data-lucide="plus" class="w-4 h-4"></i>
+      Create your first client
+    </a>
+  </div>
+  {{end}}
+</div>
+{{end}}

--- a/internal/templates/pages/api_key_created.html
+++ b/internal/templates/pages/api_key_created.html
@@ -38,7 +38,7 @@
       <span x-show="!copied">Copy to Clipboard</span>
       <span x-show="copied" x-cloak>Copied!</span>
     </button>
-    <a href="/api-keys" class="btn btn-ghost btn-sm rounded-xl">Done</a>
+    <a href="/access" class="btn btn-ghost btn-sm rounded-xl">Done</a>
   </div>
 
   <p class="text-xs text-base-content/40 mt-6 pt-4 border-t border-base-300">

--- a/internal/templates/pages/api_key_new.html
+++ b/internal/templates/pages/api_key_new.html
@@ -6,8 +6,8 @@
     <h1 class="bb-page-title">Create API Key</h1>
     <p class="text-sm text-base-content/50 mt-1">Generate a new key for API or MCP access</p>
   </div>
-  <a href="/api-keys" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> API Keys
+  <a href="/access" class="btn btn-sm btn-ghost rounded-xl gap-2">
+    <i data-lucide="arrow-left" class="w-4 h-4"></i> Access
   </a>
 </div>
 
@@ -33,7 +33,7 @@
 
     <fieldset class="fieldset mb-6">
       <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="scope">Scope</label>
-      <select id="scope" name="scope" class="select w-full bg-base-200/50 border-base-300 focus:border-primary rounded-xl">
+      <select id="scope" name="scope" class="select w-full bg-base-200 border-base-300 focus:border-primary rounded-xl">
         <option value="full_access">Full Access &mdash; read and write</option>
         <option value="read_only">Read Only &mdash; query data only</option>
       </select>
@@ -44,7 +44,7 @@
       <button type="submit" class="btn btn-primary btn-sm rounded-xl">
         <i data-lucide="plus" class="w-4 h-4"></i> Create API Key
       </button>
-      <a href="/api-keys" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
+      <a href="/access" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
     </div>
   </form>
 </div>

--- a/internal/templates/pages/csv_import.html
+++ b/internal/templates/pages/csv_import.html
@@ -59,7 +59,7 @@
       {{else}}
       <fieldset class="fieldset mb-5">
         <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="csv-user-id">Family Member</label>
-        <select id="csv-user-id" class="select w-full bg-base-200/50 border-base-300 focus:border-primary rounded-xl" required>
+        <select id="csv-user-id" class="select w-full bg-base-200 border-base-300 focus:border-primary rounded-xl" required>
           <option value="" disabled selected>Select a member...</option>
           {{range .Users}}
           <option value="{{formatUUID .ID}}">{{.Name}}</option>
@@ -101,31 +101,31 @@
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-date">
             Date Column <span class="text-xs text-base-content/30">(required)</span>
           </label>
-          <select id="map-date" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
+          <select id="map-date" class="select w-full bg-base-200 border-base-300 rounded-xl"></select>
         </fieldset>
         <fieldset class="fieldset">
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-amount">
             Amount Column <span class="text-xs text-base-content/30">(required)</span>
           </label>
-          <select id="map-amount" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
+          <select id="map-amount" class="select w-full bg-base-200 border-base-300 rounded-xl"></select>
         </fieldset>
         <fieldset class="fieldset">
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-description">
             Description Column <span class="text-xs text-base-content/30">(required)</span>
           </label>
-          <select id="map-description" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
+          <select id="map-description" class="select w-full bg-base-200 border-base-300 rounded-xl"></select>
         </fieldset>
         <fieldset class="fieldset">
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-category">
             Category Column <span class="text-xs text-base-content/30">(optional)</span>
           </label>
-          <select id="map-category" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
+          <select id="map-category" class="select w-full bg-base-200 border-base-300 rounded-xl"></select>
         </fieldset>
         <fieldset class="fieldset">
           <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="map-merchant">
             Merchant Column <span class="text-xs text-base-content/30">(optional)</span>
           </label>
-          <select id="map-merchant" class="select w-full bg-base-200/50 border-base-300 rounded-xl"></select>
+          <select id="map-merchant" class="select w-full bg-base-200 border-base-300 rounded-xl"></select>
         </fieldset>
       </div>
 

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -8,8 +8,9 @@
 
 <div class="grid gap-6 bb-stagger">
 
-  <!-- Card 1: Server Instructions (most frequently edited) -->
+  <!-- Card 1: Server Instructions -->
   <div id="instructions" class="bb-card p-0 overflow-hidden" x-data="{
+    expanded: location.hash === '#instructions',
     instructions: {{.Instructions | printf `%q`}},
     defaultInstructions: {{.DefaultInstructions | printf `%q`}},
     async resetToDefaults() {
@@ -19,105 +20,115 @@
       }
     }
   }">
-    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
+    <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
       <!-- NOTE: Avoid bg-secondary/10 + text-secondary for card header icons —
            the secondary color has almost no contrast against the light background,
            making the icon look transparent/ghostly. Use info or primary instead. -->
       <div class="w-10 h-10 rounded-xl bg-info/10 flex items-center justify-center flex-shrink-0">
         <i data-lucide="scroll-text" class="w-5 h-5 text-info"></i>
       </div>
-      <div class="min-w-0">
+      <div class="min-w-0 flex-1">
         <h2 class="font-semibold">Server Instructions</h2>
-        <p class="text-xs text-base-content/40">Instructions sent to agents when they connect via MCP</p>
+        <p class="text-xs text-base-content/40" x-show="!expanded">Custom instructions sent to agents when they connect via MCP</p>
+        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Instructions sent to agents when they connect via MCP</p>
       </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
     </div>
-    <div class="px-4 sm:px-6 py-5">
-      <div class="alert alert-warning alert-soft mb-4 text-xs rounded-xl">
-        <i data-lucide="triangle-alert" class="w-4 h-4"></i>
-        <span>These instructions guide how agents understand your data model, query patterns, and available tools. Editing may cause agents to misuse tools or produce incorrect results.</span>
+    <div x-show="expanded" x-collapse>
+      <div class="px-4 sm:px-6 py-5">
+        <div class="alert alert-warning alert-soft mb-4 text-xs rounded-xl">
+          <i data-lucide="triangle-alert" class="w-4 h-4"></i>
+          <span>These instructions guide how agents understand your data model, query patterns, and available tools. Editing may cause agents to misuse tools or produce incorrect results.</span>
+        </div>
+        <form method="POST" action="/mcp-settings/instructions">
+          <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+
+          <div class="form-control mb-4">
+            <textarea name="instructions" class="textarea textarea-bordered font-mono text-xs leading-relaxed w-full rounded-xl" style="min-height: 24rem" maxlength="20000" x-model="instructions" placeholder="Server instructions for MCP agents..."></textarea>
+            <label class="label">
+              <span class="label-text-alt text-base-content/40" x-text="instructions.length + '/20000'"></span>
+            </label>
+          </div>
+
+          <div class="flex flex-wrap gap-2 items-center">
+            <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Instructions</button>
+            <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="resetToDefaults()">Reset to Defaults</button>
+          </div>
+        </form>
       </div>
-      <form method="POST" action="/mcp-settings/instructions">
-        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-
-        <div class="form-control mb-4">
-          <textarea name="instructions" class="textarea textarea-bordered font-mono text-xs leading-relaxed w-full rounded-xl" style="min-height: 24rem" maxlength="20000" x-model="instructions" placeholder="Server instructions for MCP agents..."></textarea>
-          <label class="label">
-            <span class="label-text-alt text-base-content/40" x-text="instructions.length + '/20000'"></span>
-          </label>
-        </div>
-
-        <div class="flex flex-wrap gap-2 items-center">
-          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Instructions</button>
-          <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="resetToDefaults()">Reset to Defaults</button>
-        </div>
-      </form>
     </div>
   </div>
 
   <!-- Card 2: Tools Enabled -->
-  <div class="bb-card p-0 overflow-hidden">
-    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
+  <div id="tools" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#tools' }">
+    <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
       <div class="w-10 h-10 rounded-xl bg-primary/10 flex items-center justify-center flex-shrink-0">
         <i data-lucide="wrench" class="w-5 h-5 text-primary"></i>
       </div>
-      <div class="min-w-0">
+      <div class="min-w-0 flex-1">
         <h2 class="font-semibold">Tools Enabled</h2>
-        <p class="text-xs text-base-content/40">Enable or disable individual MCP tools</p>
+        <p class="text-xs text-base-content/40" x-show="!expanded">{{.ToolsEnabledCount}} of {{.ToolsTotalCount}} tools enabled{{if gt .ToolsDisabledCount 0}} · {{.ToolsDisabledCount}} disabled{{end}}</p>
+        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Enable or disable individual MCP tools</p>
       </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
     </div>
-    <div class="px-4 sm:px-6 py-5">
-      <p class="text-sm text-base-content/50 mb-4">Disabled tools are hidden from all agents. Read-only API keys cannot invoke write tools regardless of this setting.</p>
-      <form method="POST" action="/mcp-settings/tools">
-        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-        <div class="space-y-1">
-          {{range .Tools}}
-          <div class="flex items-start gap-2 sm:gap-3 p-2 sm:p-3 rounded-xl hover:bg-base-200/50 transition-colors duration-150">
-            <input type="checkbox" name="enabled_tools" value="{{.Name}}" class="toggle toggle-sm toggle-primary mt-0.5 flex-shrink-0" {{if .Enabled}}checked{{end}}>
-            <div class="min-w-0 flex-1">
-              <div class="flex items-center gap-2 flex-wrap">
-                <span class="font-mono text-xs sm:text-sm break-all sm:break-normal">{{.Name}}</span>
-                {{if eq .Classification "write"}}
-                  <span class="badge badge-soft badge-warning badge-xs rounded-lg font-medium">write</span>
-                {{else}}
-                  <span class="badge badge-soft badge-success badge-xs rounded-lg font-medium">read</span>
-                {{end}}
+    <div x-show="expanded" x-collapse x-cloak>
+      <div class="px-4 sm:px-6 py-5">
+        <p class="text-sm text-base-content/50 mb-4">Disabled tools are hidden from all agents. Read-only API keys cannot invoke write tools regardless of this setting.</p>
+        <form method="POST" action="/mcp-settings/tools">
+          <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+          <div class="space-y-1">
+            {{range .Tools}}
+            <div class="flex items-start gap-2 sm:gap-3 p-2 sm:p-3 rounded-xl hover:bg-base-200/50 transition-colors duration-150">
+              <input type="checkbox" name="enabled_tools" value="{{.Name}}" class="toggle toggle-sm toggle-primary mt-0.5 flex-shrink-0" {{if .Enabled}}checked{{end}}>
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2 flex-wrap">
+                  <span class="font-mono text-xs sm:text-sm break-all sm:break-normal">{{.Name}}</span>
+                  {{if eq .Classification "write"}}
+                    <span class="badge badge-soft badge-warning badge-xs rounded-lg font-medium">write</span>
+                  {{else}}
+                    <span class="badge badge-soft badge-success badge-xs rounded-lg font-medium">read</span>
+                  {{end}}
+                </div>
+                <div class="text-xs text-base-content/40 mt-0.5 line-clamp-2 sm:line-clamp-1">{{.Description}}</div>
               </div>
-              <div class="text-xs text-base-content/40 mt-0.5 line-clamp-2 sm:line-clamp-1">{{.Description}}</div>
             </div>
+            {{end}}
           </div>
-          {{end}}
-        </div>
-        <div class="mt-5">
-          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Tools</button>
-        </div>
-      </form>
+          <div class="mt-5">
+            <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Tools</button>
+          </div>
+        </form>
+      </div>
     </div>
   </div>
 
   <!-- Card 3: MCP Connection -->
-  <div class="bb-card p-0 overflow-hidden" x-data="{ copiedConfig: false }">
-    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
+  <div id="connection" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#connection', copiedConfig: false }">
+    <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
       <div class="w-10 h-10 rounded-xl bg-warning/10 flex items-center justify-center flex-shrink-0">
         <i data-lucide="plug" class="w-5 h-5 text-warning"></i>
       </div>
-      <div class="min-w-0">
+      <div class="min-w-0 flex-1">
         <h2 class="font-semibold">Connection</h2>
-        <p class="text-xs text-base-content/40">Connect MCP agents to your Breadbox server</p>
+        <p class="text-xs text-base-content/40">Endpoints and config for connecting MCP agents</p>
       </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
     </div>
-    <div class="px-4 sm:px-6 py-5 space-y-5">
-      <div>
-        <h3 class="font-medium text-sm mb-2 text-base-content/60">HTTP Endpoint</h3>
-        <div class="bg-base-200 rounded-xl p-3 font-mono text-sm break-all text-base-content/70">https://&lt;host&gt;/mcp</div>
-      </div>
-      <div>
-        <h3 class="font-medium text-sm mb-2 text-base-content/60">Stdio Command</h3>
-        <div class="bg-base-200 rounded-xl p-3 font-mono text-sm text-base-content/70">docker exec -i breadbox-app-1 /app/breadbox mcp-stdio</div>
-      </div>
-      <div>
-        <h3 class="font-medium text-sm mb-2 text-base-content/60">Claude Desktop Config (stdio)</h3>
-        <div class="relative">
-          <pre class="bg-base-200 rounded-xl p-4 text-sm font-mono overflow-auto text-base-content/70">{
+    <div x-show="expanded" x-collapse x-cloak>
+      <div class="px-4 sm:px-6 py-5 space-y-5">
+        <div>
+          <h3 class="font-medium text-sm mb-2 text-base-content/60">HTTP Endpoint</h3>
+          <div class="bg-base-200 rounded-xl p-3 font-mono text-sm break-all text-base-content/70">https://&lt;host&gt;/mcp</div>
+        </div>
+        <div>
+          <h3 class="font-medium text-sm mb-2 text-base-content/60">Stdio Command</h3>
+          <div class="bg-base-200 rounded-xl p-3 font-mono text-sm text-base-content/70">docker exec -i breadbox-app-1 /app/breadbox mcp-stdio</div>
+        </div>
+        <div>
+          <h3 class="font-medium text-sm mb-2 text-base-content/60">Claude Desktop Config (stdio)</h3>
+          <div class="relative">
+            <pre class="bg-base-200 rounded-xl p-4 text-sm font-mono overflow-auto text-base-content/70">{
   "mcpServers": {
     "breadbox": {
       "command": "docker",
@@ -125,25 +136,26 @@
     }
   }
 }</pre>
-          <button
-            class="btn btn-sm btn-ghost rounded-xl absolute top-2 right-2"
-            @click="navigator.clipboard.writeText(JSON.stringify({mcpServers:{breadbox:{command:'docker',args:['exec','-i','breadbox-app-1','/app/breadbox','mcp-stdio']}}}, null, 2)).then(() => { copiedConfig = true; setTimeout(() => copiedConfig = false, 2000) })"
-          >
-            <template x-if="!copiedConfig">
-              <span class="flex items-center gap-1"><i data-lucide="copy" class="w-4 h-4"></i> Copy</span>
-            </template>
-            <template x-if="copiedConfig">
-              <span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-4 h-4"></i> Copied!</span>
-            </template>
-          </button>
+            <button
+              class="btn btn-sm btn-ghost rounded-xl absolute top-2 right-2"
+              @click.stop="navigator.clipboard.writeText(JSON.stringify({mcpServers:{breadbox:{command:'docker',args:['exec','-i','breadbox-app-1','/app/breadbox','mcp-stdio']}}}, null, 2)).then(() => { copiedConfig = true; setTimeout(() => copiedConfig = false, 2000) })"
+            >
+              <template x-if="!copiedConfig">
+                <span class="flex items-center gap-1"><i data-lucide="copy" class="w-4 h-4"></i> Copy</span>
+              </template>
+              <template x-if="copiedConfig">
+                <span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-4 h-4"></i> Copied!</span>
+              </template>
+            </button>
+          </div>
         </div>
       </div>
     </div>
   </div>
 
-  <!-- Card 3: Review Agent Instructions -->
-  <div class="bb-card p-0 overflow-hidden" x-data="{ expanded: false }">
-    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3 cursor-pointer" @click="expanded = !expanded">
+  <!-- Card 4: Review Agent Instructions [Deprecated] -->
+  <div id="review-instructions" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#review-instructions' }">
+    <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
       <div class="w-10 h-10 rounded-xl bg-base-200 flex items-center justify-center flex-shrink-0">
         <i data-lucide="clipboard-check" class="w-5 h-5 text-base-content/40"></i>
       </div>
@@ -166,7 +178,7 @@
           <p class="text-xs text-base-content/50 mb-3">Use when a new account is synced and you have many uncategorized transactions.</p>
           <div class="relative">
             <pre class="bg-base-200 rounded-xl p-4 text-xs whitespace-pre-wrap overflow-auto max-h-60 font-mono text-base-content/70">{{.InitialReviewInstructions}}</pre>
-            <button class="btn btn-xs btn-ghost rounded-lg absolute top-2 right-2" @click="navigator.clipboard.writeText({{.InitialReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })">
+            <button class="btn btn-xs btn-ghost rounded-lg absolute top-2 right-2" @click.stop="navigator.clipboard.writeText({{.InitialReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })">
               <template x-if="!copied"><span class="flex items-center gap-1"><i data-lucide="copy" class="w-3.5 h-3.5"></i> Copy</span></template>
               <template x-if="copied"><span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-3.5 h-3.5"></i> Copied!</span></template>
             </button>
@@ -183,7 +195,7 @@
           <p class="text-xs text-base-content/50 mb-3">Use for routine review of incoming transactions. Reviews a small batch with more attention per transaction.</p>
           <div class="relative">
             <pre class="bg-base-200 rounded-xl p-4 text-xs whitespace-pre-wrap overflow-auto max-h-60 font-mono text-base-content/70">{{.RecurringReviewInstructions}}</pre>
-            <button class="btn btn-xs btn-ghost rounded-lg absolute top-2 right-2" @click="navigator.clipboard.writeText({{.RecurringReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })">
+            <button class="btn btn-xs btn-ghost rounded-lg absolute top-2 right-2" @click.stop="navigator.clipboard.writeText({{.RecurringReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })">
               <template x-if="!copied"><span class="flex items-center gap-1"><i data-lucide="copy" class="w-3.5 h-3.5"></i> Copy</span></template>
               <template x-if="copied"><span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-3.5 h-3.5"></i> Copied!</span></template>
             </button>
@@ -195,4 +207,13 @@
   </div>
 
 </div>
+
+<script>
+// Deep-link: scroll to and auto-expand the targeted section
+(function() {
+  if (!location.hash) return;
+  var el = document.querySelector(location.hash);
+  if (el) setTimeout(function() { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 100);
+})();
+</script>
 {{end}}

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -141,50 +141,7 @@
     </div>
   </div>
 
-  <!-- Card 3: Server Instructions -->
-  <div id="instructions" class="bb-card p-0 overflow-hidden" x-data="{
-    instructions: {{.Instructions | printf `%q`}},
-    defaultInstructions: {{.DefaultInstructions | printf `%q`}},
-    async resetToDefaults() {
-      const ok = await bbConfirm({title:'Reset to defaults?',message:'Your current instructions will be replaced with the default server instructions.',confirmLabel:'Reset',variant:'warning'});
-      if (ok) {
-        this.instructions = this.defaultInstructions;
-      }
-    }
-  }">
-    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
-      <div class="w-10 h-10 rounded-xl bg-secondary/10 flex items-center justify-center flex-shrink-0">
-        <i data-lucide="scroll-text" class="w-5 h-5 text-secondary"></i>
-      </div>
-      <div class="min-w-0">
-        <h2 class="font-semibold">Server Instructions</h2>
-        <p class="text-xs text-base-content/40">Instructions sent to agents when they connect via MCP</p>
-      </div>
-    </div>
-    <div class="px-4 sm:px-6 py-5">
-      <div class="alert alert-warning alert-soft mb-4 text-xs rounded-xl">
-        <i data-lucide="triangle-alert" class="w-4 h-4"></i>
-        <span>These instructions guide how agents understand your data model, query patterns, and available tools. Editing may cause agents to misuse tools or produce incorrect results.</span>
-      </div>
-      <form method="POST" action="/mcp-settings/instructions">
-        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-
-        <div class="form-control mb-4">
-          <textarea name="instructions" class="textarea textarea-bordered font-mono text-xs leading-relaxed w-full rounded-xl" style="min-height: 24rem" maxlength="20000" x-model="instructions" placeholder="Server instructions for MCP agents..."></textarea>
-          <label class="label">
-            <span class="label-text-alt text-base-content/40" x-text="instructions.length + '/20000'"></span>
-          </label>
-        </div>
-
-        <div class="flex flex-wrap gap-2 items-center">
-          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Instructions</button>
-          <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="resetToDefaults()">Reset to Defaults</button>
-        </div>
-      </form>
-    </div>
-  </div>
-
-  <!-- Card 4: Review Agent Instructions -->
+  <!-- Card 3: Review Agent Instructions -->
   <div class="bb-card p-0 overflow-hidden" x-data="{ expanded: false }">
     <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3 cursor-pointer" @click="expanded = !expanded">
       <div class="w-10 h-10 rounded-xl bg-base-200 flex items-center justify-center flex-shrink-0">

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -187,12 +187,12 @@
   <!-- Card 4: Review Agent Instructions -->
   <div class="bb-card p-0 overflow-hidden" x-data="{ expanded: false }">
     <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3 cursor-pointer" @click="expanded = !expanded">
-      <div class="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center flex-shrink-0">
-        <i data-lucide="clipboard-check" class="w-5 h-5 text-accent"></i>
+      <div class="w-10 h-10 rounded-xl bg-base-200 flex items-center justify-center flex-shrink-0">
+        <i data-lucide="clipboard-check" class="w-5 h-5 text-base-content/40"></i>
       </div>
       <div class="min-w-0 flex-1">
-        <h2 class="font-semibold">Review Agent Instructions</h2>
-        <p class="text-xs text-base-content/40">Pre-built instruction blocks for agents doing transaction review</p>
+        <h2 class="font-semibold">Review Agent Instructions <span class="badge badge-soft badge-warning badge-xs ml-1">Deprecated</span></h2>
+        <p class="text-xs text-base-content/40">Pre-built instruction blocks — being replaced by Agent Wizard prompt builder</p>
       </div>
       <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
     </div>

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -94,5 +94,148 @@
     </div>
   </div>
 
+  <!-- Card 3: MCP Connection -->
+  <div class="bb-card p-0 overflow-hidden" x-data="{ copiedConfig: false }">
+    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-warning/10 flex items-center justify-center flex-shrink-0">
+        <i data-lucide="plug" class="w-5 h-5 text-warning"></i>
+      </div>
+      <div class="min-w-0">
+        <h2 class="font-semibold">Connection</h2>
+        <p class="text-xs text-base-content/40">Connect MCP agents to your Breadbox server</p>
+      </div>
+    </div>
+    <div class="px-4 sm:px-6 py-5 space-y-5">
+      <div>
+        <h3 class="font-medium text-sm mb-2 text-base-content/60">HTTP Endpoint</h3>
+        <div class="bg-base-200 rounded-xl p-3 font-mono text-sm break-all text-base-content/70">https://&lt;host&gt;/mcp</div>
+      </div>
+      <div>
+        <h3 class="font-medium text-sm mb-2 text-base-content/60">Stdio Command</h3>
+        <div class="bg-base-200 rounded-xl p-3 font-mono text-sm text-base-content/70">docker exec -i breadbox-app-1 /app/breadbox mcp-stdio</div>
+      </div>
+      <div>
+        <h3 class="font-medium text-sm mb-2 text-base-content/60">Claude Desktop Config (stdio)</h3>
+        <div class="relative">
+          <pre class="bg-base-200 rounded-xl p-4 text-sm font-mono overflow-auto text-base-content/70">{
+  "mcpServers": {
+    "breadbox": {
+      "command": "docker",
+      "args": ["exec", "-i", "breadbox-app-1", "/app/breadbox", "mcp-stdio"]
+    }
+  }
+}</pre>
+          <button
+            class="btn btn-sm btn-ghost rounded-xl absolute top-2 right-2"
+            @click="navigator.clipboard.writeText(JSON.stringify({mcpServers:{breadbox:{command:'docker',args:['exec','-i','breadbox-app-1','/app/breadbox','mcp-stdio']}}}, null, 2)).then(() => { copiedConfig = true; setTimeout(() => copiedConfig = false, 2000) })"
+          >
+            <template x-if="!copiedConfig">
+              <span class="flex items-center gap-1"><i data-lucide="copy" class="w-4 h-4"></i> Copy</span>
+            </template>
+            <template x-if="copiedConfig">
+              <span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-4 h-4"></i> Copied!</span>
+            </template>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Card 3: Server Instructions -->
+  <div id="instructions" class="bb-card p-0 overflow-hidden" x-data="{
+    instructions: {{.Instructions | printf `%q`}},
+    defaultInstructions: {{.DefaultInstructions | printf `%q`}},
+    async resetToDefaults() {
+      const ok = await bbConfirm({title:'Reset to defaults?',message:'Your current instructions will be replaced with the default server instructions.',confirmLabel:'Reset',variant:'warning'});
+      if (ok) {
+        this.instructions = this.defaultInstructions;
+      }
+    }
+  }">
+    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-secondary/10 flex items-center justify-center flex-shrink-0">
+        <i data-lucide="scroll-text" class="w-5 h-5 text-secondary"></i>
+      </div>
+      <div class="min-w-0">
+        <h2 class="font-semibold">Server Instructions</h2>
+        <p class="text-xs text-base-content/40">Instructions sent to agents when they connect via MCP</p>
+      </div>
+    </div>
+    <div class="px-4 sm:px-6 py-5">
+      <div class="alert alert-warning alert-soft mb-4 text-xs rounded-xl">
+        <i data-lucide="triangle-alert" class="w-4 h-4"></i>
+        <span>These instructions guide how agents understand your data model, query patterns, and available tools. Editing may cause agents to misuse tools or produce incorrect results.</span>
+      </div>
+      <form method="POST" action="/mcp-settings/instructions">
+        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+
+        <div class="form-control mb-4">
+          <textarea name="instructions" class="textarea textarea-bordered font-mono text-xs leading-relaxed w-full rounded-xl" style="min-height: 24rem" maxlength="20000" x-model="instructions" placeholder="Server instructions for MCP agents..."></textarea>
+          <label class="label">
+            <span class="label-text-alt text-base-content/40" x-text="instructions.length + '/20000'"></span>
+          </label>
+        </div>
+
+        <div class="flex flex-wrap gap-2 items-center">
+          <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Instructions</button>
+          <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="resetToDefaults()">Reset to Defaults</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Card 4: Review Agent Instructions -->
+  <div class="bb-card p-0 overflow-hidden" x-data="{ expanded: false }">
+    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3 cursor-pointer" @click="expanded = !expanded">
+      <div class="w-10 h-10 rounded-xl bg-accent/10 flex items-center justify-center flex-shrink-0">
+        <i data-lucide="clipboard-check" class="w-5 h-5 text-accent"></i>
+      </div>
+      <div class="min-w-0 flex-1">
+        <h2 class="font-semibold">Review Agent Instructions</h2>
+        <p class="text-xs text-base-content/40">Pre-built instruction blocks for agents doing transaction review</p>
+      </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+    </div>
+    <div x-show="expanded" x-collapse x-cloak>
+      <div class="px-4 sm:px-6 py-5 space-y-6">
+
+        <!-- Initial Review -->
+        <div x-data="{ copied: false }">
+          <div class="flex items-center gap-2 mb-2">
+            <i data-lucide="layers" class="w-4 h-4 text-primary"></i>
+            <h3 class="font-medium text-sm">Initial Review</h3>
+            <span class="badge badge-primary badge-xs rounded-lg">Bulk Analysis</span>
+          </div>
+          <p class="text-xs text-base-content/50 mb-3">Use when a new account is synced and you have many uncategorized transactions.</p>
+          <div class="relative">
+            <pre class="bg-base-200 rounded-xl p-4 text-xs whitespace-pre-wrap overflow-auto max-h-60 font-mono text-base-content/70">{{.InitialReviewInstructions}}</pre>
+            <button class="btn btn-xs btn-ghost rounded-lg absolute top-2 right-2" @click="navigator.clipboard.writeText({{.InitialReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })">
+              <template x-if="!copied"><span class="flex items-center gap-1"><i data-lucide="copy" class="w-3.5 h-3.5"></i> Copy</span></template>
+              <template x-if="copied"><span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-3.5 h-3.5"></i> Copied!</span></template>
+            </button>
+          </div>
+        </div>
+
+        <!-- Recurring Review -->
+        <div x-data="{ copied: false }">
+          <div class="flex items-center gap-2 mb-2">
+            <i data-lucide="repeat" class="w-4 h-4 text-success"></i>
+            <h3 class="font-medium text-sm">Recurring Review</h3>
+            <span class="badge badge-secondary badge-xs rounded-lg">Daily / Weekly</span>
+          </div>
+          <p class="text-xs text-base-content/50 mb-3">Use for routine review of incoming transactions. Reviews a small batch with more attention per transaction.</p>
+          <div class="relative">
+            <pre class="bg-base-200 rounded-xl p-4 text-xs whitespace-pre-wrap overflow-auto max-h-60 font-mono text-base-content/70">{{.RecurringReviewInstructions}}</pre>
+            <button class="btn btn-xs btn-ghost rounded-lg absolute top-2 right-2" @click="navigator.clipboard.writeText({{.RecurringReviewInstructions | printf `%q`}}).then(() => { copied = true; setTimeout(() => copied = false, 2000) })">
+              <template x-if="!copied"><span class="flex items-center gap-1"><i data-lucide="copy" class="w-3.5 h-3.5"></i> Copy</span></template>
+              <template x-if="copied"><span class="flex items-center gap-1 text-success"><i data-lucide="check" class="w-3.5 h-3.5"></i> Copied!</span></template>
+            </button>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
 </div>
 {{end}}

--- a/internal/templates/pages/oauth_client_created.html
+++ b/internal/templates/pages/oauth_client_created.html
@@ -51,7 +51,7 @@
       <span x-show="!copiedSecret">Copy Secret</span>
       <span x-show="copiedSecret" x-cloak>Copied!</span>
     </button>
-    <a href="/oauth-clients" class="btn btn-ghost btn-sm rounded-xl">Done</a>
+    <a href="/access" class="btn btn-ghost btn-sm rounded-xl">Done</a>
   </div>
 
   <div class="mt-6 pt-4 border-t border-base-300 space-y-3">

--- a/internal/templates/pages/oauth_client_new.html
+++ b/internal/templates/pages/oauth_client_new.html
@@ -6,8 +6,8 @@
     <h1 class="bb-page-title">Create OAuth Client</h1>
     <p class="text-sm text-base-content/50 mt-1">Generate credentials for an external connector (e.g., Claude)</p>
   </div>
-  <a href="/oauth-clients" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> OAuth Clients
+  <a href="/access" class="btn btn-sm btn-ghost rounded-xl gap-2">
+    <i data-lucide="arrow-left" class="w-4 h-4"></i> Access
   </a>
 </div>
 
@@ -33,7 +33,7 @@
 
     <fieldset class="fieldset mb-6">
       <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="scope">Scope</label>
-      <select id="scope" name="scope" class="select w-full bg-base-200/50 border-base-300 focus:border-primary rounded-xl">
+      <select id="scope" name="scope" class="select w-full bg-base-200 border-base-300 focus:border-primary rounded-xl">
         <option value="full_access">Full Access &mdash; read and write via MCP</option>
         <option value="read_only">Read Only &mdash; query data only</option>
       </select>
@@ -44,7 +44,7 @@
       <button type="submit" class="btn btn-primary btn-sm rounded-xl">
         <i data-lucide="plus" class="w-4 h-4"></i> Create OAuth Client
       </button>
-      <a href="/oauth-clients" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
+      <a href="/access" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
     </div>
   </form>
 </div>

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -6,188 +6,210 @@
   </div>
 </div>
 
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 bb-stagger">
+<div class="grid gap-6 bb-stagger">
 
-  <!-- Sync & Scheduling -->
-  <div class="bb-card p-6">
-    <div class="flex items-center gap-3 mb-5">
-      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
+  <!-- Card 1: Sync Schedule -->
+  <div id="sync" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#sync' }">
+    <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
+      <div class="w-10 h-10 rounded-xl bg-primary/8 flex items-center justify-center flex-shrink-0">
         <i data-lucide="refresh-cw" class="w-5 h-5 text-primary"></i>
       </div>
-      <div>
-        <h2 class="text-base font-semibold">Sync Schedule</h2>
-        <p class="text-xs text-base-content/45">Automatic bank data sync interval</p>
+      <div class="min-w-0 flex-1">
+        <h2 class="font-semibold">Sync Schedule</h2>
+        <p class="text-xs text-base-content/40" x-show="!expanded">Every {{.SyncIntervalMinutes}} minutes{{if ne .NextSyncTime ""}} · Next: {{.NextSyncTime}}{{end}}</p>
+        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Automatic bank data sync interval</p>
+      </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+    </div>
+    <div x-show="expanded" x-collapse x-cloak>
+      <div class="px-4 sm:px-6 py-5">
+        <form method="POST" action="/settings/sync">
+          <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+
+          <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="sync_interval_minutes">
+            Sync Interval {{configSource .ConfigSources "sync_interval_minutes"}}
+          </label>
+          <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm select-bordered w-full max-w-sm rounded-xl bg-base-200">
+            <option value="15"{{if eq .SyncIntervalMinutes 15}} selected{{end}}>Every 15 minutes</option>
+            <option value="30"{{if eq .SyncIntervalMinutes 30}} selected{{end}}>Every 30 minutes</option>
+            <option value="60"{{if eq .SyncIntervalMinutes 60}} selected{{end}}>Every hour</option>
+            <option value="240"{{if eq .SyncIntervalMinutes 240}} selected{{end}}>Every 4 hours</option>
+            <option value="480"{{if eq .SyncIntervalMinutes 480}} selected{{end}}>Every 8 hours</option>
+            <option value="720"{{if eq .SyncIntervalMinutes 720}} selected{{end}}>Every 12 hours</option>
+            <option value="1440"{{if eq .SyncIntervalMinutes 1440}} selected{{end}}>Every 24 hours</option>
+          </select>
+
+          {{if ne .NextSyncTime ""}}
+          <p class="text-xs text-base-content/40 mt-3 flex items-center gap-1.5">
+            <i data-lucide="clock" class="w-3.5 h-3.5"></i>
+            Next sync: {{.NextSyncTime}}
+          </p>
+          {{end}}
+
+          <div class="mt-5">
+            <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Schedule</button>
+          </div>
+        </form>
       </div>
     </div>
-
-    <form method="POST" action="/settings/sync">
-      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-
-      <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="sync_interval_minutes">
-        Sync Interval {{configSource .ConfigSources "sync_interval_minutes"}}
-      </label>
-      <select id="sync_interval_minutes" name="sync_interval_minutes" class="select select-sm select-bordered w-full rounded-xl">
-        <option value="15"{{if eq .SyncIntervalMinutes 15}} selected{{end}}>Every 15 minutes</option>
-        <option value="30"{{if eq .SyncIntervalMinutes 30}} selected{{end}}>Every 30 minutes</option>
-        <option value="60"{{if eq .SyncIntervalMinutes 60}} selected{{end}}>Every hour</option>
-        <option value="240"{{if eq .SyncIntervalMinutes 240}} selected{{end}}>Every 4 hours</option>
-        <option value="480"{{if eq .SyncIntervalMinutes 480}} selected{{end}}>Every 8 hours</option>
-        <option value="720"{{if eq .SyncIntervalMinutes 720}} selected{{end}}>Every 12 hours</option>
-        <option value="1440"{{if eq .SyncIntervalMinutes 1440}} selected{{end}}>Every 24 hours</option>
-      </select>
-
-      {{if ne .NextSyncTime ""}}
-      <p class="text-xs text-base-content/40 mt-3 flex items-center gap-1.5">
-        <i data-lucide="clock" class="w-3.5 h-3.5"></i>
-        Next sync: {{.NextSyncTime}}
-      </p>
-      {{end}}
-
-      <div class="mt-5 pt-4 border-t border-base-300">
-        <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Schedule</button>
-      </div>
-    </form>
   </div>
 
-  <!-- Sync Log Retention -->
-  <div class="bb-card p-6">
-    <div class="flex items-center gap-3 mb-5">
-      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-warning/8">
+  <!-- Card 2: Sync Log Retention -->
+  <div id="retention" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#retention' }">
+    <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
+      <div class="w-10 h-10 rounded-xl bg-warning/8 flex items-center justify-center flex-shrink-0">
         <i data-lucide="archive" class="w-5 h-5 text-warning"></i>
       </div>
-      <div>
-        <h2 class="text-base font-semibold">Sync Log Retention</h2>
-        <p class="text-xs text-base-content/45">Auto-delete old sync logs to save storage</p>
+      <div class="min-w-0 flex-1">
+        <h2 class="font-semibold">Sync Log Retention</h2>
+        <p class="text-xs text-base-content/40" x-show="!expanded">{{if eq .SyncLogRetentionDays 0}}Keeping forever{{else}}{{.SyncLogRetentionDays}} days{{end}} · {{.SyncLogCount}} logs stored</p>
+        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Auto-delete old sync logs to save storage</p>
+      </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+    </div>
+    <div x-show="expanded" x-collapse x-cloak>
+      <div class="px-4 sm:px-6 py-5">
+        <div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40 mb-5">
+          <div class="flex items-center gap-2.5">
+            <i data-lucide="database" class="w-4 h-4 text-base-content/50"></i>
+            <span class="text-sm font-medium">Total Sync Logs</span>
+          </div>
+          <span class="text-sm font-semibold tabular-nums">{{.SyncLogCount}}</span>
+        </div>
+
+        <form method="POST" action="/settings/retention">
+          <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+
+          <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="sync_log_retention_days">
+            Retention Period
+          </label>
+          <select id="sync_log_retention_days" name="sync_log_retention_days" class="select select-sm select-bordered w-full max-w-sm rounded-xl bg-base-200">
+            <option value="7"{{if eq .SyncLogRetentionDays 7}} selected{{end}}>7 days</option>
+            <option value="14"{{if eq .SyncLogRetentionDays 14}} selected{{end}}>14 days</option>
+            <option value="30"{{if eq .SyncLogRetentionDays 30}} selected{{end}}>30 days</option>
+            <option value="60"{{if eq .SyncLogRetentionDays 60}} selected{{end}}>60 days</option>
+            <option value="90"{{if eq .SyncLogRetentionDays 90}} selected{{end}}>90 days (default)</option>
+            <option value="180"{{if eq .SyncLogRetentionDays 180}} selected{{end}}>180 days</option>
+            <option value="365"{{if eq .SyncLogRetentionDays 365}} selected{{end}}>1 year</option>
+            <option value="0"{{if eq .SyncLogRetentionDays 0}} selected{{end}}>Keep forever</option>
+          </select>
+
+          <p class="text-xs text-base-content/40 mt-3 flex items-center gap-1.5">
+            <i data-lucide="clock" class="w-3.5 h-3.5"></i>
+            Cleanup runs daily at 3:00 AM
+          </p>
+
+          <div class="mt-5">
+            <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Retention</button>
+          </div>
+        </form>
       </div>
     </div>
-
-    <div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40 mb-5">
-      <div class="flex items-center gap-2.5">
-        <i data-lucide="database" class="w-4 h-4 text-base-content/50"></i>
-        <span class="text-sm font-medium">Total Sync Logs</span>
-      </div>
-      <span class="text-sm font-semibold tabular-nums">{{.SyncLogCount}}</span>
-    </div>
-
-    <form method="POST" action="/settings/retention">
-      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-
-      <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="sync_log_retention_days">
-        Retention Period
-      </label>
-      <select id="sync_log_retention_days" name="sync_log_retention_days" class="select select-sm select-bordered w-full rounded-xl">
-        <option value="7"{{if eq .SyncLogRetentionDays 7}} selected{{end}}>7 days</option>
-        <option value="14"{{if eq .SyncLogRetentionDays 14}} selected{{end}}>14 days</option>
-        <option value="30"{{if eq .SyncLogRetentionDays 30}} selected{{end}}>30 days</option>
-        <option value="60"{{if eq .SyncLogRetentionDays 60}} selected{{end}}>60 days</option>
-        <option value="90"{{if eq .SyncLogRetentionDays 90}} selected{{end}}>90 days (default)</option>
-        <option value="180"{{if eq .SyncLogRetentionDays 180}} selected{{end}}>180 days</option>
-        <option value="365"{{if eq .SyncLogRetentionDays 365}} selected{{end}}>1 year</option>
-        <option value="0"{{if eq .SyncLogRetentionDays 0}} selected{{end}}>Keep forever</option>
-      </select>
-
-      <p class="text-xs text-base-content/40 mt-3 flex items-center gap-1.5">
-        <i data-lucide="clock" class="w-3.5 h-3.5"></i>
-        Cleanup runs daily at 3:00 AM
-      </p>
-
-      <div class="mt-5 pt-4 border-t border-base-300">
-        <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Retention</button>
-      </div>
-    </form>
   </div>
 
-  <!-- Security -->
-  <div class="bb-card p-6">
-    <div class="flex items-center gap-3 mb-5">
-      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-error/8">
+  <!-- Card 3: Security -->
+  <div id="security" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#security' }">
+    <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
+      <div class="w-10 h-10 rounded-xl bg-error/8 flex items-center justify-center flex-shrink-0">
         <i data-lucide="shield" class="w-5 h-5 text-error"></i>
       </div>
-      <div>
-        <h2 class="text-base font-semibold">Security</h2>
-        <p class="text-xs text-base-content/45">Encryption and authentication</p>
+      <div class="min-w-0 flex-1">
+        <h2 class="font-semibold">Security</h2>
+        <p class="text-xs text-base-content/40" x-show="!expanded">Encryption {{if .HasEncryptionKey}}active{{else}}not set{{end}} · Password management</p>
+        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Encryption and authentication</p>
+      </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+    </div>
+    <div x-show="expanded" x-collapse x-cloak>
+      <div class="px-4 sm:px-6 py-5">
+        <!-- Encryption Key Status -->
+        <div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40 mb-5">
+          <div class="flex items-center gap-2.5">
+            <i data-lucide="key-round" class="w-4 h-4 text-base-content/50"></i>
+            <span class="text-sm font-medium">Encryption Key</span>
+          </div>
+          {{if .HasEncryptionKey}}
+          <span class="badge badge-success badge-sm">Active</span>
+          {{else}}
+          <span class="badge badge-error badge-sm">Not Set</span>
+          {{end}}
+        </div>
+
+        {{if not .HasEncryptionKey}}
+        <div class="text-xs text-error/80 bg-error/5 rounded-lg p-3 mb-5">
+          <i data-lucide="alert-triangle" class="w-3.5 h-3.5 inline mr-1"></i>
+          Access tokens cannot be stored without an encryption key. Set the ENCRYPTION_KEY environment variable.
+        </div>
+        {{end}}
+
+        <!-- Change Password -->
+        <h3 class="text-sm font-semibold text-base-content/70 mb-3">Change Password</h3>
+        <form method="POST" action="/settings/password" class="space-y-3 max-w-sm">
+          <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+          <div>
+            <label class="text-xs font-medium text-base-content/50 mb-1 block" for="current_password">Current Password</label>
+            <input type="password" id="current_password" name="current_password" required class="input input-sm input-bordered w-full rounded-xl">
+          </div>
+          <div>
+            <label class="text-xs font-medium text-base-content/50 mb-1 block" for="new_password">New Password</label>
+            <input type="password" id="new_password" name="new_password" required minlength="8" class="input input-sm input-bordered w-full rounded-xl">
+          </div>
+          <div>
+            <label class="text-xs font-medium text-base-content/50 mb-1 block" for="confirm_password">Confirm New Password</label>
+            <input type="password" id="confirm_password" name="confirm_password" required class="input input-sm input-bordered w-full rounded-xl">
+          </div>
+          <div class="pt-2">
+            <button type="submit" class="btn btn-primary btn-sm rounded-xl">Update Password</button>
+          </div>
+        </form>
       </div>
     </div>
-
-    <!-- Encryption Key Status -->
-    <div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40 mb-5">
-      <div class="flex items-center gap-2.5">
-        <i data-lucide="key-round" class="w-4 h-4 text-base-content/50"></i>
-        <span class="text-sm font-medium">Encryption Key</span>
-      </div>
-      {{if .HasEncryptionKey}}
-      <span class="badge badge-success badge-sm">Active</span>
-      {{else}}
-      <div class="flex items-center gap-1.5">
-        <span class="badge badge-error badge-sm">Not Set</span>
-      </div>
-      {{end}}
-    </div>
-
-    {{if not .HasEncryptionKey}}
-    <div class="text-xs text-error/80 bg-error/5 rounded-lg p-3 mb-5">
-      <i data-lucide="alert-triangle" class="w-3.5 h-3.5 inline mr-1"></i>
-      Access tokens cannot be stored without an encryption key. Set the ENCRYPTION_KEY environment variable.
-    </div>
-    {{end}}
-
-    <!-- Change Password -->
-    <h3 class="text-sm font-semibold text-base-content/70 mb-3">Change Password</h3>
-    <form method="POST" action="/settings/password" class="space-y-3">
-      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-      <div>
-        <label class="text-xs font-medium text-base-content/50 mb-1 block" for="current_password">Current Password</label>
-        <input type="password" id="current_password" name="current_password" required class="input input-sm input-bordered w-full rounded-xl">
-      </div>
-      <div>
-        <label class="text-xs font-medium text-base-content/50 mb-1 block" for="new_password">New Password</label>
-        <input type="password" id="new_password" name="new_password" required minlength="8" class="input input-sm input-bordered w-full rounded-xl">
-      </div>
-      <div>
-        <label class="text-xs font-medium text-base-content/50 mb-1 block" for="confirm_password">Confirm New Password</label>
-        <input type="password" id="confirm_password" name="confirm_password" required class="input input-sm input-bordered w-full rounded-xl">
-      </div>
-      <div class="pt-2">
-        <button type="submit" class="btn btn-primary btn-sm rounded-xl">Update Password</button>
-      </div>
-    </form>
   </div>
 
-  <!-- System Info -->
-  <div class="bb-card p-6 lg:col-span-2">
-    <div class="flex items-center gap-3 mb-5">
-      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-base-200/60">
+  <!-- Card 4: System Info (always expanded) -->
+  <div id="system" class="bb-card p-0 overflow-hidden">
+    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
+      <div class="w-10 h-10 rounded-xl bg-base-200/60 flex items-center justify-center flex-shrink-0">
         <i data-lucide="cpu" class="w-5 h-5 text-base-content/50"></i>
       </div>
-      <div>
-        <h2 class="text-base font-semibold">System</h2>
-        <p class="text-xs text-base-content/45">Runtime and version information</p>
+      <div class="min-w-0">
+        <h2 class="font-semibold">System</h2>
+        <p class="text-xs text-base-content/40">Runtime and version information</p>
       </div>
     </div>
-
-    <div class="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-3">
-      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
-        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Version</div>
-        <div class="text-sm font-semibold tabular-nums">{{.Version}}</div>
-      </div>
-      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
-        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Go Runtime</div>
-        <div class="text-sm font-semibold">{{.GoVersion}}</div>
-      </div>
-      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40 min-w-0">
-        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">PostgreSQL</div>
-        <div class="text-sm font-semibold truncate min-w-0" title="{{.PostgresVersion}}">{{.PostgresVersion}}</div>
-      </div>
-      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
-        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Uptime</div>
-        <div class="text-sm font-semibold">{{.Uptime}}</div>
-      </div>
-      <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
-        <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Providers</div>
-        <div class="text-sm font-semibold">{{.ProviderCount}} configured</div>
+    <div class="px-4 sm:px-6 py-5">
+      <div class="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
+          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Version</div>
+          <div class="text-sm font-semibold tabular-nums">{{.Version}}</div>
+        </div>
+        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
+          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Go Runtime</div>
+          <div class="text-sm font-semibold">{{.GoVersion}}</div>
+        </div>
+        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40 min-w-0">
+          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">PostgreSQL</div>
+          <div class="text-sm font-semibold truncate min-w-0" title="{{.PostgresVersion}}">{{.PostgresVersion}}</div>
+        </div>
+        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
+          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Uptime</div>
+          <div class="text-sm font-semibold">{{.Uptime}}</div>
+        </div>
+        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
+          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Providers</div>
+          <div class="text-sm font-semibold">{{.ProviderCount}} configured</div>
+        </div>
       </div>
     </div>
   </div>
 
 </div>
+
+<script>
+(function() {
+  if (!location.hash) return;
+  var el = document.querySelector(location.hash);
+  if (el) setTimeout(function() { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 100);
+})();
+</script>
 {{end}}

--- a/internal/templates/pages/sync_log_detail.html
+++ b/internal/templates/pages/sync_log_detail.html
@@ -105,29 +105,31 @@
 </div>
 
 <!-- Details Card -->
-<div class="bb-card p-0 mb-6">
-  <div class="px-5 py-3.5 border-b border-base-200">
-    <h2 class="text-sm font-semibold">Sync Details</h2>
-  </div>
-  <div class="bb-info-grid px-5 py-4 text-sm">
-    <div class="flex justify-between py-1.5">
-      <span class="text-base-content/50">Connection</span>
-      <a href="/connections/{{.Log.ConnectionID}}" class="font-medium hover:text-primary transition-colors">{{.Log.InstitutionName}}</a>
+<div class="bb-card p-5 mb-6">
+  <h2 class="text-sm font-semibold text-base-content/50 mb-4">Sync Details</h2>
+  <div class="grid grid-cols-2 sm:grid-cols-4 gap-5">
+    <div>
+      <p class="text-xs text-base-content/40 mb-1">Connection</p>
+      <p class="text-sm font-medium"><a href="/connections/{{.Log.ConnectionID}}" class="hover:text-primary transition-colors">{{.Log.InstitutionName}}</a></p>
     </div>
-    <div class="flex justify-between py-1.5 border-t border-base-200/50">
-      <span class="text-base-content/50">Trigger</span>
-      <span class="font-medium">{{.Log.Trigger}}</span>
+    <div>
+      <p class="text-xs text-base-content/40 mb-1">Provider</p>
+      <p class="text-sm font-medium capitalize">{{.Log.Provider}}</p>
+    </div>
+    <div>
+      <p class="text-xs text-base-content/40 mb-1">Trigger</p>
+      <p class="text-sm font-medium">{{.Log.Trigger}}</p>
     </div>
     {{if .Log.StartedAt}}
-    <div class="flex justify-between py-1.5 border-t border-base-200/50">
-      <span class="text-base-content/50">Started</span>
-      <span class="font-medium">{{relativeTime .Log.StartedAt}}</span>
+    <div>
+      <p class="text-xs text-base-content/40 mb-1">Started</p>
+      <p class="text-sm font-medium">{{relativeTime .Log.StartedAt}}</p>
     </div>
     {{end}}
     {{if .Log.Duration}}
-    <div class="flex justify-between py-1.5 border-t border-base-200/50">
-      <span class="text-base-content/50">Duration</span>
-      <span class="font-medium tabular-nums">{{deref .Log.Duration}}</span>
+    <div>
+      <p class="text-xs text-base-content/40 mb-1">Duration</p>
+      <p class="text-sm font-medium tabular-nums">{{deref .Log.Duration}}</p>
     </div>
     {{end}}
   </div>
@@ -183,7 +185,7 @@
       </div>
       <div class="flex-1 min-w-0">
         <span class="text-sm font-medium truncate block">{{.RuleName}}</span>
-        <span class="text-xs text-base-content/30 font-mono">{{.RuleID}}</span>
+        {{if .Conditions}}<div class="text-xs text-base-content/40 mt-0.5 font-mono truncate" title="{{conditionSummary .Conditions}}">{{conditionSummary .Conditions}}</div>{{end}}
       </div>
       <div class="flex items-center gap-1.5 shrink-0">
         <span class="badge badge-ghost badge-sm tabular-nums font-semibold">{{.Count}} hit{{if ne .Count 1}}s{{end}}</span>

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -42,9 +42,6 @@
     <span class="bb-nav-badge">{{.NavBadges.PendingReviews}}</span>
     {{end}}
   </a>
-  <a href="/review-instructions" class="bb-sidebar-link{{if eq .CurrentPage "review-instructions"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="message-square-code"></i> Review Agent
-  </a>
   <a href="/reports" class="bb-sidebar-link{{if eq .CurrentPage "reports"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="file-text"></i>
     <span class="flex-1">Reports</span>

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -60,11 +60,8 @@
   <a href="/providers" class="bb-sidebar-link{{if eq .CurrentPage "providers"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="plug"></i> Providers
   </a>
-  <a href="/api-keys" class="bb-sidebar-link{{if eq .CurrentPage "api-keys"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="key"></i> API Keys
-  </a>
-  <a href="/oauth-clients" class="bb-sidebar-link{{if eq .CurrentPage "oauth-clients"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="fingerprint"></i> OAuth Clients
+  <a href="/access" class="bb-sidebar-link{{if eq .CurrentPage "access"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="shield-check"></i> Access
   </a>
   <a href="/sync-logs" class="bb-sidebar-link{{if eq .CurrentPage "sync-logs"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="refresh-cw"></i> Sync Logs


### PR DESCRIPTION
## Summary
- Merges standalone Review Instructions page into the MCP Settings page
- Adds collapsible "Review Agent Instructions" card with Initial Review and Recurring Review blocks
- Adds "Connection" card with MCP endpoint URLs and Claude Desktop config
- Removes "Review Agent" from sidebar nav
- Old `/review-instructions` URL redirects to `/mcp-settings`

## Test plan
- [ ] Navigate to `/mcp-settings` — Connection card and Review Agent Instructions card visible
- [ ] Review Agent Instructions card expands/collapses on click
- [ ] Copy buttons work for instruction blocks and config JSON
- [ ] `/review-instructions` redirects to `/mcp-settings`
- [ ] Sidebar no longer shows "Review Agent" link

🤖 Generated with [Claude Code](https://claude.com/claude-code)