### PR TITLE
Add MCP Getting Started guide page

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -110,6 +110,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/review-instructions", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/mcp-settings", http.StatusMovedPermanently)
 		})
+		r.Get("/mcp-getting-started", MCPGuideHandler(svc, sm, tr))
 		r.Get("/agent-wizard", AgentWizardHandler(sm, tr))
 		r.Get("/agent-wizard/{type}", PromptBuilderHandler(sm, tr))
 		r.Get("/rules", RulesPageHandler(svc, sm, tr, a.Config.Version))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -661,6 +661,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/oauth_client_new.html",
 		"pages/oauth_client_created.html",
 		"pages/agent_wizard.html",
+		"pages/mcp_guide.html",
 		"pages/prompt_builder.html",
 	}
 

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -644,6 +644,7 @@
         { id: 'nav-account-links', group: 'Data', title: 'Account Links', desc: 'Cross-account deduplication', icon: 'link-2', href: '/account-links', keywords: 'linked accounts dedup matching' },
         { id: 'nav-users', group: 'Data', title: 'Family Members', desc: 'Manage family members', icon: 'users', href: '/users', keywords: 'people household members' },
         // Agents
+        { id: 'agent-getting-started', group: 'Agents', title: 'Getting Started', desc: 'Connect an MCP agent', icon: 'rocket', href: '/mcp-getting-started', keywords: 'getting started mcp connect agent setup guide onboarding' },
         { id: 'agent-wizard', group: 'Agents', title: 'Agent Wizard', desc: 'Create agent prompts', icon: 'wand-sparkles', href: '/agent-wizard', keywords: 'wizard setup prompt create agent flow' },
         { id: 'agent-reviews', group: 'Agents', title: 'Review Queue', desc: 'Transaction review queue', icon: 'clipboard-check', href: '/reviews', keywords: 'pending approve categorize' },
         { id: 'agent-review-instructions', group: 'Agents', title: 'Review Agent Instructions', desc: 'Pre-built prompts for transaction review', icon: 'clipboard-check', href: '/mcp-settings', keywords: 'agent instructions prompts review' },

--- a/internal/templates/pages/agent_wizard.html
+++ b/internal/templates/pages/agent_wizard.html
@@ -6,6 +6,11 @@
   </div>
 </div>
 
+<div class="alert alert-info alert-soft text-sm rounded-xl mb-6">
+  <i data-lucide="rocket" class="w-4 h-4"></i>
+  <span>New to MCP agents? Follow the <a href="/mcp-getting-started" class="link font-medium">Getting Started guide</a> to connect your first agent.</span>
+</div>
+
 <div class="space-y-8 bb-stagger">
 
   <!-- Section: Essential -->

--- a/internal/templates/pages/mcp_guide.html
+++ b/internal/templates/pages/mcp_guide.html
@@ -306,6 +306,16 @@ function mcpGuide(mcpURL) {
       {id:'windsurf', label:'Windsurf', icon:'wind'},
       {id:'other', label:'Other', icon:'puzzle'}
     ],
+    init() {
+      // Render Lucide icons in all tab panels after Alpine hydrates.
+      var self = this;
+      setTimeout(function() {
+        self.tabs.forEach(function(t) {
+          var panel = self.$refs['panel-' + t.id];
+          if (panel) lucide.createIcons({nodes: [panel]});
+        });
+      }, 50);
+    },
     switchTab(id) {
       this.tab = id;
       var self = this;

--- a/internal/templates/pages/mcp_guide.html
+++ b/internal/templates/pages/mcp_guide.html
@@ -51,9 +51,9 @@
             </div>
             <p class="text-xs text-base-content/50 mb-3">Add a header to your agent config. Best for personal use and CLI tools.</p>
             {{if .HasAPIKeys}}
-            <a href="/api-keys" class="btn btn-ghost btn-xs rounded-lg">Manage Keys <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
+            <a href="/access" class="btn btn-ghost btn-xs rounded-lg">Manage Access <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
             {{else}}
-            <a href="/api-keys/new" class="btn btn-primary btn-xs rounded-lg">Create API Key <i data-lucide="plus" class="w-3 h-3"></i></a>
+            <a href="/access" class="btn btn-primary btn-xs rounded-lg">Create API Key <i data-lucide="plus" class="w-3 h-3"></i></a>
             {{end}}
           </div>
           <!-- OAuth -->
@@ -65,9 +65,9 @@
             </div>
             <p class="text-xs text-base-content/50 mb-3">Automatic token flow. Required for ChatGPT, recommended for Claude.</p>
             {{if .HasOAuthClients}}
-            <a href="/oauth-clients" class="btn btn-ghost btn-xs rounded-lg">Manage Clients <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
+            <a href="/access" class="btn btn-ghost btn-xs rounded-lg">Manage Access <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
             {{else}}
-            <a href="/oauth-clients/new" class="btn btn-primary btn-xs rounded-lg">Create OAuth Client <i data-lucide="plus" class="w-3 h-3"></i></a>
+            <a href="/access" class="btn btn-primary btn-xs rounded-lg">Create OAuth Client <i data-lucide="plus" class="w-3 h-3"></i></a>
             {{end}}
           </div>
         </div>
@@ -173,7 +173,7 @@
           </div>
           <p class="text-sm text-base-content/60">ChatGPT connects via OAuth. You'll need an OAuth client set up first.</p>
           <ol class="text-sm text-base-content/60 space-y-2 list-decimal list-inside">
-            <li>Create an <a href="/oauth-clients/new" class="link link-primary">OAuth Client</a> in Breadbox if you haven't already</li>
+            <li>Create an <a href="/access" class="link link-primary">OAuth Client</a> in Breadbox if you haven't already</li>
             <li>In ChatGPT, go to <strong>Settings &rarr; Connectors</strong> (or <strong>Tools</strong>)</li>
             <li>Click <strong>Add MCP Server</strong></li>
             <li>Enter your MCP server URL:</li>

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -32,6 +32,9 @@
   </a>
 
   <div class="bb-sidebar-section">Agents</div>
+  <a href="/mcp-getting-started" class="bb-sidebar-link{{if eq .CurrentPage "mcp-getting-started"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="rocket"></i> Getting Started
+  </a>
   <a href="/agent-wizard" class="bb-sidebar-link{{if eq .CurrentPage "agent-wizard"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="wand-sparkles"></i> Agent Wizard
   </a>


### PR DESCRIPTION
## Summary
- New `/mcp-getting-started` page with 3-step onboarding flow for connecting AI agents to Breadbox
- Step 1: Shows MCP server URL + API Key vs OAuth credential cards
- Step 2: Tabbed agent configs (Claude Desktop, Claude Code, ChatGPT, Cursor, Windsurf, Other) with copy-to-clipboard and video placeholders
- Step 3: Links to Agent Wizard for deploying prompts
- Sidebar nav item, command palette entry, and Agent Wizard info banner

## Test plan
- [ ] Navigate to `/mcp-getting-started` — 3-step flow renders with correct MCP URL
- [ ] Click through each agent tab — config snippets display correctly
- [ ] Copy buttons work (clipboard has correct URL/config)
- [ ] Video placeholder areas visible (dashed borders)
- [ ] Links to API Keys, OAuth Clients, Agent Wizard all work
- [ ] Sidebar nav highlights "Getting Started" correctly
- [ ] Agent Wizard page shows info banner linking to guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)