### PR TITLE
Fix MCP guide: remove Cursor/Windsurf, prioritize OAuth

### DIFF
--- a/internal/templates/pages/mcp_guide.html
+++ b/internal/templates/pages/mcp_guide.html
@@ -42,6 +42,20 @@
       <div>
         <label class="text-xs font-medium text-base-content/50 mb-2 block">Authentication Method</label>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <!-- OAuth (recommended) -->
+          <div class="rounded-xl border-2 border-primary/30 p-4 bg-primary/5">
+            <div class="flex items-center gap-2 mb-2">
+              <i data-lucide="fingerprint" class="w-4 h-4 text-primary"></i>
+              <span class="font-medium text-sm">OAuth Client</span>
+              <span class="badge badge-primary badge-xs">Recommended</span>
+            </div>
+            <p class="text-xs text-base-content/50 mb-3">Automatic token flow with consent screen. Works with Claude, ChatGPT, and most MCP clients.</p>
+            {{if .HasOAuthClients}}
+            <a href="/access" class="btn btn-ghost btn-xs rounded-lg">Manage Access <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
+            {{else}}
+            <a href="/access" class="btn btn-primary btn-xs rounded-lg">Create OAuth Client <i data-lucide="plus" class="w-3 h-3"></i></a>
+            {{end}}
+          </div>
           <!-- API Key -->
           <div class="rounded-xl border border-base-300 p-4 hover:border-primary/30 transition-colors">
             <div class="flex items-center gap-2 mb-2">
@@ -53,21 +67,7 @@
             {{if .HasAPIKeys}}
             <a href="/access" class="btn btn-ghost btn-xs rounded-lg">Manage Access <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
             {{else}}
-            <a href="/access" class="btn btn-primary btn-xs rounded-lg">Create API Key <i data-lucide="plus" class="w-3 h-3"></i></a>
-            {{end}}
-          </div>
-          <!-- OAuth -->
-          <div class="rounded-xl border border-base-300 p-4 hover:border-primary/30 transition-colors">
-            <div class="flex items-center gap-2 mb-2">
-              <i data-lucide="fingerprint" class="w-4 h-4 text-primary"></i>
-              <span class="font-medium text-sm">OAuth Client</span>
-              <span class="badge badge-ghost badge-xs">Recommended</span>
-            </div>
-            <p class="text-xs text-base-content/50 mb-3">Automatic token flow. Required for ChatGPT, recommended for Claude.</p>
-            {{if .HasOAuthClients}}
-            <a href="/access" class="btn btn-ghost btn-xs rounded-lg">Manage Access <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
-            {{else}}
-            <a href="/access" class="btn btn-primary btn-xs rounded-lg">Create OAuth Client <i data-lucide="plus" class="w-3 h-3"></i></a>
+            <a href="/access" class="btn btn-ghost btn-xs rounded-lg">Create API Key <i data-lucide="plus" class="w-3 h-3"></i></a>
             {{end}}
           </div>
         </div>
@@ -198,55 +198,6 @@
         </div>
       </div>
 
-      <!-- Cursor -->
-      <div x-ref="panel-cursor" x-show="tab === 'cursor'" x-cloak>
-        <div class="space-y-4">
-          <div class="flex items-center gap-2 mb-1">
-            <span class="badge badge-soft badge-warning badge-xs rounded-lg">API Key</span>
-          </div>
-          <p class="text-sm text-base-content/60">Add to <code class="text-xs">.cursor/mcp.json</code> in your project root:</p>
-          <div class="relative" x-data="{ copied: false }">
-            <pre class="bg-base-200/50 rounded-xl p-4 pr-10 text-xs font-mono overflow-x-auto leading-relaxed" x-text="configSnippet('cursor')"></pre>
-            <button class="btn btn-ghost btn-xs btn-square absolute top-2 right-2 rounded-lg"
-                    @click="copyAndFlash(configSnippet('cursor'), $data)">
-              <i x-show="!copied" data-lucide="copy" class="w-3.5 h-3.5"></i>
-              <i x-show="copied" x-cloak data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
-            </button>
-          </div>
-          <div class="text-xs text-base-content/40">
-            <p>You can also add this via <strong>Settings &rarr; Features &rarr; MCP Servers &rarr; Add Server</strong> in Cursor.</p>
-          </div>
-          <!-- Video placeholder -->
-          <div class="border-2 border-dashed border-base-300 rounded-xl p-8 flex flex-col items-center justify-center text-base-content/30 gap-2">
-            <i data-lucide="play-circle" class="w-8 h-8"></i>
-            <span class="text-xs">Setup walkthrough video coming soon</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Windsurf -->
-      <div x-ref="panel-windsurf" x-show="tab === 'windsurf'" x-cloak>
-        <div class="space-y-4">
-          <div class="flex items-center gap-2 mb-1">
-            <span class="badge badge-soft badge-warning badge-xs rounded-lg">API Key</span>
-          </div>
-          <p class="text-sm text-base-content/60">Add to <code class="text-xs">~/.windsurf/mcp.json</code>:</p>
-          <div class="relative" x-data="{ copied: false }">
-            <pre class="bg-base-200/50 rounded-xl p-4 pr-10 text-xs font-mono overflow-x-auto leading-relaxed" x-text="configSnippet('windsurf')"></pre>
-            <button class="btn btn-ghost btn-xs btn-square absolute top-2 right-2 rounded-lg"
-                    @click="copyAndFlash(configSnippet('windsurf'), $data)">
-              <i x-show="!copied" data-lucide="copy" class="w-3.5 h-3.5"></i>
-              <i x-show="copied" x-cloak data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
-            </button>
-          </div>
-          <!-- Video placeholder -->
-          <div class="border-2 border-dashed border-base-300 rounded-xl p-8 flex flex-col items-center justify-center text-base-content/30 gap-2">
-            <i data-lucide="play-circle" class="w-8 h-8"></i>
-            <span class="text-xs">Setup walkthrough video coming soon</span>
-          </div>
-        </div>
-      </div>
-
       <!-- Other -->
       <div x-ref="panel-other" x-show="tab === 'other'" x-cloak>
         <div class="space-y-4">
@@ -263,7 +214,7 @@
             </button>
           </div>
           <div class="text-xs text-base-content/40">
-            <p>The wrapper key varies by tool: <code>mcpServers</code> (Claude, Cursor, Windsurf), <code>servers</code> (VS Code Copilot), <code>context_servers</code> (Zed). Check your tool's documentation.</p>
+            <p>The wrapper key varies by tool: <code>mcpServers</code> (Claude, Cursor, Windsurf, Cline), <code>servers</code> (VS Code Copilot), <code>context_servers</code> (Zed). Check your tool's documentation.</p>
           </div>
         </div>
       </div>
@@ -302,8 +253,6 @@ function mcpGuide(mcpURL) {
       {id:'claude-desktop', label:'Claude Desktop', icon:'monitor'},
       {id:'claude-code', label:'Claude Code', icon:'terminal'},
       {id:'chatgpt', label:'ChatGPT', icon:'message-circle'},
-      {id:'cursor', label:'Cursor', icon:'mouse-pointer-2'},
-      {id:'windsurf', label:'Windsurf', icon:'wind'},
       {id:'other', label:'Other', icon:'puzzle'}
     ],
     init() {
@@ -328,8 +277,6 @@ function mcpGuide(mcpURL) {
       switch (service) {
         case 'claude-desktop':
         case 'claude-code':
-        case 'cursor':
-        case 'windsurf':
           return stdConfig(mcpURL);
         case 'claude-code-cli':
           return 'claude mcp add breadbox --transport http \\\n  --url ' + mcpURL + ' \\\n  --header "X-API-Key: YOUR_API_KEY"';


### PR DESCRIPTION
## Summary
Fixes that were lost during the previous PR merge race:
- Remove Cursor and Windsurf tabs (covered by "Other" generic tab)
- OAuth card prioritized with highlighted styling and "Recommended" badge
- API Key demoted to secondary option

## Test plan
- [ ] Only 4 tabs visible: Claude Desktop, Claude Code, ChatGPT, Other
- [ ] OAuth card has primary border/tint and "Recommended" badge
- [ ] All icons render on initial page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)