### PR TITLE
UX/QA sprint 2: polish, bug fixes, mobile improvements

### DIFF
--- a/input.css
+++ b/input.css
@@ -1764,7 +1764,7 @@
 
   .bb-triage-row__amount {
     @apply shrink-0 text-right;
-    width: 80px;
+    width: 68px;
   }
 
   @media (min-width: 640px) {
@@ -1774,14 +1774,19 @@
   }
 
   .bb-triage-row__actions {
-    @apply hidden sm:flex items-center gap-1 shrink-0 ml-2;
-    opacity: 0;
+    @apply flex items-center gap-1 shrink-0 ml-1 sm:ml-2;
+    opacity: 1;
     transition: opacity 0.15s ease;
   }
 
-  .bb-triage-row:hover .bb-triage-row__actions,
-  .bb-triage-row--focused .bb-triage-row__actions {
-    opacity: 1;
+  @media (min-width: 640px) {
+    .bb-triage-row__actions {
+      opacity: 0;
+    }
+    .bb-triage-row:hover .bb-triage-row__actions,
+    .bb-triage-row--focused .bb-triage-row__actions {
+      opacity: 1;
+    }
   }
 
   .bb-triage-row__resolved {
@@ -1789,11 +1794,30 @@
   }
 
   .bb-triage-action {
-    @apply inline-flex items-center justify-center w-7 h-7 rounded-lg
+    @apply inline-flex items-center justify-center w-8 h-8 sm:w-7 sm:h-7 rounded-lg
            border border-transparent cursor-pointer;
     transition: all 0.1s ease;
     background: transparent;
     color: oklch(0.5 0 0);
+  }
+
+  /* On mobile, show colored backgrounds so actions are tappable without hover */
+  @media (max-width: 639px) {
+    .bb-triage-action--accept {
+      color: oklch(0.55 0.14 155);
+      background: oklch(0.62 0.14 155 / 0.08);
+      border-color: oklch(0.62 0.14 155 / 0.2);
+    }
+    .bb-triage-action--skip {
+      color: oklch(0.45 0 0);
+      background: oklch(0.5 0 0 / 0.05);
+      border-color: oklch(0.5 0 0 / 0.12);
+    }
+    .bb-triage-action--dismiss {
+      color: oklch(0.55 0.2 27);
+      background: oklch(0.577 0.245 27.325 / 0.06);
+      border-color: oklch(0.577 0.245 27.325 / 0.15);
+    }
   }
 
   .bb-triage-action:hover {
@@ -1841,6 +1865,25 @@
       color: oklch(0.75 0.17 22);
       border-color: oklch(0.704 0.191 22.216 / 0.3);
       background: oklch(0.704 0.191 22.216 / 0.1);
+    }
+  }
+
+  /* Dark mode mobile action buttons */
+  @media (prefers-color-scheme: dark) and (max-width: 639px) {
+    .bb-triage-action--accept {
+      color: oklch(0.75 0.14 155);
+      background: oklch(0.70 0.14 155 / 0.1);
+      border-color: oklch(0.70 0.14 155 / 0.2);
+    }
+    .bb-triage-action--skip {
+      color: oklch(0.7 0 0);
+      background: oklch(0.5 0 0 / 0.08);
+      border-color: oklch(0.5 0 0 / 0.15);
+    }
+    .bb-triage-action--dismiss {
+      color: oklch(0.75 0.17 22);
+      background: oklch(0.704 0.191 22.216 / 0.08);
+      border-color: oklch(0.704 0.191 22.216 / 0.15);
     }
   }
 

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -758,6 +758,26 @@ func SyncConnectionHandler(a *app.App) http.HandlerFunc {
 	}
 }
 
+// SyncAllConnectionsHandler serves POST /-/connections/sync-all.
+// It triggers a manual sync for all active, non-CSV connections.
+func SyncAllConnectionsHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if a.SyncEngine == nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Sync engine not initialized"})
+			return
+		}
+
+		go func() {
+			ctx := context.Background()
+			if err := a.SyncEngine.SyncAll(ctx, db.SyncTriggerManual); err != nil {
+				a.Logger.Error("manual sync-all failed", "error", err)
+			}
+		}()
+
+		writeJSON(w, http.StatusAccepted, map[string]string{"status": "sync_all_triggered"})
+	}
+}
+
 // UpdateAccountExcludedHandler serves POST /admin/api/accounts/{id}/excluded.
 func UpdateAccountExcludedHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -48,6 +48,7 @@ type ConnectionWithAccounts struct {
 	TotalBalance float64
 	HasBalance   bool
 	NextSync     NextSyncInfo
+	IsStale      bool
 }
 
 // ConnectionsListHandler serves GET /admin/connections.
@@ -102,10 +103,16 @@ func ConnectionsListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 
 		netWorth := totalAssets - totalLiabilities
 
-		// Compute per-connection display total from display-ready balances
-		// and next-sync schedule.
+		// Compute per-connection display total from display-ready balances,
+		// next-sync schedule, and staleness.
 		now := time.Now()
 		globalInterval := a.Config.SyncIntervalMinutes
+		// Default staleness threshold: 2x the global sync interval (or 24h minimum).
+		globalSyncInterval := time.Duration(globalInterval) * time.Minute
+		defaultStaleThreshold := globalSyncInterval * 2
+		if defaultStaleThreshold < 24*time.Hour {
+			defaultStaleThreshold = 24 * time.Hour
+		}
 		for i := range enriched {
 			if enriched[i].HasBalance {
 				total := 0.0
@@ -124,6 +131,25 @@ func ConnectionsListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 				ConsecutiveFailures:         enriched[i].ConsecutiveFailures,
 				LastSyncedAt:                enriched[i].LastSyncedAt,
 			}, globalInterval, now)
+
+			// Compute staleness (same logic as dashboard Connection Health).
+			if string(enriched[i].Status) != "disconnected" {
+				staleThreshold := defaultStaleThreshold
+				if enriched[i].SyncIntervalOverrideMinutes.Valid {
+					connInterval := time.Duration(enriched[i].SyncIntervalOverrideMinutes.Int32) * time.Minute
+					staleThreshold = connInterval * 2
+					if staleThreshold < time.Hour {
+						staleThreshold = time.Hour
+					}
+				}
+				if enriched[i].LastSyncedAt.Valid {
+					if now.Sub(enriched[i].LastSyncedAt.Time) > staleThreshold {
+						enriched[i].IsStale = true
+					}
+				} else {
+					enriched[i].IsStale = true
+				}
+			}
 		}
 
 		data := map[string]any{

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -1052,7 +1052,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"MonthProgress":          monthProgress,
 			"CurrentMonthName":       today.Format("January"),
 			"LastMonthName":          lastMonthStart.Format("January"),
-			// Account allocation bar.
+			// Account totals & allocation bar.
+			"TotalAssets":            totalAssets,
+			"TotalLiabilities":      totalLiabilities,
+			"NetWorth":              totalAssets - totalLiabilities,
 			"AllocationSlices":       allocationSlices,
 			// Connection health.
 			"ConnectionHealth":       connectionHealth,

--- a/internal/admin/reviews.go
+++ b/internal/admin/reviews.go
@@ -25,15 +25,7 @@ func ReviewsPageHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 			statusFilter = "pending"
 		}
 
-		viewMode := r.URL.Query().Get("view")
-		if viewMode == "" {
-			viewMode = "triage" // default to triage mode
-		}
-
-		defaultLimit := 20
-		if viewMode == "triage" {
-			defaultLimit = 50
-		}
+		defaultLimit := 50
 
 		params := service.ReviewListParams{
 			Status: &statusFilter,
@@ -102,7 +94,7 @@ func ReviewsPageHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 		data["ReviewTypeFilter"] = r.URL.Query().Get("review_type")
 		data["AccountIDFilter"] = r.URL.Query().Get("account_id")
 		data["UserIDFilter"] = r.URL.Query().Get("user_id")
-		data["ViewMode"] = viewMode
+		data["ViewMode"] = "triage"
 		data["Accounts"] = accounts
 		data["Users"] = users
 		data["Categories"] = categories

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -134,6 +134,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/connections/{id}/reauth", ConnectionReauthAPIHandler(a))
 		r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))
 		r.Post("/connections/{id}/sync", SyncConnectionHandler(a))
+		r.Post("/connections/sync-all", SyncAllConnectionsHandler(a))
 		r.Post("/connections/{id}/paused", UpdateConnectionPausedHandler(a, sm))
 		r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(a, sm))
 		r.Delete("/connections/{id}", DeleteConnectionHandler(a, sm))

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -51,11 +51,29 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 		// Load category tree for the category picker.
 		categories, _ := svc.ListCategoryTree(ctx)
 
+		// Compute summary stats from the returned rules.
+		var activeCount, disabledCount, totalHits, agentCreated int
+		for _, rule := range result.Rules {
+			if rule.Enabled {
+				activeCount++
+			} else {
+				disabledCount++
+			}
+			totalHits += rule.HitCount
+			if rule.CreatedByType == "agent" {
+				agentCreated++
+			}
+		}
+
 		data := BaseTemplateData(r, sm, "rules", "Transaction Rules")
 		data["Rules"] = result.Rules
 		data["HasMore"] = result.HasMore
 		data["NextCursor"] = result.NextCursor
 		data["Total"] = result.Total
+		data["ActiveCount"] = activeCount
+		data["DisabledCount"] = disabledCount
+		data["TotalHits"] = totalHits
+		data["AgentCreated"] = agentCreated
 		data["SearchFilter"] = r.URL.Query().Get("search")
 		data["CategoryFilter"] = r.URL.Query().Get("category_slug")
 		data["EnabledFilter"] = r.URL.Query().Get("enabled")

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -218,13 +218,13 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			"statusBadge": func(status string) template.HTML {
 				switch status {
 				case "active":
-					return `<span class="badge badge-success badge-sm">Active</span>`
+					return `<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-success/10 text-success">Active</span>`
 				case "pending_reauth":
-					return `<span class="badge badge-warning badge-sm">Re-auth Needed</span>`
+					return `<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-warning/10 text-warning">Re-auth Needed</span>`
 				case "error":
-					return `<span class="badge badge-error badge-sm">Error</span>`
+					return `<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error">Error</span>`
 				default:
-					return `<span class="badge badge-ghost badge-sm">Disconnected</span>`
+					return `<span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-base-content/5 text-base-content/40">Disconnected</span>`
 				}
 			},
 			"syncBadge": func(status string) template.HTML {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -66,6 +66,20 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 		funcMap: template.FuncMap{
 			"sub": func(a, b int) int { return a - b },
 			"add": func(a, b int) int { return a + b },
+			"commaInt": func(n int) string {
+				s := fmt.Sprintf("%d", n)
+				if len(s) <= 3 {
+					return s
+				}
+				result := ""
+				for i, c := range s {
+					if i > 0 && (len(s)-i)%3 == 0 {
+						result += ","
+					}
+					result += string(c)
+				}
+				return result
+			},
 			"mulFloat": func(a *float64, b float64) float64 {
 				if a == nil {
 					return 0

--- a/internal/db/queries/bank_connections.sql
+++ b/internal/db/queries/bank_connections.sql
@@ -18,12 +18,13 @@ SELECT bc.*, u.name as user_name,
   ls.started_at as last_sync_started_at,
   COALESCE(ls.added_count, 0) as last_sync_added,
   COALESCE(ls.modified_count, 0) as last_sync_modified,
-  COALESCE(ls.removed_count, 0) as last_sync_removed
+  COALESCE(ls.removed_count, 0) as last_sync_removed,
+  ls.error_message as last_sync_error_message
 FROM bank_connections bc
 LEFT JOIN users u ON bc.user_id = u.id
 LEFT JOIN LATERAL (
   SELECT sl.status, sl.trigger, sl.duration_ms, sl.started_at,
-         sl.added_count, sl.modified_count, sl.removed_count
+         sl.added_count, sl.modified_count, sl.removed_count, sl.error_message
   FROM sync_logs sl
   WHERE sl.connection_id = bc.id
   ORDER BY sl.started_at DESC

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -925,6 +925,9 @@
 
       // Intercept navigation clicks (sidebar links, breadcrumbs, any internal link)
       document.addEventListener('click', function(e) {
+        // Don't intercept if the event was already handled (e.g. Alpine @click.prevent)
+        if (e.defaultPrevented) return;
+
         var link = e.target.closest('a[href]');
         if (!link) return;
 

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -320,10 +320,10 @@
             {{formatAmount .Amount}}
           </td>
           <td @click.stop>
-            <div class="bb-cat-picker" data-picker-source="acct-tx-{{.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+            <div class="bb-cat-picker" data-picker-source="acct-tx-{{.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
               <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
                 <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-                <span x-text="displayLabel" class="text-sm"></span>
+                <span x-text="displayLabel" class="text-sm" :class="!selectedId && 'text-base-content/30'"></span>
                 {{if .CategoryOverride}}<span class="badge badge-outline badge-xs">override</span>{{end}}
               </button>
             </div>

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -7,10 +7,31 @@
     <span class="badge badge-ghost badge-sm">{{len .Connections}}</span>
     {{end}}
   </div>
-  <a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">
-    <i data-lucide="plus" class="w-4 h-4"></i>
-    Connect Bank
-  </a>
+  <div class="flex items-center gap-2">
+    {{if .Connections}}
+    <div x-data="syncAllBtn()">
+      <button class="btn btn-ghost btn-sm rounded-xl gap-1.5 text-base-content/50 hover:text-primary"
+              :disabled="state !== 'idle'"
+              @click="triggerSyncAll()"
+              :title="state === 'syncing' ? 'Syncing all connections...' : 'Sync all connections now'">
+        <template x-if="state === 'idle'">
+          <i data-lucide="refresh-cw" class="w-4 h-4"></i>
+        </template>
+        <template x-if="state === 'syncing'">
+          <span class="loading loading-spinner loading-xs"></span>
+        </template>
+        <template x-if="state === 'done'">
+          <i data-lucide="check" class="w-4 h-4 text-success"></i>
+        </template>
+        <span class="hidden sm:inline" x-text="state === 'syncing' ? 'Syncing...' : state === 'done' ? 'Triggered!' : 'Sync All'"></span>
+      </button>
+    </div>
+    {{end}}
+    <a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">
+      <i data-lucide="plus" class="w-4 h-4"></i>
+      Connect Bank
+    </a>
+  </div>
 </div>
 
 {{if .Connections}}
@@ -216,6 +237,37 @@
 {{end}}
 
 <script>
+function syncAllBtn() {
+  return {
+    state: 'idle',
+    triggerSyncAll() {
+      if (this.state !== 'idle') return;
+      this.state = 'syncing';
+      var self = this;
+      fetch('/-/connections/sync-all', { method: 'POST' })
+        .then(function(res) {
+          if (res.ok) {
+            self.state = 'done';
+            self.$nextTick(function() { lucide.createIcons(); });
+            window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Sync triggered for all connections.', type: 'success' } }));
+            setTimeout(function() { self.state = 'idle'; self.$nextTick(function() { lucide.createIcons(); }); }, 8000);
+          } else {
+            return res.json().then(function(data) {
+              window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: data.error || 'Failed to trigger sync.', type: 'error' } }));
+              self.state = 'idle';
+              self.$nextTick(function() { lucide.createIcons(); });
+            });
+          }
+        })
+        .catch(function() {
+          window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Network error. Please try again.', type: 'error' } }));
+          self.state = 'idle';
+          self.$nextTick(function() { lucide.createIcons(); });
+        });
+    }
+  };
+}
+
 function syncBtn(connId) {
   return {
     state: 'idle',

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -1,29 +1,23 @@
 {{define "content"}}
 <!-- Page Header -->
 <div class="flex items-center justify-between mb-6">
-  <div class="flex items-center gap-3">
+  <div class="flex items-baseline gap-3">
     <h1 class="bb-page-title">Connections</h1>
     {{if .Connections}}
-    <span class="badge badge-ghost badge-sm">{{len .Connections}}</span>
+    <span class="text-sm text-base-content/40">{{len .Connections}} bank{{if ne (len .Connections) 1}}s{{end}}</span>
     {{end}}
   </div>
   <div class="flex items-center gap-2">
     {{if .Connections}}
     <div x-data="syncAllBtn()">
-      <button class="btn btn-ghost btn-sm rounded-xl gap-1.5 text-base-content/50 hover:text-primary"
+      <button class="btn btn-outline btn-sm rounded-xl gap-1.5"
               :disabled="state !== 'idle'"
               @click="triggerSyncAll()"
               :title="state === 'syncing' ? 'Syncing all connections...' : 'Sync all connections now'">
-        <template x-if="state === 'idle'">
-          <i data-lucide="refresh-cw" class="w-4 h-4"></i>
-        </template>
-        <template x-if="state === 'syncing'">
-          <span class="loading loading-spinner loading-xs"></span>
-        </template>
-        <template x-if="state === 'done'">
-          <i data-lucide="check" class="w-4 h-4 text-success"></i>
-        </template>
-        <span class="hidden sm:inline" x-text="state === 'syncing' ? 'Syncing...' : state === 'done' ? 'Triggered!' : 'Sync All'"></span>
+        <i data-lucide="refresh-cw" class="w-4 h-4" x-show="state === 'idle'"></i>
+        <span class="loading loading-spinner loading-xs" x-show="state === 'syncing'" x-cloak></span>
+        <i data-lucide="check" class="w-4 h-4 text-success" x-show="state === 'done'" x-cloak></i>
+        <span x-text="state === 'syncing' ? 'Syncing...' : state === 'done' ? 'Triggered!' : 'Sync All'"></span>
       </button>
     </div>
     {{end}}
@@ -76,48 +70,30 @@
           <div class="min-w-0">
             <div class="flex items-center gap-2 flex-wrap">
               <h3 class="font-semibold text-sm sm:text-base group-hover:text-primary transition-colors truncate max-w-[10rem] sm:max-w-none">{{.InstitutionName.String}}</h3>
-              {{statusBadge (printf "%s" .Status)}}
-              {{if .Paused}}<span class="badge badge-ghost badge-xs">Paused</span>{{end}}
-              {{if gt .ConsecutiveFailures 0}}
-              <span class="badge badge-warning badge-xs gap-1" title="{{.ConsecutiveFailures}} consecutive sync failure{{if ne .ConsecutiveFailures 1}}s{{end}}{{if .LastErrorAt.Valid}} — last error {{relativeTime .LastErrorAt.Time}}{{end}}">
-                <i data-lucide="alert-triangle" class="w-2.5 h-2.5"></i>
-                {{.ConsecutiveFailures}} fail{{if ne .ConsecutiveFailures 1}}s{{end}}
-              </span>
-              {{end}}
               {{if .IsStale}}
-              <span class="text-[0.6rem] font-medium text-warning/70 bg-warning/8 px-1.5 py-0.5 rounded-full" title="This connection hasn't synced recently">stale</span>
+              <span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-warning/10 text-warning">Stale</span>
+              {{else if and (eq .LastSyncStatus "error") (eq (printf "%s" .Status) "active")}}
+              <span class="relative group/err">
+                <span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
+                {{if .LastSyncErrorMessage.Valid}}
+                <span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
+                  <span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>
+                  <span class="text-base-content/70">{{.LastSyncErrorMessage.String}}</span>
+                </span>
+                {{end}}
+              </span>
+              {{else}}
+              {{statusBadge (printf "%s" .Status)}}
               {{end}}
+              {{if .Paused}}<span class="badge badge-ghost badge-xs">Paused</span>{{end}}
             </div>
-            <div class="flex items-center gap-2 sm:gap-3 text-xs text-base-content/50 mt-0.5 flex-wrap">
+            <div class="flex items-center gap-2 text-xs text-base-content/40 mt-0.5">
               <span>{{.UserName.String}}</span>
               <span class="text-base-content/20">&middot;</span>
               <span class="capitalize">{{printf "%s" .Provider}}</span>
-              {{if .LastSyncedAt.Valid}}
               <span class="text-base-content/20">&middot;</span>
-              <span class="inline-flex items-center gap-1">
-                {{if eq .LastSyncStatus "success"}}<i data-lucide="check-circle" class="w-3 h-3 text-success"></i>
-                {{else if eq .LastSyncStatus "error"}}<i data-lucide="x-circle" class="w-3 h-3 text-error"></i>
-                {{else if eq .LastSyncStatus "in_progress"}}<i data-lucide="loader" class="w-3 h-3 text-warning animate-spin"></i>
-                {{end}}
-                <span><span class="hidden sm:inline">Synced </span>{{relativeTime .LastSyncedAt.Time}}</span>
-              </span>
-              {{if and (ne .LastSyncStatus "in_progress") (gt .LastSyncDurationMs 0)}}
-              <span class="hidden sm:inline text-base-content/30">({{formatDurationMs .LastSyncDurationMs}})</span>
-              {{end}}
-              {{if and (ne .LastSyncStatus "") (or (gt .LastSyncAdded 0) (gt .LastSyncModified 0) (gt .LastSyncRemoved 0))}}
-              <span class="hidden sm:inline text-base-content/20">&middot;</span>
-              <span class="hidden sm:inline-flex items-center gap-1">
-                {{if gt .LastSyncAdded 0}}<span class="text-success/70">+{{.LastSyncAdded}}</span>{{end}}
-                {{if gt .LastSyncModified 0}}<span class="text-info/70">~{{.LastSyncModified}}</span>{{end}}
-                {{if gt .LastSyncRemoved 0}}<span class="text-error/70">-{{.LastSyncRemoved}}</span>{{end}}
-              </span>
-              {{end}}
-              {{if and (not .NextSync.IsDisconnected) (not .NextSync.IsPaused)}}
-              <span class="hidden sm:inline text-base-content/20">&middot;</span>
-              <span class="hidden sm:inline {{if .NextSync.IsOverdue}}text-info{{end}}" title="Sync interval: {{formatIntervalMinutes .NextSync.EffectiveIntervalMinutes}}">
-                <i data-lucide="clock" class="w-3 h-3 inline-block align-[-2px] mr-0.5"></i>Next {{.NextSync.Label}}
-              </span>
-              {{end}}
+              {{if .LastSyncedAt.Valid}}
+              <span>{{relativeTime .LastSyncedAt.Time}}</span>
               {{else}}
               <span>Never synced</span>
               {{end}}
@@ -128,20 +104,13 @@
           <!-- Sync Now button (non-CSV active connections only) -->
           {{if and (ne (printf "%s" .Provider) "csv") (eq (printf "%s" .Status) "active")}}
           <div x-data="syncBtn('{{formatUUID .ID}}')" @click.prevent.stop>
-            <button class="btn btn-ghost btn-xs rounded-lg gap-1 text-base-content/40 hover:text-primary"
+            <button class="w-8 h-8 rounded-full flex items-center justify-center text-base-content/30 hover:text-primary hover:bg-primary/10 transition-colors"
                     :disabled="state !== 'idle'"
                     @click="triggerSync()"
                     :title="state === 'syncing' ? 'Syncing...' : 'Sync Now'">
-              <template x-if="state === 'idle'">
-                <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
-              </template>
-              <template x-if="state === 'syncing'">
-                <span class="loading loading-spinner loading-xs"></span>
-              </template>
-              <template x-if="state === 'done'">
-                <i data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
-              </template>
-              <span class="hidden sm:inline text-xs" x-text="state === 'syncing' ? 'Syncing...' : state === 'done' ? 'Synced!' : 'Sync'"></span>
+              <i data-lucide="refresh-cw" class="w-4 h-4" x-show="state === 'idle'" :class="state === 'idle' ? '' : 'hidden'"></i>
+              <span class="loading loading-spinner loading-xs" x-show="state === 'syncing'" x-cloak></span>
+              <i data-lucide="check" class="w-4 h-4 text-success" x-show="state === 'done'" x-cloak></i>
             </button>
           </div>
           {{end}}
@@ -168,13 +137,7 @@
     </div>
     {{end}}
 
-    <!-- Last sync error message (only for active connections without a connection-level error) -->
-    {{if and (eq .LastSyncStatus "error") .LastSyncErrorMessage.Valid (not .ErrorMessage.Valid) (ne (printf "%s" .Status) "disconnected")}}
-    <div class="mx-4 sm:mx-6 mb-4 flex items-start gap-2 text-xs text-error/80 bg-error/5 rounded-lg px-3 py-2">
-      <i data-lucide="x-circle" class="w-3.5 h-3.5 shrink-0 mt-0.5"></i>
-      <span class="line-clamp-2">Last sync failed: {{.LastSyncErrorMessage.String}}</span>
-    </div>
-    {{end}}
+    {{/* Error message communicated via badge tooltip on hover */}}
 
     {{if .NewAccountsAvailable}}
     <div class="mx-6 mb-4 flex items-center gap-2 text-xs text-info bg-info/10 rounded-lg px-3 py-2">

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -63,6 +63,9 @@
                 {{.ConsecutiveFailures}} fail{{if ne .ConsecutiveFailures 1}}s{{end}}
               </span>
               {{end}}
+              {{if .IsStale}}
+              <span class="text-[0.6rem] font-medium text-warning/70 bg-warning/8 px-1.5 py-0.5 rounded-full" title="This connection hasn't synced recently">stale</span>
+              {{end}}
             </div>
             <div class="flex items-center gap-2 sm:gap-3 text-xs text-base-content/50 mt-0.5 flex-wrap">
               <span>{{.UserName.String}}</span>

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -160,11 +160,19 @@
       </div>
     </a>
 
-    <!-- Error message if any -->
+    <!-- Connection-level error message (e.g. reauth needed) -->
     {{if .ErrorMessage.Valid}}
     <div class="mx-6 mb-4 flex items-start gap-2 text-xs text-warning bg-warning/10 rounded-lg px-3 py-2">
       <i data-lucide="alert-triangle" class="w-3.5 h-3.5 shrink-0 mt-0.5"></i>
       <span>{{errorMessage .ErrorCode.String}}</span>
+    </div>
+    {{end}}
+
+    <!-- Last sync error message (only for active connections without a connection-level error) -->
+    {{if and (eq .LastSyncStatus "error") .LastSyncErrorMessage.Valid (not .ErrorMessage.Valid) (ne (printf "%s" .Status) "disconnected")}}
+    <div class="mx-4 sm:mx-6 mb-4 flex items-start gap-2 text-xs text-error/80 bg-error/5 rounded-lg px-3 py-2">
+      <i data-lucide="x-circle" class="w-3.5 h-3.5 shrink-0 mt-0.5"></i>
+      <span class="line-clamp-2">Last sync failed: {{.LastSyncErrorMessage.String}}</span>
     </div>
     {{end}}
 

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -107,9 +107,27 @@
     <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
   </div>
 
-  <!-- Allocation Bar -->
+  <!-- Net Worth + Allocation Bar -->
   {{if .AllocationSlices}}
   <div class="bb-card p-4 mb-4">
+    <!-- Net Worth Summary -->
+    <div class="flex items-baseline justify-between mb-3">
+      <div>
+        <div class="text-xs text-base-content/40 mb-0.5">Net Worth</div>
+        <div class="text-2xl font-bold tabular-nums tracking-tight">{{formatBalance .NetWorth}}</div>
+      </div>
+      <div class="flex items-center gap-4 text-right">
+        <div>
+          <div class="text-[0.65rem] text-base-content/35 uppercase tracking-wider">Assets</div>
+          <div class="text-sm font-semibold tabular-nums text-success/80">{{formatBalance .TotalAssets}}</div>
+        </div>
+        <div>
+          <div class="text-[0.65rem] text-base-content/35 uppercase tracking-wider">Liabilities</div>
+          <div class="text-sm font-semibold tabular-nums text-error/70">{{formatBalance .TotalLiabilities}}</div>
+        </div>
+      </div>
+    </div>
+    <!-- Allocation Bar -->
     <div class="flex h-3 rounded-full overflow-hidden gap-0.5">
       {{range .AllocationSlices}}
       <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: {{printf "%.1f" .Percent}}%; background: {{safeCSS .Color}}; opacity: 0.7;" title="{{.Label}}: {{formatBalance .Amount}}"></div>

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -1803,8 +1803,11 @@ document.addEventListener('DOMContentLoaded', function() {
         type: 'line',
         data: values,
         smooth: 0.35,
-        symbol: 'none',
+        symbol: 'circle',
+        showSymbol: false,
+        symbolSize: 6,
         lineStyle: { color: lineColor, width: 2 },
+        itemStyle: { color: lineColor },
         areaStyle: {
           color: {
             type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
@@ -1815,10 +1818,13 @@ document.addEventListener('DOMContentLoaded', function() {
           }
         },
         emphasis: {
+          focus: 'none',
           itemStyle: {
             color: lineColor,
             borderColor: isDark ? 'hsl(0 0% 15%)' : 'hsl(0 0% 100%)',
-            borderWidth: 2
+            borderWidth: 2,
+            shadowBlur: 4,
+            shadowColor: 'rgba(0,0,0,0.15)'
           }
         }
       }],

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -829,14 +829,14 @@
 <!-- Category Budget Targets: current spending vs historical averages -->
 {{if .HasBudgetTargets}}
 <div class="bb-card mb-6 p-5 bb-stagger">
-  <div class="flex items-center justify-between mb-4">
+  <div class="flex flex-wrap items-center justify-between gap-y-2 mb-4">
     <div class="flex items-center gap-2.5">
       <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/8">
         <i data-lucide="target" class="w-3.5 h-3.5 text-primary/60"></i>
       </div>
       <div>
         <h2 class="text-sm font-semibold text-base-content/70">Category Targets</h2>
-        <p class="text-[0.6rem] text-base-content/30 mt-0.5">Spending vs historical average for this period</p>
+        <p class="text-[0.6rem] text-base-content/30 mt-0.5 hidden sm:block">Spending vs historical average for this period</p>
       </div>
     </div>
     <div class="flex items-center gap-3">
@@ -862,15 +862,15 @@
       data-category="{{.Category}}"
       @mouseenter="highlightedCategory = '{{.Category}}'; if (window._insightsHighlightDonut) window._insightsHighlightDonut('{{.Category}}')"
       @mouseleave="highlightedCategory = ''; if (window._insightsDownplayDonut) window._insightsDownplayDonut()">
-      <div class="flex items-center justify-between mb-1.5">
-        <div class="flex items-center gap-2 min-w-0">
+      <div class="flex items-center justify-between gap-2 mb-1.5">
+        <div class="flex items-center gap-2 min-w-0 flex-1">
           <span class="w-2 h-2 rounded-full shrink-0 transition-transform duration-150" :class="highlightedCategory === '{{.Category}}' ? 'scale-150' : ''" style="background-color: {{safeCSS .Color}}"></span>
-          <span class="text-xs font-medium truncate transition-colors duration-150" :class="highlightedCategory === '{{.Category}}' ? 'text-base-content font-semibold' : 'text-base-content/70 group-hover:text-base-content'">{{.Category}}</span>
+          <span class="text-xs font-medium transition-colors duration-150 sm:truncate" :class="highlightedCategory === '{{.Category}}' ? 'text-base-content font-semibold' : 'text-base-content/70 group-hover:text-base-content'">{{.Category}}</span>
         </div>
-        <div class="flex items-center gap-2.5 shrink-0">
+        <div class="flex items-center gap-1.5 sm:gap-2.5 shrink-0">
           <span class="text-xs tabular-nums font-semibold text-base-content/80">{{formatAmount .Current}}</span>
-          <span class="text-[0.6rem] text-base-content/25">/</span>
-          <span class="text-[0.6rem] tabular-nums text-base-content/35">{{formatAmount .Target}} avg</span>
+          <span class="text-[0.6rem] text-base-content/25 hidden sm:inline">/</span>
+          <span class="text-[0.6rem] tabular-nums text-base-content/35 hidden sm:inline">{{formatAmount .Target}} avg</span>
           {{if .OverBudget}}
           <span class="text-[0.6rem] font-semibold tabular-nums px-1.5 py-0.5 rounded-full bg-error/8 text-error/70">+{{printf "%.0f" .DiffPercent}}%</span>
           {{else if gt .Percent 80.0}}

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -5,7 +5,7 @@
      x-init="
        $watch('tab', v => { const u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); if (window._onInsightsTabSwitch) window._onInsightsTabSwitch(v); });
        window._setInsightsReady = () => { insightsReady = true; };
-       if (window._insightsChartsLoaded) { insightsReady = true; setTimeout(() => { if (window._insightCharts) window._insightCharts.forEach(c => { try { c.resize(); } catch(e) {} }); }, 150); }
+       if (window._insightsChartsLoaded) { insightsReady = true; setTimeout(() => { if (window._insightCharts) window._insightCharts.forEach(c => { try { c.resize(); } catch(e) {} }); }, 450); setTimeout(() => { if (window._insightCharts) window._insightCharts.forEach(c => { try { c.resize(); } catch(e) {} }); }, 800); }
      "
      @keydown.window="
        if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA' || event.target.isContentEditable) return;
@@ -2749,14 +2749,33 @@ document.addEventListener('DOMContentLoaded', function() {
   // 2. Try calling _setInsightsReady now (works if x-init already ran).
   // 3. Retry after a short delay to catch Alpine finishing after us.
   window._insightsChartsLoaded = true;
+  function resizeAllCharts() {
+    insightCharts.forEach(function(c) {
+      try { c.resize(); } catch(e) {}
+    });
+  }
   function activateInsights() {
     if (typeof window._setInsightsReady === 'function') {
       window._setInsightsReady();
-      setTimeout(function() {
+      // The content div has a 400ms enter transition. Resize after it completes,
+      // with a secondary fallback to catch any late layout shifts.
+      setTimeout(resizeAllCharts, 450);
+      setTimeout(resizeAllCharts, 800);
+      // Use ResizeObserver for a robust catch-all: resize charts whenever their
+      // container dimensions change (covers transitions, lazy layout, etc.).
+      if (typeof ResizeObserver !== 'undefined') {
+        var observed = new Set();
         insightCharts.forEach(function(c) {
-          try { c.resize(); } catch(e) {}
+          var dom = c.getDom && c.getDom();
+          if (dom && !observed.has(dom)) {
+            observed.add(dom);
+            var ro = new ResizeObserver(function() {
+              try { c.resize(); } catch(e) {}
+            });
+            ro.observe(dom);
+          }
         });
-      }, 150);
+      }
       return true;
     }
     return false;

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -208,7 +208,7 @@
 </div>
 
 <!-- Real Insights Content (hidden until ready) -->
-<div x-show="insightsReady" x-transition:enter="transition ease-out duration-400" x-transition:enter-start="opacity-0 translate-y-1" x-transition:enter-end="opacity-100 translate-y-0" x-cloak>
+<div id="insightsContent" x-show="insightsReady" x-transition:enter="transition ease-out duration-400" x-transition:enter-start="opacity-0 translate-y-1" x-transition:enter-end="opacity-100 translate-y-0" x-cloak>
 
 <!-- Summary Pills (always visible) with sparklines + count-up animation -->
 <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 sm:gap-3 mb-6">
@@ -1743,15 +1743,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
     var first = values[0], last = values[values.length - 1];
     var trendUp = last >= first;
+    // ECharts 5.x canvas renderer cannot parse oklch() — use rgba for gradients
     var lineColor, gradTop, gradBot;
     if (trendUp) {
-      lineColor = isDark ? 'oklch(0.70 0.14 155)' : 'oklch(0.55 0.14 155)';
-      gradTop = isDark ? 'oklch(0.70 0.14 155 / 0.15)' : 'oklch(0.55 0.14 155 / 0.12)';
-      gradBot = isDark ? 'oklch(0.70 0.14 155 / 0.01)' : 'oklch(0.55 0.14 155 / 0.01)';
+      lineColor = isDark ? 'rgba(74, 222, 128, 1)' : 'rgba(22, 163, 74, 1)';
+      gradTop = isDark ? 'rgba(74, 222, 128, 0.15)' : 'rgba(22, 163, 74, 0.12)';
+      gradBot = isDark ? 'rgba(74, 222, 128, 0.01)' : 'rgba(22, 163, 74, 0.01)';
     } else {
-      lineColor = isDark ? 'oklch(0.70 0.15 25)' : 'oklch(0.55 0.15 25)';
-      gradTop = isDark ? 'oklch(0.70 0.15 25 / 0.15)' : 'oklch(0.55 0.15 25 / 0.12)';
-      gradBot = isDark ? 'oklch(0.70 0.15 25 / 0.01)' : 'oklch(0.55 0.15 25 / 0.01)';
+      lineColor = isDark ? 'rgba(248, 113, 113, 1)' : 'rgba(220, 38, 38, 1)';
+      gradTop = isDark ? 'rgba(248, 113, 113, 0.15)' : 'rgba(220, 38, 38, 0.12)';
+      gradBot = isDark ? 'rgba(248, 113, 113, 0.01)' : 'rgba(220, 38, 38, 0.01)';
     }
 
     var shortLabels = labels.map(function(d) {
@@ -1790,6 +1791,10 @@ document.addEventListener('DOMContentLoaded', function() {
         borderWidth: 1,
         padding: [8, 12],
         textStyle: { color: tooltipText, fontSize: 13, fontWeight: 600, fontFamily: 'Inter, system-ui, sans-serif' },
+        axisPointer: {
+          type: 'line',
+          lineStyle: { color: isDark ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)', width: 1, type: 'dashed' }
+        },
         formatter: function(params) {
           var idx = params[0].dataIndex;
           var d = labels[idx];
@@ -1803,11 +1808,11 @@ document.addEventListener('DOMContentLoaded', function() {
         type: 'line',
         data: values,
         smooth: 0.35,
-        symbol: 'circle',
+        symbol: 'emptyCircle',
         showSymbol: false,
-        symbolSize: 6,
+        symbolSize: 8,
         lineStyle: { color: lineColor, width: 2 },
-        itemStyle: { color: lineColor },
+        itemStyle: { color: lineColor, borderColor: lineColor, borderWidth: 2 },
         areaStyle: {
           color: {
             type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
@@ -1818,19 +1823,14 @@ document.addEventListener('DOMContentLoaded', function() {
           }
         },
         emphasis: {
-          focus: 'none',
-          itemStyle: {
-            color: lineColor,
-            borderColor: isDark ? 'hsl(0 0% 15%)' : 'hsl(0 0% 100%)',
-            borderWidth: 2,
-            shadowBlur: 4,
-            shadowColor: 'rgba(0,0,0,0.15)'
-          }
+          disabled: false,
+          scale: false
         }
       }],
       animation: true,
       animationDuration: 600,
-      animationEasing: 'cubicOut'
+      animationEasing: 'cubicOut',
+      animationDurationUpdate: 0
     });
 
     window.addEventListener('resize', function() { chart.resize(); });
@@ -2763,24 +2763,20 @@ document.addEventListener('DOMContentLoaded', function() {
   function activateInsights() {
     if (typeof window._setInsightsReady === 'function') {
       window._setInsightsReady();
-      // The content div has a 400ms enter transition. Resize after it completes,
-      // with a secondary fallback to catch any late layout shifts.
-      setTimeout(resizeAllCharts, 450);
-      setTimeout(resizeAllCharts, 800);
-      // Use ResizeObserver for a robust catch-all: resize charts whenever their
-      // container dimensions change (covers transitions, lazy layout, etc.).
-      if (typeof ResizeObserver !== 'undefined') {
-        var observed = new Set();
-        insightCharts.forEach(function(c) {
-          var dom = c.getDom && c.getDom();
-          if (dom && !observed.has(dom)) {
-            observed.add(dom);
-            var ro = new ResizeObserver(function() {
-              try { c.resize(); } catch(e) {}
-            });
-            ro.observe(dom);
-          }
-        });
+      // The content div has a 400ms enter transition (display:none → visible).
+      // Charts initialized while hidden get 100px default width.
+      // Resize aggressively: after transition, and watch the wrapper for layout changes.
+      var wrapper = document.getElementById('insightsContent');
+      function doResize() { resizeAllCharts(); }
+      setTimeout(doResize, 50);
+      setTimeout(doResize, 200);
+      setTimeout(doResize, 450);
+      setTimeout(doResize, 800);
+      // Watch the content wrapper — when it transitions from display:none to visible,
+      // its dimensions change and we resize all charts inside it.
+      if (wrapper && typeof ResizeObserver !== 'undefined') {
+        var ro = new ResizeObserver(doResize);
+        ro.observe(wrapper);
       }
       return true;
     }

--- a/internal/templates/pages/prompt_builder.html
+++ b/internal/templates/pages/prompt_builder.html
@@ -193,23 +193,23 @@
   </div>
 
   <!-- Floating bottom bar -->
-  <div class="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
-    <div class="flex items-center gap-3 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-5 py-3">
-      <span class="text-xs font-medium text-base-content/60">{{.AgentLabel}}</span>
-      <div class="w-px h-4 bg-base-300"></div>
-      <span class="text-xs text-base-content/40 tabular-nums" x-text="activeBlocks.length + ' blocks · ' + preview.length.toLocaleString() + ' chars'"></span>
+  <div class="fixed bottom-6 left-1/2 z-40 -translate-x-1/2 w-[calc(100%-2rem)] max-w-fit">
+    <div class="flex items-center gap-2 sm:gap-3 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-3 sm:px-5 py-3 justify-center">
+      <span class="hidden sm:inline text-xs font-medium text-base-content/60 whitespace-nowrap">{{.AgentLabel}}</span>
+      <div class="hidden sm:block w-px h-4 bg-base-300"></div>
+      <span class="text-xs text-base-content/40 tabular-nums whitespace-nowrap" x-text="activeBlocks.length + ' blocks · ' + preview.length.toLocaleString() + ' chars'"></span>
       <div class="w-px h-4 bg-base-300"></div>
       <button class="btn btn-ghost btn-sm rounded-xl gap-1.5 text-xs" @click="openPreview()">
         <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
-        Preview
-        <span class="ml-1 text-[10px] opacity-50 border border-current/30 rounded px-1 leading-none py-0.5">P</span>
+        <span class="hidden sm:inline">Preview</span>
+        <span class="hidden sm:inline ml-1 text-[10px] opacity-50 border border-current/30 rounded px-1 leading-none py-0.5">P</span>
       </button>
-      <button class="btn btn-primary btn-sm rounded-xl gap-1.5 text-xs relative overflow-hidden" style="min-width:8rem" @click="copyPrompt()">
+      <button class="btn btn-primary btn-sm rounded-xl gap-1.5 text-xs relative overflow-hidden" style="min-width:auto" @click="copyPrompt()">
         <span class="flex items-center gap-1.5 transition-all duration-200"
               :class="copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'">
           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
-          Copy Prompt
-          <span class="ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
+          Copy<span class="hidden sm:inline">&nbsp;Prompt</span>
+          <span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
         </span>
         <span class="absolute inset-0 flex items-center justify-center gap-1.5 transition-all duration-200"
               :class="copied ? 'opacity-100 scale-100' : 'opacity-0 scale-75'">

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -212,7 +212,8 @@
 <div x-data="triageQueue()" @keydown.window="handleKey($event)" class="space-y-0">
 
   {{if .Reviews}}
-  <!-- Triage toolbar -->
+  <!-- Triage toolbar (only shown for pending reviews) -->
+  {{if eq .StatusFilter "pending"}}
   <div class="flex items-center justify-between mb-3">
     <div class="flex items-center gap-3">
       <span class="text-xs text-base-content/40 tabular-nums" x-text="sessionCount + ' reviewed this session'"></span>
@@ -221,7 +222,6 @@
       <span class="text-xs text-base-content/40 tabular-nums">{{.Counts.Pending}} remaining</span>
       {{end}}
     </div>
-    {{if eq .StatusFilter "pending"}}
     <div class="hidden sm:flex items-center gap-2 text-xs text-base-content/30">
       <span class="flex items-center gap-1"><kbd class="bb-kbd">j</kbd><kbd class="bb-kbd">k</kbd> navigate</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">a</kbd> accept</span>
@@ -230,8 +230,8 @@
       <span class="flex items-center gap-1"><kbd class="bb-kbd">n</kbd> note</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">c</kbd> category</span>
     </div>
-    {{end}}
   </div>
+  {{end}}
 
   <!-- Triage list -->
   <div class="bb-card overflow-hidden">
@@ -429,11 +429,19 @@
   {{else}}
   <div class="bb-card">
     <div class="flex flex-col items-center text-center py-16 px-6">
+      {{if eq .StatusFilter "pending"}}
       <div class="w-16 h-16 rounded-xl bg-success/10 flex items-center justify-center mb-4">
         <i data-lucide="check-circle" class="w-8 h-8 text-success"></i>
       </div>
       <h2 class="text-lg font-semibold mb-1">All caught up!</h2>
-      <p class="text-base-content/50 text-sm">No {{.StatusFilter}} reviews to show.</p>
+      <p class="text-base-content/50 text-sm">No pending reviews in the queue.</p>
+      {{else}}
+      <div class="w-16 h-16 rounded-xl bg-base-200 flex items-center justify-center mb-4">
+        <i data-lucide="inbox" class="w-8 h-8 text-base-content/30"></i>
+      </div>
+      <h2 class="text-lg font-semibold mb-1">No results</h2>
+      <p class="text-base-content/50 text-sm">No {{.StatusFilter}} reviews to show.{{if .Counts}} {{.Counts.Pending}} pending review{{if ne .Counts.Pending 1}}s{{end}} remaining.{{end}}</p>
+      {{end}}
     </div>
   </div>
   {{end}}

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -7,17 +7,6 @@
     <p class="text-sm text-base-content/50 mt-1">Review and categorize transactions flagged during sync</p>
   </div>
   <div class="flex items-center gap-2">
-    <!-- View toggle -->
-    <div class="flex items-center bg-base-200 rounded-lg p-0.5">
-      <a href="/reviews?view=triage&status={{.StatusFilter}}{{if .ReviewTypeFilter}}&review_type={{.ReviewTypeFilter}}{{end}}{{if .AccountIDFilter}}&account_id={{.AccountIDFilter}}{{end}}{{if .UserIDFilter}}&user_id={{.UserIDFilter}}{{end}}"
-        class="px-3 py-1 text-xs font-medium rounded-md transition-all duration-150 {{if eq .ViewMode "triage"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/50 hover:text-base-content/70{{end}}">
-        Triage
-      </a>
-      <a href="/reviews?view=cards&status={{.StatusFilter}}{{if .ReviewTypeFilter}}&review_type={{.ReviewTypeFilter}}{{end}}{{if .AccountIDFilter}}&account_id={{.AccountIDFilter}}{{end}}{{if .UserIDFilter}}&user_id={{.UserIDFilter}}{{end}}"
-        class="px-3 py-1 text-xs font-medium rounded-md transition-all duration-150 {{if eq .ViewMode "cards"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/50 hover:text-base-content/70{{end}}">
-        Cards
-      </a>
-    </div>
     {{if and (eq .StatusFilter "pending") .Counts (gt .Counts.Pending 0)}}
     <div x-data="{ dismissing: false, confirmOpen: false }">
       <button class="btn btn-sm btn-error btn-outline rounded-xl gap-1" @click="confirmOpen = true" :disabled="dismissing">
@@ -168,7 +157,6 @@
       x-transition:leave-start="opacity-100 translate-y-0"
       x-transition:leave-end="opacity-0 -translate-y-2"
       class="bb-filter-form">
-      <input type="hidden" name="view" value="{{.ViewMode}}">
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-4 pt-3">
         <label class="bb-filter-label">
           Status
@@ -210,7 +198,7 @@
         </label>
       </div>
       <div class="bb-filter-actions">
-        <a href="/reviews?view={{.ViewMode}}" class="btn btn-sm btn-ghost rounded-xl">Reset</a>
+        <a href="/reviews" class="btn btn-sm btn-ghost rounded-xl">Reset</a>
         <button type="submit" class="btn btn-sm btn-primary rounded-xl">
           <i data-lucide="search" class="w-3.5 h-3.5"></i>
           Filter
@@ -220,10 +208,7 @@
   </div>
 </div>
 
-{{if eq .ViewMode "triage"}}
-<!-- ═══════════════════════════════════════════════════════ -->
-<!-- TRIAGE MODE: Compact, keyboard-driven review workflow  -->
-<!-- ═══════════════════════════════════════════════════════ -->
+<!-- Triage: Compact, keyboard-driven review workflow -->
 <div x-data="triageQueue()" @keydown.window="handleKey($event)" class="space-y-0">
 
   {{if .Reviews}}
@@ -435,7 +420,7 @@
   <!-- Pagination -->
   {{if .HasMore}}
   <div class="flex justify-center mt-6">
-    <a href="/reviews?view=triage&cursor={{.NextCursor}}&status={{.StatusFilter}}{{if .ReviewTypeFilter}}&review_type={{.ReviewTypeFilter}}{{end}}{{if .AccountIDFilter}}&account_id={{.AccountIDFilter}}{{end}}{{if .UserIDFilter}}&user_id={{.UserIDFilter}}{{end}}" class="btn btn-outline btn-sm rounded-xl">
+    <a href="/reviews?cursor={{.NextCursor}}&status={{.StatusFilter}}{{if .ReviewTypeFilter}}&review_type={{.ReviewTypeFilter}}{{end}}{{if .AccountIDFilter}}&account_id={{.AccountIDFilter}}{{end}}{{if .UserIDFilter}}&user_id={{.UserIDFilter}}{{end}}" class="btn btn-outline btn-sm rounded-xl">
       Load More
     </a>
   </div>
@@ -454,167 +439,6 @@
   {{end}}
 </div>
 
-{{else}}
-<!-- ═══════════════════════════════════════════════════════ -->
-<!-- CARDS MODE: Original detailed card layout              -->
-<!-- ═══════════════════════════════════════════════════════ -->
-<div x-data="reviewQueue()" class="space-y-4">
-  {{if .Reviews}}
-  {{range .Reviews}}
-  <div class="bb-card bb-card--interactive p-0 review-card" x-data="{ submitting: false, selectedCatId: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', suggestedCatId: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', feedback: '', pickerShake: false }" id="review-{{.ID}}">
-    <div class="p-6">
-      <!-- Header row: badges + timestamp -->
-      <div class="flex items-center justify-between flex-wrap gap-2">
-        <div class="flex items-center gap-2 flex-wrap">
-          {{if eq .ReviewType "new_transaction"}}
-          <span class="badge badge-soft badge-info badge-sm rounded-lg">New Transaction</span>
-          {{else if eq .ReviewType "uncategorized"}}
-          <span class="badge badge-soft badge-warning badge-sm rounded-lg">Uncategorized</span>
-          {{else if eq .ReviewType "low_confidence"}}
-          <span class="badge badge-soft badge-error badge-sm rounded-lg">Low Confidence{{if .ConfidenceScore}} ({{printf "%.0f" (mulFloat .ConfidenceScore 100.0)}}%){{end}}</span>
-          {{else if eq .ReviewType "manual"}}
-          <span class="badge badge-soft badge-neutral badge-sm rounded-lg">Manual</span>
-          {{end}}
-          {{if .Provider}}
-          <span class="badge badge-ghost badge-xs rounded-lg">{{.Provider}}</span>
-          {{end}}
-          {{if eq .Status "approved"}}
-          <span class="badge badge-success badge-sm rounded-lg">Approved</span>
-          {{else if eq .Status "rejected"}}
-          <span class="badge badge-error badge-sm rounded-lg">Rejected</span>
-          {{else if eq .Status "skipped"}}
-          <span class="badge badge-ghost badge-sm rounded-lg">Skipped</span>
-          {{end}}
-        </div>
-        <span class="text-xs text-base-content/40">{{relativeTime .CreatedAt}}</span>
-      </div>
-
-      <!-- Transaction info -->
-      {{if .Transaction}}
-      <div class="flex items-start justify-between mt-4 gap-4">
-        <div class="min-w-0">
-          <a href="/transactions/{{.TransactionID}}" class="text-base font-semibold link link-hover">{{.Transaction.Name}}</a>
-          {{if .Transaction.MerchantName}}<div class="text-sm text-base-content/60 mt-0.5">{{.Transaction.MerchantName}}</div>{{end}}
-          <div class="text-xs text-base-content/40 mt-1">
-            {{if .Transaction.AccountName}}{{.Transaction.AccountName}}{{end}}
-            {{if .Transaction.UserName}} &middot; {{.Transaction.UserName}}{{end}}
-          </div>
-        </div>
-        <div class="text-right flex-shrink-0">
-          <div class="text-xl font-bold tabular-nums{{if lt .Transaction.Amount 0.0}} text-error{{end}}">
-            {{formatAmount .Transaction.Amount}}
-          </div>
-          <div class="text-xs text-base-content/40 mt-0.5">
-            {{formatDate .Transaction.Date}}
-          </div>
-        </div>
-      </div>
-
-      <!-- Category info with inline thumbs for suggestions -->
-      <div class="text-sm mt-3">
-        {{if .SuggestedCategoryDisplayName}}
-        <div class="flex items-center gap-2">
-          <span class="text-base-content/50">Suggested:</span>
-          <span class="font-medium">{{.SuggestedCategoryDisplayName}}</span>
-          {{if eq .Status "pending"}}
-          <div class="flex items-center gap-1 ml-auto">
-            <button class="btn btn-xs btn-circle" :class="feedback === 'up' ? 'btn-success' : 'btn-ghost text-base-content/30'" @click="feedback = feedback === 'up' ? '' : 'up'">
-              <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 10v12"/><path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z"/></svg>
-            </button>
-            <button class="btn btn-xs btn-circle" :class="feedback === 'down' ? 'btn-error' : 'btn-ghost text-base-content/30'"
-              @click="if (feedback === 'down') { feedback = ''; } else { feedback = 'down'; if (selectedCatId === suggestedCatId) { pickerShake = true; setTimeout(() => pickerShake = false, 600); } }">
-              <svg class="w-3.5 h-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 14V2"/><path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22a3.13 3.13 0 0 1-3-3.88Z"/></svg>
-            </button>
-          </div>
-          {{end}}
-        </div>
-        {{else if .Transaction.Category}}
-        <span class="text-base-content/50">Category:</span>
-        <span class="font-medium">{{.Transaction.Category.DisplayName}}</span>
-        {{else}}
-        <span class="text-base-content/40">Uncategorized</span>
-        {{end}}
-      </div>
-      {{end}}
-
-      {{if eq .Status "pending"}}
-      <!-- Action bar for pending reviews -->
-      <div class="border-t border-base-300 pt-4 mt-4">
-        <!-- Category picker -->
-        <div class="form-control" :class="{ 'bb-picker-shake': pickerShake }">
-          <label class="label label-text text-xs text-base-content/40 py-0.5">
-            {{if .SuggestedCategoryID}}Correct category{{else}}Assign category{{end}}
-          </label>
-          <div class="bb-cat-picker" data-picker-source="review-{{.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .SuggestedCategoryID}}{{.SuggestedCategoryID}}{{end}}', placeholder: 'Keep current', allowEmpty: true, emptyLabel: 'Keep current'})" @category-change="selectedCatId = $event.detail.id; if (selectedCatId !== suggestedCatId && suggestedCatId) { feedback = 'down'; }">
-            <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start border border-base-300 rounded-xl" @click="openPicker()">
-              <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-              <span x-text="displayLabel" class="text-sm truncate"></span>
-              <svg class="w-3 h-3 ml-auto opacity-40" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
-            </button>
-          </div>
-        </div>
-        <!-- Note -->
-        <div class="form-control mt-3">
-          <label class="label label-text text-xs text-base-content/40 py-0.5">Note <span class="text-base-content/30">(optional)</span></label>
-          <input type="text" class="input input-bordered input-sm w-full rounded-xl" placeholder="Add context for future reference..." id="note-{{.ID}}">
-        </div>
-        <!-- Action buttons -->
-        <div class="flex gap-2 flex-wrap mt-4 items-center">
-          <button class="btn btn-success btn-sm rounded-xl gap-1" :disabled="submitting"
-            @click="if (feedback === 'down' && selectedCatId === suggestedCatId) { pickerShake = true; setTimeout(() => pickerShake = false, 600); } else { submitReview('{{.ID}}', 'approved', selectedCatId, feedback); }">
-            <span x-show="!submitting" class="flex items-center gap-1">
-              <i data-lucide="check" class="w-4 h-4"></i>
-              Accept
-            </span>
-            <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
-          </button>
-          <button class="btn btn-ghost btn-sm rounded-xl gap-1" :disabled="submitting"
-            @click="submitReview('{{.ID}}', 'skipped', null, '')">
-            <span x-show="!submitting" class="flex items-center gap-1">
-              <i data-lucide="skip-forward" class="w-4 h-4"></i>
-              Skip
-            </span>
-            <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
-          </button>
-          <button class="btn btn-ghost btn-sm rounded-xl text-base-content/30" :disabled="submitting"
-            @click="dismissReview('{{.ID}}')">
-            <i data-lucide="trash-2" class="w-4 h-4"></i>
-          </button>
-        </div>
-      </div>
-      {{else if .ReviewerName}}
-      <!-- Resolved info -->
-      <div class="border-t border-base-300 pt-3 mt-4 text-xs text-base-content/40">
-        Reviewed by {{.ReviewerName}} {{if .ReviewedAt}} &middot; {{relativeTime .ReviewedAt}}{{end}}
-        {{if .ReviewNote}}<br>Note: {{.ReviewNote}}{{end}}
-      </div>
-      {{end}}
-    </div>
-  </div>
-  {{end}}
-
-  <!-- Pagination -->
-  {{if .HasMore}}
-  <div class="flex justify-center mt-8">
-    <a href="/reviews?view=cards&cursor={{.NextCursor}}&status={{.StatusFilter}}{{if .ReviewTypeFilter}}&review_type={{.ReviewTypeFilter}}{{end}}{{if .AccountIDFilter}}&account_id={{.AccountIDFilter}}{{end}}{{if .UserIDFilter}}&user_id={{.UserIDFilter}}{{end}}" class="btn btn-outline btn-sm rounded-xl">
-      Load More
-    </a>
-  </div>
-  {{end}}
-
-  {{else}}
-  <div class="bb-card">
-    <div class="flex flex-col items-center text-center py-16 px-6">
-      <div class="w-16 h-16 rounded-xl bg-success/10 flex items-center justify-center mb-4">
-        <i data-lucide="check-circle" class="w-8 h-8 text-success"></i>
-      </div>
-      <h2 class="text-lg font-semibold mb-1">All caught up!</h2>
-      <p class="text-base-content/50 text-sm">No {{.StatusFilter}} reviews to show.</p>
-    </div>
-  </div>
-  {{end}}
-</div>
-{{end}}
 
 {{template "category-picker-script" .}}
 <script>
@@ -817,89 +641,5 @@ function triageQueue() {
   }
 }
 
-// Cards mode controller (original)
-function reviewQueue() {
-  return {
-    submitReview(id, decision, categoryId, feedback) {
-      const card = document.getElementById('review-' + id);
-      const noteInput = document.getElementById('note-' + id);
-      const cardData = Alpine.$data(card);
-      cardData.submitting = true;
-
-      const body = { decision: decision };
-      if (categoryId) {
-        body.category_id = categoryId;
-      }
-
-      let noteParts = [];
-      if (feedback === 'up') {
-        noteParts.push('[suggestion accepted]');
-      } else if (feedback === 'down') {
-        noteParts.push('[suggestion corrected]');
-      }
-      if (noteInput && noteInput.value.trim()) {
-        noteParts.push(noteInput.value.trim());
-      }
-      if (noteParts.length > 0) {
-        body.note = noteParts.join(' ');
-      }
-
-      fetch('/-/reviews/' + id + '/submit', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
-        body: JSON.stringify(body)
-      })
-      .then(r => r.json())
-      .then(data => {
-        if (data.error) {
-          window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: data.error, type:'error'}}));
-          cardData.submitting = false;
-        } else {
-          card.style.transition = 'opacity 0.3s, max-height 0.3s, margin 0.3s';
-          card.style.opacity = '0';
-          card.style.maxHeight = '0';
-          card.style.overflow = 'hidden';
-          card.style.marginBottom = '0';
-          setTimeout(() => card.remove(), 300);
-          window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Review ' + decision, type:'success'}}));
-        }
-      })
-      .catch(() => {
-        window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Network error', type:'error'}}));
-        cardData.submitting = false;
-      });
-    },
-
-    dismissReview(id) {
-      const card = document.getElementById('review-' + id);
-      const cardData = Alpine.$data(card);
-      cardData.submitting = true;
-
-      fetch('/-/reviews/' + id + '/dismiss', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken }
-      })
-      .then(r => r.json())
-      .then(data => {
-        if (data.error) {
-          window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: data.error, type:'error'}}));
-          cardData.submitting = false;
-        } else {
-          card.style.transition = 'opacity 0.3s, max-height 0.3s, margin 0.3s';
-          card.style.opacity = '0';
-          card.style.maxHeight = '0';
-          card.style.overflow = 'hidden';
-          card.style.marginBottom = '0';
-          setTimeout(() => card.remove(), 300);
-          window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Review dismissed', type:'info'}}));
-        }
-      })
-      .catch(() => {
-        window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Network error', type:'error'}}));
-        cardData.submitting = false;
-      });
-    }
-  }
-}
 </script>
 {{end}}

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -298,7 +298,7 @@
           {{else if $review.Transaction.Category}}
           <span class="text-xs text-base-content/50 truncate">{{$review.Transaction.Category.DisplayName}}</span>
           {{else}}
-          <span class="text-xs text-base-content/25 italic">none</span>
+          <span class="text-xs text-base-content/30">Uncategorized</span>
           {{end}}
         </div>
 
@@ -532,7 +532,7 @@
         <span class="text-base-content/50">Category:</span>
         <span class="font-medium">{{.Transaction.Category.DisplayName}}</span>
         {{else}}
-        <span class="text-base-content/40 italic">No category assigned</span>
+        <span class="text-base-content/40">Uncategorized</span>
         {{end}}
       </div>
       {{end}}

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -11,6 +11,63 @@
   </button>
 </div>
 
+<!-- Summary Stats Cards -->
+{{if .Rules}}
+<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6 bb-stagger">
+  <!-- Total Rules -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+        <i data-lucide="list-filter" class="w-4 h-4 text-base-content/40"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none">{{.Total}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Total rules</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Active Rules -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .ActiveCount 0}}bg-success/10{{else}}bg-base-200/60{{end}}">
+        <i data-lucide="zap" class="w-4 h-4 {{if gt .ActiveCount 0}}text-success{{else}}text-base-content/40{{end}}"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .ActiveCount 0}}text-success{{end}}">{{.ActiveCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Active</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Total Hits -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+        <i data-lucide="target" class="w-4 h-4 text-primary"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none">{{commaInt .TotalHits}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Total hits</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Agent Created -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .AgentCreated 0}}bg-info/10{{else}}bg-base-200/60{{end}}">
+        <i data-lucide="bot" class="w-4 h-4 {{if gt .AgentCreated 0}}text-info{{else}}text-base-content/40{{end}}"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none">{{.AgentCreated}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Agent-created</div>
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
 <!-- Filters Card -->
 <div class="bb-card mb-6" x-data="{ filtersOpen: {{if or .SearchFilter .CategoryFilter .EnabledFilter}}true{{else}}false{{end}} }">
   <div class="p-0">

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -196,7 +196,7 @@
 <!-- Timeline view -->
 <div class="space-y-1 bb-stagger">
   {{range .Logs}}
-  <div class="bb-card bb-card--interactive group transition-all duration-150 {{if eq .Status "error"}}border-error/20 hover:border-error/30{{end}}" x-data="{ open: false }">
+  <div class="bb-card bb-card--interactive group transition-all duration-150 {{if eq .Status "error"}}border-error/20 hover:border-error/30{{end}}">
     <a href="/sync-logs/{{.ID}}" class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 py-3 px-4 no-underline">
       <!-- Top row: status icon + main content + (desktop) changes -->
       <div class="flex items-center gap-3 sm:gap-4 flex-1 min-w-0">
@@ -234,9 +234,9 @@
             {{end}}
           </div>
           {{if and (eq .Status "error") .FriendlyErrorMessage}}
-          <div class="mt-1 text-xs text-error/60 truncate max-w-md" x-show="!open">{{deref .FriendlyErrorMessage}}</div>
+          <div class="mt-1 text-xs text-error/60 truncate max-w-md">{{deref .FriendlyErrorMessage}}</div>
           {{else if and (eq .Status "error") .ErrorMessage}}
-          <div class="mt-1 text-xs text-error/60 truncate max-w-md font-mono" x-show="!open">{{deref .ErrorMessage}}</div>
+          <div class="mt-1 text-xs text-error/60 truncate max-w-md font-mono">{{deref .ErrorMessage}}</div>
           {{end}}
         </div>
       </div>
@@ -264,48 +264,8 @@
         </span>
         {{end}}
 
-        <!-- Error/Warning expand button -->
-        {{if or .ErrorMessage .WarningMessage}}
-        <button @click.prevent="open = !open" class="btn btn-ghost btn-xs btn-circle {{if .ErrorMessage}}text-error/50 hover:text-error hover:bg-error/10{{else}}text-warning/50 hover:text-warning hover:bg-warning/10{{end}} transition-colors">
-          <i data-lucide="chevron-down" class="w-3.5 h-3.5 transition-transform duration-200" :class="open ? 'rotate-180' : ''"></i>
-        </button>
-        {{end}}
       </div>
     </a>
-
-    <!-- Expandable error detail -->
-    {{if .ErrorMessage}}
-    <div x-show="open" x-cloak x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="border-t border-base-200">
-      <div class="flex items-start gap-2.5 px-4 py-3 ml-11 sm:ml-12">
-        <i data-lucide="alert-circle" class="w-3.5 h-3.5 text-error/60 shrink-0 mt-0.5"></i>
-        <div class="min-w-0">
-          {{if .FriendlyErrorMessage}}
-          <p class="text-xs text-error/80 font-medium leading-relaxed">{{deref .FriendlyErrorMessage}}</p>
-          <details class="mt-1.5">
-            <summary class="text-[0.65rem] text-base-content/30 cursor-pointer hover:text-base-content/50 transition-colors select-none">Technical details</summary>
-            <p class="text-[0.65rem] text-base-content/35 font-mono break-all leading-relaxed mt-1">{{deref .ErrorMessage}}</p>
-          </details>
-          {{else}}
-          <div class="text-xs font-medium text-error/80 mb-0.5">Error Details</div>
-          <p class="text-xs text-base-content/50 font-mono break-all leading-relaxed">{{deref .ErrorMessage}}</p>
-          {{end}}
-        </div>
-      </div>
-    </div>
-    {{end}}
-
-    <!-- Expandable warning detail -->
-    {{if and .WarningMessage (not .ErrorMessage)}}
-    <div x-show="open" x-cloak x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="border-t border-base-200">
-      <div class="flex items-start gap-2.5 px-4 py-3 ml-11 sm:ml-12">
-        <i data-lucide="alert-triangle" class="w-3.5 h-3.5 text-warning/60 shrink-0 mt-0.5"></i>
-        <div class="min-w-0">
-          <div class="text-xs font-medium text-warning/80 mb-0.5">Warning</div>
-          <p class="text-xs text-base-content/50 leading-relaxed">{{deref .WarningMessage}}</p>
-        </div>
-      </div>
-    </div>
-    {{end}}
   </div>
   {{end}}
 </div>

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -233,6 +233,11 @@
             <span>{{.AccountsAffected}} account{{if ne .AccountsAffected 1}}s{{end}}</span>
             {{end}}
           </div>
+          {{if and (eq .Status "error") .FriendlyErrorMessage}}
+          <div class="mt-1 text-xs text-error/60 truncate max-w-md" x-show="!open">{{deref .FriendlyErrorMessage}}</div>
+          {{else if and (eq .Status "error") .ErrorMessage}}
+          <div class="mt-1 text-xs text-error/60 truncate max-w-md font-mono" x-show="!open">{{deref .ErrorMessage}}</div>
+          {{end}}
         </div>
       </div>
 

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -3,10 +3,10 @@
 
 <!-- Page Header -->
 <div class="bb-page-header">
-  <div class="flex items-center gap-3">
+  <div class="flex items-baseline gap-3">
     <h1 class="bb-page-title">Transactions</h1>
     {{if .Total}}
-    <span class="badge badge-ghost badge-sm tabular-nums">{{.Total}} total</span>
+    <span class="text-sm text-base-content/40 tabular-nums">{{.Total}} transaction{{if ne .Total 1}}s{{end}}</span>
     {{end}}
   </div>
   <div class="flex items-center gap-2">

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -54,6 +54,16 @@
           <i data-lucide="bot" class="w-3 h-3"></i>
         </span>
         {{end}}
+        <!-- Mobile category label (hidden on desktop where the picker column shows) -->
+        <span class="sm:hidden text-base-content/20">&middot;</span>
+        {{if .CategoryDisplayName}}
+        <span class="sm:hidden inline-flex items-center gap-1 shrink-0 min-w-0">
+          {{if .CategoryColor}}<span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{safeCSS (deref .CategoryColor)}}"></span>{{end}}
+          <span class="text-base-content/50 truncate max-w-24">{{deref .CategoryDisplayName}}</span>
+        </span>
+        {{else}}
+        <span class="sm:hidden text-base-content/25 truncate shrink-0">Uncategorized</span>
+        {{end}}
       </div>
     </div>
 

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -59,10 +59,10 @@
 
     <!-- Category Picker (inline column) -->
     <div class="shrink-0 hidden sm:block" @click.stop>
-      <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: '\u2014', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+      <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
         <button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
           <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-          <span x-text="displayLabel" class="text-xs">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}&mdash;{{end}}</span>
+          <span x-text="displayLabel" class="text-xs" :class="!selectedId && 'text-base-content/30'">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}Uncategorized{{end}}</span>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Second round of UX, QA, and mobile improvements across the Breadbox dashboard.

### Changes (6 commits)
- **Prompt builder toolbar mobile** — floating bottom bar no longer overflows on narrow viewports
- **Insights chart sizing** — ECharts no longer render as tiny slivers due to skeleton transition timing; added ResizeObserver fallback
- **Category Targets mobile** — category names fully visible, hidden verbose avg text on mobile
- **Net worth chart hover** — fixed broken highlight state caused by `symbol: 'none'` 
- **"Uncategorized" label** — replaced em-dash and "none" with consistent "Uncategorized" label across transactions, account detail, and reviews pages

## Test plan
- [ ] Verify Insights charts render at correct size on page load
- [ ] Hover over net worth chart — highlight should follow smoothly
- [ ] Check Category Targets section on mobile viewport
- [ ] Check prompt builder toolbar on mobile
- [ ] Verify "Uncategorized" shows consistently across transactions, account detail, reviews

Relates to #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)