### PR TITLE
Polish MCP Getting Started guide page

### DIFF
--- a/internal/templates/pages/access.html
+++ b/internal/templates/pages/access.html
@@ -6,8 +6,77 @@
   </div>
 </div>
 
+<!-- OAuth Clients Section -->
+<div id="oauth-clients" class="mb-8">
+  <div class="flex items-center justify-between mb-3">
+    <div class="flex items-center gap-2">
+      <i data-lucide="fingerprint" class="w-4 h-4 text-primary"></i>
+      <h2 class="text-sm font-semibold">OAuth Clients</h2>
+      <span class="text-xs text-base-content/40">External connector access (e.g., Claude)</span>
+    </div>
+    <a href="/oauth-clients/new" class="btn btn-primary btn-sm btn-soft rounded-xl">
+      <i data-lucide="plus" class="w-4 h-4"></i>
+      Create Client
+    </a>
+  </div>
+
+  {{if .Clients}}
+  <div class="space-y-2">
+    {{range .Clients}}
+    <div class="bb-card px-5 py-3.5" x-data="{ confirming: false }">
+      <div class="flex items-center gap-3">
+        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
+          {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-primary/10{{end}}">
+          <i data-lucide="fingerprint" class="w-4 h-4 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-primary{{end}}"></i>
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2 flex-wrap">
+            <span class="font-semibold text-sm {{if .RevokedAt}}text-base-content/40 line-through{{end}}">{{.Name}}</span>
+            {{if eq .Scope "read_only"}}
+            <span class="badge badge-soft badge-warning badge-xs">Read Only</span>
+            {{else}}
+            <span class="badge badge-soft badge-primary badge-xs">Full Access</span>
+            {{end}}
+            {{if .RevokedAt}}
+            <span class="badge badge-soft badge-error badge-xs">Revoked</span>
+            {{end}}
+          </div>
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs text-base-content/40">
+            <code class="font-mono bg-base-200/50 px-1 py-0.5 rounded text-[0.65rem]">{{.ClientIDPrefix}}...</code>
+            <span>Created {{formatDateShort .CreatedAt}}</span>
+          </div>
+        </div>
+        {{if not .RevokedAt}}
+        <div class="shrink-0">
+          <form method="POST" action="/oauth-clients/{{.ID}}/revoke" class="inline">
+            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+            <button type="button" class="btn btn-ghost btn-xs text-base-content/40 hover:text-error" x-show="!confirming" @click="confirming = true">
+              Revoke
+            </button>
+            <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
+              <button type="submit" class="btn btn-error btn-xs btn-soft rounded-xl">Confirm</button>
+              <button type="button" class="btn btn-ghost btn-xs rounded-xl" @click="confirming = false">Cancel</button>
+            </span>
+          </form>
+        </div>
+        {{end}}
+      </div>
+    </div>
+    {{end}}
+  </div>
+  {{else}}
+  <div class="bb-card px-5 py-8 text-center">
+    <p class="text-sm text-base-content/40 mb-3">No OAuth clients yet</p>
+    <a href="/oauth-clients/new" class="btn btn-primary btn-sm btn-soft rounded-xl">
+      <i data-lucide="plus" class="w-4 h-4"></i>
+      Create your first client
+    </a>
+  </div>
+  {{end}}
+</div>
+
 <!-- API Keys Section -->
-<div class="mb-8">
+<div id="api-keys">
   <div class="flex items-center justify-between mb-3">
     <div class="flex items-center gap-2">
       <i data-lucide="key" class="w-4 h-4 text-primary"></i>
@@ -71,75 +140,6 @@
     <a href="/api-keys/new" class="btn btn-primary btn-sm btn-soft rounded-xl">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Create your first key
-    </a>
-  </div>
-  {{end}}
-</div>
-
-<!-- OAuth Clients Section -->
-<div>
-  <div class="flex items-center justify-between mb-3">
-    <div class="flex items-center gap-2">
-      <i data-lucide="fingerprint" class="w-4 h-4 text-base-content/50"></i>
-      <h2 class="text-sm font-semibold">OAuth Clients</h2>
-      <span class="text-xs text-base-content/40">External connector access (e.g., Claude)</span>
-    </div>
-    <a href="/oauth-clients/new" class="btn btn-neutral btn-sm btn-soft rounded-xl">
-      <i data-lucide="plus" class="w-4 h-4"></i>
-      Create Client
-    </a>
-  </div>
-
-  {{if .Clients}}
-  <div class="space-y-2">
-    {{range .Clients}}
-    <div class="bb-card px-5 py-3.5" x-data="{ confirming: false }">
-      <div class="flex items-center gap-3">
-        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
-          {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-base-200/60{{end}}">
-          <i data-lucide="fingerprint" class="w-4 h-4 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-base-content/50{{end}}"></i>
-        </div>
-        <div class="min-w-0 flex-1">
-          <div class="flex items-center gap-2 flex-wrap">
-            <span class="font-semibold text-sm {{if .RevokedAt}}text-base-content/40 line-through{{end}}">{{.Name}}</span>
-            {{if eq .Scope "read_only"}}
-            <span class="badge badge-soft badge-warning badge-xs">Read Only</span>
-            {{else}}
-            <span class="badge badge-soft badge-primary badge-xs">Full Access</span>
-            {{end}}
-            {{if .RevokedAt}}
-            <span class="badge badge-soft badge-error badge-xs">Revoked</span>
-            {{end}}
-          </div>
-          <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs text-base-content/40">
-            <code class="font-mono bg-base-200/50 px-1 py-0.5 rounded text-[0.65rem]">{{.ClientIDPrefix}}...</code>
-            <span>Created {{formatDateShort .CreatedAt}}</span>
-          </div>
-        </div>
-        {{if not .RevokedAt}}
-        <div class="shrink-0">
-          <form method="POST" action="/oauth-clients/{{.ID}}/revoke" class="inline">
-            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
-            <button type="button" class="btn btn-ghost btn-xs text-base-content/40 hover:text-error" x-show="!confirming" @click="confirming = true">
-              Revoke
-            </button>
-            <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
-              <button type="submit" class="btn btn-error btn-xs btn-soft rounded-xl">Confirm</button>
-              <button type="button" class="btn btn-ghost btn-xs rounded-xl" @click="confirming = false">Cancel</button>
-            </span>
-          </form>
-        </div>
-        {{end}}
-      </div>
-    </div>
-    {{end}}
-  </div>
-  {{else}}
-  <div class="bb-card px-5 py-8 text-center">
-    <p class="text-sm text-base-content/40 mb-3">No OAuth clients yet</p>
-    <a href="/oauth-clients/new" class="btn btn-neutral btn-sm btn-soft rounded-xl">
-      <i data-lucide="plus" class="w-4 h-4"></i>
-      Create your first client
     </a>
   </div>
   {{end}}

--- a/internal/templates/pages/mcp_guide.html
+++ b/internal/templates/pages/mcp_guide.html
@@ -42,33 +42,35 @@
       <div>
         <label class="text-xs font-medium text-base-content/50 mb-2 block">Authentication Method</label>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <!-- OAuth (recommended) -->
-          <div class="rounded-xl border-2 border-primary/30 p-4 bg-primary/5">
+          <!-- OAuth -->
+          <div class="rounded-xl border border-base-300 p-4 hover:border-primary/30 transition-colors flex flex-col">
             <div class="flex items-center gap-2 mb-2">
               <i data-lucide="fingerprint" class="w-4 h-4 text-primary"></i>
               <span class="font-medium text-sm">OAuth Client</span>
               <span class="badge badge-primary badge-xs">Recommended</span>
             </div>
-            <p class="text-xs text-base-content/50 mb-3">Automatic token flow with consent screen. Works with Claude, ChatGPT, and most MCP clients.</p>
-            {{if .HasOAuthClients}}
-            <a href="/access" class="btn btn-ghost btn-xs rounded-lg">Manage Access <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
-            {{else}}
-            <a href="/access" class="btn btn-primary btn-xs rounded-lg">Create OAuth Client <i data-lucide="plus" class="w-3 h-3"></i></a>
-            {{end}}
+            <p class="text-xs text-base-content/50 mb-3 flex-1">Automatic token flow with consent screen. Works with Claude, ChatGPT, and most MCP clients.</p>
+            <div class="flex flex-wrap gap-2">
+              <a href="/oauth-clients/new" class="btn btn-primary btn-xs rounded-lg">Create <i data-lucide="plus" class="w-3 h-3"></i></a>
+              {{if .HasOAuthClients}}
+              <a href="/access#oauth-clients" class="btn btn-ghost btn-xs rounded-lg">Manage <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
+              {{end}}
+            </div>
           </div>
           <!-- API Key -->
-          <div class="rounded-xl border border-base-300 p-4 hover:border-primary/30 transition-colors">
+          <div class="rounded-xl border border-base-300 p-4 hover:border-primary/30 transition-colors flex flex-col">
             <div class="flex items-center gap-2 mb-2">
               <i data-lucide="key" class="w-4 h-4 text-warning"></i>
               <span class="font-medium text-sm">API Key</span>
               <span class="badge badge-ghost badge-xs">Simple</span>
             </div>
-            <p class="text-xs text-base-content/50 mb-3">Add a header to your agent config. Best for personal use and CLI tools.</p>
-            {{if .HasAPIKeys}}
-            <a href="/access" class="btn btn-ghost btn-xs rounded-lg">Manage Access <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
-            {{else}}
-            <a href="/access" class="btn btn-ghost btn-xs rounded-lg">Create API Key <i data-lucide="plus" class="w-3 h-3"></i></a>
-            {{end}}
+            <p class="text-xs text-base-content/50 mb-3 flex-1">Add a header to your agent config. Best for personal use and CLI tools.</p>
+            <div class="flex flex-wrap gap-2">
+              <a href="/api-keys/new" class="btn btn-primary btn-xs rounded-lg">Create <i data-lucide="plus" class="w-3 h-3"></i></a>
+              {{if .HasAPIKeys}}
+              <a href="/access#api-keys" class="btn btn-ghost btn-xs rounded-lg">Manage <i data-lucide="arrow-right" class="w-3 h-3"></i></a>
+              {{end}}
+            </div>
           </div>
         </div>
       </div>
@@ -85,28 +87,68 @@
       </div>
     </div>
     <div class="px-4 sm:px-6 py-5">
-      <!-- Agent tabs -->
-      <div class="flex flex-wrap gap-1.5 mb-5" role="tablist">
-        <template x-for="t in tabs" :key="t.id">
-          <button class="btn btn-sm rounded-xl gap-1.5 transition-all"
-                  :class="tab === t.id ? 'btn-primary' : 'btn-ghost'"
-                  @click="switchTab(t.id)"
-                  role="tab"
-                  :aria-selected="tab === t.id">
-            <i :data-lucide="t.icon" class="w-3.5 h-3.5"></i>
-            <span x-text="t.label" class="hidden sm:inline"></span>
+      <!-- Agent tabs + flavor toggle -->
+      <div class="flex flex-wrap items-center justify-between gap-3 mb-5">
+        <div class="flex flex-wrap gap-1.5" role="tablist">
+          <template x-for="t in tabs" :key="t.id">
+            <button class="btn btn-sm rounded-xl gap-1.5 transition-all"
+                    :class="tab === t.id ? 'btn-primary' : 'btn-ghost'"
+                    @click="switchTab(t.id)"
+                    role="tab"
+                    :aria-selected="tab === t.id">
+              <i :data-lucide="t.icon" class="w-3.5 h-3.5"></i>
+              <span x-text="t.label" class="hidden sm:inline"></span>
+            </button>
+          </template>
+        </div>
+        <div x-show="showFlavorToggle" x-cloak class="join rounded-lg border border-base-300">
+          <button class="join-item btn btn-xs gap-1 border-0"
+                  :class="flavor === 'guide' ? 'btn-active' : 'btn-ghost'"
+                  @click="flavor = 'guide'">
+            <i data-lucide="book-open" class="w-3 h-3"></i> Guide
           </button>
-        </template>
+          <button class="join-item btn btn-xs gap-1 border-0"
+                  :class="flavor === 'config' ? 'btn-active' : 'btn-ghost'"
+                  @click="flavor = 'config'">
+            <i data-lucide="code" class="w-3 h-3"></i> Config
+          </button>
+        </div>
       </div>
 
       <!-- Claude Desktop -->
       <div x-ref="panel-claude-desktop" x-show="tab === 'claude-desktop'" x-cloak>
-        <div class="space-y-4">
+        <!-- Guide flavor -->
+        <div x-show="flavor === 'guide'" class="space-y-4">
           <div class="flex items-center gap-2 mb-1">
             <span class="badge badge-soft badge-warning badge-xs rounded-lg">API Key</span>
             <span class="badge badge-soft badge-primary badge-xs rounded-lg">OAuth</span>
           </div>
-          <p class="text-sm text-base-content/60">Add Breadbox to your Claude Desktop config file:</p>
+          <ol class="text-sm text-base-content/60 space-y-2 list-decimal list-inside">
+            <li>Open <strong>Claude Desktop</strong> and go to <strong>Settings</strong></li>
+            <li>Navigate to the <strong>Developer</strong> tab</li>
+            <li>Click <strong>Edit Config</strong> to open <code class="text-xs">claude_desktop_config.json</code></li>
+            <li>Add the Breadbox MCP server entry (switch to <em>Config</em> tab to see the snippet)</li>
+            <li>Save the file and <strong>restart Claude Desktop</strong></li>
+            <li>Breadbox tools should appear in Claude's tool list</li>
+          </ol>
+          <div class="alert alert-info alert-soft text-xs rounded-xl">
+            <i data-lucide="lightbulb" class="w-4 h-4"></i>
+            <span>Claude Desktop supports OAuth natively. If you omit the API key headers, Claude will automatically initiate the OAuth consent flow when connecting.</span>
+          </div>
+          <div class="text-xs text-base-content/40">
+            <p><strong>Config file location:</strong></p>
+            <p class="font-mono mt-1">macOS: ~/Library/Application Support/Claude/claude_desktop_config.json</p>
+            <p class="font-mono">Windows: %APPDATA%\Claude\claude_desktop_config.json</p>
+          </div>
+          <!-- Video placeholder -->
+          <div class="border-2 border-dashed border-base-300 rounded-xl p-8 flex flex-col items-center justify-center text-base-content/30 gap-2">
+            <i data-lucide="play-circle" class="w-8 h-8"></i>
+            <span class="text-xs">Setup walkthrough video coming soon</span>
+          </div>
+        </div>
+        <!-- Config flavor -->
+        <div x-show="flavor === 'config'" x-cloak class="space-y-4">
+          <p class="text-sm text-base-content/60">Add to <code class="text-xs">claude_desktop_config.json</code>:</p>
           <div class="relative" x-data="{ copied: false }">
             <pre class="bg-base-200/50 rounded-xl p-4 pr-10 text-xs font-mono overflow-x-auto leading-relaxed" x-text="configSnippet('claude-desktop')"></pre>
             <button class="btn btn-ghost btn-xs btn-square absolute top-2 right-2 rounded-lg"
@@ -120,26 +162,17 @@
             <p class="font-mono mt-1">macOS: ~/Library/Application Support/Claude/claude_desktop_config.json</p>
             <p class="font-mono">Windows: %APPDATA%\Claude\claude_desktop_config.json</p>
           </div>
-          <div class="alert alert-info alert-soft text-xs rounded-xl">
-            <i data-lucide="lightbulb" class="w-4 h-4"></i>
-            <span>Claude Desktop also supports OAuth. If you skip the headers field, Claude will automatically initiate the OAuth flow when connecting.</span>
-          </div>
-          <!-- Video placeholder -->
-          <div class="border-2 border-dashed border-base-300 rounded-xl p-8 flex flex-col items-center justify-center text-base-content/30 gap-2">
-            <i data-lucide="play-circle" class="w-8 h-8"></i>
-            <span class="text-xs">Setup walkthrough video coming soon</span>
-          </div>
         </div>
       </div>
 
-      <!-- Claude Code -->
+      <!-- Claude Code (config only) -->
       <div x-ref="panel-claude-code" x-show="tab === 'claude-code'" x-cloak>
         <div class="space-y-4">
           <div class="flex items-center gap-2 mb-1">
             <span class="badge badge-soft badge-warning badge-xs rounded-lg">API Key</span>
             <span class="badge badge-soft badge-primary badge-xs rounded-lg">OAuth</span>
           </div>
-          <p class="text-sm text-base-content/60">Run this command in your terminal:</p>
+          <p class="text-sm text-base-content/60">Run this command:</p>
           <div class="relative" x-data="{ copied: false }">
             <pre class="bg-base-200/50 rounded-xl p-4 pr-10 text-xs font-mono overflow-x-auto leading-relaxed" x-text="configSnippet('claude-code-cli')"></pre>
             <button class="btn btn-ghost btn-xs btn-square absolute top-2 right-2 rounded-lg"
@@ -157,36 +190,25 @@
               <i x-show="copied" x-cloak data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
             </button>
           </div>
-          <!-- Video placeholder -->
-          <div class="border-2 border-dashed border-base-300 rounded-xl p-8 flex flex-col items-center justify-center text-base-content/30 gap-2">
-            <i data-lucide="play-circle" class="w-8 h-8"></i>
-            <span class="text-xs">Setup walkthrough video coming soon</span>
+          <div class="alert alert-info alert-soft text-xs rounded-xl">
+            <i data-lucide="lightbulb" class="w-4 h-4"></i>
+            <span>Adding to <code>.mcp.json</code> in your project root shares the config with your team. Use environment variables for the API key.</span>
           </div>
         </div>
       </div>
 
       <!-- ChatGPT -->
       <div x-ref="panel-chatgpt" x-show="tab === 'chatgpt'" x-cloak>
-        <div class="space-y-4">
+        <!-- Guide flavor -->
+        <div x-show="flavor === 'guide'" class="space-y-4">
           <div class="flex items-center gap-2 mb-1">
             <span class="badge badge-soft badge-primary badge-xs rounded-lg">OAuth required</span>
           </div>
-          <p class="text-sm text-base-content/60">ChatGPT connects via OAuth. You'll need an OAuth client set up first.</p>
           <ol class="text-sm text-base-content/60 space-y-2 list-decimal list-inside">
-            <li>Create an <a href="/access" class="link link-primary">OAuth Client</a> in Breadbox if you haven't already</li>
+            <li>Create an <a href="/oauth-clients/new" class="link link-primary">OAuth Client</a> in Breadbox if you haven't already</li>
             <li>In ChatGPT, go to <strong>Settings &rarr; Connectors</strong> (or <strong>Tools</strong>)</li>
             <li>Click <strong>Add MCP Server</strong></li>
-            <li>Enter your MCP server URL:</li>
-          </ol>
-          <div class="relative" x-data="{ copied: false }">
-            <pre class="bg-base-200/50 rounded-xl p-4 pr-10 text-xs font-mono overflow-x-auto leading-relaxed" x-text="mcpURL"></pre>
-            <button class="btn btn-ghost btn-xs btn-square absolute top-2 right-2 rounded-lg"
-                    @click="copyAndFlash(mcpURL, $data)">
-              <i x-show="!copied" data-lucide="copy" class="w-3.5 h-3.5"></i>
-              <i x-show="copied" x-cloak data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
-            </button>
-          </div>
-          <ol class="text-sm text-base-content/60 space-y-2 list-decimal list-inside" start="5">
+            <li>Enter your MCP server URL: <code class="text-xs" x-text="mcpURL"></code></li>
             <li>ChatGPT will redirect you to Breadbox to authorize access</li>
             <li>Approve the connection on the consent screen</li>
           </ol>
@@ -196,15 +218,44 @@
             <span class="text-xs">Setup walkthrough video coming soon</span>
           </div>
         </div>
+        <!-- Config flavor -->
+        <div x-show="flavor === 'config'" x-cloak class="space-y-4">
+          <p class="text-sm text-base-content/60">ChatGPT uses OAuth &mdash; no config file needed. Just provide the MCP server URL:</p>
+          <div class="relative" x-data="{ copied: false }">
+            <pre class="bg-base-200/50 rounded-xl p-4 pr-10 text-xs font-mono overflow-x-auto leading-relaxed" x-text="mcpURL"></pre>
+            <button class="btn btn-ghost btn-xs btn-square absolute top-2 right-2 rounded-lg"
+                    @click="copyAndFlash(mcpURL, $data)">
+              <i x-show="!copied" data-lucide="copy" class="w-3.5 h-3.5"></i>
+              <i x-show="copied" x-cloak data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
+            </button>
+          </div>
+          <div class="text-xs text-base-content/40">
+            ChatGPT handles the OAuth flow automatically. No API key or config file is required.
+          </div>
+        </div>
       </div>
 
       <!-- Other -->
       <div x-ref="panel-other" x-show="tab === 'other'" x-cloak>
-        <div class="space-y-4">
+        <!-- Guide flavor -->
+        <div x-show="flavor === 'guide'" class="space-y-4">
           <div class="flex items-center gap-2 mb-1">
             <span class="badge badge-soft badge-warning badge-xs rounded-lg">API Key</span>
           </div>
-          <p class="text-sm text-base-content/60">Most MCP-compatible tools use the same config format. Add this to your tool's MCP configuration:</p>
+          <ol class="text-sm text-base-content/60 space-y-2 list-decimal list-inside">
+            <li>Find your tool's MCP server configuration (usually a JSON file or settings UI)</li>
+            <li>Add a new server entry with type <code class="text-xs">streamable-http</code></li>
+            <li>Set the URL to your MCP server URL (switch to <em>Config</em> tab to copy the snippet)</li>
+            <li>Add your API key in the headers</li>
+            <li>Restart your tool or refresh the connection</li>
+          </ol>
+          <div class="text-xs text-base-content/40">
+            <p>The wrapper key varies by tool: <code>mcpServers</code> (Claude, Cursor, Windsurf, Cline), <code>servers</code> (VS Code Copilot), <code>context_servers</code> (Zed).</p>
+          </div>
+        </div>
+        <!-- Config flavor -->
+        <div x-show="flavor === 'config'" x-cloak class="space-y-4">
+          <p class="text-sm text-base-content/60">Universal MCP config snippet:</p>
           <div class="relative" x-data="{ copied: false }">
             <pre class="bg-base-200/50 rounded-xl p-4 pr-10 text-xs font-mono overflow-x-auto leading-relaxed" x-text="configSnippet('other')"></pre>
             <button class="btn btn-ghost btn-xs btn-square absolute top-2 right-2 rounded-lg"
@@ -214,7 +265,7 @@
             </button>
           </div>
           <div class="text-xs text-base-content/40">
-            <p>The wrapper key varies by tool: <code>mcpServers</code> (Claude, Cursor, Windsurf, Cline), <code>servers</code> (VS Code Copilot), <code>context_servers</code> (Zed). Check your tool's documentation.</p>
+            <p>Wrap this in the appropriate key for your tool: <code>mcpServers</code>, <code>servers</code>, or <code>context_servers</code>.</p>
           </div>
         </div>
       </div>
@@ -248,13 +299,16 @@ function mcpGuide(mcpURL) {
   };
   return {
     tab: 'claude-desktop',
+    flavor: 'guide',
     mcpURL: mcpURL,
     tabs: [
-      {id:'claude-desktop', label:'Claude Desktop', icon:'monitor'},
-      {id:'claude-code', label:'Claude Code', icon:'terminal'},
-      {id:'chatgpt', label:'ChatGPT', icon:'message-circle'},
-      {id:'other', label:'Other', icon:'puzzle'}
+      {id:'claude-desktop', label:'Claude Desktop', icon:'monitor', hasGuide: true},
+      {id:'claude-code', label:'Claude Code', icon:'terminal', hasGuide: false},
+      {id:'chatgpt', label:'ChatGPT', icon:'message-circle', hasGuide: true},
+      {id:'other', label:'Other', icon:'puzzle', hasGuide: true}
     ],
+    get activeTab() { return this.tabs.find(function(t) { return t.id === this.tab; }.bind(this)); },
+    get showFlavorToggle() { var t = this.activeTab; return t && t.hasGuide; },
     init() {
       // Render Lucide icons in all tab panels after Alpine hydrates.
       var self = this;
@@ -267,6 +321,9 @@ function mcpGuide(mcpURL) {
     },
     switchTab(id) {
       this.tab = id;
+      var t = this.tabs.find(function(t) { return t.id === id; });
+      if (t && !t.hasGuide) this.flavor = 'config';
+      else if (this.flavor === 'config' && t && t.hasGuide) this.flavor = 'guide';
       var self = this;
       setTimeout(function() {
         var panel = self.$refs['panel-' + id];

--- a/internal/templates/pages/oauth_client_new.html
+++ b/internal/templates/pages/oauth_client_new.html
@@ -13,8 +13,8 @@
 
 <div class="bb-card p-8 max-w-lg">
   <div class="flex items-center gap-3 mb-6">
-    <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-secondary/8">
-      <i data-lucide="fingerprint" class="w-5 h-5 text-secondary"></i>
+    <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10">
+      <i data-lucide="fingerprint" class="w-5 h-5 text-primary"></i>
     </div>
     <div>
       <h2 class="text-base font-semibold">Client Details</h2>

--- a/internal/templates/pages/oauth_clients.html
+++ b/internal/templates/pages/oauth_clients.html
@@ -16,8 +16,8 @@
   <div class="bb-card p-5 flex items-center justify-between gap-4 flex-wrap" x-data="{ confirming: false }">
     <div class="flex items-center gap-4 min-w-0">
       <div class="flex items-center justify-center w-10 h-10 rounded-xl shrink-0
-        {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-secondary/8{{end}}">
-        <i data-lucide="fingerprint" class="w-5 h-5 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-secondary{{end}}"></i>
+        {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-primary/10{{end}}">
+        <i data-lucide="fingerprint" class="w-5 h-5 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-primary{{end}}"></i>
       </div>
       <div class="min-w-0">
         <div class="flex items-center gap-2 flex-wrap">


### PR DESCRIPTION
## Summary
- Add Guide/Config flavor toggle per agent panel (Guide = visual walkthrough + video placeholder, Config = raw JSON/CLI)
- Claude Code shows config-only (no toggle)
- OAuth card consistent styling with Create + Manage deep links
- Access page: OAuth section moved to top, icon contrast fixed
- OAuth client pages: secondary → primary icon color

## Test plan
- [ ] Guide/Config toggle works on Claude Desktop, ChatGPT, Other tabs
- [ ] Claude Code tab shows config directly with no toggle
- [ ] Create/Manage buttons deep link to /access#api-keys and /access#oauth-clients
- [ ] Access page shows OAuth section first
- [ ] OAuth icons have good contrast (not ghostly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)