### PR TITLE
Polish MCP guide: brand icons, smart Step 3 suggestions

### DIFF
--- a/internal/admin/mcp_guide.go
+++ b/internal/admin/mcp_guide.go
@@ -49,6 +49,21 @@ func MCPGuideHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateR
 		data["HasAPIKeys"] = hasAPIKeys
 		data["HasOAuthClients"] = hasOAuthClients
 
+		// Step 3 contextual data: pending reviews, uncategorized count, rule count.
+		var pendingReviews, uncategorizedCount, ruleCount int64
+		if counts, err := svc.GetReviewCounts(ctx); err == nil {
+			pendingReviews = counts.Pending
+		}
+		if cnt, err := svc.CountUncategorizedTransactions(ctx); err == nil {
+			uncategorizedCount = cnt
+		}
+		if result, err := svc.ListTransactionRules(ctx, service.TransactionRuleListParams{Limit: 1}); err == nil {
+			ruleCount = int64(result.Total)
+		}
+		data["PendingReviews"] = pendingReviews
+		data["UncategorizedCount"] = uncategorizedCount
+		data["RuleCount"] = ruleCount
+
 		tr.Render(w, r, "mcp_guide.html", data)
 	}
 }

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -317,6 +317,16 @@ func (s *Service) CountTransactions(ctx context.Context) (int64, error) {
 	return s.Queries.CountTransactions(ctx)
 }
 
+// CountUncategorizedTransactions returns the number of non-deleted transactions
+// with no category assigned and no manual override.
+func (s *Service) CountUncategorizedTransactions(ctx context.Context) (int64, error) {
+	var count int64
+	err := s.Pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM transactions WHERE deleted_at IS NULL AND category_id IS NULL AND category_override = FALSE").
+		Scan(&count)
+	return count, err
+}
+
 func (s *Service) CountTransactionsFiltered(ctx context.Context, params TransactionCountParams) (int64, error) {
 	query := "SELECT COUNT(*) FROM transactions t " +
 		"JOIN accounts a ON t.account_id = a.id " +


### PR DESCRIPTION
## Summary

- **Brand SVG icons** in agent selector tabs: Claude tabs use the Anthropic sparkle icon, ChatGPT tab uses the OpenAI flower icon (both inline SVGs using `currentColor` for theme compatibility)
- **Smart Step 3 suggestions**: Instead of a generic "Open Agent Wizard" link, Step 3 now queries the database for pending review count, uncategorized transaction count, and active rule count, then shows 3 contextual agent template cards tailored to the user's actual data state
- **Removed video placeholders** from all agent tabs (they were just noise with "coming soon" text)
- **New `CountUncategorizedTransactions` service method** for efficient uncategorized count query

![MCP Getting Started page](https://i.img402.dev/8bx0ogs5vp.png)

## Test plan

- [ ] Verify brand icons render in all agent tabs (Claude Desktop, Claude Code, ChatGPT)
- [ ] Verify Step 3 shows contextual cards based on actual data
- [ ] Verify all copy-to-clipboard buttons still work
- [ ] Verify links to Agent Wizard templates are correct
- [ ] Run `go test ./...` -- all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)