### PR TITLE
Polish rules page: category colors, icons, creator badges

### DIFF
--- a/input.css
+++ b/input.css
@@ -791,6 +791,45 @@
     }
   }
 
+  /* ── Rule category badge ── */
+  .bb-rule-cat-badge {
+    @apply inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full;
+    --cat-color: oklch(0.55 0 0);
+    background: color-mix(in oklch, var(--cat-color) 10%, transparent);
+    color: var(--cat-color);
+  }
+
+  .bb-rule-cat-dot {
+    @apply w-1.5 h-1.5 rounded-full shrink-0;
+    background: var(--cat-color);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-rule-cat-badge {
+      background: color-mix(in oklch, var(--cat-color) 15%, transparent);
+    }
+  }
+
+  /* ── Rule creator badge ── */
+  .bb-rule-creator-badge {
+    @apply inline-flex items-center gap-1 text-[0.65rem] font-medium px-2 py-0.5 rounded-full;
+    @apply bg-base-200 text-base-content/50;
+  }
+
+  .bb-rule-creator-badge--agent {
+    @apply bg-primary/8 text-primary/70;
+  }
+
+  .bb-rule-creator-badge--user {
+    @apply bg-base-content/6 text-base-content/50;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-rule-creator-badge--agent {
+      @apply bg-primary/12 text-primary/80;
+    }
+  }
+
   /* ── Mobile transaction cards ── */
   .bb-tx-card {
     @apply overflow-hidden;

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -368,9 +368,11 @@ func toStringSlice(v interface{}) ([]string, bool) {
 const ruleSelectQuery = `SELECT tr.id, tr.name, tr.conditions, tr.category_id, tr.priority, tr.enabled,
 	tr.expires_at, tr.created_by_type, tr.created_by_id, tr.created_by_name,
 	tr.hit_count, tr.last_hit_at, tr.created_at, tr.updated_at,
-	c.slug AS category_slug, c.display_name AS category_display_name
+	c.slug AS category_slug, c.display_name AS category_display_name,
+	COALESCE(c.icon, cp.icon) AS category_icon, COALESCE(c.color, cp.color) AS category_color
 	FROM transaction_rules tr
-	LEFT JOIN categories c ON tr.category_id = c.id`
+	LEFT JOIN categories c ON tr.category_id = c.id
+	LEFT JOIN categories cp ON c.parent_id = cp.id`
 
 // CreateTransactionRule creates a new transaction rule.
 func (s *Service) CreateTransactionRule(ctx context.Context, params CreateTransactionRuleParams) (*TransactionRuleResponse, error) {
@@ -479,7 +481,7 @@ func (s *Service) ListTransactionRules(ctx context.Context, params TransactionRu
 		limit = 500
 	}
 
-	baseFrom := `FROM transaction_rules tr LEFT JOIN categories c ON tr.category_id = c.id`
+	baseFrom := `FROM transaction_rules tr LEFT JOIN categories c ON tr.category_id = c.id LEFT JOIN categories cp ON c.parent_id = cp.id`
 
 	var whereClauses []string
 	var args []any
@@ -550,7 +552,8 @@ func (s *Service) ListTransactionRules(ctx context.Context, params TransactionRu
 	selectCols := `SELECT tr.id, tr.name, tr.conditions, tr.category_id, tr.priority, tr.enabled,
 		tr.expires_at, tr.created_by_type, tr.created_by_id, tr.created_by_name,
 		tr.hit_count, tr.last_hit_at, tr.created_at, tr.updated_at,
-		c.slug AS category_slug, c.display_name AS category_display_name `
+		c.slug AS category_slug, c.display_name AS category_display_name,
+		COALESCE(c.icon, cp.icon) AS category_icon, COALESCE(c.color, cp.color) AS category_color `
 
 	orderBy := " ORDER BY tr.created_at DESC, tr.id DESC"
 	limitClause := fmt.Sprintf(" LIMIT $%d", argN)
@@ -1157,8 +1160,10 @@ type ruleRow struct {
 	lastHitAt       pgtype.Timestamptz
 	createdAt       pgtype.Timestamptz
 	updatedAt       pgtype.Timestamptz
-	categorySlug    pgtype.Text
+	categorySlug     pgtype.Text
 	categoryDispName pgtype.Text
+	categoryIcon     pgtype.Text
+	categoryColor    pgtype.Text
 }
 
 // scanDest returns a slice of pointers for use with rows.Scan.
@@ -1167,7 +1172,7 @@ func (r *ruleRow) scanDest() []any {
 		&r.id, &r.name, &r.conditions, &r.categoryID, &r.priority, &r.enabled,
 		&r.expiresAt, &r.createdByType, &r.createdByID, &r.createdByName,
 		&r.hitCount, &r.lastHitAt, &r.createdAt, &r.updatedAt,
-		&r.categorySlug, &r.categoryDispName,
+		&r.categorySlug, &r.categoryDispName, &r.categoryIcon, &r.categoryColor,
 	}
 }
 
@@ -1183,6 +1188,8 @@ func (r *ruleRow) toResponse() TransactionRuleResponse {
 		CategoryID:    uuidPtr(r.categoryID),
 		CategorySlug:  textPtr(r.categorySlug),
 		CategoryName:  textPtr(r.categoryDispName),
+		CategoryIcon:  textPtr(r.categoryIcon),
+		CategoryColor: textPtr(r.categoryColor),
 		Priority:      int(r.priority),
 		Enabled:       r.enabled,
 		ExpiresAt:     timestampStr(r.expiresAt),

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -445,6 +445,8 @@ type TransactionRuleResponse struct {
 	CategoryID    *string   `json:"category_id,omitempty"`
 	CategorySlug  *string   `json:"category_slug,omitempty"`
 	CategoryName  *string   `json:"category_display_name,omitempty"`
+	CategoryIcon  *string   `json:"category_icon,omitempty"`
+	CategoryColor *string   `json:"category_color,omitempty"`
 	Priority      int       `json:"priority"`
 	Enabled       bool      `json:"enabled"`
 	ExpiresAt     *string   `json:"expires_at,omitempty"`

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -90,23 +90,25 @@
 
 <div class="space-y-3 bb-stagger">
 {{range .Rules}}
-<div class="bb-card p-0 overflow-hidden" x-data="{deleting: false}">
+<div class="bb-card p-0 overflow-hidden{{if not .Enabled}} opacity-60{{end}}" x-data="{deleting: false}">
   <div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-6 py-3 sm:py-4">
-    <!-- Status indicator -->
+    <!-- Category avatar -->
     <div class="flex-shrink-0">
-      {{if .Enabled}}
-        {{if and .ExpiresAt (expired .ExpiresAt)}}
-        <div class="w-10 h-10 rounded-xl bg-warning/10 flex items-center justify-center">
-          <i data-lucide="clock" class="w-5 h-5 text-warning"></i>
-        </div>
-        {{else}}
-        <div class="w-10 h-10 rounded-xl bg-success/10 flex items-center justify-center">
-          <i data-lucide="zap" class="w-5 h-5 text-success"></i>
-        </div>
-        {{end}}
+      {{if and .CategoryIcon .Enabled (not (and .ExpiresAt (expired .ExpiresAt)))}}
+      <div class="bb-tx-avatar" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
+        <i data-lucide="{{deref .CategoryIcon}}" class="w-4.5 h-4.5"></i>
+      </div>
+      {{else if and .ExpiresAt (expired .ExpiresAt)}}
+      <div class="w-9 h-9 rounded-xl bg-warning/10 flex items-center justify-center">
+        <i data-lucide="clock" class="w-4.5 h-4.5 text-warning"></i>
+      </div>
+      {{else if not .Enabled}}
+      <div class="w-9 h-9 rounded-xl bg-base-200 flex items-center justify-center">
+        <i data-lucide="pause" class="w-4.5 h-4.5 text-base-content/30"></i>
+      </div>
       {{else}}
-      <div class="w-10 h-10 rounded-xl bg-base-200 flex items-center justify-center">
-        <i data-lucide="pause" class="w-5 h-5 text-base-content/30"></i>
+      <div class="w-9 h-9 rounded-xl bg-success/10 flex items-center justify-center">
+        <i data-lucide="zap" class="w-4.5 h-4.5 text-success"></i>
       </div>
       {{end}}
     </div>
@@ -123,11 +125,14 @@
         <span class="badge badge-ghost badge-xs rounded-lg">Disabled</span>
         {{end}}
       </div>
-      <div class="text-xs text-base-content/40 mt-0.5 font-mono truncate" title="{{conditionSummary .Conditions}}">{{conditionSummary .Conditions}}</div>
+      <div class="text-xs text-base-content/40 mt-0.5 truncate" title="{{conditionSummary .Conditions}}">{{conditionSummary .Conditions}}</div>
       <!-- Mobile-only: category + stats inline -->
       <div class="flex items-center gap-2 mt-1.5 sm:hidden flex-wrap">
         {{if .CategoryName}}
-        <span class="badge badge-outline badge-xs rounded-lg">{{deref .CategoryName}}</span>
+        <span class="bb-rule-cat-badge" {{if .CategoryColor}}style="--cat-color: {{safeCSS (deref .CategoryColor)}}"{{end}}>
+          <span class="bb-rule-cat-dot"></span>
+          {{deref .CategoryName}}
+        </span>
         {{end}}
         <span class="text-xs text-base-content/40 tabular-nums">{{.HitCount}} hits</span>
         <span class="text-xs text-base-content/30">&middot;</span>
@@ -136,9 +141,12 @@
     </div>
 
     <!-- Category (tablet+) -->
-    <div class="hidden sm:flex flex-col items-end gap-0.5 flex-shrink-0">
+    <div class="hidden sm:flex items-center gap-1.5 flex-shrink-0">
       {{if .CategoryName}}
-      <span class="badge badge-outline badge-sm rounded-lg">{{deref .CategoryName}}</span>
+      <span class="bb-rule-cat-badge" {{if .CategoryColor}}style="--cat-color: {{safeCSS (deref .CategoryColor)}}"{{end}}>
+        <span class="bb-rule-cat-dot"></span>
+        {{deref .CategoryName}}
+      </span>
       {{else}}
       <span class="text-base-content/30 text-xs">&mdash;</span>
       {{end}}
@@ -146,31 +154,46 @@
 
     <!-- Stats (desktop+) -->
     <div class="hidden md:flex items-center gap-4 text-xs text-base-content/40 flex-shrink-0">
-      <div class="text-center">
-        <div class="font-semibold text-sm text-base-content/70 tabular-nums">{{.HitCount}}</div>
+      <div class="text-center min-w-10">
+        <div class="font-semibold text-sm tabular-nums {{if ge .HitCount 50}}text-primary{{else if ge .HitCount 10}}text-base-content/70{{else}}text-base-content/50{{end}}">{{.HitCount}}</div>
         <div>hits</div>
       </div>
-      <div class="text-center">
-        <div class="font-semibold text-sm text-base-content/70 tabular-nums">{{.Priority}}</div>
+      <div class="text-center min-w-10">
+        <div class="font-semibold text-sm text-base-content/50 tabular-nums">{{.Priority}}</div>
         <div>priority</div>
       </div>
     </div>
 
     <!-- Creator badge (large desktop+) -->
-    <div class="hidden lg:block flex-shrink-0">
-      <span class="badge badge-ghost badge-xs rounded-lg">{{.CreatedByType}}</span>
+    <div class="hidden lg:flex items-center gap-1 flex-shrink-0">
+      {{if eq .CreatedByType "agent"}}
+      <span class="bb-rule-creator-badge bb-rule-creator-badge--agent" title="Created by {{.CreatedByName}}">
+        <i data-lucide="bot" class="w-3 h-3"></i>
+        agent
+      </span>
+      {{else if eq .CreatedByType "user"}}
+      <span class="bb-rule-creator-badge bb-rule-creator-badge--user" title="Created by {{.CreatedByName}}">
+        <i data-lucide="user" class="w-3 h-3"></i>
+        user
+      </span>
+      {{else}}
+      <span class="bb-rule-creator-badge" title="Created by system">
+        <i data-lucide="settings" class="w-3 h-3"></i>
+        system
+      </span>
+      {{end}}
     </div>
 
     <!-- Actions -->
-    <div class="flex items-center gap-1 flex-shrink-0">
-      <button class="btn btn-ghost btn-xs btn-square rounded-lg" title="Toggle" @click.stop="toggleRule('{{.ID}}')">
-        {{if .Enabled}}<i data-lucide="pause" class="w-4 h-4 pointer-events-none"></i>{{else}}<i data-lucide="play" class="w-4 h-4 pointer-events-none"></i>{{end}}
+    <div class="flex items-center gap-0.5 flex-shrink-0">
+      <button class="btn btn-ghost btn-xs btn-square rounded-lg" title="{{if .Enabled}}Disable{{else}}Enable{{end}}" @click.stop="toggleRule('{{.ID}}')">
+        {{if .Enabled}}<i data-lucide="pause" class="w-3.5 h-3.5 pointer-events-none"></i>{{else}}<i data-lucide="play" class="w-3.5 h-3.5 pointer-events-none"></i>{{end}}
       </button>
       <button class="btn btn-ghost btn-xs btn-square rounded-lg" title="Edit" @click.stop="editRule({{toJSON .}})">
-        <i data-lucide="pencil" class="w-4 h-4 pointer-events-none"></i>
+        <i data-lucide="pencil" class="w-3.5 h-3.5 pointer-events-none"></i>
       </button>
       <button class="btn btn-ghost btn-xs btn-square rounded-lg text-error/60" title="Delete" :disabled="deleting" @click.stop="deleteRule('{{.ID}}', $el)">
-        <i data-lucide="trash-2" class="w-4 h-4 pointer-events-none"></i>
+        <i data-lucide="trash-2" class="w-3.5 h-3.5 pointer-events-none"></i>
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- **Category-colored avatars**: Rule cards now show the category's own icon (utensils for food, phone for telephone, pill for pharmacies, etc.) in a color-tinted avatar instead of a generic green lightning bolt for every rule
- **Colored category badges**: Category name badges now use the category's color with a tinted background and colored dot indicator, with automatic fallback to parent category color for subcategories
- **Creator type badges**: "agent" / "user" / "system" badges now include an appropriate icon (bot, user, settings) with distinct styling per type
- **Visual hierarchy improvements**: Hit count numbers use color intensity (primary for 50+, stronger for 10+, muted for low), disabled rules show reduced opacity, condition summaries use proportional font instead of monospace

### Desktop
![Desktop rules page](https://i.img402.dev/8wfakfw3jk.png)

### Mobile
![Mobile rules page](https://i.img402.dev/vif2n6g4in.png)

## Test plan
- [x] Rules page loads with colored category avatars and badges
- [x] Subcategories inherit parent category colors via COALESCE
- [x] Mobile layout shows category badges inline with hit counts
- [x] Disabled rules display with reduced opacity
- [x] Creator badges show appropriate icons per type
- [x] `go test ./...` passes
- [x] `go build ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)