### PR TITLE
Fix category picker changing all transactions instead of one

### DIFF
--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -232,7 +232,7 @@
       </label>
       <label class="flex flex-col gap-1">
         <span class="text-xs text-base-content/40">Category</span>
-        <div class="bb-cat-picker" data-picker-source="acct-filter-cat" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
+        <div class="bb-cat-picker" data-picker-source="acct-filter-cat" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories', sourceId: 'acct-filter-cat'})" @category-change="$refs.catInput.value = selectedSlug">
           <input type="hidden" name="category" x-ref="catInput" value="{{.FilterCategory}}">
           <button type="button" class="select select-sm select-bordered w-full sm:w-auto min-w-[8rem] text-left flex items-center gap-2" @click="openPicker()">
             <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
@@ -320,7 +320,7 @@
             {{formatAmount .Amount}}
           </td>
           <td @click.stop>
-            <div class="bb-cat-picker" data-picker-source="acct-tx-{{.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+            <div class="bb-cat-picker" data-picker-source="acct-tx-{{.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', sourceId: 'acct-tx-{{.ID}}'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
               <button type="button" class="btn btn-ghost btn-xs gap-1.5 -ml-1" @click="openPicker()">
                 <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
                 <span x-text="displayLabel" class="text-sm" :class="!selectedId && 'text-base-content/30'"></span>

--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -196,7 +196,7 @@
 
       <label class="form-control w-full">
         <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Parent Category</span></div>
-        <div class="bb-cat-picker" data-picker-source="cat-create-parent" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'None (top-level)', allowEmpty: true, emptyLabel: 'None (top-level)'})" @category-change="parentId = $event.detail.id">
+        <div class="bb-cat-picker" data-picker-source="cat-create-parent" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'None (top-level)', allowEmpty: true, emptyLabel: 'None (top-level)', sourceId: 'cat-create-parent'})" @category-change="parentId = $event.detail.id">
           <button type="button" class="select select-bordered w-full text-left flex items-center gap-2 rounded-xl" @click="openPicker()">
             <span x-text="displayLabel" class="flex-1 text-sm"></span>
             <i data-lucide="chevron-down" class="w-4 h-4 opacity-40"></i>

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -383,7 +383,7 @@
 
           <!-- Category picker + actions -->
           <div class="flex flex-col gap-2 w-full sm:w-auto sm:min-w-[220px]">
-            <div class="bb-cat-picker" data-picker-source="triage-{{$review.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if $review.SuggestedCategoryID}}{{$review.SuggestedCategoryID}}{{end}}', placeholder: 'Keep current', allowEmpty: true, emptyLabel: 'Keep current'})" @category-change="selectedCatId = $event.detail.id">
+            <div class="bb-cat-picker" data-picker-source="triage-{{$review.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if $review.SuggestedCategoryID}}{{$review.SuggestedCategoryID}}{{end}}', placeholder: 'Keep current', allowEmpty: true, emptyLabel: 'Keep current', sourceId: 'triage-{{$review.ID}}'})" @category-change="selectedCatId = $event.detail.id">
               <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start border border-base-300 rounded-xl" @click="openPicker()">
                 <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
                 <span x-text="displayLabel" class="text-xs truncate"></span>

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -155,7 +155,7 @@
   <div class="bb-card p-6" x-data="txCategoryEditor()">
     <h2 class="text-sm font-semibold text-base-content/50 mb-5">Category</h2>
 
-    <div class="bb-cat-picker" data-picker-source="txd-cat" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', initial: '{{if .Transaction.Category}}{{.Transaction.Category.ID}}{{end}}'})" @category-change="setCategoryFromPicker($event.detail)">
+    <div class="bb-cat-picker" data-picker-source="txd-cat" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', initial: '{{if .Transaction.Category}}{{.Transaction.Category.ID}}{{end}}', sourceId: 'txd-cat'})" @category-change="setCategoryFromPicker($event.detail)">
       <button type="button" class="w-full flex items-center gap-3 p-3 rounded-xl bg-base-200/50 hover:bg-base-200 transition-colors" @click="openPicker()">
         <template x-if="displayColor"><span class="w-3 h-3 rounded-full shrink-0" :style="'background-color:' + displayColor"></span></template>
         <span x-text="displayLabel" class="text-sm font-medium flex-1 text-left"></span>

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -148,7 +148,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-4">
       <label class="bb-filter-label">
         Category
-        <div class="bb-cat-picker" data-picker-source="tx-filter-cat" x-data="categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories'})" @category-change="$refs.catInput.value = selectedSlug">
+        <div class="bb-cat-picker" data-picker-source="tx-filter-cat" x-data="categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '{{.FilterCategory}}', allowEmpty: true, emptyLabel: 'All categories', sourceId: 'tx-filter-cat'})" @category-change="$refs.catInput.value = selectedSlug">
           <input type="hidden" name="category" x-ref="catInput" value="{{.FilterCategory}}">
           <button type="button" class="select select-sm select-bordered w-full text-left flex items-center gap-2" @click="openPicker()">
             <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>

--- a/internal/templates/partials/category_picker.html
+++ b/internal/templates/partials/category_picker.html
@@ -13,6 +13,7 @@ function categoryPicker(config) {
     allowEmpty: config.allowEmpty !== false,
     emptyLabel: config.emptyLabel || 'All categories',
     highlightIndex: -1,
+    _bbSourceId: config.sourceId || '',
 
     get flatList() {
       let items = [];
@@ -118,23 +119,20 @@ function categoryPicker(config) {
 
     openPicker() {
       this.open = false;
-      var self = this;
       this.$dispatch('open-category-picker', {
         mode: this.mode,
         allowEmpty: this.allowEmpty,
         emptyLabel: this.emptyLabel,
         categories: this.categories,
-        sourceId: this._bbSourceId || this.$el.closest('[data-picker-source]')?.dataset.pickerSource || ('picker-' + Math.random().toString(36).slice(2, 8))
+        sourceId: this._bbSourceId
       });
-      // Store the sourceId so we can match the response
-      if (!this._bbSourceId) {
-        this._bbSourceId = this.$el.closest('[data-picker-source]')?.dataset.pickerSource || ('picker-' + Math.random().toString(36).slice(2, 8));
-      }
     },
 
     init() {
-      // Generate a stable sourceId
-      this._bbSourceId = this.$el.closest('[data-picker-source]')?.dataset.pickerSource || ('picker-' + Math.random().toString(36).slice(2, 8));
+      // Ensure sourceId is set (prefer config value, fall back to DOM attribute)
+      if (!this._bbSourceId) {
+        this._bbSourceId = this.$el.closest('[data-picker-source]')?.dataset.pickerSource || ('picker-' + Math.random().toString(36).slice(2, 8));
+      }
 
       // Listen for category-picked responses
       var self = this;

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -69,7 +69,7 @@
 
     <!-- Category Picker (inline column) -->
     <div class="shrink-0 hidden sm:block" @click.stop>
-      <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
+      <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', sourceId: 'tx-cat-{{.ID}}'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old) { quickSetCategory('{{.ID}}', v) } })">
         <button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
           <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
           <span x-text="displayLabel" class="text-xs" :class="!selectedId && 'text-base-content/30'">{{if .CategoryDisplayName}}{{deref .CategoryDisplayName}}{{else}}Uncategorized{{end}}</span>


### PR DESCRIPTION
## Summary
- **Root cause**: The category picker's `_bbSourceId` property was set via `this._bbSourceId = ...` in `init()`, but since it wasn't declared in the component's data object, Alpine.js's scope chain resolution wrote it to the outermost parent `x-data` scope. All 50 pickers on a page shared the same sourceId (whichever initialized last), so selecting a category for one transaction fired `$watch` callbacks on every picker — sending 50 separate API calls to change all transactions to the same category.
- **Fix**: Declare `_bbSourceId` as a proper property in the `categoryPicker()` return object, initialized from a new `sourceId` config param. All 7 callers now pass `sourceId` explicitly, ensuring each picker instance owns its own identity.

## Test plan
- [x] Verified with browser instrumentation: before fix, 50 `quickSetCategory` calls per category change; after fix, exactly 1
- [x] Visual confirmation: only the clicked transaction row updates its category display
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)