### PR TITLE
Reviews triage: simplify, polish mobile, remove reject action

### DIFF
--- a/input.css
+++ b/input.css
@@ -1939,7 +1939,7 @@
 
   /* Triage detail panel */
   .bb-triage-detail {
-    @apply px-3 sm:px-6 py-4 border-t;
+    @apply px-3 sm:px-6 py-2.5 border-t;
     border-color: oklch(0.94 0 0);
     background: oklch(0.985 0 0);
   }

--- a/input.css
+++ b/input.css
@@ -1725,7 +1725,7 @@
   }
 
   .bb-triage-row__indicator {
-    @apply w-0.5 h-6 rounded-full shrink-0 transition-all duration-150;
+    @apply hidden sm:block w-0.5 h-6 rounded-full shrink-0 transition-all duration-150;
     background: transparent;
   }
 
@@ -1740,7 +1740,7 @@
   }
 
   .bb-triage-row__type {
-    @apply shrink-0 w-12;
+    @apply hidden sm:block shrink-0 w-12;
   }
 
   .bb-triage-badge {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -301,6 +301,12 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return ""
 				}
 			},
+			"badgeCount": func(n int64) string {
+				if n > 99 {
+					return "99+"
+				}
+				return fmt.Sprintf("%d", n)
+			},
 			"deref": func(s *string) string {
 				if s == nil {
 					return ""

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -63,9 +63,6 @@
     <span class="text-success font-medium">{{.Counts.ApprovedToday}}</span> approved
   </span>
   <span class="inline-flex items-center gap-1 text-base-content/50 text-xs">
-    <span class="text-error font-medium">{{.Counts.RejectedToday}}</span> rejected
-  </span>
-  <span class="inline-flex items-center gap-1 text-base-content/50 text-xs">
     <span class="font-medium">{{.Counts.SkippedToday}}</span> skipped
   </span>
   <span class="text-base-content/30 text-xs">today</span>
@@ -142,7 +139,6 @@
           <select name="status" class="select select-sm select-bordered w-full">
             <option value="pending"{{if eq .StatusFilter "pending"}} selected{{end}}>Pending</option>
             <option value="approved"{{if eq .StatusFilter "approved"}} selected{{end}}>Approved</option>
-            <option value="rejected"{{if eq .StatusFilter "rejected"}} selected{{end}}>Rejected</option>
             <option value="skipped"{{if eq .StatusFilter "skipped"}} selected{{end}}>Skipped</option>
             <option value="all"{{if eq .StatusFilter "all"}} selected{{end}}>All</option>
           </select>
@@ -199,7 +195,6 @@
       <span class="flex items-center gap-1"><kbd class="bb-kbd">j</kbd><kbd class="bb-kbd">k</kbd> navigate</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">a</kbd> accept</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">s</kbd> skip</span>
-      <span class="flex items-center gap-1"><kbd class="bb-kbd">d</kbd> dismiss</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">n</kbd> note</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">c</kbd> category</span>
     </div>
@@ -286,18 +281,11 @@
             @click="$dispatch('triage-skip', { id: '{{$review.ID}}', note: triageNote, idx: {{$idx}} })">
             <i data-lucide="fast-forward" class="w-3.5 h-3.5"></i>
           </button>
-          <button class="bb-triage-action bb-triage-action--dismiss" title="Dismiss (d)"
-            :disabled="submitting"
-            @click="$dispatch('triage-dismiss', { id: '{{$review.ID}}', idx: {{$idx}} })">
-            <i data-lucide="x" class="w-3.5 h-3.5"></i>
-          </button>
         </div>
         {{else}}
         <div class="bb-triage-row__resolved">
           {{if eq $review.Status "approved"}}
           <span class="badge badge-success badge-xs">Approved</span>
-          {{else if eq $review.Status "rejected"}}
-          <span class="badge badge-error badge-xs">Rejected</span>
           {{else if eq $review.Status "skipped"}}
           <span class="badge badge-ghost badge-xs">Skipped</span>
           {{end}}
@@ -359,10 +347,6 @@
               @click="$dispatch('triage-skip', { id: '{{$review.ID}}', note: triageNote, idx: {{$idx}} })">
               <i data-lucide="fast-forward" class="w-3 h-3"></i>
               Skip
-            </button>
-            <button class="btn btn-ghost btn-xs rounded-lg text-base-content/30" :disabled="submitting"
-              @click="$dispatch('triage-dismiss', { id: '{{$review.ID}}', idx: {{$idx}} })">
-              <i data-lucide="x" class="w-3 h-3"></i>
             </button>
           </div>
         </div>
@@ -426,9 +410,6 @@ function triageQueue() {
       this.$el.addEventListener('triage-skip', (e) => {
         this.submitTriage(e.detail.id, 'skipped', null, e.detail.note, e.detail.idx);
       });
-      this.$el.addEventListener('triage-dismiss', (e) => {
-        this.dismissTriage(e.detail.id, e.detail.idx);
-      });
     },
 
     handleKey(e) {
@@ -458,10 +439,6 @@ function triageQueue() {
         case 's':
           e.preventDefault();
           this.skipFocused();
-          break;
-        case 'd':
-          e.preventDefault();
-          this.dismissFocused();
           break;
         case 'n':
           e.preventDefault();
@@ -500,13 +477,6 @@ function triageQueue() {
       const id = row.dataset.reviewId;
       const data = Alpine.$data(row);
       this.submitTriage(id, 'skipped', null, data.triageNote, this.focusedIdx);
-    },
-
-    dismissFocused() {
-      const row = this.getFocusedRow();
-      if (!row) return;
-      const id = row.dataset.reviewId;
-      this.dismissTriage(id, this.focusedIdx);
     },
 
     openCategoryPickerForFocused() {
@@ -567,33 +537,6 @@ function triageQueue() {
         } else {
           this.removeRow(id, idx);
           window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Review ' + decision, type:'success'}}));
-        }
-      })
-      .catch(() => {
-        window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Network error', type:'error'}}));
-        data.submitting = false;
-      });
-    },
-
-    dismissTriage(id, idx) {
-      const row = document.getElementById('triage-' + id);
-      if (!row) return;
-      const data = Alpine.$data(row);
-      if (data.submitting) return;
-      data.submitting = true;
-
-      fetch('/-/reviews/' + id + '/dismiss', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken }
-      })
-      .then(r => r.json())
-      .then(d => {
-        if (d.error) {
-          window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error, type:'error'}}));
-          data.submitting = false;
-        } else {
-          this.removeRow(id, idx);
-          window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Review dismissed', type:'info'}}));
         }
       })
       .catch(() => {

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -318,70 +318,52 @@
            x-transition:leave-end="opacity-0"
            @click.stop>
 
-        <div class="flex items-start gap-6 flex-wrap">
-          <!-- Transaction detail -->
-          <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-3 flex-wrap">
+          <!-- Context: link + raw category -->
+          <div class="flex items-center gap-2 flex-1 min-w-0">
             {{if $review.Transaction}}
-            <div class="flex items-center gap-2 mb-2">
-              <a href="/transactions/{{$review.TransactionID}}" class="text-sm font-semibold link link-hover">{{$review.Transaction.Name}}</a>
-              {{if $review.Transaction.Pending}}
-              <span class="badge badge-warning badge-xs">Pending</span>
-              {{end}}
-            </div>
-            <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-1 text-xs">
-              <div>
-                <span class="text-base-content/40">Merchant</span>
-                <div class="font-medium">{{if $review.Transaction.MerchantName}}{{$review.Transaction.MerchantName}}{{else}}&mdash;{{end}}</div>
-              </div>
-              <div>
-                <span class="text-base-content/40">Account</span>
-                <div class="font-medium">{{if $review.Transaction.AccountName}}{{$review.Transaction.AccountName}}{{else}}&mdash;{{end}}</div>
-              </div>
-              <div>
-                <span class="text-base-content/40">Date</span>
-                <div class="font-medium">{{formatDate $review.Transaction.Date}}</div>
-              </div>
-              <div>
-                <span class="text-base-content/40">Amount</span>
-                <div class="font-medium tabular-nums{{if lt $review.Transaction.Amount 0.0}} text-success{{end}}">{{formatAmount $review.Transaction.Amount}}</div>
-              </div>
-            </div>
+            <a href="/transactions/{{$review.TransactionID}}" class="text-xs link link-hover text-base-content/50 shrink-0">
+              <i data-lucide="external-link" class="w-3 h-3 inline"></i>
+              View
+            </a>
+            {{if $review.Transaction.Pending}}
+            <span class="badge badge-warning badge-xs">Pending</span>
+            {{end}}
             {{if $review.Transaction.CategoryPrimaryRaw}}
-            <div class="text-xs text-base-content/40 mt-2">
-              Raw category: <span class="font-mono text-base-content/50">{{$review.Transaction.CategoryPrimaryRaw}}{{if $review.Transaction.CategoryDetailedRaw}} / {{$review.Transaction.CategoryDetailedRaw}}{{end}}</span>
-            </div>
+            <span class="text-xs text-base-content/30">|</span>
+            <span class="text-xs text-base-content/40 truncate">Raw: <span class="font-mono text-base-content/50">{{$review.Transaction.CategoryPrimaryRaw}}{{if $review.Transaction.CategoryDetailedRaw}} / {{$review.Transaction.CategoryDetailedRaw}}{{end}}</span></span>
             {{end}}
             {{end}}
           </div>
 
-          <!-- Category picker + actions -->
-          <div class="flex flex-col gap-2 w-full sm:w-auto sm:min-w-[220px]">
-            <div class="bb-cat-picker" data-picker-source="triage-{{$review.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if $review.SuggestedCategoryID}}{{$review.SuggestedCategoryID}}{{end}}', placeholder: 'Keep current', allowEmpty: true, emptyLabel: 'Keep current', sourceId: 'triage-{{$review.ID}}'})" @category-change="selectedCatId = $event.detail.id">
-              <button type="button" class="btn btn-sm btn-ghost gap-2 w-full justify-start border border-base-300 rounded-xl" @click="openPicker()">
-                <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
-                <span x-text="displayLabel" class="text-xs truncate"></span>
-                <svg class="w-3 h-3 ml-auto opacity-40" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
-              </button>
-            </div>
-            <div class="flex items-center gap-2">
-              <input type="text" class="input input-bordered input-xs flex-1 rounded-lg" placeholder="Add note..." x-model="triageNote" @keydown.stop @keydown.escape.prevent="$el.blur()">
-            </div>
-            <div class="flex gap-1.5">
-              <button class="btn btn-success btn-sm rounded-xl flex-1 gap-1" :disabled="submitting"
-                @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, note: triageNote, idx: {{$idx}} })">
-                <i data-lucide="check" class="w-3.5 h-3.5"></i>
-                Accept
-              </button>
-              <button class="btn btn-ghost btn-sm rounded-xl gap-1" :disabled="submitting"
-                @click="$dispatch('triage-skip', { id: '{{$review.ID}}', note: triageNote, idx: {{$idx}} })">
-                <i data-lucide="fast-forward" class="w-3.5 h-3.5"></i>
-                Skip
-              </button>
-              <button class="btn btn-ghost btn-sm rounded-xl text-base-content/30" :disabled="submitting"
-                @click="$dispatch('triage-dismiss', { id: '{{$review.ID}}', idx: {{$idx}} })">
-                <i data-lucide="x" class="w-3.5 h-3.5"></i>
-              </button>
-            </div>
+          <!-- Category picker -->
+          <div class="bb-cat-picker shrink-0" data-picker-source="triage-{{$review.ID}}" x-data="categoryPicker({categories: {{toJSON $.Categories}}, mode: 'assign', initial: '{{if $review.SuggestedCategoryID}}{{$review.SuggestedCategoryID}}{{end}}', placeholder: 'Keep current', allowEmpty: true, emptyLabel: 'Keep current'})" @category-change="selectedCatId = $event.detail.id">
+            <button type="button" class="btn btn-xs btn-ghost gap-1.5 justify-start border border-base-300 rounded-lg" @click="openPicker()">
+              <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>
+              <span x-text="displayLabel" class="text-xs truncate max-w-[120px]"></span>
+              <svg class="w-3 h-3 opacity-40" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+            </button>
+          </div>
+
+          <!-- Note -->
+          <input type="text" class="input input-bordered input-xs rounded-lg w-36 shrink-0" placeholder="Note..." x-model="triageNote" @keydown.stop @keydown.escape.prevent="$el.blur()">
+
+          <!-- Actions -->
+          <div class="flex gap-1 shrink-0">
+            <button class="btn btn-success btn-xs rounded-lg gap-1" :disabled="submitting"
+              @click="$dispatch('triage-accept', { id: '{{$review.ID}}', catId: selectedCatId, note: triageNote, idx: {{$idx}} })">
+              <i data-lucide="check" class="w-3 h-3"></i>
+              Accept
+            </button>
+            <button class="btn btn-ghost btn-xs rounded-lg gap-1" :disabled="submitting"
+              @click="$dispatch('triage-skip', { id: '{{$review.ID}}', note: triageNote, idx: {{$idx}} })">
+              <i data-lucide="fast-forward" class="w-3 h-3"></i>
+              Skip
+            </button>
+            <button class="btn btn-ghost btn-xs rounded-lg text-base-content/30" :disabled="submitting"
+              @click="$dispatch('triage-dismiss', { id: '{{$review.ID}}', idx: {{$idx}} })">
+              <i data-lucide="x" class="w-3 h-3"></i>
+            </button>
           </div>
         </div>
       </div>

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -195,7 +195,7 @@
   {{if eq .StatusFilter "pending"}}
   <div class="flex items-center justify-between mb-3">
     <span class="text-xs text-base-content/40 tabular-nums" x-text="sessionCount + ' reviewed this session'"></span>
-    <div class="hidden sm:flex items-center gap-2 text-xs text-base-content/30">
+    <div class="hidden lg:flex items-center gap-2 text-xs text-base-content/30">
       <span class="flex items-center gap-1"><kbd class="bb-kbd">j</kbd><kbd class="bb-kbd">k</kbd> navigate</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">a</kbd> accept</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">s</kbd> skip</span>

--- a/internal/templates/pages/reviews.html
+++ b/internal/templates/pages/reviews.html
@@ -51,45 +51,24 @@
   </div>
 </div>
 
-<!-- Stat Cards -->
+<!-- Compact Stats Bar -->
 {{if .Counts}}
-<div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6 bb-stagger">
-  <div class="bb-stat-card">
-    <div class="bb-stat-card__icon text-warning">
-      <i data-lucide="clock" class="w-5 h-5"></i>
-    </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value{{if gt .Counts.Pending 0}} text-warning{{end}}">{{.Counts.Pending}}</span>
-      <span class="bb-stat-card__label">Pending</span>
-    </div>
-  </div>
-  <div class="bb-stat-card">
-    <div class="bb-stat-card__icon text-success">
-      <i data-lucide="check-circle" class="w-5 h-5"></i>
-    </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value text-success">{{.Counts.ApprovedToday}}</span>
-      <span class="bb-stat-card__label">Approved Today</span>
-    </div>
-  </div>
-  <div class="bb-stat-card">
-    <div class="bb-stat-card__icon text-error">
-      <i data-lucide="x-circle" class="w-5 h-5"></i>
-    </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value text-error">{{.Counts.RejectedToday}}</span>
-      <span class="bb-stat-card__label">Rejected Today</span>
-    </div>
-  </div>
-  <div class="bb-stat-card">
-    <div class="bb-stat-card__icon text-base-content/40">
-      <i data-lucide="skip-forward" class="w-5 h-5"></i>
-    </div>
-    <div class="bb-stat-card__body">
-      <span class="bb-stat-card__value">{{.Counts.SkippedToday}}</span>
-      <span class="bb-stat-card__label">Skipped Today</span>
-    </div>
-  </div>
+<div class="flex items-center gap-3 mb-4 text-sm flex-wrap">
+  <span class="inline-flex items-center gap-1.5 font-semibold{{if gt .Counts.Pending 0}} text-warning{{else}} text-base-content/50{{end}}">
+    <i data-lucide="clock" class="w-3.5 h-3.5"></i>
+    {{.Counts.Pending}} pending
+  </span>
+  <span class="text-base-content/20">|</span>
+  <span class="inline-flex items-center gap-1 text-base-content/50 text-xs">
+    <span class="text-success font-medium">{{.Counts.ApprovedToday}}</span> approved
+  </span>
+  <span class="inline-flex items-center gap-1 text-base-content/50 text-xs">
+    <span class="text-error font-medium">{{.Counts.RejectedToday}}</span> rejected
+  </span>
+  <span class="inline-flex items-center gap-1 text-base-content/50 text-xs">
+    <span class="font-medium">{{.Counts.SkippedToday}}</span> skipped
+  </span>
+  <span class="text-base-content/30 text-xs">today</span>
 </div>
 {{end}}
 
@@ -215,13 +194,7 @@
   <!-- Triage toolbar (only shown for pending reviews) -->
   {{if eq .StatusFilter "pending"}}
   <div class="flex items-center justify-between mb-3">
-    <div class="flex items-center gap-3">
-      <span class="text-xs text-base-content/40 tabular-nums" x-text="sessionCount + ' reviewed this session'"></span>
-      {{if .Counts}}
-      <span class="text-xs text-base-content/30">&middot;</span>
-      <span class="text-xs text-base-content/40 tabular-nums">{{.Counts.Pending}} remaining</span>
-      {{end}}
-    </div>
+    <span class="text-xs text-base-content/40 tabular-nums" x-text="sessionCount + ' reviewed this session'"></span>
     <div class="hidden sm:flex items-center gap-2 text-xs text-base-content/30">
       <span class="flex items-center gap-1"><kbd class="bb-kbd">j</kbd><kbd class="bb-kbd">k</kbd> navigate</span>
       <span class="flex items-center gap-1"><kbd class="bb-kbd">a</kbd> accept</span>

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -12,7 +12,7 @@
     <i data-lucide="link"></i>
     <span class="flex-1">Connections</span>
     {{if and .NavBadges (gt .NavBadges.ConnectionsAttention 0)}}
-    <span class="bb-nav-badge bb-nav-badge--warn">{{.NavBadges.ConnectionsAttention}}</span>
+    <span class="bb-nav-badge bb-nav-badge--warn" title="{{.NavBadges.ConnectionsAttention}} connections need attention">{{badgeCount .NavBadges.ConnectionsAttention}}</span>
     {{end}}
   </a>
   <a href="/transactions" class="bb-sidebar-link{{if eq .CurrentPage "transactions"}} bb-sidebar-link--active{{end}}">
@@ -42,14 +42,14 @@
     <i data-lucide="clipboard-check"></i>
     <span class="flex-1">Review Queue</span>
     {{if and .NavBadges (gt .NavBadges.PendingReviews 0)}}
-    <span class="bb-nav-badge">{{.NavBadges.PendingReviews}}</span>
+    <span class="bb-nav-badge" title="{{.NavBadges.PendingReviews}} pending reviews">{{badgeCount .NavBadges.PendingReviews}}</span>
     {{end}}
   </a>
   <a href="/reports" class="bb-sidebar-link{{if eq .CurrentPage "reports"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="file-text"></i>
     <span class="flex-1">Reports</span>
     {{if and .NavBadges (gt .NavBadges.UnreadReports 0)}}
-    <span class="bb-nav-badge">{{.NavBadges.UnreadReports}}</span>
+    <span class="bb-nav-badge" title="{{.NavBadges.UnreadReports}} unread reports">{{badgeCount .NavBadges.UnreadReports}}</span>
     {{end}}
   </a>
   <a href="/mcp-settings" class="bb-sidebar-link{{if eq .CurrentPage "mcp"}} bb-sidebar-link--active{{end}}">


### PR DESCRIPTION
## Summary

Focused polish pass on the Reviews triage page across 5 commits:

- **Compact stats bar** — replaced 4 large stat cards with single inline stats line, showing ~3 more items above the fold
- **Mobile polish** — hidden type badges and focus indicator on mobile (reclaimed ~56px), keyboard shortcuts only at lg+ (1024px)
- **Compact detail panel** — removed duplicated transaction info, single-line inline layout (~70% height reduction)
- **Remove reject action** — only Accept and Skip remain as triage actions (backend untouched)
- **Nav badge cap** — sidebar badges show "99+" for counts over 99

## Test plan
- [ ] Reviews triage: verify accept and skip work (keyboard `a`/`s` and buttons)
- [ ] Reviews triage: verify reject/dismiss button and `d` key are gone
- [ ] Reviews mobile: verify type badges hidden, shortcuts hidden below 1024px
- [ ] Reviews: verify compact stats bar shows correct counts
- [ ] Nav badges: verify "99+" shows for large counts with tooltip for exact number

🤖 Generated with [Claude Code](https://claude.com/claude-code)