### PR TITLE
General UX polish: merchant names, dates, cross-page improvements

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -566,6 +566,29 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return s
 			},
+			"relativeDate": func(s string) string {
+				t, err := time.Parse("2006-01-02", s)
+				if err != nil {
+					return s
+				}
+				now := time.Now()
+				today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+				d := t.In(now.Location())
+				dateOnly := time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, now.Location())
+				days := int(today.Sub(dateOnly).Hours() / 24)
+				switch {
+				case days == 0:
+					return "Today"
+				case days == 1:
+					return "Yesterday"
+				case days >= 2 && days <= 6:
+					return fmt.Sprintf("%d days ago", days)
+				case days >= 7 && days <= 13:
+					return "1 week ago"
+				default:
+					return t.Format("Jan 2, 2006")
+				}
+			},
 			"formatNumeric": func(n pgtype.Numeric) string {
 				if !n.Valid {
 					return ""

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -308,6 +308,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				return *s
 			},
 			"lower": strings.ToLower,
+			"eqFold": strings.EqualFold,
 			"titleCase": titleCaseMerchant,
 			"syncLogFilterQuery": func(status, connID, trigger, dateFrom, dateTo string) template.URL {
 				params := url.Values{}

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -308,6 +308,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				return *s
 			},
 			"lower": strings.ToLower,
+			"titleCase": titleCaseMerchant,
 			"syncLogFilterQuery": func(status, connID, trigger, dateFrom, dateTo string) template.URL {
 				params := url.Values{}
 				if status != "" {
@@ -853,6 +854,55 @@ func formatCurrency(abs float64) string {
 		s = result
 	}
 	return fmt.Sprintf("$%s.%02d", s, cents)
+}
+
+// titleCaseMerchant converts ALL-CAPS merchant names from bank feeds into
+// readable Title Case. Mixed-case input is returned as-is to avoid mangling
+// names that are already properly cased.
+func titleCaseMerchant(s string) string {
+	if s == "" {
+		return s
+	}
+	// Only transform if the string appears to be ALL CAPS or all lowercase.
+	// Mixed-case strings like "McDonald's" are left alone.
+	upper := strings.ToUpper(s)
+	lower := strings.ToLower(s)
+	if s != upper && s != lower {
+		return s // already mixed case — leave it alone
+	}
+
+	// Small words that should stay lowercase (unless first word).
+	smallWords := map[string]bool{
+		"a": true, "an": true, "and": true, "as": true, "at": true,
+		"by": true, "for": true, "in": true, "of": true, "on": true,
+		"or": true, "the": true, "to": true, "vs": true, "via": true,
+	}
+
+	words := strings.Fields(lower)
+	for i, w := range words {
+		// Abbreviations with periods (e.g., "h.e." → "H.E."): uppercase all parts.
+		if strings.Contains(w, ".") {
+			parts := strings.Split(w, ".")
+			for j, p := range parts {
+				if len(p) > 0 {
+					parts[j] = strings.ToUpper(p)
+				}
+			}
+			words[i] = strings.Join(parts, ".")
+			continue
+		}
+		// Short words (2 letters or less) that aren't articles: keep uppercase
+		// (likely abbreviations like "AB", "US", "ATM").
+		if len(w) <= 2 && !smallWords[w] {
+			words[i] = strings.ToUpper(w)
+			continue
+		}
+		// Always capitalize the first word; small words stay lowercase otherwise.
+		if i == 0 || !smallWords[w] {
+			words[i] = strings.ToUpper(w[:1]) + w[1:]
+		}
+	}
+	return strings.Join(words, " ")
 }
 
 // AdminUsername returns the admin username from the session for use in template data maps.

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -312,7 +312,7 @@
               <span class="relative">
                 {{if .HasPendingReview}}<span class="absolute -left-2.5 top-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-info" title="Pending review"></span>{{end}}
                 <a href="/transactions/{{.ID}}" @click.stop class="font-medium text-sm hover:text-primary transition-colors no-underline">{{.Name}}</a>
-                {{if .MerchantName}}<span class="text-xs text-base-content/40 ml-1">{{.MerchantName}}</span>{{end}}
+                {{if .MerchantName}}<span class="text-xs text-base-content/40 ml-1">{{titleCase (deref .MerchantName)}}</span>{{end}}
               </span>
             </div>
           </td>
@@ -333,7 +333,7 @@
         <tr x-show="expanded" x-cloak>
           <td colspan="5" class="bg-base-200/30 px-6 py-3">
             <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
-              {{if .MerchantName}}<div><span class="text-xs text-base-content/40 block">Merchant</span>{{.MerchantName}}</div>{{end}}
+              {{if .MerchantName}}<div><span class="text-xs text-base-content/40 block">Merchant</span>{{titleCase (deref .MerchantName)}}</div>{{end}}
               <div><span class="text-xs text-base-content/40 block">Transaction ID</span><code class="font-mono text-xs text-base-content/50">{{.ID}}</code></div>
               <div><span class="text-xs text-base-content/40 block">Created</span>{{formatDateTime .CreatedAt}}</div>
               <div><span class="text-xs text-base-content/40 block">Updated</span>{{formatDateTime .UpdatedAt}}</div>

--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -77,6 +77,8 @@
             {{end}}
           </div>
           <div class="flex items-center gap-2" @click.stop>
+            {{if gt $spending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+              title="View transactions"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i></a>{{end}}
             <button class="btn btn-ghost btn-xs rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
               data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
               @click.prevent="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
@@ -123,6 +125,8 @@
                 {{end}}
               </div>
               <div class="flex gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150">
+                {{if gt $childSpending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg"
+                  title="View transactions"><i data-lucide="arrow-up-right" class="w-3 h-3"></i></a>{{end}}
                 <button class="btn btn-ghost btn-xs rounded-lg"
                   data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
                   @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -98,6 +98,12 @@
               <span>Never synced</span>
               {{end}}
             </div>
+            {{if and (eq .LastSyncStatus "error") .LastSyncErrorMessage.Valid (ne (printf "%s" .Status) "disconnected")}}
+            <div class="flex items-center gap-1.5 mt-1 text-[0.7rem] text-error/70 leading-snug max-w-xs sm:max-w-md truncate">
+              <i data-lucide="alert-circle" class="w-3 h-3 shrink-0"></i>
+              <span class="truncate">{{.LastSyncErrorMessage.String}}</span>
+            </div>
+            {{end}}
           </div>
         </div>
         <div class="flex items-center gap-2 sm:gap-3 shrink-0">

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -278,7 +278,7 @@
               <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
             </span>
             {{end}}
-            <span class="truncate shrink min-w-0">{{.AccountName}} · {{formatDate .Date}}</span>
+            <span class="truncate shrink min-w-0">{{.AccountName}} · {{relativeDate .Date}}</span>
             {{if .CategoryDisplayName}}
             <span class="text-base-content/20 shrink-0 hidden sm:inline">&middot;</span>
             <span class="items-center gap-1 shrink-0 hidden sm:inline-flex">

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -49,7 +49,7 @@
             <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/40">{{.}}</span>
             {{end}}
           </div>
-          <p class="text-sm text-base-content/70 leading-relaxed">{{.Title}}</p>
+          <p class="text-sm font-medium text-base-content/80 leading-relaxed">{{.Title}}</p>
         </div>
         <!-- Actions -->
         <div class="flex items-center gap-1 shrink-0">
@@ -66,7 +66,7 @@
       <div x-show="expanded['{{.ID}}']" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
         x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
         x-cloak @click.stop class="mt-3 ml-5 pl-3 border-l-2 border-base-200/60">
-        <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
+        <div class="bb-report-body text-sm text-base-content/80 leading-relaxed" data-markdown="{{.Body}}"></div>
       </div>
     </div>
   </div>
@@ -97,15 +97,35 @@ document.addEventListener('DOMContentLoaded', function() {
           a.setAttribute('rel', 'noopener');
         }
       });
-      el.querySelectorAll('ul, ol').forEach(function(list) {
-        list.classList.add('list-disc', 'pl-4', 'space-y-0.5');
+      el.querySelectorAll('ul').forEach(function(list) {
+        list.classList.add('list-disc', 'pl-5', 'space-y-1', 'my-2');
+      });
+      el.querySelectorAll('ol').forEach(function(list) {
+        list.classList.add('list-decimal', 'pl-5', 'space-y-1', 'my-2');
       });
       el.querySelectorAll('p').forEach(function(p) {
-        p.classList.add('mb-1');
+        p.classList.add('mb-2');
       });
       el.querySelectorAll('strong').forEach(function(s) {
-        s.classList.add('text-base-content');
+        s.classList.add('text-base-content', 'font-semibold');
       });
+      el.querySelectorAll('h1, h2, h3, h4').forEach(function(h) {
+        h.classList.add('text-base-content', 'font-semibold', 'mt-3', 'mb-1');
+      });
+      el.querySelectorAll('code').forEach(function(c) {
+        if (c.parentElement.tagName !== 'PRE') {
+          c.classList.add('bg-base-200/60', 'px-1.5', 'py-0.5', 'rounded', 'text-xs', 'font-mono');
+        }
+      });
+      el.querySelectorAll('pre').forEach(function(pre) {
+        pre.classList.add('bg-base-200/40', 'rounded-lg', 'p-3', 'my-2', 'overflow-x-auto', 'text-xs');
+      });
+      el.querySelectorAll('blockquote').forEach(function(bq) {
+        bq.classList.add('border-l-2', 'border-primary/30', 'pl-3', 'my-2', 'text-base-content/60', 'italic');
+      });
+      // Remove bottom margin from last child to avoid extra space
+      var lastChild = el.lastElementChild;
+      if (lastChild) lastChild.classList.add('!mb-0');
     }
   });
 });

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -194,6 +194,10 @@
         <span class="text-xs text-base-content/40 tabular-nums">{{.HitCount}} hits</span>
         <span class="text-xs text-base-content/30">&middot;</span>
         <span class="text-xs text-base-content/40 tabular-nums">p{{.Priority}}</span>
+        {{if .LastHitAt}}
+        <span class="text-xs text-base-content/30">&middot;</span>
+        <span class="text-xs text-base-content/40">{{relativeTime .LastHitAt}}</span>
+        {{end}}
       </div>
     </div>
 
@@ -219,6 +223,12 @@
         <div class="font-semibold text-sm text-base-content/50 tabular-nums">{{.Priority}}</div>
         <div>priority</div>
       </div>
+      {{if .LastHitAt}}
+      <div class="text-center min-w-16">
+        <div class="font-medium text-xs text-base-content/50">{{relativeTime .LastHitAt}}</div>
+        <div>last active</div>
+      </div>
+      {{end}}
     </div>
 
     <!-- Creator badge (large desktop+) -->

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -16,7 +16,7 @@
       </div>
       <div class="min-w-0 flex-1">
         <h2 class="font-semibold">Sync Schedule</h2>
-        <p class="text-xs text-base-content/40" x-show="!expanded">Every {{.SyncIntervalMinutes}} minutes{{if ne .NextSyncTime ""}} · Next: {{.NextSyncTime}}{{end}}</p>
+        <p class="text-xs text-base-content/40" x-show="!expanded">Every {{formatIntervalMinutes .SyncIntervalMinutes}}{{if ne .NextSyncTime ""}} · Next: {{.NextSyncTime}}{{end}}</p>
         <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Automatic bank data sync interval</p>
       </div>
       <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -15,7 +15,7 @@
         <span class="text-xs text-base-content/40">{{formatDate .Transaction.Date}}</span>
         {{if .Transaction.MerchantName}}
         <span class="text-xs text-base-content/30">&middot;</span>
-        <span class="text-xs text-base-content/40">{{deref .Transaction.MerchantName}}</span>
+        <span class="text-xs text-base-content/40">{{titleCase (deref .Transaction.MerchantName)}}</span>
         {{end}}
         {{if .Transaction.Pending}}<span class="badge badge-warning badge-xs ml-1">Pending</span>{{end}}
       </div>
@@ -81,7 +81,7 @@
       {{if .Transaction.MerchantName}}
       <div>
         <p class="text-xs text-base-content/40 mb-1">Merchant</p>
-        <p class="text-sm font-medium">{{deref .Transaction.MerchantName}}</p>
+        <p class="text-sm font-medium">{{titleCase (deref .Transaction.MerchantName)}}</p>
       </div>
       {{end}}
       {{if .AccountName}}

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -156,7 +156,15 @@
       {{if .CreatedAt.Valid}}
       <span>Member since {{.CreatedAt.Time.Format "Jan 2006"}}</span>
       {{end}}
-      <a href="/users/{{formatUUID .ID}}/edit" class="text-base-content/40 hover:text-primary transition-colors no-underline">Edit profile</a>
+      <div class="flex items-center gap-3">
+        {{if gt .AccountCount 0}}
+        <a href="/transactions?user_id={{formatUUID .ID}}" class="text-base-content/40 hover:text-primary transition-colors no-underline inline-flex items-center gap-1" title="View transactions for {{.Name}}">
+          <i data-lucide="receipt" class="w-3 h-3"></i>
+          <span class="hidden sm:inline">Transactions</span>
+        </a>
+        {{end}}
+        <a href="/users/{{formatUUID .ID}}/edit" class="text-base-content/40 hover:text-primary transition-colors no-underline">Edit profile</a>
+      </div>
     </div>
   </div>
   {{end}}

--- a/internal/templates/partials/tx_results.html
+++ b/internal/templates/partials/tx_results.html
@@ -37,7 +37,7 @@
           <div class="w-9"></div>
           <div class="flex-1 min-w-0">Name</div>
           <div class="hidden sm:block shrink-0">Category</div>
-          <div class="w-20 text-right hidden sm:block">Date</div>
+          <div class="w-24 text-right hidden sm:block">Date</div>
           <div class="w-24 text-right pl-3">Amount</div>
           <div class="w-4 hidden sm:block"></div>
         </div>

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -46,7 +46,7 @@
         <span class="truncate">{{.AccountName}}</span>
         {{if .MerchantName}}
         <span class="text-base-content/20 hidden sm:inline">&middot;</span>
-        <span class="text-base-content/40 truncate hidden sm:inline">{{deref .MerchantName}}</span>
+        <span class="text-base-content/40 truncate hidden sm:inline">{{titleCase (deref .MerchantName)}}</span>
         {{end}}
         {{if .AgentReviewed}}
         <span class="text-base-content/20">&middot;</span>
@@ -108,7 +108,7 @@
         {{if .MerchantName}}
         <div>
           <span class="text-base-content/30">Merchant</span>
-          <span class="text-base-content/60 ml-1.5">{{deref .MerchantName}}</span>
+          <span class="text-base-content/60 ml-1.5">{{titleCase (deref .MerchantName)}}</span>
         </div>
         {{end}}
         <div>

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -44,7 +44,7 @@
         <span class="text-base-content/20">&middot;</span>
         {{end}}
         <span class="truncate">{{.AccountName}}</span>
-        {{if .MerchantName}}
+        {{if and .MerchantName (not (eqFold .Name (deref .MerchantName)))}}
         <span class="text-base-content/20 hidden sm:inline">&middot;</span>
         <span class="text-base-content/40 truncate hidden sm:inline">{{titleCase (deref .MerchantName)}}</span>
         {{end}}

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -78,8 +78,8 @@
     </div>
 
     <!-- Date (visible in list mode, hidden in grouped since it's in header) -->
-    <div class="text-xs text-base-content/40 tabular-nums shrink-0 hidden sm:block w-20 text-right bb-tx-date">
-      {{.Date}}
+    <div class="text-xs text-base-content/40 tabular-nums shrink-0 hidden sm:block w-24 text-right bb-tx-date">
+      {{formatDate .Date}}
     </div>
 
     <!-- Amount -->


### PR DESCRIPTION
## Summary

10 incremental polish improvements across the dashboard:

### Data display
- **Title-case merchant names** — "DOLLAR TREE" → "Dollar Tree" (preserves abbreviations and mixed-case)
- **Hide redundant merchants** — "Sears - Platinum Card - Sears" → "Sears - Platinum Card"
- **Human-readable dates** — transaction list uses "Mar 26, 2018" instead of "2018-03-26"
- **Relative dates on dashboard** — "Today", "Yesterday", "2 days ago" in recent transactions
- **Readable sync interval** — "Every 720 minutes" → "Every 12h" in settings

### Navigation & discoverability
- **Categories → Transactions link** — hover-reveal arrow to view transactions filtered by category
- **Family members → Transactions link** — quick link to view a member's transactions
- **Rules: last-active time** — shows "6 hours ago" on rule cards for quick staleness check

### Error visibility
- **Connections: inline sync error** — error message visible below connection info (not just hover tooltip)

### Content readability
- **Reports: markdown styling** — proper headings, lists, code blocks, increased text contrast

## Test plan
- [ ] Transaction list: verify merchant names are title-cased, redundant merchants hidden
- [ ] Transaction list: dates show "Mar 26, 2018" format
- [ ] Dashboard: recent transactions show "Today", "Yesterday", etc.
- [ ] Categories: hover shows arrow link, clicking filters transactions
- [ ] Family members: "Transactions" link visible and working
- [ ] Rules: "last active" time visible on cards
- [ ] Connections: sync errors show inline
- [ ] Settings: sync interval shows "Every 12h"
- [ ] Reports: expanded report body is readable with proper markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)