### PR TITLE
Fix agent reports section mobile responsiveness on dashboard

### DIFF
--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -535,8 +535,8 @@
 <!-- Agent Reports -->
 {{if .AgentReports}}
 <div class="bb-card mb-6 bb-stagger" x-data="agentReports()">
-  <div class="px-5 pt-4 pb-2">
-    <div class="flex items-center justify-between mb-2">
+  <div class="px-4 sm:px-5 pt-4 pb-2">
+    <div class="flex items-center justify-between gap-2 mb-2 flex-wrap">
       <div class="flex items-center gap-2">
         <i data-lucide="bot" class="w-4 h-4 text-primary"></i>
         <h2 class="text-sm font-semibold text-base-content/70">Agent Reports</h2>
@@ -557,21 +557,21 @@
       :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden' : ''"
       id="report-{{.ID}}">
       <!-- Message card -->
-      <div class="px-5 py-3.5 hover:bg-base-200/20 transition-colors cursor-pointer" @click="toggle('{{.ID}}')">
-        <div class="flex items-start gap-3">
+      <div class="px-4 sm:px-5 py-3.5 hover:bg-base-200/20 transition-colors cursor-pointer" @click="toggle('{{.ID}}')">
+        <div class="flex items-start gap-2 sm:gap-3">
           <!-- Priority dot -->
-          <span class="w-2 h-2 rounded-full shrink-0 mt-1.5 {{if eq .Priority "critical"}}bg-error{{else if eq .Priority "warning"}}bg-warning{{else}}bg-base-content/20{{end}}"></span>
+          <span class="w-2 h-2 rounded-full shrink-0 mt-1.5 hidden sm:block {{if eq .Priority "critical"}}bg-error{{else if eq .Priority "warning"}}bg-warning{{else}}bg-base-content/20{{end}}"></span>
           <!-- Message content -->
           <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-2 text-xs mb-1">
-              <span class="font-semibold text-base-content/70">{{.DisplayAuthor}}</span>
+            <div class="flex items-center gap-1.5 sm:gap-2 text-xs mb-1 flex-wrap">
+              <span class="font-semibold text-base-content/70 truncate max-w-[10rem] sm:max-w-none">{{.DisplayAuthor}}</span>
               <span class="text-base-content/30">&middot;</span>
-              <span class="text-base-content/30">{{.CreatedAt}}</span>
+              <span class="text-base-content/30 shrink-0">{{.CreatedAt}}</span>
               {{range .Tags}}
               <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/40 hidden sm:inline">{{.}}</span>
               {{end}}
             </div>
-            <p class="text-sm text-base-content/70 leading-relaxed">{{.Title}}</p>
+            <p class="text-sm text-base-content/70 leading-relaxed line-clamp-2 sm:line-clamp-none">{{.Title}}</p>
           </div>
           <!-- Actions -->
           <div class="flex items-center gap-1.5 shrink-0">
@@ -585,7 +585,7 @@
         <!-- Expanded detail -->
         <div x-show="expanded['{{.ID}}']" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
           x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
-          x-cloak class="mt-3 ml-5 pl-3 border-l-2 border-base-200/60">
+          x-cloak class="mt-3 sm:ml-5 pl-3 border-l-2 border-base-200/60">
           <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
         </div>
       </div>


### PR DESCRIPTION
- Tighter padding on mobile, flex-wrap on header row
- Hide priority dot on mobile to save space
- Truncate author name, line-clamp report titles on mobile
- Remove expanded detail left margin on mobile