### PR TITLE
Declutter sync logs page and detail view

### DIFF
--- a/internal/templates/pages/sync_log_detail.html
+++ b/internal/templates/pages/sync_log_detail.html
@@ -18,14 +18,24 @@
       {{end}}
     </div>
     <div>
-      <h1 class="bb-page-title">{{.Log.InstitutionName}}</h1>
-      <div class="flex items-center gap-2 mt-0.5 flex-wrap">
+      <h1 class="bb-page-title"><a href="/connections/{{.Log.ConnectionID}}" class="hover:text-primary transition-colors">{{.Log.InstitutionName}}</a></h1>
+      <div class="flex items-center gap-2 mt-0.5 flex-wrap text-xs text-base-content/40">
+        <span class="capitalize">{{.Log.Provider}}</span>
+        <span class="text-base-content/20">&middot;</span>
         <span class="badge badge-ghost badge-xs">{{.Log.Trigger}}</span>
         {{syncBadge .Log.Status}}
         {{if .Log.WarningMessage}}
         <span class="badge badge-warning badge-sm gap-1">
           <i data-lucide="alert-triangle" class="w-3 h-3"></i>warning
         </span>
+        {{end}}
+        {{if .Log.StartedAt}}
+        <span class="text-base-content/20">&middot;</span>
+        <span>{{relativeTime .Log.StartedAt}}</span>
+        {{end}}
+        {{if .Log.Duration}}
+        <span class="text-base-content/20">&middot;</span>
+        <span class="tabular-nums">{{deref .Log.Duration}}</span>
         {{end}}
       </div>
     </div>
@@ -104,36 +114,6 @@
   {{end}}
 </div>
 
-<!-- Details Card -->
-<div class="bb-card p-5 mb-6">
-  <h2 class="text-sm font-semibold text-base-content/50 mb-4">Sync Details</h2>
-  <div class="grid grid-cols-2 sm:grid-cols-4 gap-5">
-    <div>
-      <p class="text-xs text-base-content/40 mb-1">Connection</p>
-      <p class="text-sm font-medium"><a href="/connections/{{.Log.ConnectionID}}" class="hover:text-primary transition-colors">{{.Log.InstitutionName}}</a></p>
-    </div>
-    <div>
-      <p class="text-xs text-base-content/40 mb-1">Provider</p>
-      <p class="text-sm font-medium capitalize">{{.Log.Provider}}</p>
-    </div>
-    <div>
-      <p class="text-xs text-base-content/40 mb-1">Trigger</p>
-      <p class="text-sm font-medium">{{.Log.Trigger}}</p>
-    </div>
-    {{if .Log.StartedAt}}
-    <div>
-      <p class="text-xs text-base-content/40 mb-1">Started</p>
-      <p class="text-sm font-medium">{{relativeTime .Log.StartedAt}}</p>
-    </div>
-    {{end}}
-    {{if .Log.Duration}}
-    <div>
-      <p class="text-xs text-base-content/40 mb-1">Duration</p>
-      <p class="text-sm font-medium tabular-nums">{{deref .Log.Duration}}</p>
-    </div>
-    {{end}}
-  </div>
-</div>
 
 <!-- Warning Card -->
 {{if .Log.WarningMessage}}

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -217,19 +217,15 @@
 
       <!-- Changes + Status (wraps to second line on mobile) -->
       <div class="flex items-center gap-3 sm:gap-4 shrink-0 pl-11 sm:pl-0">
-        <!-- Transaction changes -->
+        <!-- Transaction changes (only shown when there are actual changes) -->
+        {{if or .AddedCount .ModifiedCount .RemovedCount .UnchangedCount}}
         <div class="flex items-center gap-2 text-xs tabular-nums">
           {{if .AddedCount}}<span class="text-success font-medium">+{{.AddedCount}}</span>{{end}}
           {{if .ModifiedCount}}<span class="text-info font-medium">~{{.ModifiedCount}}</span>{{end}}
           {{if .RemovedCount}}<span class="text-error font-medium">-{{.RemovedCount}}</span>{{end}}
           {{if .UnchangedCount}}<span class="text-base-content/30 font-medium" title="{{.UnchangedCount}} unchanged transactions">={{.UnchangedCount}}</span>{{end}}
-          {{if and (not .AddedCount) (not .ModifiedCount) (not .RemovedCount) (not .UnchangedCount)}}
-          <span class="text-base-content/20 text-xs">No changes</span>
-          {{end}}
         </div>
-
-        <!-- Status badge -->
-        {{syncBadge .Status}}
+        {{end}}
 
         <!-- Warning badge -->
         {{if .WarningMessage}}

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -6,22 +6,9 @@
   </div>
 </div>
 
-<!-- Summary Stats Cards -->
+<!-- Summary Stats -->
 {{if .Stats}}
-<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-6 bb-stagger">
-  <!-- Total Syncs -->
-  <div class="bb-card p-4">
-    <div class="flex items-center gap-3">
-      <div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-        <i data-lucide="refresh-cw" class="w-4 h-4 text-base-content/40"></i>
-      </div>
-      <div>
-        <div class="text-2xl font-semibold tabular-nums leading-none">{{.Stats.TotalSyncs}}</div>
-        <div class="text-xs text-base-content/40 mt-0.5">Total syncs</div>
-      </div>
-    </div>
-  </div>
-
+<div class="grid grid-cols-3 gap-3 mb-6 bb-stagger">
   <!-- Success Rate -->
   <div class="bb-card p-4">
     <div class="flex items-center gap-3">
@@ -37,19 +24,6 @@
       <div>
         <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.SuccessRate 80.0}}text-success{{else if gt .Stats.SuccessRate 50.0}}text-warning{{else}}text-error{{end}}">{{printf "%.0f" .Stats.SuccessRate}}%</div>
         <div class="text-xs text-base-content/40 mt-0.5">Success rate</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Warnings -->
-  <div class="bb-card p-4">
-    <div class="flex items-center gap-3">
-      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .Stats.WarningCount 0}}bg-warning/10{{else}}bg-base-200/60{{end}}">
-        <i data-lucide="alert-triangle" class="w-4 h-4 {{if gt .Stats.WarningCount 0}}text-warning/70{{else}}text-base-content/40{{end}}"></i>
-      </div>
-      <div>
-        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.WarningCount 0}}text-warning{{end}}">{{.Stats.WarningCount}}</div>
-        <div class="text-xs text-base-content/40 mt-0.5">Warnings</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- **Consolidate stat cards from 5 to 3** on the sync logs list page — removed Total Syncs (redundant with status tab counts) and Warnings (rarely non-zero) cards
- **Remove redundant status badge and "No changes" placeholder** from each sync log row — the left-side color-coded icon already conveys status, and "No changes" on error rows adds no value
- **Fold Sync Details card into header** on the detail view — provider, timestamp, and duration now appear in the header subtitle line, eliminating an entire card section. Institution name is now a link to the connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)