### PR TITLE
Polish dashboard: declutter connection health and transaction rows

### DIFF
--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -272,27 +272,7 @@
             <span class="text-sm font-medium truncate">{{.Name}}</span>
             {{if .Pending}}<span class="text-[0.6rem] font-medium text-warning/80 bg-warning/10 px-1.5 py-0.5 rounded-full leading-none shrink-0">Pending</span>{{end}}
           </div>
-          <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 overflow-hidden">
-            {{if .UserName}}
-            <span class="w-4 h-4 rounded-full bg-primary/10 inline-flex items-center justify-center shrink-0" title="{{.UserName}}">
-              <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
-            </span>
-            {{end}}
-            <span class="truncate shrink min-w-0">{{.AccountName}} · {{relativeDate .Date}}</span>
-            {{if .CategoryDisplayName}}
-            <span class="text-base-content/20 shrink-0 hidden sm:inline">&middot;</span>
-            <span class="items-center gap-1 shrink-0 hidden sm:inline-flex">
-              <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
-              <span class="text-base-content/50 truncate max-w-24 lg:max-w-40">{{deref .CategoryDisplayName}}</span>
-            </span>
-            {{end}}
-            {{if .AgentReviewed}}
-            <span class="text-base-content/20 shrink-0">&middot;</span>
-            <span class="inline-flex items-center gap-0.5 text-primary/60 shrink-0" title="Categorized by AI agent">
-              <i data-lucide="bot" class="w-3 h-3"></i>
-            </span>
-            {{end}}
-          </div>
+          <div class="text-xs text-base-content/40 mt-0.5 truncate">{{.AccountName}} · {{relativeDate .Date}}</div>
         </div>
         <span class="bb-tx-amount shrink-0{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
           {{formatAmount .Amount}}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -327,28 +327,6 @@
         <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Manage</a>
       </div>
       {{if .ConnectionHealth}}
-      <!-- Health summary bar -->
-      <div class="flex items-center gap-3 mb-3 pb-3 border-b border-base-200/60">
-        {{if gt .HealthyCount 0}}
-        <span class="flex items-center gap-1.5 text-xs text-base-content/50">
-          <span class="w-2 h-2 rounded-full bg-success/60"></span>
-          {{.HealthyCount}} healthy
-        </span>
-        {{end}}
-        {{if gt .ErrorCount 0}}
-        <span class="flex items-center gap-1.5 text-xs text-error/70">
-          <span class="w-2 h-2 rounded-full bg-error/60"></span>
-          {{.ErrorCount}} error{{if gt .ErrorCount 1}}s{{end}}
-        </span>
-        {{end}}
-        {{if gt .StaleCount 0}}
-        <span class="flex items-center gap-1.5 text-xs text-warning">
-          <span class="w-2 h-2 rounded-full bg-warning/60"></span>
-          {{.StaleCount}} stale
-        </span>
-        {{end}}
-      </div>
-
       <!-- Per-connection rows -->
       <div class="space-y-1">
         {{range .ConnectionHealth}}
@@ -378,7 +356,6 @@
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-1.5">
               <span class="text-xs font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
-              <span class="text-[0.6rem] text-base-content/25 shrink-0">{{.Provider}}</span>
             </div>
             {{if and (ne .Status "active") (ne .ErrorMessage "")}}
             <div class="text-[0.6rem] text-error/60 truncate mt-0.5 font-mono max-w-full" title="{{.ErrorMessage}}">{{.ErrorMessage}}</div>
@@ -386,19 +363,6 @@
             <div class="text-[0.6rem] text-base-content/30 mt-0.5">
               {{.AccountCount}} account{{if ne .AccountCount 1}}s{{end}} · synced {{.LastSyncedAt}}
             </div>
-            {{end}}
-          </div>
-          <div class="shrink-0">
-            {{if eq .Status "active"}}
-              {{if .IsStale}}
-              <span class="text-[0.6rem] font-medium text-warning/70 bg-warning/8 px-1.5 py-0.5 rounded-full">stale</span>
-              {{else}}
-              <span class="w-1.5 h-1.5 rounded-full bg-success/50"></span>
-              {{end}}
-            {{else if eq .Status "error"}}
-            <span class="text-[0.6rem] font-medium text-error/70 bg-error/8 px-1.5 py-0.5 rounded-full">error</span>
-            {{else if eq .Status "pending_reauth"}}
-            <span class="text-[0.6rem] font-medium text-warning bg-warning/8 px-1.5 py-0.5 rounded-full">reauth</span>
             {{end}}
           </div>
         </a>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -377,108 +377,37 @@
         </div>
       </div>
       {{end}}
-    </div>
 
-    <!-- Sync Health Summary -->
-    {{if .SyncHealth}}
-    <div class="bb-card p-5">
-      <div class="flex items-center justify-between mb-3">
-        <div class="flex items-center gap-2">
-          <h2 class="text-sm font-semibold text-base-content/70">Sync Health</h2>
-          {{if eq .SyncHealth.OverallHealth "healthy"}}
-          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-success/10 text-success">
-            <span class="w-1.5 h-1.5 rounded-full bg-success animate-pulse"></span>
-            Healthy
-          </span>
-          {{else if eq .SyncHealth.OverallHealth "degraded"}}
-          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-warning/10 text-warning">
-            <span class="w-1.5 h-1.5 rounded-full bg-warning animate-pulse"></span>
-            Degraded
-          </span>
-          {{else if eq .SyncHealth.OverallHealth "unhealthy"}}
-          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-error/10 text-error">
-            <span class="w-1.5 h-1.5 rounded-full bg-error animate-pulse"></span>
-            Unhealthy
-          </span>
-          {{end}}
-        </div>
-        <a href="/sync-logs" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Logs</a>
-      </div>
-
-      <div class="space-y-2.5">
-        <!-- Last Sync -->
-        <div class="flex items-center justify-between">
-          <span class="flex items-center gap-2 text-xs text-base-content/50">
-            <i data-lucide="clock" class="w-3.5 h-3.5"></i>
-            Last sync
-          </span>
-          <span class="text-xs font-medium tabular-nums {{if .SyncHealth.LastSyncTime}}{{if eq .SyncHealth.LastSyncStatus "error"}}text-error/80{{else}}text-base-content/70{{end}}{{else}}text-base-content/40{{end}}">
-            {{if .SyncHealth.LastSyncTime}}{{deref .SyncHealth.LastSyncTime}}{{else}}Never{{end}}
-          </span>
-        </div>
-
-        <!-- Success Rate (24h) -->
-        <div class="flex items-center justify-between">
-          <span class="flex items-center gap-2 text-xs text-base-content/50">
-            <i data-lucide="bar-chart-3" class="w-3.5 h-3.5"></i>
-            24h success rate
-          </span>
-          {{if gt .SyncHealth.RecentSyncCount 0}}
-          <span class="text-xs font-medium tabular-nums {{if ge .SyncHealth.RecentSuccessRate 90.0}}text-success{{else if ge .SyncHealth.RecentSuccessRate 50.0}}text-warning{{else}}text-error/80{{end}}">
-            {{printf "%.0f" .SyncHealth.RecentSuccessRate}}%
-            <span class="text-base-content/30 font-normal">({{.SyncHealth.RecentSyncCount}} syncs)</span>
-          </span>
-          {{else}}
-          <span class="text-xs text-base-content/40">No syncs</span>
-          {{end}}
-        </div>
-
-        <!-- Errors (24h) -->
-        {{if gt .SyncHealth.RecentErrorCount 0}}
-        <div class="flex items-center justify-between">
-          <span class="flex items-center gap-2 text-xs text-base-content/50">
-            <i data-lucide="alert-triangle" class="w-3.5 h-3.5 text-error/60"></i>
-            Failed syncs (24h)
-          </span>
-          <span class="text-xs font-medium tabular-nums text-error/80">{{.SyncHealth.RecentErrorCount}}</span>
-        </div>
-        {{end}}
-
-        <!-- Connection Errors -->
-        {{if gt .SyncHealth.ConnectionErrors 0}}
-        <div class="flex items-center justify-between">
-          <span class="flex items-center gap-2 text-xs text-base-content/50">
-            <i data-lucide="unplug" class="w-3.5 h-3.5 text-error/60"></i>
-            Connections with issues
-          </span>
-          <a href="/connections" class="text-xs font-medium tabular-nums text-error/80 hover:text-error transition-colors">{{.SyncHealth.ConnectionErrors}}</a>
-        </div>
-        {{end}}
-
-        <!-- Next Sync -->
-        {{if .SyncHealth.NextSyncTime}}
-        <div class="flex items-center justify-between">
-          <span class="flex items-center gap-2 text-xs text-base-content/50">
-            <i data-lucide="timer" class="w-3.5 h-3.5"></i>
-            Next sync
-          </span>
-          <span class="text-xs font-medium text-base-content/60">{{.SyncHealth.NextSyncTime}}</span>
-        </div>
-        {{end}}
-      </div>
-
-      <!-- Success rate mini bar -->
-      {{if gt .SyncHealth.RecentSyncCount 0}}
-      <div class="mt-3 pt-3 border-t border-base-200/60">
-        <div class="flex h-1.5 rounded-full overflow-hidden bg-base-200/60">
-          {{if gt .SyncHealth.RecentSuccessRate 0.0}}
-          <div class="h-full rounded-full {{if ge .SyncHealth.RecentSuccessRate 90.0}}bg-success/60{{else if ge .SyncHealth.RecentSuccessRate 50.0}}bg-warning/60{{else}}bg-error/60{{end}} transition-all duration-700" style="width: {{printf "%.0f" .SyncHealth.RecentSuccessRate}}%;"></div>
-          {{end}}
+      <!-- Sync footer (compact) -->
+      {{if .SyncHealth}}
+      <div class="mt-2 pt-3 mx-5 mb-1 border-t border-base-200/60">
+        <div class="flex items-center justify-between text-[0.65rem] text-base-content/40">
+          <div class="flex items-center gap-3">
+            {{if eq .SyncHealth.OverallHealth "healthy"}}
+            <span class="flex items-center gap-1 text-success/70">
+              <span class="w-1.5 h-1.5 rounded-full bg-success/60"></span>
+              Syncs healthy
+            </span>
+            {{else if eq .SyncHealth.OverallHealth "degraded"}}
+            <span class="flex items-center gap-1 text-warning">
+              <span class="w-1.5 h-1.5 rounded-full bg-warning/60"></span>
+              Syncs degraded
+            </span>
+            {{else if eq .SyncHealth.OverallHealth "unhealthy"}}
+            <span class="flex items-center gap-1 text-error/70">
+              <span class="w-1.5 h-1.5 rounded-full bg-error/60"></span>
+              Syncs unhealthy
+            </span>
+            {{end}}
+            {{if .SyncHealth.NextSyncTime}}
+            <span>Next: {{.SyncHealth.NextSyncTime}}</span>
+            {{end}}
+          </div>
+          <a href="/sync-logs" class="text-base-content/30 hover:text-base-content/50 transition-colors">Logs</a>
         </div>
       </div>
       {{end}}
     </div>
-    {{end}}
 
     <!-- Quick Actions -->
     <div class="bb-card p-4">


### PR DESCRIPTION
## Summary
- **Connection Health card**: Removed redundant right-side status badges (stale/error/reauth) and provider labels ("teller") since the left-side icons already convey status. Removed the summary bar that duplicated per-row information.
- **Sync Health consolidated**: Replaced the separate Sync Health card with a compact single-line footer inside the Connection Health card, eliminating an entire card from the right column.
- **Recent Transactions simplified**: Removed user avatars, category badges, and agent-reviewed icons from dashboard transaction rows. Kept only account name and relative date for a cleaner at-a-glance view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)