### PR TITLE
Settings page: declutter and simplify layout

### DIFF
--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -34,9 +34,14 @@ func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 		ctx := r.Context()
 
 		// System info.
-		var pgVersion string
-		_ = a.DB.QueryRow(ctx, "SELECT version()").Scan(&pgVersion)
-		pgVersion = strings.TrimPrefix(pgVersion, "PostgreSQL ")
+		var pgVersionRaw string
+		_ = a.DB.QueryRow(ctx, "SELECT version()").Scan(&pgVersionRaw)
+		pgVersionRaw = strings.TrimPrefix(pgVersionRaw, "PostgreSQL ")
+		// Extract just the version number (e.g., "16.13") from the full string.
+		pgVersion := pgVersionRaw
+		if idx := strings.IndexByte(pgVersionRaw, ' '); idx > 0 {
+			pgVersion = pgVersionRaw[:idx]
+		}
 
 		// Sync log retention.
 		retentionDays, _ := a.Service.GetSyncLogRetentionDays(ctx)

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -8,21 +8,20 @@
 
 <div class="grid gap-6 bb-stagger">
 
-  <!-- Card 1: Sync Schedule -->
-  <div id="sync" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#sync' }">
+  <!-- Card 1: Sync (Schedule + Retention combined) -->
+  <div id="sync" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#sync' || location.hash === '#retention' }">
     <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
-      <div class="w-10 h-10 rounded-xl bg-primary/8 flex items-center justify-center flex-shrink-0">
-        <i data-lucide="refresh-cw" class="w-5 h-5 text-primary"></i>
-      </div>
+      <i data-lucide="refresh-cw" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
       <div class="min-w-0 flex-1">
-        <h2 class="font-semibold">Sync Schedule</h2>
-        <p class="text-xs text-base-content/40" x-show="!expanded">Every {{formatIntervalMinutes .SyncIntervalMinutes}}{{if ne .NextSyncTime ""}} · Next: {{.NextSyncTime}}{{end}}</p>
-        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Automatic bank data sync interval</p>
+        <h2 class="font-semibold">Sync</h2>
+        <p class="text-xs text-base-content/40" x-show="!expanded">Every {{formatIntervalMinutes .SyncIntervalMinutes}}{{if ne .NextSyncTime ""}} · Next: {{.NextSyncTime}}{{end}} · {{.SyncLogCount}} logs stored</p>
+        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Schedule and log retention</p>
       </div>
       <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
     </div>
     <div x-show="expanded" x-collapse x-cloak>
       <div class="px-4 sm:px-6 py-5">
+        <!-- Schedule section -->
         <form method="POST" action="/settings/sync">
           <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 
@@ -46,73 +45,51 @@
           </p>
           {{end}}
 
-          <div class="mt-5">
+          <div class="mt-4">
             <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Schedule</button>
           </div>
         </form>
-      </div>
-    </div>
-  </div>
 
-  <!-- Card 2: Sync Log Retention -->
-  <div id="retention" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#retention' }">
-    <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
-      <div class="w-10 h-10 rounded-xl bg-warning/8 flex items-center justify-center flex-shrink-0">
-        <i data-lucide="archive" class="w-5 h-5 text-warning"></i>
-      </div>
-      <div class="min-w-0 flex-1">
-        <h2 class="font-semibold">Sync Log Retention</h2>
-        <p class="text-xs text-base-content/40" x-show="!expanded">{{if eq .SyncLogRetentionDays 0}}Keeping forever{{else}}{{.SyncLogRetentionDays}} days{{end}} · {{.SyncLogCount}} logs stored</p>
-        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Auto-delete old sync logs to save storage</p>
-      </div>
-      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
-    </div>
-    <div x-show="expanded" x-collapse x-cloak>
-      <div class="px-4 sm:px-6 py-5">
-        <div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40 mb-5">
-          <div class="flex items-center gap-2.5">
-            <i data-lucide="database" class="w-4 h-4 text-base-content/50"></i>
-            <span class="text-sm font-medium">Total Sync Logs</span>
-          </div>
-          <span class="text-sm font-semibold tabular-nums">{{.SyncLogCount}}</span>
+        <!-- Retention section -->
+        <div class="border-t border-base-300 mt-5 pt-5">
+          <form method="POST" action="/settings/retention">
+            <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+
+            <div class="flex items-center justify-between mb-3">
+              <label class="text-sm font-medium text-base-content/70" for="sync_log_retention_days">
+                Log Retention
+              </label>
+              <span class="text-xs text-base-content/40 tabular-nums">{{.SyncLogCount}} logs stored</span>
+            </div>
+            <select id="sync_log_retention_days" name="sync_log_retention_days" class="select select-sm select-bordered w-full max-w-sm rounded-xl bg-base-200">
+              <option value="7"{{if eq .SyncLogRetentionDays 7}} selected{{end}}>7 days</option>
+              <option value="14"{{if eq .SyncLogRetentionDays 14}} selected{{end}}>14 days</option>
+              <option value="30"{{if eq .SyncLogRetentionDays 30}} selected{{end}}>30 days</option>
+              <option value="60"{{if eq .SyncLogRetentionDays 60}} selected{{end}}>60 days</option>
+              <option value="90"{{if eq .SyncLogRetentionDays 90}} selected{{end}}>90 days (default)</option>
+              <option value="180"{{if eq .SyncLogRetentionDays 180}} selected{{end}}>180 days</option>
+              <option value="365"{{if eq .SyncLogRetentionDays 365}} selected{{end}}>1 year</option>
+              <option value="0"{{if eq .SyncLogRetentionDays 0}} selected{{end}}>Keep forever</option>
+            </select>
+
+            <p class="text-xs text-base-content/40 mt-3 flex items-center gap-1.5">
+              <i data-lucide="clock" class="w-3.5 h-3.5"></i>
+              Cleanup runs daily at 3:00 AM
+            </p>
+
+            <div class="mt-4">
+              <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Retention</button>
+            </div>
+          </form>
         </div>
-
-        <form method="POST" action="/settings/retention">
-          <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-
-          <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="sync_log_retention_days">
-            Retention Period
-          </label>
-          <select id="sync_log_retention_days" name="sync_log_retention_days" class="select select-sm select-bordered w-full max-w-sm rounded-xl bg-base-200">
-            <option value="7"{{if eq .SyncLogRetentionDays 7}} selected{{end}}>7 days</option>
-            <option value="14"{{if eq .SyncLogRetentionDays 14}} selected{{end}}>14 days</option>
-            <option value="30"{{if eq .SyncLogRetentionDays 30}} selected{{end}}>30 days</option>
-            <option value="60"{{if eq .SyncLogRetentionDays 60}} selected{{end}}>60 days</option>
-            <option value="90"{{if eq .SyncLogRetentionDays 90}} selected{{end}}>90 days (default)</option>
-            <option value="180"{{if eq .SyncLogRetentionDays 180}} selected{{end}}>180 days</option>
-            <option value="365"{{if eq .SyncLogRetentionDays 365}} selected{{end}}>1 year</option>
-            <option value="0"{{if eq .SyncLogRetentionDays 0}} selected{{end}}>Keep forever</option>
-          </select>
-
-          <p class="text-xs text-base-content/40 mt-3 flex items-center gap-1.5">
-            <i data-lucide="clock" class="w-3.5 h-3.5"></i>
-            Cleanup runs daily at 3:00 AM
-          </p>
-
-          <div class="mt-5">
-            <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Retention</button>
-          </div>
-        </form>
       </div>
     </div>
   </div>
 
-  <!-- Card 3: Security -->
+  <!-- Card 2: Security -->
   <div id="security" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#security' }">
     <div class="px-4 sm:px-6 py-5 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
-      <div class="w-10 h-10 rounded-xl bg-error/8 flex items-center justify-center flex-shrink-0">
-        <i data-lucide="shield" class="w-5 h-5 text-error"></i>
-      </div>
+      <i data-lucide="shield" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
       <div class="min-w-0 flex-1">
         <h2 class="font-semibold">Security</h2>
         <p class="text-xs text-base-content/40" x-show="!expanded">Encryption {{if .HasEncryptionKey}}active{{else}}not set{{end}} · Password management</p>
@@ -166,12 +143,10 @@
     </div>
   </div>
 
-  <!-- Card 4: System Info (always expanded) -->
+  <!-- Card 3: System Info (always expanded) -->
   <div id="system" class="bb-card p-0 overflow-hidden">
     <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
-      <div class="w-10 h-10 rounded-xl bg-base-200/60 flex items-center justify-center flex-shrink-0">
-        <i data-lucide="cpu" class="w-5 h-5 text-base-content/50"></i>
-      </div>
+      <i data-lucide="cpu" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
       <div class="min-w-0">
         <h2 class="font-semibold">System</h2>
         <p class="text-xs text-base-content/40">Runtime and version information</p>

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -187,9 +187,9 @@
           <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Go Runtime</div>
           <div class="text-sm font-semibold">{{.GoVersion}}</div>
         </div>
-        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40 min-w-0">
+        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
           <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">PostgreSQL</div>
-          <div class="text-sm font-semibold truncate min-w-0" title="{{.PostgresVersion}}">{{.PostgresVersion}}</div>
+          <div class="text-sm font-semibold">{{.PostgresVersion}}</div>
         </div>
         <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
           <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Uptime</div>

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -143,38 +143,18 @@
     </div>
   </div>
 
-  <!-- Card 3: System Info (always expanded) -->
-  <div id="system" class="bb-card p-0 overflow-hidden">
-    <div class="px-4 sm:px-6 py-5 border-b border-base-300 flex items-center gap-3">
+  <!-- Card 3: System Info -->
+  <div id="system" class="bb-card px-4 sm:px-6 py-5">
+    <div class="flex items-center gap-3 mb-4">
       <i data-lucide="cpu" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
-      <div class="min-w-0">
-        <h2 class="font-semibold">System</h2>
-        <p class="text-xs text-base-content/40">Runtime and version information</p>
-      </div>
+      <h2 class="font-semibold">System</h2>
     </div>
-    <div class="px-4 sm:px-6 py-5">
-      <div class="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-5 gap-3">
-        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
-          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Version</div>
-          <div class="text-sm font-semibold tabular-nums">{{.Version}}</div>
-        </div>
-        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
-          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Go Runtime</div>
-          <div class="text-sm font-semibold">{{.GoVersion}}</div>
-        </div>
-        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
-          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">PostgreSQL</div>
-          <div class="text-sm font-semibold">{{.PostgresVersion}}</div>
-        </div>
-        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
-          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Uptime</div>
-          <div class="text-sm font-semibold">{{.Uptime}}</div>
-        </div>
-        <div class="flex items-center justify-between gap-3 sm:block p-3.5 rounded-xl bg-base-200/40">
-          <div class="text-xs font-medium text-base-content/40 shrink-0 sm:mb-1">Providers</div>
-          <div class="text-sm font-semibold">{{.ProviderCount}} configured</div>
-        </div>
-      </div>
+    <div class="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+      <div><span class="text-base-content/40">Version</span> <span class="font-medium tabular-nums">{{.Version}}</span></div>
+      <div><span class="text-base-content/40">Go</span> <span class="font-medium">{{.GoVersion}}</span></div>
+      <div><span class="text-base-content/40">PostgreSQL</span> <span class="font-medium">{{.PostgresVersion}}</span></div>
+      <div><span class="text-base-content/40">Uptime</span> <span class="font-medium">{{.Uptime}}</span></div>
+      <div><span class="text-base-content/40">Providers</span> <span class="font-medium">{{.ProviderCount}} configured</span></div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- **Trim PostgreSQL version**: Display just the version number (e.g. "16.13") instead of the full string with compiler details
- **Merge sync cards**: Combine Sync Schedule and Sync Log Retention into a single "Sync" card with two sections, reducing from 4 cards to 3
- **Simplify card headers**: Remove colored background circles around icons in favor of plain inline icons for less visual weight
- **Flatten system info**: Replace the 5-column grid of stat boxes with a compact inline key-value layout

## Test plan
- [ ] Visit `/settings` and verify all 3 cards render correctly
- [ ] Expand the Sync card and verify both schedule and retention forms work
- [ ] Expand the Security card and verify password change form renders
- [ ] Verify System card shows clean version info inline
- [ ] Test `#sync`, `#retention`, `#security` hash links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)