### PR TITLE
Polish Access page: table layout, collapsed revoked, simpler forms

### DIFF
--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -82,13 +82,34 @@ func AccessPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Templat
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
+		// Split keys into active and revoked for cleaner display
+		var activeKeys, revokedKeys []service.APIKeyResponse
+		for _, k := range keys {
+			if k.RevokedAt != nil {
+				revokedKeys = append(revokedKeys, k)
+			} else {
+				activeKeys = append(activeKeys, k)
+			}
+		}
+		var activeClients, revokedClients []service.OAuthClientResponse
+		for _, c := range clients {
+			if c.RevokedAt != nil {
+				revokedClients = append(revokedClients, c)
+			} else {
+				activeClients = append(activeClients, c)
+			}
+		}
 		data := map[string]any{
-			"PageTitle":   "Access",
-			"CurrentPage": "access",
-			"Keys":        keys,
-			"Clients":     clients,
-			"Flash":       GetFlash(r.Context(), sm),
-			"CSRFToken":   GetCSRFToken(r),
+			"PageTitle":      "Access",
+			"CurrentPage":    "access",
+			"Keys":           keys,
+			"ActiveKeys":     activeKeys,
+			"RevokedKeys":    revokedKeys,
+			"Clients":        clients,
+			"ActiveClients":  activeClients,
+			"RevokedClients": revokedClients,
+			"Flash":          GetFlash(r.Context(), sm),
+			"CSRFToken":      GetCSRFToken(r),
 		}
 		tr.Render(w, r, "access.html", data)
 	}

--- a/internal/templates/pages/access.html
+++ b/internal/templates/pages/access.html
@@ -12,7 +12,11 @@
     <div class="flex items-center gap-2">
       <i data-lucide="fingerprint" class="w-4 h-4 text-primary"></i>
       <h2 class="text-sm font-semibold">OAuth Clients</h2>
+      {{if .Clients}}
+      <span class="text-xs text-base-content/40">{{len .ActiveClients}} active{{if .RevokedClients}}, {{len .RevokedClients}} revoked{{end}}</span>
+      {{else}}
       <span class="text-xs text-base-content/40">External connector access (e.g., Claude)</span>
+      {{end}}
     </div>
     <a href="/oauth-clients/new" class="btn btn-primary btn-sm btn-soft rounded-xl">
       <i data-lucide="plus" class="w-4 h-4"></i>
@@ -21,49 +25,89 @@
   </div>
 
   {{if .Clients}}
-  <div class="space-y-2">
-    {{range .Clients}}
-    <div class="bb-card px-5 py-3.5" x-data="{ confirming: false }">
-      <div class="flex items-center gap-3">
-        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
-          {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-primary/10{{end}}">
-          <i data-lucide="fingerprint" class="w-4 h-4 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-primary{{end}}"></i>
-        </div>
-        <div class="min-w-0 flex-1">
-          <div class="flex items-center gap-2 flex-wrap">
-            <span class="font-semibold text-sm {{if .RevokedAt}}text-base-content/40 line-through{{end}}">{{.Name}}</span>
+  <!-- Active clients -->
+  {{if .ActiveClients}}
+  <div class="bb-card overflow-hidden">
+    <table class="table table-sm">
+      <tbody>
+        {{range .ActiveClients}}
+        <tr class="hover:bg-base-200/30" x-data="{ confirming: false }">
+          <td class="w-8 pr-0">
+            <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/10">
+              <i data-lucide="fingerprint" class="w-3.5 h-3.5 text-primary"></i>
+            </div>
+          </td>
+          <td>
+            <div class="font-semibold text-sm">{{.Name}}</div>
+            <div class="flex items-center gap-2 mt-0.5">
+              <code class="font-mono text-[0.65rem] text-base-content/40">{{.ClientIDPrefix}}...</code>
+              <span class="text-xs text-base-content/35">Created {{formatDateShort .CreatedAt}}</span>
+            </div>
+          </td>
+          <td class="w-24 text-center">
             {{if eq .Scope "read_only"}}
             <span class="badge badge-soft badge-warning badge-xs">Read Only</span>
             {{else}}
             <span class="badge badge-soft badge-primary badge-xs">Full Access</span>
             {{end}}
-            {{if .RevokedAt}}
-            <span class="badge badge-soft badge-error badge-xs">Revoked</span>
-            {{end}}
-          </div>
-          <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs text-base-content/40">
-            <code class="font-mono bg-base-200/50 px-1 py-0.5 rounded text-[0.65rem]">{{.ClientIDPrefix}}...</code>
-            <span>Created {{formatDateShort .CreatedAt}}</span>
-          </div>
-        </div>
-        {{if not .RevokedAt}}
-        <div class="shrink-0">
-          <form method="POST" action="/oauth-clients/{{.ID}}/revoke" class="inline">
-            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
-            <button type="button" class="btn btn-ghost btn-xs text-base-content/40 hover:text-error" x-show="!confirming" @click="confirming = true">
-              Revoke
-            </button>
-            <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
-              <button type="submit" class="btn btn-error btn-xs btn-soft rounded-xl">Confirm</button>
-              <button type="button" class="btn btn-ghost btn-xs rounded-xl" @click="confirming = false">Cancel</button>
-            </span>
-          </form>
-        </div>
+          </td>
+          <td class="w-28 text-right">
+            <form method="POST" action="/oauth-clients/{{.ID}}/revoke" class="inline">
+              <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+              <button type="button" class="btn btn-ghost btn-xs text-base-content/40 hover:text-error" x-show="!confirming" @click="confirming = true">
+                Revoke
+              </button>
+              <span x-show="confirming" x-cloak class="flex items-center gap-1.5 justify-end">
+                <button type="submit" class="btn btn-error btn-xs btn-soft rounded-xl">Confirm</button>
+                <button type="button" class="btn btn-ghost btn-xs rounded-xl" @click="confirming = false">Cancel</button>
+              </span>
+            </form>
+          </td>
+        </tr>
         {{end}}
+      </tbody>
+    </table>
+  </div>
+  {{end}}
+
+  <!-- Revoked clients (collapsed) -->
+  {{if .RevokedClients}}
+  <div class="mt-2" x-data="{ open: false }">
+    <button class="btn btn-ghost btn-xs text-base-content/35 gap-1" @click="open = !open">
+      <i data-lucide="chevron-right" class="w-3 h-3 transition-transform" :class="open && 'rotate-90'"></i>
+      {{len .RevokedClients}} revoked
+    </button>
+    <div x-show="open" x-cloak x-collapse class="mt-1">
+      <div class="bb-card overflow-hidden opacity-60">
+        <table class="table table-sm">
+          <tbody>
+            {{range .RevokedClients}}
+            <tr>
+              <td class="w-8 pr-0">
+                <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-base-200/40">
+                  <i data-lucide="fingerprint" class="w-3.5 h-3.5 text-base-content/25"></i>
+                </div>
+              </td>
+              <td>
+                <div class="font-semibold text-sm text-base-content/40 line-through">{{.Name}}</div>
+                <div class="flex items-center gap-2 mt-0.5">
+                  <code class="font-mono text-[0.65rem] text-base-content/30">{{.ClientIDPrefix}}...</code>
+                  <span class="text-xs text-base-content/30">Created {{formatDateShort .CreatedAt}}</span>
+                </div>
+              </td>
+              <td class="w-24 text-center">
+                <span class="badge badge-soft badge-error badge-xs">Revoked</span>
+              </td>
+              <td class="w-28"></td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
       </div>
     </div>
-    {{end}}
   </div>
+  {{end}}
+
   {{else}}
   <div class="bb-card px-5 py-8 text-center">
     <p class="text-sm text-base-content/40 mb-3">No OAuth clients yet</p>
@@ -81,7 +125,11 @@
     <div class="flex items-center gap-2">
       <i data-lucide="key" class="w-4 h-4 text-primary"></i>
       <h2 class="text-sm font-semibold">API Keys</h2>
+      {{if .Keys}}
+      <span class="text-xs text-base-content/40">{{len .ActiveKeys}} active{{if .RevokedKeys}}, {{len .RevokedKeys}} revoked{{end}}</span>
+      {{else}}
       <span class="text-xs text-base-content/40">Direct REST API and MCP access</span>
+      {{end}}
     </div>
     <a href="/api-keys/new" class="btn btn-primary btn-sm btn-soft rounded-xl">
       <i data-lucide="plus" class="w-4 h-4"></i>
@@ -90,50 +138,90 @@
   </div>
 
   {{if .Keys}}
-  <div class="space-y-2">
-    {{range .Keys}}
-    <div class="bb-card px-5 py-3.5" x-data="{ confirming: false }">
-      <div class="flex items-center gap-3">
-        <div class="flex items-center justify-center w-8 h-8 rounded-lg shrink-0
-          {{if .RevokedAt}}bg-base-200/40{{else if eq .Scope "read_only"}}bg-warning/8{{else}}bg-primary/8{{end}}">
-          <i data-lucide="key" class="w-4 h-4 {{if .RevokedAt}}text-base-content/25{{else if eq .Scope "read_only"}}text-warning{{else}}text-primary{{end}}"></i>
-        </div>
-        <div class="min-w-0 flex-1">
-          <div class="flex items-center gap-2 flex-wrap">
-            <span class="font-semibold text-sm {{if .RevokedAt}}text-base-content/40 line-through{{end}}">{{.Name}}</span>
+  <!-- Active keys -->
+  {{if .ActiveKeys}}
+  <div class="bb-card overflow-hidden">
+    <table class="table table-sm">
+      <tbody>
+        {{range .ActiveKeys}}
+        <tr class="hover:bg-base-200/30" x-data="{ confirming: false }">
+          <td class="w-8 pr-0">
+            <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-primary/8">
+              <i data-lucide="key" class="w-3.5 h-3.5 text-primary"></i>
+            </div>
+          </td>
+          <td>
+            <div class="font-semibold text-sm">{{.Name}}</div>
+            <div class="flex items-center gap-2 mt-0.5">
+              <code class="font-mono text-[0.65rem] text-base-content/40">{{.KeyPrefix}}...</code>
+              <span class="text-xs text-base-content/35">Created {{formatDateShort .CreatedAt}}</span>
+              {{if .LastUsedAt}}<span class="text-xs text-base-content/35">Last used {{relativeTime .LastUsedAt}}</span>{{end}}
+            </div>
+          </td>
+          <td class="w-24 text-center">
             {{if eq .Scope "read_only"}}
             <span class="badge badge-soft badge-warning badge-xs">Read Only</span>
             {{else}}
             <span class="badge badge-soft badge-primary badge-xs">Full Access</span>
             {{end}}
-            {{if .RevokedAt}}
-            <span class="badge badge-soft badge-error badge-xs">Revoked</span>
-            {{end}}
-          </div>
-          <div class="flex flex-wrap items-center gap-x-3 gap-y-0.5 mt-0.5 text-xs text-base-content/40">
-            <code class="font-mono bg-base-200/50 px-1 py-0.5 rounded text-[0.65rem]">{{.KeyPrefix}}...</code>
-            <span>Created {{formatDateShort .CreatedAt}}</span>
-            {{if .LastUsedAt}}<span>Last used {{relativeTime .LastUsedAt}}</span>{{end}}
-          </div>
-        </div>
-        {{if not .RevokedAt}}
-        <div class="shrink-0">
-          <form method="POST" action="/api-keys/{{.ID}}/revoke" class="inline">
-            <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
-            <button type="button" class="btn btn-ghost btn-xs text-base-content/40 hover:text-error" x-show="!confirming" @click="confirming = true">
-              Revoke
-            </button>
-            <span x-show="confirming" x-cloak class="flex items-center gap-1.5">
-              <button type="submit" class="btn btn-error btn-xs btn-soft rounded-xl">Confirm</button>
-              <button type="button" class="btn btn-ghost btn-xs rounded-xl" @click="confirming = false">Cancel</button>
-            </span>
-          </form>
-        </div>
+          </td>
+          <td class="w-28 text-right">
+            <form method="POST" action="/api-keys/{{.ID}}/revoke" class="inline">
+              <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+              <button type="button" class="btn btn-ghost btn-xs text-base-content/40 hover:text-error" x-show="!confirming" @click="confirming = true">
+                Revoke
+              </button>
+              <span x-show="confirming" x-cloak class="flex items-center gap-1.5 justify-end">
+                <button type="submit" class="btn btn-error btn-xs btn-soft rounded-xl">Confirm</button>
+                <button type="button" class="btn btn-ghost btn-xs rounded-xl" @click="confirming = false">Cancel</button>
+              </span>
+            </form>
+          </td>
+        </tr>
         {{end}}
+      </tbody>
+    </table>
+  </div>
+  {{end}}
+
+  <!-- Revoked keys (collapsed) -->
+  {{if .RevokedKeys}}
+  <div class="mt-2" x-data="{ open: false }">
+    <button class="btn btn-ghost btn-xs text-base-content/35 gap-1" @click="open = !open">
+      <i data-lucide="chevron-right" class="w-3 h-3 transition-transform" :class="open && 'rotate-90'"></i>
+      {{len .RevokedKeys}} revoked
+    </button>
+    <div x-show="open" x-cloak x-collapse class="mt-1">
+      <div class="bb-card overflow-hidden opacity-60">
+        <table class="table table-sm">
+          <tbody>
+            {{range .RevokedKeys}}
+            <tr>
+              <td class="w-8 pr-0">
+                <div class="flex items-center justify-center w-7 h-7 rounded-lg bg-base-200/40">
+                  <i data-lucide="key" class="w-3.5 h-3.5 text-base-content/25"></i>
+                </div>
+              </td>
+              <td>
+                <div class="font-semibold text-sm text-base-content/40 line-through">{{.Name}}</div>
+                <div class="flex items-center gap-2 mt-0.5">
+                  <code class="font-mono text-[0.65rem] text-base-content/30">{{.KeyPrefix}}...</code>
+                  <span class="text-xs text-base-content/30">Created {{formatDateShort .CreatedAt}}</span>
+                </div>
+              </td>
+              <td class="w-24 text-center">
+                <span class="badge badge-soft badge-error badge-xs">Revoked</span>
+              </td>
+              <td class="w-28"></td>
+            </tr>
+            {{end}}
+          </tbody>
+        </table>
       </div>
     </div>
-    {{end}}
   </div>
+  {{end}}
+
   {{else}}
   <div class="bb-card px-5 py-8 text-center">
     <p class="text-sm text-base-content/40 mb-3">No API keys yet</p>

--- a/internal/templates/pages/api_key_created.html
+++ b/internal/templates/pages/api_key_created.html
@@ -8,41 +8,35 @@
   </div>
 </div>
 
-<div class="bb-card p-8 max-w-lg">
-  <div class="flex flex-col items-center text-center mb-6">
-    <div class="w-16 h-16 rounded-xl bg-success/10 flex items-center justify-center mb-4">
-      <i data-lucide="check-circle-2" class="w-8 h-8 text-success"></i>
+<div class="bb-card p-6 max-w-lg">
+  <div class="flex items-center gap-3 mb-5">
+    <div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center">
+      <i data-lucide="check" class="w-4.5 h-4.5 text-success"></i>
     </div>
-    <h2 class="text-lg font-semibold mb-1">Key Ready</h2>
-    <p class="text-sm text-base-content/50">Copy it now -- this is the only time it will be shown.</p>
-  </div>
-
-  <div class="space-y-4 mb-6">
     <div>
-      <label class="text-xs font-medium text-base-content/50 mb-1.5 block">Name</label>
-      <div class="px-4 py-2.5 rounded-xl bg-base-200/50 text-sm font-medium">{{.KeyName}}</div>
-    </div>
-
-    <div>
-      <label class="text-xs font-medium text-base-content/50 mb-1.5 block">API Key</label>
-      <div class="relative">
-        <input type="text" value="{{.PlaintextKey}}" readonly id="api-key-value"
-               class="input input-sm font-mono w-full bg-base-200/50 border-base-300 rounded-xl pr-24 text-xs">
-      </div>
+      <h2 class="text-sm font-semibold">{{.KeyName}}</h2>
+      <p class="text-xs text-base-content/45">Copy your key now -- it won't be shown again.</p>
     </div>
   </div>
 
-  <div class="flex items-center gap-3" x-data="{ copied: false }">
-    <button class="btn btn-primary btn-sm rounded-xl" @click="navigator.clipboard.writeText(document.getElementById('api-key-value').value).then(function(){ $data.copied = true; setTimeout(function(){ $data.copied = false; }, 2000); })">
-      <i data-lucide="clipboard" class="w-4 h-4"></i>
-      <span x-show="!copied">Copy to Clipboard</span>
-      <span x-show="copied" x-cloak>Copied!</span>
-    </button>
+  <div class="mb-5">
+    <label class="text-xs font-medium text-base-content/50 mb-1.5 block">API Key</label>
+    <div class="flex gap-2" x-data="{ copied: false }">
+      <input type="text" value="{{.PlaintextKey}}" readonly id="api-key-value"
+             class="input input-sm font-mono flex-1 bg-base-200/50 border-base-300 rounded-xl text-xs">
+      <button class="btn btn-primary btn-sm rounded-xl shrink-0" @click="navigator.clipboard.writeText(document.getElementById('api-key-value').value).then(function(){ $data.copied = true; setTimeout(function(){ $data.copied = false; }, 2000); })">
+        <i data-lucide="clipboard" class="w-4 h-4"></i>
+        <span x-show="!copied">Copy</span>
+        <span x-show="copied" x-cloak>Copied!</span>
+      </button>
+    </div>
+  </div>
+
+  <div class="flex items-center justify-between pt-4 border-t border-base-300">
+    <p class="text-xs text-base-content/40">
+      Use in the <code class="font-mono text-primary/70 bg-primary/5 px-1.5 py-0.5 rounded">X-API-Key</code> header for API requests.
+    </p>
     <a href="/access" class="btn btn-ghost btn-sm rounded-xl">Done</a>
   </div>
-
-  <p class="text-xs text-base-content/40 mt-6 pt-4 border-t border-base-300">
-    Use this key in the <code class="font-mono text-primary/70 bg-primary/5 px-1.5 py-0.5 rounded">X-API-Key</code> header when making API requests.
-  </p>
 </div>
 {{end}}

--- a/internal/templates/pages/api_key_new.html
+++ b/internal/templates/pages/api_key_new.html
@@ -11,17 +11,7 @@
   </a>
 </div>
 
-<div class="bb-card p-8 max-w-lg">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
-      <i data-lucide="key-round" class="w-5 h-5 text-primary"></i>
-    </div>
-    <div>
-      <h2 class="text-base font-semibold">Key Details</h2>
-      <p class="text-xs text-base-content/45">Configure your new API key</p>
-    </div>
-  </div>
-
+<div class="bb-card p-6 max-w-lg">
   <form method="POST" action="/api-keys/new">
     <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 

--- a/internal/templates/pages/oauth_client_created.html
+++ b/internal/templates/pages/oauth_client_created.html
@@ -8,56 +8,52 @@
   </div>
 </div>
 
-<div class="bb-card p-8 max-w-lg">
-  <div class="flex flex-col items-center text-center mb-6">
-    <div class="w-16 h-16 rounded-xl bg-success/10 flex items-center justify-center mb-4">
-      <i data-lucide="check-circle-2" class="w-8 h-8 text-success"></i>
+<div class="bb-card p-6 max-w-lg" x-data="{ copiedId: false, copiedSecret: false }">
+  <div class="flex items-center gap-3 mb-5">
+    <div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center">
+      <i data-lucide="check" class="w-4.5 h-4.5 text-success"></i>
     </div>
-    <h2 class="text-lg font-semibold mb-1">Client Ready</h2>
-    <p class="text-sm text-base-content/50">Copy these credentials -- the secret will not be shown again.</p>
+    <div>
+      <h2 class="text-sm font-semibold">{{.ClientName}}</h2>
+      <p class="text-xs text-base-content/45">Copy these credentials -- the secret won't be shown again.</p>
+    </div>
   </div>
 
-  <div class="space-y-4 mb-6">
-    <div>
-      <label class="text-xs font-medium text-base-content/50 mb-1.5 block">Name</label>
-      <div class="px-4 py-2.5 rounded-xl bg-base-200/50 text-sm font-medium">{{.ClientName}}</div>
-    </div>
-
+  <div class="space-y-4 mb-5">
     <div>
       <label class="text-xs font-medium text-base-content/50 mb-1.5 block">Client ID</label>
-      <div class="relative">
+      <div class="flex gap-2">
         <input type="text" value="{{.ClientID}}" readonly id="oauth-client-id"
-               class="input input-sm font-mono w-full bg-base-200/50 border-base-300 rounded-xl text-xs">
+               class="input input-sm font-mono flex-1 bg-base-200/50 border-base-300 rounded-xl text-xs">
+        <button class="btn btn-sm btn-ghost rounded-xl shrink-0" @click="navigator.clipboard.writeText(document.getElementById('oauth-client-id').value).then(function(){ $data.copiedId = true; setTimeout(function(){ $data.copiedId = false; }, 2000); })">
+          <i data-lucide="clipboard" class="w-3.5 h-3.5"></i>
+          <span x-show="!copiedId">Copy</span>
+          <span x-show="copiedId" x-cloak>Copied!</span>
+        </button>
       </div>
     </div>
 
     <div>
       <label class="text-xs font-medium text-base-content/50 mb-1.5 block">Client Secret</label>
-      <div class="relative">
+      <div class="flex gap-2">
         <input type="text" value="{{.ClientSecret}}" readonly id="oauth-client-secret"
-               class="input input-sm font-mono w-full bg-base-200/50 border-base-300 rounded-xl text-xs">
+               class="input input-sm font-mono flex-1 bg-base-200/50 border-base-300 rounded-xl text-xs">
+        <button class="btn btn-primary btn-sm rounded-xl shrink-0" @click="navigator.clipboard.writeText(document.getElementById('oauth-client-secret').value).then(function(){ $data.copiedSecret = true; setTimeout(function(){ $data.copiedSecret = false; }, 2000); })">
+          <i data-lucide="clipboard" class="w-3.5 h-3.5"></i>
+          <span x-show="!copiedSecret">Copy</span>
+          <span x-show="copiedSecret" x-cloak>Copied!</span>
+        </button>
       </div>
     </div>
   </div>
 
-  <div class="flex items-center gap-3 flex-wrap" x-data="{ copiedId: false, copiedSecret: false }">
-    <button class="btn btn-sm btn-ghost rounded-xl" @click="navigator.clipboard.writeText(document.getElementById('oauth-client-id').value).then(function(){ $data.copiedId = true; setTimeout(function(){ $data.copiedId = false; }, 2000); })">
-      <i data-lucide="clipboard" class="w-4 h-4"></i>
-      <span x-show="!copiedId">Copy ID</span>
-      <span x-show="copiedId" x-cloak>Copied!</span>
-    </button>
-    <button class="btn btn-primary btn-sm rounded-xl" @click="navigator.clipboard.writeText(document.getElementById('oauth-client-secret').value).then(function(){ $data.copiedSecret = true; setTimeout(function(){ $data.copiedSecret = false; }, 2000); })">
-      <i data-lucide="clipboard" class="w-4 h-4"></i>
-      <span x-show="!copiedSecret">Copy Secret</span>
-      <span x-show="copiedSecret" x-cloak>Copied!</span>
-    </button>
-    <a href="/access" class="btn btn-ghost btn-sm rounded-xl">Done</a>
-  </div>
-
-  <div class="mt-6 pt-4 border-t border-base-300 space-y-3">
-    <p class="text-xs text-base-content/40">
-      To connect Claude as a connector, enter your Breadbox MCP URL and paste the Client ID and Client Secret into the "Advanced settings" fields.
-    </p>
+  <div class="pt-4 border-t border-base-300 space-y-3">
+    <div class="flex items-center justify-between">
+      <p class="text-xs text-base-content/40">
+        Paste the Client ID and Secret into your connector's settings.
+      </p>
+      <a href="/access" class="btn btn-ghost btn-sm rounded-xl shrink-0">Done</a>
+    </div>
     <div class="rounded-xl bg-base-200/50 p-3">
       <div class="text-xs font-medium text-base-content/50 mb-1">MCP Server URL</div>
       <code class="text-xs font-mono text-primary/70">https://your-breadbox-host/mcp</code>

--- a/internal/templates/pages/oauth_client_new.html
+++ b/internal/templates/pages/oauth_client_new.html
@@ -11,17 +11,7 @@
   </a>
 </div>
 
-<div class="bb-card p-8 max-w-lg">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/10">
-      <i data-lucide="fingerprint" class="w-5 h-5 text-primary"></i>
-    </div>
-    <div>
-      <h2 class="text-base font-semibold">Client Details</h2>
-      <p class="text-xs text-base-content/45">Configure your new OAuth client</p>
-    </div>
-  </div>
-
+<div class="bb-card p-6 max-w-lg">
   <form method="POST" action="/oauth-clients/new">
     <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 


### PR DESCRIPTION
## Summary
- **Access page list**: Replace card-per-item layout with compact table rows, split active/revoked items in the handler, and collapse revoked items behind an expandable toggle to reduce visual noise. Add active/revoked counts to section headers.
- **Create forms**: Remove redundant icon+header sections from API key and OAuth client create forms (page title already provides context).
- **Success pages**: Compact the key/client created pages with inline copy buttons next to credential fields, smaller success indicators, and tighter layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)