### PR TITLE
Redesign dashboard: account cards, combined health, no title

### DIFF
--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -92,25 +92,86 @@
 </div>
 {{end}}
 
-<!-- Dashboard Page Header -->
-<div class="bb-page-header">
-  <div>
-    <h1 class="bb-page-title">Dashboard</h1>
+<!-- Agent Reports -->
+{{if .AgentReports}}
+<div class="bb-card mb-6 bb-stagger" x-data="agentReports()">
+  <div class="px-5 pt-4 pb-2">
+    <div class="flex items-center justify-between gap-2 flex-wrap">
+      <div class="flex items-center gap-2.5">
+        <div class="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center">
+          <i data-lucide="bot" class="w-4 h-4 text-primary"></i>
+        </div>
+        <div>
+          <h2 class="text-sm font-semibold text-base-content/80">Agent Reports</h2>
+          <p class="text-[0.65rem] text-base-content/40">{{len .AgentReports}} unread report{{if gt (len .AgentReports) 1}}s{{end}}</p>
+        </div>
+      </div>
+      <div class="flex items-center gap-3">
+        <button class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer"
+          @click="markAllRead()">
+          Mark all read
+        </button>
+        <a href="/reports" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+      </div>
+    </div>
+  </div>
+  <div class="divide-y divide-base-200/60">
+    {{range .AgentReports}}
+    <div class="transition-all duration-300"
+      :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden' : ''"
+      id="report-{{.ID}}">
+      <div class="px-5 py-3.5 hover:bg-base-200/20 transition-colors cursor-pointer" @click="toggle('{{.ID}}')">
+        <div class="flex items-start gap-3">
+          <!-- Priority indicator -->
+          <div class="shrink-0 mt-1">
+            {{if eq .Priority "critical"}}
+            <span class="flex w-2 h-2"><span class="animate-ping absolute w-2 h-2 rounded-full bg-error/60"></span><span class="relative w-2 h-2 rounded-full bg-error"></span></span>
+            {{else if eq .Priority "warning"}}
+            <span class="w-2 h-2 rounded-full bg-warning block"></span>
+            {{else}}
+            <span class="w-2 h-2 rounded-full bg-base-content/15 block"></span>
+            {{end}}
+          </div>
+          <!-- Message content -->
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 text-xs mb-0.5 flex-wrap">
+              <span class="font-semibold text-base-content/70 truncate max-w-[10rem] sm:max-w-none">{{.DisplayAuthor}}</span>
+              <span class="text-base-content/25">&middot;</span>
+              <span class="text-base-content/30 shrink-0">{{.CreatedAt}}</span>
+              {{range .Tags}}
+              <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/40 hidden sm:inline">{{.}}</span>
+              {{end}}
+            </div>
+            <p class="text-sm text-base-content/70 leading-relaxed line-clamp-2">{{.Title}}</p>
+          </div>
+          <!-- Actions -->
+          <div class="flex items-center gap-1.5 shrink-0">
+            <i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/25 transition-transform duration-200"
+              :class="expanded['{{.ID}}'] ? 'rotate-180' : ''"></i>
+            <button @click.stop="markRead('{{.ID}}')" class="btn btn-ghost btn-xs rounded-lg cursor-pointer hover:bg-success/10 hover:text-success" title="Mark as read">
+              <i data-lucide="check" class="w-3.5 h-3.5"></i>
+            </button>
+          </div>
+        </div>
+        <!-- Expanded detail -->
+        <div x-show="expanded['{{.ID}}']" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
+          x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
+          x-cloak class="mt-3 ml-5 pl-3 border-l-2 border-primary/20">
+          <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
+        </div>
+      </div>
+    </div>
+    {{end}}
   </div>
 </div>
+{{end}}
 
 <!-- Accounts Overview -->
 {{if .Accounts}}
-<div class="mb-8">
-  <div class="flex items-center justify-between mb-4">
-    <h2 class="text-sm font-semibold text-base-content/70">Accounts</h2>
-    <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
-  </div>
-
-  <!-- Net Worth + Allocation Bar -->
+<div class="mb-6">
+  <!-- Net Worth Summary -->
   {{if .AllocationSlices}}
-  <div class="bb-card p-4 mb-4">
-    <!-- Net Worth Summary -->
+  <div class="bb-card p-4 sm:p-5 mb-6">
     <div class="flex items-baseline justify-between mb-3">
       <div>
         <div class="text-xs text-base-content/40 mb-0.5">Net Worth</div>
@@ -128,12 +189,12 @@
       </div>
     </div>
     <!-- Allocation Bar -->
-    <div class="flex h-3 rounded-full overflow-hidden gap-0.5">
+    <div class="flex h-2.5 rounded-full overflow-hidden gap-0.5">
       {{range .AllocationSlices}}
       <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: {{printf "%.1f" .Percent}}%; background: {{safeCSS .Color}}; opacity: 0.7;" title="{{.Label}}: {{formatBalance .Amount}}"></div>
       {{end}}
     </div>
-    <div class="flex items-center gap-4 mt-3 flex-wrap">
+    <div class="flex items-center gap-4 mt-2.5 flex-wrap">
       {{range .AllocationSlices}}
       <span class="flex items-center gap-1.5 text-xs text-base-content/50">
         <span class="w-2 h-2 rounded-full shrink-0" style="background: {{safeCSS .Color}}; opacity: 0.7;"></span>
@@ -145,106 +206,55 @@
   </div>
   {{end}}
 
-  <!-- Asset Groups -->
-  {{if .AssetGroups}}
-  <div class="space-y-3 mb-4 bb-stagger">
-    {{range .AssetGroups}}
-    <div class="bb-card p-0 overflow-hidden">
-      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
-        <div class="flex items-center gap-2.5">
-          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
-          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
-        </div>
-        <span class="text-sm font-semibold tabular-nums text-base-content">{{formatBalance .Total}}</span>
-      </div>
-      <div class="divide-y divide-base-300/40">
-        {{range .Accounts}}
-        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
-          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
-          </div>
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-1.5">
-              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
-              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
-              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
-              {{end}}
-            </div>
-            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
-          </div>
-          <div class="flex items-center gap-3 shrink-0">
-            {{if .SparklineData}}
-            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+  <!-- Account Cards Grid -->
+  <div class="flex items-center justify-between mb-3">
+    <h2 class="text-sm font-semibold text-base-content/70">Accounts</h2>
+    <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+  </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 bb-stagger">
+    {{range .Accounts}}
+    <a href="/accounts/{{.ID}}" class="bb-card bb-card--interactive p-4 no-underline group block">
+      <div class="flex items-start justify-between mb-2">
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-1.5">
+            <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+            {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+            <span class="shrink-0 text-[0.55rem] font-medium px-1.5 py-0.5 rounded-full leading-none {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
             {{end}}
-            <div class="text-right">
-              <div class="text-sm font-semibold tabular-nums">{{formatBalance .BalanceCurrent}}</div>
-              {{if gt .SpendingTotal 0.0}}
-              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-              {{else}}
-              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
-              {{end}}
-            </div>
           </div>
-        </a>
-        {{end}}
+          <div class="text-[0.65rem] text-base-content/40 mt-0.5 truncate">{{.InstitutionName}}{{if .Mask}} · ····{{.Mask}}{{end}}</div>
+        </div>
+        <div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0 ml-2">
+          <i data-lucide="{{accountTypeIcon .Type}}" class="w-3.5 h-3.5 text-base-content/35"></i>
+        </div>
       </div>
-    </div>
+      <!-- Sparkline -->
+      {{if .SparklineData}}
+      <div class="bb-sparkline w-full h-8 my-1.5" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+      {{else}}
+      <div class="h-8 my-1.5"></div>
+      {{end}}
+      <!-- Balance -->
+      <div class="flex items-end justify-between mt-1">
+        <div>
+          <div class="text-lg font-bold tabular-nums tracking-tight {{if .IsLiability}}text-error/80{{end}}">{{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}</div>
+        </div>
+        <div class="text-right">
+          {{if gt .SpendingTotal 0.0}}
+          <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+          {{else}}
+          <div class="text-[0.65rem] text-base-content/35">{{accountTypeLabel .Type .Subtype}}</div>
+          {{end}}
+        </div>
+      </div>
+    </a>
     {{end}}
   </div>
-  {{end}}
-
-  <!-- Liability Groups -->
-  {{if .LiabilityGroups}}
-  <div class="space-y-3 bb-stagger">
-    {{range .LiabilityGroups}}
-    <div class="bb-card p-0 overflow-hidden">
-      <div class="flex items-center justify-between px-5 py-3 bg-base-200/30 border-b border-base-300/50">
-        <div class="flex items-center gap-2.5">
-          <i data-lucide="{{.Icon}}" class="w-4 h-4 text-base-content/40"></i>
-          <span class="text-xs font-semibold text-base-content/60 tracking-wide">{{.Label}}</span>
-        </div>
-        <span class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .Total}}</span>
-      </div>
-      <div class="divide-y divide-base-300/40">
-        {{range .Accounts}}
-        <a href="/accounts/{{.ID}}" class="flex items-center gap-3 px-5 py-3 hover:bg-base-200/40 transition-colors duration-150 no-underline group">
-          <div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-            <i data-lucide="{{accountTypeIcon .Type}}" class="w-4 h-4 text-base-content/40"></i>
-          </div>
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-1.5">
-              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
-              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
-              <span class="shrink-0 text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
-              {{end}}
-            </div>
-            <div class="text-xs text-base-content/40">{{.InstitutionName}}{{if .Mask}} ····{{.Mask}}{{end}}</div>
-          </div>
-          <div class="flex items-center gap-3 shrink-0">
-            {{if .SparklineData}}
-            <div class="bb-sparkline w-20 h-6 hidden sm:block" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
-            {{end}}
-            <div class="text-right">
-              <div class="text-sm font-semibold tabular-nums text-error/80">-{{formatBalance .BalanceCurrent}}</div>
-              {{if gt .SpendingTotal 0.0}}
-              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-              {{else}}
-              <div class="text-xs text-base-content/30">{{accountTypeLabel .Type .Subtype}}</div>
-              {{end}}
-            </div>
-          </div>
-        </a>
-        {{end}}
-      </div>
-    </div>
-    {{end}}
-  </div>
-  {{end}}
 </div>
 {{end}}
 
-<!-- Recent Transactions + Connection Health -->
-<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+<!-- Recent Transactions + System Health -->
+<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
   <!-- Recent Transactions -->
   <div class="bb-card lg:col-span-2 p-5">
     <div class="flex items-center justify-between mb-3">
@@ -272,7 +282,27 @@
             <span class="text-sm font-medium truncate">{{.Name}}</span>
             {{if .Pending}}<span class="text-[0.6rem] font-medium text-warning/80 bg-warning/10 px-1.5 py-0.5 rounded-full leading-none shrink-0">Pending</span>{{end}}
           </div>
-          <div class="text-xs text-base-content/40 mt-0.5 truncate">{{.AccountName}} · {{relativeDate .Date}}</div>
+          <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 overflow-hidden">
+            {{if .UserName}}
+            <span class="w-4 h-4 rounded-full bg-primary/10 inline-flex items-center justify-center shrink-0" title="{{.UserName}}">
+              <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
+            </span>
+            {{end}}
+            <span class="truncate shrink min-w-0">{{.AccountName}} · {{relativeDate .Date}}</span>
+            {{if .CategoryDisplayName}}
+            <span class="text-base-content/20 shrink-0 hidden sm:inline">&middot;</span>
+            <span class="items-center gap-1 shrink-0 hidden sm:inline-flex">
+              <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
+              <span class="text-base-content/50 truncate max-w-24 lg:max-w-40">{{deref .CategoryDisplayName}}</span>
+            </span>
+            {{end}}
+            {{if .AgentReviewed}}
+            <span class="text-base-content/20 shrink-0">&middot;</span>
+            <span class="inline-flex items-center gap-0.5 text-primary/60 shrink-0" title="Categorized by AI agent">
+              <i data-lucide="bot" class="w-3 h-3"></i>
+            </span>
+            {{end}}
+          </div>
         </div>
         <span class="bb-tx-amount shrink-0{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
           {{formatAmount .Amount}}
@@ -291,22 +321,82 @@
     {{end}}
   </div>
 
-  <!-- Right Column: Connection Health + Quick Actions -->
+  <!-- Right Column: Combined System Health + Quick Actions -->
   <div class="flex flex-col gap-4">
-    <!-- Connection Health -->
+    <!-- Combined Connection & Sync Health -->
     <div class="bb-card p-5 flex-1">
       <div class="flex items-center justify-between mb-3">
         <div class="flex items-center gap-2">
-          <h2 class="text-sm font-semibold text-base-content/70">Connection Health</h2>
-          {{if gt .ErrorCount 0}}
-          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-error/8 text-error/80">
-            {{.ErrorCount}} issue{{if gt .ErrorCount 1}}s{{end}}
-          </span>
+          <h2 class="text-sm font-semibold text-base-content/70">System Health</h2>
+          {{if .SyncHealth}}
+            {{if eq .SyncHealth.OverallHealth "healthy"}}
+            <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-success/10 text-success">
+              <span class="w-1.5 h-1.5 rounded-full bg-success animate-pulse"></span>
+              Healthy
+            </span>
+            {{else if eq .SyncHealth.OverallHealth "degraded"}}
+            <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-warning/10 text-warning">
+              <span class="w-1.5 h-1.5 rounded-full bg-warning animate-pulse"></span>
+              Degraded
+            </span>
+            {{else if eq .SyncHealth.OverallHealth "unhealthy"}}
+            <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium bg-error/10 text-error">
+              <span class="w-1.5 h-1.5 rounded-full bg-error animate-pulse"></span>
+              Unhealthy
+            </span>
+            {{end}}
           {{end}}
         </div>
-        <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Manage</a>
+        <a href="/sync-logs" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Logs</a>
       </div>
+
+      <!-- Sync Stats Row -->
+      {{if .SyncHealth}}
+      <div class="flex items-center gap-3 mb-3 pb-3 border-b border-base-200/60 flex-wrap">
+        {{if .SyncHealth.LastSyncTime}}
+        <span class="flex items-center gap-1.5 text-xs text-base-content/50">
+          <i data-lucide="clock" class="w-3 h-3 text-base-content/30"></i>
+          {{deref .SyncHealth.LastSyncTime}}
+        </span>
+        {{end}}
+        {{if gt .SyncHealth.RecentSyncCount 0}}
+        <span class="flex items-center gap-1.5 text-xs {{if ge .SyncHealth.RecentSuccessRate 90.0}}text-success{{else if ge .SyncHealth.RecentSuccessRate 50.0}}text-warning{{else}}text-error/80{{end}}">
+          <i data-lucide="bar-chart-3" class="w-3 h-3"></i>
+          {{printf "%.0f" .SyncHealth.RecentSuccessRate}}% ({{.SyncHealth.RecentSyncCount}} syncs)
+        </span>
+        {{end}}
+        {{if .SyncHealth.NextSyncTime}}
+        <span class="flex items-center gap-1.5 text-xs text-base-content/40">
+          <i data-lucide="timer" class="w-3 h-3"></i>
+          {{.SyncHealth.NextSyncTime}}
+        </span>
+        {{end}}
+      </div>
+      {{end}}
+
+      <!-- Connection Health Summary Dots -->
       {{if .ConnectionHealth}}
+      <div class="flex items-center gap-3 mb-3 pb-3 border-b border-base-200/60">
+        {{if gt .HealthyCount 0}}
+        <span class="flex items-center gap-1.5 text-xs text-base-content/50">
+          <span class="w-2 h-2 rounded-full bg-success/60"></span>
+          {{.HealthyCount}} healthy
+        </span>
+        {{end}}
+        {{if gt .ErrorCount 0}}
+        <span class="flex items-center gap-1.5 text-xs text-error/70">
+          <span class="w-2 h-2 rounded-full bg-error/60"></span>
+          {{.ErrorCount}} error{{if gt .ErrorCount 1}}s{{end}}
+        </span>
+        {{end}}
+        {{if gt .StaleCount 0}}
+        <span class="flex items-center gap-1.5 text-xs text-warning">
+          <span class="w-2 h-2 rounded-full bg-warning/60"></span>
+          {{.StaleCount}} stale
+        </span>
+        {{end}}
+      </div>
+
       <!-- Per-connection rows -->
       <div class="space-y-1">
         {{range .ConnectionHealth}}
@@ -336,6 +426,7 @@
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-1.5">
               <span class="text-xs font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+              <span class="text-[0.6rem] text-base-content/25 shrink-0">{{.Provider}}</span>
             </div>
             {{if and (ne .Status "active") (ne .ErrorMessage "")}}
             <div class="text-[0.6rem] text-error/60 truncate mt-0.5 font-mono max-w-full" title="{{.ErrorMessage}}">{{.ErrorMessage}}</div>
@@ -343,6 +434,19 @@
             <div class="text-[0.6rem] text-base-content/30 mt-0.5">
               {{.AccountCount}} account{{if ne .AccountCount 1}}s{{end}} · synced {{.LastSyncedAt}}
             </div>
+            {{end}}
+          </div>
+          <div class="shrink-0">
+            {{if eq .Status "active"}}
+              {{if .IsStale}}
+              <span class="text-[0.6rem] font-medium text-warning/70 bg-warning/8 px-1.5 py-0.5 rounded-full">stale</span>
+              {{else}}
+              <span class="w-1.5 h-1.5 rounded-full bg-success/50"></span>
+              {{end}}
+            {{else if eq .Status "error"}}
+            <span class="text-[0.6rem] font-medium text-error/70 bg-error/8 px-1.5 py-0.5 rounded-full">error</span>
+            {{else if eq .Status "pending_reauth"}}
+            <span class="text-[0.6rem] font-medium text-warning bg-warning/8 px-1.5 py-0.5 rounded-full">reauth</span>
             {{end}}
           </div>
         </a>
@@ -358,32 +462,13 @@
       </div>
       {{end}}
 
-      <!-- Sync footer (compact) -->
-      {{if .SyncHealth}}
-      <div class="mt-2 pt-3 mx-5 mb-1 border-t border-base-200/60">
-        <div class="flex items-center justify-between text-[0.65rem] text-base-content/40">
-          <div class="flex items-center gap-3">
-            {{if eq .SyncHealth.OverallHealth "healthy"}}
-            <span class="flex items-center gap-1 text-success/70">
-              <span class="w-1.5 h-1.5 rounded-full bg-success/60"></span>
-              Syncs healthy
-            </span>
-            {{else if eq .SyncHealth.OverallHealth "degraded"}}
-            <span class="flex items-center gap-1 text-warning">
-              <span class="w-1.5 h-1.5 rounded-full bg-warning/60"></span>
-              Syncs degraded
-            </span>
-            {{else if eq .SyncHealth.OverallHealth "unhealthy"}}
-            <span class="flex items-center gap-1 text-error/70">
-              <span class="w-1.5 h-1.5 rounded-full bg-error/60"></span>
-              Syncs unhealthy
-            </span>
-            {{end}}
-            {{if .SyncHealth.NextSyncTime}}
-            <span>Next: {{.SyncHealth.NextSyncTime}}</span>
-            {{end}}
-          </div>
-          <a href="/sync-logs" class="text-base-content/30 hover:text-base-content/50 transition-colors">Logs</a>
+      <!-- Success rate mini bar -->
+      {{if and .SyncHealth (gt .SyncHealth.RecentSyncCount 0)}}
+      <div class="mt-3 pt-3 border-t border-base-200/60">
+        <div class="flex h-1.5 rounded-full overflow-hidden bg-base-200/60">
+          {{if gt .SyncHealth.RecentSuccessRate 0.0}}
+          <div class="h-full rounded-full {{if ge .SyncHealth.RecentSuccessRate 90.0}}bg-success/60{{else if ge .SyncHealth.RecentSuccessRate 50.0}}bg-warning/60{{else}}bg-error/60{{end}} transition-all duration-700" style="width: {{printf "%.0f" .SyncHealth.RecentSuccessRate}}%;"></div>
+          {{end}}
         </div>
       </div>
       {{end}}
@@ -404,69 +489,6 @@
     </div>
   </div>
 </div>
-
-<!-- Agent Reports -->
-{{if .AgentReports}}
-<div class="bb-card mb-6 bb-stagger" x-data="agentReports()">
-  <div class="px-4 sm:px-5 pt-4 pb-2">
-    <div class="flex items-center justify-between gap-2 mb-2 flex-wrap">
-      <div class="flex items-center gap-2">
-        <i data-lucide="bot" class="w-4 h-4 text-primary"></i>
-        <h2 class="text-sm font-semibold text-base-content/70">Agent Reports</h2>
-        <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary">{{len .AgentReports}} new</span>
-      </div>
-      <div class="flex items-center gap-3">
-        <button class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer"
-          @click="markAllRead()">
-          Mark all read
-        </button>
-        <a href="/reports" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
-      </div>
-    </div>
-  </div>
-  <div class="divide-y divide-base-200/60">
-    {{range .AgentReports}}
-    <div class="transition-all duration-300"
-      :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden' : ''"
-      id="report-{{.ID}}">
-      <!-- Message card -->
-      <div class="px-4 sm:px-5 py-3.5 hover:bg-base-200/20 transition-colors cursor-pointer" @click="toggle('{{.ID}}')">
-        <div class="flex items-start gap-2 sm:gap-3">
-          <!-- Priority dot -->
-          <span class="w-2 h-2 rounded-full shrink-0 mt-1.5 hidden sm:block {{if eq .Priority "critical"}}bg-error{{else if eq .Priority "warning"}}bg-warning{{else}}bg-base-content/20{{end}}"></span>
-          <!-- Message content -->
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-1.5 sm:gap-2 text-xs mb-1 flex-wrap">
-              <span class="font-semibold text-base-content/70 truncate max-w-[10rem] sm:max-w-none">{{.DisplayAuthor}}</span>
-              <span class="text-base-content/30">&middot;</span>
-              <span class="text-base-content/30 shrink-0">{{.CreatedAt}}</span>
-              {{range .Tags}}
-              <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/40 hidden sm:inline">{{.}}</span>
-              {{end}}
-            </div>
-            <p class="text-sm text-base-content/70 leading-relaxed line-clamp-2 sm:line-clamp-none">{{.Title}}</p>
-          </div>
-          <!-- Actions -->
-          <div class="flex items-center gap-1.5 shrink-0">
-            <i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/25 transition-transform duration-200"
-              :class="expanded['{{.ID}}'] ? 'rotate-180' : ''"></i>
-            <button @click.stop="markRead('{{.ID}}')" class="btn btn-success btn-ghost btn-xs rounded-lg cursor-pointer" title="Mark as read">
-              <i data-lucide="check" class="w-4 h-4"></i>
-            </button>
-          </div>
-        </div>
-        <!-- Expanded detail -->
-        <div x-show="expanded['{{.ID}}']" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
-          x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
-          x-cloak class="mt-3 sm:ml-5 pl-3 border-l-2 border-base-200/60">
-          <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
-        </div>
-      </div>
-    </div>
-    {{end}}
-  </div>
-</div>
-{{end}}
 
 <!-- Agent Reports: markdown rendering + dismiss logic -->
 {{if .AgentReports}}
@@ -537,11 +559,11 @@ document.addEventListener('DOMContentLoaded', function() {
       var isLiability = el.dataset.liability === 'true';
       if (!values || values.length === 0) return;
 
-      var w = 120, h = 32, padding = 1;
       var max = Math.max.apply(null, values);
       var hasData = max > 0;
       if (!hasData) return;
 
+      var w = 200, h = 40, padding = 2;
       var points = values.map(function(v, i) {
         var x = padding + (i / (values.length - 1)) * (w - padding * 2);
         var y = h - padding - ((v / max) * (h - padding * 2));
@@ -554,13 +576,13 @@ document.addEventListener('DOMContentLoaded', function() {
       var strokeColor, fillColor;
       if (isLiability) {
         strokeColor = isDark ? 'oklch(0.65 0.15 25)' : 'oklch(0.55 0.15 25)';
-        fillColor = isDark ? 'oklch(0.65 0.15 25 / 0.12)' : 'oklch(0.55 0.15 25 / 0.08)';
+        fillColor = isDark ? 'oklch(0.65 0.15 25 / 0.15)' : 'oklch(0.55 0.15 25 / 0.1)';
       } else {
         strokeColor = isDark ? 'oklch(0.65 0.02 250)' : 'oklch(0.45 0.02 250)';
-        fillColor = isDark ? 'oklch(0.65 0.02 250 / 0.12)' : 'oklch(0.45 0.02 250 / 0.08)';
+        fillColor = isDark ? 'oklch(0.65 0.02 250 / 0.15)' : 'oklch(0.45 0.02 250 / 0.1)';
       }
 
-      var svg = '<svg viewBox="0 0 ' + w + ' ' + h + '" preserveAspectRatio="none" class="w-full h-8">' +
+      var svg = '<svg viewBox="0 0 ' + w + ' ' + h + '" preserveAspectRatio="none" class="w-full h-full">' +
         '<path d="' + fillD + '" fill="' + fillColor + '" />' +
         '<polyline points="' + points.join(' ') + '" fill="none" stroke="' + strokeColor + '" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />' +
         '</svg>';
@@ -572,4 +594,5 @@ document.addEventListener('DOMContentLoaded', function() {
   });
 });
 </script>
+
 {{end}}


### PR DESCRIPTION
## Summary

- **Removed "Dashboard" page title** -- unnecessary since it's the home page
- **Replaced grouped account lists with small card grid** -- 4 columns on desktop (responsive: 3/2/1 on smaller screens), each card shows account name, institution, sparkline chart, balance, and 30-day spending total
- **Combined Connection Health + Sync Health** into a single "System Health" widget with overall status badge, sync stats row, connection summary dots, and per-connection rows
- **Polished Agent Reports section** -- icon with background, priority dot with ping animation for critical, cleaner header with unread count subtitle
- **Consistent spacing** (`gap-6`) between all major dashboard sections
- **Moved Agent Reports above accounts** for better visibility of unread reports

## Before
![before](https://i.img402.dev/dma0s2ww97.png)

## Test plan
- [ ] Verify dashboard loads without errors
- [ ] Check account cards show sparklines, balances, and spending
- [ ] Verify credit cards show negative balances in red
- [ ] Confirm System Health widget shows connection + sync status
- [ ] Test Agent Reports expand/collapse and mark-as-read
- [ ] Check mobile responsiveness (cards stack to 1 column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)