### PR TITLE
Dashboard: net worth + accounts merged, agent reports as message bubbles

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -986,12 +986,19 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			CreatedAt     string // relative time
 		}
 		var agentReports []DashboardReport
-		rawReports, err := svc.ListUnreadAgentReports(ctx, 10)
+		var totalUnread int
+		rawReports, err := svc.ListUnreadAgentReports(ctx, 50)
 		if err != nil {
 			a.Logger.Error("list unread agent reports", "error", err)
 		}
-		for _, r := range rawReports {
+		totalUnread = len(rawReports)
+		now := time.Now()
+		for i, r := range rawReports {
 			t, _ := time.Parse(time.RFC3339, r.CreatedAt)
+			// Show first 3, plus any additional within 24 hours
+			if i >= 3 && now.Sub(t) > 24*time.Hour {
+				continue
+			}
 			displayAuthor := r.CreatedByName
 			if r.Author != nil && *r.Author != "" {
 				displayAuthor = *r.Author
@@ -1007,6 +1014,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				CreatedAt:     relativeTime(t),
 			})
 		}
+		hasMoreReports := totalUnread > len(agentReports)
 
 		data := map[string]any{
 			"PageTitle":              "Dashboard",
@@ -1081,6 +1089,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"SpendingInsights":      spendingInsights,
 			// Agent reports.
 			"AgentReports":          agentReports,
+			"HasMoreReports":        hasMoreReports,
+			"TotalUnreadReports":    totalUnread,
 		}
 		tr.Render(w, r, "dashboard.html", data)
 	}

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -652,6 +652,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			AccountCount    int64
 			Paused          bool
 			IsStale         bool // hasn't synced in 24+ hours
+			lastSyncedRaw   time.Time
 		}
 		var connectionHealth []ConnectionHealthRow
 		var healthyCount, errorCount, staleCount int
@@ -715,18 +716,28 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 
 			connID := formatUUID(conn.ID)
 
+			var rawTime time.Time
+			if conn.LastSyncedAt.Valid {
+				rawTime = conn.LastSyncedAt.Time
+			}
 			connectionHealth = append(connectionHealth, ConnectionHealthRow{
-				ID:           connID,
-				Name:         name,
-				Provider:     string(conn.Provider),
-				Status:       status,
-				ErrorMessage: errMsg,
-				LastSyncedAt: lastSync,
-				AccountCount: conn.AccountCount,
-				Paused:       conn.Paused,
-				IsStale:      isStale,
+				ID:            connID,
+				Name:          name,
+				Provider:      string(conn.Provider),
+				Status:        status,
+				ErrorMessage:  errMsg,
+				LastSyncedAt:  lastSync,
+				AccountCount:  conn.AccountCount,
+				Paused:        conn.Paused,
+				IsStale:       isStale,
+				lastSyncedRaw: rawTime,
 			})
 		}
+
+		// Sort connections by last sync time (most recent first)
+		sort.Slice(connectionHealth, func(i, j int) bool {
+			return connectionHealth[i].lastSyncedRaw.After(connectionHealth[j].lastSyncedRaw)
+		})
 
 		// ── Sync Health Summary ──────────────────────────────────────
 		syncHealth, err := svc.GetSyncHealthSummary(ctx)

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -94,17 +94,12 @@
 
 <!-- Agent Reports -->
 {{if .AgentReports}}
-<div class="bb-card mb-6 bb-stagger" x-data="{ ...agentReports(), showReports: false }">
+<div class="bb-card mb-6 bb-stagger" x-data="{ ...agentReports(), showReports: true }">
   <!-- Header — always visible, clickable to toggle -->
   <button @click="showReports = !showReports" class="w-full text-left px-5 py-4 flex items-center justify-between gap-2 hover:bg-base-200/30 transition-colors rounded-xl" :class="showReports ? 'rounded-b-none' : ''">
-    <div class="flex items-center gap-2.5">
-      <div class="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-        <i data-lucide="bot" class="w-4 h-4 text-primary"></i>
-      </div>
-      <div class="flex items-center gap-2">
+    <div class="flex items-center gap-2">
         <h2 class="text-sm font-semibold text-base-content/80">Agent Reports</h2>
         <span class="text-[0.65rem] font-semibold px-2 py-0.5 rounded-full bg-primary/15 text-primary">{{.TotalUnreadReports}} unread</span>
-      </div>
     </div>
     <div class="flex items-center gap-3">
       <span class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer"
@@ -117,49 +112,38 @@
   </button>
 
   <!-- Collapsible report list -->
-  <div x-show="showReports" x-cloak class="border-t border-base-200/60 divide-y divide-base-200/60">
+  <div x-show="showReports" x-cloak class="border-t border-base-200/60 px-4 sm:px-5 py-4 space-y-3">
     {{range .AgentReports}}
     <div class="transition-all duration-300"
-      :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden' : ''"
+      :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !my-0' : ''"
       id="report-{{.ID}}">
-      <div class="px-5 py-3.5 hover:bg-base-200/20 transition-colors cursor-pointer" @click="toggle('{{.ID}}')">
-        <div class="flex items-start gap-3">
-          <!-- Priority indicator -->
-          <div class="shrink-0 mt-1">
+      <!-- Message bubble -->
+      <div class="flex items-start gap-2.5">
+        <!-- Bot avatar -->
+        <div class="w-7 h-7 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-0.5">
+          <i data-lucide="bot" class="w-3.5 h-3.5 text-primary"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <!-- Author + time + mark read -->
+          <div class="flex items-center gap-2 mb-1">
+            <span class="text-xs font-semibold text-base-content/70">{{.DisplayAuthor}}</span>
+            <span class="text-[0.65rem] text-base-content/30">{{.CreatedAt}}</span>
             {{if eq .Priority "critical"}}
             <span class="flex w-2 h-2"><span class="animate-ping absolute w-2 h-2 rounded-full bg-error/60"></span><span class="relative w-2 h-2 rounded-full bg-error"></span></span>
             {{else if eq .Priority "warning"}}
-            <span class="w-2 h-2 rounded-full bg-warning block"></span>
-            {{else}}
-            <span class="w-2 h-2 rounded-full bg-base-content/15 block"></span>
+            <span class="w-2 h-2 rounded-full bg-warning shrink-0"></span>
             {{end}}
+            <button @click.stop="markRead('{{.ID}}')" class="text-[0.65rem] text-base-content/30 hover:text-success transition-colors cursor-pointer ml-auto shrink-0 mr-1">Mark read</button>
           </div>
-          <!-- Message content -->
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-2 text-xs mb-0.5 flex-wrap">
-              <span class="font-semibold text-base-content/70 truncate max-w-[10rem] sm:max-w-none">{{.DisplayAuthor}}</span>
-              <span class="text-base-content/25">&middot;</span>
-              <span class="text-base-content/30 shrink-0">{{.CreatedAt}}</span>
-              {{range .Tags}}
-              <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/40 hidden sm:inline">{{.}}</span>
-              {{end}}
+          <!-- Bubble body -->
+          <div class="rounded-2xl rounded-tl-sm bg-base-200/70 shadow-sm px-3.5 py-2.5 cursor-pointer hover:bg-base-200/90 transition-colors inline-block max-w-full"
+               @click="toggle('{{.ID}}')">
+            <p class="text-sm text-base-content/80 leading-relaxed" :class="expanded['{{.ID}}'] ? '' : 'line-clamp-2'">{{.Title}}{{if .Tags}} {{range .Tags}}<span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-content/5 text-base-content/40 ml-1 inline-block align-middle">{{.}}</span>{{end}}{{end}}</p>
+            <!-- Expanded body -->
+            <div x-show="expanded['{{.ID}}']" x-cloak class="mt-2 pt-2 border-t border-base-content/5">
+              <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
             </div>
-            <p class="text-sm text-base-content/70 leading-relaxed line-clamp-2">{{.Title}}</p>
           </div>
-          <!-- Actions -->
-          <div class="flex items-center gap-1.5 shrink-0">
-            <i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/25 transition-transform duration-200"
-              :class="expanded['{{.ID}}'] ? 'rotate-180' : ''"></i>
-            <button @click.stop="markRead('{{.ID}}')" class="btn btn-ghost btn-xs rounded-lg cursor-pointer hover:bg-success/10 hover:text-success" title="Mark as read">
-              <i data-lucide="check" class="w-3.5 h-3.5"></i>
-            </button>
-          </div>
-        </div>
-        <!-- Expanded detail -->
-        <div x-show="expanded['{{.ID}}']" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
-          x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
-          x-cloak class="mt-3 ml-5 pl-3 border-l-2 border-primary/20">
-          <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
         </div>
       </div>
     </div>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -166,12 +166,12 @@
 </div>
 {{end}}
 
-<!-- Accounts Overview -->
+<!-- Net Worth & Accounts -->
 {{if .Accounts}}
-<div class="mb-6">
+<div class="bb-card mb-6" x-data="{ showAccounts: false }">
   <!-- Net Worth Summary -->
   {{if .AllocationSlices}}
-  <div class="bb-card p-4 sm:p-5 mb-6">
+  <div class="p-4 sm:p-5">
     <div class="flex items-baseline justify-between mb-3">
       <div>
         <div class="text-xs text-base-content/40 mb-0.5">Net Worth</div>
@@ -194,61 +194,66 @@
       <div class="h-full rounded-full transition-all duration-700 ease-out" style="width: {{printf "%.1f" .Percent}}%; background: {{safeCSS .Color}}; opacity: 0.7;" title="{{.Label}}: {{formatBalance .Amount}}"></div>
       {{end}}
     </div>
-    <div class="flex items-center gap-4 mt-2.5 flex-wrap">
-      {{range .AllocationSlices}}
-      <span class="flex items-center gap-1.5 text-xs text-base-content/50">
-        <span class="w-2 h-2 rounded-full shrink-0" style="background: {{safeCSS .Color}}; opacity: 0.7;"></span>
-        {{.Label}}
-        <span class="tabular-nums font-medium text-base-content/70">{{formatBalance .Amount}}</span>
-      </span>
-      {{end}}
+    <div class="flex items-center justify-between mt-2.5">
+      <div class="flex items-center gap-4 flex-wrap">
+        {{range .AllocationSlices}}
+        <span class="flex items-center gap-1.5 text-xs text-base-content/50">
+          <span class="w-2 h-2 rounded-full shrink-0" style="background: {{safeCSS .Color}}; opacity: 0.7;"></span>
+          {{.Label}}
+          <span class="tabular-nums font-medium text-base-content/70">{{formatBalance .Amount}}</span>
+        </span>
+        {{end}}
+      </div>
+      <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors shrink-0 ml-4">View all</a>
     </div>
   </div>
   {{end}}
 
-  <!-- Account Cards Grid -->
-  <div class="flex items-center justify-between mb-3">
-    <h2 class="text-sm font-semibold text-base-content/70">Accounts</h2>
-    <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+  <!-- Accounts Toggle -->
+  <div class="border-t border-base-200/60">
+    <button @click="showAccounts = !showAccounts" class="flex items-center justify-between w-full text-left px-4 sm:px-5 py-3 hover:bg-base-200/30 transition-colors rounded-b-xl" :class="showAccounts ? 'rounded-b-none' : ''">
+      <span class="text-sm font-semibold text-base-content/70">{{len .Accounts}} Accounts</span>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200" :class="showAccounts ? 'rotate-180' : ''"></i>
+    </button>
   </div>
-  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 bb-stagger">
-    {{range .Accounts}}
-    <a href="/accounts/{{.ID}}" class="bb-card bb-card--interactive p-4 no-underline group block">
-      <div class="flex items-start justify-between mb-2">
-        <div class="min-w-0 flex-1">
-          <div class="flex items-center gap-1.5">
-            <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
-            {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
-            <span class="shrink-0 text-[0.55rem] font-medium px-1.5 py-0.5 rounded-full leading-none {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+
+  <!-- Collapsible Account Cards -->
+  <div x-show="showAccounts" x-cloak class="border-t border-base-200/60 p-4 sm:p-5">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+      {{range .Accounts}}
+      <a href="/accounts/{{.ID}}" class="bb-card bb-card--interactive p-4 no-underline group block">
+        <div class="flex items-start justify-between mb-2">
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-1.5">
+              <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+              {{if and .ConnectionStatus (ne .ConnectionStatus "active")}}
+              <span class="shrink-0 text-[0.55rem] font-medium px-1.5 py-0.5 rounded-full leading-none {{if eq .ConnectionStatus "error"}}bg-error/8 text-error/70{{else if eq .ConnectionStatus "pending_reauth"}}bg-warning/8 text-warning{{else if eq .ConnectionStatus "disconnected"}}bg-base-300/60 text-base-content/40{{end}}">{{if eq .ConnectionStatus "pending_reauth"}}reauth{{else}}{{.ConnectionStatus}}{{end}}</span>
+              {{end}}
+            </div>
+            <div class="text-[0.65rem] text-base-content/40 mt-0.5 truncate">{{.InstitutionName}}{{if .Mask}} · ····{{.Mask}}{{end}}</div>
+          </div>
+          <div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0 ml-2">
+            <i data-lucide="{{accountTypeIcon .Type}}" class="w-3.5 h-3.5 text-base-content/35"></i>
+          </div>
+        </div>
+        {{if .SparklineData}}
+        <div class="bb-sparkline w-full h-8 my-1.5" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+        {{else}}
+        <div class="h-8 my-1.5"></div>
+        {{end}}
+        <div class="flex items-end justify-between mt-1">
+          <div class="text-lg font-bold tabular-nums tracking-tight {{if .IsLiability}}text-error/80{{end}}">{{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}</div>
+          <div class="text-right">
+            {{if gt .SpendingTotal 0.0}}
+            <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+            {{else}}
+            <div class="text-[0.65rem] text-base-content/35">{{accountTypeLabel .Type .Subtype}}</div>
             {{end}}
           </div>
-          <div class="text-[0.65rem] text-base-content/40 mt-0.5 truncate">{{.InstitutionName}}{{if .Mask}} · ····{{.Mask}}{{end}}</div>
         </div>
-        <div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0 ml-2">
-          <i data-lucide="{{accountTypeIcon .Type}}" class="w-3.5 h-3.5 text-base-content/35"></i>
-        </div>
-      </div>
-      <!-- Sparkline -->
-      {{if .SparklineData}}
-      <div class="bb-sparkline w-full h-8 my-1.5" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
-      {{else}}
-      <div class="h-8 my-1.5"></div>
+      </a>
       {{end}}
-      <!-- Balance -->
-      <div class="flex items-end justify-between mt-1">
-        <div>
-          <div class="text-lg font-bold tabular-nums tracking-tight {{if .IsLiability}}text-error/80{{end}}">{{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}</div>
-        </div>
-        <div class="text-right">
-          {{if gt .SpendingTotal 0.0}}
-          <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-          {{else}}
-          <div class="text-[0.65rem] text-base-content/35">{{accountTypeLabel .Type .Subtype}}</div>
-          {{end}}
-        </div>
-      </div>
-    </a>
-    {{end}}
+    </div>
   </div>
 </div>
 {{end}}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -94,28 +94,30 @@
 
 <!-- Agent Reports -->
 {{if .AgentReports}}
-<div class="bb-card mb-6 bb-stagger" x-data="agentReports()">
-  <div class="px-5 pt-4 pb-2">
-    <div class="flex items-center justify-between gap-2 flex-wrap">
-      <div class="flex items-center gap-2.5">
-        <div class="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center">
-          <i data-lucide="bot" class="w-4 h-4 text-primary"></i>
-        </div>
-        <div>
-          <h2 class="text-sm font-semibold text-base-content/80">Agent Reports</h2>
-          <p class="text-[0.65rem] text-base-content/40">{{len .AgentReports}} unread report{{if gt (len .AgentReports) 1}}s{{end}}</p>
-        </div>
+<div class="bb-card mb-6 bb-stagger" x-data="{ ...agentReports(), showReports: false }">
+  <!-- Header — always visible, clickable to toggle -->
+  <button @click="showReports = !showReports" class="w-full text-left px-5 py-4 flex items-center justify-between gap-2 hover:bg-base-200/30 transition-colors rounded-xl" :class="showReports ? 'rounded-b-none' : ''">
+    <div class="flex items-center gap-2.5">
+      <div class="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+        <i data-lucide="bot" class="w-4 h-4 text-primary"></i>
       </div>
-      <div class="flex items-center gap-3">
-        <button class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer"
-          @click="markAllRead()">
-          Mark all read
-        </button>
-        <a href="/reports" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+      <div class="flex items-center gap-2">
+        <h2 class="text-sm font-semibold text-base-content/80">Agent Reports</h2>
+        <span class="text-[0.65rem] font-semibold px-2 py-0.5 rounded-full bg-primary/15 text-primary">{{.TotalUnreadReports}} unread</span>
       </div>
     </div>
-  </div>
-  <div class="divide-y divide-base-200/60">
+    <div class="flex items-center gap-3">
+      <span class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer"
+        @click.stop="markAllRead()">
+        Mark all read
+      </span>
+      <a href="/reports" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors" @click.stop>View all</a>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200" :class="showReports ? 'rotate-180' : ''"></i>
+    </div>
+  </button>
+
+  <!-- Collapsible report list -->
+  <div x-show="showReports" x-cloak class="border-t border-base-200/60 divide-y divide-base-200/60">
     {{range .AgentReports}}
     <div class="transition-all duration-300"
       :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden' : ''"
@@ -160,6 +162,11 @@
           <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
         </div>
       </div>
+    </div>
+    {{end}}
+    {{if .HasMoreReports}}
+    <div class="px-5 py-3 border-t border-base-200/60 text-center">
+      <a href="/reports" class="text-xs text-primary/70 hover:text-primary transition-colors">View all {{.TotalUnreadReports}} unread reports &rarr;</a>
     </div>
     {{end}}
   </div>


### PR DESCRIPTION
## Summary
- Merged net worth and accounts into single card with collapsible accounts grid (hidden by default)
- Connection health rows sorted chronologically by last sync time
- Agent reports redesigned as chat-style message bubbles with bot avatars
- Reports section collapsible, expanded by default, limited to 3 + 24h window
- Prominent "X unread" badge, "View all" footer when more reports exist
- Subtle shadow and improved light mode contrast on bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)