### PR TITLE
Fix sync engine re-applying rules to unchanged transactions

### DIFF
--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -323,12 +323,12 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				skipped++
 				continue
 			}
-			ur, err := e.upsertTransaction(ctx, txQueries, &pendingAdded[i], accountIDCache, string(conn.Provider), resolver, conn.UserID, userName, logger)
+			dbTxn, err := e.upsertTransaction(ctx, txQueries, &pendingAdded[i], accountIDCache)
 			if err != nil {
 				logger.Error("upsert added transaction", "external_id", pendingAdded[i].ExternalID, "error", err)
 				continue
 			}
-			isNew, isChanged := classifyUpsertResult(ur.Txn, upsertStart)
+			isNew, isChanged := classifyUpsertResult(dbTxn, upsertStart)
 			if isNew {
 				added++
 			} else if isChanged {
@@ -336,8 +336,19 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 			} else {
 				unchanged++
 			}
+			if isNew || isChanged {
+				sources, ruleErr := e.applyRulesToTransaction(ctx, tx, &pendingAdded[i], dbTxn, accountIDCache, string(conn.Provider), resolver, conn.UserID, userName)
+				if ruleErr != nil {
+					logger.Error("apply rules to added txn", "external_id", pendingAdded[i].ExternalID, "error", ruleErr)
+				}
+				for _, src := range sources {
+					ruleApplications = append(ruleApplications, pendingApplication{
+						txnID: dbTxn.ID, ruleID: src.RuleID, actionField: src.ActionField, actionValue: src.ActionValue,
+					})
+				}
+			}
 			if reviewAutoEnqueue && (isNew || isChanged) {
-				e.enqueueForReview(ctx, txQueries, ur.Txn, isNew, confidenceThreshold, resolver)
+				e.enqueueForReview(ctx, txQueries, dbTxn, isNew, confidenceThreshold, resolver)
 			}
 			if isNew {
 				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "added")
@@ -345,11 +356,6 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "modified")
 			} else {
 				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "unchanged")
-			}
-			for _, src := range ur.Sources {
-				ruleApplications = append(ruleApplications, pendingApplication{
-					txnID: ur.Txn.ID, ruleID: src.RuleID, actionField: src.ActionField, actionValue: src.ActionValue,
-				})
 			}
 		}
 
@@ -364,35 +370,41 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				skipped++
 				continue
 			}
-			ur, err := e.upsertTransaction(ctx, txQueries, &pendingModified[i], accountIDCache, string(conn.Provider), resolver, conn.UserID, userName, logger)
+			dbTxn, err := e.upsertTransaction(ctx, txQueries, &pendingModified[i], accountIDCache)
 			if err != nil {
 				logger.Error("upsert modified transaction", "external_id", pendingModified[i].ExternalID, "error", err)
 				continue
 			}
-			_, isChanged := classifyUpsertResult(ur.Txn, upsertStart)
+			_, isChanged := classifyUpsertResult(dbTxn, upsertStart)
 			if isChanged {
 				modified++
 				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "modified")
+				sources, ruleErr := e.applyRulesToTransaction(ctx, tx, &pendingModified[i], dbTxn, accountIDCache, string(conn.Provider), resolver, conn.UserID, userName)
+				if ruleErr != nil {
+					logger.Error("apply rules to modified txn", "external_id", pendingModified[i].ExternalID, "error", ruleErr)
+				}
+				for _, src := range sources {
+					ruleApplications = append(ruleApplications, pendingApplication{
+						txnID: dbTxn.ID, ruleID: src.RuleID, actionField: src.ActionField, actionValue: src.ActionValue,
+					})
+				}
 			} else {
 				unchanged++
 				e.trackAccountCount(ctx, perAccount, accountID, accountNameCache, "unchanged")
 			}
 			if reviewAutoEnqueue && isChanged {
-				e.enqueueForReview(ctx, txQueries, ur.Txn, false, confidenceThreshold, resolver)
-			}
-			for _, src := range ur.Sources {
-				ruleApplications = append(ruleApplications, pendingApplication{
-					txnID: ur.Txn.ID, ruleID: src.RuleID, actionField: src.ActionField, actionValue: src.ActionValue,
-				})
+				e.enqueueForReview(ctx, txQueries, dbTxn, false, confidenceThreshold, resolver)
 			}
 		}
 
 		// Batch-insert rule application records.
 		for _, app := range ruleApplications {
-			_, _ = e.pool.Exec(ctx,
+			_, _ = tx.Exec(ctx,
 				`INSERT INTO transaction_rule_applications (transaction_id, rule_id, action_field, action_value, applied_by)
 				VALUES ($1, $2, $3, $4, 'sync')
-				ON CONFLICT (transaction_id, rule_id, action_field) DO UPDATE SET applied_at = NOW(), action_value = EXCLUDED.action_value`,
+				ON CONFLICT (transaction_id, rule_id, action_field) DO UPDATE
+				SET applied_at = NOW(), action_value = EXCLUDED.action_value
+				WHERE transaction_rule_applications.action_value IS DISTINCT FROM EXCLUDED.action_value`,
 				app.txnID, app.ruleID, app.actionField, app.actionValue)
 		}
 
@@ -451,54 +463,12 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 	return added, modified, removed, unchanged, perAccount, ruleHits, warning, nil
 }
 
-// upsertResult holds the result of upserting a transaction plus any rule sources that applied.
-type upsertResult struct {
-	Txn     db.Transaction
-	Sources []RuleActionSource // which rules applied which actions
-}
-
-// upsertTransaction resolves the account ID and upserts a single transaction.
-func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *provider.Transaction, cache map[string]pgtype.UUID, providerName string, resolver *RuleResolver, userID pgtype.UUID, userName string, logger *slog.Logger) (upsertResult, error) {
+// upsertTransaction upserts a single transaction without rule evaluation.
+// Rules are applied separately only when the transaction is new or changed.
+func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *provider.Transaction, cache map[string]pgtype.UUID) (db.Transaction, error) {
 	accountID, err := e.resolveAccountID(ctx, txn.AccountExternalID, cache)
 	if err != nil {
-		return upsertResult{}, fmt.Errorf("resolve account %s: %w", txn.AccountExternalID, err)
-	}
-
-	// Resolve category ID using rules first, then category mappings as fallback.
-	var categoryID pgtype.UUID
-	var sources []RuleActionSource
-	if resolver != nil {
-		tctx := TransactionContext{
-			Name:       txn.Name,
-			Amount:     txn.Amount.InexactFloat64(),
-			Pending:    txn.Pending,
-			Provider:   providerName,
-			AccountID:  formatUUID(accountID),
-			UserID:     formatUUID(userID),
-			UserName:   userName,
-		}
-		if txn.MerchantName != nil {
-			tctx.MerchantName = *txn.MerchantName
-		}
-		if txn.CategoryPrimary != nil {
-			tctx.CategoryPrimary = *txn.CategoryPrimary
-		}
-		if txn.CategoryDetailed != nil {
-			tctx.CategoryDetailed = *txn.CategoryDetailed
-		}
-		result := resolver.ResolveWithContext(providerName, tctx)
-		// Only set fields when rules explicitly matched.
-		// When no rule matches (nil), preserve existing values for
-		// existing rows (avoids overwriting categories set by reviews/agents).
-		// New rows will get NULL category_id, which enqueueForReview catches
-		// and flags as "uncategorized" for review.
-		if result != nil {
-			if result.CategoryID.Valid {
-				categoryID = result.CategoryID
-			}
-			sources = result.Sources
-			// future: apply other action fields from result
-		}
+		return db.Transaction{}, fmt.Errorf("resolve account %s: %w", txn.AccountExternalID, err)
 	}
 
 	params := db.UpsertTransactionParams{
@@ -518,14 +488,55 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 		CategoryConfidence:    optionalText(txn.CategoryConfidence),
 		PaymentChannel:        pgtype.Text{String: txn.PaymentChannel, Valid: txn.PaymentChannel != ""},
 		Pending:               txn.Pending,
-		CategoryID:            categoryID,
 	}
 
-	dbTxn, err := q.UpsertTransaction(ctx, params)
-	if err != nil {
-		return upsertResult{}, err
+	return q.UpsertTransaction(ctx, params)
+}
+
+// applyRulesToTransaction evaluates rules against a transaction and updates the
+// category if a rule matches. Called only for new or changed transactions.
+func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *provider.Transaction, dbTxn db.Transaction, cache map[string]pgtype.UUID, providerName string, resolver *RuleResolver, userID pgtype.UUID, userName string) ([]RuleActionSource, error) {
+	if resolver == nil {
+		return nil, nil
 	}
-	return upsertResult{Txn: dbTxn, Sources: sources}, nil
+
+	accountID, _ := e.resolveAccountID(ctx, txn.AccountExternalID, cache)
+	tctx := TransactionContext{
+		Name:       txn.Name,
+		Amount:     txn.Amount.InexactFloat64(),
+		Pending:    txn.Pending,
+		Provider:   providerName,
+		AccountID:  formatUUID(accountID),
+		UserID:     formatUUID(userID),
+		UserName:   userName,
+	}
+	if txn.MerchantName != nil {
+		tctx.MerchantName = *txn.MerchantName
+	}
+	if txn.CategoryPrimary != nil {
+		tctx.CategoryPrimary = *txn.CategoryPrimary
+	}
+	if txn.CategoryDetailed != nil {
+		tctx.CategoryDetailed = *txn.CategoryDetailed
+	}
+
+	result := resolver.ResolveWithContext(providerName, tctx)
+	if result == nil {
+		return nil, nil
+	}
+
+	// Only update category_id when a rule explicitly matched and the
+	// transaction doesn't have a manual override.
+	if result.CategoryID.Valid && !dbTxn.CategoryOverride {
+		_, err := tx.Exec(ctx,
+			`UPDATE transactions SET category_id = $1 WHERE id = $2 AND NOT category_override`,
+			result.CategoryID, dbTxn.ID)
+		if err != nil {
+			return result.Sources, fmt.Errorf("apply rule category: %w", err)
+		}
+	}
+
+	return result.Sources, nil
 }
 
 // updateBalancesWithRetry fetches balances with 1 retry on transient errors.
@@ -774,8 +785,10 @@ func (e *Engine) saveSyncLogAccounts(ctx context.Context, syncLogID pgtype.UUID,
 //   - (false, true):  existing row with changed values
 //   - (false, false): existing row with identical values (unchanged)
 func classifyUpsertResult(txn db.Transaction, upsertStart time.Time) (isNew bool, isChanged bool) {
-	// New row: created_at ~= updated_at (both set to NOW() on INSERT).
-	if txn.CreatedAt.Time.Sub(txn.UpdatedAt.Time).Abs() < time.Second {
+	// New row: created_at was set during this upsert (>= upsertStart) AND
+	// created_at ~= updated_at (both set to NOW() on INSERT).
+	recentCreate := txn.CreatedAt.Time.After(upsertStart.Add(-2 * time.Second))
+	if recentCreate && txn.CreatedAt.Time.Sub(txn.UpdatedAt.Time).Abs() < time.Second {
 		return true, true
 	}
 	// Existing row: if updated_at was bumped to NOW() (>= upsertStart with

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1436,3 +1436,134 @@ func TestSync_LowConfidenceReviewType(t *testing.T) {
 		t.Errorf("expected review_type 'low_confidence', got %q", reviewType)
 	}
 }
+
+func TestSync_UnchangedTransactions_SkipRuleReapplication(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategories(t, queries)
+
+	// Create a category and rule for coffee.
+	coffeeCat, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "coffee_shops", DisplayName: "Coffee Shops",
+	})
+	if err != nil {
+		t.Fatalf("create coffee category: %v", err)
+	}
+
+	_, err = pool.Exec(ctx,
+		`INSERT INTO transaction_rules (name, conditions, category_id, priority, enabled, created_by_type, created_by_name)
+		 VALUES ('Coffee Rule', '{"field":"name","op":"contains","value":"coffee"}', $1, 100, true, 'system', 'test')`,
+		coffeeCat.ID,
+	)
+	if err != nil {
+		t.Fatalf("create rule: %v", err)
+	}
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	txns := []provider.Transaction{
+		{
+			ExternalID:        "txn_coffee",
+			AccountExternalID: "ext_acct_1",
+			Amount:            decimal.NewFromFloat(5.50),
+			Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			Name:              "Starbucks Coffee",
+			ISOCurrencyCode:   "USD",
+		},
+	}
+
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added:  txns,
+			Cursor: "cursor_1",
+		},
+	}
+
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+
+	// First sync: transaction is new, rule should apply.
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	// Verify rule was applied and record the applied_at timestamp.
+	var appliedAt1 time.Time
+	err = pool.QueryRow(ctx,
+		`SELECT applied_at FROM transaction_rule_applications
+		 WHERE transaction_id = (SELECT id FROM transactions WHERE external_transaction_id = 'txn_coffee')`,
+	).Scan(&appliedAt1)
+	if err != nil {
+		t.Fatalf("query rule application after first sync: %v", err)
+	}
+
+	var hitCount1 int
+	err = pool.QueryRow(ctx, "SELECT hit_count FROM transaction_rules WHERE name = 'Coffee Rule'").Scan(&hitCount1)
+	if err != nil {
+		t.Fatalf("query hit count: %v", err)
+	}
+	if hitCount1 != 1 {
+		t.Errorf("expected hit_count 1 after first sync, got %d", hitCount1)
+	}
+
+	// Second sync: same transaction data (unchanged), rule should NOT be re-applied.
+	// Provider returns same transaction in Added (simulating a re-sync).
+	mock.syncResult = provider.SyncResult{
+		Added:  txns,
+		Cursor: "cursor_2",
+	}
+
+	// Wait long enough that classifyUpsertResult can distinguish the first
+	// sync's created_at from the second sync's upsertStart (2s tolerance).
+	time.Sleep(3 * time.Second)
+
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	// Verify applied_at was NOT bumped.
+	var appliedAt2 time.Time
+	err = pool.QueryRow(ctx,
+		`SELECT applied_at FROM transaction_rule_applications
+		 WHERE transaction_id = (SELECT id FROM transactions WHERE external_transaction_id = 'txn_coffee')`,
+	).Scan(&appliedAt2)
+	if err != nil {
+		t.Fatalf("query rule application after second sync: %v", err)
+	}
+	if !appliedAt2.Equal(appliedAt1) {
+		t.Errorf("rule application applied_at was bumped on unchanged transaction: first=%v, second=%v", appliedAt1, appliedAt2)
+	}
+
+	// Verify hit count was NOT incremented again.
+	var hitCount2 int
+	err = pool.QueryRow(ctx, "SELECT hit_count FROM transaction_rules WHERE name = 'Coffee Rule'").Scan(&hitCount2)
+	if err != nil {
+		t.Fatalf("query hit count: %v", err)
+	}
+	if hitCount2 != hitCount1 {
+		t.Errorf("expected hit_count to stay at %d after unchanged re-sync, got %d", hitCount1, hitCount2)
+	}
+
+	// Verify the sync log shows 0 added, 0 modified, 1 unchanged.
+	var addedCount, modifiedCount, unchangedCount int32
+	err = pool.QueryRow(ctx,
+		`SELECT added_count, modified_count, unchanged_count FROM sync_logs
+		 WHERE connection_id = $1 ORDER BY started_at DESC LIMIT 1`,
+		conn.ID,
+	).Scan(&addedCount, &modifiedCount, &unchangedCount)
+	if err != nil {
+		t.Fatalf("query sync log: %v", err)
+	}
+	if addedCount != 0 {
+		t.Errorf("expected added_count 0 on re-sync, got %d", addedCount)
+	}
+	if modifiedCount != 0 {
+		t.Errorf("expected modified_count 0 on re-sync, got %d", modifiedCount)
+	}
+	if unchangedCount != 1 {
+		t.Errorf("expected unchanged_count 1 on re-sync, got %d", unchangedCount)
+	}
+}

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -60,6 +60,14 @@ func TestClassifyUpsertResult(t *testing.T) {
 			wantNew:     false,
 			wantChanged: false,
 		},
+		{
+			name:        "unchanged: created_at == updated_at but both old (re-sync of recently added row)",
+			createdAt:   now.Add(-10 * time.Second),
+			updatedAt:   now.Add(-10 * time.Second),
+			upsertStart: now.Add(-100 * time.Millisecond),
+			wantNew:     false,
+			wantChanged: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/sync/main_integration_test.go
+++ b/internal/sync/main_integration_test.go
@@ -1,0 +1,13 @@
+//go:build integration
+
+package sync_test
+
+import (
+	"testing"
+
+	"breadbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	testutil.RunWithDB(m)
+}


### PR DESCRIPTION
## Summary
- Split `upsertTransaction` into two steps: pure upsert + conditional `applyRulesToTransaction`, so rules are only evaluated for new or changed transactions
- Fixed `classifyUpsertResult` to check `created_at` recency, preventing recently-added rows from being misclassified as "new" on re-sync
- Moved rule application inserts and category updates inside the DB transaction (previously used pool outside tx)
- Added `WHERE action_value IS DISTINCT FROM` guard on rule application upsert to prevent no-op timestamp bumps

## Test plan
- [x] New integration test `TestSync_UnchangedTransactions_SkipRuleReapplication` verifies unchanged transactions skip rule evaluation, don't bump `applied_at`, don't increment `hit_count`, and show correct sync log counts
- [x] New unit test case for `classifyUpsertResult` covering re-sync of recently added rows
- [x] All 22 existing sync integration tests pass
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)