### PR TITLE
Improve mobile sidebar with wider drawer, touch targets, and scroll fades

### DIFF
--- a/input.css
+++ b/input.css
@@ -272,7 +272,7 @@
 
   /* ── Sidebar ── */
   .bb-sidebar {
-    @apply bg-base-100 h-full w-64 px-3 py-5 flex flex-col border-r border-base-300;
+    @apply bg-base-100 h-full w-[85vw] max-w-80 sm:w-72 lg:w-64 px-3 py-5 flex flex-col border-r border-base-300;
   }
 
   .bb-sidebar-brand {
@@ -294,7 +294,7 @@
   }
 
   .bb-sidebar-link {
-    @apply flex items-center gap-3 px-3 py-1.5 rounded-lg text-sm font-medium
+    @apply flex items-center gap-3 px-3 py-2.5 lg:py-1.5 rounded-lg text-sm font-medium
            text-base-content/60 no-underline
            hover:bg-base-200 hover:text-base-content;
     transition: background-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
@@ -1118,7 +1118,7 @@
 
   /* ── Sidebar Cmd+K trigger ── */
   .bb-sidebar-search {
-    @apply flex items-center gap-2.5 px-3 py-2 mx-0 mb-3 rounded-lg
+    @apply flex items-center gap-2.5 px-3 py-2.5 lg:py-2 mx-0 mb-3 rounded-lg
            text-sm text-base-content/35 bg-base-200/50 border border-base-300/50
            cursor-pointer select-none;
     transition: background-color 0.15s ease, border-color 0.15s ease;
@@ -1144,7 +1144,7 @@
 
   /* ── Sidebar user profile ── */
   .bb-sidebar-profile {
-    @apply flex items-center gap-2.5 px-2 py-2 rounded-lg;
+    @apply flex items-center gap-2.5 px-2 py-3 lg:py-2 rounded-lg;
     transition: background-color 0.15s ease;
   }
 

--- a/input.css
+++ b/input.css
@@ -290,9 +290,27 @@
     scrollbar-color: oklch(var(--bc) / 0.15) transparent;
   }
 
+  /* ── Mobile: iOS 26-style scroll fade gradients ── */
   @media (max-width: 1023px) {
     .bb-sidebar-nav {
-      scrollbar-color: oklch(var(--bc) / 0.08) transparent;
+      scrollbar-width: none;
+      --fade-size: 2rem;
+      --fade-top: 0;
+      --fade-bottom: 0;
+      mask-image: linear-gradient(
+        to bottom,
+        transparent,
+        black calc(var(--fade-size) * var(--fade-top)),
+        black calc(100% - var(--fade-size) * var(--fade-bottom)),
+        transparent
+      );
+      -webkit-mask-image: linear-gradient(
+        to bottom,
+        transparent,
+        black calc(var(--fade-size) * var(--fade-top)),
+        black calc(100% - var(--fade-size) * var(--fade-bottom)),
+        transparent
+      );
     }
   }
 

--- a/input.css
+++ b/input.css
@@ -285,16 +285,24 @@
     scrollbar-color: transparent transparent;
   }
 
-  .bb-sidebar-nav:hover {
+  .bb-sidebar-nav:hover,
+  .bb-sidebar-nav:active {
     scrollbar-color: oklch(var(--bc) / 0.15) transparent;
   }
 
+  @media (max-width: 1023px) {
+    .bb-sidebar-nav {
+      scrollbar-color: oklch(var(--bc) / 0.08) transparent;
+    }
+  }
+
   .bb-sidebar-section {
-    @apply text-[0.65rem] font-medium text-base-content/40 px-3 pt-5 pb-1.5;
+    @apply text-[0.7rem] lg:text-[0.65rem] font-medium text-base-content/40 px-3 pt-5 pb-2 lg:pb-1.5;
   }
 
   .bb-sidebar-link {
-    @apply flex items-center gap-3 px-3 py-2.5 lg:py-1.5 rounded-lg text-sm font-medium
+    @apply flex items-center gap-3 px-3 py-2.5 lg:py-1.5 min-h-11 lg:min-h-0
+           rounded-lg text-sm font-medium
            text-base-content/60 no-underline
            hover:bg-base-200 hover:text-base-content;
     transition: background-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
@@ -309,7 +317,7 @@
   }
 
   .bb-sidebar-link i, .bb-sidebar-link svg {
-    @apply w-4 h-4 opacity-50;
+    @apply w-[1.125rem] h-[1.125rem] lg:w-4 lg:h-4 opacity-50;
     transition: opacity 0.15s ease;
   }
 

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -475,6 +475,20 @@
       });
     })();
 
+    // iOS 26-style scroll fade for mobile sidebar nav
+    (function() {
+      var nav = document.querySelector('.bb-sidebar-nav');
+      if (!nav) return;
+      function update() {
+        nav.style.setProperty('--fade-top', nav.scrollTop > 2 ? '1' : '0');
+        nav.style.setProperty('--fade-bottom',
+          nav.scrollHeight - nav.scrollTop - nav.clientHeight > 2 ? '1' : '0');
+      }
+      nav.addEventListener('scroll', update, {passive: true});
+      // Initial check after icons render
+      requestAnimationFrame(function() { requestAnimationFrame(update); });
+    })();
+
     // Global Confirmation Modal
     function bbConfirmModal() {
       return {


### PR DESCRIPTION
## Summary

- **Wider sidebar on mobile**: 85vw (capped at 320px) on phones, 288px on tablets, original 256px on desktop — fills the screen like native iOS apps
- **Larger touch targets**: 44px minimum height on nav links, increased padding on search bar and profile section (mobile only)
- **Design polishes**: 18px nav icons on mobile (up from 16px), larger section headers for readability
- **iOS 26-style scroll fades**: `mask-image` gradients fade content at top/bottom edges when more content is available, replacing the scrollbar on mobile. JS toggles fade direction based on scroll position.

All changes scoped to mobile via `lg:` breakpoints — desktop is unchanged.

## Test plan

- [ ] Open sidebar on iPhone/mobile viewport (~393px wide) — should fill ~85% of screen
- [ ] Tap nav links — touch targets should feel comfortable (44px+ height)
- [ ] Scroll the nav list on mobile — top/bottom edges should fade in/out as content overflows
- [ ] Verify desktop sidebar is unchanged (256px, compact links, thin scrollbar)

https://claude.ai/code/session_01859CiZ298jjbzjFmbieKw4