### PR TITLE
Polish reports header for mobile: move action into tab bar, reduce clutter

### DIFF
--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -2,23 +2,21 @@
 <div class="bb-page-header">
   <div>
     <h1 class="bb-page-title">Agent Reports</h1>
-    <p class="text-sm text-base-content/50 mt-0.5">Summaries and findings from AI agents</p>
-  </div>
-  <div class="flex items-center gap-2">
-    <button class="btn btn-ghost btn-sm rounded-xl text-xs cursor-pointer"
-      onclick="fetch('/-/reports/read-all', {method:'POST'}).then(function(){window.location.reload()})">
-      <i data-lucide="check-check" class="w-3.5 h-3.5"></i>
-      Mark all read
-    </button>
+    <p class="text-sm text-base-content/50 mt-0.5 hidden sm:block">Summaries and findings from AI agents</p>
   </div>
 </div>
 
-<!-- Filter Tabs -->
+<!-- Filter Tabs + Actions -->
 <div class="flex items-center gap-1 border-b border-base-200/80 mb-6">
-  <a href="/reports" class="px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus ""}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">All</a>
-  <a href="/reports?status=unread" class="px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus "unread"}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">Unread</a>
-  <a href="/reports?status=read" class="px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus "read"}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">Read</a>
-  <span class="ml-auto text-xs text-base-content/30 pr-2">{{.TotalCount}} report{{if ne .TotalCount 1}}s{{end}}</span>
+  <a href="/reports" class="px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus ""}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">All</a>
+  <a href="/reports?status=unread" class="px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus "unread"}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">Unread</a>
+  <a href="/reports?status=read" class="px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus "read"}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">Read</a>
+  <span class="ml-auto text-xs text-base-content/30 hidden sm:inline">{{.TotalCount}} report{{if ne .TotalCount 1}}s{{end}}</span>
+  <button class="ml-auto sm:ml-2 btn btn-ghost btn-sm rounded-xl text-xs cursor-pointer"
+    onclick="fetch('/-/reports/read-all', {method:'POST'}).then(function(){window.location.reload()})">
+    <i data-lucide="check-check" class="w-3.5 h-3.5"></i>
+    <span class="hidden sm:inline">Mark all read</span>
+  </button>
 </div>
 
 <!-- Reports List -->


### PR DESCRIPTION
- Move "Mark all read" button from header into the filter tabs row so
  it doesn't awkwardly stack below the title on mobile
- Hide button label on mobile, keep icon-only (check-check icon)
- Hide subtitle on mobile to reduce vertical space
- Reduce tab horizontal padding on mobile (px-3 vs px-4)
- Hide report count on mobile to avoid crowding the tab bar

https://claude.ai/code/session_01MyTCGFkc4kCPXsCYzbHhMD