### PR TITLE
Improve sidebar for landscape mobile: scroll entire sidebar

### DIFF
--- a/input.css
+++ b/input.css
@@ -1219,38 +1219,21 @@
     @apply opacity-50;
   }
 
-  /* ── Landscape mobile: compact sidebar to maximize scroll area ── */
+  /* ── Landscape mobile: scroll entire sidebar, keep full touch targets ── */
   @media (orientation: landscape) and (max-height: 500px) {
     .bb-sidebar {
-      @apply py-3;
-    }
-    .bb-sidebar-brand {
-      @apply mb-2;
+      @apply overflow-y-auto;
+      display: block;
     }
     .bb-sidebar-search {
       @apply hidden;
     }
-    .bb-sidebar-section {
-      @apply pt-3 pb-1;
-    }
-    .bb-sidebar-link {
-      @apply py-1.5;
-      min-height: 0;
-    }
-    .bb-sidebar-link i, .bb-sidebar-link svg {
-      @apply w-4 h-4;
+    .bb-sidebar-nav {
+      overflow-y: visible;
+      flex: none;
     }
     .bb-sidebar-footer {
-      @apply pt-2;
-    }
-    .bb-sidebar-profile {
-      @apply py-1.5 gap-2;
-    }
-    .bb-sidebar-profile-avatar {
-      @apply w-6 h-6 text-[0.6rem];
-    }
-    .bb-sidebar-profile-role {
-      @apply hidden;
+      margin-top: var(--bb-gap-sm, 0.5rem);
     }
     .bb-sidebar-version {
       @apply hidden;


### PR DESCRIPTION
On phones in landscape mode, Safari's chrome leaves very little viewport height. Instead of compacting links (making them too small to tap), this makes the entire sidebar scroll as one unit:

- Switch from flex column (pinned header/footer) to block layout so brand and profile scroll with the nav naturally
- Nav section loses its own scroll container (parent scrolls instead)
- Search bar hidden (redundant — mobile navbar has search button)
- Version badge hidden (low-priority info)
- All nav links keep full mobile touch targets (44px+)

Scoped to landscape phones only via
@media (orientation: landscape) and (max-height: 500px). Portrait mobile and desktop layouts are completely unaffected.

https://claude.ai/code/session_01859CiZ298jjbzjFmbieKw4