### PR TITLE
Fix mobile dialog UX: prevent scroll and Safari zoom on input

### DIFF
--- a/input.css
+++ b/input.css
@@ -1046,6 +1046,18 @@
     @apply w-full py-3.5 text-sm bg-transparent border-none outline-none placeholder:text-base-content/40;
   }
 
+  /* Mobile: pin to top, prevent Safari zoom on focus */
+  @media (max-width: 640px) {
+    .bb-cmdk-dialog {
+      top: 0;
+      border-radius: 0 0 0.75rem 0.75rem;
+    }
+
+    .bb-cmdk-input {
+      font-size: 16px; /* prevents Safari auto-zoom on input focus */
+    }
+  }
+
   .bb-cmdk-input:focus {
     outline: none;
     box-shadow: none;
@@ -1423,6 +1435,18 @@
   .bb-catpicker-input:focus {
     outline: none;
     box-shadow: none;
+  }
+
+  /* Mobile: pin to top, prevent Safari zoom on focus */
+  @media (max-width: 640px) {
+    .bb-catpicker-dialog {
+      top: 0;
+      border-radius: 0 0 0.75rem 0.75rem;
+    }
+
+    .bb-catpicker-input {
+      font-size: 16px;
+    }
   }
 
   .bb-catpicker-list {

--- a/input.css
+++ b/input.css
@@ -1049,8 +1049,9 @@
   /* Mobile: pin to top, prevent Safari zoom on focus */
   @media (max-width: 640px) {
     .bb-cmdk-dialog {
-      top: 0;
-      border-radius: 0 0 0.75rem 0.75rem;
+      top: calc(env(safe-area-inset-top, 0px) + 0.5rem);
+      border-radius: 0.75rem;
+      width: calc(100vw - 1rem);
     }
 
     .bb-cmdk-input {
@@ -1440,8 +1441,9 @@
   /* Mobile: pin to top, prevent Safari zoom on focus */
   @media (max-width: 640px) {
     .bb-catpicker-dialog {
-      top: 0;
-      border-radius: 0 0 0.75rem 0.75rem;
+      top: calc(env(safe-area-inset-top, 0px) + 0.5rem);
+      border-radius: 0.75rem;
+      width: calc(100vw - 1rem);
     }
 
     .bb-catpicker-input {

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -593,6 +593,7 @@
           this.search = '';
           this.activeIndex = 0;
           this.open = true;
+          document.body.style.overflow = 'hidden';
 
           var self = this;
           setTimeout(function() {
@@ -605,6 +606,7 @@
         closePicker() {
           this.open = false;
           this.search = '';
+          document.body.style.overflow = '';
         },
 
         moveDown() {
@@ -729,6 +731,7 @@
           this.activeIndex = 0;
           this._txResults = [];
           this._txLoading = false;
+          document.body.style.overflow = 'hidden';
           var self = this;
           setTimeout(function() {
             if (self.$refs.cmdkInput) {
@@ -743,6 +746,7 @@
           this.query = '';
           this._txResults = [];
           this._txLoading = false;
+          document.body.style.overflow = '';
           if (this._txTimer) clearTimeout(this._txTimer);
           if (this._txAbort) this._txAbort.abort();
         },


### PR DESCRIPTION
## Summary
Improves mobile user experience for command and category picker dialogs by preventing body scroll when dialogs are open and preventing Safari's automatic zoom on input focus.

## Key Changes
- **CSS Updates (input.css)**:
  - Added mobile-specific styles for `.bb-cmdk-dialog` and `.bb-cmdk-input` to pin dialogs to the top with safe area insets and set input font size to 16px (prevents Safari auto-zoom)
  - Added identical mobile-specific styles for `.bb-catpicker-dialog` and `.bb-catpicker-input`
  - Both apply only on screens ≤640px width

- **JavaScript Updates (base.html)**:
  - Modified `openPicker()` to set `document.body.style.overflow = 'hidden'` when opening the category picker
  - Modified `closePicker()` to reset `document.body.style.overflow = ''` when closing
  - Modified `openCmdk()` to set `document.body.style.overflow = 'hidden'` when opening the command dialog
  - Modified `closeCmdk()` to reset `document.body.style.overflow = ''` when closing

## Implementation Details
- Body scroll is prevented by toggling the overflow property when dialogs open/close, preventing unwanted background scrolling on mobile
- The 16px font size on inputs is a well-known workaround for Safari's automatic zoom behavior when focusing on inputs with font sizes smaller than 16px
- Safe area insets are used to respect notches and other device-specific safe areas on modern mobile devices

https://claude.ai/code/session_01Jum1vtm2eHV4K4B7U9jAY5