### PR TITLE
Fix mobile modal scroll-through and keyboard jump

### DIFF
--- a/input.css
+++ b/input.css
@@ -1044,6 +1044,8 @@
     background: oklch(0 0 0 / 0.4);
     backdrop-filter: blur(4px);
     animation: bb-cmdk-backdrop-in 0.15s ease-out;
+    touch-action: none;
+    -webkit-overflow-scrolling: auto;
   }
 
   @keyframes bb-cmdk-backdrop-in {
@@ -1114,6 +1116,7 @@
     @apply overflow-y-auto;
     max-height: min(55vh, 370px);
     scrollbar-width: thin;
+    overscroll-behavior: contain;
   }
 
   .bb-cmdk-group {
@@ -1414,6 +1417,8 @@
     background: oklch(0 0 0 / 0.4);
     backdrop-filter: blur(4px);
     animation: bb-catpicker-backdrop-in 0.15s ease-out;
+    touch-action: none;
+    -webkit-overflow-scrolling: auto;
   }
 
   @keyframes bb-catpicker-backdrop-in {
@@ -1484,6 +1489,7 @@
     @apply overflow-y-auto;
     max-height: min(55vh, 370px);
     scrollbar-width: thin;
+    overscroll-behavior: contain;
   }
 
   .bb-catpicker-item {

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -540,6 +540,32 @@
       });
     };
 
+    // Scroll lock: freeze body in place so modals don't cause scroll-through
+    // or viewport jumps when the iOS keyboard opens.
+    (function() {
+      var savedY = 0;
+      var lockCount = 0;
+      window.bbLockScroll = function() {
+        if (lockCount++ > 0) return; // nested lock
+        savedY = window.scrollY;
+        document.body.style.position = 'fixed';
+        document.body.style.top = '-' + savedY + 'px';
+        document.body.style.left = '0';
+        document.body.style.right = '0';
+        document.body.style.overflow = 'hidden';
+      };
+      window.bbUnlockScroll = function() {
+        if (--lockCount > 0) return; // still locked by another modal
+        lockCount = 0;
+        document.body.style.position = '';
+        document.body.style.top = '';
+        document.body.style.left = '';
+        document.body.style.right = '';
+        document.body.style.overflow = '';
+        window.scrollTo(0, savedY);
+      };
+    })();
+
     // Global Category Picker component
     function globalCategoryPicker() {
       return {
@@ -594,7 +620,7 @@
           this.search = '';
           this.activeIndex = 0;
           this.open = true;
-          document.body.style.overflow = 'hidden';
+          window.bbLockScroll();
 
           var self = this;
           setTimeout(function() {
@@ -607,7 +633,7 @@
         closePicker() {
           this.open = false;
           this.search = '';
-          document.body.style.overflow = '';
+          window.bbUnlockScroll();
         },
 
         moveDown() {
@@ -732,7 +758,7 @@
           this.activeIndex = 0;
           this._txResults = [];
           this._txLoading = false;
-          document.body.style.overflow = 'hidden';
+          window.bbLockScroll();
           var self = this;
           setTimeout(function() {
             if (self.$refs.cmdkInput) {
@@ -747,7 +773,7 @@
           this.query = '';
           this._txResults = [];
           this._txLoading = false;
-          document.body.style.overflow = '';
+          window.bbUnlockScroll();
           if (this._txTimer) clearTimeout(this._txTimer);
           if (this._txAbort) this._txAbort.abort();
         },


### PR DESCRIPTION
## Summary
- Replace `overflow: hidden` scroll lock with proper `position: fixed` body freeze that saves/restores scroll position — prevents background scrolling through the modal backdrop on iOS Safari
- Eliminate the modal "teleport" when tapping the search input mid-scroll: body is now truly frozen so the keyboard opening doesn't cause viewport shift
- Add `touch-action: none` on backdrops and `overscroll-behavior: contain` on scrollable lists to prevent scroll chaining
- Ref-counted `bbLockScroll`/`bbUnlockScroll` helpers so nested modals (e.g. category picker over command palette) work correctly

## Test plan
- [ ] On mobile Safari: scroll halfway down a page, open search modal, verify background doesn't scroll
- [ ] Tap the search input to open keyboard — modal should stay in place, no jump/teleport
- [ ] Close modal — page should restore to the same scroll position
- [ ] Open category picker from a transaction page, verify same scroll lock behavior
- [ ] On desktop: verify Cmd+K modal still works normally

https://claude.ai/code/session_01Jum1vtm2eHV4K4B7U9jAY5