### PR TITLE
Add agent report detail view with dedicated page

### DIFF
--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -83,6 +83,69 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 	}
 }
 
+// ReportDetailHandler handles GET /reports/{id}.
+func ReportDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		reportID := chi.URLParam(r, "id")
+		if reportID == "" {
+			tr.RenderNotFound(w, r)
+			return
+		}
+
+		report, err := svc.GetAgentReport(ctx, reportID)
+		if err != nil {
+			a.Logger.Error("get agent report", "id", reportID, "error", err)
+			tr.RenderNotFound(w, r)
+			return
+		}
+
+		t, _ := time.Parse(time.RFC3339, report.CreatedAt)
+		displayAuthor := report.CreatedByName
+		if report.Author != nil && *report.Author != "" {
+			displayAuthor = *report.Author
+		}
+
+		type ReportDetail struct {
+			ID            string
+			Title         string
+			Body          string
+			Priority      string
+			Tags          []string
+			DisplayAuthor string
+			CreatedAt     string
+			CreatedAtRel  string
+			IsRead        bool
+		}
+
+		detail := ReportDetail{
+			ID:            report.ID,
+			Title:         report.Title,
+			Body:          report.Body,
+			Priority:      report.Priority,
+			Tags:          report.Tags,
+			DisplayAuthor: displayAuthor,
+			CreatedAt:     t.Format("Jan 2, 2006 at 3:04 PM"),
+			CreatedAtRel:  relativeTime(t),
+			IsRead:        report.ReadAt != nil,
+		}
+
+		// Auto-mark as read when viewing.
+		if report.ReadAt == nil {
+			_ = svc.MarkAgentReportRead(ctx, reportID)
+			detail.IsRead = true
+		}
+
+		data := BaseTemplateData(r, sm, "reports", report.Title)
+		data["Report"] = detail
+		data["Breadcrumbs"] = []Breadcrumb{
+			{Label: "Reports", Href: "/reports"},
+			{Label: report.Title},
+		}
+		tr.Render(w, r, "report_detail.html", data)
+	}
+}
+
 // MarkReportReadAdminHandler handles POST /-/reports/{id}/read.
 func MarkReportReadAdminHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -106,6 +106,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/account-links/{id}", AccountLinkDetailHandler(a, svc, sm, tr))
 
 		r.Get("/reports", ReportsPageHandler(a, svc, sm, tr))
+		r.Get("/reports/{id}", ReportDetailHandler(a, svc, sm, tr))
 		r.Get("/reviews", ReviewsPageHandler(a, sm, tr, svc))
 		r.Get("/review-instructions", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/mcp-settings", http.StatusMovedPermanently)

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -131,6 +131,19 @@ func (s *Service) CountUnreadAgentReports(ctx context.Context) (int64, error) {
 	return s.Queries.CountUnreadAgentReports(ctx)
 }
 
+// GetAgentReport returns a single report by ID.
+func (s *Service) GetAgentReport(ctx context.Context, reportID string) (AgentReportResponse, error) {
+	uid, err := parseUUID(reportID)
+	if err != nil {
+		return AgentReportResponse{}, fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
+	}
+	row, err := s.Queries.GetAgentReport(ctx, uid)
+	if err != nil {
+		return AgentReportResponse{}, fmt.Errorf("get agent report: %w", err)
+	}
+	return agentReportFromRow(row), nil
+}
+
 // MarkAgentReportRead marks a single report as read.
 func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) error {
 	uid, err := parseUUID(reportID)

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -135,15 +135,11 @@
             {{end}}
             <button @click.stop="markRead('{{.ID}}')" class="text-[0.65rem] text-base-content/30 hover:text-success transition-colors cursor-pointer ml-auto shrink-0 mr-1">Mark read</button>
           </div>
-          <!-- Bubble body -->
-          <div class="rounded-2xl rounded-tl-sm bg-base-200/70 shadow-sm px-3.5 py-2.5 cursor-pointer hover:bg-base-200/90 transition-colors inline-block max-w-full"
-               @click="toggle('{{.ID}}')">
-            <p class="text-sm text-base-content/80 leading-relaxed">{{.Title}}</p>
-            <!-- Expanded body -->
-            <div x-show="expanded['{{.ID}}']" x-cloak class="mt-2 pt-2 border-t border-base-content/5">
-              <div class="bb-report-body text-sm text-base-content/60 leading-relaxed" data-markdown="{{.Body}}"></div>
-            </div>
-          </div>
+          <!-- Bubble body — links to detail page -->
+          <a href="/reports/{{.ID}}" class="rounded-2xl rounded-tl-sm bg-base-200/70 shadow-sm px-3.5 py-2.5 hover:bg-base-200/90 transition-colors inline-block max-w-full no-underline group">
+            <p class="text-sm text-base-content/80 leading-relaxed group-hover:text-base-content transition-colors">{{.Title}}</p>
+            <span class="text-xs text-base-content/30 group-hover:text-primary/60 transition-colors">View report &rarr;</span>
+          </a>
         </div>
       </div>
     </div>
@@ -486,47 +482,12 @@
   </div>
 </div>
 
-<!-- Agent Reports: markdown rendering + dismiss logic -->
+<!-- Agent Reports: dismiss logic -->
 {{if .AgentReports}}
-<script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-  document.querySelectorAll('.bb-report-body').forEach(function(el) {
-    var md = el.getAttribute('data-markdown');
-    if (md) {
-      el.innerHTML = DOMPurify.sanitize(marked.parse(md));
-      el.querySelectorAll('a').forEach(function(a) {
-        a.classList.add('link', 'link-primary');
-        if (a.href && !a.href.startsWith(window.location.origin) && !a.getAttribute('href').startsWith('/')) {
-          a.setAttribute('target', '_blank');
-          a.setAttribute('rel', 'noopener');
-        }
-      });
-      el.querySelectorAll('ul, ol').forEach(function(list) {
-        list.classList.add('list-disc', 'pl-4', 'space-y-0.5');
-      });
-      el.querySelectorAll('p').forEach(function(p) {
-        p.classList.add('mb-1');
-      });
-      el.querySelectorAll('strong').forEach(function(s) {
-        s.classList.add('text-base-content');
-      });
-    }
-  });
-});
-
 function agentReports() {
   return {
     dismissed: {},
-    expanded: {},
-    toggle(id) {
-      if (this.expanded[id]) {
-        delete this.expanded[id];
-      } else {
-        this.expanded[id] = true;
-      }
-    },
     markRead(id) {
       this.dismissed[id] = true;
       fetch('/-/reports/' + id + '/read', { method: 'POST' });

--- a/internal/templates/pages/report_detail.html
+++ b/internal/templates/pages/report_detail.html
@@ -1,0 +1,76 @@
+{{define "content"}}
+{{template "breadcrumb" .}}
+
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">{{.Report.Title}}</h1>
+    <div class="flex items-center flex-wrap gap-2 mt-1.5">
+      <span class="text-sm text-base-content/50">{{.Report.DisplayAuthor}}</span>
+      <span class="text-base-content/20">&middot;</span>
+      <span class="text-sm text-base-content/40" title="{{.Report.CreatedAt}}">{{.Report.CreatedAtRel}}</span>
+      {{if eq .Report.Priority "critical"}}
+      <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-error/10 text-error/80">critical</span>
+      {{else if eq .Report.Priority "warning"}}
+      <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-warning/10 text-warning">warning</span>
+      {{end}}
+      {{range .Report.Tags}}
+      <span class="text-xs px-2 py-0.5 rounded-full bg-base-200/80 text-base-content/50">{{.}}</span>
+      {{end}}
+    </div>
+  </div>
+</div>
+
+<div class="bb-card">
+  <div class="p-5 sm:p-6">
+    <div class="bb-report-body prose prose-sm max-w-none text-base-content/80 leading-relaxed" data-markdown="{{.Report.Body}}"></div>
+  </div>
+</div>
+
+<!-- Markdown rendering -->
+<script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  document.querySelectorAll('.bb-report-body').forEach(function(el) {
+    var md = el.getAttribute('data-markdown');
+    if (!md) return;
+    el.innerHTML = DOMPurify.sanitize(marked.parse(md));
+    el.querySelectorAll('a').forEach(function(a) {
+      a.classList.add('link', 'link-primary');
+      if (a.href && !a.href.startsWith(window.location.origin) && !a.getAttribute('href').startsWith('/')) {
+        a.setAttribute('target', '_blank');
+        a.setAttribute('rel', 'noopener');
+      }
+    });
+    el.querySelectorAll('ul').forEach(function(list) {
+      list.classList.add('list-disc', 'pl-5', 'space-y-1', 'my-2');
+    });
+    el.querySelectorAll('ol').forEach(function(list) {
+      list.classList.add('list-decimal', 'pl-5', 'space-y-1', 'my-2');
+    });
+    el.querySelectorAll('p').forEach(function(p) {
+      p.classList.add('mb-2');
+    });
+    el.querySelectorAll('strong').forEach(function(s) {
+      s.classList.add('text-base-content', 'font-semibold');
+    });
+    el.querySelectorAll('h1, h2, h3, h4').forEach(function(h) {
+      h.classList.add('text-base-content', 'font-semibold', 'mt-3', 'mb-1');
+    });
+    el.querySelectorAll('code').forEach(function(c) {
+      if (c.parentElement.tagName !== 'PRE') {
+        c.classList.add('bg-base-200/60', 'px-1.5', 'py-0.5', 'rounded', 'text-xs', 'font-mono');
+      }
+    });
+    el.querySelectorAll('pre').forEach(function(pre) {
+      pre.classList.add('bg-base-200/40', 'rounded-lg', 'p-3', 'my-2', 'overflow-x-auto', 'text-xs');
+    });
+    el.querySelectorAll('blockquote').forEach(function(bq) {
+      bq.classList.add('border-l-2', 'border-primary/30', 'pl-3', 'my-2', 'text-base-content/60', 'italic');
+    });
+    var lastChild = el.lastElementChild;
+    if (lastChild) lastChild.classList.add('!mb-0');
+  });
+});
+</script>
+{{end}}

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -21,53 +21,43 @@
 
 <!-- Reports List -->
 {{if .Reports}}
-<div class="space-y-4 bb-stagger" x-data="reportsPage()">
+<div class="space-y-3 bb-stagger" x-data="reportsPage()">
   {{range .Reports}}
-  <div class="bb-card transition-all duration-300 {{if not .IsRead}}border-l-2 border-l-primary/40{{end}}"
+  <a href="/reports/{{.ID}}" class="bb-card block no-underline transition-all duration-300 hover:shadow-md {{if not .IsRead}}border-l-2 border-l-primary/40{{end}}"
     :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !p-0 !m-0 !border-0' : ''"
     id="report-{{.ID}}">
-    <!-- Message -->
-    <div class="px-5 py-3.5 hover:bg-base-200/20 transition-colors cursor-pointer" @click="toggle('{{.ID}}')">
-      <div class="flex items-start gap-3">
-        <!-- Priority dot -->
-        <span class="w-2.5 h-2.5 rounded-full shrink-0 mt-1.5 {{if eq .Priority "critical"}}bg-error{{else if eq .Priority "warning"}}bg-warning{{else}}bg-base-content/20{{end}}"></span>
-        <!-- Message content -->
-        <div class="flex-1 min-w-0">
-          <div class="flex items-center flex-wrap gap-2 text-xs mb-1">
-            <span class="font-semibold text-base-content/70">{{.DisplayAuthor}}</span>
-            <span class="text-base-content/30">&middot;</span>
-            <span class="text-base-content/30">{{.CreatedAt}}</span>
-            {{if not .IsRead}}<span class="w-1.5 h-1.5 rounded-full bg-primary shrink-0"></span>{{end}}
-            {{if eq .Priority "critical"}}
-            <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full bg-error/10 text-error/80">critical</span>
-            {{else if eq .Priority "warning"}}
-            <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full bg-warning/10 text-warning">warning</span>
-            {{end}}
-            {{range .Tags}}
-            <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/40">{{.}}</span>
-            {{end}}
-          </div>
-          <p class="text-sm font-medium text-base-content/80 leading-relaxed">{{.Title}}</p>
-        </div>
-        <!-- Actions -->
-        <div class="flex items-center gap-1 shrink-0">
-          {{if not .IsRead}}
-          <button @click.stop="markRead('{{.ID}}')" class="btn btn-success btn-ghost btn-xs rounded-lg cursor-pointer" title="Mark as read">
-            <i data-lucide="check" class="w-4 h-4"></i>
-          </button>
+    <div class="px-5 py-3.5 flex items-start gap-3">
+      <!-- Priority dot -->
+      <span class="w-2.5 h-2.5 rounded-full shrink-0 mt-1.5 {{if eq .Priority "critical"}}bg-error{{else if eq .Priority "warning"}}bg-warning{{else}}bg-base-content/20{{end}}"></span>
+      <!-- Message content -->
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center flex-wrap gap-2 text-xs mb-1">
+          <span class="font-semibold text-base-content/70">{{.DisplayAuthor}}</span>
+          <span class="text-base-content/30">&middot;</span>
+          <span class="text-base-content/30">{{.CreatedAt}}</span>
+          {{if not .IsRead}}<span class="w-1.5 h-1.5 rounded-full bg-primary shrink-0"></span>{{end}}
+          {{if eq .Priority "critical"}}
+          <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full bg-error/10 text-error/80">critical</span>
+          {{else if eq .Priority "warning"}}
+          <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full bg-warning/10 text-warning">warning</span>
           {{end}}
-          <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/25 transition-transform duration-200"
-            :class="expanded['{{.ID}}'] ? 'rotate-180' : ''"></i>
+          {{range .Tags}}
+          <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/40">{{.}}</span>
+          {{end}}
         </div>
+        <p class="text-sm font-medium text-base-content/80 leading-relaxed">{{.Title}}</p>
       </div>
-      <!-- Expanded detail -->
-      <div x-show="expanded['{{.ID}}']" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100"
-        x-transition:leave="transition ease-in duration-150" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0"
-        x-cloak @click.stop class="mt-3 ml-5 pl-3 border-l-2 border-base-200/60">
-        <div class="bb-report-body text-sm text-base-content/80 leading-relaxed" data-markdown="{{.Body}}"></div>
+      <!-- Actions -->
+      <div class="flex items-center gap-1 shrink-0">
+        {{if not .IsRead}}
+        <button @click.prevent.stop="markRead('{{.ID}}')" class="btn btn-success btn-ghost btn-xs rounded-lg cursor-pointer" title="Mark as read">
+          <i data-lucide="check" class="w-4 h-4"></i>
+        </button>
+        {{end}}
+        <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/25"></i>
       </div>
     </div>
-  </div>
+  </a>
   {{end}}
 </div>
 {{else}}
@@ -78,67 +68,11 @@
 </div>
 {{end}}
 
-<!-- Markdown rendering + page logic -->
 {{if .Reports}}
-<script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-  document.querySelectorAll('.bb-report-body').forEach(function(el) {
-    var md = el.getAttribute('data-markdown');
-    if (md) {
-      el.innerHTML = DOMPurify.sanitize(marked.parse(md));
-      el.querySelectorAll('a').forEach(function(a) {
-        a.classList.add('link', 'link-primary');
-        if (a.href && !a.href.startsWith(window.location.origin) && !a.getAttribute('href').startsWith('/')) {
-          a.setAttribute('target', '_blank');
-          a.setAttribute('rel', 'noopener');
-        }
-      });
-      el.querySelectorAll('ul').forEach(function(list) {
-        list.classList.add('list-disc', 'pl-5', 'space-y-1', 'my-2');
-      });
-      el.querySelectorAll('ol').forEach(function(list) {
-        list.classList.add('list-decimal', 'pl-5', 'space-y-1', 'my-2');
-      });
-      el.querySelectorAll('p').forEach(function(p) {
-        p.classList.add('mb-2');
-      });
-      el.querySelectorAll('strong').forEach(function(s) {
-        s.classList.add('text-base-content', 'font-semibold');
-      });
-      el.querySelectorAll('h1, h2, h3, h4').forEach(function(h) {
-        h.classList.add('text-base-content', 'font-semibold', 'mt-3', 'mb-1');
-      });
-      el.querySelectorAll('code').forEach(function(c) {
-        if (c.parentElement.tagName !== 'PRE') {
-          c.classList.add('bg-base-200/60', 'px-1.5', 'py-0.5', 'rounded', 'text-xs', 'font-mono');
-        }
-      });
-      el.querySelectorAll('pre').forEach(function(pre) {
-        pre.classList.add('bg-base-200/40', 'rounded-lg', 'p-3', 'my-2', 'overflow-x-auto', 'text-xs');
-      });
-      el.querySelectorAll('blockquote').forEach(function(bq) {
-        bq.classList.add('border-l-2', 'border-primary/30', 'pl-3', 'my-2', 'text-base-content/60', 'italic');
-      });
-      // Remove bottom margin from last child to avoid extra space
-      var lastChild = el.lastElementChild;
-      if (lastChild) lastChild.classList.add('!mb-0');
-    }
-  });
-});
-
 function reportsPage() {
   return {
     dismissed: {},
-    expanded: {},
-    toggle(id) {
-      if (this.expanded[id]) {
-        delete this.expanded[id];
-      } else {
-        this.expanded[id] = true;
-      }
-    },
     markRead(id) {
       this.dismissed[id] = true;
       fetch('/-/reports/' + id + '/read', { method: 'POST' });


### PR DESCRIPTION
Replace inline expand/collapse for reports on dashboard and reports list
with links to a new /reports/{id} detail page. The detail page renders
the full markdown body using marked.js + DOMPurify, auto-marks reports
as read on view, and includes breadcrumb navigation.

https://claude.ai/code/session_01PRjSy84y6WHugpcCj19Boy