### PR TITLE
Register report_detail.html in template renderer

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -716,6 +716,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/account_links.html",
 		"pages/account_link_detail.html",
 		"pages/reports.html",
+		"pages/report_detail.html",
 		"pages/webhook_events.html",
 		"pages/oauth_clients.html",
 		"pages/oauth_client_new.html",


### PR DESCRIPTION
The template was created but not added to the basePages list in templates.go, causing a "template not found" error at runtime.

https://claude.ai/code/session_01PRjSy84y6WHugpcCj19Boy