### PR TITLE
Improve connection error messaging and add re-authentication flow

### DIFF
--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -98,12 +98,6 @@
               <span>Never synced</span>
               {{end}}
             </div>
-            {{if and (eq .LastSyncStatus "error") .LastSyncErrorMessage.Valid (ne (printf "%s" .Status) "disconnected")}}
-            <div class="flex items-center gap-1.5 mt-1 text-[0.7rem] text-error/70 leading-snug max-w-xs sm:max-w-md truncate">
-              <i data-lucide="alert-circle" class="w-3 h-3 shrink-0"></i>
-              <span class="truncate">{{.LastSyncErrorMessage.String}}</span>
-            </div>
-            {{end}}
           </div>
         </div>
         <div class="flex items-center gap-2 sm:gap-3 shrink-0">
@@ -137,9 +131,16 @@
 
     <!-- Connection-level error message (e.g. reauth needed) -->
     {{if .ErrorMessage.Valid}}
-    <div class="mx-6 mb-4 flex items-start gap-2 text-xs text-warning bg-warning/10 rounded-lg px-3 py-2">
-      <i data-lucide="alert-triangle" class="w-3.5 h-3.5 shrink-0 mt-0.5"></i>
-      <span>{{errorMessage .ErrorCode.String}}</span>
+    <div class="mx-4 sm:mx-6 mb-4 flex items-center justify-between gap-2 text-xs text-warning bg-warning/10 rounded-lg px-3 py-2">
+      <div class="flex items-center gap-2 min-w-0">
+        <i data-lucide="alert-triangle" class="w-3.5 h-3.5 shrink-0"></i>
+        <span class="truncate">{{errorMessage .ErrorCode.String}}</span>
+      </div>
+      {{if and (ne (printf "%s" .Provider) "csv") (or (eq .ErrorCode.String "ITEM_LOGIN_REQUIRED") (eq .ErrorCode.String "INSUFFICIENT_CREDENTIALS") (eq .ErrorCode.String "INVALID_CREDENTIALS") (eq (printf "%s" .Status) "pending_reauth"))}}
+      <a href="/connections/{{formatUUID .ID}}/reauth" class="btn btn-warning btn-xs rounded-lg shrink-0" @click.stop>Re-authenticate</a>
+      {{else}}
+      <a href="/connections/{{formatUUID .ID}}" class="btn btn-ghost btn-xs rounded-lg shrink-0" @click.stop>View Details</a>
+      {{end}}
     </div>
     {{end}}
 


### PR DESCRIPTION
## Summary
Enhanced the connections page error handling by removing redundant sync error messages and improving the connection-level error display with actionable re-authentication options.

## Key Changes
- **Removed duplicate sync error display**: Deleted the inline last sync error message that appeared below the sync status, reducing visual clutter
- **Redesigned error message layout**: Converted the connection-level error message from a simple alert to a flexible container with icon, message, and action button
- **Added re-authentication flow**: Implemented conditional logic to display a "Re-authenticate" button for authentication-related errors (login required, insufficient/invalid credentials, pending reauth) for non-CSV providers
- **Improved UX for other errors**: Added a "View Details" button for non-authentication errors to guide users to more information
- **Enhanced responsive design**: Updated margins and added proper text truncation to handle long error messages on smaller screens
- **Better visual hierarchy**: Restructured the error container to use flexbox with proper spacing and alignment between message and action button

## Implementation Details
- The re-authentication button appears only for specific error codes (`ITEM_LOGIN_REQUIRED`, `INSUFFICIENT_CREDENTIALS`, `INVALID_CREDENTIALS`) or when status is `pending_reauth`, excluding CSV providers
- Error messages now properly truncate on smaller viewports with `truncate` class
- Action buttons use `@click.stop` to prevent event propagation and maintain proper interaction handling

https://claude.ai/code/session_01FLdTBVK1BfnZCwuVDFqf82