### PR TITLE
Simplify app navigation from 17 to 12 sidebar items

### DIFF
--- a/internal/admin/account_links.go
+++ b/internal/admin/account_links.go
@@ -84,7 +84,7 @@ func AccountLinkDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionM
 
 		link, err := svc.GetAccountLink(r.Context(), id)
 		if err != nil {
-			http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+			http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
 			return
 		}
 
@@ -93,7 +93,7 @@ func AccountLinkDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionM
 			a.Logger.Error("list matches", "error", err)
 		}
 
-		data := BaseTemplateData(r, sm, "account-links", "Transaction Matches")
+		data := BaseTemplateData(r, sm, "connections", "Transaction Matches")
 		data["Link"] = link
 		data["Matches"] = matches
 
@@ -109,7 +109,7 @@ func CreateAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManager)
 
 		if primaryID == "" || dependentID == "" {
 			SetFlash(r.Context(), sm, "error", "Both accounts must be selected.")
-			http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+			http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
 			return
 		}
 
@@ -119,7 +119,7 @@ func CreateAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManager)
 		})
 		if err != nil {
 			SetFlash(r.Context(), sm, "error", "Failed to create link: "+err.Error())
-			http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+			http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
 			return
 		}
 
@@ -131,7 +131,7 @@ func CreateAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManager)
 			SetFlash(r.Context(), sm, "success", formatReconciliationFlash(result))
 		}
 
-		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+		http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
 	}
 }
 
@@ -144,7 +144,7 @@ func DeleteAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManager)
 		} else {
 			SetFlash(r.Context(), sm, "success", "Account link deleted. Attribution cleared.")
 		}
-		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+		http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
 	}
 }
 
@@ -165,7 +165,7 @@ func ReconcileAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManag
 			http.Redirect(w, r, referer, http.StatusSeeOther)
 			return
 		}
-		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+		http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
 	}
 }
 
@@ -181,7 +181,7 @@ func ConfirmMatchAdminHandler(svc *service.Service, sm *scs.SessionManager) http
 			http.Redirect(w, r, referer, http.StatusSeeOther)
 			return
 		}
-		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+		http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
 	}
 }
 
@@ -199,7 +199,7 @@ func RejectMatchAdminHandler(svc *service.Service, sm *scs.SessionManager) http.
 			http.Redirect(w, r, referer, http.StatusSeeOther)
 			return
 		}
-		http.Redirect(w, r, "/account-links", http.StatusSeeOther)
+		http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
 	}
 }
 

--- a/internal/admin/agents_page.go
+++ b/internal/admin/agents_page.go
@@ -1,0 +1,220 @@
+package admin
+
+import (
+	"net/http"
+
+	breadboxmcp "breadbox/internal/mcp"
+	"breadbox/internal/service"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+// AgentsPageHandler serves GET /admin/agents — combined Getting Started + Agent Wizard + MCP Settings.
+func AgentsPageHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		tab := r.URL.Query().Get("tab")
+		if tab != "wizard" && tab != "settings" {
+			tab = "guide"
+		}
+
+		data := BaseTemplateData(r, sm, "agents", "Agents")
+		data["Tab"] = tab
+
+		// === Getting Started data ===
+		scheme := "http"
+		if r.TLS != nil {
+			scheme = "https"
+		}
+		if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+			scheme = proto
+		}
+		host := r.Host
+		if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
+			host = fwdHost
+		}
+		data["MCPServerURL"] = scheme + "://" + host + "/mcp"
+
+		var hasAPIKeys, hasOAuthClients bool
+		if keys, err := svc.ListAPIKeys(ctx); err == nil {
+			for _, k := range keys {
+				if k.RevokedAt == nil {
+					hasAPIKeys = true
+					break
+				}
+			}
+		}
+		if clients, err := svc.ListOAuthClients(ctx); err == nil {
+			for _, c := range clients {
+				if c.RevokedAt == nil {
+					hasOAuthClients = true
+					break
+				}
+			}
+		}
+		data["HasAPIKeys"] = hasAPIKeys
+		data["HasOAuthClients"] = hasOAuthClients
+
+		var pendingReviews, uncategorizedCount, ruleCount int64
+		if counts, err := svc.GetReviewCounts(ctx); err == nil {
+			pendingReviews = counts.Pending
+		}
+		if cnt, err := svc.CountUncategorizedTransactions(ctx); err == nil {
+			uncategorizedCount = cnt
+		}
+
+		enabled := true
+		if result, err := svc.ListTransactionRules(ctx, service.TransactionRuleListParams{Enabled: &enabled, Limit: 1}); err == nil {
+			ruleCount = int64(result.Total)
+		}
+		data["PendingReviews"] = pendingReviews
+		data["UncategorizedCount"] = uncategorizedCount
+		data["RuleCount"] = ruleCount
+
+		// === Agent Wizard data ===
+		var totalAccounts int64
+		if accounts, err := svc.ListAccounts(ctx, nil); err == nil {
+			totalAccounts = int64(len(accounts))
+		}
+		data["Stats"] = AgentWizardStats{
+			PendingReviews: pendingReviews,
+			TotalRules:     ruleCount,
+			TotalAccounts:  totalAccounts,
+		}
+
+		// === MCP Settings data ===
+		cfg, err := svc.GetMCPConfig(ctx)
+		if err != nil {
+			http.Error(w, "Failed to load MCP config", http.StatusInternalServerError)
+			return
+		}
+
+		type toolInfo struct {
+			Name           string
+			Description    string
+			Classification string
+			Enabled        bool
+			Group          string
+		}
+		disabledSet := make(map[string]bool)
+		for _, t := range cfg.DisabledTools {
+			disabledSet[t] = true
+		}
+
+		toolGroups := map[string]string{
+			"list_accounts":                 "Accounts & Data",
+			"list_users":                    "Accounts & Data",
+			"get_sync_status":               "Accounts & Data",
+			"trigger_sync":                  "Accounts & Data",
+			"query_transactions":            "Transactions",
+			"count_transactions":            "Transactions",
+			"transaction_summary":           "Transactions",
+			"merchant_summary":              "Transactions",
+			"list_categories":               "Categories",
+			"export_categories":             "Categories",
+			"import_categories":             "Categories",
+			"categorize_transaction":        "Categorization",
+			"reset_transaction_category":    "Categorization",
+			"batch_categorize_transactions": "Categorization",
+			"bulk_recategorize":             "Categorization",
+			"pending_reviews_overview":      "Reviews",
+			"list_pending_reviews":          "Reviews",
+			"submit_review":                 "Reviews",
+			"batch_submit_reviews":          "Reviews",
+			"list_transaction_rules":        "Rules",
+			"create_transaction_rule":       "Rules",
+			"update_transaction_rule":       "Rules",
+			"delete_transaction_rule":       "Rules",
+			"batch_create_rules":            "Rules",
+			"apply_rules":                   "Rules",
+			"preview_rule":                  "Rules",
+			"list_account_links":            "Account Links",
+			"create_account_link":           "Account Links",
+			"delete_account_link":           "Account Links",
+			"reconcile_account_link":        "Account Links",
+			"list_transaction_matches":      "Account Links",
+			"confirm_match":                 "Account Links",
+			"reject_match":                  "Account Links",
+			"add_transaction_comment":       "Comments & Reports",
+			"list_transaction_comments":     "Comments & Reports",
+			"submit_report":                 "Comments & Reports",
+		}
+		groupOrder := []string{
+			"Accounts & Data", "Transactions", "Categories", "Categorization",
+			"Reviews", "Rules", "Account Links", "Comments & Reports",
+		}
+
+		toolsByGroup := make(map[string][]toolInfo)
+		for _, td := range mcpServer.AllToolDefs() {
+			isEnabled := !disabledSet[td.Tool.Name]
+			group := toolGroups[td.Tool.Name]
+			if group == "" {
+				group = "Other"
+			}
+			toolsByGroup[group] = append(toolsByGroup[group], toolInfo{
+				Name:           td.Tool.Name,
+				Description:    td.Tool.Description,
+				Classification: string(td.Classification),
+				Enabled:        isEnabled,
+				Group:          group,
+			})
+		}
+		var tools []toolInfo
+		for _, g := range groupOrder {
+			tools = append(tools, toolsByGroup[g]...)
+		}
+		if others := toolsByGroup["Other"]; len(others) > 0 {
+			tools = append(tools, others...)
+		}
+
+		instructions := cfg.Instructions
+		if instructions == "" {
+			instructions = breadboxmcp.DefaultInstructions
+		}
+
+		enabledCount := 0
+		for _, t := range tools {
+			if t.Enabled {
+				enabledCount++
+			}
+		}
+
+		type toolGroup struct {
+			Name  string
+			Tools []toolInfo
+		}
+		var toolGroupList []toolGroup
+		for _, g := range groupOrder {
+			if ts := toolsByGroup[g]; len(ts) > 0 {
+				toolGroupList = append(toolGroupList, toolGroup{Name: g, Tools: ts})
+			}
+		}
+		if others := toolsByGroup["Other"]; len(others) > 0 {
+			toolGroupList = append(toolGroupList, toolGroup{Name: "Other", Tools: others})
+		}
+
+		reviewGuidelines := cfg.ReviewGuidelines
+		if reviewGuidelines == "" {
+			reviewGuidelines = breadboxmcp.DefaultReviewGuidelines
+		}
+		reportFormat := cfg.ReportFormat
+		if reportFormat == "" {
+			reportFormat = breadboxmcp.DefaultReportFormat
+		}
+
+		data["MCPConfig"] = cfg
+		data["Tools"] = tools
+		data["ToolGroups"] = toolGroupList
+		data["ToolsEnabledCount"] = enabledCount
+		data["ToolsDisabledCount"] = len(tools) - enabledCount
+		data["ToolsTotalCount"] = len(tools)
+		data["Instructions"] = instructions
+		data["DefaultInstructions"] = breadboxmcp.DefaultInstructions
+		data["ReviewGuidelines"] = reviewGuidelines
+		data["DefaultReviewGuidelines"] = breadboxmcp.DefaultReviewGuidelines
+		data["ReportFormat"] = reportFormat
+		data["DefaultReportFormat"] = breadboxmcp.DefaultReportFormat
+
+		tr.Render(w, r, "agents.html", data)
+	}
+}

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -12,6 +12,7 @@ import (
 	"breadbox/internal/app"
 	"breadbox/internal/db"
 	"breadbox/internal/provider"
+	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -52,7 +53,7 @@ type ConnectionWithAccounts struct {
 }
 
 // ConnectionsListHandler serves GET /admin/connections.
-func ConnectionsListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
+func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -152,15 +153,60 @@ func ConnectionsListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			}
 		}
 
+		tab := r.URL.Query().Get("tab")
+		if tab != "links" {
+			tab = "connections"
+		}
+
+		// Fetch account links for the "Account Links" tab.
+		links, err := svc.ListAccountLinks(ctx)
+		if err != nil {
+			a.Logger.Error("list account links", "error", err)
+		}
+		allAccounts, _ := svc.ListAccounts(ctx, nil)
+		var linkAccounts []AccountForLink
+		for _, acct := range allAccounts {
+			displayName := acct.Name
+			userName := ""
+			if acct.ConnectionID != nil {
+				detail, err := svc.GetAccountDetail(ctx, acct.ID)
+				if err == nil {
+					if detail.DisplayName != nil && *detail.DisplayName != "" {
+						displayName = *detail.DisplayName
+					}
+					userName = detail.UserName
+				}
+			}
+			mask := ""
+			if acct.Mask != nil {
+				mask = *acct.Mask
+			}
+			instName := ""
+			if acct.InstitutionName != nil {
+				instName = *acct.InstitutionName
+			}
+			linkAccounts = append(linkAccounts, AccountForLink{
+				ID:              acct.ID,
+				DisplayName:     displayName,
+				Mask:            mask,
+				UserName:        userName,
+				InstitutionName: instName,
+			})
+		}
+
 		data := map[string]any{
 			"PageTitle":        "Connections",
 			"CurrentPage":      "connections",
 			"Connections":      enriched,
 			"CSRFToken":        GetCSRFToken(r),
+			"Flash":            GetFlash(ctx, sm),
 			"TotalAssets":      totalAssets,
 			"TotalLiabilities": totalLiabilities,
 			"NetWorth":         netWorth,
 			"HasAnyBalance":    hasAnyBalance,
+			"Tab":              tab,
+			"Links":            links,
+			"LinkAccounts":     linkAccounts,
 		}
 		tr.Render(w, r, "connections.html", data)
 	}

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -1017,8 +1017,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		hasMoreReports := totalUnread > len(agentReports)
 
 		data := map[string]any{
-			"PageTitle":              "Dashboard",
-			"CurrentPage":            "dashboard",
+			"PageTitle":              "Home",
+			"CurrentPage":            "home",
 			"AccountCount":           accountCount,
 			"TxCount":                txCount,
 			"LastSync":               lastSyncText,

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -1,0 +1,180 @@
+package admin
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/service"
+
+	"github.com/alexedwards/scs/v2"
+)
+
+// LogsPageHandler serves GET /admin/logs — combined sync logs + webhook events.
+func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		tab := r.URL.Query().Get("tab")
+		if tab != "webhooks" {
+			tab = "syncs"
+		}
+
+		data := map[string]any{
+			"PageTitle":   "Logs",
+			"CurrentPage": "logs",
+			"CSRFToken":   GetCSRFToken(r),
+			"Flash":       GetFlash(ctx, sm),
+			"Tab":         tab,
+		}
+
+		// Always fetch sync logs data.
+		{
+			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+			if page < 1 {
+				page = 1
+			}
+
+			params := service.SyncLogListParams{
+				Page:     page,
+				PageSize: 25,
+			}
+
+			if connID := r.URL.Query().Get("connection_id"); connID != "" {
+				params.ConnectionID = &connID
+			}
+			if status := r.URL.Query().Get("status"); status != "" {
+				params.Status = &status
+			}
+			if trigger := r.URL.Query().Get("trigger"); trigger != "" {
+				params.Trigger = &trigger
+			}
+			if v := r.URL.Query().Get("date_from"); v != "" {
+				if t, err := time.Parse("2006-01-02", v); err == nil {
+					params.DateFrom = &t
+				}
+			}
+			if v := r.URL.Query().Get("date_to"); v != "" {
+				if t, err := time.Parse("2006-01-02", v); err == nil {
+					t = t.AddDate(0, 0, 1)
+					params.DateTo = &t
+				}
+			}
+
+			result, err := svc.ListSyncLogsPaginated(ctx, params)
+			if err != nil {
+				a.Logger.Error("list sync logs", "error", err)
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
+
+			connections, err := a.Queries.ListBankConnections(ctx)
+			if err != nil {
+				a.Logger.Error("list bank connections for sync log filters", "error", err)
+			}
+
+			filterConnID := stringOrEmpty(params.ConnectionID)
+			filterStatus := stringOrEmpty(params.Status)
+			filterTrigger := stringOrEmpty(params.Trigger)
+			filterDateFrom := r.URL.Query().Get("date_from")
+			filterDateTo := r.URL.Query().Get("date_to")
+
+			baseParams := service.SyncLogListParams{
+				ConnectionID: params.ConnectionID,
+				Trigger:      params.Trigger,
+				DateFrom:     params.DateFrom,
+				DateTo:       params.DateTo,
+			}
+
+			stats, err := svc.SyncLogStats(ctx, baseParams)
+			if err != nil {
+				a.Logger.Error("sync log stats", "error", err)
+				stats = &service.SyncLogStats{}
+			}
+
+			successStatus := "success"
+			errorStatus := "error"
+			inProgressStatus := "in_progress"
+			successParams := baseParams
+			successParams.Status = &successStatus
+			errorParams := baseParams
+			errorParams.Status = &errorStatus
+			inProgressParams := baseParams
+			inProgressParams.Status = &inProgressStatus
+
+			successCount, _ := svc.CountSyncLogsFiltered(ctx, successParams)
+			errorCount, _ := svc.CountSyncLogsFiltered(ctx, errorParams)
+			inProgressCount, _ := svc.CountSyncLogsFiltered(ctx, inProgressParams)
+
+			hasAdvancedFilters := filterConnID != "" || filterTrigger != "" || filterDateFrom != "" || filterDateTo != ""
+
+			data["Logs"] = result.Logs
+			data["Connections"] = connections
+			data["FilterConnID"] = filterConnID
+			data["FilterStatus"] = filterStatus
+			data["FilterTrigger"] = filterTrigger
+			data["FilterDateFrom"] = filterDateFrom
+			data["FilterDateTo"] = filterDateTo
+			data["HasAdvancedFilters"] = hasAdvancedFilters
+			data["Page"] = result.Page
+			data["TotalPages"] = result.TotalPages
+			data["Total"] = result.Total
+			data["Stats"] = stats
+			data["SuccessCount"] = successCount
+			data["ErrorCount"] = errorCount
+			data["InProgressCount"] = inProgressCount
+			data["WarningCount"] = stats.WarningCount
+		}
+
+		// Always fetch webhook events data.
+		{
+			page, _ := strconv.Atoi(r.URL.Query().Get("wh_page"))
+			if page < 1 {
+				page = 1
+			}
+
+			params := service.WebhookEventListParams{
+				Page:     page,
+				PageSize: 25,
+			}
+
+			if prov := r.URL.Query().Get("wh_provider"); prov != "" {
+				params.Provider = &prov
+			}
+			if status := r.URL.Query().Get("wh_status"); status != "" {
+				params.Status = &status
+			}
+
+			result, err := svc.ListWebhookEventsPaginated(ctx, params)
+			if err != nil {
+				a.Logger.Error("list webhook events", "error", err)
+				result = &service.WebhookEventListResult{}
+			}
+
+			whStats, err := svc.WebhookEventCounts(ctx)
+			if err != nil {
+				a.Logger.Error("webhook event counts", "error", err)
+				whStats = &service.WebhookEventStats{}
+			}
+
+			whFilterProvider := ""
+			if params.Provider != nil {
+				whFilterProvider = *params.Provider
+			}
+			whFilterStatus := ""
+			if params.Status != nil {
+				whFilterStatus = *params.Status
+			}
+
+			data["WHEvents"] = result.Events
+			data["WHPage"] = result.Page
+			data["WHTotalPages"] = result.TotalPages
+			data["WHTotal"] = result.Total
+			data["WHStats"] = whStats
+			data["WHFilterProvider"] = whFilterProvider
+			data["WHFilterStatus"] = whFilterStatus
+		}
+
+		tr.Render(w, r, "logs.html", data)
+	}
+}

--- a/internal/admin/mcp.go
+++ b/internal/admin/mcp.go
@@ -164,11 +164,11 @@ func MCPSaveModeHandler(svc *service.Service, sm *scs.SessionManager) http.Handl
 		mode := r.FormValue("mode")
 		if err := svc.SaveMCPMode(r.Context(), mode); err != nil {
 			SetFlash(r.Context(), sm, "error", "Invalid mode: must be read_only or read_write")
-			http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "MCP mode updated.")
-		http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
+		http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
 	}
 }
 
@@ -177,7 +177,7 @@ func MCPSaveToolsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer,
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			SetFlash(r.Context(), sm, "error", "Invalid form data")
-			http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
 			return
 		}
 
@@ -196,11 +196,11 @@ func MCPSaveToolsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer,
 
 		if err := svc.SaveMCPDisabledTools(r.Context(), disabled); err != nil {
 			SetFlash(r.Context(), sm, "error", "Failed to save tool settings")
-			http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Tool settings updated.")
-		http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
+		http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
 	}
 }
 
@@ -211,11 +211,11 @@ func MCPSaveInstructionsHandler(svc *service.Service, sm *scs.SessionManager) ht
 
 		if err := svc.SaveMCPInstructions(r.Context(), instructions); err != nil {
 			SetFlash(r.Context(), sm, "error", err.Error())
-			http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
+			http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Instructions saved.")
-		http.Redirect(w, r, "/mcp-settings", http.StatusSeeOther)
+		http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
 	}
 }
 
@@ -225,11 +225,11 @@ func MCPSaveReviewGuidelinesHandler(svc *service.Service, sm *scs.SessionManager
 		guidelines := strings.TrimSpace(r.FormValue("review_guidelines"))
 		if err := svc.SaveMCPReviewGuidelines(r.Context(), guidelines); err != nil {
 			SetFlash(r.Context(), sm, "error", err.Error())
-			http.Redirect(w, r, "/mcp-settings#review-guidelines", http.StatusSeeOther)
+			http.Redirect(w, r, "/agents?tab=settings#review-guidelines", http.StatusSeeOther)
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Review guidelines saved.")
-		http.Redirect(w, r, "/mcp-settings#review-guidelines", http.StatusSeeOther)
+		http.Redirect(w, r, "/agents?tab=settings#review-guidelines", http.StatusSeeOther)
 	}
 }
 
@@ -239,10 +239,10 @@ func MCPSaveReportFormatHandler(svc *service.Service, sm *scs.SessionManager) ht
 		format := strings.TrimSpace(r.FormValue("report_format"))
 		if err := svc.SaveMCPReportFormat(r.Context(), format); err != nil {
 			SetFlash(r.Context(), sm, "error", err.Error())
-			http.Redirect(w, r, "/mcp-settings#report-format", http.StatusSeeOther)
+			http.Redirect(w, r, "/agents?tab=settings#report-format", http.StatusSeeOther)
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Report format saved.")
-		http.Redirect(w, r, "/mcp-settings#report-format", http.StatusSeeOther)
+		http.Redirect(w, r, "/agents?tab=settings#report-format", http.StatusSeeOther)
 	}
 }

--- a/internal/admin/prompt_builder.go
+++ b/internal/admin/prompt_builder.go
@@ -62,7 +62,7 @@ func PromptBuilderHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.Han
 
 		blocksJSON, _ := json.Marshal(blocks)
 
-		data := BaseTemplateData(r, sm, "agent-wizard", cfg.Label+" — Agent Wizard")
+		data := BaseTemplateData(r, sm, "agents", cfg.Label+" — Prompt Library")
 		data["AgentType"] = agentType
 		data["AgentLabel"] = cfg.Label
 		data["AgentDescription"] = cfg.Description

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -58,7 +58,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/onboarding/dismiss", DismissOnboardingHandler(a))
 
 		r.Route("/connections", func(r chi.Router) {
-			r.Get("/", ConnectionsListHandler(a, tr))
+			r.Get("/", ConnectionsListHandler(a, svc, sm, tr))
 			r.Get("/new", NewConnectionHandler(a, tr))
 			r.Get("/import-csv", CSVImportPageHandler(a, tr))
 			r.Get("/{id}", ConnectionDetailHandler(a, tr))
@@ -98,21 +98,33 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/transactions/search", TransactionSearchHandler(a, sm, tr, svc))
 		r.Get("/transactions/{id}", TransactionDetailHandler(a, sm, tr, svc))
 		r.Get("/accounts/{id}", AccountDetailHandler(a, sm, tr, svc))
-		r.Get("/sync-logs", SyncLogsHandler(a, sm, tr, svc))
+		r.Get("/logs", LogsPageHandler(a, svc, sm, tr))
+		r.Get("/sync-logs", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/logs?tab=syncs", http.StatusMovedPermanently)
+		})
 		r.Get("/sync-logs/{id}", SyncLogDetailHandler(a, sm, tr, svc))
-		r.Get("/webhook-events", WebhookEventsHandler(a, sm, tr, svc))
+		r.Get("/webhook-events", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/logs?tab=webhooks", http.StatusMovedPermanently)
+		})
 
-		r.Get("/account-links", AccountLinksPageHandler(a, svc, sm, tr))
+		r.Get("/account-links", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/connections?tab=links", http.StatusMovedPermanently)
+		})
 		r.Get("/account-links/{id}", AccountLinkDetailHandler(a, svc, sm, tr))
 
 		r.Get("/reports", ReportsPageHandler(a, svc, sm, tr))
 		r.Get("/reports/{id}", ReportDetailHandler(a, svc, sm, tr))
 		r.Get("/reviews", ReviewsPageHandler(a, sm, tr, svc))
+		r.Get("/agents", AgentsPageHandler(svc, mcpServer, sm, tr))
 		r.Get("/review-instructions", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/mcp-settings", http.StatusMovedPermanently)
+			http.Redirect(w, r, "/agents?tab=settings", http.StatusMovedPermanently)
 		})
-		r.Get("/mcp-getting-started", MCPGuideHandler(svc, sm, tr))
-		r.Get("/agent-wizard", AgentWizardHandler(svc, sm, tr))
+		r.Get("/mcp-getting-started", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/agents?tab=guide", http.StatusMovedPermanently)
+		})
+		r.Get("/agent-wizard", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/agents?tab=wizard", http.StatusMovedPermanently)
+		})
 		r.Get("/agent-wizard/{type}", PromptBuilderHandler(sm, tr))
 		r.Get("/agent-wizard/{type}/copy", PromptCopyHandler())
 		r.Get("/rules", RulesPageHandler(svc, sm, tr, a.Config.Version))
@@ -120,10 +132,14 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/rules/{id}", RuleDetailPageHandler(svc, sm, tr))
 		r.Get("/rules/{id}/edit", RuleFormPageHandler(svc, sm, tr))
 
-		r.Get("/categories", CategoriesPageHandler(svc, sm, tr))
+		r.Get("/categories", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/rules?tab=categories", http.StatusMovedPermanently)
+		})
 
 		r.Route("/mcp-settings", func(r chi.Router) {
-			r.Get("/", MCPSettingsGetHandler(svc, mcpServer, sm, tr))
+			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+				http.Redirect(w, r, "/agents?tab=settings", http.StatusMovedPermanently)
+			})
 			r.Post("/mode", MCPSaveModeHandler(svc, sm))
 			r.Post("/tools", MCPSaveToolsHandler(svc, mcpServer, sm))
 			r.Post("/instructions", MCPSaveInstructionsHandler(svc, sm))

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -66,7 +66,13 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 			}
 		}
 
-		data := BaseTemplateData(r, sm, "rules", "Transaction Rules")
+		tab := r.URL.Query().Get("tab")
+		if tab != "categories" {
+			tab = "rules"
+		}
+
+		data := BaseTemplateData(r, sm, "rules", "Rules & Categories")
+		data["Tab"] = tab
 		data["Rules"] = result.Rules
 		data["HasMore"] = result.HasMore
 		data["NextCursor"] = result.NextCursor
@@ -81,6 +87,88 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 		data["Categories"] = categories
 		data["FlatCategories"] = flattenCategories(categories)
 		data["Version"] = version
+
+		// Categories tab data.
+		{
+			type catSpending struct {
+				Amount           float64
+				TransactionCount int64
+				Percent          float64
+			}
+			spendingByCategory := make(map[string]catSpending)
+			var totalSpending float64
+			var maxCategorySpend float64
+
+			spendingDays := 30
+			if d := r.URL.Query().Get("days"); d != "" {
+				switch d {
+				case "7":
+					spendingDays = 7
+				case "30":
+					spendingDays = 30
+				case "90":
+					spendingDays = 90
+				case "365":
+					spendingDays = 365
+				}
+			}
+			spendingStart := time.Now().AddDate(0, 0, -spendingDays)
+
+			catSummary, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
+				GroupBy:      "category",
+				StartDate:    &spendingStart,
+				SpendingOnly: true,
+			})
+			if err == nil && catSummary != nil {
+				for _, row := range catSummary.Summary {
+					name := "Uncategorized"
+					if row.Category != nil && *row.Category != "" {
+						name = *row.Category
+					}
+					spendingByCategory[name] = catSpending{
+						Amount:           row.TotalAmount,
+						TransactionCount: row.TransactionCount,
+					}
+					totalSpending += row.TotalAmount
+				}
+
+				for _, parent := range categories {
+					var parentAmount float64
+					var parentCount int64
+					if ps, ok := spendingByCategory[parent.DisplayName]; ok {
+						parentAmount += ps.Amount
+						parentCount += ps.TransactionCount
+					}
+					for _, child := range parent.Children {
+						if cs, ok := spendingByCategory[child.DisplayName]; ok {
+							parentAmount += cs.Amount
+							parentCount += cs.TransactionCount
+						}
+					}
+					if parentAmount > 0 || parentCount > 0 {
+						spendingByCategory[parent.DisplayName] = catSpending{
+							Amount:           parentAmount,
+							TransactionCount: parentCount,
+						}
+					}
+					if parentAmount > maxCategorySpend {
+						maxCategorySpend = parentAmount
+					}
+				}
+
+				if totalSpending > 0 {
+					for name, cs := range spendingByCategory {
+						cs.Percent = (cs.Amount / totalSpending) * 100
+						spendingByCategory[name] = cs
+					}
+				}
+			}
+
+			data["SpendingByCategory"] = spendingByCategory
+			data["TotalSpending"] = totalSpending
+			data["MaxCategorySpend"] = maxCategorySpend
+			data["SpendingDays"] = spendingDays
+		}
 
 		tr.Render(w, r, "rules.html", data)
 	}

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -155,13 +155,13 @@ func SyncLogDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 
 		data := map[string]any{
 			"PageTitle":   "Sync Log Detail",
-			"CurrentPage": "sync-logs",
+			"CurrentPage": "logs",
 			"CSRFToken":   GetCSRFToken(r),
 			"Flash":       GetFlash(ctx, sm),
 			"Log":         syncLog,
 			"Accounts":    accounts,
 			"Breadcrumbs": []Breadcrumb{
-				{Label: "Sync Logs", Href: "/sync-logs"},
+				{Label: "Logs", Href: "/logs?tab=syncs"},
 				{Label: syncLog.InstitutionName},
 			},
 		}

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -718,12 +718,22 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/reports.html",
 		"pages/report_detail.html",
 		"pages/webhook_events.html",
+		"pages/logs.html",
 		"pages/oauth_clients.html",
 		"pages/oauth_client_new.html",
 		"pages/oauth_client_created.html",
 		"pages/agent_wizard.html",
 		"pages/mcp_guide.html",
 		"pages/prompt_builder.html",
+	}
+
+	// Pages that need multiple page files parsed together (for sub-template sharing).
+	compositePages := map[string][]string{
+		"pages/agents.html": {
+			"pages/mcp_guide.html",
+			"pages/agent_wizard.html",
+			"pages/mcp_settings.html",
+		},
 	}
 
 	// Pages using the wizard layout (login + first-run admin creation + OAuth consent).
@@ -737,6 +747,19 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		if err := tr.parseBasePage(page); err != nil {
 			return err
 		}
+	}
+
+	// Composite pages: parsed with extra page files so sub-templates are available.
+	for page, extras := range compositePages {
+		files := []string{"layout/base.html"}
+		files = append(files, templatePartials...)
+		files = append(files, extras...)
+		files = append(files, page)
+		t, err := template.New("").Funcs(tr.funcMap).ParseFS(templates.FS, files...)
+		if err != nil {
+			return fmt.Errorf("parse composite page %s: %w", page, err)
+		}
+		tr.templates[path.Base(page)] = t
 	}
 
 	for _, page := range wizardPages {

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -136,7 +136,7 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 		}
 
 		data := map[string]any{
-			"PageTitle":     "Family Members",
+			"PageTitle":     "Household",
 			"CurrentPage":   "users",
 			"EnrichedUsers": enrichedUsers,
 			"CSRFToken":     GetCSRFToken(r),
@@ -155,7 +155,7 @@ func NewUserHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			"IsEdit":      false,
 			"CSRFToken":   GetCSRFToken(r),
 			"Breadcrumbs": []Breadcrumb{
-				{Label: "Family Members", Href: "/users"},
+				{Label: "Household", Href: "/users"},
 				{Label: "Add Member"},
 			},
 		}
@@ -190,7 +190,7 @@ func EditUserHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			"UserID":      idStr,
 			"CSRFToken":   GetCSRFToken(r),
 			"Breadcrumbs": []Breadcrumb{
-				{Label: "Family Members", Href: "/users"},
+				{Label: "Household", Href: "/users"},
 				{Label: user.Name},
 			},
 		}

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -685,33 +685,27 @@
     // Command Palette Alpine component
     function commandPalette() {
       var allItems = [
-        // Data
-        { id: 'nav-dashboard', group: 'Data', title: 'Dashboard', desc: 'Overview and stats', icon: 'layout-dashboard', href: '/', keywords: 'home overview net worth' },
-        { id: 'nav-insights', group: 'Data', title: 'Insights', desc: 'Spending trends and analysis', icon: 'lightbulb', href: '/insights', keywords: 'charts trends spending income analysis pace' },
-        { id: 'nav-connections', group: 'Data', title: 'Connections', desc: 'Bank connections', icon: 'link', href: '/connections', keywords: 'banks accounts linked' },
-        { id: 'nav-transactions', group: 'Data', title: 'Transactions', desc: 'View all transactions', icon: 'receipt', href: '/transactions', keywords: 'payments expenses spending' },
-        { id: 'nav-rules', group: 'Data', title: 'Rules', desc: 'Auto-categorization rules', icon: 'list-filter', href: '/rules', keywords: 'automation patterns categorize' },
-        { id: 'nav-categories', group: 'Data', title: 'Categories', desc: 'Category taxonomy', icon: 'tag', href: '/categories', keywords: 'tags labels organize' },
-        { id: 'nav-account-links', group: 'Data', title: 'Account Links', desc: 'Cross-account deduplication', icon: 'link-2', href: '/account-links', keywords: 'linked accounts dedup matching' },
-        { id: 'nav-users', group: 'Data', title: 'Family Members', desc: 'Manage family members', icon: 'users', href: '/users', keywords: 'people household members' },
-        // Agents
-        { id: 'agent-getting-started', group: 'Agents', title: 'Getting Started', desc: 'Connect an MCP agent', icon: 'rocket', href: '/mcp-getting-started', keywords: 'getting started mcp connect agent setup guide onboarding' },
-        { id: 'agent-wizard', group: 'Agents', title: 'Agent Wizard', desc: 'Create agent prompts', icon: 'wand-sparkles', href: '/agent-wizard', keywords: 'wizard setup prompt create agent flow' },
-        { id: 'agent-reviews', group: 'Agents', title: 'Review Queue', desc: 'Transaction review queue', icon: 'clipboard-check', href: '/reviews', keywords: 'pending approve categorize' },
-        { id: 'agent-review-instructions', group: 'Agents', title: 'Review Agent Instructions', desc: 'Pre-built prompts for transaction review', icon: 'clipboard-check', href: '/mcp-settings', keywords: 'agent instructions prompts review' },
-        { id: 'agent-reports', group: 'Agents', title: 'Reports', desc: 'Agent reports and findings', icon: 'file-text', href: '/reports', keywords: 'agent summaries notifications' },
-        { id: 'agent-mcp', group: 'Agents', title: 'MCP Settings', desc: 'Tools and server instructions', icon: 'bot', href: '/mcp-settings', keywords: 'mcp tools permissions instructions' },
+        // Overview
+        { id: 'nav-home', group: 'Overview', title: 'Home', desc: 'Overview and stats', icon: 'house', href: '/', keywords: 'home dashboard overview net worth' },
+        { id: 'nav-insights', group: 'Overview', title: 'Insights', desc: 'Spending trends and analysis', icon: 'lightbulb', href: '/insights', keywords: 'charts trends spending income analysis pace' },
+        { id: 'nav-transactions', group: 'Overview', title: 'Transactions', desc: 'View all transactions', icon: 'receipt', href: '/transactions', keywords: 'payments expenses spending' },
+        { id: 'nav-reports', group: 'Overview', title: 'Reports', desc: 'Agent reports and findings', icon: 'file-text', href: '/reports', keywords: 'agent summaries notifications' },
+        // Manage
+        { id: 'nav-connections', group: 'Manage', title: 'Connections', desc: 'Bank connections and account links', icon: 'link', href: '/connections', keywords: 'banks accounts linked dedup matching' },
+        { id: 'nav-agents', group: 'Manage', title: 'Agents', desc: 'Agent setup, prompts, and MCP settings', icon: 'bot', href: '/agents', keywords: 'getting started mcp connect agent setup guide wizard prompt tools permissions instructions' },
+        { id: 'nav-rules', group: 'Manage', title: 'Rules & Categories', desc: 'Auto-categorization rules and taxonomy', icon: 'list-filter', href: '/rules', keywords: 'automation patterns categorize tags labels organize' },
+        { id: 'nav-reviews', group: 'Manage', title: 'Review Queue', desc: 'Transaction review queue', icon: 'clipboard-check', href: '/reviews', keywords: 'pending approve categorize' },
+        { id: 'nav-users', group: 'Manage', title: 'Household', desc: 'Manage household members', icon: 'users', href: '/users', keywords: 'people family members' },
         // System
         { id: 'sys-providers', group: 'System', title: 'Providers', desc: 'Configure Plaid, Teller, CSV', icon: 'plug', href: '/providers', keywords: 'plaid teller csv bank setup' },
         { id: 'sys-access', group: 'System', title: 'Access', desc: 'API keys and OAuth clients', icon: 'shield-check', href: '/access', keywords: 'tokens authentication api keys oauth connector claude' },
-        { id: 'sys-sync-logs', group: 'System', title: 'Sync Logs', desc: 'Sync history and status', icon: 'refresh-cw', href: '/sync-logs', keywords: 'history errors status' },
-        { id: 'sys-webhooks', group: 'System', title: 'Webhooks', desc: 'Webhook event history', icon: 'webhook', href: '/webhook-events', keywords: 'events plaid teller notifications' },
+        { id: 'sys-logs', group: 'System', title: 'Logs', desc: 'Sync logs and webhook events', icon: 'scroll-text', href: '/logs', keywords: 'sync history errors status webhooks events' },
         { id: 'sys-settings', group: 'System', title: 'Settings', desc: 'Sync schedule, security, system', icon: 'settings', href: '/settings', keywords: 'schedule password encryption' },
         // Quick Actions
         { id: 'act-connect', group: 'Quick Actions', title: 'Connect a Bank', desc: 'Add a new bank connection', icon: 'plus-circle', href: '/connections/new', keywords: 'add new link' },
         { id: 'act-import', group: 'Quick Actions', title: 'Import CSV', desc: 'Import transactions from CSV', icon: 'upload', href: '/connections/import-csv', keywords: 'upload file' },
         { id: 'act-api-key', group: 'Quick Actions', title: 'Create API Key', desc: 'Generate a new API key', icon: 'key-round', href: '/api-keys/new', keywords: 'new token' },
-        { id: 'act-user', group: 'Quick Actions', title: 'Add Family Member', desc: 'Add a new family member', icon: 'user-plus', href: '/users/new', keywords: 'new person' },
+        { id: 'act-user', group: 'Quick Actions', title: 'Add Member', desc: 'Add a new household member', icon: 'user-plus', href: '/users/new', keywords: 'new person family' },
       ];
 
       return {

--- a/internal/templates/pages/account_link_detail.html
+++ b/internal/templates/pages/account_link_detail.html
@@ -4,7 +4,7 @@
 <div class="bb-page-header">
   <div>
     <div class="breadcrumbs text-sm mb-1">
-      <ul><li><a href="/account-links">Account Links</a></li><li>{{.Link.PrimaryAccountName}} &rarr; {{.Link.DependentAccountName}}</li></ul>
+      <ul><li><a href="/connections?tab=links">Account Links</a></li><li>{{.Link.PrimaryAccountName}} &rarr; {{.Link.DependentAccountName}}</li></ul>
     </div>
     <h1 class="bb-page-title">Transaction Matches</h1>
     <p class="text-base-content/60 text-sm mt-1">

--- a/internal/templates/pages/agent_wizard.html
+++ b/internal/templates/pages/agent_wizard.html
@@ -1,15 +1,10 @@
-{{define "content"}}
-{{$stats := .Stats}}
-<div class="bb-page-header">
-  <div>
-    <h1 class="bb-page-title">Agent Wizard</h1>
-    <p class="text-sm text-base-content/50 mt-1">Create agent prompts for automating financial tasks</p>
-  </div>
-</div>
+{{define "content"}}{{template "agents-wizard-content" .}}{{end}}
 
+{{define "agents-wizard-content"}}
+{{$stats := .Stats}}
 <div class="alert alert-info alert-soft text-sm rounded-xl mb-6">
   <i data-lucide="rocket" class="w-4 h-4"></i>
-  <span>New to MCP agents? Follow the <a href="/mcp-getting-started" class="link font-medium">Getting Started guide</a> to connect your first agent.</span>
+  <span>New to MCP agents? Follow the <a href="/agents?tab=guide" class="link font-medium">Getting Started guide</a> to connect your first agent.</span>
 </div>
 
 <div class="space-y-8 bb-stagger">

--- a/internal/templates/pages/agents.html
+++ b/internal/templates/pages/agents.html
@@ -1,0 +1,50 @@
+{{define "content"}}
+<div x-data="{ tab: '{{.Tab}}' }"
+     x-init="$watch('tab', function(v) { var u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); })">
+
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Agents</h1>
+    <p class="text-sm text-base-content/50 mt-1">Set up and configure AI agent access to your financial data</p>
+  </div>
+</div>
+
+<!-- Tab Switcher -->
+<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit">
+  <button @click="tab = 'guide'"
+    :class="tab === 'guide' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
+    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    <i data-lucide="rocket" class="w-3.5 h-3.5"></i>
+    Getting Started
+  </button>
+  <button @click="tab = 'wizard'"
+    :class="tab === 'wizard' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
+    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    <i data-lucide="wand-sparkles" class="w-3.5 h-3.5"></i>
+    Prompt Library
+  </button>
+  <button @click="tab = 'settings'"
+    :class="tab === 'settings' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
+    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    <i data-lucide="settings" class="w-3.5 h-3.5"></i>
+    MCP Settings
+  </button>
+</div>
+
+<!-- Getting Started Tab -->
+<div x-show="tab === 'guide'">
+  {{template "agents-guide-content" .}}
+</div>
+
+<!-- Prompt Library Tab -->
+<div x-show="tab === 'wizard'" x-cloak>
+  {{template "agents-wizard-content" .}}
+</div>
+
+<!-- MCP Settings Tab -->
+<div x-show="tab === 'settings'" x-cloak>
+  {{template "agents-settings-content" .}}
+</div>
+
+</div><!-- /alpine x-data tabs -->
+{{end}}

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -1,32 +1,63 @@
 {{define "content"}}
+<div x-data="{ tab: '{{.Tab}}' }"
+     x-init="$watch('tab', function(v) { var u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); })">
+
 <!-- Page Header -->
 <div class="flex items-center justify-between mb-6">
   <div class="flex items-baseline gap-3">
     <h1 class="bb-page-title">Connections</h1>
     {{if .Connections}}
-    <span class="text-sm text-base-content/40">{{len .Connections}} bank{{if ne (len .Connections) 1}}s{{end}}</span>
+    <span class="text-sm text-base-content/40" x-show="tab === 'connections'">{{len .Connections}} bank{{if ne (len .Connections) 1}}s{{end}}</span>
     {{end}}
   </div>
   <div class="flex items-center gap-2">
-    {{if .Connections}}
-    <div x-data="syncAllBtn()">
-      <button class="btn btn-outline btn-sm rounded-xl gap-2"
-              :disabled="state !== 'idle'"
-              @click="triggerSyncAll()"
-              :title="state === 'syncing' ? 'Syncing all connections...' : 'Sync all connections now'">
-        <i data-lucide="refresh-cw" class="w-4 h-4" x-show="state === 'idle'"></i>
-        <span class="loading loading-spinner loading-xs" x-show="state === 'syncing'" x-cloak></span>
-        <i data-lucide="check" class="w-4 h-4 text-success" x-show="state === 'done'" x-cloak></i>
-        <span x-text="state === 'syncing' ? 'Syncing...' : state === 'done' ? 'Triggered!' : 'Sync All'"></span>
+    <template x-if="tab === 'connections'">
+      <div class="flex items-center gap-2">
+        {{if .Connections}}
+        <div x-data="syncAllBtn()">
+          <button class="btn btn-outline btn-sm rounded-xl gap-2"
+                  :disabled="state !== 'idle'"
+                  @click="triggerSyncAll()"
+                  :title="state === 'syncing' ? 'Syncing all connections...' : 'Sync all connections now'">
+            <i data-lucide="refresh-cw" class="w-4 h-4" x-show="state === 'idle'"></i>
+            <span class="loading loading-spinner loading-xs" x-show="state === 'syncing'" x-cloak></span>
+            <i data-lucide="check" class="w-4 h-4 text-success" x-show="state === 'done'" x-cloak></i>
+            <span x-text="state === 'syncing' ? 'Syncing...' : state === 'done' ? 'Triggered!' : 'Sync All'"></span>
+          </button>
+        </div>
+        {{end}}
+        <a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">
+          <i data-lucide="plus" class="w-4 h-4"></i>
+          Connect Bank
+        </a>
+      </div>
+    </template>
+    <template x-if="tab === 'links'">
+      <button class="btn btn-primary btn-sm rounded-xl" onclick="document.getElementById('create-link-modal').showModal()">
+        <i data-lucide="plus" class="w-4 h-4"></i> New Link
       </button>
-    </div>
-    {{end}}
-    <a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">
-      <i data-lucide="plus" class="w-4 h-4"></i>
-      Connect Bank
-    </a>
+    </template>
   </div>
 </div>
+
+<!-- Tab Switcher -->
+<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit">
+  <button @click="tab = 'connections'"
+    :class="tab === 'connections' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
+    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    <i data-lucide="link" class="w-3.5 h-3.5"></i>
+    Connections
+  </button>
+  <button @click="tab = 'links'"
+    :class="tab === 'links' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
+    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    <i data-lucide="link-2" class="w-3.5 h-3.5"></i>
+    Account Links
+  </button>
+</div>
+
+<!-- ==================== CONNECTIONS TAB ==================== -->
+<div x-show="tab === 'connections'">
 
 {{if .Connections}}
 
@@ -277,4 +308,134 @@ function syncBtn(connId) {
   };
 }
 </script>
+
+</div><!-- /connections tab -->
+
+<!-- ==================== ACCOUNT LINKS TAB ==================== -->
+<div x-show="tab === 'links'" x-cloak>
+
+{{if .Links}}
+<div class="space-y-3 bb-stagger">
+  {{range .Links}}
+  <div class="bb-card p-5">
+    <div class="flex flex-col sm:flex-row sm:items-start justify-between gap-3">
+      <div class="flex-1 min-w-0">
+        <!-- Account link: stacked on mobile, inline on desktop -->
+        <div class="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+          <div class="flex items-center gap-2 min-w-0">
+            <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-primary/8 shrink-0">
+              <i data-lucide="credit-card" class="w-4 h-4 text-primary"></i>
+            </div>
+            <div class="min-w-0">
+              <span class="font-semibold text-sm truncate block">{{.PrimaryAccountName}}</span>
+              <span class="text-xs text-base-content/40">{{.PrimaryUserName}}</span>
+            </div>
+          </div>
+          <i data-lucide="arrow-right" class="w-4 h-4 text-base-content/30 shrink-0 hidden sm:block"></i>
+          <i data-lucide="arrow-down" class="w-4 h-4 text-base-content/30 shrink-0 sm:hidden ml-3"></i>
+          <div class="flex items-center gap-2 min-w-0 sm:ml-0 ml-3">
+            <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-secondary/8 shrink-0">
+              <i data-lucide="credit-card" class="w-4 h-4 text-secondary"></i>
+            </div>
+            <div class="min-w-0">
+              <span class="font-semibold text-sm truncate block">{{.DependentAccountName}}</span>
+              <span class="text-xs text-base-content/40">{{.DependentUserName}}</span>
+            </div>
+          </div>
+          {{if not .Enabled}}<span class="badge badge-ghost badge-sm">Disabled</span>{{end}}
+        </div>
+        <!-- Stats row -->
+        <div class="flex items-center gap-3 sm:gap-4 mt-3 text-xs text-base-content/50 flex-wrap">
+          <span class="flex items-center gap-1">
+            <i data-lucide="check-circle-2" class="w-3.5 h-3.5 text-success"></i>
+            {{.MatchCount}} matched
+          </span>
+          {{if gt .UnmatchedDependentCount 0}}
+          <span class="flex items-center gap-1">
+            <i data-lucide="help-circle" class="w-3.5 h-3.5 text-warning"></i>
+            {{.UnmatchedDependentCount}} unmatched
+          </span>
+          {{end}}
+          <span class="hidden sm:inline">Strategy: {{.MatchStrategy}}</span>
+          {{if gt .MatchToleranceDays 0}}<span class="hidden sm:inline">Tolerance: {{.MatchToleranceDays}}d</span>{{end}}
+        </div>
+      </div>
+      <!-- Actions -->
+      <div class="flex items-center gap-1 shrink-0 sm:self-start self-end">
+        <form method="POST" action="/-/account-links/{{.ID}}/reconcile" class="inline">
+          <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+          <button type="submit" class="btn btn-ghost btn-xs rounded-lg" title="Run reconciliation">
+            <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
+          </button>
+        </form>
+        <a href="/account-links/{{.ID}}" class="btn btn-ghost btn-xs rounded-lg" title="View matches">
+          <i data-lucide="list" class="w-3.5 h-3.5"></i>
+        </a>
+        <form method="POST" action="/-/account-links/{{.ID}}/delete" class="inline"
+              x-data @submit.prevent="bbConfirm({title:'Delete account link?',message:'All transaction attribution from this link will be cleared. This cannot be undone.',confirmLabel:'Delete',variant:'danger'}).then(ok => { if(ok) $el.submit(); })">
+          <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+          <button type="submit" class="btn btn-ghost btn-xs text-error rounded-lg" title="Delete link">
+            <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+  {{end}}
+</div>
+{{else}}
+<div class="bb-card p-12 text-center">
+  <div class="flex flex-col items-center">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
+      <i data-lucide="link-2" class="w-8 h-8 text-base-content/25"></i>
+    </div>
+    <h3 class="text-lg font-semibold mb-1">No Account Links</h3>
+    <p class="text-sm text-base-content/50 mb-5 max-w-sm">
+      Account links connect authorized user accounts to primary accounts for deduplication.
+      If two family members connect the same credit card, linking prevents double-counting.
+    </p>
+    <button class="btn btn-primary btn-sm rounded-xl" onclick="document.getElementById('create-link-modal').showModal()">
+      <i data-lucide="plus" class="w-4 h-4"></i> Create First Link
+    </button>
+  </div>
+</div>
+{{end}}
+
+</div><!-- /links tab -->
+
+<!-- Create Account Link Modal -->
+<dialog id="create-link-modal" class="modal">
+  <div class="modal-box rounded-2xl">
+    <h3 class="font-bold text-lg">Create Account Link</h3>
+    <p class="text-sm text-base-content/50 mt-1">Link a dependent (authorized user) account to the primary cardholder's account.</p>
+    <form method="POST" action="/-/account-links" class="mt-4 space-y-4" x-data="{ loading: false }" @submit="loading = true">
+      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+      <div class="form-control">
+        <label class="label label-text text-sm font-medium">Primary Account</label>
+        <select name="primary_account_id" class="select select-bordered select-sm w-full rounded-xl" required>
+          <option value="">Select the primary cardholder's account...</option>
+          {{range .LinkAccounts}}
+          <option value="{{.ID}}">{{.DisplayName}}{{if .Mask}} ••{{.Mask}}{{end}} ({{.UserName}} - {{.InstitutionName}})</option>
+          {{end}}
+        </select>
+      </div>
+      <div class="form-control">
+        <label class="label label-text text-sm font-medium">Dependent Account</label>
+        <select name="dependent_account_id" class="select select-bordered select-sm w-full rounded-xl" required>
+          <option value="">Select the authorized user's account...</option>
+          {{range .LinkAccounts}}
+          <option value="{{.ID}}">{{.DisplayName}}{{if .Mask}} ••{{.Mask}}{{end}} ({{.UserName}} - {{.InstitutionName}})</option>
+          {{end}}
+        </select>
+      </div>
+      <div class="modal-action">
+        <button type="button" class="btn btn-ghost btn-sm rounded-xl" onclick="document.getElementById('create-link-modal').close()">Cancel</button>
+        <button type="submit" class="btn btn-primary btn-sm rounded-xl" :class="{ 'loading': loading }" :disabled="loading">Create Link</button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+</div><!-- /alpine x-data tabs -->
 {{end}}

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -339,7 +339,7 @@
             {{end}}
           {{end}}
         </div>
-        <a href="/sync-logs" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Logs</a>
+        <a href="/logs" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Logs</a>
       </div>
 
       <!-- Sync Stats Row -->

--- a/internal/templates/pages/insights.html
+++ b/internal/templates/pages/insights.html
@@ -762,7 +762,7 @@
       </div>
       <div class="flex items-center gap-2">
         <span x-show="isDrilledDown" x-cloak class="text-[0.6rem] text-base-content/30">click chart or</span>
-        <a x-show="!isDrilledDown" href="/categories" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
+        <a x-show="!isDrilledDown" href="/rules?tab=categories" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
         <button x-show="isDrilledDown" @click="drillUp()" x-cloak
           class="text-xs text-primary/60 hover:text-primary/80 transition-colors cursor-pointer bg-transparent">back to categories</button>
       </div>

--- a/internal/templates/pages/logs.html
+++ b/internal/templates/pages/logs.html
@@ -1,0 +1,530 @@
+{{define "content"}}
+<div x-data="{ tab: '{{.Tab}}' }"
+     x-init="$watch('tab', function(v) { var u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); })">
+
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Logs</h1>
+    <p class="text-sm text-base-content/50 mt-1">Sync history and webhook events</p>
+  </div>
+</div>
+
+<!-- Tab Switcher -->
+<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit">
+  <button @click="tab = 'syncs'"
+    :class="tab === 'syncs' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
+    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
+    Sync Logs
+  </button>
+  <button @click="tab = 'webhooks'"
+    :class="tab === 'webhooks' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
+    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    <i data-lucide="webhook" class="w-3.5 h-3.5"></i>
+    Webhooks
+  </button>
+</div>
+
+<!-- ==================== SYNC LOGS TAB ==================== -->
+<div x-show="tab === 'syncs'" x-cloak>
+
+<!-- Summary Stats -->
+{{if .Stats}}
+<div class="grid grid-cols-3 gap-3 mb-6 bb-stagger">
+  <!-- Success Rate -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .Stats.SuccessRate 80.0}}bg-success/10{{else if gt .Stats.SuccessRate 50.0}}bg-warning/10{{else}}bg-error/10{{end}}">
+        {{if gt .Stats.SuccessRate 80.0}}
+        <i data-lucide="check-circle-2" class="w-4 h-4 text-success"></i>
+        {{else if gt .Stats.SuccessRate 50.0}}
+        <i data-lucide="alert-triangle" class="w-4 h-4 text-warning"></i>
+        {{else}}
+        <i data-lucide="x-circle" class="w-4 h-4 text-error"></i>
+        {{end}}
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.SuccessRate 80.0}}text-success{{else if gt .Stats.SuccessRate 50.0}}text-warning{{else}}text-error{{end}}">{{printf "%.0f" .Stats.SuccessRate}}%</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Success rate</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Errors -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .Stats.ErrorCount 0}}bg-error/10{{else}}bg-base-200/60{{end}}">
+        <i data-lucide="alert-circle" class="w-4 h-4 {{if gt .Stats.ErrorCount 0}}text-error/70{{else}}text-base-content/40{{end}}"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .Stats.ErrorCount 0}}text-error{{end}}">{{.Stats.ErrorCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Errors</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Avg Duration -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+        <i data-lucide="timer" class="w-4 h-4 text-base-content/40"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none">
+          {{if gt .Stats.AvgDurationMs 999.0}}{{printf "%.1f" (divFloat .Stats.AvgDurationMs 1000.0)}}s{{else}}{{printf "%.0f" .Stats.AvgDurationMs}}ms{{end}}
+        </div>
+        <div class="text-xs text-base-content/40 mt-0.5">Avg duration</div>
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
+<!-- Collapsible Filter Bar -->
+<div class="bb-card mb-5" x-data="{ filtersOpen: {{if .HasAdvancedFilters}}true{{else}}false{{end}} }">
+  <div class="p-0">
+    <button type="button" class="bb-filter-toggle" @click="filtersOpen = !filtersOpen">
+      <div class="flex items-center gap-2">
+        <i data-lucide="sliders-horizontal" class="w-4 h-4 text-base-content/60"></i>
+        <span>Filters</span>
+        {{if .HasAdvancedFilters}}
+        <span class="badge badge-primary badge-xs">Active</span>
+        {{end}}
+      </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 transition-transform duration-200" :class="filtersOpen ? 'rotate-180' : ''"></i>
+    </button>
+
+    <form method="GET" action="/logs" x-show="filtersOpen" x-cloak
+      x-transition:enter="transition ease-out duration-200"
+      x-transition:enter-start="opacity-0 -translate-y-2"
+      x-transition:enter-end="opacity-100 translate-y-0"
+      x-transition:leave="transition ease-in duration-150"
+      x-transition:leave-start="opacity-100 translate-y-0"
+      x-transition:leave-end="opacity-0 -translate-y-2"
+      class="bb-filter-form px-4 pb-4 pt-2">
+      <input type="hidden" name="tab" value="syncs">
+      {{if .FilterStatus}}<input type="hidden" name="status" value="{{.FilterStatus}}">{{end}}
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-3">
+        <label class="bb-filter-label">
+          Connection
+          <select name="connection_id" class="select select-sm select-bordered w-full">
+            <option value="">All connections</option>
+            {{range .Connections}}
+            <option value="{{formatUUID .ID}}"{{if eq (formatUUID .ID) $.FilterConnID}} selected{{end}}>{{.InstitutionName.String}}</option>
+            {{end}}
+          </select>
+        </label>
+        <label class="bb-filter-label">
+          Trigger
+          <select name="trigger" class="select select-sm select-bordered w-full">
+            <option value="">All triggers</option>
+            <option value="cron"{{if eq .FilterTrigger "cron"}} selected{{end}}>Cron</option>
+            <option value="manual"{{if eq .FilterTrigger "manual"}} selected{{end}}>Manual</option>
+            <option value="webhook"{{if eq .FilterTrigger "webhook"}} selected{{end}}>Webhook</option>
+            <option value="initial"{{if eq .FilterTrigger "initial"}} selected{{end}}>Initial</option>
+          </select>
+        </label>
+        <label class="bb-filter-label">
+          From Date
+          <input type="date" name="date_from" value="{{.FilterDateFrom}}" class="input input-sm input-bordered w-full">
+        </label>
+        <label class="bb-filter-label">
+          To Date
+          <input type="date" name="date_to" value="{{.FilterDateTo}}" class="input input-sm input-bordered w-full">
+        </label>
+      </div>
+      <div class="bb-filter-actions">
+        <a href="/logs?tab=syncs" class="btn btn-sm btn-ghost rounded-xl">Reset</a>
+        <button type="submit" class="btn btn-sm btn-primary rounded-xl">
+          <i data-lucide="search" class="w-3.5 h-3.5"></i>
+          Apply Filters
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<!-- Status Filter Tabs -->
+<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
+  <!-- Status pill tabs -->
+  <div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 overflow-x-auto">
+    <a href="/logs?tab=syncs&{{syncLogFilterQuery "" .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5 whitespace-nowrap
+              {{if not .FilterStatus}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      All
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.Stats.TotalSyncs}}</span>
+    </a>
+    <a href="/logs?tab=syncs&{{syncLogFilterQuery "success" .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5 whitespace-nowrap
+              {{if eq .FilterStatus "success"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-success shrink-0"></span>
+      Success
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.SuccessCount}}</span>
+    </a>
+    <a href="/logs?tab=syncs&{{syncLogFilterQuery "error" .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5 whitespace-nowrap
+              {{if eq .FilterStatus "error"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-error shrink-0"></span>
+      Errors
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.ErrorCount}}</span>
+    </a>
+    <a href="/logs?tab=syncs&{{syncLogFilterQuery "in_progress" .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5 whitespace-nowrap
+              {{if eq .FilterStatus "in_progress"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-warning shrink-0"></span>
+      In Progress
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.InProgressCount}}</span>
+    </a>
+  </div>
+
+  {{if or .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo .FilterStatus}}
+  <a href="/logs?tab=syncs" class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-base-content/50 hover:text-base-content/80">
+    <i data-lucide="x" class="w-3 h-3"></i>
+    Clear all filters
+  </a>
+  {{end}}
+</div>
+
+{{if .Logs}}
+
+<!-- Results count -->
+<div class="text-xs text-base-content/40 mb-3 px-1">{{.Total}} sync log{{if ne .Total 1}}s{{end}}</div>
+
+<!-- Timeline view -->
+<div class="space-y-1 bb-stagger">
+  {{range .Logs}}
+  <div class="bb-card bb-card--interactive group transition-all duration-150 {{if eq .Status "error"}}border-error/20 hover:border-error/30{{end}}">
+    <a href="/sync-logs/{{.ID}}" class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 py-3 px-4 no-underline">
+      <!-- Top row: status icon + main content + (desktop) changes -->
+      <div class="flex items-center gap-3 sm:gap-4 flex-1 min-w-0">
+        <!-- Status indicator -->
+        <div class="relative shrink-0">
+          <div class="w-8 h-8 rounded-lg flex items-center justify-center
+                      {{if eq .Status "success"}}bg-success/10{{else if eq .Status "error"}}bg-error/10{{else if eq .Status "in_progress"}}bg-warning/10{{else}}bg-base-200/50{{end}}">
+            {{if eq .Status "success"}}
+            <i data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
+            {{else if eq .Status "error"}}
+            <i data-lucide="x" class="w-3.5 h-3.5 text-error"></i>
+            {{else if eq .Status "in_progress"}}
+            <i data-lucide="loader" class="w-3.5 h-3.5 text-warning animate-spin"></i>
+            {{else}}
+            <i data-lucide="minus" class="w-3.5 h-3.5 text-base-content/30"></i>
+            {{end}}
+          </div>
+        </div>
+
+        <!-- Main content -->
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium group-hover:text-primary transition-colors truncate">{{.InstitutionName}}</span>
+            <span class="badge badge-ghost badge-xs opacity-60 shrink-0">{{.Trigger}}</span>
+          </div>
+          <div class="flex items-center gap-3 mt-0.5 text-xs text-base-content/40">
+            <span>{{relativeTime .StartedAt}}</span>
+            {{if .Duration}}
+            <span class="text-base-content/25">&middot;</span>
+            <span class="tabular-nums">{{.Duration}}</span>
+            {{end}}
+            {{if .AccountsAffected}}
+            <span class="text-base-content/25">&middot;</span>
+            <span>{{.AccountsAffected}} account{{if ne .AccountsAffected 1}}s{{end}}</span>
+            {{end}}
+          </div>
+          {{if and (eq .Status "error") .FriendlyErrorMessage}}
+          <div class="mt-1 text-xs text-error/60 truncate max-w-md">{{deref .FriendlyErrorMessage}}</div>
+          {{else if and (eq .Status "error") .ErrorMessage}}
+          <div class="mt-1 text-xs text-error/60 truncate max-w-md font-mono">{{deref .ErrorMessage}}</div>
+          {{end}}
+        </div>
+      </div>
+
+      <!-- Changes + Status (wraps to second line on mobile) -->
+      <div class="flex items-center gap-3 sm:gap-4 shrink-0 pl-11 sm:pl-0">
+        <!-- Transaction changes (only shown when there are actual changes) -->
+        {{if or .AddedCount .ModifiedCount .RemovedCount .UnchangedCount}}
+        <div class="flex items-center gap-2 text-xs tabular-nums">
+          {{if .AddedCount}}<span class="text-success font-medium">+{{.AddedCount}}</span>{{end}}
+          {{if .ModifiedCount}}<span class="text-info font-medium">~{{.ModifiedCount}}</span>{{end}}
+          {{if .RemovedCount}}<span class="text-error font-medium">-{{.RemovedCount}}</span>{{end}}
+          {{if .UnchangedCount}}<span class="text-base-content/30 font-medium" title="{{.UnchangedCount}} unchanged transactions">={{.UnchangedCount}}</span>{{end}}
+        </div>
+        {{end}}
+
+        <!-- Warning badge -->
+        {{if .WarningMessage}}
+        <span class="badge badge-soft badge-warning badge-sm gap-1">
+          <i data-lucide="alert-triangle" class="w-3 h-3"></i>warning
+        </span>
+        {{end}}
+
+      </div>
+    </a>
+  </div>
+  {{end}}
+</div>
+
+{{if gt .TotalPages 1}}
+<div class="flex items-center justify-between mt-6">
+  <div>
+    {{if gt .Page 1}}
+    <a href="/logs?tab=syncs&page={{sub .Page 1}}&{{syncLogFilterQuery .FilterStatus .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}" class="btn btn-sm btn-ghost rounded-xl">&laquo; Previous</a>
+    {{end}}
+  </div>
+  <span class="text-xs text-base-content/40">Page {{.Page}} of {{.TotalPages}}</span>
+  <div>
+    {{if lt .Page .TotalPages}}
+    <a href="/logs?tab=syncs&page={{add .Page 1}}&{{syncLogFilterQuery .FilterStatus .FilterConnID .FilterTrigger .FilterDateFrom .FilterDateTo}}" class="btn btn-sm btn-ghost rounded-xl">Next &raquo;</a>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+{{else}}
+<div class="bb-card p-12 text-center">
+  <div class="flex flex-col items-center">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
+      <i data-lucide="refresh-cw" class="w-8 h-8 text-base-content/25"></i>
+    </div>
+    <h3 class="text-lg font-semibold mb-1">No sync logs found</h3>
+    <p class="text-sm text-base-content/50 mb-5">{{if or .FilterConnID .FilterStatus .FilterTrigger .FilterDateFrom .FilterDateTo}}Try adjusting your filters.{{else}}Sync logs will appear here after your first bank sync.{{end}}</p>
+    {{if or .FilterConnID .FilterStatus .FilterTrigger .FilterDateFrom .FilterDateTo}}
+    <a href="/logs?tab=syncs" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+</div><!-- /syncs tab -->
+
+<!-- ==================== WEBHOOKS TAB ==================== -->
+<div x-show="tab === 'webhooks'" x-cloak>
+
+<!-- Summary Stats Cards -->
+{{if .WHStats}}
+<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6 bb-stagger">
+  <!-- Total Events -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
+        <i data-lucide="webhook" class="w-4 h-4 text-base-content/40"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none">{{.WHStats.TotalEvents}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Total events</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Processed -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center shrink-0">
+        <i data-lucide="check-circle-2" class="w-4 h-4 text-success"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none text-success">{{.WHStats.ProcessedCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Processed</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Received (in-flight) -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg bg-warning/10 flex items-center justify-center shrink-0">
+        <i data-lucide="clock" class="w-4 h-4 text-warning"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .WHStats.ReceivedCount 0}}text-warning{{end}}">{{.WHStats.ReceivedCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">In-flight</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Errors -->
+  <div class="bb-card p-4">
+    <div class="flex items-center gap-3">
+      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .WHStats.ErrorCount 0}}bg-error/10{{else}}bg-base-200/60{{end}}">
+        <i data-lucide="alert-circle" class="w-4 h-4 {{if gt .WHStats.ErrorCount 0}}text-error/70{{else}}text-base-content/40{{end}}"></i>
+      </div>
+      <div>
+        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .WHStats.ErrorCount 0}}text-error{{end}}">{{.WHStats.ErrorCount}}</div>
+        <div class="text-xs text-base-content/40 mt-0.5">Errors</div>
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
+<!-- Status Filter Tabs + Provider Dropdown -->
+<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
+  <!-- Status pill tabs -->
+  <div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5">
+    <a href="/logs?tab=webhooks{{if .WHFilterProvider}}&wh_provider={{.WHFilterProvider}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if not .WHFilterStatus}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      All
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.WHStats.TotalEvents}}</span>
+    </a>
+    <a href="/logs?tab=webhooks&wh_status=processed{{if .WHFilterProvider}}&wh_provider={{.WHFilterProvider}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if eq .WHFilterStatus "processed"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-success"></span>
+      Processed
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.WHStats.ProcessedCount}}</span>
+    </a>
+    <a href="/logs?tab=webhooks&wh_status=received{{if .WHFilterProvider}}&wh_provider={{.WHFilterProvider}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if eq .WHFilterStatus "received"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-warning"></span>
+      In-flight
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.WHStats.ReceivedCount}}</span>
+    </a>
+    <a href="/logs?tab=webhooks&wh_status=error{{if .WHFilterProvider}}&wh_provider={{.WHFilterProvider}}{{end}}"
+       class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-150 no-underline flex items-center gap-1.5
+              {{if eq .WHFilterStatus "error"}}bg-base-100 text-base-content shadow-sm{{else}}text-base-content/40 hover:text-base-content/60{{end}}">
+      <span class="w-1.5 h-1.5 rounded-full bg-error"></span>
+      Errors
+      <span class="text-[0.6rem] tabular-nums opacity-60">{{.WHStats.ErrorCount}}</span>
+    </a>
+  </div>
+
+  <!-- Provider filter dropdown -->
+  <form method="GET" action="/logs" class="flex items-center gap-2">
+    <input type="hidden" name="tab" value="webhooks">
+    {{if .WHFilterStatus}}<input type="hidden" name="wh_status" value="{{.WHFilterStatus}}">{{end}}
+    <select name="wh_provider" class="select select-sm select-bordered rounded-xl text-xs min-w-[10rem]"
+            onchange="this.form.submit()">
+      <option value="">All providers</option>
+      <option value="plaid"{{if eq .WHFilterProvider "plaid"}} selected{{end}}>Plaid</option>
+      <option value="teller"{{if eq .WHFilterProvider "teller"}} selected{{end}}>Teller</option>
+    </select>
+    {{if .WHFilterProvider}}
+    <a href="/logs?tab=webhooks{{if $.WHFilterStatus}}&wh_status={{$.WHFilterStatus}}{{end}}" class="btn btn-ghost btn-xs rounded-lg">
+      <i data-lucide="x" class="w-3 h-3"></i>
+    </a>
+    {{end}}
+  </form>
+</div>
+
+{{if .WHEvents}}
+
+<!-- Results count -->
+<div class="text-xs text-base-content/40 mb-3 px-1">{{.WHTotal}} webhook event{{if ne .WHTotal 1}}s{{end}}</div>
+
+<!-- Event list -->
+<div class="space-y-1 bb-stagger">
+  {{range .WHEvents}}
+  <div class="bb-card group transition-all duration-150 {{if eq .Status "error"}}border-error/20{{end}}" x-data="{ open: false }">
+    <div class="flex items-center gap-4 py-3 px-4 cursor-pointer" @click="open = !open">
+      <!-- Status indicator -->
+      <div class="relative shrink-0">
+        <div class="w-8 h-8 rounded-lg flex items-center justify-center
+                    {{if eq .Status "processed"}}bg-success/10{{else if eq .Status "error"}}bg-error/10{{else}}bg-warning/10{{end}}">
+          {{if eq .Status "processed"}}
+          <i data-lucide="check" class="w-3.5 h-3.5 text-success"></i>
+          {{else if eq .Status "error"}}
+          <i data-lucide="x" class="w-3.5 h-3.5 text-error"></i>
+          {{else}}
+          <i data-lucide="clock" class="w-3.5 h-3.5 text-warning"></i>
+          {{end}}
+        </div>
+      </div>
+
+      <!-- Main content -->
+      <div class="flex-1 min-w-0">
+        <div class="flex items-center gap-2">
+          <span class="text-sm font-medium">{{.EventType}}</span>
+          <span class="badge badge-ghost badge-xs opacity-60">{{.Provider}}</span>
+        </div>
+        <div class="flex items-center gap-3 mt-0.5 text-xs text-base-content/40">
+          <span>{{relativeTime .CreatedAt}}</span>
+          {{if .InstitutionName}}
+          <span class="text-base-content/25">&middot;</span>
+          <span>{{deref .InstitutionName}}</span>
+          {{end}}
+        </div>
+      </div>
+
+      <!-- Status badge + expand -->
+      <div class="flex items-center gap-3 shrink-0">
+        {{if eq .Status "processed"}}
+        <span class="badge badge-soft badge-success badge-sm">processed</span>
+        {{else if eq .Status "error"}}
+        <span class="badge badge-soft badge-error badge-sm">error</span>
+        {{else}}
+        <span class="badge badge-soft badge-warning badge-sm">{{.Status}}</span>
+        {{end}}
+
+        <button class="btn btn-ghost btn-xs btn-square rounded-lg text-base-content/30 hover:text-base-content/60 transition-colors">
+          <i data-lucide="chevron-down" class="w-3.5 h-3.5 transition-transform duration-200" :class="open ? 'rotate-180' : ''"></i>
+        </button>
+      </div>
+    </div>
+
+    <!-- Expandable detail -->
+    <div x-show="open" x-cloak x-transition:enter="transition ease-out duration-150" x-transition:enter-start="opacity-0" x-transition:enter-end="opacity-100" x-transition:leave="transition ease-in duration-100" x-transition:leave-start="opacity-100" x-transition:leave-end="opacity-0" class="border-t border-base-200">
+      <div class="px-4 py-3 ml-12 space-y-2">
+        {{if .ConnectionID}}
+        <div class="flex items-center gap-2 text-xs">
+          <span class="text-base-content/40 w-24 shrink-0">Connection</span>
+          <a href="/connections/{{deref .ConnectionID}}" class="font-medium hover:text-primary transition-colors font-mono text-xs">
+            {{if .InstitutionName}}{{deref .InstitutionName}}{{else}}{{deref .ConnectionID}}{{end}}
+          </a>
+        </div>
+        {{end}}
+        <div class="flex items-center gap-2 text-xs">
+          <span class="text-base-content/40 w-24 shrink-0">Payload hash</span>
+          <span class="font-mono text-base-content/50 text-[0.65rem] break-all select-all">{{.PayloadHash}}</span>
+        </div>
+        <div class="flex items-center gap-2 text-xs">
+          <span class="text-base-content/40 w-24 shrink-0">Received at</span>
+          <span class="font-medium">{{formatDateTime .CreatedAt}}</span>
+        </div>
+        {{if .ErrorMessage}}
+        <div class="flex items-start gap-2 text-xs mt-2">
+          <i data-lucide="alert-circle" class="w-3.5 h-3.5 text-error/60 shrink-0 mt-0.5"></i>
+          <p class="text-error/80 font-mono break-all leading-relaxed">{{deref .ErrorMessage}}</p>
+        </div>
+        {{end}}
+      </div>
+    </div>
+  </div>
+  {{end}}
+</div>
+
+{{if gt .WHTotalPages 1}}
+<div class="flex items-center justify-between mt-6">
+  <div>
+    {{if gt .WHPage 1}}
+    <a href="/logs?tab=webhooks&wh_page={{sub .WHPage 1}}{{if $.WHFilterProvider}}&wh_provider={{$.WHFilterProvider}}{{end}}{{if $.WHFilterStatus}}&wh_status={{$.WHFilterStatus}}{{end}}" class="btn btn-sm btn-ghost rounded-xl">&laquo; Previous</a>
+    {{end}}
+  </div>
+  <span class="text-xs text-base-content/40">Page {{.WHPage}} of {{.WHTotalPages}}</span>
+  <div>
+    {{if lt .WHPage .WHTotalPages}}
+    <a href="/logs?tab=webhooks&wh_page={{add .WHPage 1}}{{if $.WHFilterProvider}}&wh_provider={{$.WHFilterProvider}}{{end}}{{if $.WHFilterStatus}}&wh_status={{$.WHFilterStatus}}{{end}}" class="btn btn-sm btn-ghost rounded-xl">Next &raquo;</a>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+{{else}}
+<div class="bb-card p-12 text-center">
+  <div class="flex flex-col items-center">
+    <div class="w-16 h-16 rounded-xl bg-base-200/60 flex items-center justify-center mb-4">
+      <i data-lucide="webhook" class="w-8 h-8 text-base-content/25"></i>
+    </div>
+    <h3 class="text-lg font-semibold mb-1">No webhook events</h3>
+    <p class="text-sm text-base-content/50 mb-5">{{if or .WHFilterProvider .WHFilterStatus}}Try adjusting your filters.{{else}}Webhook events will appear here when providers send notifications.{{end}}</p>
+    {{if or .WHFilterProvider .WHFilterStatus}}
+    <a href="/logs?tab=webhooks" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
+    {{end}}
+  </div>
+</div>
+{{end}}
+
+</div><!-- /webhooks tab -->
+
+</div><!-- /alpine x-data tabs -->
+{{end}}

--- a/internal/templates/pages/mcp_guide.html
+++ b/internal/templates/pages/mcp_guide.html
@@ -1,10 +1,6 @@
-{{define "content"}}
-<div class="bb-page-header">
-  <div>
-    <h1 class="bb-page-title">Getting Started with MCP Agents</h1>
-    <p class="text-sm text-base-content/50 mt-1">Connect your AI agents to Breadbox in three steps</p>
-  </div>
-</div>
+{{define "content"}}{{template "agents-guide-content" .}}{{end}}
+
+{{define "agents-guide-content"}}
 
 <!-- Steps indicator -->
 <ul class="steps steps-horizontal w-full mb-8 text-sm">
@@ -283,7 +279,7 @@
     </div>
     <div class="px-4 sm:px-5 py-4">
       <p class="text-sm text-base-content/60 mb-4">Once your agent is connected, use the Agent Wizard to create prompts for common tasks like reviewing transactions, categorizing spending, and generating reports.</p>
-      <a href="/agent-wizard" class="btn btn-primary btn-sm rounded-xl gap-2">
+      <a href="/agents?tab=wizard" class="btn btn-primary btn-sm rounded-xl gap-2">
         <i data-lucide="wand-sparkles" class="w-4 h-4"></i>
         Open Agent Wizard
       </a>

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -1,11 +1,6 @@
-{{define "content"}}
-<div class="bb-page-header">
-  <div>
-    <h1 class="bb-page-title">MCP Settings</h1>
-    <p class="text-sm text-base-content/50 mt-1">Configure how AI agents interact with your financial data</p>
-  </div>
-</div>
+{{define "content"}}{{template "agents-settings-content" .}}{{end}}
 
+{{define "agents-settings-content"}}
 <div class="grid gap-6 bb-stagger">
 
   <!-- Card 1: Server Instructions -->

--- a/internal/templates/pages/prompt_builder.html
+++ b/internal/templates/pages/prompt_builder.html
@@ -2,7 +2,7 @@
 <div class="bb-page-header">
   <div>
     <div class="flex items-center gap-2 text-sm text-base-content/50 mb-1">
-      <a href="/agent-wizard" class="hover:text-base-content transition-colors">Agent Wizard</a>
+      <a href="/agents?tab=wizard" class="hover:text-base-content transition-colors">Prompt Library</a>
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
       <span class="text-base-content/70">Prompt Builder</span>
     </div>

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -1,15 +1,55 @@
 {{define "content"}}
-<div x-data="rulesPage()">
+<div x-data="{ rcTab: '{{.Tab}}' }"
+     x-init="$watch('rcTab', function(v) { var u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); })">
 
 <div class="bb-page-header">
   <div>
-    <h1 class="bb-page-title">Transaction Rules</h1>
-    <p class="text-sm text-base-content/50 mt-1">Auto-categorize future transactions based on pattern matching</p>
+    <h1 class="bb-page-title">Rules & Categories</h1>
+    <p class="text-sm text-base-content/50 mt-1" x-show="rcTab === 'rules'">Auto-categorize future transactions based on pattern matching</p>
+    <p class="text-sm text-base-content/50 mt-1" x-show="rcTab === 'categories'" x-cloak>Organize transactions with a two-level category taxonomy</p>
   </div>
-  <a href="/rules/new" class="btn btn-primary btn-sm rounded-xl">
-    <i data-lucide="plus" class="w-4 h-4"></i> New Rule
-  </a>
+  <div class="flex items-center gap-2">
+    <template x-if="rcTab === 'rules'">
+      <a href="/rules/new" class="btn btn-primary btn-sm rounded-xl">
+        <i data-lucide="plus" class="w-4 h-4"></i> New Rule
+      </a>
+    </template>
+    <template x-if="rcTab === 'categories'">
+      <div class="flex items-center gap-2 flex-wrap">
+        <!-- Period selector -->
+        <div class="flex items-center bg-base-200/50 rounded-lg p-0.5">
+          <a href="?tab=categories&days=7" class="px-2.5 py-1 text-xs rounded-md transition-colors {{if eq .SpendingDays 7}}bg-base-100 shadow-sm font-medium text-base-content{{else}}text-base-content/50 hover:text-base-content/70{{end}}">7d</a>
+          <a href="?tab=categories&days=30" class="px-2.5 py-1 text-xs rounded-md transition-colors {{if eq .SpendingDays 30}}bg-base-100 shadow-sm font-medium text-base-content{{else}}text-base-content/50 hover:text-base-content/70{{end}}">30d</a>
+          <a href="?tab=categories&days=90" class="px-2.5 py-1 text-xs rounded-md transition-colors {{if eq .SpendingDays 90}}bg-base-100 shadow-sm font-medium text-base-content{{else}}text-base-content/50 hover:text-base-content/70{{end}}">90d</a>
+          <a href="?tab=categories&days=365" class="px-2.5 py-1 text-xs rounded-md transition-colors {{if eq .SpendingDays 365}}bg-base-100 shadow-sm font-medium text-base-content{{else}}text-base-content/50 hover:text-base-content/70{{end}}">1y</a>
+        </div>
+        <button class="btn btn-sm btn-primary rounded-xl gap-2" onclick="document.getElementById('create-cat-modal').showModal()">
+          <i data-lucide="plus" class="w-4 h-4"></i>
+          Add Category
+        </button>
+      </div>
+    </template>
+  </div>
 </div>
+
+<!-- Tab Switcher -->
+<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit">
+  <button @click="rcTab = 'rules'"
+    :class="rcTab === 'rules' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
+    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    <i data-lucide="list-filter" class="w-3.5 h-3.5"></i>
+    Rules
+  </button>
+  <button @click="rcTab = 'categories'"
+    :class="rcTab === 'categories' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
+    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    <i data-lucide="tag" class="w-3.5 h-3.5"></i>
+    Categories
+  </button>
+</div>
+
+<!-- ==================== RULES TAB ==================== -->
+<div x-show="rcTab === 'rules'" x-data="rulesPage()">
 
 <!-- Summary Stats Cards -->
 {{if .Rules}}
@@ -301,4 +341,359 @@ function rulesPage() {
   };
 }
 </script>
+
+</div><!-- /rules tab -->
+
+<!-- ==================== CATEGORIES TAB ==================== -->
+<div x-show="rcTab === 'categories'" x-cloak>
+{{template "category-picker-styles" .}}
+
+<!-- Spending Summary -->
+{{if gt .TotalSpending 0.0}}
+<div class="flex items-center gap-4 mb-4 px-1">
+  <span class="text-xs text-base-content/40">{{len .Categories}} categories</span>
+  <span class="text-xs text-base-content/30">&middot;</span>
+  <span class="text-xs text-base-content/40">{{formatBalance .TotalSpending}} spent in {{.SpendingDays}}d</span>
+</div>
+{{else}}
+<div class="text-sm text-base-content/40 mb-4 px-1">{{len .Categories}} top-level categories</div>
+{{end}}
+
+<!-- Categories Tree -->
+<div>
+    {{if .Categories}}
+    <div class="space-y-2 sm:space-y-3 bb-stagger">
+      {{range .Categories}}
+      {{$spending := index $.SpendingByCategory .DisplayName}}
+      <div class="bb-card overflow-hidden group" x-data="{open: false}">
+        <!-- Parent row -->
+        <div role="button" tabindex="0" class="w-full flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3 sm:py-4 hover:bg-base-200/30 transition-colors duration-150 text-left cursor-pointer select-none"
+          @click="open = !open" @keydown.enter="open = !open" @keydown.space.prevent="open = !open">
+          <div class="flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 rounded-xl shrink-0"
+            style="{{if .Color}}background-color: {{safeCSS .Color}}18{{else}}background-color: {{safeCSS "oklch(48% 0.17 265 / 0.08)"}}{{end}}">
+            {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-4.5 h-4.5 sm:w-5 sm:h-5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
+            {{else}}{{if .Color}}<span class="w-3 h-3 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
+            {{else}}<i data-lucide="tag" class="w-4.5 h-4.5 sm:w-5 sm:h-5 text-primary/60"></i>{{end}}{{end}}
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2">
+              <span class="font-semibold text-sm">{{.DisplayName}}</span>
+              {{if .Hidden}}<span class="badge badge-ghost badge-xs">Hidden</span>{{end}}
+              {{if .IsSystem}}<span class="badge badge-soft badge-info badge-xs">System</span>{{end}}
+              {{if .Children}}<span class="text-[0.65rem] font-medium px-1.5 py-0.5 rounded-full bg-base-200/60 text-base-content/40">{{len .Children}}</span>{{end}}
+            </div>
+            <div class="flex items-center gap-2 mt-0.5">
+              {{if gt $spending.TransactionCount 0}}
+              <span class="text-xs tabular-nums font-medium text-base-content/60">{{formatBalance $spending.Amount}}</span>
+              <span class="text-xs text-base-content/25">&middot;</span>
+              <span class="text-xs text-base-content/40 tabular-nums">{{$spending.TransactionCount}} txn{{if ne $spending.TransactionCount 1}}s{{end}}</span>
+              {{if gt $spending.Percent 0.0}}
+              <span class="text-xs text-base-content/25">&middot;</span>
+              <span class="text-[0.65rem] text-base-content/35 tabular-nums">{{printf "%.0f" $spending.Percent}}%</span>
+              {{end}}
+              {{else}}
+              <span class="text-xs text-base-content/30">No spending</span>
+              {{end}}
+            </div>
+            <!-- Mini spend bar -->
+            {{if and (gt $.MaxCategorySpend 0.0) (gt $spending.Amount 0.0)}}
+            <div class="h-1 mt-1.5 rounded-full bg-base-200/50 overflow-hidden max-w-48 hidden sm:block">
+              <div class="h-full rounded-full transition-all duration-500" style="width: {{printf "%.1f" $spending.Percent}}%; background-color: {{if .Color}}{{safeCSS .Color}}{{else}}oklch(0.55 0.12 250){{end}}; opacity: 0.6;"></div>
+            </div>
+            {{end}}
+          </div>
+          <div class="flex items-center gap-2" @click.stop>
+            {{if gt $spending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+              title="View transactions"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i></a>{{end}}
+            <button class="btn btn-ghost btn-xs rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+              data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+              @click.prevent="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+              title="Edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i></button>
+            {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
+              data-id="{{.ID}}" data-name="{{.DisplayName}}"
+              @click.prevent="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+              title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
+          </div>
+          <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 shrink-0" :class="open ? 'rotate-180' : ''"></i>
+        </div>
+
+        {{if .Children}}
+        <!-- Children -->
+        <div x-show="open" x-cloak
+          x-transition:enter="transition ease-out duration-200"
+          x-transition:enter-start="opacity-0 -translate-y-1"
+          x-transition:enter-end="opacity-100 translate-y-0"
+          x-transition:leave="transition ease-in duration-150"
+          x-transition:leave-start="opacity-100"
+          x-transition:leave-end="opacity-0"
+          class="border-t border-base-300/50">
+          <div class="px-2 sm:px-3 py-1.5 sm:py-2">
+            {{range .Children}}
+            {{$childSpending := index $.SpendingByCategory .DisplayName}}
+            <div class="group flex items-center gap-2.5 sm:gap-3 py-2.5 px-2 sm:px-3 rounded-xl hover:bg-base-200/40 transition-colors duration-150">
+              <div class="w-6 h-6 sm:w-7 sm:h-7 rounded-lg flex items-center justify-center shrink-0"
+                style="{{if .Color}}background-color: {{safeCSS .Color}}12{{end}}">
+                {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-3.5 h-3.5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
+                {{else if .Color}}<span class="w-2 h-2 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
+                {{else}}<span class="w-2 h-2 rounded-full bg-base-content/20"></span>{{end}}
+              </div>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2">
+                  <span class="text-sm">{{.DisplayName}}</span>
+                  {{if .Hidden}}<span class="badge badge-ghost badge-xs">Hidden</span>{{end}}
+                </div>
+                {{if gt $childSpending.TransactionCount 0}}
+                <div class="flex items-center gap-2 mt-0.5">
+                  <span class="text-xs tabular-nums text-base-content/50">{{formatBalance $childSpending.Amount}}</span>
+                  <span class="text-xs text-base-content/25">&middot;</span>
+                  <span class="text-xs text-base-content/35 tabular-nums">{{$childSpending.TransactionCount}} txn{{if ne $childSpending.TransactionCount 1}}s{{end}}</span>
+                </div>
+                {{end}}
+              </div>
+              <div class="flex gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150">
+                {{if gt $childSpending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg"
+                  title="View transactions"><i data-lucide="arrow-up-right" class="w-3 h-3"></i></a>{{end}}
+                <button class="btn btn-ghost btn-xs rounded-lg"
+                  data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+                  @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                  title="Edit"><i data-lucide="pencil" class="w-3 h-3"></i></button>
+                {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error"
+                  data-id="{{.ID}}" data-name="{{.DisplayName}}"
+                  @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                  title="Delete"><i data-lucide="trash-2" class="w-3 h-3"></i></button>{{end}}
+              </div>
+            </div>
+            {{end}}
+          </div>
+        </div>
+        {{else}}
+        <div x-show="open" x-cloak
+          x-transition:enter="transition ease-out duration-200"
+          x-transition:enter-start="opacity-0"
+          x-transition:enter-end="opacity-100"
+          class="border-t border-base-300 px-4 sm:px-5 py-3 sm:py-4">
+          <p class="text-sm text-base-content/40">No subcategories</p>
+        </div>
+        {{end}}
+      </div>
+      {{end}}
+    </div>
+    {{else}}
+    <!-- Empty state -->
+    <div class="bb-card">
+      <div class="flex flex-col items-center text-center py-16 px-6">
+        <div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
+          <i data-lucide="tag" class="w-8 h-8 text-primary"></i>
+        </div>
+        <h2 class="text-lg font-semibold mb-1">No categories yet</h2>
+        <p class="text-base-content/50 text-sm mb-6 max-w-sm">Create your first category to start organizing transactions into a clean taxonomy.</p>
+        <button class="btn btn-primary btn-sm rounded-xl gap-2" onclick="document.getElementById('create-cat-modal').showModal()">
+          <i data-lucide="plus" class="w-4 h-4"></i> Add Category
+        </button>
+      </div>
+    </div>
+    {{end}}
+  </div>
+
+<!-- ═══════════ Create Category Modal ═══════════ -->
+<dialog id="create-cat-modal" class="modal modal-bottom sm:modal-middle">
+  <form class="modal-box rounded-xl max-w-lg" x-data="{displayName: '', parentId: '', icon: '', color: '#6366f1', sortOrder: 0, submitting: false, showIconPicker: false,
+    commonIcons: ['shopping-cart','utensils','car','home','briefcase','heart','zap','book','plane','music','gift','coffee','scissors','shirt','gamepad-2','graduation-cap','building-2','fuel','bus','train'],
+    presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c']
+  }" @submit.prevent="
+    submitting = true;
+    fetch('/-/categories', {method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({display_name: displayName, parent_id: parentId || undefined, icon: icon || undefined, color: color || undefined, sort_order: sortOrder})})
+    .then(r => { if(r.ok) location.reload(); else r.json().then(d => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Error', type:'error'}})); submitting = false; }); })
+    .catch(() => { submitting = false; })
+  ">
+    <h3 class="text-lg font-bold">Add Category</h3>
+    <p class="text-sm text-base-content/50 mt-1">Create a new category in your taxonomy</p>
+    <div class="space-y-4 mt-6">
+      <!-- Live preview -->
+      <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-xl">
+        <div class="w-9 h-9 rounded-xl flex items-center justify-center" :style="'background-color:' + (color || '#6366f1') + '15'">
+          <template x-if="icon"><i :data-lucide="icon" class="w-4.5 h-4.5" :style="'color:' + (color || '#6366f1')"></i></template>
+          <template x-if="!icon"><span class="w-2.5 h-2.5 rounded-full" :style="'background-color:' + (color || '#6366f1')"></span></template>
+        </div>
+        <span class="font-semibold text-sm" x-text="displayName || 'Category Name'"></span>
+      </div>
+
+      <label class="form-control w-full">
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Display Name</span></div>
+        <input type="text" x-model="displayName" class="input input-bordered w-full rounded-xl" required placeholder="e.g. Food & Drink">
+      </label>
+
+      <label class="form-control w-full">
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Parent Category</span></div>
+        <div class="bb-cat-picker" data-picker-source="cat-create-parent" x-data="categoryPicker({categories: {{toJSON .Categories}}, mode: 'assign', placeholder: 'None (top-level)', allowEmpty: true, emptyLabel: 'None (top-level)', sourceId: 'cat-create-parent'})" @category-change="parentId = $event.detail.id">
+          <button type="button" class="select select-bordered w-full text-left flex items-center gap-2 rounded-xl" @click="openPicker()">
+            <span x-text="displayLabel" class="flex-1 text-sm"></span>
+            <i data-lucide="chevron-down" class="w-4 h-4 opacity-40"></i>
+          </button>
+        </div>
+      </label>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div class="form-control">
+          <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Icon</span></div>
+          <div class="flex gap-2 items-center">
+            <input type="text" x-model="icon" class="input input-bordered flex-1 rounded-xl" placeholder="e.g. shopping-cart">
+            <button type="button" class="btn btn-sm btn-ghost rounded-xl" @click="showIconPicker = !showIconPicker" title="Browse icons">
+              <i data-lucide="grid-3x3" class="w-4 h-4"></i>
+            </button>
+          </div>
+          <div x-show="showIconPicker" x-cloak class="mt-2 p-2.5 bg-base-200/40 rounded-xl">
+            <div class="grid grid-cols-5 gap-1">
+              <template x-for="ic in commonIcons">
+                <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="icon = ic; showIconPicker = false; $nextTick(() => lucide.createIcons())">
+                  <i :data-lucide="ic" class="w-4 h-4"></i>
+                </button>
+              </template>
+            </div>
+          </div>
+        </div>
+        <div class="form-control">
+          <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Color</span></div>
+          <div class="flex flex-wrap gap-1.5">
+            <template x-for="c in presetColors">
+              <button type="button" class="w-7 h-7 rounded-full border-2 transition-all duration-150 hover:scale-110" :style="'background-color:' + c" :class="color === c ? 'border-base-content scale-110 shadow-sm' : 'border-transparent'" @click="color = c"></button>
+            </template>
+            <label class="w-7 h-7 rounded-full border-2 border-dashed border-base-content/20 cursor-pointer overflow-hidden flex items-center justify-center hover:border-base-content/40 transition-colors" title="Custom color">
+              <input type="color" x-model="color" class="opacity-0 absolute w-0 h-0">
+              <i data-lucide="palette" class="w-3.5 h-3.5 opacity-40"></i>
+            </label>
+          </div>
+        </div>
+      </div>
+
+      <label class="form-control w-full">
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Sort Order</span></div>
+        <input type="number" x-model.number="sortOrder" class="input input-bordered w-full rounded-xl" value="0">
+      </label>
+    </div>
+    <div class="modal-action">
+      <button type="button" class="btn btn-ghost btn-sm rounded-xl" onclick="document.getElementById('create-cat-modal').close()">Cancel</button>
+      <button type="submit" class="btn btn-primary btn-sm rounded-xl" :disabled="submitting || !displayName">
+        <span x-show="!submitting">Create</span>
+        <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+      </button>
+    </div>
+  </form>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+<!-- ═══════════ Edit Category Modal ═══════════ -->
+<dialog id="edit-cat-modal" class="modal modal-bottom sm:modal-middle" x-data="{editId: '', editDisplayName: '', editIcon: '', editColor: '', editSortOrder: 0, editHidden: false, submitting: false, showIconPicker: false,
+  commonIcons: ['shopping-cart','utensils','car','home','briefcase','heart','zap','book','plane','music','gift','coffee','scissors','shirt','gamepad-2','graduation-cap','building-2','fuel','bus','train'],
+  presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c']
+}" @edit-category.window="editId = $event.detail.id; editDisplayName = $event.detail.displayName; editIcon = $event.detail.icon; editColor = $event.detail.color || '#6366f1'; editSortOrder = $event.detail.sortOrder; editHidden = $event.detail.hidden; showIconPicker = false; document.getElementById('edit-cat-modal').showModal(); $nextTick(() => lucide.createIcons())">
+  <div class="modal-box rounded-xl max-w-lg">
+    <h3 class="text-lg font-bold">Edit Category</h3>
+    <p class="text-sm text-base-content/50 mt-1">Update category appearance and settings</p>
+    <div class="space-y-4 mt-6">
+      <!-- Live preview -->
+      <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-xl">
+        <div class="w-9 h-9 rounded-xl flex items-center justify-center" :style="'background-color:' + (editColor || '#6366f1') + '15'">
+          <template x-if="editIcon"><i :data-lucide="editIcon" class="w-4.5 h-4.5" :style="'color:' + (editColor || '#6366f1')"></i></template>
+          <template x-if="!editIcon"><span class="w-2.5 h-2.5 rounded-full" :style="'background-color:' + (editColor || '#6366f1')"></span></template>
+        </div>
+        <span class="font-semibold text-sm" x-text="editDisplayName || 'Category Name'"></span>
+        <span x-show="editHidden" class="badge badge-ghost badge-xs">Hidden</span>
+      </div>
+
+      <label class="form-control w-full">
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Display Name</span></div>
+        <input type="text" x-model="editDisplayName" class="input input-bordered w-full rounded-xl" required>
+      </label>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div class="form-control">
+          <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Icon</span></div>
+          <div class="flex gap-2 items-center">
+            <input type="text" x-model="editIcon" class="input input-bordered flex-1 rounded-xl" placeholder="e.g. shopping-cart">
+            <button type="button" class="btn btn-sm btn-ghost rounded-xl" @click="showIconPicker = !showIconPicker">
+              <i data-lucide="grid-3x3" class="w-4 h-4"></i>
+            </button>
+          </div>
+          <div x-show="showIconPicker" x-cloak class="mt-2 p-2.5 bg-base-200/40 rounded-xl">
+            <div class="grid grid-cols-5 gap-1">
+              <template x-for="ic in commonIcons">
+                <button type="button" class="btn btn-ghost btn-sm rounded-xl" @click="editIcon = ic; showIconPicker = false; $nextTick(() => lucide.createIcons())">
+                  <i :data-lucide="ic" class="w-4 h-4"></i>
+                </button>
+              </template>
+            </div>
+          </div>
+        </div>
+        <div class="form-control">
+          <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Color</span></div>
+          <div class="flex flex-wrap gap-1.5">
+            <template x-for="c in presetColors">
+              <button type="button" class="w-7 h-7 rounded-full border-2 transition-all duration-150 hover:scale-110" :style="'background-color:' + c" :class="editColor === c ? 'border-base-content scale-110 shadow-sm' : 'border-transparent'" @click="editColor = c"></button>
+            </template>
+            <label class="w-7 h-7 rounded-full border-2 border-dashed border-base-content/20 cursor-pointer overflow-hidden flex items-center justify-center hover:border-base-content/40 transition-colors" title="Custom color">
+              <input type="color" x-model="editColor" class="opacity-0 absolute w-0 h-0">
+              <i data-lucide="palette" class="w-3.5 h-3.5 opacity-40"></i>
+            </label>
+          </div>
+        </div>
+      </div>
+      <label class="form-control w-full">
+        <div class="label"><span class="label-text text-xs font-medium text-base-content/60">Sort Order</span></div>
+        <input type="number" x-model.number="editSortOrder" class="input input-bordered w-full rounded-xl">
+      </label>
+      <label class="label cursor-pointer justify-start gap-3">
+        <input type="checkbox" x-model="editHidden" class="toggle toggle-sm">
+        <div>
+          <span class="label-text text-sm">Hidden</span>
+          <span class="text-xs text-base-content/40 block">Hidden categories still work for mapping but don't appear in dropdowns</span>
+        </div>
+      </label>
+    </div>
+    <div class="modal-action">
+      <button type="button" class="btn btn-ghost btn-sm rounded-xl" onclick="document.getElementById('edit-cat-modal').close()">Cancel</button>
+      <button type="button" class="btn btn-primary btn-sm rounded-xl" :disabled="submitting || !editDisplayName" @click="
+        submitting = true;
+        fetch('/-/categories/' + editId, {method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({display_name: editDisplayName, icon: editIcon || undefined, color: editColor || undefined, sort_order: editSortOrder, hidden: editHidden})})
+        .then(r => { if(r.ok) location.reload(); else r.json().then(d => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Error', type:'error'}})); submitting = false; }); })
+        .catch(() => { submitting = false; })
+      ">
+        <span x-show="!submitting">Save</span>
+        <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+      </button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+<!-- ═══════════ Delete Category Modal ═══════════ -->
+<dialog id="delete-cat-modal" class="modal modal-bottom sm:modal-middle" x-data="{deleteId: '', deleteName: '', submitting: false}" @delete-category.window="deleteId = $event.detail.id; deleteName = $event.detail.name; document.getElementById('delete-cat-modal').showModal()">
+  <div class="modal-box rounded-xl max-w-md">
+    <div class="flex items-center gap-3 mb-4">
+      <div class="w-10 h-10 rounded-xl bg-error/10 flex items-center justify-center">
+        <i data-lucide="alert-triangle" class="w-5 h-5 text-error"></i>
+      </div>
+      <h3 class="font-bold text-lg">Delete Category</h3>
+    </div>
+    <p class="text-sm text-base-content/70">Are you sure you want to delete <strong x-text="deleteName"></strong>? Affected transactions will be set to Uncategorized.</p>
+    <div class="modal-action">
+      <button type="button" class="btn btn-ghost btn-sm rounded-xl" onclick="document.getElementById('delete-cat-modal').close()">Cancel</button>
+      <button type="button" class="btn btn-error btn-sm rounded-xl" :disabled="submitting" @click="
+        submitting = true;
+        fetch('/-/categories/' + deleteId, {method: 'DELETE'})
+        .then(r => { if(r.ok) location.reload(); else r.json().then(d => { window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Error', type:'error'}})); submitting = false; }); })
+        .catch(() => { submitting = false; })
+      ">
+        <span x-show="!submitting">Delete</span>
+        <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+      </button>
+    </div>
+  </div>
+  <form method="dialog" class="modal-backdrop"><button>close</button></form>
+</dialog>
+
+{{template "category-picker-script" .}}
+
+</div><!-- /categories tab -->
+
+</div><!-- /alpine x-data tabs -->
 {{end}}

--- a/internal/templates/pages/user_form.html
+++ b/internal/templates/pages/user_form.html
@@ -3,11 +3,11 @@
 
 <div class="bb-page-header">
   <div>
-    <h1 class="bb-page-title">{{if .IsEdit}}Edit {{.User.Name}}{{else}}Add Family Member{{end}}</h1>
-    <p class="text-sm text-base-content/50 mt-1">{{if .IsEdit}}Update member details{{else}}Add a new person to your family group{{end}}</p>
+    <h1 class="bb-page-title">{{if .IsEdit}}Edit {{.User.Name}}{{else}}Add Member{{end}}</h1>
+    <p class="text-sm text-base-content/50 mt-1">{{if .IsEdit}}Update member details{{else}}Add a new person to your household{{end}}</p>
   </div>
   <a href="/users" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> Family Members
+    <i data-lucide="arrow-left" class="w-4 h-4"></i> Household
   </a>
 </div>
 

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -1,7 +1,7 @@
 {{define "content"}}
 <div class="bb-page-header">
   <div>
-    <h1 class="bb-page-title">Family Members</h1>
+    <h1 class="bb-page-title">Household</h1>
     <p class="text-sm text-base-content/50 mt-1">Manage who has bank connections in Breadbox</p>
   </div>
   <a href="/users/new" class="btn btn-primary btn-sm rounded-xl">

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -1,49 +1,15 @@
 {{define "nav"}}
 <nav class="bb-sidebar-nav">
-  <div class="bb-sidebar-section">Data</div>
-  <a href="/" class="bb-sidebar-link{{if eq .CurrentPage "dashboard"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="layout-dashboard"></i>
-    <span class="flex-1">Dashboard</span>
+  <div class="bb-sidebar-section">Overview</div>
+  <a href="/" class="bb-sidebar-link{{if eq .CurrentPage "home"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="house"></i>
+    <span class="flex-1">Home</span>
   </a>
   <a href="/insights" class="bb-sidebar-link{{if eq .CurrentPage "insights"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="lightbulb"></i> Insights
   </a>
-  <a href="/connections" class="bb-sidebar-link{{if eq .CurrentPage "connections"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="link"></i>
-    <span class="flex-1">Connections</span>
-    {{if and .NavBadges (gt .NavBadges.ConnectionsAttention 0)}}
-    <span class="bb-nav-badge bb-nav-badge--warn" title="{{.NavBadges.ConnectionsAttention}} connections need attention">{{badgeCount .NavBadges.ConnectionsAttention}}</span>
-    {{end}}
-  </a>
   <a href="/transactions" class="bb-sidebar-link{{if eq .CurrentPage "transactions"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="receipt"></i> Transactions
-  </a>
-  <a href="/rules" class="bb-sidebar-link{{if eq .CurrentPage "rules"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="list-filter"></i> Rules
-  </a>
-  <a href="/categories" class="bb-sidebar-link{{if eq .CurrentPage "categories"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="tag"></i> Categories
-  </a>
-  <a href="/account-links" class="bb-sidebar-link{{if eq .CurrentPage "account-links"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="link-2"></i> Account Links
-  </a>
-  <a href="/users" class="bb-sidebar-link{{if eq .CurrentPage "users"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="users"></i> Family Members
-  </a>
-
-  <div class="bb-sidebar-section">Agents</div>
-  <a href="/mcp-getting-started" class="bb-sidebar-link{{if eq .CurrentPage "mcp-getting-started"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="rocket"></i> Getting Started
-  </a>
-  <a href="/agent-wizard" class="bb-sidebar-link{{if eq .CurrentPage "agent-wizard"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="wand-sparkles"></i> Agent Wizard
-  </a>
-  <a href="/reviews" class="bb-sidebar-link{{if eq .CurrentPage "reviews"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="clipboard-check"></i>
-    <span class="flex-1">Review Queue</span>
-    {{if and .NavBadges (gt .NavBadges.PendingReviews 0)}}
-    <span class="bb-nav-badge" title="{{.NavBadges.PendingReviews}} pending reviews">{{badgeCount .NavBadges.PendingReviews}}</span>
-    {{end}}
   </a>
   <a href="/reports" class="bb-sidebar-link{{if eq .CurrentPage "reports"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="file-text"></i>
@@ -52,8 +18,30 @@
     <span class="bb-nav-badge" title="{{.NavBadges.UnreadReports}} unread reports">{{badgeCount .NavBadges.UnreadReports}}</span>
     {{end}}
   </a>
-  <a href="/mcp-settings" class="bb-sidebar-link{{if eq .CurrentPage "mcp"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="bot"></i> MCP Settings
+
+  <div class="bb-sidebar-section">Manage</div>
+  <a href="/connections" class="bb-sidebar-link{{if eq .CurrentPage "connections"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="link"></i>
+    <span class="flex-1">Connections</span>
+    {{if and .NavBadges (gt .NavBadges.ConnectionsAttention 0)}}
+    <span class="bb-nav-badge bb-nav-badge--warn" title="{{.NavBadges.ConnectionsAttention}} connections need attention">{{badgeCount .NavBadges.ConnectionsAttention}}</span>
+    {{end}}
+  </a>
+  <a href="/agents" class="bb-sidebar-link{{if eq .CurrentPage "agents"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="bot"></i> Agents
+  </a>
+  <a href="/rules" class="bb-sidebar-link{{if or (eq .CurrentPage "rules") (eq .CurrentPage "categories")}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="list-filter"></i> Rules & Categories
+  </a>
+  <a href="/reviews" class="bb-sidebar-link{{if eq .CurrentPage "reviews"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="clipboard-check"></i>
+    <span class="flex-1">Review Queue</span>
+    {{if and .NavBadges (gt .NavBadges.PendingReviews 0)}}
+    <span class="bb-nav-badge" title="{{.NavBadges.PendingReviews}} pending reviews">{{badgeCount .NavBadges.PendingReviews}}</span>
+    {{end}}
+  </a>
+  <a href="/users" class="bb-sidebar-link{{if eq .CurrentPage "users"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="users"></i> Household
   </a>
 
   <div class="bb-sidebar-section">System</div>
@@ -63,11 +51,8 @@
   <a href="/access" class="bb-sidebar-link{{if eq .CurrentPage "access"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="shield-check"></i> Access
   </a>
-  <a href="/sync-logs" class="bb-sidebar-link{{if eq .CurrentPage "sync-logs"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="refresh-cw"></i> Sync Logs
-  </a>
-  <a href="/webhook-events" class="bb-sidebar-link{{if eq .CurrentPage "webhook-events"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="webhook"></i> Webhooks
+  <a href="/logs" class="bb-sidebar-link{{if eq .CurrentPage "logs"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="scroll-text"></i> Logs
   </a>
   <a href="/settings" class="bb-sidebar-link{{if eq .CurrentPage "settings"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="settings"></i> Settings


### PR DESCRIPTION
Restructure the admin sidebar into 3 intent-based sections:
- Overview: Home, Insights, Transactions, Reports
- Manage: Connections, Agents, Rules & Categories, Review Queue, Household
- System: Providers, Access, Logs, Settings

Key changes:
- Rename Dashboard→Home, Family Members→Household
- Merge Sync Logs + Webhooks into tabbed "Logs" page
- Merge Account Links into Connections as a tab
- Merge Rules + Categories into tabbed "Rules & Categories" page
- Merge Getting Started + Agent Wizard + MCP Settings into tabbed "Agents" page
- Move Reports from Agents to Overview section
- Move Review Queue from Agents to Manage section
- Old URLs redirect (301) to new locations for backward compatibility
- Update command palette groups and keywords to match new IA
- Parse agents.html as composite template with source files for sub-template access

https://claude.ai/code/session_01Vgm1JQWLbu2pZBjDKADFkR