### PR TITLE
Add offset-based pagination to transaction rules admin UI

### DIFF
--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"breadbox/internal/service"
@@ -18,8 +20,22 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page < 1 {
+			page = 1
+		}
+
+		pageSize := 50
+		if v, err := strconv.Atoi(r.URL.Query().Get("per_page")); err == nil {
+			switch v {
+			case 25, 50, 100:
+				pageSize = v
+			}
+		}
+
 		params := service.TransactionRuleListParams{
-			Limit: 50,
+			Page:     page,
+			PageSize: pageSize,
 		}
 
 		if v := r.URL.Query().Get("search"); v != "" {
@@ -32,14 +48,6 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 			b, err := strconv.ParseBool(v)
 			if err == nil {
 				params.Enabled = &b
-			}
-		}
-		if v := r.URL.Query().Get("cursor"); v != "" {
-			params.Cursor = v
-		}
-		if v := r.URL.Query().Get("limit"); v != "" {
-			if l, err := strconv.Atoi(v); err == nil && l > 0 {
-				params.Limit = l
 			}
 		}
 
@@ -71,12 +79,19 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 			tab = "rules"
 		}
 
+		// Build pagination base URL (all params except page).
+		paginationBase := buildRulesPaginationBase(r)
+
 		data := BaseTemplateData(r, sm, "rules", "Rules & Categories")
 		data["Tab"] = tab
 		data["Rules"] = result.Rules
-		data["HasMore"] = result.HasMore
-		data["NextCursor"] = result.NextCursor
 		data["Total"] = result.Total
+		data["Page"] = result.Page
+		data["PageSize"] = result.PageSize
+		data["TotalPages"] = result.TotalPages
+		data["PaginationBase"] = paginationBase
+		data["ShowingStart"] = (result.Page-1)*result.PageSize + 1
+		data["ShowingEnd"] = min(int64(result.Page*result.PageSize), result.Total)
 		data["ActiveCount"] = activeCount
 		data["DisabledCount"] = disabledCount
 		data["TotalHits"] = totalHits
@@ -172,6 +187,23 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 
 		tr.Render(w, r, "rules.html", data)
 	}
+}
+
+// buildRulesPaginationBase returns the pagination base URL for the rules page.
+func buildRulesPaginationBase(r *http.Request) string {
+	params := []string{"search", "category_slug", "enabled", "per_page"}
+	q := r.URL.Query()
+	var qs []string
+	for _, key := range params {
+		if v := q.Get(key); v != "" {
+			qs = append(qs, key+"="+url.QueryEscape(v))
+		}
+	}
+	base := "/rules?page="
+	if len(qs) > 0 {
+		base = "/rules?" + strings.Join(qs, "&") + "&page="
+	}
+	return base
 }
 
 // RuleFormPageHandler serves GET /admin/rules/new and /admin/rules/{id}/edit.

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -608,8 +608,61 @@ func (s *Service) ListTransactionRules(ctx context.Context, params TransactionRu
 		return nil, fmt.Errorf("count rules: %w", err)
 	}
 
-	// Add cursor condition for the main query
+	// Main query
+	selectCols := `SELECT tr.id, tr.short_id, tr.name, tr.conditions, tr.category_id, tr.priority, tr.enabled,
+		tr.expires_at, tr.created_by_type, tr.created_by_id, tr.created_by_name,
+		tr.hit_count, tr.last_hit_at, tr.created_at, tr.updated_at,
+		tr.actions, c.slug AS category_slug, c.display_name AS category_display_name,
+		COALESCE(c.icon, cp.icon) AS category_icon, COALESCE(c.color, cp.color) AS category_color `
+
+	orderBy := " ORDER BY tr.created_at DESC, tr.id DESC"
 	whereSQL := filterWhereSQL
+
+	// Offset-based pagination (admin UI)
+	if params.Page > 0 {
+		pageSize := params.PageSize
+		if pageSize <= 0 {
+			pageSize = 50
+		}
+		offset := (params.Page - 1) * pageSize
+		limitClause := fmt.Sprintf(" LIMIT $%d OFFSET $%d", argN, argN+1)
+		args = append(args, pageSize, offset)
+
+		fullQuery := selectCols + baseFrom + whereSQL + orderBy + limitClause
+		rows, err := s.Pool.Query(ctx, fullQuery, args...)
+		if err != nil {
+			return nil, fmt.Errorf("query rules: %w", err)
+		}
+		defer rows.Close()
+
+		var rules []TransactionRuleResponse
+		for rows.Next() {
+			var row ruleRow
+			if err := rows.Scan(row.scanDest()...); err != nil {
+				return nil, fmt.Errorf("scan rule: %w", err)
+			}
+			rules = append(rules, row.toResponse())
+		}
+		if err := rows.Err(); err != nil {
+			return nil, fmt.Errorf("iterate rules: %w", err)
+		}
+
+		totalPages := int(total) / pageSize
+		if int(total)%pageSize != 0 {
+			totalPages++
+		}
+
+		return &TransactionRuleListResult{
+			Rules:      rules,
+			Total:      total,
+			Page:       params.Page,
+			PageSize:   pageSize,
+			TotalPages: totalPages,
+			HasMore:    params.Page < totalPages,
+		}, nil
+	}
+
+	// Cursor-based pagination (API/MCP)
 	if params.Cursor != "" {
 		cursorTime, cursorIDStr, err := decodeTimestampCursor(params.Cursor)
 		if err != nil {
@@ -629,14 +682,6 @@ func (s *Service) ListTransactionRules(ctx context.Context, params TransactionRu
 		argN += 2
 	}
 
-	// Main query
-	selectCols := `SELECT tr.id, tr.short_id, tr.name, tr.conditions, tr.category_id, tr.priority, tr.enabled,
-		tr.expires_at, tr.created_by_type, tr.created_by_id, tr.created_by_name,
-		tr.hit_count, tr.last_hit_at, tr.created_at, tr.updated_at,
-		tr.actions, c.slug AS category_slug, c.display_name AS category_display_name,
-		COALESCE(c.icon, cp.icon) AS category_icon, COALESCE(c.color, cp.color) AS category_color `
-
-	orderBy := " ORDER BY tr.created_at DESC, tr.id DESC"
 	limitClause := fmt.Sprintf(" LIMIT $%d", argN)
 	args = append(args, limit+1)
 

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -500,6 +500,9 @@ type TransactionRuleListParams struct {
 	SearchMode   *string
 	Limit        int
 	Cursor       string
+	// Offset-based pagination (used by admin UI). When Page > 0, cursor is ignored.
+	Page     int
+	PageSize int
 }
 
 type TransactionRuleListResult struct {
@@ -507,6 +510,10 @@ type TransactionRuleListResult struct {
 	NextCursor string                    `json:"next_cursor,omitempty"`
 	HasMore    bool                      `json:"has_more"`
 	Total      int64                     `json:"total"`
+	// Offset-based pagination fields (populated when Page > 0)
+	Page       int `json:"page,omitempty"`
+	PageSize   int `json:"page_size,omitempty"`
+	TotalPages int `json:"total_pages,omitempty"`
 }
 
 type CreateTransactionRuleParams struct {

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -166,7 +166,7 @@
 
 <!-- Rules count -->
 <div class="text-sm text-base-content/40 mb-4 px-1">
-  {{.Total}} rule{{if ne .Total 1}}s{{end}} found
+  {{if gt .TotalPages 1}}Showing {{.ShowingStart}}&ndash;{{.ShowingEnd}} of {{end}}{{.Total}} rule{{if ne .Total 1}}s{{end}} found
 </div>
 
 <!-- Rules as cards instead of table for Mercury feel -->
@@ -309,15 +309,64 @@
 </div>
 
 <!-- Pagination -->
-{{if .HasMore}}
-<div class="flex justify-center mt-8">
-  <a href="/rules?cursor={{.NextCursor}}{{if .SearchFilter}}&search={{.SearchFilter}}{{end}}{{if .CategoryFilter}}&category_slug={{.CategoryFilter}}{{end}}{{if .EnabledFilter}}&enabled={{.EnabledFilter}}{{end}}" class="btn btn-sm btn-outline rounded-xl">Load More</a>
+{{if gt .TotalPages 1}}
+<div class="bb-paginator mt-8" id="bb-rules-paginator">
+  <div class="bb-paginator__info">
+    <span class="text-xs text-base-content/50 tabular-nums hidden sm:inline">
+      Showing {{.ShowingStart}}&ndash;{{.ShowingEnd}} of {{.Total}}
+    </span>
+    <div class="bb-paginator__per-page">
+      <label class="text-xs text-base-content/40 whitespace-nowrap">Per page</label>
+      <select class="select select-xs select-bordered rounded-lg tabular-nums" onchange="bbSetRulesPerPage(this.value)">
+        <option value="25"{{if eq .PageSize 25}} selected{{end}}>25</option>
+        <option value="50"{{if eq .PageSize 50}} selected{{end}}>50</option>
+        <option value="100"{{if eq .PageSize 100}} selected{{end}}>100</option>
+      </select>
+    </div>
+  </div>
+  <div class="bb-paginator__nav">
+    {{if gt .Page 2}}
+    <a href="{{printf "%s%d" $.PaginationBase 1}}" class="bb-paginator__btn" title="First page">
+      <i data-lucide="chevrons-left" class="w-3.5 h-3.5"></i>
+    </a>
+    {{end}}
+    {{if gt .Page 1}}
+    <a href="{{printf "%s%d" $.PaginationBase (sub $.Page 1)}}" class="bb-paginator__btn" title="Previous page">
+      <i data-lucide="chevron-left" class="w-3.5 h-3.5"></i>
+    </a>
+    {{end}}
+    {{range pageRange .Page .TotalPages}}
+    {{if eq . 0}}
+    <span class="bb-paginator__ellipsis">&hellip;</span>
+    {{else if eq . $.Page}}
+    <span class="bb-paginator__btn bb-paginator__btn--active">{{.}}</span>
+    {{else}}
+    <a href="{{printf "%s%d" $.PaginationBase .}}" class="bb-paginator__btn">{{.}}</a>
+    {{end}}
+    {{end}}
+    {{if lt .Page .TotalPages}}
+    <a href="{{printf "%s%d" $.PaginationBase (add $.Page 1)}}" class="bb-paginator__btn" title="Next page">
+      <i data-lucide="chevron-right" class="w-3.5 h-3.5"></i>
+    </a>
+    {{end}}
+    {{if lt .Page (sub .TotalPages 1)}}
+    <a href="{{printf "%s%d" $.PaginationBase $.TotalPages}}" class="bb-paginator__btn" title="Last page">
+      <i data-lucide="chevrons-right" class="w-3.5 h-3.5"></i>
+    </a>
+    {{end}}
+  </div>
 </div>
 {{end}}
 
 </div>
 
 <script>
+function bbSetRulesPerPage(val) {
+  const u = new URL(window.location.href);
+  u.searchParams.set('per_page', val);
+  u.searchParams.delete('page');
+  window.location.href = u.toString();
+}
 function rulesPage() {
   return {
     async toggleRule(id) {


### PR DESCRIPTION
## Summary
Implements offset-based pagination for the transaction rules admin UI while maintaining cursor-based pagination for API/MCP endpoints. The admin interface now displays traditional page-based navigation with configurable page sizes instead of the previous "Load More" button.

## Key Changes
- **Service Layer**: Modified `ListTransactionRules()` to support both pagination modes:
  - When `Page > 0`: Uses offset-based pagination (admin UI)
  - When `Page == 0`: Uses cursor-based pagination (API/MCP)
  - Added `Page`, `PageSize`, and `TotalPages` fields to `TransactionRuleListResult`

- **Admin Handler**: Updated `RulesPageHandler()` to:
  - Parse `page` and `per_page` query parameters
  - Support configurable page sizes (25, 50, 100 items per page)
  - Build pagination base URL preserving search/filter parameters
  - Calculate and pass pagination metadata to template

- **Template**: Replaced "Load More" button with full pagination UI:
  - Page number buttons with ellipsis for large page counts
  - First/Previous/Next/Last navigation buttons
  - Per-page size selector dropdown
  - Updated item count display showing range (e.g., "Showing 1–50 of 150")

- **Types**: Extended `TransactionRuleListParams` and `TransactionRuleListResult` with offset-based pagination fields

## Implementation Details
- Pagination logic is cleanly separated: offset-based path returns early, cursor-based path follows
- Page size validation ensures only 25, 50, or 100 are accepted
- Pagination base URL builder preserves all relevant filters while allowing page changes
- Template uses helper functions (`pageRange`, `sub`, `add`, `min`) for pagination rendering
- Backward compatible: cursor-based pagination remains unchanged for API consumers

https://claude.ai/code/session_01BSa5AVUUrys1ctTWSjLsze