### PR TITLE
Fix Rules & Categories page: separate x-show and x-data on rules tab

### DIFF
--- a/internal/admin/rules_render_test.go
+++ b/internal/admin/rules_render_test.go
@@ -1,0 +1,100 @@
+package admin
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+func TestRulesTemplateWithCategories(t *testing.T) {
+	tr, err := NewTemplateRenderer(nil)
+	if err != nil {
+		t.Fatalf("NewTemplateRenderer: %v", err)
+	}
+
+	type catSpending struct {
+		Amount           float64
+		TransactionCount int64
+		Percent          float64
+	}
+
+	color := "#ef4444"
+	icon := "utensils"
+
+	data := map[string]interface{}{
+		"PageTitle":      "Rules & Categories",
+		"CurrentPage":    "rules",
+		"CSRFToken":      "test",
+		"Flash":          nil,
+		"Tab":            "categories",
+		"Rules":          []interface{}{},
+		"HasMore":        false,
+		"NextCursor":     "",
+		"Total":          int64(0),
+		"ActiveCount":    0,
+		"DisabledCount":  0,
+		"TotalHits":      0,
+		"AgentCreated":   0,
+		"SearchFilter":   "",
+		"CategoryFilter": "",
+		"EnabledFilter":  "",
+		"Categories": []service.CategoryResponse{
+			{
+				ID: "1", DisplayName: "Food & Drink", Slug: "food_and_drink",
+				Color: &color, Icon: &icon,
+				Children: []service.CategoryResponse{
+					{ID: "2", DisplayName: "Groceries", Slug: "food_and_drink_groceries"},
+				},
+			},
+		},
+		"FlatCategories":     []interface{}{},
+		"Version":            "dev",
+		"SpendingByCategory": map[string]catSpending{"Food & Drink": {Amount: 500.0, TransactionCount: 10, Percent: 50.0}},
+		"TotalSpending":      1000.0,
+		"MaxCategorySpend":   500.0,
+		"SpendingDays":       30,
+	}
+
+	var buf bytes.Buffer
+	err = tr.RenderTo(&buf, "rules.html", data)
+	if err != nil {
+		t.Fatalf("RenderTo error: %v", err)
+	}
+
+	html := buf.String()
+
+	// Verify the categories tab content is rendered
+	if !strings.Contains(html, "Food &amp; Drink") {
+		t.Error("category 'Food & Drink' not found in rendered output")
+	}
+	if !strings.Contains(html, "Groceries") {
+		t.Error("subcategory 'Groceries' not found in rendered output")
+	}
+
+	// Verify both tab x-show directives exist
+	if !strings.Contains(html, `x-show="rcTab === 'rules'"`) {
+		t.Error("rules tab x-show directive not found")
+	}
+	if !strings.Contains(html, `x-show="rcTab === 'categories'"`) {
+		t.Error("categories tab x-show directive not found")
+	}
+
+	// Verify x-show and x-data are on SEPARATE elements (not same div)
+	if strings.Contains(html, `x-show="rcTab === 'rules'" x-data="rulesPage()"`) {
+		t.Error("x-show and x-data should be on separate elements, not combined")
+	}
+
+	// Verify the Alpine tab state initializes correctly
+	if !strings.Contains(html, `x-data="{ rcTab: 'categories' }"`) {
+		t.Error("Alpine tab state should initialize to 'categories' for this test")
+	}
+
+	// Verify create-cat-modal exists for the categories tab
+	if !strings.Contains(html, `id="create-cat-modal"`) {
+		t.Error("create-cat-modal dialog not found")
+	}
+
+	t.Logf("Rendered %d bytes", buf.Len())
+}

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -49,7 +49,8 @@
 </div>
 
 <!-- ==================== RULES TAB ==================== -->
-<div x-show="rcTab === 'rules'" x-data="rulesPage()">
+<div x-show="rcTab === 'rules'">
+<div x-data="rulesPage()">
 
 <!-- Summary Stats Cards -->
 {{if .Rules}}
@@ -342,6 +343,7 @@ function rulesPage() {
 }
 </script>
 
+</div><!-- /rulesPage x-data -->
 </div><!-- /rules tab -->
 
 <!-- ==================== CATEGORIES TAB ==================== -->


### PR DESCRIPTION
In Alpine.js, combining x-show and x-data on the same element can cause scope issues where x-show evaluates in the new component scope before parent scope variables (like rcTab) are accessible. This caused the rules tab visibility to malfunction, which could cascade to break the categories tab display.

Fix: Nest x-data="rulesPage()" inside a separate inner div, keeping x-show="rcTab === 'rules'" on the outer wrapper that inherits the parent tab scope cleanly.

Also add a template rendering test that verifies both tabs render correctly with real CategoryResponse types.

https://claude.ai/code/session_01Vgm1JQWLbu2pZBjDKADFkR