### PR TITLE
Fix categories tab not rendering on Rules & Categories page

### DIFF
--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -353,8 +353,6 @@
 </div>
 {{end}}
 
-</div>
-
 <script>
 function bbSetRulesPerPage(val) {
   const u = new URL(window.location.href);


### PR DESCRIPTION
## Summary
- Removed extra `</div>` in `rules.html` that prematurely closed the Alpine.js `x-data` wrapper
- The categories tab content was outside the Alpine scope, so `rcTab` couldn't be resolved and the content stayed hidden (`display: none`)
- Sidebar disappearing on click was also caused by the broken div nesting

## Test plan
- [x] `go test ./internal/admin/ -run TestRulesTemplateWithCategories` passes
- [x] Categories tab renders correctly at `/rules?tab=categories`
- [x] Rules tab still works at `/rules`
- [x] Sidebar stays visible when interacting with the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)