### PR TITLE
Fix user_name to respect attributed_user_id

### DIFF
--- a/internal/service/reviews.go
+++ b/internal/service/reviews.go
@@ -73,7 +73,7 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 		t.amount, t.iso_currency_code, t.date, t.name, t.merchant_name,
 		t.category_primary, t.category_detailed, t.pending, t.created_at AS t_created_at, t.updated_at AS t_updated_at,
 		t.short_id AS t_short_id, t.account_id, COALESCE(a.display_name, a.name) AS account_name,
-		u.name AS user_name,
+		COALESCE(au.name, u.name) AS user_name,
 		t.category_id, t.category_override,
 		c.slug AS cat_slug, c.display_name AS cat_display_name, c.icon AS cat_icon, c.color AS cat_color,
 		pc.slug AS cat_primary_slug, pc.display_name AS cat_primary_display_name,
@@ -83,6 +83,7 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 		JOIN accounts a ON t.account_id = a.id
 		LEFT JOIN bank_connections bc ON a.connection_id = bc.id
 		LEFT JOIN users u ON bc.user_id = u.id
+		LEFT JOIN users au ON t.attributed_user_id = au.id
 		LEFT JOIN categories sc ON rq.suggested_category_id = sc.id
 		LEFT JOIN categories scp ON sc.parent_id = scp.id
 		LEFT JOIN categories rc ON rq.resolved_category_id = rc.id

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -19,7 +19,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		"t.category_primary, t.category_detailed, t.category_confidence, " +
 		"t.payment_channel, t.pending, t.deleted_at, t.created_at, t.updated_at, " +
 		"COALESCE(a.display_name, a.name) AS account_name, " +
-		"u.name AS user_name, " +
+		"COALESCE(au.name, u.name) AS user_name, " +
 		"t.category_id, t.category_override, " +
 		"c.slug AS cat_slug, c.display_name AS cat_display_name, c.icon AS cat_icon, c.color AS cat_color, " +
 		"pc.slug AS cat_primary_slug, pc.display_name AS cat_primary_display_name, " +
@@ -442,7 +442,7 @@ func (s *Service) CountTransactionsFiltered(ctx context.Context, params Transact
 
 func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransactionListParams) (*AdminTransactionListResult, error) {
 	selectPrefix := "SELECT t.id, t.account_id, COALESCE(a.display_name, a.name, ''), " +
-		"COALESCE(bc.institution_name, ''), COALESCE(u.name, ''), " +
+		"COALESCE(bc.institution_name, ''), COALESCE(au.name, u.name, ''), " +
 		"t.date, t.name, t.merchant_name, t.amount, t.iso_currency_code, " +
 		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, " +
@@ -453,6 +453,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		"LEFT JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
 		"LEFT JOIN users u ON bc.user_id = u.id " +
+		"LEFT JOIN users au ON t.attributed_user_id = au.id " +
 		"LEFT JOIN categories c ON t.category_id = c.id " +
 		"LEFT JOIN categories pc ON c.parent_id = pc.id "
 	query := selectPrefix + fromClause + "WHERE t.deleted_at IS NULL"


### PR DESCRIPTION
## Summary
- Transaction queries (`ListTransactions`, `ListTransactionsAdmin`, `ListReviews`) always displayed the bank connection owner as `user_name`, ignoring `attributed_user_id` set by account link matching
- Changed `u.name AS user_name` → `COALESCE(au.name, u.name) AS user_name` so dependent account transactions correctly show the person who made the transaction
- Added missing `LEFT JOIN users au ON t.attributed_user_id = au.id` to admin and review queries

## Test plan
- [x] Integration tests pass (`TestList.*Transaction`, `TestReview`)
- [ ] Verify in dashboard: transactions from a dependent linked account show the dependent user's name, not the primary cardholder
- [ ] Verify MCP `query_transactions` returns correct `user_name` for attributed transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)