### PR TITLE
Add MCP session audit logging and dev workflow improvements

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -26,10 +26,13 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 
   # Inject env vars if CLAUDE_ENV_FILE is available
   if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    # DATABASE_URL
     if [ -z "${DATABASE_URL:-}" ]; then
       echo 'DATABASE_URL=postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable' >> "$CLAUDE_ENV_FILE"
       echo "    Set DATABASE_URL"
     fi
+
+    # ENCRYPTION_KEY — grab from running breadbox process
     if [ -z "${ENCRYPTION_KEY:-}" ]; then
       RUNNING_PID="$(pgrep -f 'breadbox serve' | head -1 || true)"
       if [ -n "$RUNNING_PID" ]; then
@@ -38,6 +41,45 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
           echo "ENCRYPTION_KEY=$EK" >> "$CLAUDE_ENV_FILE"
           echo "    Set ENCRYPTION_KEY from running process"
         fi
+      fi
+    fi
+
+    # PORT — find next available port starting from 8081
+    # Uses lock files under main repo's .claude/ to prevent races between
+    # concurrent worktree sessions that haven't started their server yet.
+    if [ -z "${PORT:-}" ]; then
+      MAIN_REPO="$(dirname "$GIT_COMMON")"
+      PORT_LOCKS="$MAIN_REPO/.claude/port-locks"
+      mkdir -p "$PORT_LOCKS"
+
+      # Clean up stale lock files (port not in use AND lock older than 5 min)
+      for lockfile in "$PORT_LOCKS"/*; do
+        [ -f "$lockfile" ] || continue
+        LOCK_PORT="$(basename "$lockfile")"
+        if ! lsof -i :"$LOCK_PORT" >/dev/null 2>&1; then
+          LOCK_AGE=$(( $(date +%s) - $(stat -f %m "$lockfile" 2>/dev/null || echo 0) ))
+          if [ "$LOCK_AGE" -gt 300 ]; then
+            rm -f "$lockfile"
+          fi
+        fi
+      done
+
+      PORT=8081
+      while [ "$PORT" -le 8099 ]; do
+        if ! lsof -i :"$PORT" >/dev/null 2>&1 && ! [ -f "$PORT_LOCKS/$PORT" ]; then
+          # Claim it atomically
+          if (set -o noclobber; echo "$$" > "$PORT_LOCKS/$PORT") 2>/dev/null; then
+            break
+          fi
+        fi
+        PORT=$((PORT + 1))
+      done
+
+      if [ "$PORT" -le 8099 ]; then
+        echo "PORT=$PORT" >> "$CLAUDE_ENV_FILE"
+        echo "    Set PORT=$PORT (use 'make dev' to start server)"
+      else
+        echo "WARN: no available port in 8081-8099"
       fi
     fi
   fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -16,12 +16,24 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
     exit 0
   fi
 
-  # Worktree: verify build works with the copied artifacts
+  # Worktree: verify build works with the copied artifacts.
+  # .worktreeinclude copies sqlc files from the main repo's working directory,
+  # which may be on a different branch. If the build fails, regenerate with sqlc.
   echo "==> Worktree session — verifying Go build..."
-  if go build ./... 2>&1; then
-    echo "    Build OK"
+  if ! go build ./... 2>&1; then
+    echo "    Build failed — regenerating sqlc files..."
+    if command -v sqlc &>/dev/null && sqlc generate 2>&1; then
+      echo "    sqlc regenerated"
+      if go build ./... 2>&1; then
+        echo "    Build OK after regeneration"
+      else
+        echo "WARN: go build still failing after sqlc regenerate"
+      fi
+    else
+      echo "WARN: sqlc not available, build may be broken"
+    fi
   else
-    echo "WARN: go build failed — check for missing generated files"
+    echo "    Build OK"
   fi
 
   # Inject env vars if CLAUDE_ENV_FILE is available

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,14 +1,52 @@
 #!/bin/bash
-# Session startup hook for Claude Code Web.
-# Installs tools and generates gitignored build artifacts.
-
-# Only run in Claude Code Web (remote) sessions
-if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
-  exit 0
-fi
+# Session startup hook for Claude Code.
+# - Remote (web) sessions: installs tools and generates build artifacts from scratch
+# - Local worktree sessions: verifies build and injects env vars
+#   (file copying is handled by .worktreeinclude)
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 cd "$PROJECT_DIR"
+
+# --- Local sessions ---
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  # Check if we're in a git worktree
+  GIT_COMMON="$(git rev-parse --git-common-dir 2>/dev/null || echo ".git")"
+  if [ "$GIT_COMMON" = ".git" ]; then
+    # Main repo — nothing to do
+    exit 0
+  fi
+
+  # Worktree: verify build works with the copied artifacts
+  echo "==> Worktree session — verifying Go build..."
+  if go build ./... 2>&1; then
+    echo "    Build OK"
+  else
+    echo "WARN: go build failed — check for missing generated files"
+  fi
+
+  # Inject env vars if CLAUDE_ENV_FILE is available
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    if [ -z "${DATABASE_URL:-}" ]; then
+      echo 'DATABASE_URL=postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable' >> "$CLAUDE_ENV_FILE"
+      echo "    Set DATABASE_URL"
+    fi
+    if [ -z "${ENCRYPTION_KEY:-}" ]; then
+      RUNNING_PID="$(pgrep -f 'breadbox serve' | head -1 || true)"
+      if [ -n "$RUNNING_PID" ]; then
+        EK="$(ps eww -p "$RUNNING_PID" 2>/dev/null | tr ' ' '\n' | grep '^ENCRYPTION_KEY=' | cut -d= -f2 || true)"
+        if [ -n "$EK" ]; then
+          echo "ENCRYPTION_KEY=$EK" >> "$CLAUDE_ENV_FILE"
+          echo "    Set ENCRYPTION_KEY from running process"
+        fi
+      fi
+    fi
+  fi
+
+  echo "==> Worktree setup complete."
+  exit 0
+fi
+
+# --- Remote (web) sessions below ---
 
 SQLC_VERSION="1.30.0"
 

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"180bc97d-300f-40a0-8a57-3ce5d41da8b7","pid":50619,"acquiredAt":1774336104223}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,5 +10,31 @@
         ]
       }
     ]
+  },
+  "enabledPlugins": {
+    "mcp-server-dev@claude-plugins-official": true
+  },
+  "sandbox": {
+    "enabled": true,
+    "autoAllow": true,
+    "filesystem": {
+      "allowWrite": [
+        "~/go",
+        "~/Library/Caches/go-build",
+        "/tmp"
+      ]
+    },
+    "network": {
+      "allowedDomains": [
+        "localhost",
+        "127.0.0.1",
+        "proxy.golang.org",
+        "sum.golang.org",
+        "storage.googleapis.com",
+        "github.com",
+        "api.github.com",
+        "objects.githubusercontent.com"
+      ]
+    }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ internal/db/*.sql.go
 
 # Claude Code worktrees
 .claude/worktrees/
+
+# MCP config (contains API key)
+.mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,9 @@ internal/db/*.sql.go
 # OS
 .DS_Store
 
-# Claude Code worktrees
+# Claude Code worktrees and port locks
 .claude/worktrees/
+.claude/port-locks/
 
 # MCP config (contains API key)
 .mcp.json

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -13,5 +13,8 @@ internal/db/models.go
 internal/db/querier.go
 internal/db/*.sql.go
 
+# Teller mTLS certificates
+teller/
+
 # Local env (if present)
 .local.env

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,17 @@
+# Gitignored build artifacts to copy into worktrees automatically.
+# Only files matching these patterns AND ignored by .gitignore get copied.
+
+# Tailwind CSS standalone binary
+tailwindcss-extra
+
+# Built CSS
+static/css/styles.css
+
+# sqlc generated files
+internal/db/db.go
+internal/db/models.go
+internal/db/querier.go
+internal/db/*.sql.go
+
+# Local env (if present)
+.local.env


### PR DESCRIPTION
## Summary
- **MCP session audit logging**: Track tool calls per MCP session with timestamps, durations, and error counts. New admin pages at `/agents` and `/agents/sessions/:id`.
- **Worktree setup**: Add `.worktreeinclude` to auto-copy gitignored build artifacts (sqlc, tailwind, CSS) into worktrees. Improve `session-start.sh` to verify builds and inject env vars for worktree sessions.
- **Sandbox config**: Enable OS-level sandboxing with auto-allow mode, granting write access to Go toolchain paths and network access to localhost/Go infra/GitHub.

## Test plan
- [ ] Verify MCP session logging by connecting an MCP client and checking `/agents`
- [ ] Test worktree setup: `claude -w test-worktree` should have all build artifacts ready
- [ ] Verify sandbox doesn't block normal dev workflow (`go build`, `go test`, `make dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)