### PR TITLE
Add dedicated Getting Started landing page

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -10,16 +10,21 @@ import (
 	"time"
 
 	"breadbox/internal/app"
-	"breadbox/internal/db"
 	"breadbox/internal/service"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // DashboardHandler serves GET /admin/ — the dashboard home page.
+// When onboarding has not been dismissed, the root path redirects to /getting-started.
 func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+
+		// Redirect to getting-started page if onboarding is not dismissed.
+		dismissed, _ := a.Queries.GetAppConfig(ctx, "onboarding_dismissed")
+		if !(dismissed.Value.Valid && dismissed.Value.String == "true") {
+			http.Redirect(w, r, "/getting-started", http.StatusSeeOther)
+			return
+		}
 
 		needsAttention, err := a.Queries.CountConnectionsNeedingAttention(ctx)
 		if err != nil {
@@ -40,32 +45,6 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		})
 		if err != nil {
 			a.Logger.Error("recent transactions", "error", err)
-		}
-
-		// Onboarding checklist detection.
-		showOnboarding := false
-		var hasProvider, hasMember, hasConnection bool
-
-		dismissed, _ := a.Queries.GetAppConfig(ctx, "onboarding_dismissed")
-		if !(dismissed.Value.Valid && dismissed.Value.String == "true") {
-			showOnboarding = true
-
-			// Check provider
-			hasProvider = a.Config.PlaidClientID != "" || a.Config.TellerAppID != ""
-
-			// Check members
-			userCount, err := a.Queries.CountUsers(ctx)
-			if err != nil {
-				a.Logger.Error("count users", "error", err)
-			}
-			hasMember = userCount > 0
-
-			// Check connections
-			connCount, err := a.Queries.CountConnections(ctx)
-			if err != nil {
-				a.Logger.Error("count connections", "error", err)
-			}
-			hasConnection = connCount > 0
 		}
 
 		// Version check for update banner.
@@ -458,10 +437,6 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"CurrentPage":          "home",
 			"NeedsAttention":       needsAttention,
 			"CSRFToken":            GetCSRFToken(r),
-			"ShowOnboarding":       showOnboarding,
-			"HasProvider":          hasProvider,
-			"HasMember":            hasMember,
-			"HasConnection":        hasConnection,
 			"ShowUpdateBanner":     showUpdateBanner,
 			"LatestVersion":        latestVersion,
 			"LatestURL":            latestURL,
@@ -492,17 +467,6 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"TotalUnreadReports": totalUnread,
 		}
 		tr.Render(w, r, "dashboard.html", data)
-	}
-}
-
-// DismissOnboardingHandler handles POST /admin/onboarding/dismiss.
-func DismissOnboardingHandler(a *app.App) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		_ = a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
-			Key:   "onboarding_dismissed",
-			Value: pgtype.Text{String: "true", Valid: true},
-		})
-		http.Redirect(w, r, "/", http.StatusSeeOther)
 	}
 }
 

--- a/internal/admin/getting_started.go
+++ b/internal/admin/getting_started.go
@@ -105,10 +105,15 @@ func GettingStartedHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRende
 // Sets onboarding_dismissed=true and redirects to the dashboard.
 func DismissGettingStartedHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_ = a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
+		if err := a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
 			Key:   "onboarding_dismissed",
 			Value: pgtype.Text{String: "true", Valid: true},
-		})
+		}); err != nil {
+			a.Logger.Error("dismiss getting started: set app config", "error", err)
+			SetFlash(r.Context(), sm, "error", "Failed to dismiss guide. Please try again.")
+			http.Redirect(w, r, "/getting-started", http.StatusSeeOther)
+			return
+		}
 		SetFlash(r.Context(), sm, "success", "Getting Started guide dismissed. You can re-open it from Settings.")
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 	}
@@ -118,10 +123,15 @@ func DismissGettingStartedHandler(a *app.App, sm *scs.SessionManager) http.Handl
 // Clears onboarding_dismissed and redirects to /getting-started.
 func ReopenGettingStartedHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_ = a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
+		if err := a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
 			Key:   "onboarding_dismissed",
 			Value: pgtype.Text{String: "false", Valid: true},
-		})
+		}); err != nil {
+			a.Logger.Error("reopen getting started: set app config", "error", err)
+			SetFlash(r.Context(), sm, "error", "Failed to re-open guide. Please try again.")
+			http.Redirect(w, r, "/settings", http.StatusSeeOther)
+			return
+		}
 		SetFlash(r.Context(), sm, "success", "Getting Started guide re-opened.")
 		http.Redirect(w, r, "/getting-started", http.StatusSeeOther)
 	}

--- a/internal/admin/getting_started.go
+++ b/internal/admin/getting_started.go
@@ -1,0 +1,128 @@
+package admin
+
+import (
+	"net/http"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// GettingStartedHandler serves GET /getting-started — the setup walkthrough page.
+func GettingStartedHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		// Step completion checks.
+		// Step 1: Create a family member (user).
+		userCount, err := a.Queries.CountUsers(ctx)
+		if err != nil {
+			a.Logger.Error("getting started: count users", "error", err)
+		}
+		hasMember := userCount > 0
+
+		// Step 2: Configure a bank provider (Plaid or Teller).
+		hasProvider := a.Config.PlaidClientID != "" || a.Config.TellerAppID != ""
+
+		// Step 3: Connect a bank.
+		connCount, err := a.Queries.CountConnections(ctx)
+		if err != nil {
+			a.Logger.Error("getting started: count connections", "error", err)
+		}
+		hasConnection := connCount > 0
+
+		// Step 4: First successful sync.
+		successfulSyncs, err := a.Queries.CountSuccessfulSyncs(ctx)
+		if err != nil {
+			a.Logger.Error("getting started: count successful syncs", "error", err)
+		}
+		hasSync := successfulSyncs > 0
+
+		// Step 5: Configure agents (at least one API key).
+		activeAPIKeys, err := a.Queries.CountActiveApiKeys(ctx)
+		if err != nil {
+			a.Logger.Error("getting started: count active api keys", "error", err)
+		}
+		hasAPIKey := activeAPIKeys > 0
+
+		// Progress metrics.
+		accountCount, err := a.Queries.CountAccounts(ctx)
+		if err != nil {
+			a.Logger.Error("getting started: count accounts", "error", err)
+		}
+
+		txCount, err := a.Queries.CountTransactions(ctx)
+		if err != nil {
+			a.Logger.Error("getting started: count transactions", "error", err)
+		}
+
+		// Count completed steps.
+		completedSteps := 0
+		if hasMember {
+			completedSteps++
+		}
+		if hasProvider {
+			completedSteps++
+		}
+		if hasConnection {
+			completedSteps++
+		}
+		if hasSync {
+			completedSteps++
+		}
+		if hasAPIKey {
+			completedSteps++
+		}
+
+		// Check if onboarding is dismissed (for the nav badge display).
+		dismissed := false
+		dismissedCfg, _ := a.Queries.GetAppConfig(ctx, "onboarding_dismissed")
+		if dismissedCfg.Value.Valid && dismissedCfg.Value.String == "true" {
+			dismissed = true
+		}
+
+		data := BaseTemplateData(r, sm, "getting-started", "Getting Started")
+		data["HasMember"] = hasMember
+		data["HasProvider"] = hasProvider
+		data["HasConnection"] = hasConnection
+		data["HasSync"] = hasSync
+		data["HasAPIKey"] = hasAPIKey
+		data["CompletedSteps"] = completedSteps
+		data["TotalSteps"] = 5
+		data["ConnectionCount"] = connCount
+		data["AccountCount"] = accountCount
+		data["TransactionCount"] = txCount
+		data["SuccessfulSyncs"] = successfulSyncs
+		data["OnboardingDismissed"] = dismissed
+
+		tr.Render(w, r, "getting_started.html", data)
+	}
+}
+
+// DismissGettingStartedHandler handles POST /getting-started/dismiss.
+// Sets onboarding_dismissed=true and redirects to the dashboard.
+func DismissGettingStartedHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
+			Key:   "onboarding_dismissed",
+			Value: pgtype.Text{String: "true", Valid: true},
+		})
+		SetFlash(r.Context(), sm, "success", "Getting Started guide dismissed. You can re-open it from Settings.")
+		http.Redirect(w, r, "/", http.StatusSeeOther)
+	}
+}
+
+// ReopenGettingStartedHandler handles POST /getting-started/reopen.
+// Clears onboarding_dismissed and redirects to /getting-started.
+func ReopenGettingStartedHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		_ = a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
+			Key:   "onboarding_dismissed",
+			Value: pgtype.Text{String: "false", Valid: true},
+		})
+		SetFlash(r.Context(), sm, "success", "Getting Started guide re-opened.")
+		http.Redirect(w, r, "/getting-started", http.StatusSeeOther)
+	}
+}

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -17,6 +17,7 @@ type NavBadges struct {
 	PendingReviews       int64
 	ConnectionsAttention int64
 	UnreadReports        int64
+	ShowGettingStarted   bool
 }
 
 // NavBadgesMiddleware fetches sidebar notification badge counts and stores them
@@ -44,6 +45,10 @@ func NavBadgesMiddleware(queries *db.Queries, logger *slog.Logger) func(http.Han
 			} else {
 				logger.Debug("nav badges: count unread agent reports", "error", err)
 			}
+
+			// Check if getting started guide should show in nav.
+			dismissed, _ := queries.GetAppConfig(ctx, "onboarding_dismissed")
+			badges.ShowGettingStarted = !(dismissed.Value.Valid && dismissed.Value.String == "true")
 
 			ctx = context.WithValue(ctx, navBadgesKey, badges)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -58,6 +58,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Use(NavBadgesMiddleware(a.Queries, a.Logger))
 
 		r.Get("/", DashboardHandler(a, svc, tr))
+		r.Get("/getting-started", GettingStartedHandler(a, sm, tr))
+		r.Post("/getting-started/dismiss", DismissGettingStartedHandler(a, sm))
+		r.Post("/getting-started/reopen", ReopenGettingStartedHandler(a, sm))
 		r.Get("/insights", InsightsHandler(a, svc, tr))
 
 		r.Get("/connections", ConnectionsListHandler(a, svc, sm, tr))
@@ -84,7 +87,8 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Use(CSRFMiddleware(sm))
 		r.Use(NavBadgesMiddleware(a.Queries, a.Logger))
 
-		r.Post("/onboarding/dismiss", DismissOnboardingHandler(a))
+		// Legacy onboarding dismiss route — redirect to new handler.
+		r.Post("/onboarding/dismiss", DismissGettingStartedHandler(a, sm))
 
 		r.Route("/connections", func(r chi.Router) {
 			r.Get("/new", NewConnectionHandler(a, tr))

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -47,6 +47,13 @@ func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 		retentionDays, _ := a.Service.GetSyncLogRetentionDays(ctx)
 		syncLogCount, _ := a.Service.CountSyncLogs(ctx)
 
+		// Check onboarding dismissed state for help section.
+		onboardingDismissed := false
+		dismissedCfg, _ := a.Queries.GetAppConfig(ctx, "onboarding_dismissed")
+		if dismissedCfg.Value.Valid && dismissedCfg.Value.String == "true" {
+			onboardingDismissed = true
+		}
+
 		data := map[string]any{
 			"PageTitle":           "Settings",
 			"CurrentPage":         "settings",
@@ -66,6 +73,8 @@ func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 			"ConfigSources":   a.Config.ConfigSources,
 			// Safety indicators
 			"HasEncryptionKey": len(a.Config.EncryptionKey) > 0,
+			// Help section
+			"OnboardingDismissed": onboardingDismissed,
 			// Next sync time
 			"NextSyncTime": func() string {
 				if a.Scheduler != nil {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -741,6 +741,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/prompt_builder.html",
 		"pages/session_detail.html",
 		"pages/my_account.html",
+		"pages/getting_started.html",
 	}
 
 	// Pages that need multiple page files parsed together (for sub-template sharing).

--- a/internal/db/queries/api_keys.sql
+++ b/internal/db/queries/api_keys.sql
@@ -15,3 +15,6 @@ SELECT * FROM api_keys WHERE id = $1;
 
 -- name: UpdateApiKeyLastUsed :exec
 UPDATE api_keys SET last_used_at = NOW() WHERE id = $1;
+
+-- name: CountActiveApiKeys :one
+SELECT COUNT(*) FROM api_keys WHERE revoked_at IS NULL;

--- a/internal/db/queries/sync_logs.sql
+++ b/internal/db/queries/sync_logs.sql
@@ -40,3 +40,6 @@ WHERE started_at < $1
 
 -- name: CountSyncLogs :one
 SELECT COUNT(*) FROM sync_logs;
+
+-- name: CountSuccessfulSyncs :one
+SELECT COUNT(*) FROM sync_logs WHERE status = 'success';

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -50,38 +50,6 @@
 </div>
 {{end}}
 
-{{if .ShowOnboarding}}
-<div class="bb-card mb-6">
-  <div class="p-6">
-    <h2 class="flex items-center gap-2 text-lg font-semibold">
-      <i data-lucide="rocket" class="w-5 h-5 text-primary"></i>
-      Getting Started
-    </h2>
-    <p class="text-sm text-base-content/70 mb-2">Complete these steps to set up Breadbox.</p>
-    <ul class="steps steps-vertical text-sm">
-      <li class="step step-primary">
-        <span class="text-left">Create admin account</span>
-      </li>
-      <li class="step{{if .HasProvider}} step-primary{{end}}">
-        <span class="text-left">{{if .HasProvider}}Bank provider configured{{else}}<a href="/providers" class="link">Configure a bank provider</a>{{end}}</span>
-      </li>
-      <li class="step{{if .HasMember}} step-primary{{end}}">
-        <span class="text-left">{{if .HasMember}}Family member added{{else}}<a href="/users/new" class="link">Add a family member</a>{{end}}</span>
-      </li>
-      <li class="step{{if .HasConnection}} step-primary{{end}}">
-        <span class="text-left">{{if .HasConnection}}Bank connected{{else}}<a href="/connections/new" class="link">Connect your first bank</a>{{end}}</span>
-      </li>
-    </ul>
-    <div class="flex justify-end mt-2">
-      <form method="POST" action="/onboarding/dismiss">
-        <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-        <button type="submit" class="btn btn-ghost btn-sm rounded-xl">Dismiss</button>
-      </form>
-    </div>
-  </div>
-</div>
-{{end}}
-
 {{if gt .NeedsAttention 0}}
 <div role="alert" class="alert alert-warning rounded-xl mb-6">
   <i data-lucide="alert-triangle" class="w-5 h-5"></i>

--- a/internal/templates/pages/getting_started.html
+++ b/internal/templates/pages/getting_started.html
@@ -1,0 +1,231 @@
+{{define "content"}}
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title flex items-center gap-2">
+      <i data-lucide="compass" class="w-6 h-6 text-primary"></i>
+      Getting Started
+    </h1>
+    <p class="text-sm text-base-content/50 mt-1">Set up Breadbox step by step. Complete each step to start tracking your finances.</p>
+  </div>
+</div>
+
+<!-- Progress summary -->
+<div class="bb-card p-4 sm:p-5 mb-6 bb-stagger">
+  <div class="flex flex-col sm:flex-row sm:items-center gap-4">
+    <div class="flex-1">
+      <div class="flex items-center gap-2 mb-2">
+        <span class="text-sm font-semibold">Setup Progress</span>
+        <span class="badge badge-sm {{if eq .CompletedSteps .TotalSteps}}badge-success{{else}}badge-ghost{{end}}">{{.CompletedSteps}} / {{.TotalSteps}}</span>
+      </div>
+      <progress class="progress {{if eq .CompletedSteps .TotalSteps}}progress-success{{else}}progress-primary{{end}} w-full" value="{{.CompletedSteps}}" max="{{.TotalSteps}}"></progress>
+    </div>
+    {{if gt .TransactionCount 0}}
+    <div class="flex flex-wrap gap-4 text-sm tabular-nums">
+      <div class="flex items-center gap-1.5">
+        <i data-lucide="link" class="w-3.5 h-3.5 text-base-content/40"></i>
+        <span class="text-base-content/50">Connections</span>
+        <span class="font-semibold">{{commaInt .ConnectionCount}}</span>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <i data-lucide="wallet" class="w-3.5 h-3.5 text-base-content/40"></i>
+        <span class="text-base-content/50">Accounts</span>
+        <span class="font-semibold">{{commaInt .AccountCount}}</span>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <i data-lucide="receipt" class="w-3.5 h-3.5 text-base-content/40"></i>
+        <span class="text-base-content/50">Transactions</span>
+        <span class="font-semibold">{{commaInt .TransactionCount}}</span>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content/40"></i>
+        <span class="text-base-content/50">Syncs</span>
+        <span class="font-semibold">{{commaInt .SuccessfulSyncs}}</span>
+      </div>
+    </div>
+    {{end}}
+  </div>
+</div>
+
+<!-- Steps -->
+<div class="grid gap-4 bb-stagger">
+
+  <!-- Step 1: Create a family member -->
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="flex items-start gap-4 p-4 sm:p-5">
+      <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center {{if .HasMember}}bg-success/10 text-success{{else}}bg-primary/10 text-primary{{end}}">
+        {{if .HasMember}}
+        <i data-lucide="check" class="w-4 h-4"></i>
+        {{else}}
+        <span class="text-sm font-bold">1</span>
+        {{end}}
+      </div>
+      <div class="flex-1 min-w-0">
+        <h3 class="font-semibold {{if .HasMember}}text-success{{end}}">Add a family member</h3>
+        <p class="text-sm text-base-content/50 mt-0.5">
+          {{if .HasMember}}
+          Family member added. Bank connections are linked to household members.
+          {{else}}
+          Create a household member to link bank connections to. Each member represents a person in your household.
+          {{end}}
+        </p>
+      </div>
+      <div class="flex-shrink-0">
+        {{if .HasMember}}
+        <a href="/users" class="btn btn-ghost btn-sm rounded-xl">View Members</a>
+        {{else}}
+        <a href="/users/new" class="btn btn-primary btn-sm rounded-xl">Add Member</a>
+        {{end}}
+      </div>
+    </div>
+  </div>
+
+  <!-- Step 2: Configure a provider -->
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="flex items-start gap-4 p-4 sm:p-5">
+      <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center {{if .HasProvider}}bg-success/10 text-success{{else if .HasMember}}bg-primary/10 text-primary{{else}}bg-base-200 text-base-content/30{{end}}">
+        {{if .HasProvider}}
+        <i data-lucide="check" class="w-4 h-4"></i>
+        {{else}}
+        <span class="text-sm font-bold">2</span>
+        {{end}}
+      </div>
+      <div class="flex-1 min-w-0">
+        <h3 class="font-semibold {{if .HasProvider}}text-success{{end}}">Configure a bank provider</h3>
+        <p class="text-sm text-base-content/50 mt-0.5">
+          {{if .HasProvider}}
+          Provider configured. You can connect bank accounts through Plaid or Teller.
+          {{else}}
+          Set up Plaid or Teller to connect bank accounts. You can also import transactions via CSV.
+          {{end}}
+        </p>
+      </div>
+      <div class="flex-shrink-0">
+        {{if .HasProvider}}
+        <a href="/providers" class="btn btn-ghost btn-sm rounded-xl">View Providers</a>
+        {{else}}
+        <a href="/providers" class="btn btn-primary btn-sm rounded-xl">Configure</a>
+        {{end}}
+      </div>
+    </div>
+  </div>
+
+  <!-- Step 3: Connect a bank -->
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="flex items-start gap-4 p-4 sm:p-5">
+      <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center {{if .HasConnection}}bg-success/10 text-success{{else if and .HasMember .HasProvider}}bg-primary/10 text-primary{{else}}bg-base-200 text-base-content/30{{end}}">
+        {{if .HasConnection}}
+        <i data-lucide="check" class="w-4 h-4"></i>
+        {{else}}
+        <span class="text-sm font-bold">3</span>
+        {{end}}
+      </div>
+      <div class="flex-1 min-w-0">
+        <h3 class="font-semibold {{if .HasConnection}}text-success{{end}}">Connect your first bank</h3>
+        <p class="text-sm text-base-content/50 mt-0.5">
+          {{if .HasConnection}}
+          Bank connected. Accounts and transactions will sync automatically.
+          {{else if .HasProvider}}
+          Link a bank account to start syncing transactions.
+          {{else}}
+          Configure a provider first, then connect a bank account.
+          {{end}}
+        </p>
+      </div>
+      <div class="flex-shrink-0">
+        {{if .HasConnection}}
+        <a href="/connections" class="btn btn-ghost btn-sm rounded-xl">View Connections</a>
+        {{else if .HasProvider}}
+        <a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">Connect Bank</a>
+        {{else}}
+        <span class="btn btn-sm btn-disabled rounded-xl">Connect Bank</span>
+        {{end}}
+      </div>
+    </div>
+  </div>
+
+  <!-- Step 4: First sync -->
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="flex items-start gap-4 p-4 sm:p-5">
+      <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center {{if .HasSync}}bg-success/10 text-success{{else if .HasConnection}}bg-primary/10 text-primary{{else}}bg-base-200 text-base-content/30{{end}}">
+        {{if .HasSync}}
+        <i data-lucide="check" class="w-4 h-4"></i>
+        {{else}}
+        <span class="text-sm font-bold">4</span>
+        {{end}}
+      </div>
+      <div class="flex-1 min-w-0">
+        <h3 class="font-semibold {{if .HasSync}}text-success{{end}}">Complete first sync</h3>
+        <p class="text-sm text-base-content/50 mt-0.5">
+          {{if .HasSync}}
+          Sync complete. {{commaInt .TransactionCount}} transactions synced across {{commaInt .AccountCount}} accounts.
+          {{else if .HasConnection}}
+          Your first sync should start automatically. Check the sync logs if it hasn't started.
+          {{else}}
+          Connect a bank first, then transactions will sync automatically.
+          {{end}}
+        </p>
+      </div>
+      <div class="flex-shrink-0">
+        {{if .HasSync}}
+        <a href="/transactions" class="btn btn-ghost btn-sm rounded-xl">View Transactions</a>
+        {{else if .HasConnection}}
+        <a href="/logs" class="btn btn-ghost btn-sm rounded-xl">View Logs</a>
+        {{else}}
+        <span class="btn btn-sm btn-disabled rounded-xl">View Logs</span>
+        {{end}}
+      </div>
+    </div>
+  </div>
+
+  <!-- Step 5: Configure agents -->
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="flex items-start gap-4 p-4 sm:p-5">
+      <div class="flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center {{if .HasAPIKey}}bg-success/10 text-success{{else if .HasSync}}bg-primary/10 text-primary{{else}}bg-base-200 text-base-content/30{{end}}">
+        {{if .HasAPIKey}}
+        <i data-lucide="check" class="w-4 h-4"></i>
+        {{else}}
+        <span class="text-sm font-bold">5</span>
+        {{end}}
+      </div>
+      <div class="flex-1 min-w-0">
+        <h3 class="font-semibold {{if .HasAPIKey}}text-success{{end}}">Set up AI agents</h3>
+        <p class="text-sm text-base-content/50 mt-0.5">
+          {{if .HasAPIKey}}
+          API key created. AI agents can access Breadbox via the MCP server or REST API.
+          {{else}}
+          Create an API key so AI agents can query your financial data via the MCP server.
+          {{end}}
+        </p>
+      </div>
+      <div class="flex-shrink-0">
+        {{if .HasAPIKey}}
+        <a href="/agents" class="btn btn-ghost btn-sm rounded-xl">View Agents</a>
+        {{else}}
+        <a href="/agents" class="btn btn-primary btn-sm rounded-xl">Set Up Agents</a>
+        {{end}}
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<!-- Dismiss section -->
+<div class="mt-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 bb-stagger">
+  {{if not .OnboardingDismissed}}
+  <form method="POST" action="/getting-started/dismiss">
+    <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+    <button type="submit" class="btn btn-ghost btn-sm rounded-xl text-base-content/50">
+      <i data-lucide="x" class="w-3.5 h-3.5"></i>
+      Dismiss guide
+      <span class="text-xs text-base-content/30 ml-1 hidden sm:inline">-- you can always find it at /getting-started or in Settings</span>
+    </button>
+  </form>
+  {{else}}
+  <div class="text-xs text-base-content/30 flex items-center gap-1.5">
+    <i data-lucide="info" class="w-3 h-3"></i>
+    This guide is always available at /getting-started or from Settings.
+  </div>
+  {{end}}
+</div>
+
+{{end}}

--- a/internal/templates/pages/settings.html
+++ b/internal/templates/pages/settings.html
@@ -158,6 +158,42 @@
     </div>
   </div>
 
+  <!-- Card 4: Help -->
+  <div id="help" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#help' }">
+    <div class="px-4 sm:px-5 py-4 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
+      <i data-lucide="life-buoy" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+      <div class="min-w-0 flex-1">
+        <h2 class="font-semibold">Help</h2>
+        <p class="text-xs text-base-content/40" x-show="!expanded">Setup guide and documentation</p>
+        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Resources and guides</p>
+      </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+    </div>
+    <div x-show="expanded" x-collapse x-cloak>
+      <div class="px-4 sm:px-5 py-4">
+        <div class="flex flex-col gap-3">
+          <div class="flex items-center justify-between p-3 rounded-xl bg-base-200/40">
+            <div class="flex items-center gap-2.5">
+              <i data-lucide="compass" class="w-4 h-4 text-base-content/50"></i>
+              <div>
+                <span class="text-sm font-medium">Getting Started Guide</span>
+                <p class="text-xs text-base-content/40">Step-by-step setup walkthrough</p>
+              </div>
+            </div>
+            {{if .OnboardingDismissed}}
+            <form method="POST" action="/getting-started/reopen">
+              <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+              <button type="submit" class="btn btn-ghost btn-sm rounded-xl">Re-open</button>
+            </form>
+            {{else}}
+            <a href="/getting-started" class="btn btn-ghost btn-sm rounded-xl">Open</a>
+            {{end}}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
 </div>
 
 <script>

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -1,5 +1,12 @@
 {{define "nav"}}
 <nav class="bb-sidebar-nav">
+  {{if and .NavBadges .NavBadges.ShowGettingStarted}}
+  <div class="bb-sidebar-section">Setup</div>
+  <a href="/getting-started" class="bb-sidebar-link{{if eq .CurrentPage "getting-started"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="compass"></i>
+    <span class="flex-1">Getting Started</span>
+  </a>
+  {{end}}
   <div class="bb-sidebar-section">Overview</div>
   <a href="/" class="bb-sidebar-link{{if eq .CurrentPage "home"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="house"></i>


### PR DESCRIPTION
## Summary
- Replace the dashboard onboarding checklist widget with a dedicated `/getting-started` page that walks new users through 5 setup steps: add family member, configure provider, connect bank, first sync, set up agents
- Root path `/` redirects to `/getting-started` until the guide is dismissed; after dismissal, `/` serves the dashboard normally
- Guide is re-openable from Settings > Help section or by navigating directly to `/getting-started`
- Sidebar nav shows a "Getting Started" link under a "Setup" section while the guide is active
- Live progress metrics (connections, accounts, transactions, syncs) shown when data exists
- New SQL queries: `CountSuccessfulSyncs`, `CountActiveApiKeys`

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all unit tests)
- [ ] Fresh install: root `/` redirects to `/getting-started`
- [ ] Step completion reflects actual state (members, providers, connections, syncs, API keys)
- [ ] Dismiss button sets `onboarding_dismissed` and redirects to dashboard
- [ ] After dismiss: `/` serves dashboard, nav link hidden, page still accessible at `/getting-started`
- [ ] Settings > Help > Re-open clears dismiss and redirects back to guide
- [ ] Mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)