### PR TITLE
Add in-app database backup and restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ internal/db/*.sql.go
 *.cert
 *.crt
 
+# Backups
+backups/
+
 # OS
 .DS_Store
 

--- a/cmd/breadbox/main.go
+++ b/cmd/breadbox/main.go
@@ -6,7 +6,10 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -197,6 +200,33 @@ func runServe() error {
 	scheduler := sync.NewScheduler(a.SyncEngine, a.Queries, logger, syncTimeout)
 	scheduler.Start(cfg.SyncIntervalMinutes)
 	a.Scheduler = scheduler
+
+	// Initialize backup service if pg_dump is available.
+	if _, err := exec.LookPath("pg_dump"); err == nil {
+		backupDir := os.Getenv("BACKUP_DIR")
+		if backupDir == "" {
+			// Default: ./backups/ relative to working directory, or /var/lib/breadbox/backups/ in Docker.
+			if cfg.Environment == "docker" {
+				backupDir = "/var/lib/breadbox/backups"
+			} else {
+				backupDir = filepath.Join(".", "backups")
+			}
+		}
+		bs := service.NewBackupService(cfg.DatabaseURL, backupDir, logger)
+		a.BackupService = bs
+
+		// Schedule automated backups — runs every hour, checks app_config for actual schedule.
+		backupQueries := a.Queries
+		if err := scheduler.AddFunc("0 * * * *", func() {
+			runScheduledBackup(bs, backupQueries, logger)
+		}); err != nil {
+			logger.Error("failed to add backup cron job", "error", err)
+		}
+
+		logger.Info("backup service initialized", "backup_dir", backupDir)
+	} else {
+		logger.Warn("pg_dump not found — backup service disabled")
+	}
 
 	// Run startup sync for stale connections in background.
 	go scheduler.RunStartupSync(ctx, cfg.SyncIntervalMinutes)
@@ -527,4 +557,64 @@ func runSeed() error {
 	defer pool.Close()
 
 	return seed.Run(ctx, pool, logger)
+}
+
+// runScheduledBackup checks the backup schedule config and runs a backup if due.
+// Called every hour by the cron scheduler. The schedule config determines the
+// actual backup frequency (daily at 2/3/4am, or weekly on Sundays at 2am).
+func runScheduledBackup(bs *service.BackupService, queries *db.Queries, logger *slog.Logger) {
+	ctx := context.Background()
+
+	row, err := queries.GetAppConfig(ctx, "backup_schedule")
+	if err != nil || !row.Value.Valid || row.Value.String == "" {
+		return // Backups not scheduled
+	}
+	schedule := row.Value.String
+
+	now := time.Now()
+	hour := now.Hour()
+	weekday := now.Weekday()
+
+	// Check if we should run based on the schedule.
+	shouldRun := false
+	switch schedule {
+	case "daily_2am":
+		shouldRun = hour == 2
+	case "daily_3am":
+		shouldRun = hour == 3
+	case "daily_4am":
+		shouldRun = hour == 4
+	case "weekly":
+		shouldRun = hour == 2 && weekday == time.Sunday
+	}
+
+	if !shouldRun {
+		return
+	}
+
+	logger.Info("scheduled backup starting", "schedule", schedule)
+
+	filename, err := bs.CreateBackup(ctx, "scheduled")
+	if err != nil {
+		logger.Error("scheduled backup failed", "error", err)
+		return
+	}
+
+	logger.Info("scheduled backup completed", "filename", filename)
+
+	// Clean up old backups based on retention setting.
+	retentionDays := 7 // default
+	retRow, err := queries.GetAppConfig(ctx, "backup_retention_days")
+	if err == nil && retRow.Value.Valid && retRow.Value.String != "" {
+		if d, parseErr := strconv.Atoi(retRow.Value.String); parseErr == nil && d > 0 {
+			retentionDays = d
+		}
+	}
+
+	deleted, err := bs.CleanupOldBackups(retentionDays)
+	if err != nil {
+		logger.Error("backup cleanup failed", "error", err)
+	} else if deleted > 0 {
+		logger.Info("backup cleanup completed", "deleted", deleted, "retention_days", retentionDays)
+	}
 }

--- a/internal/admin/backups.go
+++ b/internal/admin/backups.go
@@ -1,0 +1,272 @@
+package admin
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+	"breadbox/internal/service"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// BackupsPageHandler serves GET /backups — the backup management page.
+func BackupsPageHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if a.BackupService == nil {
+			data := BaseTemplateData(r, sm, "backups", "Backups")
+			data["Error"] = "Backup service is not available. pg_dump may not be installed."
+			tr.Render(w, r, "backups.html", data)
+			return
+		}
+
+		backups, err := a.BackupService.ListBackups()
+		if err != nil {
+			a.Logger.Error("list backups", "error", err)
+			backups = nil
+		}
+
+		totalSize, _ := a.BackupService.TotalBackupSize()
+
+		schedule := a.Service.GetBackupSchedule(ctx)
+		retentionDays := a.Service.GetBackupRetentionDays(ctx)
+
+		data := BaseTemplateData(r, sm, "backups", "Backups")
+		data["Backups"] = backups
+		data["BackupCount"] = len(backups)
+		data["TotalSize"] = service.FormatBytes(totalSize)
+		data["Schedule"] = schedule
+		data["RetentionDays"] = retentionDays
+		data["HasEncryptionKey"] = len(a.Config.EncryptionKey) > 0
+		data["DatabaseName"] = service.ParseDatabaseName(a.Config.DatabaseURL)
+		data["BackupDir"] = a.BackupService.BackupDir()
+		tr.Render(w, r, "backups.html", data)
+	}
+}
+
+// CreateBackupHandler serves POST /-/backups/create — triggers a manual backup.
+func CreateBackupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if a.BackupService == nil {
+			SetFlash(ctx, sm, "error", "Backup service is not available.")
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		filename, err := a.BackupService.CreateBackup(ctx, "manual")
+		if err != nil {
+			a.Logger.Error("create backup", "error", err)
+			SetFlash(ctx, sm, "error", "Failed to create backup: "+err.Error())
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		SetFlash(ctx, sm, "success", fmt.Sprintf("Backup created: %s", filename))
+		http.Redirect(w, r, "/backups", http.StatusSeeOther)
+	}
+}
+
+// DownloadBackupHandler serves GET /-/backups/{filename}/download.
+func DownloadBackupHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if a.BackupService == nil {
+			http.Error(w, "Backup service not available", http.StatusServiceUnavailable)
+			return
+		}
+
+		filename := chi.URLParam(r, "filename")
+		fullPath, err := a.BackupService.GetBackupPath(filename)
+		if err != nil {
+			http.Error(w, "Backup not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+		http.ServeFile(w, r, fullPath)
+	}
+}
+
+// DeleteBackupHandler serves DELETE /-/backups/{filename}.
+func DeleteBackupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if a.BackupService == nil {
+			SetFlash(ctx, sm, "error", "Backup service not available.")
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		filename := chi.URLParam(r, "filename")
+		if err := a.BackupService.DeleteBackup(filename); err != nil {
+			a.Logger.Error("delete backup", "error", err, "filename", filename)
+			SetFlash(ctx, sm, "error", "Failed to delete backup.")
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		SetFlash(ctx, sm, "success", fmt.Sprintf("Backup deleted: %s", filename))
+		http.Redirect(w, r, "/backups", http.StatusSeeOther)
+	}
+}
+
+// RestoreBackupHandler serves POST /-/backups/restore — restores from an uploaded file.
+func RestoreBackupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if a.BackupService == nil {
+			SetFlash(ctx, sm, "error", "Backup service not available.")
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		// Limit upload to 500MB.
+		r.Body = http.MaxBytesReader(w, r.Body, 500<<20)
+
+		source := r.FormValue("restore_source")
+
+		switch source {
+		case "upload":
+			file, header, err := r.FormFile("backup_file")
+			if err != nil {
+				SetFlash(ctx, sm, "error", "No backup file provided.")
+				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				return
+			}
+			defer file.Close()
+
+			if !strings.HasSuffix(header.Filename, ".sql.gz") {
+				SetFlash(ctx, sm, "error", "Invalid file type. Only .sql.gz files are supported.")
+				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				return
+			}
+
+			if err := a.BackupService.RestoreFromReader(ctx, file); err != nil {
+				a.Logger.Error("restore from upload", "error", err)
+				SetFlash(ctx, sm, "error", "Restore failed: "+err.Error())
+				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				return
+			}
+
+			SetFlash(ctx, sm, "success", "Database restored successfully from uploaded file. You may need to restart the server.")
+
+		case "existing":
+			filename := r.FormValue("backup_filename")
+			if filename == "" {
+				SetFlash(ctx, sm, "error", "No backup file selected.")
+				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				return
+			}
+
+			if err := a.BackupService.RestoreBackup(ctx, filename); err != nil {
+				a.Logger.Error("restore from existing", "error", err, "filename", filename)
+				SetFlash(ctx, sm, "error", "Restore failed: "+err.Error())
+				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				return
+			}
+
+			SetFlash(ctx, sm, "success", fmt.Sprintf("Database restored from %s. You may need to restart the server.", filename))
+
+		default:
+			SetFlash(ctx, sm, "error", "Invalid restore source.")
+		}
+
+		http.Redirect(w, r, "/backups", http.StatusSeeOther)
+	}
+}
+
+// BackupScheduleHandler serves POST /-/backups/schedule — saves backup schedule settings.
+func BackupScheduleHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		schedule := r.FormValue("backup_schedule")
+		retentionStr := r.FormValue("backup_retention_days")
+
+		// Validate schedule.
+		validSchedules := map[string]bool{
+			"":          true, // disabled
+			"daily_2am": true,
+			"daily_3am": true,
+			"daily_4am": true,
+			"weekly":    true,
+		}
+		if !validSchedules[schedule] {
+			SetFlash(ctx, sm, "error", "Invalid backup schedule.")
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		// Validate retention.
+		retentionDays, err := strconv.Atoi(retentionStr)
+		if err != nil || retentionDays < 1 || retentionDays > 365 {
+			SetFlash(ctx, sm, "error", "Invalid retention period. Must be 1-365 days.")
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		// Save schedule.
+		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+			Key:   "backup_schedule",
+			Value: pgtype.Text{String: schedule, Valid: true},
+		}); err != nil {
+			a.Logger.Error("save backup schedule", "error", err)
+			SetFlash(ctx, sm, "error", "Failed to save backup schedule.")
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		// Save retention.
+		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
+			Key:   "backup_retention_days",
+			Value: pgtype.Text{String: fmt.Sprintf("%d", retentionDays), Valid: true},
+		}); err != nil {
+			a.Logger.Error("save backup retention", "error", err)
+			SetFlash(ctx, sm, "error", "Failed to save retention setting.")
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		if schedule == "" {
+			SetFlash(ctx, sm, "success", "Scheduled backups disabled.")
+		} else {
+			SetFlash(ctx, sm, "success", fmt.Sprintf("Backup schedule saved. Retention: %d days.", retentionDays))
+		}
+		http.Redirect(w, r, "/backups", http.StatusSeeOther)
+	}
+}
+
+// RestoreExistingBackupHandler serves POST /-/backups/{filename}/restore.
+func RestoreExistingBackupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if a.BackupService == nil {
+			SetFlash(ctx, sm, "error", "Backup service not available.")
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		filename := chi.URLParam(r, "filename")
+		if err := a.BackupService.RestoreBackup(ctx, filename); err != nil {
+			a.Logger.Error("restore backup", "error", err, "filename", filename)
+			SetFlash(ctx, sm, "error", "Restore failed: "+err.Error())
+			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			return
+		}
+
+		SetFlash(ctx, sm, "success", fmt.Sprintf("Database restored from %s. You may need to restart the server.", filename))
+		http.Redirect(w, r, "/backups", http.StatusSeeOther)
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -175,6 +175,8 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/providers/plaid", ProvidersSavePlaidHandler(a, sm))
 		r.Post("/providers/teller", ProvidersSaveTellerHandler(a, sm))
 
+		r.Get("/backups", BackupsPageHandler(a, sm, tr))
+
 		r.Get("/settings", SettingsGetHandler(a, sm, tr))
 		r.Post("/settings/sync", SettingsSyncPostHandler(a, sm))
 		r.Post("/settings/retention", SettingsRetentionPostHandler(a, sm))
@@ -225,6 +227,14 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 			r.Post("/update/dismiss", DismissUpdateHandler(a))
 			r.Post("/update", TriggerUpdateHandler(a))
+
+			// Backups
+			r.Post("/backups/create", CreateBackupHandler(a, sm))
+			r.Get("/backups/{filename}/download", DownloadBackupHandler(a))
+			r.Post("/backups/{filename}/restore", RestoreExistingBackupHandler(a, sm))
+			r.Post("/backups/{filename}/delete", DeleteBackupHandler(a, sm))
+			r.Post("/backups/restore", RestoreBackupHandler(a, sm))
+			r.Post("/backups/schedule", BackupScheduleHandler(a, sm))
 
 			// Category CRUD
 			r.Post("/categories", CreateCategoryAdminHandler(svc))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -678,6 +678,9 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return m
 			},
+			"formatBytes": func(bytes int64) string {
+				return service.FormatBytes(bytes)
+			},
 		},
 	}
 	if err := tr.parseTemplates(); err != nil {
@@ -727,6 +730,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/rule_form.html",
 		"pages/rule_detail.html",
 		"pages/insights.html",
+		"pages/backups.html",
 		"pages/account_links.html",
 		"pages/account_link_detail.html",
 		"pages/reports.html",

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -29,6 +29,7 @@ type App struct {
 	SyncEngine            *sync.Engine
 	Service               *service.Service
 	Scheduler             *sync.Scheduler
+	BackupService         *service.BackupService
 	VersionChecker        *version.Checker
 	DockerSocketAvailable bool
 }

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -1,0 +1,410 @@
+package service
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// BackupInfo describes a backup file on disk.
+type BackupInfo struct {
+	Filename  string    `json:"filename"`
+	Size      int64     `json:"size"`
+	CreatedAt time.Time `json:"created_at"`
+	Trigger   string    `json:"trigger"` // "manual" or "scheduled"
+}
+
+// BackupService handles database backup and restore operations.
+type BackupService struct {
+	databaseURL string
+	backupDir   string
+	logger      *slog.Logger
+}
+
+// NewBackupService creates a new BackupService.
+// backupDir is the directory where backup files are stored.
+func NewBackupService(databaseURL, backupDir string, logger *slog.Logger) *BackupService {
+	return &BackupService{
+		databaseURL: databaseURL,
+		backupDir:   backupDir,
+		logger:      logger,
+	}
+}
+
+// BackupDir returns the configured backup directory.
+func (bs *BackupService) BackupDir() string {
+	return bs.backupDir
+}
+
+// EnsureBackupDir creates the backup directory if it doesn't exist.
+func (bs *BackupService) EnsureBackupDir() error {
+	return os.MkdirAll(bs.backupDir, 0750)
+}
+
+// CreateBackup runs pg_dump and compresses the output to a .sql.gz file.
+// trigger should be "manual" or "scheduled".
+// Returns the filename of the created backup.
+func (bs *BackupService) CreateBackup(ctx context.Context, trigger string) (string, error) {
+	if err := bs.EnsureBackupDir(); err != nil {
+		return "", fmt.Errorf("create backup directory: %w", err)
+	}
+
+	// Check that pg_dump is available.
+	if _, err := exec.LookPath("pg_dump"); err != nil {
+		return "", fmt.Errorf("pg_dump not found on PATH: %w", err)
+	}
+
+	timestamp := time.Now().UTC().Format("20060102_150405")
+	filename := fmt.Sprintf("breadbox_%s_%s.sql.gz", trigger, timestamp)
+	fullPath := filepath.Join(bs.backupDir, filename)
+
+	// Build pg_dump args. Use --no-owner and --no-acl for portability.
+	args := []string{
+		"--format=plain",
+		"--no-owner",
+		"--no-acl",
+		"--clean",
+		"--if-exists",
+		bs.databaseURL,
+	}
+
+	cmd := exec.CommandContext(ctx, "pg_dump", args...)
+
+	// Capture stderr for error reporting.
+	var stderrBuf strings.Builder
+	cmd.Stderr = &stderrBuf
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("create stdout pipe: %w", err)
+	}
+
+	outFile, err := os.Create(fullPath)
+	if err != nil {
+		return "", fmt.Errorf("create backup file: %w", err)
+	}
+	defer outFile.Close()
+
+	gzWriter := gzip.NewWriter(outFile)
+	defer gzWriter.Close()
+
+	if err := cmd.Start(); err != nil {
+		os.Remove(fullPath)
+		return "", fmt.Errorf("start pg_dump: %w", err)
+	}
+
+	if _, err := io.Copy(gzWriter, stdout); err != nil {
+		os.Remove(fullPath)
+		return "", fmt.Errorf("write backup data: %w", err)
+	}
+
+	if err := gzWriter.Close(); err != nil {
+		os.Remove(fullPath)
+		return "", fmt.Errorf("close gzip writer: %w", err)
+	}
+	if err := outFile.Close(); err != nil {
+		os.Remove(fullPath)
+		return "", fmt.Errorf("close backup file: %w", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		os.Remove(fullPath)
+		return "", fmt.Errorf("pg_dump failed: %s: %w", stderrBuf.String(), err)
+	}
+
+	// Verify the file was actually created with content.
+	info, err := os.Stat(fullPath)
+	if err != nil || info.Size() == 0 {
+		os.Remove(fullPath)
+		return "", fmt.Errorf("backup file is empty or missing")
+	}
+
+	bs.logger.Info("backup created", "filename", filename, "size", info.Size(), "trigger", trigger)
+	return filename, nil
+}
+
+// ListBackups returns all backup files sorted by creation time (newest first).
+func (bs *BackupService) ListBackups() ([]BackupInfo, error) {
+	if err := bs.EnsureBackupDir(); err != nil {
+		return nil, fmt.Errorf("ensure backup directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(bs.backupDir)
+	if err != nil {
+		return nil, fmt.Errorf("read backup directory: %w", err)
+	}
+
+	var backups []BackupInfo
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(entry.Name(), ".sql.gz") {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+
+		trigger := parseTriggerFromFilename(entry.Name())
+
+		backups = append(backups, BackupInfo{
+			Filename:  entry.Name(),
+			Size:      info.Size(),
+			CreatedAt: info.ModTime(),
+			Trigger:   trigger,
+		})
+	}
+
+	// Sort newest first.
+	sort.Slice(backups, func(i, j int) bool {
+		return backups[i].CreatedAt.After(backups[j].CreatedAt)
+	})
+
+	return backups, nil
+}
+
+// GetBackupPath returns the full path for a backup filename.
+// Returns an error if the filename contains path traversal.
+func (bs *BackupService) GetBackupPath(filename string) (string, error) {
+	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
+		return "", fmt.Errorf("invalid backup filename")
+	}
+	if !strings.HasSuffix(filename, ".sql.gz") {
+		return "", fmt.Errorf("invalid backup file extension")
+	}
+	fullPath := filepath.Join(bs.backupDir, filename)
+
+	// Verify the file exists.
+	if _, err := os.Stat(fullPath); err != nil {
+		return "", fmt.Errorf("backup file not found: %s", filename)
+	}
+	return fullPath, nil
+}
+
+// DeleteBackup removes a backup file.
+func (bs *BackupService) DeleteBackup(filename string) error {
+	fullPath, err := bs.GetBackupPath(filename)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(fullPath); err != nil {
+		return fmt.Errorf("delete backup: %w", err)
+	}
+	bs.logger.Info("backup deleted", "filename", filename)
+	return nil
+}
+
+// RestoreBackup decompresses a .sql.gz file and runs it through psql.
+// This is a destructive operation that replaces the current database contents.
+func (bs *BackupService) RestoreBackup(ctx context.Context, filename string) error {
+	fullPath, err := bs.GetBackupPath(filename)
+	if err != nil {
+		return err
+	}
+
+	// Check that psql is available.
+	if _, err := exec.LookPath("psql"); err != nil {
+		return fmt.Errorf("psql not found on PATH: %w", err)
+	}
+
+	// Open and decompress the backup file.
+	f, err := os.Open(fullPath)
+	if err != nil {
+		return fmt.Errorf("open backup file: %w", err)
+	}
+	defer f.Close()
+
+	gzReader, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("decompress backup: %w", err)
+	}
+	defer gzReader.Close()
+
+	// Run psql with the decompressed SQL as stdin.
+	// Use --single-transaction for atomicity.
+	args := []string{
+		"--single-transaction",
+		"--set", "ON_ERROR_STOP=on",
+		bs.databaseURL,
+	}
+
+	cmd := exec.CommandContext(ctx, "psql", args...)
+	cmd.Stdin = gzReader
+
+	var stderrBuf strings.Builder
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("psql restore failed: %s: %w", stderrBuf.String(), err)
+	}
+
+	bs.logger.Info("backup restored", "filename", filename)
+	return nil
+}
+
+// RestoreFromReader decompresses a gzipped SQL stream and runs it through psql.
+// Used for uploaded backup files that aren't yet saved to disk.
+func (bs *BackupService) RestoreFromReader(ctx context.Context, r io.Reader) error {
+	// Check that psql is available.
+	if _, err := exec.LookPath("psql"); err != nil {
+		return fmt.Errorf("psql not found on PATH: %w", err)
+	}
+
+	gzReader, err := gzip.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("decompress backup: %w", err)
+	}
+	defer gzReader.Close()
+
+	args := []string{
+		"--single-transaction",
+		"--set", "ON_ERROR_STOP=on",
+		bs.databaseURL,
+	}
+
+	cmd := exec.CommandContext(ctx, "psql", args...)
+	cmd.Stdin = gzReader
+
+	var stderrBuf strings.Builder
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("psql restore failed: %s: %w", stderrBuf.String(), err)
+	}
+
+	bs.logger.Info("backup restored from upload")
+	return nil
+}
+
+// CleanupOldBackups deletes backups older than retentionDays.
+// Returns the number of files deleted.
+func (bs *BackupService) CleanupOldBackups(retentionDays int) (int, error) {
+	if retentionDays <= 0 {
+		return 0, nil
+	}
+
+	backups, err := bs.ListBackups()
+	if err != nil {
+		return 0, err
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -retentionDays)
+	deleted := 0
+	for _, b := range backups {
+		if b.CreatedAt.Before(cutoff) {
+			if err := os.Remove(filepath.Join(bs.backupDir, b.Filename)); err != nil {
+				bs.logger.Error("failed to delete old backup", "filename", b.Filename, "error", err)
+				continue
+			}
+			deleted++
+		}
+	}
+
+	if deleted > 0 {
+		bs.logger.Info("cleaned up old backups", "deleted", deleted, "retention_days", retentionDays)
+	}
+	return deleted, nil
+}
+
+// TotalBackupSize returns the total size of all backups in bytes.
+func (bs *BackupService) TotalBackupSize() (int64, error) {
+	backups, err := bs.ListBackups()
+	if err != nil {
+		return 0, err
+	}
+	var total int64
+	for _, b := range backups {
+		total += b.Size
+	}
+	return total, nil
+}
+
+// ParseDatabaseName extracts the database name from a PostgreSQL connection URL
+// for display purposes. Returns just the database name, not credentials.
+func ParseDatabaseName(databaseURL string) string {
+	u, err := url.Parse(databaseURL)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "unknown"
+	}
+	name := strings.TrimPrefix(u.Path, "/")
+	if name == "" {
+		return "unknown"
+	}
+	return name
+}
+
+// parseTriggerFromFilename extracts the trigger type from a backup filename.
+// Expected format: breadbox_<trigger>_<timestamp>.sql.gz
+func parseTriggerFromFilename(filename string) string {
+	name := strings.TrimSuffix(filename, ".sql.gz")
+	parts := strings.SplitN(name, "_", 3) // breadbox, trigger, timestamp
+	if len(parts) >= 2 {
+		switch parts[1] {
+		case "manual", "scheduled":
+			return parts[1]
+		}
+	}
+	return "unknown"
+}
+
+// FormatBytes formats a byte count into a human-readable string.
+func FormatBytes(bytes int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+	switch {
+	case bytes >= GB:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(GB))
+	case bytes >= MB:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(MB))
+	case bytes >= KB:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+// GetBackupSchedule returns the backup schedule from app_config.
+// Returns empty string if not configured (disabled).
+func (s *Service) GetBackupSchedule(ctx context.Context) string {
+	row, err := s.Queries.GetAppConfig(ctx, "backup_schedule")
+	if err != nil {
+		return ""
+	}
+	if !row.Value.Valid || row.Value.String == "" {
+		return ""
+	}
+	return row.Value.String
+}
+
+// GetBackupRetentionDays returns the backup retention days from app_config.
+// Returns default of 7 if not configured.
+func (s *Service) GetBackupRetentionDays(ctx context.Context) int {
+	row, err := s.Queries.GetAppConfig(ctx, "backup_retention_days")
+	if err != nil {
+		return 7
+	}
+	if !row.Value.Valid || row.Value.String == "" {
+		return 7
+	}
+	days, err := strconv.Atoi(row.Value.String)
+	if err != nil || days < 0 {
+		return 7
+	}
+	return days
+}

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -89,33 +89,43 @@ func (bs *BackupService) CreateBackup(ctx context.Context, trigger string) (stri
 		return "", fmt.Errorf("create stdout pipe: %w", err)
 	}
 
+	var fileClosed bool
 	outFile, err := os.Create(fullPath)
 	if err != nil {
 		return "", fmt.Errorf("create backup file: %w", err)
 	}
-	defer outFile.Close()
+	defer func() {
+		if !fileClosed {
+			outFile.Close()
+			os.Remove(fullPath) // cleanup incomplete backup
+		}
+	}()
 
 	gzWriter := gzip.NewWriter(outFile)
-	defer gzWriter.Close()
+	defer func() {
+		if !fileClosed {
+			gzWriter.Close()
+		}
+	}()
 
 	if err := cmd.Start(); err != nil {
 		os.Remove(fullPath)
 		return "", fmt.Errorf("start pg_dump: %w", err)
 	}
+	// Ensure the process is always reaped even if we return early.
+	defer func() { _ = cmd.Wait() }()
 
 	if _, err := io.Copy(gzWriter, stdout); err != nil {
-		os.Remove(fullPath)
 		return "", fmt.Errorf("write backup data: %w", err)
 	}
 
 	if err := gzWriter.Close(); err != nil {
-		os.Remove(fullPath)
 		return "", fmt.Errorf("close gzip writer: %w", err)
 	}
 	if err := outFile.Close(); err != nil {
-		os.Remove(fullPath)
 		return "", fmt.Errorf("close backup file: %w", err)
 	}
+	fileClosed = true
 
 	if err := cmd.Wait(); err != nil {
 		os.Remove(fullPath)

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -178,9 +178,11 @@ func (bs *BackupService) ListBackups() ([]BackupInfo, error) {
 		})
 	}
 
-	// Sort newest first.
+	// Sort newest first by filename (contains YYYYMMDD_HHMMSS timestamp).
+	// Filename sort is more reliable than ModTime because test helpers and
+	// file copies can produce identical modification times.
 	sort.Slice(backups, func(i, j int) bool {
-		return backups[i].CreatedAt.After(backups[j].CreatedAt)
+		return backups[i].Filename > backups[j].Filename
 	})
 
 	return backups, nil

--- a/internal/service/backup_test.go
+++ b/internal/service/backup_test.go
@@ -1,0 +1,294 @@
+package service
+
+import (
+	"context"
+	"compress/gzip"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{100, "100 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+		{1073741824, "1.0 GB"},
+	}
+	for _, tt := range tests {
+		got := FormatBytes(tt.input)
+		if got != tt.want {
+			t.Errorf("FormatBytes(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseDatabaseName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"postgres://user:pass@localhost:5432/breadbox?sslmode=disable", "breadbox"},
+		{"postgres://user:pass@localhost/mydb", "mydb"},
+		{"postgres://user:pass@localhost/", "unknown"},
+		{"not-a-url", "unknown"},
+	}
+	for _, tt := range tests {
+		got := ParseDatabaseName(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseDatabaseName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseTriggerFromFilename(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"breadbox_manual_20260404_120000.sql.gz", "manual"},
+		{"breadbox_scheduled_20260404_020000.sql.gz", "scheduled"},
+		{"random_file.sql.gz", "unknown"},
+		{"breadbox_unknown_20260404.sql.gz", "unknown"},
+	}
+	for _, tt := range tests {
+		got := parseTriggerFromFilename(tt.input)
+		if got != tt.want {
+			t.Errorf("parseTriggerFromFilename(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestBackupService_EnsureBackupDir(t *testing.T) {
+	dir := t.TempDir()
+	backupDir := filepath.Join(dir, "backups")
+
+	bs := NewBackupService("postgres://test:test@localhost/test", backupDir, slog.Default())
+	if err := bs.EnsureBackupDir(); err != nil {
+		t.Fatalf("EnsureBackupDir: %v", err)
+	}
+
+	info, err := os.Stat(backupDir)
+	if err != nil {
+		t.Fatalf("stat backup dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal("backup dir is not a directory")
+	}
+}
+
+func TestBackupService_ListBackups_Empty(t *testing.T) {
+	dir := t.TempDir()
+	bs := NewBackupService("", dir, slog.Default())
+
+	backups, err := bs.ListBackups()
+	if err != nil {
+		t.Fatalf("ListBackups: %v", err)
+	}
+	if len(backups) != 0 {
+		t.Fatalf("expected 0 backups, got %d", len(backups))
+	}
+}
+
+func TestBackupService_ListBackups_WithFiles(t *testing.T) {
+	dir := t.TempDir()
+	bs := NewBackupService("", dir, slog.Default())
+
+	// Create fake backup files.
+	for _, name := range []string{
+		"breadbox_manual_20260401_120000.sql.gz",
+		"breadbox_scheduled_20260402_020000.sql.gz",
+		"not_a_backup.txt",
+	} {
+		path := filepath.Join(dir, name)
+		if err := createFakeGzFile(path); err != nil {
+			t.Fatalf("create fake file %s: %v", name, err)
+		}
+	}
+
+	backups, err := bs.ListBackups()
+	if err != nil {
+		t.Fatalf("ListBackups: %v", err)
+	}
+	if len(backups) != 2 {
+		t.Fatalf("expected 2 backups, got %d", len(backups))
+	}
+
+	// Should be sorted newest first.
+	if backups[0].Trigger != "scheduled" {
+		t.Errorf("expected first backup trigger=scheduled, got %s", backups[0].Trigger)
+	}
+	if backups[1].Trigger != "manual" {
+		t.Errorf("expected second backup trigger=manual, got %s", backups[1].Trigger)
+	}
+}
+
+func TestBackupService_DeleteBackup(t *testing.T) {
+	dir := t.TempDir()
+	bs := NewBackupService("", dir, slog.Default())
+
+	filename := "breadbox_manual_20260401_120000.sql.gz"
+	path := filepath.Join(dir, filename)
+	if err := createFakeGzFile(path); err != nil {
+		t.Fatalf("create fake file: %v", err)
+	}
+
+	if err := bs.DeleteBackup(filename); err != nil {
+		t.Fatalf("DeleteBackup: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("backup file should have been deleted")
+	}
+}
+
+func TestBackupService_DeleteBackup_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	bs := NewBackupService("", dir, slog.Default())
+
+	err := bs.DeleteBackup("nonexistent.sql.gz")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestBackupService_GetBackupPath_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	bs := NewBackupService("", dir, slog.Default())
+
+	tests := []string{
+		"../../../etc/passwd.sql.gz",
+		"foo/bar.sql.gz",
+		"..\\evil.sql.gz",
+	}
+	for _, name := range tests {
+		_, err := bs.GetBackupPath(name)
+		if err == nil {
+			t.Errorf("expected error for path traversal: %s", name)
+		}
+	}
+}
+
+func TestBackupService_GetBackupPath_InvalidExtension(t *testing.T) {
+	dir := t.TempDir()
+	bs := NewBackupService("", dir, slog.Default())
+
+	_, err := bs.GetBackupPath("evil.sh")
+	if err == nil {
+		t.Fatal("expected error for invalid extension")
+	}
+}
+
+func TestBackupService_CleanupOldBackups(t *testing.T) {
+	dir := t.TempDir()
+	bs := NewBackupService("", dir, slog.Default())
+
+	// Create a file and set its mtime to 10 days ago.
+	oldFile := filepath.Join(dir, "breadbox_scheduled_20260301_020000.sql.gz")
+	if err := createFakeGzFile(oldFile); err != nil {
+		t.Fatalf("create fake file: %v", err)
+	}
+	oldTime := time.Now().AddDate(0, 0, -10)
+	os.Chtimes(oldFile, oldTime, oldTime)
+
+	// Create a recent file.
+	newFile := filepath.Join(dir, "breadbox_manual_20260404_120000.sql.gz")
+	if err := createFakeGzFile(newFile); err != nil {
+		t.Fatalf("create fake file: %v", err)
+	}
+
+	deleted, err := bs.CleanupOldBackups(7) // Keep 7 days
+	if err != nil {
+		t.Fatalf("CleanupOldBackups: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("expected 1 deleted, got %d", deleted)
+	}
+
+	// Old file should be gone.
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Fatal("old backup should have been deleted")
+	}
+
+	// New file should remain.
+	if _, err := os.Stat(newFile); err != nil {
+		t.Fatal("new backup should still exist")
+	}
+}
+
+func TestBackupService_CleanupOldBackups_DisabledWithZero(t *testing.T) {
+	dir := t.TempDir()
+	bs := NewBackupService("", dir, slog.Default())
+
+	deleted, err := bs.CleanupOldBackups(0)
+	if err != nil {
+		t.Fatalf("CleanupOldBackups: %v", err)
+	}
+	if deleted != 0 {
+		t.Fatalf("expected 0 deleted when disabled, got %d", deleted)
+	}
+}
+
+func TestBackupService_TotalBackupSize(t *testing.T) {
+	dir := t.TempDir()
+	bs := NewBackupService("", dir, slog.Default())
+
+	// Create two files with known content.
+	for _, name := range []string{
+		"breadbox_manual_20260401_120000.sql.gz",
+		"breadbox_manual_20260402_120000.sql.gz",
+	} {
+		if err := createFakeGzFile(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("create fake file: %v", err)
+		}
+	}
+
+	total, err := bs.TotalBackupSize()
+	if err != nil {
+		t.Fatalf("TotalBackupSize: %v", err)
+	}
+	if total <= 0 {
+		t.Fatal("expected positive total size")
+	}
+}
+
+func TestBackupService_CreateBackup_NoPgDump(t *testing.T) {
+	// This test verifies that CreateBackup fails gracefully when pg_dump is not in PATH.
+	dir := t.TempDir()
+	bs := NewBackupService("postgres://test:test@localhost/test", dir, slog.Default())
+
+	// Override PATH to exclude pg_dump.
+	originalPath := os.Getenv("PATH")
+	os.Setenv("PATH", dir) // temp dir has no executables
+	defer os.Setenv("PATH", originalPath)
+
+	_, err := bs.CreateBackup(context.Background(), "manual")
+	if err == nil {
+		t.Fatal("expected error when pg_dump is not available")
+	}
+}
+
+// createFakeGzFile creates a small valid gzip file for testing.
+func createFakeGzFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gw := gzip.NewWriter(f)
+	_, err = gw.Write([]byte("-- fake SQL dump\n"))
+	if err != nil {
+		return err
+	}
+	return gw.Close()
+}

--- a/internal/sync/scheduler.go
+++ b/internal/sync/scheduler.go
@@ -75,6 +75,13 @@ func (s *Scheduler) NextRun() time.Time {
 	return entries[0].Next
 }
 
+// AddFunc registers an additional cron job with the scheduler.
+// spec is a standard cron expression (e.g., "0 2 * * *" for daily at 2am).
+func (s *Scheduler) AddFunc(spec string, cmd func()) error {
+	_, err := s.cron.AddFunc(spec, cmd)
+	return err
+}
+
 // Stop gracefully stops the scheduler, waiting for any running jobs to finish.
 func (s *Scheduler) Stop() {
 	ctx := s.cron.Stop()

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -261,6 +261,14 @@
             </span>
           </div>
           <div class="bb-shortcuts-row">
+            <span class="bb-shortcuts-label">Backups</span>
+            <span class="bb-shortcuts-keys">
+              <kbd class="bb-shortcuts-kbd">g</kbd>
+              <span class="bb-shortcuts-then">then</span>
+              <kbd class="bb-shortcuts-kbd">b</kbd>
+            </span>
+          </div>
+          <div class="bb-shortcuts-row">
             <span class="bb-shortcuts-label">Settings</span>
             <span class="bb-shortcuts-keys">
               <kbd class="bb-shortcuts-kbd">g</kbd>
@@ -721,6 +729,7 @@
         { id: 'sys-providers', group: 'System', title: 'Providers', desc: 'Configure Plaid, Teller, CSV', icon: 'plug', href: '/providers', keywords: 'plaid teller csv bank setup' },
         { id: 'sys-access', group: 'System', title: 'Access', desc: 'API keys and OAuth clients', icon: 'shield-check', href: '/access', keywords: 'tokens authentication api keys oauth connector claude' },
         { id: 'sys-logs', group: 'System', title: 'Logs', desc: 'Sync logs and webhook events', icon: 'scroll-text', href: '/logs', keywords: 'sync history errors status webhooks events' },
+        { id: 'sys-backups', group: 'System', title: 'Backups', desc: 'Database backup and restore', icon: 'hard-drive', href: '/backups', keywords: 'backup restore database dump export' },
         { id: 'sys-settings', group: 'System', title: 'Settings', desc: 'Sync schedule, security, system', icon: 'settings', href: '/settings', keywords: 'schedule password encryption' },
         // Quick Actions
         { id: 'act-connect', group: 'Quick Actions', title: 'Connect a Bank', desc: 'Add a new bank connection', icon: 'plus-circle', href: '/connections/new', keywords: 'add new link' },
@@ -1072,6 +1081,7 @@
         u: '/rules',
         a: '/categories',
         l: '/sync-logs',
+        b: '/backups',
         s: '/settings',
         p: '/providers',
         m: '/mcp-settings',

--- a/internal/templates/pages/backups.html
+++ b/internal/templates/pages/backups.html
@@ -1,0 +1,280 @@
+{{define "content"}}
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Backups</h1>
+    <p class="text-sm text-base-content/50 mt-1">Database backup, restore, and scheduled backups</p>
+  </div>
+  <div class="flex items-center gap-2">
+    {{if not .Error}}
+    <form method="POST" action="/-/backups/create">
+      <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+      <button type="submit" class="btn btn-primary btn-sm rounded-xl">
+        <i data-lucide="download" class="w-4 h-4"></i>
+        Create Backup Now
+      </button>
+    </form>
+    {{end}}
+  </div>
+</div>
+
+<div class="grid gap-6 bb-stagger">
+
+  <!-- Encryption Key Warning -->
+  <div class="alert alert-warning shadow-sm">
+    <i data-lucide="shield-alert" class="w-5 h-5 flex-shrink-0"></i>
+    <div>
+      <h3 class="font-semibold text-sm">Back up your ENCRYPTION_KEY separately</h3>
+      <p class="text-xs mt-1 leading-relaxed">
+        Database backups contain encrypted bank credentials that are useless without the matching
+        <code class="text-xs bg-base-300/50 px-1 py-0.5 rounded">ENCRYPTION_KEY</code>.
+        If you lose the key, all bank connections must be re-linked from scratch. Store it in a
+        password manager or secure vault — never commit it to version control.
+      </p>
+      {{if not .HasEncryptionKey}}
+      <p class="text-xs mt-2 text-error font-semibold">
+        <i data-lucide="alert-triangle" class="w-3.5 h-3.5 inline mr-0.5"></i>
+        No encryption key is currently set. Bank credentials cannot be stored or restored.
+      </p>
+      {{end}}
+    </div>
+  </div>
+
+  {{if .Error}}
+  <div class="alert alert-error shadow-sm">
+    <i data-lucide="alert-circle" class="w-5 h-5 flex-shrink-0"></i>
+    <span class="text-sm">{{.Error}}</span>
+  </div>
+  {{else}}
+
+  <!-- Stats -->
+  <div class="flex flex-wrap gap-4">
+    <div class="bb-card p-4 flex-1 min-w-[140px]">
+      <div class="text-xs text-base-content/40 mb-1">Backups</div>
+      <div class="text-2xl font-bold tabular-nums">{{.BackupCount}}</div>
+    </div>
+    <div class="bb-card p-4 flex-1 min-w-[140px]">
+      <div class="text-xs text-base-content/40 mb-1">Total Size</div>
+      <div class="text-2xl font-bold tabular-nums">{{.TotalSize}}</div>
+    </div>
+    <div class="bb-card p-4 flex-1 min-w-[140px]">
+      <div class="text-xs text-base-content/40 mb-1">Schedule</div>
+      <div class="text-2xl font-bold">
+        {{if eq .Schedule ""}}Off{{else if eq .Schedule "daily_2am"}}Daily 2am{{else if eq .Schedule "daily_3am"}}Daily 3am{{else if eq .Schedule "daily_4am"}}Daily 4am{{else if eq .Schedule "weekly"}}Weekly{{else}}{{.Schedule}}{{end}}
+      </div>
+    </div>
+    <div class="bb-card p-4 flex-1 min-w-[140px]">
+      <div class="text-xs text-base-content/40 mb-1">Retention</div>
+      <div class="text-2xl font-bold tabular-nums">{{.RetentionDays}}d</div>
+    </div>
+  </div>
+
+  <!-- Schedule Configuration -->
+  <div id="schedule" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#schedule' }">
+    <div class="px-4 sm:px-5 py-4 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
+      <i data-lucide="clock" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+      <div class="min-w-0 flex-1">
+        <h2 class="font-semibold">Schedule</h2>
+        <p class="text-xs text-base-content/40" x-show="!expanded">
+          {{if eq .Schedule ""}}Automatic backups disabled{{else}}Automatic backups enabled · Retention: {{.RetentionDays}} days{{end}}
+        </p>
+        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Configure automatic backup frequency and retention</p>
+      </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+    </div>
+    <div x-show="expanded" x-collapse x-cloak>
+      <div class="px-4 sm:px-5 py-4">
+        <form method="POST" action="/-/backups/schedule">
+          <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+
+          <div class="grid sm:grid-cols-2 gap-4 max-w-lg">
+            <div>
+              <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="backup_schedule">Frequency</label>
+              <select id="backup_schedule" name="backup_schedule" class="select select-sm select-bordered w-full rounded-xl bg-base-200">
+                <option value=""{{if eq .Schedule ""}} selected{{end}}>Disabled</option>
+                <option value="daily_2am"{{if eq .Schedule "daily_2am"}} selected{{end}}>Daily at 2:00 AM</option>
+                <option value="daily_3am"{{if eq .Schedule "daily_3am"}} selected{{end}}>Daily at 3:00 AM</option>
+                <option value="daily_4am"{{if eq .Schedule "daily_4am"}} selected{{end}}>Daily at 4:00 AM</option>
+                <option value="weekly"{{if eq .Schedule "weekly"}} selected{{end}}>Weekly (Sunday 2:00 AM)</option>
+              </select>
+            </div>
+            <div>
+              <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="backup_retention_days">Retention</label>
+              <select id="backup_retention_days" name="backup_retention_days" class="select select-sm select-bordered w-full rounded-xl bg-base-200">
+                <option value="3"{{if eq .RetentionDays 3}} selected{{end}}>3 days</option>
+                <option value="7"{{if eq .RetentionDays 7}} selected{{end}}>7 days (default)</option>
+                <option value="14"{{if eq .RetentionDays 14}} selected{{end}}>14 days</option>
+                <option value="30"{{if eq .RetentionDays 30}} selected{{end}}>30 days</option>
+                <option value="60"{{if eq .RetentionDays 60}} selected{{end}}>60 days</option>
+                <option value="90"{{if eq .RetentionDays 90}} selected{{end}}>90 days</option>
+                <option value="180"{{if eq .RetentionDays 180}} selected{{end}}>180 days</option>
+                <option value="365"{{if eq .RetentionDays 365}} selected{{end}}>1 year</option>
+              </select>
+            </div>
+          </div>
+
+          <p class="text-xs text-base-content/40 mt-3 flex items-center gap-1.5">
+            <i data-lucide="folder" class="w-3.5 h-3.5"></i>
+            Backups stored in: <code class="text-xs bg-base-300/50 px-1 py-0.5 rounded">{{.BackupDir}}</code>
+          </p>
+
+          <div class="mt-4">
+            <button type="submit" class="btn btn-primary btn-sm rounded-xl">Save Schedule</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Backup List -->
+  <div class="bb-card p-0 overflow-hidden">
+    <div class="px-4 sm:px-5 py-4 flex items-center gap-3 border-b border-base-300">
+      <i data-lucide="archive" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+      <h2 class="font-semibold">Backup Files</h2>
+      <span class="text-xs text-base-content/40 ml-auto tabular-nums">{{.BackupCount}} files</span>
+    </div>
+
+    {{if eq .BackupCount 0}}
+    <div class="px-4 sm:px-5 py-8 text-center text-sm text-base-content/40">
+      <i data-lucide="database" class="w-8 h-8 mx-auto mb-2 opacity-30"></i>
+      <p>No backups yet. Click "Create Backup Now" to create your first backup.</p>
+    </div>
+    {{else}}
+    <div class="overflow-x-auto">
+      <table class="table table-sm">
+        <thead>
+          <tr>
+            <th>Filename</th>
+            <th>Size</th>
+            <th>Created</th>
+            <th>Type</th>
+            <th class="text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{range .Backups}}
+          <tr>
+            <td>
+              <div class="flex items-center gap-2">
+                <i data-lucide="file-archive" class="w-4 h-4 text-base-content/30 flex-shrink-0"></i>
+                <span class="font-mono text-xs">{{.Filename}}</span>
+              </div>
+            </td>
+            <td class="tabular-nums text-sm">{{formatBytes .Size}}</td>
+            <td class="text-sm">{{relativeTime .CreatedAt}}</td>
+            <td>
+              {{if eq .Trigger "manual"}}
+              <span class="badge badge-ghost badge-sm">manual</span>
+              {{else if eq .Trigger "scheduled"}}
+              <span class="badge badge-soft badge-info badge-sm">scheduled</span>
+              {{else}}
+              <span class="badge badge-ghost badge-sm">{{.Trigger}}</span>
+              {{end}}
+            </td>
+            <td>
+              <div class="flex items-center justify-end gap-1">
+                <a href="/-/backups/{{.Filename}}/download" class="btn btn-ghost btn-xs rounded-lg" title="Download">
+                  <i data-lucide="download" class="w-3.5 h-3.5"></i>
+                </a>
+                <form method="POST" action="/-/backups/{{.Filename}}/restore"
+                      x-data
+                      @submit.prevent="$dispatch('bb-confirm', {
+                        title: 'Restore this backup?',
+                        message: 'This will replace all current data with the contents of this backup. This action cannot be undone.',
+                        variant: 'danger',
+                        confirmLabel: 'Restore',
+                        cancelLabel: 'Cancel',
+                        onConfirm: () => $el.submit()
+                      })">
+                  <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+                  <button type="submit" class="btn btn-ghost btn-xs rounded-lg text-warning" title="Restore">
+                    <i data-lucide="rotate-ccw" class="w-3.5 h-3.5"></i>
+                  </button>
+                </form>
+                <form method="POST" action="/-/backups/{{.Filename}}/delete"
+                      x-data
+                      @submit.prevent="$dispatch('bb-confirm', {
+                        title: 'Delete this backup?',
+                        message: 'The backup file will be permanently removed from disk.',
+                        variant: 'danger',
+                        confirmLabel: 'Delete',
+                        cancelLabel: 'Cancel',
+                        onConfirm: () => $el.submit()
+                      })">
+                  <input type="hidden" name="_csrf" value="{{$.CSRFToken}}">
+                  <button type="submit" class="btn btn-ghost btn-xs rounded-lg text-error" title="Delete">
+                    <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+                  </button>
+                </form>
+              </div>
+            </td>
+          </tr>
+          {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{end}}
+  </div>
+
+  <!-- Restore from Upload -->
+  <div id="restore" class="bb-card p-0 overflow-hidden" x-data="{ expanded: location.hash === '#restore' }">
+    <div class="px-4 sm:px-5 py-4 flex items-center gap-3 cursor-pointer" :class="expanded && 'border-b border-base-300'" @click="expanded = !expanded">
+      <i data-lucide="upload" class="w-5 h-5 text-base-content/40 flex-shrink-0"></i>
+      <div class="min-w-0 flex-1">
+        <h2 class="font-semibold">Restore from File</h2>
+        <p class="text-xs text-base-content/40" x-show="!expanded">Upload a .sql.gz backup file to restore</p>
+        <p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Upload a previously downloaded backup to restore</p>
+      </div>
+      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
+    </div>
+    <div x-show="expanded" x-collapse x-cloak>
+      <div class="px-4 sm:px-5 py-4">
+        <div class="text-xs text-error/80 bg-error/5 rounded-lg p-3 mb-4">
+          <i data-lucide="alert-triangle" class="w-3.5 h-3.5 inline mr-1"></i>
+          <strong>Warning:</strong> Restoring a backup will replace all current data. Make sure you have the correct
+          <code class="text-xs bg-base-300/50 px-1 py-0.5 rounded">ENCRYPTION_KEY</code> that matches the backup,
+          or bank connections will need to be re-linked.
+        </div>
+
+        <form method="POST" action="/-/backups/restore" enctype="multipart/form-data"
+              x-data="{ filename: '' }"
+              @submit.prevent="$dispatch('bb-confirm', {
+                title: 'Restore database from upload?',
+                message: 'This will replace ALL current data with the contents of the uploaded file. This action cannot be undone.',
+                variant: 'danger',
+                confirmLabel: 'Restore',
+                cancelLabel: 'Cancel',
+                onConfirm: () => $el.submit()
+              })">
+          <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
+          <input type="hidden" name="restore_source" value="upload">
+
+          <div class="max-w-md">
+            <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="backup_file">Backup File (.sql.gz)</label>
+            <input type="file" id="backup_file" name="backup_file" accept=".sql.gz,.gz"
+                   class="file-input file-input-bordered file-input-sm w-full rounded-xl"
+                   @change="filename = $event.target.files[0]?.name || ''"
+                   required>
+          </div>
+
+          <div class="mt-4">
+            <button type="submit" class="btn btn-warning btn-sm rounded-xl" :disabled="!filename">
+              <i data-lucide="rotate-ccw" class="w-4 h-4"></i>
+              Restore from Upload
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  {{end}}
+</div>
+
+<script>
+(function() {
+  if (!location.hash) return;
+  var el = document.querySelector(location.hash);
+  if (el) setTimeout(function() { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 100);
+})();
+</script>
+{{end}}

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -59,6 +59,9 @@
   <a href="/logs" class="bb-sidebar-link{{if eq .CurrentPage "logs"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="scroll-text"></i> Logs
   </a>
+  <a href="/backups" class="bb-sidebar-link{{if eq .CurrentPage "backups"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="hard-drive"></i> Backups
+  </a>
   <a href="/settings" class="bb-sidebar-link{{if eq .CurrentPage "settings"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="settings"></i> Settings
   </a>


### PR DESCRIPTION
## Summary
- Add a Backups page (`/backups`) with full backup management: manual trigger, download, restore from existing backup or uploaded file, and delete
- Scheduled backups via `backup_schedule` and `backup_retention_days` app_config keys (daily at 2/3/4am or weekly, with configurable retention)
- Prominent ENCRYPTION_KEY warning card explaining that the key must be backed up separately from the database
- Backup service wraps `pg_dump`/`psql` and stores compressed `.sql.gz` archives in a configurable directory (`BACKUP_DIR` env var or `./backups/`)
- Graceful degradation: if `pg_dump` is not found, the backup service is disabled and the page shows an informative error
- Nav sidebar entry with `hard-drive` Lucide icon, command palette entry, keyboard shortcut (`g` then `b`)
- 11 unit tests covering file operations, path traversal protection, cleanup, formatting

## New files
- `internal/service/backup.go` -- BackupService (create/list/delete/restore/cleanup)
- `internal/service/backup_test.go` -- unit tests
- `internal/admin/backups.go` -- admin handlers (page, create, download, delete, restore, schedule)
- `internal/templates/pages/backups.html` -- backup management page template

## Modified files
- `internal/app/app.go` -- add `BackupService` field to App struct
- `cmd/breadbox/main.go` -- initialize backup service on startup, add scheduled backup cron job
- `internal/sync/scheduler.go` -- add `AddFunc` method for registering external cron jobs
- `internal/admin/router.go` -- register backup routes
- `internal/admin/templates.go` -- register template + `formatBytes` func
- `internal/templates/partials/nav.html` -- add Backups nav entry
- `internal/templates/layout/base.html` -- command palette + keyboard shortcuts
- `.gitignore` -- exclude `backups/` directory

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (11 new unit tests for backup service)
- [ ] Manual: navigate to `/backups`, verify page renders with encryption key warning
- [ ] Manual: click "Create Backup Now", verify `.sql.gz` file appears in list
- [ ] Manual: download a backup, verify it's a valid gzip of SQL
- [ ] Manual: restore from an existing backup, verify data is intact
- [ ] Manual: delete a backup, verify it's removed
- [ ] Manual: configure schedule and retention, verify settings persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)