### PR TITLE
Fix categories page layout into aligned rows

### DIFF
--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -33,124 +33,177 @@
 <div class="text-sm text-base-content/40 mb-4 px-1">{{len .Categories}} top-level categories</div>
 {{end}}
 
-<!-- Categories Tree -->
+<!-- Categories List -->
 <div>
     {{if .Categories}}
-    <div class="space-y-2 sm:space-y-3 bb-stagger">
-      {{range .Categories}}
-      {{$spending := index $.SpendingByCategory .DisplayName}}
-      <div class="bb-card overflow-hidden group" x-data="{open: false}">
-        <!-- Parent row -->
-        <div role="button" tabindex="0" class="w-full flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3 sm:py-4 hover:bg-base-200/30 transition-colors duration-150 text-left cursor-pointer select-none"
-          @click="open = !open" @keydown.enter="open = !open" @keydown.space.prevent="open = !open">
-          <div class="flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 rounded-xl shrink-0"
-            style="{{if .Color}}background-color: {{safeCSS .Color}}18{{else}}background-color: {{safeCSS "oklch(48% 0.17 265 / 0.08)"}}{{end}}">
-            {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-5 h-5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
-            {{else}}{{if .Color}}<span class="w-3 h-3 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
-            {{else}}<i data-lucide="tag" class="w-5 h-5 text-primary/60"></i>{{end}}{{end}}
-          </div>
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-2">
-              <span class="font-semibold text-sm">{{.DisplayName}}</span>
-              {{if .Hidden}}<span class="badge badge-ghost badge-xs">Hidden</span>{{end}}
-              {{if .IsSystem}}<span class="badge badge-soft badge-info badge-xs">System</span>{{end}}
-              {{if .Children}}<span class="text-[0.65rem] font-medium px-1.5 py-0.5 rounded-full bg-base-200/60 text-base-content/40">{{len .Children}}</span>{{end}}
-            </div>
-            <div class="flex items-center gap-2 mt-0.5">
-              {{if gt $spending.TransactionCount 0}}
-              <span class="text-xs tabular-nums font-medium text-base-content/60">{{formatBalance $spending.Amount}}</span>
-              <span class="text-xs text-base-content/25">&middot;</span>
-              <span class="text-xs text-base-content/40 tabular-nums">{{$spending.TransactionCount}} txn{{if ne $spending.TransactionCount 1}}s{{end}}</span>
-              {{if gt $spending.Percent 0.0}}
-              <span class="text-xs text-base-content/25">&middot;</span>
-              <span class="text-[0.65rem] text-base-content/35 tabular-nums">{{printf "%.0f" $spending.Percent}}%</span>
-              {{end}}
-              {{else}}
-              <span class="text-xs text-base-content/30">No spending</span>
-              {{end}}
-            </div>
-            <!-- Mini spend bar -->
-            {{if and (gt $.MaxCategorySpend 0.0) (gt $spending.Amount 0.0)}}
-            <div class="h-1 mt-1.5 rounded-full bg-base-200/50 overflow-hidden max-w-48 hidden sm:block">
-              <div class="h-full rounded-full transition-all duration-500" style="width: {{printf "%.1f" $spending.Percent}}%; background-color: {{if .Color}}{{safeCSS .Color}}{{else}}oklch(0.55 0.12 250){{end}}; opacity: 0.6;"></div>
-            </div>
-            {{end}}
-          </div>
-          <div class="flex items-center gap-2" @click.stop>
-            {{if gt $spending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
-              title="View transactions"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i></a>{{end}}
-            <button class="btn btn-ghost btn-xs rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
-              data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
-              @click.prevent="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
-              title="Edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i></button>
-            {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
-              data-id="{{.ID}}" data-name="{{.DisplayName}}"
-              @click.prevent="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
-              title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
-          </div>
-          <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 shrink-0" :class="open ? 'rotate-180' : ''"></i>
-        </div>
+    <div class="bb-card overflow-hidden">
+      <!-- Table header - desktop only -->
+      <div class="hidden sm:grid grid-cols-[auto_1fr_auto_auto_auto_auto] items-center gap-4 px-5 py-2.5 border-b border-base-300/50 text-xs font-medium text-base-content/40 uppercase tracking-wider">
+        <div class="w-10"></div>
+        <div>Name</div>
+        <div class="text-right w-24">Amount</div>
+        <div class="text-right w-16">Txns</div>
+        <div class="text-right w-14">%</div>
+        <div class="w-20"></div>
+      </div>
 
-        {{if .Children}}
-        <!-- Children -->
-        <div x-show="open" x-cloak
-          x-transition:enter="transition ease-out duration-200"
-          x-transition:enter-start="opacity-0 -translate-y-1"
-          x-transition:enter-end="opacity-100 translate-y-0"
-          x-transition:leave="transition ease-in duration-150"
-          x-transition:leave-start="opacity-100"
-          x-transition:leave-end="opacity-0"
-          class="border-t border-base-300/50">
-          <div class="px-2 sm:px-3 py-1.5 sm:py-2">
-            {{range .Children}}
-            {{$childSpending := index $.SpendingByCategory .DisplayName}}
-            <div class="group flex items-center gap-2.5 sm:gap-3 py-2.5 px-2 sm:px-3 rounded-xl hover:bg-base-200/40 transition-colors duration-150">
-              <div class="w-6 h-6 sm:w-7 sm:h-7 rounded-lg flex items-center justify-center shrink-0"
-                style="{{if .Color}}background-color: {{safeCSS .Color}}12{{end}}">
-                {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-3.5 h-3.5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
-                {{else if .Color}}<span class="w-2 h-2 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
-                {{else}}<span class="w-2 h-2 rounded-full bg-base-content/20"></span>{{end}}
-              </div>
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2">
-                  <span class="text-sm">{{.DisplayName}}</span>
-                  {{if .Hidden}}<span class="badge badge-ghost badge-xs">Hidden</span>{{end}}
-                </div>
-                {{if gt $childSpending.TransactionCount 0}}
-                <div class="flex items-center gap-2 mt-0.5">
-                  <span class="text-xs tabular-nums text-base-content/50">{{formatBalance $childSpending.Amount}}</span>
-                  <span class="text-xs text-base-content/25">&middot;</span>
-                  <span class="text-xs text-base-content/35 tabular-nums">{{$childSpending.TransactionCount}} txn{{if ne $childSpending.TransactionCount 1}}s{{end}}</span>
-                </div>
-                {{end}}
-              </div>
-              <div class="flex gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150">
-                {{if gt $childSpending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg"
-                  title="View transactions"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i></a>{{end}}
+      <div class="divide-y divide-base-300/40 bb-stagger">
+        {{range .Categories}}
+        {{$spending := index $.SpendingByCategory .DisplayName}}
+        <div x-data="{open: false}">
+          <!-- Parent row -->
+          <div role="button" tabindex="0"
+            class="group w-full grid grid-cols-[auto_1fr_auto_auto] sm:grid-cols-[auto_1fr_auto_auto_auto_auto] items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3 hover:bg-base-200/30 transition-colors duration-150 cursor-pointer select-none"
+            @click="open = !open" @keydown.enter="open = !open" @keydown.space.prevent="open = !open">
+            <!-- Icon -->
+            <div class="flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 rounded-xl shrink-0"
+              style="{{if .Color}}background-color: {{safeCSS .Color}}18{{else}}background-color: {{safeCSS "oklch(48% 0.17 265 / 0.08)"}}{{end}}">
+              {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-5 h-5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
+              {{else}}{{if .Color}}<span class="w-3 h-3 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
+              {{else}}<i data-lucide="tag" class="w-5 h-5 text-primary/60"></i>{{end}}{{end}}
+            </div>
+            <!-- Name + chevron + child count -->
+            <div class="flex items-center gap-2 min-w-0">
+              <i data-lucide="chevron-right" class="w-3.5 h-3.5 text-base-content/30 transition-transform duration-200 shrink-0" :class="open ? 'rotate-90' : ''"></i>
+              <span class="font-semibold text-sm truncate {{if .IsSystem}}text-base-content/40{{else if .Hidden}}text-base-content/40 italic{{end}}">{{.DisplayName}}</span>
+              {{if .Children}}<span class="text-[0.65rem] font-medium px-1.5 py-0.5 rounded-full bg-base-200/60 text-base-content/40 shrink-0">{{len .Children}}</span>{{end}}
+              <!-- Mobile: inline spending -->
+              <span class="sm:hidden text-xs tabular-nums text-base-content/50 ml-auto shrink-0">
+                {{if gt $spending.TransactionCount 0}}{{formatBalance $spending.Amount}}{{end}}
+              </span>
+            </div>
+            <!-- Amount - desktop -->
+            <div class="hidden sm:block text-right w-24">
+              {{if gt $spending.TransactionCount 0}}<span class="text-sm tabular-nums font-medium">{{formatBalance $spending.Amount}}</span>
+              {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+            </div>
+            <!-- Count - desktop -->
+            <div class="hidden sm:block text-right w-16">
+              {{if gt $spending.TransactionCount 0}}<span class="text-xs tabular-nums text-base-content/50">{{$spending.TransactionCount}}</span>
+              {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+            </div>
+            <!-- Percent - desktop -->
+            <div class="hidden sm:block text-right w-14">
+              {{if gt $spending.Percent 0.0}}<span class="text-xs tabular-nums text-base-content/40">{{printf "%.0f" $spending.Percent}}%</span>
+              {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+            </div>
+            <!-- Actions -->
+            <div class="flex items-center justify-end w-20" @click.stop>
+              <!-- Desktop: inline buttons -->
+              <div class="hidden sm:flex items-center gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                {{if gt $spending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg" title="View transactions"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i></a>{{end}}
                 <button class="btn btn-ghost btn-xs rounded-lg"
                   data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
-                  @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                  @click.prevent="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
                   title="Edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i></button>
                 {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error"
                   data-id="{{.ID}}" data-name="{{.DisplayName}}"
-                  @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                  @click.prevent="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
                   title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
               </div>
+              <!-- Mobile: dropdown menu -->
+              <div class="dropdown dropdown-end sm:hidden">
+                <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-square rounded-lg">
+                  <i data-lucide="ellipsis-vertical" class="w-4 h-4"></i>
+                </div>
+                <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-40 p-1">
+                  {{if gt $spending.TransactionCount 0}}<li><a href="/transactions?category={{.Slug}}"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i> View txns</a></li>{{end}}
+                  <li><button
+                    data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+                    @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                    ><i data-lucide="pencil" class="w-3.5 h-3.5"></i> Edit</button></li>
+                  {{if not .IsSystem}}<li><button class="text-error"
+                    data-id="{{.ID}}" data-name="{{.DisplayName}}"
+                    @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                    ><i data-lucide="trash-2" class="w-3.5 h-3.5"></i> Delete</button></li>{{end}}
+                </ul>
+              </div>
             </div>
-            {{end}}
           </div>
-        </div>
-        {{else}}
-        <div x-show="open" x-cloak
-          x-transition:enter="transition ease-out duration-200"
-          x-transition:enter-start="opacity-0"
-          x-transition:enter-end="opacity-100"
-          class="border-t border-base-300 px-4 sm:px-5 py-3 sm:py-4">
-          <p class="text-sm text-base-content/40">No subcategories</p>
+
+          {{if .Children}}
+          <!-- Children -->
+          <div x-show="open" x-cloak x-collapse>
+            <div class="border-t border-base-300/30 bg-base-200/20">
+              {{range .Children}}
+              {{$childSpending := index $.SpendingByCategory .DisplayName}}
+              <div class="group grid grid-cols-[auto_1fr_auto_auto] sm:grid-cols-[auto_1fr_auto_auto_auto_auto] items-center gap-3 sm:gap-4 pl-10 sm:pl-14 pr-4 sm:pr-5 py-2.5 hover:bg-base-200/30 transition-colors duration-150">
+                <!-- Icon (smaller for children) -->
+                <div class="flex items-center justify-center w-7 h-7 sm:w-8 sm:h-8 rounded-lg shrink-0"
+                  style="{{if .Color}}background-color: {{safeCSS .Color}}12{{end}}">
+                  {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-3.5 h-3.5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
+                  {{else if .Color}}<span class="w-2 h-2 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
+                  {{else}}<span class="w-2 h-2 rounded-full bg-base-content/20"></span>{{end}}
+                </div>
+                <!-- Name -->
+                <div class="flex items-center gap-2 min-w-0">
+                  <span class="text-sm truncate {{if .Hidden}}text-base-content/40 italic{{end}}">{{.DisplayName}}</span>
+                  <!-- Mobile: inline spending -->
+                  <span class="sm:hidden text-xs tabular-nums text-base-content/50 ml-auto shrink-0">
+                    {{if gt $childSpending.TransactionCount 0}}{{formatBalance $childSpending.Amount}}{{end}}
+                  </span>
+                </div>
+                <!-- Amount - desktop -->
+                <div class="hidden sm:block text-right w-24">
+                  {{if gt $childSpending.TransactionCount 0}}<span class="text-sm tabular-nums text-base-content/70">{{formatBalance $childSpending.Amount}}</span>
+                  {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+                </div>
+                <!-- Count - desktop -->
+                <div class="hidden sm:block text-right w-16">
+                  {{if gt $childSpending.TransactionCount 0}}<span class="text-xs tabular-nums text-base-content/50">{{$childSpending.TransactionCount}}</span>
+                  {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+                </div>
+                <!-- Percent - desktop -->
+                <div class="hidden sm:block text-right w-14">
+                  {{if gt $childSpending.Percent 0.0}}<span class="text-xs tabular-nums text-base-content/40">{{printf "%.0f" $childSpending.Percent}}%</span>
+                  {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+                </div>
+                <!-- Actions -->
+                <div class="flex items-center justify-end w-20" @click.stop>
+                  <!-- Desktop: inline buttons -->
+                  <div class="hidden sm:flex items-center gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                    {{if gt $childSpending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg" title="View transactions"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i></a>{{end}}
+                    <button class="btn btn-ghost btn-xs rounded-lg"
+                      data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+                      @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                      title="Edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i></button>
+                    {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error"
+                      data-id="{{.ID}}" data-name="{{.DisplayName}}"
+                      @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                      title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
+                  </div>
+                  <!-- Mobile: dropdown menu -->
+                  <div class="dropdown dropdown-end sm:hidden">
+                    <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-square rounded-lg">
+                      <i data-lucide="ellipsis-vertical" class="w-4 h-4"></i>
+                    </div>
+                    <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-40 p-1">
+                      {{if gt $childSpending.TransactionCount 0}}<li><a href="/transactions?category={{.Slug}}"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i> View txns</a></li>{{end}}
+                      <li><button
+                        data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+                        @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                        ><i data-lucide="pencil" class="w-3.5 h-3.5"></i> Edit</button></li>
+                      {{if not .IsSystem}}<li><button class="text-error"
+                        data-id="{{.ID}}" data-name="{{.DisplayName}}"
+                        @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                        ><i data-lucide="trash-2" class="w-3.5 h-3.5"></i> Delete</button></li>{{end}}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+              {{end}}
+            </div>
+          </div>
+          {{else}}
+          <div x-show="open" x-cloak x-collapse>
+            <div class="border-t border-base-300/30 bg-base-200/20 py-3 pl-14 sm:pl-20 pr-5">
+              <p class="text-sm text-base-content/30 italic">No subcategories</p>
+            </div>
+          </div>
+          {{end}}
         </div>
         {{end}}
       </div>
-      {{end}}
     </div>
     {{else}}
     <!-- Empty state -->

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -402,124 +402,177 @@ function rulesPage() {
 <div class="text-sm text-base-content/40 mb-4 px-1">{{len .Categories}} top-level categories</div>
 {{end}}
 
-<!-- Categories Tree -->
+<!-- Categories List -->
 <div>
     {{if .Categories}}
-    <div class="space-y-2 sm:space-y-3 bb-stagger">
-      {{range .Categories}}
-      {{$spending := index $.SpendingByCategory .DisplayName}}
-      <div class="bb-card overflow-hidden group" x-data="{open: false}">
-        <!-- Parent row -->
-        <div role="button" tabindex="0" class="w-full flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3 sm:py-4 hover:bg-base-200/30 transition-colors duration-150 text-left cursor-pointer select-none"
-          @click="open = !open" @keydown.enter="open = !open" @keydown.space.prevent="open = !open">
-          <div class="flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 rounded-xl shrink-0"
-            style="{{if .Color}}background-color: {{safeCSS .Color}}18{{else}}background-color: {{safeCSS "oklch(48% 0.17 265 / 0.08)"}}{{end}}">
-            {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-4.5 h-4.5 sm:w-5 sm:h-5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
-            {{else}}{{if .Color}}<span class="w-3 h-3 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
-            {{else}}<i data-lucide="tag" class="w-4.5 h-4.5 sm:w-5 sm:h-5 text-primary/60"></i>{{end}}{{end}}
-          </div>
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-2">
-              <span class="font-semibold text-sm">{{.DisplayName}}</span>
-              {{if .Hidden}}<span class="badge badge-ghost badge-xs">Hidden</span>{{end}}
-              {{if .IsSystem}}<span class="badge badge-soft badge-info badge-xs">System</span>{{end}}
-              {{if .Children}}<span class="text-[0.65rem] font-medium px-1.5 py-0.5 rounded-full bg-base-200/60 text-base-content/40">{{len .Children}}</span>{{end}}
-            </div>
-            <div class="flex items-center gap-2 mt-0.5">
-              {{if gt $spending.TransactionCount 0}}
-              <span class="text-xs tabular-nums font-medium text-base-content/60">{{formatBalance $spending.Amount}}</span>
-              <span class="text-xs text-base-content/25">&middot;</span>
-              <span class="text-xs text-base-content/40 tabular-nums">{{$spending.TransactionCount}} txn{{if ne $spending.TransactionCount 1}}s{{end}}</span>
-              {{if gt $spending.Percent 0.0}}
-              <span class="text-xs text-base-content/25">&middot;</span>
-              <span class="text-[0.65rem] text-base-content/35 tabular-nums">{{printf "%.0f" $spending.Percent}}%</span>
-              {{end}}
-              {{else}}
-              <span class="text-xs text-base-content/30">No spending</span>
-              {{end}}
-            </div>
-            <!-- Mini spend bar -->
-            {{if and (gt $.MaxCategorySpend 0.0) (gt $spending.Amount 0.0)}}
-            <div class="h-1 mt-1.5 rounded-full bg-base-200/50 overflow-hidden max-w-48 hidden sm:block">
-              <div class="h-full rounded-full transition-all duration-500" style="width: {{printf "%.1f" $spending.Percent}}%; background-color: {{if .Color}}{{safeCSS .Color}}{{else}}oklch(0.55 0.12 250){{end}}; opacity: 0.6;"></div>
-            </div>
-            {{end}}
-          </div>
-          <div class="flex items-center gap-2" @click.stop>
-            {{if gt $spending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
-              title="View transactions"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i></a>{{end}}
-            <button class="btn btn-ghost btn-xs rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
-              data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
-              @click.prevent="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
-              title="Edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i></button>
-            {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error sm:opacity-0 sm:group-hover:opacity-100 transition-opacity"
-              data-id="{{.ID}}" data-name="{{.DisplayName}}"
-              @click.prevent="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
-              title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
-          </div>
-          <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 shrink-0" :class="open ? 'rotate-180' : ''"></i>
-        </div>
+    <div class="bb-card overflow-hidden">
+      <!-- Table header - desktop only -->
+      <div class="hidden sm:grid grid-cols-[auto_1fr_auto_auto_auto_auto] items-center gap-4 px-5 py-2.5 border-b border-base-300/50 text-xs font-medium text-base-content/40 uppercase tracking-wider">
+        <div class="w-10"></div>
+        <div>Name</div>
+        <div class="text-right w-24">Amount</div>
+        <div class="text-right w-16">Txns</div>
+        <div class="text-right w-14">%</div>
+        <div class="w-20"></div>
+      </div>
 
-        {{if .Children}}
-        <!-- Children -->
-        <div x-show="open" x-cloak
-          x-transition:enter="transition ease-out duration-200"
-          x-transition:enter-start="opacity-0 -translate-y-1"
-          x-transition:enter-end="opacity-100 translate-y-0"
-          x-transition:leave="transition ease-in duration-150"
-          x-transition:leave-start="opacity-100"
-          x-transition:leave-end="opacity-0"
-          class="border-t border-base-300/50">
-          <div class="px-2 sm:px-3 py-1.5 sm:py-2">
-            {{range .Children}}
-            {{$childSpending := index $.SpendingByCategory .DisplayName}}
-            <div class="group flex items-center gap-2.5 sm:gap-3 py-2.5 px-2 sm:px-3 rounded-xl hover:bg-base-200/40 transition-colors duration-150">
-              <div class="w-6 h-6 sm:w-7 sm:h-7 rounded-lg flex items-center justify-center shrink-0"
-                style="{{if .Color}}background-color: {{safeCSS .Color}}12{{end}}">
-                {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-3.5 h-3.5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
-                {{else if .Color}}<span class="w-2 h-2 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
-                {{else}}<span class="w-2 h-2 rounded-full bg-base-content/20"></span>{{end}}
-              </div>
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-2">
-                  <span class="text-sm">{{.DisplayName}}</span>
-                  {{if .Hidden}}<span class="badge badge-ghost badge-xs">Hidden</span>{{end}}
-                </div>
-                {{if gt $childSpending.TransactionCount 0}}
-                <div class="flex items-center gap-2 mt-0.5">
-                  <span class="text-xs tabular-nums text-base-content/50">{{formatBalance $childSpending.Amount}}</span>
-                  <span class="text-xs text-base-content/25">&middot;</span>
-                  <span class="text-xs text-base-content/35 tabular-nums">{{$childSpending.TransactionCount}} txn{{if ne $childSpending.TransactionCount 1}}s{{end}}</span>
-                </div>
-                {{end}}
-              </div>
-              <div class="flex gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150">
-                {{if gt $childSpending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg"
-                  title="View transactions"><i data-lucide="arrow-up-right" class="w-3 h-3"></i></a>{{end}}
+      <div class="divide-y divide-base-300/40 bb-stagger">
+        {{range .Categories}}
+        {{$spending := index $.SpendingByCategory .DisplayName}}
+        <div x-data="{open: false}">
+          <!-- Parent row -->
+          <div role="button" tabindex="0"
+            class="group w-full grid grid-cols-[auto_1fr_auto_auto] sm:grid-cols-[auto_1fr_auto_auto_auto_auto] items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3 hover:bg-base-200/30 transition-colors duration-150 cursor-pointer select-none"
+            @click="open = !open" @keydown.enter="open = !open" @keydown.space.prevent="open = !open">
+            <!-- Icon -->
+            <div class="flex items-center justify-center w-9 h-9 sm:w-10 sm:h-10 rounded-xl shrink-0"
+              style="{{if .Color}}background-color: {{safeCSS .Color}}18{{else}}background-color: {{safeCSS "oklch(48% 0.17 265 / 0.08)"}}{{end}}">
+              {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-5 h-5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
+              {{else}}{{if .Color}}<span class="w-3 h-3 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
+              {{else}}<i data-lucide="tag" class="w-5 h-5 text-primary/60"></i>{{end}}{{end}}
+            </div>
+            <!-- Name + chevron + child count -->
+            <div class="flex items-center gap-2 min-w-0">
+              <i data-lucide="chevron-right" class="w-3.5 h-3.5 text-base-content/30 transition-transform duration-200 shrink-0" :class="open ? 'rotate-90' : ''"></i>
+              <span class="font-semibold text-sm truncate {{if .IsSystem}}text-base-content/40{{else if .Hidden}}text-base-content/40 italic{{end}}">{{.DisplayName}}</span>
+              {{if .Children}}<span class="text-[0.65rem] font-medium px-1.5 py-0.5 rounded-full bg-base-200/60 text-base-content/40 shrink-0">{{len .Children}}</span>{{end}}
+              <!-- Mobile: inline spending -->
+              <span class="sm:hidden text-xs tabular-nums text-base-content/50 ml-auto shrink-0">
+                {{if gt $spending.TransactionCount 0}}{{formatBalance $spending.Amount}}{{end}}
+              </span>
+            </div>
+            <!-- Amount - desktop -->
+            <div class="hidden sm:block text-right w-24">
+              {{if gt $spending.TransactionCount 0}}<span class="text-sm tabular-nums font-medium">{{formatBalance $spending.Amount}}</span>
+              {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+            </div>
+            <!-- Count - desktop -->
+            <div class="hidden sm:block text-right w-16">
+              {{if gt $spending.TransactionCount 0}}<span class="text-xs tabular-nums text-base-content/50">{{$spending.TransactionCount}}</span>
+              {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+            </div>
+            <!-- Percent - desktop -->
+            <div class="hidden sm:block text-right w-14">
+              {{if gt $spending.Percent 0.0}}<span class="text-xs tabular-nums text-base-content/40">{{printf "%.0f" $spending.Percent}}%</span>
+              {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+            </div>
+            <!-- Actions -->
+            <div class="flex items-center justify-end w-20" @click.stop>
+              <!-- Desktop: inline buttons -->
+              <div class="hidden sm:flex items-center gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                {{if gt $spending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg" title="View transactions"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i></a>{{end}}
                 <button class="btn btn-ghost btn-xs rounded-lg"
                   data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
-                  @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
-                  title="Edit"><i data-lucide="pencil" class="w-3 h-3"></i></button>
+                  @click.prevent="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                  title="Edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i></button>
                 {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error"
                   data-id="{{.ID}}" data-name="{{.DisplayName}}"
-                  @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
-                  title="Delete"><i data-lucide="trash-2" class="w-3 h-3"></i></button>{{end}}
+                  @click.prevent="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                  title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
+              </div>
+              <!-- Mobile: dropdown menu -->
+              <div class="dropdown dropdown-end sm:hidden">
+                <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-square rounded-lg">
+                  <i data-lucide="ellipsis-vertical" class="w-4 h-4"></i>
+                </div>
+                <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-40 p-1">
+                  {{if gt $spending.TransactionCount 0}}<li><a href="/transactions?category={{.Slug}}"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i> View txns</a></li>{{end}}
+                  <li><button
+                    data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+                    @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                    ><i data-lucide="pencil" class="w-3.5 h-3.5"></i> Edit</button></li>
+                  {{if not .IsSystem}}<li><button class="text-error"
+                    data-id="{{.ID}}" data-name="{{.DisplayName}}"
+                    @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                    ><i data-lucide="trash-2" class="w-3.5 h-3.5"></i> Delete</button></li>{{end}}
+                </ul>
               </div>
             </div>
-            {{end}}
           </div>
-        </div>
-        {{else}}
-        <div x-show="open" x-cloak
-          x-transition:enter="transition ease-out duration-200"
-          x-transition:enter-start="opacity-0"
-          x-transition:enter-end="opacity-100"
-          class="border-t border-base-300 px-4 sm:px-5 py-3 sm:py-4">
-          <p class="text-sm text-base-content/40">No subcategories</p>
+
+          {{if .Children}}
+          <!-- Children -->
+          <div x-show="open" x-cloak x-collapse>
+            <div class="border-t border-base-300/30 bg-base-200/20">
+              {{range .Children}}
+              {{$childSpending := index $.SpendingByCategory .DisplayName}}
+              <div class="group grid grid-cols-[auto_1fr_auto_auto] sm:grid-cols-[auto_1fr_auto_auto_auto_auto] items-center gap-3 sm:gap-4 pl-10 sm:pl-14 pr-4 sm:pr-5 py-2.5 hover:bg-base-200/30 transition-colors duration-150">
+                <!-- Icon (smaller for children) -->
+                <div class="flex items-center justify-center w-7 h-7 sm:w-8 sm:h-8 rounded-lg shrink-0"
+                  style="{{if .Color}}background-color: {{safeCSS .Color}}12{{end}}">
+                  {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-3.5 h-3.5" style="{{if .Color}}color: {{safeCSS .Color}}{{end}}"></i>
+                  {{else if .Color}}<span class="w-2 h-2 rounded-full" style="background-color: {{safeCSS .Color}}"></span>
+                  {{else}}<span class="w-2 h-2 rounded-full bg-base-content/20"></span>{{end}}
+                </div>
+                <!-- Name -->
+                <div class="flex items-center gap-2 min-w-0">
+                  <span class="text-sm truncate {{if .Hidden}}text-base-content/40 italic{{end}}">{{.DisplayName}}</span>
+                  <!-- Mobile: inline spending -->
+                  <span class="sm:hidden text-xs tabular-nums text-base-content/50 ml-auto shrink-0">
+                    {{if gt $childSpending.TransactionCount 0}}{{formatBalance $childSpending.Amount}}{{end}}
+                  </span>
+                </div>
+                <!-- Amount - desktop -->
+                <div class="hidden sm:block text-right w-24">
+                  {{if gt $childSpending.TransactionCount 0}}<span class="text-sm tabular-nums text-base-content/70">{{formatBalance $childSpending.Amount}}</span>
+                  {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+                </div>
+                <!-- Count - desktop -->
+                <div class="hidden sm:block text-right w-16">
+                  {{if gt $childSpending.TransactionCount 0}}<span class="text-xs tabular-nums text-base-content/50">{{$childSpending.TransactionCount}}</span>
+                  {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+                </div>
+                <!-- Percent - desktop -->
+                <div class="hidden sm:block text-right w-14">
+                  {{if gt $childSpending.Percent 0.0}}<span class="text-xs tabular-nums text-base-content/40">{{printf "%.0f" $childSpending.Percent}}%</span>
+                  {{else}}<span class="text-xs text-base-content/25">&mdash;</span>{{end}}
+                </div>
+                <!-- Actions -->
+                <div class="flex items-center justify-end w-20" @click.stop>
+                  <!-- Desktop: inline buttons -->
+                  <div class="hidden sm:flex items-center gap-1 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity">
+                    {{if gt $childSpending.TransactionCount 0}}<a href="/transactions?category={{.Slug}}" class="btn btn-ghost btn-xs rounded-lg" title="View transactions"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i></a>{{end}}
+                    <button class="btn btn-ghost btn-xs rounded-lg"
+                      data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+                      @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                      title="Edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i></button>
+                    {{if not .IsSystem}}<button class="btn btn-ghost btn-xs rounded-lg text-error"
+                      data-id="{{.ID}}" data-name="{{.DisplayName}}"
+                      @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                      title="Delete"><i data-lucide="trash-2" class="w-3.5 h-3.5"></i></button>{{end}}
+                  </div>
+                  <!-- Mobile: dropdown menu -->
+                  <div class="dropdown dropdown-end sm:hidden">
+                    <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-square rounded-lg">
+                      <i data-lucide="ellipsis-vertical" class="w-4 h-4"></i>
+                    </div>
+                    <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-40 p-1">
+                      {{if gt $childSpending.TransactionCount 0}}<li><a href="/transactions?category={{.Slug}}"><i data-lucide="arrow-up-right" class="w-3.5 h-3.5"></i> View txns</a></li>{{end}}
+                      <li><button
+                        data-id="{{.ID}}" data-display-name="{{.DisplayName}}" data-icon="{{if .Icon}}{{.Icon}}{{end}}" data-color="{{if .Color}}{{.Color}}{{end}}" data-sort-order="{{.SortOrder}}" data-hidden="{{.Hidden}}"
+                        @click="$dispatch('edit-category', {id: $el.dataset.id, displayName: $el.dataset.displayName, icon: $el.dataset.icon, color: $el.dataset.color, sortOrder: parseInt($el.dataset.sortOrder) || 0, hidden: $el.dataset.hidden === 'true'})"
+                        ><i data-lucide="pencil" class="w-3.5 h-3.5"></i> Edit</button></li>
+                      {{if not .IsSystem}}<li><button class="text-error"
+                        data-id="{{.ID}}" data-name="{{.DisplayName}}"
+                        @click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
+                        ><i data-lucide="trash-2" class="w-3.5 h-3.5"></i> Delete</button></li>{{end}}
+                    </ul>
+                  </div>
+                </div>
+              </div>
+              {{end}}
+            </div>
+          </div>
+          {{else}}
+          <div x-show="open" x-cloak x-collapse>
+            <div class="border-t border-base-300/30 bg-base-200/20 py-3 pl-14 sm:pl-20 pr-5">
+              <p class="text-sm text-base-content/30 italic">No subcategories</p>
+            </div>
+          </div>
+          {{end}}
         </div>
         {{end}}
       </div>
-      {{end}}
     </div>
     {{else}}
     <!-- Empty state -->


### PR DESCRIPTION
## Summary
- Restructure categories from individual cards to a unified list with table-like grid rows for proper column alignment (icon, name, amount, txns, %, actions)
- Replace inline action buttons with a dropdown menu on mobile for better touch targets
- Remove redundant mini spend bars (% display kept as more informative), replace explicit System/Hidden badges with subtle text styling (muted, italic)
- Update both standalone `/categories` page and the categories tab within `/rules`

## Test plan
- [ ] Desktop: verify column alignment across parent categories with varied name lengths
- [ ] Desktop: hover over rows to confirm action buttons appear
- [ ] Desktop: expand/collapse subcategories, verify indentation and background tint
- [ ] Mobile: verify spending amount shows inline next to name
- [ ] Mobile: tap ellipsis menu, confirm View/Edit/Delete options work
- [ ] System categories show muted text style (no explicit badge)
- [ ] Hidden categories show italic + muted text style (no explicit badge)
- [ ] Empty state renders correctly when no categories exist
- [ ] Rules page categories tab matches standalone categories page layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)