### PR TITLE
Add SHA256 checksums to GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,11 +186,18 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Generate SHA256 checksums
+        run: |
+          cd artifacts
+          sha256sum breadbox-* > SHA256SUMS
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          files: artifacts/breadbox-*
+          files: |
+            artifacts/breadbox-*
+            artifacts/SHA256SUMS
 
   deploy:
     name: Deploy


### PR DESCRIPTION
## Summary
- Generate a `SHA256SUMS` file containing SHA-256 hashes of all release binaries in the `publish-release` CI job
- Upload the checksums file alongside binaries to GitHub Releases, enabling users to verify download integrity

## Test plan
- [ ] Tag a test release and verify `SHA256SUMS` file appears in the release assets
- [ ] Verify checksums file contains entries for all four binaries (linux/darwin x amd64/arm64)
- [ ] Download a binary and verify its hash matches the entry in `SHA256SUMS` via `sha256sum -c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)