### PR TITLE
Add household member accounts with role-based access

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -7,12 +7,23 @@ import (
 	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
+	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/crypto/bcrypt"
 )
 
 const (
 	sessionKeyAdminID       = "admin_id"
 	sessionKeyAdminUsername = "admin_username"
+	sessionKeyAccountRole   = "account_role"   // "admin" or "member"
+	sessionKeyUserID        = "user_id"         // linked family member UUID (member accounts only)
+	sessionKeyAccountType   = "account_type"    // "admin_account" or "member_account"
+	sessionKeyMemberID      = "member_id"       // member_accounts.id (member accounts only)
+)
+
+// Session role constants.
+const (
+	RoleAdmin  = "admin"
+	RoleMember = "member"
 )
 
 // dummyHash is a pre-computed bcrypt hash used for constant-time login responses.
@@ -22,6 +33,7 @@ const (
 var dummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), 12)
 
 // LoginHandler returns an http.HandlerFunc that handles GET and POST /login.
+// It checks both admin_accounts and member_accounts tables for authentication.
 func LoginHandler(sm *scs.SessionManager, queries *db.Queries, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
@@ -51,12 +63,7 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, tr *TemplateRende
 			return
 		}
 
-		admin, err := queries.GetAdminAccountByUsername(r.Context(), username)
-		if err != nil {
-			// Run a dummy bcrypt comparison to prevent timing-based username enumeration.
-			// Without this, an attacker can distinguish "user not found" (~0ms) from
-			// "wrong password" (~200ms bcrypt) by measuring response time.
-			bcrypt.CompareHashAndPassword(dummyHash, []byte(password))
+		renderLoginError := func() {
 			data := map[string]any{
 				"PageTitle": "Sign In",
 				"CSRFToken": GenerateCSRFToken(r.Context(), sm),
@@ -64,29 +71,67 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, tr *TemplateRende
 				"Error":     "Invalid username or password",
 			}
 			tr.Render(w, r, "login.html", data)
-			return
 		}
 
-		if err := bcrypt.CompareHashAndPassword(admin.HashedPassword, []byte(password)); err != nil {
-			data := map[string]any{
-				"PageTitle": "Sign In",
-				"CSRFToken": GenerateCSRFToken(r.Context(), sm),
-				"Username":  username,
-				"Error":     "Invalid username or password",
+		// Try admin_accounts first.
+		admin, adminErr := queries.GetAdminAccountByUsername(r.Context(), username)
+		if adminErr == nil {
+			if err := bcrypt.CompareHashAndPassword(admin.HashedPassword, []byte(password)); err != nil {
+				renderLoginError()
+				return
 			}
-			tr.Render(w, r, "login.html", data)
+
+			if err := sm.RenewToken(r.Context()); err != nil {
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
+
+			sm.Put(r.Context(), sessionKeyAdminID, formatUUID(admin.ID))
+			sm.Put(r.Context(), sessionKeyAdminUsername, admin.Username)
+			sm.Put(r.Context(), sessionKeyAccountRole, RoleAdmin)
+			sm.Put(r.Context(), sessionKeyAccountType, "admin_account")
+			http.Redirect(w, r, "/", http.StatusSeeOther)
 			return
 		}
 
-		// Renew session token to prevent session fixation.
-		if err := sm.RenewToken(r.Context()); err != nil {
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
+		// Try member_accounts.
+		member, memberErr := queries.GetMemberAccountByUsername(r.Context(), username)
+		if memberErr == nil {
+			// Member must have a password set (non-nil).
+			if member.HashedPassword == nil {
+				// Account exists but no password set yet — redirect to setup.
+				if err := sm.RenewToken(r.Context()); err != nil {
+					http.Error(w, "Internal server error", http.StatusInternalServerError)
+					return
+				}
+				sm.Put(r.Context(), sessionKeyMemberID, formatUUID(member.ID))
+				http.Redirect(w, r, "/member-setup", http.StatusSeeOther)
+				return
+			}
+
+			if err := bcrypt.CompareHashAndPassword(member.HashedPassword, []byte(password)); err != nil {
+				renderLoginError()
+				return
+			}
+
+			if err := sm.RenewToken(r.Context()); err != nil {
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
+
+			sm.Put(r.Context(), sessionKeyAdminID, formatUUID(member.ID))
+			sm.Put(r.Context(), sessionKeyAdminUsername, member.Username)
+			sm.Put(r.Context(), sessionKeyAccountRole, member.Role)
+			sm.Put(r.Context(), sessionKeyAccountType, "member_account")
+			sm.Put(r.Context(), sessionKeyUserID, formatUUID(member.UserID))
+			sm.Put(r.Context(), sessionKeyMemberID, formatUUID(member.ID))
+			http.Redirect(w, r, "/", http.StatusSeeOther)
 			return
 		}
 
-		sm.Put(r.Context(), sessionKeyAdminID, formatUUID(admin.ID))
-		sm.Put(r.Context(), sessionKeyAdminUsername, admin.Username)
-		http.Redirect(w, r, "/", http.StatusSeeOther)
+		// Neither found — run dummy bcrypt to prevent timing enumeration.
+		bcrypt.CompareHashAndPassword(dummyHash, []byte(password))
+		renderLoginError()
 	}
 }
 
@@ -98,6 +143,123 @@ func ActorFromSession(sm *scs.SessionManager, r *http.Request) service.Actor {
 		name = "admin"
 	}
 	return service.Actor{Type: "user", ID: id, Name: name}
+}
+
+// SessionRole returns the role of the logged-in user ("admin" or "member").
+// Returns "admin" for legacy admin_account sessions that lack the role key.
+func SessionRole(sm *scs.SessionManager, r *http.Request) string {
+	role := sm.GetString(r.Context(), sessionKeyAccountRole)
+	if role == "" {
+		// Legacy admin sessions don't have the role key.
+		return RoleAdmin
+	}
+	return role
+}
+
+// SessionUserID returns the family member user_id for member accounts.
+// Returns empty string for admin accounts (which aren't linked to a user).
+func SessionUserID(sm *scs.SessionManager, r *http.Request) string {
+	return sm.GetString(r.Context(), sessionKeyUserID)
+}
+
+// SessionMemberID returns the member_accounts.id for member account sessions.
+// Returns empty string for legacy admin accounts.
+func SessionMemberID(sm *scs.SessionManager, r *http.Request) string {
+	return sm.GetString(r.Context(), sessionKeyMemberID)
+}
+
+// IsAdmin returns true if the current session is an admin (either admin_account or member with admin role).
+func IsAdmin(sm *scs.SessionManager, r *http.Request) bool {
+	return SessionRole(sm, r) == RoleAdmin
+}
+
+// MemberSetupHandler handles GET/POST /member-setup — first-time password setup for members.
+func MemberSetupHandler(sm *scs.SessionManager, queries *db.Queries, tr *TemplateRenderer) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		memberIDStr := sm.GetString(r.Context(), sessionKeyMemberID)
+		if memberIDStr == "" {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		var memberID pgtype.UUID
+		if err := memberID.Scan(memberIDStr); err != nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		member, err := queries.GetMemberAccountByID(r.Context(), memberID)
+		if err != nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		// If password is already set, redirect to login.
+		if member.HashedPassword != nil {
+			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			return
+		}
+
+		if r.Method == http.MethodGet {
+			data := map[string]any{
+				"PageTitle": "Set Your Password",
+				"CSRFToken": GenerateCSRFToken(r.Context(), sm),
+				"Username":  member.Username,
+				"Error":     "",
+				"Errors":    map[string]string{},
+			}
+			tr.Render(w, r, "member_setup.html", data)
+			return
+		}
+
+		// POST: set password.
+		password := r.FormValue("password")
+		confirmPassword := r.FormValue("confirm_password")
+
+		errors := map[string]string{}
+		if len(password) < 8 {
+			errors["Password"] = "Password must be at least 8 characters"
+		}
+		if password != confirmPassword {
+			errors["ConfirmPassword"] = "Passwords do not match"
+		}
+
+		if len(errors) > 0 {
+			data := map[string]any{
+				"PageTitle": "Set Your Password",
+				"CSRFToken": GenerateCSRFToken(r.Context(), sm),
+				"Username":  member.Username,
+				"Error":     "",
+				"Errors":    errors,
+			}
+			tr.Render(w, r, "member_setup.html", data)
+			return
+		}
+
+		hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), 12)
+		if err != nil {
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		if err := queries.UpdateMemberAccountPassword(r.Context(), db.UpdateMemberAccountPasswordParams{
+			ID:             memberID,
+			HashedPassword: hashedPassword,
+		}); err != nil {
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+
+		// Renew session token (clear setup state) and set flash for login page.
+		if err := sm.RenewToken(r.Context()); err != nil {
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
+			return
+		}
+		// Remove setup-only session keys but keep the session alive for flash.
+		sm.Remove(r.Context(), sessionKeyMemberID)
+		SetFlash(r.Context(), sm, "success", "Password set successfully. Please sign in.")
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+	}
 }
 
 // LogoutHandler returns an http.HandlerFunc that handles POST /logout.

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -422,7 +422,7 @@ func ExchangeTokenHandler(a *app.App) http.HandlerFunc {
 }
 
 // ConnectionDetailHandler serves GET /admin/connections/{id}.
-func ConnectionDetailHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
+func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		idStr := chi.URLParam(r, "id")
@@ -438,6 +438,16 @@ func ConnectionDetailHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc 
 			a.Logger.Error("get bank connection", "error", err)
 			tr.RenderNotFound(w, r)
 			return
+		}
+
+		// IDOR check: non-admin members can only view their own connections.
+		if !IsAdmin(sm, r) {
+			memberUID := SessionUserID(sm, r)
+			connUserID := formatUUID(conn.UserID)
+			if connUserID == "" || connUserID != memberUID {
+				tr.RenderNotFound(w, r)
+				return
+			}
 		}
 
 		accounts, err := a.Queries.ListAccountsByConnection(ctx, connID)

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -53,15 +53,37 @@ type ConnectionWithAccounts struct {
 }
 
 // ConnectionsListHandler serves GET /admin/connections.
+// For members, only shows connections owned by their linked user.
 func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		connections, err := a.Queries.ListBankConnections(ctx)
-		if err != nil {
-			a.Logger.Error("list bank connections", "error", err)
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
+		var connections []db.ListBankConnectionsRow
+		var err error
+
+		// Scope to member's own connections if not admin.
+		memberUserID := SessionUserID(sm, r)
+		if !IsAdmin(sm, r) && memberUserID != "" {
+			var uid pgtype.UUID
+			if scanErr := uid.Scan(memberUserID); scanErr == nil {
+				userConns, queryErr := a.Queries.ListBankConnectionsByUser(ctx, uid)
+				if queryErr != nil {
+					a.Logger.Error("list bank connections by user", "error", queryErr)
+					http.Error(w, "Internal server error", http.StatusInternalServerError)
+					return
+				}
+				// Convert to the common row type (same fields).
+				for _, uc := range userConns {
+					connections = append(connections, db.ListBankConnectionsRow(uc))
+				}
+			}
+		} else {
+			connections, err = a.Queries.ListBankConnections(ctx)
+			if err != nil {
+				a.Logger.Error("list bank connections", "error", err)
+				http.Error(w, "Internal server error", http.StatusInternalServerError)
+				return
+			}
 		}
 
 		// Fetch accounts for each connection and compute balances.

--- a/internal/admin/member_password.go
+++ b/internal/admin/member_password.go
@@ -1,0 +1,76 @@
+package admin
+
+import (
+	"net/http"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/jackc/pgx/v5/pgtype"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// changePasswordFromMember handles password change for a member account.
+// Used by both /my-account/password and /settings/password (when logged in as member).
+func changePasswordFromMember(a *app.App, sm *scs.SessionManager, w http.ResponseWriter, r *http.Request, memberIDStr, redirectPath string) {
+	ctx := r.Context()
+
+	var memberID pgtype.UUID
+	if err := memberID.Scan(memberIDStr); err != nil {
+		SetFlash(ctx, sm, "error", "Invalid session.")
+		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		return
+	}
+
+	member, err := a.Queries.GetMemberAccountByID(ctx, memberID)
+	if err != nil {
+		SetFlash(ctx, sm, "error", "Account not found.")
+		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		return
+	}
+
+	currentPassword := r.FormValue("current_password")
+	newPassword := r.FormValue("new_password")
+	confirmPassword := r.FormValue("confirm_password")
+
+	if member.HashedPassword != nil {
+		if err := bcrypt.CompareHashAndPassword(member.HashedPassword, []byte(currentPassword)); err != nil {
+			SetFlash(ctx, sm, "error", "Current password is incorrect.")
+			http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+			return
+		}
+	}
+
+	if len(newPassword) < 8 {
+		SetFlash(ctx, sm, "error", "New password must be at least 8 characters.")
+		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		return
+	}
+
+	if newPassword != confirmPassword {
+		SetFlash(ctx, sm, "error", "New passwords do not match.")
+		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		return
+	}
+
+	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
+	if err != nil {
+		SetFlash(ctx, sm, "error", "Failed to hash password.")
+		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		return
+	}
+
+	if err := a.Queries.UpdateMemberAccountPassword(ctx, db.UpdateMemberAccountPasswordParams{
+		ID:             memberID,
+		HashedPassword: hashedPassword,
+	}); err != nil {
+		a.Logger.Error("update member password", "error", err)
+		SetFlash(ctx, sm, "error", "Failed to update password.")
+		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		return
+	}
+
+	SetFlash(ctx, sm, "success", "Password updated successfully.")
+	http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+}

--- a/internal/admin/member_password.go
+++ b/internal/admin/member_password.go
@@ -34,12 +34,15 @@ func changePasswordFromMember(a *app.App, sm *scs.SessionManager, w http.Respons
 	newPassword := r.FormValue("new_password")
 	confirmPassword := r.FormValue("confirm_password")
 
-	if member.HashedPassword != nil {
-		if err := bcrypt.CompareHashAndPassword(member.HashedPassword, []byte(currentPassword)); err != nil {
-			SetFlash(ctx, sm, "error", "Current password is incorrect.")
-			http.Redirect(w, r, redirectPath, http.StatusSeeOther)
-			return
-		}
+	if member.HashedPassword == nil {
+		SetFlash(ctx, sm, "error", "No password set. Please contact your administrator.")
+		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		return
+	}
+	if err := bcrypt.CompareHashAndPassword(member.HashedPassword, []byte(currentPassword)); err != nil {
+		SetFlash(ctx, sm, "error", "Current password is incorrect.")
+		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		return
 	}
 
 	if len(newPassword) < 8 {

--- a/internal/admin/members.go
+++ b/internal/admin/members.go
@@ -1,0 +1,219 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"breadbox/internal/app"
+	"breadbox/internal/service"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// MembersPageHandler serves GET /users (updated to include member accounts tab).
+// This is kept as the enhanced users page — member account management is shown alongside
+// existing family member management.
+
+// createMemberAccountRequest is the JSON body for POST /-/members.
+type createMemberAccountRequest struct {
+	UserID   string `json:"user_id"`
+	Username string `json:"username"`
+	Role     string `json:"role"`
+}
+
+// CreateMemberAccountHandler serves POST /-/members — create a member account.
+func CreateMemberAccountHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req createMemberAccountRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+			return
+		}
+
+		req.Username = strings.TrimSpace(req.Username)
+		if req.Username == "" {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Username is required"},
+			})
+			return
+		}
+
+		if len(req.Username) > 64 {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Username must be 64 characters or fewer"},
+			})
+			return
+		}
+
+		if req.UserID == "" {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Family member (user_id) is required"},
+			})
+			return
+		}
+
+		if req.Role == "" {
+			req.Role = "member"
+		}
+
+		member, err := svc.CreateMemberAccount(r.Context(), service.CreateMemberAccountParams{
+			UserID:   req.UserID,
+			Username: req.Username,
+			Role:     req.Role,
+		})
+		if err != nil {
+			if strings.Contains(err.Error(), "username already taken") {
+				writeJSON(w, http.StatusConflict, map[string]any{
+					"error": map[string]string{"code": "USERNAME_TAKEN", "message": "This username is already in use"},
+				})
+				return
+			}
+			if strings.Contains(err.Error(), "already has a member account") {
+				writeJSON(w, http.StatusConflict, map[string]any{
+					"error": map[string]string{"code": "DUPLICATE_MEMBER", "message": "This family member already has a login account"},
+				})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to create member account"})
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, member)
+	}
+}
+
+// ListMemberAccountsHandler serves GET /-/members — list all member accounts.
+func ListMemberAccountsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		members, err := svc.ListMemberAccounts(r.Context())
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to list member accounts"})
+			return
+		}
+		writeJSON(w, http.StatusOK, members)
+	}
+}
+
+// UpdateMemberRoleHandler serves PUT /-/members/{id}/role.
+func UpdateMemberRoleHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		var req struct {
+			Role string `json:"role"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+			return
+		}
+
+		if err := svc.UpdateMemberRole(r.Context(), id, req.Role); err != nil {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
+				"error": map[string]string{"code": "VALIDATION_ERROR", "message": err.Error()},
+			})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+}
+
+// DeleteMemberAccountHandler serves DELETE /-/members/{id}.
+func DeleteMemberAccountHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		if err := svc.DeleteMemberAccount(r.Context(), id); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to delete member account"})
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	}
+}
+
+// WipeUserDataHandler serves POST /-/users/{id}/wipe — delete all connections and transactions for a user.
+func WipeUserDataHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		txnCount, err := a.Service.WipeUserData(r.Context(), id)
+		if err != nil {
+			a.Logger.Error("wipe user data", "error", err, "user_id", id)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to wipe user data"})
+			return
+		}
+
+		SetFlash(r.Context(), sm, "success", "User data wiped successfully.")
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":              "ok",
+			"transactions_deleted": txnCount,
+		})
+	}
+}
+
+// MyAccountHandler serves GET /my-account — member's own account page.
+func MyAccountHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		memberIDStr := SessionMemberID(sm, r)
+		userIDStr := SessionUserID(sm, r)
+
+		data := BaseTemplateData(r, sm, "my-account", "My Account")
+		data["MemberID"] = memberIDStr
+		data["UserID"] = userIDStr
+
+		// Load the user's connections and accounts for display.
+		if userIDStr != "" {
+			conns, err := svc.ListConnections(r.Context(), &userIDStr)
+			if err == nil {
+				data["Connections"] = conns
+			}
+		}
+
+		tr.Render(w, r, "my_account.html", data)
+	}
+}
+
+// MyAccountChangePasswordHandler serves POST /my-account/password — member changes their own password.
+func MyAccountChangePasswordHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		memberIDStr := SessionMemberID(sm, r)
+		if memberIDStr == "" {
+			SetFlash(ctx, sm, "error", "Invalid session.")
+			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			return
+		}
+
+		changePasswordFromMember(a, sm, w, r, memberIDStr, "/my-account")
+	}
+}
+
+// MyAccountWipeDataHandler serves POST /my-account/wipe-data — member wipes their own data.
+func MyAccountWipeDataHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		userIDStr := SessionUserID(sm, r)
+		if userIDStr == "" {
+			SetFlash(ctx, sm, "error", "Invalid session.")
+			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			return
+		}
+
+		txnCount, err := a.Service.WipeUserData(ctx, userIDStr)
+		if err != nil {
+			a.Logger.Error("member wipe own data", "error", err, "user_id", userIDStr)
+			SetFlash(ctx, sm, "error", "Failed to wipe data.")
+			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			return
+		}
+
+		a.Logger.Info("member wiped own data", "user_id", userIDStr, "transactions_deleted", txnCount)
+		SetFlash(ctx, sm, "success", "Your data has been wiped successfully.")
+		http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+	}
+}

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -59,7 +59,8 @@ func getNavBadges(ctx context.Context) NavBadges {
 	return NavBadges{}
 }
 
-// RequireAuth is chi middleware that checks for an authenticated admin session.
+// RequireAuth is chi middleware that checks for an authenticated session.
+// Works for both admin_account and member_account sessions.
 // If the session does not contain an admin_id, it redirects to /login.
 func RequireAuth(sm *scs.SessionManager) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -67,6 +68,25 @@ func RequireAuth(sm *scs.SessionManager) func(http.Handler) http.Handler {
 			adminID := sm.GetString(r.Context(), sessionKeyAdminID)
 			if adminID == "" {
 				http.Redirect(w, r, "/login", http.StatusSeeOther)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// RequireAdmin is chi middleware that blocks non-admin users.
+// Must be used after RequireAuth. Returns 403 for members trying to access admin-only routes.
+func RequireAdmin(sm *scs.SessionManager) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			role := sm.GetString(r.Context(), sessionKeyAccountRole)
+			if role == "" {
+				// Legacy admin sessions without the role key are treated as admin.
+				role = RoleAdmin
+			}
+			if role != RoleAdmin {
+				http.Error(w, "Admin access required", http.StatusForbidden)
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -37,8 +37,8 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 	r.Post("/logout", LogoutHandler(sm))
 
 	// Member password setup (partially authenticated — member ID in session but no full login).
-	r.Get("/member-setup", MemberSetupHandler(sm, a.Queries, tr))
-	r.Post("/member-setup", MemberSetupHandler(sm, a.Queries, tr))
+	r.With(CSRFMiddleware(sm)).Get("/member-setup", MemberSetupHandler(sm, a.Queries, tr))
+	r.With(CSRFMiddleware(sm)).Post("/member-setup", MemberSetupHandler(sm, a.Queries, tr))
 
 	// OAuth 2.1 authorize flow (needs session for consent screen).
 	r.Get("/oauth/authorize", OAuthAuthorizeHandler(svc, sm, tr))
@@ -61,7 +61,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/insights", InsightsHandler(a, svc, tr))
 
 		r.Get("/connections", ConnectionsListHandler(a, svc, sm, tr))
-		r.Get("/connections/{id}", ConnectionDetailHandler(a, tr))
+		r.Get("/connections/{id}", ConnectionDetailHandler(a, sm, tr))
 
 		r.Get("/transactions", TransactionListHandler(a, sm, tr, svc))
 		r.Get("/transactions/search", TransactionSearchHandler(a, sm, tr, svc))

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -36,6 +36,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 	})
 	r.Post("/logout", LogoutHandler(sm))
 
+	// Member password setup (partially authenticated — member ID in session but no full login).
+	r.Get("/member-setup", MemberSetupHandler(sm, a.Queries, tr))
+	r.Post("/member-setup", MemberSetupHandler(sm, a.Queries, tr))
+
 	// OAuth 2.1 authorize flow (needs session for consent screen).
 	r.Get("/oauth/authorize", OAuthAuthorizeHandler(svc, sm, tr))
 	r.Post("/oauth/authorize", OAuthAuthorizeSubmitHandler(svc, sm))
@@ -47,7 +51,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 	// Programmatic setup API (unauthenticated).
 	r.Post("/-/setup", ProgrammaticSetupHandler(a.Queries, sm))
 
-	// Authenticated admin routes (HTML pages).
+	// Authenticated routes accessible to all roles (admin + member).
 	r.Group(func(r chi.Router) {
 		r.Use(RequireAuth(sm))
 		r.Use(CSRFMiddleware(sm))
@@ -55,13 +59,36 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 		r.Get("/", DashboardHandler(a, svc, tr))
 		r.Get("/insights", InsightsHandler(a, svc, tr))
+
+		r.Get("/connections", ConnectionsListHandler(a, svc, sm, tr))
+		r.Get("/connections/{id}", ConnectionDetailHandler(a, tr))
+
+		r.Get("/transactions", TransactionListHandler(a, sm, tr, svc))
+		r.Get("/transactions/search", TransactionSearchHandler(a, sm, tr, svc))
+		r.Get("/transactions/{id}", TransactionDetailHandler(a, sm, tr, svc))
+		r.Get("/accounts/{id}", AccountDetailHandler(a, sm, tr, svc))
+
+		// Member account self-service pages.
+		r.Get("/my-account", MyAccountHandler(a, sm, tr, svc))
+		r.Post("/my-account/password", MyAccountChangePasswordHandler(a, sm))
+		r.Post("/my-account/wipe-data", MyAccountWipeDataHandler(a, sm))
+
+		// Password change works for both admin and member sessions.
+		r.Post("/settings/password", ChangePasswordHandler(a, sm))
+	})
+
+	// Admin-only authenticated routes (HTML pages).
+	r.Group(func(r chi.Router) {
+		r.Use(RequireAuth(sm))
+		r.Use(RequireAdmin(sm))
+		r.Use(CSRFMiddleware(sm))
+		r.Use(NavBadgesMiddleware(a.Queries, a.Logger))
+
 		r.Post("/onboarding/dismiss", DismissOnboardingHandler(a))
 
 		r.Route("/connections", func(r chi.Router) {
-			r.Get("/", ConnectionsListHandler(a, svc, sm, tr))
 			r.Get("/new", NewConnectionHandler(a, tr))
 			r.Get("/import-csv", CSVImportPageHandler(a, tr))
-			r.Get("/{id}", ConnectionDetailHandler(a, tr))
 			r.Get("/{id}/reauth", ConnectionReauthHandler(a, tr))
 		})
 
@@ -94,10 +121,6 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/{id}/revoke", OAuthClientRevokePageHandler(svc, sm))
 		})
 
-		r.Get("/transactions", TransactionListHandler(a, sm, tr, svc))
-		r.Get("/transactions/search", TransactionSearchHandler(a, sm, tr, svc))
-		r.Get("/transactions/{id}", TransactionDetailHandler(a, sm, tr, svc))
-		r.Get("/accounts/{id}", AccountDetailHandler(a, sm, tr, svc))
 		r.Get("/logs", LogsPageHandler(a, svc, sm, tr))
 		r.Get("/sync-logs", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/logs?tab=syncs", http.StatusMovedPermanently)
@@ -155,95 +178,106 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/settings", SettingsGetHandler(a, sm, tr))
 		r.Post("/settings/sync", SettingsSyncPostHandler(a, sm))
 		r.Post("/settings/retention", SettingsRetentionPostHandler(a, sm))
-		r.Post("/settings/password", ChangePasswordHandler(a, sm))
 	})
 
-	// Admin API (authenticated, JSON responses).
+	// Admin API (authenticated, JSON responses) — admin-only operations.
 	r.Route("/-", func(r chi.Router) {
 		r.Use(RequireAuth(sm))
 		r.Use(CSRFMiddleware(sm))
 
-		r.Post("/link-token", LinkTokenHandler(a))
-		r.Post("/exchange-token", ExchangeTokenHandler(a))
-		r.Post("/connections/{id}/reauth", ConnectionReauthAPIHandler(a))
-		r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))
-		r.Post("/connections/{id}/sync", SyncConnectionHandler(a))
-		r.Post("/connections/sync-all", SyncAllConnectionsHandler(a))
-		r.Post("/connections/{id}/paused", UpdateConnectionPausedHandler(a, sm))
-		r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(a, sm))
-		r.Delete("/connections/{id}", DeleteConnectionHandler(a, sm))
-		r.Post("/accounts/{id}/excluded", UpdateAccountExcludedHandler(a, sm))
-		r.Post("/accounts/{id}/display-name", UpdateAccountDisplayNameHandler(a, sm))
-		r.Post("/test-provider/{provider}", ProvidersTestHandler(a))
-		r.Post("/users", CreateUserHandler(a, sm))
-		r.Put("/users/{id}", UpdateUserHandler(a, sm))
+		// Quick search — accessible to all roles.
+		r.Get("/search/transactions", QuickSearchTransactionsHandler(svc))
 
-		r.Post("/csv/upload", CSVUploadHandler(a, sm))
-		r.Post("/csv/preview", CSVPreviewHandler(a, sm))
-		r.Post("/csv/import", CSVImportHandler(a, sm, svc))
-
-		r.Get("/api-keys", ListAPIKeysHandler(svc))
-		r.Post("/api-keys", CreateAPIKeyHandler(svc))
-		r.Delete("/api-keys/{id}", RevokeAPIKeyHandler(svc))
-
-		r.Get("/oauth-clients", ListOAuthClientsHandler(svc))
-		r.Post("/oauth-clients", CreateOAuthClientHandler(svc))
-		r.Delete("/oauth-clients/{id}", RevokeOAuthClientHandler(svc))
-
-		r.Post("/update/dismiss", DismissUpdateHandler(a))
-		r.Post("/update", TriggerUpdateHandler(a))
-
-		// Category CRUD
-		r.Post("/categories", CreateCategoryAdminHandler(svc))
-		r.Put("/categories/{id}", UpdateCategoryAdminHandler(svc))
-		r.Delete("/categories/{id}", DeleteCategoryAdminHandler(svc))
-		r.Post("/categories/{id}/merge", MergeCategoryAdminHandler(svc))
-
-		// Category bulk export/import (TSV)
-		r.Get("/categories/export-tsv", ExportCategoriesTSVAdminHandler(svc))
-		r.Post("/categories/import-tsv", ImportCategoriesTSVAdminHandler(svc))
-
-		// Transaction CSV export
-		r.Get("/transactions/export-csv", ExportTransactionsCSVHandler(a, svc))
-
-		// Transaction bulk categorize
-		r.Post("/transactions/batch-categorize", BatchSetTransactionCategoryAdminHandler(svc))
-
-		// Transaction category override
-		r.Post("/transactions/{id}/category", SetTransactionCategoryAdminHandler(svc))
-		r.Delete("/transactions/{id}/category", ResetTransactionCategoryAdminHandler(svc))
-
-		// Transaction comments
+		// Transaction comments — accessible to all roles.
 		r.Post("/transactions/{id}/comments", CreateTransactionCommentHandler(a, sm, svc))
 		r.Delete("/transactions/{id}/comments/{comment_id}", DeleteTransactionCommentHandler(a, sm, svc))
 
-		// Review queue
-		r.Post("/reviews/{id}/submit", SubmitReviewAdminHandler(a, sm, svc))
-		r.Post("/reviews/{id}/dismiss", DismissReviewAdminHandler(a, sm, svc))
-		r.Post("/reviews/dismiss-all", DismissAllReviewsAdminHandler(a, sm, svc))
-		r.Post("/reviews/enqueue", EnqueueReviewAdminHandler(a, sm, svc))
-		r.Post("/reviews/settings", ReviewSettingsHandler(a, sm))
+		// Admin-only API routes.
+		r.Group(func(r chi.Router) {
+			r.Use(RequireAdmin(sm))
 
-		// Transaction rules
-		r.Post("/rules", CreateRuleAdminHandler(svc, sm))
-		r.Put("/rules/{id}", UpdateRuleAdminHandler(svc, sm))
-		r.Delete("/rules/{id}", DeleteRuleAdminHandler(svc))
-		r.Post("/rules/{id}/toggle", ToggleRuleAdminHandler(svc))
-		r.Post("/rules/{id}/apply", ApplyRuleAdminHandler(svc))
+			r.Post("/link-token", LinkTokenHandler(a))
+			r.Post("/exchange-token", ExchangeTokenHandler(a))
+			r.Post("/connections/{id}/reauth", ConnectionReauthAPIHandler(a))
+			r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))
+			r.Post("/connections/{id}/sync", SyncConnectionHandler(a))
+			r.Post("/connections/sync-all", SyncAllConnectionsHandler(a))
+			r.Post("/connections/{id}/paused", UpdateConnectionPausedHandler(a, sm))
+			r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(a, sm))
+			r.Delete("/connections/{id}", DeleteConnectionHandler(a, sm))
+			r.Post("/accounts/{id}/excluded", UpdateAccountExcludedHandler(a, sm))
+			r.Post("/accounts/{id}/display-name", UpdateAccountDisplayNameHandler(a, sm))
+			r.Post("/test-provider/{provider}", ProvidersTestHandler(a))
+			r.Post("/users", CreateUserHandler(a, sm))
+			r.Put("/users/{id}", UpdateUserHandler(a, sm))
 
-		// Account links
-		r.Post("/account-links", CreateAccountLinkAdminHandler(svc, sm))
-		r.Post("/account-links/{id}/delete", DeleteAccountLinkAdminHandler(svc, sm))
-		r.Post("/account-links/{id}/reconcile", ReconcileAccountLinkAdminHandler(svc, sm))
-		r.Post("/transaction-matches/{id}/confirm", ConfirmMatchAdminHandler(svc, sm))
-		r.Post("/transaction-matches/{id}/reject", RejectMatchAdminHandler(svc, sm))
+			r.Post("/csv/upload", CSVUploadHandler(a, sm))
+			r.Post("/csv/preview", CSVPreviewHandler(a, sm))
+			r.Post("/csv/import", CSVImportHandler(a, sm, svc))
 
-		// Quick search (command palette)
-		r.Get("/search/transactions", QuickSearchTransactionsHandler(svc))
+			r.Get("/api-keys", ListAPIKeysHandler(svc))
+			r.Post("/api-keys", CreateAPIKeyHandler(svc))
+			r.Delete("/api-keys/{id}", RevokeAPIKeyHandler(svc))
 
-		// Agent reports
-		r.Post("/reports/{id}/read", MarkReportReadAdminHandler(svc))
-		r.Post("/reports/read-all", MarkAllReportsReadAdminHandler(svc))
+			r.Get("/oauth-clients", ListOAuthClientsHandler(svc))
+			r.Post("/oauth-clients", CreateOAuthClientHandler(svc))
+			r.Delete("/oauth-clients/{id}", RevokeOAuthClientHandler(svc))
+
+			r.Post("/update/dismiss", DismissUpdateHandler(a))
+			r.Post("/update", TriggerUpdateHandler(a))
+
+			// Category CRUD
+			r.Post("/categories", CreateCategoryAdminHandler(svc))
+			r.Put("/categories/{id}", UpdateCategoryAdminHandler(svc))
+			r.Delete("/categories/{id}", DeleteCategoryAdminHandler(svc))
+			r.Post("/categories/{id}/merge", MergeCategoryAdminHandler(svc))
+
+			// Category bulk export/import (TSV)
+			r.Get("/categories/export-tsv", ExportCategoriesTSVAdminHandler(svc))
+			r.Post("/categories/import-tsv", ImportCategoriesTSVAdminHandler(svc))
+
+			// Transaction CSV export
+			r.Get("/transactions/export-csv", ExportTransactionsCSVHandler(a, svc))
+
+			// Transaction bulk categorize
+			r.Post("/transactions/batch-categorize", BatchSetTransactionCategoryAdminHandler(svc))
+
+			// Transaction category override
+			r.Post("/transactions/{id}/category", SetTransactionCategoryAdminHandler(svc))
+			r.Delete("/transactions/{id}/category", ResetTransactionCategoryAdminHandler(svc))
+
+			// Review queue
+			r.Post("/reviews/{id}/submit", SubmitReviewAdminHandler(a, sm, svc))
+			r.Post("/reviews/{id}/dismiss", DismissReviewAdminHandler(a, sm, svc))
+			r.Post("/reviews/dismiss-all", DismissAllReviewsAdminHandler(a, sm, svc))
+			r.Post("/reviews/enqueue", EnqueueReviewAdminHandler(a, sm, svc))
+			r.Post("/reviews/settings", ReviewSettingsHandler(a, sm))
+
+			// Transaction rules
+			r.Post("/rules", CreateRuleAdminHandler(svc, sm))
+			r.Put("/rules/{id}", UpdateRuleAdminHandler(svc, sm))
+			r.Delete("/rules/{id}", DeleteRuleAdminHandler(svc))
+			r.Post("/rules/{id}/toggle", ToggleRuleAdminHandler(svc))
+			r.Post("/rules/{id}/apply", ApplyRuleAdminHandler(svc))
+
+			// Account links
+			r.Post("/account-links", CreateAccountLinkAdminHandler(svc, sm))
+			r.Post("/account-links/{id}/delete", DeleteAccountLinkAdminHandler(svc, sm))
+			r.Post("/account-links/{id}/reconcile", ReconcileAccountLinkAdminHandler(svc, sm))
+			r.Post("/transaction-matches/{id}/confirm", ConfirmMatchAdminHandler(svc, sm))
+			r.Post("/transaction-matches/{id}/reject", RejectMatchAdminHandler(svc, sm))
+
+			// Agent reports
+			r.Post("/reports/{id}/read", MarkReportReadAdminHandler(svc))
+			r.Post("/reports/read-all", MarkAllReportsReadAdminHandler(svc))
+
+			// Member account management
+			r.Get("/members", ListMemberAccountsHandler(svc))
+			r.Post("/members", CreateMemberAccountHandler(svc, sm))
+			r.Put("/members/{id}/role", UpdateMemberRoleHandler(svc, sm))
+			r.Delete("/members/{id}", DeleteMemberAccountHandler(svc, sm))
+			r.Post("/users/{id}/wipe", WipeUserDataHandler(a, sm))
+		})
 	})
 
 	return r

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -109,10 +109,20 @@ func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 }
 
 // ChangePasswordHandler serves POST /admin/settings/password.
+// Works for both admin_account and member_account sessions.
 func ChangePasswordHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		// Check if this is a member account session.
+		accountType := sm.GetString(ctx, sessionKeyAccountType)
+		if accountType == "member_account" {
+			memberIDStr := sm.GetString(ctx, sessionKeyMemberID)
+			changePasswordFromMember(a, sm, w, r, memberIDStr, "/settings")
+			return
+		}
+
+		// Legacy admin account flow.
 		adminIDStr := sm.GetString(ctx, sessionKeyAdminID)
 		if adminIDStr == "" {
 			http.Redirect(w, r, "/login", http.StatusSeeOther)

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -730,6 +730,7 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		"pages/mcp_guide.html",
 		"pages/prompt_builder.html",
 		"pages/session_detail.html",
+		"pages/my_account.html",
 	}
 
 	// Pages that need multiple page files parsed together (for sub-template sharing).
@@ -741,10 +742,11 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		},
 	}
 
-	// Pages using the wizard layout (login + first-run admin creation + OAuth consent).
+	// Pages using the wizard layout (login + first-run admin creation + OAuth consent + member setup).
 	wizardPages := []string{
 		"pages/login.html",
 		"pages/setup_create_admin.html",
+		"pages/member_setup.html",
 		"pages/oauth_authorize.html",
 	}
 
@@ -840,6 +842,15 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, name 
 		if _, exists := m["NavBadges"]; !exists {
 			m["NavBadges"] = getNavBadges(r.Context())
 		}
+		// Auto-inject role info for nav rendering.
+		if _, exists := m["SessionRole"]; !exists && tr.sm != nil {
+			role := tr.sm.GetString(r.Context(), sessionKeyAccountRole)
+			if role == "" {
+				role = RoleAdmin
+			}
+			m["SessionRole"] = role
+			m["IsAdmin"] = role == RoleAdmin
+		}
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
@@ -868,12 +879,18 @@ func (tr *TemplateRenderer) RenderPartial(w http.ResponseWriter, r *http.Request
 // BaseTemplateData returns the common fields needed by every template as a map.
 // Handlers can add page-specific fields to the returned map before rendering.
 func BaseTemplateData(r *http.Request, sm *scs.SessionManager, currentPage, pageTitle string) map[string]any {
+	role := sm.GetString(r.Context(), sessionKeyAccountRole)
+	if role == "" {
+		role = RoleAdmin
+	}
 	return map[string]any{
 		"PageTitle":     pageTitle,
 		"CurrentPage":   currentPage,
 		"Flash":         GetFlash(r.Context(), sm),
 		"CSRFToken":     GetCSRFToken(r),
 		"AdminUsername": sm.GetString(r.Context(), sessionKeyAdminUsername),
+		"SessionRole":   role,
+		"IsAdmin":       role == RoleAdmin,
 	}
 }
 

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -169,6 +169,13 @@ func TransactionListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRend
 			params.SortOrder = "asc"
 		}
 
+		// Scope to member's own data if not admin.
+		if !IsAdmin(sm, r) {
+			if uid := SessionUserID(sm, r); uid != "" {
+				params.UserID = &uid
+			}
+		}
+
 		result, err := svc.ListTransactionsAdmin(ctx, params)
 		if err != nil {
 			a.Logger.Error("list admin transactions", "error", err)
@@ -337,6 +344,13 @@ func TransactionSearchHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 		}
 		if v := r.URL.Query().Get("sort"); v == "asc" {
 			params.SortOrder = "asc"
+		}
+
+		// Scope to member's own data if not admin.
+		if !IsAdmin(sm, r) {
+			if uid := SessionUserID(sm, r); uid != "" {
+				params.UserID = &uid
+			}
 		}
 
 		result, err := svc.ListTransactionsAdmin(ctx, params)

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -408,6 +408,15 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 			return
 		}
 
+		// IDOR check: non-admin members can only view their own accounts.
+		memberUID := SessionUserID(sm, r)
+		if !IsAdmin(sm, r) {
+			if detail.UserID == nil || *detail.UserID != memberUID {
+				tr.RenderNotFound(w, r)
+				return
+			}
+		}
+
 		// Fetch transactions for this account.
 		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
 		if page < 1 {
@@ -418,6 +427,11 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 			Page:      page,
 			PageSize:  50,
 			AccountID: &idStr,
+		}
+
+		// Scope transaction query to member's user for non-admins.
+		if !IsAdmin(sm, r) {
+			txParams.UserID = &memberUID
 		}
 
 		if v := r.URL.Query().Get("start_date"); v != "" {
@@ -727,6 +741,23 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			a.Logger.Error("get transaction detail", "error", err)
 			tr.RenderError(w, r)
 			return
+		}
+
+		// IDOR check: non-admin members can only view transactions belonging to their user.
+		if !IsAdmin(sm, r) {
+			memberUID := SessionUserID(sm, r)
+			// Look up the account to determine ownership.
+			ownerMatch := false
+			if txn.AccountID != nil {
+				acctCheck, acctErr := svc.GetAccount(ctx, *txn.AccountID)
+				if acctErr == nil && acctCheck.UserID != nil && *acctCheck.UserID == memberUID {
+					ownerMatch = true
+				}
+			}
+			if !ownerMatch {
+				tr.RenderNotFound(w, r)
+				return
+			}
 		}
 
 		comments, err := svc.ListComments(ctx, idStr)

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -135,12 +135,25 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			enrichedUsers = append(enrichedUsers, eu)
 		}
 
+		// Load member accounts.
+		memberAccounts, err := a.Queries.ListMemberAccounts(ctx)
+		if err != nil {
+			a.Logger.Error("list member accounts", "error", err)
+		}
+		// Build a map of user_id -> member account for quick lookup in template.
+		memberAccountMap := make(map[string]db.ListMemberAccountsRow)
+		for _, ma := range memberAccounts {
+			memberAccountMap[formatUUID(ma.UserID)] = ma
+		}
+
 		data := map[string]any{
-			"PageTitle":     "Household",
-			"CurrentPage":   "users",
-			"EnrichedUsers": enrichedUsers,
-			"CSRFToken":     GetCSRFToken(r),
-			"Created":       r.URL.Query().Get("created") == "1",
+			"PageTitle":        "Household",
+			"CurrentPage":      "users",
+			"EnrichedUsers":    enrichedUsers,
+			"MemberAccounts":   memberAccounts,
+			"MemberAccountMap": memberAccountMap,
+			"CSRFToken":        GetCSRFToken(r),
+			"Created":          r.URL.Query().Get("created") == "1",
 		}
 		tr.Render(w, r, "users.html", data)
 	}

--- a/internal/db/migrations/20260405062625_member_accounts.sql
+++ b/internal/db/migrations/20260405062625_member_accounts.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+
+-- Member accounts: household members who can log in with scoped access.
+-- Linked to the users (family members) table. Role determines permissions.
+CREATE TABLE member_accounts (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    username        TEXT        NOT NULL UNIQUE,
+    hashed_password BYTEA       NULL, -- NULL until member sets their password
+    role            TEXT        NOT NULL DEFAULT 'member' CHECK (role IN ('admin', 'member')),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX member_accounts_username_idx ON member_accounts (username);
+CREATE UNIQUE INDEX member_accounts_user_id_idx ON member_accounts (user_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS member_accounts_user_id_idx;
+DROP INDEX IF EXISTS member_accounts_username_idx;
+DROP TABLE IF EXISTS member_accounts;

--- a/internal/db/queries/bank_connections.sql
+++ b/internal/db/queries/bank_connections.sql
@@ -35,6 +35,30 @@ LEFT JOIN LATERAL (
 ) ls ON true
 ORDER BY bc.created_at DESC;
 
+-- name: ListBankConnectionsByUser :many
+SELECT bc.*, u.name as user_name,
+  (SELECT COUNT(*) FROM accounts a WHERE a.connection_id = bc.id) as account_count,
+  COALESCE(ls.status::text, '')::text as last_sync_status,
+  COALESCE(ls.trigger::text, '')::text as last_sync_trigger,
+  COALESCE(ls.duration_ms, 0) as last_sync_duration_ms,
+  ls.started_at as last_sync_started_at,
+  COALESCE(ls.added_count, 0) as last_sync_added,
+  COALESCE(ls.modified_count, 0) as last_sync_modified,
+  COALESCE(ls.removed_count, 0) as last_sync_removed,
+  ls.error_message as last_sync_error_message
+FROM bank_connections bc
+LEFT JOIN users u ON bc.user_id = u.id
+LEFT JOIN LATERAL (
+  SELECT sl.status, sl.trigger, sl.duration_ms, sl.started_at,
+         sl.added_count, sl.modified_count, sl.removed_count, sl.error_message
+  FROM sync_logs sl
+  WHERE sl.connection_id = bc.id
+  ORDER BY sl.started_at DESC
+  LIMIT 1
+) ls ON true
+WHERE bc.user_id = $1
+ORDER BY bc.created_at DESC;
+
 -- name: UpdateBankConnectionStatus :exec
 UPDATE bank_connections
 SET status = $2, error_code = $3, error_message = $4, updated_at = NOW()

--- a/internal/db/queries/member_accounts.sql
+++ b/internal/db/queries/member_accounts.sql
@@ -1,0 +1,31 @@
+-- name: CreateMemberAccount :one
+INSERT INTO member_accounts (user_id, username, hashed_password, role)
+VALUES ($1, $2, $3, $4)
+RETURNING *;
+
+-- name: GetMemberAccountByUsername :one
+SELECT * FROM member_accounts WHERE username = $1;
+
+-- name: GetMemberAccountByID :one
+SELECT * FROM member_accounts WHERE id = $1;
+
+-- name: GetMemberAccountByUserID :one
+SELECT * FROM member_accounts WHERE user_id = $1;
+
+-- name: ListMemberAccounts :many
+SELECT ma.*, u.name as user_name, u.email as user_email
+FROM member_accounts ma
+JOIN users u ON u.id = ma.user_id
+ORDER BY u.name;
+
+-- name: UpdateMemberAccountPassword :exec
+UPDATE member_accounts SET hashed_password = $2, updated_at = NOW() WHERE id = $1;
+
+-- name: UpdateMemberAccountRole :exec
+UPDATE member_accounts SET role = $2, updated_at = NOW() WHERE id = $1;
+
+-- name: DeleteMemberAccount :exec
+DELETE FROM member_accounts WHERE id = $1;
+
+-- name: CountMemberAccounts :one
+SELECT COUNT(*) FROM member_accounts;

--- a/internal/service/members.go
+++ b/internal/service/members.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// MemberAccountResponse is the API/service response for a member account.
+type MemberAccountResponse struct {
+	ID           string  `json:"id"`
+	UserID       string  `json:"user_id"`
+	UserName     string  `json:"user_name"`
+	UserEmail    *string `json:"user_email"`
+	Username     string  `json:"username"`
+	Role         string  `json:"role"`
+	HasPassword  bool    `json:"has_password"`
+	CreatedAt    string  `json:"created_at"`
+	UpdatedAt    string  `json:"updated_at"`
+}
+
+// CreateMemberAccountParams holds the inputs for creating a member account.
+type CreateMemberAccountParams struct {
+	UserID   string
+	Username string
+	Role     string // "admin" or "member"
+}
+
+// CreateMemberAccount creates a new member account linked to an existing user.
+func (s *Service) CreateMemberAccount(ctx context.Context, params CreateMemberAccountParams) (*MemberAccountResponse, error) {
+	// Resolve user ID.
+	userUUID, err := s.resolveUserID(ctx, params.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user_id: %w", err)
+	}
+
+	// Validate role.
+	if params.Role != "admin" && params.Role != "member" {
+		return nil, fmt.Errorf("invalid role: must be 'admin' or 'member'")
+	}
+
+	// Check that user doesn't already have a member account.
+	_, err = s.Queries.GetMemberAccountByUserID(ctx, userUUID)
+	if err == nil {
+		return nil, fmt.Errorf("user already has a member account")
+	}
+
+	// Check username uniqueness across both admin_accounts and member_accounts.
+	_, err = s.Queries.GetAdminAccountByUsername(ctx, params.Username)
+	if err == nil {
+		return nil, fmt.Errorf("username already taken")
+	}
+
+	member, err := s.Queries.CreateMemberAccount(ctx, db.CreateMemberAccountParams{
+		UserID:   userUUID,
+		Username: params.Username,
+		Role:     params.Role,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create member account: %w", err)
+	}
+
+	// Look up user details for response.
+	user, err := s.Queries.GetUser(ctx, userUUID)
+	if err != nil {
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+
+	return &MemberAccountResponse{
+		ID:          formatUUID(member.ID),
+		UserID:      formatUUID(member.UserID),
+		UserName:    user.Name,
+		UserEmail:   textPtr(user.Email),
+		Username:    member.Username,
+		Role:        member.Role,
+		HasPassword: member.HashedPassword != nil,
+		CreatedAt:   member.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:   member.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+	}, nil
+}
+
+// ListMemberAccounts returns all member accounts with their linked user details.
+func (s *Service) ListMemberAccounts(ctx context.Context) ([]MemberAccountResponse, error) {
+	rows, err := s.Queries.ListMemberAccounts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list member accounts: %w", err)
+	}
+
+	result := make([]MemberAccountResponse, len(rows))
+	for i, r := range rows {
+		result[i] = MemberAccountResponse{
+			ID:          formatUUID(r.ID),
+			UserID:      formatUUID(r.UserID),
+			UserName:    r.UserName,
+			UserEmail:   textPtr(r.UserEmail),
+			Username:    r.Username,
+			Role:        r.Role,
+			HasPassword: r.HashedPassword != nil,
+			CreatedAt:   r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			UpdatedAt:   r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		}
+	}
+	return result, nil
+}
+
+// UpdateMemberRole updates a member account's role.
+func (s *Service) UpdateMemberRole(ctx context.Context, memberID string, role string) error {
+	if role != "admin" && role != "member" {
+		return fmt.Errorf("invalid role: must be 'admin' or 'member'")
+	}
+
+	var id pgtype.UUID
+	if err := id.Scan(memberID); err != nil {
+		return fmt.Errorf("invalid member id: %w", err)
+	}
+
+	return s.Queries.UpdateMemberAccountRole(ctx, db.UpdateMemberAccountRoleParams{
+		ID:   id,
+		Role: role,
+	})
+}
+
+// DeleteMemberAccount deletes a member account (does not delete the linked user).
+func (s *Service) DeleteMemberAccount(ctx context.Context, memberID string) error {
+	var id pgtype.UUID
+	if err := id.Scan(memberID); err != nil {
+		return fmt.Errorf("invalid member id: %w", err)
+	}
+
+	return s.Queries.DeleteMemberAccount(ctx, id)
+}
+
+// WipeUserData deletes all connections and transactions for a given user.
+// This is a destructive operation available to both admins and the member themselves.
+func (s *Service) WipeUserData(ctx context.Context, userID string) (int64, error) {
+	uid, err := s.resolveUserID(ctx, userID)
+	if err != nil {
+		return 0, fmt.Errorf("invalid user_id: %w", err)
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Count transactions that will be deleted (for reporting).
+	var txnCount int64
+	err = tx.QueryRow(ctx, `
+		SELECT COUNT(*) FROM transactions t
+		JOIN accounts a ON a.id = t.account_id
+		JOIN bank_connections bc ON bc.id = a.connection_id
+		WHERE bc.user_id = $1
+	`, uid).Scan(&txnCount)
+	if err != nil {
+		return 0, fmt.Errorf("count transactions: %w", err)
+	}
+
+	// Delete transactions for all accounts under this user's connections.
+	_, err = tx.Exec(ctx, `
+		DELETE FROM transactions t
+		USING accounts a
+		JOIN bank_connections bc ON bc.id = a.connection_id
+		WHERE t.account_id = a.id AND bc.user_id = $1
+	`, uid)
+	if err != nil {
+		return 0, fmt.Errorf("delete transactions: %w", err)
+	}
+
+	// Delete accounts.
+	_, err = tx.Exec(ctx, `
+		DELETE FROM accounts a
+		USING bank_connections bc
+		WHERE a.connection_id = bc.id AND bc.user_id = $1
+	`, uid)
+	if err != nil {
+		return 0, fmt.Errorf("delete accounts: %w", err)
+	}
+
+	// Delete connections.
+	_, err = tx.Exec(ctx, `
+		DELETE FROM bank_connections WHERE user_id = $1
+	`, uid)
+	if err != nil {
+		return 0, fmt.Errorf("delete connections: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit: %w", err)
+	}
+
+	return txnCount, nil
+}

--- a/internal/service/members_integration_test.go
+++ b/internal/service/members_integration_test.go
@@ -1,0 +1,334 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/db"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// --- Member Accounts ---
+
+func TestCreateMemberAccount_Success(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+
+	member, err := svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID:   formatUUID(user.ID),
+		Username: "alice",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if member.Username != "alice" {
+		t.Errorf("expected username alice, got %s", member.Username)
+	}
+	if member.Role != "member" {
+		t.Errorf("expected role member, got %s", member.Role)
+	}
+	if member.UserName != "Alice" {
+		t.Errorf("expected user_name Alice, got %s", member.UserName)
+	}
+	if member.HasPassword {
+		t.Errorf("expected has_password false for new member")
+	}
+}
+
+func TestCreateMemberAccount_AdminRole(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Bob")
+
+	member, err := svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID:   formatUUID(user.ID),
+		Username: "bob_admin",
+		Role:     "admin",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if member.Role != "admin" {
+		t.Errorf("expected role admin, got %s", member.Role)
+	}
+}
+
+func TestCreateMemberAccount_DuplicateUser(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+
+	_, err := svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID:   formatUUID(user.ID),
+		Username: "alice1",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error on first create: %v", err)
+	}
+
+	// Second account for same user should fail.
+	_, err = svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID:   formatUUID(user.ID),
+		Username: "alice2",
+		Role:     "member",
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate user, got nil")
+	}
+}
+
+func TestCreateMemberAccount_DuplicateUsername(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user1 := testutil.MustCreateUser(t, queries, "Alice")
+	user2 := testutil.MustCreateUser(t, queries, "Bob")
+
+	_, err := svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID:   formatUUID(user1.ID),
+		Username: "shared_name",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error on first create: %v", err)
+	}
+
+	// Same username should fail.
+	_, err = svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID:   formatUUID(user2.ID),
+		Username: "shared_name",
+		Role:     "member",
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate username, got nil")
+	}
+}
+
+func TestCreateMemberAccount_UsernameConflictsWithAdmin(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	// Create an admin account first.
+	hashedPw, _ := bcrypt.GenerateFromPassword([]byte("testpassword"), 10)
+	_, err := queries.CreateAdminAccount(ctx, db.CreateAdminAccountParams{
+		Username:       "admin_user",
+		HashedPassword: hashedPw,
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+
+	// Try to create a member with same username as admin.
+	_, err = svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID:   formatUUID(user.ID),
+		Username: "admin_user",
+		Role:     "member",
+	})
+	if err == nil {
+		t.Fatal("expected error for username conflict with admin, got nil")
+	}
+}
+
+func TestCreateMemberAccount_InvalidRole(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+
+	_, err := svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID:   formatUUID(user.ID),
+		Username: "alice",
+		Role:     "superuser",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid role, got nil")
+	}
+}
+
+func TestListMemberAccounts_Empty(t *testing.T) {
+	svc, _, _ := newService(t)
+
+	members, err := svc.ListMemberAccounts(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(members) != 0 {
+		t.Fatalf("expected 0 members, got %d", len(members))
+	}
+}
+
+func TestListMemberAccounts_WithData(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user1 := testutil.MustCreateUser(t, queries, "Alice")
+	user2 := testutil.MustCreateUser(t, queries, "Bob")
+
+	_, _ = svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID: formatUUID(user1.ID), Username: "alice", Role: "member",
+	})
+	_, _ = svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID: formatUUID(user2.ID), Username: "bob", Role: "admin",
+	})
+
+	members, err := svc.ListMemberAccounts(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(members) != 2 {
+		t.Fatalf("expected 2 members, got %d", len(members))
+	}
+	// Ordered by user name.
+	if members[0].UserName != "Alice" {
+		t.Errorf("expected first member Alice, got %s", members[0].UserName)
+	}
+}
+
+func TestUpdateMemberRole(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	member, _ := svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID: formatUUID(user.ID), Username: "alice", Role: "member",
+	})
+
+	if err := svc.UpdateMemberRole(ctx, member.ID, "admin"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the role was updated.
+	members, _ := svc.ListMemberAccounts(ctx)
+	if len(members) != 1 || members[0].Role != "admin" {
+		t.Errorf("expected role admin after update, got %s", members[0].Role)
+	}
+}
+
+func TestUpdateMemberRole_InvalidRole(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	member, _ := svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID: formatUUID(user.ID), Username: "alice", Role: "member",
+	})
+
+	if err := svc.UpdateMemberRole(ctx, member.ID, "superuser"); err == nil {
+		t.Fatal("expected error for invalid role, got nil")
+	}
+}
+
+func TestDeleteMemberAccount(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	member, _ := svc.CreateMemberAccount(ctx, service.CreateMemberAccountParams{
+		UserID: formatUUID(user.ID), Username: "alice", Role: "member",
+	})
+
+	if err := svc.DeleteMemberAccount(ctx, member.ID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	members, _ := svc.ListMemberAccounts(ctx)
+	if len(members) != 0 {
+		t.Errorf("expected 0 members after delete, got %d", len(members))
+	}
+
+	// User should still exist.
+	users, _ := svc.ListUsers(ctx)
+	if len(users) != 1 {
+		t.Errorf("expected user to survive member account deletion, got %d users", len(users))
+	}
+}
+
+func TestWipeUserData(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_1", "Checking")
+	testutil.MustCreateTransaction(t, queries, acct.ID, "txn_1", "Coffee", 500, "2026-01-15")
+	testutil.MustCreateTransaction(t, queries, acct.ID, "txn_2", "Lunch", 1200, "2026-01-16")
+
+	txnCount, err := svc.WipeUserData(ctx, formatUUID(user.ID))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if txnCount != 2 {
+		t.Errorf("expected 2 transactions deleted, got %d", txnCount)
+	}
+
+	// Verify data is gone.
+	conns, _ := svc.ListConnections(ctx, nil)
+	if len(conns) != 0 {
+		t.Errorf("expected 0 connections after wipe, got %d", len(conns))
+	}
+
+	// User should still exist.
+	users, _ := svc.ListUsers(ctx)
+	if len(users) != 1 {
+		t.Errorf("expected user to survive data wipe, got %d users", len(users))
+	}
+}
+
+func TestWipeUserData_NoData(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+
+	txnCount, err := svc.WipeUserData(ctx, formatUUID(user.ID))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if txnCount != 0 {
+		t.Errorf("expected 0 transactions deleted, got %d", txnCount)
+	}
+}
+
+func TestWipeUserData_DoesNotAffectOtherUsers(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	alice := testutil.MustCreateUser(t, queries, "Alice")
+	bob := testutil.MustCreateUser(t, queries, "Bob")
+
+	aliceConn := testutil.MustCreateConnection(t, queries, alice.ID, "alice_item")
+	aliceAcct := testutil.MustCreateAccount(t, queries, aliceConn.ID, "alice_ext", "Alice Checking")
+	testutil.MustCreateTransaction(t, queries, aliceAcct.ID, "alice_txn", "Alice Coffee", 500, "2026-01-15")
+
+	bobConn := testutil.MustCreateConnection(t, queries, bob.ID, "bob_item")
+	bobAcct := testutil.MustCreateAccount(t, queries, bobConn.ID, "bob_ext", "Bob Checking")
+	testutil.MustCreateTransaction(t, queries, bobAcct.ID, "bob_txn", "Bob Coffee", 600, "2026-01-15")
+
+	// Wipe Alice's data.
+	_, err := svc.WipeUserData(ctx, formatUUID(alice.ID))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Bob's data should be untouched.
+	bobID := formatUUID(bob.ID)
+	conns, _ := svc.ListConnections(ctx, &bobID)
+	if len(conns) != 1 {
+		t.Errorf("expected Bob to still have 1 connection, got %d", len(conns))
+	}
+}

--- a/internal/templates/pages/member_setup.html
+++ b/internal/templates/pages/member_setup.html
@@ -1,0 +1,39 @@
+{{define "content"}}
+<div class="text-center mb-8">
+  <h1 class="text-xl font-semibold tracking-tight">Set your password</h1>
+  <p class="text-sm text-base-content/50 mt-1.5">Welcome, <strong>{{.Username}}</strong>. Create a password to complete your account setup.</p>
+</div>
+
+{{if .Error}}
+<div role="alert" class="flex items-center gap-3 rounded-xl bg-error/10 text-error px-4 py-3 text-sm mb-6">
+  <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+  <span>{{.Error}}</span>
+</div>
+{{end}}
+
+<form method="POST" action="/member-setup" class="space-y-5">
+  {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
+
+  <div>
+    <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="password">Password</label>
+    <input type="password" id="password" name="password" required autocomplete="new-password" minlength="8"
+           placeholder="Create a password"
+           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.Password}} input-error{{end}}">
+    <p class="text-xs text-base-content/40 mt-1.5">Minimum 8 characters</p>
+    {{if .Errors.Password}}<p class="text-xs text-error mt-1">{{.Errors.Password}}</p>{{end}}
+  </div>
+
+  <div>
+    <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="confirm_password">Confirm Password</label>
+    <input type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password"
+           placeholder="Confirm your password"
+           class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200{{if .Errors.ConfirmPassword}} input-error{{end}}">
+    {{if .Errors.ConfirmPassword}}<p class="text-xs text-error mt-1.5">{{.Errors.ConfirmPassword}}</p>{{end}}
+  </div>
+
+  <button type="submit" class="btn btn-primary w-full h-12 rounded-xl text-base font-semibold transition-colors duration-150 mt-1">
+    Set Password
+    <i data-lucide="arrow-right" class="w-4 h-4 ml-1"></i>
+  </button>
+</form>
+{{end}}

--- a/internal/templates/pages/my_account.html
+++ b/internal/templates/pages/my_account.html
@@ -1,0 +1,112 @@
+{{define "content"}}
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">My Account</h1>
+    <p class="text-sm text-base-content/50 mt-1">Manage your account settings and data</p>
+  </div>
+</div>
+
+{{if .Flash}}
+<div role="alert" class="alert {{if eq .Flash.Type "success"}}alert-success{{else if eq .Flash.Type "error"}}alert-error{{else}}alert-info{{end}} rounded-xl mb-6">
+  {{if eq .Flash.Type "success"}}<i data-lucide="check-circle" class="w-5 h-5"></i>{{else if eq .Flash.Type "error"}}<i data-lucide="alert-circle" class="w-5 h-5"></i>{{else}}<i data-lucide="info" class="w-5 h-5"></i>{{end}}
+  <span>{{.Flash.Message}}</span>
+</div>
+{{end}}
+
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+  <!-- Change Password -->
+  <div class="bb-card">
+    <div class="p-5 border-b border-base-300">
+      <h2 class="font-semibold text-base flex items-center gap-2">
+        <i data-lucide="lock" class="w-4 h-4 text-base-content/40"></i>
+        Change Password
+      </h2>
+    </div>
+    <form method="POST" action="/my-account/password" class="p-5 space-y-4">
+      {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
+
+      <div>
+        <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="current_password">Current Password</label>
+        <input type="password" id="current_password" name="current_password" required autocomplete="current-password"
+               class="input w-full rounded-lg text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="new_password">New Password</label>
+        <input type="password" id="new_password" name="new_password" required autocomplete="new-password" minlength="8"
+               class="input w-full rounded-lg text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
+        <p class="text-xs text-base-content/40 mt-1">Minimum 8 characters</p>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="confirm_password">Confirm New Password</label>
+        <input type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password"
+               class="input w-full rounded-lg text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
+      </div>
+
+      <button type="submit" class="btn btn-primary btn-sm rounded-lg">Update Password</button>
+    </form>
+  </div>
+
+  <!-- My Connections -->
+  <div class="bb-card">
+    <div class="p-5 border-b border-base-300">
+      <h2 class="font-semibold text-base flex items-center gap-2">
+        <i data-lucide="link" class="w-4 h-4 text-base-content/40"></i>
+        My Connections
+      </h2>
+    </div>
+    <div class="p-5">
+      {{if .Connections}}
+      <div class="space-y-3">
+        {{range .Connections}}
+        <a href="/connections/{{.ID}}" class="flex items-center justify-between p-3 rounded-lg bg-base-200/30 hover:bg-base-200/50 transition-colors no-underline">
+          <div>
+            <div class="text-sm font-medium">{{if .InstitutionName}}{{deref .InstitutionName}}{{else}}Connection{{end}}</div>
+            <div class="text-xs text-base-content/40">{{.Provider}} &middot; {{.Status}}</div>
+          </div>
+          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/30"></i>
+        </a>
+        {{end}}
+      </div>
+      {{else}}
+      <p class="text-sm text-base-content/40">No connections linked to your account.</p>
+      {{end}}
+    </div>
+  </div>
+
+  <!-- Danger Zone -->
+  <div class="bb-card border-error/20">
+    <div class="p-5 border-b border-error/20">
+      <h2 class="font-semibold text-base flex items-center gap-2 text-error">
+        <i data-lucide="alert-triangle" class="w-4 h-4"></i>
+        Danger Zone
+      </h2>
+    </div>
+    <div class="p-5" x-data="{ confirmWipe: false }">
+      <p class="text-sm text-base-content/60 mb-4">
+        Permanently delete all your financial data including bank connections, accounts, and transactions.
+        This action cannot be undone.
+      </p>
+      <template x-if="!confirmWipe">
+        <button @click="confirmWipe = true" class="btn btn-error btn-sm btn-outline rounded-lg">
+          <i data-lucide="trash-2" class="w-4 h-4"></i>
+          Wipe My Data
+        </button>
+      </template>
+      <template x-if="confirmWipe">
+        <div class="space-y-3">
+          <p class="text-sm font-medium text-error">Are you sure? This will permanently delete all your data.</p>
+          <div class="flex gap-2">
+            <form method="POST" action="/my-account/wipe-data">
+              {{if $.CSRFToken}}<input type="hidden" name="_csrf" value="{{$.CSRFToken}}">{{end}}
+              <button type="submit" class="btn btn-error btn-sm rounded-lg">Yes, wipe my data</button>
+            </form>
+            <button @click="confirmWipe = false" class="btn btn-ghost btn-sm rounded-lg">Cancel</button>
+          </div>
+        </div>
+      </template>
+    </div>
+  </div>
+</div>
+{{end}}

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -151,6 +151,67 @@
     </div>
     {{end}}
 
+    <!-- Login Account Status -->
+    {{$uid := formatUUID .ID}}
+    {{$ma := index $.MemberAccountMap $uid}}
+    <div class="border-t border-base-300 px-4 sm:px-5 py-3 bg-base-200/20">
+      {{if $ma.Username}}
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2 text-xs">
+          <i data-lucide="user-check" class="w-3.5 h-3.5 text-success/60"></i>
+          <span class="text-base-content/50">Login: <span class="font-medium text-base-content/70">{{$ma.Username}}</span></span>
+          <span class="badge badge-xs {{if eq $ma.Role "admin"}}badge-primary{{else}}badge-ghost{{end}}">{{$ma.Role}}</span>
+          {{if not $ma.HashedPassword}}
+          <span class="badge badge-xs badge-warning">no password</span>
+          {{end}}
+        </div>
+        <div class="flex items-center gap-1" x-data>
+          <button class="btn btn-ghost btn-xs rounded-lg opacity-40 hover:opacity-100"
+                  @click="if(confirm('Delete login account for {{.Name}}?')) fetch('/-/members/{{formatUUID $ma.ID}}', {method:'DELETE'}).then(()=>window.location.reload())"
+                  title="Remove login account">
+            <i data-lucide="user-x" class="w-3.5 h-3.5"></i>
+          </button>
+        </div>
+      </div>
+      {{else}}
+      <div class="flex items-center justify-between" x-data="{ showForm: false, username: '', role: 'member', submitting: false, error: '' }">
+        <template x-if="!showForm">
+          <button @click="showForm = true" class="btn btn-ghost btn-xs rounded-lg text-base-content/40 hover:text-primary">
+            <i data-lucide="user-plus" class="w-3.5 h-3.5"></i>
+            <span>Create login</span>
+          </button>
+        </template>
+        <template x-if="showForm">
+          <div class="flex flex-wrap items-center gap-2 w-full">
+            <input x-model="username" type="text" placeholder="Username" class="input input-xs rounded-lg bg-base-200 border-base-300 w-28 text-xs" maxlength="64">
+            <select x-model="role" class="select select-xs rounded-lg bg-base-200 border-base-300 text-xs">
+              <option value="member">Member</option>
+              <option value="admin">Admin</option>
+            </select>
+            <button @click="
+              if(!username.trim()) { error = 'Username required'; return; }
+              submitting = true; error = '';
+              fetch('/-/members', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({user_id: '{{$uid}}', username: username.trim(), role: role})
+              }).then(r => { if(!r.ok) return r.json().then(d => { throw d }); return r.json(); })
+                .then(() => window.location.reload())
+                .catch(e => { error = e.error?.message || 'Failed'; submitting = false; })
+            " :disabled="submitting" class="btn btn-primary btn-xs rounded-lg">
+              <span x-show="!submitting">Create</span>
+              <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+            </button>
+            <button @click="showForm = false; error = ''" class="btn btn-ghost btn-xs rounded-lg">Cancel</button>
+            <template x-if="error">
+              <span class="text-xs text-error" x-text="error"></span>
+            </template>
+          </div>
+        </template>
+      </div>
+      {{end}}
+    </div>
+
     <!-- Footer -->
     <div class="mt-auto px-4 sm:px-5 py-2.5 border-t border-base-300 flex items-center justify-between text-xs text-base-content/30 bg-base-200/20">
       {{if .CreatedAt.Valid}}

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -11,6 +11,7 @@
   <a href="/transactions" class="bb-sidebar-link{{if eq .CurrentPage "transactions"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="receipt"></i> Transactions
   </a>
+  {{if .IsAdmin}}
   <a href="/reports" class="bb-sidebar-link{{if eq .CurrentPage "reports"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="file-text"></i>
     <span class="flex-1">Reports</span>
@@ -18,6 +19,7 @@
     <span class="bb-nav-badge" title="{{.NavBadges.UnreadReports}} unread reports">{{badgeCount .NavBadges.UnreadReports}}</span>
     {{end}}
   </a>
+  {{end}}
 
   <div class="bb-sidebar-section">Manage</div>
   <a href="/connections" class="bb-sidebar-link{{if eq .CurrentPage "connections"}} bb-sidebar-link--active{{end}}">
@@ -27,6 +29,7 @@
     <span class="bb-nav-badge bb-nav-badge--warn" title="{{.NavBadges.ConnectionsAttention}} connections need attention">{{badgeCount .NavBadges.ConnectionsAttention}}</span>
     {{end}}
   </a>
+  {{if .IsAdmin}}
   <a href="/agents" class="bb-sidebar-link{{if eq .CurrentPage "agents"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="bot"></i> Agents
   </a>
@@ -43,7 +46,9 @@
   <a href="/users" class="bb-sidebar-link{{if eq .CurrentPage "users"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="users"></i> Household
   </a>
+  {{end}}
 
+  {{if .IsAdmin}}
   <div class="bb-sidebar-section">System</div>
   <a href="/providers" class="bb-sidebar-link{{if eq .CurrentPage "providers"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="plug"></i> Providers
@@ -57,6 +62,12 @@
   <a href="/settings" class="bb-sidebar-link{{if eq .CurrentPage "settings"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="settings"></i> Settings
   </a>
+  {{else}}
+  <div class="bb-sidebar-section">Account</div>
+  <a href="/my-account" class="bb-sidebar-link{{if eq .CurrentPage "my-account"}} bb-sidebar-link--active{{end}}">
+    <i data-lucide="settings"></i> My Account
+  </a>
+  {{end}}
 </nav>
 
 <!-- User profile + Sign out -->
@@ -67,7 +78,7 @@
     </div>
     <div class="bb-sidebar-profile-info">
       <div class="bb-sidebar-profile-name">{{if .AdminUsername}}{{.AdminUsername}}{{else}}Admin{{end}}</div>
-      <div class="bb-sidebar-profile-role">Administrator</div>
+      <div class="bb-sidebar-profile-role">{{if .IsAdmin}}Administrator{{else}}Member{{end}}</div>
     </div>
     <form method="POST" action="/logout" class="bb-sidebar-profile-logout">
       {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}


### PR DESCRIPTION
## Summary

- **Member accounts**: New `member_accounts` table linked to existing `users` (family members). Admin creates the account with a username and role; the member sets their own password on first login.
- **Unified login**: Login page checks both `admin_accounts` and `member_accounts`. Members without a password are redirected to a setup page.
- **Role-based route protection**: `RequireAdmin` middleware blocks members from admin-only pages (system settings, providers, rules, reviews, API keys, user/member management). Members can access dashboard, their own connections, transactions, and account settings.
- **Member-scoped views**: Connections and transactions are filtered to the member's own data. Nav sidebar hides admin-only sections for members.
- **Data ownership**: Members can wipe all their own data (connections, accounts, transactions) from the My Account page. Admins can also wipe data for any user.
- **Password management**: Members change their password via My Account page. The existing Settings password change also works for member sessions.
- **Admin member management**: Admins create/delete member accounts inline from the Household page. Role can be set to `admin` or `member`.
- **Integration tests**: 14 tests covering member account CRUD, role validation, username conflicts, data wipe isolation.

## Files changed

| Area | Files |
|------|-------|
| Migration | `internal/db/migrations/20260405062625_member_accounts.sql` |
| SQL queries | `internal/db/queries/member_accounts.sql`, `bank_connections.sql` (new user-scoped query) |
| Auth | `internal/admin/auth.go` (unified login, session helpers, member setup) |
| Middleware | `internal/admin/middleware.go` (RequireAdmin) |
| Router | `internal/admin/router.go` (split admin-only vs member-accessible routes) |
| Handlers | `internal/admin/members.go`, `member_password.go` (new), `settings.go`, `connections.go`, `transactions.go`, `users.go`, `templates.go` |
| Service | `internal/service/members.go` (CRUD, WipeUserData) |
| Templates | `member_setup.html`, `my_account.html` (new), `users.html`, `nav.html` |
| Tests | `internal/service/members_integration_test.go` |

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (unit tests)
- [ ] Integration tests pass (`make test-integration` -- new member account tests)
- [ ] Admin login still works as before
- [ ] Create member account from Household page, verify inline form
- [ ] Log in as member, verify scoped nav and data
- [ ] Member password setup flow on first login
- [ ] Member data wipe from My Account page
- [ ] Admin-only routes return 403 for member sessions

Generated with Claude Code