### PR TITLE
Update README installation for end-user distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,83 @@ Breadbox syncs your bank data into a PostgreSQL database you control, then expos
 - **AES-256-GCM encryption** for provider credentials at rest
 - **Single binary** -- one Go binary serves everything (API, MCP, dashboard, webhooks, cron)
 
-## Quick Start
+## Installation
 
 ### Docker (recommended)
 
+No need to clone the repo. This pulls the pre-built image from GHCR and starts Breadbox with PostgreSQL:
+
 ```bash
-git clone https://github.com/canalesb93/breadbox.git && cd breadbox
-cp .env.example .docker.env
+mkdir breadbox && cd breadbox
+curl -O https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/docker-compose.prod.yml
+mv docker-compose.prod.yml docker-compose.yml
+```
 
-# Edit .docker.env — set ENCRYPTION_KEY (generate with: openssl rand -hex 32)
+Create a `.env` file with required configuration:
 
-docker compose up -d
+```bash
+cat > .env <<EOF
+DATABASE_URL=postgres://breadbox:breadbox@db:5432/breadbox?sslmode=disable
+ENCRYPTION_KEY=$(openssl rand -hex 32)
+SERVER_PORT=8080
+ENVIRONMENT=docker
+POSTGRES_USER=breadbox
+POSTGRES_PASSWORD=$(openssl rand -base64 32 | tr -d '=/+')
+POSTGRES_DB=breadbox
+EOF
+```
 
+Start the services:
+
+```bash
+docker compose up -d breadbox db
 # Visit http://localhost:8080 to start the setup wizard
 ```
 
-### From source
+> **Note:** This starts Breadbox and PostgreSQL without the Caddy reverse proxy, exposing port 8080 directly. For production with automatic HTTPS, run `docker compose up -d` (all services) and configure your domain in the Caddyfile -- see [Production Deployment](#production-deployment) below.
+
+To pin a specific version instead of `latest`, edit `docker-compose.yml` and change the image tag:
+
+```yaml
+image: ghcr.io/canalesb93/breadbox:v0.1.0
+```
+
+### Binary download
+
+Pre-built binaries for Linux and macOS (amd64/arm64) are available on the [GitHub Releases](https://github.com/canalesb93/breadbox/releases) page.
+
+```bash
+# Download the binary for your platform (example: Linux amd64)
+curl -fsSL https://github.com/canalesb93/breadbox/releases/latest/download/breadbox-linux-amd64 -o breadbox
+chmod +x breadbox
+
+# Requires a running PostgreSQL instance
+export DATABASE_URL="postgres://user:pass@localhost:5432/breadbox?sslmode=disable"
+export ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+./breadbox serve
+# Visit http://localhost:8080
+```
+
+### Go install
+
+Build from source using Go:
+
+```bash
+git clone https://github.com/canalesb93/breadbox.git && cd breadbox
+go install ./cmd/breadbox
+
+# Requires a running PostgreSQL instance
+export DATABASE_URL="postgres://user:pass@localhost:5432/breadbox?sslmode=disable"
+export ENCRYPTION_KEY="$(openssl rand -hex 32)"
+
+breadbox serve
+# Visit http://localhost:8080
+```
+
+> **Note:** The module path is `breadbox`, so `go install github.com/...@latest` is not supported. Clone the repo and install locally.
+
+### From source (development)
 
 ```bash
 git clone https://github.com/canalesb93/breadbox.git && cd breadbox
@@ -52,18 +113,15 @@ make dev
 # Visit http://localhost:8080
 ```
 
-### Binary download
+### Production deployment
 
-Download the latest release from [GitHub Releases](https://github.com/canalesb93/breadbox/releases):
+For production with automatic HTTPS via Caddy, use the one-liner install script:
 
 ```bash
-# Configure
-cp .env.example .local.env
-# Edit .local.env — set DATABASE_URL and ENCRYPTION_KEY
-
-# Run
-./breadbox serve
+curl -fsSL https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/install.sh | sudo bash
 ```
+
+This installs Docker if needed, downloads the deployment files, generates secrets, and starts Breadbox with Caddy for automatic TLS. See [`deploy/`](deploy/) for details.
 
 ## MCP Integration
 

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -4,6 +4,8 @@ services:
     restart: unless-stopped
     env_file: .env
     command: ["sh", "-c", "/app/breadbox migrate && /app/breadbox serve"]
+    ports:
+      - "8080:8080"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Rewrite Docker quick start to pull the pre-built GHCR image (`ghcr.io/canalesb93/breadbox:latest`) instead of cloning the repo and building from source
- Add binary download section pointing to GitHub Releases (linux/darwin, amd64/arm64)
- Add `go install` section (clone + `go install ./cmd/breadbox`, since the module path is `breadbox` not a full GitHub URL)
- Rename "From source" to "From source (development)" and reorder sections: Docker > Binary > Go Install > From Source > Production
- Add production deployment section referencing `deploy/install.sh`
- Expose port 8080 on the breadbox service in `deploy/docker-compose.prod.yml` so it works without Caddy for local quick start

## Test plan
- [ ] Verify Docker quick start instructions work end-to-end on a clean machine
- [ ] Verify binary download URL resolves after next release
- [ ] Verify `go install ./cmd/breadbox` works from a fresh clone
- [ ] Verify `docker compose up -d` (all services including Caddy) still works for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)