### PR TITLE
Add GitHub repo link and version status to sidebar nav

### DIFF
--- a/input.css
+++ b/input.css
@@ -1187,6 +1187,21 @@
     @apply opacity-50;
   }
 
+  .bb-sidebar-version-link {
+    @apply inline-flex items-center gap-1 no-underline;
+    color: inherit;
+    transition: color 0.15s ease;
+  }
+  .bb-sidebar-version-link:hover {
+    color: var(--color-base-content);
+  }
+
+  .bb-sidebar-version .badge {
+    @apply no-underline;
+    font-size: 0.55rem;
+    line-height: 1;
+  }
+
   /* ── Landscape mobile: scroll entire sidebar, keep full touch targets ── */
   @media (orientation: landscape) and (max-height: 500px) {
     .bb-sidebar {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -17,6 +17,7 @@ import (
 	"breadbox/internal/service"
 	bsync "breadbox/internal/sync"
 	"breadbox/internal/templates"
+	"breadbox/internal/version"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -51,11 +52,12 @@ type Breadcrumb struct {
 
 // TemplateRenderer parses and renders HTML templates.
 type TemplateRenderer struct {
-	mu        sync.RWMutex
-	templates map[string]*template.Template
-	funcMap   template.FuncMap
-	sm        *scs.SessionManager
-	version   string
+	mu             sync.RWMutex
+	templates      map[string]*template.Template
+	funcMap        template.FuncMap
+	sm             *scs.SessionManager
+	version        string
+	versionChecker *version.Checker
 }
 
 // NewTemplateRenderer parses all embedded templates and returns a renderer.
@@ -836,6 +838,15 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, name 
 		if _, exists := m["AppVersion"]; !exists && tr.version != "" {
 			m["AppVersion"] = tr.version
 		}
+		// Auto-inject version update status for nav footer.
+		if _, exists := m["NavUpdateAvailable"]; !exists && tr.versionChecker != nil {
+			updateAvailable, latest, err := tr.versionChecker.CheckForUpdate(r.Context())
+			if err == nil && updateAvailable != nil && *updateAvailable && latest != nil {
+				m["NavUpdateAvailable"] = true
+				m["NavLatestVersion"] = latest.Version
+				m["NavLatestURL"] = latest.URL
+			}
+		}
 		// Auto-inject sidebar notification badges from middleware context.
 		if _, exists := m["NavBadges"]; !exists {
 			m["NavBadges"] = getNavBadges(r.Context())
@@ -894,6 +905,11 @@ func (tr *TemplateRenderer) RenderError(w http.ResponseWriter, r *http.Request) 
 // SetVersion sets the application version for auto-injection into template data.
 func (tr *TemplateRenderer) SetVersion(v string) {
 	tr.version = v
+}
+
+// SetVersionChecker sets the version checker for auto-injecting update status into template data.
+func (tr *TemplateRenderer) SetVersionChecker(vc *version.Checker) {
+	tr.versionChecker = vc
 }
 
 // formatCurrency formats a non-negative float as "$X,XXX.XX".

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -135,6 +135,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		a.Logger.Error("failed to initialize template renderer", "error", err)
 	} else {
 		tr.SetVersion(a.Config.Version)
+		tr.SetVersionChecker(a.VersionChecker)
 		adminRouter := admin.NewAdminRouter(a, sm, tr, svc, mcpServer)
 		r.Mount("/", adminRouter)
 	}

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -77,12 +77,18 @@
     </form>
   </div>
   <div class="bb-sidebar-version">
-    {{if .AppVersion}}
-    <i data-lucide="package" class="w-3 h-3"></i>
-    <span>Breadbox v{{.AppVersion}}</span>
+    <a href="https://github.com/canalesb93/breadbox" target="_blank" rel="noopener" class="bb-sidebar-version-link" title="View on GitHub">
+      <i data-lucide="github" class="w-3 h-3"></i>
+      <span>Breadbox</span>
+    </a>
+    {{if .NavUpdateAvailable}}
+    <a href="{{.NavLatestURL}}" target="_blank" rel="noopener" class="badge badge-warning badge-xs gap-0.5" title="Update available: v{{.NavLatestVersion}}">
+      v{{.AppVersion}} &rarr; v{{.NavLatestVersion}}
+    </a>
+    {{else if .AppVersion}}
+    <a href="https://github.com/canalesb93/breadbox/releases" target="_blank" rel="noopener" class="badge badge-ghost badge-xs" title="Version {{.AppVersion}}">v{{.AppVersion}}</a>
     {{else}}
-    <i data-lucide="package" class="w-3 h-3"></i>
-    <span>Breadbox vdev</span>
+    <span class="badge badge-ghost badge-xs">dev</span>
     {{end}}
     <span class="ml-auto" style="cursor:pointer;opacity:0.5" @click="$dispatch('open-shortcuts')" title="Keyboard shortcuts">
       <kbd class="bb-shortcuts-kbd" style="font-size:0.5rem;min-width:1rem;height:1rem;padding:0 0.25rem">?</kbd>


### PR DESCRIPTION
## Summary
- Replaces the plain "Breadbox vX.X.X" text in the sidebar footer with a GitHub icon linking to the repo, a "Breadbox" label, and a version badge linking to the releases page
- When an update is available, the version badge turns into a `badge-warning` indicator showing the upgrade path (e.g., "v0.1.0 -> v0.2.0") linking to the latest release
- Reuses the existing `version.Checker` (1hr in-memory cache) via auto-injection in the template renderer, so every page gets update info with zero extra HTTP calls

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all unit tests)
- [ ] Visual check: sidebar footer shows GitHub icon + "Breadbox" + version badge on all pages
- [ ] Version badge links to GitHub releases page
- [ ] "Breadbox" text links to repo
- [ ] Works in both light and dark mode
- [ ] When running `dev` version, shows "dev" badge (no GitHub API call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)