### PR TITLE
Fix 4 UI bugs: mobile overflow, reauth banner, breadcrumbs, category icons

### DIFF
--- a/input.css
+++ b/input.css
@@ -226,11 +226,17 @@
 
   /* ── Breadcrumbs: shadcn-style navigation trail ── */
   .bb-breadcrumb {
-    @apply flex items-center gap-1.5 text-sm mb-6;
+    @apply flex items-center gap-1.5 text-sm mb-6 overflow-x-auto whitespace-nowrap;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;        /* Firefox */
+    -ms-overflow-style: none;     /* IE/Edge */
+  }
+  .bb-breadcrumb::-webkit-scrollbar {
+    display: none;                /* Chrome/Safari */
   }
 
   .bb-breadcrumb-item {
-    @apply text-base-content/40 transition-colors duration-150;
+    @apply text-base-content/40 transition-colors duration-150 shrink-0;
   }
 
   .bb-breadcrumb-item a {
@@ -238,7 +244,7 @@
   }
 
   .bb-breadcrumb-sep {
-    @apply text-base-content/25 select-none;
+    @apply text-base-content/25 select-none shrink-0;
   }
 
   .bb-breadcrumb-sep svg {
@@ -246,7 +252,7 @@
   }
 
   .bb-breadcrumb-current {
-    @apply text-base-content/70 font-medium truncate max-w-[20rem];
+    @apply text-base-content/70 font-medium shrink-0;
   }
 
   /* ── Cards: shadcn-style — border, not shadow ── */

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -348,7 +348,8 @@
       </div>
 
       <!-- Results list -->
-      <div class="bb-catpicker-list" x-ref="catPickerList">
+      <div class="bb-catpicker-list" x-ref="catPickerList"
+           x-effect="filteredList; $nextTick(() => { if (typeof lucide !== 'undefined' && $refs.catPickerList) lucide.createIcons({ nodes: [$refs.catPickerList] }); })">
         <div class="py-1">
           <template x-for="(item, idx) in filteredList" :key="item.slug + '-' + idx">
             <div class="bb-catpicker-item"

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -1,17 +1,17 @@
 {{define "content"}}
+<div class="max-w-full overflow-x-hidden">
 {{template "breadcrumb" .}}
 
 {{if or (eq (printf "%s" .Connection.Status) "error") (eq (printf "%s" .Connection.Status) "pending_reauth")}}
-<div class="bb-card border-error/30 bg-error/5 p-5 mb-6 flex items-start gap-4">
-  <div class="w-10 h-10 rounded-xl bg-error/10 flex items-center justify-center shrink-0">
-    <i data-lucide="alert-triangle" class="w-5 h-5 text-error"></i>
+<div class="bb-card border-error/30 bg-error/5 px-5 py-4 mb-6 flex items-center gap-4 flex-wrap">
+  <div class="w-9 h-9 rounded-xl bg-error/10 flex items-center justify-center shrink-0">
+    <i data-lucide="alert-triangle" class="w-4 h-4 text-error"></i>
   </div>
   <div class="flex-1 min-w-0">
-    <p class="font-semibold text-sm">This connection requires re-authentication</p>
-    <p class="text-sm text-base-content/60 mt-0.5">The bank may have changed its login requirements, or your session may have expired.</p>
-    {{if .Connection.ErrorCode.Valid}}<p class="text-xs text-base-content/50 mt-1">{{errorMessage .Connection.ErrorCode.String}}</p>{{else if .Connection.ErrorMessage.Valid}}<p class="text-xs text-base-content/50 mt-1">{{.Connection.ErrorMessage.String}}</p>{{end}}
-    <a href="/connections/{{.ConnID}}/reauth" class="btn btn-sm btn-error mt-3 rounded-xl">Re-authenticate</a>
+    <p class="font-semibold text-sm">This connection needs re-authentication</p>
+    {{if .Connection.ErrorCode.Valid}}<p class="text-xs text-base-content/50 mt-0.5">{{errorMessage .Connection.ErrorCode.String}}</p>{{else if .Connection.ErrorMessage.Valid}}<p class="text-xs text-base-content/50 mt-0.5 truncate">{{.Connection.ErrorMessage.String}}</p>{{end}}
   </div>
+  <a href="/connections/{{.ConnID}}/reauth" class="btn btn-sm btn-error rounded-xl shrink-0">Re-authenticate</a>
 </div>
 {{end}}
 
@@ -29,7 +29,7 @@
 
 <!-- Header with actions -->
 <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
-  <div class="flex items-center gap-4">
+  <div class="flex items-center gap-4 min-w-0">
     <div class="w-11 h-11 rounded-xl flex items-center justify-center shrink-0
       {{if eq (printf "%s" .Connection.Provider) "plaid"}}bg-info/10
       {{else if eq (printf "%s" .Connection.Provider) "teller"}}bg-success/10
@@ -42,9 +42,9 @@
       <i data-lucide="file-spreadsheet" class="w-5 h-5 text-warning"></i>
       {{end}}
     </div>
-    <div>
-      <div class="flex items-center gap-2.5">
-        <h1 class="bb-page-title">{{.Connection.InstitutionName.String}}</h1>
+    <div class="min-w-0">
+      <div class="flex items-center gap-2.5 flex-wrap">
+        <h1 class="bb-page-title truncate">{{.Connection.InstitutionName.String}}</h1>
         {{statusBadge (printf "%s" .Connection.Status)}}
         {{if .Connection.Paused}}<span class="badge badge-ghost badge-sm">Paused</span>{{end}}
       </div>
@@ -61,7 +61,7 @@
       </div>
     </div>
   </div>
-  <div class="flex items-center gap-2 flex-wrap shrink-0">
+  <div class="flex items-center gap-2 flex-wrap shrink-0" x-data="{ confirming: false }">
     {{if or (eq (printf "%s" .Connection.Status) "error") (eq (printf "%s" .Connection.Status) "pending_reauth")}}
     <a href="/connections/{{.ConnID}}/reauth" class="btn btn-sm btn-outline rounded-xl">Re-authenticate</a>
     {{end}}
@@ -81,14 +81,12 @@
       <i data-lucide="{{if .Connection.Paused}}play{{else}}pause{{end}}" class="w-3.5 h-3.5"></i>
       {{if .Connection.Paused}}Resume{{else}}Pause{{end}}
     </button>
-    <span x-data="{ confirming: false }">
-      <button class="btn btn-sm btn-ghost text-error/70 hover:text-error rounded-xl" x-show="!confirming" @click="confirming = true" id="remove-btn">
-        <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
-      </button>
-      <span x-show="confirming" x-cloak class="inline-flex gap-2">
-        <button class="btn btn-error btn-sm rounded-xl" @click="removeConnection()">Yes, Remove</button>
-        <button class="btn btn-ghost btn-sm rounded-xl" @click="confirming = false">Cancel</button>
-      </span>
+    <button class="btn btn-sm btn-ghost text-error/70 hover:text-error rounded-xl" x-show="!confirming" @click="confirming = true" id="remove-btn">
+      <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+    </button>
+    <span x-show="confirming" x-cloak class="inline-flex gap-2">
+      <button class="btn btn-error btn-sm rounded-xl" @click="removeConnection()">Yes, Remove</button>
+      <button class="btn btn-ghost btn-sm rounded-xl" @click="confirming = false">Cancel</button>
     </span>
   </div>
 </div>
@@ -563,4 +561,5 @@ function toggleExcluded(accountId, checked) {
   });
 }
 </script>
+</div><!-- /overflow wrapper -->
 {{end}}


### PR DESCRIPTION
## Summary
- **Connection detail mobile overflow**: Wrapped page content in `overflow-x-hidden` container, added `min-w-0` to header text area for proper truncation, and flattened the delete confirmation into the action bar's `x-data` scope to eliminate an extra wrapping `<span>`
- **Reauth banner simplification**: Condensed from multi-line stacked layout to compact single-line with inline action button; removed the verbose explanation paragraph ("The bank may have changed...") since the status badge already communicates the state
- **Breadcrumb horizontal scroll**: Changed `.bb-breadcrumb` from wrapping to `overflow-x-auto whitespace-nowrap` with hidden scrollbar, added `shrink-0` to items and separators so they don't compress
- **Category picker icons after search**: Added `x-effect` on the picker list container that watches `filteredList` and calls `lucide.createIcons()` via `$nextTick` after Alpine re-renders the filtered results

## Test plan
- [ ] Open a connection detail page on mobile viewport (< 400px) -- no horizontal scrolling
- [ ] Verify action buttons wrap cleanly on narrow screens
- [ ] Check reauth banner on an error/pending_reauth connection -- compact, no redundant text
- [ ] Navigate to a page with breadcrumbs on mobile -- horizontally scrollable, no text wrapping
- [ ] Open category picker modal, type a search term -- icons remain visible after filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)