### PR TITLE
Redesign dashboard: collapsible accounts + attention/connections cards

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -438,6 +438,18 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			txCount = 0
 		}
 
+		// Compute attention items count for the dashboard card.
+		attentionCount := 0
+		if uncatCount > 0 {
+			attentionCount++
+		}
+		if reviewsEnabled && reviewPending > 0 {
+			attentionCount++
+		}
+		if errorCount > 0 {
+			attentionCount++
+		}
+
 		data := map[string]any{
 			"PageTitle":             "Home",
 			"CurrentPage":          "home",
@@ -469,6 +481,9 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"TxCount":          txCount,
 			"UncategorizedCount": uncatCount,
 			// Agent reports.
+			// Attention items.
+			"AttentionCount":    attentionCount,
+			"HasAttentionItems": attentionCount > 0,
 			"AgentReports":       agentReports,
 			"HasMoreReports":     hasMoreReports,
 			"TotalUnreadReports": totalUnread,

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -70,21 +70,7 @@
     <!-- Net worth + sync health row -->
     <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-4">
       <div>
-        <div class="text-xs text-base-content/40 mb-0.5 flex items-center gap-2">
-          Net Worth
-          {{if .SyncHealth}}
-          <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[0.6rem] font-medium
-            {{if eq .SyncHealth.OverallHealth "healthy"}}bg-success/10 text-success
-            {{else if eq .SyncHealth.OverallHealth "degraded"}}bg-warning/10 text-warning
-            {{else if eq .SyncHealth.OverallHealth "unhealthy"}}bg-error/10 text-error{{end}}">
-            <span class="w-1.5 h-1.5 rounded-full
-              {{if eq .SyncHealth.OverallHealth "healthy"}}bg-success
-              {{else if eq .SyncHealth.OverallHealth "degraded"}}bg-warning
-              {{else}}bg-error{{end}}"></span>
-            {{if .SyncHealth.LastSyncTime}}Synced {{deref .SyncHealth.LastSyncTime}}{{else}}No syncs yet{{end}}
-          </span>
-          {{end}}
-        </div>
+        <div class="text-xs text-base-content/40 mb-0.5">Net Worth</div>
         <div class="text-3xl sm:text-4xl font-bold tabular-nums tracking-tight">{{formatBalance .NetWorth}}</div>
       </div>
       <div class="flex items-center gap-5 sm:text-right">
@@ -117,54 +103,59 @@
   </div>
   {{end}}
 
-  <!-- Accounts Grid -->
-  <div class="border-t border-base-200/60">
-    <div class="px-4 sm:px-5 py-3 flex items-center justify-between">
-      <span class="text-sm font-semibold text-base-content/70">{{len .Accounts}} Accounts</span>
-      <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Manage</a>
-    </div>
-    <div class="px-4 sm:px-5 pb-4 sm:pb-5">
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-        {{range .Accounts}}
-        <a href="/accounts/{{.ID}}" class="bb-card bb-card--interactive p-4 no-underline group block">
-          <div class="flex items-start justify-between mb-2">
-            <div class="min-w-0 flex-1">
-              <div class="flex items-center gap-1.5">
-                <!-- Connection health dot -->
-                {{if eq .ConnectionStatus "active"}}
-                <span class="w-1.5 h-1.5 rounded-full bg-success/60 shrink-0" title="Connected"></span>
-                {{else if eq .ConnectionStatus "error"}}
-                <span class="w-1.5 h-1.5 rounded-full bg-error/70 shrink-0" title="Error"></span>
-                {{else if eq .ConnectionStatus "pending_reauth"}}
-                <span class="w-1.5 h-1.5 rounded-full bg-warning shrink-0" title="Needs reauth"></span>
-                {{else if eq .ConnectionStatus "disconnected"}}
-                <span class="w-1.5 h-1.5 rounded-full bg-base-300 shrink-0" title="Disconnected"></span>
-                {{end}}
-                <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+  <!-- Accounts Grid (collapsible) -->
+  <div class="border-t border-base-200/60" x-data="{ showAccounts: false }">
+    <button @click="showAccounts = !showAccounts" class="w-full px-4 sm:px-5 py-3 flex items-center justify-between cursor-pointer hover:bg-base-200/30 transition-colors">
+      <span class="flex items-center gap-2">
+        <span class="text-sm font-semibold text-base-content/70">{{len .Accounts}} Accounts</span>
+        <i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/30 transition-transform duration-200" :class="showAccounts ? 'rotate-180' : ''"></i>
+      </span>
+      <a href="/connections" @click.stop class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Manage</a>
+    </button>
+    <div x-show="showAccounts" x-cloak x-collapse>
+      <div class="px-4 sm:px-5 pb-4 sm:pb-5">
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
+          {{range .Accounts}}
+          <a href="/accounts/{{.ID}}" class="bb-card bb-card--interactive p-4 no-underline group block">
+            <div class="flex items-start justify-between mb-2">
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-1.5">
+                  <!-- Connection health dot -->
+                  {{if eq .ConnectionStatus "active"}}
+                  <span class="w-1.5 h-1.5 rounded-full bg-success/60 shrink-0" title="Connected"></span>
+                  {{else if eq .ConnectionStatus "error"}}
+                  <span class="w-1.5 h-1.5 rounded-full bg-error/70 shrink-0" title="Error"></span>
+                  {{else if eq .ConnectionStatus "pending_reauth"}}
+                  <span class="w-1.5 h-1.5 rounded-full bg-warning shrink-0" title="Needs reauth"></span>
+                  {{else if eq .ConnectionStatus "disconnected"}}
+                  <span class="w-1.5 h-1.5 rounded-full bg-base-300 shrink-0" title="Disconnected"></span>
+                  {{end}}
+                  <span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{{.Name}}</span>
+                </div>
+                <div class="text-[0.65rem] text-base-content/40 mt-0.5 truncate">{{.InstitutionName}}{{if .Mask}} · ····{{.Mask}}{{end}}</div>
               </div>
-              <div class="text-[0.65rem] text-base-content/40 mt-0.5 truncate">{{.InstitutionName}}{{if .Mask}} · ····{{.Mask}}{{end}}</div>
+              <div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0 ml-2">
+                <i data-lucide="{{accountTypeIcon .Type}}" class="w-3.5 h-3.5 text-base-content/35"></i>
+              </div>
             </div>
-            <div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0 ml-2">
-              <i data-lucide="{{accountTypeIcon .Type}}" class="w-3.5 h-3.5 text-base-content/35"></i>
+            {{if .SparklineData}}
+            <div class="bb-sparkline w-full h-8 my-1.5" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
+            {{else}}
+            <div class="h-8 my-1.5"></div>
+            {{end}}
+            <div class="flex items-end justify-between mt-1">
+              <div class="text-lg font-bold tabular-nums tracking-tight {{if .IsLiability}}text-error/80{{end}}">{{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}</div>
+              <div class="text-right">
+                {{if gt .SpendingTotal 0.0}}
+                <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
+                {{else}}
+                <div class="text-[0.65rem] text-base-content/35">{{accountTypeLabel .Type .Subtype}}</div>
+                {{end}}
+              </div>
             </div>
-          </div>
-          {{if .SparklineData}}
-          <div class="bb-sparkline w-full h-8 my-1.5" data-values="{{.SparklineData}}" data-liability="{{.IsLiability}}"></div>
-          {{else}}
-          <div class="h-8 my-1.5"></div>
+          </a>
           {{end}}
-          <div class="flex items-end justify-between mt-1">
-            <div class="text-lg font-bold tabular-nums tracking-tight {{if .IsLiability}}text-error/80{{end}}">{{if .IsLiability}}-{{end}}{{formatBalance .BalanceCurrent}}</div>
-            <div class="text-right">
-              {{if gt .SpendingTotal 0.0}}
-              <div class="text-[0.65rem] text-base-content/40 tabular-nums">{{formatBalance .SpendingTotal}} spent</div>
-              {{else}}
-              <div class="text-[0.65rem] text-base-content/35">{{accountTypeLabel .Type .Subtype}}</div>
-              {{end}}
-            </div>
-          </div>
-        </a>
-        {{end}}
+        </div>
       </div>
     </div>
   </div>
@@ -321,74 +312,104 @@
 </div>
 
 <!-- ============================================================ -->
-<!-- STATUS BAR: connection health + quick stats                   -->
+<!-- ATTENTION ITEMS + CONNECTION HEALTH (2-col on desktop)        -->
 <!-- ============================================================ -->
-{{if .ConnectionHealth}}
-<div class="bb-card mb-6 p-4 sm:p-5" x-data="{ showDetail: false }">
-  <div class="flex items-center justify-between">
-    <div class="flex items-center gap-4 flex-wrap">
-      <!-- Connection health summary dots -->
-      {{if gt .HealthyCount 0}}
-      <span class="flex items-center gap-1.5 text-xs text-base-content/50">
-        <span class="w-2 h-2 rounded-full bg-success/60"></span>
-        {{.HealthyCount}} healthy
-      </span>
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+
+  <!-- Attention Items -->
+  <div class="bb-card">
+    <div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
+      <div class="flex items-center gap-2">
+        <i data-lucide="bell" class="w-4 h-4 text-base-content/40"></i>
+        <h2 class="text-sm font-semibold text-base-content/80">Attention</h2>
+        {{if .HasAttentionItems}}
+        <span class="text-[0.65rem] font-semibold px-2 py-0.5 rounded-full bg-warning/15 text-warning">{{.AttentionCount}} item{{if gt .AttentionCount 1}}s{{end}}</span>
+        {{end}}
+      </div>
+    </div>
+    {{if .HasAttentionItems}}
+    <div class="px-3 sm:px-4 py-2">
+      {{if gt .UncategorizedCount 0}}
+      <a href="/transactions?filter=uncategorized" class="flex items-center gap-3 py-2.5 px-2 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline group">
+        <div class="w-8 h-8 rounded-lg bg-warning/10 flex items-center justify-center shrink-0">
+          <i data-lucide="tag" class="w-4 h-4 text-warning"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-medium group-hover:text-primary transition-colors">{{commaInt .UncategorizedCount}} uncategorized</div>
+          <div class="text-[0.65rem] text-base-content/40 mt-0.5">Review and assign categories</div>
+        </div>
+        <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 group-hover:text-base-content/40 transition-colors shrink-0"></i>
+      </a>
+      {{end}}
+      {{if and .ReviewsEnabled (gt .ReviewPending 0)}}
+      <a href="/reviews" class="flex items-center gap-3 py-2.5 px-2 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline group">
+        <div class="w-8 h-8 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
+          <i data-lucide="clipboard-check" class="w-4 h-4 text-info"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-medium group-hover:text-primary transition-colors">{{commaInt .ReviewPending}} pending reviews</div>
+          <div class="text-[0.65rem] text-base-content/40 mt-0.5">Awaiting your approval</div>
+        </div>
+        <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 group-hover:text-base-content/40 transition-colors shrink-0"></i>
+      </a>
       {{end}}
       {{if gt .ErrorCount 0}}
-      <span class="flex items-center gap-1.5 text-xs text-error/70">
-        <span class="w-2 h-2 rounded-full bg-error/60"></span>
-        {{.ErrorCount}} error{{if gt .ErrorCount 1}}s{{end}}
-      </span>
-      {{end}}
-      {{if gt .StaleCount 0}}
-      <span class="flex items-center gap-1.5 text-xs text-warning">
-        <span class="w-2 h-2 rounded-full bg-warning/60"></span>
-        {{.StaleCount}} stale
-      </span>
-      {{end}}
-      <!-- Quick stats -->
-      <span class="text-base-content/15">|</span>
-      <span class="text-xs text-base-content/40">{{commaInt .TxCount}} transactions</span>
-      {{if gt .UncategorizedCount 0}}
-      <a href="/transactions" class="text-xs text-warning/70 hover:text-warning transition-colors">{{commaInt .UncategorizedCount}} uncategorized</a>
-      {{end}}
-      {{if gt .ReviewPending 0}}
-      <a href="/reviews" class="text-xs text-info/70 hover:text-info transition-colors">{{commaInt .ReviewPending}} pending reviews</a>
+      <a href="/connections" class="flex items-center gap-3 py-2.5 px-2 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline group">
+        <div class="w-8 h-8 rounded-lg bg-error/10 flex items-center justify-center shrink-0">
+          <i data-lucide="alert-circle" class="w-4 h-4 text-error/70"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="text-sm font-medium group-hover:text-primary transition-colors">{{.ErrorCount}} connection{{if gt .ErrorCount 1}}s{{end}} need{{if eq .ErrorCount 1}}s{{end}} attention</div>
+          <div class="text-[0.65rem] text-base-content/40 mt-0.5">Authentication or sync errors</div>
+        </div>
+        <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 group-hover:text-base-content/40 transition-colors shrink-0"></i>
+      </a>
       {{end}}
     </div>
-    <button @click="showDetail = !showDetail" class="text-xs text-base-content/30 hover:text-base-content/50 transition-colors flex items-center gap-1">
-      <span class="hidden sm:inline">Details</span>
-      <i data-lucide="chevron-down" class="w-3.5 h-3.5 transition-transform duration-200" :class="showDetail ? 'rotate-180' : ''"></i>
-    </button>
+    {{else}}
+    <div class="px-5 py-8 text-center">
+      <i data-lucide="check-circle-2" class="w-8 h-8 mx-auto mb-2 text-success/30"></i>
+      <p class="text-sm text-base-content/40">All caught up</p>
+      <p class="text-xs text-base-content/30 mt-0.5">No items need your attention right now.</p>
+    </div>
+    {{end}}
   </div>
 
-  <!-- Expandable connection detail -->
-  <div x-show="showDetail" x-cloak x-collapse class="mt-4 pt-4 border-t border-base-200/60">
+  <!-- Connection Health -->
+  {{if .ConnectionHealth}}
+  <div class="bb-card">
+    <div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
+      <div class="flex items-center gap-2">
+        <i data-lucide="link-2" class="w-4 h-4 text-base-content/40"></i>
+        <h2 class="text-sm font-semibold text-base-content/80">Connections</h2>
+      </div>
+      <a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Manage</a>
+    </div>
     {{if .SyncHealth}}
-    <div class="flex items-center gap-4 mb-3 flex-wrap">
+    <div class="flex items-center gap-5 flex-wrap px-5 py-3 text-xs text-base-content/50 border-b border-base-200/60">
       {{if .SyncHealth.LastSyncTime}}
-      <span class="flex items-center gap-1.5 text-xs text-base-content/50">
+      <span class="flex items-center gap-1.5">
         <i data-lucide="clock" class="w-3 h-3 text-base-content/30"></i>
-        Last sync {{deref .SyncHealth.LastSyncTime}}
+        Synced {{deref .SyncHealth.LastSyncTime}}
       </span>
       {{end}}
       {{if gt .SyncHealth.RecentSyncCount 0}}
-      <span class="flex items-center gap-1.5 text-xs {{if ge .SyncHealth.RecentSuccessRate 90.0}}text-success{{else if ge .SyncHealth.RecentSuccessRate 50.0}}text-warning{{else}}text-error/80{{end}}">
+      <span class="flex items-center gap-1.5 {{if ge .SyncHealth.RecentSuccessRate 90.0}}text-success{{else if ge .SyncHealth.RecentSuccessRate 50.0}}text-warning{{else}}text-error/80{{end}}">
         <i data-lucide="bar-chart-3" class="w-3 h-3"></i>
-        {{printf "%.0f" .SyncHealth.RecentSuccessRate}}% success ({{.SyncHealth.RecentSyncCount}} syncs / 24h)
+        {{printf "%.0f" .SyncHealth.RecentSuccessRate}}% success
       </span>
       {{end}}
       {{if .SyncHealth.NextSyncTime}}
-      <span class="flex items-center gap-1.5 text-xs text-base-content/40">
+      <span class="flex items-center gap-1.5 text-base-content/40">
         <i data-lucide="timer" class="w-3 h-3"></i>
         Next: {{.SyncHealth.NextSyncTime}}
       </span>
       {{end}}
     </div>
     {{end}}
-    <div class="space-y-1">
+    <div class="px-3 sm:px-4 py-2">
       {{range .ConnectionHealth}}
-      <a href="/connections/{{.ID}}" class="flex items-center gap-2.5 py-2 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline group">
+      <a href="/connections/{{.ID}}" class="flex items-center gap-2.5 py-2.5 px-2 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline group">
         <div class="relative shrink-0">
           <div class="w-7 h-7 rounded-lg flex items-center justify-center
             {{if eq .Status "error"}}bg-error/10
@@ -440,20 +461,23 @@
       </a>
       {{end}}
     </div>
-
-    <!-- Sync success rate bar -->
-    {{if and .SyncHealth (gt .SyncHealth.RecentSyncCount 0)}}
-    <div class="mt-3 pt-3 border-t border-base-200/60">
-      <div class="flex h-1.5 rounded-full overflow-hidden bg-base-200/60">
-        {{if gt .SyncHealth.RecentSuccessRate 0.0}}
-        <div class="h-full rounded-full {{if ge .SyncHealth.RecentSuccessRate 90.0}}bg-success/60{{else if ge .SyncHealth.RecentSuccessRate 50.0}}bg-warning/60{{else}}bg-error/60{{end}} transition-all duration-700" style="width: {{printf "%.0f" .SyncHealth.RecentSuccessRate}}%;"></div>
-        {{end}}
+  </div>
+  {{else}}
+  <div class="bb-card">
+    <div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
+      <div class="flex items-center gap-2">
+        <i data-lucide="link-2" class="w-4 h-4 text-base-content/40"></i>
+        <h2 class="text-sm font-semibold text-base-content/80">Connections</h2>
       </div>
     </div>
-    {{end}}
+    <div class="px-5 py-8 text-center">
+      <i data-lucide="link-2" class="w-8 h-8 mx-auto mb-2 text-base-content/15"></i>
+      <p class="text-sm text-base-content/40">No connections yet</p>
+      <a href="/connections/new" class="btn btn-primary btn-sm mt-3 rounded-xl">Connect a bank</a>
+    </div>
   </div>
+  {{end}}
 </div>
-{{end}}
 
 <!-- Agent Reports: dismiss logic -->
 <script>


### PR DESCRIPTION
## Summary
- Make accounts grid collapsible (collapsed by default) with Alpine.js toggle — click "N Accounts" to expand/collapse
- Replace cramped single-row status bar with two purpose-built cards in a 2-col grid:
  - **Attention Items**: surfaces actionable items (uncategorized transactions, pending reviews, connection errors) with full-row tap targets and clear visual hierarchy
  - **Connection Health**: sync summary strip + always-visible per-connection rows — no hidden expand/collapse state
- Move sync status pill from net worth hero to Connections card

## Test plan
- [ ] Verify accounts grid collapses/expands on click
- [ ] Verify "Manage" link still navigates to /connections without toggling
- [ ] Verify Attention card shows correct counts and links
- [ ] Verify Connection Health card shows sync stats and per-connection rows
- [ ] Verify empty states render correctly (no attention items, no connections)
- [ ] Check mobile responsiveness (cards stack vertically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)