### PR TITLE
Merge login info into user card header, fix button wrapping

### DIFF
--- a/internal/templates/pages/create_login.html
+++ b/internal/templates/pages/create_login.html
@@ -189,8 +189,8 @@
         </template>
 
         <div class="flex gap-3 pt-2">
-          <button type="submit" class="btn btn-primary btn-sm rounded-xl" :disabled="submitting">
-            <span x-show="!submitting"><i data-lucide="plus" class="w-4 h-4"></i> Create Login</span>
+          <button type="submit" class="btn btn-primary btn-sm rounded-xl whitespace-nowrap" :disabled="submitting">
+            <span x-show="!submitting" class="inline-flex items-center gap-1.5"><i data-lucide="plus" class="w-4 h-4"></i> Create Login</span>
             <span x-show="submitting" class="loading loading-spinner loading-sm"></span>
           </button>
           <a href="/users" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>

--- a/internal/templates/pages/user_form.html
+++ b/internal/templates/pages/user_form.html
@@ -110,8 +110,8 @@
         </template>
 
         <div class="flex gap-3 pt-2">
-          <button type="submit" class="btn btn-primary btn-sm rounded-xl" :disabled="submitting">
-            <span x-show="!submitting"><i data-lucide="plus" class="w-4 h-4"></i> Create Member</span>
+          <button type="submit" class="btn btn-primary btn-sm rounded-xl whitespace-nowrap" :disabled="submitting">
+            <span x-show="!submitting" class="inline-flex items-center gap-1.5"><i data-lucide="plus" class="w-4 h-4"></i> Create Member</span>
             <span x-show="submitting" class="loading loading-spinner loading-sm"></span>
           </button>
           <a href="/users" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
@@ -247,9 +247,8 @@ function userForm() {
     <div id="form-error" class="rounded-xl bg-error/10 border border-error/20 text-error text-sm px-4 py-3 mb-4 hidden"></div>
 
     <div class="flex gap-3 pt-2">
-      <button type="submit" class="btn btn-primary btn-sm rounded-xl">
-        <i data-lucide="save" class="w-4 h-4"></i>
-        Save Changes
+      <button type="submit" class="btn btn-primary btn-sm rounded-xl whitespace-nowrap">
+        <span class="inline-flex items-center gap-1.5"><i data-lucide="save" class="w-4 h-4"></i> Save Changes</span>
       </button>
       <a href="/users" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
     </div>

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -20,6 +20,8 @@
 {{if .EnrichedUsers}}
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-5 bb-stagger">
   {{range .EnrichedUsers}}
+  {{$uid := formatUUID .ID}}
+  {{$la := index $.LoginAccountMap $uid}}
   <div class="bb-card overflow-hidden flex flex-col">
     <!-- Member Header -->
     <div class="p-4 sm:p-6 pb-4">
@@ -31,16 +33,35 @@
           <div>
             <div class="flex items-center gap-2">
               <h3 class="font-semibold text-base">{{.Name}}</h3>
-              <a href="/users/{{formatUUID .ID}}/edit" class="btn btn-ghost btn-xs rounded-lg opacity-40 hover:opacity-100 transition-opacity" title="Edit member">
-                <i data-lucide="pencil" class="w-3.5 h-3.5"></i>
-              </a>
+              {{if $la.Username}}
+              <span class="badge badge-xs {{if eq $la.Role "admin"}}badge-primary{{else if eq $la.Role "editor"}}badge-secondary{{else}}badge-ghost{{end}}">{{$la.Role}}</span>
+              {{if not $la.HashedPassword}}
+              <span class="badge badge-xs badge-warning">setup pending</span>
+              {{end}}
+              {{end}}
             </div>
             {{if .Email.Valid}}
             <p class="text-xs text-base-content/45 mt-0.5">{{.Email.String}}</p>
             {{else}}
             <p class="text-xs text-base-content/30 italic mt-0.5">No email</p>
             {{end}}
+            {{if not $la.Username}}
+            <a href="/users/{{$uid}}/create-login" class="text-xs text-base-content/40 hover:text-primary transition-colors no-underline inline-flex items-center gap-1 mt-1">
+              <i data-lucide="user-plus" class="w-3 h-3"></i>
+              <span>Create login</span>
+            </a>
+            {{end}}
           </div>
+        </div>
+        <div class="flex items-center gap-1">
+          <a href="/users/{{$uid}}/edit" class="btn btn-ghost btn-xs rounded-lg opacity-40 hover:opacity-100 transition-opacity" title="Edit member">
+            <i data-lucide="pencil" class="w-3.5 h-3.5"></i>
+          </a>
+          {{if $la.Username}}
+          <a href="/users/{{$uid}}/create-login" class="btn btn-ghost btn-xs rounded-lg opacity-40 hover:opacity-100 transition-opacity" title="Manage login">
+            <i data-lucide="settings" class="w-3.5 h-3.5"></i>
+          </a>
+          {{end}}
         </div>
       </div>
 
@@ -150,35 +171,6 @@
       </div>
     </div>
     {{end}}
-
-    <!-- Login Account Status -->
-    {{$uid := formatUUID .ID}}
-    {{$la := index $.LoginAccountMap $uid}}
-    <div class="border-t border-base-300 px-4 sm:px-5 py-3 bg-base-200/20">
-      {{if $la.Username}}
-      <div class="flex items-center justify-between">
-        <div class="flex items-center gap-2 text-xs">
-          <i data-lucide="key" class="w-3.5 h-3.5 text-success/60"></i>
-          <span class="text-base-content/50">Login: <span class="font-medium text-base-content/70">{{$la.Username}}</span></span>
-          <span class="badge badge-xs {{if eq $la.Role "admin"}}badge-primary{{else if eq $la.Role "editor"}}badge-secondary{{else}}badge-ghost{{end}}">{{$la.Role}}</span>
-          {{if not $la.HashedPassword}}
-          <span class="badge badge-xs badge-warning">setup pending</span>
-          {{end}}
-        </div>
-        <a href="/users/{{$uid}}/create-login" class="btn btn-ghost btn-xs rounded-lg opacity-40 hover:opacity-100" title="Manage login">
-          <i data-lucide="settings" class="w-3.5 h-3.5"></i>
-        </a>
-      </div>
-      {{else}}
-      <div class="flex items-center justify-between">
-        <span class="text-xs text-base-content/30">No login account</span>
-        <a href="/users/{{$uid}}/create-login" class="btn btn-ghost btn-xs rounded-lg text-base-content/40 hover:text-primary">
-          <i data-lucide="user-plus" class="w-3.5 h-3.5"></i>
-          <span>Create login</span>
-        </a>
-      </div>
-      {{end}}
-    </div>
 
     <!-- Footer -->
     <div class="mt-auto px-4 sm:px-5 py-2.5 border-t border-base-300 flex items-center justify-between text-xs text-base-content/30 bg-base-200/20">


### PR DESCRIPTION
## Summary
- Merged login account info (role badge, setup pending status, manage gear icon) into the card header on `/users`, removing the redundant bottom bar that duplicated the email
- Fixed icon+text wrapping on buttons across `/create-login`, `/users/new`, and `/users/{id}/edit` pages

## Test plan
- [ ] Visit `/users` — verify role badges appear inline with names, setup pending shows for Pepe, "Create login" link shows for Ricardo
- [ ] Click gear icon to reach manage login page
- [ ] Visit `/users/new` — verify "Create Member" button doesn't wrap
- [ ] Visit `/users/{id}/create-login` — verify "Create Login" button doesn't wrap
- [ ] Check mobile viewport for overflow issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)