### PR TITLE
Add user avatars: generated patterns + custom photo upload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/image v0.24.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
+golang.org/x/image v0.24.0 h1:AN7zRgVsbvmTfNyqIbbOraYL8mSwcKncEj8ofjgzcMQ=
+golang.org/x/image v0.24.0/go.mod h1:4b/ITuLfqYq1hqZcjofwctIhi7sZh2WaCjvsBNjjya8=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/input.css
+++ b/input.css
@@ -153,6 +153,9 @@
 
 /* ─── shadcn-inspired global overrides ─── */
 @layer base {
+  /* Ensure Lucide SVG icons inside interactive elements don't steal clicks. */
+  a svg, button svg { pointer-events: none; }
+
   html { scroll-behavior: smooth; }
 
   body {
@@ -1149,9 +1152,8 @@
   }
 
   .bb-sidebar-profile-avatar {
-    @apply w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center
-           text-xs font-semibold text-primary shrink-0 uppercase;
-    transition: background-color 0.15s ease;
+    @apply w-8 h-8 rounded-full object-cover shrink-0;
+    transition: opacity 0.15s ease;
   }
 
   .bb-sidebar-profile-info {

--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -18,6 +18,7 @@ const (
 	sessionKeyAccountUsername = "account_username"  // auth_accounts.username
 	sessionKeyAccountRole     = "account_role"      // "admin", "editor", or "viewer"
 	sessionKeyUserID          = "user_id"           // linked family member UUID (NULL-linked admins have "")
+	sessionKeyAvatarVersion   = "avatar_v"          // bumped on avatar change for cache busting
 )
 
 // Role constants.

--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -1,0 +1,295 @@
+package admin
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/avatar"
+	"breadbox/internal/db"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const maxAvatarUploadSize = 5 << 20 // 5 MB
+
+// AvatarHandler serves GET /avatars/{id} — returns uploaded image or generated SVG.
+// Looks up the user by UUID. If not found, generates a pattern from the raw ID string
+// (covers unlinked admin accounts whose session falls back to account UUID).
+func AvatarHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idStr := chi.URLParam(r, "id")
+
+		uid, err := resolveUUID(idStr)
+		if err != nil {
+			serveGeneratedAvatar(w, r, idStr)
+			return
+		}
+
+		row, err := a.Queries.GetUserAvatar(r.Context(), uid)
+		if err != nil {
+			// Not a user — generate a stable pattern from the raw ID.
+			serveGeneratedAvatar(w, r, idStr)
+			return
+		}
+
+		if row.AvatarData != nil && row.AvatarContentType.Valid {
+			serveUploadedAvatar(w, r, row.AvatarData, row.AvatarContentType.String)
+			return
+		}
+
+		seed := formatUUID(uid)
+		if row.AvatarSeed.Valid && row.AvatarSeed.String != "" {
+			seed = row.AvatarSeed.String
+		}
+		serveGeneratedAvatar(w, r, seed)
+	}
+}
+
+// AvatarPreviewHandler serves GET /avatars/preview/{seed} — generates a pattern preview.
+// Used by the create member form to show a live preview before the user exists.
+func AvatarPreviewHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		seed := chi.URLParam(r, "seed")
+		if seed == "" {
+			seed = "default"
+		}
+		serveGeneratedAvatar(w, r, seed)
+	}
+}
+
+func serveUploadedAvatar(w http.ResponseWriter, r *http.Request, data []byte, contentType string) {
+	etag := fmt.Sprintf(`"%x"`, sha256.Sum256(data))
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	w.Header().Set("ETag", etag)
+	w.Write(data)
+}
+
+func serveGeneratedAvatar(w http.ResponseWriter, r *http.Request, seed string) {
+	svg := avatar.GenerateSVG(seed, 256)
+	etag := fmt.Sprintf(`"%x"`, sha256.Sum256(svg))
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", "image/svg+xml")
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	w.Header().Set("ETag", etag)
+	w.Write(svg)
+}
+
+func resolveUUID(idStr string) (pgtype.UUID, error) {
+	var uid pgtype.UUID
+	if err := uid.Scan(idStr); err != nil {
+		return pgtype.UUID{}, err
+	}
+	return uid, nil
+}
+
+// --- Admin avatar management (for any user) ---
+
+// UploadUserAvatarHandler serves POST /-/users/{id}/avatar.
+func UploadUserAvatarHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := parseUserID(w, r)
+		if !ok {
+			return
+		}
+		processAndStoreAvatar(a, w, r, userID)
+	}
+}
+
+// DeleteUserAvatarHandler serves DELETE /-/users/{id}/avatar.
+func DeleteUserAvatarHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := parseUserID(w, r)
+		if !ok {
+			return
+		}
+		if err := a.Queries.ClearUserAvatar(r.Context(), userID); err != nil {
+			a.Logger.Error("clear avatar", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to remove avatar"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}
+}
+
+// RegenerateUserAvatarHandler serves POST /-/users/{id}/avatar/regenerate.
+func RegenerateUserAvatarHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := parseUserID(w, r)
+		if !ok {
+			return
+		}
+		seed := randomSeed()
+		if err := a.Queries.ClearUserAvatar(r.Context(), userID); err != nil {
+			a.Logger.Error("clear avatar for regenerate", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to regenerate"})
+			return
+		}
+		if err := a.Queries.SetUserAvatarSeed(r.Context(), db.SetUserAvatarSeedParams{
+			ID: userID, AvatarSeed: pgtype.Text{String: seed, Valid: true},
+		}); err != nil {
+			a.Logger.Error("set avatar seed", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to regenerate"})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "seed": seed})
+	}
+}
+
+// --- Self-service avatar (requires linked user) ---
+
+// UploadMyAvatarHandler serves POST /my-account/avatar.
+func UploadMyAvatarHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := requireSessionUser(w, sm, r)
+		if !ok {
+			return
+		}
+		processAndStoreAvatar(a, w, r, userID)
+		bumpAvatarVersion(sm, r)
+	}
+}
+
+// DeleteMyAvatarHandler serves DELETE /my-account/avatar.
+func DeleteMyAvatarHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := requireSessionUser(w, sm, r)
+		if !ok {
+			return
+		}
+		if err := a.Queries.ClearUserAvatar(r.Context(), userID); err != nil {
+			a.Logger.Error("clear avatar", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to remove avatar"})
+			return
+		}
+		bumpAvatarVersion(sm, r)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+	}
+}
+
+// RegenerateMyAvatarHandler serves POST /my-account/avatar/regenerate.
+func RegenerateMyAvatarHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := requireSessionUser(w, sm, r)
+		if !ok {
+			return
+		}
+		seed := randomSeed()
+		if err := a.Queries.ClearUserAvatar(r.Context(), userID); err != nil {
+			a.Logger.Error("clear avatar for regenerate", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to regenerate"})
+			return
+		}
+		if err := a.Queries.SetUserAvatarSeed(r.Context(), db.SetUserAvatarSeedParams{
+			ID: userID, AvatarSeed: pgtype.Text{String: seed, Valid: true},
+		}); err != nil {
+			a.Logger.Error("set avatar seed", "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to regenerate"})
+			return
+		}
+		bumpAvatarVersion(sm, r)
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true, "seed": seed})
+	}
+}
+
+// --- Helpers ---
+
+func parseUserID(w http.ResponseWriter, r *http.Request) (pgtype.UUID, bool) {
+	var userID pgtype.UUID
+	if err := userID.Scan(chi.URLParam(r, "id")); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid user ID"})
+		return pgtype.UUID{}, false
+	}
+	return userID, true
+}
+
+func requireSessionUser(w http.ResponseWriter, sm *scs.SessionManager, r *http.Request) (pgtype.UUID, bool) {
+	uid := SessionUserID(sm, r)
+	if uid == "" {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "Account must be linked to a household member to manage avatars"})
+		return pgtype.UUID{}, false
+	}
+	var userID pgtype.UUID
+	if err := userID.Scan(uid); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Invalid session"})
+		return pgtype.UUID{}, false
+	}
+	return userID, true
+}
+
+// bumpAvatarVersion updates the session's avatar version so the sidebar
+// avatar URL fingerprint changes, busting the browser cache.
+func bumpAvatarVersion(sm *scs.SessionManager, r *http.Request) {
+	sm.Put(r.Context(), sessionKeyAvatarVersion, strconv.FormatInt(time.Now().Unix(), 10))
+}
+
+func processAndStoreAvatar(a *app.App, w http.ResponseWriter, r *http.Request, userID pgtype.UUID) {
+	processed, ct, ok := parseAvatarUpload(a, w, r)
+	if !ok {
+		return
+	}
+	if err := a.Queries.SetUserAvatar(r.Context(), db.SetUserAvatarParams{
+		ID:                userID,
+		AvatarData:        processed,
+		AvatarContentType: pgtype.Text{String: ct, Valid: true},
+	}); err != nil {
+		a.Logger.Error("store avatar", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to save avatar"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "avatar_url": "/avatars/" + formatUUID(userID)})
+}
+
+func parseAvatarUpload(a *app.App, w http.ResponseWriter, r *http.Request) ([]byte, string, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxAvatarUploadSize)
+	if err := r.ParseMultipartForm(maxAvatarUploadSize); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "File too large (max 5MB)"})
+		return nil, "", false
+	}
+	file, header, err := r.FormFile("avatar")
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "No file uploaded"})
+		return nil, "", false
+	}
+	defer file.Close()
+
+	contentType := header.Header.Get("Content-Type")
+	if contentType != "image/png" && contentType != "image/jpeg" && contentType != "image/gif" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Unsupported image type. Use PNG, JPEG, or GIF."})
+		return nil, "", false
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Failed to read file"})
+		return nil, "", false
+	}
+	processed, ct, err := avatar.ProcessUpload(data, contentType)
+	if err != nil {
+		a.Logger.Error("process avatar", "error", err)
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Failed to process image"})
+		return nil, "", false
+	}
+	return processed, ct, true
+}
+
+func randomSeed() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -28,6 +28,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		tr.RenderNotFound(w, r)
 	})
 
+	// Avatar serving — unauthenticated (like static files).
+	r.Get("/avatars/preview/{seed}", AvatarPreviewHandler())
+	r.Get("/avatars/{id}", AvatarHandler(a))
+
 	// Unauthenticated routes.
 	r.Group(func(r chi.Router) {
 		r.Use(OAuthLoginReturnMiddleware(sm))
@@ -80,6 +84,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// Member account self-service pages.
 		r.Get("/my-account", MyAccountHandler(a, sm, tr, svc))
 		r.Post("/my-account/password", MyAccountChangePasswordHandler(a, sm))
+		r.Post("/my-account/avatar", UploadMyAvatarHandler(a, sm))
+		r.Delete("/my-account/avatar", DeleteMyAvatarHandler(a, sm))
+		r.Post("/my-account/avatar/regenerate", RegenerateMyAvatarHandler(a, sm))
 		r.Post("/my-account/wipe-data", MyAccountWipeDataHandler(a, sm))
 
 		// Password change works for both admin and member sessions.
@@ -257,6 +264,9 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/test-provider/{provider}", ProvidersTestHandler(a))
 			r.Post("/users", CreateUserHandler(a, sm))
 			r.Put("/users/{id}", UpdateUserHandler(a, sm))
+			r.Post("/users/{id}/avatar", UploadUserAvatarHandler(a))
+			r.Delete("/users/{id}/avatar", DeleteUserAvatarHandler(a))
+			r.Post("/users/{id}/avatar/regenerate", RegenerateUserAvatarHandler(a))
 
 			r.Post("/csv/upload", CSVUploadHandler(a, sm))
 			r.Post("/csv/preview", CSVPreviewHandler(a, sm))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -393,6 +393,45 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return result
 			},
+			"avatarURL": func(args ...any) string {
+				if len(args) == 0 {
+					return "/avatars/unknown"
+				}
+				var base string
+				switch v := args[0].(type) {
+				case pgtype.UUID:
+					if !v.Valid {
+						return "/avatars/unknown"
+					}
+					base = "/avatars/" + formatUUID(v)
+				case string:
+					if v == "" {
+						return "/avatars/unknown"
+					}
+					base = "/avatars/" + v
+				case *string:
+					if v == nil || *v == "" {
+						return "/avatars/unknown"
+					}
+					base = "/avatars/" + *v
+				default:
+					return "/avatars/unknown"
+				}
+				// Optional second arg: version fingerprint for cache busting.
+				if len(args) > 1 {
+					switch v := args[1].(type) {
+					case pgtype.Timestamptz:
+						if v.Valid {
+							base += "?v=" + fmt.Sprintf("%d", v.Time.Unix())
+						}
+					case string:
+						if v != "" {
+							base += "?v=" + v
+						}
+					}
+				}
+				return base
+			},
 			"firstChar": func(s string) string {
 				if s == "" {
 					return "?"
@@ -867,15 +906,30 @@ func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, name 
 		if _, exists := m["NavBadges"]; !exists {
 			m["NavBadges"] = getNavBadges(r.Context())
 		}
-		// Auto-inject role info for nav rendering.
-		if _, exists := m["SessionRole"]; !exists && tr.sm != nil {
-			role := tr.sm.GetString(r.Context(), sessionKeyAccountRole)
-			if role == "" {
-				role = RoleAdmin
+		// Auto-inject all nav-required session fields.
+		// This is the single source of truth — handlers don't need to set these.
+		if tr.sm != nil {
+			if _, exists := m["SessionRole"]; !exists {
+				role := tr.sm.GetString(r.Context(), sessionKeyAccountRole)
+				if role == "" {
+					role = RoleAdmin
+				}
+				m["SessionRole"] = role
+				m["IsAdmin"] = role == RoleAdmin
+				m["IsEditor"] = role == RoleAdmin || role == RoleEditor
+				m["RoleDisplay"] = RoleDisplayName(role)
 			}
-			m["SessionRole"] = role
-			m["IsAdmin"] = role == RoleAdmin
-			m["IsEditor"] = role == RoleAdmin || role == RoleEditor
+			if _, exists := m["SessionUserID"]; !exists {
+				uid := tr.sm.GetString(r.Context(), sessionKeyUserID)
+				m["HasLinkedUser"] = uid != ""
+				if uid == "" {
+					uid = tr.sm.GetString(r.Context(), sessionKeyAccountID)
+				}
+				m["SessionUserID"] = uid
+			}
+			if _, exists := m["SessionAvatarVersion"]; !exists {
+				m["SessionAvatarVersion"] = tr.sm.GetString(r.Context(), sessionKeyAvatarVersion)
+			}
 		}
 	}
 

--- a/internal/avatar/avatar.go
+++ b/internal/avatar/avatar.go
@@ -1,0 +1,168 @@
+// Package avatar generates deterministic SVG identicons and processes uploaded images.
+package avatar
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math"
+	"strings"
+)
+
+// GenerateSVG produces a deterministic SVG identicon from the given seed string.
+// The seed is typically a user UUID. Size controls the SVG viewBox dimensions.
+// The pattern is designed to look good inside circular containers (border-radius: 50%).
+func GenerateSVG(seed string, size int) []byte {
+	hash := sha256.Sum256([]byte(seed))
+
+	// Pick two complementary colors from hash for a richer palette.
+	hue1 := float64(uint16(hash[0])<<8|uint16(hash[1])) / 65535.0 * 360.0
+	sat1 := 50.0 + float64(hash[2])/255.0*15.0 // 50-65%
+	lit1 := 50.0 + float64(hash[3])/255.0*12.0 // 50-62%
+
+	// Second color: offset hue by 30-90 degrees for harmony.
+	hueOffset := 30.0 + float64(hash[4])/255.0*60.0
+	hue2 := math.Mod(hue1+hueOffset, 360)
+	sat2 := 40.0 + float64(hash[5])/255.0*20.0
+	lit2 := 55.0 + float64(hash[6])/255.0*15.0
+
+	fg1 := hslToHex(hue1, sat1, lit1)
+	fg2 := hslToHex(hue2, sat2, lit2)
+	bg := hslToHex(hue1, sat1*0.25, 94.0)
+
+	s := float64(size)
+	center := s / 2
+	radius := s / 2
+
+	var b strings.Builder
+	fmt.Fprintf(&b, `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %d %d" width="%d" height="%d">`, size, size, size, size)
+
+	// Circular clip path — ensures the pattern fills the circle cleanly.
+	fmt.Fprintf(&b, `<defs><clipPath id="c"><circle cx="%.0f" cy="%.0f" r="%.0f"/></clipPath></defs>`, center, center, radius)
+	fmt.Fprintf(&b, `<g clip-path="url(#c)">`)
+
+	// Background circle.
+	fmt.Fprintf(&b, `<rect width="%d" height="%d" fill="%s"/>`, size, size, bg)
+
+	// Use hash byte to pick a pattern style: rings or mosaic.
+	if hash[7]%2 == 0 {
+		renderRings(hash, &b, s, center, fg1, fg2)
+	} else {
+		renderMosaic(hash, &b, s, fg1, fg2)
+	}
+
+	b.WriteString(`</g></svg>`)
+	return []byte(b.String())
+}
+
+// renderRings draws offset circles with padding from the edge.
+func renderRings(hash [32]byte, b *strings.Builder, s, center float64, fg1, fg2 string) {
+	padding := s * 0.08 // keep circles away from the clip edge
+	maxR := s/2 - padding
+
+	// Large background shape offset from center.
+	r1 := s*0.30 + float64(hash[10])/255.0*s*0.10
+	ox1 := clampOffset(hash[8], s, r1, maxR)
+	oy1 := clampOffset(hash[9], s, r1, maxR)
+	fmt.Fprintf(b, `<circle cx="%.1f" cy="%.1f" r="%.1f" fill="%s" opacity="0.7"/>`,
+		center+ox1, center+oy1, r1, fg1)
+
+	// Medium shape.
+	r2 := s*0.18 + float64(hash[13])/255.0*s*0.10
+	ox2 := clampOffset(hash[11], s, r2, maxR)
+	oy2 := clampOffset(hash[12], s, r2, maxR)
+	fmt.Fprintf(b, `<circle cx="%.1f" cy="%.1f" r="%.1f" fill="%s" opacity="0.8"/>`,
+		center+ox2, center+oy2, r2, fg2)
+
+	// Small accent.
+	r3 := s*0.08 + float64(hash[16])/255.0*s*0.08
+	ox3 := clampOffset(hash[14], s, r3, maxR)
+	oy3 := clampOffset(hash[15], s, r3, maxR)
+	fmt.Fprintf(b, `<circle cx="%.1f" cy="%.1f" r="%.1f" fill="%s" opacity="0.9"/>`,
+		center+ox3, center+oy3, r3, fg1)
+}
+
+// clampOffset returns a center offset that keeps a circle of radius r within maxR from center.
+func clampOffset(hashByte byte, s, r, maxR float64) float64 {
+	raw := (float64(hashByte)/255.0 - 0.5) * s * 0.4
+	limit := maxR - r
+	if limit < 0 {
+		return 0
+	}
+	if raw > limit {
+		return limit
+	}
+	if raw < -limit {
+		return -limit
+	}
+	return raw
+}
+
+// renderMosaic draws a radial grid of cells, keeping only those within the circle.
+func renderMosaic(hash [32]byte, b *strings.Builder, s float64, fg1, fg2 string) {
+	// 4x4 grid with mirror symmetry, centered in the circle.
+	gridSize := 4
+	cellSize := s / float64(gridSize+1) // leave half-cell margin
+	offset := cellSize * 0.5
+	center := s / 2
+	radius := s * 0.48
+
+	for row := 0; row < gridSize; row++ {
+		for col := 0; col < (gridSize+1)/2; col++ {
+			byteIdx := 8 + row*2 + col
+			if hash[byteIdx]%3 == 0 {
+				continue // skip ~1/3 of cells for visual interest
+			}
+
+			// Draw cell and its mirror.
+			for _, c := range []int{col, gridSize - 1 - col} {
+				cx := offset + float64(c)*cellSize + cellSize/2
+				cy := offset + float64(row)*cellSize + cellSize/2
+				dist := math.Sqrt((cx-center)*(cx-center) + (cy-center)*(cy-center))
+				if dist+cellSize*0.4 > radius {
+					continue // skip cells that would extend past the circle
+				}
+
+				color := fg1
+				if hash[byteIdx]%2 == 0 {
+					color = fg2
+				}
+
+				gap := cellSize * 0.08
+				fmt.Fprintf(b, `<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" fill="%s" rx="%.1f"/>`,
+					offset+float64(c)*cellSize+gap, offset+float64(row)*cellSize+gap,
+					cellSize-gap*2, cellSize-gap*2, color, cellSize*0.2)
+			}
+		}
+	}
+}
+
+
+func hslToHex(h, s, l float64) string {
+	s /= 100.0
+	l /= 100.0
+
+	c := (1 - math.Abs(2*l-1)) * s
+	x := c * (1 - math.Abs(math.Mod(h/60.0, 2)-1))
+	m := l - c/2
+
+	var r, g, b float64
+	switch {
+	case h < 60:
+		r, g, b = c, x, 0
+	case h < 120:
+		r, g, b = x, c, 0
+	case h < 180:
+		r, g, b = 0, c, x
+	case h < 240:
+		r, g, b = 0, x, c
+	case h < 300:
+		r, g, b = x, 0, c
+	default:
+		r, g, b = c, 0, x
+	}
+
+	ri := int(math.Round((r + m) * 255))
+	gi := int(math.Round((g + m) * 255))
+	bi := int(math.Round((b + m) * 255))
+	return fmt.Sprintf("#%02x%02x%02x", ri, gi, bi)
+}

--- a/internal/avatar/avatar_test.go
+++ b/internal/avatar/avatar_test.go
@@ -1,0 +1,52 @@
+package avatar
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateSVG_Deterministic(t *testing.T) {
+	svg1 := GenerateSVG("test-seed", 256)
+	svg2 := GenerateSVG("test-seed", 256)
+
+	if string(svg1) != string(svg2) {
+		t.Error("expected identical SVGs for same seed")
+	}
+}
+
+func TestGenerateSVG_DifferentSeeds(t *testing.T) {
+	svg1 := GenerateSVG("user-1", 256)
+	svg2 := GenerateSVG("user-2", 256)
+
+	if string(svg1) == string(svg2) {
+		t.Error("expected different SVGs for different seeds")
+	}
+}
+
+func TestGenerateSVG_ValidSVG(t *testing.T) {
+	svg := string(GenerateSVG("test", 256))
+
+	if !strings.HasPrefix(svg, "<svg") {
+		t.Error("expected SVG to start with <svg")
+	}
+	if !strings.HasSuffix(svg, "</svg>") {
+		t.Error("expected SVG to end with </svg>")
+	}
+	if !strings.Contains(svg, `viewBox="0 0 256 256"`) {
+		t.Error("expected viewBox attribute")
+	}
+}
+
+func TestProcessUpload_UnsupportedType(t *testing.T) {
+	_, _, err := ProcessUpload([]byte("not an image"), "image/webp")
+	if err == nil {
+		t.Error("expected error for unsupported type")
+	}
+}
+
+func TestProcessUpload_CorruptImage(t *testing.T) {
+	_, _, err := ProcessUpload([]byte("corrupt data"), "image/png")
+	if err == nil {
+		t.Error("expected error for corrupt image data")
+	}
+}

--- a/internal/avatar/resize.go
+++ b/internal/avatar/resize.go
@@ -1,0 +1,80 @@
+package avatar
+
+import (
+	"bytes"
+	"fmt"
+	"image"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+
+	"golang.org/x/image/draw"
+)
+
+const targetSize = 256
+
+// ProcessUpload decodes an uploaded image, center-crops it to a square,
+// resizes to 256x256, and returns PNG bytes.
+func ProcessUpload(data []byte, contentType string) ([]byte, string, error) {
+	var img image.Image
+	var err error
+
+	switch contentType {
+	case "image/png":
+		img, err = png.Decode(bytes.NewReader(data))
+	case "image/jpeg":
+		img, err = jpeg.Decode(bytes.NewReader(data))
+	case "image/gif":
+		img, err = gif.Decode(bytes.NewReader(data))
+	default:
+		return nil, "", fmt.Errorf("unsupported image type: %s", contentType)
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("decode image: %w", err)
+	}
+
+	cropped := centerCrop(img)
+
+	dst := image.NewRGBA(image.Rect(0, 0, targetSize, targetSize))
+	draw.CatmullRom.Scale(dst, dst.Bounds(), cropped, cropped.Bounds(), draw.Over, nil)
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, dst); err != nil {
+		return nil, "", fmt.Errorf("encode png: %w", err)
+	}
+
+	return buf.Bytes(), "image/png", nil
+}
+
+// centerCrop returns a square sub-image taken from the center of img.
+func centerCrop(img image.Image) image.Image {
+	bounds := img.Bounds()
+	w := bounds.Dx()
+	h := bounds.Dy()
+
+	if w == h {
+		return img
+	}
+
+	var cropRect image.Rectangle
+	if w > h {
+		offset := (w - h) / 2
+		cropRect = image.Rect(bounds.Min.X+offset, bounds.Min.Y, bounds.Min.X+offset+h, bounds.Max.Y)
+	} else {
+		offset := (h - w) / 2
+		cropRect = image.Rect(bounds.Min.X, bounds.Min.Y+offset, bounds.Max.X, bounds.Min.Y+offset+w)
+	}
+
+	type subImager interface {
+		SubImage(r image.Rectangle) image.Image
+	}
+	if si, ok := img.(subImager); ok {
+		return si.SubImage(cropRect)
+	}
+
+	// Fallback: copy pixels manually.
+	size := cropRect.Dx()
+	dst := image.NewRGBA(image.Rect(0, 0, size, size))
+	draw.Copy(dst, image.Point{}, img, cropRect, draw.Src, nil)
+	return dst
+}

--- a/internal/db/migrations/20260407120000_user_avatars.sql
+++ b/internal/db/migrations/20260407120000_user_avatars.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN avatar_data BYTEA;
+ALTER TABLE users ADD COLUMN avatar_content_type TEXT;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN IF EXISTS avatar_content_type;
+ALTER TABLE users DROP COLUMN IF EXISTS avatar_data;

--- a/internal/db/migrations/20260407130000_avatar_seed.sql
+++ b/internal/db/migrations/20260407130000_avatar_seed.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN avatar_seed TEXT;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN IF EXISTS avatar_seed;

--- a/internal/db/migrations/20260408120000_auth_account_avatars.sql
+++ b/internal/db/migrations/20260408120000_auth_account_avatars.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- Cleanup: remove auth_account avatar columns added during development.
+-- Avatar functionality lives on the users table only.
+-- Unlinked admin accounts get a generated pattern from their account ID.
+ALTER TABLE auth_accounts DROP COLUMN IF EXISTS avatar_data;
+ALTER TABLE auth_accounts DROP COLUMN IF EXISTS avatar_content_type;
+ALTER TABLE auth_accounts DROP COLUMN IF EXISTS avatar_seed;
+
+-- +goose Down
+ALTER TABLE auth_accounts ADD COLUMN avatar_data BYTEA;
+ALTER TABLE auth_accounts ADD COLUMN avatar_content_type TEXT;
+ALTER TABLE auth_accounts ADD COLUMN avatar_seed TEXT;

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -19,3 +19,18 @@ SELECT id FROM users WHERE short_id = $1;
 
 -- name: CountUsers :one
 SELECT count(*) FROM users;
+
+-- name: GetUserAvatar :one
+SELECT avatar_data, avatar_content_type, avatar_seed, updated_at FROM users WHERE id = $1;
+
+-- name: SetUserAvatarSeed :exec
+UPDATE users SET avatar_seed = $2, updated_at = NOW()
+WHERE id = $1;
+
+-- name: SetUserAvatar :exec
+UPDATE users SET avatar_data = $2, avatar_content_type = $3, updated_at = NOW()
+WHERE id = $1;
+
+-- name: ClearUserAvatar :exec
+UPDATE users SET avatar_data = NULL, avatar_content_type = NULL, updated_at = NOW()
+WHERE id = $1;

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -23,7 +23,8 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		"t.category_id, t.category_override, " +
 		"c.slug AS cat_slug, c.display_name AS cat_display_name, c.icon AS cat_icon, c.color AS cat_color, " +
 		"pc.slug AS cat_primary_slug, pc.display_name AS cat_primary_display_name, " +
-		"t.attributed_user_id, au.name AS attributed_user_name " +
+		"t.attributed_user_id, au.name AS attributed_user_name, " +
+		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id " +
 		"FROM transactions t " +
 		"JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
@@ -219,6 +220,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			catPrimaryDisplayName  pgtype.Text
 			attributedUserID       pgtype.UUID
 			attributedUserName     pgtype.Text
+			effectiveUserID        pgtype.UUID
 		)
 
 		if err := rows.Scan(
@@ -233,6 +235,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			&catSlug, &catDisplayName, &catIcon, &catColor,
 			&catPrimarySlug, &catPrimaryDisplayName,
 			&attributedUserID, &attributedUserName,
+			&effectiveUserID,
 		); err != nil {
 			return nil, fmt.Errorf("scan transaction: %w", err)
 		}
@@ -271,6 +274,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			UserName:            textPtr(userName),
 			AttributedUserID:    uuidPtr(attributedUserID),
 			AttributedUserName:  textPtr(attributedUserName),
+			EffectiveUserID:     uuidPtr(effectiveUserID),
 			Amount:              amountVal,
 			IsoCurrencyCode:     textPtr(isoCurrencyCode),
 			Date:                dateVal,
@@ -448,7 +452,8 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		"t.category_override, t.pending, " +
 		"EXISTS(SELECT 1 FROM review_queue rq WHERE rq.transaction_id = t.id AND rq.reviewer_type = 'agent' AND rq.status IN ('approved', 'rejected')) AS agent_reviewed, " +
 		"EXISTS(SELECT 1 FROM review_queue rq WHERE rq.transaction_id = t.id AND rq.status = 'pending') AS has_pending_review, " +
-		"t.created_at, t.updated_at "
+		"t.created_at, t.updated_at, " +
+		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id "
 	fromClause := "FROM transactions t " +
 		"LEFT JOIN accounts a ON t.account_id = a.id " +
 		"LEFT JOIN bank_connections bc ON a.connection_id = bc.id " +
@@ -666,6 +671,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			hasPendingReview bool
 			createdAt        pgtype.Timestamptz
 			updatedAt        pgtype.Timestamptz
+			effectiveUserID  pgtype.UUID
 		)
 
 		if err := rows.Scan(
@@ -674,6 +680,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			&date, &name, &merchantName, &amount, &isoCurrencyCode,
 			&categoryID, &catDisplayName, &catSlug, &catIcon, &catColor,
 			&categoryOverride, &pending, &agentReviewed, &hasPendingReview, &createdAt, &updatedAt,
+			&effectiveUserID,
 		); err != nil {
 			return nil, fmt.Errorf("scan admin transaction: %w", err)
 		}
@@ -700,6 +707,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			AccountName:         accountName,
 			InstitutionName:     institutionName,
 			UserName:            userName,
+			EffectiveUserID:     uuidPtr(effectiveUserID),
 			Date:                dateVal,
 			Name:                name,
 			MerchantName:        textPtr(merchantName),

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -41,6 +41,7 @@ type TransactionResponse struct {
 	UserName            *string                  `json:"user_name"`
 	AttributedUserID    *string                  `json:"attributed_user_id,omitempty"`
 	AttributedUserName  *string                  `json:"attributed_user_name,omitempty"`
+	EffectiveUserID     *string                  `json:"effective_user_id,omitempty"`
 	Amount              float64                  `json:"amount"`
 	IsoCurrencyCode     *string                  `json:"iso_currency_code"`
 	Date                string                   `json:"date"`
@@ -280,6 +281,7 @@ type AdminTransactionRow struct {
 	AccountName         string
 	InstitutionName     string
 	UserName            string
+	EffectiveUserID     *string
 	Date                string
 	Name                string
 	MerchantName        *string

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -1005,6 +1005,15 @@
         fill.classList.add('bb-progress-bar__fill--done');
         isActive = false;
 
+        // Always restore main content interactivity.
+        var main = document.querySelector('main');
+        if (main) {
+          main.style.opacity = '';
+          main.style.filter = '';
+          main.style.pointerEvents = '';
+          main.style.transition = '';
+        }
+
         setTimeout(function() {
           bar.classList.add('bb-progress-bar--fade');
           setTimeout(function() {

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -273,9 +273,13 @@
           </div>
           <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 overflow-hidden">
             {{if .UserName}}
+            {{if .EffectiveUserID}}
+            <img src="{{avatarURL .EffectiveUserID}}" alt="" class="w-4 h-4 rounded-full object-cover shrink-0" title="{{.UserName}}">
+            {{else}}
             <span class="w-4 h-4 rounded-full bg-primary/10 inline-flex items-center justify-center shrink-0" title="{{.UserName}}">
               <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
             </span>
+            {{end}}
             {{end}}
             <span class="truncate shrink min-w-0">{{.AccountName}} · {{relativeDate .Date}}</span>
             {{if .CategoryDisplayName}}

--- a/internal/templates/pages/my_account.html
+++ b/internal/templates/pages/my_account.html
@@ -13,6 +13,52 @@
 </div>
 {{end}}
 
+{{if .UserID}}
+<div class="bb-card mb-6" x-data="myAvatar()">
+  <div class="p-5 border-b border-base-300">
+    <h2 class="font-semibold text-base flex items-center gap-2">
+      <i data-lucide="user-circle" class="w-4 h-4 text-base-content/40"></i>
+      Profile Picture
+    </h2>
+  </div>
+  <div class="p-5">
+    <div class="flex items-center gap-5">
+      <div class="relative group">
+        <img :src="avatarSrc" alt="" class="w-20 h-20 rounded-full object-cover ring-2 ring-base-300">
+        <button type="button" @click="$refs.fileInput.click()"
+          class="absolute inset-0 rounded-full bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer">
+          <i data-lucide="camera" class="w-5 h-5 text-white"></i>
+        </button>
+        <input type="file" x-ref="fileInput" accept="image/png,image/jpeg,image/gif" class="hidden" @change="onFileSelect">
+      </div>
+      <div>
+        <p class="text-xs text-base-content/45">PNG, JPG, or GIF. Max 5 MB.</p>
+        <div class="flex items-center gap-2 mt-2">
+          <button type="button" @click="$refs.fileInput.click()" class="btn btn-ghost btn-xs rounded-lg">
+            <i data-lucide="upload" class="w-3.5 h-3.5"></i>
+            Upload
+          </button>
+          <button type="button" @click="regenerate()" class="btn btn-ghost btn-xs rounded-lg">
+            <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
+            Regenerate
+          </button>
+          <button type="button" x-show="hasCustom" @click="removeAvatar()" class="btn btn-ghost btn-xs rounded-lg text-error/70 hover:text-error">
+            <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+            Remove
+          </button>
+        </div>
+        <template x-if="error">
+          <p class="text-xs text-error mt-2" x-text="error"></p>
+        </template>
+        <template x-if="uploading">
+          <p class="text-xs text-base-content/50 mt-2">Uploading...</p>
+        </template>
+      </div>
+    </div>
+  </div>
+</div>
+{{end}}
+
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
   <!-- Change Password -->
   <div class="bb-card">
@@ -109,4 +155,97 @@
     </div>
   </div>
 </div>
+
+{{if .UserID}}
+<script>
+function myAvatar() {
+  var uid = '{{.UserID}}';
+  return {
+    avatarSrc: '/avatars/' + uid + '?v=' + Date.now(),
+    hasCustom: false,
+    error: '',
+    uploading: false,
+
+    init() {
+      var self = this;
+      fetch('/avatars/' + uid, { method: 'HEAD' })
+        .then(function(r) {
+          var ct = r.headers.get('content-type') || '';
+          self.hasCustom = ct.indexOf('svg') === -1;
+        })
+        .catch(function() {});
+    },
+
+    onFileSelect(e) {
+      var file = e.target.files[0];
+      if (!file) return;
+      this.error = '';
+
+      if (!file.type.match(/^image\/(png|jpeg|gif)$/)) {
+        this.error = 'Please select a PNG, JPG, or GIF image.';
+        e.target.value = '';
+        return;
+      }
+      if (file.size > 5 * 1024 * 1024) {
+        this.error = 'Image must be under 5 MB.';
+        e.target.value = '';
+        return;
+      }
+
+      var self = this;
+      self.uploading = true;
+      var fd = new FormData();
+      fd.append('avatar', file);
+
+      fetch('/my-account/avatar', { method: 'POST', body: fd })
+        .then(function(res) {
+          if (!res.ok) return res.json().then(function(d) { throw d; });
+          return res.json();
+        })
+        .then(function() {
+          self.avatarSrc = '/avatars/' + uid + '?v=' + Date.now();
+          self.hasCustom = true;
+          self.uploading = false;
+        })
+        .catch(function(err) {
+          self.error = (err.error || 'Upload failed');
+          self.uploading = false;
+        });
+      e.target.value = '';
+    },
+
+    removeAvatar() {
+      var self = this;
+      self.error = '';
+      fetch('/my-account/avatar', { method: 'DELETE' })
+        .then(function(res) {
+          if (!res.ok) return res.json().then(function(d) { throw d; });
+          self.avatarSrc = '/avatars/' + uid + '?v=' + Date.now();
+          self.hasCustom = false;
+        })
+        .catch(function(err) {
+          self.error = (err.error || 'Remove failed');
+        });
+    },
+
+    regenerate() {
+      var self = this;
+      self.error = '';
+      fetch('/my-account/avatar/regenerate', { method: 'POST' })
+        .then(function(res) {
+          if (!res.ok) return res.json().then(function(d) { throw d; });
+          return res.json();
+        })
+        .then(function() {
+          self.avatarSrc = '/avatars/' + uid + '?v=' + Date.now();
+          self.hasCustom = false;
+        })
+        .catch(function(err) {
+          self.error = (err.error || 'Regenerate failed');
+        });
+    }
+  };
+}
+</script>
+{{end}}
 {{end}}

--- a/internal/templates/pages/user_form.html
+++ b/internal/templates/pages/user_form.html
@@ -51,9 +51,15 @@
   <!-- Form state -->
   <template x-if="!setupURL">
     <div class="bb-card p-8">
-      <div class="flex items-center gap-3 mb-6">
-        <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
-          <i data-lucide="user-plus" class="w-5 h-5 text-primary"></i>
+      <!-- Avatar preview + header -->
+      <div class="flex items-center gap-4 mb-6">
+        <div class="relative group">
+          <img :src="avatarPreviewSrc" alt="" class="w-14 h-14 rounded-full object-cover ring-2 ring-base-300">
+          <button type="button" @click="shuffleAvatar()"
+            class="absolute inset-0 rounded-full bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+            title="Shuffle pattern">
+            <i data-lucide="refresh-cw" class="w-4 h-4 text-white"></i>
+          </button>
         </div>
         <div>
           <h2 class="text-base font-semibold">New Member</h2>
@@ -67,7 +73,7 @@
             Name <span class="text-error text-xs">*</span>
           </label>
           <input type="text" id="name" name="name" class="input input-bordered w-full rounded-xl" required maxlength="128"
-            placeholder="e.g., Alex Canales">
+            placeholder="e.g., Alex Canales" @input="updateAvatarPreview($event.target.value)">
         </fieldset>
 
         <fieldset class="fieldset mb-5">
@@ -123,12 +129,28 @@
 
 <script>
 function userForm() {
+  var initialSeed = 'new-member-' + Date.now();
   return {
     createLogin: false,
     role: 'viewer',
     submitting: false,
     error: '',
     setupURL: '',
+    avatarSeed: initialSeed,
+    avatarPreviewSrc: '/avatars/preview/' + encodeURIComponent(initialSeed),
+
+    updateAvatarPreview(name) {
+      var seed = name.trim() || this.avatarSeed;
+      this.avatarPreviewSrc = '/avatars/preview/' + encodeURIComponent(seed) + '?v=' + Date.now();
+    },
+
+    shuffleAvatar() {
+      this.avatarSeed = 'seed-' + Math.random().toString(36).slice(2);
+      var nameVal = document.getElementById('name').value.trim();
+      // If name is typed, append seed to make it unique; otherwise use seed alone.
+      var seed = nameVal ? nameVal + '-' + this.avatarSeed : this.avatarSeed;
+      this.avatarPreviewSrc = '/avatars/preview/' + encodeURIComponent(seed) + '?v=' + Date.now();
+    },
 
     submit() {
       this.error = '';
@@ -213,15 +235,43 @@ function userForm() {
 </script>
 
 {{else}}
-<!-- Edit mode uses the simpler form without login toggle -->
-<div class="bb-card p-8 max-w-lg">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
-      <i data-lucide="user-pen" class="w-5 h-5 text-primary"></i>
-    </div>
-    <div>
-      <h2 class="text-base font-semibold">Member Details</h2>
-      <p class="text-xs text-base-content/45">Update name and email</p>
+<!-- Edit mode with avatar upload -->
+<div x-data="avatarEditor('{{.UserID}}')" class="max-w-lg">
+  <!-- Avatar Card -->
+  <div class="bb-card p-6 mb-5">
+    <div class="flex items-center gap-5">
+      <div class="relative group">
+        <img :src="avatarSrc" alt="" class="w-20 h-20 rounded-full object-cover ring-2 ring-base-300">
+        <button type="button" @click="$refs.fileInput.click()"
+          class="absolute inset-0 rounded-full bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer">
+          <i data-lucide="camera" class="w-5 h-5 text-white"></i>
+        </button>
+        <input type="file" x-ref="fileInput" accept="image/png,image/jpeg,image/gif" class="hidden" @change="onFileSelect">
+      </div>
+      <div class="flex-1">
+        <h3 class="text-sm font-semibold">Profile Picture</h3>
+        <p class="text-xs text-base-content/45 mt-0.5">PNG, JPG, or GIF. Max 5 MB.</p>
+        <div class="flex items-center gap-2 mt-3">
+          <button type="button" @click="$refs.fileInput.click()" class="btn btn-ghost btn-xs rounded-lg">
+            <i data-lucide="upload" class="w-3.5 h-3.5"></i>
+            Upload
+          </button>
+          <button type="button" @click="regenerate()" class="btn btn-ghost btn-xs rounded-lg">
+            <i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
+            Regenerate
+          </button>
+          <button type="button" x-show="hasCustomAvatar" @click="removeAvatar()" class="btn btn-ghost btn-xs rounded-lg text-error/70 hover:text-error">
+            <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+            Remove
+          </button>
+        </div>
+        <template x-if="avatarError">
+          <p class="text-xs text-error mt-2" x-text="avatarError"></p>
+        </template>
+        <template x-if="avatarUploading">
+          <p class="text-xs text-base-content/50 mt-2">Uploading...</p>
+        </template>
+      </div>
     </div>
   </div>
 
@@ -256,6 +306,85 @@ function userForm() {
 </div>
 
 <script>
+function avatarEditor(userId) {
+  return {
+    userId: userId,
+    avatarSrc: '/avatars/' + userId + '?v=' + Date.now(),
+    hasCustomAvatar: {{if .User.AvatarData}}true{{else}}false{{end}},
+    avatarError: '',
+    avatarUploading: false,
+
+    onFileSelect(e) {
+      var file = e.target.files[0];
+      if (!file) return;
+      this.avatarError = '';
+
+      if (!file.type.match(/^image\/(png|jpeg|gif)$/)) {
+        this.avatarError = 'Please select a PNG, JPG, or GIF image.';
+        e.target.value = '';
+        return;
+      }
+      if (file.size > 5 * 1024 * 1024) {
+        this.avatarError = 'Image must be under 5 MB.';
+        e.target.value = '';
+        return;
+      }
+
+      var self = this;
+      self.avatarUploading = true;
+      var fd = new FormData();
+      fd.append('avatar', file);
+
+      fetch('/-/users/' + self.userId + '/avatar', { method: 'POST', body: fd })
+        .then(function(res) {
+          if (!res.ok) return res.json().then(function(d) { throw d; });
+          return res.json();
+        })
+        .then(function() {
+          self.avatarSrc = '/avatars/' + self.userId + '?v=' + Date.now();
+          self.hasCustomAvatar = true;
+          self.avatarUploading = false;
+        })
+        .catch(function(err) {
+          self.avatarError = (err.error || 'Upload failed');
+          self.avatarUploading = false;
+        });
+      e.target.value = '';
+    },
+
+    removeAvatar() {
+      var self = this;
+      self.avatarError = '';
+      fetch('/-/users/' + self.userId + '/avatar', { method: 'DELETE' })
+        .then(function(res) {
+          if (!res.ok) return res.json().then(function(d) { throw d; });
+          self.avatarSrc = '/avatars/' + self.userId + '?v=' + Date.now();
+          self.hasCustomAvatar = false;
+        })
+        .catch(function(err) {
+          self.avatarError = (err.error || 'Remove failed');
+        });
+    },
+
+    regenerate() {
+      var self = this;
+      self.avatarError = '';
+      fetch('/-/users/' + self.userId + '/avatar/regenerate', { method: 'POST' })
+        .then(function(res) {
+          if (!res.ok) return res.json().then(function(d) { throw d; });
+          return res.json();
+        })
+        .then(function() {
+          self.avatarSrc = '/avatars/' + self.userId + '?v=' + Date.now();
+          self.hasCustomAvatar = false;
+        })
+        .catch(function(err) {
+          self.avatarError = (err.error || 'Regenerate failed');
+        });
+    }
+  };
+}
+
 (function () {
   var form = document.getElementById("user-form");
   var formError = document.getElementById("form-error");

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -27,9 +27,7 @@
     <div class="p-4 sm:p-6 pb-4">
       <div class="flex items-start justify-between">
         <div class="flex items-center gap-4">
-          <div class="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold text-lg shrink-0">
-            {{slice .Name 0 1}}
-          </div>
+          <img src="{{avatarURL .ID .UpdatedAt}}" alt="" class="w-12 h-12 rounded-full object-cover shrink-0">
           <div>
             <div class="flex items-center gap-2">
               <h3 class="font-semibold text-base">{{.Name}}</h3>

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -89,9 +89,11 @@
 <!-- User profile + Sign out -->
 <div class="mt-auto pt-3 border-t border-base-300 px-2">
   <div class="flex items-center gap-2.5 py-2">
-    <a href="/my-account" class="bb-sidebar-profile-avatar no-underline shrink-0" title="My Account">
-      {{if .AdminUsername}}{{slice .AdminUsername 0 1}}{{else}}A{{end}}
+    {{if .HasLinkedUser}}
+    <a href="/my-account" class="shrink-0" title="My Account">
+      <img src="{{avatarURL .SessionUserID .SessionAvatarVersion}}" alt="" class="bb-sidebar-profile-avatar">
     </a>
+    {{end}}
     <a href="/my-account" class="flex-1 min-w-0 no-underline" title="My Account">
       <div class="bb-sidebar-profile-name">{{if .AdminUsername}}{{.AdminUsername}}{{else}}Admin{{end}}</div>
       <div class="bb-sidebar-profile-role">{{.RoleDisplay}}</div>

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -36,11 +36,15 @@
       </div>
       <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40">
         {{if .UserName}}
-        <!-- Mobile: show short name; Desktop: show initial avatar -->
+        <!-- Mobile: show short name; Desktop: show avatar -->
         <span class="sm:hidden text-base-content/50 shrink-0">{{firstWord .UserName}}</span>
+        {{if .EffectiveUserID}}
+        <img src="{{avatarURL .EffectiveUserID}}" alt="" class="hidden sm:inline-block w-4 h-4 rounded-full object-cover shrink-0" title="{{.UserName}}">
+        {{else}}
         <span class="hidden sm:inline-flex w-4 h-4 rounded-full bg-primary/10 items-center justify-center shrink-0" title="{{.UserName}}">
           <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
         </span>
+        {{end}}
         <span class="text-base-content/20">&middot;</span>
         {{end}}
         <span class="truncate">{{.AccountName}}</span>


### PR DESCRIPTION
## Summary
- Replace first-letter circles with unique generated pattern avatars (rings/mosaic styles) across the entire app — sidebar, household cards, transaction rows, dashboard
- Support custom photo upload (PNG/JPG/GIF, auto center-crop + resize to 256x256) with regenerate and remove options
- Live avatar preview on the new member form that updates as you type the name
- Admin can manage any user's avatar via the edit form; users manage their own on My Account
- Avatars stored on `users` table only — unlinked admin accounts get a stable generated pattern but no customization (link to a household member for full control)

## Bug fixes included
- **Edit button unreliable on household cards**: Lucide SVG icons inside `<a>`/`<button>` tags were intercepting clicks. Fixed globally with `a svg, button svg { pointer-events: none }` in CSS
- **Progress bar stuck state**: `finish()` now restores `main` element opacity/pointer-events, preventing pages from becoming unclickable after navigation
- **Inconsistent nav fields**: `RoleDisplay`, `SessionUserID`, `HasLinkedUser` now auto-injected by `Render()` so all pages show correct sidebar state regardless of how handlers build template data

## Test plan
- [ ] Visit `/users` — each member card shows a unique generated avatar
- [ ] Edit a user → upload a photo → verify it appears on the card and in transaction rows
- [ ] Click "Regenerate" → pattern changes immediately
- [ ] Click "Remove" → falls back to generated pattern
- [ ] Visit `/users/new` → avatar preview updates as you type, shuffle button works
- [ ] Visit `/my-account` (linked user) → avatar section with upload/regenerate/remove
- [ ] Visit `/my-account` (unlinked admin) → no avatar section shown
- [ ] Sidebar avatar consistent across all pages for linked users, hidden for unlinked admins
- [ ] Edit pencil buttons on household cards click reliably
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)