### PR TITLE
Fix dev-stop to match processes by port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ dev: generate
 	SERVER_PORT=$(PORT) go run ./cmd/breadbox serve; rm -f .breadbox-port
 
 dev-stop:
-	@pids=$$(pgrep -f 'go run ./cmd/breadbox serve' 2>/dev/null || true); \
+	@pids=$$(lsof -ti:8080-8099 2>/dev/null | sort -u || true); \
 	if [ -z "$$pids" ]; then \
 		echo "No dev instances running."; \
 	else \
 		echo "$$pids" | xargs kill 2>/dev/null; \
-		echo "Stopped dev instances: $$pids"; \
+		echo "Stopped dev instances on ports 8080-8099: $$pids"; \
 	fi
 
 build: generate


### PR DESCRIPTION
## Summary
- `make dev-stop` used `pgrep -f 'go run ./cmd/breadbox serve'` which never matched the actual compiled binary
- Switched to `lsof -ti:8080-8099` to find all dev instances by listening port

## Test plan
- [x] Run `make dev` then `make dev-stop` — confirms it kills the process

🤖 Generated with [Claude Code](https://claude.com/claude-code)