### PR TITLE
perf(search): reduce allocations in SQL clause builders

### DIFF
--- a/internal/service/search.go
+++ b/internal/service/search.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -56,35 +56,56 @@ func BuildSearchClause(search string, mode string, columns []string, nullableCol
 		return SearchClauseResult{ArgN: argN}
 	}
 
-	var termClauses []string
-	var args []any
+	// Pre-allocate a single builder for the whole clause and an args slice
+	// sized for the common case. In "words" mode one term may emit multiple
+	// args (one per word) — the slice will grow if needed but the upfront
+	// capacity covers the usual non-words path exactly.
+	var sb strings.Builder
+	sb.Grow(estimateClauseSize(mode, len(columns), len(terms), columns))
+	args := make([]any, 0, len(terms))
 
+	// We build the clause in a scratch segment so that if no term produces
+	// output we can return early without needing to trim the builder.
+	// Structure: " AND ( <term1> OR <term2> ... )"
+	// The outer " AND (" and trailing ")" are only written if ≥1 term wrote
+	// content.
+	wrote := false
 	for _, term := range terms {
 		term = strings.TrimSpace(term)
 		if term == "" {
 			continue
 		}
 
-		var clause string
+		// In words mode we need to know up-front if the term produces any
+		// words — otherwise it emits no SQL and we must not write the
+		// separator before it.
+		if mode == SearchModeWords && len(strings.Fields(term)) == 0 {
+			continue
+		}
+
+		if !wrote {
+			sb.WriteString(" AND (")
+			wrote = true
+		} else {
+			sb.WriteString(" OR ")
+		}
+
 		switch mode {
 		case SearchModeFuzzy:
-			clause, args, argN = buildFuzzyClause(term, columns, nullableColumns, args, argN)
+			args, argN = writeFuzzyClause(&sb, term, columns, nullableColumns, args, argN)
 		case SearchModeWords:
-			clause, args, argN = buildWordsClause(term, columns, nullableColumns, args, argN)
+			args, argN = writeWordsClause(&sb, term, columns, nullableColumns, args, argN)
 		default: // contains
-			clause, args, argN = buildContainsClause(term, columns, nullableColumns, args, argN)
-		}
-		if clause != "" {
-			termClauses = append(termClauses, clause)
+			args, argN = writeContainsClause(&sb, term, columns, args, argN)
 		}
 	}
 
-	if len(termClauses) == 0 {
+	if !wrote {
 		return SearchClauseResult{ArgN: argN}
 	}
 
-	sql := " AND (" + strings.Join(termClauses, " OR ") + ")"
-	return SearchClauseResult{SQL: sql, Args: args, ArgN: argN}
+	sb.WriteByte(')')
+	return SearchClauseResult{SQL: sb.String(), Args: args, ArgN: argN}
 }
 
 // BuildExcludeSearchClause generates a SQL WHERE clause that excludes matching rows.
@@ -100,107 +121,225 @@ func BuildExcludeSearchClause(search string, columns []string, nullableColumns m
 		return SearchClauseResult{ArgN: argN}
 	}
 
-	var termClauses []string
-	var args []any
+	var sb strings.Builder
+	sb.Grow(estimateExcludeSize(len(columns), len(terms), columns, nullableColumns))
+	args := make([]any, 0, len(terms))
 
+	wrote := false
 	for _, term := range terms {
 		term = strings.TrimSpace(term)
 		if term == "" {
 			continue
 		}
 
-		// For exclude, each column must NOT match (AND logic per column).
-		var colClauses []string
-		for _, col := range columns {
+		// Each term contributes a " AND (col1clause AND col2clause ...)"
+		// fragment.
+		sb.WriteString(" AND (")
+
+		argNStr := strconv.Itoa(argN)
+		for i, col := range columns {
+			if i > 0 {
+				sb.WriteString(" AND ")
+			}
 			if nullableColumns[col] {
-				colClauses = append(colClauses, fmt.Sprintf("(%s IS NULL OR %s NOT ILIKE '%%' || $%d || '%%')", col, col, argN))
+				// (col IS NULL OR col NOT ILIKE '%' || $N || '%')
+				sb.WriteByte('(')
+				sb.WriteString(col)
+				sb.WriteString(" IS NULL OR ")
+				sb.WriteString(col)
+				sb.WriteString(" NOT ILIKE '%' || $")
+				sb.WriteString(argNStr)
+				sb.WriteString(" || '%')")
 			} else {
-				colClauses = append(colClauses, fmt.Sprintf("%s NOT ILIKE '%%' || $%d || '%%'", col, argN))
+				// col NOT ILIKE '%' || $N || '%'
+				sb.WriteString(col)
+				sb.WriteString(" NOT ILIKE '%' || $")
+				sb.WriteString(argNStr)
+				sb.WriteString(" || '%'")
 			}
 		}
+
+		sb.WriteByte(')')
+
 		args = append(args, term)
 		argN++
-		termClauses = append(termClauses, "("+strings.Join(colClauses, " AND ")+")")
+		wrote = true
 	}
 
-	if len(termClauses) == 0 {
+	if !wrote {
 		return SearchClauseResult{ArgN: argN}
 	}
 
-	// Any term match should exclude: NOT (match1 OR match2)
-	// Equivalent to: AND NOT match1 AND NOT match2
-	var parts []string
-	for _, tc := range termClauses {
-		parts = append(parts, " AND "+tc)
-	}
-	return SearchClauseResult{SQL: strings.Join(parts, ""), Args: args, ArgN: argN}
+	return SearchClauseResult{SQL: sb.String(), Args: args, ArgN: argN}
 }
 
 // splitTerms splits a search string on commas for multi-value OR.
 // Single terms (no commas) return a slice with one element.
 func splitTerms(search string) []string {
-	parts := strings.Split(search, ",")
-	var result []string
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			result = append(result, p)
+	// Fast path: no comma — single-term slice (or empty).
+	if !strings.Contains(search, ",") {
+		trimmed := strings.TrimSpace(search)
+		if trimmed == "" {
+			return nil
 		}
+		return []string{trimmed}
+	}
+
+	// Pre-size to the exact comma count + 1 to avoid regrowing.
+	n := strings.Count(search, ",") + 1
+	result := make([]string, 0, n)
+	start := 0
+	for i := 0; i < len(search); i++ {
+		if search[i] == ',' {
+			p := strings.TrimSpace(search[start:i])
+			if p != "" {
+				result = append(result, p)
+			}
+			start = i + 1
+		}
+	}
+	p := strings.TrimSpace(search[start:])
+	if p != "" {
+		result = append(result, p)
 	}
 	return result
 }
 
-// buildContainsClause builds an ILIKE substring match for a single term across columns.
-func buildContainsClause(term string, columns []string, nullableColumns map[string]bool, args []any, argN int) (string, []any, int) {
-	var colClauses []string
-	for _, col := range columns {
-		colClauses = append(colClauses, fmt.Sprintf("%s ILIKE '%%' || $%d || '%%'", col, argN))
+// writeContainsClause appends an ILIKE substring clause for a single term
+// across columns directly to sb. Returns the updated args slice and argN.
+func writeContainsClause(sb *strings.Builder, term string, columns []string, args []any, argN int) ([]any, int) {
+	argNStr := strconv.Itoa(argN)
+	sb.WriteByte('(')
+	for i, col := range columns {
+		if i > 0 {
+			sb.WriteString(" OR ")
+		}
+		sb.WriteString(col)
+		sb.WriteString(" ILIKE '%' || $")
+		sb.WriteString(argNStr)
+		sb.WriteString(" || '%'")
 	}
+	sb.WriteByte(')')
 	args = append(args, term)
 	argN++
-	return "(" + strings.Join(colClauses, " OR ") + ")", args, argN
+	return args, argN
 }
 
-// buildWordsClause splits the term on spaces and requires all words to match.
-// Each word must appear in at least one of the searched columns.
-func buildWordsClause(term string, columns []string, nullableColumns map[string]bool, args []any, argN int) (string, []any, int) {
+// writeWordsClause splits the term on spaces and requires all words to match.
+// Each word must appear in at least one of the searched columns. Caller must
+// ensure the term produces at least one word.
+func writeWordsClause(sb *strings.Builder, term string, columns []string, _ map[string]bool, args []any, argN int) ([]any, int) {
 	words := strings.Fields(term)
 	if len(words) == 0 {
-		return "", args, argN
+		// Defensive: caller should have filtered this out.
+		return args, argN
 	}
-	// Single word: same as contains
+	// Single word: identical to contains.
 	if len(words) == 1 {
-		return buildContainsClause(words[0], columns, nullableColumns, args, argN)
+		return writeContainsClause(sb, words[0], columns, args, argN)
 	}
 
-	// Each word must match at least one column
-	var wordClauses []string
-	for _, word := range words {
-		var colClauses []string
-		for _, col := range columns {
-			colClauses = append(colClauses, fmt.Sprintf("%s ILIKE '%%' || $%d || '%%'", col, argN))
+	// Multi-word: ((col OR col) AND (col OR col) ...)
+	sb.WriteByte('(')
+	for wi, word := range words {
+		if wi > 0 {
+			sb.WriteString(" AND ")
 		}
+		argNStr := strconv.Itoa(argN)
+		sb.WriteByte('(')
+		for ci, col := range columns {
+			if ci > 0 {
+				sb.WriteString(" OR ")
+			}
+			sb.WriteString(col)
+			sb.WriteString(" ILIKE '%' || $")
+			sb.WriteString(argNStr)
+			sb.WriteString(" || '%'")
+		}
+		sb.WriteByte(')')
 		args = append(args, word)
 		argN++
-		wordClauses = append(wordClauses, "("+strings.Join(colClauses, " OR ")+")")
 	}
-	return "(" + strings.Join(wordClauses, " AND ") + ")", args, argN
+	sb.WriteByte(')')
+	return args, argN
 }
 
-// buildFuzzyClause uses pg_trgm similarity() for typo-tolerant matching.
+// writeFuzzyClause uses pg_trgm similarity() for typo-tolerant matching.
 // Threshold is 0.15 (lower than default 0.3) to catch more partial matches.
-func buildFuzzyClause(term string, columns []string, nullableColumns map[string]bool, args []any, argN int) (string, []any, int) {
-	var colClauses []string
-	for _, col := range columns {
+func writeFuzzyClause(sb *strings.Builder, term string, columns []string, nullableColumns map[string]bool, args []any, argN int) ([]any, int) {
+	argNStr := strconv.Itoa(argN)
+	sb.WriteByte('(')
+	for i, col := range columns {
+		if i > 0 {
+			sb.WriteString(" OR ")
+		}
 		if nullableColumns[col] {
-			colClauses = append(colClauses, fmt.Sprintf("(%s IS NOT NULL AND similarity(%s, $%d) > 0.15)", col, col, argN))
+			// (col IS NOT NULL AND similarity(col, $N) > 0.15)
+			sb.WriteByte('(')
+			sb.WriteString(col)
+			sb.WriteString(" IS NOT NULL AND similarity(")
+			sb.WriteString(col)
+			sb.WriteString(", $")
+			sb.WriteString(argNStr)
+			sb.WriteString(") > 0.15)")
 		} else {
-			colClauses = append(colClauses, fmt.Sprintf("similarity(%s, $%d) > 0.15", col, argN))
+			// similarity(col, $N) > 0.15
+			sb.WriteString("similarity(")
+			sb.WriteString(col)
+			sb.WriteString(", $")
+			sb.WriteString(argNStr)
+			sb.WriteString(") > 0.15")
 		}
 	}
+	sb.WriteByte(')')
 	args = append(args, term)
 	argN++
-	return "(" + strings.Join(colClauses, " OR ") + ")", args, argN
+	return args, argN
+}
+
+// estimateClauseSize approximates the output buffer size for
+// BuildSearchClause so the Builder can Grow once rather than reallocating.
+// Overshoot is free; undershoot triggers a realloc.
+func estimateClauseSize(mode string, numCols, numTerms int, columns []string) int {
+	colLenSum := 0
+	for _, c := range columns {
+		colLenSum += len(c)
+	}
+	// Per-column fixed overhead (ILIKE '%' || $NN || '%' + separators).
+	perColumn := 24
+	if mode == SearchModeFuzzy {
+		// Fuzzy clauses are longer (similarity() and optional IS NOT NULL).
+		perColumn = 64
+	}
+	// Words mode may AND multiple word sub-clauses per term; allow 4x slack.
+	multiplier := 1
+	if mode == SearchModeWords {
+		multiplier = 4
+	}
+	// " AND (" + trailing ")" + per-term ( " OR " + "(... )" )
+	return 8 + numTerms*multiplier*(colLenSum+numCols*perColumn+8)
+}
+
+// estimateExcludeSize approximates the output buffer size for
+// BuildExcludeSearchClause.
+func estimateExcludeSize(numCols, numTerms int, columns []string, nullableColumns map[string]bool) int {
+	colLenSum := 0
+	nullableCount := 0
+	for _, c := range columns {
+		colLenSum += len(c)
+		if nullableColumns[c] {
+			nullableCount++
+		}
+	}
+	// Per-column: non-nullable ~32, nullable ~60 (IS NULL OR col NOT ILIKE...).
+	perColumnNonNull := 32
+	perColumnNullable := 64
+	perTerm := 7 + // " AND ("
+		colLenSum +
+		(numCols-nullableCount)*perColumnNonNull +
+		nullableCount*perColumnNullable +
+		1 // ")"
+	return 8 + numTerms*perTerm
 }
 
 // TransactionSearchColumns are the standard columns searched for transactions.

--- a/internal/service/search_bench_test.go
+++ b/internal/service/search_bench_test.go
@@ -1,0 +1,306 @@
+package service
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Benchmarks for BuildSearchClause and BuildExcludeSearchClause.
+//
+// These cover the hot path used by almost every MCP read and REST read
+// that filters transactions, across three search modes and a range of
+// column/term widths.
+//
+// Run with:
+//   go test -run=^$ -bench=BenchmarkBuildSearch -benchmem ./internal/service/ -count=5
+
+// Small: 1 column, 1 term, contains mode.
+func BenchmarkBuildSearchClause_SmallContains(b *testing.B) {
+	cols := []string{"t.name"}
+	var nullable map[string]bool
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = BuildSearchClause("starbucks", "contains", cols, nullable, 1)
+	}
+}
+
+// Medium: 2 columns, 3 comma-separated terms, words mode.
+func BenchmarkBuildSearchClause_MediumWords(b *testing.B) {
+	cols := []string{"t.name", "t.merchant_name"}
+	nullable := map[string]bool{"t.merchant_name": true}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = BuildSearchClause("century link,verizon wireless,amazon prime", "words", cols, nullable, 1)
+	}
+}
+
+// Large: 4 columns, 5 terms, fuzzy mode.
+func BenchmarkBuildSearchClause_LargeFuzzy(b *testing.B) {
+	cols := []string{"t.name", "t.merchant_name", "t.description", "t.note"}
+	nullable := map[string]bool{"t.merchant_name": true, "t.description": true, "t.note": true}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = BuildSearchClause("starbucks,amazon,target,walmart,costco", "fuzzy", cols, nullable, 1)
+	}
+}
+
+// Large combined: a fuzzy search clause plus an exclude clause, mirroring a
+// realistic "hunt for unknown charges while excluding known merchants" query.
+func BenchmarkBuildSearchClause_LargeFuzzyWithExclude(b *testing.B) {
+	cols := []string{"t.name", "t.merchant_name", "t.description", "t.note"}
+	nullable := map[string]bool{"t.merchant_name": true, "t.description": true, "t.note": true}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		search := BuildSearchClause("starbucks,amazon,target,walmart,costco", "fuzzy", cols, nullable, 1)
+		_ = BuildExcludeSearchClause("netflix,spotify,hulu,disney,apple", cols, nullable, search.ArgN)
+	}
+}
+
+// Exclude alone at medium width, for isolated attribution of the exclude path.
+func BenchmarkBuildExcludeSearchClause_Medium(b *testing.B) {
+	cols := []string{"t.name", "t.merchant_name"}
+	nullable := map[string]bool{"t.merchant_name": true}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = BuildExcludeSearchClause("starbucks,amazon,target", cols, nullable, 1)
+	}
+}
+
+// --- Equivalence checks ---
+//
+// These tests pin the exact SQL produced by BuildSearchClause and
+// BuildExcludeSearchClause against the previous (Sprintf/Join) implementation
+// so the perf refactor is proven to be byte-identical. They are regular Go
+// tests (not benchmarks) and run under `go test ./internal/service/...`.
+
+// referenceSearchResult is a copy of the pre-refactor implementation, kept
+// here purely as an oracle. Any change to BuildSearchClause that does not
+// preserve the exact produced SQL will fail TestBuildSearchClauseEquivalence.
+func referenceSearchResult(search string, mode string, columns []string, nullableColumns map[string]bool, argN int) SearchClauseResult {
+	if search == "" {
+		return SearchClauseResult{ArgN: argN}
+	}
+	if mode == "" {
+		mode = SearchModeContains
+	}
+
+	terms := splitTerms(search)
+	if len(terms) == 0 {
+		return SearchClauseResult{ArgN: argN}
+	}
+
+	var termClauses []string
+	var args []any
+
+	for _, term := range terms {
+		term = strings.TrimSpace(term)
+		if term == "" {
+			continue
+		}
+
+		var clause string
+		switch mode {
+		case SearchModeFuzzy:
+			clause, args, argN = refFuzzy(term, columns, nullableColumns, args, argN)
+		case SearchModeWords:
+			clause, args, argN = refWords(term, columns, nullableColumns, args, argN)
+		default:
+			clause, args, argN = refContains(term, columns, args, argN)
+		}
+		if clause != "" {
+			termClauses = append(termClauses, clause)
+		}
+	}
+
+	if len(termClauses) == 0 {
+		return SearchClauseResult{ArgN: argN}
+	}
+
+	sql := " AND (" + strings.Join(termClauses, " OR ") + ")"
+	return SearchClauseResult{SQL: sql, Args: args, ArgN: argN}
+}
+
+func referenceExcludeResult(search string, columns []string, nullableColumns map[string]bool, argN int) SearchClauseResult {
+	if search == "" {
+		return SearchClauseResult{ArgN: argN}
+	}
+
+	terms := splitTerms(search)
+	if len(terms) == 0 {
+		return SearchClauseResult{ArgN: argN}
+	}
+
+	var termClauses []string
+	var args []any
+
+	for _, term := range terms {
+		term = strings.TrimSpace(term)
+		if term == "" {
+			continue
+		}
+
+		var colClauses []string
+		for _, col := range columns {
+			if nullableColumns[col] {
+				colClauses = append(colClauses, fmt.Sprintf("(%s IS NULL OR %s NOT ILIKE '%%' || $%d || '%%')", col, col, argN))
+			} else {
+				colClauses = append(colClauses, fmt.Sprintf("%s NOT ILIKE '%%' || $%d || '%%'", col, argN))
+			}
+		}
+		args = append(args, term)
+		argN++
+		termClauses = append(termClauses, "("+strings.Join(colClauses, " AND ")+")")
+	}
+
+	if len(termClauses) == 0 {
+		return SearchClauseResult{ArgN: argN}
+	}
+
+	var parts []string
+	for _, tc := range termClauses {
+		parts = append(parts, " AND "+tc)
+	}
+	return SearchClauseResult{SQL: strings.Join(parts, ""), Args: args, ArgN: argN}
+}
+
+func refContains(term string, columns []string, args []any, argN int) (string, []any, int) {
+	var colClauses []string
+	for _, col := range columns {
+		colClauses = append(colClauses, fmt.Sprintf("%s ILIKE '%%' || $%d || '%%'", col, argN))
+	}
+	args = append(args, term)
+	argN++
+	return "(" + strings.Join(colClauses, " OR ") + ")", args, argN
+}
+
+func refWords(term string, columns []string, nullableColumns map[string]bool, args []any, argN int) (string, []any, int) {
+	words := strings.Fields(term)
+	if len(words) == 0 {
+		return "", args, argN
+	}
+	if len(words) == 1 {
+		return refContains(words[0], columns, args, argN)
+	}
+	var wordClauses []string
+	for _, word := range words {
+		var colClauses []string
+		for _, col := range columns {
+			colClauses = append(colClauses, fmt.Sprintf("%s ILIKE '%%' || $%d || '%%'", col, argN))
+		}
+		args = append(args, word)
+		argN++
+		wordClauses = append(wordClauses, "("+strings.Join(colClauses, " OR ")+")")
+	}
+	_ = nullableColumns
+	return "(" + strings.Join(wordClauses, " AND ") + ")", args, argN
+}
+
+func refFuzzy(term string, columns []string, nullableColumns map[string]bool, args []any, argN int) (string, []any, int) {
+	var colClauses []string
+	for _, col := range columns {
+		if nullableColumns[col] {
+			colClauses = append(colClauses, fmt.Sprintf("(%s IS NOT NULL AND similarity(%s, $%d) > 0.15)", col, col, argN))
+		} else {
+			colClauses = append(colClauses, fmt.Sprintf("similarity(%s, $%d) > 0.15", col, argN))
+		}
+	}
+	args = append(args, term)
+	argN++
+	return "(" + strings.Join(colClauses, " OR ") + ")", args, argN
+}
+
+func TestBuildSearchClauseEquivalence(t *testing.T) {
+	txCols := []string{"t.name", "t.merchant_name"}
+	txNullable := map[string]bool{"t.merchant_name": true}
+	wideCols := []string{"t.name", "t.merchant_name", "t.description", "t.note"}
+	wideNullable := map[string]bool{"t.merchant_name": true, "t.description": true, "t.note": true}
+	ruleCols := []string{"tr.name"}
+
+	type tc struct {
+		name     string
+		search   string
+		mode     string
+		cols     []string
+		nullable map[string]bool
+		argN     int
+	}
+	cases := []tc{
+		{"empty", "", "contains", txCols, txNullable, 1},
+		{"simple-contains", "starbucks", "contains", txCols, txNullable, 1},
+		{"default-mode", "starbucks", "", txCols, txNullable, 5},
+		{"words-single", "starbucks", "words", txCols, txNullable, 1},
+		{"words-multi", "century link", "words", txCols, txNullable, 1},
+		{"words-comma", "century link,verizon wireless", "words", txCols, txNullable, 1},
+		{"fuzzy-simple", "starbuks", "fuzzy", txCols, txNullable, 1},
+		{"fuzzy-wide", "starbucks,amazon,target,walmart,costco", "fuzzy", wideCols, wideNullable, 7},
+		{"contains-comma", "starbucks,amazon", "contains", txCols, txNullable, 1},
+		{"contains-comma-spaces", " starbucks , amazon , ", "contains", txCols, txNullable, 1},
+		{"contains-single-col", "foo", "contains", ruleCols, nil, 3},
+		{"contains-no-nullable", "foo,bar,baz", "contains", ruleCols, nil, 1},
+		{"all-whitespace-term", " , , ", "contains", txCols, txNullable, 1},
+		{"mixed-whitespace", "foo,  ,bar", "contains", txCols, txNullable, 1},
+		{"words-with-extra-spaces", "  century   link  ", "words", txCols, txNullable, 9},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := BuildSearchClause(c.search, c.mode, c.cols, c.nullable, c.argN)
+			want := referenceSearchResult(c.search, c.mode, c.cols, c.nullable, c.argN)
+			if got.SQL != want.SQL {
+				t.Errorf("SQL mismatch:\n  got:  %q\n  want: %q", got.SQL, want.SQL)
+			}
+			if !reflect.DeepEqual(got.Args, want.Args) {
+				t.Errorf("Args mismatch:\n  got:  %v\n  want: %v", got.Args, want.Args)
+			}
+			if got.ArgN != want.ArgN {
+				t.Errorf("ArgN mismatch: got %d, want %d", got.ArgN, want.ArgN)
+			}
+		})
+	}
+}
+
+func TestBuildExcludeSearchClauseEquivalence(t *testing.T) {
+	txCols := []string{"t.name", "t.merchant_name"}
+	txNullable := map[string]bool{"t.merchant_name": true}
+	ruleCols := []string{"tr.name"}
+
+	type tc struct {
+		name     string
+		search   string
+		cols     []string
+		nullable map[string]bool
+		argN     int
+	}
+	cases := []tc{
+		{"empty", "", txCols, txNullable, 1},
+		{"simple", "starbucks", txCols, txNullable, 1},
+		{"comma", "starbucks,amazon", txCols, txNullable, 1},
+		{"comma-with-spaces", " starbucks , amazon , ", txCols, txNullable, 1},
+		{"no-nullable", "foo", ruleCols, nil, 1},
+		{"multi-terms-nonnullable", "foo,bar,baz", ruleCols, nil, 3},
+		{"mixed-whitespace", "foo,  ,bar", txCols, txNullable, 1},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := BuildExcludeSearchClause(c.search, c.cols, c.nullable, c.argN)
+			want := referenceExcludeResult(c.search, c.cols, c.nullable, c.argN)
+			if got.SQL != want.SQL {
+				t.Errorf("SQL mismatch:\n  got:  %q\n  want: %q", got.SQL, want.SQL)
+			}
+			if !reflect.DeepEqual(got.Args, want.Args) {
+				t.Errorf("Args mismatch:\n  got:  %v\n  want: %v", got.Args, want.Args)
+			}
+			if got.ArgN != want.ArgN {
+				t.Errorf("ArgN mismatch: got %d, want %d", got.ArgN, want.ArgN)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Added `internal/service/search_bench_test.go` with baseline benchmarks for `BuildSearchClause` / `BuildExcludeSearchClause` across small/medium/large workloads and all three search modes, plus a combined search+exclude case.
- Refactored both functions to use a single `strings.Builder` (with `Grow`-based pre-sizing), pre-allocated `[]any` argument slices, and `strconv.Itoa` in place of `fmt.Sprintf` — without changing the produced SQL fragments or placeholder indices.

## Benchmarks (`go test -bench=. -benchmem -count=5`, Apple M2 Pro)

| Benchmark | Before (ns/op / B/op / allocs/op) | After (ns/op / B/op / allocs/op) | Δ allocs |
| --- | --- | --- | --- |
| `SmallContains` (1 col, 1 term, contains) | 271.8 / 224 / 10 | 92.1 / 96 / 4 | **−60%** |
| `MediumWords` (2 cols, 3 terms, words) | 3029 / 4690 / 82 | 670 / 1504 / 16 | **−80%** |
| `LargeFuzzy` (4 cols, 5 terms, fuzzy) | 4378 / 8245 / 100 | 798 / 1776 / 8 | **−92%** |
| `LargeFuzzyWithExclude` (4 cols, 5+5 terms, fuzzy + exclude) | 9523 / 16906 / 208 | 1609 / 3424 / 16 | **−92%** |
| `ExcludeMedium` (2 cols, 3 terms) | 1653 / 2625 / 47 | 310 / 528 / 6 | **−87%** |

Across the board: **3-6x faster**, **57-80% less memory**, **60-92% fewer allocations**. These helpers sit on the hot path for almost every transaction / merchant / rule read from both the REST API and MCP tools, so the reduction in per-request garbage matters under load.

## Behavior preservation
- Function signatures unchanged (`BuildSearchClause`, `BuildExcludeSearchClause`, `SearchClauseResult`, `splitTerms`, exported column/field constants all untouched).
- Output SQL strings are **byte-identical** to the prior implementation — verified by `TestBuildSearchClauseEquivalence` (15 sub-cases) and `TestBuildExcludeSearchClauseEquivalence` (7 sub-cases) in `search_bench_test.go`, which run the new implementation against a kept-in-test-file copy of the pre-refactor `fmt.Sprintf` + `strings.Join` code. The equivalence tests also run under the regular `go test` suite, not just benchmarks, so future regressions are caught automatically.
- Existing tests in `internal/service/search_test.go` still pass unchanged.

## Key internal changes
- Single top-level `strings.Builder` per call, `Grow`'d up front based on a rough size estimate.
- All intermediate `[]string` slices removed (`colClauses`, `termClauses`, `wordClauses`, `parts`).
- `fmt.Sprintf("%d", argN)` replaced with `strconv.Itoa(argN)` (hoisted once per clause for contains/fuzzy; once per word for multi-word).
- `args` pre-allocated with `make([]any, 0, len(terms))`.
- `splitTerms` fast-pathed for the common no-comma case and pre-sized for the comma case, avoiding `strings.Split`'s allocation entirely.
- Helper functions renamed `build*Clause` → `write*Clause` to reflect that they write directly into the shared builder instead of returning fragment strings.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/service/...` (unit tests + new equivalence tests, 22 sub-cases)
- [x] `go test -run=^$ -bench=BenchmarkBuildSearch -benchmem ./internal/service/ -count=5` (5 iterations, consistent results)
- [x] `go vet ./internal/service/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)