### PR TITLE
Fix cloud session reliability: Go proxy, curl timeouts, sandbox key

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -106,14 +106,14 @@ SQLC_VERSION="1.30.0"
 
 # --- Go modules ---
 echo "==> Downloading Go modules..."
-if ! GONOSUMCHECK=* GONOSUMDB=* GOPROXY=direct go mod download 2>&1; then
+if ! go mod download 2>&1; then
   echo "WARN: go mod download failed, continuing anyway"
 fi
 
 # --- sqlc ---
 echo "==> Installing sqlc ${SQLC_VERSION}..."
 if ! command -v sqlc &>/dev/null || [ "$(sqlc version 2>/dev/null)" != "v${SQLC_VERSION}" ]; then
-  curl -sL "https://github.com/sqlc-dev/sqlc/releases/download/v${SQLC_VERSION}/sqlc_${SQLC_VERSION}_linux_amd64.tar.gz" \
+  curl -sL -m 120 "https://github.com/sqlc-dev/sqlc/releases/download/v${SQLC_VERSION}/sqlc_${SQLC_VERSION}_linux_amd64.tar.gz" \
     | tar xz -C /usr/local/bin sqlc \
     && echo "    sqlc $(sqlc version) installed" \
     || echo "WARN: sqlc install failed"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,7 +27,7 @@
   },
   "sandbox": {
     "enabled": true,
-    "autoAllow": true,
+    "autoAllowBashIfSandboxed": true,
     "filesystem": {
       "allowWrite": [
         "~/go",

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ docker-down:
 css-install:
 	@if [ ! -f $(TAILWIND_BIN) ]; then \
 		echo "Downloading tailwindcss-extra..."; \
-		curl -sLo $(TAILWIND_BIN) https://github.com/dobicinaitis/tailwind-cli-extra/releases/latest/download/tailwindcss-extra-$$(uname -s | tr '[:upper:]' '[:lower:]')-$$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/'); \
+		curl -sLo $(TAILWIND_BIN) -m 120 https://github.com/dobicinaitis/tailwind-cli-extra/releases/latest/download/tailwindcss-extra-$$(uname -s | tr '[:upper:]' '[:lower:]')-$$(uname -m | sed 's/x86_64/x64/' | sed 's/aarch64/arm64/'); \
 		chmod +x $(TAILWIND_BIN); \
 	fi
 


### PR DESCRIPTION
## Summary
- Remove `GOPROXY=direct` from session-start hook so cloud sessions use `proxy.golang.org` (in the Trusted allowlist) instead of hitting source VCS hosts directly through the security proxy
- Add `-m 120` timeout to curl commands (sqlc install, tailwind download) to prevent indefinite hangs
- Fix sandbox config key: `autoAllow` → `autoAllowBashIfSandboxed` per official docs

## Test plan
- [ ] Verify cloud session starts successfully on claude.ai/code
- [ ] Verify local worktree sessions still work (`claude -w`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)