### PR TITLE
refactor: extract shared pgtype conversion helper (FormatUUID)

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
@@ -114,11 +115,11 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, tr *TemplateRende
 			return
 		}
 
-		sm.Put(r.Context(), sessionKeyAccountID, formatUUID(account.ID))
+		sm.Put(r.Context(), sessionKeyAccountID, pgconv.FormatUUID(account.ID))
 		sm.Put(r.Context(), sessionKeyAccountUsername, account.Username)
 		sm.Put(r.Context(), sessionKeyAccountRole, account.Role)
 		if account.UserID.Valid {
-			sm.Put(r.Context(), sessionKeyUserID, formatUUID(account.UserID))
+			sm.Put(r.Context(), sessionKeyUserID, pgconv.FormatUUID(account.UserID))
 		} else {
 			sm.Remove(r.Context(), sessionKeyUserID)
 		}

--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -13,6 +13,7 @@ import (
 	"breadbox/internal/app"
 	"breadbox/internal/avatar"
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -46,7 +47,7 @@ func AvatarHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
-		seed := formatUUID(uid)
+		seed := pgconv.FormatUUID(uid)
 		if row.AvatarSeed.Valid && row.AvatarSeed.String != "" {
 			seed = row.AvatarSeed.String
 		}
@@ -253,7 +254,7 @@ func processAndStoreAvatar(a *app.App, w http.ResponseWriter, r *http.Request, u
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to save avatar"})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "avatar_url": "/avatars/" + formatUUID(userID)})
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "avatar_url": "/avatars/" + pgconv.FormatUUID(userID)})
 }
 
 func parseAvatarUpload(a *app.App, w http.ResponseWriter, r *http.Request) ([]byte, string, bool) {

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -11,6 +11,7 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
 	"breadbox/internal/service"
 
@@ -96,7 +97,7 @@ func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionMan
 
 			accounts, err := a.Queries.ListAccountsByConnection(ctx, conn.ID)
 			if err != nil {
-				a.Logger.Error("list accounts for connection", "error", err, "connection_id", formatUUID(conn.ID))
+				a.Logger.Error("list accounts for connection", "error", err, "connection_id", pgconv.FormatUUID(conn.ID))
 			} else {
 				for _, acct := range accounts {
 					ca := ConnectionAccount{Account: acct}
@@ -414,7 +415,7 @@ func ExchangeTokenHandler(a *app.App) http.HandlerFunc {
 			}
 		}
 
-		connID := formatUUID(bankConn.ID)
+		connID := pgconv.FormatUUID(bankConn.ID)
 
 		writeJSON(w, http.StatusCreated, exchangeTokenResponse{
 			ConnectionID:    connID,
@@ -446,7 +447,7 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 		// IDOR check: viewers can only view their own connections. Editors+ see all.
 		if !IsEditor(sm, r) {
 			memberUID := SessionUserID(sm, r)
-			connUserID := formatUUID(conn.UserID)
+			connUserID := pgconv.FormatUUID(conn.UserID)
 			if connUserID == "" || connUserID != memberUID {
 				tr.RenderNotFound(w, r)
 				return
@@ -701,7 +702,7 @@ func ConnectionReauthAPIHandler(a *app.App) http.HandlerFunc {
 			ProviderName:         string(conn.Provider),
 			ExternalID:           conn.ExternalID.String,
 			EncryptedCredentials: conn.EncryptedCredentials,
-			UserID:               formatUUID(conn.UserID),
+			UserID:               pgconv.FormatUUID(conn.UserID),
 		}
 
 		session, err := prov.CreateReauthSession(ctx, provConn)
@@ -766,7 +767,7 @@ func DeleteConnectionHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 					ProviderName:         string(conn.Provider),
 					ExternalID:           conn.ExternalID.String,
 					EncryptedCredentials: conn.EncryptedCredentials,
-					UserID:               formatUUID(conn.UserID),
+					UserID:               pgconv.FormatUUID(conn.UserID),
 				}
 				if removeErr := prov.RemoveConnection(ctx, provConn); removeErr != nil {
 					a.Logger.Error("remove connection from provider", "error", removeErr)
@@ -1105,12 +1106,3 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	json.NewEncoder(w).Encode(v)
 }
 
-// formatUUID converts a pgtype.UUID to its string representation.
-func formatUUID(u pgtype.UUID) string {
-	if !u.Valid {
-		return ""
-	}
-	b := u.Bytes
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
-		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
-}

--- a/internal/admin/csv_import.go
+++ b/internal/admin/csv_import.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"breadbox/internal/app"
+	"breadbox/internal/pgconv"
 	csvpkg "breadbox/internal/provider/csv"
 	"breadbox/internal/service"
 
@@ -55,7 +56,7 @@ func CSVImportPageHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 				conn, err := a.Queries.GetBankConnection(ctx, connUUID)
 				if err == nil {
 					data["ExistingConnectionName"] = conn.InstitutionName.String
-					data["ExistingUserID"] = formatUUID(conn.UserID)
+					data["ExistingUserID"] = pgconv.FormatUUID(conn.UserID)
 					data["ExistingUserName"] = conn.UserName
 					breadcrumbs = append(breadcrumbs, Breadcrumb{Label: conn.InstitutionName.String, Href: "/connections/" + connectionID})
 				}

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"breadbox/internal/app"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 )
 
@@ -315,7 +316,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				errorCount++
 			}
 
-			connID := formatUUID(conn.ID)
+			connID := pgconv.FormatUUID(conn.ID)
 
 			var rawTime time.Time
 			if conn.LastSyncedAt.Valid {

--- a/internal/admin/members.go
+++ b/internal/admin/members.go
@@ -8,6 +8,7 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
@@ -300,7 +301,7 @@ func LinkAdminToUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc
 		}
 
 		// Update session so the change takes effect immediately.
-		sm.Put(ctx, sessionKeyUserID, formatUUID(userID))
+		sm.Put(ctx, sessionKeyUserID, pgconv.FormatUUID(userID))
 
 		SetFlash(ctx, sm, "success", "Account linked to household member.")
 		http.Redirect(w, r, "/my-account", http.StatusSeeOther)

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	bsync "breadbox/internal/sync"
 	"breadbox/internal/templates"
@@ -165,7 +166,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 			},
 			"formatUUID": func(u pgtype.UUID) string {
-				return formatUUID(u)
+				return pgconv.FormatUUID(u)
 			},
 			"formatIntervalMinutes": func(minutes int) string {
 				// Render a sync interval in human-readable form (e.g., "12h", "4h", "30m", "1d").
@@ -403,7 +404,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					if !v.Valid {
 						return "/avatars/unknown"
 					}
-					base = "/avatars/" + formatUUID(v)
+					base = "/avatars/" + pgconv.FormatUUID(v)
 				case string:
 					if v == "" {
 						return "/avatars/unknown"

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -10,6 +10,7 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -64,7 +65,7 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 
 			accounts, err := a.Queries.ListAccountsByUser(ctx, u.ID)
 			if err != nil {
-				a.Logger.Error("list accounts for user", "error", err, "user_id", formatUUID(u.ID))
+				a.Logger.Error("list accounts for user", "error", err, "user_id", pgconv.FormatUUID(u.ID))
 			} else {
 				eu.AccountCount = len(accounts)
 				// Count distinct connections from displayed accounts so the
@@ -72,7 +73,7 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 				connSet := make(map[string]struct{})
 				for _, acct := range accounts {
 					if acct.ConnectionID.Valid {
-						connSet[formatUUID(acct.ConnectionID)] = struct{}{}
+						connSet[pgconv.FormatUUID(acct.ConnectionID)] = struct{}{}
 					}
 				}
 				eu.ConnectionCount = int64(len(connSet))
@@ -117,7 +118,7 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 
 					connStatus := string(acct.ConnectionStatus)
 					eu.Accounts = append(eu.Accounts, UserAccountSummary{
-						ID:               formatUUID(acct.ID),
+						ID:               pgconv.FormatUUID(acct.ID),
 						Name:             displayName,
 						Type:             acct.Type,
 						Subtype:          subtype,
@@ -143,7 +144,7 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 		// Build a map of user_id -> login account for quick lookup in template.
 		loginAccountMap := make(map[string]db.ListAuthAccountsWithUserRow)
 		for _, la := range loginAccounts {
-			loginAccountMap[formatUUID(la.UserID)] = la
+			loginAccountMap[pgconv.FormatUUID(la.UserID)] = la
 		}
 
 		data := map[string]any{
@@ -262,7 +263,7 @@ func CreateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 			return
 		}
 
-		userID := formatUUID(user.ID)
+		userID := pgconv.FormatUUID(user.ID)
 
 		writeJSON(w, http.StatusCreated, map[string]any{
 			"id":         userID,
@@ -353,7 +354,7 @@ func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{
-			"id":         formatUUID(user.ID),
+			"id":         pgconv.FormatUUID(user.ID),
 			"name":       user.Name,
 			"email":      nullTextToPtr(user.Email),
 			"created_at": user.CreatedAt.Time,

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -19,6 +19,7 @@ import (
 
 	"breadbox/internal/db"
 	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -286,13 +287,6 @@ func seedUncategorized(t *testing.T, q *db.Queries) db.Category {
 	return cat
 }
 
-func fmtUUID(u pgtype.UUID) string {
-	if !u.Valid {
-		return ""
-	}
-	b := u.Bytes
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
-}
 
 // ============================================================
 // Authentication & Scope Tests
@@ -630,7 +624,7 @@ func TestAPI_GetTransaction_NotFound(t *testing.T) {
 func TestAPI_GetTransaction_Found(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doGet(t, "/api/v1/transactions/"+txnID)
 	assertStatus(t, resp, http.StatusOK)
@@ -870,7 +864,7 @@ func TestAPI_DeleteCategory_Success(t *testing.T) {
 func TestAPI_DeleteCategory_UndeletableSystem(t *testing.T) {
 	env := setupTestEnv(t)
 	uncat := seedUncategorized(t, env.Queries)
-	uncatID := fmtUUID(uncat.ID)
+	uncatID := pgconv.FormatUUID(uncat.ID)
 
 	resp := env.doDelete(t, "/api/v1/categories/"+uncatID)
 	readErrorCode(t, resp, http.StatusConflict, "CATEGORY_UNDELETABLE")
@@ -900,7 +894,7 @@ func TestAPI_SetTransactionCategory_NotFound(t *testing.T) {
 func TestAPI_SetTransactionCategory_MissingCategoryID(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPatch(t, "/api/v1/transactions/"+txnID+"/category", map[string]string{})
 	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
@@ -909,7 +903,7 @@ func TestAPI_SetTransactionCategory_MissingCategoryID(t *testing.T) {
 func TestAPI_SetTransactionCategory_CategoryNotFound(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPatch(t, "/api/v1/transactions/"+txnID+"/category", map[string]string{
 		"category_id": "00000000-0000-0000-0000-000000000099",
@@ -920,7 +914,7 @@ func TestAPI_SetTransactionCategory_CategoryNotFound(t *testing.T) {
 func TestAPI_SetTransactionCategory_Success(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	catResp := env.doPost(t, "/api/v1/categories", map[string]any{
 		"display_name": "Coffee",
@@ -951,7 +945,7 @@ func TestAPI_ResetTransactionCategory_Success(t *testing.T) {
 	env := setupTestEnv(t)
 	seedUncategorized(t, env.Queries)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	// Create and set category
 	catResp := env.doPost(t, "/api/v1/categories", map[string]any{
@@ -1286,7 +1280,7 @@ func TestAPI_GetReview_NotFound(t *testing.T) {
 func TestAPI_EnqueueReview_Success(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
 		"transaction_id": txnID,
@@ -1315,7 +1309,7 @@ func TestAPI_EnqueueReview_TransactionNotFound(t *testing.T) {
 func TestAPI_EnqueueReview_DuplicatePending(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
 		"transaction_id": txnID,
@@ -1332,7 +1326,7 @@ func TestAPI_EnqueueReview_DuplicatePending(t *testing.T) {
 func TestAPI_SubmitReview_Approve(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
 		"transaction_id": txnID,
@@ -1355,7 +1349,7 @@ func TestAPI_SubmitReview_Approve(t *testing.T) {
 func TestAPI_SubmitReview_Reject(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
 		"transaction_id": txnID,
@@ -1378,7 +1372,7 @@ func TestAPI_SubmitReview_Reject(t *testing.T) {
 func TestAPI_SubmitReview_Skip(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
 		"transaction_id": txnID,
@@ -1401,7 +1395,7 @@ func TestAPI_SubmitReview_Skip(t *testing.T) {
 func TestAPI_SubmitReview_InvalidDecision(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
 		"transaction_id": txnID,
@@ -1419,7 +1413,7 @@ func TestAPI_SubmitReview_InvalidDecision(t *testing.T) {
 func TestAPI_SubmitReview_AlreadyResolved(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
 		"transaction_id": txnID,
@@ -1441,7 +1435,7 @@ func TestAPI_SubmitReview_AlreadyResolved(t *testing.T) {
 func TestAPI_DismissReview_Success(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPost(t, "/api/v1/reviews/enqueue", map[string]string{
 		"transaction_id": txnID,
@@ -1469,7 +1463,7 @@ func TestAPI_DismissReview_NotFound(t *testing.T) {
 func TestAPI_CreateComment_Success(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/comments", map[string]string{
 		"content": "This is a test comment",
@@ -1495,7 +1489,7 @@ func TestAPI_CreateComment_TransactionNotFound(t *testing.T) {
 func TestAPI_ListComments_Empty(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	resp := env.doGet(t, "/api/v1/transactions/"+txnID+"/comments")
 	assertStatus(t, resp, http.StatusOK)
@@ -1510,7 +1504,7 @@ func TestAPI_ListComments_Empty(t *testing.T) {
 func TestAPI_ListComments_WithData(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	env.doPost(t, "/api/v1/transactions/"+txnID+"/comments", map[string]string{
 		"content": "First comment",
@@ -1674,7 +1668,7 @@ func TestAPI_MergeCategories_MissingTargetID(t *testing.T) {
 func TestAPI_BatchCategorize_Success(t *testing.T) {
 	env := setupTestEnv(t)
 	_, _, txn := seedFixture(t, env.Queries)
-	txnID := fmtUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	env.doPost(t, "/api/v1/categories", map[string]any{
 		"display_name": "Dining",

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"breadbox/internal/testutil"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 

--- a/internal/middleware/apikey.go
+++ b/internal/middleware/apikey.go
@@ -7,18 +7,9 @@ import (
 	"strings"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
-
-func formatUUID(u pgtype.UUID) string {
-	if !u.Valid {
-		return ""
-	}
-	b := u.Bytes
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
-}
 
 // APIKeyAuth returns middleware that validates either the X-API-Key header or
 // an Authorization: Bearer token against the database using the service layer.
@@ -55,7 +46,7 @@ func APIKeyAuth(svc *service.Service) func(http.Handler) http.Handler {
 					Scope: accessToken.Scope,
 				}
 
-				keyID := formatUUID(accessToken.ID)
+				keyID := pgconv.FormatUUID(accessToken.ID)
 				ctx := service.ContextWithAPIKey(r.Context(), keyID, syntheticKey.Name)
 				ctx = SetAPIKey(ctx, syntheticKey)
 				next.ServeHTTP(w, r.WithContext(ctx))
@@ -88,7 +79,7 @@ func APIKeyAuth(svc *service.Service) func(http.Handler) http.Handler {
 				return
 			}
 
-			keyID := formatUUID(apiKey.ID)
+			keyID := pgconv.FormatUUID(apiKey.ID)
 			ctx := service.ContextWithAPIKey(r.Context(), keyID, apiKey.Name)
 			ctx = SetAPIKey(ctx, apiKey)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -156,18 +157,18 @@ func TestFormatUUID_Valid(t *testing.T) {
 		Bytes: [16]byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
 		Valid: true,
 	}
-	got := formatUUID(u)
+	got := pgconv.FormatUUID(u)
 	want := "12345678-9abc-def0-1234-56789abcdef0"
 	if got != want {
-		t.Errorf("formatUUID() = %q, want %q", got, want)
+		t.Errorf("pgconv.FormatUUID() = %q, want %q", got, want)
 	}
 }
 
 func TestFormatUUID_Invalid(t *testing.T) {
 	u := pgtype.UUID{Valid: false}
-	got := formatUUID(u)
+	got := pgconv.FormatUUID(u)
 	if got != "" {
-		t.Errorf("formatUUID(invalid) = %q, want empty", got)
+		t.Errorf("pgconv.FormatUUID(invalid) = %q, want empty", got)
 	}
 }
 

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -1,0 +1,19 @@
+// Package pgconv provides shared conversion helpers for pgtype values.
+package pgconv
+
+import (
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// FormatUUID converts a pgtype.UUID to its standard string representation
+// (e.g., "12345678-9abc-def0-1234-56789abcdef0"). Returns an empty string
+// if the UUID is not valid.
+func FormatUUID(u pgtype.UUID) string {
+	if !u.Valid {
+		return ""
+	}
+	b := u.Bytes
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -1,0 +1,51 @@
+package pgconv
+
+import (
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestFormatUUID_Valid(t *testing.T) {
+	u := pgtype.UUID{
+		Bytes: [16]byte{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0},
+		Valid: true,
+	}
+	got := FormatUUID(u)
+	want := "12345678-9abc-def0-1234-56789abcdef0"
+	if got != want {
+		t.Errorf("FormatUUID() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatUUID_Invalid(t *testing.T) {
+	u := pgtype.UUID{Valid: false}
+	got := FormatUUID(u)
+	if got != "" {
+		t.Errorf("FormatUUID(invalid) = %q, want empty", got)
+	}
+}
+
+func TestFormatUUID_ZeroBytes(t *testing.T) {
+	u := pgtype.UUID{
+		Bytes: [16]byte{},
+		Valid: true,
+	}
+	got := FormatUUID(u)
+	want := "00000000-0000-0000-0000-000000000000"
+	if got != want {
+		t.Errorf("FormatUUID(zero) = %q, want %q", got, want)
+	}
+}
+
+func TestFormatUUID_MaxBytes(t *testing.T) {
+	u := pgtype.UUID{
+		Bytes: [16]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+		Valid: true,
+	}
+	got := FormatUUID(u)
+	want := "ffffffff-ffff-ffff-ffff-ffffffffffff"
+	if got != want {
+		t.Errorf("FormatUUID(max) = %q, want %q", got, want)
+	}
+}

--- a/internal/service/account_link_integration_test.go
+++ b/internal/service/account_link_integration_test.go
@@ -7,35 +7,12 @@ import (
 	"errors"
 	"testing"
 
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
-
-
-// formatUUIDForTest converts a pgtype.UUID to a string for test assertions.
-func formatUUIDForTest(u pgtype.UUID) string {
-	if !u.Valid {
-		return ""
-	}
-	b := u.Bytes
-	return bytesToUUIDString(b)
-}
-
-func bytesToUUIDString(b [16]byte) string {
-	return hexEncode(b[0:4]) + "-" + hexEncode(b[4:6]) + "-" + hexEncode(b[6:8]) + "-" + hexEncode(b[8:10]) + "-" + hexEncode(b[10:16])
-}
-
-func hexEncode(b []byte) string {
-	const hex = "0123456789abcdef"
-	result := make([]byte, len(b)*2)
-	for i, v := range b {
-		result[i*2] = hex[v>>4]
-		result[i*2+1] = hex[v&0x0f]
-	}
-	return string(result)
-}
 
 // --- CreateAccountLink ---
 
@@ -50,8 +27,8 @@ func TestCreateAccountLink_Success(t *testing.T) {
 	dependentAcct := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
 
 	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(primaryAcct.ID),
-		DependentAccountID: formatUUIDForTest(dependentAcct.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(primaryAcct.ID),
+		DependentAccountID: pgconv.FormatUUID(dependentAcct.ID),
 		MatchStrategy:      "date_amount_name",
 		MatchToleranceDays: 1,
 	})
@@ -62,10 +39,10 @@ func TestCreateAccountLink_Success(t *testing.T) {
 	if link.ID == "" {
 		t.Error("expected non-empty ID")
 	}
-	if link.PrimaryAccountID != formatUUIDForTest(primaryAcct.ID) {
-		t.Errorf("primary account mismatch: got %s, want %s", link.PrimaryAccountID, formatUUIDForTest(primaryAcct.ID))
+	if link.PrimaryAccountID != pgconv.FormatUUID(primaryAcct.ID) {
+		t.Errorf("primary account mismatch: got %s, want %s", link.PrimaryAccountID, pgconv.FormatUUID(primaryAcct.ID))
 	}
-	if link.DependentAccountID != formatUUIDForTest(dependentAcct.ID) {
+	if link.DependentAccountID != pgconv.FormatUUID(dependentAcct.ID) {
 		t.Errorf("dependent account mismatch")
 	}
 	if link.MatchStrategy != "date_amount_name" {
@@ -99,8 +76,8 @@ func TestCreateAccountLink_DefaultStrategy(t *testing.T) {
 	dependentAcct := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
 
 	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(primaryAcct.ID),
-		DependentAccountID: formatUUIDForTest(dependentAcct.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(primaryAcct.ID),
+		DependentAccountID: pgconv.FormatUUID(dependentAcct.ID),
 		// No strategy specified — should default to "date_amount_name"
 	})
 	if err != nil {
@@ -119,7 +96,7 @@ func TestCreateAccountLink_InvalidPrimaryAccount(t *testing.T) {
 
 	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
 		PrimaryAccountID:   "00000000-0000-0000-0000-000000000001",
-		DependentAccountID: formatUUIDForTest(acct.ID),
+		DependentAccountID: pgconv.FormatUUID(acct.ID),
 	})
 	if err == nil {
 		t.Fatal("expected error for nonexistent primary account")
@@ -136,7 +113,7 @@ func TestCreateAccountLink_InvalidDependentAccount(t *testing.T) {
 	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_1", "Real Account")
 
 	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct.ID),
 		DependentAccountID: "00000000-0000-0000-0000-000000000001",
 	})
 	if err == nil {
@@ -173,8 +150,8 @@ func TestCreateAccountLink_DuplicateLink(t *testing.T) {
 	dependentAcct := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
 
 	params := service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(primaryAcct.ID),
-		DependentAccountID: formatUUIDForTest(dependentAcct.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(primaryAcct.ID),
+		DependentAccountID: pgconv.FormatUUID(dependentAcct.ID),
 	}
 
 	_, err := svc.CreateAccountLink(context.Background(), params)
@@ -195,7 +172,7 @@ func TestCreateAccountLink_SelfLink(t *testing.T) {
 	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
 	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_1", "Acct")
 
-	acctID := formatUUIDForTest(acct.ID)
+	acctID := pgconv.FormatUUID(acct.ID)
 	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
 		PrimaryAccountID:   acctID,
 		DependentAccountID: acctID,
@@ -218,8 +195,8 @@ func TestCreateAccountLink_CircularLinkRejected(t *testing.T) {
 	conn2 := testutil.MustCreateConnection(t, queries, user2.ID, "item_b")
 	acctB := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_b", "Account B")
 
-	acctAID := formatUUIDForTest(acctA.ID)
-	acctBID := formatUUIDForTest(acctB.ID)
+	acctAID := pgconv.FormatUUID(acctA.ID)
+	acctBID := pgconv.FormatUUID(acctB.ID)
 
 	// Create A→B link (A is primary, B is dependent).
 	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
@@ -258,8 +235,8 @@ func TestGetAccountLink_Success(t *testing.T) {
 	dependentAcct := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
 
 	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(primaryAcct.ID),
-		DependentAccountID: formatUUIDForTest(dependentAcct.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(primaryAcct.ID),
+		DependentAccountID: pgconv.FormatUUID(dependentAcct.ID),
 		MatchToleranceDays: 2,
 	})
 	if err != nil {
@@ -337,15 +314,15 @@ func TestListAccountLinks_WithData(t *testing.T) {
 	acct3 := testutil.MustCreateAccount(t, queries, conn3.ID, "ext_3", "Acct3")
 
 	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink 1: %v", err)
 	}
 	_, err = svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct3.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct3.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink 2: %v", err)
@@ -373,8 +350,8 @@ func TestUpdateAccountLink_Success(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
 
 	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 		MatchToleranceDays: 0,
 	})
 	if err != nil {
@@ -411,8 +388,8 @@ func TestUpdateAccountLink_Disable(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
 
 	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink: %v", err)
@@ -450,8 +427,8 @@ func TestUpdateAccountLink_ReEnable(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
 
 	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink: %v", err)
@@ -509,8 +486,8 @@ func TestDeleteAccountLink_Success(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
 
 	created, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink: %v", err)
@@ -559,8 +536,8 @@ func TestManualMatch_Success(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_dependent", "Dependent Card")
 
 	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink: %v", err)
@@ -569,7 +546,7 @@ func TestManualMatch_Success(t *testing.T) {
 	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_p1", "Coffee Shop", 550, "2025-01-15")
 	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_d1", "Coffee Shop", 550, "2025-01-15")
 
-	match, err := svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	match, err := svc.ManualMatch(context.Background(), link.ID, pgconv.FormatUUID(txn1.ID), pgconv.FormatUUID(txn2.ID))
 	if err != nil {
 		t.Fatalf("ManualMatch: %v", err)
 	}
@@ -583,10 +560,10 @@ func TestManualMatch_Success(t *testing.T) {
 	if len(match.MatchedOn) != 1 || match.MatchedOn[0] != "manual" {
 		t.Errorf("matched_on: got %v, want [manual]", match.MatchedOn)
 	}
-	if match.PrimaryTransactionID != formatUUIDForTest(txn1.ID) {
+	if match.PrimaryTransactionID != pgconv.FormatUUID(txn1.ID) {
 		t.Error("primary transaction ID mismatch")
 	}
-	if match.DependentTransactionID != formatUUIDForTest(txn2.ID) {
+	if match.DependentTransactionID != pgconv.FormatUUID(txn2.ID) {
 		t.Error("dependent transaction ID mismatch")
 	}
 }
@@ -628,8 +605,8 @@ func TestConfirmMatch_Success(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
 
 	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink: %v", err)
@@ -638,7 +615,7 @@ func TestConfirmMatch_Success(t *testing.T) {
 	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_1", "Store", 1000, "2025-01-15")
 	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_2", "Store", 1000, "2025-01-15")
 
-	match, err := svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	match, err := svc.ManualMatch(context.Background(), link.ID, pgconv.FormatUUID(txn1.ID), pgconv.FormatUUID(txn2.ID))
 	if err != nil {
 		t.Fatalf("ManualMatch: %v", err)
 	}
@@ -670,8 +647,8 @@ func TestRejectMatch_Success(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
 
 	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink: %v", err)
@@ -680,7 +657,7 @@ func TestRejectMatch_Success(t *testing.T) {
 	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_1", "Store", 1000, "2025-01-15")
 	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_2", "Store", 1000, "2025-01-15")
 
-	match, err := svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	match, err := svc.ManualMatch(context.Background(), link.ID, pgconv.FormatUUID(txn1.ID), pgconv.FormatUUID(txn2.ID))
 	if err != nil {
 		t.Fatalf("ManualMatch: %v", err)
 	}
@@ -722,8 +699,8 @@ func TestListTransactionMatches_Empty(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
 
 	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink: %v", err)
@@ -749,8 +726,8 @@ func TestListTransactionMatches_WithData(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Acct2")
 
 	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink: %v", err)
@@ -759,7 +736,7 @@ func TestListTransactionMatches_WithData(t *testing.T) {
 	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_1", "Store A", 1000, "2025-01-15")
 	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_2", "Store A", 1000, "2025-01-15")
 
-	_, err = svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	_, err = svc.ManualMatch(context.Background(), link.ID, pgconv.FormatUUID(txn1.ID), pgconv.FormatUUID(txn2.ID))
 	if err != nil {
 		t.Fatalf("ManualMatch: %v", err)
 	}
@@ -804,8 +781,8 @@ func TestDeleteAccountLink_ClearsAttribution(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Dependent Card")
 
 	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("CreateAccountLink: %v", err)
@@ -814,7 +791,7 @@ func TestDeleteAccountLink_ClearsAttribution(t *testing.T) {
 	txn1 := testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_p1", "Coffee", 550, "2025-01-15")
 	txn2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_d1", "Coffee", 550, "2025-01-15")
 
-	_, err = svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txn1.ID), formatUUIDForTest(txn2.ID))
+	_, err = svc.ManualMatch(context.Background(), link.ID, pgconv.FormatUUID(txn1.ID), pgconv.FormatUUID(txn2.ID))
 	if err != nil {
 		t.Fatalf("ManualMatch: %v", err)
 	}

--- a/internal/service/category_integration_test.go
+++ b/internal/service/category_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -342,7 +343,7 @@ func TestDeleteCategory_CannotDeleteUncategorized(t *testing.T) {
 	ctx := context.Background()
 
 	uncat := mustSeedUncategorized(t, q)
-	_, err := svc.DeleteCategory(ctx, formatUUID(uncat.ID))
+	_, err := svc.DeleteCategory(ctx, pgconv.FormatUUID(uncat.ID))
 	if !errors.Is(err, service.ErrCategoryUndeletable) {
 		t.Errorf("expected ErrCategoryUndeletable, got: %v", err)
 	}
@@ -612,7 +613,7 @@ func TestSetTransactionCategory_Success(t *testing.T) {
 	acctID := seedTxnFixture(t, q)
 	txn := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "txn_manual", "Manual Txn", 500, "2025-02-01")
 
-	err := svc.SetTransactionCategory(ctx, formatUUID(txn.ID), target.ID)
+	err := svc.SetTransactionCategory(ctx, pgconv.FormatUUID(txn.ID), target.ID)
 	if err != nil {
 		t.Fatalf("SetTransactionCategory: %v", err)
 	}
@@ -652,7 +653,7 @@ func TestSetTransactionCategory_InvalidCategory(t *testing.T) {
 	acctID := seedTxnFixture(t, q)
 	txn := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "txn_badcat", "Bad Cat", 100, "2025-02-01")
 
-	err := svc.SetTransactionCategory(ctx, formatUUID(txn.ID), "00000000-0000-0000-0000-000000000000")
+	err := svc.SetTransactionCategory(ctx, pgconv.FormatUUID(txn.ID), "00000000-0000-0000-0000-000000000000")
 	if !errors.Is(err, service.ErrCategoryNotFound) {
 		t.Errorf("expected ErrCategoryNotFound, got: %v", err)
 	}
@@ -682,7 +683,7 @@ func TestBatchSetTransactionCategory_SetsOverrideFlag(t *testing.T) {
 	txn1 := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "batch_txn_1", "Txn 1", 100, "2025-01-10")
 
 	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
-		{TransactionID: formatUUID(txn1.ID), CategorySlug: "batch_groceries"},
+		{TransactionID: pgconv.FormatUUID(txn1.ID), CategorySlug: "batch_groceries"},
 	})
 	if err != nil {
 		t.Fatalf("BatchSetTransactionCategory: %v", err)
@@ -713,8 +714,8 @@ func TestBatchSetTransactionCategory_PartialFailure(t *testing.T) {
 	txn := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "batch_partial", "Partial", 100, "2025-01-10")
 
 	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
-		{TransactionID: formatUUID(txn.ID), CategorySlug: "batch_good"},
-		{TransactionID: formatUUID(txn.ID), CategorySlug: "nonexistent_slug"},
+		{TransactionID: pgconv.FormatUUID(txn.ID), CategorySlug: "batch_good"},
+		{TransactionID: pgconv.FormatUUID(txn.ID), CategorySlug: "nonexistent_slug"},
 	})
 	if err != nil {
 		t.Fatalf("BatchSetTransactionCategory: %v", err)

--- a/internal/service/comments_apikeys_integration_test.go
+++ b/internal/service/comments_apikeys_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -24,7 +25,7 @@ func TestCreateComment_Success(t *testing.T) {
 
 	actor := service.Actor{Type: "agent", ID: "key-123", Name: "TestBot"}
 	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       "This is a test comment",
 		Actor:         actor,
 	})
@@ -40,7 +41,7 @@ func TestCreateComment_Success(t *testing.T) {
 	if comment.AuthorName != "TestBot" {
 		t.Errorf("author_name = %q, want %q", comment.AuthorName, "TestBot")
 	}
-	if comment.TransactionID != formatUUID(txn.ID) {
+	if comment.TransactionID != pgconv.FormatUUID(txn.ID) {
 		t.Errorf("transaction_id mismatch")
 	}
 }
@@ -52,7 +53,7 @@ func TestCreateComment_EmptyContent(t *testing.T) {
 	txn := seedTransaction(t, queries, acctID, "ext_comment_2", "Coffee", 100, "2024-06-01")
 
 	_, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       "",
 		Actor:         service.SystemActor(),
 	})
@@ -68,7 +69,7 @@ func TestCreateComment_WhitespaceOnlyContent(t *testing.T) {
 	txn := seedTransaction(t, queries, acctID, "ext_comment_ws", "Coffee", 100, "2024-06-01")
 
 	_, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       "   \t\n  ",
 		Actor:         service.SystemActor(),
 	})
@@ -85,7 +86,7 @@ func TestCreateComment_TooLong(t *testing.T) {
 
 	longContent := strings.Repeat("x", 10001)
 	_, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       longContent,
 		Actor:         service.SystemActor(),
 	})
@@ -102,7 +103,7 @@ func TestCreateComment_MaxLength(t *testing.T) {
 
 	maxContent := strings.Repeat("x", 10000)
 	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       maxContent,
 		Actor:         service.SystemActor(),
 	})
@@ -148,7 +149,7 @@ func TestListComments_Empty(t *testing.T) {
 	acctID := seedTxnFixture(t, queries)
 	txn := seedTransaction(t, queries, acctID, "ext_no_comments", "Coffee", 100, "2024-06-01")
 
-	comments, err := svc.ListComments(ctx, formatUUID(txn.ID))
+	comments, err := svc.ListComments(ctx, pgconv.FormatUUID(txn.ID))
 	if err != nil {
 		t.Fatalf("ListComments failed: %v", err)
 	}
@@ -162,7 +163,7 @@ func TestListComments_OrderByCreatedAt(t *testing.T) {
 	ctx := context.Background()
 	acctID := seedTxnFixture(t, queries)
 	txn := seedTransaction(t, queries, acctID, "ext_multi_comment", "Coffee", 100, "2024-06-01")
-	txnID := formatUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	// Create comments in order
 	_, err := svc.CreateComment(ctx, service.CreateCommentParams{
@@ -211,7 +212,7 @@ func TestUpdateComment_Success(t *testing.T) {
 
 	actor := service.Actor{Type: "agent", ID: "key-456", Name: "Bot"}
 	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       "Original content",
 		Actor:         actor,
 	})
@@ -239,7 +240,7 @@ func TestUpdateComment_ForbiddenForDifferentAgent(t *testing.T) {
 
 	author := service.Actor{Type: "agent", ID: "key-100", Name: "BotA"}
 	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       "Author's comment",
 		Actor:         author,
 	})
@@ -266,7 +267,7 @@ func TestUpdateComment_AdminCanModerate(t *testing.T) {
 
 	agent := service.Actor{Type: "agent", ID: "key-300", Name: "Bot"}
 	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       "Agent comment",
 		Actor:         agent,
 	})
@@ -309,7 +310,7 @@ func TestDeleteComment_Success(t *testing.T) {
 
 	actor := service.Actor{Type: "agent", ID: "key-500", Name: "Bot"}
 	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       "To be deleted",
 		Actor:         actor,
 	})
@@ -323,7 +324,7 @@ func TestDeleteComment_Success(t *testing.T) {
 	}
 
 	// Verify it's gone
-	comments, err := svc.ListComments(ctx, formatUUID(txn.ID))
+	comments, err := svc.ListComments(ctx, pgconv.FormatUUID(txn.ID))
 	if err != nil {
 		t.Fatalf("ListComments after delete: %v", err)
 	}
@@ -340,7 +341,7 @@ func TestDeleteComment_ForbiddenForDifferentAgent(t *testing.T) {
 
 	author := service.Actor{Type: "agent", ID: "key-600", Name: "BotA"}
 	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       "Protected comment",
 		Actor:         author,
 	})
@@ -372,7 +373,7 @@ func TestCreateComment_ContentTrimmed(t *testing.T) {
 	txn := seedTransaction(t, queries, acctID, "ext_trim", "Coffee", 100, "2024-06-01")
 
 	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
-		TransactionID: formatUUID(txn.ID),
+		TransactionID: pgconv.FormatUUID(txn.ID),
 		Content:       "  trimmed content  ",
 		Actor:         service.SystemActor(),
 	})

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -6,16 +6,13 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func formatUUID(u pgtype.UUID) string {
-	if !u.Valid {
-		return ""
-	}
-	b := u.Bytes
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+	return pgconv.FormatUUID(u)
 }
 
 func uuidPtr(u pgtype.UUID) *string {

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -141,7 +142,7 @@ func TestListAccounts_FilterByUser(t *testing.T) {
 	testutil.MustCreateAccount(t, queries, connA.ID, "ext_a1", "Alice Checking")
 	testutil.MustCreateAccount(t, queries, connB.ID, "ext_b1", "Bob Checking")
 
-	aliceID := formatUUID(alice.ID)
+	aliceID := pgconv.FormatUUID(alice.ID)
 	accounts, err := svc.ListAccounts(ctx, &aliceID)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -868,15 +869,6 @@ func TestImportCategoriesTSV_MergeNonexistentSource(t *testing.T) {
 
 // --- Helpers ---
 
-func formatUUID(u pgtype.UUID) string {
-	if !u.Valid {
-		return ""
-	}
-	b := u.Bytes
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
-		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
-}
-
 // --- Connection Deletion Soft-Deletes Transactions ---
 
 func TestSoftDeleteTransactionsByConnectionID(t *testing.T) {
@@ -941,8 +933,8 @@ func TestBatchSetTransactionCategory_Success(t *testing.T) {
 	}
 
 	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
-		{TransactionID: formatUUID(txn1.ID), CategorySlug: "food_and_drink"},
-		{TransactionID: formatUUID(txn2.ID), CategorySlug: "transportation"},
+		{TransactionID: pgconv.FormatUUID(txn1.ID), CategorySlug: "food_and_drink"},
+		{TransactionID: pgconv.FormatUUID(txn2.ID), CategorySlug: "transportation"},
 	})
 	if err != nil {
 		t.Fatalf("BatchSetTransactionCategory: %v", err)
@@ -1000,7 +992,7 @@ func TestBatchSetTransactionCategory_InvalidTxnID(t *testing.T) {
 
 	// Nonexistent transaction ID now correctly reports as failed (ErrNotFound).
 	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
-		{TransactionID: formatUUID(txn1.ID), CategorySlug: "food_and_drink"},
+		{TransactionID: pgconv.FormatUUID(txn1.ID), CategorySlug: "food_and_drink"},
 		{TransactionID: "00000000-0000-0000-0000-000000000099", CategorySlug: "food_and_drink"},
 	})
 	if err != nil {

--- a/internal/service/mcp_synclog_csv_integration_test.go
+++ b/internal/service/mcp_synclog_csv_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -250,7 +251,7 @@ func TestListSyncLogsPaginated_FilterByConnection(t *testing.T) {
 		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
 	})
 
-	conn1ID := formatUUID(conn1.ID)
+	conn1ID := pgconv.FormatUUID(conn1.ID)
 	result, err := svc.ListSyncLogsPaginated(ctx, service.SyncLogListParams{
 		Page:         1,
 		PageSize:     10,
@@ -493,7 +494,7 @@ func TestSyncLogStats_FilterByConnection(t *testing.T) {
 		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
 	})
 
-	conn1ID := formatUUID(conn1.ID)
+	conn1ID := pgconv.FormatUUID(conn1.ID)
 	stats, err := svc.SyncLogStats(ctx, service.SyncLogListParams{
 		ConnectionID: &conn1ID,
 	})
@@ -805,7 +806,7 @@ func TestGetConnectionStatus_WithSyncLog(t *testing.T) {
 		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
 	})
 
-	connID := formatUUID(conn.ID)
+	connID := pgconv.FormatUUID(conn.ID)
 	status, err := svc.GetConnectionStatus(ctx, connID)
 	if err != nil {
 		t.Fatalf("GetConnectionStatus: %v", err)
@@ -831,7 +832,7 @@ func TestGetConnectionStatus_NoSyncLog(t *testing.T) {
 	user := testutil.MustCreateUser(t, queries, "Alice")
 	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_status_nosync")
 
-	connID := formatUUID(conn.ID)
+	connID := pgconv.FormatUUID(conn.ID)
 	status, err := svc.GetConnectionStatus(ctx, connID)
 	if err != nil {
 		t.Fatalf("GetConnectionStatus: %v", err)
@@ -903,7 +904,7 @@ func TestListConnections_FilterByUser(t *testing.T) {
 	testutil.MustCreateConnection(t, queries, alice.ID, "alice_conn_2")
 	testutil.MustCreateConnection(t, queries, bob.ID, "bob_conn_1")
 
-	aliceID := formatUUID(alice.ID)
+	aliceID := pgconv.FormatUUID(alice.ID)
 	conns, err := svc.ListConnections(ctx, &aliceID)
 	if err != nil {
 		t.Fatalf("ListConnections: %v", err)
@@ -932,7 +933,7 @@ func TestGetAccount_Success(t *testing.T) {
 	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_acct_1")
 	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_get", "Checking Account")
 
-	acctID := formatUUID(acct.ID)
+	acctID := pgconv.FormatUUID(acct.ID)
 	resp, err := svc.GetAccount(ctx, acctID)
 	if err != nil {
 		t.Fatalf("GetAccount: %v", err)
@@ -963,7 +964,7 @@ func TestGetAccountDetail_Success(t *testing.T) {
 	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_detail_1")
 	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_detail_1", "My Savings")
 
-	acctID := formatUUID(acct.ID)
+	acctID := pgconv.FormatUUID(acct.ID)
 	detail, err := svc.GetAccountDetail(ctx, acctID)
 	if err != nil {
 		t.Fatalf("GetAccountDetail: %v", err)
@@ -1006,7 +1007,7 @@ func TestImportCSV_BasicSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
-	userID := formatUUID(user.ID)
+	userID := pgconv.FormatUUID(user.ID)
 
 	result, err := svc.ImportCSV(ctx, service.CSVImportParams{
 		UserID:      userID,
@@ -1048,7 +1049,7 @@ func TestImportCSV_SkipsInvalidRows(t *testing.T) {
 	ctx := context.Background()
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
-	userID := formatUUID(user.ID)
+	userID := pgconv.FormatUUID(user.ID)
 
 	result, err := svc.ImportCSV(ctx, service.CSVImportParams{
 		UserID:      userID,
@@ -1086,7 +1087,7 @@ func TestImportCSV_Deduplication(t *testing.T) {
 	ctx := context.Background()
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
-	userID := formatUUID(user.ID)
+	userID := pgconv.FormatUUID(user.ID)
 
 	params := service.CSVImportParams{
 		UserID:      userID,
@@ -1155,9 +1156,9 @@ func TestImportCSV_ReimportNonCSVConnection(t *testing.T) {
 	user := testutil.MustCreateUser(t, queries, "Alice")
 	conn := testutil.MustCreateConnection(t, queries, user.ID, "plaid_conn")
 
-	connID := formatUUID(conn.ID)
+	connID := pgconv.FormatUUID(conn.ID)
 	_, err := svc.ImportCSV(ctx, service.CSVImportParams{
-		UserID:       formatUUID(user.ID),
+		UserID:       pgconv.FormatUUID(user.ID),
 		ConnectionID: connID,
 		AccountName:  "Test",
 		ColumnMapping: map[string]int{
@@ -1177,7 +1178,7 @@ func TestImportCSV_DefaultAccountName(t *testing.T) {
 	ctx := context.Background()
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
-	userID := formatUUID(user.ID)
+	userID := pgconv.FormatUUID(user.ID)
 
 	result, err := svc.ImportCSV(ctx, service.CSVImportParams{
 		UserID:      userID,
@@ -1211,7 +1212,7 @@ func TestImportCSV_DebitCreditColumns(t *testing.T) {
 	ctx := context.Background()
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
-	userID := formatUUID(user.ID)
+	userID := pgconv.FormatUUID(user.ID)
 
 	result, err := svc.ImportCSV(ctx, service.CSVImportParams{
 		UserID:      userID,
@@ -1245,7 +1246,7 @@ func TestImportCSV_WithCategoryAndMerchant(t *testing.T) {
 	ctx := context.Background()
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
-	userID := formatUUID(user.ID)
+	userID := pgconv.FormatUUID(user.ID)
 
 	result, err := svc.ImportCSV(ctx, service.CSVImportParams{
 		UserID:      userID,
@@ -1275,7 +1276,7 @@ func TestImportCSV_AllRowsSkipped_ErrorStatus(t *testing.T) {
 	ctx := context.Background()
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
-	userID := formatUUID(user.ID)
+	userID := pgconv.FormatUUID(user.ID)
 
 	result, err := svc.ImportCSV(ctx, service.CSVImportParams{
 		UserID:      userID,

--- a/internal/service/members_integration_test.go
+++ b/internal/service/members_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -22,7 +23,7 @@ func TestCreateLoginAccount_Success(t *testing.T) {
 	user := testutil.MustCreateUser(t, queries, "Alice")
 
 	member, err := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID:   formatUUID(user.ID),
+		UserID:   pgconv.FormatUUID(user.ID),
 		Username: "alice",
 		Role:     "viewer",
 	})
@@ -51,7 +52,7 @@ func TestCreateLoginAccount_AdminRole(t *testing.T) {
 	user := testutil.MustCreateUser(t, queries, "Bob")
 
 	member, err := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID:   formatUUID(user.ID),
+		UserID:   pgconv.FormatUUID(user.ID),
 		Username: "bob_admin",
 		Role:     "admin",
 	})
@@ -71,7 +72,7 @@ func TestCreateLoginAccount_EditorRole(t *testing.T) {
 	user := testutil.MustCreateUser(t, queries, "Carol")
 
 	member, err := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID:   formatUUID(user.ID),
+		UserID:   pgconv.FormatUUID(user.ID),
 		Username: "carol_editor",
 		Role:     "editor",
 	})
@@ -91,7 +92,7 @@ func TestCreateLoginAccount_DuplicateUser(t *testing.T) {
 	user := testutil.MustCreateUser(t, queries, "Alice")
 
 	_, err := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID:   formatUUID(user.ID),
+		UserID:   pgconv.FormatUUID(user.ID),
 		Username: "alice1",
 		Role:     "viewer",
 	})
@@ -101,7 +102,7 @@ func TestCreateLoginAccount_DuplicateUser(t *testing.T) {
 
 	// Second account for same user should fail.
 	_, err = svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID:   formatUUID(user.ID),
+		UserID:   pgconv.FormatUUID(user.ID),
 		Username: "alice2",
 		Role:     "viewer",
 	})
@@ -118,7 +119,7 @@ func TestCreateLoginAccount_DuplicateUsername(t *testing.T) {
 	user2 := testutil.MustCreateUser(t, queries, "Bob")
 
 	_, err := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID:   formatUUID(user1.ID),
+		UserID:   pgconv.FormatUUID(user1.ID),
 		Username: "shared_name",
 		Role:     "viewer",
 	})
@@ -128,7 +129,7 @@ func TestCreateLoginAccount_DuplicateUsername(t *testing.T) {
 
 	// Same username should fail.
 	_, err = svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID:   formatUUID(user2.ID),
+		UserID:   pgconv.FormatUUID(user2.ID),
 		Username: "shared_name",
 		Role:     "viewer",
 	})
@@ -156,7 +157,7 @@ func TestCreateLoginAccount_UsernameConflictsWithExisting(t *testing.T) {
 
 	// Try to create a login account with same username as admin.
 	_, err = svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID:   formatUUID(user.ID),
+		UserID:   pgconv.FormatUUID(user.ID),
 		Username: "admin_user",
 		Role:     "viewer",
 	})
@@ -172,7 +173,7 @@ func TestCreateLoginAccount_InvalidRole(t *testing.T) {
 	user := testutil.MustCreateUser(t, queries, "Alice")
 
 	_, err := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID:   formatUUID(user.ID),
+		UserID:   pgconv.FormatUUID(user.ID),
 		Username: "alice",
 		Role:     "superuser",
 	})
@@ -201,10 +202,10 @@ func TestListLoginAccounts_WithData(t *testing.T) {
 	user2 := testutil.MustCreateUser(t, queries, "Bob")
 
 	_, _ = svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID: formatUUID(user1.ID), Username: "alice", Role: "viewer",
+		UserID: pgconv.FormatUUID(user1.ID), Username: "alice", Role: "viewer",
 	})
 	_, _ = svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID: formatUUID(user2.ID), Username: "bob", Role: "admin",
+		UserID: pgconv.FormatUUID(user2.ID), Username: "bob", Role: "admin",
 	})
 
 	members, err := svc.ListLoginAccounts(ctx)
@@ -226,7 +227,7 @@ func TestUpdateLoginAccountRole(t *testing.T) {
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
 	member, _ := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID: formatUUID(user.ID), Username: "alice", Role: "viewer",
+		UserID: pgconv.FormatUUID(user.ID), Username: "alice", Role: "viewer",
 	})
 
 	if err := svc.UpdateLoginAccountRole(ctx, member.ID, "editor"); err != nil {
@@ -246,7 +247,7 @@ func TestUpdateLoginAccountRole_ToAdmin(t *testing.T) {
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
 	member, _ := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID: formatUUID(user.ID), Username: "alice", Role: "viewer",
+		UserID: pgconv.FormatUUID(user.ID), Username: "alice", Role: "viewer",
 	})
 
 	if err := svc.UpdateLoginAccountRole(ctx, member.ID, "admin"); err != nil {
@@ -265,7 +266,7 @@ func TestUpdateLoginAccountRole_InvalidRole(t *testing.T) {
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
 	member, _ := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID: formatUUID(user.ID), Username: "alice", Role: "viewer",
+		UserID: pgconv.FormatUUID(user.ID), Username: "alice", Role: "viewer",
 	})
 
 	if err := svc.UpdateLoginAccountRole(ctx, member.ID, "superuser"); err == nil {
@@ -279,7 +280,7 @@ func TestDeleteLoginAccount(t *testing.T) {
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
 	member, _ := svc.CreateLoginAccount(ctx, service.CreateLoginAccountParams{
-		UserID: formatUUID(user.ID), Username: "alice", Role: "viewer",
+		UserID: pgconv.FormatUUID(user.ID), Username: "alice", Role: "viewer",
 	})
 
 	if err := svc.DeleteLoginAccount(ctx, member.ID); err != nil {
@@ -308,7 +309,7 @@ func TestWipeUserData(t *testing.T) {
 	testutil.MustCreateTransaction(t, queries, acct.ID, "txn_1", "Coffee", 500, "2026-01-15")
 	testutil.MustCreateTransaction(t, queries, acct.ID, "txn_2", "Lunch", 1200, "2026-01-16")
 
-	txnCount, err := svc.WipeUserData(ctx, formatUUID(user.ID))
+	txnCount, err := svc.WipeUserData(ctx, pgconv.FormatUUID(user.ID))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -335,7 +336,7 @@ func TestWipeUserData_NoData(t *testing.T) {
 
 	user := testutil.MustCreateUser(t, queries, "Alice")
 
-	txnCount, err := svc.WipeUserData(ctx, formatUUID(user.ID))
+	txnCount, err := svc.WipeUserData(ctx, pgconv.FormatUUID(user.ID))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -360,13 +361,13 @@ func TestWipeUserData_DoesNotAffectOtherUsers(t *testing.T) {
 	testutil.MustCreateTransaction(t, queries, bobAcct.ID, "bob_txn", "Bob Coffee", 600, "2026-01-15")
 
 	// Wipe Alice's data.
-	_, err := svc.WipeUserData(ctx, formatUUID(alice.ID))
+	_, err := svc.WipeUserData(ctx, pgconv.FormatUUID(alice.ID))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Bob's data should be untouched.
-	bobID := formatUUID(bob.ID)
+	bobID := pgconv.FormatUUID(bob.ID)
 	conns, _ := svc.ListConnections(ctx, &bobID)
 	if len(conns) != 1 {
 		t.Errorf("expected Bob to still have 1 connection, got %d", len(conns))

--- a/internal/service/review_integration_test.go
+++ b/internal/service/review_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -59,7 +60,7 @@ func TestEnqueueManualReview_Success(t *testing.T) {
 	ctx := context.Background()
 
 	txn := reviewTestFixture(t, queries)
-	txnID := formatUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	review, err := svc.EnqueueManualReview(ctx, txnID, testActor)
 	if err != nil {
@@ -82,7 +83,7 @@ func TestEnqueueManualReview_DuplicatePending(t *testing.T) {
 	ctx := context.Background()
 
 	txn := reviewTestFixture(t, queries)
-	txnID := formatUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	// First enqueue succeeds
 	_, err := svc.EnqueueManualReview(ctx, txnID, testActor)
@@ -102,7 +103,7 @@ func TestEnqueueManualReview_SoftDeletedTransaction(t *testing.T) {
 	ctx := context.Background()
 
 	txn := reviewTestFixture(t, queries)
-	txnID := formatUUID(txn.ID)
+	txnID := pgconv.FormatUUID(txn.ID)
 
 	// Soft-delete the transaction
 	_, err := pool.Exec(ctx, "UPDATE transactions SET deleted_at = NOW() WHERE id = $1", txn.ID)
@@ -135,13 +136,13 @@ func TestGetReview_Success(t *testing.T) {
 	txn := reviewTestFixture(t, queries)
 	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
 
-	result, err := svc.GetReview(ctx, formatUUID(review.ID))
+	result, err := svc.GetReview(ctx, pgconv.FormatUUID(review.ID))
 	if err != nil {
 		t.Fatalf("GetReview: %v", err)
 	}
 
-	if result.ID != formatUUID(review.ID) {
-		t.Errorf("expected id=%s, got %s", formatUUID(review.ID), result.ID)
+	if result.ID != pgconv.FormatUUID(review.ID) {
+		t.Errorf("expected id=%s, got %s", pgconv.FormatUUID(review.ID), result.ID)
 	}
 	if result.ReviewType != "new_transaction" {
 		t.Errorf("expected review_type=new_transaction, got %s", result.ReviewType)
@@ -308,7 +309,7 @@ func TestSubmitReview_Approve(t *testing.T) {
 	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
 
 	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID: formatUUID(review.ID),
+		ReviewID: pgconv.FormatUUID(review.ID),
 		Decision: "approved",
 		Actor:    testActor,
 	})
@@ -334,7 +335,7 @@ func TestSubmitReview_Reject(t *testing.T) {
 	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
 
 	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID: formatUUID(review.ID),
+		ReviewID: pgconv.FormatUUID(review.ID),
 		Decision: "rejected",
 		Actor:    testActor,
 	})
@@ -354,7 +355,7 @@ func TestSubmitReview_Skip(t *testing.T) {
 	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
 
 	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID: formatUUID(review.ID),
+		ReviewID: pgconv.FormatUUID(review.ID),
 		Decision: "skipped",
 		Actor:    testActor,
 	})
@@ -374,7 +375,7 @@ func TestSubmitReview_InvalidDecision(t *testing.T) {
 	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
 
 	_, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID: formatUUID(review.ID),
+		ReviewID: pgconv.FormatUUID(review.ID),
 		Decision: "invalid",
 		Actor:    testActor,
 	})
@@ -392,7 +393,7 @@ func TestSubmitReview_AlreadyResolved(t *testing.T) {
 
 	// First submit succeeds
 	_, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID: formatUUID(review.ID),
+		ReviewID: pgconv.FormatUUID(review.ID),
 		Decision: "approved",
 		Actor:    testActor,
 	})
@@ -402,7 +403,7 @@ func TestSubmitReview_AlreadyResolved(t *testing.T) {
 
 	// Second submit should fail
 	_, err = svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID: formatUUID(review.ID),
+		ReviewID: pgconv.FormatUUID(review.ID),
 		Decision: "rejected",
 		Actor:    testActor,
 	})
@@ -420,11 +421,11 @@ func TestSubmitReview_WithCategoryOverride(t *testing.T) {
 
 	// Create a category
 	cat := mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
-	catID := formatUUID(cat.ID)
+	catID := pgconv.FormatUUID(cat.ID)
 
 	// Approve with explicit category
 	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID:   formatUUID(review.ID),
+		ReviewID:   pgconv.FormatUUID(review.ID),
 		Decision:   "approved",
 		CategoryID: &catID,
 		Actor:      testActor,
@@ -446,8 +447,8 @@ func TestSubmitReview_WithCategoryOverride(t *testing.T) {
 	if !txnCatID.Valid {
 		t.Error("expected transaction category_id to be set")
 	}
-	if formatUUID(txnCatID) != catID {
-		t.Errorf("expected transaction category_id=%s, got %s", catID, formatUUID(txnCatID))
+	if pgconv.FormatUUID(txnCatID) != catID {
+		t.Errorf("expected transaction category_id=%s, got %s", catID, pgconv.FormatUUID(txnCatID))
 	}
 	if !catOverride {
 		t.Error("expected category_override=true after review approval with category")
@@ -463,7 +464,7 @@ func TestSubmitReview_WithNote(t *testing.T) {
 
 	note := "This looks like a duplicate charge"
 	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID: formatUUID(review.ID),
+		ReviewID: pgconv.FormatUUID(review.ID),
 		Decision: "rejected",
 		Note:     &note,
 		Actor:    testActor,
@@ -508,8 +509,8 @@ func TestBulkSubmitReviews_Success(t *testing.T) {
 
 	result, err := svc.BulkSubmitReviews(ctx, service.BulkSubmitReviewParams{
 		Reviews: []service.BulkReviewItem{
-			{ReviewID: formatUUID(r1.ID), Decision: "approved"},
-			{ReviewID: formatUUID(r2.ID), Decision: "rejected"},
+			{ReviewID: pgconv.FormatUUID(r1.ID), Decision: "approved"},
+			{ReviewID: pgconv.FormatUUID(r2.ID), Decision: "rejected"},
 		},
 		Actor: testActor,
 	})
@@ -533,7 +534,7 @@ func TestBulkSubmitReviews_PartialFailure(t *testing.T) {
 
 	result, err := svc.BulkSubmitReviews(ctx, service.BulkSubmitReviewParams{
 		Reviews: []service.BulkReviewItem{
-			{ReviewID: formatUUID(review.ID), Decision: "approved"},
+			{ReviewID: pgconv.FormatUUID(review.ID), Decision: "approved"},
 			{ReviewID: "00000000-0000-0000-0000-000000000000", Decision: "approved"}, // nonexistent
 		},
 		Actor: testActor,
@@ -571,13 +572,13 @@ func TestDismissReview_Success(t *testing.T) {
 	txn := reviewTestFixture(t, queries)
 	review := mustEnqueueReview(t, queries, txn.ID, "new_transaction")
 
-	err := svc.DismissReview(ctx, formatUUID(review.ID), testActor)
+	err := svc.DismissReview(ctx, pgconv.FormatUUID(review.ID), testActor)
 	if err != nil {
 		t.Fatalf("DismissReview: %v", err)
 	}
 
 	// Verify it's gone
-	_, err = svc.GetReview(ctx, formatUUID(review.ID))
+	_, err = svc.GetReview(ctx, pgconv.FormatUUID(review.ID))
 	if !errors.Is(err, service.ErrNotFound) {
 		t.Errorf("expected ErrNotFound after dismiss, got %v", err)
 	}
@@ -592,7 +593,7 @@ func TestDismissReview_AlreadyResolved(t *testing.T) {
 
 	// Resolve it first
 	_, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID: formatUUID(review.ID),
+		ReviewID: pgconv.FormatUUID(review.ID),
 		Decision: "approved",
 		Actor:    testActor,
 	})
@@ -601,7 +602,7 @@ func TestDismissReview_AlreadyResolved(t *testing.T) {
 	}
 
 	// Now try to dismiss
-	err = svc.DismissReview(ctx, formatUUID(review.ID), testActor)
+	err = svc.DismissReview(ctx, pgconv.FormatUUID(review.ID), testActor)
 	if !errors.Is(err, service.ErrReviewAlreadyResolved) {
 		t.Errorf("expected ErrReviewAlreadyResolved, got %v", err)
 	}
@@ -699,7 +700,7 @@ func TestGetReviewCounts_WithData(t *testing.T) {
 
 	// Approve r3 (this makes it approved today)
 	_, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID: formatUUID(r3.ID),
+		ReviewID: pgconv.FormatUUID(r3.ID),
 		Decision: "approved",
 		Actor:    testActor,
 	})
@@ -880,11 +881,11 @@ func TestSubmitReview_RejectWithCategoryDoesNotModifyTransaction(t *testing.T) {
 
 	// Create a category
 	cat := mustCreateCategory(t, queries, "reject_test_cat", "Reject Test Category")
-	catID := formatUUID(cat.ID)
+	catID := pgconv.FormatUUID(cat.ID)
 
 	// Reject with an explicit category — the category should NOT be applied
 	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID:   formatUUID(review.ID),
+		ReviewID:   pgconv.FormatUUID(review.ID),
 		Decision:   "rejected",
 		CategoryID: &catID,
 		Actor:      testActor,
@@ -905,7 +906,7 @@ func TestSubmitReview_RejectWithCategoryDoesNotModifyTransaction(t *testing.T) {
 		t.Fatalf("query transaction: %v", err)
 	}
 	if txnCatID.Valid {
-		t.Errorf("expected transaction category_id to remain NULL after rejection, got %s", formatUUID(txnCatID))
+		t.Errorf("expected transaction category_id to remain NULL after rejection, got %s", pgconv.FormatUUID(txnCatID))
 	}
 	if catOverride {
 		t.Error("expected category_override=false after rejection, but got true")
@@ -924,11 +925,11 @@ func TestSubmitReview_SkipWithCategoryDoesNotModifyTransaction(t *testing.T) {
 	review := mustEnqueueReview(t, queries, txn.ID, "uncategorized")
 
 	cat := mustCreateCategory(t, queries, "skip_test_cat", "Skip Test Category")
-	catID := formatUUID(cat.ID)
+	catID := pgconv.FormatUUID(cat.ID)
 
 	// Skip with an explicit category — the category should NOT be applied
 	result, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
-		ReviewID:   formatUUID(review.ID),
+		ReviewID:   pgconv.FormatUUID(review.ID),
 		Decision:   "skipped",
 		CategoryID: &catID,
 		Actor:      testActor,
@@ -948,7 +949,7 @@ func TestSubmitReview_SkipWithCategoryDoesNotModifyTransaction(t *testing.T) {
 		t.Fatalf("query transaction: %v", err)
 	}
 	if txnCatID.Valid {
-		t.Errorf("expected transaction category_id to remain NULL after skip, got %s", formatUUID(txnCatID))
+		t.Errorf("expected transaction category_id to remain NULL after skip, got %s", pgconv.FormatUUID(txnCatID))
 	}
 	if catOverride {
 		t.Error("expected category_override=false after skip, but got true")

--- a/internal/service/rules_integration_test.go
+++ b/internal/service/rules_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 )
@@ -730,7 +731,7 @@ func TestCreateAccountLink_SelfLinkRejected(t *testing.T) {
 	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
 	acct := testutil.MustCreateAccount(t, queries, conn.ID, "ext_1", "Acct")
 
-	acctID := formatUUIDForTest(acct.ID)
+	acctID := pgconv.FormatUUID(acct.ID)
 	_, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
 		PrimaryAccountID:   acctID,
 		DependentAccountID: acctID,
@@ -753,8 +754,8 @@ func TestGetAccountLink_MatchCounts(t *testing.T) {
 	acct2 := testutil.MustCreateAccount(t, queries, conn2.ID, "ext_2", "Dependent")
 
 	link, err := svc.CreateAccountLink(context.Background(), service.CreateAccountLinkParams{
-		PrimaryAccountID:   formatUUIDForTest(acct1.ID),
-		DependentAccountID: formatUUIDForTest(acct2.ID),
+		PrimaryAccountID:   pgconv.FormatUUID(acct1.ID),
+		DependentAccountID: pgconv.FormatUUID(acct2.ID),
 	})
 	if err != nil {
 		t.Fatalf("create link: %v", err)
@@ -769,11 +770,11 @@ func TestGetAccountLink_MatchCounts(t *testing.T) {
 	txnD2 := testutil.MustCreateTransaction(t, queries, acct2.ID, "d2", "Store B", 2000, "2025-01-16")
 	_ = testutil.MustCreateTransaction(t, queries, acct2.ID, "d3", "Store C", 3000, "2025-01-17")
 
-	_, err = svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txnP1.ID), formatUUIDForTest(txnD1.ID))
+	_, err = svc.ManualMatch(context.Background(), link.ID, pgconv.FormatUUID(txnP1.ID), pgconv.FormatUUID(txnD1.ID))
 	if err != nil {
 		t.Fatalf("match 1: %v", err)
 	}
-	_, err = svc.ManualMatch(context.Background(), link.ID, formatUUIDForTest(txnP2.ID), formatUUIDForTest(txnD2.ID))
+	_, err = svc.ManualMatch(context.Background(), link.ID, pgconv.FormatUUID(txnP2.ID), pgconv.FormatUUID(txnD2.ID))
 	if err != nil {
 		t.Fatalf("match 2: %v", err)
 	}

--- a/internal/service/short_id_integration_test.go
+++ b/internal/service/short_id_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/shortid"
 	"breadbox/internal/testutil"
@@ -148,7 +149,7 @@ func TestShortID_Resolver_GetAccount_ByUUID(t *testing.T) {
 	conn := testutil.MustCreateConnection(t, queries, user.ID, "sid_resolve_conn")
 	dbAcct := testutil.MustCreateAccount(t, queries, conn.ID, "sid_resolve_acct", "Checking")
 
-	uuid := formatUUID(dbAcct.ID)
+	uuid := pgconv.FormatUUID(dbAcct.ID)
 	acct, err := svc.GetAccount(ctx, uuid)
 	if err != nil {
 		t.Fatalf("GetAccount by UUID: %v", err)
@@ -170,8 +171,8 @@ func TestShortID_Resolver_GetAccount_ByShortID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAccount by short_id %q: %v", dbAcct.ShortID, err)
 	}
-	if acct.ID != formatUUID(dbAcct.ID) {
-		t.Fatalf("expected UUID %q, got %q", formatUUID(dbAcct.ID), acct.ID)
+	if acct.ID != pgconv.FormatUUID(dbAcct.ID) {
+		t.Fatalf("expected UUID %q, got %q", pgconv.FormatUUID(dbAcct.ID), acct.ID)
 	}
 }
 
@@ -188,8 +189,8 @@ func TestShortID_Resolver_GetTransaction_ByShortID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetTransaction by short_id %q: %v", dbTxn.ShortID, err)
 	}
-	if txn.ID != formatUUID(dbTxn.ID) {
-		t.Fatalf("expected UUID %q, got %q", formatUUID(dbTxn.ID), txn.ID)
+	if txn.ID != pgconv.FormatUUID(dbTxn.ID) {
+		t.Fatalf("expected UUID %q, got %q", pgconv.FormatUUID(dbTxn.ID), txn.ID)
 	}
 	if txn.ShortID != dbTxn.ShortID {
 		t.Fatalf("expected ShortID %q, got %q", dbTxn.ShortID, txn.ShortID)

--- a/internal/service/transaction_query_integration_test.go
+++ b/internal/service/transaction_query_integration_test.go
@@ -9,7 +9,6 @@ package service_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 	"testing"
 	"time"

--- a/internal/service/transaction_query_integration_test.go
+++ b/internal/service/transaction_query_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -268,7 +269,7 @@ func TestGetTransactionSummary_AccountFilter(t *testing.T) {
 
 	start := testutil.MustParseDate("2025-01-01")
 	end := testutil.MustParseDate("2025-02-01")
-	acct1ID := formatUUID(acct1.ID)
+	acct1ID := pgconv.FormatUUID(acct1.ID)
 
 	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
 		GroupBy:   "day",
@@ -302,7 +303,7 @@ func TestGetTransactionSummary_UserFilter(t *testing.T) {
 
 	start := testutil.MustParseDate("2025-01-01")
 	end := testutil.MustParseDate("2025-02-01")
-	aliceID := formatUUID(alice.ID)
+	aliceID := pgconv.FormatUUID(alice.ID)
 
 	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
 		GroupBy:   "day",
@@ -527,7 +528,7 @@ func TestListTransactions_UserFilter(t *testing.T) {
 	testutil.MustCreateTransaction(t, queries, acctA.ID, "txn_alice", "Alice Purchase", 1000, "2025-01-15")
 	testutil.MustCreateTransaction(t, queries, acctB.ID, "txn_bob", "Bob Purchase", 2000, "2025-01-15")
 
-	aliceID := formatUUID(alice.ID)
+	aliceID := pgconv.FormatUUID(alice.ID)
 	result, err := svc.ListTransactions(ctx, service.TransactionListParams{UserID: &aliceID})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -554,7 +555,7 @@ func TestListTransactions_AccountFilter(t *testing.T) {
 	testutil.MustCreateTransaction(t, queries, acct1.ID, "txn_c", "Checking Txn", 1000, "2025-01-15")
 	testutil.MustCreateTransaction(t, queries, acct2.ID, "txn_s", "Savings Txn", 2000, "2025-01-15")
 
-	acct1ID := formatUUID(acct1.ID)
+	acct1ID := pgconv.FormatUUID(acct1.ID)
 	result, err := svc.ListTransactions(ctx, service.TransactionListParams{AccountID: &acct1ID})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -852,7 +853,7 @@ func TestCountTransactionsFiltered_UserFilter(t *testing.T) {
 	testutil.MustCreateTransaction(t, queries, acctA.ID, "txn_a", "Alice Txn", 100, "2025-01-15")
 	testutil.MustCreateTransaction(t, queries, acctB.ID, "txn_b", "Bob Txn", 200, "2025-01-15")
 
-	aliceID := formatUUID(alice.ID)
+	aliceID := pgconv.FormatUUID(alice.ID)
 	count, err := svc.CountTransactionsFiltered(ctx, service.TransactionCountParams{UserID: &aliceID})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1012,7 +1013,7 @@ func TestGetTransaction_WithCategory(t *testing.T) {
 
 	txn := upsertTxnWithCategory(t, queries, acctID, "txn_get", "Whole Foods", 2500, "2025-01-15", child.ID)
 
-	resp, err := svc.GetTransaction(ctx, formatUUID(txn.ID))
+	resp, err := svc.GetTransaction(ctx, pgconv.FormatUUID(txn.ID))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1118,7 +1119,7 @@ func TestGetTransactionSummary_ValidAccountIDFilter(t *testing.T) {
 
 	start := testutil.MustParseDate("2025-01-01")
 	end := testutil.MustParseDate("2025-02-01")
-	acctIDStr := formatTestUUID(acctID)
+	acctIDStr := pgconv.FormatUUID(acctID)
 
 	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
 		GroupBy:   "month",
@@ -1146,7 +1147,7 @@ func TestGetTransactionSummary_ValidUserIDFilter(t *testing.T) {
 
 	start := testutil.MustParseDate("2025-01-01")
 	end := testutil.MustParseDate("2025-02-01")
-	userIDStr := formatTestUUID(user.ID)
+	userIDStr := pgconv.FormatUUID(user.ID)
 
 	result, err := svc.GetTransactionSummary(ctx, service.TransactionSummaryParams{
 		GroupBy:   "month",
@@ -1206,12 +1207,6 @@ func upsertTxnWithAmount(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID,
 // isInvalidParam checks if an error wraps service.ErrInvalidParameter.
 func isInvalidParam(err error) bool {
 	return errors.Is(err, service.ErrInvalidParameter)
-}
-
-// formatTestUUID converts a pgtype.UUID to a standard UUID string.
-func formatTestUUID(u pgtype.UUID) string {
-	b := u.Bytes
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 func upsertTxnWithMerchant(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID, name, merchant string, amountCents int64, date string) db.Transaction {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
 
 	"github.com/jackc/pgx/v5"
@@ -62,7 +63,7 @@ func NewEngine(queries *db.Queries, pool *pgxpool.Pool, providers map[string]pro
 
 // Sync runs an incremental transaction sync for a single bank connection.
 func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.SyncTrigger) error {
-	connIDStr := formatUUID(connectionID)
+	connIDStr := pgconv.FormatUUID(connectionID)
 	logger := e.logger.With("connection_id", connIDStr, "trigger", string(trigger))
 
 	// Acquire per-connection lock. If already locked, skip.
@@ -184,7 +185,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		ProviderName:         string(conn.Provider),
 		ExternalID:           conn.ExternalID.String,
 		EncryptedCredentials: conn.EncryptedCredentials,
-		UserID:               formatUUID(conn.UserID),
+		UserID:               pgconv.FormatUUID(conn.UserID),
 	}
 
 	// Track cursors for pagination.
@@ -221,7 +222,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 	} else {
 		for _, acct := range connAccounts {
 			accountIDCache[acct.ExternalAccountID] = acct.ID
-			key := formatUUID(acct.ID)
+			key := pgconv.FormatUUID(acct.ID)
 			if acct.DisplayName.Valid && acct.DisplayName.String != "" {
 				accountNameCache[key] = acct.DisplayName.String
 			} else {
@@ -568,8 +569,8 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 		Amount:     txn.Amount.InexactFloat64(),
 		Pending:    txn.Pending,
 		Provider:   providerName,
-		AccountID:  formatUUID(accountID),
-		UserID:     formatUUID(userID),
+		AccountID:  pgconv.FormatUUID(accountID),
+		UserID:     pgconv.FormatUUID(userID),
 		UserName:   userName,
 	}
 	if txn.MerchantName != nil {
@@ -758,7 +759,7 @@ func (e *Engine) SyncAll(ctx context.Context, trigger db.SyncTrigger) error {
 			defer func() { <-sem }()
 
 			if err := e.Sync(ctx, connID, trigger); err != nil {
-				e.logger.Error("sync connection failed", "connection_id", formatUUID(connID), "error", err)
+				e.logger.Error("sync connection failed", "connection_id", pgconv.FormatUUID(connID), "error", err)
 			}
 		}()
 	}
@@ -774,7 +775,7 @@ func (e *Engine) Matcher() *Matcher {
 
 // trackAccountCount increments the per-account counter for the given operation type.
 func (e *Engine) trackAccountCount(ctx context.Context, perAccount map[string]*accountSyncCounts, accountID pgtype.UUID, nameCache map[string]string, op string) {
-	key := formatUUID(accountID)
+	key := pgconv.FormatUUID(accountID)
 	if key == "" {
 		return
 	}
@@ -895,10 +896,3 @@ func optionalDecimalToNumeric(d *decimal.Decimal) pgtype.Numeric {
 	return decimalToNumeric(*d)
 }
 
-func formatUUID(u pgtype.UUID) string {
-	if !u.Valid {
-		return ""
-	}
-	b := u.Bytes
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
-}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"breadbox/internal/db"
-	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
 	"breadbox/internal/sync"
 	"breadbox/internal/testutil"

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
 	"breadbox/internal/sync"
 	"breadbox/internal/testutil"
@@ -161,13 +162,6 @@ func seedCategoriesWithFood(t *testing.T, queries *db.Queries) (uncat db.Categor
 	return uncat, food
 }
 
-func formatUUID(u pgtype.UUID) string {
-	if !u.Valid {
-		return ""
-	}
-	b := u.Bytes
-	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
-}
 
 // --- Tests ---
 

--- a/internal/sync/matcher.go
+++ b/internal/sync/matcher.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -40,7 +41,7 @@ func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, 
 		return 0, nil
 	}
 
-	logger := m.logger.With("link_id", formatUUID(link.ID))
+	logger := m.logger.With("link_id", pgconv.FormatUUID(link.ID))
 
 	// Resolve the dependent account's user ID for attribution.
 	depUserID, err := m.queries.GetDependentUserID(ctx, link.DependentAccountID)
@@ -108,7 +109,7 @@ func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, 
 		candidateRows, err := m.pool.Query(ctx, candidateQuery,
 			link.PrimaryAccountID, dep.Amount, dep.Date, tolerance)
 		if err != nil {
-			logger.Error("query candidates", "dep_id", formatUUID(dep.ID), "error", err)
+			logger.Error("query candidates", "dep_id", pgconv.FormatUUID(dep.ID), "error", err)
 			continue
 		}
 
@@ -141,7 +142,7 @@ func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, 
 
 		if bestCandidate == nil {
 			logger.Debug("ambiguous match, skipping",
-				"dep_id", formatUUID(dep.ID),
+				"dep_id", pgconv.FormatUUID(dep.ID),
 				"candidates", len(candidates))
 			continue
 		}
@@ -159,7 +160,7 @@ func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, 
 		})
 		if err != nil {
 			// ON CONFLICT DO NOTHING — already matched.
-			logger.Debug("match insert skipped (conflict)", "dep_id", formatUUID(dep.ID))
+			logger.Debug("match insert skipped (conflict)", "dep_id", pgconv.FormatUUID(dep.ID))
 			continue
 		}
 
@@ -168,7 +169,7 @@ func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, 
 			ID:               bestCandidate.ID,
 			AttributedUserID: depUserID,
 		}); err != nil {
-			logger.Error("set attribution", "primary_id", formatUUID(bestCandidate.ID), "error", err)
+			logger.Error("set attribution", "primary_id", pgconv.FormatUUID(bestCandidate.ID), "error", err)
 		}
 
 		newMatches++
@@ -192,7 +193,7 @@ func (m *Matcher) ReconcileForConnection(ctx context.Context, connectionID pgtyp
 
 	for _, link := range links {
 		if _, err := m.ReconcileLink(ctx, link); err != nil {
-			m.logger.Error("reconcile link", "link_id", formatUUID(link.ID), "error", err)
+			m.logger.Error("reconcile link", "link_id", pgconv.FormatUUID(link.ID), "error", err)
 		}
 	}
 }

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 
+	"breadbox/internal/pgconv"
+
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -155,14 +157,14 @@ func loadRules(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) ([]
 		var cond Condition
 		if err := json.Unmarshal(rr.conditions, &cond); err != nil {
 			logger.Warn("skipping rule with invalid conditions JSON",
-				"rule_id", formatUUID(rr.id), "error", err)
+				"rule_id", pgconv.FormatUUID(rr.id), "error", err)
 			continue
 		}
 
 		cc, err := compileCondition(&cond)
 		if err != nil {
 			logger.Warn("skipping rule with invalid condition",
-				"rule_id", formatUUID(rr.id), "error", err)
+				"rule_id", pgconv.FormatUUID(rr.id), "error", err)
 			continue
 		}
 
@@ -290,7 +292,7 @@ func (r *RuleResolver) HitCountsJSON() []byte {
 	result := make(map[string]int, len(r.hitCounts))
 	for uuidBytes, count := range r.hitCounts {
 		id := pgtype.UUID{Bytes: uuidBytes, Valid: true}
-		result[formatUUID(id)] = count
+		result[pgconv.FormatUUID(id)] = count
 	}
 
 	data, err := json.Marshal(result)
@@ -313,7 +315,7 @@ func (r *RuleResolver) FlushHitCounts(ctx context.Context, pool *pgxpool.Pool) e
 			"UPDATE transaction_rules SET hit_count = hit_count + $1, last_hit_at = NOW() WHERE id = $2",
 			count, id)
 		if err != nil {
-			return fmt.Errorf("update hit count for rule %s: %w", formatUUID(id), err)
+			return fmt.Errorf("update hit count for rule %s: %w", pgconv.FormatUUID(id), err)
 		}
 	}
 

--- a/internal/sync/rule_resolver_test.go
+++ b/internal/sync/rule_resolver_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"breadbox/internal/pgconv"
+
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -767,8 +769,8 @@ func TestHitCountsJSON_WithHits(t *testing.T) {
 		t.Errorf("expected 2 entries, got %d", len(parsed))
 	}
 
-	ruleAID := formatUUID(ruleA)
-	ruleBID := formatUUID(ruleB)
+	ruleAID := pgconv.FormatUUID(ruleA)
+	ruleBID := pgconv.FormatUUID(ruleB)
 
 	if parsed[ruleAID] != 5 {
 		t.Errorf("expected 5 hits for rule A, got %d", parsed[ruleAID])
@@ -810,7 +812,7 @@ func TestHitCountsJSON_IntegrationWithResolveWithContext(t *testing.T) {
 		t.Fatalf("failed to unmarshal: %v", err)
 	}
 
-	ruleIDStr := formatUUID(ruleID)
+	ruleIDStr := pgconv.FormatUUID(ruleID)
 	if parsed[ruleIDStr] != 3 {
 		t.Errorf("expected 3 hits, got %d", parsed[ruleIDStr])
 	}

--- a/internal/sync/scheduler.go
+++ b/internal/sync/scheduler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/robfig/cron/v3"
@@ -155,7 +156,7 @@ func (s *Scheduler) syncAllScheduled(ctx context.Context, globalIntervalMinutes 
 			syncCtx, cancel := context.WithTimeout(ctx, s.syncTimeout)
 			defer cancel()
 			if err := s.engine.Sync(syncCtx, connID, db.SyncTriggerCron); err != nil {
-				s.logger.Error("scheduled sync failed", "connection_id", formatUUID(connID), "error", err)
+				s.logger.Error("scheduled sync failed", "connection_id", pgconv.FormatUUID(connID), "error", err)
 			}
 		}()
 		synced++
@@ -199,7 +200,7 @@ func (s *Scheduler) RunStartupSync(ctx context.Context, globalIntervalMinutes in
 			syncCtx, cancel := context.WithTimeout(ctx, s.syncTimeout)
 			if err := s.engine.Sync(syncCtx, conn.ID, db.SyncTriggerCron); err != nil {
 				s.logger.Error("startup sync: connection failed",
-					"connection_id", formatUUID(conn.ID),
+					"connection_id", pgconv.FormatUUID(conn.ID),
 					"error", err,
 				)
 			}


### PR DESCRIPTION
## Summary
- Created `internal/pgconv/pgconv.go` with shared `FormatUUID` helper.
- Replaced 4 identical production implementations across sync, admin, middleware, and service packages, plus 4 test-only variants (`fmtUUID`, `formatTestUUID`, `formatUUIDForTest`+`bytesToUUIDString`+`hexEncode`).
- Added unit tests in `internal/pgconv/pgconv_test.go` covering valid, invalid, zero-bytes, and max-bytes cases.
- `internal/service/convert.go` retains a thin `formatUUID` wrapper delegating to `pgconv.FormatUUID` to avoid touching files with active PRs (`transactions.go`, `rules.go`).

## Motivation
This helper was copy-pasted identically across 4+ packages. A single source of truth reduces maintenance burden and ensures consistent behavior.

## Changes
- **New**: `internal/pgconv/pgconv.go`, `internal/pgconv/pgconv_test.go`
- **Modified (production)**: `internal/sync/engine.go`, `internal/sync/scheduler.go`, `internal/sync/matcher.go`, `internal/sync/rule_resolver.go`, `internal/middleware/apikey.go`, `internal/admin/connections.go`, `internal/admin/auth.go`, `internal/admin/avatars.go`, `internal/admin/csv_import.go`, `internal/admin/dashboard.go`, `internal/admin/templates.go`, `internal/admin/users.go`, `internal/service/convert.go`
- **Modified (tests)**: `internal/middleware/middleware_test.go`, `internal/sync/engine_integration_test.go`, `internal/sync/rule_resolver_test.go`, `internal/api/api_integration_test.go`, `internal/service/integration_test.go`, `internal/service/account_link_integration_test.go`, `internal/service/rules_integration_test.go`, `internal/service/transaction_query_integration_test.go`, `internal/service/review_integration_test.go`, `internal/service/members_integration_test.go`, `internal/service/mcp_synclog_csv_integration_test.go`, `internal/service/comments_apikeys_integration_test.go`, `internal/service/category_integration_test.go`, `internal/service/short_id_integration_test.go`

## Behavior preservation
- No functional changes -- same inputs produce same outputs.
- All existing unit tests pass.

## Test plan
- [x] `go build ./...` (only pre-existing avatars.go sqlc issue)
- [x] `go test ./internal/pgconv/... ./internal/service/... ./internal/sync/... ./internal/middleware/...`
- [x] `go vet ./internal/pgconv/... ./internal/service/... ./internal/sync/... ./internal/middleware/...`
- [x] New unit tests for valid UUID, invalid UUID, zero bytes, max bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)