### PR TITLE
refactor(service): consolidate 10 ID resolver functions into generic helper

### DIFF
--- a/internal/service/resolve.go
+++ b/internal/service/resolve.go
@@ -9,13 +9,18 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-// resolveTransactionID accepts either a UUID string or an 8-char short ID
-// and returns the corresponding pgtype.UUID for database queries.
-func (s *Service) resolveTransactionID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
+// shortIDLookup is the signature shared by all sqlc-generated GetXxxUUIDByShortID queries.
+type shortIDLookup func(ctx context.Context, shortID string) (pgtype.UUID, error)
+
+// resolveID is the generic resolver. It accepts either a UUID string or an
+// 8-char short ID and returns the corresponding pgtype.UUID. notFoundErr is
+// returned when a short ID lookup finds no rows (e.g. ErrNotFound or
+// ErrCategoryNotFound).
+func (s *Service) resolveID(ctx context.Context, idOrShort string, lookup shortIDLookup, notFoundErr error) (pgtype.UUID, error) {
 	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetTransactionUUIDByShortID(ctx, idOrShort)
+		uid, err := lookup(ctx, idOrShort)
 		if err != nil {
-			return pgtype.UUID{}, ErrNotFound
+			return pgtype.UUID{}, notFoundErr
 		}
 		return uid, nil
 	}
@@ -24,148 +29,55 @@ func (s *Service) resolveTransactionID(ctx context.Context, idOrShort string) (p
 		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
 	}
 	return uid, nil
+}
+
+// resolveTransactionID accepts either a UUID string or an 8-char short ID
+// and returns the corresponding pgtype.UUID for database queries.
+func (s *Service) resolveTransactionID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
+	return s.resolveID(ctx, idOrShort, s.Queries.GetTransactionUUIDByShortID, ErrNotFound)
 }
 
 // resolveAccountID accepts either a UUID string or a short ID.
 func (s *Service) resolveAccountID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
-	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetAccountUUIDByShortID(ctx, idOrShort)
-		if err != nil {
-			return pgtype.UUID{}, ErrNotFound
-		}
-		return uid, nil
-	}
-	uid, err := parseUUID(idOrShort)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
-	}
-	return uid, nil
+	return s.resolveID(ctx, idOrShort, s.Queries.GetAccountUUIDByShortID, ErrNotFound)
 }
 
 // resolveUserID accepts either a UUID string or a short ID.
 func (s *Service) resolveUserID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
-	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetUserUUIDByShortID(ctx, idOrShort)
-		if err != nil {
-			return pgtype.UUID{}, ErrNotFound
-		}
-		return uid, nil
-	}
-	uid, err := parseUUID(idOrShort)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
-	}
-	return uid, nil
+	return s.resolveID(ctx, idOrShort, s.Queries.GetUserUUIDByShortID, ErrNotFound)
 }
 
 // resolveCategoryID accepts either a UUID string or a short ID.
 func (s *Service) resolveCategoryID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
-	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetCategoryUUIDByShortID(ctx, idOrShort)
-		if err != nil {
-			return pgtype.UUID{}, ErrCategoryNotFound
-		}
-		return uid, nil
-	}
-	uid, err := parseUUID(idOrShort)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
-	}
-	return uid, nil
+	return s.resolveID(ctx, idOrShort, s.Queries.GetCategoryUUIDByShortID, ErrCategoryNotFound)
 }
 
 // resolveConnectionID accepts either a UUID string or a short ID.
 func (s *Service) resolveConnectionID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
-	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetConnectionUUIDByShortID(ctx, idOrShort)
-		if err != nil {
-			return pgtype.UUID{}, ErrNotFound
-		}
-		return uid, nil
-	}
-	uid, err := parseUUID(idOrShort)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
-	}
-	return uid, nil
+	return s.resolveID(ctx, idOrShort, s.Queries.GetConnectionUUIDByShortID, ErrNotFound)
 }
 
 // resolveReviewID accepts either a UUID string or a short ID.
 func (s *Service) resolveReviewID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
-	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetReviewUUIDByShortID(ctx, idOrShort)
-		if err != nil {
-			return pgtype.UUID{}, ErrNotFound
-		}
-		return uid, nil
-	}
-	uid, err := parseUUID(idOrShort)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
-	}
-	return uid, nil
+	return s.resolveID(ctx, idOrShort, s.Queries.GetReviewUUIDByShortID, ErrNotFound)
 }
 
 // resolveRuleID accepts either a UUID string or a short ID.
 func (s *Service) resolveRuleID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
-	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetRuleUUIDByShortID(ctx, idOrShort)
-		if err != nil {
-			return pgtype.UUID{}, ErrNotFound
-		}
-		return uid, nil
-	}
-	uid, err := parseUUID(idOrShort)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
-	}
-	return uid, nil
+	return s.resolveID(ctx, idOrShort, s.Queries.GetRuleUUIDByShortID, ErrNotFound)
 }
 
 // resolveAccountLinkID accepts either a UUID string or a short ID.
 func (s *Service) resolveAccountLinkID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
-	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetAccountLinkUUIDByShortID(ctx, idOrShort)
-		if err != nil {
-			return pgtype.UUID{}, ErrNotFound
-		}
-		return uid, nil
-	}
-	uid, err := parseUUID(idOrShort)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
-	}
-	return uid, nil
+	return s.resolveID(ctx, idOrShort, s.Queries.GetAccountLinkUUIDByShortID, ErrNotFound)
 }
 
 // resolveMatchID accepts either a UUID string or a short ID.
 func (s *Service) resolveMatchID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
-	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetMatchUUIDByShortID(ctx, idOrShort)
-		if err != nil {
-			return pgtype.UUID{}, ErrNotFound
-		}
-		return uid, nil
-	}
-	uid, err := parseUUID(idOrShort)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
-	}
-	return uid, nil
+	return s.resolveID(ctx, idOrShort, s.Queries.GetMatchUUIDByShortID, ErrNotFound)
 }
 
 // resolveCommentID accepts either a UUID string or a short ID.
 func (s *Service) resolveCommentID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
-	if shortid.IsShortID(idOrShort) {
-		uid, err := s.Queries.GetCommentUUIDByShortID(ctx, idOrShort)
-		if err != nil {
-			return pgtype.UUID{}, ErrNotFound
-		}
-		return uid, nil
-	}
-	uid, err := parseUUID(idOrShort)
-	if err != nil {
-		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
-	}
-	return uid, nil
+	return s.resolveID(ctx, idOrShort, s.Queries.GetCommentUUIDByShortID, ErrNotFound)
 }

--- a/internal/service/resolve_test.go
+++ b/internal/service/resolve_test.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// validUUID is a well-formed UUID for testing parseUUID passthrough.
+const validUUID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
+
+// mockLookupOK returns a fixed UUID, simulating a successful short ID query.
+func mockLookupOK(_ context.Context, _ string) (pgtype.UUID, error) {
+	uid, _ := parseUUID(validUUID)
+	return uid, nil
+}
+
+// mockLookupErr simulates a short ID lookup that finds no rows.
+func mockLookupErr(_ context.Context, _ string) (pgtype.UUID, error) {
+	return pgtype.UUID{}, fmt.Errorf("no rows")
+}
+
+func TestResolveID_ShortID_Found(t *testing.T) {
+	s := &Service{}
+	uid, err := s.resolveID(context.Background(), "AbCd1234", mockLookupOK, ErrNotFound)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !uid.Valid {
+		t.Fatal("expected valid UUID")
+	}
+}
+
+func TestResolveID_ShortID_NotFound(t *testing.T) {
+	s := &Service{}
+	_, err := s.resolveID(context.Background(), "AbCd1234", mockLookupErr, ErrNotFound)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+func TestResolveID_ShortID_CustomError(t *testing.T) {
+	s := &Service{}
+	_, err := s.resolveID(context.Background(), "AbCd1234", mockLookupErr, ErrCategoryNotFound)
+	if !errors.Is(err, ErrCategoryNotFound) {
+		t.Fatalf("expected ErrCategoryNotFound, got: %v", err)
+	}
+}
+
+func TestResolveID_ValidUUID(t *testing.T) {
+	s := &Service{}
+	// mockLookupErr should never be called for a UUID input.
+	uid, err := s.resolveID(context.Background(), validUUID, mockLookupErr, ErrNotFound)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !uid.Valid {
+		t.Fatal("expected valid UUID")
+	}
+}
+
+func TestResolveID_InvalidInput(t *testing.T) {
+	s := &Service{}
+	_, err := s.resolveID(context.Background(), "not-a-uuid-or-short", mockLookupErr, ErrNotFound)
+	if err == nil {
+		t.Fatal("expected error for invalid input")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatal("should not be ErrNotFound — should be an 'invalid id' error")
+	}
+}


### PR DESCRIPTION
## Summary
- Created generic `resolveID()` helper that accepts a short-ID lookup function and not-found error.
- Rewrote all 10 entity-specific resolvers as one-line wrappers calling the generic helper.
- ~120 lines of duplicated logic consolidated into ~20 lines of shared code.
- Added 5 unit tests covering short ID found/not-found, custom error propagation, UUID passthrough, and invalid input.

## Motivation
Ten resolver functions were copy-pasted with identical logic, differing only in the sqlc query called and (in one case) the not-found error returned. A generic helper ensures consistent behavior and reduces maintenance burden.

## Changes
- `internal/service/resolve.go`: added `shortIDLookup` type alias, generic `resolveID`, simplified all 10 wrappers
- `internal/service/resolve_test.go`: new unit tests for the generic resolver

## Behavior preservation
- All resolver method signatures unchanged.
- Same `ErrNotFound` / `ErrCategoryNotFound` behavior, same UUID parsing, same short ID detection.
- All existing tests pass.

## Test plan
- [x] `go build ./internal/service/...`
- [x] `go test ./internal/service/...`
- [x] `go vet ./internal/service/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)