### PR TITLE
feat(admin): polish Household flow and extract form-card design primitives

### DIFF
--- a/.claude/commands/apply-design.md
+++ b/.claude/commands/apply-design.md
@@ -1,0 +1,95 @@
+---
+description: Apply the Breadbox form-card design system to a page (forms, settings, detail views, modals).
+---
+
+You are applying Breadbox's canonical form-card design language to the page the user names. Your job is to bring that page into visual and structural alignment with our design system so it looks like it was built by the same hand as the rest of the app.
+
+## Read first
+
+Before touching anything, read these in order:
+
+1. `docs/design-system.md` — canonical design system reference. §4 (Cards, Icon Tiles), §5 (Form Card Pattern), §7 (Dirty-State Form Tracking, Danger Zone Card, Overflow Action Menu), §12 (Alerts) are the relevant sections.
+2. `internal/templates/pages/create_login.html` — the reference implementation. Both the **create** (`!done` template) and **manage** (`IsManage` branch) states are canonical. Study how they wrap a `<form>` directly as the card, how the icon header is structured, how the action row handles Cancel + primary.
+3. `internal/templates/pages/user_form.html` — the **edit** branch is another canonical example, plus it shows how to fit an avatar picker inside an icon header.
+4. `input.css` around the `/* ── Form card primitives ── */` block — the CSS classes you'll be using.
+
+## Core pattern
+
+```html
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Page Title</h1>
+    <p class="text-sm text-base-content/50 mt-1">Short subtitle</p>
+  </div>
+</div>
+
+<div class="max-w-lg">
+  <form @submit.prevent="submit()" class="bb-card p-0 overflow-hidden">
+    <div class="p-5 sm:p-6">
+      <div class="bb-icon-header">
+        <div class="bb-icon-header__tile bb-icon-tile--primary">
+          <i data-lucide="ICON" class="w-5 h-5"></i>
+        </div>
+        <div class="bb-icon-header__text">
+          <h2 class="text-sm font-semibold">Section title</h2>
+          <p class="text-xs text-base-content/45">Short helper text</p>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <div>
+          <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="field_id">Label</label>
+          <input id="field_id" class="bb-form-input" ...>
+        </div>
+        <!-- more fields... use bb-form-select for <select> -->
+
+        <template x-if="error">
+          <div role="alert" class="bb-form-error">
+            <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+            <span x-text="error"></span>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <div class="bb-action-row">
+      <a href="/back" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
+      <button type="submit" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32" :disabled="submitting">
+        <span x-show="!submitting" class="inline-flex items-center gap-1.5">
+          <i data-lucide="save" class="w-3.5 h-3.5"></i>Save Changes
+        </span>
+        <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+      </button>
+    </div>
+  </form>
+</div>
+```
+
+## Checklist (apply every applicable item)
+
+- [ ] Page has a `bb-page-header` at the top with title + one-line subtitle. **Do not** add a back-button on the right of the header — the breadcrumb handles navigation.
+- [ ] Main card is `bb-card p-0 overflow-hidden` wrapped in `max-w-lg` (forms) or wider (dashboards). Put the `class` on the `<form>` itself when the card *is* a form — avoids a redundant wrapper.
+- [ ] Top section is `p-5 sm:p-6` (never `p-8` — that's the old centered-card style).
+- [ ] Card starts with a `bb-icon-header` + colored tile. Pick the tile color by intent: `primary` for create/edit, `success` for completed/success states, `warning` for inline prompts, `error` only inside `bb-danger-card`. Icons inside the tile are `w-5 h-5` and inherit `currentColor` — don't set a text color on them.
+- [ ] Form fields are grouped with `space-y-4`. Each field is a `<div>` with a `<label>` (`block text-xs font-medium text-base-content/50 mb-1.5`) and `bb-form-input` / `bb-form-select`.
+- [ ] Inline errors use `<div role="alert" class="bb-form-error">` with an `alert-circle` icon.
+- [ ] Action row is `bb-action-row`, right-aligned, with **Cancel** (ghost) on the left and the primary button on the right. Primary button gets `min-w-32` so the spinner doesn't cause width jitter. Primary button icon is `w-3.5 h-3.5`.
+- [ ] Destructive actions go in a **separate** card below: `<div class="bb-card bb-danger-card p-5 sm:p-6 mt-4">` with the horizontal title-on-left / button-on-right layout from the design-system doc. Never mix Save and Delete in the same action row.
+- [ ] For edit pages where save is explicit (not auto-save on change), use the **dirty-state tracking** Alpine pattern from §7: `initialX` / `x` / `get dirty()` / `save()` with a 2-second `saved` confirmation.
+- [ ] If a card has ≥2 secondary actions, collapse them into an `ellipsis-vertical` dropdown menu — don't line up multiple icon buttons.
+- [ ] If you changed `input.css`, run `make css` to regenerate `static/css/styles.css`.
+- [ ] `go build ./...` still succeeds.
+
+## Anti-patterns to fix on sight
+
+- Inline `flex items-center gap-3 mb-5` + `w-10 h-10 rounded-xl bg-{color}/10` icon header block → replace with `bb-icon-header` + `bb-icon-tile--{color}`.
+- `input input-bordered w-full rounded-xl bg-base-200/50 focus:bg-base-100 transition-colors` → `bb-form-input`.
+- `select select-bordered w-full rounded-xl bg-base-200` → `bb-form-select`.
+- `p-4 sm:p-5 border-t border-base-300 bg-base-200/20 flex items-center justify-end gap-2` → `bb-action-row`.
+- `rounded-xl bg-error/10 border border-error/20 text-error text-sm px-4 py-3` old error alerts → `bb-form-error` with `alert-circle` icon.
+- Tall `p-8` / `max-w-md mx-auto` centered forms → switch to `max-w-lg` + `bb-page-header` above + sectioned card.
+- Full-width primary CTA `btn-primary w-full h-12` → switch to `bb-action-row` with a right-aligned `btn-sm btn-primary` (our forms live inside the app chrome, not on a blank auth page).
+
+## When you're done
+
+Briefly report: files changed, any design-system primitives you had to stretch (and why), and anything that didn't fit the pattern cleanly so the next agent can refine it.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -180,6 +180,25 @@ Base class: `bb-card` — provides `bg-base-100 rounded-xl border border-base-30
 
 **Interactive cards** add `bb-card--interactive` for hover effects (cursor change, background shift).
 
+**Danger-zone cards** add `bb-danger-card` (soft error tint: `border-error/20 bg-error/[0.02]`) — use for destructive-action cards placed below the main form card.
+
+### Icon Tiles (`bb-icon-tile--*`)
+
+Colored 40×40 rounded squares used inside card headers to ground the page's purpose. Pair `.bb-icon-header__tile` (geometry) with a color modifier; the icon inside inherits `currentColor`, so don't set a text color on it.
+
+| Modifier | Background | Text |
+|---|---|---|
+| `.bb-icon-tile--primary` | `bg-primary/8` | `text-primary` |
+| `.bb-icon-tile--success` | `bg-success/10` | `text-success` |
+| `.bb-icon-tile--warning` | `bg-warning/10` | `text-warning` |
+| `.bb-icon-tile--error` | `bg-error/10` | `text-error` |
+
+```html
+<div class="bb-icon-header__tile bb-icon-tile--primary">
+  <i data-lucide="user-plus" class="w-5 h-5"></i>
+</div>
+```
+
 ### Modals
 
 All `<dialog>` elements use:
@@ -331,6 +350,73 @@ For filtered "no results" states (e.g., transactions with active filters), a com
 </div>
 ```
 
+### Form Card Pattern
+
+The canonical pattern for create/edit/settings forms. A sectioned card with a colored icon header on top, form fields in the middle, and a subtle action row (Cancel + Save/Create) at the bottom. Use `max-w-lg` for the container.
+
+**Reference implementations:** `internal/templates/pages/create_login.html` (both create and manage modes) and `internal/templates/pages/user_form.html` (edit mode).
+
+```html
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Create Login</h1>
+    <p class="text-sm text-base-content/50 mt-1">Create a sign-in account for {{.User.Name}}</p>
+  </div>
+</div>
+
+<div class="max-w-lg">
+  <form @submit.prevent="submit()" class="bb-card p-0 overflow-hidden">
+    <!-- Top section: icon header + fields -->
+    <div class="p-5 sm:p-6">
+      <div class="bb-icon-header">
+        <div class="bb-icon-header__tile bb-icon-tile--primary">
+          <i data-lucide="user-plus" class="w-5 h-5"></i>
+        </div>
+        <div class="bb-icon-header__text">
+          <h2 class="text-sm font-semibold">New login account</h2>
+          <p class="text-xs text-base-content/45">They'll receive a link to set their password</p>
+        </div>
+      </div>
+
+      <div class="space-y-4">
+        <div>
+          <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="email">Email</label>
+          <input type="email" id="email" class="bb-form-input" required placeholder="e.g., alex@example.com">
+        </div>
+        <div>
+          <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="role">Role</label>
+          <select id="role" class="bb-form-select">…</select>
+        </div>
+        <template x-if="error">
+          <div role="alert" class="bb-form-error">
+            <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+            <span x-text="error"></span>
+          </div>
+        </template>
+      </div>
+    </div>
+
+    <!-- Bottom action row -->
+    <div class="bb-action-row">
+      <a href="/users" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
+      <button type="submit" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32" :disabled="submitting">
+        <span x-show="!submitting" class="inline-flex items-center gap-1.5">
+          <i data-lucide="save" class="w-3.5 h-3.5"></i>Save Changes
+        </span>
+        <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+      </button>
+    </div>
+  </form>
+</div>
+```
+
+**Conventions:**
+- Top section uses `p-5 sm:p-6` (mobile/desktop). Do **not** use `p-8` — that was the old centered-card style.
+- Field groups use `space-y-4`. Labels use `text-xs font-medium text-base-content/50 mb-1.5 block`.
+- Primary submit button gets `min-w-32` so it doesn't jitter between its label and the loading spinner.
+- Icons inside the primary button are `w-3.5 h-3.5` (not `w-4 h-4`) to match the compact `btn-sm` weight.
+- For destructive operations, add a **separate** `bb-card bb-danger-card` below — never mix the save action with the delete action in one card.
+
 ## 6. Table Guidelines
 
 ### Base Table
@@ -434,6 +520,89 @@ Use DaisyUI form control patterns:
   <span class="label-text-alt text-error">Password must be at least 8 characters</span>
 </label>
 ```
+
+### Dirty-State Form Tracking (Alpine)
+
+For settings-style edit screens where Save is explicit (not auto-save on change), the canonical pattern is an Alpine-local `initialX` / `x` / computed `dirty` / `save()` model. The Save button stays disabled until something changes, and a transient "Saved" indicator confirms success for 2 seconds.
+
+**Reference:** manage-login mode in `create_login.html`.
+
+```html
+<div class="bb-card p-0 overflow-hidden" x-data="{
+  initialRole: '{{.LoginAccount.Role}}',
+  role: '{{.LoginAccount.Role}}',
+  saving: false,
+  saved: false,
+  error: '',
+  get dirty() { return this.role !== this.initialRole; },
+  save() {
+    this.error = '';
+    this.saving = true;
+    var self = this;
+    fetch('…', { method: 'PUT', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({role: this.role}) })
+      .then(function(r) {
+        if (!r.ok) return r.json().then(function(d) { throw d; });
+        self.initialRole = self.role;
+        self.saving = false;
+        self.saved = true;
+        setTimeout(function() { self.saved = false; }, 2000);
+      })
+      .catch(function(e) {
+        self.saving = false;
+        self.error = (e && e.error && e.error.message) || 'Failed to save changes';
+      });
+  }
+}">
+  <!-- top section: fields bound with x-model -->
+  <div class="bb-action-row">
+    <span x-show="saved" x-transition.opacity class="text-xs text-success inline-flex items-center gap-1 mr-2">
+      <i data-lucide="check" class="w-3.5 h-3.5"></i> Saved
+    </span>
+    <a href="/users" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
+    <button @click="save()" :disabled="!dirty || saving" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32">
+      <span x-show="!saving" class="inline-flex items-center gap-1.5"><i data-lucide="save" class="w-3.5 h-3.5"></i>Save Changes</span>
+      <span x-show="saving" class="loading loading-spinner loading-xs"></span>
+    </button>
+  </div>
+</div>
+```
+
+### Danger Zone Card
+
+Destructive operations (delete, revoke, disconnect) go in a **separate** `bb-card bb-danger-card` placed below the main form card — never inside the primary Save row. Horizontal layout on desktop, stacked on mobile.
+
+```html
+<div class="bb-card bb-danger-card p-5 sm:p-6 mt-4">
+  <div class="flex items-start justify-between gap-4 flex-col sm:flex-row sm:items-center">
+    <div>
+      <h3 class="text-sm font-semibold text-error/80">Delete login account</h3>
+      <p class="text-xs text-base-content/50 mt-0.5">{{.Name}} will no longer be able to sign in. This cannot be undone.</p>
+    </div>
+    <button class="btn btn-error btn-soft btn-sm rounded-xl shrink-0" @click="…">
+      <i data-lucide="user-x" class="w-4 h-4"></i>
+      Delete Login
+    </button>
+  </div>
+</div>
+```
+
+### Overflow Action Menu
+
+When a card has ≥2 secondary actions (Edit, Manage, Transactions, Delete, …) prefer a single `ellipsis-vertical` dropdown over a cluster of icon buttons. Used on member cards in `/users`, also in `categories.html` and `rules.html`.
+
+```html
+<div class="dropdown dropdown-end">
+  <div tabindex="0" role="button" class="btn btn-ghost btn-sm btn-square rounded-lg opacity-40 hover:opacity-100 transition-opacity">
+    <i data-lucide="ellipsis-vertical" class="w-5 h-5"></i>
+  </div>
+  <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-44 p-1">
+    <li><a href="…"><i data-lucide="pencil" class="w-3.5 h-3.5"></i> Edit profile</a></li>
+    <li><a href="…"><i data-lucide="settings" class="w-3.5 h-3.5"></i> Manage login</a></li>
+  </ul>
+</div>
+```
+
+Keep icons at `w-3.5 h-3.5` in dropdown rows to match the `btn-xs` baseline weight of menu items.
 
 ## 8. Icon System
 
@@ -541,6 +710,17 @@ fetch('/api/...').then(() => {
 
 ## 12. Alerts
 
-All alerts use: `<div role="alert" class="alert alert-{type} rounded-xl mb-6">`.
+**Page-level alerts** use: `<div role="alert" class="alert alert-{type} rounded-xl mb-6">`.
 
 Flash messages (`partials/flash.html`) and inline alerts follow the same pattern. Use `alert-soft` for less prominent inline warnings.
+
+**Form-level errors** inside a `.bb-card` use the `.bb-form-error` inline variant — softer, tighter, and sits flush with the form fields rather than the page chrome:
+
+```html
+<div role="alert" class="bb-form-error">
+  <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+  <span x-text="error"></span>
+</div>
+```
+
+Always pair with an `alert-circle` icon so the error reads at a glance. This is the canonical pattern for inline Alpine-driven form validation errors.

--- a/input.css
+++ b/input.css
@@ -153,8 +153,8 @@
 
 /* ─── shadcn-inspired global overrides ─── */
 @layer base {
-  /* Ensure Lucide SVG icons inside interactive elements don't steal clicks. */
-  a svg, button svg { pointer-events: none; }
+  /* Ensure Lucide SVG icons don't steal clicks from interactive parents. */
+  svg.lucide { pointer-events: none; }
 
   html { scroll-behavior: smooth; }
 
@@ -283,6 +283,33 @@
       border-color: oklch(0.35 0 0);
     }
   }
+
+  /* ── Form card primitives ── */
+  /* Icon-header: colored tile + title + optional subtitle.
+     Used at the top of sectioned form cards (bb-card p-0 overflow-hidden). */
+  .bb-icon-header { @apply flex items-center gap-3 mb-5; }
+  .bb-icon-header__tile { @apply flex items-center justify-center w-10 h-10 rounded-xl shrink-0; }
+  .bb-icon-header__text { @apply min-w-0; }
+
+  /* Color modifiers for the icon tile. Pair with .bb-icon-header__tile. */
+  .bb-icon-tile--primary { @apply bg-primary/8 text-primary; }
+  .bb-icon-tile--success { @apply bg-success/10 text-success; }
+  .bb-icon-tile--warning { @apply bg-warning/10 text-warning; }
+  .bb-icon-tile--error   { @apply bg-error/10 text-error; }
+
+  /* Action row at the bottom of a sectioned form card.
+     Holds Cancel + primary (Save/Create) buttons right-aligned. */
+  .bb-action-row { @apply p-4 sm:p-5 border-t border-base-300 bg-base-200/20 flex items-center justify-end gap-2; }
+
+  /* Form inputs/selects with subtle base-200 bg that clears on focus. */
+  .bb-form-input { @apply input w-full rounded-xl bg-base-200/50 focus:bg-base-100 transition-colors; }
+  .bb-form-select { @apply select w-full rounded-xl bg-base-200; }
+
+  /* Inline error alert inside a form card (pairs with alert-circle icon). */
+  .bb-form-error { @apply flex items-center gap-3 rounded-xl bg-error/10 text-error px-4 py-3 text-sm; }
+
+  /* Danger-zone card tint — combine with .bb-card for destructive-action cards. */
+  .bb-danger-card { @apply border-error/20 bg-error/[0.02]; }
 
   /* ── Mobile Navbar (glassmorphism) ── */
   .bb-mobile-navbar {

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -145,7 +145,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/onboarding/dismiss", DismissGettingStartedHandler(a, sm))
 
 		r.Route("/users", func(r chi.Router) {
-			r.Get("/", UsersListHandler(a, tr))
+			r.Get("/", UsersListHandler(a, sm, tr))
 			r.Get("/new", NewUserHandler(a, tr))
 			r.Get("/{id}/edit", EditUserHandler(a, tr))
 			r.Get("/{id}/create-login", CreateLoginPageHandler(a, tr))

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -45,7 +45,7 @@ type EnrichedUser struct {
 }
 
 // UsersListHandler serves GET /admin/users.
-func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
+func UsersListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -147,6 +147,16 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			loginAccountMap[pgconv.FormatUUID(la.UserID)] = la
 		}
 
+		// Check if the current admin is unlinked (no household member).
+		userIDStr := SessionUserID(sm, r)
+		isUnlinked := userIDStr == ""
+		var unlinkedUsers []db.User
+		if isUnlinked {
+			if uu, err := a.Queries.ListUsersWithoutAuthAccount(ctx); err == nil {
+				unlinkedUsers = uu
+			}
+		}
+
 		data := map[string]any{
 			"PageTitle":        "Household",
 			"CurrentPage":      "users",
@@ -155,6 +165,8 @@ func UsersListHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 			"LoginAccountMap":  loginAccountMap,
 			"CSRFToken":        GetCSRFToken(r),
 			"Created":          r.URL.Query().Get("created") == "1",
+			"IsUnlinked":       isUnlinked,
+			"UnlinkedUsers":    unlinkedUsers,
 		}
 		tr.Render(w, r, "users.html", data)
 	}

--- a/internal/templates/pages/create_login.html
+++ b/internal/templates/pages/create_login.html
@@ -1,100 +1,145 @@
 {{define "content"}}
 {{template "breadcrumb" .}}
 
-<div class="bb-page-header">
-  <div>
-    <h1 class="bb-page-title">{{if .IsManage}}Manage Login{{else}}Create Login{{end}}</h1>
-    <p class="text-sm text-base-content/50 mt-1">{{if .IsManage}}Manage login account for {{.User.Name}}{{else}}Create a login account for {{.User.Name}}{{end}}</p>
-  </div>
-  <a href="/users" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> Household
-  </a>
-</div>
-
 {{if .IsManage}}
 <!-- Manage existing login account -->
-<div class="bb-card p-8 max-w-lg">
-  <div class="flex items-center gap-3 mb-6">
-    <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
-      <i data-lucide="key" class="w-5 h-5 text-primary"></i>
-    </div>
-    <div>
-      <h2 class="text-base font-semibold">Login Account</h2>
-      <p class="text-xs text-base-content/45">Account details for {{.User.Name}}</p>
-    </div>
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Manage Login</h1>
+    <p class="text-sm text-base-content/50 mt-1">Login account for {{.User.Name}}</p>
   </div>
+</div>
 
-  <div class="space-y-4">
-    <div class="bb-info-grid">
-      <div>
-        <span class="text-xs text-base-content/40">Email / Username</span>
-        <span class="text-sm font-medium">{{.LoginAccount.Username}}</span>
+<div class="max-w-lg">
+  <div class="bb-card p-0 overflow-hidden" x-data="{
+    initialRole: '{{.LoginAccount.Role}}',
+    role: '{{.LoginAccount.Role}}',
+    saving: false,
+    saved: false,
+    error: '',
+    get dirty() { return this.role !== this.initialRole; },
+    save() {
+      this.error = '';
+      this.saving = true;
+      var self = this;
+      fetch('/-/members/{{formatUUID .LoginAccount.ID}}/role', {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({role: this.role})
+      }).then(function(r) {
+        if (!r.ok) return r.json().then(function(d) { throw d; });
+        self.initialRole = self.role;
+        self.saving = false;
+        self.saved = true;
+        setTimeout(function() { self.saved = false; }, 2000);
+      }).catch(function(e) {
+        self.saving = false;
+        self.error = (e && e.error && e.error.message) || 'Failed to save changes';
+      });
+    }
+  }">
+    <!-- Account info -->
+    <div class="p-5 sm:p-6">
+      <div class="bb-icon-header">
+        <div class="bb-icon-header__tile bb-icon-tile--primary">
+          <i data-lucide="key" class="w-5 h-5"></i>
+        </div>
+        <div class="bb-icon-header__text">
+          <h2 class="text-sm font-semibold truncate">{{.LoginAccount.Username}}</h2>
+          <p class="text-xs text-base-content/45">Login account</p>
+        </div>
       </div>
-      <div>
-        <span class="text-xs text-base-content/40">Role</span>
-        <div class="flex items-center gap-2" x-data="{ role: '{{.LoginAccount.Role}}', saving: false }">
-          <select x-model="role" class="select select-sm select-bordered rounded-xl bg-base-200 text-sm"
-                  @change="
-                    saving = true;
-                    fetch('/-/members/{{formatUUID .LoginAccount.ID}}/role', {
-                      method: 'PUT',
-                      headers: {'Content-Type': 'application/json'},
-                      body: JSON.stringify({role: role})
-                    }).then(r => { saving = false; if(!r.ok) alert('Failed to update role'); })
-                  ">
+
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <label class="block text-xs text-base-content/40 mb-1.5" for="manage_role">Role</label>
+          <select id="manage_role" x-model="role" class="select select-sm rounded-xl bg-base-200 text-sm w-full">
             <option value="viewer">Viewer</option>
             <option value="editor">Editor</option>
           </select>
-          <span x-show="saving" class="loading loading-spinner loading-xs"></span>
+        </div>
+        <div>
+          <span class="block text-xs text-base-content/40 mb-1.5">Password</span>
+          <div class="pt-0.5">
+            {{if .LoginAccount.HashedPassword}}<span class="badge badge-sm badge-success badge-soft">Set</span>{{else}}<span class="badge badge-sm badge-warning badge-soft">Not set</span>{{end}}
+          </div>
         </div>
       </div>
-      <div>
-        <span class="text-xs text-base-content/40">Password</span>
-        <span class="text-sm">{{if .LoginAccount.HashedPassword}}<span class="badge badge-sm badge-success badge-soft">Set</span>{{else}}<span class="badge badge-sm badge-warning badge-soft">Not set</span>{{end}}</span>
-      </div>
+
+      <template x-if="error">
+        <div role="alert" class="bb-form-error mt-4">
+          <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+          <span x-text="error"></span>
+        </div>
+      </template>
     </div>
 
-    {{if not .LoginAccount.HashedPassword}}
-    <!-- Setup link section -->
-    <div class="border-t border-base-300 pt-4 mt-4" x-data="{ setupURL: '{{.SetupURL}}', regenerating: false, copied: false }">
-      <h3 class="text-sm font-semibold mb-2">Setup Link</h3>
-      <p class="text-xs text-base-content/50 mb-3">Share this link with {{.User.Name}} so they can set their password.</p>
-
-      <div class="flex items-center gap-2 mb-3">
-        <input type="text" :value="setupURL" readonly
-               class="input input-bordered input-sm rounded-xl flex-1 text-xs font-mono bg-base-200 select-all cursor-text">
-        <button @click="navigator.clipboard.writeText(setupURL); copied = true; setTimeout(() => copied = false, 2000)"
-                class="btn btn-sm btn-ghost rounded-xl" :class="copied ? 'text-success' : ''">
-          <i x-show="!copied" data-lucide="copy" class="w-4 h-4"></i>
-          <i x-show="copied" data-lucide="check" class="w-4 h-4"></i>
-        </button>
-      </div>
-
-      <button @click="
-        regenerating = true;
-        fetch('/-/members/{{formatUUID .LoginAccount.ID}}/setup-token', {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'}
-        }).then(r => r.json()).then(data => {
-          regenerating = false;
-          if(data.setup_token) {
-            setupURL = window.location.origin + '/setup-account/' + data.setup_token;
-            copied = false;
-          }
-        }).catch(() => { regenerating = false; })
-      " :disabled="regenerating" class="btn btn-ghost btn-xs rounded-lg">
-        <span x-show="!regenerating"><i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i> Regenerate link</span>
-        <span x-show="regenerating" class="loading loading-spinner loading-xs"></span>
+    <!-- Action row -->
+    <div class="bb-action-row">
+      <span x-show="saved" x-transition.opacity class="text-xs text-success inline-flex items-center gap-1 mr-2">
+        <i data-lucide="check" class="w-3.5 h-3.5"></i> Saved
+      </span>
+      <a href="/users" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
+      <button @click="save()" :disabled="!dirty || saving" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32">
+        <span x-show="!saving" class="inline-flex items-center gap-1.5"><i data-lucide="save" class="w-3.5 h-3.5"></i>Save Changes</span>
+        <span x-show="saving" class="loading loading-spinner loading-xs"></span>
       </button>
     </div>
-    {{end}}
+  </div>
 
-    <!-- Danger zone -->
-    <div class="border-t border-base-300 pt-4 mt-4" x-data>
+  {{if not .LoginAccount.HashedPassword}}
+  <!-- Setup link (separate card) -->
+  <div class="bb-card p-5 sm:p-6 mt-4" x-data="{ setupURL: '{{.SetupURL}}', regenerating: false, copied: false }">
+    <div class="bb-icon-header">
+      <div class="bb-icon-header__tile bb-icon-tile--warning">
+        <i data-lucide="link" class="w-5 h-5"></i>
+      </div>
+      <div class="bb-icon-header__text">
+        <h2 class="text-sm font-semibold">Setup Link</h2>
+        <p class="text-xs text-base-content/45">Share this link with {{.User.Name}} so they can set their password.</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-2 mb-3">
+      <input type="text" :value="setupURL" readonly
+             class="input input-sm rounded-xl flex-1 text-xs font-mono bg-base-200/50 select-all cursor-text">
+      <button @click="navigator.clipboard.writeText(setupURL); copied = true; setTimeout(() => copied = false, 2000)"
+              class="btn btn-sm btn-ghost rounded-xl" :class="copied ? 'text-success' : ''">
+        <i x-show="!copied" data-lucide="copy" class="w-4 h-4"></i>
+        <i x-show="copied" data-lucide="check" class="w-4 h-4"></i>
+      </button>
+    </div>
+
+    <button @click="
+      regenerating = true;
+      fetch('/-/members/{{formatUUID .LoginAccount.ID}}/setup-token', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'}
+      }).then(r => r.json()).then(data => {
+        regenerating = false;
+        if(data.setup_token) {
+          setupURL = window.location.origin + '/setup-account/' + data.setup_token;
+          copied = false;
+        }
+      }).catch(() => { regenerating = false; })
+    " :disabled="regenerating" class="btn btn-sm btn-ghost rounded-xl gap-1.5 text-base-content/60 hover:text-base-content">
+      <i data-lucide="refresh-cw" class="w-3.5 h-3.5" :class="regenerating ? 'animate-spin' : ''"></i>
+      <span x-text="regenerating ? 'Regenerating…' : 'Regenerate link'"></span>
+    </button>
+  </div>
+  {{end}}
+
+  <!-- Danger zone (separate card) -->
+  <div class="bb-card bb-danger-card p-5 sm:p-6 mt-4" x-data>
+    <div class="flex items-start justify-between gap-4 flex-col sm:flex-row sm:items-center">
+      <div>
+        <h3 class="text-sm font-semibold text-error/80">Delete login account</h3>
+        <p class="text-xs text-base-content/50 mt-0.5">{{.User.Name}} will no longer be able to sign in. This cannot be undone.</p>
+      </div>
       <button @click="if(confirm('Delete login account for {{.User.Name}}? They will no longer be able to sign in.')) fetch('/-/members/{{formatUUID .LoginAccount.ID}}', {method:'DELETE'}).then(()=>window.location.href='/users')"
-              class="btn btn-error btn-soft btn-sm rounded-xl">
+              class="btn btn-error btn-soft btn-sm rounded-xl shrink-0">
         <i data-lucide="user-x" class="w-4 h-4"></i>
-        Delete Login Account
+        Delete Login
       </button>
     </div>
   </div>
@@ -102,134 +147,150 @@
 
 {{else}}
 <!-- Create new login account -->
-<div class="bb-card p-8 max-w-lg" x-data="{ submitting: false, error: '', setupURL: '', done: false }">
+<div class="bb-page-header">
+  <div>
+    <h1 class="bb-page-title">Create Login</h1>
+    <p class="text-sm text-base-content/50 mt-1">Create a sign-in account for {{.User.Name}}</p>
+  </div>
+</div>
+
+<div class="max-w-lg" x-data="{ submitting: false, error: '', setupURL: '', done: false }">
   <template x-if="!done">
-    <div>
-      <div class="flex items-center gap-3 mb-6">
-        <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
-          <i data-lucide="user-plus" class="w-5 h-5 text-primary"></i>
-        </div>
-        <div>
-          <h2 class="text-base font-semibold">Create Login for {{.User.Name}}</h2>
-          <p class="text-xs text-base-content/45">They'll receive a link to set their password</p>
-        </div>
-      </div>
+    <form @submit.prevent="
+      error = '';
+      var email = document.getElementById('login_email').value.trim();
+      var role = document.getElementById('login_role').value;
+      if(!email) { error = 'Email is required'; return; }
+      if(!email.includes('@') || !email.includes('.')) { error = 'Please enter a valid email address'; return; }
+      submitting = true;
 
-      <form @submit.prevent="
-        error = '';
-        var email = document.getElementById('login_email').value.trim();
-        var role = document.getElementById('login_role').value;
-        if(!email) { error = 'Email is required'; return; }
-        if(!email.includes('@') || !email.includes('.')) { error = 'Please enter a valid email address'; return; }
-        submitting = true;
+      // Update user email if changed
+      var emailChanged = email !== '{{if .User.Email.Valid}}{{.User.Email.String}}{{end}}';
+      var chain = Promise.resolve();
+      if(emailChanged) {
+        chain = fetch('/-/users/{{.UserID}}', {
+          method: 'PUT',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({email: email})
+        }).then(r => { if(!r.ok) return r.json().then(d => { throw d }); });
+      }
 
-        // Update user email if changed
-        var emailChanged = email !== '{{if .User.Email.Valid}}{{.User.Email.String}}{{end}}';
-        var chain = Promise.resolve();
-        if(emailChanged) {
-          chain = fetch('/-/users/{{.UserID}}', {
-            method: 'PUT',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({email: email})
-          }).then(r => { if(!r.ok) return r.json().then(d => { throw d }); });
-        }
-
-        chain.then(() => {
-          return fetch('/-/members', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({user_id: '{{.UserID}}', username: email, role: role})
-          });
-        }).then(r => {
-          if(!r.ok) return r.json().then(d => { throw d });
-          return r.json();
-        }).then(data => {
-          submitting = false;
-          if(data.setup_token) {
-            setupURL = window.location.origin + '/setup-account/' + data.setup_token;
-            done = true;
-            if (window.bbProgress) window.bbProgress.finish();
-            var main = document.querySelector('main');
-            if (main) { main.style.opacity = ''; main.style.filter = ''; main.style.pointerEvents = ''; }
-            $nextTick(() => { if (typeof lucide !== 'undefined') lucide.createIcons(); });
-          } else {
-            window.location.href = '/users';
-          }
-        }).catch(e => {
-          submitting = false;
+      chain.then(() => {
+        return fetch('/-/members', {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({user_id: '{{.UserID}}', username: email, role: role})
+        });
+      }).then(r => {
+        if(!r.ok) return r.json().then(d => { throw d });
+        return r.json();
+      }).then(data => {
+        submitting = false;
+        if(data.setup_token) {
+          setupURL = window.location.origin + '/setup-account/' + data.setup_token;
+          done = true;
           if (window.bbProgress) window.bbProgress.finish();
           var main = document.querySelector('main');
           if (main) { main.style.opacity = ''; main.style.filter = ''; main.style.pointerEvents = ''; }
-          error = (e.error && e.error.message) || 'Failed to create login account';
-        });
-      ">
-        <fieldset class="fieldset mb-5">
-          <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="login_email">
-            Email <span class="text-error text-xs">*</span>
-          </label>
-          <input type="email" id="login_email" name="login_email"
-                 class="input input-bordered w-full rounded-xl" required
-                 value="{{if .User.Email.Valid}}{{.User.Email.String}}{{end}}"
-                 placeholder="e.g., alex@example.com">
-          <p class="text-xs text-base-content/30 mt-1">This will be their sign-in email and username</p>
-        </fieldset>
-
-        <fieldset class="fieldset mb-6">
-          <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="login_role">
-            Role
-          </label>
-          <select id="login_role" name="login_role" class="select select-bordered w-full rounded-xl bg-base-200">
-            <option value="viewer">Viewer &mdash; can only see their own data</option>
-            <option value="editor">Editor &mdash; can view and edit all household data</option>
-          </select>
-        </fieldset>
-
-        <template x-if="error">
-          <div class="rounded-xl bg-error/10 border border-error/20 text-error text-sm px-4 py-3 mb-4" x-text="error"></div>
-        </template>
-
-        <div class="flex gap-3 pt-2">
-          <button type="submit" class="btn btn-primary btn-sm rounded-xl whitespace-nowrap" :disabled="submitting">
-            <span x-show="!submitting" class="inline-flex items-center gap-1.5"><i data-lucide="plus" class="w-4 h-4"></i> Create Login</span>
-            <span x-show="submitting" class="loading loading-spinner loading-sm"></span>
-          </button>
-          <a href="/users" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
+          $nextTick(() => { if (typeof lucide !== 'undefined') lucide.createIcons(); });
+        } else {
+          window.location.href = '/users';
+        }
+      }).catch(e => {
+        submitting = false;
+        if (window.bbProgress) window.bbProgress.finish();
+        var main = document.querySelector('main');
+        if (main) { main.style.opacity = ''; main.style.filter = ''; main.style.pointerEvents = ''; }
+        error = (e.error && e.error.message) || 'Failed to create login account';
+      });
+    " class="bb-card p-0 overflow-hidden">
+      <!-- Header + fields -->
+      <div class="p-5 sm:p-6">
+        <div class="bb-icon-header">
+          <div class="bb-icon-header__tile bb-icon-tile--primary">
+            <i data-lucide="user-plus" class="w-5 h-5"></i>
+          </div>
+          <div class="bb-icon-header__text">
+            <h2 class="text-sm font-semibold">New login account</h2>
+            <p class="text-xs text-base-content/45">They'll receive a link to set their password</p>
+          </div>
         </div>
-      </form>
-    </div>
+
+        <div class="space-y-4">
+          <div>
+            <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="login_email">Email</label>
+            <input type="email" id="login_email" name="login_email" class="bb-form-input"
+                   required
+                   value="{{if .User.Email.Valid}}{{.User.Email.String}}{{end}}"
+                   placeholder="e.g., alex@example.com">
+            <p class="text-xs text-base-content/40 mt-1.5">This will be their sign-in username</p>
+          </div>
+
+          <div>
+            <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="login_role">Role</label>
+            <select id="login_role" name="login_role" class="bb-form-select">
+              <option value="viewer">Viewer &mdash; can only see their own data</option>
+              <option value="editor">Editor &mdash; can view and edit all data</option>
+            </select>
+          </div>
+
+          <template x-if="error">
+            <div role="alert" class="bb-form-error">
+              <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+              <span x-text="error"></span>
+            </div>
+          </template>
+        </div>
+      </div>
+
+      <!-- Action row -->
+      <div class="bb-action-row">
+        <a href="/users" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
+        <button type="submit" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32" :disabled="submitting">
+          <span x-show="!submitting" class="inline-flex items-center gap-1.5"><i data-lucide="user-plus" class="w-3.5 h-3.5"></i>Create Login</span>
+          <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+        </button>
+      </div>
+    </form>
   </template>
 
   <template x-if="done">
-    <div>
-      <div class="flex items-center gap-3 mb-6">
-        <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-success/10">
-          <i data-lucide="check-circle" class="w-5 h-5 text-success"></i>
+    <div class="bb-card p-0 overflow-hidden">
+      <!-- Header -->
+      <div class="p-5 sm:p-6">
+        <div class="bb-icon-header">
+          <div class="bb-icon-header__tile bb-icon-tile--success">
+            <i data-lucide="circle-check" class="w-5 h-5"></i>
+          </div>
+          <div class="bb-icon-header__text">
+            <h2 class="text-sm font-semibold">Login created</h2>
+            <p class="text-xs text-base-content/45">Share the setup link with {{.User.Name}}</p>
+          </div>
         </div>
-        <div>
-          <h2 class="text-base font-semibold">Login Created</h2>
-          <p class="text-xs text-base-content/45">Share the setup link with {{.User.Name}}</p>
+
+        <div x-data="{ copied: false }">
+          <label class="block text-xs font-medium text-base-content/50 mb-1.5">Setup Link</label>
+          <div class="flex items-center gap-2 mb-2">
+            <input type="text" :value="setupURL" readonly
+                   class="input input-sm rounded-xl flex-1 text-xs font-mono bg-base-200/50 select-all cursor-text">
+            <button @click="navigator.clipboard.writeText(setupURL); copied = true; setTimeout(() => copied = false, 2000)"
+                    class="btn btn-sm rounded-xl gap-1.5 min-w-24 transition-colors" :class="copied ? 'btn-success' : 'btn-primary'">
+              <i data-lucide="copy" class="w-3.5 h-3.5" x-show="!copied"></i>
+              <i data-lucide="check" class="w-3.5 h-3.5" x-show="copied"></i>
+              <span x-text="copied ? 'Copied' : 'Copy'"></span>
+            </button>
+          </div>
+          <p class="text-xs text-base-content/40">Expires in 7 days. You can regenerate it from the manage login page.</p>
         </div>
       </div>
 
-      <p class="text-sm text-base-content/60 mb-4">Share this link with {{.User.Name}} so they can set their password and start using Breadbox.</p>
-
-      <div class="flex items-center gap-2 mb-4" x-data="{ copied: false }">
-        <input type="text" :value="setupURL" readonly
-               class="input input-bordered input-sm rounded-xl flex-1 text-xs font-mono bg-base-200 select-all cursor-text">
-        <button @click="navigator.clipboard.writeText(setupURL); copied = true; setTimeout(() => copied = false, 2000)"
-                class="btn btn-sm btn-primary rounded-xl" :class="copied ? 'btn-success' : ''">
-          <i x-show="!copied" data-lucide="copy" class="w-4 h-4"></i>
-          <i x-show="copied" data-lucide="check" class="w-4 h-4"></i>
-          <span x-text="copied ? 'Copied!' : 'Copy Link'"></span>
-        </button>
+      <!-- Action row -->
+      <div class="bb-action-row">
+        <a href="/users" class="btn btn-sm btn-primary rounded-xl gap-1.5">
+          <i data-lucide="arrow-left" class="w-3.5 h-3.5"></i>
+          Back to Household
+        </a>
       </div>
-
-      <p class="text-xs text-base-content/40 mb-6">This link expires in 7 days. You can regenerate it from the Household page.</p>
-
-      <a href="/users" class="btn btn-ghost btn-sm rounded-xl">
-        <i data-lucide="arrow-left" class="w-4 h-4"></i>
-        Back to Household
-      </a>
     </div>
   </template>
 </div>

--- a/internal/templates/pages/my_account.html
+++ b/internal/templates/pages/my_account.html
@@ -7,62 +7,9 @@
 </div>
 
 {{if .IsUnlinked}}
-<div class="bb-card mb-6 border-warning/30" x-data="{ mode: 'create' }">
-  <div class="p-5 border-b border-warning/30">
-    <h2 class="font-semibold text-base flex items-center gap-2">
-      <i data-lucide="user-plus" class="w-4 h-4 text-warning"></i>
-      Link to Household Member
-    </h2>
-  </div>
-  <div class="p-5">
-    <p class="text-sm text-base-content/60 mb-4">
-      Your admin account isn't linked to a household member yet. Link it to manage bank connections and view your financial data.
-    </p>
-
-    {{if .UnlinkedUsers}}
-    <div class="flex gap-1 mb-4">
-      <button type="button" @click="mode = 'create'"
-        :class="mode === 'create' ? 'btn-primary' : 'btn-ghost'" class="btn btn-xs rounded-lg">Create New</button>
-      <button type="button" @click="mode = 'existing'"
-        :class="mode === 'existing' ? 'btn-primary' : 'btn-ghost'" class="btn btn-xs rounded-lg">Link Existing</button>
-    </div>
-    {{end}}
-
-    <form method="POST" action="/my-account/link-user" x-show="mode === 'create'">
-      {{if $.CSRFToken}}<input type="hidden" name="_csrf" value="{{$.CSRFToken}}">{{end}}
-      <input type="hidden" name="mode" value="create">
-      <div class="mb-3">
-        <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="link_name">Your Name</label>
-        <input type="text" id="link_name" name="name" required placeholder="Your name"
-               class="input w-full rounded-lg text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
-      </div>
-      <button type="submit" class="btn btn-primary btn-sm rounded-lg">
-        <i data-lucide="user-plus" class="w-4 h-4"></i>
-        Create & Link
-      </button>
-    </form>
-
-    {{if .UnlinkedUsers}}
-    <form method="POST" action="/my-account/link-user" x-show="mode === 'existing'" x-cloak>
-      {{if $.CSRFToken}}<input type="hidden" name="_csrf" value="{{$.CSRFToken}}">{{end}}
-      <input type="hidden" name="mode" value="existing">
-      <div class="mb-3">
-        <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="link_user_id">Household Member</label>
-        <select id="link_user_id" name="user_id" required
-                class="select w-full rounded-lg text-sm bg-base-200 border-base-300 focus:bg-base-100 focus:border-primary/40">
-          <option value="">Select a member...</option>
-          {{range .UnlinkedUsers}}
-          <option value="{{formatUUID .ID}}">{{.Name}}</option>
-          {{end}}
-        </select>
-      </div>
-      <button type="submit" class="btn btn-primary btn-sm rounded-lg">
-        <i data-lucide="link" class="w-4 h-4"></i>
-        Link Account
-      </button>
-    </form>
-    {{end}}
-  </div>
+<div role="alert" class="alert alert-warning rounded-xl mb-6">
+  <i data-lucide="user-plus" class="w-5 h-5"></i>
+  <span>Your admin account isn't linked to a household member yet. <a href="/users" class="link font-medium">Link it from the Household page</a>.</span>
 </div>
 {{end}}
 

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -289,13 +289,13 @@
     <!-- Actions -->
     <div class="flex items-center gap-0.5 flex-shrink-0">
       <button class="btn btn-ghost btn-xs btn-square rounded-lg" title="{{if .Enabled}}Disable{{else}}Enable{{end}}" @click.stop="toggleRule('{{.ID}}')">
-        {{if .Enabled}}<i data-lucide="pause" class="w-3.5 h-3.5 pointer-events-none"></i>{{else}}<i data-lucide="play" class="w-3.5 h-3.5 pointer-events-none"></i>{{end}}
+        {{if .Enabled}}<i data-lucide="pause" class="w-3.5 h-3.5"></i>{{else}}<i data-lucide="play" class="w-3.5 h-3.5"></i>{{end}}
       </button>
       <a href="/rules/{{.ID}}/edit" class="btn btn-ghost btn-xs btn-square rounded-lg" title="Edit" @click.stop>
-        <i data-lucide="pencil" class="w-3.5 h-3.5 pointer-events-none"></i>
+        <i data-lucide="pencil" class="w-3.5 h-3.5"></i>
       </a>
       <button class="btn btn-ghost btn-xs btn-square rounded-lg text-error/60" title="Delete" :disabled="deleting" @click.stop="deleteRule('{{.ID}}', $el)">
-        <i data-lucide="trash-2" class="w-3.5 h-3.5 pointer-events-none"></i>
+        <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
       </button>
     </div>
   </div>

--- a/internal/templates/pages/user_form.html
+++ b/internal/templates/pages/user_form.html
@@ -6,9 +6,6 @@
     <h1 class="bb-page-title">{{if .IsEdit}}Edit {{.User.Name}}{{else}}Add Member{{end}}</h1>
     <p class="text-sm text-base-content/50 mt-1">{{if .IsEdit}}Update member details{{else}}Add a new person to your household{{end}}</p>
   </div>
-  <a href="/users" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> Household
-  </a>
 </div>
 
 {{if not .IsEdit}}
@@ -237,72 +234,88 @@ function userForm() {
 {{else}}
 <!-- Edit mode with avatar upload -->
 <div x-data="avatarEditor('{{.UserID}}')" class="max-w-lg">
-  <div class="bb-card p-8">
-    <!-- Avatar + header -->
-    <div class="flex items-center gap-4 mb-6">
-      <div class="relative group">
-        <img :src="avatarSrc" alt="" class="w-14 h-14 rounded-full object-cover ring-2 ring-base-300">
-        <button type="button" @click="$refs.fileInput.click()"
-          class="absolute inset-0 rounded-full bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer">
-          <i data-lucide="camera" class="w-5 h-5 text-white"></i>
-        </button>
-        <input type="file" x-ref="fileInput" accept="image/png,image/jpeg,image/gif" class="hidden" @change="onFileSelect">
-      </div>
-      <div>
-        <h2 class="text-base font-semibold">{{.User.Name}}</h2>
-        <p class="text-xs text-base-content/45">
-          <span class="inline-flex items-center gap-1.5">
-            <button type="button" @click="$refs.fileInput.click()" class="link link-hover text-xs">Upload photo</button>
+  <form @submit.prevent="submitForm()" class="bb-card p-0 overflow-hidden">
+    <!-- Header + fields -->
+    <div class="p-5 sm:p-6">
+      <!-- Avatar header -->
+      <div class="bb-icon-header">
+        <div class="relative group shrink-0">
+          <img :src="avatarSrc" alt="" class="w-10 h-10 rounded-full object-cover ring-2 ring-base-300">
+          <button type="button" @click="$refs.fileInput.click()"
+            class="absolute inset-0 rounded-full bg-black/40 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
+            title="Upload photo">
+            <i data-lucide="camera" class="w-4 h-4 text-white"></i>
+          </button>
+          <input type="file" x-ref="fileInput" accept="image/png,image/jpeg,image/gif" class="hidden" @change="onFileSelect">
+        </div>
+        <div class="bb-icon-header__text">
+          <h2 class="text-sm font-semibold truncate">{{.User.Name}}</h2>
+          <p class="text-xs text-base-content/45">
+            <button type="button" @click="$refs.fileInput.click()" class="link link-hover inline-flex items-center gap-1"><i data-lucide="upload" class="w-3 h-3"></i>Upload photo</button>
             <span class="text-base-content/20">&middot;</span>
-            <button type="button" @click="regenerate()" class="link link-hover text-xs">Regenerate</button>
+            <button type="button" @click="regenerate()" class="link link-hover inline-flex items-center gap-1"><i data-lucide="refresh-cw" class="w-3 h-3"></i>Regenerate</button>
             <template x-if="hasCustomAvatar">
               <span>
                 <span class="text-base-content/20">&middot;</span>
-                <button type="button" @click="removeAvatar()" class="link link-hover text-xs text-error/70 hover:text-error">Remove</button>
+                <button type="button" @click="removeAvatar()" class="link link-hover text-error/70 hover:text-error">Remove</button>
               </span>
             </template>
-          </span>
+          </p>
+        </div>
+      </div>
+
+      <template x-if="avatarError">
+        <div role="alert" class="bb-form-error mb-4">
+          <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+          <span x-text="avatarError"></span>
+        </div>
+      </template>
+      <template x-if="avatarUploading">
+        <p class="text-xs text-base-content/50 mb-4 inline-flex items-center gap-1.5">
+          <span class="loading loading-spinner loading-xs"></span>
+          Uploading photo...
         </p>
-        <template x-if="avatarError">
-          <p class="text-xs text-error mt-1" x-text="avatarError"></p>
-        </template>
-        <template x-if="avatarUploading">
-          <p class="text-xs text-base-content/50 mt-1">Uploading...</p>
+      </template>
+
+      <!-- Form fields -->
+      <div class="space-y-4">
+        <div>
+          <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="name">
+            Name <span class="text-error">*</span>
+          </label>
+          <input type="text" id="name" name="name" class="bb-form-input"
+                 required maxlength="128"
+                 value="{{.User.Name}}"
+                 placeholder="e.g., Alex Canales">
+        </div>
+
+        <div>
+          <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="email">
+            Email <span class="text-base-content/30">(optional)</span>
+          </label>
+          <input type="email" id="email" name="email" class="bb-form-input"
+                 value="{{if .User.Email.Valid}}{{.User.Email.String}}{{end}}"
+                 placeholder="e.g., alex@example.com">
+        </div>
+
+        <template x-if="formError">
+          <div role="alert" class="bb-form-error">
+            <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+            <span x-text="formError"></span>
+          </div>
         </template>
       </div>
     </div>
 
-    <form @submit.prevent="submitForm()">
-      <fieldset class="fieldset mb-5">
-        <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="name">
-          Name <span class="text-error text-xs">*</span>
-        </label>
-        <input type="text" id="name" name="name" class="input input-bordered w-full rounded-xl" required maxlength="128"
-          value="{{.User.Name}}"
-          placeholder="e.g., Alex Canales">
-      </fieldset>
-
-      <fieldset class="fieldset mb-5">
-        <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="email">
-          Email <span class="text-xs text-base-content/30">(optional)</span>
-        </label>
-        <input type="email" id="email" name="email" class="input input-bordered w-full rounded-xl"
-          value="{{if .User.Email.Valid}}{{.User.Email.String}}{{end}}"
-          placeholder="e.g., alex@example.com">
-      </fieldset>
-
-      <template x-if="formError">
-        <div class="rounded-xl bg-error/10 border border-error/20 text-error text-sm px-4 py-3 mb-4" x-text="formError"></div>
-      </template>
-
-      <div class="flex gap-3 pt-2">
-        <button type="submit" class="btn btn-primary btn-sm rounded-xl whitespace-nowrap">
-          <span class="inline-flex items-center gap-1.5"><i data-lucide="save" class="w-4 h-4"></i> Save Changes</span>
-        </button>
-        <a href="/users" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
-      </div>
-    </form>
-  </div>
+    <!-- Action row -->
+    <div class="bb-action-row">
+      <a href="/users" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
+      <button type="submit" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32" :disabled="submitting">
+        <span x-show="!submitting" class="inline-flex items-center gap-1.5"><i data-lucide="save" class="w-3.5 h-3.5"></i>Save Changes</span>
+        <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+      </button>
+    </div>
+  </form>
 </div>
 
 <script>

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -17,6 +17,61 @@
 </div>
 {{end}}
 
+{{if .IsUnlinked}}
+<!-- Admin link prompt: admin account not yet linked to a household member -->
+<div class="bb-card p-0 overflow-hidden mb-6 border-warning/30 bg-warning/[0.03]" x-data="{ mode: 'create', open: true }" x-show="open">
+  <div class="p-4 sm:p-5 flex items-start gap-3">
+    <div class="bb-icon-header__tile bb-icon-tile--warning">
+      <i data-lucide="user-plus" class="w-5 h-5"></i>
+    </div>
+    <div class="min-w-0 flex-1">
+      <h3 class="text-sm font-semibold">Link your admin account to a household member</h3>
+      <p class="text-xs text-base-content/60 mt-0.5">Your admin account isn't linked yet. Link it to manage bank connections and view your financial data.</p>
+
+      {{if .UnlinkedUsers}}
+      <div class="flex gap-1 mt-3 mb-3">
+        <button type="button" @click="mode = 'create'"
+          :class="mode === 'create' ? 'btn-primary' : 'btn-ghost'" class="btn btn-xs rounded-lg">Create New</button>
+        <button type="button" @click="mode = 'existing'"
+          :class="mode === 'existing' ? 'btn-primary' : 'btn-ghost'" class="btn btn-xs rounded-lg">Link Existing</button>
+      </div>
+      {{else}}
+      <div class="mt-3"></div>
+      {{end}}
+
+      <form method="POST" action="/my-account/link-user" x-show="mode === 'create'" class="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
+        {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
+        <input type="hidden" name="mode" value="create">
+        <input type="text" name="name" required placeholder="Your name"
+               class="input input-sm w-full sm:max-w-64 rounded-xl bg-base-200/50">
+        <button type="submit" class="btn btn-primary btn-sm rounded-xl gap-1.5 shrink-0">
+          <i data-lucide="user-plus" class="w-3.5 h-3.5"></i>
+          Create &amp; Link
+        </button>
+      </form>
+
+      {{if .UnlinkedUsers}}
+      <form method="POST" action="/my-account/link-user" x-show="mode === 'existing'" x-cloak class="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
+        {{if .CSRFToken}}<input type="hidden" name="_csrf" value="{{.CSRFToken}}">{{end}}
+        <input type="hidden" name="mode" value="existing">
+        <select name="user_id" required
+                class="select select-sm w-full sm:max-w-64 rounded-xl bg-base-200">
+          <option value="">Select a member…</option>
+          {{range .UnlinkedUsers}}
+          <option value="{{formatUUID .ID}}">{{.Name}}</option>
+          {{end}}
+        </select>
+        <button type="submit" class="btn btn-primary btn-sm rounded-xl gap-1.5 shrink-0">
+          <i data-lucide="link" class="w-3.5 h-3.5"></i>
+          Link Account
+        </button>
+      </form>
+      {{end}}
+    </div>
+  </div>
+</div>
+{{end}}
+
 {{if .EnrichedUsers}}
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-5 bb-stagger">
   {{range .EnrichedUsers}}
@@ -25,17 +80,19 @@
   <div class="bb-card overflow-hidden flex flex-col">
     <!-- Member Header -->
     <div class="p-4 sm:p-6 pb-4">
-      <div class="flex items-start justify-between">
-        <div class="flex items-center gap-4">
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex items-center gap-4 min-w-0">
           <img src="{{avatarURL .ID .UpdatedAt}}" alt="" class="w-12 h-12 rounded-full object-cover shrink-0">
           <div>
-            <div class="flex items-center gap-2">
+            <div class="flex items-center gap-2 flex-wrap">
               <h3 class="font-semibold text-base">{{.Name}}</h3>
               {{if $la.Username}}
               <span class="badge badge-xs {{if eq $la.Role "admin"}}badge-primary{{else if eq $la.Role "editor"}}badge-secondary{{else}}badge-ghost{{end}}">{{$la.Role}}</span>
               {{if not $la.HashedPassword}}
               <span class="badge badge-xs badge-warning">setup pending</span>
               {{end}}
+              {{else}}
+              <span class="badge badge-xs badge-ghost">no login</span>
               {{end}}
             </div>
             {{if .Email.Valid}}
@@ -43,65 +100,26 @@
             {{else}}
             <p class="text-xs text-base-content/30 italic mt-0.5">No email</p>
             {{end}}
-            {{if not $la.Username}}
-            <a href="/users/{{$uid}}/create-login" class="text-xs text-base-content/40 hover:text-primary transition-colors no-underline inline-flex items-center gap-1 mt-1">
-              <i data-lucide="user-plus" class="w-3 h-3"></i>
-              <span>Create login</span>
-            </a>
-            {{end}}
           </div>
         </div>
-        <div class="flex items-center gap-1">
-          <a href="/users/{{$uid}}/edit" class="btn btn-ghost btn-xs rounded-lg opacity-40 hover:opacity-100 transition-opacity" title="Edit member">
-            <i data-lucide="pencil" class="w-3.5 h-3.5"></i>
-          </a>
-          {{if $la.Username}}
-          <a href="/users/{{$uid}}/create-login" class="btn btn-ghost btn-xs rounded-lg opacity-40 hover:opacity-100 transition-opacity" title="Manage login">
-            <i data-lucide="settings" class="w-3.5 h-3.5"></i>
-          </a>
-          {{end}}
+        <div class="dropdown dropdown-end">
+          <div tabindex="0" role="button" class="btn btn-ghost btn-sm btn-square rounded-lg opacity-40 hover:opacity-100 transition-opacity">
+            <i data-lucide="ellipsis-vertical" class="w-5 h-5"></i>
+          </div>
+          <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-44 p-1">
+            <li><a href="/users/{{$uid}}/edit"><i data-lucide="pencil" class="w-3.5 h-3.5"></i> Edit profile</a></li>
+            {{if $la.Username}}
+            <li><a href="/users/{{$uid}}/create-login"><i data-lucide="settings" class="w-3.5 h-3.5"></i> Manage login</a></li>
+            {{else}}
+            <li><a href="/users/{{$uid}}/create-login"><i data-lucide="user-plus" class="w-3.5 h-3.5"></i> Create login</a></li>
+            {{end}}
+            {{if gt .AccountCount 0}}
+            <li><a href="/transactions?user_id={{formatUUID .ID}}"><i data-lucide="receipt" class="w-3.5 h-3.5"></i> Transactions</a></li>
+            {{end}}
+          </ul>
         </div>
       </div>
 
-      <!-- Financial Summary -->
-      {{if gt .AccountCount 0}}
-      <div class="mt-5 pt-4 border-t border-base-300">
-        <div class="sm:hidden">
-          <div class="mb-2">
-            <p class="text-xs text-base-content/40 mb-1">Net Worth</p>
-            <p class="text-lg font-semibold tabular-nums{{if lt .NetWorth 0.0}} text-error{{end}}">
-              {{formatAmount .NetWorth}}
-            </p>
-          </div>
-          <div class="grid grid-cols-2 gap-4">
-            <div>
-              <p class="text-xs text-base-content/40 mb-1">Assets</p>
-              <p class="text-sm font-medium tabular-nums text-base-content/70">{{formatAmount .TotalAssets}}</p>
-            </div>
-            <div>
-              <p class="text-xs text-base-content/40 mb-1">Liabilities</p>
-              <p class="text-sm font-medium tabular-nums text-error/70">{{formatAmount .TotalLiabilities}}</p>
-            </div>
-          </div>
-        </div>
-        <div class="hidden sm:grid grid-cols-3 gap-4">
-          <div>
-            <p class="text-xs text-base-content/40 mb-1">Net Worth</p>
-            <p class="text-lg font-semibold tabular-nums{{if lt .NetWorth 0.0}} text-error{{end}}">
-              {{formatAmount .NetWorth}}
-            </p>
-          </div>
-          <div>
-            <p class="text-xs text-base-content/40 mb-1">Assets</p>
-            <p class="text-sm font-medium tabular-nums text-base-content/70">{{formatAmount .TotalAssets}}</p>
-          </div>
-          <div>
-            <p class="text-xs text-base-content/40 mb-1">Liabilities</p>
-            <p class="text-sm font-medium tabular-nums text-error/70">{{formatAmount .TotalLiabilities}}</p>
-          </div>
-        </div>
-      </div>
-      {{end}}
     </div>
 
     <!-- Accounts List -->
@@ -161,30 +179,24 @@
     </div>
     {{else}}
     <!-- No accounts state -->
-    <div class="border-t border-base-300 px-4 sm:px-5 py-4 bg-base-200/20">
-      <div class="flex items-center gap-3 text-sm text-base-content/40">
-        <i data-lucide="link" class="w-4 h-4 shrink-0"></i>
-        <span>No bank accounts connected</span>
-        <a href="/connections/new" class="btn btn-ghost btn-xs rounded-lg ml-auto">Connect</a>
+    <div class="border-t border-base-300 px-4 sm:px-5 py-8 bg-base-200/20 flex-1 flex flex-col items-center justify-center text-center">
+      <div class="w-12 h-12 rounded-xl bg-base-200/60 flex items-center justify-center mb-3">
+        <i data-lucide="landmark" class="w-6 h-6 text-base-content/25"></i>
       </div>
+      <p class="text-sm text-base-content/40 mb-3">No bank accounts connected</p>
+      <a href="/connections/new" class="btn btn-ghost btn-sm rounded-xl">
+        <i data-lucide="plus" class="w-3.5 h-3.5"></i>
+        Connect a bank
+      </a>
     </div>
     {{end}}
 
     <!-- Footer -->
-    <div class="mt-auto px-4 sm:px-5 py-2.5 border-t border-base-300 flex items-center justify-between text-xs text-base-content/30 bg-base-200/20">
-      {{if .CreatedAt.Valid}}
+    {{if .CreatedAt.Valid}}
+    <div class="mt-auto px-4 sm:px-5 py-2.5 border-t border-base-300 text-xs text-base-content/30 bg-base-200/20">
       <span>Member since {{.CreatedAt.Time.Format "Jan 2006"}}</span>
-      {{end}}
-      <div class="flex items-center gap-3">
-        {{if gt .AccountCount 0}}
-        <a href="/transactions?user_id={{formatUUID .ID}}" class="text-base-content/40 hover:text-primary transition-colors no-underline inline-flex items-center gap-1" title="View transactions for {{.Name}}">
-          <i data-lucide="receipt" class="w-3 h-3"></i>
-          <span class="hidden sm:inline">Transactions</span>
-        </a>
-        {{end}}
-        <a href="/users/{{formatUUID .ID}}/edit" class="text-base-content/40 hover:text-primary transition-colors no-underline">Edit profile</a>
-      </div>
     </div>
+    {{end}}
   </div>
   {{end}}
 </div>


### PR DESCRIPTION
## Summary

- Reworks `/users`, `/users/{id}/edit`, and `/users/{id}/create-login` into a cohesive form-card design language with sectioned cards, icon headers, action rows, dirty-state tracking, and separated Danger Zone / Setup Link cards.
- Extracts the repeated Tailwind class strings into reusable CSS primitives in `input.css` (`bb-icon-header`, `bb-icon-tile--{color}`, `bb-action-row`, `bb-form-input`, `bb-form-select`, `bb-form-error`, `bb-danger-card`) so future pages can adopt the style in a few classes instead of re-deriving it.
- Fixes Lucide SVGs stealing clicks from non-`<a>` / non-`<button>` parents by broadening the pointer-events rule to `svg.lucide`.
- Documents the new patterns in `docs/design-system.md` and adds a `/apply-design` slash command so future agents can bring other pages into alignment.

### What changed in each page

- **`/users`**: overflow dropdown consolidates Edit / Manage / Transactions actions (replaces the old two icon buttons and footer links); new `no login` ghost badge for unlinked members; no-accounts state upgraded to a centered empty-state block that fills the card height; Net Worth / Assets / Liabilities block removed; footer reduced to just "Member since"; the old "Link to Household Member" card from `/my-account` now lives at the top of this page as a compact inline form.
- **`/users/{id}/create-login`** (create mode): sectioned `bb-card p-0 overflow-hidden` with icon header, `bb-form-input` / `bb-form-select` fields, and a `bb-action-row` with Cancel + Create Login. Success state mirrors the same sectioned structure.
- **`/users/{id}/create-login`** (manage mode): three stacked cards — main account card with Save Changes (dirty-state tracked), a separate Setup Link card (shown only when the password isn't set), and a separate Danger Zone card for Delete Login.
- **`/users/{id}/edit`**: same form-card shell as create-login so both flows feel like one system.

### Design system additions

`docs/design-system.md` now documents:
- §4 Icon Tiles (`.bb-icon-tile--{primary,success,warning,error}`) and the Danger Zone card variant
- §5 Form Card Pattern (full copy-paste example + conventions)
- §7 Dirty-State Form Tracking, Danger Zone Card, Overflow Action Menu
- §12 `.bb-form-error` inline form-error alert

`/apply-design` is a new slash command pointing future agents at the reference implementations (`create_login.html`, `user_form.html`), giving them the HTML skeleton and a checklist of anti-patterns to fix on sight.

## Test plan

- [ ] Visual: load `/users` — overflow menu works, clicking icons triggers the dropdown (not the old bug), "no login" badge shows for unlinked members, admin-link prompt shows only when admin is unlinked
- [ ] Visual: `/users/new` — form matches the new style with Cancel + Create Member action row
- [ ] Visual: `/users/{id}/edit` — avatar upload, Save Changes with spinner, Cancel
- [ ] Visual: `/users/{id}/create-login` (create) — submit, verify success state with copy link
- [ ] Visual: `/users/{id}/create-login` (manage) — change role, Save Changes toggles dirty state, "Saved" indicator appears briefly; Setup Link and Danger Zone render as separate cards
- [ ] Run `make css` — compiled `static/css/styles.css` contains `.bb-icon-header`, `.bb-action-row`, `.bb-form-input`, `.bb-danger-card`
- [ ] Run `go build ./...` — succeeds
- [ ] Verify `/apply-design` appears in Claude Code `/` autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)