### PR TITLE
feat(admin): add "Keep me signed in" option with longer session lifetime

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -115,6 +115,8 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, tr *TemplateRende
 			return
 		}
 
+		sm.RememberMe(r.Context(), r.FormValue("remember_me") != "")
+
 		sm.Put(r.Context(), sessionKeyAccountID, pgconv.FormatUUID(account.ID))
 		sm.Put(r.Context(), sessionKeyAccountUsername, account.Username)
 		sm.Put(r.Context(), sessionKeyAccountRole, account.Role)

--- a/internal/admin/session.go
+++ b/internal/admin/session.go
@@ -14,10 +14,14 @@ import (
 func NewSessionManager(pool *pgxpool.Pool, isSecure bool) *scs.SessionManager {
 	sm := scs.New()
 	sm.Store = pgxstore.New(pool)
-	sm.Lifetime = 12 * time.Hour
+	sm.Lifetime = 30 * 24 * time.Hour
+	sm.IdleTimeout = 14 * 24 * time.Hour
 	sm.Cookie.HttpOnly = true
 	sm.Cookie.SameSite = http.SameSiteLaxMode
 	sm.Cookie.Secure = isSecure
 	sm.Cookie.Path = "/"
+	// Default to a browser-session cookie; LoginHandler flips this to a
+	// persistent cookie when the user opts into "Keep me signed in".
+	sm.Cookie.Persist = false
 	return sm
 }

--- a/internal/templates/pages/login.html
+++ b/internal/templates/pages/login.html
@@ -28,6 +28,11 @@
            class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200">
   </div>
 
+  <label class="flex items-center gap-2 cursor-pointer select-none text-sm text-base-content/70">
+    <input type="checkbox" name="remember_me" value="1" checked class="checkbox checkbox-sm checkbox-primary">
+    Keep me signed in for 30 days
+  </label>
+
   <button type="submit" class="btn btn-primary w-full h-12 rounded-xl text-base font-semibold transition-colors duration-150 mt-1">
     Sign In
     <i data-lucide="arrow-right" class="w-4 h-4 ml-1"></i>


### PR DESCRIPTION
## Summary
- Raises admin session `Lifetime` from 12h to 30d and adds a 14-day `IdleTimeout` as a safety net for abandoned sessions
- Adds a "Keep me signed in for 30 days" checkbox to `/login` (checked by default) — toggles SCS `RememberMe` to decide between a browser-session cookie and a 30-day persistent cookie
- Existing sessions keep working until their cookies expire; new logins pick up the new semantics

## Test plan
- [ ] Fresh login with the box **checked** → close browser, reopen → still signed in
- [ ] Fresh login with the box **unchecked** → close browser, reopen → prompted to sign in
- [ ] Existing session from before the deploy still works until its 12h window ends
- [ ] Logout flow still clears the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)