### PR TITLE
chore(ui): disable mobile entrance animations, drop Rules stats

### DIFF
--- a/input.css
+++ b/input.css
@@ -648,6 +648,14 @@
     }
   }
 
+  /* Disable entrance animations on small/touch screens — feels sluggish on mobile */
+  @media (max-width: 640px), (hover: none) and (pointer: coarse) {
+    .bb-page-enter,
+    .bb-stagger > * {
+      animation: none !important;
+    }
+  }
+
   /* ── Financial Health Score ring ── */
   .bb-health-ring {
     stroke: currentColor;

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -52,63 +52,6 @@
 <div x-show="rcTab === 'rules'">
 <div x-data="rulesPage()">
 
-<!-- Summary Stats Cards -->
-{{if .Rules}}
-<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6 bb-stagger">
-  <!-- Total Rules -->
-  <div class="bb-card p-4">
-    <div class="flex items-center gap-3">
-      <div class="w-9 h-9 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0">
-        <i data-lucide="list-filter" class="w-4 h-4 text-base-content/40"></i>
-      </div>
-      <div>
-        <div class="text-2xl font-semibold tabular-nums leading-none">{{.Total}}</div>
-        <div class="text-xs text-base-content/40 mt-0.5">Total rules</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Active Rules -->
-  <div class="bb-card p-4">
-    <div class="flex items-center gap-3">
-      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .ActiveCount 0}}bg-success/10{{else}}bg-base-200/60{{end}}">
-        <i data-lucide="zap" class="w-4 h-4 {{if gt .ActiveCount 0}}text-success{{else}}text-base-content/40{{end}}"></i>
-      </div>
-      <div>
-        <div class="text-2xl font-semibold tabular-nums leading-none {{if gt .ActiveCount 0}}text-success{{end}}">{{.ActiveCount}}</div>
-        <div class="text-xs text-base-content/40 mt-0.5">Active</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Total Hits -->
-  <div class="bb-card p-4">
-    <div class="flex items-center gap-3">
-      <div class="w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-        <i data-lucide="target" class="w-4 h-4 text-primary"></i>
-      </div>
-      <div>
-        <div class="text-2xl font-semibold tabular-nums leading-none">{{commaInt .TotalHits}}</div>
-        <div class="text-xs text-base-content/40 mt-0.5">Total hits</div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Agent Created -->
-  <div class="bb-card p-4">
-    <div class="flex items-center gap-3">
-      <div class="w-9 h-9 rounded-lg flex items-center justify-center shrink-0 {{if gt .AgentCreated 0}}bg-info/10{{else}}bg-base-200/60{{end}}">
-        <i data-lucide="bot" class="w-4 h-4 {{if gt .AgentCreated 0}}text-info{{else}}text-base-content/40{{end}}"></i>
-      </div>
-      <div>
-        <div class="text-2xl font-semibold tabular-nums leading-none">{{.AgentCreated}}</div>
-        <div class="text-xs text-base-content/40 mt-0.5">Agent-created</div>
-      </div>
-    </div>
-  </div>
-</div>
-{{end}}
-
 <!-- Filters Card -->
 <div class="bb-card mb-6" x-data="{ filtersOpen: {{if or .SearchFilter .CategoryFilter .EnabledFilter}}true{{else}}false{{end}} }">
   <div class="p-0">


### PR DESCRIPTION
## Summary
- Skip `bb-page-enter` and `bb-stagger` child animations on mobile (`max-width: 640px`) and coarse-pointer devices — the entrance animations feel sluggish on phones.
- Remove the summary stats row (Total / Active / Total hits / Agent-created) from the top of `/rules` to reduce visual noise.

## Test plan
- [ ] Desktop: entrance animations still play on `/transactions`, `/rules`, etc.
- [ ] Mobile (or DevTools responsive mode ≤640px): pages appear instantly, no fade/slide.
- [ ] `/rules` renders with filters directly below the header, no stats cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)