### PR TITLE
Show Breadbox brand in mobile navbar, link to root

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -70,7 +70,7 @@
           </label>
         </div>
         <div class="flex-1 min-w-0">
-          <span class="text-sm font-semibold truncate">{{.PageTitle}}</span>
+          <a href="/" class="text-sm font-semibold truncate">Breadbox</a>
         </div>
         <div class="flex-none">
           <button class="btn btn-square btn-ghost" x-data @click="$dispatch('open-cmdk')" title="Search">


### PR DESCRIPTION
The mobile navbar previously showed the current page title. Replace it
with a consistent "Breadbox" label that links to the dashboard, matching
the sidebar brand behavior on desktop.

https://claude.ai/code/session_01E42UzdysJjhASJFcRsRdcC