### PR TITLE
fix(ui): enforce design system badges, rounding, and inline delete UX

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -126,8 +126,8 @@
             </div>
           </div>
           <div class="bb-confirm-actions">
-            <button class="btn btn-sm btn-ghost rounded-lg" @click="cancel()" x-text="cancelLabel"></button>
-            <button class="btn btn-sm rounded-lg"
+            <button class="btn btn-sm btn-ghost rounded-xl" @click="cancel()" x-text="cancelLabel"></button>
+            <button class="btn btn-sm rounded-xl"
                     :class="variant === 'danger' ? 'btn-error' : 'btn-warning'"
                     @click="confirm()"
                     x-text="confirmLabel"

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -422,8 +422,8 @@ function syncBtn(connId) {
 </div><!-- /links tab -->
 
 <!-- Create Account Link Modal -->
-<dialog id="create-link-modal" class="modal">
-  <div class="modal-box rounded-2xl">
+<dialog id="create-link-modal" class="modal modal-bottom sm:modal-middle">
+  <div class="modal-box rounded-xl max-w-lg">
     <h3 class="font-bold text-lg">Create Account Link</h3>
     <p class="text-sm text-base-content/50 mt-1">Link a dependent (authorized user) account to the primary cardholder's account.</p>
     <form method="POST" action="/-/account-links" class="mt-4 space-y-4" x-data="{ loading: false }" @submit="loading = true">

--- a/internal/templates/pages/create_login.html
+++ b/internal/templates/pages/create_login.html
@@ -53,7 +53,7 @@
       <div class="grid grid-cols-2 gap-4">
         <div>
           <label class="block text-xs text-base-content/40 mb-1.5" for="manage_role">Role</label>
-          <select id="manage_role" x-model="role" class="select select-sm rounded-xl bg-base-200 text-sm w-full">
+          <select id="manage_role" x-model="role" class="select select-sm select-bordered rounded-xl text-sm w-full">
             <option value="viewer">Viewer</option>
             <option value="editor">Editor</option>
           </select>
@@ -130,18 +130,57 @@
   {{end}}
 
   <!-- Danger zone (separate card) -->
-  <div class="bb-card bb-danger-card p-5 sm:p-6 mt-4" x-data>
+  <div class="bb-card bb-danger-card p-5 sm:p-6 mt-4" x-data="{
+    confirming: false,
+    deleting: false,
+    error: '',
+    confirmDelete() {
+      this.error = '';
+      this.deleting = true;
+      var self = this;
+      fetch('/-/members/{{formatUUID .LoginAccount.ID}}', { method: 'DELETE' })
+        .then(function(r) {
+          if (!r.ok) return r.json().then(function(d) { throw d; }, function() { throw { error: { message: 'Failed to delete login account' } }; });
+          window.location.href = '/users';
+        })
+        .catch(function(e) {
+          self.deleting = false;
+          self.confirming = false;
+          self.error = (e && e.error && e.error.message) || 'Failed to delete login account';
+        });
+    }
+  }">
     <div class="flex items-start justify-between gap-4 flex-col sm:flex-row sm:items-center">
       <div>
         <h3 class="text-sm font-semibold text-error/80">Delete login account</h3>
         <p class="text-xs text-base-content/50 mt-0.5">{{.User.Name}} will no longer be able to sign in. This cannot be undone.</p>
       </div>
-      <button @click="if(confirm('Delete login account for {{.User.Name}}? They will no longer be able to sign in.')) fetch('/-/members/{{formatUUID .LoginAccount.ID}}', {method:'DELETE'}).then(()=>window.location.href='/users')"
-              class="btn btn-error btn-soft btn-sm rounded-xl shrink-0">
-        <i data-lucide="user-x" class="w-4 h-4"></i>
-        Delete Login
-      </button>
+      <div class="flex items-center gap-2 shrink-0">
+        <template x-if="!confirming">
+          <button @click="confirming = true" class="btn btn-error btn-soft btn-sm rounded-xl">
+            <i data-lucide="user-x" class="w-4 h-4"></i>
+            Delete Login
+          </button>
+        </template>
+        <template x-if="confirming">
+          <div class="flex items-center gap-2">
+            <button @click="confirming = false" :disabled="deleting" class="btn btn-ghost btn-sm rounded-xl">Cancel</button>
+            <button @click="confirmDelete()" :disabled="deleting" class="btn btn-error btn-sm rounded-xl gap-1.5 min-w-28">
+              <span x-show="!deleting" class="inline-flex items-center gap-1.5">
+                <i data-lucide="user-x" class="w-3.5 h-3.5"></i> Confirm Delete
+              </span>
+              <span x-show="deleting" class="loading loading-spinner loading-xs"></span>
+            </button>
+          </div>
+        </template>
+      </div>
     </div>
+    <template x-if="error">
+      <div role="alert" class="bb-form-error mt-3">
+        <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+        <span x-text="error"></span>
+      </div>
+    </template>
   </div>
 </div>
 

--- a/internal/templates/pages/mcp_settings.html
+++ b/internal/templates/pages/mcp_settings.html
@@ -168,9 +168,9 @@
                     <div class="flex items-center gap-2 flex-wrap">
                       <span class="font-mono text-xs sm:text-sm break-all sm:break-normal">{{.Name}}</span>
                       {{if eq .Classification "write"}}
-                        <span class="badge badge-soft badge-warning badge-xs rounded-lg font-medium">write</span>
+                        <span class="badge badge-soft badge-warning badge-xs font-medium">write</span>
                       {{else}}
-                        <span class="badge badge-soft badge-success badge-xs rounded-lg font-medium">read</span>
+                        <span class="badge badge-soft badge-success badge-xs font-medium">read</span>
                       {{end}}
                     </div>
                     <div class="text-xs text-base-content/40 mt-0.5">{{.Description}}</div>

--- a/internal/templates/pages/my_account.html
+++ b/internal/templates/pages/my_account.html
@@ -74,23 +74,23 @@
       <div>
         <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="current_password">Current Password</label>
         <input type="password" id="current_password" name="current_password" required autocomplete="current-password"
-               class="input w-full rounded-lg text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
+               class="input w-full rounded-xl text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
       </div>
 
       <div>
         <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="new_password">New Password</label>
         <input type="password" id="new_password" name="new_password" required autocomplete="new-password" minlength="8"
-               class="input w-full rounded-lg text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
+               class="input w-full rounded-xl text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
         <p class="text-xs text-base-content/40 mt-1">Minimum 8 characters</p>
       </div>
 
       <div>
         <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="confirm_password">Confirm New Password</label>
         <input type="password" id="confirm_password" name="confirm_password" required autocomplete="new-password"
-               class="input w-full rounded-lg text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
+               class="input w-full rounded-xl text-sm bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40">
       </div>
 
-      <button type="submit" class="btn btn-primary btn-sm rounded-lg">Update Password</button>
+      <button type="submit" class="btn btn-primary btn-sm rounded-xl">Update Password</button>
     </form>
   </div>
 
@@ -135,7 +135,7 @@
         This action cannot be undone.
       </p>
       <template x-if="!confirmWipe">
-        <button @click="confirmWipe = true" class="btn btn-error btn-sm btn-outline rounded-lg">
+        <button @click="confirmWipe = true" class="btn btn-error btn-sm btn-outline rounded-xl">
           <i data-lucide="trash-2" class="w-4 h-4"></i>
           Wipe My Data
         </button>
@@ -146,9 +146,9 @@
           <div class="flex gap-2">
             <form method="POST" action="/my-account/wipe-data">
               {{if $.CSRFToken}}<input type="hidden" name="_csrf" value="{{$.CSRFToken}}">{{end}}
-              <button type="submit" class="btn btn-error btn-sm rounded-lg">Yes, wipe my data</button>
+              <button type="submit" class="btn btn-error btn-sm rounded-xl">Yes, wipe my data</button>
             </form>
-            <button @click="confirmWipe = false" class="btn btn-ghost btn-sm rounded-lg">Cancel</button>
+            <button @click="confirmWipe = false" class="btn btn-ghost btn-sm rounded-xl">Cancel</button>
           </div>
         </div>
       </template>

--- a/internal/templates/pages/providers.html
+++ b/internal/templates/pages/providers.html
@@ -23,14 +23,14 @@
       </div>
       <div class="flex items-center gap-2 flex-shrink-0 flex-wrap justify-end">
         {{if and $plaidHealth.LastSyncTime (eq $plaidHealth.LastSyncStatus "error")}}
-          <span class="badge badge-soft badge-error badge-sm rounded-lg">Sync Error</span>
+          <span class="badge badge-soft badge-error badge-sm">Sync Error</span>
         {{else if and $plaidHealth.LastSyncTime (eq $plaidHealth.LastSyncStatus "success")}}
-          <span class="badge badge-soft badge-success badge-sm rounded-lg">Healthy</span>
+          <span class="badge badge-soft badge-success badge-sm">Healthy</span>
         {{end}}
         {{if .PlaidConfigured}}
-          <span class="badge badge-success badge-sm rounded-lg">Configured</span>
+          <span class="badge badge-success badge-sm">Configured</span>
         {{else}}
-          <span class="badge badge-ghost badge-sm rounded-lg">Not Configured</span>
+          <span class="badge badge-ghost badge-sm">Not Configured</span>
         {{end}}
       </div>
     </div>
@@ -149,14 +149,14 @@
       </div>
       <div class="flex items-center gap-2 flex-shrink-0 flex-wrap justify-end">
         {{if and $tellerHealth.LastSyncTime (eq $tellerHealth.LastSyncStatus "error")}}
-          <span class="badge badge-soft badge-error badge-sm rounded-lg">Sync Error</span>
+          <span class="badge badge-soft badge-error badge-sm">Sync Error</span>
         {{else if and $tellerHealth.LastSyncTime (eq $tellerHealth.LastSyncStatus "success")}}
-          <span class="badge badge-soft badge-success badge-sm rounded-lg">Healthy</span>
+          <span class="badge badge-soft badge-success badge-sm">Healthy</span>
         {{end}}
         {{if .TellerConfigured}}
-          <span class="badge badge-success badge-sm rounded-lg">Configured</span>
+          <span class="badge badge-success badge-sm">Configured</span>
         {{else}}
-          <span class="badge badge-ghost badge-sm rounded-lg">Not Configured</span>
+          <span class="badge badge-ghost badge-sm">Not Configured</span>
         {{end}}
       </div>
     </div>
@@ -298,7 +298,7 @@
           <p class="text-xs text-base-content/40 truncate">Import transactions from bank-exported files</p>
         </div>
       </div>
-      <span class="badge badge-success badge-sm rounded-lg flex-shrink-0">Always Available</span>
+      <span class="badge badge-success badge-sm flex-shrink-0">Always Available</span>
     </div>
 
     <div class="px-4 sm:px-5 py-4 space-y-4">

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -154,10 +154,10 @@
         <span class="font-semibold text-sm truncate">{{.Name}}</span>
         {{if .Enabled}}
           {{if and .ExpiresAt (expired .ExpiresAt)}}
-          <span class="badge badge-warning badge-xs rounded-lg">Expired</span>
+          <span class="badge badge-warning badge-xs">Expired</span>
           {{end}}
         {{else}}
-        <span class="badge badge-ghost badge-xs rounded-lg">Disabled</span>
+        <span class="badge badge-ghost badge-xs">Disabled</span>
         {{end}}
       </div>
       <div class="text-xs text-base-content/40 mt-0.5 truncate" title="{{conditionSummary .Conditions}}">{{conditionSummary .Conditions}}</div>


### PR DESCRIPTION
## Summary

Small design-system compliance pass focused on cross-cutting violations and one visible UX bug.

### Design system fixes

- **Badges** — removed `rounded-lg` overrides on 13 status/metadata badges across `providers.html`, `mcp_settings.html`, and `rules.html`. Per design system §4, DaisyUI badges carry their own radius and should never get `rounded-lg/xl` added.
- **Rounding consistency on My Account** — all `btn-sm` buttons (Update Password, Wipe Data, Cancel, Confirm) and the three password inputs were using `rounded-lg`; normalized to `rounded-xl` so the page matches the rest of the app.
- **Global confirm modal** (`base.html`) — the two action buttons were `btn-sm rounded-lg`; updated to `rounded-xl`. Every `btn-sm` in the codebase now uses `rounded-xl`.
- **Account Link modal** (`connections.html`) — was using bare `class="modal"` with `modal-box rounded-2xl`; updated to `modal modal-bottom sm:modal-middle` + `modal-box rounded-xl max-w-lg` so it docks from the bottom on mobile like every other modal.
- **Manage-login role select** — was `select select-sm rounded-xl bg-base-200 text-sm w-full` (missing `select-bordered`, non-standard); replaced with the standard bordered select.

### UX bug fix: Delete Login

The "Delete Login" button on `/users/:id/create-login` used this one-liner:

```html
@click="if(confirm('…')) fetch('…', {method:'DELETE'}).then(()=>window.location.href='/users')"
```

Two problems: (1) browser `confirm()` is inconsistent with every other destructive action in the app (per CLAUDE.md — inline patterns preferred), and (2) if the DELETE fails, the page still navigates away and the error is swallowed.

Replaced with a proper two-step inline Alpine pattern:
- First click reveals **Cancel** + **Confirm Delete** buttons
- Confirm shows a loading spinner while the DELETE is in flight
- On failure, resets state and renders a `bb-form-error` alert inside the card
- Only navigates to `/users` on 2xx response

Matches the pattern used in `my_account.html`'s Wipe Data flow and `create_login.html`'s own manage-mode Save button.

## Test plan
- [x] `go build ./...` succeeds
- [x] `go vet ./...` clean
- [x] `go test ./...` passes (all unit test packages green)
- [ ] Visually verify on `/providers`, `/mcp`, `/rules` that status badges render correctly
- [ ] Visually verify `/my-account` password form inputs and buttons match other forms
- [ ] Visually verify `/users/:id/create-login` in manage mode — trigger Delete Login, confirm the two-step inline flow and error handling (e.g., trip it by temporarily DELETEing the record out of band)
- [ ] Visually verify the Account Link create modal on mobile (slides up from bottom)
- [ ] Trigger the global confirm modal (any destructive admin action) and confirm button rounding matches `btn-sm`

https://claude.ai/code/session_01CLXNik8dkBxg24USEkwodb