### PR TITLE
feat(sync): live Sync Now polling + surface silent tx failures

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -14,6 +14,7 @@ import (
 	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
 	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -840,6 +841,75 @@ func SyncConnectionHandler(a *app.App) http.HandlerFunc {
 	}
 }
 
+// SyncConnectionStatusHandler serves GET /-/connections/{id}/sync-status.
+// Returns a compact JSON payload describing the most recent sync log for the
+// connection — used by the detail page to poll progress without full reloads.
+func SyncConnectionStatusHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idStr := chi.URLParam(r, "id")
+
+		var connID pgtype.UUID
+		if err := connID.Scan(idStr); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid connection ID"})
+			return
+		}
+
+		logs, err := a.Queries.GetSyncLogsByConnection(r.Context(), db.GetSyncLogsByConnectionParams{
+			ConnectionID: connID,
+			Limit:        1,
+		})
+		if err != nil {
+			a.Logger.Error("sync-status: query sync logs", "connection_id", idStr, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to read sync status"})
+			return
+		}
+
+		if len(logs) == 0 {
+			writeJSON(w, http.StatusOK, map[string]any{"status": "none"})
+			return
+		}
+
+		log := logs[0]
+
+		resp := map[string]any{
+			"short_id":        log.ShortID,
+			"trigger":         string(log.Trigger),
+			"status":          string(log.Status),
+			"added_count":     log.AddedCount,
+			"modified_count":  log.ModifiedCount,
+			"removed_count":   log.RemovedCount,
+			"unchanged_count": log.UnchangedCount,
+		}
+		if log.StartedAt.Valid {
+			resp["started_at"] = log.StartedAt.Time.Format(time.RFC3339)
+		}
+		if log.CompletedAt.Valid {
+			resp["completed_at"] = log.CompletedAt.Time.Format(time.RFC3339)
+		}
+		var durationMs int32
+		var hasDuration bool
+		if log.DurationMs.Valid {
+			durationMs = log.DurationMs.Int32
+			hasDuration = true
+		} else if log.StartedAt.Valid && log.CompletedAt.Valid {
+			durationMs = int32(log.CompletedAt.Time.Sub(log.StartedAt.Time).Milliseconds())
+			hasDuration = true
+		}
+		if hasDuration {
+			resp["duration_ms"] = durationMs
+			resp["duration_label"] = formatSyncStatusDuration(durationMs)
+		}
+		if log.ErrorMessage.Valid {
+			resp["error_message"] = log.ErrorMessage.String
+			if friendly := bsync.FriendlyError(log.ErrorMessage.String); friendly != "" {
+				resp["friendly_error_message"] = friendly
+			}
+		}
+
+		writeJSON(w, http.StatusOK, resp)
+	}
+}
+
 // SyncAllConnectionsHandler serves POST /-/connections/sync-all.
 // It triggers a manual sync for all active, non-CSV connections.
 func SyncAllConnectionsHandler(a *app.App) http.HandlerFunc {
@@ -1097,6 +1167,24 @@ func relativeTimeUntil(target, now time.Time) string {
 	default:
 		return "in <1m"
 	}
+}
+
+// formatSyncStatusDuration mirrors the "formatDurationMs" template helper so
+// the sync-status JSON payload carries a preformatted label the client can
+// render without duplicating the formatting logic.
+func formatSyncStatusDuration(ms int32) string {
+	if ms < 1000 {
+		return fmt.Sprintf("%dms", ms)
+	}
+	if ms < 60000 {
+		return fmt.Sprintf("%.1fs", float64(ms)/1000)
+	}
+	mins := ms / 60000
+	secs := (ms % 60000) / 1000
+	if secs == 0 {
+		return fmt.Sprintf("%dm", mins)
+	}
+	return fmt.Sprintf("%dm %ds", mins, secs)
 }
 
 // writeJSON writes a JSON response with the given status code.

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -256,6 +256,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Post("/connections/{id}/reauth", ConnectionReauthAPIHandler(a))
 			r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))
 			r.Post("/connections/{id}/sync", SyncConnectionHandler(a))
+			r.Get("/connections/{id}/sync-status", SyncConnectionStatusHandler(a))
 			r.Post("/connections/sync-all", SyncAllConnectionsHandler(a))
 			r.Post("/connections/{id}/paused", UpdateConnectionPausedHandler(a, sm))
 			r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(a, sm))

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -125,20 +125,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return fmt.Sprintf("%.0fm", d.Minutes())
 			},
-			"formatDurationMs": func(ms int32) string {
-				if ms < 1000 {
-					return fmt.Sprintf("%dms", ms)
-				}
-				if ms < 60000 {
-					return fmt.Sprintf("%.1fs", float64(ms)/1000)
-				}
-				mins := ms / 60000
-				secs := (ms % 60000) / 1000
-				if secs == 0 {
-					return fmt.Sprintf("%dm", mins)
-				}
-				return fmt.Sprintf("%dm %ds", mins, secs)
-			},
+			"formatDurationMs": formatSyncStatusDuration,
 			"relativeTime": func(t interface{}) string {
 				switch v := t.(type) {
 				case time.Time:

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -281,6 +281,13 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		}
 		defer tx.Rollback(ctx)
 
+		// Sanity: confirm the tx is usable immediately after BEGIN. If this fails
+		// we know the pool handed us a poisoned connection rather than a later
+		// statement being the root cause of a 25P02 cascade.
+		if _, err := tx.Exec(ctx, "SELECT 1"); err != nil {
+			logger.Error("tx sanity check failed", "error", err)
+		}
+
 		txQueries := e.db.WithTx(tx)
 
 		// Process removed FIRST.
@@ -356,13 +363,15 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 
 		// Batch-insert rule application records.
 		for _, app := range ruleApplications {
-			_, _ = tx.Exec(ctx,
+			if _, err := tx.Exec(ctx,
 				`INSERT INTO transaction_rule_applications (transaction_id, rule_id, action_field, action_value, applied_by)
 				VALUES ($1, $2, $3, $4, 'sync')
 				ON CONFLICT (transaction_id, rule_id, action_field) DO UPDATE
 				SET applied_at = NOW(), action_value = EXCLUDED.action_value
 				WHERE transaction_rule_applications.action_value IS DISTINCT FROM EXCLUDED.action_value`,
-				app.txnID, app.ruleID, app.actionField, app.actionValue)
+				app.txnID, app.ruleID, app.actionField, app.actionValue); err != nil {
+				logger.Error("insert rule application", "transaction_id", app.txnID, "rule_id", app.ruleID, "error", err)
+			}
 		}
 
 		if skipped > 0 {

--- a/internal/sync/review.go
+++ b/internal/sync/review.go
@@ -54,5 +54,7 @@ func (e *Engine) enqueueForReview(ctx context.Context, txQueries *db.Queries, tx
 	}
 
 	// ON CONFLICT DO NOTHING handles the unique pending constraint
-	_, _ = txQueries.EnqueueReview(ctx, params)
+	if _, err := txQueries.EnqueueReview(ctx, params); err != nil {
+		e.logger.Error("enqueue review", "transaction_id", txnResult.ID, "review_type", reviewType, "error", err)
+	}
 }

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -325,78 +325,49 @@
     <h2 class="text-sm font-semibold text-base-content/70">Sync History</h2>
     <span class="text-xs text-base-content/30">Last 10</span>
   </div>
-  <!-- Skeleton shown during sync -->
-  <div id="sync-history-skeleton" class="px-4 sm:px-5 pb-4" style="display:none">
-    <div class="flex items-center gap-3 p-3 rounded-xl bg-primary/5 border border-primary/10 mb-2">
-      <div class="w-8 h-8 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
-        <span class="loading loading-spinner loading-xs text-primary"></span>
-      </div>
-      <div>
-        <div class="text-sm font-medium">Syncing in progress</div>
-        <div class="text-xs text-base-content/40">Fetching latest transactions...</div>
-      </div>
-    </div>
-    {{template "skeleton-sync-list" .}}
-  </div>
   <div id="sync-history-content">
-  {{if .SyncLogs}}
-  <div class="px-4 sm:px-5 pb-4">
+  <div id="sync-history-list" class="px-4 sm:px-5 pb-4{{if not .SyncLogs}} hidden{{end}}">
     {{range .SyncLogs}}
-    <div class="flex gap-3 py-3 border-b border-base-300/30 last:border-0">
-      <!-- Timeline dot -->
-      <div class="flex flex-col items-center shrink-0 pt-0.5">
+    <div class="flex gap-3 py-3 border-b border-base-300/30 last:border-0"
+         data-sync-log-row="{{.ShortID}}"
+         data-sync-log-status="{{printf "%s" .Status}}">
+      <div class="flex flex-col items-center shrink-0 pt-0.5" data-sync-log-icon>
         <div class="w-6 h-6 rounded-full flex items-center justify-center
           {{if eq (printf "%s" .Status) "success"}}bg-success/12
           {{else if eq (printf "%s" .Status) "error"}}bg-error/12
           {{else}}bg-base-200{{end}}">
           {{if eq (printf "%s" .Status) "success"}}<i data-lucide="check" class="w-3 h-3 text-success"></i>
           {{else if eq (printf "%s" .Status) "error"}}<i data-lucide="x" class="w-3 h-3 text-error"></i>
-          {{else}}<i data-lucide="loader" class="w-3 h-3 text-base-content/40 animate-spin"></i>{{end}}
+          {{else}}<span class="loading loading-spinner loading-xs text-primary"></span>{{end}}
         </div>
       </div>
-      <!-- Content -->
       <div class="flex-1 min-w-0 flex items-center justify-between gap-2">
         <div class="min-w-0">
           <div class="flex items-center gap-2 flex-wrap">
             <span class="text-sm font-medium capitalize">{{.Trigger}}</span>
-            <span class="text-xs text-base-content/35 tabular-nums">{{relativeTime .StartedAt}}</span>
-            {{if .DurationMs.Valid}}
-            <span class="text-[0.6rem] text-base-content/25 tabular-nums bg-base-200/50 px-1.5 py-0.5 rounded-full">{{formatDurationMs .DurationMs.Int32}}</span>
-            {{else if and .StartedAt.Valid .CompletedAt.Valid}}
-            <span class="text-[0.6rem] text-base-content/25 tabular-nums bg-base-200/50 px-1.5 py-0.5 rounded-full">{{syncDuration .StartedAt.Time .CompletedAt.Time}}</span>
-            {{end}}
+            <span class="text-xs text-base-content/35 tabular-nums" data-sync-log-time>{{relativeTime .StartedAt}}</span>
+            <span class="text-[0.6rem] text-base-content/25 tabular-nums bg-base-200/50 px-1.5 py-0.5 rounded-full{{if not .DurationMs.Valid}}{{if not (and .StartedAt.Valid .CompletedAt.Valid)}} hidden{{end}}{{end}}" data-sync-log-duration>{{if .DurationMs.Valid}}{{formatDurationMs .DurationMs.Int32}}{{else if and .StartedAt.Valid .CompletedAt.Valid}}{{syncDuration .StartedAt.Time .CompletedAt.Time}}{{end}}</span>
           </div>
-          {{if and (eq (printf "%s" .Status) "error") .ErrorMessage.Valid}}
-          {{$friendly := syncFriendlyError .ErrorMessage.String}}
-          {{if $friendly}}
-          <p class="text-xs text-error/60 mt-0.5 max-w-md truncate" title="{{.ErrorMessage.String}}">{{$friendly}}</p>
-          {{else}}
-          <p class="text-xs text-error/60 mt-0.5 max-w-md truncate" title="{{.ErrorMessage.String}}">{{.ErrorMessage.String}}</p>
-          {{end}}
-          {{end}}
+          <p class="text-xs text-error/60 mt-0.5 max-w-md truncate{{if not (and (eq (printf "%s" .Status) "error") .ErrorMessage.Valid)}} hidden{{end}}" data-sync-log-error title="{{if .ErrorMessage.Valid}}{{.ErrorMessage.String}}{{end}}">{{if and (eq (printf "%s" .Status) "error") .ErrorMessage.Valid}}{{$friendly := syncFriendlyError .ErrorMessage.String}}{{if $friendly}}{{$friendly}}{{else}}{{.ErrorMessage.String}}{{end}}{{end}}</p>
         </div>
-        <div class="flex items-center gap-2.5 tabular-nums text-xs shrink-0">
-          {{if or .AddedCount .ModifiedCount .RemovedCount}}
-          <div class="flex items-center gap-1.5">
-            {{if .AddedCount}}<span class="text-success font-medium">+{{.AddedCount}}</span>{{end}}
-            {{if .ModifiedCount}}<span class="text-info font-medium">~{{.ModifiedCount}}</span>{{end}}
-            {{if .RemovedCount}}<span class="text-error font-medium">-{{.RemovedCount}}</span>{{end}}
+        <div class="flex items-center gap-2.5 tabular-nums text-xs shrink-0" data-sync-log-counts>
+          <div class="flex items-center gap-1.5{{if not (or .AddedCount .ModifiedCount .RemovedCount)}} hidden{{end}}" data-sync-log-counts-main>
+            <span class="text-success font-medium{{if not .AddedCount}} hidden{{end}}" data-sync-log-added>{{if .AddedCount}}+{{.AddedCount}}{{end}}</span>
+            <span class="text-info font-medium{{if not .ModifiedCount}} hidden{{end}}" data-sync-log-modified>{{if .ModifiedCount}}~{{.ModifiedCount}}{{end}}</span>
+            <span class="text-error font-medium{{if not .RemovedCount}} hidden{{end}}" data-sync-log-removed>{{if .RemovedCount}}-{{.RemovedCount}}{{end}}</span>
           </div>
-          {{end}}
-          {{if .UnchangedCount}}<span class="text-base-content/25 text-[0.6rem]" title="{{.UnchangedCount}} unchanged">={{.UnchangedCount}}</span>{{end}}
+          <span class="text-base-content/25 text-[0.6rem]{{if not .UnchangedCount}} hidden{{end}}" data-sync-log-unchanged title="{{.UnchangedCount}} unchanged">{{if .UnchangedCount}}={{.UnchangedCount}}{{end}}</span>
         </div>
       </div>
     </div>
     {{end}}
   </div>
-  {{else}}
-  <div class="px-4 sm:px-5 pb-4">
+  <div id="sync-history-empty" class="px-4 sm:px-5 pb-4{{if .SyncLogs}} hidden{{end}}">
     <div class="flex flex-col items-center justify-center py-10 text-base-content/30">
       <i data-lucide="refresh-cw" class="w-10 h-10 mb-3 opacity-50"></i>
       <p class="text-sm">No sync history yet</p>
     </div>
   </div>
-  {{end}}
   </div><!-- /sync-history-content -->
 </div>
 
@@ -405,49 +376,220 @@ function showToast(message, type) {
   window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
 }
 
-function syncConnection() {
+var SYNC_POLL_INTERVAL_MS = 1500;
+var SYNC_POLL_MAX_MS = 5 * 60 * 1000;
+var syncPollTimer = null;
+var syncPollStartedAt = 0;
+
+function setSyncButtonIdle() {
   var btn = document.getElementById('sync-btn');
+  if (!btn) return;
+  btn.disabled = false;
+  btn.innerHTML = '<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i> Sync Now';
+  lucide.createIcons({nodes: [btn]});
+}
+
+function setSyncButtonBusy() {
+  var btn = document.getElementById('sync-btn');
+  if (!btn) return;
   btn.disabled = true;
   btn.innerHTML = '<span class="loading loading-spinner loading-xs"></span> Syncing...';
+}
 
-  var syncHistory = document.getElementById('sync-history-content');
-  var syncSkeleton = document.getElementById('sync-history-skeleton');
-  if (syncHistory && syncSkeleton) {
-    syncHistory.classList.add('bb-loading-fade');
-    syncSkeleton.style.display = 'block';
+function buildSyncLogRow(payload) {
+  var row = document.createElement('div');
+  row.className = 'flex gap-3 py-3 border-b border-base-300/30 last:border-0';
+  row.setAttribute('data-sync-log-row', payload.short_id || 'pending');
+  row.setAttribute('data-sync-log-status', payload.status || 'in_progress');
+  row.innerHTML = ''
+    + '<div class="flex flex-col items-center shrink-0 pt-0.5" data-sync-log-icon>'
+    +   '<div class="w-6 h-6 rounded-full flex items-center justify-center bg-base-200">'
+    +     '<span class="loading loading-spinner loading-xs text-primary"></span>'
+    +   '</div>'
+    + '</div>'
+    + '<div class="flex-1 min-w-0 flex items-center justify-between gap-2">'
+    +   '<div class="min-w-0">'
+    +     '<div class="flex items-center gap-2 flex-wrap">'
+    +       '<span class="text-sm font-medium capitalize"></span>'
+    +       '<span class="text-xs text-base-content/35 tabular-nums" data-sync-log-time>just now</span>'
+    +       '<span class="text-[0.6rem] text-base-content/25 tabular-nums bg-base-200/50 px-1.5 py-0.5 rounded-full hidden" data-sync-log-duration></span>'
+    +     '</div>'
+    +     '<p class="text-xs text-error/60 mt-0.5 max-w-md truncate hidden" data-sync-log-error></p>'
+    +   '</div>'
+    +   '<div class="flex items-center gap-2.5 tabular-nums text-xs shrink-0" data-sync-log-counts>'
+    +     '<div class="flex items-center gap-1.5 hidden" data-sync-log-counts-main>'
+    +       '<span class="text-success font-medium hidden" data-sync-log-added></span>'
+    +       '<span class="text-info font-medium hidden" data-sync-log-modified></span>'
+    +       '<span class="text-error font-medium hidden" data-sync-log-removed></span>'
+    +     '</div>'
+    +     '<span class="text-base-content/25 text-[0.6rem] hidden" data-sync-log-unchanged></span>'
+    +   '</div>'
+    + '</div>';
+  row.querySelector('span.capitalize').textContent = payload.trigger || 'manual';
+  return row;
+}
+
+function toggleHidden(el, hidden) {
+  if (!el) return;
+  if (hidden) el.classList.add('hidden'); else el.classList.remove('hidden');
+}
+
+function updateSyncLogRow(row, payload) {
+  if (!row) return;
+  var status = payload.status || 'in_progress';
+  row.setAttribute('data-sync-log-status', status);
+  if (payload.short_id) row.setAttribute('data-sync-log-row', payload.short_id);
+
+  var iconWrap = row.querySelector('[data-sync-log-icon] > div');
+  if (iconWrap) {
+    var iconHTML, iconClass;
+    if (status === 'success') {
+      iconClass = 'bg-success/12';
+      iconHTML = '<i data-lucide="check" class="w-3 h-3 text-success"></i>';
+    } else if (status === 'error') {
+      iconClass = 'bg-error/12';
+      iconHTML = '<i data-lucide="x" class="w-3 h-3 text-error"></i>';
+    } else {
+      iconClass = 'bg-base-200';
+      iconHTML = '<span class="loading loading-spinner loading-xs text-primary"></span>';
+    }
+    iconWrap.className = 'w-6 h-6 rounded-full flex items-center justify-center ' + iconClass;
+    iconWrap.innerHTML = iconHTML;
+    if (status === 'success' || status === 'error') lucide.createIcons({nodes: [iconWrap]});
   }
 
-  if (window.bbProgress) window.bbProgress.start();
-
-  fetch("/-/connections/{{.ConnID}}/sync", { method: "POST" })
-  .then(function(res) {
-    if (res.ok) {
-      btn.innerHTML = '<i data-lucide="check" class="w-3.5 h-3.5"></i> Synced!';
-      lucide.createIcons({nodes: [btn]});
-      if (window.bbProgress) window.bbProgress.finish();
-      setTimeout(function() { window.location.reload(); }, 3000);
+  var dur = row.querySelector('[data-sync-log-duration]');
+  if (dur) {
+    if (payload.duration_label) {
+      dur.textContent = payload.duration_label;
+      toggleHidden(dur, false);
     } else {
-      return res.json().then(function(data) {
-        showToast(data.error || "Failed to trigger sync.");
-        btn.disabled = false;
-        btn.innerHTML = '<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i> Sync Now';
-        lucide.createIcons({nodes: [btn]});
-        if (syncHistory) syncHistory.classList.remove('bb-loading-fade');
-        if (syncSkeleton) syncSkeleton.style.display = 'none';
-        if (window.bbProgress) window.bbProgress.finish();
-      });
+      toggleHidden(dur, true);
     }
-  })
-  .catch(function() {
-    showToast("Network error. Please try again.");
-    btn.disabled = false;
-    btn.innerHTML = '<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i> Sync Now';
-    lucide.createIcons({nodes: [btn]});
-    if (syncHistory) syncHistory.classList.remove('bb-loading-fade');
-    if (syncSkeleton) syncSkeleton.style.display = 'none';
-    if (window.bbProgress) window.bbProgress.finish();
-  });
+  }
+
+  var err = row.querySelector('[data-sync-log-error]');
+  if (err) {
+    if (status === 'error' && (payload.friendly_error_message || payload.error_message)) {
+      err.textContent = payload.friendly_error_message || payload.error_message;
+      err.title = payload.error_message || '';
+      toggleHidden(err, false);
+    } else {
+      toggleHidden(err, true);
+    }
+  }
+
+  var added = payload.added_count || 0;
+  var modified = payload.modified_count || 0;
+  var removed = payload.removed_count || 0;
+  var unchanged = payload.unchanged_count || 0;
+  var addedEl = row.querySelector('[data-sync-log-added]');
+  var modEl = row.querySelector('[data-sync-log-modified]');
+  var remEl = row.querySelector('[data-sync-log-removed]');
+  var unchEl = row.querySelector('[data-sync-log-unchanged]');
+  var main = row.querySelector('[data-sync-log-counts-main]');
+  if (addedEl) { addedEl.textContent = added ? '+' + added : ''; toggleHidden(addedEl, !added); }
+  if (modEl)   { modEl.textContent   = modified ? '~' + modified : ''; toggleHidden(modEl, !modified); }
+  if (remEl)   { remEl.textContent   = removed ? '-' + removed : ''; toggleHidden(remEl, !removed); }
+  if (unchEl)  { unchEl.textContent  = unchanged ? '=' + unchanged : ''; unchEl.title = unchanged + ' unchanged'; toggleHidden(unchEl, !unchanged); }
+  toggleHidden(main, !(added || modified || removed));
 }
+
+function findPollTargetRow() {
+  var list = document.getElementById('sync-history-list');
+  if (!list) return null;
+  var pending = list.querySelector('[data-sync-log-row="pending"]');
+  if (pending) return pending;
+  var first = list.querySelector('[data-sync-log-row]');
+  if (first && first.getAttribute('data-sync-log-status') === 'in_progress') return first;
+  return null;
+}
+
+function stopSyncPoll() {
+  if (syncPollTimer) { clearTimeout(syncPollTimer); syncPollTimer = null; }
+}
+
+function pollSyncStatus() {
+  stopSyncPoll();
+  if (!syncPollStartedAt) syncPollStartedAt = Date.now();
+
+  fetch('/-/connections/{{.ConnID}}/sync-status', { headers: { 'Accept': 'application/json' } })
+    .then(function(res) { return res.ok ? res.json() : null; })
+    .then(function(payload) {
+      if (!payload || payload.status === 'none') {
+        syncPollTimer = setTimeout(pollSyncStatus, SYNC_POLL_INTERVAL_MS);
+        return;
+      }
+
+      var row = findPollTargetRow();
+      if (row) updateSyncLogRow(row, payload);
+
+      if (payload.status === 'in_progress') {
+        if (Date.now() - syncPollStartedAt > SYNC_POLL_MAX_MS) {
+          showToast('Sync is taking longer than expected — refresh to check status.', 'warning');
+          syncPollStartedAt = 0;
+          setSyncButtonIdle();
+          return;
+        }
+        syncPollTimer = setTimeout(pollSyncStatus, SYNC_POLL_INTERVAL_MS);
+        return;
+      }
+
+      syncPollStartedAt = 0;
+      setSyncButtonIdle();
+      if (payload.status === 'error') {
+        showToast(payload.friendly_error_message || payload.error_message || 'Sync failed.', 'error');
+      }
+    })
+    .catch(function() {
+      syncPollTimer = setTimeout(pollSyncStatus, SYNC_POLL_INTERVAL_MS);
+    });
+}
+
+function syncConnection() {
+  setSyncButtonBusy();
+
+  var list = document.getElementById('sync-history-list');
+  var empty = document.getElementById('sync-history-empty');
+  if (list && !list.querySelector('[data-sync-log-row="pending"]')) {
+    var pending = buildSyncLogRow({ status: 'in_progress', trigger: 'manual' });
+    if (list.firstElementChild) list.insertBefore(pending, list.firstElementChild);
+    else list.appendChild(pending);
+    toggleHidden(list, false);
+    toggleHidden(empty, true);
+  }
+
+  fetch('/-/connections/{{.ConnID}}/sync', { method: 'POST' })
+    .then(function(res) {
+      if (res.ok) {
+        syncPollStartedAt = Date.now();
+        pollSyncStatus();
+        return;
+      }
+      return res.json().then(function(data) {
+        showToast((data && data.error) || 'Failed to trigger sync.');
+        var p = list && list.querySelector('[data-sync-log-row="pending"]');
+        if (p) p.remove();
+        if (list && !list.firstElementChild) { toggleHidden(list, true); toggleHidden(empty, false); }
+        setSyncButtonIdle();
+      });
+    })
+    .catch(function() {
+      showToast('Network error. Please try again.');
+      var p = list && list.querySelector('[data-sync-log-row="pending"]');
+      if (p) p.remove();
+      if (list && !list.firstElementChild) { toggleHidden(list, true); toggleHidden(empty, false); }
+      setSyncButtonIdle();
+    });
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  var first = document.querySelector('#sync-history-list [data-sync-log-row]');
+  if (first && first.getAttribute('data-sync-log-status') === 'in_progress') {
+    setSyncButtonBusy();
+    pollSyncStatus();
+  }
+});
 
 function removeConnection() {
   if (window.bbProgress) window.bbProgress.start();


### PR DESCRIPTION
## Summary

- Replace the skeleton+3s-reload Sync Now flow with live polling of `/-/connections/:id/sync-status`. Clicking Sync Now optimistically prepends an in-progress row and updates it in place every 1.5s until the sync log resolves — no page reload, no skeletons over real data. Auto-resumes polling on page load when the latest sync log is still `in_progress`, so cron/webhook-triggered syncs also update live.
- Stop swallowing three sync-engine error paths (`EnqueueReview`, per-txn rule-application INSERT, post-BEGIN tx sanity check). A silent `EnqueueReview` failure had been hiding behind a `SQLSTATE 25P02` cascade that blamed `update cursor`; the real first-cause error now surfaces in the log.

## Test plan

- [x] go build ./... and go test ./internal/admin/... pass
- [x] Manual sync on a Teller connection completes live, row flips success/error without a page reload
- [ ] Load /connections/:id while a cron sync is mid-flight — top row should auto-poll to completion
- [ ] Force an error path and confirm the friendly message appears in the row

🤖 Generated with [Claude Code](https://claude.com/claude-code)