### PR TITLE
feat(mcp): compact FK short-id pairs in responses

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"breadbox/internal/service"
@@ -1277,18 +1278,16 @@ func jsonResult(v any) (*mcpsdk.CallToolResult, any, error) {
 	}, nil, nil
 }
 
-// compactIDs recursively walks a JSON structure and replaces "id" with the
-// "short_id" value wherever both fields exist in the same object, then removes
-// "short_id". This makes MCP responses use compact 8-char IDs by default.
+// compactIDs recursively walks a JSON structure and compacts ID pairs in place.
+// For every key ending in "_short_id" (or the bare "short_id") with a non-null
+// string value, the sibling "{prefix}_id" (or bare "id") field is replaced with
+// the short_id value and the "_short_id" key is removed. This covers both an
+// object's own id/short_id pair and its FK references (e.g. account_id +
+// account_short_id → account_id=<short>).
 func compactIDs(v any) {
 	switch val := v.(type) {
 	case map[string]any:
-		if shortID, ok := val["short_id"]; ok {
-			if _, hasID := val["id"]; hasID {
-				val["id"] = shortID
-			}
-			delete(val, "short_id")
-		}
+		compactIDPairs(val)
 		for _, child := range val {
 			compactIDs(child)
 		}
@@ -1299,20 +1298,60 @@ func compactIDs(v any) {
 	}
 }
 
-// compactIDsBytes performs the id/short_id compaction directly on JSON bytes,
-// avoiding the unmarshal→walk→remarshal cycle. It scans the byte stream for
-// objects containing "id" and "short_id" keys, replaces the id value with
-// the short_id value, and removes the short_id entry.
+// compactIDPairs applies id/short_id compaction to a single object map.
+func compactIDPairs(m map[string]any) {
+	for key, val := range m {
+		prefix, ok := shortIDPrefix(key)
+		if !ok {
+			continue
+		}
+		shortVal, isString := val.(string)
+		if !isString || shortVal == "" {
+			// Non-string or null short_id: drop the sibling short_id key but
+			// leave the id value intact (compaction is ambiguous without a
+			// concrete short value).
+			delete(m, key)
+			continue
+		}
+		idKey := "id"
+		if prefix != "" {
+			idKey = prefix + "_id"
+		}
+		if _, hasID := m[idKey]; hasID {
+			m[idKey] = shortVal
+		}
+		delete(m, key)
+	}
+}
+
+// shortIDPrefix reports whether key names a short-id sibling and returns its
+// prefix. "short_id" → ("", true); "account_short_id" → ("account", true);
+// anything else → ("", false).
+func shortIDPrefix(key string) (string, bool) {
+	if key == "short_id" {
+		return "", true
+	}
+	if strings.HasSuffix(key, "_short_id") && len(key) > len("_short_id") {
+		return key[:len(key)-len("_short_id")], true
+	}
+	return "", false
+}
+
+// compactIDsBytes performs id/short_id compaction directly on JSON bytes,
+// avoiding the unmarshal→walk→remarshal cycle. It scans the byte stream and
+// collapses short-id sibling pairs:
 //
-// ORDERING ASSUMPTION: This function requires "id" to appear before "short_id"
-// in each JSON object. If "short_id" is encountered first, it is dropped but
-// the "id" value is NOT replaced. This assumption holds for json.Marshal output
-// because: (1) map keys are sorted alphabetically ("id" < "short_id"), and
-// (2) struct fields are marshaled in declaration order (all Breadbox response
-// structs declare ID before ShortID). See TestCompactIDsBytesFieldOrdering.
+//   - own id: {"id":"<uuid>","short_id":"<short>"} → {"id":"<short>"}
+//   - FK id:  {"account_id":"<uuid>","account_short_id":"<short>"} →
+//             {"account_id":"<short>"}
+//
+// Any key ending in "_short_id" (or the bare "short_id") triggers the rewrite;
+// the "_short_id" key is always dropped. If the sibling id field is missing or
+// the short-id value is null, the id value is left untouched.
 func compactIDsBytes(data []byte) []byte {
-	// Quick check: if no short_id key exists, return as-is.
-	if !bytes.Contains(data, []byte(`"short_id"`)) {
+	// Quick check: if no short_id key exists anywhere, return as-is. Matches
+	// both "short_id" and any "*_short_id" suffix.
+	if !bytes.Contains(data, []byte(`short_id"`)) {
 		return data
 	}
 
@@ -1343,81 +1382,119 @@ func compactIDsScan(data []byte, out []byte) []byte {
 	return out
 }
 
-// compactIDsScanObject processes a JSON object starting at data[pos] (the '{').
-// It looks for "id" and "short_id" key-value pairs to perform the swap.
+// compactIDsScanObject processes a JSON object starting at data[pos] (the '{')
+// and compacts any id/short_id pairs within it (including FK pairs like
+// account_id/account_short_id). Operates in two phases: collect each entry's
+// key and value range, then emit — replacing id values with their sibling
+// short-id value when present, and dropping *_short_id keys.
 func compactIDsScanObject(data []byte, pos int, out []byte) (int, []byte) {
-	out = append(out, '{')
 	pos++ // skip '{'
 
-	// Track id value replacement state.
-	var idValueStart, idValueEnd int // byte range of the "id" value in out
-	hasID := false
-	firstEntry := true
+	type objEntry struct {
+		keyStart, keyEnd int // raw quoted key bytes in data
+		key              string
+		valStart, valEnd int
+	}
+
+	var entries []objEntry
+	// Small stack allocation for common case (≤8 fields typical; most responses fit within 32).
+	var entriesBuf [32]objEntry
+	entries = entriesBuf[:0]
 
 	for pos < len(data) && data[pos] != '}' {
-		// Skip comma between entries.
 		if data[pos] == ',' {
 			pos++
 		}
-
-		// Read key (must be a string).
 		keyStart := pos
 		key, keyEnd := scanJSONString(data, pos)
 		pos = keyEnd
-
-		// Skip colon.
 		if pos < len(data) && data[pos] == ':' {
 			pos++
 		}
-
-		// Check what key this is.
-		if key == "id" {
-			// Write the key, remember where the value starts in output.
-			if !firstEntry {
-				out = append(out, ',')
-			}
-			firstEntry = false
-			out = append(out, data[keyStart:keyEnd]...)
-			out = append(out, ':')
-			idValueStart = len(out)
-			pos, out = copyJSONValue(data, pos, out)
-			idValueEnd = len(out)
-			hasID = true
-		} else if key == "short_id" {
-			// Read the short_id value.
-			valStart := pos
-			valEnd := skipJSONValue(data, pos)
-			pos = valEnd
-
-			if hasID {
-				// Replace the id value in output with short_id value.
-				shortIDVal := data[valStart:valEnd]
-				// Rebuild output: everything before id value + short_id value + everything after id value.
-				tail := make([]byte, len(out)-idValueEnd)
-				copy(tail, out[idValueEnd:])
-				out = out[:idValueStart]
-				out = append(out, shortIDVal...)
-				out = append(out, tail...)
-			}
-			// Drop short_id from output (don't write it).
-		} else {
-			// Regular key: copy key + colon + value.
-			if !firstEntry {
-				out = append(out, ',')
-			}
-			firstEntry = false
-			out = append(out, data[keyStart:keyEnd]...)
-			out = append(out, ':')
-			pos, out = copyJSONValue(data, pos, out)
-		}
+		valStart := pos
+		valEnd := skipJSONValue(data, pos)
+		pos = valEnd
+		entries = append(entries, objEntry{keyStart, keyEnd, key, valStart, valEnd})
+	}
+	if pos < len(data) {
+		pos++ // skip '}'
 	}
 
-	// Skip closing '}'.
-	if pos < len(data) {
-		pos++
+	// Build prefix → entry index for *_short_id keys (only non-null string values
+	// are eligible; null/non-string short_ids can't replace an id value).
+	var shortByPrefix map[string]int
+	for i := range entries {
+		e := &entries[i]
+		prefix, ok := shortIDPrefix(e.key)
+		if !ok {
+			continue
+		}
+		// Skip if value is null — we still drop the short_id key below, but
+		// don't compact the id.
+		val := data[e.valStart:e.valEnd]
+		if len(val) == 0 || val[0] != '"' {
+			continue
+		}
+		if shortByPrefix == nil {
+			shortByPrefix = make(map[string]int, 4)
+		}
+		shortByPrefix[prefix] = i
+	}
+
+	// Emit entries, skipping short_id keys and swapping id values when paired.
+	out = append(out, '{')
+	first := true
+	for i := range entries {
+		e := &entries[i]
+		if _, isShort := shortIDPrefix(e.key); isShort {
+			continue // drop short_id/*_short_id keys
+		}
+
+		vs, ve := e.valStart, e.valEnd
+		if shortByPrefix != nil {
+			if prefix, isIDKey := idKeyPrefix(e.key); isIDKey {
+				if idx, ok := shortByPrefix[prefix]; ok {
+					vs, ve = entries[idx].valStart, entries[idx].valEnd
+				}
+			}
+		}
+
+		if !first {
+			out = append(out, ',')
+		}
+		first = false
+		out = append(out, data[e.keyStart:e.keyEnd]...)
+		out = append(out, ':')
+
+		// If the value source is the original id position (not swapped), scan
+		// for nested compaction. When swapped, the short-id value is a plain
+		// string so we can copy verbatim.
+		if vs == e.valStart && ve == e.valEnd && ve > vs {
+			switch data[vs] {
+			case '{':
+				_, out = compactIDsScanObject(data, vs, out)
+				continue
+			case '[':
+				_, out = compactIDsScanArray(data, vs, out)
+				continue
+			}
+		}
+		out = append(out, data[vs:ve]...)
 	}
 	out = append(out, '}')
 	return pos, out
+}
+
+// idKeyPrefix reports whether key names an id sibling and returns its prefix.
+// "id" → ("", true); "account_id" → ("account", true); else ("", false).
+func idKeyPrefix(key string) (string, bool) {
+	if key == "id" {
+		return "", true
+	}
+	if strings.HasSuffix(key, "_id") && len(key) > len("_id") {
+		return key[:len(key)-len("_id")], true
+	}
+	return "", false
 }
 
 // compactIDsScanArray processes a JSON array starting at data[pos] (the '[').

--- a/internal/mcp/tools_bench_test.go
+++ b/internal/mcp/tools_bench_test.go
@@ -245,47 +245,35 @@ func benchmarkJsonResultN(b *testing.B, n int) {
 	}
 }
 
-// TestCompactIDsBytesFieldOrdering verifies behavior when "short_id" appears
-// before "id" in the JSON byte stream. json.Marshal guarantees "id" < "short_id"
-// alphabetically for maps and by declaration order for structs, but this test
-// documents what happens if that assumption is violated.
+// TestCompactIDsBytesFieldOrdering verifies that compaction works regardless
+// of whether "short_id" appears before or after "id" in the JSON byte stream.
+// The two-phase object scanner collects all entries before emitting, so
+// ordering does not matter.
 func TestCompactIDsBytesFieldOrdering(t *testing.T) {
-	// Case 1: Normal order (id before short_id) — should compact.
-	normalJSON := []byte(`{"id":"uuid-123","short_id":"abc","name":"test"}`)
-	normalGot := compactIDsBytes(normalJSON)
-	var normalParsed map[string]any
-	if err := json.Unmarshal(normalGot, &normalParsed); err != nil {
-		t.Fatalf("unmarshal normal: %v", err)
+	cases := []struct {
+		name string
+		json string
+	}{
+		{"id_before_short_id", `{"id":"uuid-123","short_id":"abc","name":"test"}`},
+		{"short_id_before_id", `{"short_id":"abc","id":"uuid-123","name":"test"}`},
 	}
-	if normalParsed["id"] != "abc" {
-		t.Errorf("normal order: expected id='abc', got id=%q", normalParsed["id"])
-	}
-	if _, hasShort := normalParsed["short_id"]; hasShort {
-		t.Error("normal order: short_id should be removed")
-	}
-
-	// Case 2: Reversed order (short_id before id) — compaction does NOT happen
-	// because the scanner has not yet seen "id" when it encounters "short_id".
-	// The short_id field is still dropped, but id retains its original value.
-	// This documents the ordering assumption; if this test fails, the scanner
-	// has been updated to handle reversed order (which is fine).
-	reversedJSON := []byte(`{"short_id":"abc","id":"uuid-123","name":"test"}`)
-	reversedGot := compactIDsBytes(reversedJSON)
-	var reversedParsed map[string]any
-	if err := json.Unmarshal(reversedGot, &reversedParsed); err != nil {
-		t.Fatalf("unmarshal reversed: %v", err)
-	}
-	if _, hasShort := reversedParsed["short_id"]; hasShort {
-		t.Error("reversed order: short_id should be removed")
-	}
-	// id keeps its original UUID value — compaction requires id before short_id.
-	if reversedParsed["id"] != "uuid-123" {
-		t.Errorf("reversed order: expected id='uuid-123' (no compaction), got id=%q", reversedParsed["id"])
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := compactIDsBytes([]byte(tc.json))
+			var parsed map[string]any
+			if err := json.Unmarshal(got, &parsed); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if parsed["id"] != "abc" {
+				t.Errorf("expected id='abc', got id=%q", parsed["id"])
+			}
+			if _, hasShort := parsed["short_id"]; hasShort {
+				t.Error("short_id should be removed")
+			}
+		})
 	}
 
-	// Case 3: Struct with ShortID declared before ID — verify json.Marshal
-	// still produces "id" before "short_id" (struct tags control JSON key names,
-	// and declaration order determines marshal order).
+	// Struct with ShortID declared before ID — compaction still applies.
 	type ReversedDeclOrder struct {
 		ShortID string `json:"short_id"`
 		ID      string `json:"id"`
@@ -293,19 +281,64 @@ func TestCompactIDsBytesFieldOrdering(t *testing.T) {
 	}
 	s := ReversedDeclOrder{ShortID: "compact1", ID: "full-uuid", Name: "test"}
 	data, _ := json.Marshal(s)
-
-	// With this struct, json.Marshal produces short_id BEFORE id,
-	// so compactIDsBytes will NOT perform the id replacement.
 	got := compactIDsBytes(data)
 	var parsed map[string]any
 	if err := json.Unmarshal(got, &parsed); err != nil {
 		t.Fatalf("unmarshal struct: %v", err)
 	}
+	if parsed["id"] != "compact1" {
+		t.Errorf("struct: expected id='compact1', got id=%q", parsed["id"])
+	}
 	if _, hasShort := parsed["short_id"]; hasShort {
 		t.Error("struct: short_id should be removed")
 	}
-	// Compaction does not occur because short_id appears first in marshal output.
-	if parsed["id"] != "full-uuid" {
-		t.Errorf("struct: expected id='full-uuid' (no compaction), got id=%q", parsed["id"])
+}
+
+// TestCompactIDsBytesFKPairs verifies that FK sibling pairs like
+// account_id/account_short_id are collapsed to a single account_id carrying
+// the short value.
+func TestCompactIDsBytesFKPairs(t *testing.T) {
+	input := []byte(`{"id":"own-uuid","short_id":"ownshort","account_id":"acct-uuid","account_short_id":"acctshort","category_id":"cat-uuid","category_short_id":"catshort","name":"t1"}`)
+	got := compactIDsBytes(input)
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := map[string]string{
+		"id":          "ownshort",
+		"account_id":  "acctshort",
+		"category_id": "catshort",
+		"name":        "t1",
+	}
+	for k, v := range want {
+		if parsed[k] != v {
+			t.Errorf("%s: got %v want %q", k, parsed[k], v)
+		}
+	}
+	for _, k := range []string{"short_id", "account_short_id", "category_short_id"} {
+		if _, has := parsed[k]; has {
+			t.Errorf("%s should be removed", k)
+		}
+	}
+}
+
+// TestCompactIDsBytesFKNullShort verifies that a null short_id sibling drops
+// the _short_id key but leaves the _id value untouched (compaction would
+// otherwise discard a valid UUID).
+func TestCompactIDsBytesFKNullShort(t *testing.T) {
+	input := []byte(`{"id":"own-uuid","short_id":"ownshort","account_id":"acct-uuid","account_short_id":null}`)
+	got := compactIDsBytes(input)
+	var parsed map[string]any
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed["id"] != "ownshort" {
+		t.Errorf("id: got %v", parsed["id"])
+	}
+	if parsed["account_id"] != "acct-uuid" {
+		t.Errorf("account_id: expected preserved UUID, got %v", parsed["account_id"])
+	}
+	if _, has := parsed["account_short_id"]; has {
+		t.Error("account_short_id should be removed even when null")
 	}
 }

--- a/internal/service/fields.go
+++ b/internal/service/fields.go
@@ -212,6 +212,9 @@ func FilterReviewFields(r ReviewResponse, fields map[string]bool) map[string]any
 			m["short_id"] = r.ShortID
 		case "transaction_id":
 			m["transaction_id"] = r.TransactionID
+			if r.TransactionShortID != nil {
+				m["transaction_short_id"] = r.TransactionShortID
+			}
 		case "review_type":
 			m["review_type"] = r.ReviewType
 		case "status":
@@ -289,6 +292,9 @@ func FilterTransactionFields(t TransactionResponse, fields map[string]bool) map[
 			m["short_id"] = t.ShortID
 		case "account_id":
 			m["account_id"] = t.AccountID
+			if t.AccountShortID != nil {
+				m["account_short_id"] = t.AccountShortID
+			}
 		case "account_name":
 			m["account_name"] = t.AccountName
 		case "user_name":

--- a/internal/service/reviews.go
+++ b/internal/service/reviews.go
@@ -78,10 +78,13 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 		rq.reviewer_type, rq.reviewer_id, rq.reviewer_name,
 		rq.resolved_category_id, rq.created_at, rq.reviewed_at,
 		sc.slug AS suggested_slug, sc.display_name AS suggested_display_name, scp.display_name AS suggested_parent_display_name,
+		sc.short_id AS suggested_short_id,
 		rc.slug AS resolved_slug, rc.display_name AS resolved_display_name, rcp.display_name AS resolved_parent_display_name,
+		rc.short_id AS resolved_short_id,
 		t.amount, t.iso_currency_code, t.date, t.name, t.merchant_name,
 		t.category_primary, t.category_detailed, t.pending, t.created_at AS t_created_at, t.updated_at AS t_updated_at,
 		t.short_id AS t_short_id, t.account_id, COALESCE(a.display_name, a.name) AS account_name,
+		a.short_id AS account_short_id,
 		COALESCE(au.name, u.name) AS user_name,
 		t.category_id, t.category_override,
 		c.slug AS cat_slug, c.display_name AS cat_display_name, c.icon AS cat_icon, c.color AS cat_color,
@@ -205,9 +208,11 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 			suggestedSlug              pgtype.Text
 			suggestedDisplayName       pgtype.Text
 			suggestedParentDisplayName pgtype.Text
+			suggestedShortID           pgtype.Text
 			resolvedSlug               pgtype.Text
 			resolvedDisplayName        pgtype.Text
 			resolvedParentDisplayName  pgtype.Text
+			resolvedShortID            pgtype.Text
 			tAmount               pgtype.Numeric
 			tIsoCurrencyCode      pgtype.Text
 			tDate                 pgtype.Date
@@ -221,6 +226,7 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 			tShortID              string
 			tAccountID            pgtype.UUID
 			accountName           string
+			accountShortID        string
 			userName              pgtype.Text
 			tCategoryID           pgtype.UUID
 			tCategoryOverride     bool
@@ -239,10 +245,12 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 			&rReviewerType, &rReviewerID, &rReviewerName,
 			&rResolvedCategoryID, &rCreatedAt, &rReviewedAt,
 			&suggestedSlug, &suggestedDisplayName, &suggestedParentDisplayName,
+			&suggestedShortID,
 			&resolvedSlug, &resolvedDisplayName, &resolvedParentDisplayName,
+			&resolvedShortID,
 			&tAmount, &tIsoCurrencyCode, &tDate, &tName, &tMerchantName,
 			&tCategoryPrimary, &tCategoryDetailed, &tPending, &tCreatedAt, &tUpdatedAt,
-			&tShortID, &tAccountID, &accountName, &userName,
+			&tShortID, &tAccountID, &accountName, &accountShortID, &userName,
 			&tCategoryID, &tCategoryOverride,
 			&catSlug, &catDisplayName, &catIcon, &catColor,
 			&catPrimarySlug, &catPrimaryDisplayName,
@@ -275,10 +283,12 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 			}
 		}
 
+		accountShortIDVal := accountShortID
 		txnResp := &TransactionResponse{
 			ID:                  formatUUID(rTransactionID),
 			ShortID:             tShortID,
 			AccountID:           uuidPtr(tAccountID),
+			AccountShortID:      &accountShortIDVal,
 			AccountName:         &accountName,
 			UserName:            textPtr(userName),
 			Amount:              amountVal,
@@ -295,14 +305,17 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 			UpdatedAt:           tUpdatedAt.Time.UTC().Format(time.RFC3339),
 		}
 
+		txnShortIDVal := tShortID
 		review := ReviewResponse{
 			ID:                           formatUUID(rID),
 			ShortID:                      rqShortID,
 			TransactionID:                formatUUID(rTransactionID),
+			TransactionShortID:           &txnShortIDVal,
 			ReviewType:                   rReviewType,
 			Status:                       rStatus,
 			Provider:                     textPtr(connectionProvider),
 			SuggestedCategoryID:          uuidPtr(rSuggestedCategoryID),
+			SuggestedCategoryShortID:     textPtr(suggestedShortID),
 			SuggestedCategory:            textPtr(suggestedSlug),
 			SuggestedCategoryDisplayName: buildCategoryDisplayName(suggestedDisplayName, suggestedParentDisplayName),
 			ConfidenceScore:              numericFloat(rConfidenceScore),
@@ -310,6 +323,7 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 			ReviewerID:                   textPtr(rReviewerID),
 			ReviewerName:                 textPtr(rReviewerName),
 			ResolvedCategoryID:           uuidPtr(rResolvedCategoryID),
+			ResolvedCategoryShortID:      textPtr(resolvedShortID),
 			ResolvedCategory:             textPtr(resolvedSlug),
 			ResolvedCategoryDisplayName:  buildCategoryDisplayName(resolvedDisplayName, resolvedParentDisplayName),
 			CreatedAt:                    rCreatedAt.Time.UTC().Format(time.RFC3339),

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -26,6 +26,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		"t.category_primary, t.category_detailed, t.category_confidence, " +
 		"t.payment_channel, t.pending, t.deleted_at, t.created_at, t.updated_at, " +
 		"COALESCE(a.display_name, a.name) AS account_name, " +
+		"a.short_id AS account_short_id, " +
 		"COALESCE(au.name, u.name) AS user_name, " +
 		"t.category_id, t.category_override, " +
 		"c.slug AS cat_slug, c.display_name AS cat_display_name, c.icon AS cat_icon, c.color AS cat_color, " +
@@ -236,6 +237,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			createdAt              pgtype.Timestamptz
 			updatedAt              pgtype.Timestamptz
 			accountName            string
+			accountShortID         string
 			userName               pgtype.Text
 			categoryID             pgtype.UUID
 			categoryOverride       bool
@@ -257,7 +259,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			&name, &merchantName, &categoryPrimary, &categoryDetailed,
 			&categoryConfidence, &paymentChannel, &pending,
 			&deletedAt, &createdAt, &updatedAt,
-			&accountName, &userName,
+			&accountName, &accountShortID, &userName,
 			&categoryID, &categoryOverride,
 			&catSlug, &catDisplayName, &catIcon, &catColor,
 			&catPrimarySlug, &catPrimaryDisplayName,
@@ -293,10 +295,12 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			}
 		}
 
+		accountShortIDVal := accountShortID
 		transactions = append(transactions, TransactionResponse{
 			ID:                  formatUUID(id),
 			ShortID:             shortID,
 			AccountID:           uuidPtr(accountID),
+			AccountShortID:      &accountShortIDVal,
 			AccountName:         &accountName,
 			UserName:            textPtr(userName),
 			AttributedUserID:    uuidPtr(attributedUserID),

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -37,6 +37,7 @@ type TransactionResponse struct {
 	ID                  string                   `json:"id"`
 	ShortID             string                   `json:"short_id"`
 	AccountID           *string                  `json:"account_id"`
+	AccountShortID      *string                  `json:"account_short_id,omitempty"`
 	AccountName         *string                  `json:"account_name"`
 	UserName            *string                  `json:"user_name"`
 	AttributedUserID    *string                  `json:"attributed_user_id,omitempty"`
@@ -348,13 +349,15 @@ type CommentResponse struct {
 // Review queue types
 
 type ReviewResponse struct {
-	ID                  string               `json:"id"`
-	ShortID             string               `json:"short_id"`
-	TransactionID       string               `json:"transaction_id"`
-	ReviewType          string               `json:"review_type"`
-	Status              string               `json:"status"`
-	Provider            *string              `json:"provider,omitempty"`
+	ID                 string  `json:"id"`
+	ShortID            string  `json:"short_id"`
+	TransactionID      string  `json:"transaction_id"`
+	TransactionShortID *string `json:"transaction_short_id,omitempty"`
+	ReviewType         string  `json:"review_type"`
+	Status             string  `json:"status"`
+	Provider           *string `json:"provider,omitempty"`
 	SuggestedCategoryID          *string              `json:"suggested_category_id,omitempty"`
+	SuggestedCategoryShortID     *string              `json:"suggested_category_short_id,omitempty"`
 	SuggestedCategory            *string              `json:"suggested_category_slug,omitempty"`
 	SuggestedCategoryDisplayName *string              `json:"suggested_category_display_name,omitempty"`
 	ConfidenceScore              *float64             `json:"confidence_score,omitempty"`
@@ -362,6 +365,7 @@ type ReviewResponse struct {
 	ReviewerID                   *string              `json:"reviewer_id,omitempty"`
 	ReviewerName                 *string              `json:"reviewer_name,omitempty"`
 	ResolvedCategoryID           *string              `json:"resolved_category_id,omitempty"`
+	ResolvedCategoryShortID      *string              `json:"resolved_category_short_id,omitempty"`
 	ResolvedCategory             *string              `json:"resolved_category_slug,omitempty"`
 	ResolvedCategoryDisplayName  *string              `json:"resolved_category_display_name,omitempty"`
 	CreatedAt           string               `json:"created_at"`


### PR DESCRIPTION
Closes #378.

## Summary

- Generalize `compactIDsBytes` in the MCP response pipeline: any `X_id`/`X_short_id` sibling pair on the same object is now collapsed to a single `X_id` field carrying the 8-char short value. The own-entity `id`/`short_id` path still works (special case where prefix is empty).
- Denormalize `account_short_id` onto `TransactionResponse`, and `transaction_short_id`/`suggested_category_short_id`/`resolved_category_short_id` onto `ReviewResponse`. The SQL queries for `ListTransactions` and `ListReviews` JOIN the referenced tables' `short_id` columns.
- Rewrite `compactIDsScanObject` using a two-phase (collect entries → emit) scan so ordering no longer matters. Null short-id values drop the `_short_id` key but preserve the UUID in the `_id` field.

REST responses now include the extra `*_short_id` fields (additive). MCP responses drop them after compaction.

## Test plan

- [x] `go test ./...` unit tests
- [x] Full integration test suite (`make test-integration`)
- [x] New coverage: `TestCompactIDsBytesFKPairs`, `TestCompactIDsBytesFKNullShort`, updated `TestCompactIDsBytesFieldOrdering` for order-independence
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)