### PR TITLE
fix(ui): widen sync log error messages and add hover tooltips

### DIFF
--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -348,7 +348,7 @@
             <span class="text-xs text-base-content/35 tabular-nums" data-sync-log-time>{{relativeTime .StartedAt}}</span>
             <span class="text-[0.6rem] text-base-content/25 tabular-nums bg-base-200/50 px-1.5 py-0.5 rounded-full{{if not .DurationMs.Valid}}{{if not (and .StartedAt.Valid .CompletedAt.Valid)}} hidden{{end}}{{end}}" data-sync-log-duration>{{if .DurationMs.Valid}}{{formatDurationMs .DurationMs.Int32}}{{else if and .StartedAt.Valid .CompletedAt.Valid}}{{syncDuration .StartedAt.Time .CompletedAt.Time}}{{end}}</span>
           </div>
-          <p class="text-xs text-error/60 mt-0.5 max-w-md truncate{{if not (and (eq (printf "%s" .Status) "error") .ErrorMessage.Valid)}} hidden{{end}}" data-sync-log-error title="{{if .ErrorMessage.Valid}}{{.ErrorMessage.String}}{{end}}">{{if and (eq (printf "%s" .Status) "error") .ErrorMessage.Valid}}{{$friendly := syncFriendlyError .ErrorMessage.String}}{{if $friendly}}{{$friendly}}{{else}}{{.ErrorMessage.String}}{{end}}{{end}}</p>
+          <p class="text-xs text-error/60 mt-0.5 truncate{{if not (and (eq (printf "%s" .Status) "error") .ErrorMessage.Valid)}} hidden{{end}}" data-sync-log-error title="{{if .ErrorMessage.Valid}}{{.ErrorMessage.String}}{{end}}">{{if and (eq (printf "%s" .Status) "error") .ErrorMessage.Valid}}{{$friendly := syncFriendlyError .ErrorMessage.String}}{{if $friendly}}{{$friendly}}{{else}}{{.ErrorMessage.String}}{{end}}{{end}}</p>
         </div>
         <div class="flex items-center gap-2.5 tabular-nums text-xs shrink-0" data-sync-log-counts>
           <div class="flex items-center gap-1.5{{if not (or .AddedCount .ModifiedCount .RemovedCount)}} hidden{{end}}" data-sync-log-counts-main>
@@ -414,7 +414,7 @@ function buildSyncLogRow(payload) {
     +       '<span class="text-xs text-base-content/35 tabular-nums" data-sync-log-time>just now</span>'
     +       '<span class="text-[0.6rem] text-base-content/25 tabular-nums bg-base-200/50 px-1.5 py-0.5 rounded-full hidden" data-sync-log-duration></span>'
     +     '</div>'
-    +     '<p class="text-xs text-error/60 mt-0.5 max-w-md truncate hidden" data-sync-log-error></p>'
+    +     '<p class="text-xs text-error/60 mt-0.5 truncate hidden" data-sync-log-error></p>'
     +   '</div>'
     +   '<div class="flex items-center gap-2.5 tabular-nums text-xs shrink-0" data-sync-log-counts>'
     +     '<div class="flex items-center gap-1.5 hidden" data-sync-log-counts-main>'

--- a/internal/templates/pages/logs.html
+++ b/internal/templates/pages/logs.html
@@ -225,9 +225,9 @@
             {{end}}
           </div>
           {{if and (eq .Status "error") .FriendlyErrorMessage}}
-          <div class="mt-1 text-xs text-error/60 truncate max-w-md">{{deref .FriendlyErrorMessage}}</div>
+          <div class="mt-1 text-xs text-error/60 truncate" title="{{deref .FriendlyErrorMessage}}">{{deref .FriendlyErrorMessage}}</div>
           {{else if and (eq .Status "error") .ErrorMessage}}
-          <div class="mt-1 text-xs text-error/60 truncate max-w-md font-mono">{{deref .ErrorMessage}}</div>
+          <div class="mt-1 text-xs text-error/60 truncate font-mono" title="{{deref .ErrorMessage}}">{{deref .ErrorMessage}}</div>
           {{end}}
         </div>
       </div>

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -202,9 +202,9 @@
             {{end}}
           </div>
           {{if and (eq .Status "error") .FriendlyErrorMessage}}
-          <div class="mt-1 text-xs text-error/60 truncate max-w-md">{{deref .FriendlyErrorMessage}}</div>
+          <div class="mt-1 text-xs text-error/60 truncate" title="{{deref .FriendlyErrorMessage}}">{{deref .FriendlyErrorMessage}}</div>
           {{else if and (eq .Status "error") .ErrorMessage}}
-          <div class="mt-1 text-xs text-error/60 truncate max-w-md font-mono">{{deref .ErrorMessage}}</div>
+          <div class="mt-1 text-xs text-error/60 truncate font-mono" title="{{deref .ErrorMessage}}">{{deref .ErrorMessage}}</div>
           {{end}}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Drop `max-w-md` cap on sync log error text so errors use the full row width before truncating
- Add `title` attributes on the logs + sync_logs pages so the full error is visible on hover
- Keep connection_detail dynamic row template in sync with the static markup

## Test plan
- [ ] Visit `/logs` and `/sync-logs` with an errored sync and confirm errors wrap to available width and hovering shows the full message
- [ ] Visit a connection detail page and confirm both server-rendered and newly-streamed sync log rows render identically