### PR TITLE
fix(reviews): allow manual re-enqueue + use avatars in comment timeline

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -810,6 +810,10 @@ func buildActivityTimeline(reviews []service.ReviewResponse, comments []service.
 			if r.ReviewerType != nil {
 				e.ActorType = *r.ReviewerType
 			}
+			if r.ReviewerID != nil && *r.ReviewerID != "" {
+				id := *r.ReviewerID
+				e.ActorID = &id
+			}
 			switch r.Status {
 			case "approved":
 				e.ReviewStatus = "approved"
@@ -844,14 +848,19 @@ func buildActivityTimeline(reviews []service.ReviewResponse, comments []service.
 		if strings.HasPrefix(c.Content, "[Review: ") {
 			continue
 		}
-		entries = append(entries, service.ActivityEntry{
+		entry := service.ActivityEntry{
 			Type:      "comment",
 			Timestamp: c.CreatedAt,
 			ActorName: c.AuthorName,
 			ActorType: c.AuthorType,
 			Detail:    c.Content,
 			CommentID: c.ID,
-		})
+		}
+		if c.AuthorID != nil && *c.AuthorID != "" {
+			id := *c.AuthorID
+			entry.ActorID = &id
+		}
+		entries = append(entries, entry)
 	}
 
 	// Convert rule applications

--- a/internal/db/queries/reviews.sql
+++ b/internal/db/queries/reviews.sql
@@ -1,9 +1,21 @@
 -- name: EnqueueReview :one
+-- Used by sync to auto-enqueue. Skips transactions that already have any review
+-- (pending or resolved) to avoid re-flagging previously-seen transactions on every sync.
 INSERT INTO review_queue (transaction_id, review_type, suggested_category_id, confidence_score)
 SELECT $1, $2, $3, $4
 WHERE NOT EXISTS (
   SELECT 1 FROM review_queue WHERE transaction_id = $1
 )
+ON CONFLICT (transaction_id) WHERE status = 'pending' DO NOTHING
+RETURNING *;
+
+-- name: EnqueueReviewManual :one
+-- Used for manual enqueue (user/agent-triggered). Allows creating a new pending
+-- review even when prior resolved reviews exist (for re_review workflow). The
+-- partial unique index on (transaction_id) WHERE status = 'pending' still
+-- prevents duplicate pending reviews.
+INSERT INTO review_queue (transaction_id, review_type, suggested_category_id, confidence_score)
+VALUES ($1, $2, $3, $4)
 ON CONFLICT (transaction_id) WHERE status = 'pending' DO NOTHING
 RETURNING *;
 

--- a/internal/service/review_integration_test.go
+++ b/internal/service/review_integration_test.go
@@ -98,6 +98,43 @@ func TestEnqueueManualReview_DuplicatePending(t *testing.T) {
 	}
 }
 
+func TestEnqueueManualReview_ReReviewAfterResolved(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	txn := reviewTestFixture(t, queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	// Enqueue and then resolve (approve) a review — simulating the normal lifecycle.
+	first, err := svc.EnqueueManualReview(ctx, txnID, testActor)
+	if err != nil {
+		t.Fatalf("first EnqueueManualReview: %v", err)
+	}
+	if _, err := svc.SubmitReview(ctx, service.SubmitReviewParams{
+		ReviewID: first.ID,
+		Decision: "approved",
+		Actor:    testActor,
+	}); err != nil {
+		t.Fatalf("SubmitReview approve: %v", err)
+	}
+
+	// Manually re-enqueue. Prior behavior: ErrReviewAlreadyPending (bug).
+	// Expected: a fresh pending review with review_type=re_review.
+	second, err := svc.EnqueueManualReview(ctx, txnID, testActor)
+	if err != nil {
+		t.Fatalf("re-enqueue after resolve: %v", err)
+	}
+	if second.Status != "pending" {
+		t.Errorf("expected status=pending, got %s", second.Status)
+	}
+	if second.ReviewType != "re_review" {
+		t.Errorf("expected review_type=re_review, got %s", second.ReviewType)
+	}
+	if second.ID == first.ID {
+		t.Error("expected a new review row, got the same review ID as the resolved one")
+	}
+}
+
 func TestEnqueueManualReview_SoftDeletedTransaction(t *testing.T) {
 	svc, queries, pool := newService(t)
 	ctx := context.Background()

--- a/internal/service/reviews.go
+++ b/internal/service/reviews.go
@@ -781,7 +781,7 @@ func (s *Service) EnqueueManualReview(ctx context.Context, transactionID string,
 		reviewType = "re_review"
 	}
 
-	review, err := s.Queries.EnqueueReview(ctx, db.EnqueueReviewParams{
+	review, err := s.Queries.EnqueueReviewManual(ctx, db.EnqueueReviewManualParams{
 		TransactionID: txnID,
 		ReviewType:    reviewType,
 	})

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -440,8 +440,9 @@ type ActivityEntry struct {
 	Type      string `json:"type"`      // "review", "comment", "rule"
 	Timestamp string `json:"timestamp"` // RFC3339
 
-	ActorName string `json:"actor_name"`
-	ActorType string `json:"actor_type"` // "user", "agent", "system"
+	ActorName string  `json:"actor_name"`
+	ActorType string  `json:"actor_type"`         // "user", "agent", "system"
+	ActorID   *string `json:"actor_id,omitempty"` // user UUID when available (for avatar rendering)
 
 	Summary string `json:"summary"`          // Short: "Approved as Food & Drink"
 	Detail  string `json:"detail,omitempty"` // Longer text (review note or comment body)

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -211,6 +211,8 @@
       <div class="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-0.5">
         <i data-lucide="bot" class="w-4 h-4 text-primary"></i>
       </div>
+      {{else if and (eq .ActorType "user") .ActorID}}
+      <img src="{{avatarURL (deref .ActorID)}}" alt="" class="w-8 h-8 rounded-full object-cover shrink-0 mt-0.5" title="{{.ActorName}}">
       {{else}}
       <div class="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-0.5">
         <span class="text-xs font-semibold text-primary leading-none">{{firstChar .ActorName}}</span>


### PR DESCRIPTION
## Summary
- **Toggle bug**: the \"Send to review queue\" toggle on the transaction detail page silently failed (409) for any transaction with a prior resolved review. Root cause was an overly-strict `WHERE NOT EXISTS` in `EnqueueReview` that blocked inserts when any review row existed. Split into `EnqueueReview` (sync, conservative — unchanged) and `EnqueueReviewManual` (manual path — only blocks on a currently-pending row via the partial unique index), so `re_review` now works end-to-end.
- **Avatars**: comment and review-resolution events in the activity timeline now render the user's avatar image (matching `tx_row.html` / `dashboard.html`) instead of a first-letter circle. Added `ActorID` to `ActivityEntry` and populated from `AuthorID` / `ReviewerID`.

## Test plan
- [x] `go build ./...`
- [x] `go test -tags integration -p 1 ./internal/service/... ./internal/admin/... ./internal/api/...` — all pass
- [x] New regression test: `TestEnqueueManualReview_ReReviewAfterResolved`
- [x] Manual: toggled a transaction with a prior `approved` review — server now returns 201, a new `re_review` row appears, and the UI reflects `(already pending)` after reload
- [x] Manual: added a comment on the transaction detail page — timeline renders the user's avatar image, not a letter circle

🤖 Generated with [Claude Code](https://claude.com/claude-code)