### PR TITLE
fix(mcp): accept category_slug in categorize_transaction

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -297,7 +297,7 @@ func (s *MCPServer) buildToolRegistry() {
 			"Trigger a manual sync of bank data from the provider (Plaid or Teller). Optionally specify a connection_id to sync a single connection; otherwise syncs all active connections. Returns immediately — the sync runs in the background. Check get_sync_status for results.",
 			s.handleTriggerSync, svc),
 		makeToolDefLogged("categorize_transaction", ToolWrite,
-			"Manually override a transaction's category. Use list_categories to find the category ID, then pass both the transaction_id and category_id. This creates a permanent override that won't be changed by automatic sync.",
+			"Manually override a transaction's category. Pass transaction_id plus either category_id or category_slug (e.g. 'food_and_drink_groceries'). Use list_categories to find valid slugs/IDs. This creates a permanent override that won't be changed by automatic sync.",
 			s.handleCategorizeTransaction, svc),
 		makeToolDefLogged("reset_transaction_category", ToolWrite,
 			"Remove a manual category override from a transaction and re-resolve its category from the automatic mapping rules. Use this to undo a categorize_transaction action.",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -95,7 +95,8 @@ type triggerSyncInput struct {
 type categorizeTransactionInput struct {
 	WriteSessionContext
 	TransactionID string `json:"transaction_id" jsonschema:"The transaction ID to categorize"`
-	CategoryID    string `json:"category_id" jsonschema:"The category ID to assign (use list_categories to find IDs)"`
+	CategoryID    string `json:"category_id,omitempty" jsonschema:"Category ID to assign. Provide either category_id or category_slug (not both)."`
+	CategorySlug  string `json:"category_slug,omitempty" jsonschema:"Category slug to assign (e.g. food_and_drink_groceries). Alternative to category_id — the slug is resolved to an ID automatically."`
 }
 
 type resetTransactionCategoryInput struct {
@@ -422,10 +423,24 @@ func (s *MCPServer) handleCategorizeTransaction(ctx context.Context, _ *mcpsdk.C
 		return errorResult(err), nil, nil
 	}
 	ctx = context.Background()
-	if input.TransactionID == "" || input.CategoryID == "" {
-		return errorResult(fmt.Errorf("transaction_id and category_id are required")), nil, nil
+	if input.TransactionID == "" {
+		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
 	}
-	if err := s.svc.SetTransactionCategory(ctx, input.TransactionID, input.CategoryID); err != nil {
+	if input.CategoryID == "" && input.CategorySlug == "" {
+		return errorResult(fmt.Errorf("either category_id or category_slug is required")), nil, nil
+	}
+
+	// Resolve category_slug to category_id if provided. category_id takes precedence.
+	categoryID := input.CategoryID
+	if categoryID == "" && input.CategorySlug != "" {
+		cat, err := s.svc.GetCategoryBySlug(ctx, input.CategorySlug)
+		if err != nil {
+			return errorResult(fmt.Errorf("invalid category_slug %q: %w", input.CategorySlug, err)), nil, nil
+		}
+		categoryID = cat.ID
+	}
+
+	if err := s.svc.SetTransactionCategory(ctx, input.TransactionID, categoryID); err != nil {
 		return errorResult(err), nil, nil
 	}
 	return &mcpsdk.CallToolResult{


### PR DESCRIPTION
Closes #383

## Summary
- `categorize_transaction` MCP tool now accepts either `category_id` or `category_slug`, matching the slug-first pattern used by `submit_review` and `batch_categorize_transactions`.
- Agents can categorize a transaction directly with a known slug (e.g. `food_and_drink_groceries`) instead of having to call `list_categories` first to look up an ID.
- `category_id` still takes precedence if both are provided; if neither is set, the tool returns a clear error.

## Changes
- `internal/mcp/tools.go`: added `CategorySlug` to `categorizeTransactionInput`; handler resolves slug via `s.svc.GetCategoryBySlug` (same helper used by `submit_review`).
- `internal/mcp/server.go`: updated tool description to note both options.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/mcp/...` passes
- [x] `go test ./internal/service/...` passes

Generated with [Claude Code](https://claude.com/claude-code)