### PR TITLE
refactor(mcp): move pending_reviews_overview handler to tools.go

### DIFF
--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -803,6 +803,10 @@ type batchReviewItem struct {
 	Note         *string `json:"note,omitempty" jsonschema:"Optional short rationale for this decision. Recorded as a transaction comment attributed to you and shown inline on the review resolution in the transaction's activity timeline. Do NOT also call add_transaction_comment for the same transaction — pass the narrative here instead."`
 }
 
+type pendingReviewsOverviewInput struct {
+	ReadSessionContext
+}
+
 func (s *MCPServer) handleCreateTransactionRule(ctx context.Context, _ *mcpsdk.CallToolRequest, input createTransactionRuleInput) (*mcpsdk.CallToolResult, any, error) {
 	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
@@ -1026,6 +1030,25 @@ func (s *MCPServer) handleBatchSubmitReviews(ctx context.Context, _ *mcpsdk.Call
 		Reviews: items,
 		Actor:   actor,
 	})
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(result)
+}
+
+func (s *MCPServer) handlePendingReviewsOverview(_ context.Context, _ *mcpsdk.CallToolRequest, _ pendingReviewsOverviewInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+
+	if !s.svc.IsReviewsEnabled(ctx) {
+		return jsonResult(map[string]any{
+			"total_pending":   0,
+			"counts_by_type":  []any{},
+			"category_groups": []any{},
+			"note":            "Transaction reviews are currently disabled. Enable them in the admin dashboard at /reviews.",
+		})
+	}
+
+	result, err := s.svc.GetPendingReviewsOverview(ctx)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}

--- a/internal/mcp/tools_account_links.go
+++ b/internal/mcp/tools_account_links.go
@@ -47,10 +47,6 @@ type rejectMatchInput struct {
 	MatchID string `json:"match_id" jsonschema:"The transaction match ID to reject"`
 }
 
-type pendingReviewsOverviewInput struct {
-	ReadSessionContext
-}
-
 // --- Handlers ---
 
 func (s *MCPServer) handleListAccountLinks(_ context.Context, _ *mcpsdk.CallToolRequest, _ listAccountLinksInput) (*mcpsdk.CallToolResult, any, error) {
@@ -145,23 +141,4 @@ func (s *MCPServer) handleRejectMatch(ctx context.Context, _ *mcpsdk.CallToolReq
 		return errorResult(err), nil, nil
 	}
 	return jsonResult(map[string]string{"status": "rejected"})
-}
-
-func (s *MCPServer) handlePendingReviewsOverview(_ context.Context, _ *mcpsdk.CallToolRequest, _ pendingReviewsOverviewInput) (*mcpsdk.CallToolResult, any, error) {
-	ctx := context.Background()
-
-	if !s.svc.IsReviewsEnabled(ctx) {
-		return jsonResult(map[string]any{
-			"total_pending":   0,
-			"counts_by_type":  []any{},
-			"category_groups": []any{},
-			"note":            "Transaction reviews are currently disabled. Enable them in the admin dashboard at /reviews.",
-		})
-	}
-
-	result, err := s.svc.GetPendingReviewsOverview(ctx)
-	if err != nil {
-		return errorResult(err), nil, nil
-	}
-	return jsonResult(result)
 }


### PR DESCRIPTION
Closes #388

## Summary
Relocates `handlePendingReviewsOverview` and its `pendingReviewsOverviewInput` type from `internal/mcp/tools_account_links.go` to `internal/mcp/tools.go`, placing them next to the other review handlers (`handleListPendingReviews`, `handleSubmitReview`, `handleBatchSubmitReviews`). Pure file hygiene — no behavior change.

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./internal/mcp/...` passes
- [x] `go vet ./...` clean