### PR TITLE
feat(mcp): add UPPER_SNAKE_CASE error codes to tool error envelopes

### DIFF
--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+
+	"breadbox/internal/service"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Error codes returned by MCP tool error envelopes.
+//
+// These mirror the UPPER_SNAKE_CASE codes used by the REST API in
+// internal/api so that agents can programmatically distinguish error
+// conditions without parsing the human-readable message.
+const (
+	CodeNotFound              = "NOT_FOUND"
+	CodeForbidden             = "FORBIDDEN"
+	CodeInvalidParameter      = "INVALID_PARAMETER"
+	CodeInvalidCategory       = "INVALID_CATEGORY"
+	CodeInvalidCursor         = "INVALID_CURSOR"
+	CodeInvalidDecision       = "INVALID_DECISION"
+	CodeReviewAlreadyPending  = "REVIEW_ALREADY_PENDING"
+	CodeReviewAlreadyResolved = "REVIEW_ALREADY_RESOLVED"
+	CodeReviewsDisabled       = "REVIEWS_DISABLED"
+	CodeSyncInProgress        = "SYNC_IN_PROGRESS"
+	CodeSlugConflict          = "SLUG_CONFLICT"
+	CodeCategoryUndeletable   = "CATEGORY_UNDELETABLE"
+	CodeInvalidAPIKey         = "INVALID_API_KEY"
+	CodeRevokedAPIKey         = "REVOKED_API_KEY"
+	CodeInternalError         = "INTERNAL_ERROR"
+)
+
+// ErrReviewsDisabled is a sentinel for use by MCP tool handlers when
+// the review queue is disabled. The service layer exposes a boolean
+// (IsReviewsEnabled) rather than returning an error, but we want a
+// stable sentinel for ErrorCode to match against.
+var ErrReviewsDisabled = errors.New("transaction reviews are currently disabled. Enable them in the admin dashboard at /reviews")
+
+// ErrorCode maps a Go error to a stable UPPER_SNAKE_CASE code string.
+//
+// It uses errors.Is so wrapped errors (fmt.Errorf("...: %w", err)) still
+// resolve to the correct code. Unknown errors fall through to
+// CodeInternalError, matching the REST API convention where unmapped
+// service errors surface as 500/INTERNAL_ERROR.
+func ErrorCode(err error) string {
+	if err == nil {
+		return ""
+	}
+	switch {
+	case errors.Is(err, service.ErrNotFound),
+		errors.Is(err, service.ErrCategoryNotFound):
+		return CodeNotFound
+	case errors.Is(err, service.ErrForbidden):
+		return CodeForbidden
+	case errors.Is(err, service.ErrReviewAlreadyPending):
+		return CodeReviewAlreadyPending
+	case errors.Is(err, service.ErrReviewAlreadyResolved):
+		return CodeReviewAlreadyResolved
+	case errors.Is(err, ErrReviewsDisabled):
+		return CodeReviewsDisabled
+	case errors.Is(err, service.ErrInvalidDecision):
+		return CodeInvalidDecision
+	case errors.Is(err, service.ErrInvalidCursor):
+		return CodeInvalidCursor
+	case errors.Is(err, service.ErrInvalidParameter):
+		return CodeInvalidParameter
+	case errors.Is(err, service.ErrSyncInProgress):
+		return CodeSyncInProgress
+	case errors.Is(err, service.ErrSlugConflict):
+		return CodeSlugConflict
+	case errors.Is(err, service.ErrCategoryUndeletable):
+		return CodeCategoryUndeletable
+	case errors.Is(err, service.ErrInvalidAPIKey):
+		return CodeInvalidAPIKey
+	case errors.Is(err, service.ErrRevokedAPIKey):
+		return CodeRevokedAPIKey
+	}
+	return CodeInternalError
+}
+
+// errorResult builds an MCP tool error result with an UPPER_SNAKE_CASE
+// code derived from the error via ErrorCode.
+//
+// Shape: {"code": "REVIEW_ALREADY_RESOLVED", "error": "review has already been resolved"}
+func errorResult(err error) *mcpsdk.CallToolResult {
+	return errorResultWithCode(ErrorCode(err), err.Error())
+}
+
+// errorResultWithCode is the low-level builder that lets callers
+// specify both the code and human-readable message directly. Useful
+// for validation errors that don't originate from a service sentinel
+// (e.g., missing required input fields).
+func errorResultWithCode(code, message string) *mcpsdk.CallToolResult {
+	payload := map[string]string{
+		"code":  code,
+		"error": message,
+	}
+	errJSON, _ := json.Marshal(payload)
+	return &mcpsdk.CallToolResult{
+		IsError: true,
+		Content: []mcpsdk.Content{
+			&mcpsdk.TextContent{Text: string(errJSON)},
+		},
+	}
+}

--- a/internal/mcp/errors_test.go
+++ b/internal/mcp/errors_test.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	"breadbox/internal/service"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestErrorCode_Mapping(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"not found", service.ErrNotFound, CodeNotFound},
+		{"category not found", service.ErrCategoryNotFound, CodeNotFound},
+		{"forbidden", service.ErrForbidden, CodeForbidden},
+		{"review already pending", service.ErrReviewAlreadyPending, CodeReviewAlreadyPending},
+		{"review already resolved", service.ErrReviewAlreadyResolved, CodeReviewAlreadyResolved},
+		{"reviews disabled", ErrReviewsDisabled, CodeReviewsDisabled},
+		{"invalid decision", service.ErrInvalidDecision, CodeInvalidDecision},
+		{"invalid cursor", service.ErrInvalidCursor, CodeInvalidCursor},
+		{"invalid parameter", service.ErrInvalidParameter, CodeInvalidParameter},
+		{"sync in progress", service.ErrSyncInProgress, CodeSyncInProgress},
+		{"slug conflict", service.ErrSlugConflict, CodeSlugConflict},
+		{"category undeletable", service.ErrCategoryUndeletable, CodeCategoryUndeletable},
+		{"unknown error", errors.New("something blew up"), CodeInternalError},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ErrorCode(tc.err); got != tc.want {
+				t.Fatalf("ErrorCode(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrorCode_WrappedError(t *testing.T) {
+	// errors.Is should unwrap fmt.Errorf chains.
+	wrapped := fmt.Errorf("failed to load category: %w", service.ErrCategoryNotFound)
+	if got := ErrorCode(wrapped); got != CodeNotFound {
+		t.Fatalf("ErrorCode(wrapped ErrCategoryNotFound) = %q, want %q", got, CodeNotFound)
+	}
+
+	deeper := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", service.ErrReviewAlreadyResolved))
+	if got := ErrorCode(deeper); got != CodeReviewAlreadyResolved {
+		t.Fatalf("ErrorCode(deeply wrapped ErrReviewAlreadyResolved) = %q, want %q", got, CodeReviewAlreadyResolved)
+	}
+}
+
+func TestErrorResult_EnvelopeShape(t *testing.T) {
+	res := errorResult(service.ErrReviewAlreadyResolved)
+	if !res.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(res.Content))
+	}
+	tc, ok := res.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Content[0])
+	}
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(tc.Text), &payload); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v. raw=%q", err, tc.Text)
+	}
+	if payload["code"] != CodeReviewAlreadyResolved {
+		t.Fatalf("code = %q, want %q", payload["code"], CodeReviewAlreadyResolved)
+	}
+	if payload["error"] != service.ErrReviewAlreadyResolved.Error() {
+		t.Fatalf("error message = %q, want %q", payload["error"], service.ErrReviewAlreadyResolved.Error())
+	}
+}
+
+func TestErrorResult_UnknownErrorGetsInternalCode(t *testing.T) {
+	res := errorResult(errors.New("surprise"))
+	tc := res.Content[0].(*mcpsdk.TextContent)
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(tc.Text), &payload); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+	if payload["code"] != CodeInternalError {
+		t.Fatalf("unknown err should get INTERNAL_ERROR, got %q", payload["code"])
+	}
+	if payload["error"] != "surprise" {
+		t.Fatalf("error message = %q, want %q", payload["error"], "surprise")
+	}
+}
+
+func TestErrorResultWithCode_DirectBuilder(t *testing.T) {
+	res := errorResultWithCode(CodeInvalidParameter, "search_mode must be contains, words, or fuzzy")
+	if !res.IsError {
+		t.Fatal("expected IsError=true")
+	}
+	tc := res.Content[0].(*mcpsdk.TextContent)
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(tc.Text), &payload); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+	if payload["code"] != CodeInvalidParameter {
+		t.Fatalf("code = %q, want %q", payload["code"], CodeInvalidParameter)
+	}
+	if payload["error"] != "search_mode must be contains, words, or fuzzy" {
+		t.Fatalf("unexpected message: %q", payload["error"])
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -689,7 +689,7 @@ func (s *MCPServer) handleSubmitReview(ctx context.Context, _ *mcpsdk.CallToolRe
 	}
 
 	if !s.svc.IsReviewsEnabled(context.Background()) {
-		return errorResult(fmt.Errorf("transaction reviews are currently disabled. Enable them in the admin dashboard at /reviews")), nil, nil
+		return errorResult(ErrReviewsDisabled), nil, nil
 	}
 
 	if input.ReviewID == "" || input.Decision == "" {
@@ -992,7 +992,7 @@ func (s *MCPServer) handleBatchSubmitReviews(ctx context.Context, _ *mcpsdk.Call
 	}
 
 	if !s.svc.IsReviewsEnabled(context.Background()) {
-		return errorResult(fmt.Errorf("transaction reviews are currently disabled. Enable them in the admin dashboard at /reviews")), nil, nil
+		return errorResult(ErrReviewsDisabled), nil, nil
 	}
 
 	if len(input.Reviews) == 0 {
@@ -1637,12 +1637,3 @@ func scanJSONString(data []byte, pos int) (string, int) {
 	return s, end
 }
 
-func errorResult(err error) *mcpsdk.CallToolResult {
-	errJSON, _ := json.Marshal(map[string]string{"error": err.Error()})
-	return &mcpsdk.CallToolResult{
-		IsError: true,
-		Content: []mcpsdk.Content{
-			&mcpsdk.TextContent{Text: string(errJSON)},
-		},
-	}
-}


### PR DESCRIPTION
Closes #385

## Summary
- MCP tool error envelopes now include a stable `code` field alongside `error`, matching the REST API convention. Shape: `{"code": "REVIEW_ALREADY_RESOLVED", "error": "review has already been resolved"}`.
- New `internal/mcp/errors.go` exports `ErrorCode(err error) string` that uses `errors.Is` to map `internal/service` sentinels to UPPER_SNAKE_CASE codes. Unwraps `fmt.Errorf("...: %w", err)` chains so wrapped service errors still resolve correctly.
- Existing `errorResult(err)` helper signature preserved — all ~80 call sites across `tools.go` and `tools_account_links.go` get the new envelope shape with zero churn.
- Introduced `errorResultWithCode(code, message)` for input-validation errors that don't originate from a service sentinel.
- Added `ErrReviewsDisabled` sentinel in the `mcp` package so the two "reviews disabled" sites emit `REVIEWS_DISABLED` instead of falling through to `INTERNAL_ERROR`.

## Codes added
`NOT_FOUND`, `FORBIDDEN`, `INVALID_PARAMETER`, `INVALID_CATEGORY`, `INVALID_CURSOR`, `INVALID_DECISION`, `REVIEW_ALREADY_PENDING`, `REVIEW_ALREADY_RESOLVED`, `REVIEWS_DISABLED`, `SYNC_IN_PROGRESS`, `SLUG_CONFLICT`, `CATEGORY_UNDELETABLE`, `INVALID_API_KEY`, `REVOKED_API_KEY`, `INTERNAL_ERROR` (fallback).

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/mcp/...` passes (new `errors_test.go` covers mapping, wrapped errors, envelope shape, unknown-error fallback, direct builder)
- [ ] Trigger an MCP tool that hits a known sentinel (e.g. `submit_review` on an already-resolved review) and confirm the response envelope now contains `"code": "REVIEW_ALREADY_RESOLVED"`
- [ ] Trigger an MCP tool while reviews are disabled and confirm `"code": "REVIEWS_DISABLED"`