### PR TITLE
feat(mcp): rename bulk_recategorize params to from_category/to_category

### DIFF
--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -126,12 +126,15 @@ Categorize multiple transactions at once. Max 500 items per call.
 
 ### bulk_recategorize (Write)
 
-Server-side UPDATE of all transactions matching filters. Requires at least one filter for safety.
+Server-side UPDATE of all transactions matching filters. Requires at least one filter for safety. Moves transactions matching `from_category` (and other filters) to `to_category`.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `category_slug` | string | Target category slug |
+| `to_category` | string | Destination category slug (required) |
+| `from_category` | string | Optional source category slug filter |
 | Plus filters | | Same as `query_transactions` |
+| `target_category_slug` | string | Deprecated — use `to_category` |
+| `category_slug` | string | Deprecated — use `from_category` |
 
 ### import_categories (Write)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -354,7 +354,7 @@ func (s *MCPServer) buildToolRegistry() {
 			"Categorize multiple transactions at once. Each item needs a transaction_id and category_slug. Max 500 items per request. Sets category_override=true on each transaction. More efficient than calling categorize_transaction repeatedly. Returns succeeded count and any per-item errors.",
 			s.handleBatchCategorize, svc),
 		makeToolDefLogged("bulk_recategorize", ToolWrite,
-			"Recategorize all transactions matching a filter to a new category. Requires target_category_slug and at least one filter (safety requirement). Sets category_override=true since this is an explicit action. Use this for bulk corrections — e.g., recategorize all transactions currently tagged 'general_merchandise' in a date range to 'groceries'. Returns matched/updated counts.",
+			"Moves transactions matching `from_category` (and other filters) to `to_category`. Requires `to_category` and at least one filter (safety requirement). Sets category_override=true since this is an explicit action. Use this for bulk corrections — e.g., move all transactions currently in `general_merchandise` within a date range to `groceries`. Returns matched/updated counts. Note: the legacy params `target_category_slug` and `category_slug` are still accepted but deprecated — prefer `to_category`/`from_category`.",
 			s.handleBulkRecategorize, svc),
 		makeToolDefLogged("list_account_links", ToolRead,
 			"List account links between primary and dependent/authorized-user accounts. Account links deduplicate transactions that appear in both a primary cardholder and authorized user's bank feeds. Returns link details, match counts, and unmatched transaction counts.",

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1113,17 +1113,20 @@ type batchCategorizeItemInput struct {
 
 type bulkRecategorizeInput struct {
 	WriteSessionContext
-	TargetCategorySlug string   `json:"target_category_slug" jsonschema:"required,Category slug to assign to all matching transactions"`
+	FromCategory       string   `json:"from_category,omitempty" jsonschema:"Source category slug — only transactions currently in this category are matched. Optional if other filters are provided."`
+	ToCategory         string   `json:"to_category,omitempty" jsonschema:"Destination category slug — matching transactions are moved here. Required (or provide target_category_slug)."`
 	StartDate          string   `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD) inclusive"`
 	EndDate            string   `json:"end_date,omitempty" jsonschema:"End date (YYYY-MM-DD) exclusive"`
 	AccountID          string   `json:"account_id,omitempty" jsonschema:"Filter by account ID"`
 	UserID             string   `json:"user_id,omitempty" jsonschema:"Filter by user ID (family member)"`
-	CategorySlug       string   `json:"category_slug,omitempty" jsonschema:"Filter by current category slug"`
 	MinAmount          *float64 `json:"min_amount,omitempty" jsonschema:"Minimum amount (positive=debit, negative=credit)"`
 	MaxAmount          *float64 `json:"max_amount,omitempty" jsonschema:"Maximum amount (positive=debit, negative=credit)"`
 	Pending            *bool    `json:"pending,omitempty" jsonschema:"Filter by pending status"`
 	Search             string   `json:"search,omitempty" jsonschema:"Search transaction name or merchant"`
 	NameContains       string   `json:"name_contains,omitempty" jsonschema:"Filter transactions whose name contains this string"`
+	// Deprecated fields — retained for backward compatibility with older agent sessions.
+	TargetCategorySlug string `json:"target_category_slug,omitempty" jsonschema:"Deprecated: use to_category instead. Destination category slug."`
+	CategorySlug       string `json:"category_slug,omitempty" jsonschema:"Deprecated: use from_category instead. Source category slug filter."`
 }
 
 func (s *MCPServer) handleBatchCategorize(ctx context.Context, _ *mcpsdk.CallToolRequest, input batchCategorizeInput) (*mcpsdk.CallToolResult, any, error) {
@@ -1153,12 +1156,23 @@ func (s *MCPServer) handleBulkRecategorize(ctx context.Context, _ *mcpsdk.CallTo
 	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
-	if input.TargetCategorySlug == "" {
-		return errorResult(fmt.Errorf("target_category_slug is required")), nil, nil
+
+	// Prefer new param names; fall back to deprecated aliases for backward compatibility.
+	toCategory := input.ToCategory
+	if toCategory == "" {
+		toCategory = input.TargetCategorySlug
+	}
+	fromCategory := input.FromCategory
+	if fromCategory == "" {
+		fromCategory = input.CategorySlug
+	}
+
+	if toCategory == "" {
+		return errorResult(fmt.Errorf("to_category is required")), nil, nil
 	}
 
 	params := service.BulkRecategorizeParams{
-		TargetCategorySlug: input.TargetCategorySlug,
+		TargetCategorySlug: toCategory,
 	}
 
 	if input.StartDate != "" {
@@ -1181,8 +1195,8 @@ func (s *MCPServer) handleBulkRecategorize(ctx context.Context, _ *mcpsdk.CallTo
 	if input.UserID != "" {
 		params.UserID = &input.UserID
 	}
-	if input.CategorySlug != "" {
-		params.CategorySlug = &input.CategorySlug
+	if fromCategory != "" {
+		params.CategorySlug = &fromCategory
 	}
 	if input.MinAmount != nil {
 		params.MinAmount = input.MinAmount


### PR DESCRIPTION
Closes #386.

## Summary

- `bulk_recategorize` previously took `category_slug` (the current-category filter) and `target_category_slug` (the destination). The names are too similar and easy to swap — an agent could move transactions the wrong direction.
- Introduce `from_category` and `to_category` with clear directional naming. Tool description now explicitly reads: "Moves transactions matching `from_category` (and other filters) to `to_category`."

## Backward compatibility

- The old fields `target_category_slug` and `category_slug` are still accepted on the MCP input struct, but their jsonschema descriptions are marked Deprecated.
- The handler prefers the new names; falls back to the old names if the new ones are empty. Existing agent sessions continue to work without changes.
- REST API counterpart (`POST /api/v1/transactions/bulk-recategorize`) is intentionally unchanged — its request body is defined inline in the handler (not shared with the MCP struct), and the footgun concern is about agents, not API clients. Can be mirrored later if desired.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/mcp/... ./internal/service/...` (unit)
- [x] Integration: `TestBulkRecategorizeByFilter_*` in `service` and `api` packages pass
- [ ] Spot-check in a live MCP session: call `bulk_recategorize` with `from_category`/`to_category` and with the deprecated names, confirm both work