### PR TITLE
chore(reviews): remove vestigial low_confidence review_type

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -617,7 +617,7 @@ The following keys are seeded during initial migration and used by the applicati
 |---|---|---|---|---|
 | `id` | `UUID` | No | `gen_random_uuid()` | Primary key. |
 | `transaction_id` | `UUID` | No | — | FK → `transactions(id)`. The transaction under review. |
-| `review_type` | `TEXT` | No | — | Why the review was created: `new_transaction`, `uncategorized`, `low_confidence`, `manual`. |
+| `review_type` | `TEXT` | No | — | Why the review was created: `new_transaction`, `uncategorized`, `manual`, `re_review`. |
 | `status` | `TEXT` | No | `'pending'` | Current state: `pending`, `approved`, `rejected`, `skipped`. |
 | `suggested_category_id` | `UUID` | Yes | `NULL` | FK → `categories(id)`. Category suggested by the system at enqueue time. |
 | `confidence_score` | `NUMERIC(5,4)` | Yes | `NULL` | Normalized confidence score (0.0–1.0) from the provider. |

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -777,8 +777,6 @@ func buildActivityTimeline(reviews []service.ReviewResponse, comments []service.
 		switch r.ReviewType {
 		case "uncategorized":
 			enqueueReason = "Uncategorized transaction"
-		case "low_confidence":
-			enqueueReason = "Low confidence categorization"
 		case "new_transaction":
 			enqueueReason = "New transaction"
 		case "re_review":

--- a/internal/db/migrations/20260413041114_drop_review_type_low_confidence.sql
+++ b/internal/db/migrations/20260413041114_drop_review_type_low_confidence.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Remove vestigial 'low_confidence' from review_type. No code path ever
+-- sets it (only 'uncategorized' or 'new_transaction'), so it was dead weight
+-- on the CHECK constraint. Defensively remap any stragglers to 'manual'.
+UPDATE review_queue SET review_type = 'manual' WHERE review_type = 'low_confidence';
+ALTER TABLE review_queue DROP CONSTRAINT IF EXISTS review_queue_review_type_check;
+ALTER TABLE review_queue ADD CONSTRAINT review_queue_review_type_check
+    CHECK (review_type IN ('new_transaction', 'uncategorized', 'manual', 're_review'));
+
+-- +goose Down
+ALTER TABLE review_queue DROP CONSTRAINT IF EXISTS review_queue_review_type_check;
+ALTER TABLE review_queue ADD CONSTRAINT review_queue_review_type_check
+    CHECK (review_type IN ('new_transaction', 'uncategorized', 'low_confidence', 'manual', 're_review'));

--- a/internal/service/reviews.go
+++ b/internal/service/reviews.go
@@ -62,8 +62,8 @@ func (s *Service) ListReviews(ctx context.Context, params ReviewListParams) (*Re
 	// Validate review_type enum if provided
 	if params.ReviewType != nil && *params.ReviewType != "" {
 		switch *params.ReviewType {
-		case "new_transaction", "uncategorized", "low_confidence", "manual", "re_review":
-			// valid — low_confidence is accepted for filtering historical data
+		case "new_transaction", "uncategorized", "manual", "re_review":
+			// valid
 		default:
 			return nil, fmt.Errorf("%w: invalid review_type %q, must be one of: new_transaction, uncategorized, manual, re_review", ErrInvalidParameter, *params.ReviewType)
 		}


### PR DESCRIPTION
Closes #387

## Summary
- Drops `low_confidence` from the `review_queue.review_type` CHECK constraint — no sync path ever sets it (only `uncategorized` or `new_transaction`). It was dead weight.
- Removes `low_confidence` from the `ListReviews` filter allowlist in `internal/service/reviews.go` so the API surface matches the schema.
- Removes the unreachable `low_confidence` case from the transaction activity-feed switch in `internal/admin/transactions.go`.
- Updates `docs/data-model.md` to reflect the actual set (`new_transaction`, `uncategorized`, `manual`, `re_review`).

## Migration safety
- Additive-ish: the CHECK constraint is rewritten to drop an unused value. Safe per CLAUDE.md's guidance on shared dev DB state.
- Defensive `UPDATE ... SET review_type = 'manual' WHERE review_type = 'low_confidence'` runs first so any historical rows (should be zero) don't trip the new constraint.
- Down migration restores the prior constraint (which also included `re_review`) for reversibility.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` (unit) all packages pass
- [x] `make test-integration` equivalent: `go test -tags integration -p 1 ./...` passes against `breadbox_test` (initial noise was another agent sharing the DB; clean rerun passes)
- [x] Migration applied locally; `\d+ review_queue` confirms constraint is `CHECK (review_type = ANY (ARRAY['new_transaction', 'uncategorized', 'manual', 're_review']))`

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)