### PR TITLE
docs: slim CLAUDE.md and split conventions into scoped rules

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -1,0 +1,90 @@
+---
+paths:
+  - "internal/api/**"
+  - "internal/admin/**"
+  - "internal/middleware/**"
+---
+
+# REST API & admin handlers
+
+## Error envelope
+
+All error responses use:
+
+```json
+{ "error": { "code": "UPPER_SNAKE_CASE", "message": "Human-readable description" } }
+```
+
+- Codes are **stable contracts** — treat them as API surface. Don't rename on a whim.
+- Use `internal/api/response.go` helpers (`writeError`, `writeJSON`) — don't hand-roll.
+- 4xx for client errors, 5xx only for actual server bugs. Validation errors are 400 with a specific code like `INVALID_DATE_RANGE`.
+
+## Auth
+
+### API keys (REST `/api/v1/*`)
+
+- Header: `X-API-Key: bb_xxxxx`.
+- Format: `bb_` prefix + base62 body (32 random bytes).
+- Stored as SHA-256 hex hash. Prefix stored separately for UI display. `revoked_at` for soft-revoke.
+- `scope` column: `full_access` or `read_only`. `middleware.RequireWriteScope()` blocks read-only keys from write endpoints.
+- Full key record exposed to handlers via `middleware.SetAPIKey()` / `GetAPIKey()` for actor attribution.
+
+### Admin sessions (`/` and `/-/*`)
+
+- `alexedwards/scs` session manager with `pgxstore`.
+- Cookies: `HttpOnly; SameSite=Lax; Secure`.
+- CSRF token via `internal/admin/csrf.go` on state-changing forms.
+- First-run: `CountAdminAccounts == 0` → redirect to `/setup`. No separate flag.
+
+## Field selection
+
+`?fields=` query param on list and detail endpoints. Supports individual field names and aliases:
+- `minimal`, `core`, `category`, `timestamps`, `triage`, `review_core`, `transaction_core`.
+- `id` and `short_id` **always** included.
+
+Filtering happens in handlers via `service.FilterFields(response, parsedFields)` — the service method returns the full struct.
+
+## Dynamic filters
+
+Query endpoints (`/api/v1/transactions`, `/rules`, `/reviews`, `/merchants`) share a filter vocabulary built on positional `$N` SQL. See `internal/service/` for the composable filter builders. Handlers just parse query params and pass them in.
+
+## Pagination
+
+Cursor pagination (not OFFSET) for transactions, rules, reviews. Response envelope:
+
+```json
+{ "data": [...], "next_cursor": "opaque-string-or-null" }
+```
+
+Pass `cursor=...` on the next request. Only works with default sort (date DESC) for transactions.
+
+## Search modes
+
+`search_mode` param on `query_transactions`, `count_transactions`, `merchant_summary`, `list_transaction_rules`:
+- `contains` (default) — substring `ILIKE`.
+- `words` — split on spaces, AND all words. Handles "Century Link" vs "CenturyLink".
+- `fuzzy` — pg_trgm similarity. Typo-tolerant.
+
+Comma-separated values in `search` are auto-ORed in all modes. Shared impl in `internal/service/search.go`.
+
+`exclude_search` (minimum 2 chars) adds `NOT ILIKE` on name and merchant_name. Useful for hunting unknown charges.
+
+## Actor pattern
+
+Write endpoints attribute changes to an actor (user, agent, system). `middleware.Actor(r)` returns `{Type, ID, Name}` pulled from the session or API key. Pass it to service methods that create rules, submit reports, etc.
+
+## Health endpoints
+
+Split for orchestrators:
+- `GET /health/live` — basic HTTP 200, no dependencies.
+- `GET /health/ready` — DB ping + scheduler status.
+
+## Admin-only endpoints
+
+Prefixed `/-/` to disambiguate from user-facing routes. Examples: `POST /-/reports/{id}/read`, `POST /-/reports/read-all`. CSRF + session required.
+
+## Webhooks
+
+- Path: `/webhooks/:provider`.
+- No auth middleware — each provider handler verifies HMAC / signature internally.
+- Enqueue to `webhook_events` table; sync engine consumes. Don't block the HTTP response on the actual sync.

--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -1,0 +1,68 @@
+---
+paths:
+  - "internal/mcp/**"
+---
+
+# MCP server
+
+## Architecture
+
+- SDK: `github.com/modelcontextprotocol/go-sdk` v1.4.0.
+- Transport: Streamable HTTP at `/mcp` (API key auth) + stdio via `breadbox mcp-stdio` subcommand (no auth, local only).
+- Tool handlers call the **service layer directly** — no HTTP round-trip, no re-serialization.
+
+## Tool registry
+
+`MCPServer.allTools []ToolDef` is the master list. Each `ToolDef` has:
+- `Name` (snake_case verb_noun: `list_transactions`, `submit_review`)
+- `Description` (domain-rich — see below)
+- `Classification`: `ToolRead` or `ToolWrite`
+- `Handler` with typed input/output structs
+
+`BuildServer(MCPServerConfig)` filters the tool list per request and returns a fresh `*mcpsdk.Server`. Write tools are suppressed when:
+1. `mcp_mode == read_only` (global toggle in `app_config`)
+2. Tool name is in `mcp_disabled_tools` JSON array
+3. API key scope is `read_only`
+
+## Input/output conventions
+
+Tool inputs are typed structs with `jsonschema` tags:
+
+```go
+type QueryTransactionsInput struct {
+    Limit    int      `json:"limit,omitempty" jsonschema:"description=Max rows,maximum=500"`
+    MinAmount *float64 `json:"min_amount,omitempty"`
+}
+```
+
+Use `*float64` (not `float64`) for optional numeric filters so zero is a valid filter value.
+
+Outputs go through `jsonResult()` which calls `compactIDs()` — replaces every `id` field with the `short_id` value and drops the `short_id` field. Agents see compact 8-char IDs; REST API consumers still get both.
+
+Errors: return with `IsError: true` and a text content block `{"error": "message"}`. Never panic.
+
+## Descriptions
+
+Tool descriptions are **domain-rich**, not generic. Include:
+- Amount sign convention (positive = debit, negative = credit/refund)
+- What each filter does and how filters compose
+- Pagination behavior (cursor vs offset)
+- Limits (500 for list/batch tools)
+
+Good descriptions are load-bearing — they're the only documentation agents see at tool-call time.
+
+## Server instructions
+
+`MCPServerConfig.Instructions` is domain-rich onboarding: data model overview, amount conventions, category system, recommended query patterns. Templates in `internal/mcp/templates.go` (`spend_review`, `monthly_analysis`, `reporting`) are presets users can load and edit. User-edited text stored as `mcp_custom_instructions` in `app_config`.
+
+## Resource
+
+`breadbox://overview` returns live stats: users, accounts by type, connections with counts, 30-day spending summary with top 5 categories, pending transaction count.
+
+## Permissions admin page
+
+`/mcp` dashboard has four cards: global mode, per-tool enable/disable, server instructions, API key scope info. Nav icon: `bot`.
+
+## Disabled-feature behavior
+
+When review queue is off (`review_auto_enqueue=false`), review MCP tools return empty results with an explanatory note (read tools) or an error (write tools) — they don't just disappear from the registry. This keeps tool-count stable for agents.

--- a/.claude/rules/migrations.md
+++ b/.claude/rules/migrations.md
@@ -1,0 +1,48 @@
+---
+paths:
+  - "internal/db/migrations/*.sql"
+  - "internal/db/queries/*.sql"
+  - "sqlc.yaml"
+---
+
+# Migrations & sqlc
+
+## Naming
+
+- **Timestamp prefix** for new migrations: `YYYYMMDDHHMMSS_description.sql` (e.g., `20260415153000_add_oauth.sql`). Generate with `date -u +%Y%m%d%H%M%S`.
+- Legacy sequential names (`00001`–`00029`) stay as-is. goose sorts by numeric prefix, so timestamps always run after them.
+- One concern per migration. Pair `up` and `down` (goose `-- +goose Up` / `-- +goose Down`).
+
+## After adding a migration
+
+1. `sqlc generate` — regenerates `internal/db/*.sql.go`.
+2. `go build ./...` — verifies the generated code compiles against call sites.
+3. Run the app or integration tests to confirm the migration applies cleanly.
+
+## PL/pgSQL gotcha
+
+Goose can't parse `$$`-quoted function bodies by default. Wrap every `CREATE FUNCTION ... $$ ... $$ LANGUAGE plpgsql;` in goose statement markers:
+
+```sql
+-- +goose StatementBegin
+CREATE FUNCTION ...
+$$ ... $$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+```
+
+## Shared-DB safety
+
+Multiple worktrees and agent sessions share the same dev `breadbox` database. **Additive migrations only** in an agent session unless you've coordinated:
+
+- Safe: `ADD COLUMN`, `CREATE TABLE`, `CREATE INDEX`, `CREATE TYPE`, adding enum values at the end.
+- Dangerous: `DROP TABLE`, `DROP COLUMN`, `ALTER TYPE`, renaming anything, reordering enum values. These will break other running `breadbox serve` processes mid-session.
+
+## sqlc conventions
+
+- Queries live in `internal/db/queries/*.sql`. One file per entity matching the `*.sql.go` output.
+- Use `:one`, `:many`, `:exec` annotations. Return rows should include `id` and `short_id` when the entity has a short_id trigger.
+- Dynamic SQL (composable filters, cursor pagination) is **not** written in sqlc — it's hand-rolled in the service layer with positional `$N` params. See `.claude/rules/service.md`.
+
+## Short-ID trigger
+
+Every entity table needs `short_id TEXT NOT NULL UNIQUE` and a BEFORE INSERT trigger calling `set_short_id()`. See `internal/db/migrations/` for the canonical pattern — copy from an existing table when adding a new one.

--- a/.claude/rules/providers.md
+++ b/.claude/rules/providers.md
@@ -1,0 +1,62 @@
+---
+paths:
+  - "internal/provider/**"
+  - "internal/webhook/**"
+---
+
+# Providers
+
+## Interface
+
+`internal/provider.Provider` (in `provider.go`) is the abstraction. Implementations: `plaid/`, `teller/`, `csv/`.
+
+Methods take a `Connection` **struct** (not an ID) so implementations can decrypt credentials internally without re-fetching from the DB.
+
+## Error sentinels
+
+Provider-agnostic sentinels in `internal/provider/errors.go`:
+- `ErrReauthRequired` — credentials invalid; UI should prompt reauth.
+- `ErrSyncRetryable` — transient; sync engine retries with backoff.
+- `ErrNotSupported` — CSV uses this for sync/webhook/reauth (import-only).
+
+Each provider wraps upstream errors (Plaid item errors, Teller HTTP 401, etc.) into these sentinels. Keep the sync engine and UI provider-agnostic.
+
+## Encryption
+
+Access tokens and Teller PEM files are AES-256-GCM encrypted at rest via `internal/crypto/encrypt.go`. `ENCRYPTION_KEY` (64-char hex) required at startup if any provider is configured — **fail fast in `main.go`**, not at first sync.
+
+Connection storage uses generic columns: `external_id` + `encrypted_credentials`, not provider-specific names. Unique constraint on `(provider, external_id)`.
+
+## Plaid
+
+- SDK: `github.com/plaid/plaid-go`.
+- Pending → posted: Plaid removes the pending ID and creates a new posted ID linked via `pending_transaction_id`. Matcher handles the dedupe.
+- Categories: raw Plaid primary/detailed strings stored in `category_primary`/`category_detailed` for audit; structured category assigned via rules during sync.
+
+## Teller
+
+- No SDK. Hand-written HTTP client with **mTLS**: app-level cert/key + per-connection access token via HTTP Basic Auth.
+- Config env: `TELLER_APP_ID`, `TELLER_CERT_PATH`, `TELLER_KEY_PATH`, `TELLER_ENV`, `TELLER_WEBHOOK_SECRET`. All editable via `/providers` admin page; uploaded PEMs are encrypted and stored in `app_config`. Env paths take precedence over DB PEMs.
+- `NewClientFromPEM(certPEM, keyPEM)` builds an mTLS client from in-memory bytes.
+- **Amount sign is opposite Plaid**: Teller negative=debit, Plaid positive=debit. Provider negates before returning — downstream sees Plaid convention.
+- Sync: date-range polling with 10-day overlap (no cursor). Post-sync, soft-delete stale *pending* transactions not returned by the API. Posted transactions are **never** auto-deleted.
+- Raw Teller category strings (`dining`, `groceries`, etc.) stored directly in `category_primary`. Rules handle categorization.
+
+## CSV
+
+- Import-only. Provider interface methods return `ErrNotSupported` for sync/webhook/reauth, `nil` for `RemoveConnection`.
+- Actual import bypasses the provider interface — calls the service layer directly from `internal/admin/csv_import.go`.
+- Dedup: `external_transaction_id = SHA-256(account_id|date|amount|description)` per account. Standard `UpsertTransaction` ON CONFLICT handles it.
+
+## Hot reload
+
+`app.ReinitProvider(name)` rebuilds a provider after dashboard config changes. The sync engine holds a shared `map[string]provider.Provider` reference — same map, updated values, so running schedules pick up new config on the next tick.
+
+## Adding a new provider
+
+1. New subdir under `internal/provider/`.
+2. Implement the full `Provider` interface. Unsupported methods return `ErrNotSupported`.
+3. Add to provider type enum (`plaid`, `teller`, `csv`, ...).
+4. Register in `app.InitProviders`.
+5. Admin card on `/providers`.
+6. Document in `docs/<provider>-integration.md`.

--- a/.claude/rules/service.md
+++ b/.claude/rules/service.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "internal/service/**"
+---
+
+# Service layer
+
+## Purpose
+
+`internal/service/` is the **shared business-logic layer**. Both REST API handlers (`internal/api/`) and MCP tools (`internal/mcp/`) call into it — MCP does **not** loopback through HTTP.
+
+- Takes `*db.Queries` (for sqlc calls) + `*pgxpool.Pool` (for dynamic SQL and transactions).
+- Returns plain Go types, not `pgtype.*`. Convert at the boundary.
+- Accepts either UUID or short_id for entity parameters — resolve via `internal/service/resolve.go`.
+
+## pgtype conversion
+
+Never leak `pgtype.Text`, `pgtype.Numeric`, `pgtype.Timestamptz`, etc. out of the service layer. Use helpers in `internal/pgconv/` (or inline) to produce Go primitives (`string`, `*string`, `float64`, `time.Time`, `*time.Time`).
+
+Amounts: convert `pgtype.Numeric` → `float64` carefully. Always carry `iso_currency_code` alongside.
+
+## Dynamic SQL
+
+Transaction queries, rule listings, review queues, merchant aggregations, and bulk recategorize are written as hand-rolled SQL with positional `$N` params — **not** sqlc.
+
+Pattern:
+1. Build `WHERE` clauses and args incrementally based on filters.
+2. Use `fmt.Sprintf` **only** for fixed identifiers (column names, JOIN clauses) — never for user input. User input goes through `$N`.
+3. Use cursor pagination (`(date, id) < ($N, $N)`) for stable ordering, not OFFSET.
+4. Scan into a row struct with a `toResponse()` method for DRY conversion.
+
+See `internal/service/transactions.go` and `internal/service/rules.go` for canonical examples.
+
+## Short-ID resolution
+
+`ResolveEntityID(ctx, q, input)` functions in `resolve.go` accept either a UUID or an 8-char base62 short_id and return the canonical UUID. Every public service method that takes an entity ID should call these at the top.
+
+## Field selection
+
+`ParseFields(raw, aliases)` and `FilterFields(response, fields)` in `internal/service/fields.go` implement the `?fields=` query param. Aliases (`minimal`, `core`, `category`, etc.) are defined per entity. `id` and `short_id` are **always** included regardless of filter.
+
+Filtering happens at the **handler** layer, not in the service method — the service returns the full struct.
+
+## Actor pattern
+
+Mutations that need auditing (rules, reports) accept an `Actor` struct (`Type`, `ID`, `Name`) sourced from request context. Helpers in `internal/middleware/` extract the actor for both admin sessions and API keys.
+
+## Transactions (DB)
+
+Multi-statement writes use `pool.BeginTx` + deferred rollback + explicit commit. Sync writes are wrapped in a single transaction for atomicity — see `.claude/rules/sync.md`.

--- a/.claude/rules/sync.md
+++ b/.claude/rules/sync.md
@@ -1,0 +1,60 @@
+---
+paths:
+  - "internal/sync/**"
+---
+
+# Sync engine
+
+## Trigger paths
+
+- `cron` — scheduled via `robfig/cron`. Fires at the minimum configured interval; checks each connection's staleness individually.
+- `webhook` — provider push (Plaid `TRANSACTIONS_*`, Teller webhook events). Verified via HMAC where applicable.
+- `manual` — admin "Sync Now" button or `POST /api/v1/connections/{id}/sync`.
+- `initial` — first sync after connection creation (runs inline during onboarding).
+
+## Atomicity
+
+Each connection's sync runs inside a **single DB transaction**. Upserts, deletions, rule application, hit-count increments, and sync-log updates all commit together. A crash mid-sync rolls back cleanly.
+
+## Per-sync timeout
+
+Configurable context deadline (default 5 minutes). Exceeded timeouts mark the sync log as `error` with the deadline message.
+
+## Orphaned sync logs
+
+On startup, `MarkOrphanedSyncLogs()` sets any `in_progress` log to `error` with "interrupted by server restart". Prevents stuck connections after a crash or force-kill.
+
+## Pause vs status
+
+- `paused BOOLEAN` is orthogonal to `status`. **Only cron respects pause**; manual and webhook sync bypass it.
+- `status` reflects last sync outcome: `active`, `error`, `pending_reauth`, `disconnected`.
+- Per-connection `sync_interval_override_minutes` lets users customize cadence.
+
+## In-sync hooks
+
+After each transaction upsert inside the sync transaction:
+
+1. **Transaction rules** — `ApplyRulesToTransaction` matches active non-expired rules in priority order. First match wins. `category_override=true` rows are **skipped**. Batched hit-count increments via `BatchIncrementHitCounts`.
+2. **Review enqueue** — `enqueueForReview` adds a `review_queue` row if `review_auto_enqueue=true`. Priority: uncategorized > new_transaction. Skips `category_override=true`. `ON CONFLICT DO NOTHING` for idempotency.
+
+Both steps live inside the sync tx — either everything commits or nothing does.
+
+## Post-sync reconciliation
+
+`matcher.ReconcileForConnection()` runs **after** the sync tx commits. Matches cross-connection duplicate transactions (e.g., same charge on a shared card) by date + exact amount:
+
+- Single candidate → auto-match (`confidence: auto`).
+- Multiple candidates → name similarity tiebreaker.
+- Ambiguous → skip for manual review via admin UI or MCP `confirm_match`/`reject_match`.
+
+Matched pairs go in `transaction_matches`; attribution flows through `transactions.attributed_user_id`.
+
+## Account exclusion
+
+`accounts.excluded = TRUE` skips the **transaction upsert** only — balances still refresh. Useful for accounts the user doesn't want cluttering totals but still wants synced.
+
+`accounts.is_dependent_linked = TRUE` flags accounts linked to a primary cardholder account. Their transactions are excluded from totals at query time via `AND a.is_dependent_linked = FALSE`.
+
+## Retries
+
+`internal/provider/retry.go` wraps sync calls with exponential backoff on `ErrSyncRetryable`. `ErrReauthRequired` is **not** retried — it flips status to `pending_reauth` immediately.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,75 @@
+---
+paths:
+  - "**/*_test.go"
+  - "internal/testutil/**"
+  - "Makefile"
+---
+
+# Testing
+
+## Two tiers
+
+- **Unit**: `go test ./...`. No DB. Used for crypto, CSV parsing, pure service helpers.
+- **Integration**: `make test-integration` (or `DATABASE_URL=... go test -tags integration -count=1 -p 1 ./...`). Requires PostgreSQL with a `breadbox_test` database. Migrations run automatically in `TestMain` via goose.
+
+## Build tag separation
+
+Integration test files **must** start with:
+
+```go
+//go:build integration
+```
+
+Without it, `go test ./...` will try to run them without a DB and fail. Unit tests in the same package stay untagged.
+
+## TestMain + testutil
+
+Any package doing DB-backed tests needs a `TestMain` calling `testutil.RunWithDB(m)`:
+
+```go
+//go:build integration
+
+package service_test
+
+import (
+    "testing"
+    "github.com/canalesb93/breadbox/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+    testutil.RunWithDB(m)
+}
+```
+
+Then in each test:
+- `testutil.Pool(t)` — `*pgxpool.Pool`
+- `testutil.Queries(t)` — `*db.Queries`
+- `testutil.ServicePool(t)` — both at once, convenient for service constructors
+
+Tables are truncated between tests automatically.
+
+## Fixture helpers
+
+Use these — they `t.Fatal` on setup errors so silent failures surface immediately:
+
+- `testutil.MustCreateUser(t, q, ...)`
+- `testutil.MustCreateConnection(t, q, ...)` / `MustCreateTellerConnection`
+- `testutil.MustCreateAccount(t, q, ...)`
+- `testutil.MustCreateTransaction(t, q, ...)`
+
+Add new helpers here when you find yourself writing the same setup in three tests.
+
+## Hard rules
+
+- **No `t.Parallel()`**. Tests share the same DB; parallelism corrupts state.
+- **`-p 1`** at the `go test` level — also enforces serial package execution.
+- Test through the **service layer**, not HTTP handlers, unless you're specifically testing routing or middleware. Service-layer tests are faster, easier to set up, and cover the same logic.
+- Always write an integration test for new service methods and REST endpoints.
+
+## CI
+
+GitHub Actions spins up PostgreSQL and runs `go test -tags integration -p 1 ./...` with `DATABASE_URL` set. No extra config needed — if it works locally with `make test-integration`, it works in CI.
+
+## Session hook
+
+`.claude/hooks/session-start.sh` ensures the `breadbox` role and `breadbox_test` database exist. If tests fail with a missing-role error, re-run the hook or recreate the DB manually.

--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -1,0 +1,81 @@
+---
+paths:
+  - "internal/templates/**"
+  - "internal/admin/**"
+  - "input.css"
+  - "static/**"
+---
+
+# Admin UI
+
+## Stack
+
+- `html/template` (standard library), no templating engine.
+- **DaisyUI 5 + Tailwind CSS v4** via `tailwindcss-extra` standalone CLI. **No Node.js**.
+- **Alpine.js v3** via CDN for interactivity. No build step.
+- **Lucide** icons via CDN. `data-lucide="icon-name"` attributes replaced with inline SVG by `lucide.createIcons()`.
+
+## CSS build
+
+- `make css` compiles `input.css` → `static/css/styles.css`.
+- `make css-watch` for dev (rebuilds on change).
+- Dockerfile runs `make css` in the build stage. Don't commit `styles.css` changes — it's a build artifact.
+
+## Footguns
+
+### Never use `bg-base-200/50` (or any `/opacity` modifier) on `<select>` elements
+
+Alpha transparency renders as **fully transparent** in browsers on `<select>`. Use solid `bg-base-200`. `<input>` handles `/50` fine — the bug is specific to `<select>`.
+
+### SPA progress bar requires manual cleanup on error paths
+
+`base.html` has a global progress bar and content fade (opacity/blur/pointer-events) that **auto-starts on internal link clicks**. When JS does async work (e.g., `fetch` + `window.location.href` on success), every error path **must** call:
+
+```js
+window.bbProgress.finish();
+document.querySelector('main').style.opacity = '';
+document.querySelector('main').style.filter = '';
+document.querySelector('main').style.pointerEvents = '';
+```
+
+Otherwise the progress bar trickles forever and the page stays blurred/unclickable. Convention: define a `restorePageState()` helper at the top of each Alpine component and call it on every error/early-return.
+
+## Conventions
+
+### DaisyUI components (replaces old `bb-*` classes)
+
+Use these built-in components: `drawer` (sidebar), `stat` (metric cards), `table` (data tables), `badge` (status), `menu` (nav), `card` (sections), `modal` (dialogs), `toast` + `alert` (notifications), `steps` (wizard progress), `collapse` (accordions).
+
+### Custom `@apply` classes
+
+Keep these in `input.css` for app-specific repeated patterns:
+- `.bb-filter-bar`, `.bb-pagination`, `.bb-action-bar`, `.bb-amount`, `.bb-info-grid`.
+
+Add new ones only when a pattern appears 3+ times — premature abstraction otherwise.
+
+### Spacing tokens
+
+Use `--bb-gap-xs` (0.25rem) through `--bb-gap-xl` (2rem) defined in `:root`. Don't hardcode spacing.
+
+### Dark mode
+
+DaisyUI `light`/`dark` themes with `prefers-color-scheme` auto-switch. **No hardcoded `data-theme`** — let the OS drive it. Badge and flash colors use DaisyUI semantic classes (`badge-success`, `alert-error`, etc.) so they adapt automatically.
+
+### Template helpers
+
+- `BaseTemplateData(r, sm, currentPage, pageTitle)` → `map[string]any`. Handlers extend the returned map.
+- `statusBadge()` / `syncBadge()` render status chips — use these instead of copy-pasted if-chains.
+- `errorMessage()` maps provider error codes to human-friendly strings.
+- `configSource()` renders the env/db/default badge next to config values.
+
+### Replacing `alert()` / `confirm()`
+
+Use Alpine inline patterns (modal + `x-data` state). Never blocking browser dialogs — they're hostile in an admin context and ignore dark mode.
+
+## Modal & AJAX patterns
+
+Admin list pages (reviews, rules, reports) use AJAX actions with card fade-out animations via Alpine. See `/reviews` (`reviewQueue()` component) for the reference pattern: inline approve/reject/skip/dismiss, optimistic UI, fade transitions, error recovery via `restorePageState()`.
+
+## Icons
+
+Lucide names only. Nav-level icons are stable; don't rename on a whim (users build muscle memory). Current nav: `home`, `credit-card`, `receipt`, `folder`, `link-2` (account links), `users`, `key`, `bot` (MCP), `list-filter` (rules), `inbox` (reviews), `flag` (reports), `scroll` (sync logs), `settings`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,147 +1,50 @@
 # Breadbox
 
-Self-hosted financial data aggregation for households. Syncs bank data via Plaid and Teller, stores it in PostgreSQL, exposes it to AI agents via MCP and REST API.
+Self-hosted financial data aggregation for households. Syncs bank data via Plaid, Teller, and CSV; stores it in PostgreSQL; exposes it to AI agents via MCP and REST API.
 
-## Tech Stack
+## Stack
 
-Go 1.24+ single binary. PostgreSQL, chi/v5 router, pgx/v5 + sqlc, goose migrations, robfig/cron. Admin UI: Go html/template + DaisyUI 5 + Tailwind CSS v4 + Alpine.js v3. MCP: github.com/modelcontextprotocol/go-sdk (Streamable HTTP). Plaid: github.com/plaid/plaid-go. Teller: hand-written HTTP client with mTLS (no SDK).
+Go 1.24+ single binary. PostgreSQL, chi/v5, pgx/v5 + sqlc, goose migrations, robfig/cron. Admin UI: `html/template` + DaisyUI 5 + Tailwind v4 + Alpine.js v3 (CDN, no Node). MCP: `github.com/modelcontextprotocol/go-sdk` v1.4.0 (Streamable HTTP at `/mcp`, stdio via `breadbox mcp-stdio`).
+
+One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), MCP, admin dashboard, webhooks (`/webhooks/:provider`). Bank providers are abstracted behind the `internal/provider.Provider` interface.
+
+## Codebase Map
+
+- `internal/service/` — shared service layer. REST handlers and MCP tools call into here (no HTTP round-trip for MCP). Converts `pgtype.*` → Go primitives. See `.claude/rules/service.md`.
+- `internal/api/` — REST handlers. See `.claude/rules/api.md`.
+- `internal/admin/` — admin dashboard handlers. See `.claude/rules/api.md`.
+- `internal/mcp/` — MCP tool registry + server. See `.claude/rules/mcp.md`.
+- `internal/provider/` — provider interface + error sentinels. Subdirs: `plaid/`, `teller/`, `csv/`. See `.claude/rules/providers.md`.
+- `internal/sync/` — sync engine, matcher, rule application. See `.claude/rules/sync.md`.
+- `internal/db/` — sqlc-generated code (`*.sql.go`), queries (`queries/*.sql`), migrations (`migrations/*.sql`). See `.claude/rules/migrations.md`.
+- `internal/templates/` — `html/template` admin UI. See `.claude/rules/ui.md`.
+- `internal/crypto/` — AES-256-GCM encrypt/decrypt shared across providers.
+- `internal/shortid/` — 8-char base62 alias generation.
+- `internal/testutil/` — DB fixtures and test helpers. See `.claude/rules/testing.md`.
+- `docs/` — canonical specs. Data model, architecture, API/MCP references, design system, per-provider details.
 
 ## Testing
 
-- **Unit tests**: `go test ./...` (no DB needed). Covers crypto, CSV parsing, service utilities.
-- **Integration tests**: `make test-integration` or `DATABASE_URL=... go test -tags integration -count=1 -p 1 ./...`. Requires a running PostgreSQL with `breadbox_test` database. Migrations run automatically via goose in `TestMain`. `-p 1` is required because multiple packages share the same test database.
-- **Build tag separation**: Integration test files must have `//go:build integration` at the top. This ensures `go test ./...` (without `-tags integration`) only runs unit tests and doesn't require a database.
-- **Test helper**: `internal/testutil/db.go` — call `testutil.RunWithDB(m)` from `TestMain`, then use `testutil.Pool(t)` or `testutil.Queries(t)` in tests. Tables are truncated between tests automatically.
-- **Fixture helpers**: Use `testutil.MustCreateUser`, `MustCreateConnection`, `MustCreateTellerConnection`, `MustCreateAccount`, `MustCreateTransaction` to create test data. These fatal on error to catch silent setup failures.
-- **Adding integration tests**: Any package that needs DB access should add a `TestMain` calling `testutil.RunWithDB(m)`. Use the `testutil.ServicePool(t)` helper to get pool+queries. See `internal/service/integration_test.go` for examples. Do NOT use `t.Parallel()` — tests share a database.
-- **Session hook**: `.claude/hooks/session-start.sh` creates the `breadbox` role and `breadbox_test` database automatically on web sessions.
-- **CI**: GitHub Actions spins up PostgreSQL, then runs `go test -tags integration -p 1 ./...` with `DATABASE_URL` set. Migrations run automatically via `testutil.RunWithDB`.
-- **When adding new features**: Always add integration tests for new service layer methods and API endpoints. Prefer testing through the service layer rather than HTTP handlers.
+- `go test ./...` — unit only (no DB).
+- `make test-integration` — DB-backed tests against `breadbox_test`. Requires `DATABASE_URL`.
+- Integration files must start with `//go:build integration`.
+- `-p 1` required; never `t.Parallel()` — tests share one DB.
+- Details in `.claude/rules/testing.md`.
 
-## Architecture
+## Gotchas
 
-One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), MCP server (`/mcp`), admin dashboard (`/...`), webhooks (`/webhooks/:provider`). Bank data providers are abstracted behind a `Provider` Go interface (Plaid first, Teller + CSV later).
+These bite in every session regardless of what you're touching.
 
-## Migrations
-
-- **Timestamp-based naming**: New migrations use `YYYYMMDDHHMMSS_description.sql` format (e.g., `20260325153000_add_oauth.sql`). This prevents conflicts when parallel branches each need a migration. Existing sequential migrations (`00001`–`00029`) remain as-is — goose sorts by numeric prefix so timestamps (larger numbers) always run after them.
-- **Creating a migration**: Use the current UTC timestamp as the prefix. Example: `date -u +%Y%m%d%H%M%S` gives `20260325153000`.
-- **After adding a migration**: Run `sqlc generate` to regenerate Go code, then `go build ./...` to verify.
-- **PL/pgSQL in migrations**: Goose cannot parse `$$`-quoted function bodies by default. Wrap each `CREATE FUNCTION ... $$ ... $$ LANGUAGE plpgsql;` block in `-- +goose StatementBegin` / `-- +goose StatementEnd`.
-
-## Key Design Decisions
-
-- REST API is the core data layer; MCP tools and dashboard consume the service layer directly (no HTTP round-trip)
-- Amounts are NUMERIC(12,2), always with `iso_currency_code` per transaction — never sum across currencies
-- Pending→posted: Plaid removes pending ID, creates new posted ID linked via `pending_transaction_id`
-- Soft deletes: transactions use `deleted_at`, connections set to `disconnected` status
-- FK policy: accounts/transactions use SET NULL on connection delete (preserve history), sync_logs use CASCADE
-- Config precedence: environment variables → app_config DB table → defaults
-- Access tokens AES-256-GCM encrypted at rest
-- API key auth: `X-API-Key: bb_xxxxx` header, SHA-256 hashed, `revoked_at` for soft-revoke
-- Admin sessions: `alexedwards/scs` + `pgxstore`, cookies `HttpOnly; SameSite=Lax; Secure`
-- Error codes: `UPPER_SNAKE_CASE` in JSON envelope `{ "error": { "code": "...", "message": "..." } }`
-- Service layer (`internal/service/`): shared between REST API handlers and MCP tools. Converts `pgtype.*` → Go primitives for clean JSON. Takes `*db.Queries` + `*pgxpool.Pool` (for dynamic queries).
-- MCP server (`internal/mcp/`): wraps service layer as 7 MCP tools + 1 resource. Streamable HTTP at `/mcp` (API key auth), stdio via `breadbox mcp-stdio` (no auth). Uses `github.com/modelcontextprotocol/go-sdk` v1.4.0. Tool handlers use typed input structs with `jsonschema` tags. Errors: `IsError: true` with `{"error": "..."}` text content. Resource: `breadbox://overview` returns live stats.
-- Transaction queries use dynamic SQL with positional `$N` params (not sqlc) for composable filters + cursor pagination
-- API key format: `bb_` + base62 body (32 random bytes). Stored as SHA-256 hex hash. Prefix stored for display.
-- Short IDs: every entity table has a `short_id TEXT NOT NULL UNIQUE` column — an 8-character base62 alias for the UUID primary key. Generated automatically by a Postgres BEFORE INSERT trigger (`set_short_id()` calling `generate_short_id()`). All service methods accept either UUID or short_id via resolver functions (`internal/service/resolve.go`). Response structs include both `id` (UUID) and `short_id`. MCP responses compact IDs: `jsonResult()` in `internal/mcp/tools.go` calls `compactIDs()` to replace `id` with the `short_id` value and remove the `short_id` field, so agents only see compact 8-char IDs. REST API continues returning both fields. `internal/shortid/` package provides `Generate()` and `IsShortID()`. Field selection always includes `short_id` alongside `id`.
-- Multi-provider DB columns: `bank_connections` uses generic `external_id` + `encrypted_credentials` (not provider-specific column names). Unique constraint on `(provider, external_id)`.
-- Shared crypto: `internal/crypto/encrypt.go` — AES-256-GCM encrypt/decrypt used by all providers
-- Provider errors: `provider.ErrReauthRequired`, `provider.ErrSyncRetryable` — provider-agnostic sentinels in `internal/provider/errors.go`. Each provider wraps these.
-- Provider interface: `CreateReauthSession` and `RemoveConnection` accept a `Connection` struct (not a string ID) so providers can decrypt credentials internally.
-- Teller auth: mTLS (app-level cert/key files) + per-connection access token via HTTP Basic Auth. Config: `TELLER_APP_ID`, `TELLER_CERT_PATH`, `TELLER_KEY_PATH`, `TELLER_ENV`, `TELLER_WEBHOOK_SECRET`.
-- Teller sync: date-range polling with 10-day overlap (no cursor). After sync, auto soft-delete stale *pending* transactions not returned by the API. Posted transactions are never auto-deleted.
-- Teller amounts: sign is opposite to Plaid. Teller negative=debit, Plaid positive=debit. Provider negates amounts before returning.
-- CSV provider: import-only, stub `Provider` interface (`ErrNotSupported` for sync/webhook/reauth, nil for `RemoveConnection`). Bypasses provider interface for actual import — uses service layer directly.
-- CSV dedup: `external_transaction_id = SHA-256(account_id|date|amount|description)` per account. Standard `UpsertTransaction` ON CONFLICT handles it.
-- Account settings: `display_name TEXT NULL` (template uses `COALESCE(display_name, name)`), `excluded BOOLEAN DEFAULT FALSE` (skips transaction upsert only, balances still refresh)
-- Connection pause: `paused BOOLEAN DEFAULT FALSE` orthogonal to `status`. Only cron respects pause; manual "Sync Now" bypasses it.
-- Per-connection sync interval: `sync_interval_override_minutes INTEGER NULL`. Cron fires at minimum interval, checks each connection's staleness individually.
-- Alpine.js v3 for admin UI interactivity (CDN, no build step). Replaces `alert()`/`confirm()` with inline patterns.
-- Dark mode: DaisyUI `light`/`dark` themes with `prefers-color-scheme` auto-switch (no hardcoded `data-theme`). Badge/flash colors use DaisyUI semantic classes.
-- Badge rendering: `statusBadge()` and `syncBadge()` template functions replace copy-pasted if-chains.
-- **Select element backgrounds**: Never use `bg-base-200/50` (or any `/opacity` modifier) on `<select>` elements — the alpha transparency renders as fully transparent in browsers. Use solid `bg-base-200` instead. `<input>` elements handle `bg-base-200/50` fine; `<select>` does not.
-- **SPA progress bar**: `base.html` has a global progress bar and content fade (opacity/blur/pointer-events) that auto-starts on internal link clicks. When JS does async work (fetch + `window.location.href` on success), any error path **must** call `window.bbProgress.finish()` and restore `main` element styles (`opacity: '', filter: '', pointerEvents: ''`). Without this, the progress bar trickles forever and the page stays blurred/unclickable. Pattern: add a `restorePageState()` helper that does both, call it on every error/early-return path.
-- CSS spacing tokens: `--bb-gap-xs` (0.25rem) through `--bb-gap-xl` (2rem) in `:root`. Use these instead of hardcoded spacing values.
-- Template data helper: `BaseTemplateData(r, sm, currentPage, pageTitle)` returns `map[string]any` with common fields. Handlers can extend the returned map.
-- First-run: `CountAdminAccounts == 0` → redirect to `/setup` (single-page admin creation form). No `setup_complete` flag. Wizard layout, no step indicator.
-- Onboarding checklist: dashboard "Getting Started" card shown until dismissed (`onboarding_dismissed` in `app_config`). Checks: provider configured, family member exists, connection exists.
-- CLI admin management: `breadbox create-admin` command with `--username`/`--password` flags or interactive prompts.
-- Programmatic setup: `POST /api/setup` creates admin + sets config (only works when no admin exists).
-- Config source tracking: `ConfigSources map[string]string` populated in `Load()` (env) and `LoadWithDB()` (db/default). `configSource` template function renders badges.
-- Settings password change: POST `/settings/password`, validates current password via bcrypt, minimum 8 chars for new password
-- Settings system info: `Version` and `StartTime` on `Config` struct, set in `main.go`. PostgreSQL version via inline `SELECT version()` query.
-- Teller settings: All Teller config (app_id, env, webhook_secret, cert/key PEM) editable via `/providers`. Cert/key PEM files uploaded through dashboard are AES-256-GCM encrypted and stored base64-encoded in `app_config`. Env file paths take precedence over DB PEM.
-- Provider page: `/providers` is a top-level nav page with equal-weight cards for Plaid, Teller, CSV. No "primary provider" concept. Settings page no longer contains provider configuration.
-- Provider reinitialization: `app.ReinitProvider(name)` hot-reloads providers after dashboard config changes. Sync engine shares the same `map[string]provider.Provider` reference.
-- Teller PEM client: `teller.NewClientFromPEM(certPEM, keyPEM)` creates mTLS client from in-memory PEM bytes (alternative to file-path constructor).
-- Human-readable error messages: `errorMessage()` template function maps provider error codes to user-friendly strings
-- Health check split: `/health/live` (basic HTTP 200) vs `/health/ready` (DB + scheduler verification)
-- Sync writes wrapped in a single DB transaction for atomicity (Phase 14)
-- Orphaned sync logs: on startup, mark stale `in_progress` logs as `error` with "interrupted by server restart"
-- Per-sync timeout: configurable context deadline per connection sync (default 5 minutes)
-- ENCRYPTION_KEY required at startup when Plaid or Teller providers are configured (fail fast, not runtime crash)
-- LOG_LEVEL env var: debug/info/warn/error, overrides environment-based defaults
-- Transaction responses include denormalized `account_name` and `user_name` (JOIN in dynamic query builder)
-- MCP tool descriptions: domain-rich with amount conventions, filter docs, pagination behavior (not generic)
-- MCP server instructions: domain-rich onboarding text (data model, amount convention, category system, recommended query patterns)
-- Teller categories: raw Teller category strings (e.g., `dining`, `groceries`) are stored directly in `category_primary`. Transaction rules handle categorization during sync.
-- Teller SHOPPING fix: historical migration corrected `SHOPPING*` to `GENERAL_MERCHANDISE*`. No longer relevant since raw Teller categories are now stored directly.
-- Transaction sort options: `sort_by` (date/amount/name) + `sort_order` (asc/desc). Cursor pagination only works with date sort.
-- Category system: `categories` table (UUID PK, slug, display_name, parent_id for 2-level hierarchy, icon, color). Transactions have `category_id` FK (SET NULL) + `category_override` boolean. Raw provider strings kept in `category_primary`/`category_detailed` for auditability. Transaction rules handle categorization during sync.
-- Category slugs: `lowercase_with_underscores` format (e.g., `food_and_drink_groceries`). Immutable after creation. Display names are mutable.
-- Category API: transaction responses include structured `category` object; raw fields renamed to `category_primary_raw`/`category_detailed_raw`. Filter by `category_slug` param.
-- MCP `min_amount`/`max_amount` use `*float64` (not `float64`) to allow filtering by zero values
-- Field selection: `?fields=` param on `GET /api/v1/transactions`, `GET /api/v1/transactions/{id}`, and MCP `query_transactions`. Supports individual field names (e.g., `fields=name,amount,date,account_name`) and aliases: `minimal` (name,amount,date — smallest useful set), `core` (id,date,amount,name,iso_currency_code), `category` (category,category_primary_raw,category_detailed_raw), `timestamps` (created_at,updated_at,datetime,authorized_datetime). `id` and `short_id` always included. Filtering happens in handlers, not service layer.
-- Transaction summary: `GET /api/v1/transactions/summary` and MCP `transaction_summary` tool. Server-side aggregation with `group_by`: category, month, week, day, category_month. Multi-currency handled per-row. Default date range: 30 days.
-- Merchant summary: `GET /api/v1/transactions/merchants` and MCP `merchant_summary` tool. Server-side GROUP BY on `COALESCE(merchant_name, name)` returning distinct merchants with transaction_count, total_amount, avg_amount, first_date, last_date, iso_currency_code. Supports same filters as transaction queries plus `min_count` (HAVING COUNT >= N) and `spending_only`. Default date range: 90 days. Limit 500.
-- Exclude search: `exclude_search` param on `query_transactions`, `count_transactions`, and `merchant_summary`. Adds `NOT ILIKE` clause on name and merchant_name. Minimum 2 characters (REST API validation). Used to filter out known merchants when hunting for unknown charges.
-- Search modes: `search_mode` param on `query_transactions`, `count_transactions`, `merchant_summary`, `list_transaction_rules`. Values: `contains` (default, substring ILIKE), `words` (split on spaces, AND all words — handles formatting differences like "Century Link" vs "CenturyLink"), `fuzzy` (pg_trgm similarity for typo tolerance). Comma-separated values in `search` are auto-ORed in all modes. Shared implementation in `internal/service/search.go` via `BuildSearchClause`/`BuildExcludeSearchClause`.
-- Enhanced overview resource: `breadbox://overview` includes users list, accounts_by_type, connections with account counts, 30-day spending summary with top 5 categories, pending transaction count.
-- CSS framework: DaisyUI 5 + Tailwind CSS v4 via `tailwindcss-extra` standalone CLI binary. No Node.js. Replaces Pico CSS.
-- CSS build: `make css` compiles `input.css` → `static/css/styles.css`. `make css-watch` for dev. Dockerfile runs `make css` in build stage.
-- DaisyUI theme: `light` (default) + `dark` auto-switch via `prefers-color-scheme`
-- Icons: Lucide via CDN, `data-lucide` attributes replaced with inline SVG by `lucide.createIcons()`
-- DaisyUI components replace `bb-*` classes: `drawer` (sidebar), `stat` (metric cards), `table` (data tables), `badge` (status), `menu` (nav), `card` (sections), `modal` (dialogs), `toast`+`alert` (notifications), `steps` (wizard progress), `collapse` (accordions)
-- Custom `@apply` classes in `input.css` for app-specific patterns: `.bb-filter-bar`, `.bb-pagination`, `.bb-action-bar`, `.bb-amount`, `.bb-info-grid`
-- CI/CD: GitHub Actions (`.github/workflows/ci.yml`). PR → vet+test+build. Main → multi-arch push to `ghcr.io/canalesb93/breadbox:latest`. Tag → versioned image. Auto-deploy to dev VM via SSH.
-- Production deployment: `deploy/docker-compose.prod.yml` with Caddy (auto HTTPS), PostgreSQL, Breadbox from ghcr.io. `deploy/install.sh` for one-liner setup. `deploy/update.sh` for CLI updates.
-- Version checker: `internal/version/checker.go` — in-memory cached (1hr TTL) GitHub Releases API check. Shared by REST `GET /api/v1/version` (no auth) and dashboard handler.
-- Docker socket detection: `os.Stat("/var/run/docker.sock")` at startup → `App.DockerSocketAvailable`. Used by update handler to pull images via Docker Engine API (`net/http` with Unix socket transport, no Docker SDK dependency).
-- Update flow: dashboard banner shows when GitHub release is newer than current. Pull via Docker socket if available, then user runs `docker compose up -d`. Dismiss stores `update_dismissed_version` in `app_config`.
-- Dev VM: `breadbox.exe.xyz` hosted on exe.dev. exe.dev handles TLS termination and HTTP proxying automatically (no Caddy needed on dev). Breadbox listens on a local port and exe.dev proxies `https://breadbox.exe.xyz` to it. Auto-deploy from GitHub Actions on main merge via SSH (`appleboy/ssh-action`). Secrets: `DEPLOY_SSH_KEY`, `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_PATH`.
-- MCP permissions: global `mcp_mode` (read_only/read_write), per-tool enable/disable via `mcp_disabled_tools` JSON array, custom instructions via `mcp_custom_instructions` — all stored in `app_config`. Default mode is `read_only`.
-- MCP tool registry: `MCPServer.allTools []ToolDef` with `ToolClassification` (read/write). `BuildServer(MCPServerConfig)` creates a filtered `*mcpsdk.Server` per request. Write tools suppressed when mode is read_only, tool is in disabled list, or API key scope is read_only.
-- MCP instruction templates: hardcoded Go constants in `internal/mcp/templates.go` (spend_review, monthly_analysis, reporting). Loaded into editor via Alpine.js, saved as `mcp_custom_instructions`.
-- API key scope: `scope TEXT NOT NULL DEFAULT 'full_access'` column on `api_keys`. Values: `full_access`, `read_only`. `RequireWriteScope()` middleware blocks read-only keys from write REST endpoints. Full API key record stored in request context via `middleware.SetAPIKey()`/`GetAPIKey()`.
-- MCP admin page: `/mcp` with four cards — global mode, tool access, server instructions, API key scope info. Nav item with `bot` Lucide icon between API Keys and Sync Logs.
-- Review queue: `review_queue` table with `review_type` (new_transaction, uncategorized, manual, re_review) and `status` (pending, approved, rejected, skipped). **Off by default** (`review_auto_enqueue=false`). When enabled, auto-enqueued during sync. MCP tools return empty/error when disabled. `reviewer_complete` constraint ensures reviewer metadata is set on resolution.
-- Review sync hook: `Engine.enqueueForReview()` called after each upsert inside the sync transaction. Priority: uncategorized > new_transaction. Skips `category_override=true` transactions. ON CONFLICT DO NOTHING for idempotency.
-- Review service: `ListReviews` uses dynamic SQL with transaction JOINs and cursor pagination (ASC for pending FIFO, DESC for resolved). `SubmitReview` handles category override + comment creation. `BulkSubmitReviews` iterates individually.
-- Review admin page: `/reviews` shows "Reviews are Disabled" card with enable button when off. When enabled, shows filter bar (status, type, account, user), card-based review queue with inline approve/reject/skip/dismiss, Alpine.js `reviewQueue()` for AJAX actions with card fade-out animation. Enable flow offers to bulk-enqueue existing uncategorized transactions.
-- Review MCP tools: `list_pending_reviews` (ToolRead, returns empty with note when disabled), `submit_review` (ToolWrite, returns error when disabled), `batch_submit_reviews` (ToolWrite, returns error when disabled, max 500), `pending_reviews_overview` (ToolRead, returns zeros with note when disabled) in `internal/mcp/tools.go`. Limits: `list_pending_reviews` max 500, `batch_submit_reviews` max 500.
-- Review REST API: read endpoints at `/api/v1/reviews`, `/api/v1/reviews/counts`, `/api/v1/reviews/{id}`; write endpoints at `POST /reviews/{id}/submit`, `POST /reviews/bulk`, `POST /reviews/enqueue`, `DELETE /reviews/{id}`.
-- Transaction rules: `transaction_rules` table with recursive JSON condition tree (`conditions JSONB`). Rules auto-categorize future transactions during sync by matching conditions on transaction fields. Priority-ordered (higher wins). Support AND/OR/NOT logic with operators: eq, neq, contains, not_contains, matches (regex), gt, gte, lt, lte, in. Available fields: name, merchant_name, amount, category_primary, category_detailed, pending, provider, account_id, user_id, user_name.
-- Transaction rules service: `internal/service/rules.go` — `ValidateCondition` (recursive validation), `CompileCondition` (pre-compile regexes), `EvaluateCondition` (short-circuit evaluation). CRUD via dynamic SQL with cursor pagination. `ruleRow` struct with `scanDest()`/`toResponse()` eliminates scan variable duplication.
-- Transaction rules MCP tools: `create_transaction_rule` (ToolWrite, supports `apply_retroactively` flag), `list_transaction_rules` (ToolRead), `update_transaction_rule` (ToolWrite), `delete_transaction_rule` (ToolWrite), `apply_rules` (ToolWrite, applies rules retroactively to existing transactions — optional `rule_id` for single rule or all active rules), `preview_rule` (ToolRead, dry-run a condition against existing transactions — returns match count + samples).
-- Transaction rules REST API: read endpoints at `/api/v1/rules`, `/api/v1/rules/{id}`; write endpoints at `POST /rules`, `PUT /rules/{id}`, `DELETE /rules/{id}`, `POST /rules/{id}/apply`, `POST /rules/apply-all`, `POST /rules/preview`.
-- Retroactive rule application: `ApplyRuleRetroactively` and `ApplyAllRulesRetroactively` in `internal/service/rules.go`. Batched keyset pagination (1000/batch), evaluates conditions in Go, bulk UPDATEs matching non-overridden transactions. Respects `category_override=true`.
-- Transaction rules admin: `/rules` page with table, filter bar (search, category, enabled), create/edit modal with JSON condition editor, toggle enable/disable, delete. Nav item with `list-filter` Lucide icon.
-- Rule creator tracking: `created_by_type` (user/agent/system), `created_by_id`, `created_by_name` — uses Actor pattern from request context.
-- Rule expiry: optional `expires_at` timestamp. `expires_in` param on create accepts duration strings (24h, 30d, 1w). Expired rules excluded from sync but remain visible.
-- Rule hit tracking: `hit_count` and `last_hit_at` updated by `BatchIncrementHitCounts` during sync.
-- Batch categorize: `batch_categorize_transactions` MCP tool (ToolWrite, max 500 items) and `POST /api/v1/transactions/batch-categorize`. Takes array of `{transaction_id, category_slug}` pairs. Pre-resolves slugs with cache.
-- Bulk recategorize: `bulk_recategorize` MCP tool (ToolWrite) and `POST /api/v1/transactions/bulk-recategorize`. Server-side UPDATE with dynamic WHERE clause (same filter params as query_transactions) + target category. Requires at least one filter (safety). Sets `category_override=TRUE`.
-- Review field selection: `list_pending_reviews` supports `fields` param. Aliases: `triage` (review id/type/status + transaction name/amount/date/category_primary_raw/account_name/user_name/merchant_name), `review_core` (review metadata only), `transaction_core` (key transaction fields). Implemented in `internal/service/fields.go` via `ParseReviewFields`/`FilterReviewFields`.
-- Account linking: `account_links` table links dependent (authorized user) accounts to primary (cardholder) accounts for cross-connection transaction deduplication. `transaction_matches` table stores matched pairs. `transactions.attributed_user_id` overrides user attribution. `accounts.is_dependent_linked` flag excludes dependent transactions from totals at query time.
-- Account link matching: `internal/sync/matcher.go` matches by date + exact amount. Runs post-sync via `Engine.matcher.ReconcileForConnection()`. Single candidate → auto-match. Multiple candidates → name similarity tiebreaker. Ambiguous → skip for manual review.
-- Attribution-aware filtering: transaction queries use `COALESCE(t.attributed_user_id, bc.user_id)` for user filtering. "User's transactions" includes their own plus those attributed to them on shared cards. Dependent account transactions excluded from totals via `AND a.is_dependent_linked = FALSE`.
-- Account link MCP tools: `list_account_links`, `create_account_link` (ToolWrite, auto-runs initial reconciliation), `delete_account_link`, `reconcile_account_link`, `list_transaction_matches`, `confirm_match`, `reject_match`.
-- Account link REST API: `/api/v1/account-links` CRUD + `/reconcile` + `/matches`. `/api/v1/transaction-matches/{id}/confirm|reject`. `POST /api/v1/transaction-matches/manual`.
-- Account link admin: `/account-links` page with link list, create modal, match detail view. Nav item with `link-2` Lucide icon between Categories and Family Members.
-- Agent reports: `agent_reports` table for agents to submit summaries and flag transactions. `submit_report` MCP tool (ToolWrite) with title + markdown body. Dashboard widget shows unread reports with markdown rendering (marked.js CDN). Transaction deep-links via `[Name](/transactions/ID)` in markdown. Mark read/dismiss via admin API. Nav badge shows unread count.
-- Agent report REST API: `GET /api/v1/reports`, `POST /api/v1/reports`, `GET /api/v1/reports/unread-count`, `PATCH /api/v1/reports/{id}/read`. Admin API: `POST /-/reports/{id}/read`, `POST /-/reports/read-all`.
+- **Amounts**: `NUMERIC(12,2)` + always pair with `iso_currency_code`. Never sum across currencies.
+- **Short IDs**: every entity has an 8-char base62 `short_id` alongside UUID `id`, generated by a Postgres trigger. Service methods accept either via `internal/service/resolve.go`. MCP responses compact `id` → short_id value via `compactIDs()` in `internal/mcp/tools.go`; REST returns both.
+- **Soft deletes**: transactions use `deleted_at`; connections set `status='disconnected'`. FK policy: accounts/transactions `SET NULL` on connection delete (preserve history); `sync_logs` `CASCADE`.
+- **Encryption**: access tokens and Teller PEM files are AES-256-GCM encrypted at rest. `ENCRYPTION_KEY` (64-char hex) required at startup if any provider is configured — fail fast, not runtime.
+- **Attribution-aware filtering**: transaction queries use `COALESCE(t.attributed_user_id, bc.user_id)` for user filtering. Dependent-linked accounts excluded from totals via `a.is_dependent_linked = FALSE`.
+- **`category_override=true`** is sacred. Transaction rules and review enqueue must skip overridden rows.
+- **Shared dev DB**: multiple worktrees/agents run against one `breadbox` database. Additive migrations only (`ADD COLUMN`, `CREATE TABLE`, `CREATE INDEX`). Destructive changes (`DROP`, `ALTER TYPE`) break other running servers — coordinate first.
+- **Error envelope**: JSON `{ "error": { "code": "UPPER_SNAKE_CASE", "message": "..." } }`.
+- **Config precedence**: env vars → `app_config` DB table → defaults. Tracked in `ConfigSources` for badge rendering.
+- **Dynamic SQL** (positional `$N`) is used for transaction queries, rules, reviews, and merchants — not sqlc. Composable filters + cursor pagination live in the service layer.
 
 ## Canonical Enums
 
@@ -156,91 +59,51 @@ One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), M
 - Review status: `pending`, `approved`, `rejected`, `skipped`
 - Reviewer type: `user`, `agent`
 - Rule creator type: `user`, `agent`, `system`
-- Condition operators (string): `eq`, `neq`, `contains`, `not_contains`, `matches`, `in`
-- Condition operators (numeric): `eq`, `neq`, `gt`, `gte`, `lt`, `lte`
-- Condition operators (bool): `eq`, `neq`
+- Condition operators — string: `eq`, `neq`, `contains`, `not_contains`, `matches`, `in`; numeric: `eq`, `neq`, `gt`, `gte`, `lt`, `lte`; bool: `eq`, `neq`
 - Match confidence: `auto`, `confirmed`, `rejected`
 - Match strategy: `date_amount_name`
 
-## Spec Documents
+## Local Dev
 
-Detailed specs live in `docs/`. The canonical source for schema and enums is `docs/data-model.md`. The canonical source for the Provider interface is `docs/architecture.md`. Teller-specific details are in `docs/teller-integration.md`. CSV import details are in `docs/csv-import.md`. Design system (CSS framework, components, icons) is in `docs/design-system.md`. REST API quick reference is in `docs/api-reference.md`. MCP tools reference is in `docs/mcp-tools-reference.md`.
-
-## Local Dev & Git Worktrees
-
-### Quick Start
-
-Prerequisites: Go 1.24+, PostgreSQL (Homebrew or Docker).
+Prereqs: Go 1.24+, PostgreSQL.
 
 ```
-make db       # start Postgres via Docker (skip if you have local Postgres)
-make dev      # auto-installs sqlc + tailwind, generates code, runs migrations, starts server
+make db       # start Postgres via Docker (skip if local Postgres)
+make dev      # installs sqlc/tailwind, generates code, migrates, starts server
 ```
 
-On first run, `make dev` will download `tailwindcss-extra`, install `sqlc` via `go install`, and generate all build artifacts. Subsequent runs skip these steps if artifacts exist.
+- Dev DB: `postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable`
+- Test DB: `postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable`
+- Required env when any provider configured: `DATABASE_URL` (set explicitly — pgx's Unix-socket fallback often breaks in worktrees), `ENCRYPTION_KEY` (recover from a running process via `ps eww -p $(pgrep -f 'breadbox serve' | head -1) | tr ' ' '\n' | grep ENCRYPTION_KEY`).
+- Worktrees (`claude -w`): `.worktreeinclude` copies build artifacts; `.claude/hooks/session-start.sh` assigns a port from 8081–8099 and injects env via `CLAUDE_ENV_FILE`. Main repo uses 8080.
+- Stop all dev servers: `make dev-stop`.
 
-### Database
+## Releases
 
-PostgreSQL credentials: `breadbox:breadbox`. All worktrees and dev server instances share the same database.
+- `main` is branch-protected — PR-only, CI must pass.
+- Semver tags trigger release CI: cross-platform binaries, Docker image, GitHub Release.
+- Merge to `main` auto-deploys to `breadbox.exe.xyz` via SSH.
+- See `CHANGELOG.md` and `CONTRIBUTING.md`.
 
-- **Dev database**: `postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable`
-- **Test database**: `postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable`
-- **Local Postgres**: Homebrew `postgresql@15` or `make db` (Docker). Both use port 5432.
-- **Migrations**: Run automatically on `breadbox serve` startup. For manual control: `make migrate-up` / `make migrate-down`.
-- **Shared state warning**: Multiple agents/worktrees may run simultaneously against the same `breadbox` database. Avoid destructive schema changes (DROP TABLE, DROP COLUMN, ALTER TYPE) without coordinating — another agent's running server will break. Additive migrations (ADD COLUMN, CREATE TABLE, CREATE INDEX) are safe.
+## References
 
-### Required Environment Variables
+Canonical specs in `docs/`:
 
-The app requires these env vars when Plaid or Teller providers are configured in the DB:
+- `data-model.md` — schema and enums (canonical)
+- `architecture.md` — provider interface and layer boundaries
+- `api-reference.md` — REST endpoints
+- `mcp-tools-reference.md` — MCP tools
+- `design-system.md` — CSS framework, components, icons
+- `plaid-integration.md`, `teller-integration.md`, `csv-import.md` — provider specifics
+- `admin-dashboard.md`, `mcp-server.md`, `rest-api.md`, `backup.md` — subsystem details
 
-- `DATABASE_URL` — pgx falls back to Unix socket with current OS user if unset, which may not work in all contexts (e.g., worktrees spawned by agents). Always set it explicitly.
-- `ENCRYPTION_KEY` — 64-char hex (32-byte AES-256-GCM key). Required at startup if any provider is configured. To find the key from a running breadbox process: `ps eww -p $(pgrep -f "breadbox serve" | head -1) | tr ' ' '\n' | grep ENCRYPTION_KEY`
+Scoped rules in `.claude/rules/` load when you touch matching files:
 
-### Worktree Automation
-
-Worktrees are fully automated via `claude --worktree` (or `claude -w`). Three mechanisms handle setup:
-
-1. **`.worktreeinclude`**: Automatically copies gitignored build artifacts (sqlc files, `tailwindcss-extra`, `styles.css`, teller certs, `.local.env`) from the main repo into the worktree at creation time.
-2. **`SessionStart` hook** (`.claude/hooks/session-start.sh`): Verifies `go build` works (falls back to `sqlc generate` if copied files are stale), injects `DATABASE_URL`, `ENCRYPTION_KEY`, and `PORT` via `CLAUDE_ENV_FILE`.
-3. **Port assignment**: The hook scans ports 8081–8099 for the first available one and claims it with an atomic lock file under `.claude/port-locks/` to prevent races between concurrent sessions. Main repo uses 8080.
-
-After setup, the agent just runs `make dev` — the `PORT` env var is already set, and `generate` skips since artifacts exist.
-
-### Sandbox
-
-OS-level sandboxing is enabled via `.claude/settings.json` with auto-allow mode. This replaces manual "bypass permissions" for most operations:
-
-- **Filesystem**: Write access to project dir, `~/go`, `~/Library/Caches/go-build`, `/tmp`, `/var/folders`.
-- **Network**: `localhost`, Go module proxy, GitHub.
-- **Excluded commands**: `make dev*`, `make test*`, `go run *`, `go test *` run outside the sandbox (they need full network access for Postgres and HTTP binding).
-
-### Manual Worktree Setup
-
-If not using `claude -w`, you can set up manually:
-
-1. `git worktree add -b <branch> .claude/worktrees/<name>`
-2. Copy artifacts: `cp tailwindcss-extra static/css/styles.css internal/db/*.go .claude/worktrees/<name>/` (matching paths)
-3. `cd .claude/worktrees/<name> && PORT=808X make dev`
-
-### Cleanup
-
-- Worktrees created by `claude -w` are cleaned up automatically when the session ends.
-- Manual cleanup: `git worktree remove .claude/worktrees/<name>`
-- Kill dev servers: `kill $(lsof -ti:<PORT>)` or `make dev-stop` (kills all instances)
-
-## Releases & CI
-
-- **Branch protection**: `main` is a restricted branch — direct pushes are blocked. All changes must go through a pull request with passing CI status checks.
-- **Versioning**: Semantic versioning (`v0.1.0`). See `CHANGELOG.md`.
-- **Releasing**: Manual. Create a git tag and push it — CI handles the rest.
-  ```
-  git tag -a v0.1.0 -m "Description"
-  git push origin v0.1.0
-  ```
-- **What CI does on tag push**: runs tests, builds cross-platform binaries (linux/darwin, amd64/arm64), creates GitHub Release with binaries attached, builds + pushes versioned Docker image.
-- **What CI does on merge to main**: runs tests, builds + pushes `latest` Docker image, auto-deploys to dev instance. Deploy job only runs on `canalesb93/breadbox` (skipped on forks).
-- **What CI does on PR**: runs tests only. No builds, no deploys.
-
-## Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and contribution guidelines.
+- `migrations.md` — migration conventions
+- `testing.md` — test patterns and fixtures
+- `service.md` — service-layer conventions
+- `api.md` — REST/admin handler conventions
+- `mcp.md` — MCP tool and permission patterns
+- `providers.md` — provider integrations
+- `sync.md` — sync engine patterns
+- `ui.md` — admin UI, CSS, Alpine, icons


### PR DESCRIPTION
Trim CLAUDE.md from 246 to 109 lines by moving feature-specific conventions
into .claude/rules/*.md files with path-scoped YAML frontmatter. Each rule
only loads into context when Claude touches matching files, reducing the
per-session context cost and keeping the root file focused on gotchas that
apply every session.

Aligns with current Anthropic guidance (<200 lines per CLAUDE.md, progressive
disclosure via .claude/rules/).

New rule files:
- migrations.md, testing.md, service.md, mcp.md
- providers.md, sync.md, ui.md, api.md

https://claude.ai/code/session_01CtwhupRzhFDZSYtCwJqWcv