### PR TITLE
feat(tags): phase 2 — tags, transaction_tags, annotations + dual-write

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -646,25 +646,22 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			}
 		}
 
-		comments, err := svc.ListComments(ctx, idStr)
+		// Phase 2: read the activity timeline from annotations (the canonical
+		// source). Reviews are still queried separately because their own
+		// lifecycle events (enqueue, resolve) aren't modeled as annotations.
+		annotations, err := svc.ListAnnotations(ctx, idStr)
 		if err != nil && !errors.Is(err, service.ErrNotFound) {
-			a.Logger.Error("list transaction comments", "error", err)
+			a.Logger.Error("list transaction annotations", "error", err)
 		}
 
-		// Fetch review history for this transaction.
+		// Still needed for pending-review UI state and the review enqueue events.
 		reviews, err := svc.ListReviewsByTransactionID(ctx, idStr)
 		if err != nil && !errors.Is(err, service.ErrNotFound) {
 			a.Logger.Error("list transaction reviews", "error", err)
 		}
 
-		// Fetch rule applications for this transaction.
-		ruleApps, err := svc.ListRuleApplicationsByTransactionID(ctx, idStr)
-		if err != nil {
-			a.Logger.Error("list transaction rule applications", "error", err)
-		}
-
-		// Build unified activity timeline.
-		activity := buildActivityTimeline(reviews, comments, ruleApps)
+		// Build unified activity timeline from annotations + review lifecycle.
+		activity := buildActivityTimeline(reviews, annotations)
 
 		// Check if there's a pending review (to disable re-enqueue)
 		hasPendingReview := false
@@ -757,22 +754,30 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 	}
 }
 
-// buildActivityTimeline merges reviews, comments, and rule applications into a sorted timeline.
-func buildActivityTimeline(reviews []service.ReviewResponse, comments []service.CommentResponse, ruleApps []service.TransactionRuleApplicationDetail) []service.ActivityEntry {
+// buildActivityTimeline merges the review lifecycle (enqueue + resolution)
+// with the annotation-driven timeline into a sorted activity list.
+//
+// Phase 2: annotations are the canonical source for comments, tag operations,
+// rule-driven category/tag/comment changes, and manual category sets. Reviews
+// still own their own enqueue/resolve lifecycle events because those aren't
+// (currently) modeled as annotations.
+func buildActivityTimeline(reviews []service.ReviewResponse, annotations []service.Annotation) []service.ActivityEntry {
 	var entries []service.ActivityEntry
 
-	// Index comments that belong to a review resolution so we can render their
-	// content inline on the resolution event and skip them as standalone entries.
-	commentsByReview := make(map[string]service.CommentResponse, len(comments))
-	for _, c := range comments {
-		if c.ReviewID != nil && *c.ReviewID != "" {
-			commentsByReview[*c.ReviewID] = c
+	// Index review-linked comment annotations by review_id so we can render
+	// them inline on the resolution event and skip them as standalone entries.
+	reviewLinkedComments := make(map[string]service.Annotation)
+	for _, a := range annotations {
+		if a.Kind != "comment" || a.Payload == nil {
+			continue
+		}
+		if rid, ok := a.Payload["review_id"].(string); ok && rid != "" {
+			reviewLinkedComments[rid] = a
 		}
 	}
 
-	// Convert reviews — for resolved reviews, emit both the enqueue and resolution events
+	// Review lifecycle events.
 	for _, r := range reviews {
-		// Always emit the "enqueued" event (using CreatedAt)
 		var enqueueReason string
 		switch r.ReviewType {
 		case "uncategorized":
@@ -796,7 +801,6 @@ func buildActivityTimeline(reviews []service.ReviewResponse, comments []service.
 			ReviewStatus: "pending",
 		})
 
-		// For resolved reviews, also emit the resolution event
 		if r.Status != "pending" && r.ReviewedAt != nil {
 			e := service.ActivityEntry{
 				Type:      "review",
@@ -827,68 +831,153 @@ func buildActivityTimeline(reviews []service.ReviewResponse, comments []service.
 				e.ReviewStatus = "skipped"
 				e.Summary = "Skipped"
 			}
-			if linked, ok := commentsByReview[r.ID]; ok {
-				e.Detail = linked.Content
-				e.CommentID = linked.ID
+			if linked, ok := reviewLinkedComments[r.ID]; ok {
+				if content, _ := linked.Payload["content"].(string); content != "" {
+					e.Detail = content
+				}
+				if cid, _ := linked.Payload["comment_id"].(string); cid != "" {
+					e.CommentID = cid
+				}
 			}
 			entries = append(entries, e)
 		}
 	}
 
-	// Convert free-standing comments. Linked review-note comments were already
-	// rendered as the Detail of their resolution event above; skip them here
-	// to avoid double-surfacing. Filter legacy [Review: ...] prefix duplicates
-	// from pre-consolidation imports.
-	for _, c := range comments {
-		if c.ReviewID != nil && *c.ReviewID != "" {
-			continue
+	// Annotations.
+	for _, a := range annotations {
+		switch a.Kind {
+		case "comment":
+			// Skip review-linked comments (rendered inline on the resolution event).
+			if rid, _ := a.Payload["review_id"].(string); rid != "" {
+				continue
+			}
+			content, _ := a.Payload["content"].(string)
+			// Filter legacy [Review: ...] prefix duplicates from pre-consolidation imports.
+			if strings.HasPrefix(content, "[Review: ") {
+				continue
+			}
+			entry := service.ActivityEntry{
+				Type:      "comment",
+				Timestamp: a.CreatedAt,
+				ActorName: a.ActorName,
+				ActorType: a.ActorType,
+				Detail:    content,
+			}
+			if cid, _ := a.Payload["comment_id"].(string); cid != "" {
+				entry.CommentID = cid
+			}
+			if a.ActorID != nil && *a.ActorID != "" {
+				id := *a.ActorID
+				entry.ActorID = &id
+			}
+			entries = append(entries, entry)
+
+		case "rule_applied":
+			ruleName, _ := a.Payload["rule_name"].(string)
+			field, _ := a.Payload["action_field"].(string)
+			value, _ := a.Payload["action_value"].(string)
+			appliedBy, _ := a.Payload["applied_by"].(string)
+			summary := "Rule \"" + ruleName + "\" applied"
+			switch field {
+			case "category":
+				summary = "Rule \"" + ruleName + "\" set category to " + value
+			case "tag":
+				summary = "Rule \"" + ruleName + "\" added tag " + value
+			case "comment":
+				summary = "Rule \"" + ruleName + "\" added a comment"
+			}
+			how := "during sync"
+			if appliedBy == "retroactive" {
+				how = "retroactively"
+			}
+			entries = append(entries, service.ActivityEntry{
+				Type:      "rule",
+				Timestamp: a.CreatedAt,
+				ActorName: how,
+				ActorType: "system",
+				Summary:   summary,
+				RuleName:  ruleName,
+				RuleID:    derefOr(a.RuleID, ""),
+			})
+
+		case "tag_added":
+			slug, _ := a.Payload["slug"].(string)
+			note, _ := a.Payload["note"].(string)
+			summary := "Added tag " + slug
+			entry := service.ActivityEntry{
+				Type:      "tag",
+				Timestamp: a.CreatedAt,
+				ActorName: a.ActorName,
+				ActorType: a.ActorType,
+				Summary:   summary,
+				Detail:    note,
+				TagSlug:   slug,
+			}
+			if a.ActorID != nil && *a.ActorID != "" {
+				id := *a.ActorID
+				entry.ActorID = &id
+			}
+			entries = append(entries, entry)
+
+		case "tag_removed":
+			slug, _ := a.Payload["slug"].(string)
+			note, _ := a.Payload["note"].(string)
+			summary := "Removed tag " + slug
+			entry := service.ActivityEntry{
+				Type:      "tag",
+				Timestamp: a.CreatedAt,
+				ActorName: a.ActorName,
+				ActorType: a.ActorType,
+				Summary:   summary,
+				Detail:    note,
+				TagSlug:   slug,
+			}
+			if a.ActorID != nil && *a.ActorID != "" {
+				id := *a.ActorID
+				entry.ActorID = &id
+			}
+			entries = append(entries, entry)
+
+		case "category_set":
+			slug, _ := a.Payload["category_slug"].(string)
+			source, _ := a.Payload["source"].(string)
+			summary := "Category set to " + slug
+			if source == "rule" {
+				// Represented separately via the rule_applied annotation
+				// written alongside category_set during sync. Skip to avoid
+				// double-rendering.
+				continue
+			}
+			entry := service.ActivityEntry{
+				Type:      "category",
+				Timestamp: a.CreatedAt,
+				ActorName: a.ActorName,
+				ActorType: a.ActorType,
+				Summary:   summary,
+				CategoryName: slug,
+			}
+			if a.ActorID != nil && *a.ActorID != "" {
+				id := *a.ActorID
+				entry.ActorID = &id
+			}
+			entries = append(entries, entry)
 		}
-		if strings.HasPrefix(c.Content, "[Review: ") {
-			continue
-		}
-		entry := service.ActivityEntry{
-			Type:      "comment",
-			Timestamp: c.CreatedAt,
-			ActorName: c.AuthorName,
-			ActorType: c.AuthorType,
-			Detail:    c.Content,
-			CommentID: c.ID,
-		}
-		if c.AuthorID != nil && *c.AuthorID != "" {
-			id := *c.AuthorID
-			entry.ActorID = &id
-		}
-		entries = append(entries, entry)
 	}
 
-	// Convert rule applications
-	for _, ra := range ruleApps {
-		summary := "Rule \"" + ra.RuleName + "\" set category"
-		if ra.CategoryDisplayName != "" {
-			summary = "Rule \"" + ra.RuleName + "\" set category to " + ra.CategoryDisplayName
-		}
-		how := "during sync"
-		if ra.AppliedBy == "retroactive" {
-			how = "retroactively"
-		}
-		entries = append(entries, service.ActivityEntry{
-			Type:      "rule",
-			Timestamp: ra.AppliedAt,
-			ActorName: how,
-			ActorType: "system",
-			Summary:   summary,
-			RuleName:  ra.RuleName,
-			RuleID:    ra.RuleID,
-			CategoryName: ra.CategoryDisplayName,
-		})
-	}
-
-	// Sort by timestamp descending (newest first)
+	// Sort by timestamp descending (newest first).
 	sort.Slice(entries, func(i, j int) bool {
 		return entries[i].Timestamp > entries[j].Timestamp
 	})
 
 	return entries
+}
+
+// derefOr returns *p if non-nil, else def.
+func derefOr(p *string, def string) string {
+	if p == nil {
+		return def
+	}
+	return *p
 }
 
 // CreateTransactionCommentHandler serves POST /admin/api/transactions/{id}/comments.

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -103,17 +103,20 @@ func TestBuildActivityTimeline_LinkedCommentRendersInResolution(t *testing.T) {
 		CreatedAt:                   "2026-04-03T09:00:00Z",
 		ReviewedAt:                  &reviewedAt,
 	}}
-	linkedID := reviewID
-	comments := []service.CommentResponse{{
-		ID:         "comment-linked",
-		AuthorName: reviewerName,
-		AuthorType: reviewerType,
-		Content:    "matched recurring merchant rule",
-		ReviewID:   &linkedID,
-		CreatedAt:  "2026-04-03T10:00:00Z",
+	annotations := []service.Annotation{{
+		ID:        "ann-linked",
+		Kind:      "comment",
+		ActorName: reviewerName,
+		ActorType: reviewerType,
+		Payload: map[string]interface{}{
+			"content":    "matched recurring merchant rule",
+			"comment_id": "comment-linked",
+			"review_id":  reviewID,
+		},
+		CreatedAt: "2026-04-03T10:00:00Z",
 	}}
 
-	entries := buildActivityTimeline(reviews, comments, nil)
+	entries := buildActivityTimeline(reviews, annotations)
 
 	var resolution *service.ActivityEntry
 	for i := range entries {
@@ -136,15 +139,19 @@ func TestBuildActivityTimeline_LinkedCommentRendersInResolution(t *testing.T) {
 }
 
 func TestBuildActivityTimeline_FreeStandingCommentStillEmitted(t *testing.T) {
-	comments := []service.CommentResponse{{
-		ID:         "comment-free",
-		AuthorName: "Alice",
-		AuthorType: "user",
-		Content:    "split with Bob",
-		CreatedAt:  "2026-04-04T12:00:00Z",
+	annotations := []service.Annotation{{
+		ID:        "ann-free",
+		Kind:      "comment",
+		ActorName: "Alice",
+		ActorType: "user",
+		Payload: map[string]interface{}{
+			"content":    "split with Bob",
+			"comment_id": "comment-free",
+		},
+		CreatedAt: "2026-04-04T12:00:00Z",
 	}}
 
-	entries := buildActivityTimeline(nil, comments, nil)
+	entries := buildActivityTimeline(nil, annotations)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
@@ -158,15 +165,19 @@ func TestBuildActivityTimeline_FreeStandingCommentStillEmitted(t *testing.T) {
 }
 
 func TestBuildActivityTimeline_LegacyPrefixCommentSuppressed(t *testing.T) {
-	comments := []service.CommentResponse{{
-		ID:         "comment-legacy",
-		AuthorName: "Legacy",
-		AuthorType: "system",
-		Content:    "[Review: Some note migrated before consolidation]",
-		CreatedAt:  "2026-03-01T00:00:00Z",
+	annotations := []service.Annotation{{
+		ID:        "ann-legacy",
+		Kind:      "comment",
+		ActorName: "Legacy",
+		ActorType: "system",
+		Payload: map[string]interface{}{
+			"content":    "[Review: Some note migrated before consolidation]",
+			"comment_id": "comment-legacy",
+		},
+		CreatedAt: "2026-03-01T00:00:00Z",
 	}}
 
-	entries := buildActivityTimeline(nil, comments, nil)
+	entries := buildActivityTimeline(nil, annotations)
 
 	if len(entries) != 0 {
 		t.Fatalf("expected legacy [Review: ...] comment to be suppressed, got %d entries", len(entries))

--- a/internal/db/migrations/20260415075421_tags_and_annotations.sql
+++ b/internal/db/migrations/20260415075421_tags_and_annotations.sql
@@ -1,0 +1,98 @@
+-- +goose Up
+
+-- Phase 2 of the review-system redesign: foundation tables for tags +
+-- annotations. Tags replace the review_queue as the primary "flag a
+-- transaction" mechanism; annotations are the canonical activity timeline
+-- (Phase 3 retires transaction_comments and transaction_rule_applications).
+-- This migration only creates the tables + seeds; the sync engine is wired
+-- up in Go. Dual-writes keep the old tables populated during the bridge.
+
+CREATE TABLE tags (
+    id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    short_id     TEXT        NOT NULL UNIQUE,
+    slug         TEXT        NOT NULL UNIQUE,
+    display_name TEXT        NOT NULL,
+    description  TEXT        NOT NULL DEFAULT '',
+    color        TEXT        NULL,
+    icon         TEXT        NULL,
+    lifecycle    TEXT        NOT NULL DEFAULT 'persistent'
+                             CHECK (lifecycle IN ('persistent','ephemeral')),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TRIGGER set_short_id_tags
+    BEFORE INSERT ON tags
+    FOR EACH ROW EXECUTE FUNCTION set_short_id();
+
+CREATE TABLE transaction_tags (
+    transaction_id UUID        NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
+    tag_id         UUID        NOT NULL REFERENCES tags(id)         ON DELETE CASCADE,
+    added_by_type  TEXT        NOT NULL CHECK (added_by_type IN ('user','agent','rule','system')),
+    added_by_id    TEXT        NULL,
+    added_by_name  TEXT        NOT NULL DEFAULT '',
+    added_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (transaction_id, tag_id)
+);
+
+CREATE INDEX transaction_tags_tag_idx    ON transaction_tags(tag_id);
+CREATE INDEX transaction_tags_recent_idx ON transaction_tags(tag_id, added_at DESC);
+
+CREATE TABLE annotations (
+    id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    short_id       TEXT        NOT NULL UNIQUE,
+    transaction_id UUID        NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
+    kind           TEXT        NOT NULL CHECK (kind IN (
+                       'comment', 'rule_applied',
+                       'tag_added', 'tag_removed',
+                       'category_set')),
+    actor_type     TEXT        NOT NULL CHECK (actor_type IN ('user','agent','system')),
+    actor_id       TEXT        NULL,
+    actor_name     TEXT        NOT NULL,
+    session_id     UUID        NULL REFERENCES mcp_sessions(id),
+    payload        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    tag_id         UUID        NULL REFERENCES tags(id)              ON DELETE SET NULL,
+    rule_id        UUID        NULL REFERENCES transaction_rules(id) ON DELETE SET NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TRIGGER set_short_id_annotations
+    BEFORE INSERT ON annotations
+    FOR EACH ROW EXECUTE FUNCTION set_short_id();
+
+CREATE INDEX annotations_txn_idx  ON annotations(transaction_id, created_at ASC);
+CREATE INDEX annotations_kind_idx ON annotations(kind, created_at DESC);
+
+-- Seed: needs-review tag (ephemeral).
+-- Ephemeral tags require a note when removed (tracked via annotations payload).
+INSERT INTO tags (slug, display_name, description, color, lifecycle)
+VALUES ('needs-review', 'Needs Review', 'Awaiting initial categorization review.', '#f59e0b', 'ephemeral');
+
+-- Seed: rule that auto-tags every newly-synced transaction with needs-review.
+-- Actions JSONB shape uses typed Phase 1 format: [{"type": "add_tag", "tag_slug": "<slug>"}].
+-- NULL conditions = match-all (Phase 1 semantic).
+-- trigger=on_create means it fires only for newly-inserted transactions during sync.
+INSERT INTO transaction_rules (
+    name, conditions, actions, trigger, priority,
+    enabled, created_by_type, created_by_name
+) VALUES (
+    'Auto-tag new transactions for review',
+    NULL,
+    '[{"type": "add_tag", "tag_slug": "needs-review"}]'::jsonb,
+    'on_create',
+    0,
+    TRUE,
+    'system',
+    'Breadbox'
+);
+
+-- +goose Down
+
+DELETE FROM transaction_rules WHERE name = 'Auto-tag new transactions for review' AND created_by_type = 'system';
+
+DROP TRIGGER IF EXISTS set_short_id_annotations ON annotations;
+DROP TRIGGER IF EXISTS set_short_id_tags ON tags;
+
+DROP TABLE IF EXISTS annotations;
+DROP TABLE IF EXISTS transaction_tags;
+DROP TABLE IF EXISTS tags;

--- a/internal/db/queries/annotations.sql
+++ b/internal/db/queries/annotations.sql
@@ -1,0 +1,16 @@
+-- name: InsertAnnotation :one
+INSERT INTO annotations (
+    transaction_id, kind, actor_type, actor_id, actor_name,
+    session_id, payload, tag_id, rule_id
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING *;
+
+-- name: ListAnnotationsByTransaction :many
+SELECT * FROM annotations
+WHERE transaction_id = $1
+ORDER BY created_at ASC;
+
+-- name: CountAnnotationsByTransactionAndKind :one
+SELECT COUNT(*) FROM annotations
+WHERE transaction_id = $1 AND kind = $2;

--- a/internal/db/queries/tags.sql
+++ b/internal/db/queries/tags.sql
@@ -1,0 +1,30 @@
+-- name: InsertTag :one
+INSERT INTO tags (slug, display_name, description, color, icon, lifecycle)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING *;
+
+-- name: GetTagByID :one
+SELECT * FROM tags WHERE id = $1;
+
+-- name: GetTagBySlug :one
+SELECT * FROM tags WHERE slug = $1;
+
+-- name: GetTagUUIDByShortID :one
+SELECT id FROM tags WHERE short_id = $1;
+
+-- name: ListTags :many
+SELECT * FROM tags ORDER BY display_name;
+
+-- name: UpdateTag :one
+UPDATE tags
+SET display_name = $2,
+    description = $3,
+    color = $4,
+    icon = $5,
+    lifecycle = $6,
+    updated_at = NOW()
+WHERE id = $1
+RETURNING *;
+
+-- name: DeleteTag :execrows
+DELETE FROM tags WHERE id = $1;

--- a/internal/db/queries/transaction_tags.sql
+++ b/internal/db/queries/transaction_tags.sql
@@ -1,0 +1,22 @@
+-- name: AddTransactionTag :execrows
+INSERT INTO transaction_tags (transaction_id, tag_id, added_by_type, added_by_id, added_by_name)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (transaction_id, tag_id) DO NOTHING;
+
+-- name: RemoveTransactionTag :execrows
+DELETE FROM transaction_tags
+WHERE transaction_id = $1 AND tag_id = $2;
+
+-- name: ListTagsByTransaction :many
+SELECT t.*
+FROM tags t
+JOIN transaction_tags tt ON tt.tag_id = t.id
+WHERE tt.transaction_id = $1
+ORDER BY tt.added_at ASC;
+
+-- name: ListTagSlugsByTransaction :many
+SELECT t.slug
+FROM tags t
+JOIN transaction_tags tt ON tt.tag_id = t.id
+WHERE tt.transaction_id = $1
+ORDER BY t.slug ASC;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -383,6 +383,19 @@ func (s *MCPServer) buildToolRegistry() {
 		makeToolDefLogged("submit_report", ToolWrite,
 			"Send a message to the family's dashboard. The title is the main message — write it as a concise, self-contained 1-2 sentence summary the family can understand at a glance without expanding. The body provides the detailed breakdown (markdown with headers, bullets, transaction links). Use priority to signal urgency and author to identify your role.",
 			s.handleSubmitReport, svc),
+		// --- Phase 2 tags + annotations ---
+		makeToolDefLogged("list_tags", ToolRead,
+			"List all tags registered in the system. Each tag has a slug (stable identifier), display_name, and lifecycle ('persistent' or 'ephemeral'). Ephemeral tags (e.g. 'needs-review') require a note on removal. Tags attached to transactions can be queried via the tags / any_tag filters on query_transactions.",
+			s.handleListTags, svc),
+		makeToolDefLogged("list_annotations", ToolRead,
+			"List the activity timeline for a transaction. Each annotation is a single event: comment, tag_added, tag_removed, rule_applied, or category_set. Ordered by created_at ASC. Payload carries kind-specific fields (content for comments, slug for tags, rule_name for rule applications).",
+			s.handleListAnnotations, svc),
+		makeToolDefLogged("add_transaction_tag", ToolWrite,
+			"Attach a tag to a transaction. Tags are an open-ended labeling system — auto-creates a persistent tag if the slug doesn't exist yet. Use note to attach a short rationale that is stored on the tag_added annotation. Idempotent: returns already_present=true if the tag was already attached.",
+			s.handleAddTransactionTag, svc),
+		makeToolDefLogged("remove_transaction_tag", ToolWrite,
+			"Remove a tag from a transaction. For ephemeral tags (lifecycle='ephemeral', like 'needs-review'), a non-empty note is REQUIRED — it's recorded on the tag_removed annotation so the reason for removal is auditable. For persistent tags, the note is optional. Idempotent: returns already_absent=true if the tag wasn't attached.",
+			s.handleRemoveTransactionTag, svc),
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -65,6 +65,8 @@ type queryTransactionsInput struct {
 	Search        string   `json:"search,omitempty" jsonschema:"Search transaction name or merchant. Comma-separated values are ORed (e.g. starbucks,amazon matches either)."`
 	SearchMode    string   `json:"search_mode,omitempty" jsonschema:"How to match the search term: contains (default, substring match), words (all words must match, good for multi-word queries), fuzzy (typo-tolerant via trigram similarity)"`
 	ExcludeSearch string   `json:"exclude_search,omitempty" jsonschema:"Exclude transactions whose name or merchant matches this text. Comma-separated values are ORed. Use to filter out known merchants."`
+	Tags          []string `json:"tags,omitempty" jsonschema:"Filter to transactions that have EVERY tag slug in this list (AND semantics). Use list_tags to see available tags."`
+	AnyTag        []string `json:"any_tag,omitempty" jsonschema:"Filter to transactions that have AT LEAST ONE tag slug in this list (OR semantics)."`
 	Limit         int      `json:"limit,omitempty" jsonschema:"Max results (default 50, max 500)"`
 	Cursor        string   `json:"cursor,omitempty" jsonschema:"Pagination cursor from previous result"`
 	SortBy        string   `json:"sort_by,omitempty" jsonschema:"Sort: date (default), amount, name"`
@@ -85,6 +87,8 @@ type countTransactionsInput struct {
 	Search        string   `json:"search,omitempty" jsonschema:"Search name or merchant. Comma-separated values are ORed."`
 	SearchMode    string   `json:"search_mode,omitempty" jsonschema:"Search mode: contains (default), words, fuzzy"`
 	ExcludeSearch string   `json:"exclude_search,omitempty" jsonschema:"Exclude transactions matching this text"`
+	Tags          []string `json:"tags,omitempty" jsonschema:"Filter to transactions that have EVERY tag slug in this list (AND semantics)."`
+	AnyTag        []string `json:"any_tag,omitempty" jsonschema:"Filter to transactions that have AT LEAST ONE tag slug in this list (OR semantics)."`
 }
 
 type triggerSyncInput struct {
@@ -266,6 +270,12 @@ func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToo
 	if input.ExcludeSearch != "" {
 		params.ExcludeSearch = &input.ExcludeSearch
 	}
+	if len(input.Tags) > 0 {
+		params.Tags = input.Tags
+	}
+	if len(input.AnyTag) > 0 {
+		params.AnyTag = input.AnyTag
+	}
 	if input.SortBy != "" {
 		params.SortBy = &input.SortBy
 	}
@@ -353,6 +363,12 @@ func (s *MCPServer) handleCountTransactions(_ context.Context, _ *mcpsdk.CallToo
 	}
 	if input.ExcludeSearch != "" {
 		params.ExcludeSearch = &input.ExcludeSearch
+	}
+	if len(input.Tags) > 0 {
+		params.Tags = input.Tags
+	}
+	if len(input.AnyTag) > 0 {
+		params.AnyTag = input.AnyTag
 	}
 
 	count, err := s.svc.CountTransactionsFiltered(ctx, params)

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -1,0 +1,102 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"breadbox/internal/service"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// --- Input types ---
+
+type listTagsInput struct {
+	ReadSessionContext
+}
+
+type listAnnotationsInput struct {
+	ReadSessionContext
+	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
+}
+
+type addTransactionTagInput struct {
+	WriteSessionContext
+	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
+	TagSlug       string `json:"tag_slug" jsonschema:"required,Tag slug to add (e.g. 'needs-review'). Auto-created as persistent if not registered."`
+	Note          string `json:"note,omitempty" jsonschema:"Optional note attached to the tag_added annotation."`
+}
+
+type removeTransactionTagInput struct {
+	WriteSessionContext
+	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
+	TagSlug       string `json:"tag_slug" jsonschema:"required,Tag slug to remove"`
+	Note          string `json:"note,omitempty" jsonschema:"Required when the tag's lifecycle is 'ephemeral'. Short rationale for removal."`
+}
+
+// --- Handlers ---
+
+func (s *MCPServer) handleListTags(_ context.Context, _ *mcpsdk.CallToolRequest, _ listTagsInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	tags, err := s.svc.ListTags(ctx)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(tags)
+}
+
+func (s *MCPServer) handleListAnnotations(_ context.Context, _ *mcpsdk.CallToolRequest, input listAnnotationsInput) (*mcpsdk.CallToolResult, any, error) {
+	ctx := context.Background()
+	if input.TransactionID == "" {
+		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
+	}
+	annotations, err := s.svc.ListAnnotations(ctx, input.TransactionID)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return errorResult(fmt.Errorf("transaction not found")), nil, nil
+		}
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(annotations)
+}
+
+func (s *MCPServer) handleAddTransactionTag(ctx context.Context, _ *mcpsdk.CallToolRequest, input addTransactionTagInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := s.checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	if input.TransactionID == "" || input.TagSlug == "" {
+		return errorResult(fmt.Errorf("transaction_id and tag_slug are required")), nil, nil
+	}
+	actor := service.ActorFromContext(ctx)
+	added, alreadyPresent, err := s.svc.AddTransactionTag(context.Background(), input.TransactionID, input.TagSlug, actor, input.Note)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(map[string]any{
+		"added":           added,
+		"already_present": alreadyPresent,
+		"tag_slug":        input.TagSlug,
+		"transaction_id":  input.TransactionID,
+	})
+}
+
+func (s *MCPServer) handleRemoveTransactionTag(ctx context.Context, _ *mcpsdk.CallToolRequest, input removeTransactionTagInput) (*mcpsdk.CallToolResult, any, error) {
+	if err := s.checkWritePermission(ctx); err != nil {
+		return errorResult(err), nil, nil
+	}
+	if input.TransactionID == "" || input.TagSlug == "" {
+		return errorResult(fmt.Errorf("transaction_id and tag_slug are required")), nil, nil
+	}
+	actor := service.ActorFromContext(ctx)
+	removed, alreadyAbsent, err := s.svc.RemoveTransactionTag(context.Background(), input.TransactionID, input.TagSlug, actor, input.Note)
+	if err != nil {
+		return errorResult(err), nil, nil
+	}
+	return jsonResult(map[string]any{
+		"removed":        removed,
+		"already_absent": alreadyAbsent,
+		"tag_slug":       input.TagSlug,
+		"transaction_id": input.TransactionID,
+	})
+}

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Annotation is the canonical timeline event for a transaction. Phase 2 starts
+// dual-writing annotations alongside the legacy transaction_comments and
+// transaction_rule_applications tables; Phase 3 retires those tables in favor
+// of this single source of truth.
+type Annotation struct {
+	ID            string                 `json:"id"`
+	ShortID       string                 `json:"short_id"`
+	TransactionID string                 `json:"transaction_id"`
+	Kind          string                 `json:"kind"` // comment | rule_applied | tag_added | tag_removed | category_set
+	ActorType     string                 `json:"actor_type"`
+	ActorID       *string                `json:"actor_id,omitempty"`
+	ActorName     string                 `json:"actor_name"`
+	SessionID     *string                `json:"session_id,omitempty"`
+	Payload       map[string]interface{} `json:"payload,omitempty"`
+	TagID         *string                `json:"tag_id,omitempty"`
+	RuleID        *string                `json:"rule_id,omitempty"`
+	CreatedAt     string                 `json:"created_at"`
+}
+
+// writeAnnotationParams is the shared input for writing an annotation row via
+// either the pool-backed Queries or a transaction-scoped db.Queries (WithTx).
+type writeAnnotationParams struct {
+	TransactionID pgtype.UUID
+	Kind          string
+	ActorType     string
+	ActorID       string
+	ActorName     string
+	SessionID     pgtype.UUID
+	Payload       map[string]interface{}
+	TagID         pgtype.UUID
+	RuleID        pgtype.UUID
+}
+
+// writeAnnotation inserts an annotation row via the supplied db.Queries handle.
+// Passing a tx-scoped handle (from WithTx) keeps the write atomic with any
+// surrounding DB transaction. Failures are returned to the caller.
+func writeAnnotation(ctx context.Context, q *db.Queries, params writeAnnotationParams) error {
+	var payload []byte
+	if params.Payload != nil {
+		b, err := json.Marshal(params.Payload)
+		if err != nil {
+			return fmt.Errorf("marshal annotation payload: %w", err)
+		}
+		payload = b
+	} else {
+		payload = []byte(`{}`)
+	}
+
+	actorID := pgtype.Text{}
+	if params.ActorID != "" {
+		actorID = pgtype.Text{String: params.ActorID, Valid: true}
+	}
+
+	_, err := q.InsertAnnotation(ctx, db.InsertAnnotationParams{
+		TransactionID: params.TransactionID,
+		Kind:          params.Kind,
+		ActorType:     params.ActorType,
+		ActorID:       actorID,
+		ActorName:     params.ActorName,
+		SessionID:     params.SessionID,
+		Payload:       payload,
+		TagID:         params.TagID,
+		RuleID:        params.RuleID,
+	})
+	if err != nil {
+		return fmt.Errorf("insert annotation: %w", err)
+	}
+	return nil
+}
+
+// ListAnnotations returns all annotations for a transaction, ordered by
+// created_at ASC. Drives the transaction detail activity timeline.
+func (s *Service) ListAnnotations(ctx context.Context, transactionID string) ([]Annotation, error) {
+	txnID, err := s.resolveTransactionID(ctx, transactionID)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	rows, err := s.Queries.ListAnnotationsByTransaction(ctx, txnID)
+	if err != nil {
+		return nil, fmt.Errorf("list annotations: %w", err)
+	}
+
+	result := make([]Annotation, len(rows))
+	for i, r := range rows {
+		result[i] = annotationFromRow(r)
+	}
+	return result, nil
+}
+
+// annotationFromRow converts a db.Annotation into its service-layer response.
+func annotationFromRow(a db.Annotation) Annotation {
+	ann := Annotation{
+		ID:            formatUUID(a.ID),
+		ShortID:       a.ShortID,
+		TransactionID: formatUUID(a.TransactionID),
+		Kind:          a.Kind,
+		ActorType:     a.ActorType,
+		ActorID:       textPtr(a.ActorID),
+		ActorName:     a.ActorName,
+		CreatedAt:     a.CreatedAt.Time.UTC().Format(time.RFC3339),
+	}
+
+	if a.SessionID.Valid {
+		s := formatUUID(a.SessionID)
+		ann.SessionID = &s
+	}
+	if a.TagID.Valid {
+		s := formatUUID(a.TagID)
+		ann.TagID = &s
+	}
+	if a.RuleID.Valid {
+		s := formatUUID(a.RuleID)
+		ann.RuleID = &s
+	}
+
+	if len(a.Payload) > 0 && string(a.Payload) != "{}" {
+		var payload map[string]interface{}
+		if err := json.Unmarshal(a.Payload, &payload); err == nil {
+			ann.Payload = payload
+		}
+	}
+
+	return ann
+}

--- a/internal/service/comments.go
+++ b/internal/service/comments.go
@@ -14,7 +14,10 @@ import (
 
 const maxCommentLength = 10000
 
-// CreateComment adds a comment to a transaction.
+// CreateComment adds a comment to a transaction. Phase 2 dual-writes an
+// annotation row with kind='comment' in the same DB transaction so the
+// annotations table is the canonical timeline. transaction_comments is
+// retired in Phase 3 once every read-path is migrated.
 func (s *Service) CreateComment(ctx context.Context, params CreateCommentParams) (*CommentResponse, error) {
 	content := strings.TrimSpace(params.Content)
 	if content == "" || len(content) > maxCommentLength {
@@ -53,7 +56,14 @@ func (s *Service) CreateComment(ctx context.Context, params CreateCommentParams)
 		reviewID = parsed
 	}
 
-	comment, err := s.Queries.CreateComment(ctx, db.CreateCommentParams{
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin create_comment: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	comment, err := qtx.CreateComment(ctx, db.CreateCommentParams{
 		TransactionID: txnID,
 		AuthorType:    params.Actor.Type,
 		AuthorID:      authorID,
@@ -65,8 +75,50 @@ func (s *Service) CreateComment(ctx context.Context, params CreateCommentParams)
 		return nil, fmt.Errorf("create comment: %w", err)
 	}
 
+	// Annotation dual-write. actor_type maps user|agent|system; values outside
+	// the constraint set are forced to "user" to stay valid.
+	actorType := normalizeAnnotationActorType(params.Actor.Type)
+	payload := map[string]interface{}{
+		"content":    content,
+		"comment_id": comment.ShortID,
+	}
+	if params.ReviewID != "" {
+		payload["review_id"] = params.ReviewID
+	}
+	if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
+		TransactionID: txnID,
+		Kind:          "comment",
+		ActorType:     actorType,
+		ActorID:       params.Actor.ID,
+		ActorName:     params.Actor.Name,
+		Payload:       payload,
+	}); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit create_comment: %w", err)
+	}
+
 	resp := commentFromRow(comment)
 	return &resp, nil
+}
+
+// normalizeAnnotationActorType coerces a free-form actor type string into one
+// of the values the annotations.actor_type CHECK constraint accepts.
+func normalizeAnnotationActorType(t string) string {
+	switch t {
+	case "user", "agent", "system":
+		return t
+	case "rule":
+		// Rule-originated annotations have their own rule_id column — the
+		// actor_type still uses "system" in that case. Phase 2 sync path
+		// passes actor_type="system" directly; this branch catches any
+		// external caller that might pass "rule".
+		return "system"
+	default:
+		return "user"
+	}
 }
 
 // ListComments returns all comments for a transaction, ordered by created_at ASC.

--- a/internal/service/reviews.go
+++ b/internal/service/reviews.go
@@ -676,15 +676,59 @@ func (s *Service) SubmitReview(ctx context.Context, params SubmitReviewParams) (
 		if params.Actor.ID != "" {
 			authorID = pgtype.Text{String: params.Actor.ID, Valid: true}
 		}
-		if _, err := qtx.CreateComment(ctx, db.CreateCommentParams{
+		comment, err := qtx.CreateComment(ctx, db.CreateCommentParams{
 			TransactionID: existing.TransactionID,
 			AuthorType:    params.Actor.Type,
 			AuthorID:      authorID,
 			AuthorName:    params.Actor.Name,
 			Content:       trimmedNote,
 			ReviewID:      reviewID,
-		}); err != nil {
+		})
+		if err != nil {
 			return nil, fmt.Errorf("create review note comment: %w", err)
+		}
+
+		// Annotation dual-write for the review note.
+		notePayload := map[string]interface{}{
+			"content":    trimmedNote,
+			"comment_id": comment.ShortID,
+			"review_id":  formatUUID(reviewID),
+		}
+		if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
+			TransactionID: existing.TransactionID,
+			Kind:          "comment",
+			ActorType:     normalizeAnnotationActorType(params.Actor.Type),
+			ActorID:       params.Actor.ID,
+			ActorName:     params.Actor.Name,
+			Payload:       notePayload,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	// Annotation for the resolved category choice (only when approving + a
+	// category was resolved). The legacy transactions.category_override +
+	// SetTransactionCategory path fires outside this tx (see below), but the
+	// annotation belongs with the review decision for the timeline.
+	if params.Decision == "approved" && categoryToApply != nil {
+		catSlug := ""
+		if cat, err := s.GetCategory(ctx, *categoryToApply); err == nil {
+			catSlug = cat.Slug
+		}
+		payload := map[string]interface{}{
+			"category_slug": catSlug,
+			"source":        "review",
+			"review_id":     formatUUID(reviewID),
+		}
+		if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
+			TransactionID: existing.TransactionID,
+			Kind:          "category_set",
+			ActorType:     normalizeAnnotationActorType(params.Actor.Type),
+			ActorID:       params.Actor.ID,
+			ActorName:     params.Actor.Name,
+			Payload:       payload,
+		}); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -1057,15 +1057,25 @@ func (s *Service) ListActiveRulesForSync(ctx context.Context) ([]TransactionRule
 
 // transactionContextQuery is the base query for loading transactions with full context
 // (JOIN through accounts → bank_connections → users) for rule evaluation.
+//
+// Phase 2: aggregates tag slugs from transaction_tags so tag-based conditions
+// work during retroactive apply. GROUP BY t.id is required because of the
+// LEFT JOIN onto the tag pivot.
 const transactionContextQuery = `SELECT t.id, t.name, COALESCE(t.merchant_name, ''), t.amount,
 	COALESCE(t.category_primary, ''), COALESCE(t.category_detailed, ''),
-	t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, '')
+	t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, ''),
+	COALESCE(array_agg(DISTINCT tag.slug) FILTER (WHERE tag.slug IS NOT NULL), ARRAY[]::text[])
 	FROM transactions t
 	JOIN accounts a ON t.account_id = a.id
 	JOIN bank_connections bc ON a.connection_id = bc.id
 	LEFT JOIN users u ON bc.user_id = u.id
+	LEFT JOIN transaction_tags tt ON tt.transaction_id = t.id
+	LEFT JOIN tags tag ON tag.id = tt.tag_id
 	WHERE t.deleted_at IS NULL AND t.category_override = FALSE
 	AND (a.is_dependent_linked = FALSE OR NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id))`
+
+// transactionContextGroupBy is the GROUP BY clause matching transactionContextQuery.
+const transactionContextGroupBy = ` GROUP BY t.id, t.name, t.merchant_name, t.amount, t.category_primary, t.category_detailed, t.pending, bc.provider, t.account_id, u.id, u.name`
 
 // transactionContextRow holds a scanned transaction row for rule evaluation.
 type transactionContextRow struct {
@@ -1087,6 +1097,7 @@ func scanTransactionContextRow(dest []any) *transactionContextRow {
 	dest[8] = &r.tctx.AccountID
 	dest[9] = &r.tctx.UserID
 	dest[10] = &r.tctx.UserName
+	dest[11] = &r.tctx.Tags
 	return r
 }
 
@@ -1141,6 +1152,7 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 			args = append(args, lastID)
 			argN++
 		}
+		query += transactionContextGroupBy
 		query += " ORDER BY t.id ASC"
 		query += fmt.Sprintf(" LIMIT $%d", argN)
 		args = append(args, 1000)
@@ -1155,7 +1167,7 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 
 		for rows.Next() {
 			rowCount++
-			dest := make([]any, 11)
+			dest := make([]any, 12)
 			r := scanTransactionContextRow(dest)
 			if err := rows.Scan(dest...); err != nil {
 				rows.Close()
@@ -1278,6 +1290,7 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 			args = append(args, lastID)
 			argN++
 		}
+		query += transactionContextGroupBy
 		query += " ORDER BY t.id ASC"
 		query += fmt.Sprintf(" LIMIT $%d", argN)
 		args = append(args, 1000)
@@ -1300,7 +1313,7 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 
 		for rows.Next() {
 			rowCount++
-			dest := make([]any, 11)
+			dest := make([]any, 12)
 			r := scanTransactionContextRow(dest)
 			if err := rows.Scan(dest...); err != nil {
 				rows.Close()
@@ -1693,14 +1706,39 @@ func (s *Service) convertRuleRows(ctx context.Context, scanned []ruleRow) []Tran
 	return rules
 }
 
-// recordRuleApplications inserts rule application records for a batch of transactions.
+// recordRuleApplications inserts rule application records for a batch of
+// transactions. Phase 2 also dual-writes a matching rule_applied annotation
+// per transaction so the activity timeline (backed by annotations) stays
+// complete. transaction_rule_applications is retired in Phase 3.
 func (s *Service) recordRuleApplications(ctx context.Context, ruleID pgtype.UUID, txnIDs []pgtype.UUID, actionField, actionValue, appliedBy string) {
+	// Look up rule metadata for annotation actor fields.
+	var ruleShortID, ruleName string
+	_ = s.Pool.QueryRow(ctx, `SELECT short_id, name FROM transaction_rules WHERE id = $1`, ruleID).Scan(&ruleShortID, &ruleName)
+
 	for _, txnID := range txnIDs {
 		_, _ = s.Pool.Exec(ctx,
 			`INSERT INTO transaction_rule_applications (transaction_id, rule_id, action_field, action_value, applied_by)
 			VALUES ($1, $2, $3, $4, $5)
 			ON CONFLICT (transaction_id, rule_id, action_field) DO UPDATE SET applied_at = NOW(), action_value = EXCLUDED.action_value, applied_by = EXCLUDED.applied_by`,
 			txnID, ruleID, actionField, actionValue, appliedBy)
+
+		// rule_applied annotation.
+		payload := map[string]interface{}{
+			"rule_id":      ruleShortID,
+			"rule_name":    ruleName,
+			"action_field": actionField,
+			"action_value": actionValue,
+			"applied_by":   appliedBy,
+		}
+		_ = writeAnnotation(ctx, s.Queries, writeAnnotationParams{
+			TransactionID: txnID,
+			Kind:          "rule_applied",
+			ActorType:     "system",
+			ActorID:       ruleShortID,
+			ActorName:     ruleName,
+			Payload:       payload,
+			RuleID:        ruleID,
+		})
 	}
 }
 

--- a/internal/service/tags.go
+++ b/internal/service/tags.go
@@ -1,0 +1,314 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/shortid"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TagResponse is the API/MCP shape for a tag record.
+type TagResponse struct {
+	ID          string  `json:"id"`
+	ShortID     string  `json:"short_id"`
+	Slug        string  `json:"slug"`
+	DisplayName string  `json:"display_name"`
+	Description string  `json:"description"`
+	Color       *string `json:"color,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+	Lifecycle   string  `json:"lifecycle"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
+}
+
+// CreateTagParams holds parameters for creating a tag.
+type CreateTagParams struct {
+	Slug        string
+	DisplayName string
+	Description string
+	Color       *string
+	Icon        *string
+	Lifecycle   string // "persistent" (default) | "ephemeral"
+}
+
+// UpdateTagParams holds parameters for updating an existing tag.
+type UpdateTagParams struct {
+	DisplayName *string
+	Description *string
+	Color       *string
+	Icon        *string
+	Lifecycle   *string
+}
+
+// tagSlugRegex enforces the tag slug format: lowercase alphanumerics with
+// optional hyphens/colons between, e.g. "needs-review", "subscription:monthly".
+// A single-character slug matching [a-z0-9] is also accepted.
+var tagSlugRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9\-:]*[a-z0-9])?$`)
+
+// validateTagSlug reports an error if slug does not match the expected format.
+func validateTagSlug(slug string) error {
+	if !tagSlugRegex.MatchString(slug) {
+		return fmt.Errorf("%w: tag slug %q must match ^[a-z0-9][a-z0-9\\-:]*[a-z0-9]$ (lowercase alphanumerics with hyphens/colons)", ErrInvalidParameter, slug)
+	}
+	return nil
+}
+
+// validateLifecycle accepts "persistent" and "ephemeral".
+func validateLifecycle(lifecycle string) error {
+	if lifecycle != "persistent" && lifecycle != "ephemeral" {
+		return fmt.Errorf("%w: lifecycle must be 'persistent' or 'ephemeral'", ErrInvalidParameter)
+	}
+	return nil
+}
+
+// titleCaseSlug converts a slug ("needs-review") to a title-cased display name
+// ("Needs Review"). Used as the default display_name for auto-created tags.
+func titleCaseSlug(slug string) string {
+	parts := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == ':' || r == '_'
+	})
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+// CreateTag validates and inserts a new tag record. Slug regex:
+// ^[a-z0-9][a-z0-9\-:]*[a-z0-9]$. display_name must be non-empty. Lifecycle
+// defaults to "persistent".
+func (s *Service) CreateTag(ctx context.Context, params CreateTagParams) (*TagResponse, error) {
+	if err := validateTagSlug(params.Slug); err != nil {
+		return nil, err
+	}
+	displayName := strings.TrimSpace(params.DisplayName)
+	if displayName == "" {
+		return nil, fmt.Errorf("%w: display_name is required", ErrInvalidParameter)
+	}
+	lifecycle := params.Lifecycle
+	if lifecycle == "" {
+		lifecycle = "persistent"
+	}
+	if err := validateLifecycle(lifecycle); err != nil {
+		return nil, err
+	}
+
+	color := pgtype.Text{}
+	if params.Color != nil {
+		color = pgtype.Text{String: *params.Color, Valid: true}
+	}
+	icon := pgtype.Text{}
+	if params.Icon != nil {
+		icon = pgtype.Text{String: *params.Icon, Valid: true}
+	}
+
+	tag, err := s.Queries.InsertTag(ctx, db.InsertTagParams{
+		Slug:        params.Slug,
+		DisplayName: displayName,
+		Description: params.Description,
+		Color:       color,
+		Icon:        icon,
+		Lifecycle:   lifecycle,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("insert tag: %w", err)
+	}
+
+	resp := tagFromRow(tag)
+	return &resp, nil
+}
+
+// GetTag returns a single tag by UUID, short ID, or slug.
+func (s *Service) GetTag(ctx context.Context, idOrSlug string) (*TagResponse, error) {
+	// Short ID lookup first
+	if shortid.IsShortID(idOrSlug) {
+		uid, err := s.Queries.GetTagUUIDByShortID(ctx, idOrSlug)
+		if err != nil {
+			return nil, ErrNotFound
+		}
+		tag, err := s.Queries.GetTagByID(ctx, uid)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, ErrNotFound
+			}
+			return nil, fmt.Errorf("get tag: %w", err)
+		}
+		resp := tagFromRow(tag)
+		return &resp, nil
+	}
+
+	// Try UUID
+	if uid, err := parseUUID(idOrSlug); err == nil {
+		tag, err := s.Queries.GetTagByID(ctx, uid)
+		if err == nil {
+			resp := tagFromRow(tag)
+			return &resp, nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return nil, fmt.Errorf("get tag: %w", err)
+		}
+		// Fall through — maybe the string looked UUID-ish but is actually a slug
+	}
+
+	// Fall back to slug
+	tag, err := s.Queries.GetTagBySlug(ctx, idOrSlug)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get tag by slug: %w", err)
+	}
+	resp := tagFromRow(tag)
+	return &resp, nil
+}
+
+// ListTags returns all tags, ordered by display_name.
+func (s *Service) ListTags(ctx context.Context) ([]TagResponse, error) {
+	rows, err := s.Queries.ListTags(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list tags: %w", err)
+	}
+	result := make([]TagResponse, len(rows))
+	for i, r := range rows {
+		result[i] = tagFromRow(r)
+	}
+	return result, nil
+}
+
+// UpdateTag updates mutable fields on a tag. Slug is immutable.
+func (s *Service) UpdateTag(ctx context.Context, id string, params UpdateTagParams) (*TagResponse, error) {
+	existing, err := s.GetTag(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	displayName := existing.DisplayName
+	if params.DisplayName != nil {
+		trimmed := strings.TrimSpace(*params.DisplayName)
+		if trimmed == "" {
+			return nil, fmt.Errorf("%w: display_name cannot be empty", ErrInvalidParameter)
+		}
+		displayName = trimmed
+	}
+
+	description := existing.Description
+	if params.Description != nil {
+		description = *params.Description
+	}
+
+	color := pgtype.Text{}
+	if existing.Color != nil {
+		color = pgtype.Text{String: *existing.Color, Valid: true}
+	}
+	if params.Color != nil {
+		color = pgtype.Text{String: *params.Color, Valid: *params.Color != ""}
+	}
+
+	icon := pgtype.Text{}
+	if existing.Icon != nil {
+		icon = pgtype.Text{String: *existing.Icon, Valid: true}
+	}
+	if params.Icon != nil {
+		icon = pgtype.Text{String: *params.Icon, Valid: *params.Icon != ""}
+	}
+
+	lifecycle := existing.Lifecycle
+	if params.Lifecycle != nil {
+		if err := validateLifecycle(*params.Lifecycle); err != nil {
+			return nil, err
+		}
+		lifecycle = *params.Lifecycle
+	}
+
+	existingUID, _ := parseUUID(existing.ID)
+	tag, err := s.Queries.UpdateTag(ctx, db.UpdateTagParams{
+		ID:          existingUID,
+		DisplayName: displayName,
+		Description: description,
+		Color:       color,
+		Icon:        icon,
+		Lifecycle:   lifecycle,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update tag: %w", err)
+	}
+	resp := tagFromRow(tag)
+	return &resp, nil
+}
+
+// DeleteTag removes a tag and cascades to transaction_tags rows via FK.
+// Annotations that reference the tag retain tag_id=NULL (ON DELETE SET NULL).
+func (s *Service) DeleteTag(ctx context.Context, id string) error {
+	existing, err := s.GetTag(ctx, id)
+	if err != nil {
+		return err
+	}
+	uid, err := parseUUID(existing.ID)
+	if err != nil {
+		return ErrNotFound
+	}
+	rows, err := s.Queries.DeleteTag(ctx, uid)
+	if err != nil {
+		return fmt.Errorf("delete tag: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// getOrCreateTagBySlug returns the UUID+row of the tag with the given slug.
+// If the tag doesn't exist, it's auto-created with lifecycle=persistent and
+// display_name=title-cased slug. Safe to call from inside a DB tx — the passed
+// db.Queries handle is used for lookup + insert.
+func (s *Service) getOrCreateTagBySlug(ctx context.Context, q *db.Queries, slug string) (db.Tag, error) {
+	if err := validateTagSlug(slug); err != nil {
+		return db.Tag{}, err
+	}
+	tag, err := q.GetTagBySlug(ctx, slug)
+	if err == nil {
+		return tag, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return db.Tag{}, fmt.Errorf("get tag by slug: %w", err)
+	}
+	// Auto-create
+	created, err := q.InsertTag(ctx, db.InsertTagParams{
+		Slug:        slug,
+		DisplayName: titleCaseSlug(slug),
+		Lifecycle:   "persistent",
+	})
+	if err != nil {
+		return db.Tag{}, fmt.Errorf("auto-create tag %q: %w", slug, err)
+	}
+	return created, nil
+}
+
+// tagFromRow converts a db.Tag to a TagResponse.
+func tagFromRow(t db.Tag) TagResponse {
+	return TagResponse{
+		ID:          formatUUID(t.ID),
+		ShortID:     t.ShortID,
+		Slug:        t.Slug,
+		DisplayName: t.DisplayName,
+		Description: t.Description,
+		Color:       textPtr(t.Color),
+		Icon:        textPtr(t.Icon),
+		Lifecycle:   t.Lifecycle,
+		CreatedAt:   t.CreatedAt.Time.UTC().Format(time.RFC3339),
+		UpdatedAt:   t.UpdatedAt.Time.UTC().Format(time.RFC3339),
+	}
+}

--- a/internal/service/tags_integration_test.go
+++ b/internal/service/tags_integration_test.go
@@ -1,0 +1,245 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// TestCreateTag_SlugValidation exercises the slug regex against good + bad inputs.
+func TestCreateTag_SlugValidation(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+
+	good := []string{"needs-review", "subscription:monthly", "a", "a1", "work:2026"}
+	for _, slug := range good {
+		_, err := svc.CreateTag(ctx, service.CreateTagParams{
+			Slug:        slug,
+			DisplayName: "Test",
+		})
+		if err != nil {
+			t.Errorf("expected slug %q to be valid, got error: %v", slug, err)
+		}
+	}
+
+	bad := []string{"", "Upper", "bad space", "-leading", "trailing-", "::double"}
+	for _, slug := range bad {
+		_, err := svc.CreateTag(ctx, service.CreateTagParams{
+			Slug:        slug,
+			DisplayName: "Test",
+		})
+		if err == nil {
+			t.Errorf("expected slug %q to be rejected", slug)
+		}
+	}
+}
+
+// TestCreateTag_DefaultsLifecycle verifies lifecycle defaults to "persistent".
+func TestCreateTag_DefaultsLifecycle(t *testing.T) {
+	svc, _, _ := newService(t)
+	ctx := context.Background()
+	tag, err := svc.CreateTag(ctx, service.CreateTagParams{
+		Slug:        "work",
+		DisplayName: "Work",
+	})
+	if err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+	if tag.Lifecycle != "persistent" {
+		t.Errorf("expected lifecycle=persistent, got %q", tag.Lifecycle)
+	}
+}
+
+// TestAddTransactionTag_AutoCreatesTag verifies that adding a tag whose slug
+// doesn't exist creates it as persistent with a title-cased display name.
+func TestAddTransactionTag_AutoCreatesTag(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn1", "Coffee", 500, "2026-03-01")
+
+	// Slug does not exist yet.
+	if _, err := queries.GetTagBySlug(ctx, "vacation-2026"); err == nil {
+		t.Fatalf("precondition: expected vacation-2026 tag not to exist")
+	}
+
+	added, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "vacation-2026", service.Actor{Type: "user", ID: "u1", Name: "Alice"}, "")
+	if err != nil {
+		t.Fatalf("AddTransactionTag: %v", err)
+	}
+	if !added {
+		t.Fatal("expected added=true")
+	}
+	// Tag should now exist.
+	tag, err := queries.GetTagBySlug(ctx, "vacation-2026")
+	if err != nil {
+		t.Fatalf("tag was not created: %v", err)
+	}
+	if tag.Lifecycle != "persistent" {
+		t.Errorf("expected persistent lifecycle, got %q", tag.Lifecycle)
+	}
+	if tag.DisplayName != "Vacation 2026" {
+		t.Errorf("expected display name 'Vacation 2026', got %q", tag.DisplayName)
+	}
+}
+
+// TestAddTransactionTag_WritesAnnotation verifies tag_added annotation is written.
+func TestAddTransactionTag_WritesAnnotation(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn2", "Coffee", 500, "2026-03-01")
+
+	_, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "agent", ID: "agent-1", Name: "ReviewBot"}, "")
+	if err != nil {
+		t.Fatalf("AddTransactionTag: %v", err)
+	}
+
+	n := testutil.MustCountAnnotations(t, queries, txn.ID, "tag_added")
+	if n != 1 {
+		t.Errorf("expected 1 tag_added annotation, got %d", n)
+	}
+
+	// Idempotent second add: no new annotation.
+	_, alreadyPresent, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "agent", ID: "agent-1", Name: "ReviewBot"}, "")
+	if err != nil {
+		t.Fatalf("second AddTransactionTag: %v", err)
+	}
+	if !alreadyPresent {
+		t.Error("expected alreadyPresent=true on second add")
+	}
+	n = testutil.MustCountAnnotations(t, queries, txn.ID, "tag_added")
+	if n != 1 {
+		t.Errorf("expected annotation count unchanged at 1 after idempotent add, got %d", n)
+	}
+}
+
+// TestRemoveTransactionTag_EphemeralRequiresNote verifies that removing a
+// tag whose lifecycle is ephemeral requires a non-empty note.
+func TestRemoveTransactionTag_EphemeralRequiresNote(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn3", "Coffee", 500, "2026-03-01")
+
+	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review", "ephemeral")
+
+	// First add the tag.
+	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", Name: "A"}, ""); err != nil {
+		t.Fatalf("AddTransactionTag: %v", err)
+	}
+
+	// Remove without note → error.
+	_, _, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", Name: "A"}, "")
+	if err == nil {
+		t.Fatal("expected error when removing ephemeral tag without note")
+	}
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "note is required") {
+		t.Errorf("expected error to mention 'note is required', got: %v", err)
+	}
+
+	// With note → succeeds.
+	removed, _, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", Name: "A"}, "reviewed")
+	if err != nil {
+		t.Fatalf("RemoveTransactionTag with note: %v", err)
+	}
+	if !removed {
+		t.Error("expected removed=true")
+	}
+
+	n := testutil.MustCountAnnotations(t, queries, txn.ID, "tag_removed")
+	if n != 1 {
+		t.Errorf("expected 1 tag_removed annotation, got %d", n)
+	}
+}
+
+// TestRemoveTransactionTag_NonEphemeralAcceptsEmptyNote verifies that
+// persistent tags can be removed without a note.
+func TestRemoveTransactionTag_NonEphemeralAcceptsEmptyNote(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn4", "Coffee", 500, "2026-03-01")
+
+	testutil.MustCreateTag(t, queries, "watchlist", "Watch", "persistent")
+
+	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "watchlist", service.Actor{Type: "user", Name: "A"}, ""); err != nil {
+		t.Fatalf("AddTransactionTag: %v", err)
+	}
+	removed, _, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "watchlist", service.Actor{Type: "user", Name: "A"}, "")
+	if err != nil {
+		t.Fatalf("RemoveTransactionTag: %v", err)
+	}
+	if !removed {
+		t.Error("expected removed=true")
+	}
+}
+
+// TestRemoveTransactionTag_AlreadyAbsent_NoError verifies removing a tag
+// that is not attached returns alreadyAbsent=true with no error.
+func TestRemoveTransactionTag_AlreadyAbsent_NoError(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn5", "Coffee", 500, "2026-03-01")
+
+	testutil.MustCreateTag(t, queries, "unused", "Unused", "persistent")
+
+	removed, alreadyAbsent, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "unused", service.Actor{Type: "user", Name: "A"}, "")
+	if err != nil {
+		t.Fatalf("RemoveTransactionTag: %v", err)
+	}
+	if removed {
+		t.Error("expected removed=false")
+	}
+	if !alreadyAbsent {
+		t.Error("expected alreadyAbsent=true")
+	}
+
+	// Also: slug that doesn't even exist at all returns alreadyAbsent.
+	removed, alreadyAbsent, err = svc.RemoveTransactionTag(ctx, txn.ShortID, "nonexistent", service.Actor{Type: "user", Name: "A"}, "")
+	if err != nil {
+		t.Fatalf("RemoveTransactionTag nonexistent: %v", err)
+	}
+	if removed || !alreadyAbsent {
+		t.Errorf("expected removed=false alreadyAbsent=true for nonexistent slug, got removed=%v alreadyAbsent=%v", removed, alreadyAbsent)
+	}
+}
+
+// TestListTransactionTags returns tags with provenance.
+func TestListTransactionTags(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn6", "Coffee", 500, "2026-03-01")
+
+	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", ID: "u1", Name: "Alice"}, ""); err != nil {
+		t.Fatalf("AddTransactionTag: %v", err)
+	}
+
+	tags, err := svc.ListTransactionTags(ctx, txn.ShortID)
+	if err != nil {
+		t.Fatalf("ListTransactionTags: %v", err)
+	}
+	if len(tags) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(tags))
+	}
+	if tags[0].Slug != "needs-review" {
+		t.Errorf("expected slug=needs-review, got %q", tags[0].Slug)
+	}
+	if tags[0].AddedByType != "user" {
+		t.Errorf("expected AddedByType=user, got %q", tags[0].AddedByType)
+	}
+	if tags[0].AddedByName != "Alice" {
+		t.Errorf("expected AddedByName=Alice, got %q", tags[0].AddedByName)
+	}
+}

--- a/internal/service/transaction_tags.go
+++ b/internal/service/transaction_tags.go
@@ -1,0 +1,258 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// TransactionTagResponse is the enriched per-transaction tag entry returned to
+// API/MCP consumers. Includes the tag's slug + lifecycle plus provenance info.
+type TransactionTagResponse struct {
+	Slug        string  `json:"slug"`
+	DisplayName string  `json:"display_name"`
+	Color       *string `json:"color,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+	Lifecycle   string  `json:"lifecycle"`
+	AddedAt     string  `json:"added_at"`
+	AddedByType string  `json:"added_by_type"`
+	AddedByName string  `json:"added_by_name"`
+}
+
+// AddTransactionTag applies a tag to a transaction. If the slug doesn't exist,
+// it is auto-created as a persistent tag. Writes an `tag_added` annotation in
+// the same DB transaction.
+//
+// Return values:
+//   - added:          true when a new (transaction, tag) pair was created.
+//   - alreadyPresent: true when the pair already existed (no-op, no annotation
+//     written).
+func (s *Service) AddTransactionTag(ctx context.Context, txnID, slug string, actor Actor, note string) (added bool, alreadyPresent bool, _ error) {
+	txnUUID, err := s.resolveTransactionID(ctx, txnID)
+	if err != nil {
+		return false, false, ErrNotFound
+	}
+	if err := validateTagSlug(slug); err != nil {
+		return false, false, err
+	}
+	if actor.Type == "" {
+		actor = SystemActor()
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return false, false, fmt.Errorf("begin add_transaction_tag: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	// Resolve or auto-create the tag.
+	tag, err := s.getOrCreateTagBySlug(ctx, qtx, slug)
+	if err != nil {
+		return false, false, err
+	}
+
+	addedByType := actor.Type
+	if addedByType == "system" || addedByType == "" {
+		addedByType = "system"
+	}
+	var addedByID pgtype.Text
+	if actor.ID != "" {
+		addedByID = pgtype.Text{String: actor.ID, Valid: true}
+	}
+
+	rows, err := qtx.AddTransactionTag(ctx, db.AddTransactionTagParams{
+		TransactionID: txnUUID,
+		TagID:         tag.ID,
+		AddedByType:   addedByType,
+		AddedByID:     addedByID,
+		AddedByName:   actor.Name,
+	})
+	if err != nil {
+		return false, false, fmt.Errorf("add transaction tag: %w", err)
+	}
+
+	if rows == 0 {
+		// Already present. No annotation written.
+		if err := tx.Commit(ctx); err != nil {
+			return false, true, fmt.Errorf("commit add_transaction_tag: %w", err)
+		}
+		return false, true, nil
+	}
+
+	// Write annotation for the audit trail.
+	payload := map[string]interface{}{"slug": slug}
+	if note != "" {
+		payload["note"] = note
+	}
+	actorType := actor.Type
+	if actorType == "rule" {
+		// Annotations carry a constrained actor_type set; map "rule" onto
+		// "system" so check constraints pass. The tag row still records
+		// added_by_type="rule" for its own provenance.
+		actorType = "system"
+	}
+	if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
+		TransactionID: txnUUID,
+		Kind:          "tag_added",
+		ActorType:     actorType,
+		ActorID:       actor.ID,
+		ActorName:     actor.Name,
+		Payload:       payload,
+		TagID:         tag.ID,
+	}); err != nil {
+		return false, false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return false, false, fmt.Errorf("commit add_transaction_tag: %w", err)
+	}
+	return true, false, nil
+}
+
+// RemoveTransactionTag removes a tag from a transaction. For tags whose
+// lifecycle is "ephemeral", a non-empty note is required. Returns:
+//   - removed:      true when the (transaction, tag) pair was deleted.
+//   - alreadyAbsent: true when the pair wasn't present (no-op, no error).
+func (s *Service) RemoveTransactionTag(ctx context.Context, txnID, slug string, actor Actor, note string) (removed bool, alreadyAbsent bool, _ error) {
+	txnUUID, err := s.resolveTransactionID(ctx, txnID)
+	if err != nil {
+		return false, false, ErrNotFound
+	}
+	if err := validateTagSlug(slug); err != nil {
+		return false, false, err
+	}
+	if actor.Type == "" {
+		actor = SystemActor()
+	}
+
+	// Fetch the tag first — we need lifecycle to enforce the note-required rule.
+	tag, err := s.Queries.GetTagBySlug(ctx, slug)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, true, nil
+		}
+		return false, false, fmt.Errorf("get tag by slug: %w", err)
+	}
+
+	trimmedNote := strings.TrimSpace(note)
+	if tag.Lifecycle == "ephemeral" && trimmedNote == "" {
+		return false, false, fmt.Errorf("%w: note is required when removing ephemeral tag %q", ErrInvalidParameter, slug)
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return false, false, fmt.Errorf("begin remove_transaction_tag: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	rows, err := qtx.RemoveTransactionTag(ctx, db.RemoveTransactionTagParams{
+		TransactionID: txnUUID,
+		TagID:         tag.ID,
+	})
+	if err != nil {
+		return false, false, fmt.Errorf("remove transaction tag: %w", err)
+	}
+
+	if rows == 0 {
+		if err := tx.Commit(ctx); err != nil {
+			return false, true, fmt.Errorf("commit remove_transaction_tag: %w", err)
+		}
+		return false, true, nil
+	}
+
+	payload := map[string]interface{}{"slug": slug}
+	if trimmedNote != "" {
+		payload["note"] = trimmedNote
+	}
+	actorType := actor.Type
+	if actorType == "rule" {
+		actorType = "system"
+	}
+	if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
+		TransactionID: txnUUID,
+		Kind:          "tag_removed",
+		ActorType:     actorType,
+		ActorID:       actor.ID,
+		ActorName:     actor.Name,
+		Payload:       payload,
+		TagID:         tag.ID,
+	}); err != nil {
+		return false, false, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return false, false, fmt.Errorf("commit remove_transaction_tag: %w", err)
+	}
+	return true, false, nil
+}
+
+// ListTransactionTags returns all tags currently attached to a transaction,
+// enriched with the most-recent added_by provenance for each.
+func (s *Service) ListTransactionTags(ctx context.Context, txnID string) ([]TransactionTagResponse, error) {
+	txnUUID, err := s.resolveTransactionID(ctx, txnID)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	// ListTagsByTransaction returns the joined tag rows ordered by added_at ASC.
+	// We also need the added_by_* provenance from transaction_tags; a small
+	// dynamic query covers both in a single round-trip.
+	rows, err := s.Pool.Query(ctx, `
+		SELECT t.slug, t.display_name, t.color, t.icon, t.lifecycle,
+		       tt.added_at, tt.added_by_type, tt.added_by_name
+		FROM tags t
+		JOIN transaction_tags tt ON tt.tag_id = t.id
+		WHERE tt.transaction_id = $1
+		ORDER BY tt.added_at ASC`, txnUUID)
+	if err != nil {
+		return nil, fmt.Errorf("list transaction tags: %w", err)
+	}
+	defer rows.Close()
+
+	var result []TransactionTagResponse
+	for rows.Next() {
+		var slug, displayName, lifecycle, addedByType, addedByName string
+		var color, icon pgtype.Text
+		var addedAt pgtype.Timestamptz
+		if err := rows.Scan(&slug, &displayName, &color, &icon, &lifecycle, &addedAt, &addedByType, &addedByName); err != nil {
+			return nil, fmt.Errorf("scan transaction tag: %w", err)
+		}
+		result = append(result, TransactionTagResponse{
+			Slug:        slug,
+			DisplayName: displayName,
+			Color:       textPtr(color),
+			Icon:        textPtr(icon),
+			Lifecycle:   lifecycle,
+			AddedAt:     addedAt.Time.UTC().Format(time.RFC3339),
+			AddedByType: addedByType,
+			AddedByName: addedByName,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate transaction tags: %w", err)
+	}
+	return result, nil
+}
+
+// ListTagSlugsForTransaction returns just the slugs of the tags currently on
+// the transaction. Lighter than ListTransactionTags for places that only need
+// the slug list (e.g. attaching to a transaction response).
+func (s *Service) ListTagSlugsForTransaction(ctx context.Context, txnID pgtype.UUID) ([]string, error) {
+	slugs, err := s.Queries.ListTagSlugsByTransaction(ctx, txnID)
+	if err != nil {
+		return nil, fmt.Errorf("list tag slugs: %w", err)
+	}
+	if slugs == nil {
+		return []string{}, nil
+	}
+	return slugs, nil
+}

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -157,6 +157,27 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		argN = ec.ArgN
 	}
 
+	// Tag filters (Phase 2). Tags is AND semantics (transaction has every
+	// slug), AnyTag is OR (transaction has at least one).
+	if len(params.Tags) > 0 {
+		// For each tag in Tags, require an EXISTS — this is tractable because
+		// common usage is 1-2 tags per filter.
+		for _, slug := range params.Tags {
+			buf.WriteString(" AND EXISTS (SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = $")
+			buf.WriteString(strconv.Itoa(argN))
+			buf.WriteByte(')')
+			args = append(args, slug)
+			argN++
+		}
+	}
+	if len(params.AnyTag) > 0 {
+		buf.WriteString(" AND EXISTS (SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = ANY($")
+		buf.WriteString(strconv.Itoa(argN))
+		buf.WriteString("))")
+		args = append(args, params.AnyTag)
+		argN++
+	}
+
 	if params.Cursor != "" {
 		cursorDate, cursorID, err := DecodeCursor(params.Cursor)
 		if err != nil {
@@ -334,6 +355,12 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		transactions = transactions[:limit]
 	}
 
+	// Attach tags in one extra round-trip for the full result page. Uses ANY()
+	// so it's a single query regardless of page size.
+	if err := s.attachTagsToTransactions(ctx, transactions); err != nil {
+		s.Logger.Warn("attach tags to transactions", "error", err)
+	}
+
 	var nextCursor string
 	isDefaultSort := params.SortBy == nil || *params.SortBy == "date"
 	if hasMore && len(transactions) > 0 && isDefaultSort {
@@ -348,6 +375,49 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		HasMore:      hasMore,
 		Limit:        limit,
 	}, nil
+}
+
+// attachTagsToTransactions fills in the Tags field on each TransactionResponse
+// in-place using a single ANY() query.
+func (s *Service) attachTagsToTransactions(ctx context.Context, txns []TransactionResponse) error {
+	if len(txns) == 0 {
+		return nil
+	}
+	ids := make([]pgtype.UUID, 0, len(txns))
+	idx := make(map[string]int, len(txns))
+	for i, t := range txns {
+		uid, err := parseUUID(t.ID)
+		if err != nil {
+			continue
+		}
+		ids = append(ids, uid)
+		idx[t.ID] = i
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	rows, err := s.Pool.Query(ctx, `
+		SELECT tt.transaction_id, tag.slug
+		FROM transaction_tags tt
+		JOIN tags tag ON tag.id = tt.tag_id
+		WHERE tt.transaction_id = ANY($1)
+		ORDER BY tt.added_at ASC`, ids)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var txnID pgtype.UUID
+		var slug string
+		if err := rows.Scan(&txnID, &slug); err != nil {
+			return err
+		}
+		key := formatUUID(txnID)
+		if i, ok := idx[key]; ok {
+			txns[i].Tags = append(txns[i].Tags, slug)
+		}
+	}
+	return rows.Err()
 }
 
 func (s *Service) CountTransactions(ctx context.Context) (int64, error) {
@@ -480,6 +550,24 @@ func (s *Service) CountTransactionsFiltered(ctx context.Context, params Transact
 		buf.WriteString(ec.SQL)
 		args = append(args, ec.Args...)
 		argN = ec.ArgN
+	}
+
+	// Tag filters (Phase 2).
+	if len(params.Tags) > 0 {
+		for _, slug := range params.Tags {
+			buf.WriteString(" AND EXISTS (SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = $")
+			buf.WriteString(strconv.Itoa(argN))
+			buf.WriteByte(')')
+			args = append(args, slug)
+			argN++
+		}
+	}
+	if len(params.AnyTag) > 0 {
+		buf.WriteString(" AND EXISTS (SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = ANY($")
+		buf.WriteString(strconv.Itoa(argN))
+		buf.WriteString("))")
+		args = append(args, params.AnyTag)
+		argN++
 	}
 
 	_ = argN // keep for consistency

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -60,6 +60,11 @@ type TransactionResponse struct {
 	Pending             bool                     `json:"pending"`
 	CreatedAt           string                   `json:"created_at"`
 	UpdatedAt           string                   `json:"updated_at"`
+
+	// Tags attached to this transaction (slug list). Empty slice when none are
+	// attached. Populated by ListTransactions / GetTransaction when the Phase 2
+	// tags subsystem is active.
+	Tags []string `json:"tags,omitempty"`
 }
 
 type TransactionListResult struct {
@@ -86,6 +91,10 @@ type TransactionListParams struct {
 	SortBy           *string
 	SortOrder        *string
 	IncludeDependent bool
+	// Tags (AND) — transaction must have EVERY tag in this list.
+	Tags []string
+	// AnyTag (OR) — transaction must have AT LEAST ONE tag in this list.
+	AnyTag []string
 }
 
 type TransactionCountParams struct {
@@ -101,6 +110,8 @@ type TransactionCountParams struct {
 	SearchMode       *string
 	ExcludeSearch    *string
 	IncludeDependent bool
+	Tags             []string
+	AnyTag           []string
 }
 
 type CategoryPair struct {
@@ -444,7 +455,7 @@ type RuleAction struct {
 
 // ActivityEntry represents a single event in a transaction's activity timeline.
 type ActivityEntry struct {
-	Type      string `json:"type"`      // "review", "comment", "rule"
+	Type      string `json:"type"`      // "review", "comment", "rule", "tag", "category"
 	Timestamp string `json:"timestamp"` // RFC3339
 
 	ActorName string  `json:"actor_name"`
@@ -460,6 +471,7 @@ type ActivityEntry struct {
 	RuleName     string `json:"rule_name,omitempty"`
 	RuleID       string `json:"rule_id,omitempty"`
 	CommentID    string `json:"comment_id,omitempty"`
+	TagSlug      string `json:"tag_slug,omitempty"` // for tag_added / tag_removed entries
 }
 
 type Condition struct {

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -18,6 +19,12 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// jsonMarshalMap marshals a map[string]any into JSON bytes. Tiny wrapper to
+// keep callers concise.
+func jsonMarshalMap(m map[string]any) ([]byte, error) {
+	return json.Marshal(m)
+}
+
 // accountSyncCounts tracks per-account transaction counts during a sync.
 type accountSyncCounts struct {
 	AccountID   pgtype.UUID
@@ -29,10 +36,13 @@ type accountSyncCounts struct {
 }
 
 // pendingApplication holds a deferred rule application record to be batch-inserted
-// after the transaction processing loops complete.
+// after the transaction processing loops complete. Phase 2 also uses this to
+// drive the matching `rule_applied` annotation row (dual-write bridge).
 type pendingApplication struct {
 	txnID       pgtype.UUID
 	ruleID      pgtype.UUID
+	ruleShortID string
+	ruleName    string
 	actionField string
 	actionValue string
 }
@@ -355,7 +365,9 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 			ruleApplications = append(ruleApplications, result.ruleApplications...)
 		}
 
-		// Batch-insert rule application records.
+		// Batch-insert rule application records, and dual-write the matching
+		// rule_applied annotation (Phase 2 bridge — transaction_rule_applications
+		// is retired in Phase 3).
 		for _, app := range ruleApplications {
 			if _, err := tx.Exec(ctx,
 				`INSERT INTO transaction_rule_applications (transaction_id, rule_id, action_field, action_value, applied_by)
@@ -365,6 +377,28 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				WHERE transaction_rule_applications.action_value IS DISTINCT FROM EXCLUDED.action_value`,
 				app.txnID, app.ruleID, app.actionField, app.actionValue); err != nil {
 				logger.Error("insert rule application", "transaction_id", app.txnID, "rule_id", app.ruleID, "error", err)
+				continue
+			}
+			// rule_applied annotation. actor_type="system" (annotations constrain
+			// actor_type to user|agent|system — rule_id in the dedicated column
+			// carries the rule back-reference).
+			payload := map[string]any{
+				"rule_id":      app.ruleShortID,
+				"rule_name":    app.ruleName,
+				"action_field": app.actionField,
+				"action_value": app.actionValue,
+				"applied_by":   "sync",
+			}
+			if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
+				TransactionID: app.txnID,
+				Kind:          "rule_applied",
+				ActorType:     "system",
+				ActorID:       app.ruleShortID,
+				ActorName:     app.ruleName,
+				Payload:       payload,
+				RuleID:        app.ruleID,
+			}); err != nil {
+				logger.Error("insert rule_applied annotation", "transaction_id", app.txnID, "rule_id", app.ruleID, "error", err)
 			}
 		}
 
@@ -511,7 +545,12 @@ func (e *Engine) processTransaction(ctx context.Context, txn *provider.Transacti
 		}
 		for _, src := range sources {
 			result.ruleApplications = append(result.ruleApplications, pendingApplication{
-				txnID: dbTxn.ID, ruleID: src.RuleID, actionField: src.ActionField, actionValue: src.ActionValue,
+				txnID:       dbTxn.ID,
+				ruleID:      src.RuleID,
+				ruleShortID: src.RuleShortID,
+				ruleName:    src.RuleName,
+				actionField: src.ActionField,
+				actionValue: src.ActionValue,
 			})
 		}
 	}
@@ -558,14 +597,17 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 	return q.UpsertTransaction(ctx, params)
 }
 
-// applyRulesToTransaction evaluates rules against a transaction and updates the
-// category if a rule matches. Called only for new or changed transactions.
+// applyRulesToTransaction evaluates rules against a transaction and applies
+// their actions. Called only for new or changed transactions.
 //
 // isNew is threaded through to ResolveWithContext so trigger filtering
-// (on_create / on_update / always) decides which rules fire. Only set_category
-// actions materialize to the transactions table in Phase 1; add_tag and
-// add_comment actions are captured in Sources (for audit) but their
-// persistence to transaction_tags / transaction_comments lands in Phase 2.
+// (on_create / on_update / always) decides which rules fire.
+//
+// Phase 2: set_category, add_tag, and add_comment actions all persist to the
+// transactions / transaction_tags / transaction_comments tables inside the
+// sync tx. Each persistent change writes an accompanying annotation row so the
+// activity timeline (backed by annotations) captures every effect.
+// transaction_comments + transaction_rule_applications are retired in Phase 3.
 func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *provider.Transaction, dbTxn db.Transaction, cache map[string]pgtype.UUID, providerName string, resolver *RuleResolver, userID pgtype.UUID, userName string, isNew bool) ([]RuleActionSource, error) {
 	if resolver == nil {
 		return nil, nil
@@ -591,9 +633,34 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 		tctx.CategoryDetailed = *txn.CategoryDetailed
 	}
 
+	// For changed transactions, load the current tag slugs so tag-based
+	// conditions can match. New transactions start with empty tags (any tags
+	// added by this sync pass are not visible to other rules in the same call).
+	if !isNew {
+		if slugs, err := e.loadTagSlugsInTx(ctx, tx, dbTxn.ID); err == nil {
+			tctx.Tags = slugs
+		}
+	}
+
 	result := resolver.ResolveWithContext(providerName, tctx, isNew)
 	if result == nil {
 		return nil, nil
+	}
+
+	// Build quick lookup of Source rule-metadata by (field, value) so the tag /
+	// comment / category persistence below can attach the right rule_id, name,
+	// and short_id to each annotation.
+	type ruleRef struct {
+		ruleID      pgtype.UUID
+		ruleShortID string
+		ruleName    string
+	}
+	sourceByKey := make(map[string]ruleRef, len(result.Sources))
+	for _, src := range result.Sources {
+		key := src.ActionField + "|" + src.ActionValue
+		if _, exists := sourceByKey[key]; !exists {
+			sourceByKey[key] = ruleRef{src.RuleID, src.RuleShortID, src.RuleName}
+		}
 	}
 
 	// set_category: write category_id when a rule matched and the transaction
@@ -607,14 +674,242 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 			if err != nil {
 				return result.Sources, fmt.Errorf("apply rule category: %w", err)
 			}
+
+			src := sourceByKey["category|"+result.CategorySlug]
+			if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
+				TransactionID: dbTxn.ID,
+				Kind:          "category_set",
+				ActorType:     "system",
+				ActorID:       src.ruleShortID,
+				ActorName:     src.ruleName,
+				Payload: map[string]any{
+					"category_slug": result.CategorySlug,
+					"source":        "rule",
+				},
+				RuleID: src.ruleID,
+			}); err != nil {
+				return result.Sources, fmt.Errorf("annotate category_set: %w", err)
+			}
 		}
 	}
 
-	// TODO(phase-2): persist result.TagsToAdd to transaction_tags and
-	// result.Comments to transaction_comments inside the sync transaction.
-	// Phase 1 plumbs these but they're no-ops.
+	// add_tag: persist each tag to transaction_tags (auto-create missing tags)
+	// and write a matching tag_added annotation. Using the sync tx keeps the
+	// tag rows, annotations, and rule_applications all atomic together.
+	for _, slug := range result.TagsToAdd {
+		src := sourceByKey["tag|"+slug]
+		if err := e.applyTagFromRule(ctx, tx, dbTxn.ID, slug, src.ruleID, src.ruleShortID, src.ruleName); err != nil {
+			return result.Sources, err
+		}
+	}
+
+	// add_comment: dual-write to transaction_comments (legacy) and annotations
+	// (Phase 2 source of truth). Rule-authored comments attribute to the rule
+	// via rule_id back-reference.
+	for _, content := range result.Comments {
+		src := sourceByKey["comment|"+content]
+		if err := e.applyCommentFromRule(ctx, tx, dbTxn.ID, content, src.ruleID, src.ruleShortID, src.ruleName); err != nil {
+			return result.Sources, err
+		}
+	}
 
 	return result.Sources, nil
+}
+
+// loadTagSlugsInTx returns the current tag slugs for a transaction using the
+// sync DB transaction. Used by applyRulesToTransaction for changed txns so
+// tag-based conditions can match real data.
+func (e *Engine) loadTagSlugsInTx(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID) ([]string, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT t.slug
+		FROM tags t
+		JOIN transaction_tags tt ON tt.tag_id = t.id
+		WHERE tt.transaction_id = $1
+		ORDER BY t.slug ASC`, txnID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var slugs []string
+	for rows.Next() {
+		var slug string
+		if err := rows.Scan(&slug); err != nil {
+			return nil, err
+		}
+		slugs = append(slugs, slug)
+	}
+	return slugs, rows.Err()
+}
+
+// applyTagFromRule upserts a (transaction, tag) row and writes the matching
+// tag_added annotation. Auto-creates the tag if its slug isn't registered yet.
+// All DB writes share the sync tx.
+func (e *Engine) applyTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, slug string, ruleID pgtype.UUID, ruleShortID, ruleName string) error {
+	// Ensure the tag exists. INSERT ON CONFLICT DO NOTHING + RETURNING is
+	// awkward when the row already exists (no row returned), so we do a
+	// two-step upsert: SELECT, then insert if missing. Short id trigger
+	// populates short_id on insert.
+	var tagID pgtype.UUID
+	err := tx.QueryRow(ctx, `SELECT id FROM tags WHERE slug = $1`, slug).Scan(&tagID)
+	if err != nil {
+		// Either no row (auto-create) or some other error.
+		err2 := tx.QueryRow(ctx, `
+			INSERT INTO tags (slug, display_name, lifecycle)
+			VALUES ($1, $2, 'persistent')
+			ON CONFLICT (slug) DO UPDATE SET updated_at = tags.updated_at
+			RETURNING id`, slug, titleCaseSlugForRule(slug)).Scan(&tagID)
+		if err2 != nil {
+			return fmt.Errorf("get or create tag %q: %w", slug, err2)
+		}
+	}
+
+	// Upsert transaction_tags. ON CONFLICT DO NOTHING keeps the first-wins
+	// semantic: if a prior add already recorded provenance, don't overwrite.
+	_, err = tx.Exec(ctx,
+		`INSERT INTO transaction_tags (transaction_id, tag_id, added_by_type, added_by_id, added_by_name)
+		VALUES ($1, $2, 'rule', $3, $4)
+		ON CONFLICT (transaction_id, tag_id) DO NOTHING`,
+		txnID, tagID, ruleShortID, ruleName)
+	if err != nil {
+		return fmt.Errorf("upsert transaction_tag: %w", err)
+	}
+
+	// Annotation. Only write when the tag was actually newly attached (we
+	// always write here since the upsert may be idempotent — the ON CONFLICT
+	// path means we might double-annotate across syncs, but that's OK for the
+	// bridge era; Phase 3 can dedupe if it matters).
+	//
+	// To avoid noise, check whether the row existed already by looking for a
+	// prior tag_added annotation within the same tag scope.
+	var exists bool
+	if err := tx.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM annotations WHERE transaction_id = $1 AND kind = 'tag_added' AND tag_id = $2)`,
+		txnID, tagID).Scan(&exists); err != nil {
+		return fmt.Errorf("check prior tag_added annotation: %w", err)
+	}
+	if exists {
+		return nil
+	}
+
+	payload := map[string]any{
+		"slug":      slug,
+		"source":    "rule",
+		"rule_id":   ruleShortID,
+		"rule_name": ruleName,
+	}
+	if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
+		TransactionID: txnID,
+		Kind:          "tag_added",
+		ActorType:     "system",
+		ActorID:       ruleShortID,
+		ActorName:     ruleName,
+		Payload:       payload,
+		TagID:         tagID,
+		RuleID:        ruleID,
+	}); err != nil {
+		return fmt.Errorf("annotate tag_added: %w", err)
+	}
+	return nil
+}
+
+// applyCommentFromRule dual-writes a rule-authored comment to
+// transaction_comments and the annotations table (Phase 2 bridge).
+func (e *Engine) applyCommentFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, content string, ruleID pgtype.UUID, ruleShortID, ruleName string) error {
+	// Legacy comment row. AuthorType=system so the existing activity timeline
+	// renderers keep working during the bridge.
+	_, err := tx.Exec(ctx,
+		`INSERT INTO transaction_comments (transaction_id, author_type, author_id, author_name, content)
+		VALUES ($1, 'system', $2, $3, $4)`,
+		txnID, ruleShortID, ruleName, content)
+	if err != nil {
+		return fmt.Errorf("insert rule comment: %w", err)
+	}
+
+	payload := map[string]any{
+		"content":   content,
+		"source":    "rule",
+		"rule_id":   ruleShortID,
+		"rule_name": ruleName,
+	}
+	if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
+		TransactionID: txnID,
+		Kind:          "comment",
+		ActorType:     "system",
+		ActorID:       ruleShortID,
+		ActorName:     ruleName,
+		Payload:       payload,
+		RuleID:        ruleID,
+	}); err != nil {
+		return fmt.Errorf("annotate rule comment: %w", err)
+	}
+	return nil
+}
+
+// titleCaseSlugForRule converts a slug ("needs-review") to a display name
+// ("Needs Review") for auto-created tags during sync. Mirrors
+// service.titleCaseSlug; duplicated here to keep sync → service dependency
+// direction one-way.
+func titleCaseSlugForRule(slug string) string {
+	out := make([]byte, 0, len(slug))
+	capitalize := true
+	for i := 0; i < len(slug); i++ {
+		c := slug[i]
+		if c == '-' || c == ':' || c == '_' {
+			out = append(out, ' ')
+			capitalize = true
+			continue
+		}
+		if capitalize && c >= 'a' && c <= 'z' {
+			out = append(out, c-32)
+			capitalize = false
+			continue
+		}
+		out = append(out, c)
+		capitalize = false
+	}
+	return string(out)
+}
+
+// writeSyncAnnotationParams is the sync-package-local mirror of
+// service.writeAnnotationParams — the sync package can't import service
+// without breaking the one-way dep direction. Only the fields the sync engine
+// needs are included.
+type writeSyncAnnotationParams struct {
+	TransactionID pgtype.UUID
+	Kind          string
+	ActorType     string
+	ActorID       string
+	ActorName     string
+	Payload       map[string]any
+	TagID         pgtype.UUID
+	RuleID        pgtype.UUID
+}
+
+// writeSyncAnnotation inserts an annotation row using the supplied sync tx.
+func writeSyncAnnotation(ctx context.Context, tx pgx.Tx, params writeSyncAnnotationParams) error {
+	var payloadJSON []byte
+	if params.Payload == nil {
+		payloadJSON = []byte(`{}`)
+	} else {
+		b, err := jsonMarshalMap(params.Payload)
+		if err != nil {
+			return fmt.Errorf("marshal payload: %w", err)
+		}
+		payloadJSON = b
+	}
+
+	actorID := pgtype.Text{}
+	if params.ActorID != "" {
+		actorID = pgtype.Text{String: params.ActorID, Valid: true}
+	}
+
+	_, err := tx.Exec(ctx,
+		`INSERT INTO annotations (transaction_id, kind, actor_type, actor_id, actor_name, session_id, payload, tag_id, rule_id)
+		VALUES ($1, $2, $3, $4, $5, NULL, $6::jsonb, $7, $8)`,
+		params.TransactionID, params.Kind, params.ActorType, actorID, params.ActorName, payloadJSON,
+		params.TagID, params.RuleID)
+	return err
 }
 
 // updateBalancesWithRetry fetches balances with 1 retry on transient errors.

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -42,8 +42,12 @@ type TransactionContext struct {
 }
 
 // RuleActionSource tracks which rule contributed which action for audit.
+// RuleName and RuleShortID are populated so the sync engine can write
+// annotations with human-readable actor fields (Phase 2).
 type RuleActionSource struct {
 	RuleID      pgtype.UUID
+	RuleShortID string
+	RuleName    string
 	ActionField string // "category", "tag", "comment"
 	ActionValue string // slug for category/tag, content for comment
 }
@@ -87,6 +91,8 @@ type RuleResolver struct {
 
 type compiledRule struct {
 	id        pgtype.UUID
+	shortID   string
+	name      string
 	actions   []typedAction
 	trigger   string // "on_create", "on_update", or "always"
 	condition *compiledCondition
@@ -105,6 +111,8 @@ type compiledCondition struct {
 // ruleRow holds the raw data from the transaction_rules table query.
 type ruleRow struct {
 	id          pgtype.UUID
+	shortID     string
+	name        string
 	conditions  []byte // may be NULL (match-all)
 	actionsJSON []byte
 	trigger     string
@@ -157,7 +165,7 @@ func NewRuleResolver(ctx context.Context, pool *pgxpool.Pool, provider string, l
 // compiles their conditions, parses actions, and returns them sorted by
 // priority DESC, created_at DESC.
 func loadRules(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) ([]compiledRule, error) {
-	query := `SELECT id, conditions, actions, trigger
+	query := `SELECT id, short_id, name, conditions, actions, trigger
 		FROM transaction_rules
 		WHERE enabled = true
 		  AND (expires_at IS NULL OR expires_at > NOW())
@@ -172,7 +180,7 @@ func loadRules(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) ([]
 	var rawRules []ruleRow
 	for rows.Next() {
 		var rr ruleRow
-		if err := rows.Scan(&rr.id, &rr.conditions, &rr.actionsJSON, &rr.trigger); err != nil {
+		if err := rows.Scan(&rr.id, &rr.shortID, &rr.name, &rr.conditions, &rr.actionsJSON, &rr.trigger); err != nil {
 			return nil, fmt.Errorf("scan transaction rule: %w", err)
 		}
 		rawRules = append(rawRules, rr)
@@ -212,6 +220,8 @@ func loadRules(ctx context.Context, pool *pgxpool.Pool, logger *slog.Logger) ([]
 
 		compiled = append(compiled, compiledRule{
 			id:        rr.id,
+			shortID:   rr.shortID,
+			name:      rr.name,
 			actions:   actions,
 			trigger:   trigger,
 			condition: cc,
@@ -387,6 +397,8 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 					result.CategorySlug = a.CategorySlug
 					result.Sources = append(result.Sources, RuleActionSource{
 						RuleID:      rule.id,
+						RuleShortID: rule.shortID,
+						RuleName:    rule.name,
 						ActionField: "category",
 						ActionValue: a.CategorySlug,
 					})
@@ -399,6 +411,8 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 					result.TagsToAdd = append(result.TagsToAdd, a.TagSlug)
 					result.Sources = append(result.Sources, RuleActionSource{
 						RuleID:      rule.id,
+						RuleShortID: rule.shortID,
+						RuleName:    rule.name,
 						ActionField: "tag",
 						ActionValue: a.TagSlug,
 					})
@@ -410,6 +424,8 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 				result.Comments = append(result.Comments, a.Content)
 				result.Sources = append(result.Sources, RuleActionSource{
 					RuleID:      rule.id,
+					RuleShortID: rule.shortID,
+					RuleName:    rule.name,
 					ActionField: "comment",
 					ActionValue: a.Content,
 				})

--- a/internal/sync/tags_integration_test.go
+++ b/internal/sync/tags_integration_test.go
@@ -1,0 +1,181 @@
+//go:build integration
+
+package sync_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/provider"
+	"breadbox/internal/testutil"
+
+	"github.com/shopspring/decimal"
+)
+
+// TestSync_AddTagAction_PersistsTag exercises the Phase 2 add_tag wiring: a
+// rule with an add_tag action fires during sync, and the tag is attached to
+// the transaction with provenance. A matching tag_added annotation row is
+// also written.
+func TestSync_AddTagAction_PersistsTag(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategories(t, queries)
+
+	// Seed a persistent "dining" tag so we don't rely on auto-create in this
+	// test — the auto-create path is covered by the seeded-rule test below.
+	tag := testutil.MustCreateTag(t, queries, "dining", "Dining", "persistent")
+
+	// Rule: name contains "Restaurant" → add_tag "dining".
+	testutil.MustCreateTransactionRule(
+		t, queries, "Dining Tag",
+		[]byte(`{"field":"name","op":"contains","value":"Restaurant"}`),
+		[]byte(`[{"type":"add_tag","tag_slug":"dining"}]`),
+		"on_create",
+	)
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added: []provider.Transaction{
+				{
+					ExternalID:        "txn_tagged",
+					AccountExternalID: "ext_acct_1",
+					Amount:            decimal.NewFromFloat(42.50),
+					Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+					Name:              "Restaurant ABC",
+					ISOCurrencyCode:   "USD",
+				},
+			},
+			Cursor: "cursor_1",
+		},
+	}
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+
+	// Verify transaction_tags row exists.
+	var count int
+	err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM transaction_tags tt
+		JOIN transactions t ON tt.transaction_id = t.id
+		WHERE t.external_transaction_id = 'txn_tagged' AND tt.tag_id = $1`, tag.ID).Scan(&count)
+	if err != nil {
+		t.Fatalf("count transaction_tags: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 transaction_tags row, got %d", count)
+	}
+
+	// Verify tag_added annotation was written with rule back-reference.
+	var annCount int
+	err = pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM annotations a
+		JOIN transactions t ON a.transaction_id = t.id
+		WHERE t.external_transaction_id = 'txn_tagged'
+		  AND a.kind = 'tag_added'
+		  AND a.tag_id = $1
+		  AND a.rule_id IS NOT NULL`, tag.ID).Scan(&annCount)
+	if err != nil {
+		t.Fatalf("count annotations: %v", err)
+	}
+	if annCount != 1 {
+		t.Errorf("expected 1 tag_added annotation with rule_id, got %d", annCount)
+	}
+
+	// Verify provenance: added_by_type='rule'.
+	var addedByType string
+	err = pool.QueryRow(ctx, `
+		SELECT added_by_type FROM transaction_tags tt
+		JOIN transactions t ON tt.transaction_id = t.id
+		WHERE t.external_transaction_id = 'txn_tagged' AND tt.tag_id = $1`, tag.ID).Scan(&addedByType)
+	if err != nil {
+		t.Fatalf("query added_by_type: %v", err)
+	}
+	if addedByType != "rule" {
+		t.Errorf("expected added_by_type=rule, got %q", addedByType)
+	}
+}
+
+// TestSync_SeededRule_TagsAllNewTransactions verifies the behavior the
+// Phase 2 migration's seed rule intends: a rule with match-all conditions
+// (NULL) and a single add_tag action tagging newly-synced transactions with
+// 'needs-review'.
+//
+// Testutil truncates all tables between tests, so the migration's seeded
+// rows are wiped. We re-seed the tag + rule here mirroring the migration
+// exactly (same slug, same lifecycle, same action shape) to prove the
+// seeded behavior works end-to-end.
+func TestSync_SeededRule_TagsAllNewTransactions(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategories(t, queries)
+
+	// Re-seed the needs-review tag + rule just like the migration.
+	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review", "ephemeral")
+	testutil.MustCreateTransactionRule(
+		t, queries, "Auto-tag new transactions for review",
+		nil, // match-all conditions
+		[]byte(`[{"type":"add_tag","tag_slug":"needs-review"}]`),
+		"on_create",
+	)
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added: []provider.Transaction{
+				{
+					ExternalID:        "txn_seeded_1",
+					AccountExternalID: "ext_acct_1",
+					Amount:            decimal.NewFromFloat(10.00),
+					Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+					Name:              "Unknown Merchant",
+					ISOCurrencyCode:   "USD",
+				},
+				{
+					ExternalID:        "txn_seeded_2",
+					AccountExternalID: "ext_acct_1",
+					Amount:            decimal.NewFromFloat(20.00),
+					Date:              time.Date(2025, 3, 2, 0, 0, 0, 0, time.UTC),
+					Name:              "Another Merchant",
+					ISOCurrencyCode:   "USD",
+				},
+			},
+			Cursor: "cursor_seed",
+		},
+	}
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+
+	// Every synced transaction should carry the needs-review tag.
+	var taggedCount int
+	err := pool.QueryRow(ctx, `
+		SELECT COUNT(DISTINCT t.id)
+		FROM transactions t
+		JOIN transaction_tags tt ON tt.transaction_id = t.id
+		JOIN tags tag ON tag.id = tt.tag_id
+		WHERE tag.slug = 'needs-review'
+		  AND t.external_transaction_id IN ('txn_seeded_1', 'txn_seeded_2')`).Scan(&taggedCount)
+	if err != nil {
+		t.Fatalf("count tagged transactions: %v", err)
+	}
+	if taggedCount != 2 {
+		t.Errorf("expected seeded rule to tag both synced transactions, got %d", taggedCount)
+	}
+}

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -291,6 +291,52 @@ func MustCreateReview(t *testing.T, q *db.Queries, txnID pgtype.UUID, reviewType
 	return review
 }
 
+// MustCreateTag inserts a tag row and fatals on error. lifecycle defaults to
+// "persistent" if empty.
+func MustCreateTag(t *testing.T, q *db.Queries, slug, displayName, lifecycle string) db.Tag {
+	t.Helper()
+	if lifecycle == "" {
+		lifecycle = "persistent"
+	}
+	tag, err := q.InsertTag(context.Background(), db.InsertTagParams{
+		Slug:        slug,
+		DisplayName: displayName,
+		Lifecycle:   lifecycle,
+	})
+	if err != nil {
+		t.Fatalf("MustCreateTag(%q): %v", slug, err)
+	}
+	return tag
+}
+
+// MustCreateTransactionTag attaches a tag to a transaction and fatals on error.
+func MustCreateTransactionTag(t *testing.T, q *db.Queries, txnID, tagID pgtype.UUID) {
+	t.Helper()
+	_, err := q.AddTransactionTag(context.Background(), db.AddTransactionTagParams{
+		TransactionID: txnID,
+		TagID:         tagID,
+		AddedByType:   "system",
+		AddedByName:   "test",
+	})
+	if err != nil {
+		t.Fatalf("MustCreateTransactionTag: %v", err)
+	}
+}
+
+// MustCountAnnotations returns the number of annotations of a given kind for
+// a transaction. Fatals on error.
+func MustCountAnnotations(t *testing.T, q *db.Queries, txnID pgtype.UUID, kind string) int {
+	t.Helper()
+	n, err := q.CountAnnotationsByTransactionAndKind(context.Background(), db.CountAnnotationsByTransactionAndKindParams{
+		TransactionID: txnID,
+		Kind:          kind,
+	})
+	if err != nil {
+		t.Fatalf("MustCountAnnotations(%q): %v", kind, err)
+	}
+	return int(n)
+}
+
 // MustCreateAgentReport creates an agent report and fatals on error.
 func MustCreateAgentReport(t *testing.T, q *db.Queries, title, body string) db.AgentReport {
 	t.Helper()


### PR DESCRIPTION
## Summary

Stacked on #397 (Phase 1). Introduces the foundation tables for the tag-coordination model and the unified annotations audit log.

- **3 new tables**: `tags`, `transaction_tags`, `annotations` with short_id triggers.
- **Seeded values**: `needs-review` ephemeral tag + a system rule (`Auto-tag new transactions for review`, NULL conditions, `trigger=on_create`, action `add_tag: needs-review`) that auto-tags every newly-synced transaction. The seeded rule's existence IS the "auto-enqueue" switch — Phase 1 deleted the `review_auto_enqueue` config flag.
- **Sync engine**: the `add_tag` rule action now actually persists tags. Atomically inside the sync DB tx: insert into `transaction_tags`, write a `tag_added` annotation. Rule-driven `set_category` writes a `category_set` annotation. `rule_applied` annotations get written for every rule-applied event.
- **Service layer**: new `AddTransactionTag`/`RemoveTransactionTag` with auto-create on unknown tag slug (lifecycle=persistent). `RemoveTransactionTag` requires a `note` when the tag's lifecycle is `ephemeral` (protects the audit trail from "agent silently removed needs-review with no reason").
- **Annotations as source of truth**: `buildActivityTimeline` now reads from annotations. `transaction_comments` and `transaction_rule_applications` continue to be dual-written for the bridge — Phase 3 retires them.
- **Filters**: `query_transactions` / `count_transactions` gain `tags []string` (AND) and `any_tag []string` (OR). Responses include `tags []string` per transaction.
- **MCP**: 4 new tools — `list_tags`, `list_annotations`, `add_transaction_tag`, `remove_transaction_tag`. Existing query tools gained tag filters.

Reviewer note: the dual-write strategy means new comments/rule-apps land in BOTH the legacy table and the annotations table. The annotations table is now canonical for read paths. Phase 3 will drop the legacy tables after a one-shot backfill of any rows that pre-date Phase 2.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` and `go vet -tags integration ./...` clean
- [x] Full integration suite passes (~60s service, ~8s sync)
- [x] New integration tests: `TestCreateTag_AutoSlug`, `TestAddTransactionTag_AutoCreatesTag`, `TestAddTransactionTag_WritesAnnotation`, `TestRemoveTransactionTag_EphemeralRequiresNote`, `TestRemoveTransactionTag_NonEphemeralAcceptsEmptyNote`, `TestRemoveTransactionTag_AlreadyAbsent_NoError`, `TestSync_AddTagAction_PersistsTag`, `TestSync_SeededRule_TagsAllNewTransactions`
- [x] Smoke against running dev server: seeded `needs-review` tag present, seeded rule has correct trigger/actions, transaction detail page renders activity timeline backed by annotations (no 500), tag chips on detail page deferred to Phase 4

## Followup

- Phase 3: backfill remaining `transaction_comments`/`transaction_rule_applications`/`review_queue` rows into annotations, drop the legacy tables, delete `enqueueForReview`/`SubmitReview` plumbing.
- Phase 4: tags admin UI, `/tags` page, transaction edit page, drop `/reviews` route, new MCP tools (`update_transactions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)