### PR TITLE
fix(ui): enforce design system consistency and mobile polish

### DIFF
--- a/internal/templates/pages/agents.html
+++ b/internal/templates/pages/agents.html
@@ -10,7 +10,7 @@
 </div>
 
 <!-- Tab Switcher -->
-<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit">
+<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit max-w-full overflow-x-auto">
   <button @click="tab = 'guide'"
     :class="tab === 'guide' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
     class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
@@ -57,36 +57,34 @@
 {{if .Sessions}}
   <div class="space-y-3">
     {{range .Sessions}}
-    <a href="/agents/sessions/{{.ShortID}}" class="card bg-base-100 shadow-sm hover:shadow-md transition-shadow no-underline block">
-      <div class="card-body p-4">
-        <div class="flex items-start justify-between gap-4">
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-2 mb-1">
-              <span class="font-medium text-base-content">{{.Purpose}}</span>
-              {{if .ReportID}}
-                <span class="badge badge-sm badge-success gap-1">
-                  <i data-lucide="file-text" class="w-3 h-3"></i> Report
-                </span>
-              {{end}}
-            </div>
-            <div class="flex items-center gap-3 text-xs text-base-content/50">
-              {{if .AgentName}}
-                <span class="flex items-center gap-1">
-                  <i data-lucide="bot" class="w-3 h-3"></i>
-                  {{.AgentName}}
-                </span>
-              {{else}}
-                <span class="flex items-center gap-1">
-                  <i data-lucide="key" class="w-3 h-3"></i>
-                  {{.APIKeyName}}
-                </span>
-              {{end}}
-              <span>{{.ToolCallCount}} tool calls</span>
-              <span>{{relativeTime .CreatedAt}}</span>
-            </div>
+    <a href="/agents/sessions/{{.ShortID}}" class="bb-card bb-card--interactive p-4 block no-underline">
+      <div class="flex items-start justify-between gap-4">
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-2 mb-1 flex-wrap">
+            <span class="font-medium text-base-content">{{.Purpose}}</span>
+            {{if .ReportID}}
+              <span class="badge badge-soft badge-success badge-sm gap-1">
+                <i data-lucide="file-text" class="w-3 h-3"></i> Report
+              </span>
+            {{end}}
           </div>
-          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/30 shrink-0 mt-1"></i>
+          <div class="flex items-center gap-3 text-xs text-base-content/50 flex-wrap">
+            {{if .AgentName}}
+              <span class="flex items-center gap-1">
+                <i data-lucide="bot" class="w-3 h-3"></i>
+                {{.AgentName}}
+              </span>
+            {{else}}
+              <span class="flex items-center gap-1">
+                <i data-lucide="key" class="w-3 h-3"></i>
+                {{.APIKeyName}}
+              </span>
+            {{end}}
+            <span>{{.ToolCallCount}} tool calls</span>
+            <span>{{relativeTime .CreatedAt}}</span>
+          </div>
         </div>
+        <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/30 shrink-0 mt-1"></i>
       </div>
     </a>
     {{end}}
@@ -106,10 +104,12 @@
   </div>
   {{end}}
 {{else}}
-  <div class="card bg-base-100 shadow-sm">
-    <div class="card-body items-center text-center py-12">
-      <i data-lucide="scroll-text" class="w-12 h-12 text-base-content/20 mb-3"></i>
-      <h3 class="font-medium text-base-content/70">No agent sessions yet</h3>
+  <div class="bb-card p-12 text-center">
+    <div class="flex flex-col items-center">
+      <div class="w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center mb-4">
+        <i data-lucide="scroll-text" class="w-7 h-7 text-base-content/30"></i>
+      </div>
+      <h3 class="text-base font-semibold mb-1">No agent sessions yet</h3>
       <p class="text-sm text-base-content/50 max-w-md">When AI agents use the MCP tools with sessions enabled, their activity will appear here.</p>
     </div>
   </div>

--- a/internal/templates/pages/api_key_created.html
+++ b/internal/templates/pages/api_key_created.html
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<div class="bb-card p-6 max-w-lg">
+<div class="bb-card p-5 sm:p-6 max-w-lg">
   <div class="flex items-center gap-3 mb-5">
     <div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center">
       <i data-lucide="check" class="w-5 h-5 text-success"></i>

--- a/internal/templates/pages/api_key_new.html
+++ b/internal/templates/pages/api_key_new.html
@@ -11,7 +11,7 @@
   </a>
 </div>
 
-<div class="bb-card p-6 max-w-lg">
+<div class="bb-card p-5 sm:p-6 max-w-lg">
   <form method="POST" action="/api-keys/new">
     <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 

--- a/internal/templates/pages/connection_new.html
+++ b/internal/templates/pages/connection_new.html
@@ -13,7 +13,7 @@
 
 {{if not (or .HasPlaid .HasTeller)}}
 <!-- No providers configured -->
-<div class="bb-card p-8 max-w-lg">
+<div class="bb-card p-5 sm:p-6 max-w-lg">
   <div class="flex flex-col items-center text-center">
     <div class="w-16 h-16 rounded-xl bg-warning/10 flex items-center justify-center mb-4">
       <i data-lucide="plug-zap" class="w-8 h-8 text-warning"></i>
@@ -27,12 +27,12 @@
 </div>
 {{else}}
 <div id="step-select" {{if .ShowLink}}class="hidden"{{end}}>
-  <div class="bb-card p-8 max-w-lg">
-    <div class="flex items-center gap-3 mb-6">
-      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
-        <i data-lucide="user-plus" class="w-5 h-5 text-primary"></i>
+  <div class="bb-card p-5 sm:p-6 max-w-lg">
+    <div class="bb-icon-header">
+      <div class="bb-icon-header__tile bb-icon-tile--primary">
+        <i data-lucide="user-plus" class="w-5 h-5"></i>
       </div>
-      <div>
+      <div class="bb-icon-header__text">
         <h2 class="text-base font-semibold">Select Details</h2>
         <p class="text-xs text-base-content/45">Choose provider and family member</p>
       </div>
@@ -93,7 +93,7 @@
 </div>
 
 <div id="step-link" class="hidden">
-  <div class="bb-card p-8 max-w-lg">
+  <div class="bb-card p-5 sm:p-6 max-w-lg">
     <div class="flex flex-col items-center text-center">
       <div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
         <i data-lucide="link" class="w-8 h-8 text-primary"></i>

--- a/internal/templates/pages/connection_reauth.html
+++ b/internal/templates/pages/connection_reauth.html
@@ -17,7 +17,7 @@
   </a>
 </div>
 
-<div class="bb-card p-8 max-w-lg">
+<div class="bb-card p-5 sm:p-6 max-w-lg">
   <div class="flex flex-col items-center text-center">
     <div class="w-16 h-16 rounded-xl bg-warning/10 flex items-center justify-center mb-4">
       <i data-lucide="shield-alert" class="w-8 h-8 text-warning"></i>

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -3,14 +3,14 @@
      x-init="$watch('tab', function(v) { var u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); })">
 
 <!-- Page Header -->
-<div class="flex items-center justify-between mb-6">
+<div class="bb-page-header">
   <div class="flex items-baseline gap-3">
     <h1 class="bb-page-title">Connections</h1>
     {{if .Connections}}
     <span class="text-sm text-base-content/40" x-show="tab === 'connections'">{{len .Connections}} bank{{if ne (len .Connections) 1}}s{{end}}</span>
     {{end}}
   </div>
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2 flex-wrap">
     <div x-show="tab === 'connections'" x-cloak class="flex items-center gap-2">
       {{if .Connections}}
       <div x-data="syncAllBtn()">

--- a/internal/templates/pages/csv_import.html
+++ b/internal/templates/pages/csv_import.html
@@ -36,7 +36,7 @@
 
   <!-- Step 1: Upload -->
   <div id="step-1" x-show="step === 1" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" {{if .ConnectionID}}{{end}}>
-    <div class="bb-card p-8 max-w-2xl">
+    <div class="bb-card p-5 sm:p-6 max-w-2xl">
       <div class="flex items-center gap-3 mb-6">
         <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
           <i data-lucide="upload" class="w-5 h-5 text-primary"></i>
@@ -85,7 +85,7 @@
 
   <!-- Step 2: Map Columns -->
   <div id="step-2" x-show="step === 2" x-cloak x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0">
-    <div class="bb-card p-8 max-w-3xl">
+    <div class="bb-card p-5 sm:p-6 max-w-3xl">
       <div class="flex items-center gap-3 mb-6">
         <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-accent/8">
           <i data-lucide="columns" class="w-5 h-5 text-accent"></i>
@@ -215,7 +215,7 @@
 
   <!-- Step 3: Confirm -->
   <div id="step-3" x-show="step === 3" x-cloak x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0">
-    <div class="bb-card p-8 max-w-lg">
+    <div class="bb-card p-5 sm:p-6 max-w-lg">
       <div class="flex items-center gap-3 mb-6">
         <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-warning/8">
           <i data-lucide="file-check" class="w-5 h-5 text-warning"></i>
@@ -255,7 +255,7 @@
 
   <!-- Step 4: Complete -->
   <div id="step-4" x-show="step === 4" x-cloak x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0">
-    <div class="bb-card p-8 max-w-lg">
+    <div class="bb-card p-5 sm:p-6 max-w-lg">
       <div class="flex flex-col items-center text-center mb-8">
         <div class="w-16 h-16 rounded-xl bg-success/10 flex items-center justify-center mb-4">
           <i data-lucide="check-circle-2" class="w-8 h-8 text-success"></i>

--- a/internal/templates/pages/oauth_client_created.html
+++ b/internal/templates/pages/oauth_client_created.html
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<div class="bb-card p-6 max-w-lg" x-data="{ copiedId: false, copiedSecret: false }">
+<div class="bb-card p-5 sm:p-6 max-w-lg" x-data="{ copiedId: false, copiedSecret: false }">
   <div class="flex items-center gap-3 mb-5">
     <div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center">
       <i data-lucide="check" class="w-5 h-5 text-success"></i>

--- a/internal/templates/pages/oauth_client_new.html
+++ b/internal/templates/pages/oauth_client_new.html
@@ -11,7 +11,7 @@
   </a>
 </div>
 
-<div class="bb-card p-6 max-w-lg">
+<div class="bb-card p-5 sm:p-6 max-w-lg">
   <form method="POST" action="/oauth-clients/new">
     <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
 

--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -189,7 +189,7 @@
           <td class="text-sm"><a href="/transactions/{{.TransactionID}}" class="hover:text-primary">{{.TransactionName}}</a></td>
           <td class="text-sm text-right tabular-nums bb-amount">{{printf "%.2f" .Amount}}</td>
           <td class="text-sm text-base-content/60">{{.Date}}</td>
-          <td class="text-sm"><span class="badge badge-outline badge-xs">{{.ActionValue}}</span></td>
+          <td class="text-sm"><span class="badge badge-ghost badge-xs">{{.ActionValue}}</span></td>
           <td class="text-sm text-base-content/60">
             {{if eq .AppliedBy "sync"}}During sync{{else if eq .AppliedBy "retroactive"}}Retroactive{{else}}Manual{{end}}
           </td>
@@ -235,7 +235,7 @@
           <td class="text-sm text-base-content/60">{{.Date}}</td>
           <td class="text-sm">
             {{if .CurrentCategorySlug}}
-            <span class="badge badge-outline badge-xs">{{.CurrentCategorySlug}}</span>
+            <span class="badge badge-ghost badge-xs">{{.CurrentCategorySlug}}</span>
             {{else}}
             <span class="text-base-content/30">Uncategorized</span>
             {{end}}

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -551,7 +551,7 @@ function rulesPage() {
       <!-- Live preview -->
       <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-xl">
         <div class="w-9 h-9 rounded-xl flex items-center justify-center" :style="'background-color:' + (color || '#6366f1') + '15'">
-          <template x-if="icon"><i :data-lucide="icon" class="w-4.5 h-4.5" :style="'color:' + (color || '#6366f1')"></i></template>
+          <template x-if="icon"><i :data-lucide="icon" class="w-5 h-5" :style="'color:' + (color || '#6366f1')"></i></template>
           <template x-if="!icon"><span class="w-2.5 h-2.5 rounded-full" :style="'background-color:' + (color || '#6366f1')"></span></template>
         </div>
         <span class="font-semibold text-sm" x-text="displayName || 'Category Name'"></span>
@@ -633,7 +633,7 @@ function rulesPage() {
       <!-- Live preview -->
       <div class="flex items-center gap-3 p-4 bg-base-200/40 rounded-xl">
         <div class="w-9 h-9 rounded-xl flex items-center justify-center" :style="'background-color:' + (editColor || '#6366f1') + '15'">
-          <template x-if="editIcon"><i :data-lucide="editIcon" class="w-4.5 h-4.5" :style="'color:' + (editColor || '#6366f1')"></i></template>
+          <template x-if="editIcon"><i :data-lucide="editIcon" class="w-5 h-5" :style="'color:' + (editColor || '#6366f1')"></i></template>
           <template x-if="!editIcon"><span class="w-2.5 h-2.5 rounded-full" :style="'background-color:' + (editColor || '#6366f1')"></span></template>
         </div>
         <span class="font-semibold text-sm" x-text="editDisplayName || 'Category Name'"></span>

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -8,7 +8,7 @@
 
 <!-- Summary Stats -->
 {{if .Stats}}
-<div class="grid grid-cols-3 gap-3 mb-6 bb-stagger">
+<div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6 bb-stagger">
   <!-- Success Rate -->
   <div class="bb-card p-4">
     <div class="flex items-center gap-3">

--- a/internal/templates/pages/user_form.html
+++ b/internal/templates/pages/user_form.html
@@ -12,7 +12,7 @@
 <div x-data="userForm()" class="max-w-lg">
   <!-- Success state: show setup URL after login creation -->
   <template x-if="setupURL">
-    <div class="bb-card p-8">
+    <div class="bb-card p-5 sm:p-6">
       <div class="flex items-center gap-3 mb-6">
         <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-success/10">
           <i data-lucide="check-circle" class="w-5 h-5 text-success"></i>
@@ -47,7 +47,7 @@
 
   <!-- Form state -->
   <template x-if="!setupURL">
-    <div class="bb-card p-8">
+    <div class="bb-card p-5 sm:p-6">
       <!-- Avatar preview + header -->
       <div class="flex items-center gap-4 mb-6">
         <div class="relative group">


### PR DESCRIPTION
## Summary

Sweep of admin templates to close small gaps with `docs/design-system.md`, with a particular focus on mobile responsiveness. No visual regressions expected on desktop — changes either match existing canonical patterns or are strict mobile improvements.

### Design system violations fixed

- **Invalid Tailwind classes** in `rules.html`: `w-4.5 h-4.5` → `w-5 h-5`. These are not valid Tailwind utilities and silently rendered without sizing, leaving the category icon preview unsized.
- **`badge-outline`** (not part of the design system) replaced with `badge-ghost` for metadata chips in `rule_detail.html`.
- **`card bg-base-100 shadow-sm`** replaced with canonical `bb-card` / `bb-card bb-card--interactive` on agent session cards in `agents.html`.
- **Form-card padding**: `bb-card p-8` / `bb-card p-6` → `bb-card p-5 sm:p-6` per design-system.md §5 ("Do not use p-8 — that was the old centered-card style"). Affected: `user_form`, `csv_import` (4 steps), `connection_new` (3 sections), `connection_reauth`, `api_key_new`, `api_key_created`, `oauth_client_new`, `oauth_client_created`.
- **Icon-header primitives**: migrate the provider-select header in `connection_new.html` to use `bb-icon-header` + `bb-icon-header__tile bb-icon-tile--primary`.
- **Empty state on agents activity tab** rebuilt to match the canonical §4 pattern (`p-12`, rounded icon tile, title, description).
- **Badge soft-style**: promote the agent-session report badge from `badge-success` to `badge-soft badge-success badge-sm` per §4 badge conventions.

### Mobile UX

- **Connections page header**: static `flex justify-between mb-6` → `bb-page-header` so title and action buttons stack instead of fighting for horizontal space on mobile. Action buttons now wrap via `flex-wrap`.
- **Sync logs stat grid**: `grid-cols-3` → `grid-cols-1 sm:grid-cols-3` so the three stat cards don't cram into ~100px on iPhone-class widths.
- **Agents tab switcher**: added `max-w-full overflow-x-auto` so the four-tab bar ("Getting Started / Prompt Library / MCP Settings / Activity") scrolls horizontally on narrow mobile instead of overflowing the viewport.

## Test plan

- [x] `make css` builds cleanly
- [x] `go build ./...` passes
- [x] `go test -count=1 ./...` passes (including `TestRulesTemplateWithCategories` which validates template parsing)
- [ ] Manual spot check on mobile viewport: connections header, sync logs stats, agents tabs
- [ ] Manual verification of category icon preview in `/rules` → Add Category modal (was silently unsized)

https://claude.ai/code/session_014UuQ1wYrQrpCDKirYr7pcB