### PR TITLE
Fix icon clicks being intercepted inside buttons

### DIFF
--- a/input.css
+++ b/input.css
@@ -154,7 +154,7 @@
 /* ─── shadcn-inspired global overrides ─── */
 @layer base {
   /* Ensure Lucide SVG icons don't steal clicks from interactive parents. */
-  svg.lucide { pointer-events: none; }
+  svg.lucide, svg.lucide * { pointer-events: none; }
 
   html { scroll-behavior: smooth; }
 


### PR DESCRIPTION
The existing `svg.lucide { pointer-events: none }` rule only disabled
pointer events on the SVG root element. Child elements (path, line,
circle, etc.) inside the Lucide SVGs could still capture clicks,
preventing button actions from firing. Extend the rule to
`svg.lucide, svg.lucide *` so all nested SVG children also pass
clicks through to the parent button.

https://claude.ai/code/session_01YauSJ1vycD9s4vNuChxqQY