### PR TITLE
feat(nav): hide Insights entry, sync palette with sidebar

### DIFF
--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -20,6 +20,7 @@ paths:
 - `make css` compiles `input.css` → `static/css/styles.css`.
 - `make css-watch` for dev (rebuilds on change).
 - Dockerfile runs `make css` in the build stage. Don't commit `styles.css` changes — it's a build artifact.
+- **CSS is embedded into the binary** via `static/embed.go` (`//go:embed all:css favicon.svg`). After `make css` you must **restart the server** for changes to take effect — a browser hard-reload alone won't help because the running binary still serves the stale embedded copy.
 
 ## Footguns
 

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -1054,18 +1054,17 @@
       var allItems = [
         // Overview
         { id: 'nav-home', group: 'Overview', title: 'Home', desc: 'Overview and stats', icon: 'house', href: '/', keywords: 'home dashboard overview net worth' },
-        { id: 'nav-insights', group: 'Overview', title: 'Insights', desc: 'Spending trends and analysis', icon: 'lightbulb', href: '/insights', keywords: 'charts trends spending income analysis pace' },
         { id: 'nav-transactions', group: 'Overview', title: 'Transactions', desc: 'View all transactions', icon: 'receipt', href: '/transactions', keywords: 'payments expenses spending' },
         { id: 'nav-reports', group: 'Overview', title: 'Reports', desc: 'Agent reports and findings', icon: 'file-text', href: '/reports', keywords: 'agent summaries notifications' },
         // Manage
         { id: 'nav-connections', group: 'Manage', title: 'Connections', desc: 'Bank connections and account links', icon: 'link', href: '/connections', keywords: 'banks accounts linked dedup matching' },
         { id: 'nav-agents', group: 'Manage', title: 'Agents', desc: 'Agent setup, prompts, and MCP settings', icon: 'bot', href: '/agents', keywords: 'getting started mcp connect agent setup guide wizard prompt tools permissions instructions' },
-        { id: 'nav-rules', group: 'Manage', title: 'Rules & Categories', desc: 'Auto-categorization rules and taxonomy', icon: 'list-filter', href: '/rules', keywords: 'automation patterns categorize tags labels organize' },
-        { id: 'nav-reviews', group: 'Manage', title: 'Review Queue', desc: 'Transaction review queue', icon: 'clipboard-check', href: '/reviews', keywords: 'pending approve categorize' },
+        { id: 'nav-rules', group: 'Manage', title: 'Rules & Categories', desc: 'Auto-categorization rules and taxonomy', icon: 'list-filter', href: '/rules', keywords: 'automation patterns categorize labels organize' },
+        { id: 'nav-tags', group: 'Manage', title: 'Tags', desc: 'Tag transactions and triage review queue', icon: 'tags', href: '/tags', keywords: 'labels needs-review triage annotations' },
         { id: 'nav-users', group: 'Manage', title: 'Household', desc: 'Manage household members', icon: 'users', href: '/users', keywords: 'people family members' },
         // System
-        { id: 'sys-providers', group: 'System', title: 'Providers', desc: 'Configure Plaid, Teller, CSV', icon: 'plug', href: '/providers', keywords: 'plaid teller csv bank setup' },
         { id: 'sys-access', group: 'System', title: 'Access', desc: 'API keys and OAuth clients', icon: 'shield-check', href: '/access', keywords: 'tokens authentication api keys oauth connector claude' },
+        { id: 'sys-providers', group: 'System', title: 'Providers', desc: 'Configure Plaid, Teller, CSV', icon: 'plug', href: '/providers', keywords: 'plaid teller csv bank setup' },
         { id: 'sys-logs', group: 'System', title: 'Logs', desc: 'Sync logs and webhook events', icon: 'scroll-text', href: '/logs', keywords: 'sync history errors status webhooks events' },
         { id: 'sys-backups', group: 'System', title: 'Backups', desc: 'Database backup and restore', icon: 'hard-drive', href: '/backups', keywords: 'backup restore database dump export' },
         { id: 'sys-settings', group: 'System', title: 'Settings', desc: 'Sync schedule, security, system', icon: 'settings', href: '/settings', keywords: 'schedule password encryption' },

--- a/internal/templates/partials/nav.html
+++ b/internal/templates/partials/nav.html
@@ -12,9 +12,6 @@
     <i data-lucide="house"></i>
     <span class="flex-1">Home</span>
   </a>
-  <a href="/insights" class="bb-sidebar-link{{if eq .CurrentPage "insights"}} bb-sidebar-link--active{{end}}">
-    <i data-lucide="lightbulb"></i> Insights
-  </a>
   <a href="/transactions" class="bb-sidebar-link{{if eq .CurrentPage "transactions"}} bb-sidebar-link--active{{end}}">
     <i data-lucide="receipt"></i> Transactions
   </a>


### PR DESCRIPTION
## Summary
- Drops the Insights link from the sidebar and the global command palette (route remains at `/insights`, just hidden from navigation).
- Syncs the command palette with the sidebar: adds the missing **Tags** entry, removes the stale **Review Queue** entry, reorders **System** so Access comes before Providers.
- Documents in `.claude/rules/ui.md` that static CSS is `go:embed`-bundled, so `make css` requires a server restart.

## Test plan
- [ ] Load any page — Insights link no longer appears in the sidebar.
- [ ] Open the command palette (cmd+K or sidebar search) — no Insights, no Review Queue, Tags is present, System order matches sidebar.
- [ ] Directly visiting `/insights` still renders the page (route not removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)