### PR TITLE
feat(agent-wizard): title in prompt + toolbar polish

### DIFF
--- a/internal/prompts/config.go
+++ b/internal/prompts/config.go
@@ -153,12 +153,18 @@ func LoadBlock(id string) (Block, error) {
 		body = strings.TrimSpace(lines[3])
 	}
 
+	// Prepend the title as an H1 so it appears in the composed prompt, not just the UI.
+	content = body
+	if title != "" {
+		content = "# " + title + "\n\n" + body
+	}
+
 	return Block{
 		ID:              id,
 		Title:           title,
 		Description:     description,
-		Content:         body,
-		OriginalContent: body,
+		Content:         content,
+		OriginalContent: content,
 	}, nil
 }
 

--- a/internal/templates/pages/prompt_builder.html
+++ b/internal/templates/pages/prompt_builder.html
@@ -197,8 +197,6 @@
   <!-- Floating bottom bar -->
   <div class="fixed bottom-6 left-1/2 z-40 -translate-x-1/2 w-[calc(100%-2rem)] max-w-fit">
     <div class="flex items-center gap-2 sm:gap-3 bg-base-100 border border-base-300 rounded-2xl shadow-lg px-3 sm:px-5 py-3 justify-center">
-      <span class="hidden sm:inline text-xs font-medium text-base-content/60 whitespace-nowrap">{{.AgentLabel}}</span>
-      <div class="hidden sm:block w-px h-4 bg-base-300"></div>
       <span class="text-xs text-base-content/40 tabular-nums whitespace-nowrap" x-text="activeBlocks.length + ' blocks · ' + preview.length.toLocaleString() + ' chars'"></span>
       <div class="w-px h-4 bg-base-300"></div>
       <button class="btn btn-ghost btn-sm rounded-xl gap-2 text-xs" @click="openPreview()">
@@ -210,7 +208,7 @@
         <span class="flex items-center gap-1.5 transition-all duration-200"
               :class="copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'">
           <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
-          Copy<span class="hidden sm:inline">&nbsp;Prompt</span>
+          <span>Copy<span class="hidden sm:inline"> Prompt</span></span>
           <span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
         </span>
         <span class="absolute inset-0 flex items-center justify-center gap-1.5 transition-all duration-200"


### PR DESCRIPTION
## Summary
- Include each block's `# Title` as the first line of its composed content so copied/previewed prompts read as structured docs (Initial Setup, Bulk Review, etc.) instead of anonymous prose.
- Remove the redundant agent name from the prompt builder's floating toolbar and fix the double space inside the "Copy Prompt" button (the `gap-1.5` parent was stacking with a `&nbsp;`).

## Test plan
- [ ] Open any `/agent-wizard/:agent` page — toolbar shows blocks/chars + Preview + Copy, no agent title label.
- [ ] "Copy Prompt" button shows a single space between the words.
- [ ] Copy/preview the prompt — each section now starts with its H1 title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)