### PR TITLE
fix(backups): preflight pg_dump version check + ship client in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,10 @@ FROM alpine:3.21
 
 # CA certificates: required for TLS connections to Plaid API and PostgreSQL
 # tzdata: required for cron schedule timezone handling
-RUN apk --no-cache add ca-certificates tzdata
+# postgresql16-client: required by the /backups page for pg_dump and psql.
+#   Must match the server major version (postgres:16-alpine in compose) —
+#   pg_dump refuses to dump a newer server.
+RUN apk --no-cache add ca-certificates tzdata postgresql16-client
 
 WORKDIR /app
 COPY --from=builder /breadbox /app/breadbox

--- a/internal/admin/backups.go
+++ b/internal/admin/backups.go
@@ -37,6 +37,7 @@ func BackupsPageHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 
 		schedule := a.Service.GetBackupSchedule(ctx)
 		retentionDays := a.Service.GetBackupRetentionDays(ctx)
+		preflight := a.BackupService.Preflight(ctx)
 
 		data := BaseTemplateData(r, sm, "backups", "Backups")
 		data["Backups"] = backups
@@ -47,6 +48,8 @@ func BackupsPageHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 		data["HasEncryptionKey"] = len(a.Config.EncryptionKey) > 0
 		data["DatabaseName"] = service.ParseDatabaseName(a.Config.DatabaseURL)
 		data["BackupDir"] = a.BackupService.BackupDir()
+		data["PreflightOK"] = preflight.OK
+		data["PreflightMessage"] = preflight.Message
 		tr.Render(w, r, "backups.html", data)
 	}
 }

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -59,9 +60,8 @@ func (bs *BackupService) CreateBackup(ctx context.Context, trigger string) (stri
 		return "", fmt.Errorf("create backup directory: %w", err)
 	}
 
-	// Check that pg_dump is available.
-	if _, err := exec.LookPath("pg_dump"); err != nil {
-		return "", fmt.Errorf("pg_dump not found on PATH: %w", err)
+	if pf := bs.Preflight(ctx); !pf.OK {
+		return "", fmt.Errorf("%s", pf.Message)
 	}
 
 	timestamp := time.Now().UTC().Format("20060102_150405")
@@ -370,6 +370,94 @@ func parseTriggerFromFilename(filename string) string {
 		}
 	}
 	return "unknown"
+}
+
+// PreflightResult reports whether backup tooling is usable on this host.
+type PreflightResult struct {
+	OK              bool
+	PgDumpAvailable bool
+	PsqlAvailable   bool
+	PgDumpMajor     int
+	PsqlMajor       int
+	ServerMajor     int
+	Message         string
+}
+
+var pgVersionRe = regexp.MustCompile(`\b(\d+)\.\d+`)
+
+// Preflight checks that pg_dump and psql are on PATH and that their major
+// version is at least the server's. pg_dump refuses to dump a newer server,
+// so a mismatch is a blocker, not a warning.
+func (bs *BackupService) Preflight(ctx context.Context) PreflightResult {
+	var res PreflightResult
+
+	if _, err := exec.LookPath("pg_dump"); err == nil {
+		res.PgDumpAvailable = true
+		res.PgDumpMajor = parseClientMajor(ctx, "pg_dump")
+	}
+	if _, err := exec.LookPath("psql"); err == nil {
+		res.PsqlAvailable = true
+		res.PsqlMajor = parseClientMajor(ctx, "psql")
+	}
+
+	if !res.PgDumpAvailable || !res.PsqlAvailable {
+		var missing []string
+		if !res.PgDumpAvailable {
+			missing = append(missing, "pg_dump")
+		}
+		if !res.PsqlAvailable {
+			missing = append(missing, "psql")
+		}
+		res.Message = fmt.Sprintf("Missing tool(s) on PATH: %s. Install the PostgreSQL client (e.g. postgresql-client package) on the host.", strings.Join(missing, ", "))
+		return res
+	}
+
+	res.ServerMajor = queryServerMajor(ctx, bs.databaseURL)
+
+	if res.ServerMajor > 0 && res.PgDumpMajor > 0 && res.PgDumpMajor < res.ServerMajor {
+		res.Message = fmt.Sprintf(
+			"pg_dump is version %d but the database server is version %d. pg_dump refuses to dump a newer server. Install postgresql-client ≥ %d on the host.",
+			res.PgDumpMajor, res.ServerMajor, res.ServerMajor,
+		)
+		return res
+	}
+
+	res.OK = true
+	return res
+}
+
+// parseClientMajor runs `<tool> --version` and extracts the major version.
+// Returns 0 if parsing fails — callers treat that as "unknown, proceed".
+func parseClientMajor(ctx context.Context, tool string) int {
+	out, err := exec.CommandContext(ctx, tool, "--version").Output()
+	if err != nil {
+		return 0
+	}
+	m := pgVersionRe.FindStringSubmatch(string(out))
+	if len(m) < 2 {
+		return 0
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0
+	}
+	return major
+}
+
+// queryServerMajor asks the server for its version via `psql -t -c 'SHOW server_version_num'`.
+// server_version_num is formatted as MMmmpp since PG 10 (e.g. 160013 → major 16).
+// Returns 0 on any failure.
+func queryServerMajor(ctx context.Context, databaseURL string) int {
+	cmd := exec.CommandContext(ctx, "psql", "-t", "-A", "-X", "-c", "SHOW server_version_num", databaseURL)
+	out, err := cmd.Output()
+	if err != nil {
+		return 0
+	}
+	verNum, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil || verNum == 0 {
+		return 0
+	}
+	return verNum / 10000
 }
 
 // FormatBytes formats a byte count into a human-readable string.

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -692,6 +692,8 @@
         cancelLabel: 'Cancel',
         variant: 'danger',
         _resolve: null,
+        _onConfirm: null,
+        _onCancel: null,
 
         showConfirm(detail) {
           this.title = detail.title || 'Are you sure?';
@@ -700,6 +702,8 @@
           this.cancelLabel = detail.cancelLabel || 'Cancel';
           this.variant = detail.variant || 'danger';
           this._resolve = detail.resolve || null;
+          this._onConfirm = typeof detail.onConfirm === 'function' ? detail.onConfirm : null;
+          this._onCancel = typeof detail.onCancel === 'function' ? detail.onCancel : null;
           this.visible = true;
           var self = this;
           setTimeout(function() {
@@ -711,14 +715,18 @@
 
         confirm() {
           this.visible = false;
-          if (this._resolve) this._resolve(true);
-          this._resolve = null;
+          var resolve = this._resolve, onConfirm = this._onConfirm;
+          this._resolve = this._onConfirm = this._onCancel = null;
+          if (resolve) resolve(true);
+          if (onConfirm) onConfirm();
         },
 
         cancel() {
           this.visible = false;
-          if (this._resolve) this._resolve(false);
-          this._resolve = null;
+          var resolve = this._resolve, onCancel = this._onCancel;
+          this._resolve = this._onConfirm = this._onCancel = null;
+          if (resolve) resolve(false);
+          if (onCancel) onCancel();
         }
       };
     }

--- a/internal/templates/pages/backups.html
+++ b/internal/templates/pages/backups.html
@@ -8,7 +8,7 @@
     {{if not .Error}}
     <form method="POST" action="/-/backups/create">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-      <button type="submit" class="btn btn-primary btn-sm rounded-xl">
+      <button type="submit" class="btn btn-primary btn-sm rounded-xl" {{if not .PreflightOK}}disabled title="{{.PreflightMessage}}"{{end}}>
         <i data-lucide="download" class="w-4 h-4"></i>
         Create Backup Now
       </button>
@@ -45,6 +45,16 @@
     <span class="text-sm">{{.Error}}</span>
   </div>
   {{else}}
+
+  {{if not .PreflightOK}}
+  <div class="alert alert-error shadow-sm">
+    <i data-lucide="alert-circle" class="w-5 h-5 flex-shrink-0"></i>
+    <div>
+      <h3 class="font-semibold text-sm">Backups unavailable</h3>
+      <p class="text-xs mt-1 leading-relaxed">{{.PreflightMessage}}</p>
+    </div>
+  </div>
+  {{end}}
 
   <!-- Stats -->
   <div class="flex flex-wrap gap-4">


### PR DESCRIPTION
## Summary

- The `/backups` page was failing with an opaque `pg_dump: error: aborting because of server version mismatch` — `pg_dump` refuses to dump a newer server, and the host's client was older than the running PostgreSQL.
- The Docker runtime image (`alpine:3.21`) shipped without `pg_dump`/`psql` at all, so self-hosted Docker deploys could never have created a backup in the first place.

## Changes

- `internal/service/backup.go` — new `Preflight(ctx)` checks both binaries are on `PATH` and compares `pg_dump` major against the server's `server_version_num`. Returns an actionable message ("install postgresql-client ≥ N on the host"). `CreateBackup` now short-circuits on preflight failure instead of leaking raw `pg_dump` stderr.
- `internal/admin/backups.go` + `internal/templates/pages/backups.html` — red banner on `/backups` when preflight fails; "Create Backup Now" is disabled with the preflight message as its tooltip.
- `Dockerfile` — install `postgresql16-client` in the runtime stage so the shipped image has the tooling the feature depends on. Matched to `postgres:16-alpine` from compose.

## Test plan

- [x] Manual: `/backups` on a worktree with `pg_dump` 15 and a PG 16 server now shows the red banner and disables the button (verified via Chrome DevTools).
- [x] Manual: after installing `postgresql@16` and restarting with the matching client on `PATH`, "Create Backup Now" succeeds and a `.sql.gz` file appears in the list.
- [ ] CI: `go build ./...` and existing `TestBackupService_CreateBackup_NoPgDump` still pass (Preflight returns `OK=false` when `pg_dump` is missing, so the test still sees an error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)