### PR TITLE
fix(tx list): XSS hardening + stuck processing on non-JSON response

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -1052,8 +1052,9 @@
         // We can't use <template x-if> with lucide icons here: lucide mutates the
         // <i data-lucide> into <svg>, Alpine loses its node reference, and on
         // condition-flip the stale <svg> is left behind — stacking glyphs.
-        // Instead: one stable .bb-tagpicker-chip-glyph span per chip, innerHTML
-        // replaced imperatively so nothing leaks.
+        // Instead: one stable .bb-tagpicker-chip-glyph span per chip, replaced
+        // imperatively so nothing leaks. Build the <i> via createElement so the
+        // tag icon (admin-controlled) can't escape the data-lucide attribute.
         syncChipGlyph(el, state, tagIcon) {
           var slot = el.querySelector('.bb-tagpicker-chip-glyph');
           if (!slot) return;
@@ -1062,9 +1063,12 @@
           else if (state === 'mixed') icon = 'minus';
           else if (state === 'pending-add') icon = 'plus';
           else if (state === 'pending-remove') icon = 'x';
-          else if (state === 'absent' && tagIcon) icon = tagIcon;
-          if (!icon) { slot.innerHTML = ''; return; }
-          slot.innerHTML = '<i data-lucide="' + icon + '"></i>';
+          else if (state === 'absent' && tagIcon && /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(tagIcon)) icon = tagIcon;
+          slot.replaceChildren();
+          if (!icon) return;
+          var i = document.createElement('i');
+          i.setAttribute('data-lucide', icon);
+          slot.appendChild(i);
           if (typeof lucide !== 'undefined') {
             lucide.createIcons({ nodes: [slot] });
           }

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -851,10 +851,15 @@ document.addEventListener('alpine:init', function() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ items: items })
       })
-      .then(function(r) { return r.json(); })
-      .then(function(data) {
+      // Catch JSON parse failures (non-JSON 5xx from a proxy, etc) here so
+      // they reach the outer .catch — without this guard the throw bypasses
+      // the catch and `processing` stays true forever, silently wedging the
+      // per-row category-picker $watch guard for the rest of the session.
+      .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, body: d}; }); })
+      .then(function(res) {
         self.processing = false;
-        if (data.succeeded > 0) {
+        var data = res.body || {};
+        if (res.ok && data.succeeded > 0) {
           var msg = data.succeeded + ' transaction' + (data.succeeded === 1 ? '' : 's') + ' categorized' + (data.failed > 0 ? ' (' + data.failed + ' failed)' : '');
           window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: msg, type: data.failed > 0 ? 'warning' : 'success'}}));
         } else {
@@ -1008,9 +1013,11 @@ document.addEventListener('alpine:init', function() {
       }
       var row = this._getRows()[this.focusedIdx];
       if (!row) return;
-      var link = row.querySelector('a[href*="/transactions/"]');
-      if (!link) return;
-      var id = link.href.split('/').pop();
+      // Read the id from data-tx-id (set on every row), not the link href —
+      // splitting href on '/' would break silently if the URL ever grew a
+      // query string or fragment.
+      var id = row.dataset.txId;
+      if (!id) return;
       window.dispatchEvent(new CustomEvent('open-tag-picker', {
         detail: {
           sourceId: 'txrow-' + id,
@@ -1032,9 +1039,8 @@ document.addEventListener('alpine:init', function() {
     toggleSelect() {
       var row = this._getRows()[this.focusedIdx];
       if (!row) return;
-      var link = row.querySelector('a[href*="/transactions/"]');
-      if (!link) return;
-      var id = link.href.split('/').pop();
+      var id = row.dataset.txId;
+      if (!id) return;
       if (!Alpine.store('bulk').selecting) Alpine.store('bulk').toggleMode();
       Alpine.store('bulk').toggle(id);
     },
@@ -1231,18 +1237,32 @@ function updateRowCategory(txId, slug) {
   }
 
   // 1) Update the avatar (or convert a letter-avatar to an icon-avatar).
+  // Build via DOM APIs (textContent / safe icon-name whitelist) instead of
+  // string-concat innerHTML — display_name is admin-controlled and could
+  // otherwise smuggle stored XSS through the category metadata.
   var avatarWrap = row.querySelector('.bb-tx-avatar')?.parentElement;
   if (avatarWrap) {
     var color = (meta && (meta.color || (parentMeta && parentMeta.color))) || 'oklch(0.65 0 0)';
     var icon = meta && (meta.icon || (parentMeta && parentMeta.icon));
-    if (icon) {
-      avatarWrap.innerHTML = '<div class="bb-tx-avatar" style="--avatar-color: ' + color + '">'
-        + '<i data-lucide="' + icon + '" class="w-4 h-4"></i></div>';
+    var avatar = document.createElement('div');
+    if (_safeLucideName(icon)) {
+      avatar.className = 'bb-tx-avatar';
+      avatar.style.setProperty('--avatar-color', color);
+      var iconEl = document.createElement('i');
+      iconEl.setAttribute('data-lucide', icon);
+      iconEl.className = 'w-4 h-4';
+      avatar.appendChild(iconEl);
+      avatarWrap.replaceChildren(avatar);
       if (typeof lucide !== 'undefined') lucide.createIcons({ nodes: [avatarWrap] });
     } else {
-      // Fall back to letter avatar (no category icon resolved).
+      // Fall back to letter avatar (no category icon resolved or icon name
+      // failed validation — the latter shouldn't happen for trusted data).
       var name = row.querySelector('a[href*="/transactions/"]')?.textContent?.trim() || '?';
-      avatarWrap.innerHTML = '<div class="bb-tx-avatar bb-tx-avatar--letter"><span>' + name.charAt(0).toUpperCase() + '</span></div>';
+      avatar.className = 'bb-tx-avatar bb-tx-avatar--letter';
+      var letter = document.createElement('span');
+      letter.textContent = name.charAt(0).toUpperCase();
+      avatar.appendChild(letter);
+      avatarWrap.replaceChildren(avatar);
     }
   }
 
@@ -1257,19 +1277,40 @@ function updateRowCategory(txId, slug) {
     if (data) data.selectedId = (meta && meta.id) || '';
   }
 
-  // 3) Update the mobile category label (server-rendered span).
+  // 3) Update the mobile category label. Use textContent for the
+  // display_name (admin-controlled) so HTML in a category name can't
+  // execute via the bulk update path.
   var mobileLabel = row.querySelector('span.sm\\:hidden.inline-flex.items-center.gap-1, span.sm\\:hidden.text-base-content\\/25');
   if (mobileLabel) {
+    var newLabel = document.createElement('span');
     if (meta) {
+      newLabel.className = 'sm:hidden inline-flex items-center gap-1 shrink-0 min-w-0';
       var labelColor = (meta.color || (parentMeta && parentMeta.color)) || '';
-      mobileLabel.outerHTML = '<span class="sm:hidden inline-flex items-center gap-1 shrink-0 min-w-0">'
-        + (labelColor ? '<span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: ' + labelColor + '"></span>' : '')
-        + '<span class="text-base-content/50 truncate max-w-24">' + (meta.display_name || meta.slug) + '</span>'
-        + '</span>';
+      if (labelColor) {
+        var dot = document.createElement('span');
+        dot.className = 'w-1.5 h-1.5 rounded-full shrink-0';
+        dot.style.backgroundColor = labelColor;
+        newLabel.appendChild(dot);
+      }
+      var name = document.createElement('span');
+      name.className = 'text-base-content/50 truncate max-w-24';
+      name.textContent = meta.display_name || meta.slug;
+      newLabel.appendChild(name);
     } else {
-      mobileLabel.outerHTML = '<span class="sm:hidden text-base-content/25 truncate shrink-0">Uncategorized</span>';
+      newLabel.className = 'sm:hidden text-base-content/25 truncate shrink-0';
+      newLabel.textContent = 'Uncategorized';
     }
+    mobileLabel.replaceWith(newLabel);
   }
+}
+
+// Lucide icon names are slug-shaped (e.g. "trending-up", "circle-off"). Reject
+// anything else so a malicious icon value can't break out of the data-lucide
+// attribute and inject scripts when set via innerHTML in `syncChipGlyph` or
+// the avatar update above. Returns the icon if safe, null otherwise.
+function _safeLucideName(name) {
+  if (!name || typeof name !== 'string') return null;
+  return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(name) ? name : null;
 }
 
 /* ── Single transaction category quick-set ── */


### PR DESCRIPTION
## Summary

Three fixes from the post-merge review of #412.

- **XSS hardening in `updateRowCategory` and `syncChipGlyph`.** Category `display_name` and `icon` are admin-controlled and were interpolated unescaped into `innerHTML` / `outerHTML`. Self-XSS in practice but still stored XSS. Switched to `createElement` + `textContent` for all interpolated strings; icon names are now validated against the Lucide slug shape (`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`) before being assigned to `data-lucide`. A bad icon falls back to the letter avatar.
- **`bulk.categorize()` no longer wedges on non-JSON responses.** The old `.then(r => r.json())` chain let `r.json()` throw inside the `.then()` (bypassing `.catch()`), leaving `self.processing` stuck at `true` for the rest of the session and silently breaking the per-row category-picker `$watch` guard. Matches `runBatchUpdate`'s safe wrapping pattern now.
- **`txNav` reads ids from `row.dataset.txId`.** `openTagPicker` and `toggleSelect` previously parsed the link href via `.split('/').pop()` — would break silently if the URL ever grew query params or a fragment.

## Test plan

- [ ] Add a category named `<img src=x onerror=alert(1)>` and bulk-categorize a few transactions to it. Verify no script executes and the row label shows the literal text.
- [ ] (Manual; harder to repro) Behind a misbehaving proxy that returns HTML on 5xx — confirm the bulk action surfaces a "Failed" toast instead of leaving the picker silently broken.
- [ ] `t` keyboard shortcut on a row opens the tag picker for that single row.
- [ ] All previous behavior from #412 still works: tag picker on bulk + single, in-place categorize updates the row, in-place tag updates, no double-toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)