### PR TITLE
fix(tx list): collapse tags to icon+count pill on mobile

### DIFF
--- a/input.css
+++ b/input.css
@@ -504,6 +504,16 @@
     height: 0.65rem;
   }
 
+  /* On mobile (<sm), transaction-row tag chips collapse into a single icon +
+     count pill rendered beside the container (see data-tx-tag-mobile in
+     tx_row.html). Chips stay in the DOM so the bulk picker's
+     computeAppliedCounts() can still read them; they're just visually hidden. */
+  @media (max-width: 639.98px) {
+    .bb-tx-tag-container .bb-tag {
+      display: none;
+    }
+  }
+
   /* Filter/selector state: faded when unselected */
   .bb-tag-ghost {
     opacity: 0.35;

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -1181,11 +1181,14 @@ function updateRowTags(txId, changes) {
   });
 
   // Toggle the leading separator so it only exists when there are tags.
+  // The sep is desktop-only — on mobile the count pill below carries its own
+  // leading middot.
   var sep = container.querySelector('[data-tx-tag-sep]');
-  var hasChips = container.querySelector('.bb-tag');
+  var chips = container.querySelectorAll('.bb-tag');
+  var hasChips = chips.length > 0;
   if (hasChips && !sep) {
     sep = document.createElement('span');
-    sep.className = 'text-base-content/20';
+    sep.className = 'text-base-content/20 hidden sm:inline';
     sep.setAttribute('data-tx-tag-sep', '');
     sep.textContent = '·';
     container.insertBefore(sep, container.firstChild);
@@ -1193,8 +1196,29 @@ function updateRowTags(txId, changes) {
     sep.remove();
   }
 
-  // Render any newly-added Lucide icons.
-  if (typeof lucide !== 'undefined') lucide.createIcons({ nodes: [container] });
+  // Sync the mobile-only tag count pill. Lives as a sibling of the container
+  // so it can be `sm:hidden` without fighting the container's `contents`
+  // display. Created on demand, removed when the row has no tags.
+  var mobile = row.querySelector('[data-tx-tag-mobile]');
+  if (hasChips) {
+    if (!mobile) {
+      mobile = document.createElement('span');
+      mobile.className = 'sm:hidden inline-flex items-center gap-0.5 text-base-content/40 shrink-0';
+      mobile.setAttribute('data-tx-tag-mobile', '');
+      mobile.innerHTML = '<span class="text-base-content/20 mr-0.5">·</span>'
+        + '<i data-lucide="tag" class="w-3 h-3"></i>'
+        + '<span class="text-[0.65rem] tabular-nums font-medium" data-tx-tag-count></span>';
+      container.parentNode.insertBefore(mobile, container.nextSibling);
+    }
+    var countEl = mobile.querySelector('[data-tx-tag-count]');
+    if (countEl) countEl.textContent = chips.length;
+    mobile.setAttribute('title', chips.length + ' tag' + (chips.length === 1 ? '' : 's'));
+  } else if (mobile) {
+    mobile.remove();
+  }
+
+  // Render any newly-added Lucide icons (container chips + mobile pill icon).
+  if (typeof lucide !== 'undefined') lucide.createIcons({ nodes: [row] });
 }
 
 /* ── In-place category update on a row ──

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -65,15 +65,29 @@
         {{end}}
         <!-- Tag container — updated in place by JS on add/remove. The leading
              middot separator is part of this container so it vanishes when the
-             last tag is removed. -->
+             last tag is removed. Chips themselves are hidden on mobile by CSS
+             (`.bb-tx-tag-container .bb-tag` inside the max-width:639px query);
+             the mobile-only count pill below takes their place. -->
         <span class="bb-tx-tag-container contents" data-tx-tag-container>
           {{if .Tags}}
-          <span class="text-base-content/20" data-tx-tag-sep>&middot;</span>
+          <span class="text-base-content/20 hidden sm:inline" data-tx-tag-sep>&middot;</span>
           {{range .Tags}}
           {{template "tag-chip-sm" .}}
           {{end}}
           {{end}}
         </span>
+        <!-- Mobile tag indicator: single pill with tag icon + count. Kept in
+             sync by updateRowTags(). Rendered only when tags exist so the
+             leading middot doesn't orphan. -->
+        {{if .Tags}}
+        <span class="sm:hidden inline-flex items-center gap-0.5 text-base-content/40 shrink-0"
+              data-tx-tag-mobile
+              title="{{len .Tags}} tag{{if ne (len .Tags) 1}}s{{end}}">
+          <span class="text-base-content/20 mr-0.5">&middot;</span>
+          <i data-lucide="tag" class="w-3 h-3"></i>
+          <span class="text-[0.65rem] tabular-nums font-medium" data-tx-tag-count>{{len .Tags}}</span>
+        </span>
+        {{end}}
         <!-- Mobile category label (hidden on desktop where the picker column shows) -->
         <span class="sm:hidden text-base-content/20">&middot;</span>
         {{if .CategoryDisplayName}}


### PR DESCRIPTION
## Summary

- On mobile (<640px), transaction-row tag chips now collapse into a single `· 🏷 N` pill so wide tag sets stop overflowing narrow viewports.
- Chips stay in the DOM (just visually hidden via CSS) so `computeAppliedCounts()` keeps driving the bulk tag picker with correct per-slug counts.
- `updateRowTags()` keeps the mobile pill in sync when tags are added/removed.

## Test plan

- [x] Desktop: full chips render, mobile pill hidden, `·` separator visible.
- [x] Mobile rule (verified via injected stylesheet): chips hidden, mobile pill shows with correct count (1/2/3 tags).
- [ ] Bulk picker: select rows on mobile, confirm applied/mixed states still reflect actual tag membership.
- [ ] Add/remove a tag via the picker and verify the mobile pill count updates without a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)