### PR TITLE
feat(rules): rename on_update → on_change with back-compat (Phase 1b)

### DIFF
--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -158,10 +158,12 @@ The `trigger` field controls when the rule runs during sync.
 | Trigger     | Fires on new (first-synced) transactions | Fires on changed re-synced transactions |
 | ----------- | :--------------------------------------: | :-------------------------------------: |
 | `on_create` |                    ✅                    |                   ❌                    |
-| `on_update` |                    ❌                    |                   ✅                    |
+| `on_change` |                    ❌                    |                   ✅                    |
 | `always`    |                    ✅                    |                   ✅                    |
 
 A transaction is "changed" when the provider returned a different version of an existing row; a truly-unchanged re-sync runs no rules. Default trigger when omitted: `on_create`.
+
+> **Legacy alias.** `on_update` is accepted as a synonym for `on_change` in all inputs (admin UI, MCP, REST). The service normalizes it to `on_change` on write. Pre-existing rows stored as `on_update` continue to fire — the sync resolver treats both values identically.
 
 Retroactive apply (`apply_rules`) ignores trigger — it's a bulk operation intended to evaluate a rule's condition across the entire history regardless of when the transaction was ingested.
 
@@ -206,7 +208,6 @@ The rule engine has two entry points. They share condition evaluation and priori
 
 ## Roadmap (not yet shipped)
 
-- **`on_change` trigger.** `on_update` will be renamed to `on_change` with a DB-level alias for back-compat. Semantics unchanged.
 - **New condition fields.** `category` (assigned category slug, distinct from `category_primary` raw provider field) and `account_name`. *Note:* the resolver already mutates a local `Category` slot during chaining; the public condition field is wired up in the next phase.
 - **New action.** `remove_tag`, symmetric with `add_tag`; useful for clearing transient tags like `needs-review` once a higher-priority-stage rule has pre-categorized the transaction.
 

--- a/internal/db/migrations/20260417032707_rename_on_update_to_on_change.sql
+++ b/internal/db/migrations/20260417032707_rename_on_update_to_on_change.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+
+-- Rename the `on_update` trigger to `on_change`. The CHECK constraint is
+-- widened to accept both values for a transition window; existing rows
+-- are flipped to the new name. The service layer normalizes either input
+-- to `on_change` on write, and the sync resolver treats both identically,
+-- so an accidentally-pinned `on_update` value continues to function.
+--
+-- A later migration can tighten the CHECK to `on_change`-only once the
+-- renaming window closes; no schema lock is needed in the meantime.
+
+ALTER TABLE transaction_rules DROP CONSTRAINT IF EXISTS transaction_rules_trigger_check;
+ALTER TABLE transaction_rules
+    ADD CONSTRAINT transaction_rules_trigger_check
+    CHECK (trigger IN ('on_create', 'on_update', 'on_change', 'always'));
+
+UPDATE transaction_rules SET trigger = 'on_change' WHERE trigger = 'on_update';
+
+-- +goose Down
+
+-- Revert rows and tighten the constraint back to the original set.
+UPDATE transaction_rules SET trigger = 'on_update' WHERE trigger = 'on_change';
+
+ALTER TABLE transaction_rules DROP CONSTRAINT IF EXISTS transaction_rules_trigger_check;
+ALTER TABLE transaction_rules
+    ADD CONSTRAINT transaction_rules_trigger_check
+    CHECK (trigger IN ('on_create', 'on_update', 'always'));

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -631,7 +631,7 @@ type createTransactionRuleInput struct {
 	Conditions         map[string]any      `json:"conditions,omitempty" jsonschema:"JSON condition object. Omit or pass {} to match every transaction. Simple: {\"field\":\"name\",\"op\":\"contains\",\"value\":\"uber\"}. AND/OR/NOT. Fields: name merchant_name amount category_primary category_detailed pending provider account_id user_id user_name tags. Ops: eq neq contains not_contains matches(regex) gt gte lt lte in."`
 	Actions            []map[string]string `json:"actions,omitempty" jsonschema:"Array of typed actions. {\"type\":\"set_category\",\"category_slug\":\"...\"}, {\"type\":\"add_tag\",\"tag_slug\":\"...\"}, or {\"type\":\"add_comment\",\"content\":\"...\"}. If omitted, use category_slug instead."`
 	CategorySlug       string              `json:"category_slug,omitempty" jsonschema:"Shorthand for actions: [{\"type\":\"set_category\",\"category_slug\":\"<slug>\"}]. Either actions or category_slug is required."`
-	Trigger            string              `json:"trigger,omitempty" jsonschema:"When the rule fires: 'on_create' (default — new transactions), 'on_update' (only on re-sync changes), 'always' (both)."`
+	Trigger            string              `json:"trigger,omitempty" jsonschema:"When the rule fires: 'on_create' (default — new transactions), 'on_change' (only on re-sync changes), 'always' (both). 'on_update' is accepted as a legacy alias for 'on_change'."`
 	Priority           int                 `json:"priority,omitempty" jsonschema:"Priority (higher wins when multiple rules set the same field). Default 10."`
 	ExpiresIn          string              `json:"expires_in,omitempty" jsonschema:"Optional expiry duration: 24h, 30d, 1w. Rule auto-disables after this period."`
 	ApplyRetroactively bool                `json:"apply_retroactively,omitempty" jsonschema:"If true, immediately apply this rule to all existing non-overridden transactions after creation."`
@@ -654,7 +654,7 @@ type updateTransactionRuleInput struct {
 	Conditions   map[string]any       `json:"conditions,omitempty" jsonschema:"New condition tree (same format as create). Pass {} to change to match-all."`
 	Actions      *[]map[string]string `json:"actions,omitempty" jsonschema:"Replace actions array with typed actions. Each: {\"type\":\"set_category\",\"category_slug\":\"...\"} or {\"type\":\"add_tag\",\"tag_slug\":\"...\"} or {\"type\":\"add_comment\",\"content\":\"...\"}."`
 	CategorySlug *string              `json:"category_slug,omitempty" jsonschema:"Shorthand: replace the set_category action. Other actions are kept."`
-	Trigger      *string              `json:"trigger,omitempty" jsonschema:"New trigger: on_create, on_update, or always."`
+	Trigger      *string              `json:"trigger,omitempty" jsonschema:"New trigger: on_create, on_change, or always. 'on_update' accepted as alias for on_change."`
 	Priority     *int                 `json:"priority,omitempty" jsonschema:"New priority"`
 	Enabled      *bool                `json:"enabled,omitempty" jsonschema:"Enable or disable the rule"`
 	ExpiresAt    *string              `json:"expires_at,omitempty" jsonschema:"New expiry timestamp (RFC3339) or empty string to clear"`
@@ -675,7 +675,7 @@ type batchRuleItem struct {
 	Actions      []map[string]string `json:"actions,omitempty" jsonschema:"Actions array (typed — same format as create_transaction_rule)"`
 	CategorySlug string              `json:"category_slug,omitempty" jsonschema:"Shorthand for set_category action. Either actions or category_slug required."`
 	Conditions   map[string]any      `json:"conditions,omitempty" jsonschema:"Condition tree as JSON object. Omit or {} for match-all."`
-	Trigger      string              `json:"trigger,omitempty" jsonschema:"on_create (default), on_update, or always."`
+	Trigger      string              `json:"trigger,omitempty" jsonschema:"on_create (default), on_change, or always. 'on_update' accepted as alias for on_change."`
 	Priority     int                 `json:"priority,omitempty" jsonschema:"Priority (default 10)"`
 	ExpiresIn    string              `json:"expires_in,omitempty" jsonschema:"Optional expiry duration"`
 }

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -555,20 +555,29 @@ func categoryActionSlug(actions []RuleAction) string {
 }
 
 // validTriggers lists accepted values for transaction_rules.trigger.
+// "on_update" is retained as a back-compat alias for "on_change" — inputs
+// are normalized to "on_change" before being persisted, but rows previously
+// stored as "on_update" continue to function (both sync and retroactive
+// paths accept either value).
 var validTriggers = map[string]bool{
 	"on_create": true,
-	"on_update": true,
+	"on_change": true,
+	"on_update": true, // alias for on_change
 	"always":    true,
 }
 
-// normalizeTrigger returns the trigger string if valid, defaulting to
-// "on_create" on empty input, and an error for unknown values.
+// normalizeTrigger returns the canonical trigger string, defaulting to
+// "on_create" on empty input. "on_update" is accepted and rewritten to
+// "on_change". Returns an error for unknown values.
 func normalizeTrigger(trigger string) (string, error) {
 	if trigger == "" {
 		return "on_create", nil
 	}
+	if trigger == "on_update" {
+		return "on_change", nil
+	}
 	if !validTriggers[trigger] {
-		return "", fmt.Errorf("%w: invalid trigger %q (expected on_create|on_update|always)", ErrInvalidParameter, trigger)
+		return "", fmt.Errorf("%w: invalid trigger %q (expected on_create|on_change|always)", ErrInvalidParameter, trigger)
 	}
 	return trigger, nil
 }
@@ -592,7 +601,7 @@ const ruleSelectColumnCount = 16
 // Category info is derived from actions[{type:"set_category"}] at response
 // time. conditions may be a zero-value Condition{} (= match all; stored as
 // NULL). trigger defaults to "on_create" and must be one of
-// on_create|on_update|always.
+// on_create|on_change|always ("on_update" accepted as legacy alias).
 func (s *Service) CreateTransactionRule(ctx context.Context, params CreateTransactionRuleParams) (*TransactionRuleResponse, error) {
 	// Validate conditions (zero-value => match-all)
 	if err := ValidateCondition(params.Conditions); err != nil {
@@ -1888,12 +1897,13 @@ func ActionsSummary(actions []RuleAction, categoryName string) string {
 
 // TriggerLabel returns the human-readable label for a rule trigger value.
 // Falls back to the raw value (or "On create" when empty) for unknown values.
+// "on_update" is accepted as a back-compat alias for "on_change".
 func TriggerLabel(trigger string) string {
 	switch trigger {
 	case "", "on_create":
 		return "On create"
-	case "on_update":
-		return "On update"
+	case "on_change", "on_update":
+		return "On change"
 	case "always":
 		return "Always"
 	default:

--- a/internal/service/rules_test.go
+++ b/internal/service/rules_test.go
@@ -442,13 +442,44 @@ func TestTriggerLabel(t *testing.T) {
 	tests := map[string]string{
 		"":          "On create",
 		"on_create": "On create",
-		"on_update": "On update",
+		"on_change": "On change",
+		"on_update": "On change", // legacy alias
 		"always":    "Always",
 		"weird":     "weird",
 	}
 	for in, want := range tests {
 		if got := TriggerLabel(in); got != want {
 			t.Errorf("TriggerLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeTrigger(t *testing.T) {
+	cases := []struct {
+		in     string
+		out    string
+		errful bool
+	}{
+		{"", "on_create", false},
+		{"on_create", "on_create", false},
+		{"on_change", "on_change", false},
+		{"on_update", "on_change", false}, // legacy alias normalized
+		{"always", "always", false},
+		{"nonsense", "", true},
+	}
+	for _, tc := range cases {
+		got, err := normalizeTrigger(tc.in)
+		if tc.errful {
+			if err == nil {
+				t.Errorf("normalizeTrigger(%q) expected error", tc.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("normalizeTrigger(%q) unexpected err: %v", tc.in, err)
+		}
+		if got != tc.out {
+			t.Errorf("normalizeTrigger(%q) = %q want %q", tc.in, got, tc.out)
 		}
 	}
 }

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -493,7 +493,7 @@ type CreateTransactionRuleParams struct {
 	Conditions   Condition
 	Actions      []RuleAction // if set, takes precedence over CategorySlug
 	CategorySlug string       // sugar for actions: [{"type":"set_category","category_slug":slug}]
-	Trigger      string       // "on_create" (default), "on_update", or "always"
+	Trigger      string       // "on_create" (default), "on_change", or "always" ("on_update" accepted as alias)
 	Priority     int
 	ExpiresIn    string // e.g., "30d", "24h"
 	Actor        Actor

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -584,7 +584,8 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 // their actions. Called only for new or changed transactions.
 //
 // isNew is threaded through to ResolveWithContext so trigger filtering
-// (on_create / on_update / always) decides which rules fire.
+// (on_create / on_change / always; "on_update" accepted as alias) decides
+// which rules fire.
 //
 // set_category updates transactions.category_id, add_tag persists to
 // transaction_tags, add_comment writes an annotation. Every persistent change

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -499,12 +499,13 @@ func dropCategorySource(src []RuleActionSource) []RuleActionSource {
 }
 
 // triggerMatches reports whether a rule with the given trigger should fire
-// given an isNew signal from the sync classification.
+// given an isNew signal from the sync classification. `on_update` is accepted
+// as a back-compat alias for `on_change` (the preferred canonical name).
 func triggerMatches(trigger string, isNew bool) bool {
 	switch trigger {
 	case "on_create":
 		return isNew
-	case "on_update":
+	case "on_change", "on_update":
 		return !isNew
 	case "always", "":
 		return true

--- a/internal/sync/rule_resolver_test.go
+++ b/internal/sync/rule_resolver_test.go
@@ -758,7 +758,9 @@ func TestResolveWithContext_TriggerMatrix(t *testing.T) {
 	}{
 		{"on_create", true, true},
 		{"on_create", false, false},
-		{"on_update", true, false},
+		{"on_change", true, false},
+		{"on_change", false, true},
+		{"on_update", true, false}, // legacy alias — same behavior as on_change
 		{"on_update", false, true},
 		{"always", true, true},
 		{"always", false, true},

--- a/internal/templates/pages/rule_form.html
+++ b/internal/templates/pages/rule_form.html
@@ -207,11 +207,11 @@
         <label class="label" for="rule-trigger"><span class="label-text text-xs text-base-content/60">Trigger</span></label>
         <select id="rule-trigger" x-model="form.trigger" class="select select-bordered select-sm rounded-xl bg-base-200">
           <option value="on_create">On create</option>
-          <option value="on_update">On update</option>
+          <option value="on_change">On change</option>
           <option value="always">Always</option>
         </select>
         <p class="text-xs text-base-content/40 mt-1" x-show="form.trigger === 'on_create'">Fires only when a transaction is first synced.</p>
-        <p class="text-xs text-base-content/40 mt-1" x-show="form.trigger === 'on_update'">Fires only when an existing transaction changes.</p>
+        <p class="text-xs text-base-content/40 mt-1" x-show="form.trigger === 'on_change' || form.trigger === 'on_update'">Fires only when an existing transaction changes on re-sync.</p>
         <p class="text-xs text-base-content/40 mt-1" x-show="form.trigger === 'always'">Fires on every sync that touches the transaction.</p>
       </div>
       <div class="form-control">
@@ -327,10 +327,13 @@ function ruleForm() {
       actions = [{ field: 'category', value: '', error: '' }];
     }
 
+    // Normalize legacy on_update → on_change so the <select> binds cleanly.
+    const trigger = existingRule.trigger === 'on_update' ? 'on_change' : (existingRule.trigger || 'on_create');
+
     return {
       name: existingRule.name,
       priority: existingRule.priority,
-      trigger: existingRule.trigger || 'on_create',
+      trigger,
       logic,
       conditions,
       conditions_json: existingRule.conditions ? JSON.stringify(existingRule.conditions, null, 2) : '',


### PR DESCRIPTION
## Summary

Phase 1b of the transaction-rules polish project. Stacked on #418 (Phase 1a).

Renames the `on_update` trigger to `on_change` — a clearer description of what actually fires (a re-sync event that surfaced a changed row). Full back-compat preserved so existing rules and agent code paths keep working.

### Changes

- **Migration** `20260417032707_rename_on_update_to_on_change.sql` widens the `transaction_rules.trigger` CHECK constraint to accept `on_create | on_update | on_change | always` and flips existing `on_update` rows to `on_change`.
- **Service normalization**: `normalizeTrigger` rewrites `on_update` → `on_change` on write so inputs can use either name.
- **Sync resolver**: `triggerMatches` treats both values identically, so a rule row somehow pinned to `on_update` continues to fire.
- **Admin UI**: dropdown offers "On change". Rule-edit form detects legacy `on_update` on load and normalizes to `on_change` so the `<select>` binds correctly.
- **MCP tool descriptions** document the rename and flag `on_update` as a legacy alias.
- **docs/rule-dsl.md** graduates the "renamed trigger" item from roadmap to shipped.

### Tests

- `TestNormalizeTrigger` — new; pins `on_update` → `on_change` rewrite + unknown rejection.
- `TestTriggerLabel` — updated: both `on_change` and `on_update` render as "On change".
- `TestResolveWithContext_TriggerMatrix` — extended to verify `on_update` legacy alias fires identically to `on_change`.
- Full integration suite green (`make test-integration`).

### Compatibility

No semantic change. The rename is purely a clarification.

## Test plan

- [x] `go test ./...`
- [x] `make test-integration`
- [ ] Verify admin UI renders "On change" and legacy rules (hypothetically pinned `on_update`) load without issue — will validate in Phase 4 with Chrome devtools as part of the UI polish pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)