### PR TITLE
feat(rules): remove_tag action + net-diff tag persistence (Phase 1d)

### DIFF
--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -137,6 +137,17 @@ Adds a tag. The tag is auto-created with `lifecycle = persistent` if the slug do
 - Slug format: `^[a-z0-9][a-z0-9\-:]*[a-z0-9]$` (lowercase, digits, hyphens, colons; no leading/trailing punctuation).
 - Writes a `tag_added` annotation; deduped against prior annotations of the same tag on the same transaction.
 
+### `remove_tag`
+
+```json
+{ "type": "remove_tag", "tag_slug": "needs-review" }
+```
+
+Removes a tag from the transaction. No-op if the tag isn't attached. Slug validation matches `add_tag`.
+
+- Writes a `tag_removed` annotation. The rule's name is captured in the annotation payload as the removal note, so ephemeral-tag removal has a source attribution on the activity timeline.
+- **Net-diff semantics in a pipeline.** If an earlier-stage rule's `add_tag` and a later-stage rule's `remove_tag` target the same slug in a single sync pass, they cancel — neither the INSERT nor the DELETE hits the DB, and no annotations are emitted. This keeps the timeline clean when rules compose.
+
 ### `add_comment`
 
 ```json
@@ -216,8 +227,11 @@ The rule engine has two entry points. They share condition evaluation and priori
 
 `preview_rule` evaluates a *single* rule's condition against stored transactions and returns the match count plus a sample. It does **not** simulate the full rule pipeline — higher-priority-stage rules that would normally fire first are not considered. Preview is for answering "what would this rule match right now?" — not "what would the sync outcome be?".
 
-## Roadmap (not yet shipped)
+## Roadmap
 
-- **New action.** `remove_tag`, symmetric with `add_tag`; useful for clearing transient tags like `needs-review` once a higher-priority-stage rule has pre-categorized the transaction.
+All Phase 1 items have shipped. Upcoming work:
+
+- **Sync / retroactive parity.** Retroactive `apply_rules` currently materializes `set_category` only; `add_tag` / `remove_tag` will be wired in the next phase so bulk back-fills match sync-time behavior.
+- **Admin UI polish.** Live preview in the rule form, priority-stage presets ("Baseline / Standard / Refinement / Override"), retroactive-apply confirmation modal.
 
 Tag-based chaining is already live in the resolver. The remaining roadmap items polish the surface.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -629,7 +629,7 @@ type createTransactionRuleInput struct {
 	WriteSessionContext
 	Name               string              `json:"name" jsonschema:"required,Name for this rule (human-readable description)"`
 	Conditions         map[string]any      `json:"conditions,omitempty" jsonschema:"JSON condition object. Omit or pass {} to match every transaction. Simple: {\"field\":\"name\",\"op\":\"contains\",\"value\":\"uber\"}. AND/OR/NOT. Fields: name merchant_name amount category_primary category_detailed category(assigned slug) pending provider account_id account_name user_id user_name tags. Ops: eq neq contains not_contains matches(regex) gt gte lt lte in. See docs/rule-dsl.md for the complete DSL."`
-	Actions            []map[string]string `json:"actions,omitempty" jsonschema:"Array of typed actions. {\"type\":\"set_category\",\"category_slug\":\"...\"}, {\"type\":\"add_tag\",\"tag_slug\":\"...\"}, or {\"type\":\"add_comment\",\"content\":\"...\"}. If omitted, use category_slug instead."`
+	Actions            []map[string]string `json:"actions,omitempty" jsonschema:"Array of typed actions. {\"type\":\"set_category\",\"category_slug\":\"...\"}, {\"type\":\"add_tag\",\"tag_slug\":\"...\"}, {\"type\":\"remove_tag\",\"tag_slug\":\"...\"}, or {\"type\":\"add_comment\",\"content\":\"...\"}. If omitted, use category_slug instead."`
 	CategorySlug       string              `json:"category_slug,omitempty" jsonschema:"Shorthand for actions: [{\"type\":\"set_category\",\"category_slug\":\"<slug>\"}]. Either actions or category_slug is required."`
 	Trigger            string              `json:"trigger,omitempty" jsonschema:"When the rule fires: 'on_create' (default — new transactions), 'on_change' (only on re-sync changes), 'always' (both). 'on_update' is accepted as a legacy alias for 'on_change'."`
 	Priority           int                 `json:"priority,omitempty" jsonschema:"Priority (higher wins when multiple rules set the same field). Default 10."`
@@ -652,7 +652,7 @@ type updateTransactionRuleInput struct {
 	ID           string               `json:"id" jsonschema:"required,UUID of the rule to update"`
 	Name         *string              `json:"name,omitempty" jsonschema:"New name for the rule"`
 	Conditions   map[string]any       `json:"conditions,omitempty" jsonschema:"New condition tree (same format as create). Pass {} to change to match-all."`
-	Actions      *[]map[string]string `json:"actions,omitempty" jsonschema:"Replace actions array with typed actions. Each: {\"type\":\"set_category\",\"category_slug\":\"...\"} or {\"type\":\"add_tag\",\"tag_slug\":\"...\"} or {\"type\":\"add_comment\",\"content\":\"...\"}."`
+	Actions      *[]map[string]string `json:"actions,omitempty" jsonschema:"Replace actions array with typed actions. Each: {\"type\":\"set_category\",\"category_slug\":\"...\"}, {\"type\":\"add_tag\",\"tag_slug\":\"...\"}, {\"type\":\"remove_tag\",\"tag_slug\":\"...\"}, or {\"type\":\"add_comment\",\"content\":\"...\"}."`
 	CategorySlug *string              `json:"category_slug,omitempty" jsonschema:"Shorthand: replace the set_category action. Other actions are kept."`
 	Trigger      *string              `json:"trigger,omitempty" jsonschema:"New trigger: on_create, on_change, or always. 'on_update' accepted as alias for on_change."`
 	Priority     *int                 `json:"priority,omitempty" jsonschema:"New priority"`

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -499,6 +499,7 @@ func toStringSlice(v interface{}) ([]string, bool) {
 var validActionTypes = map[string]bool{
 	"set_category": true,
 	"add_tag":      true,
+	"remove_tag":   true,
 	"add_comment":  true,
 }
 
@@ -518,7 +519,7 @@ func (s *Service) ValidateActions(ctx context.Context, actions []RuleAction) err
 	seenCategory := false
 	for _, a := range actions {
 		if !validActionTypes[a.Type] {
-			return fmt.Errorf("%w: unknown action type %q (expected set_category|add_tag|add_comment)", ErrInvalidParameter, a.Type)
+			return fmt.Errorf("%w: unknown action type %q (expected set_category|add_tag|remove_tag|add_comment)", ErrInvalidParameter, a.Type)
 		}
 		switch a.Type {
 		case "set_category":
@@ -532,9 +533,9 @@ func (s *Service) ValidateActions(ctx context.Context, actions []RuleAction) err
 			if _, err := s.GetCategoryBySlug(ctx, a.CategorySlug); err != nil {
 				return fmt.Errorf("%w: category slug %q not found", ErrInvalidParameter, a.CategorySlug)
 			}
-		case "add_tag":
+		case "add_tag", "remove_tag":
 			if a.TagSlug == "" {
-				return fmt.Errorf("%w: add_tag action requires tag_slug", ErrInvalidParameter)
+				return fmt.Errorf("%w: %s action requires tag_slug", ErrInvalidParameter, a.Type)
 			}
 			if !tagSlugPattern.MatchString(a.TagSlug) {
 				return fmt.Errorf("%w: tag_slug %q must match ^[a-z0-9][a-z0-9\\-:]*[a-z0-9]$", ErrInvalidParameter, a.TagSlug)
@@ -1894,6 +1895,8 @@ func ActionsSummary(actions []RuleAction, categoryName string) string {
 		return "Set category: " + label
 	case "add_tag":
 		return "Add tag " + a.TagSlug
+	case "remove_tag":
+		return "Remove tag " + a.TagSlug
 	case "add_comment":
 		return "Add comment"
 	default:

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -694,6 +694,17 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 		}
 	}
 
+	// remove_tag: delete the (transaction, tag) row and write a tag_removed
+	// annotation. Only slugs that survived net-diff cancellation at the
+	// resolver are here — an earlier-stage add-then-later-stage-remove pair
+	// produces no DB write.
+	for _, slug := range result.TagsToRemove {
+		src := sourceByKey["tag_remove|"+slug]
+		if err := e.removeTagFromRule(ctx, tx, dbTxn.ID, slug, src.ruleID, src.ruleShortID, src.ruleName); err != nil {
+			return result.Sources, err
+		}
+	}
+
 	// add_comment: persist as a comment annotation. Rule-authored comments
 	// attribute to the rule via rule_id back-reference.
 	for _, content := range result.Comments {
@@ -795,6 +806,52 @@ func (e *Engine) applyTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.U
 		RuleID:        ruleID,
 	}); err != nil {
 		return fmt.Errorf("annotate tag_added: %w", err)
+	}
+	return nil
+}
+
+// removeTagFromRule deletes a (transaction, tag) row and writes the matching
+// tag_removed annotation. No-op if the tag slug doesn't exist. The rule's
+// name is used as the removal note so ephemeral-tag removal has a source
+// attribution visible in the activity timeline.
+func (e *Engine) removeTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, slug string, ruleID pgtype.UUID, ruleShortID, ruleName string) error {
+	var tagID pgtype.UUID
+	err := tx.QueryRow(ctx, `SELECT id FROM tags WHERE slug = $1`, slug).Scan(&tagID)
+	if err != nil {
+		// Tag doesn't exist — no-op.
+		return nil
+	}
+
+	cmd, err := tx.Exec(ctx,
+		`DELETE FROM transaction_tags WHERE transaction_id = $1 AND tag_id = $2`,
+		txnID, tagID)
+	if err != nil {
+		return fmt.Errorf("delete transaction_tag: %w", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		// Nothing was attached; skip the annotation so we don't pollute
+		// the timeline with phantom removals.
+		return nil
+	}
+
+	payload := map[string]any{
+		"slug":      slug,
+		"source":    "rule",
+		"rule_id":   ruleShortID,
+		"rule_name": ruleName,
+		"note":      fmt.Sprintf("Removed by rule: %s", ruleName),
+	}
+	if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
+		TransactionID: txnID,
+		Kind:          "tag_removed",
+		ActorType:     "system",
+		ActorID:       ruleShortID,
+		ActorName:     ruleName,
+		Payload:       payload,
+		TagID:         tagID,
+		RuleID:        ruleID,
+	}); err != nil {
+		return fmt.Errorf("annotate tag_removed: %w", err)
 	}
 	return nil
 }

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -66,22 +66,31 @@ type RuleActionSource struct {
 //   - set_category: last-writer-wins. Lower-priority rules run first (baseline),
 //     higher-priority rules run later and may overwrite the category.
 //   - add_tag: accumulates unique slugs across matching rules.
+//   - remove_tag: accumulates slugs to delete. If an earlier-stage rule added
+//     a slug that a later-stage rule removes in the same pass, both cancel
+//     and neither appears in the DB-write set.
 //   - add_comment: accumulates all content strings across matching rules.
 //
 // Rules evaluate against a live-mutating TransactionContext, so later-priority
 // rules can react to earlier rules' tag and category changes via the `tags`
-// and `category_primary` / `category` condition fields.
+// and `category` condition fields.
 type RuleActions struct {
 	// CategorySlug is the slug chosen by the last rule whose set_category
 	// action matched. Empty when no rule set a category.
 	CategorySlug string
-	// TagsToAdd is the accumulated list of unique tag slugs from add_tag actions.
+	// TagsToAdd is the net list of unique tag slugs to insert into
+	// transaction_tags. Cancelled by a later-stage remove_tag in the same pass.
 	TagsToAdd []string
+	// TagsToRemove is the net list of tag slugs to delete from transaction_tags.
+	// Only slugs that were present in the transaction's initial tag set and
+	// were not re-added by an earlier-stage rule appear here.
+	TagsToRemove []string
 	// Comments is the accumulated list of comment content strings from
 	// add_comment actions.
 	Comments []string
 	// Sources records per-action provenance for the audit trail. For
 	// set_category, only the winning (last) rule's source is retained.
+	// For tag actions, only net-surviving adds/removes have sources.
 	Sources []RuleActionSource
 }
 
@@ -268,7 +277,7 @@ func parseTypedActions(raw []byte, ruleID pgtype.UUID, logger *slog.Logger) []ty
 		case "set_category":
 			slug, _ := m["category_slug"].(string)
 			out = append(out, typedAction{Type: t, CategorySlug: slug})
-		case "add_tag":
+		case "add_tag", "remove_tag":
 			slug, _ := m["tag_slug"].(string)
 			out = append(out, typedAction{Type: t, TagSlug: slug})
 		case "add_comment":
@@ -449,6 +458,13 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 				if a.TagSlug == "" {
 					continue
 				}
+				// If a prior-stage rule's remove_tag had queued this slug,
+				// the later add cancels it — strip from TagsToRemove and
+				// drop the prior remove source.
+				if i := stringSliceIndex(result.TagsToRemove, a.TagSlug); i >= 0 {
+					result.TagsToRemove = append(result.TagsToRemove[:i], result.TagsToRemove[i+1:]...)
+					result.Sources = dropTagSource(result.Sources, "tag_remove", a.TagSlug)
+				}
 				if !stringSliceContains(result.TagsToAdd, a.TagSlug) {
 					result.TagsToAdd = append(result.TagsToAdd, a.TagSlug)
 					result.Sources = append(result.Sources, RuleActionSource{
@@ -463,6 +479,35 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 				// can observe the addition.
 				if !stringSliceContains(tctx.Tags, a.TagSlug) {
 					tctx.Tags = append(tctx.Tags, a.TagSlug)
+				}
+			case "remove_tag":
+				if a.TagSlug == "" {
+					continue
+				}
+				// If a same-pass earlier-stage rule added this slug, cancel
+				// that add rather than queueing a delete. The net effect is
+				// no DB write for this slug.
+				if i := stringSliceIndex(result.TagsToAdd, a.TagSlug); i >= 0 {
+					result.TagsToAdd = append(result.TagsToAdd[:i], result.TagsToAdd[i+1:]...)
+					result.Sources = dropTagSource(result.Sources, "tag", a.TagSlug)
+				} else if stringSliceContains(tctx.Tags, a.TagSlug) {
+					// Only queue a delete if the slug is actually present on
+					// the transaction (loaded initial tags). Otherwise the
+					// remove is a no-op.
+					if !stringSliceContains(result.TagsToRemove, a.TagSlug) {
+						result.TagsToRemove = append(result.TagsToRemove, a.TagSlug)
+						result.Sources = append(result.Sources, RuleActionSource{
+							RuleID:      rule.id,
+							RuleShortID: rule.shortID,
+							RuleName:    rule.name,
+							ActionField: "tag_remove",
+							ActionValue: a.TagSlug,
+						})
+					}
+				}
+				// Mirror into live context so later rules see the slug gone.
+				if i := stringSliceIndex(tctx.Tags, a.TagSlug); i >= 0 {
+					tctx.Tags = append(tctx.Tags[:i], tctx.Tags[i+1:]...)
 				}
 			case "add_comment":
 				if a.Content == "" {
@@ -497,6 +542,35 @@ func dropCategorySource(src []RuleActionSource) []RuleActionSource {
 		kept = append(kept, s)
 	}
 	return kept
+}
+
+// dropTagSource removes a specific (field, value) source entry — used when a
+// later-stage rule cancels an earlier-stage rule's add/remove_tag intent
+// (the cancelled intent produces no DB write, so its source doesn't belong
+// in the audit trail).
+func dropTagSource(src []RuleActionSource, field, value string) []RuleActionSource {
+	if len(src) == 0 {
+		return src
+	}
+	kept := src[:0]
+	for _, s := range src {
+		if s.ActionField == field && s.ActionValue == value {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return kept
+}
+
+// stringSliceIndex returns the index of s in slice (case-insensitive),
+// or -1 if not present.
+func stringSliceIndex(slice []string, s string) int {
+	for i, v := range slice {
+		if strings.EqualFold(v, s) {
+			return i
+		}
+	}
+	return -1
 }
 
 // triggerMatches reports whether a rule with the given trigger should fire

--- a/internal/sync/rule_resolver_test.go
+++ b/internal/sync/rule_resolver_test.go
@@ -782,6 +782,175 @@ func TestResolveWithContext_ChainingDoesNotLeakIntoCallerContext(t *testing.T) {
 	}
 }
 
+func TestResolveWithContext_RemoveTag_PresentOnTransaction(t *testing.T) {
+	// Transaction carries `needs-review`. Rule's remove_tag deletes it.
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:        testUUID(10),
+				actions:   []typedAction{{Type: "remove_tag", TagSlug: "needs-review"}},
+				trigger:   "always",
+				condition: nil, // match-all
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	tctx := TransactionContext{Tags: []string{"needs-review", "other"}}
+	result := r.ResolveWithContext("plaid", tctx, false)
+	if result == nil {
+		t.Fatal("expected result")
+	}
+	if len(result.TagsToRemove) != 1 || result.TagsToRemove[0] != "needs-review" {
+		t.Errorf("expected TagsToRemove=[needs-review], got %v", result.TagsToRemove)
+	}
+	if len(result.TagsToAdd) != 0 {
+		t.Errorf("expected no adds, got %v", result.TagsToAdd)
+	}
+}
+
+func TestResolveWithContext_RemoveTag_NotPresentIsNoOp(t *testing.T) {
+	// Transaction has no tags. Rule's remove_tag is a no-op.
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:        testUUID(10),
+				actions:   []typedAction{{Type: "remove_tag", TagSlug: "needs-review"}},
+				trigger:   "always",
+				condition: nil,
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	result := r.ResolveWithContext("plaid", TransactionContext{}, true)
+	// Rule matched (hit_count bumped), but produced no side-effect.
+	if result == nil {
+		t.Fatal("expected result with hit_count bump")
+	}
+	if len(result.TagsToRemove) != 0 {
+		t.Errorf("expected no removes for absent slug, got %v", result.TagsToRemove)
+	}
+}
+
+func TestResolveWithContext_AddThenRemoveCancelsOut(t *testing.T) {
+	// Earlier rule adds "coffee"; later rule removes it. Net: no DB write.
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:        testUUID(10),
+				actions:   []typedAction{{Type: "add_tag", TagSlug: "coffee"}},
+				trigger:   "always",
+				condition: mustCompile(t, &Condition{Field: "name", Op: "contains", Value: "starbucks"}),
+			},
+			{
+				id:        testUUID(11),
+				actions:   []typedAction{{Type: "remove_tag", TagSlug: "coffee"}},
+				trigger:   "always",
+				condition: mustCompile(t, &Condition{Field: "amount", Op: "lt", Value: float64(1)}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	// Both rules match; they should cancel.
+	tctx := TransactionContext{Name: "Starbucks", Amount: 0.50}
+	result := r.ResolveWithContext("plaid", tctx, true)
+	if result == nil {
+		t.Fatal("expected result with hits")
+	}
+	if len(result.TagsToAdd) != 0 {
+		t.Errorf("expected TagsToAdd cancelled, got %v", result.TagsToAdd)
+	}
+	if len(result.TagsToRemove) != 0 {
+		t.Errorf("expected TagsToRemove cancelled, got %v", result.TagsToRemove)
+	}
+	// No tag-related sources should remain.
+	for _, s := range result.Sources {
+		if s.ActionField == "tag" || s.ActionField == "tag_remove" {
+			t.Errorf("unexpected cancelled-action source: %+v", s)
+		}
+	}
+}
+
+func TestResolveWithContext_RemoveThenAddReAdds(t *testing.T) {
+	// Earlier rule removes tag; later rule re-adds same tag. Net: tag present.
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:        testUUID(10),
+				actions:   []typedAction{{Type: "remove_tag", TagSlug: "needs-review"}},
+				trigger:   "always",
+				condition: nil,
+			},
+			{
+				id:        testUUID(11),
+				actions:   []typedAction{{Type: "add_tag", TagSlug: "needs-review"}},
+				trigger:   "always",
+				condition: nil,
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	tctx := TransactionContext{Tags: []string{"needs-review"}}
+	result := r.ResolveWithContext("plaid", tctx, false)
+	if result == nil {
+		t.Fatal("expected result")
+	}
+	// Remove cancelled by re-add; the final state should preserve the tag
+	// without any DB writes (nothing added, nothing removed — the prior
+	// remove's queued delete is dropped when the later add fires).
+	if len(result.TagsToRemove) != 0 {
+		t.Errorf("expected TagsToRemove cancelled, got %v", result.TagsToRemove)
+	}
+	// The add might still be queued if it's genuinely a "new" add. Under
+	// our semantics, add checks for presence in tctx.Tags first — the
+	// earlier remove stripped it from tctx.Tags, so the add sees it as
+	// absent and queues a new insert. That's reasonable: we re-add.
+	if len(result.TagsToAdd) != 1 || result.TagsToAdd[0] != "needs-review" {
+		t.Errorf("expected TagsToAdd=[needs-review] as re-add, got %v", result.TagsToAdd)
+	}
+}
+
+func TestResolveWithContext_RemoveTagVisibleToLaterRule(t *testing.T) {
+	// Rule A removes "needs-review". Rule B conditions on `tags not_contains "needs-review"`
+	// — it should observe the removal and fire.
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:        testUUID(10),
+				actions:   []typedAction{{Type: "remove_tag", TagSlug: "needs-review"}},
+				trigger:   "always",
+				condition: nil,
+			},
+			{
+				id:        testUUID(11),
+				actions:   []typedAction{{Type: "set_category", CategorySlug: "reviewed"}},
+				trigger:   "always",
+				condition: mustCompile(t, &Condition{
+					Field: "tags", Op: "not_contains", Value: "needs-review",
+				}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	tctx := TransactionContext{Tags: []string{"needs-review"}}
+	result := r.ResolveWithContext("plaid", tctx, false)
+	if result == nil {
+		t.Fatal("expected result")
+	}
+	if result.CategorySlug != "reviewed" {
+		t.Errorf("expected later rule to observe removal and set category, got %q", result.CategorySlug)
+	}
+}
+
 func TestResolveWithContext_ChainingExistingTagsVisible(t *testing.T) {
 	// A re-synced transaction already carries `needs-review`. A rule whose
 	// condition asks `tags contains "needs-review"` should match it.

--- a/internal/sync/tags_integration_test.go
+++ b/internal/sync/tags_integration_test.go
@@ -104,6 +104,113 @@ func TestSync_AddTagAction_PersistsTag(t *testing.T) {
 	}
 }
 
+// TestSync_RemoveTagAction_DeletesTagAndAnnotates exercises the remove_tag
+// action end-to-end. The test pre-seeds a transaction with `needs-review`,
+// then re-syncs with a rule that fires on "always" and removes the tag.
+// Verifies the transaction_tags row is deleted and a tag_removed annotation
+// is written with the rule as the actor.
+func TestSync_RemoveTagAction_DeletesTagAndAnnotates(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategories(t, queries)
+
+	// Pre-seed tag and rule.
+	tag := testutil.MustCreateTag(t, queries, "needs-review", "Needs Review", "ephemeral")
+	testutil.MustCreateTransactionRule(
+		t, queries, "Clear review flag for coffee",
+		[]byte(`{"field":"name","op":"contains","value":"Starbucks"}`),
+		[]byte(`[{"type":"remove_tag","tag_slug":"needs-review"}]`),
+		"always",
+	)
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	// First sync: creates the transaction. Our rule (trigger=always) tags
+	// nothing but the absence of a pre-existing needs-review means the
+	// remove is a no-op here.
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added: []provider.Transaction{
+				{
+					ExternalID:        "txn_sbx",
+					AccountExternalID: "ext_acct_1",
+					Amount:            decimal.NewFromFloat(5.50),
+					Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+					Name:              "Starbucks Coffee",
+					ISOCurrencyCode:   "USD",
+				},
+			},
+			Cursor: "cursor_1",
+		},
+	}
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("first Sync() error: %v", err)
+	}
+
+	// Manually attach needs-review to the transaction (simulates a prior
+	// sync pass or user action).
+	_, err := pool.Exec(ctx, `
+		INSERT INTO transaction_tags (transaction_id, tag_id, added_by_type, added_by_name)
+		SELECT t.id, $1, 'user', 'Alice'
+		FROM transactions t WHERE t.external_transaction_id = 'txn_sbx'`, tag.ID)
+	if err != nil {
+		t.Fatalf("attach needs-review: %v", err)
+	}
+
+	// Second sync: provider returns the same transaction with an updated
+	// balance / amount, causing an isChanged path that re-runs rules.
+	mock.syncResult = provider.SyncResult{
+		Modified: []provider.Transaction{
+			{
+				ExternalID:        "txn_sbx",
+				AccountExternalID: "ext_acct_1",
+				Amount:            decimal.NewFromFloat(5.75), // changed
+				Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+				Name:              "Starbucks Coffee",
+				ISOCurrencyCode:   "USD",
+			},
+		},
+		Cursor: "cursor_2",
+	}
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("second Sync() error: %v", err)
+	}
+
+	// Verify transaction_tags row is gone.
+	var ttCount int
+	err = pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM transaction_tags tt
+		JOIN transactions t ON tt.transaction_id = t.id
+		WHERE t.external_transaction_id = 'txn_sbx' AND tt.tag_id = $1`, tag.ID).Scan(&ttCount)
+	if err != nil {
+		t.Fatalf("count transaction_tags: %v", err)
+	}
+	if ttCount != 0 {
+		t.Errorf("expected needs-review tag removed, %d row(s) remain", ttCount)
+	}
+
+	// Verify tag_removed annotation with rule back-reference.
+	var annCount int
+	err = pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM annotations a
+		JOIN transactions t ON a.transaction_id = t.id
+		WHERE t.external_transaction_id = 'txn_sbx'
+		  AND a.kind = 'tag_removed'
+		  AND a.tag_id = $1
+		  AND a.rule_id IS NOT NULL`, tag.ID).Scan(&annCount)
+	if err != nil {
+		t.Fatalf("count annotations: %v", err)
+	}
+	if annCount != 1 {
+		t.Errorf("expected 1 tag_removed annotation, got %d", annCount)
+	}
+}
+
 // TestSync_SeededRule_TagsAllNewTransactions verifies the seeded review rule:
 // match-all conditions (NULL) with a single add_tag action tagging
 // newly-synced transactions with 'needs-review'.

--- a/internal/templates/pages/rule_form.html
+++ b/internal/templates/pages/rule_form.html
@@ -157,15 +157,16 @@
             </select>
           </template>
 
-          <!-- Value: tag slug input with autocomplete -->
-          <template x-if="action.field === 'tag'">
+          <!-- Value: tag slug input with autocomplete (add_tag or remove_tag) -->
+          <template x-if="action.field === 'tag' || action.field === 'tag_remove'">
             <div class="flex-1 min-w-0">
               <input type="text" x-model="action.value" @input="validateTagSlug(idx)" list="bb-tag-slugs"
                 class="input input-bordered input-xs rounded-lg bg-base-100 w-full mt-px"
                 placeholder="needs-review, subscription:monthly, ..."
                 pattern="^[a-z0-9][a-z0-9\-:]*[a-z0-9]$" />
               <p x-show="action.error" x-cloak class="text-[0.65rem] text-error mt-1" x-text="action.error"></p>
-              <p x-show="!action.error" class="text-[0.65rem] text-base-content/40 mt-1">Lowercase, hyphens or colons. e.g. <code>needs-review</code></p>
+              <p x-show="!action.error && action.field === 'tag'" class="text-[0.65rem] text-base-content/40 mt-1">Lowercase, hyphens or colons. e.g. <code>needs-review</code></p>
+              <p x-show="!action.error && action.field === 'tag_remove'" class="text-[0.65rem] text-base-content/40 mt-1">Tag to remove from matching transactions.</p>
             </div>
           </template>
 
@@ -258,13 +259,15 @@ function ruleForm() {
   const defaultOps = { string: 'contains', numeric: 'gte', bool: 'eq' };
   const emptyCondition = () => ({ field: 'name', op: 'contains', value: '' });
 
-  // Action type registry — first-class typed actions match the API's three
-  // supported action.type values (set_category | add_tag | add_comment).
-  // The internal "field" name is a UI alias; we map back at submit time.
+  // Action type registry — first-class typed actions match the API's
+  // supported action.type values (set_category | add_tag | remove_tag |
+  // add_comment). The internal "field" name is a UI alias; we map back
+  // at submit time.
   const actionTypes = [
-    { value: 'category', label: 'Set category' },
-    { value: 'tag',      label: 'Add tag' },
-    { value: 'comment',  label: 'Add comment' },
+    { value: 'category',   label: 'Set category' },
+    { value: 'tag',        label: 'Add tag' },
+    { value: 'tag_remove', label: 'Remove tag' },
+    { value: 'comment',    label: 'Add comment' },
   ];
 
   // Tag slug regex must match the server-side validator in
@@ -280,6 +283,9 @@ function ruleForm() {
     }
     if (a.type === 'add_tag') {
       return { field: 'tag', value: a.tag_slug || '', error: '' };
+    }
+    if (a.type === 'remove_tag') {
+      return { field: 'tag_remove', value: a.tag_slug || '', error: '' };
     }
     if (a.type === 'add_comment') {
       return { field: 'comment', value: a.content || '', error: '' };
@@ -499,6 +505,7 @@ function ruleForm() {
         .map(a => {
           if (a.field === 'category') return { type: 'set_category', category_slug: a.value };
           if (a.field === 'tag') return { type: 'add_tag', tag_slug: a.value };
+          if (a.field === 'tag_remove') return { type: 'remove_tag', tag_slug: a.value };
           if (a.field === 'comment') return { type: 'add_comment', content: a.value };
           return { type: a.field, category_slug: a.value };
         });


### PR DESCRIPTION
## Summary

Final Phase 1 primitive. Stacked on #420 (Phase 1c).

Adds `remove_tag` as a first-class action, symmetric with `add_tag`. Under Phase 1a chaining, the resolver computes a **net diff** so add-then-remove in the same pipeline cancels cleanly.

### Resolver semantics

- **Cancellation.** Earlier-stage `add_tag X` + later-stage `remove_tag X` → both cancel, no DB writes, no audit annotations.
- **Re-add.** Earlier-stage `remove_tag X` + later-stage `add_tag X` → remove cancels, add proceeds as a fresh insert (tctx.Tags observed absent after the remove).
- **No-op.** `remove_tag X` when `X` isn't on the transaction (and wasn't added by an earlier stage) is silent.
- **Visibility.** A later-stage rule's `tags not_contains X` condition observes the removal mid-pass.

### Persistence

- New `removeTagFromRule` engine helper: `DELETE FROM transaction_tags ...` then writes a `tag_removed` annotation with the rule as actor. The rule's name is captured in the annotation payload as a removal note — useful auditing for ephemeral tags (`needs-review` etc).
- RowsAffected gate prevents phantom annotations.

### Admin UI

Fourth option in the actions dropdown ("Remove tag") reusing the tag slug input. Minimal — full visual polish comes in Phase 4.

### Tests

Unit:
- `TestResolveWithContext_RemoveTag_PresentOnTransaction`
- `TestResolveWithContext_RemoveTag_NotPresentIsNoOp`
- `TestResolveWithContext_AddThenRemoveCancelsOut`
- `TestResolveWithContext_RemoveThenAddReAdds`
- `TestResolveWithContext_RemoveTagVisibleToLaterRule`

Integration:
- `TestSync_RemoveTagAction_DeletesTagAndAnnotates` — end-to-end. Pre-seeds a transaction with `needs-review`, re-syncs with a rule matching it via `remove_tag`, verifies the `transaction_tags` row is deleted and the `tag_removed` annotation is written with `rule_id` back-reference.

`docs/rule-dsl.md` — `remove_tag` graduated to shipped with net-diff semantics documented; Phase 1 is now fully complete.

## Test plan

- [x] `go test ./...` green
- [x] `make test-integration` green
- [ ] CI green on push
- [ ] Admin UI verification (Phase 4 with Chrome devtools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)