### PR TITLE
feat(rules): admin UI polish (Phase 4)

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -299,6 +299,18 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				return ""
 			},
 			"triggerLabel": service.TriggerLabel,
+			"ruleHasRetroactiveAction": func(actions []service.RuleAction) bool {
+				// Retroactive apply materializes set_category / add_tag / remove_tag.
+				// add_comment is sync-only. A rule with only comments isn't
+				// usefully apply-able retroactively.
+				for _, a := range actions {
+					switch a.Type {
+					case "set_category", "add_tag", "remove_tag":
+						return true
+					}
+				}
+				return false
+			},
 			"badgeCount": func(n int64) string {
 				if n > 99 {
 					return "99+"

--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -267,16 +267,17 @@
   {{end}}
 </div>
 
-<!-- Pending Matches (only meaningful for category rules — retroactive apply
-     materializes set_category to transactions.category_id; tag/comment actions
-     are no-ops in retroactive). Hide for non-category-only rules. -->
-{{if and .Preview (gt .Preview.MatchCount 0) .Rule.CategorySlug}}
+<!-- Pending Matches: existing transactions that would match this rule's
+     condition but haven't been touched by it yet. Retroactive apply runs
+     set_category + add_tag + remove_tag (add_comment is sync-only). Shown
+     for any rule with at least one applicable action. -->
+{{if and .Preview (gt .Preview.MatchCount 0) (ruleHasRetroactiveAction .Rule.Actions)}}
 <div class="bb-card p-5 mb-4">
   <div class="flex items-center justify-between mb-1">
-    <span class="label-text text-sm font-medium">Uncategorized Matches</span>
+    <span class="label-text text-sm font-medium">Matching transactions</span>
     <span class="badge badge-soft badge-warning badge-sm">{{commaInt .Preview.MatchCount}} pending</span>
   </div>
-  <p class="text-xs text-base-content/40 mb-3">These existing transactions match the rule but were imported before it was created</p>
+  <p class="text-xs text-base-content/40 mb-3">These existing transactions match the rule but haven't been touched by it yet.</p>
 
   <div class="overflow-x-auto">
     <table class="table table-sm">
@@ -312,7 +313,7 @@
 
   <div class="mt-4 flex items-center justify-between">
     <p class="text-xs text-base-content/40">Apply this rule to categorize these existing transactions</p>
-    <button class="btn btn-sm btn-outline rounded-xl" @click="applyRetroactively()" :disabled="applying">
+    <button class="btn btn-sm btn-outline rounded-xl" @click="openApplyModal()" :disabled="applying">
       <span x-show="applying" class="loading loading-spinner loading-xs"></span>
       <i data-lucide="play" class="w-3.5 h-3.5" x-show="!applying"></i>
       Categorize as {{if .ActionCategoryName}}{{.ActionCategoryName}}{{else}}matched category{{end}}
@@ -324,6 +325,43 @@
   </div>
   <div x-show="applyError" x-cloak role="alert" class="alert alert-error text-sm mt-3 rounded-xl">
     <span x-text="applyError"></span>
+  </div>
+
+  <!-- Retroactive apply confirmation modal -->
+  <div x-show="showApplyModal" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40" @click.self="closeApplyModal()">
+    <div class="bb-card max-w-md w-full p-6 bg-base-100 shadow-xl rounded-2xl" role="dialog" aria-modal="true" @keydown.escape.window="closeApplyModal()">
+      <div class="flex items-start gap-3">
+        <div class="w-10 h-10 rounded-xl bg-warning/10 flex items-center justify-center shrink-0">
+          <i data-lucide="alert-triangle" class="w-5 h-5 text-warning"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <h3 class="text-base font-semibold">Apply this rule retroactively?</h3>
+          <p class="text-sm text-base-content/60 mt-1">
+            This will run the rule's actions against <strong>{{commaInt .Preview.MatchCount}}</strong>
+            matching {{if eq .Preview.MatchCount 1}}transaction{{else}}transactions{{end}}.
+          </p>
+          <ul class="mt-3 text-xs text-base-content/50 space-y-1 list-disc pl-4">
+            <li><code class="text-[10px]">set_category</code> skips transactions where you've set a manual override.</li>
+            <li><code class="text-[10px]">add_tag</code> / <code class="text-[10px]">remove_tag</code> apply to every match regardless of override.</li>
+            <li><code class="text-[10px]">add_comment</code> is sync-only — it won't fire retroactively.</li>
+          </ul>
+          <div class="form-control mt-4">
+            <label class="label cursor-pointer justify-start gap-2 py-1">
+              <input type="checkbox" x-model="confirmApply" class="checkbox checkbox-sm checkbox-warning" />
+              <span class="label-text text-xs">I understand this cannot be undone in bulk.</span>
+            </label>
+          </div>
+        </div>
+      </div>
+      <div class="flex items-center justify-end gap-2 mt-5">
+        <button type="button" class="btn btn-sm btn-ghost rounded-xl" @click="closeApplyModal()">Cancel</button>
+        <button type="button" class="btn btn-sm btn-warning rounded-xl" :disabled="!confirmApply || applying" @click="applyRetroactively()">
+          <span x-show="applying" class="loading loading-spinner loading-xs"></span>
+          <i data-lucide="play" class="w-3.5 h-3.5" x-show="!applying"></i>
+          Apply to {{commaInt .Preview.MatchCount}}
+        </button>
+      </div>
+    </div>
   </div>
 </div>
 {{end}}
@@ -372,7 +410,20 @@ function ruleDetail() {
     applying: false,
     applyResult: '',
     applyError: '',
+    showApplyModal: false,
+    confirmApply: false,
+    openApplyModal() {
+      this.confirmApply = false;
+      this.applyError = '';
+      this.applyResult = '';
+      this.showApplyModal = true;
+    },
+    closeApplyModal() {
+      if (this.applying) return;
+      this.showApplyModal = false;
+    },
     async applyRetroactively() {
+      if (!this.confirmApply) return;
       this.applying = true;
       this.applyResult = '';
       this.applyError = '';
@@ -384,8 +435,9 @@ function ruleDetail() {
           this.applying = false;
           return;
         }
-        this.applyResult = 'Categorized ' + (data.affected_count || 0) + ' transactions';
+        this.applyResult = 'Applied to ' + (data.affected_count || 0) + ' transactions';
         this.applying = false;
+        this.showApplyModal = false;
         setTimeout(() => location.reload(), 1500);
       } catch (e) {
         this.applyError = 'Network error: ' + e.message;

--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -327,7 +327,10 @@
     <span x-text="applyError"></span>
   </div>
 
-  <!-- Retroactive apply confirmation modal -->
+  <!-- Retroactive apply confirmation modal — teleported to <body> so the
+       SPA progress bar's filter/opacity on <main> doesn't break the
+       fixed-positioning containing block. -->
+  <template x-teleport="body">
   <div x-show="showApplyModal" x-cloak class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40" @click.self="closeApplyModal()">
     <div class="bb-card max-w-md w-full p-6 bg-base-100 shadow-xl rounded-2xl" role="dialog" aria-modal="true" @keydown.escape.window="closeApplyModal()">
       <div class="flex items-start gap-3">
@@ -363,6 +366,7 @@
       </div>
     </div>
   </div>
+  </template>
 </div>
 {{end}}
 

--- a/internal/templates/pages/rule_form.html
+++ b/internal/templates/pages/rule_form.html
@@ -96,20 +96,25 @@
           <!-- Operator — options are driven by fieldType so string / numeric /
                bool / tags each have their own label set with no duplicate
                <option value="..."> across groups (duplicates break <select>
-               display in Chrome/Safari). -->
-          <select x-model="cond.op" @change="syncToJson()" class="select select-bordered select-xs rounded-lg bg-base-100 w-28 shrink-0">
+               display in Chrome/Safari). Disabled until a field is picked. -->
+          <select x-model="cond.op" @change="syncToJson()" :disabled="!cond.field"
+            class="select select-bordered select-xs rounded-lg bg-base-100 w-28 shrink-0 disabled:bg-base-200 disabled:opacity-70">
+            <option value="" x-show="!cond.field">Operator...</option>
             <template x-for="opt in operatorOptions(cond.field)" :key="opt.value">
               <option :value="opt.value" x-text="opt.label"></option>
             </template>
           </select>
-          <!-- Value -->
-          <select x-model="cond.value" x-show="fieldType(cond.field) === 'bool'" @change="syncToJson()" class="select select-bordered select-xs rounded-lg bg-base-100 w-20 shrink-0">
+          <!-- Value — disabled placeholder when no field picked, otherwise
+               switches by fieldType. -->
+          <input type="text" disabled x-show="!cond.field"
+            class="input input-bordered input-xs rounded-lg bg-base-200 opacity-70 flex-1 min-w-0" placeholder="value..." />
+          <select x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'bool'" @change="syncToJson()" class="select select-bordered select-xs rounded-lg bg-base-100 w-20 shrink-0">
             <option value="true">true</option>
             <option value="false">false</option>
           </select>
-          <input type="number" x-model="cond.value" step="0.01" x-show="fieldType(cond.field) === 'numeric'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 w-24 shrink-0" placeholder="0.00" />
-          <input type="text" x-model="cond.value" x-show="fieldType(cond.field) === 'string'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" placeholder="value..." />
-          <input type="text" x-model="cond.value" x-show="fieldType(cond.field) === 'tags'" list="bb-tag-slugs" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" :placeholder="cond.op === 'in' ? 'slug1, slug2, ...' : 'tag-slug'" />
+          <input type="number" x-model="cond.value" step="0.01" x-show="cond.field && fieldType(cond.field) === 'numeric'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 w-24 shrink-0" placeholder="0.00" />
+          <input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'string'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" placeholder="value..." />
+          <input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'tags'" list="bb-tag-slugs" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" :placeholder="cond.op === 'in' ? 'slug1, slug2, ...' : 'tag-slug'" />
           <!-- Remove (always available — removing the last one switches to match-all) -->
           <button type="button" class="btn btn-ghost btn-xs btn-square rounded-lg shrink-0" @click="removeCondition(idx)" :title="form.conditions.length === 1 ? 'Remove (rule will match all transactions)' : 'Remove'">
             <i data-lucide="x" class="w-3.5 h-3.5 text-base-content/40"></i>

--- a/internal/templates/pages/rule_form.html
+++ b/internal/templates/pages/rule_form.html
@@ -73,14 +73,25 @@
           <!-- Field -->
           <select x-model="cond.field" @change="onFieldChange(idx)" class="select select-bordered select-xs rounded-lg bg-base-100 flex-1 min-w-0">
             <option value="">Field...</option>
-            <option value="name">Name</option>
-            <option value="merchant_name">Merchant</option>
-            <option value="amount">Amount</option>
-            <option value="category_primary">Category (raw)</option>
-            <option value="category_detailed">Category detail</option>
-            <option value="provider">Provider</option>
-            <option value="user_name">Family member</option>
-            <option value="pending">Pending</option>
+            <optgroup label="Transaction">
+              <option value="name">Name</option>
+              <option value="merchant_name">Merchant</option>
+              <option value="amount">Amount</option>
+              <option value="pending">Pending</option>
+            </optgroup>
+            <optgroup label="Category">
+              <option value="category">Category (assigned)</option>
+              <option value="category_primary">Category (raw primary)</option>
+              <option value="category_detailed">Category (raw detail)</option>
+            </optgroup>
+            <optgroup label="Tags">
+              <option value="tags">Tag</option>
+            </optgroup>
+            <optgroup label="Account / User">
+              <option value="account_name">Account name</option>
+              <option value="user_name">Family member</option>
+              <option value="provider">Provider</option>
+            </optgroup>
           </select>
           <!-- Operator -->
           <select x-model="cond.op" @change="syncToJson()" class="select select-bordered select-xs rounded-lg bg-base-100 w-28 shrink-0">
@@ -98,6 +109,9 @@
             <option value="neq" x-show="fieldType(cond.field) === 'numeric'">&ne;</option>
             <option value="eq" x-show="fieldType(cond.field) === 'bool'">is</option>
             <option value="neq" x-show="fieldType(cond.field) === 'bool'">is not</option>
+            <option value="contains" x-show="fieldType(cond.field) === 'tags'">has</option>
+            <option value="not_contains" x-show="fieldType(cond.field) === 'tags'">does not have</option>
+            <option value="in" x-show="fieldType(cond.field) === 'tags'">has any of</option>
           </select>
           <!-- Value -->
           <select x-model="cond.value" x-show="fieldType(cond.field) === 'bool'" @change="syncToJson()" class="select select-bordered select-xs rounded-lg bg-base-100 w-20 shrink-0">
@@ -106,6 +120,7 @@
           </select>
           <input type="number" x-model="cond.value" step="0.01" x-show="fieldType(cond.field) === 'numeric'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 w-24 shrink-0" placeholder="0.00" />
           <input type="text" x-model="cond.value" x-show="fieldType(cond.field) === 'string'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" placeholder="value..." />
+          <input type="text" x-model="cond.value" x-show="fieldType(cond.field) === 'tags'" list="bb-tag-slugs" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" :placeholder="cond.op === 'in' ? 'slug1, slug2, ...' : 'tag-slug'" />
           <!-- Remove (always available — removing the last one switches to match-all) -->
           <button type="button" class="btn btn-ghost btn-xs btn-square rounded-lg shrink-0" @click="removeCondition(idx)" :title="form.conditions.length === 1 ? 'Remove (rule will match all transactions)' : 'Remove'">
             <i data-lucide="x" class="w-3.5 h-3.5 text-base-content/40"></i>
@@ -213,12 +228,32 @@
         </select>
         <p class="text-xs text-base-content/40 mt-1" x-show="form.trigger === 'on_create'">Fires only when a transaction is first synced.</p>
         <p class="text-xs text-base-content/40 mt-1" x-show="form.trigger === 'on_change' || form.trigger === 'on_update'">Fires only when an existing transaction changes on re-sync.</p>
-        <p class="text-xs text-base-content/40 mt-1" x-show="form.trigger === 'always'">Fires on every sync that touches the transaction.</p>
+        <p class="text-xs text-warning/80 mt-1" x-show="form.trigger === 'always'" x-cloak>
+          <i data-lucide="alert-triangle" class="w-3 h-3 inline-block -mt-0.5 mr-0.5"></i>
+          Fires on every sync that touches this transaction — use sparingly.
+        </p>
       </div>
       <div class="form-control">
-        <label class="label" for="rule-priority"><span class="label-text text-xs text-base-content/60">Priority</span></label>
-        <input id="rule-priority" type="number" x-model.number="form.priority" class="input input-bordered input-sm rounded-xl bg-base-200/50" min="0" max="1000" />
-        <p class="text-xs text-base-content/40 mt-1">Higher priority wins when multiple rules set the same field</p>
+        <label class="label" for="rule-priority">
+          <span class="label-text text-xs text-base-content/60">Pipeline stage</span>
+          <span class="tooltip tooltip-left" data-tip="Lower stages run first (baseline). Higher stages run later and win set_category. Tags accumulate across all stages.">
+            <i data-lucide="info" class="w-3 h-3 text-base-content/30"></i>
+          </span>
+        </label>
+        <div class="flex items-center gap-1 bg-base-200/60 rounded-xl p-1">
+          <template x-for="preset in priorityPresets" :key="preset.value">
+            <button type="button"
+              class="flex-1 text-xs font-medium py-1 px-2 rounded-lg transition-colors"
+              :class="form.priority === preset.value ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/50 hover:text-base-content/70'"
+              @click="form.priority = preset.value"
+              :title="preset.hint"
+              x-text="preset.label"></button>
+          </template>
+        </div>
+        <div class="flex items-center gap-2 mt-1">
+          <input id="rule-priority" type="number" x-model.number="form.priority" class="input input-bordered input-xs rounded-lg bg-base-200/50 w-20" min="0" max="1000" />
+          <p class="text-xs text-base-content/40" x-text="priorityLabel(form.priority)"></p>
+        </div>
       </div>
       <div class="form-control" x-show="!isEdit">
         <label class="label" for="rule-expires-in"><span class="label-text text-xs text-base-content/60">Expires in</span></label>
@@ -253,10 +288,13 @@ function ruleForm() {
   const fieldTypes = {
     name: 'string', merchant_name: 'string', amount: 'numeric',
     category_primary: 'string', category_detailed: 'string',
-    pending: 'bool', provider: 'string', account_id: 'string',
-    user_id: 'string', user_name: 'string'
+    category: 'string',
+    pending: 'bool', provider: 'string',
+    account_id: 'string', account_name: 'string',
+    user_id: 'string', user_name: 'string',
+    tags: 'tags',
   };
-  const defaultOps = { string: 'contains', numeric: 'gte', bool: 'eq' };
+  const defaultOps = { string: 'contains', numeric: 'gte', bool: 'eq', tags: 'contains' };
   const emptyCondition = () => ({ field: 'name', op: 'contains', value: '' });
 
   // Action type registry — first-class typed actions match the API's
@@ -348,6 +386,24 @@ function ruleForm() {
     };
   }
 
+  // Pipeline-stage presets. Numeric values are conventional, not enforced —
+  // users can still pick any integer 0..1000 in the fallback number input.
+  // Under priority-ASC ordering, lower stages run first.
+  const priorityPresets = [
+    { value: 0,   label: 'Baseline',   hint: 'Runs first — broad defaults, seeded rules' },
+    { value: 10,  label: 'Standard',   hint: 'Default rule stage' },
+    { value: 50,  label: 'Refinement', hint: 'Runs after standard rules — reacts to their output' },
+    { value: 100, label: 'Override',   hint: 'Runs last — wins set_category conflicts' },
+  ];
+  function priorityLabelFor(p) {
+    const match = priorityPresets.find(x => x.value === p);
+    if (match) return match.hint;
+    if (p < 10) return 'Runs very early — before standard rules';
+    if (p < 50) return 'Runs with standard rules';
+    if (p < 100) return 'Runs as a refinement';
+    return 'Runs very late — has the final word';
+  }
+
   return {
     isEdit: {{ if .IsEdit }}true{{ else }}false{{ end }},
     editingId: existingRule?.id || '',
@@ -356,9 +412,11 @@ function ruleForm() {
     submitting: false,
     formError: '',
     actionTypes,
+    priorityPresets,
     form: initForm(),
 
     fieldType(field) { return fieldTypes[field] || 'string'; },
+    priorityLabel(p) { return priorityLabelFor(p); },
 
     restorePageState() {
       const main = document.querySelector('main');
@@ -453,8 +511,15 @@ function ruleForm() {
       if (conds.length === 0) return null;
       const mapped = conds.map(c => {
         let val = c.value;
-        if (this.fieldType(c.field) === 'numeric') val = parseFloat(val) || 0;
-        else if (this.fieldType(c.field) === 'bool') val = val === 'true';
+        const type = this.fieldType(c.field);
+        if (type === 'numeric') val = parseFloat(val) || 0;
+        else if (type === 'bool') val = val === 'true';
+        else if (type === 'tags' && c.op === 'in') {
+          // Tags `in` takes an array; UI collects a comma-separated string.
+          val = String(val).split(',').map(s => s.trim()).filter(Boolean);
+        }
+        // string `in` op isn't exposed via the visual builder — advanced
+        // users use the JSON editor for that shape.
         return { field: c.field, op: c.op, value: val };
       });
       if (mapped.length === 1) return mapped[0];

--- a/internal/templates/pages/rule_form.html
+++ b/internal/templates/pages/rule_form.html
@@ -93,25 +93,14 @@
               <option value="provider">Provider</option>
             </optgroup>
           </select>
-          <!-- Operator -->
+          <!-- Operator — options are driven by fieldType so string / numeric /
+               bool / tags each have their own label set with no duplicate
+               <option value="..."> across groups (duplicates break <select>
+               display in Chrome/Safari). -->
           <select x-model="cond.op" @change="syncToJson()" class="select select-bordered select-xs rounded-lg bg-base-100 w-28 shrink-0">
-            <option value="contains" x-show="fieldType(cond.field) === 'string'">contains</option>
-            <option value="eq" x-show="fieldType(cond.field) === 'string'">equals</option>
-            <option value="neq" x-show="fieldType(cond.field) === 'string'">not equals</option>
-            <option value="not_contains" x-show="fieldType(cond.field) === 'string'">not contains</option>
-            <option value="matches" x-show="fieldType(cond.field) === 'string'">regex</option>
-            <option value="in" x-show="fieldType(cond.field) === 'string'">in list</option>
-            <option value="gte" x-show="fieldType(cond.field) === 'numeric'">&ge;</option>
-            <option value="lte" x-show="fieldType(cond.field) === 'numeric'">&le;</option>
-            <option value="eq" x-show="fieldType(cond.field) === 'numeric'">=</option>
-            <option value="gt" x-show="fieldType(cond.field) === 'numeric'">&gt;</option>
-            <option value="lt" x-show="fieldType(cond.field) === 'numeric'">&lt;</option>
-            <option value="neq" x-show="fieldType(cond.field) === 'numeric'">&ne;</option>
-            <option value="eq" x-show="fieldType(cond.field) === 'bool'">is</option>
-            <option value="neq" x-show="fieldType(cond.field) === 'bool'">is not</option>
-            <option value="contains" x-show="fieldType(cond.field) === 'tags'">has</option>
-            <option value="not_contains" x-show="fieldType(cond.field) === 'tags'">does not have</option>
-            <option value="in" x-show="fieldType(cond.field) === 'tags'">has any of</option>
+            <template x-for="opt in operatorOptions(cond.field)" :key="opt.value">
+              <option :value="opt.value" x-text="opt.label"></option>
+            </template>
           </select>
           <!-- Value -->
           <select x-model="cond.value" x-show="fieldType(cond.field) === 'bool'" @change="syncToJson()" class="select select-bordered select-xs rounded-lg bg-base-100 w-20 shrink-0">
@@ -295,7 +284,39 @@ function ruleForm() {
     tags: 'tags',
   };
   const defaultOps = { string: 'contains', numeric: 'gte', bool: 'eq', tags: 'contains' };
-  const emptyCondition = () => ({ field: 'name', op: 'contains', value: '' });
+  // Operator option sets keyed by fieldType. Kept as labels (not HTML glyphs)
+  // because the visual builder renders via x-text now.
+  const operatorOptionsByType = {
+    string: [
+      { value: 'contains',     label: 'contains' },
+      { value: 'eq',           label: 'equals' },
+      { value: 'neq',          label: 'not equals' },
+      { value: 'not_contains', label: 'not contains' },
+      { value: 'matches',      label: 'regex' },
+      { value: 'in',           label: 'in list' },
+    ],
+    numeric: [
+      { value: 'gte', label: '\u2265' },
+      { value: 'lte', label: '\u2264' },
+      { value: 'eq',  label: '=' },
+      { value: 'gt',  label: '>' },
+      { value: 'lt',  label: '<' },
+      { value: 'neq', label: '\u2260' },
+    ],
+    bool: [
+      { value: 'eq',  label: 'is' },
+      { value: 'neq', label: 'is not' },
+    ],
+    tags: [
+      { value: 'contains',     label: 'has' },
+      { value: 'not_contains', label: 'does not have' },
+      { value: 'in',           label: 'has any of' },
+    ],
+  };
+  // The initial condition row renders empty so the user must pick a field
+  // explicitly — the operator + value inputs then snap to sensible defaults
+  // via onFieldChange().
+  const emptyCondition = () => ({ field: '', op: '', value: '' });
 
   // Action type registry — first-class typed actions match the API's
   // supported action.type values (set_category | add_tag | remove_tag |
@@ -416,6 +437,12 @@ function ruleForm() {
     form: initForm(),
 
     fieldType(field) { return fieldTypes[field] || 'string'; },
+    operatorOptions(field) {
+      // Empty field → show an empty options set so the operator select is
+      // visually blank until a field is picked.
+      if (!field) return [];
+      return operatorOptionsByType[this.fieldType(field)] || operatorOptionsByType.string;
+    },
     priorityLabel(p) { return priorityLabelFor(p); },
 
     restorePageState() {


### PR DESCRIPTION
## Summary

Phase 4 of the rules polish project. Three targeted UI improvements, each validated via Chrome devtools on localhost:8084 before committing.

### Condition builder — expose Phase 1c fields

Field picker now groups options by semantic cluster and surfaces the condition fields that Phase 1c added but weren't reachable from the visual builder:

- **Transaction**: name, merchant, amount, pending
- **Category**: `category` (assigned), `category_primary` (raw), `category_detailed` (raw)
- **Tags**: `tag` — with dedicated operator labels ("has", "does not have", "has any of")
- **Account / User**: `account_name`, family member, provider

Tag `in`-operator values take a comma-separated string in the visual input; the submit path splits + trims. Autocomplete reuses the `bb-tag-slugs` datalist.

### Pipeline-stage presets

Replaces the raw priority number input with 4 preset chips — **Baseline (0)**, **Standard (10)**, **Refinement (50)**, **Override (100)** — backed by a fallback numeric input for custom values. A contextual help line under the input describes what that stage means. Info-tooltip on the label explains pipeline-stage ordering.

This addresses the "agents pick random values" concern from the Phase 1a design discussion: presets give agents a shared vocabulary without removing the escape hatch.

Also: warning banner on `always` trigger.

### Retroactive-apply confirmation modal

"Apply retroactively" was one click away from a bulk DB mutation. It now opens a modal that:

- Shows the exact match count.
- Lists per-action-type behavior (`set_category` respects override, `add_tag`/`remove_tag` apply regardless, `add_comment` is sync-only).
- Requires an "I understand this cannot be undone in bulk" checkbox before the Apply button enables.
- Dismisses on Escape or backdrop-click (unless a request is in flight).

The "Matching transactions" section (formerly "Uncategorized Matches") now shows for any rule with at least one retroactive-applicable action — not just set_category-setting rules. New `ruleHasRetroactiveAction` template helper.

## Chrome devtools validation

- Condition builder: confirmed grouped field picker renders, tag operator dropdown shows "has / does not have / has any of", `buildConditionsJSON()` produces correct shapes for `tags`/`category`/`account_name`.
- Priority presets: all 4 buttons render with correct tooltips, clicking a preset updates the numeric fallback + contextual label.
- Trigger warning: `always` selection shows the warning banner.
- Modal: opens with correct match count (tested with 26 pending matches), confirm checkbox gates the Apply button, backdrop/Escape close.

## Test plan

- [x] `go test ./...` green
- [x] Chrome devtools validation of each UI change
- [ ] CI green on push

## Not in scope

- Live preview panel in rule form (debounced match count + sample transactions) — deferred to a follow-up; the match-count is already visible via `preview_rule` MCP and the existing detail page.
- Rule list sort by hits/last-active — deferred.
- Allow editing expiry on existing rules — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)