### PR TITLE
feat(search): polish transaction results in command palette

### DIFF
--- a/input.css
+++ b/input.css
@@ -1252,7 +1252,7 @@
   }
 
   .bb-cmdk-item {
-    @apply flex items-center gap-3 px-4 py-2 mx-2 rounded-lg text-sm cursor-pointer;
+    @apply mx-2 rounded-lg text-sm cursor-pointer;
     transition: background-color 0.1s ease, color 0.1s ease;
   }
 
@@ -1269,6 +1269,10 @@
     .bb-cmdk-item[data-active="true"] {
       @apply bg-primary/12;
     }
+  }
+
+  .bb-cmdk-generic {
+    @apply flex items-center gap-3 px-4 py-2;
   }
 
   .bb-cmdk-item-icon {
@@ -1303,6 +1307,63 @@
 
   .bb-cmdk-item-shortcut {
     @apply flex items-center gap-1 shrink-0;
+  }
+
+  /* ── Transaction result variant — mirrors the main tx-row layout ── */
+  .bb-cmdk-tx {
+    @apply flex items-center gap-3 px-4 py-2;
+  }
+
+  .bb-cmdk-tx-avatar {
+    --avatar-color: oklch(0.65 0 0);
+    @apply w-8 h-8 rounded-lg flex items-center justify-center shrink-0;
+    background-color: color-mix(in srgb, var(--avatar-color) 15%, transparent);
+    color: var(--avatar-color);
+  }
+
+  .bb-cmdk-tx-avatar svg,
+  .bb-cmdk-tx-avatar i {
+    @apply w-4 h-4;
+  }
+
+  .bb-cmdk-tx-main {
+    @apply flex-1 min-w-0;
+  }
+
+  .bb-cmdk-tx-title-row {
+    @apply flex items-center gap-2;
+  }
+
+  .bb-cmdk-tx-title {
+    @apply text-sm font-medium truncate;
+  }
+
+  .bb-cmdk-tx-meta {
+    @apply flex items-center gap-1.5 mt-0.5 text-xs text-base-content/45 min-w-0;
+  }
+
+  .bb-cmdk-tx-meta > .truncate {
+    @apply min-w-0;
+  }
+
+  .bb-cmdk-tx-user {
+    @apply text-base-content/55 shrink-0;
+  }
+
+  .bb-cmdk-tx-sep {
+    @apply text-base-content/20 shrink-0;
+  }
+
+  .bb-cmdk-tx-cat {
+    @apply inline-flex items-center gap-1 shrink-0 min-w-0;
+  }
+
+  .bb-cmdk-tx-right {
+    @apply flex flex-col items-end shrink-0 leading-tight;
+  }
+
+  .bb-cmdk-tx-date {
+    @apply text-[0.65rem] text-base-content/40 tabular-nums;
   }
 
   .bb-cmdk-kbd {

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -1156,29 +1156,46 @@ func QuickSearchTransactionsHandler(svc *service.Service) http.HandlerFunc {
 		}
 
 		type txResult struct {
-			ID            string  `json:"id"`
-			Name          string  `json:"name"`
-			Amount        float64 `json:"amount"`
-			Date          string  `json:"date"`
-			Account       string  `json:"account"`
-			Merchant      *string `json:"merchant,omitempty"`
-			Pending       bool    `json:"pending,omitempty"`
-			CategoryIcon  *string `json:"category_icon,omitempty"`
-			CategoryColor *string `json:"category_color,omitempty"`
+			ID                  string  `json:"id"`
+			Name                string  `json:"name"`
+			Amount              float64 `json:"amount"`
+			AmountLabel         string  `json:"amount_label"`
+			Date                string  `json:"date"`
+			DateLabel           string  `json:"date_label"`
+			Account             string  `json:"account"`
+			Merchant            *string `json:"merchant,omitempty"`
+			UserName            string  `json:"user_name,omitempty"`
+			Pending             bool    `json:"pending,omitempty"`
+			CategoryIcon        *string `json:"category_icon,omitempty"`
+			CategoryColor       *string `json:"category_color,omitempty"`
+			CategoryDisplayName *string `json:"category_display_name,omitempty"`
 		}
 
 		items := make([]txResult, 0, len(result.Transactions))
 		for _, tx := range result.Transactions {
+			amountAbs := math.Abs(tx.Amount)
+			amountLabel := formatCurrency(amountAbs)
+			if tx.Amount < 0 {
+				amountLabel = "-" + amountLabel
+			}
+			dateLabel := tx.Date
+			if t, err := time.Parse("2006-01-02", tx.Date); err == nil {
+				dateLabel = t.Format("Jan 2")
+			}
 			items = append(items, txResult{
-				ID:            tx.ID,
-				Name:          tx.Name,
-				Amount:        tx.Amount,
-				Date:          tx.Date,
-				Account:       tx.AccountName,
-				Merchant:      tx.MerchantName,
-				Pending:       tx.Pending,
-				CategoryIcon:  tx.CategoryIcon,
-				CategoryColor: tx.CategoryColor,
+				ID:                  tx.ID,
+				Name:                tx.Name,
+				Amount:              tx.Amount,
+				AmountLabel:         amountLabel,
+				Date:                tx.Date,
+				DateLabel:           dateLabel,
+				Account:             tx.AccountName,
+				Merchant:            tx.MerchantName,
+				UserName:            tx.UserName,
+				Pending:             tx.Pending,
+				CategoryIcon:        tx.CategoryIcon,
+				CategoryColor:       tx.CategoryColor,
+				CategoryDisplayName: tx.CategoryDisplayName,
 			})
 		}
 

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -569,39 +569,97 @@
             <template x-if="group._loading">
               <div>
                 <div class="bb-cmdk-item" style="pointer-events:none">
-                  <div class="bb-cmdk-item-icon"><div class="w-4 h-4 bg-base-300/40 rounded animate-pulse"></div></div>
-                  <div class="bb-cmdk-item-label"><div class="h-3.5 bg-base-300/40 rounded w-36 animate-pulse"></div><div class="h-2.5 bg-base-300/30 rounded w-48 mt-1.5 animate-pulse"></div></div>
+                  <div class="bb-cmdk-generic">
+                    <div class="bb-cmdk-item-icon"><div class="w-4 h-4 bg-base-300/40 rounded animate-pulse"></div></div>
+                    <div class="bb-cmdk-item-label"><div class="h-3.5 bg-base-300/40 rounded w-36 animate-pulse"></div><div class="h-2.5 bg-base-300/30 rounded w-48 mt-1.5 animate-pulse"></div></div>
+                  </div>
                 </div>
                 <div class="bb-cmdk-item" style="pointer-events:none">
-                  <div class="bb-cmdk-item-icon"><div class="w-4 h-4 bg-base-300/40 rounded animate-pulse"></div></div>
-                  <div class="bb-cmdk-item-label"><div class="h-3.5 bg-base-300/40 rounded w-44 animate-pulse"></div><div class="h-2.5 bg-base-300/30 rounded w-40 mt-1.5 animate-pulse"></div></div>
+                  <div class="bb-cmdk-generic">
+                    <div class="bb-cmdk-item-icon"><div class="w-4 h-4 bg-base-300/40 rounded animate-pulse"></div></div>
+                    <div class="bb-cmdk-item-label"><div class="h-3.5 bg-base-300/40 rounded w-44 animate-pulse"></div><div class="h-2.5 bg-base-300/30 rounded w-40 mt-1.5 animate-pulse"></div></div>
+                  </div>
                 </div>
                 <div class="bb-cmdk-item" style="pointer-events:none">
-                  <div class="bb-cmdk-item-icon"><div class="w-4 h-4 bg-base-300/40 rounded animate-pulse"></div></div>
-                  <div class="bb-cmdk-item-label"><div class="h-3.5 bg-base-300/40 rounded w-32 animate-pulse"></div><div class="h-2.5 bg-base-300/30 rounded w-52 mt-1.5 animate-pulse"></div></div>
+                  <div class="bb-cmdk-generic">
+                    <div class="bb-cmdk-item-icon"><div class="w-4 h-4 bg-base-300/40 rounded animate-pulse"></div></div>
+                    <div class="bb-cmdk-item-label"><div class="h-3.5 bg-base-300/40 rounded w-32 animate-pulse"></div><div class="h-2.5 bg-base-300/30 rounded w-52 mt-1.5 animate-pulse"></div></div>
+                  </div>
                 </div>
               </div>
             </template>
             <!-- Real items -->
             <template x-for="(item, ii) in group.items" :key="item.id">
               <div class="bb-cmdk-item"
+                   :class="item._kind === 'tx' ? 'bb-cmdk-item--tx' : ''"
                    :data-active="activeIndex === item._flatIndex"
                    :data-cmdk-idx="item._flatIndex"
                    @click="go(item)"
                    @mouseenter="activeIndex = item._flatIndex">
-                <div class="bb-cmdk-item-icon" :style="item.iconColor ? 'background-color: color-mix(in srgb, ' + item.iconColor + ' 15%, transparent); color: ' + item.iconColor : ''">
-                  <i :data-lucide="item.icon"></i>
-                </div>
-                <div class="bb-cmdk-item-label">
-                  <div class="bb-cmdk-item-title" x-text="item.title"></div>
-                  <template x-if="item.desc">
-                    <div class="bb-cmdk-item-desc" x-text="item.desc"></div>
-                  </template>
-                </div>
-                <template x-if="item.shortcut">
-                  <div class="bb-cmdk-item-shortcut">
-                    <template x-for="k in item.shortcut" :key="k">
-                      <span class="bb-cmdk-kbd" x-text="k"></span>
+                <!-- Transaction variant: mirrors the tx-row layout in the list -->
+                <template x-if="item._kind === 'tx'">
+                  <div class="bb-cmdk-tx">
+                    <div class="bb-cmdk-tx-avatar"
+                         :style="item.iconColor ? '--avatar-color: ' + item.iconColor : ''">
+                      <i :data-lucide="item.icon"></i>
+                    </div>
+                    <div class="bb-cmdk-tx-main">
+                      <div class="bb-cmdk-tx-title-row">
+                        <span class="bb-cmdk-tx-title" x-text="item.title"></span>
+                        <template x-if="item.tx.pending">
+                          <span class="badge badge-soft badge-xs badge-warning rounded-md shrink-0">Pending</span>
+                        </template>
+                      </div>
+                      <div class="bb-cmdk-tx-meta">
+                        <template x-if="item.tx.userName">
+                          <span class="bb-cmdk-tx-user" x-text="item.tx.userName.split(' ')[0]"></span>
+                        </template>
+                        <template x-if="item.tx.userName && item.tx.account">
+                          <span class="bb-cmdk-tx-sep">&middot;</span>
+                        </template>
+                        <template x-if="item.tx.account">
+                          <span class="truncate" x-text="item.tx.account"></span>
+                        </template>
+                        <template x-if="item.tx.categoryName">
+                          <span class="bb-cmdk-tx-sep">&middot;</span>
+                        </template>
+                        <template x-if="item.tx.categoryName">
+                          <span class="bb-cmdk-tx-cat">
+                            <template x-if="item.tx.categoryColor">
+                              <span class="bb-cat-dot" :style="'background-color:' + item.tx.categoryColor"></span>
+                            </template>
+                            <span class="truncate" x-text="item.tx.categoryName"></span>
+                          </span>
+                        </template>
+                      </div>
+                    </div>
+                    <div class="bb-cmdk-tx-right">
+                      <div class="bb-cmdk-tx-date" x-text="item.tx.dateLabel"></div>
+                      <div class="bb-tx-amount tabular-nums"
+                           :class="item.tx.amount < 0 ? 'bb-tx-amount--income' : ''"
+                           x-text="item.tx.amountLabel"></div>
+                    </div>
+                  </div>
+                </template>
+
+                <!-- Generic command / action variant -->
+                <template x-if="item._kind !== 'tx'">
+                  <div class="bb-cmdk-generic">
+                    <div class="bb-cmdk-item-icon" :style="item.iconColor ? 'background-color: color-mix(in srgb, ' + item.iconColor + ' 15%, transparent); color: ' + item.iconColor : ''">
+                      <i :data-lucide="item.icon"></i>
+                    </div>
+                    <div class="bb-cmdk-item-label">
+                      <div class="bb-cmdk-item-title" x-text="item.title"></div>
+                      <template x-if="item.desc">
+                        <div class="bb-cmdk-item-desc" x-text="item.desc"></div>
+                      </template>
+                    </div>
+                    <template x-if="item.shortcut">
+                      <div class="bb-cmdk-item-shortcut">
+                        <template x-for="k in item.shortcut" :key="k">
+                          <span class="bb-cmdk-kbd" x-text="k"></span>
+                        </template>
+                      </div>
                     </template>
                   </div>
                 </template>
@@ -1307,19 +1365,25 @@
             .then(function(items) {
               self._txLoading = false;
               self._txResults = items.map(function(tx) {
-                var sign = tx.amount >= 0 ? '-' : '+';
-                var abs = Math.abs(tx.amount).toFixed(2);
-                var desc = sign + '$' + abs + '  ·  ' + tx.date;
-                if (tx.account) desc += '  ·  ' + tx.account;
                 return {
                   id: 'tx-' + tx.id,
                   group: 'Transactions',
+                  _kind: 'tx',
                   title: tx.name,
-                  desc: desc,
-                  icon: tx.pending ? 'clock' : (tx.category_icon || 'receipt'),
+                  icon: tx.category_icon || 'receipt',
                   iconColor: tx.category_color || null,
                   href: '/transactions/' + tx.id,
-                  keywords: ''
+                  keywords: '',
+                  tx: {
+                    amount: tx.amount,
+                    amountLabel: tx.amount_label,
+                    dateLabel: tx.date_label,
+                    account: tx.account || '',
+                    userName: tx.user_name || '',
+                    pending: !!tx.pending,
+                    categoryName: tx.category_display_name || '',
+                    categoryColor: tx.category_color || ''
+                  }
                 };
               });
               setTimeout(function() {


### PR DESCRIPTION
## Summary
- Command palette transaction results now mirror the main `tx-row` layout: tinted category avatar, bold name + optional Pending badge, `user · account · category (dot)` meta line, and a right-aligned date over the amount (green for income).
- `/-/search/transactions` returns pre-formatted `amount_label` and `date_label` using the same helpers the transactions list uses, plus `user_name` and `category_display_name`.
- Split `.bb-cmdk-generic` out of `.bb-cmdk-item` so existing command/action items keep their original layout; skeleton loaders updated to match.

## Test plan
- [ ] Open Cmd+K, search for an expense (e.g. `starbucks`) — avatar tinted by category color, amount in default color with date above
- [ ] Search for income (e.g. `deposit`) — amount renders green via `bb-tx-amount--income`
- [ ] Pending transaction shows the `Pending` badge inline with the title
- [ ] Uncategorized transactions render without a category dot and don't orphan a separator
- [ ] Non-transaction commands/actions in the palette still render with their original icon + title + desc layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)