### PR TITLE
feat(rules): redesign rule form + polish action builder

### DIFF
--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -174,7 +174,7 @@ A rule can carry multiple actions of different types. Override (`category_overri
 
 #### Which combinations make sense
 
-A single rule is limited to **one action per type** (at most one `set_category`, one `add_tag`, one `remove_tag`, one `add_comment`). The admin UI enforces this by disabling already-picked types in the action dropdown. To apply more than one tag, create additional rules — their outputs accumulate at the tag layer.
+Only `set_category` is singleton per rule — repeating it is rejected at write time. `add_tag`, `remove_tag`, and `add_comment` can appear multiple times in one rule (e.g. add two tags at once, or add one and remove another). The admin UI disables a second `set_category` dropdown option once one is picked; tag and comment rows are freely repeatable.
 
 Useful combinations:
 

--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -172,6 +172,29 @@ A rule can carry multiple actions of different types. Override (`category_overri
 }
 ```
 
+#### Which combinations make sense
+
+A single rule is limited to **one action per type** (at most one `set_category`, one `add_tag`, one `remove_tag`, one `add_comment`). The admin UI enforces this by disabling already-picked types in the action dropdown. To apply more than one tag, create additional rules — their outputs accumulate at the tag layer.
+
+Useful combinations:
+
+| Actions | Use case |
+| --- | --- |
+| `set_category` alone | Straightforward reclassification (e.g. `Uber` → `Transportation > Rideshare`). |
+| `set_category` + `add_tag` | Reclassify and annotate simultaneously (e.g. `Uber` → `Transportation > Rideshare` + `recurring`). |
+| `add_tag` alone | Add a tag without touching category. Safe pairing with override-protected transactions. |
+| `remove_tag` alone | Clean up a tag a prior rule or agent added (e.g. remove `needs-review` once a condition proves the transaction is benign). |
+| `add_tag` + `remove_tag` (different slugs) | Transition a transaction between tags (e.g. add `reviewed`, remove `needs-review`). |
+| `set_category` + `add_comment` | Reclassify and explain why — useful for audit trails. |
+
+Combinations to avoid:
+
+- **Same-slug `add_tag` + `remove_tag`** — cancels out under net-diff semantics. The admin UI flags this with an inline warning.
+- **`set_category` with no conditions** — match-all + reclassify will stomp every transaction on every sync. The form shows an "All transactions" banner for any match-all rule; double-check before saving.
+- **`add_comment` on `always` trigger** — fires on every sync, accumulating duplicate comment annotations. Prefer `on_create` or a narrower condition.
+
+See `docs/data-model.md` §annotations for how each action materializes into the timeline, and `internal/sync/engine.go applyRulesToTransaction` for the sync-side ordering guarantees.
+
 ## Triggers
 
 The `trigger` field controls when the rule runs during sync.

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -51,6 +51,11 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 			}
 		}
 
+		// Sort key — whitelisted in ruleOrderByClause so unknown values fall
+		// back to created_at DESC instead of injecting arbitrary SQL.
+		sortBy := r.URL.Query().Get("sort_by")
+		params.SortBy = sortBy
+
 		result, err := svc.ListTransactionRules(ctx, params)
 		if err != nil {
 			tr.Render(w, r, "500.html", map[string]any{"PageTitle": "Error", "CurrentPage": "rules"})
@@ -99,6 +104,7 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 		data["SearchFilter"] = r.URL.Query().Get("search")
 		data["CategoryFilter"] = r.URL.Query().Get("category_slug")
 		data["EnabledFilter"] = r.URL.Query().Get("enabled")
+		data["SortBy"] = sortBy
 		data["Categories"] = categories
 		data["FlatCategories"] = flattenCategories(categories)
 		data["Version"] = version
@@ -191,7 +197,7 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 
 // buildRulesPaginationBase returns the pagination base URL for the rules page.
 func buildRulesPaginationBase(r *http.Request) string {
-	params := []string{"search", "category_slug", "enabled", "per_page"}
+	params := []string{"search", "category_slug", "enabled", "per_page", "sort_by"}
 	q := r.URL.Query()
 	var qs []string
 	for _, key := range params {

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -298,7 +298,10 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return ""
 			},
-			"triggerLabel": service.TriggerLabel,
+			"triggerLabel":    service.TriggerLabel,
+			"ruleFieldLabel":  ruleFieldLabel,
+			"ruleOpLabel":     ruleOpLabel,
+			"ruleValueFormat": ruleValueFormat,
 			"ruleHasRetroactiveAction": func(actions []service.RuleAction) bool {
 				// Retroactive apply materializes set_category / add_tag / remove_tag.
 				// add_comment is sync-only. A rule with only comments isn't
@@ -768,6 +771,7 @@ var templatePartials = []string{
 	"partials/tx_row.html",
 	"partials/tx_results.html",
 	"partials/tag_chip.html",
+	"partials/condition_row.html",
 }
 
 func (tr *TemplateRenderer) parseTemplates() error {
@@ -1103,6 +1107,123 @@ func titleCaseMerchant(s string) string {
 // AdminUsername returns the username from the session for use in template data maps.
 func AdminUsername(r *http.Request, sm *scs.SessionManager) string {
 	return sm.GetString(r.Context(), sessionKeyAccountUsername)
+}
+
+// ruleFieldLabel maps a rule-condition field name to its human-readable
+// label. Falls back to title-casing the raw identifier so unknown fields
+// still read reasonably.
+func ruleFieldLabel(field string) string {
+	switch field {
+	case "name":
+		return "Name"
+	case "merchant_name":
+		return "Merchant"
+	case "amount":
+		return "Amount"
+	case "pending":
+		return "Pending"
+	case "category":
+		return "Category"
+	case "category_primary":
+		return "Category (primary)"
+	case "category_detailed":
+		return "Category (detail)"
+	case "tags":
+		return "Tag"
+	case "account_name":
+		return "Account"
+	case "user_name":
+		return "Family member"
+	case "provider":
+		return "Provider"
+	default:
+		if field == "" {
+			return "—"
+		}
+		return titleCaseMerchant(strings.ReplaceAll(field, "_", " "))
+	}
+}
+
+// ruleOpLabel maps an operator code to a short display symbol/phrase. The
+// field argument lets us pick type-appropriate wording (e.g. "contains" for
+// strings vs "has" for tag-list fields, "=" for numerics vs "is" for bools).
+func ruleOpLabel(op, field string) string {
+	numericFields := map[string]bool{"amount": true}
+	boolFields := map[string]bool{"pending": true}
+	tagField := field == "tags"
+	switch op {
+	case "contains":
+		if tagField {
+			return "has"
+		}
+		return "contains"
+	case "not_contains":
+		if tagField {
+			return "does not have"
+		}
+		return "does not contain"
+	case "in":
+		if tagField {
+			return "has any of"
+		}
+		return "in"
+	case "matches":
+		return "matches /regex/"
+	case "eq":
+		if numericFields[field] {
+			return "="
+		}
+		if boolFields[field] {
+			return "is"
+		}
+		return "is"
+	case "neq":
+		if numericFields[field] {
+			return "≠"
+		}
+		if boolFields[field] {
+			return "is not"
+		}
+		return "is not"
+	case "gt":
+		return ">"
+	case "gte":
+		return "≥"
+	case "lt":
+		return "<"
+	case "lte":
+		return "≤"
+	default:
+		if op == "" {
+			return "—"
+		}
+		return op
+	}
+}
+
+// ruleValueFormat renders a condition's value for display. Arrays come back
+// comma-separated; booleans as "true"/"false"; everything else via fmt.Sprint.
+func ruleValueFormat(v any) string {
+	if v == nil {
+		return ""
+	}
+	switch vv := v.(type) {
+	case []any:
+		parts := make([]string, 0, len(vv))
+		for _, x := range vv {
+			parts = append(parts, fmt.Sprint(x))
+		}
+		return strings.Join(parts, ", ")
+	case string:
+		return vv
+	case bool:
+		if vv {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprint(v)
+	}
 }
 
 // RenderTo writes the named template to any io.Writer.

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -2312,16 +2312,18 @@ func ActionsSummary(actions []RuleAction, categoryName string) string {
 }
 
 // TriggerLabel returns the human-readable label for a rule trigger value.
-// Falls back to the raw value (or "On create" when empty) for unknown values.
-// "on_update" is accepted as a back-compat alias for "on_change".
+// The "On sync …" phrasing makes it explicit that rules fire during provider
+// sync, not on arbitrary admin edits. "on_update" is accepted as a back-compat
+// alias for "on_change". Falls back to the raw value for unknown triggers and
+// "On sync create" when the value is empty.
 func TriggerLabel(trigger string) string {
 	switch trigger {
 	case "", "on_create":
-		return "On create"
+		return "On sync create"
 	case "on_change", "on_update":
-		return "On change"
+		return "On sync change"
 	case "always":
-		return "Always"
+		return "Every sync"
 	default:
 		return trigger
 	}

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -726,6 +726,40 @@ func (s *Service) GetTransactionRule(ctx context.Context, id string) (*Transacti
 	return s.ruleRowToResponse(ctx, &row), nil
 }
 
+// ruleOrderByClause maps a requested sort to the actual ORDER BY fragment.
+// Unknown values fall back to created_at DESC so the admin UI can't inject
+// arbitrary SQL via the query string.
+func ruleOrderByClause(sortBy, sortDir string) string {
+	dir := "DESC"
+	if sortDir == "asc" {
+		dir = "ASC"
+	}
+	switch sortBy {
+	case "hit_count":
+		return " ORDER BY tr.hit_count " + dir + ", tr.id DESC"
+	case "last_hit_at":
+		// NULLs sort last regardless of direction — rules that have never
+		// fired should stay at the bottom.
+		nullsOrder := "NULLS LAST"
+		if dir == "ASC" {
+			nullsOrder = "NULLS LAST"
+		}
+		return " ORDER BY tr.last_hit_at " + dir + " " + nullsOrder + ", tr.id DESC"
+	case "priority":
+		if sortDir == "" {
+			dir = "ASC" // pipeline stages read left-to-right
+		}
+		return " ORDER BY tr.priority " + dir + ", tr.created_at DESC, tr.id DESC"
+	case "name":
+		if sortDir == "" {
+			dir = "ASC"
+		}
+		return " ORDER BY LOWER(tr.name) " + dir + ", tr.id DESC"
+	default:
+		return " ORDER BY tr.created_at DESC, tr.id DESC"
+	}
+}
+
 // ListTransactionRules returns a filtered, paginated list of transaction rules.
 //
 // Category filtering matches against the set_category action inside the
@@ -794,7 +828,7 @@ func (s *Service) ListTransactionRules(ctx context.Context, params TransactionRu
 		tr.priority, tr.enabled, tr.expires_at, tr.created_by_type, tr.created_by_id, tr.created_by_name,
 		tr.hit_count, tr.last_hit_at, tr.created_at, tr.updated_at `
 
-	orderBy := " ORDER BY tr.created_at DESC, tr.id DESC"
+	orderBy := ruleOrderByClause(params.SortBy, params.SortDir)
 	whereSQL := filterWhereSQL
 
 	// Offset-based pagination (admin UI)

--- a/internal/service/rules_test.go
+++ b/internal/service/rules_test.go
@@ -440,11 +440,11 @@ func TestActionsSummary(t *testing.T) {
 
 func TestTriggerLabel(t *testing.T) {
 	tests := map[string]string{
-		"":          "On create",
-		"on_create": "On create",
-		"on_change": "On change",
-		"on_update": "On change", // legacy alias
-		"always":    "Always",
+		"":          "On sync create",
+		"on_create": "On sync create",
+		"on_change": "On sync change",
+		"on_update": "On sync change", // legacy alias
+		"always":    "Every sync",
 		"weird":     "weird",
 	}
 	for in, want := range tests {

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -473,8 +473,14 @@ type TransactionRuleListParams struct {
 	Enabled      *bool
 	Search       *string
 	SearchMode   *string
-	Limit        int
-	Cursor       string
+	// SortBy drives the ORDER BY clause for the offset-paginated path (admin UI).
+	// Accepted values: "created_at" (default), "hit_count", "last_hit_at", "priority", "name".
+	// Ignored by the cursor-paginated path (API), which must stay stable on (date, id).
+	SortBy string
+	// SortDir is "asc" or "desc". Empty → per-column default (desc for most, asc for name/priority).
+	SortDir string
+	Limit   int
+	Cursor  string
 	// Offset-based pagination (used by admin UI). When Page > 0, cursor is ignored.
 	Page     int
 	PageSize int

--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -60,48 +60,49 @@
   <div class="mt-3 space-y-3">
     <!-- Conditions -->
     <div>
-      <span class="text-xs text-base-content/40 uppercase tracking-wider">When</span>
-      <div class="mt-1 space-y-1">
-        {{if $matchAll}}
-        <div class="flex items-center gap-3 p-3 bg-info/5 border border-info/15 rounded-xl">
-          <div class="w-8 h-8 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
-            <i data-lucide="infinity" class="w-4 h-4 text-info"></i>
-          </div>
-          <div class="flex-1 min-w-0">
-            <p class="text-sm font-medium">All transactions</p>
-            <p class="text-xs text-base-content/50">No conditions &mdash; this rule fires on every transaction.</p>
-          </div>
-        </div>
-        {{else if .Rule.Conditions.And}}
-        <p class="text-xs text-base-content/50 mb-1"><strong>All</strong> of these match:</p>
-        {{range .Rule.Conditions.And}}
-        <div class="flex items-center gap-2 p-2 bg-base-200/40 rounded-lg">
-          <span class="text-sm text-base-content/60 w-28 shrink-0 capitalize">{{.Field}}</span>
-          <span class="text-xs font-mono text-base-content/40 w-20 shrink-0">{{.Op}}</span>
-          <span class="text-sm font-medium">{{.Value}}</span>
-        </div>
-        {{end}}
-        {{else if .Rule.Conditions.Or}}
-        <p class="text-xs text-base-content/50 mb-1"><strong>Any</strong> of these match:</p>
-        {{range .Rule.Conditions.Or}}
-        <div class="flex items-center gap-2 p-2 bg-base-200/40 rounded-lg">
-          <span class="text-sm text-base-content/60 w-28 shrink-0 capitalize">{{.Field}}</span>
-          <span class="text-xs font-mono text-base-content/40 w-20 shrink-0">{{.Op}}</span>
-          <span class="text-sm font-medium">{{.Value}}</span>
-        </div>
-        {{end}}
-        {{else if .Rule.Conditions.Field}}
-        <div class="flex items-center gap-2 p-2 bg-base-200/40 rounded-lg">
-          <span class="text-sm text-base-content/60 w-28 shrink-0 capitalize">{{.Rule.Conditions.Field}}</span>
-          <span class="text-xs font-mono text-base-content/40 w-20 shrink-0">{{.Rule.Conditions.Op}}</span>
-          <span class="text-sm font-medium">{{.Rule.Conditions.Value}}</span>
-        </div>
-        {{else}}
-        <div class="p-3 bg-base-200/40 rounded-xl">
-          <code class="text-xs font-mono text-base-content/70">{{.ConditionSummary}}</code>
-        </div>
+      {{- $conj := "" -}}{{- $conjClass := "text-base-content/30" -}}
+      {{- if .Rule.Conditions.And -}}{{- $conj = "AND" -}}{{- end -}}
+      {{- if .Rule.Conditions.Or -}}{{- $conj = "OR" -}}{{- $conjClass = "text-warning" -}}{{- end -}}
+      <div class="flex items-center justify-between mb-2">
+        <span class="text-xs text-base-content/40 uppercase tracking-wider">When</span>
+        {{if $conj}}
+        <span class="text-[0.65rem] font-medium uppercase tracking-wider {{$conjClass}}">
+          {{if eq $conj "AND"}}All must match{{else}}Any may match{{end}}
+        </span>
         {{end}}
       </div>
+
+      {{if $matchAll}}
+      <div class="flex items-center gap-3 p-3 bg-info/5 border border-info/15 rounded-xl">
+        <div class="w-8 h-8 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
+          <i data-lucide="infinity" class="w-4 h-4 text-info"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-medium">All transactions</p>
+          <p class="text-xs text-base-content/50">No conditions &mdash; this rule fires on every transaction.</p>
+        </div>
+      </div>
+      {{else if .Rule.Conditions.And}}
+      <div class="space-y-1.5">
+        {{range $i, $c := .Rule.Conditions.And}}
+        {{template "condition-row" dict "Cond" $c "Idx" $i "Conj" "AND"}}
+        {{end}}
+      </div>
+      {{else if .Rule.Conditions.Or}}
+      <div class="space-y-1.5">
+        {{range $i, $c := .Rule.Conditions.Or}}
+        {{template "condition-row" dict "Cond" $c "Idx" $i "Conj" "OR"}}
+        {{end}}
+      </div>
+      {{else if .Rule.Conditions.Field}}
+      <div class="space-y-1.5">
+        {{template "condition-row" dict "Cond" .Rule.Conditions "Idx" 0 "Conj" ""}}
+      </div>
+      {{else}}
+      <div class="p-3 bg-base-200/50 border border-base-content/10 rounded-xl">
+        <code class="text-xs font-mono text-base-content/70">{{.ConditionSummary}}</code>
+      </div>
+      {{end}}
     </div>
 
     <!-- Actions -->
@@ -130,9 +131,17 @@
             <p class="text-sm">Add tag <span class="font-semibold">{{.TagSlug}}</span></p>
             <p class="text-xs text-base-content/40">Tag is attached to matching transactions during sync.</p>
           </div>
+          {{else if eq .Type "remove_tag"}}
+          <div class="w-8 h-8 rounded-lg bg-error/10 flex items-center justify-center shrink-0">
+            <i data-lucide="minus-circle" class="w-4 h-4 text-error"></i>
+          </div>
+          <div class="flex-1 min-w-0">
+            <p class="text-sm">Remove tag <span class="font-semibold">{{.TagSlug}}</span></p>
+            <p class="text-xs text-base-content/40">Tag is removed from matching transactions during sync.</p>
+          </div>
           {{else if eq .Type "add_comment"}}
-          <div class="w-8 h-8 rounded-lg bg-secondary/10 flex items-center justify-center shrink-0">
-            <i data-lucide="message-square" class="w-4 h-4 text-secondary"></i>
+          <div class="w-8 h-8 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
+            <i data-lucide="message-square" class="w-4 h-4 text-info"></i>
           </div>
           <div class="flex-1 min-w-0">
             <p class="text-sm">Add comment</p>

--- a/internal/templates/pages/rule_form.html
+++ b/internal/templates/pages/rule_form.html
@@ -84,7 +84,7 @@
       <!-- Condition rows -->
       <div class="space-y-2" x-show="form.conditions.length > 0">
         <template x-for="(cond, idx) in form.conditions" :key="idx">
-          <div class="flex items-center gap-2 p-2.5 bg-base-200/40 rounded-xl">
+          <div class="flex items-center gap-2 p-2.5 bg-base-200/50 border border-base-content/10 rounded-xl">
             <!-- Conjunction label -->
             <div class="w-10 shrink-0 text-center">
               <span x-show="idx === 0" class="text-xs text-base-content/30 font-medium">IF</span>
@@ -172,7 +172,7 @@
       <div class="flex items-center justify-between mb-2">
         <div>
           <h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/60">Then</h3>
-          <p class="text-xs text-base-content/40 mt-1">Up to one of each action type (set category, add tag, remove tag, add comment).</p>
+          <p class="text-xs text-base-content/40 mt-1">Add one or more. Only "Set category" is limited to a single action per rule.</p>
         </div>
         <button type="button" class="btn btn-ghost btn-xs rounded-lg gap-1.5 shrink-0" @click="addAction()"
                 :disabled="!canAddAction()"
@@ -183,8 +183,8 @@
 
       <div class="space-y-2">
         <template x-for="(action, idx) in form.actions" :key="idx">
-          <div class="flex items-start gap-2 p-2.5 rounded-xl transition-colors"
-               :class="action.field === 'tag_remove' ? 'bg-error/5 border border-error/15' : 'bg-base-200/40'">
+          <div class="flex items-start gap-2 p-2.5 rounded-xl border transition-colors"
+               :class="action.field === 'tag_remove' ? 'bg-error/5 border-error/25' : 'bg-base-200/50 border-base-300/70'">
             <!-- Action type selector -->
             <select x-model="action.field" @change="onActionTypeChange(idx)"
                     class="select select-bordered select-xs rounded-lg bg-base-100 w-36 shrink-0 mt-px"
@@ -279,15 +279,15 @@
         <div>
           <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="rule-trigger">Trigger</label>
           <select id="rule-trigger" x-model="form.trigger" class="bb-form-select select-sm">
-            <option value="on_create">On create</option>
-            <option value="on_change">On change</option>
-            <option value="always">Always</option>
+            <option value="on_create">On sync create</option>
+            <option value="on_change">On sync change</option>
+            <option value="always">Every sync</option>
           </select>
-          <p class="text-xs text-base-content/40 mt-1.5" x-show="form.trigger === 'on_create'">Fires only when a transaction is first synced.</p>
-          <p class="text-xs text-base-content/40 mt-1.5" x-show="form.trigger === 'on_change' || form.trigger === 'on_update'">Fires only when an existing transaction changes on re-sync.</p>
+          <p class="text-xs text-base-content/40 mt-1.5" x-show="form.trigger === 'on_create'">Fires when a provider first syncs the transaction.</p>
+          <p class="text-xs text-base-content/40 mt-1.5" x-show="form.trigger === 'on_change' || form.trigger === 'on_update'">Fires when a provider re-syncs and the transaction changed.</p>
           <p class="text-xs text-warning/80 mt-1.5" x-show="form.trigger === 'always'" x-cloak>
             <i data-lucide="alert-triangle" class="w-3 h-3 inline-block -mt-0.5 mr-0.5"></i>
-            Fires on every sync that touches this transaction &mdash; use sparingly.
+            Fires on every provider sync that touches this transaction &mdash; use sparingly.
           </p>
         </div>
         <div>
@@ -549,22 +549,19 @@ function ruleForm() {
       this.syncToJson();
     },
 
-    // Action helpers
+    // Action helpers. Only set_category is singleton (backend enforces one
+    // per rule); add_tag / remove_tag / add_comment may repeat.
     isActionUsed(field) {
+      if (field !== 'category') return false;
       return this.form.actions.some(a => a.field === field);
     },
-    // Disable the "Add action" button when every type is already in use
-    // OR there's still an unpicked draft row waiting for a type.
+    // Block "Add action" only while there's an unpicked draft row.
     canAddAction() {
-      const distinct = new Set(this.form.actions.filter(a => a.field).map(a => a.field));
-      if (distinct.size >= actionTypes.length) return false;
       if (this.form.actions.some(a => !a.field)) return false;
       return true;
     },
     addActionTooltip() {
       if (this.form.actions.some(a => !a.field)) return 'Pick an action type first';
-      const distinct = new Set(this.form.actions.filter(a => a.field).map(a => a.field));
-      if (distinct.size >= actionTypes.length) return 'All action types in use';
       return 'Add another action';
     },
     addAction() {

--- a/internal/templates/pages/rule_form.html
+++ b/internal/templates/pages/rule_form.html
@@ -9,272 +9,337 @@
   </div>
 </div>
 
-<form @submit.prevent="submitRule()" class="max-w-2xl">
+<div class="max-w-2xl">
+  <form @submit.prevent="submitRule()" class="bb-card p-0 overflow-hidden">
 
-  <!-- Name -->
-  <div class="bb-card p-5 mb-4">
-    <label class="label"><span class="label-text text-sm font-medium">Rule Name</span></label>
-    <div class="relative">
-      <input type="text" x-model="form.name" x-ref="nameInput" @focus="nameFocused = true" @blur="setTimeout(() => nameFocused = false, 150)" class="input input-bordered input-sm rounded-xl w-full bg-base-200/50 pr-16" placeholder="e.g., Uber Eats → Food Delivery" required />
-      <button type="button" x-show="nameFocused" x-cloak x-transition.opacity class="absolute right-2 top-1/2 -translate-y-1/2 text-[10px] text-base-content/30 hover:text-base-content/50 transition-colors" @mousedown.prevent="insertArrow()" title="Insert arrow">insert →</button>
-    </div>
-    <p class="text-xs text-base-content/40 mt-1">A descriptive name to identify this rule</p>
-  </div>
-
-  <!-- Conditions -->
-  <div class="bb-card p-5 mb-4">
-    <div class="flex items-center justify-between mb-1">
-      <span class="label-text text-sm font-medium">When</span>
-      <div class="flex items-center gap-2">
-        <!-- AND/OR toggle -->
-        <div class="flex items-center gap-1 bg-base-200/60 rounded-lg p-0.5" x-show="form.conditions.length > 1">
-          <button type="button" class="px-2.5 py-0.5 text-xs font-medium rounded-md transition-colors"
-            :class="form.logic === 'and' ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/40 hover:text-base-content/60'"
-            @click="form.logic = 'and'; syncToJson()">AND</button>
-          <button type="button" class="px-2.5 py-0.5 text-xs font-medium rounded-md transition-colors"
-            :class="form.logic === 'or' ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/40 hover:text-base-content/60'"
-            @click="form.logic = 'or'; syncToJson()">OR</button>
+    <!-- Top section: icon header + rule name -->
+    <div class="p-5 sm:p-6">
+      <div class="bb-icon-header">
+        <div class="bb-icon-header__tile bb-icon-tile--primary">
+          <i data-lucide="list-filter" class="w-5 h-5"></i>
         </div>
-        <button type="button" class="btn btn-ghost btn-xs rounded-lg gap-1.5" @click="addCondition()">
-          <i data-lucide="plus" class="w-3.5 h-3.5"></i> Add
+        <div class="bb-icon-header__text">
+          <h2 class="text-sm font-semibold" x-text="isEdit ? 'Rule details' : 'New rule'"></h2>
+          <p class="text-xs text-base-content/45">Pick when it fires and what it does</p>
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="rule-name">Rule name</label>
+        <div class="relative">
+          <input id="rule-name" type="text" x-model="form.name" x-ref="nameInput"
+                 @focus="nameFocused = true" @blur="setTimeout(() => nameFocused = false, 150)"
+                 class="bb-form-input pr-16"
+                 placeholder="e.g., Uber Eats → Food Delivery" required />
+          <button type="button" x-show="nameFocused" x-cloak x-transition.opacity
+                  class="absolute right-3 top-1/2 -translate-y-1/2 text-[10px] text-base-content/30 hover:text-base-content/50 transition-colors"
+                  @mousedown.prevent="insertArrow()" title="Insert arrow">insert →</button>
+        </div>
+        <p class="text-xs text-base-content/40 mt-1.5">A short, descriptive name so you can find this rule later.</p>
+      </div>
+    </div>
+
+    <!-- Conditions section -->
+    <div class="border-t border-base-300 p-5 sm:p-6">
+      <div class="flex items-center justify-between mb-2">
+        <div>
+          <h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/60">When</h3>
+          <p class="text-xs text-base-content/40 mt-1">
+            <span x-show="form.conditions.length === 0">No conditions &mdash; this rule fires on <strong>every transaction</strong></span>
+            <span x-show="form.conditions.length === 1">Match transactions where</span>
+            <span x-show="form.conditions.length > 1 && form.logic === 'and'">Match transactions where <strong>all</strong> conditions are true</span>
+            <span x-show="form.conditions.length > 1 && form.logic === 'or'">Match transactions where <strong>any</strong> condition is true</span>
+          </p>
+        </div>
+        <div class="flex items-center gap-2 shrink-0">
+          <!-- AND/OR toggle -->
+          <div class="flex items-center gap-1 bg-base-200/60 rounded-lg p-0.5" x-show="form.conditions.length > 1">
+            <button type="button" class="px-2.5 py-0.5 text-xs font-medium rounded-md transition-colors"
+              :class="form.logic === 'and' ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/40 hover:text-base-content/60'"
+              @click="form.logic = 'and'; syncToJson()">AND</button>
+            <button type="button" class="px-2.5 py-0.5 text-xs font-medium rounded-md transition-colors"
+              :class="form.logic === 'or' ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/40 hover:text-base-content/60'"
+              @click="form.logic = 'or'; syncToJson()">OR</button>
+          </div>
+          <button type="button" class="btn btn-ghost btn-xs rounded-lg gap-1.5" @click="addCondition()">
+            <i data-lucide="plus" class="w-3.5 h-3.5"></i> Add
+          </button>
+        </div>
+      </div>
+
+      <!-- Match-all banner -->
+      <div x-show="form.conditions.length === 0" class="flex items-center gap-3 p-3 bg-info/5 border border-info/15 rounded-xl">
+        <div class="w-8 h-8 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
+          <i data-lucide="infinity" class="w-4 h-4 text-info"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-sm font-medium">All transactions</p>
+          <p class="text-xs text-base-content/50">This rule will apply to every transaction. Use sparingly.</p>
+        </div>
+        <button type="button" class="btn btn-xs btn-outline rounded-lg" @click="addCondition()">
+          <i data-lucide="plus" class="w-3 h-3"></i> Add condition
         </button>
       </div>
-    </div>
-    <p class="text-xs text-base-content/40 mb-3">
-      <span x-show="form.conditions.length === 0">No conditions &mdash; this rule will fire on <strong>every transaction</strong></span>
-      <span x-show="form.conditions.length === 1">Match transactions where</span>
-      <span x-show="form.conditions.length > 1 && form.logic === 'and'">Match transactions where <strong>all</strong> conditions are true</span>
-      <span x-show="form.conditions.length > 1 && form.logic === 'or'">Match transactions where <strong>any</strong> condition is true</span>
-    </p>
 
-    <!-- Match-all banner -->
-    <div x-show="form.conditions.length === 0" class="flex items-center gap-3 p-3 bg-info/5 border border-info/15 rounded-xl mb-2">
-      <div class="w-8 h-8 rounded-lg bg-info/10 flex items-center justify-center shrink-0">
-        <i data-lucide="infinity" class="w-4 h-4 text-info"></i>
-      </div>
-      <div class="flex-1 min-w-0">
-        <p class="text-sm font-medium">All transactions</p>
-        <p class="text-xs text-base-content/50">This rule will apply to every transaction. Use sparingly.</p>
-      </div>
-      <button type="button" class="btn btn-xs btn-outline rounded-lg" @click="addCondition()">
-        <i data-lucide="plus" class="w-3 h-3"></i> Add condition
-      </button>
-    </div>
-
-    <!-- Condition rows -->
-    <div class="space-y-2">
-      <template x-for="(cond, idx) in form.conditions" :key="idx">
-        <div class="flex items-center gap-2 p-2.5 bg-base-200/40 rounded-xl">
-          <!-- Conjunction label -->
-          <div class="w-10 shrink-0 text-center">
-            <span x-show="idx === 0" class="text-xs text-base-content/30 font-medium">IF</span>
-            <span x-show="idx > 0" class="text-xs font-medium" :class="form.logic === 'or' ? 'text-warning' : 'text-base-content/30'" x-text="form.logic.toUpperCase()"></span>
-          </div>
-          <!-- Field -->
-          <select x-model="cond.field" @change="onFieldChange(idx)" class="select select-bordered select-xs rounded-lg bg-base-100 flex-1 min-w-0">
-            <option value="">Field...</option>
-            <optgroup label="Transaction">
-              <option value="name">Name</option>
-              <option value="merchant_name">Merchant</option>
-              <option value="amount">Amount</option>
-              <option value="pending">Pending</option>
-            </optgroup>
-            <optgroup label="Category">
-              <option value="category">Category (assigned)</option>
-              <option value="category_primary">Category (raw primary)</option>
-              <option value="category_detailed">Category (raw detail)</option>
-            </optgroup>
-            <optgroup label="Tags">
-              <option value="tags">Tag</option>
-            </optgroup>
-            <optgroup label="Account / User">
-              <option value="account_name">Account name</option>
-              <option value="user_name">Family member</option>
-              <option value="provider">Provider</option>
-            </optgroup>
-          </select>
-          <!-- Operator — options are driven by fieldType so string / numeric /
-               bool / tags each have their own label set with no duplicate
-               <option value="..."> across groups (duplicates break <select>
-               display in Chrome/Safari). Disabled until a field is picked. -->
-          <select x-model="cond.op" @change="syncToJson()" :disabled="!cond.field"
-            class="select select-bordered select-xs rounded-lg bg-base-100 w-28 shrink-0 disabled:bg-base-200 disabled:opacity-70">
-            <option value="" x-show="!cond.field">Operator...</option>
-            <template x-for="opt in operatorOptions(cond.field)" :key="opt.value">
-              <option :value="opt.value" x-text="opt.label"></option>
-            </template>
-          </select>
-          <!-- Value — disabled placeholder when no field picked, otherwise
-               switches by fieldType. -->
-          <input type="text" disabled x-show="!cond.field"
-            class="input input-bordered input-xs rounded-lg bg-base-200 opacity-70 flex-1 min-w-0" placeholder="value..." />
-          <select x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'bool'" @change="syncToJson()" class="select select-bordered select-xs rounded-lg bg-base-100 w-20 shrink-0">
-            <option value="true">true</option>
-            <option value="false">false</option>
-          </select>
-          <input type="number" x-model="cond.value" step="0.01" x-show="cond.field && fieldType(cond.field) === 'numeric'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 w-24 shrink-0" placeholder="0.00" />
-          <input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'string'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" placeholder="value..." />
-          <input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'tags'" list="bb-tag-slugs" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" :placeholder="cond.op === 'in' ? 'slug1, slug2, ...' : 'tag-slug'" />
-          <!-- Remove (always available — removing the last one switches to match-all) -->
-          <button type="button" class="btn btn-ghost btn-xs btn-square rounded-lg shrink-0" @click="removeCondition(idx)" :title="form.conditions.length === 1 ? 'Remove (rule will match all transactions)' : 'Remove'">
-            <i data-lucide="x" class="w-3.5 h-3.5 text-base-content/40"></i>
-          </button>
-        </div>
-      </template>
-    </div>
-
-    <!-- Advanced JSON toggle -->
-    <div class="mt-3">
-      <button type="button" class="text-xs text-base-content/40 hover:text-base-content/60 flex items-center gap-1" @click="showJsonEditor = !showJsonEditor">
-        <i data-lucide="code-2" class="w-3 h-3"></i>
-        <span x-text="showJsonEditor ? 'Hide JSON' : 'Edit as JSON'"></span>
-      </button>
-      <div x-show="showJsonEditor" x-cloak class="mt-2">
-        <textarea x-model="form.conditions_json" @input="syncFromJson()" class="textarea textarea-bordered textarea-sm font-mono text-xs rounded-xl w-full bg-base-200/50" rows="5" placeholder='{"field": "name", "op": "contains", "value": "uber"}'></textarea>
-        <p class="text-xs text-base-content/40 mt-1">Supports nested AND/OR/NOT trees. Visual builder handles simple cases.</p>
-      </div>
-    </div>
-  </div>
-
-  <!-- Actions -->
-  <div class="bb-card p-5 mb-4">
-    <div class="flex items-center justify-between mb-1">
-      <span class="label-text text-sm font-medium">Then</span>
-      <button type="button" class="btn btn-ghost btn-xs rounded-lg gap-1.5" @click="addAction()" :disabled="availableActionTypes().length === 0" :title="availableActionTypes().length === 0 ? 'All action types in use' : 'Add another action'">
-        <i data-lucide="plus" class="w-3.5 h-3.5"></i> Add action
-      </button>
-    </div>
-    <p class="text-xs text-base-content/40 mb-3">Each rule can run one of each action type (set category, add tag, add comment).</p>
-
-    <div class="space-y-2">
-      <template x-for="(action, idx) in form.actions" :key="idx">
-        <div class="flex items-start gap-2 p-2.5 bg-base-200/40 rounded-xl">
-          <!-- Action type selector -->
-          <select x-model="action.field" @change="onActionTypeChange(idx)" class="select select-bordered select-xs rounded-lg bg-base-100 w-36 shrink-0 mt-px">
-            <template x-for="at in actionTypes" :key="at.value">
-              <option :value="at.value" x-text="at.label" :disabled="at.value !== action.field && isActionUsed(at.value)"></option>
-            </template>
-          </select>
-
-          <!-- Value: category picker -->
-          <template x-if="action.field === 'category'">
-            <select x-model="action.value" class="select select-bordered select-xs rounded-lg bg-base-100 flex-1 min-w-0 mt-px">
-              <option value="">Select category...</option>
-              {{range .FlatCategories}}
-              <option value="{{.Slug}}">{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
-              {{end}}
+      <!-- Condition rows -->
+      <div class="space-y-2" x-show="form.conditions.length > 0">
+        <template x-for="(cond, idx) in form.conditions" :key="idx">
+          <div class="flex items-center gap-2 p-2.5 bg-base-200/40 rounded-xl">
+            <!-- Conjunction label -->
+            <div class="w-10 shrink-0 text-center">
+              <span x-show="idx === 0" class="text-xs text-base-content/30 font-medium">IF</span>
+              <span x-show="idx > 0" class="text-xs font-medium" :class="form.logic === 'or' ? 'text-warning' : 'text-base-content/30'" x-text="form.logic.toUpperCase()"></span>
+            </div>
+            <!-- Field -->
+            <select x-model="cond.field" @change="onFieldChange(idx)" class="select select-bordered select-xs rounded-lg bg-base-100 flex-1 min-w-0">
+              <option value="">Field...</option>
+              <optgroup label="Transaction">
+                <option value="name">Name</option>
+                <option value="merchant_name">Merchant</option>
+                <option value="amount">Amount</option>
+                <option value="pending">Pending</option>
+              </optgroup>
+              <optgroup label="Category">
+                <option value="category">Category (assigned)</option>
+                <option value="category_primary">Category (raw primary)</option>
+                <option value="category_detailed">Category (raw detail)</option>
+              </optgroup>
+              <optgroup label="Tags">
+                <option value="tags">Tag</option>
+              </optgroup>
+              <optgroup label="Account / User">
+                <option value="account_name">Account name</option>
+                <option value="user_name">Family member</option>
+                <option value="provider">Provider</option>
+              </optgroup>
             </select>
-          </template>
+            <!-- Operator — disabled until a field is picked. Options are
+                 rendered inline (not x-for) so x-model syncs correctly on
+                 first paint when editing an existing rule. Each option value
+                 appears exactly once; labels shift per fieldType via x-text. -->
+            <select x-model="cond.op" @change="syncToJson()" :disabled="!cond.field"
+              class="select select-bordered select-xs rounded-lg bg-base-100 w-28 shrink-0 disabled:bg-base-200 disabled:opacity-70">
+              <option value="" x-show="!cond.field">Operator...</option>
+              <option value="contains" x-show="cond.field && (fieldType(cond.field) === 'string' || fieldType(cond.field) === 'tags')"
+                      x-text="fieldType(cond.field) === 'tags' ? 'has' : 'contains'"></option>
+              <option value="not_contains" x-show="cond.field && (fieldType(cond.field) === 'string' || fieldType(cond.field) === 'tags')"
+                      x-text="fieldType(cond.field) === 'tags' ? 'does not have' : 'not contains'"></option>
+              <option value="in" x-show="cond.field && (fieldType(cond.field) === 'string' || fieldType(cond.field) === 'tags')"
+                      x-text="fieldType(cond.field) === 'tags' ? 'has any of' : 'in list'"></option>
+              <option value="matches" x-show="cond.field && fieldType(cond.field) === 'string'">regex</option>
+              <option value="eq" x-show="cond.field && (fieldType(cond.field) === 'string' || fieldType(cond.field) === 'numeric' || fieldType(cond.field) === 'bool')"
+                      x-text="fieldType(cond.field) === 'numeric' ? '=' : (fieldType(cond.field) === 'bool' ? 'is' : 'equals')"></option>
+              <option value="neq" x-show="cond.field && (fieldType(cond.field) === 'string' || fieldType(cond.field) === 'numeric' || fieldType(cond.field) === 'bool')"
+                      x-text="fieldType(cond.field) === 'numeric' ? '\u2260' : (fieldType(cond.field) === 'bool' ? 'is not' : 'not equals')"></option>
+              <option value="gte" x-show="cond.field && fieldType(cond.field) === 'numeric'">&ge;</option>
+              <option value="lte" x-show="cond.field && fieldType(cond.field) === 'numeric'">&le;</option>
+              <option value="gt"  x-show="cond.field && fieldType(cond.field) === 'numeric'">&gt;</option>
+              <option value="lt"  x-show="cond.field && fieldType(cond.field) === 'numeric'">&lt;</option>
+            </select>
+            <!-- Value — disabled placeholder when no field picked -->
+            <input type="text" disabled x-show="!cond.field"
+              class="input input-bordered input-xs rounded-lg bg-base-200 opacity-70 flex-1 min-w-0" placeholder="value..." />
+            <select x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'bool'" @change="syncToJson()" class="select select-bordered select-xs rounded-lg bg-base-100 w-20 shrink-0">
+              <option value="true">true</option>
+              <option value="false">false</option>
+            </select>
+            <input type="number" x-model="cond.value" step="0.01" x-show="cond.field && fieldType(cond.field) === 'numeric'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 w-24 shrink-0" placeholder="0.00" />
+            <input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'string'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" placeholder="value..." />
+            <input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'tags'" list="bb-tag-slugs" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" :placeholder="cond.op === 'in' ? 'slug1, slug2, ...' : 'tag-slug'" />
+            <!-- Remove -->
+            <button type="button" class="btn btn-ghost btn-xs btn-square rounded-lg shrink-0" @click="removeCondition(idx)" :title="form.conditions.length === 1 ? 'Remove (rule will match all transactions)' : 'Remove'">
+              <i data-lucide="x" class="w-3.5 h-3.5 text-base-content/40"></i>
+            </button>
+          </div>
+        </template>
+      </div>
 
-          <!-- Value: tag slug input with autocomplete (add_tag or remove_tag) -->
-          <template x-if="action.field === 'tag' || action.field === 'tag_remove'">
-            <div class="flex-1 min-w-0">
-              <input type="text" x-model="action.value" @input="validateTagSlug(idx)" list="bb-tag-slugs"
-                class="input input-bordered input-xs rounded-lg bg-base-100 w-full mt-px"
-                placeholder="needs-review, subscription:monthly, ..."
-                pattern="^[a-z0-9][a-z0-9\-:]*[a-z0-9]$" />
-              <p x-show="action.error" x-cloak class="text-[0.65rem] text-error mt-1" x-text="action.error"></p>
-              <p x-show="!action.error && action.field === 'tag'" class="text-[0.65rem] text-base-content/40 mt-1">Lowercase, hyphens or colons. e.g. <code>needs-review</code></p>
-              <p x-show="!action.error && action.field === 'tag_remove'" class="text-[0.65rem] text-base-content/40 mt-1">Tag to remove from matching transactions.</p>
-            </div>
-          </template>
+      <!-- Advanced JSON toggle -->
+      <div class="mt-3">
+        <button type="button" class="text-xs text-base-content/40 hover:text-base-content/60 flex items-center gap-1" @click="showJsonEditor = !showJsonEditor">
+          <i data-lucide="code-2" class="w-3 h-3"></i>
+          <span x-text="showJsonEditor ? 'Hide JSON' : 'Edit as JSON'"></span>
+        </button>
+        <div x-show="showJsonEditor" x-cloak class="mt-2">
+          <textarea x-model="form.conditions_json" @input="syncFromJson()" class="textarea textarea-bordered textarea-sm font-mono text-xs rounded-xl w-full bg-base-200/50" rows="5" placeholder='{"field": "name", "op": "contains", "value": "uber"}'></textarea>
+          <p class="text-xs text-base-content/40 mt-1">Supports nested AND/OR/NOT trees. Visual builder handles simple cases.</p>
+        </div>
+      </div>
+    </div>
 
-          <!-- Value: comment textarea -->
-          <template x-if="action.field === 'comment'">
-            <div class="flex-1 min-w-0">
-              <textarea x-model="action.value" rows="2"
-                class="textarea textarea-bordered textarea-xs rounded-lg bg-base-100 w-full text-xs"
-                placeholder="Comment to attach to matching transactions..."></textarea>
-              <p class="text-[0.65rem] text-base-content/40 mt-1">Plain text. The comment is attributed to this rule.</p>
-            </div>
-          </template>
+    <!-- Actions section -->
+    <div class="border-t border-base-300 p-5 sm:p-6">
+      <div class="flex items-center justify-between mb-2">
+        <div>
+          <h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/60">Then</h3>
+          <p class="text-xs text-base-content/40 mt-1">Up to one of each action type (set category, add tag, remove tag, add comment).</p>
+        </div>
+        <button type="button" class="btn btn-ghost btn-xs rounded-lg gap-1.5 shrink-0" @click="addAction()"
+                :disabled="!canAddAction()"
+                :title="addActionTooltip()">
+          <i data-lucide="plus" class="w-3.5 h-3.5"></i> Add action
+        </button>
+      </div>
 
-          <!-- Remove -->
-          <button type="button" class="btn btn-ghost btn-xs btn-square rounded-lg shrink-0 mt-px" @click="removeAction(idx)" :disabled="form.actions.length === 1" :title="form.actions.length === 1 ? 'A rule needs at least one action' : 'Remove this action'">
-            <i data-lucide="x" class="w-3.5 h-3.5 text-base-content/40"></i>
-          </button>
+      <div class="space-y-2">
+        <template x-for="(action, idx) in form.actions" :key="idx">
+          <div class="flex items-start gap-2 p-2.5 rounded-xl transition-colors"
+               :class="action.field === 'tag_remove' ? 'bg-error/5 border border-error/15' : 'bg-base-200/40'">
+            <!-- Action type selector -->
+            <select x-model="action.field" @change="onActionTypeChange(idx)"
+                    class="select select-bordered select-xs rounded-lg bg-base-100 w-36 shrink-0 mt-px"
+                    :class="action.field === 'tag_remove' ? 'text-error font-medium' : ''">
+              <option value="">Action...</option>
+              <option value="category"   :disabled="action.field !== 'category'   && isActionUsed('category')">Set category</option>
+              <option value="tag"        :disabled="action.field !== 'tag'        && isActionUsed('tag')">Add tag</option>
+              <option value="tag_remove" :disabled="action.field !== 'tag_remove' && isActionUsed('tag_remove')">Remove tag</option>
+              <option value="comment"    :disabled="action.field !== 'comment'    && isActionUsed('comment')">Add comment</option>
+            </select>
+
+            <!-- Value: disabled placeholder when no type picked -->
+            <template x-if="!action.field">
+              <input type="text" disabled
+                     class="input input-bordered input-xs rounded-lg bg-base-200 opacity-70 flex-1 min-w-0 mt-px"
+                     placeholder="pick an action above..." />
+            </template>
+
+            <!-- Value: category picker -->
+            <template x-if="action.field === 'category'">
+              <select x-model="action.value" class="select select-bordered select-xs rounded-lg bg-base-100 flex-1 min-w-0 mt-px">
+                <option value="">Select category...</option>
+                {{range .FlatCategories}}
+                <option value="{{.Slug}}">{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
+                {{end}}
+              </select>
+            </template>
+
+            <!-- Value: tag slug input (add_tag or remove_tag) -->
+            <template x-if="action.field === 'tag' || action.field === 'tag_remove'">
+              <div class="flex-1 min-w-0">
+                <input type="text" x-model="action.value" @input="validateTagSlug(idx)" list="bb-tag-slugs"
+                  class="input input-bordered input-xs rounded-lg w-full mt-px"
+                  :class="action.field === 'tag_remove' ? 'bg-error/[0.04] border-error/30 text-error placeholder:text-error/40 focus:border-error/50' : 'bg-base-100'"
+                  placeholder="needs-review, subscription:monthly, ..."
+                  pattern="^[a-z0-9][a-z0-9\-:]*[a-z0-9]$" />
+                <p x-show="action.error" x-cloak class="text-[0.65rem] text-error mt-1" x-text="action.error"></p>
+                <p x-show="!action.error && action.field === 'tag'" class="text-[0.65rem] text-base-content/40 mt-1">Lowercase, hyphens or colons. e.g. <code>needs-review</code></p>
+                <p x-show="!action.error && action.field === 'tag_remove'" class="text-[0.65rem] text-error/70 mt-1 inline-flex items-center gap-1"><i data-lucide="minus-circle" class="w-3 h-3"></i>Tag to remove from matching transactions</p>
+              </div>
+            </template>
+
+            <!-- Value: comment textarea -->
+            <template x-if="action.field === 'comment'">
+              <div class="flex-1 min-w-0">
+                <textarea x-model="action.value" rows="2"
+                  class="textarea textarea-bordered textarea-xs rounded-lg bg-base-100 w-full text-xs"
+                  placeholder="Comment to attach to matching transactions..."></textarea>
+                <p class="text-[0.65rem] text-base-content/40 mt-1">Plain text. The comment is attributed to this rule.</p>
+              </div>
+            </template>
+
+            <!-- Remove -->
+            <button type="button" class="btn btn-ghost btn-xs btn-square rounded-lg shrink-0 mt-px"
+                    @click="removeAction(idx)"
+                    :disabled="form.actions.length === 1"
+                    :title="form.actions.length === 1 ? 'A rule needs at least one action' : 'Remove this action'">
+              <i data-lucide="x" class="w-3.5 h-3.5 text-base-content/40"></i>
+            </button>
+          </div>
+        </template>
+      </div>
+
+      <!-- Datalist for tag autocomplete -->
+      {{if .Tags}}
+      <datalist id="bb-tag-slugs">
+        {{range .Tags}}<option value="{{.Slug}}">{{.DisplayName}}</option>{{end}}
+      </datalist>
+      {{end}}
+
+      <!-- Combination warnings -->
+      <template x-if="combinationWarnings().length > 0">
+        <div class="mt-3 flex items-start gap-2 p-2.5 rounded-xl bg-warning/5 border border-warning/20">
+          <i data-lucide="alert-triangle" class="w-3.5 h-3.5 text-warning shrink-0 mt-0.5"></i>
+          <div class="text-xs text-warning/90 space-y-0.5">
+            <template x-for="(w, i) in combinationWarnings()" :key="i">
+              <p x-text="w"></p>
+            </template>
+          </div>
         </div>
       </template>
-    </div>
 
-    <!-- Datalist for tag autocomplete -->
-    {{if .Tags}}
-    <datalist id="bb-tag-slugs">
-      {{range .Tags}}<option value="{{.Slug}}">{{.DisplayName}}</option>{{end}}
-    </datalist>
-    {{end}}
-
-    <div x-show="form.actions.length === 0" class="text-xs text-base-content/40 text-center py-4">
-      No actions configured. Click "Add action" to add one.
-    </div>
-  </div>
-
-  <!-- Settings -->
-  <div class="bb-card p-5 mb-6">
-    <span class="label-text text-sm font-medium">Settings</span>
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-3">
-      <div class="form-control">
-        <label class="label" for="rule-trigger"><span class="label-text text-xs text-base-content/60">Trigger</span></label>
-        <select id="rule-trigger" x-model="form.trigger" class="select select-bordered select-sm rounded-xl bg-base-200">
-          <option value="on_create">On create</option>
-          <option value="on_change">On change</option>
-          <option value="always">Always</option>
-        </select>
-        <p class="text-xs text-base-content/40 mt-1" x-show="form.trigger === 'on_create'">Fires only when a transaction is first synced.</p>
-        <p class="text-xs text-base-content/40 mt-1" x-show="form.trigger === 'on_change' || form.trigger === 'on_update'">Fires only when an existing transaction changes on re-sync.</p>
-        <p class="text-xs text-warning/80 mt-1" x-show="form.trigger === 'always'" x-cloak>
-          <i data-lucide="alert-triangle" class="w-3 h-3 inline-block -mt-0.5 mr-0.5"></i>
-          Fires on every sync that touches this transaction — use sparingly.
-        </p>
+      <div x-show="form.actions.length === 0" class="text-xs text-base-content/40 text-center py-4">
+        No actions configured. Click "Add action" to add one.
       </div>
-      <div class="form-control">
-        <label class="label" for="rule-priority">
-          <span class="label-text text-xs text-base-content/60">Pipeline stage</span>
-          <span class="tooltip tooltip-left" data-tip="Lower stages run first (baseline). Higher stages run later and win set_category. Tags accumulate across all stages.">
-            <i data-lucide="info" class="w-3 h-3 text-base-content/30"></i>
-          </span>
-        </label>
-        <div class="flex items-center gap-1 bg-base-200/60 rounded-xl p-1">
-          <template x-for="preset in priorityPresets" :key="preset.value">
-            <button type="button"
-              class="flex-1 text-xs font-medium py-1 px-2 rounded-lg transition-colors"
-              :class="form.priority === preset.value ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/50 hover:text-base-content/70'"
-              @click="form.priority = preset.value"
-              :title="preset.hint"
-              x-text="preset.label"></button>
-          </template>
+    </div>
+
+    <!-- Settings section -->
+    <div class="border-t border-base-300 p-5 sm:p-6">
+      <h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/60 mb-3">Settings</h3>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="rule-trigger">Trigger</label>
+          <select id="rule-trigger" x-model="form.trigger" class="bb-form-select select-sm">
+            <option value="on_create">On create</option>
+            <option value="on_change">On change</option>
+            <option value="always">Always</option>
+          </select>
+          <p class="text-xs text-base-content/40 mt-1.5" x-show="form.trigger === 'on_create'">Fires only when a transaction is first synced.</p>
+          <p class="text-xs text-base-content/40 mt-1.5" x-show="form.trigger === 'on_change' || form.trigger === 'on_update'">Fires only when an existing transaction changes on re-sync.</p>
+          <p class="text-xs text-warning/80 mt-1.5" x-show="form.trigger === 'always'" x-cloak>
+            <i data-lucide="alert-triangle" class="w-3 h-3 inline-block -mt-0.5 mr-0.5"></i>
+            Fires on every sync that touches this transaction &mdash; use sparingly.
+          </p>
         </div>
-        <div class="flex items-center gap-2 mt-1">
-          <input id="rule-priority" type="number" x-model.number="form.priority" class="input input-bordered input-xs rounded-lg bg-base-200/50 w-20" min="0" max="1000" />
-          <p class="text-xs text-base-content/40" x-text="priorityLabel(form.priority)"></p>
+        <div>
+          <label class="flex items-center gap-1.5 text-xs font-medium text-base-content/50 mb-1.5" for="rule-priority">
+            <span>Pipeline stage</span>
+            <span class="tooltip tooltip-left" data-tip="Lower stages run first (baseline). Higher stages run later and win set_category. Tags accumulate across all stages.">
+              <i data-lucide="info" class="w-3 h-3 text-base-content/30"></i>
+            </span>
+          </label>
+          <div class="flex items-center gap-1 bg-base-200/60 rounded-xl p-1">
+            <template x-for="preset in priorityPresets" :key="preset.value">
+              <button type="button"
+                class="flex-1 text-xs font-medium py-1 px-2 rounded-lg transition-colors"
+                :class="form.priority === preset.value ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/50 hover:text-base-content/70'"
+                @click="form.priority = preset.value"
+                :title="preset.hint"
+                x-text="preset.label"></button>
+            </template>
+          </div>
+          <div class="flex items-center gap-2 mt-1.5">
+            <input id="rule-priority" type="number" x-model.number="form.priority"
+                   class="input input-bordered input-xs rounded-lg bg-base-200/50 w-20" min="0" max="1000" />
+            <p class="text-xs text-base-content/40" x-text="priorityLabel(form.priority)"></p>
+          </div>
         </div>
       </div>
-      <div class="form-control" x-show="!isEdit">
-        <label class="label" for="rule-expires-in"><span class="label-text text-xs text-base-content/60">Expires in</span></label>
-        <input id="rule-expires-in" type="text" x-model="form.expires_in" class="input input-bordered input-sm rounded-xl bg-base-200/50" placeholder="e.g., 30d" />
-        <p class="text-xs text-base-content/40 mt-1">24h, 7d, 4w, or leave empty for never</p>
-      </div>
     </div>
-  </div>
 
-  <!-- Error -->
-  <div x-show="formError" x-cloak role="alert" class="alert alert-error text-sm mb-4 rounded-xl">
-    <span x-text="formError"></span>
-  </div>
+    <!-- Error -->
+    <template x-if="formError">
+      <div class="border-t border-base-300 px-5 sm:px-6 pt-4">
+        <div role="alert" class="bb-form-error">
+          <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+          <span x-text="formError"></span>
+        </div>
+      </div>
+    </template>
 
-  <!-- Submit -->
-  <div class="flex items-center justify-end gap-2 pt-2">
-    <a href="/rules" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
-    <button type="submit" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32" :disabled="submitting">
-      <span x-show="!submitting" class="inline-flex items-center gap-1.5">
-        <i data-lucide="save" class="w-3.5 h-3.5"></i>
-        <span x-text="isEdit ? 'Save Changes' : 'Create Rule'"></span>
-      </span>
-      <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
-    </button>
-  </div>
+    <!-- Action row -->
+    <div class="bb-action-row">
+      <a href="/rules" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
+      <button type="submit" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32" :disabled="submitting">
+        <span x-show="!submitting" class="inline-flex items-center gap-1.5">
+          <i data-lucide="save" class="w-3.5 h-3.5"></i>
+          <span x-text="isEdit ? 'Save Changes' : 'Create Rule'"></span>
+        </span>
+        <span x-show="submitting" class="loading loading-spinner loading-xs"></span>
+      </button>
+    </div>
 
-</form>
+  </form>
+</div>
 </div>
 
 <script>
@@ -322,6 +387,9 @@ function ruleForm() {
   // explicitly — the operator + value inputs then snap to sensible defaults
   // via onFieldChange().
   const emptyCondition = () => ({ field: '', op: '', value: '' });
+  // New action rows start as unpicked drafts so "Action..." is the default
+  // and the value input stays disabled until a type is chosen.
+  const emptyAction = () => ({ field: '', value: '', error: '' });
 
   // Action type registry — first-class typed actions match the API's
   // supported action.type values (set_category | add_tag | remove_tag |
@@ -355,7 +423,7 @@ function ruleForm() {
       return { field: 'comment', value: a.content || '', error: '' };
     }
     // Tolerate unknown types so the form still loads — validation happens at submit.
-    return { field: a.type || a.field || 'category', value: a.category_slug || a.tag_slug || a.content || a.value || '', error: '' };
+    return { field: a.type || a.field || '', value: a.category_slug || a.tag_slug || a.content || a.value || '', error: '' };
   }
 
   // Initialize form from existing rule or defaults
@@ -368,8 +436,7 @@ function ruleForm() {
         logic: 'and',
         conditions: [emptyCondition()],
         conditions_json: '',
-        actions: [{ field: 'category', value: '', error: '' }],
-        expires_in: ''
+        actions: [emptyAction()]
       };
     }
 
@@ -388,13 +455,13 @@ function ruleForm() {
     }
     // else: NULL or empty {} → conditions stays [] (match-all)
 
-    // Parse actions (Phase 1 typed shape: {type, category_slug|tag_slug|content})
+    // Parse actions (typed shape: {type, category_slug|tag_slug|content})
     let actions = (existingRule.actions || []).map(actionToForm);
     if (actions.length === 0 && existingRule.category_slug) {
       actions = [{ field: 'category', value: existingRule.category_slug, error: '' }];
     }
     if (actions.length === 0) {
-      actions = [{ field: 'category', value: '', error: '' }];
+      actions = [emptyAction()];
     }
 
     // Normalize legacy on_update → on_change so the <select> binds cleanly.
@@ -407,8 +474,7 @@ function ruleForm() {
       logic,
       conditions,
       conditions_json: existingRule.conditions ? JSON.stringify(existingRule.conditions, null, 2) : '',
-      actions,
-      expires_in: ''
+      actions
     };
   }
 
@@ -487,15 +553,24 @@ function ruleForm() {
     isActionUsed(field) {
       return this.form.actions.some(a => a.field === field);
     },
-    availableActionTypes() {
-      return actionTypes.filter(at => !this.isActionUsed(at.value));
+    // Disable the "Add action" button when every type is already in use
+    // OR there's still an unpicked draft row waiting for a type.
+    canAddAction() {
+      const distinct = new Set(this.form.actions.filter(a => a.field).map(a => a.field));
+      if (distinct.size >= actionTypes.length) return false;
+      if (this.form.actions.some(a => !a.field)) return false;
+      return true;
+    },
+    addActionTooltip() {
+      if (this.form.actions.some(a => !a.field)) return 'Pick an action type first';
+      const distinct = new Set(this.form.actions.filter(a => a.field).map(a => a.field));
+      if (distinct.size >= actionTypes.length) return 'All action types in use';
+      return 'Add another action';
     },
     addAction() {
-      const available = this.availableActionTypes();
-      if (available.length > 0) {
-        this.form.actions.push({ field: available[0].value, value: '', error: '' });
-        this.$nextTick(() => lucide.createIcons());
-      }
+      if (!this.canAddAction()) return;
+      this.form.actions.push(emptyAction());
+      this.$nextTick(() => lucide.createIcons());
     },
     removeAction(idx) {
       this.form.actions.splice(idx, 1);
@@ -513,6 +588,21 @@ function ruleForm() {
       } else {
         a.error = '';
       }
+    },
+    // Flag action combinations that cancel out or are otherwise suspicious
+    // so the user sees the problem before hitting submit.
+    combinationWarnings() {
+      const warnings = [];
+      const addTags = this.form.actions.filter(a => a.field === 'tag' && a.value);
+      const removeTags = this.form.actions.filter(a => a.field === 'tag_remove' && a.value);
+      for (const a of addTags) {
+        for (const r of removeTags) {
+          if (a.value === r.value) {
+            warnings.push(`Tag "${a.value}" is being added and removed — these cancel out.`);
+          }
+        }
+      }
+      return warnings;
     },
 
     // JSON sync
@@ -584,7 +674,7 @@ function ruleForm() {
       // Per-action validation (tag slug shape, missing values).
       let actionError = '';
       this.form.actions.forEach(a => {
-        if (a.field === 'tag' && a.value && !tagSlugRegex.test(a.value)) {
+        if ((a.field === 'tag' || a.field === 'tag_remove') && a.value && !tagSlugRegex.test(a.value)) {
           a.error = 'Lowercase letters, numbers, hyphens, or colons (e.g. needs-review)';
           actionError = actionError || 'Fix the tag slug before saving.';
         }
@@ -596,7 +686,7 @@ function ruleForm() {
         return;
       }
 
-      // Build typed actions array for the API
+      // Build typed actions array for the API. Drop incomplete drafts.
       const actions = this.form.actions
         .filter(a => a.field && (a.value !== undefined && a.value !== ''))
         .map(a => {
@@ -621,9 +711,6 @@ function ruleForm() {
           trigger: this.form.trigger || 'on_create',
           priority: this.form.priority,
         };
-        if (!this.isEdit) {
-          body.expires_in = this.form.expires_in || undefined;
-        }
 
         const url = this.isEdit ? '/-/rules/' + this.editingId : '/-/rules';
         const method = this.isEdit ? 'PUT' : 'POST';

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -102,9 +102,23 @@
   </div>
 </div>
 
-<!-- Rules count -->
-<div class="text-sm text-base-content/40 mb-4 px-1">
-  {{if gt .TotalPages 1}}Showing {{.ShowingStart}}&ndash;{{.ShowingEnd}} of {{end}}{{.Total}} rule{{if ne .Total 1}}s{{end}} found
+<!-- Rules count + sort -->
+<div class="flex items-center justify-between flex-wrap gap-3 mb-4 px-1">
+  <div class="text-sm text-base-content/40">
+    {{if gt .TotalPages 1}}Showing {{.ShowingStart}}&ndash;{{.ShowingEnd}} of {{end}}{{.Total}} rule{{if ne .Total 1}}s{{end}} found
+  </div>
+  {{if .Rules}}
+  <label class="flex items-center gap-2 text-xs text-base-content/40">
+    <span class="hidden sm:inline">Sort by</span>
+    <select onchange="bbSetRulesSort(this.value)" class="select select-bordered select-xs rounded-lg bg-base-100 min-w-32 tabular-nums">
+      <option value=""            {{if eq .SortBy ""}}selected{{end}}>Newest first</option>
+      <option value="hit_count"   {{if eq .SortBy "hit_count"}}selected{{end}}>Most hits</option>
+      <option value="last_hit_at" {{if eq .SortBy "last_hit_at"}}selected{{end}}>Recently active</option>
+      <option value="priority"    {{if eq .SortBy "priority"}}selected{{end}}>Pipeline stage</option>
+      <option value="name"        {{if eq .SortBy "name"}}selected{{end}}>Name (A–Z)</option>
+    </select>
+  </label>
+  {{end}}
 </div>
 
 <!-- Rules as cards instead of table for Mercury feel -->
@@ -315,6 +329,13 @@
 function bbSetRulesPerPage(val) {
   const u = new URL(window.location.href);
   u.searchParams.set('per_page', val);
+  u.searchParams.delete('page');
+  window.location.href = u.toString();
+}
+function bbSetRulesSort(val) {
+  const u = new URL(window.location.href);
+  if (val) u.searchParams.set('sort_by', val);
+  else u.searchParams.delete('sort_by');
   u.searchParams.delete('page');
   window.location.href = u.toString();
 }

--- a/internal/templates/partials/condition_row.html
+++ b/internal/templates/partials/condition_row.html
@@ -1,0 +1,21 @@
+{{define "condition-row"}}
+{{- $c := .Cond -}}
+{{- $isFirst := eq .Idx 0 -}}
+{{- $conj := .Conj -}}
+<div class="flex items-center gap-2 p-2.5 bg-base-200/50 border border-base-content/10 rounded-xl">
+  <!-- Conjunction / IF prefix -->
+  <div class="w-10 shrink-0 text-center">
+    {{if $isFirst}}
+    <span class="text-[0.65rem] font-semibold tracking-wider text-base-content/30">IF</span>
+    {{else}}
+    <span class="text-[0.65rem] font-semibold tracking-wider {{if eq $conj "OR"}}text-warning{{else}}text-base-content/30{{end}}">{{$conj}}</span>
+    {{end}}
+  </div>
+  <!-- Field -->
+  <span class="text-sm font-medium text-base-content/80 truncate">{{ruleFieldLabel $c.Field}}</span>
+  <!-- Operator pill -->
+  <span class="inline-flex items-center px-2 py-0.5 rounded-md bg-base-100 border border-base-content/10 text-xs text-base-content/55 font-mono">{{ruleOpLabel $c.Op $c.Field}}</span>
+  <!-- Value -->
+  <span class="text-sm font-semibold text-base-content truncate" title="{{ruleValueFormat $c.Value}}">{{ruleValueFormat $c.Value}}</span>
+</div>
+{{end}}


### PR DESCRIPTION
Closes [#426](https://github.com/canalesb93/breadbox/issues/426), closes [#427](https://github.com/canalesb93/breadbox/issues/427).

## Summary

- **Form-card redesign.** One sectioned `bb-card` with icon header + right-aligned action row, matching `user_form.html` / `create_login.html`. Replaces four stacked cards and the old free-floating submit bar.
- **Expiry section removed from the UI.** Schema, REST, MCP, and service logic are untouched — rules with non-null `expires_at` still expire as expected; the admin UI just stops offering a way to set it per request.
- **Action builder polish (#427).** New rows default to an "Action..." placeholder; value input stays disabled until a type is picked; `remove_tag` gets distinct red-tinted styling; adding + removing the same tag slug surfaces an inline warning. Fixes a first-paint race where the condition operator + action type selects lost their value on edit (x-for vs x-model ordering).
- **Rules list sort (#426).** `?sort_by=` with server-side whitelist in `ruleOrderByClause`: newest · hit_count · last_hit_at · priority · name. Preserved across pagination.
- **Docs.** `docs/rule-dsl.md` gains a "Which combinations make sense" table under Actions.

## Before / After

### New-rule form

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://i.img402.dev/gp1m40bgr4.jpg" width="420" alt="new rule — before"></td>
<td><img src="https://i.img402.dev/bie3sht1i8.jpg" width="420" alt="new rule — after"></td>
</tr>
</table>

### Edit-rule form

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://i.img402.dev/dat6q9kfk7.jpg" width="420" alt="edit rule — before"></td>
<td><img src="https://i.img402.dev/sddmchqoyk.jpg" width="420" alt="edit rule — after"></td>
</tr>
</table>

### Rules list — new sort dropdown

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://i.img402.dev/tier7hz0n0.jpg" width="420" alt="rules list — before"></td>
<td><img src="https://i.img402.dev/r3rv4lbeae.jpg" width="420" alt="rules list — after"></td>
</tr>
</table>

### Action builder — remove_tag styling + combination warning

<img src="https://i.img402.dev/fg1k2e1gri.jpg" width="800" alt="action builder with same-slug add_tag + remove_tag warning">

### Mobile (390x844)

<img src="https://i.img402.dev/u2tgjo6s48.jpg" width="390" alt="new rule form on mobile">

## Test plan

- [x] `go build ./...` + `go vet ./...` clean.
- [x] `make css` regenerated.
- [x] New rule form renders with empty "Action..." placeholder; value input progressively enables.
- [x] Edit rule (`/rules/{id}/edit`) correctly shows existing field + operator + action type selected — no more revert to "Operator..." / "Action..." on first paint.
- [x] `remove_tag` row has red tint + warning accent.
- [x] Adding and removing `needs-review` on the same rule surfaces the "cancel out" warning.
- [x] `/rules?sort_by=hit_count` reorders the list (525-hit system rule jumps above 54-hit rule).
- [x] Editing and saving an existing rule redirects back to `/rules` and persists changes.
- [x] Mobile viewport at 390x844 renders cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Polish pass (review feedback)

- **Row contrast.** Condition + action rows now use `bg-base-200/50` + `border-base-content/10` — matches the rule-name input's default DaisyUI border so the row edge is visible without drowning disabled children.
- **Trigger labels.** Renamed across form, detail, list, and `TriggerLabel` helper to make the provider-sync context explicit:
  - `on_create` → "On sync create"
  - `on_change` → "On sync change"
  - `always` → "Every sync"
- **Multi-tag actions.** Backend already accepted multiple `add_tag` / `remove_tag` / `add_comment` per rule; the UI lifts its one-per-type lock for those. Only `set_category` remains singleton (still enforced server-side). Docs + form helper text updated.
- **Rule detail page.**
  - Missing `remove_tag` branch fixed (was rendering "Unknown action type").
  - `add_comment` icon swapped from `text-secondary` (almost invisible) to `text-info`.
  - New `partials/condition_row.html` — humanized field label (e.g. `category_primary` → "Category (primary)"), operator shown as a small mono-pill, IF/AND/OR prefix matching the edit form.

### Updated screenshots

**New-rule form (post-polish)**

<img src="https://i.img402.dev/1nowpytj3u.jpg" width="800" alt="new rule form — polished rows + trigger labels + multi-action copy">

**Rule detail — polished `When` rows**

<img src="https://i.img402.dev/9fmtc7y5w2.jpg" width="800" alt="rule detail — polished condition rows and action icons">
