### PR TITLE
feat(dev): hot-reload dev loop via make dev-watch

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,28 @@
+root = "."
+tmp_dir = "tmp"
+
+[build]
+  # Only Go changes trigger a rebuild. HTML/CSS are served from disk at runtime
+  # (BREADBOX_DEV_RELOAD=1), so including them here would cause spurious restarts.
+  cmd = "go build -o ./tmp/breadbox ./cmd/breadbox"
+  bin = "./tmp/breadbox"
+  full_bin = "./tmp/breadbox serve"
+  include_ext = ["go"]
+  exclude_dir = ["tmp", "static", "internal/templates", "internal/db/migrations", "docs", "node_modules", ".git", ".claude"]
+  exclude_regex = ["_test\\.go$", "\\.sql\\.go$"]
+  delay = 300
+  stop_on_error = true
+  send_interrupt = true
+  kill_delay = "2s"
+
+[log]
+  time = false
+
+[color]
+  main = "magenta"
+  watcher = "cyan"
+  build = "yellow"
+  runner = "green"
+
+[misc]
+  clean_on_exit = true

--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -20,7 +20,25 @@ paths:
 - `make css` compiles `input.css` → `static/css/styles.css`.
 - `make css-watch` for dev (rebuilds on change).
 - Dockerfile runs `make css` in the build stage. Don't commit `styles.css` changes — it's a build artifact.
-- **CSS is embedded into the binary** via `static/embed.go` (`//go:embed all:css favicon.svg`). After `make css` you must **restart the server** for changes to take effect — a browser hard-reload alone won't help because the running binary still serves the stale embedded copy.
+- **CSS is embedded into the binary** via `static/embed.go` (`//go:embed all:css favicon.svg`). In a plain `make dev` server you must **restart** after `make css` for changes to take effect — a browser hard-reload alone won't help because the running binary serves the stale embedded copy. `make dev-watch` avoids this (see below).
+
+## Hot-reload dev loop — prefer this for UI work
+
+`make dev-watch` runs three things together so UI edits apply without restarting the server:
+
+1. **`tailwindcss-extra --watch`** — rebuilds `static/css/styles.css` on every `input.css` or template change.
+2. **`air`** — rebuilds and restarts the Go binary on `*.go` changes only (config: `.air.toml`). HTML/CSS edits do **not** trigger a Go rebuild.
+3. **`BREADBOX_DEV_RELOAD=1`** — makes the running binary serve templates and static files from disk (`internal/templates/` and `static/`) instead of the embedded FS. Templates are re-parsed on every request so `.html` edits apply on reload.
+
+Typical agent loop becomes: edit `.html` or `input.css` → reload browser. No restart, no `make css`, no rebuild.
+
+Caveats:
+- Run `make dev-watch` from the **repo root**. The dev-reload paths are relative (`internal/templates`, `static`). Override with `BREADBOX_TEMPLATES_DIR` / `BREADBOX_STATIC_DIR` if needed.
+- `BREADBOX_DEV_RELOAD=1` is dev-only. Never set it in prod — it disables the embedded FS and re-parses templates per request (slow, and broken if the source tree isn't present).
+- Go code changes still trigger a ~1–2s restart via air. If you edited only HTML/CSS and see a restart, check whether a template change touched `*.go` (unlikely) or something else in the Go build graph.
+- For CI / production builds, `make dev-watch` is irrelevant — embedded FS is always used, and the server behaves exactly as before.
+
+Use `make dev` (no watch) when you specifically want the production embedded-FS behavior — e.g. validating an embed regression.
 
 ## Footguns
 
@@ -106,4 +124,6 @@ Before/after diffs: use the side-by-side table pattern documented in the `valida
 
 Do NOT use `![alt](url)` — GitHub renders the full native size and tall captures become painful to review. `{width=...}` kramdown syntax and `style="..."` attributes are silently stripped by GitHub's sanitizer.
 
-**Restart `make dev`** after template / CSS / Alpine edits before capturing — the binary serves embedded CSS and reloading the browser alone won't pick up the change (see "CSS build" above).
+**Picking up your edits before capture**:
+- If the server is running under `make dev-watch`, template/CSS/Alpine edits are already live — just reload the browser.
+- If it's running under `make dev`, restart it first — the binary serves embedded CSS and reloading the browser alone won't pick up the change (see "CSS build" above).

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ static/css/styles.css
 .breadbox-port
 .docker.env
 
+# air (hot-reload) build output — used by `make dev-watch`
+tmp/
+
 # Go
 vendor/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,9 +68,12 @@ These bite in every session regardless of what you're touching.
 Prereqs: Go 1.24+, PostgreSQL.
 
 ```
-make db       # start Postgres via Docker (skip if local Postgres)
-make dev      # installs sqlc/tailwind, generates code, migrates, starts server
+make db         # start Postgres via Docker (skip if local Postgres)
+make dev        # starts server with embedded assets (prod-like; restart on any UI edit)
+make dev-watch  # hot-reload: air rebuilds Go on *.go changes; HTML/CSS served from disk — no restart for UI edits
 ```
+
+Prefer `make dev-watch` for UI work. See `.claude/rules/ui.md` for the hot-reload loop and when to fall back to `make dev`.
 
 - Dev DB: `postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable`
 - Test DB: `postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable`

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ export
 
 TAILWIND_BIN := ./tailwindcss-extra
 
-.PHONY: dev dev-stop build test test-integration lint generate migrate-up migrate-down migrate-create sqlc sqlc-install seed db db-stop docker-up docker-down css css-watch css-install
+.PHONY: dev dev-watch dev-stop build test test-integration lint generate migrate-up migrate-down migrate-create sqlc sqlc-install seed db db-stop docker-up docker-down css css-watch css-install air-install
 
 PORT ?= 8080
 
@@ -29,6 +29,35 @@ dev: generate
 	fi
 	@echo $(PORT) > .breadbox-port
 	SERVER_PORT=$(PORT) go run ./cmd/breadbox serve; rm -f .breadbox-port
+
+# dev-watch: hot-reload everything — Go rebuilds via air, CSS rebuilds via
+# tailwind --watch, and BREADBOX_DEV_RELOAD=1 makes the running binary read
+# templates + static files from disk so HTML/CSS edits apply without a restart.
+# Only Go changes trigger a rebuild.
+dev-watch: generate air-install
+	@if [ -z "$$DATABASE_URL" ]; then \
+		echo "Error: DATABASE_URL is not set."; \
+		echo "  Set it for local dev:  export DATABASE_URL=postgres://breadbox:breadbox@localhost:5432/breadbox?sslmode=disable"; \
+		echo "  Or add it to .local.env (auto-loaded by Make)"; \
+		exit 1; \
+	fi
+	@if lsof -ti:$(PORT) >/dev/null 2>&1; then \
+		echo "Error: port $(PORT) is already in use."; \
+		echo "  - Run on another port:  make dev-watch PORT=8081"; \
+		echo "  - Or kill the existing process:  kill $$(lsof -ti:$(PORT))"; \
+		exit 1; \
+	fi
+	@echo $(PORT) > .breadbox-port
+	@trap 'rm -f .breadbox-port; kill 0' EXIT INT TERM; \
+		$(TAILWIND_BIN) -i input.css -o static/css/styles.css --watch & \
+		BREADBOX_DEV_RELOAD=1 SERVER_PORT=$(PORT) air -c .air.toml; \
+		wait
+
+air-install:
+	@if ! command -v air &>/dev/null; then \
+		echo "Installing air..."; \
+		go install github.com/air-verse/air@latest; \
+	fi
 
 dev-stop:
 	@pids=$$(lsof -ti:8080-8099 2>/dev/null | sort -u || true); \
@@ -67,6 +96,7 @@ sqlc-install:
 	fi
 
 sqlc: sqlc-install
+	@rm -f internal/db/*.sql.go internal/db/models.go internal/db/db.go
 	sqlc generate
 
 seed:

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -55,6 +55,7 @@ type Breadcrumb struct {
 type TemplateRenderer struct {
 	mu             sync.RWMutex
 	templates      map[string]*template.Template
+	specs          map[string][]string // name → file list, used to re-parse in dev mode
 	funcMap        template.FuncMap
 	sm             *scs.SessionManager
 	version        string
@@ -66,6 +67,7 @@ type TemplateRenderer struct {
 func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 	tr := &TemplateRenderer{
 		templates: make(map[string]*template.Template),
+		specs:     make(map[string][]string),
 		sm:        sm,
 		funcMap: template.FuncMap{
 			"sub": func(a, b int) int { return a - b },
@@ -350,8 +352,8 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return buf.String()
 			},
-			"lower": strings.ToLower,
-			"eqFold": strings.EqualFold,
+			"lower":     strings.ToLower,
+			"eqFold":    strings.EqualFold,
 			"titleCase": titleCaseMerchant,
 			"syncLogFilterQuery": func(status, connID, trigger, dateFrom, dateTo string) template.URL {
 				params := url.Values{}
@@ -551,22 +553,22 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			"accountTypeLabel": func(acctType, subtype string) string {
 				if subtype != "" {
 					labels := map[string]string{
-						"checking":         "Checking",
-						"savings":          "Savings",
-						"credit card":      "Credit Card",
-						"credit_card":      "Credit Card",
-						"money market":     "Money Market",
-						"money_market":     "Money Market",
-						"cd":               "CD",
-						"paypal":           "PayPal",
-						"student":          "Student Loan",
-						"mortgage":         "Mortgage",
-						"auto":             "Auto Loan",
-						"401k":             "401(k)",
-						"ira":              "IRA",
-						"brokerage":        "Brokerage",
-						"prepaid":          "Prepaid",
-						"hsa":              "HSA",
+						"checking":     "Checking",
+						"savings":      "Savings",
+						"credit card":  "Credit Card",
+						"credit_card":  "Credit Card",
+						"money market": "Money Market",
+						"money_market": "Money Market",
+						"cd":           "CD",
+						"paypal":       "PayPal",
+						"student":      "Student Loan",
+						"mortgage":     "Mortgage",
+						"auto":         "Auto Loan",
+						"401k":         "401(k)",
+						"ira":          "IRA",
+						"brokerage":    "Brokerage",
+						"prepaid":      "Prepaid",
+						"hsa":          "HSA",
 					}
 					if label, ok := labels[subtype]; ok {
 						return label
@@ -574,7 +576,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return subtype
 				}
 				labels := map[string]string{
-					"depository":  "Bank Account",
+					"depository": "Bank Account",
 					"credit":     "Credit Card",
 					"loan":       "Loan",
 					"investment": "Investment",
@@ -854,7 +856,9 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		if err != nil {
 			return fmt.Errorf("parse composite page %s: %w", page, err)
 		}
-		tr.templates[path.Base(page)] = t
+		name := path.Base(page)
+		tr.templates[name] = t
+		tr.specs[name] = files
 	}
 
 	for _, page := range wizardPages {
@@ -867,7 +871,9 @@ func (tr *TemplateRenderer) parseTemplates() error {
 			return fmt.Errorf("parse wizard page %s: %w", page, err)
 		}
 		// Store using just the filename (e.g., "login.html").
-		tr.templates[path.Base(page)] = t
+		name := path.Base(page)
+		tr.templates[name] = t
+		tr.specs[name] = files
 	}
 
 	return nil
@@ -882,7 +888,9 @@ func (tr *TemplateRenderer) parseBasePage(pagePath string) error {
 	if err != nil {
 		return fmt.Errorf("parse base page %s: %w", pagePath, err)
 	}
-	tr.templates[path.Base(pagePath)] = t
+	name := path.Base(pagePath)
+	tr.templates[name] = t
+	tr.specs[name] = files
 	return nil
 }
 
@@ -899,8 +907,10 @@ func (tr *TemplateRenderer) RegisterBasePage(pagePath string) error {
 		return err
 	}
 
+	name := path.Base(pagePath)
 	tr.mu.Lock()
-	tr.templates[path.Base(pagePath)] = t
+	tr.templates[name] = t
+	tr.specs[name] = files
 	tr.mu.Unlock()
 	return nil
 }
@@ -912,10 +922,23 @@ func (tr *TemplateRenderer) RegisterBasePage(pagePath string) error {
 func (tr *TemplateRenderer) Render(w http.ResponseWriter, r *http.Request, name string, data interface{}) {
 	tr.mu.RLock()
 	t, ok := tr.templates[name]
+	files := tr.specs[name]
 	tr.mu.RUnlock()
 	if !ok {
 		http.Error(w, "template not found: "+name, http.StatusInternalServerError)
 		return
+	}
+
+	// Dev-reload: re-parse the template from disk on every render so template
+	// edits apply without rebuilding the binary. Requires BREADBOX_DEV_RELOAD=1
+	// and templates.FS pointing at the source directory (see internal/templates/embed.go).
+	if templates.DevReload && len(files) > 0 {
+		fresh, err := template.New("").Funcs(tr.funcMap).ParseFS(templates.FS, files...)
+		if err != nil {
+			http.Error(w, "dev-reload parse failed: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		t = fresh
 	}
 
 	// Auto-inject common fields into map data if not already present.

--- a/internal/templates/embed.go
+++ b/internal/templates/embed.go
@@ -1,6 +1,30 @@
 package templates
 
-import "embed"
+import (
+	"embed"
+	"io/fs"
+	"os"
+)
 
 //go:embed layout/*.html pages/*.html partials/*.html
-var FS embed.FS
+var embedded embed.FS
+
+// FS serves template files. Defaults to the embedded FS baked into the binary.
+// When BREADBOX_DEV_RELOAD=1 is set, it reads from disk instead so edits apply
+// without a rebuild. The source directory is BREADBOX_TEMPLATES_DIR, or
+// "internal/templates" if unset (i.e. the repo root).
+var FS fs.FS = embedded
+
+// DevReload reports whether template reloading from disk is enabled.
+var DevReload = os.Getenv("BREADBOX_DEV_RELOAD") == "1"
+
+func init() {
+	if !DevReload {
+		return
+	}
+	dir := os.Getenv("BREADBOX_TEMPLATES_DIR")
+	if dir == "" {
+		dir = "internal/templates"
+	}
+	FS = os.DirFS(dir)
+}

--- a/static/embed.go
+++ b/static/embed.go
@@ -1,6 +1,27 @@
 package static
 
-import "embed"
+import (
+	"embed"
+	"io/fs"
+	"os"
+)
 
 //go:embed all:css favicon.svg
-var FS embed.FS
+var embedded embed.FS
+
+// FS serves static assets. Defaults to the embedded FS baked into the binary.
+// When BREADBOX_DEV_RELOAD=1 is set, it reads from disk so `make css-watch`
+// output is picked up on every request without a rebuild. Source directory is
+// BREADBOX_STATIC_DIR, or "static" if unset.
+var FS fs.FS = embedded
+
+func init() {
+	if os.Getenv("BREADBOX_DEV_RELOAD") != "1" {
+		return
+	}
+	dir := os.Getenv("BREADBOX_STATIC_DIR")
+	if dir == "" {
+		dir = "static"
+	}
+	FS = os.DirFS(dir)
+}


### PR DESCRIPTION
## Summary
- `make dev-watch` runs `tailwindcss --watch` + `air` with `BREADBOX_DEV_RELOAD=1` (new flag in this PR) so HTML/CSS edits apply without restarting the server — only Go changes trigger a rebuild.
- Templates and static FS swap to `os.DirFS` when `BREADBOX_DEV_RELOAD=1`; templates re-parse per render in that mode. Embedded FS (prod) behavior unchanged.
- `make sqlc` now clears stale generated files before regen, mirroring the wipe the session-start hook already does for worktrees. Prevents orphaned `*.sql.go` from breaking the build (hit this during verification — `comments.sql.go`/`reviews.sql.go` had no remaining query files).
- Agent-facing docs updated (`.claude/rules/ui.md`, `CLAUDE.md`) so the loop is the default for UI work.

## Worktree compatibility
- Paths resolve relative to the binary's CWD (worktree root), so each worktree's `internal/templates/` and `static/` are isolated.
- `PORT` override unchanged; 8081–8099 assignment from `session-start.sh` still applies (`make dev-watch PORT=8091`).
- `.worktreeinclude` already copies the prerequisites (tailwind binary, compiled CSS, sqlc artifacts).
- `tmp/` (air build dir) is per-worktree and gitignored.

## Test plan
- [x] `make sqlc && go build ./...` — green after the wipe-before-regen change.
- [x] `make dev-watch PORT=8095` — server boots, `/health/live` returns 200, tailwind watch emits CSS.
- [x] Edit `internal/templates/pages/login.html` while running — change visible on next request with no Go restart.
- [x] `static/css/styles.css` served bytes match on-disk bytes (confirms disk-served, not embedded).
- [ ] Manual: confirm `make dev` (non-watch) still serves embedded assets unchanged — production regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
