### PR TITLE
docs(api/mcp): remove stale review endpoint references

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -114,7 +114,7 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 
 ## Tags & Reviews
 
-The review queue is a tag. Transactions carrying the seeded `needs-review` tag (or any operator-defined trigger tag) are the backlog. A seeded `on_create` system rule auto-attaches `needs-review` to every newly-synced transaction; disable that rule to opt out. Ephemeral tags (lifecycle `ephemeral`) require a note on removal — recorded on the `tag_removed` annotation.
+The review queue is a tag. Transactions carrying the seeded `needs-review` tag (or any operator-defined trigger tag) are the backlog. A seeded `on_create` system rule auto-attaches `needs-review` to every newly-synced transaction; disable that rule to opt out. When removing an ephemeral tag (lifecycle `ephemeral`), passing a rationale `note` is strongly recommended — it's recorded on the `tag_removed` annotation.
 
 Tag management is exposed via the MCP tools (`list_tags`, `add_transaction_tag`, `remove_transaction_tag`, `create_tag`, `update_tag`, `delete_tag`, `update_transactions`, `list_annotations`) and the admin dashboard (`/tags`, `/transactions/:id/edit`, bulk actions on `/transactions`).
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -162,13 +162,13 @@ Attach a tag to a transaction. Auto-creates a persistent tag if the slug is unkn
 
 ### remove_transaction_tag (Write)
 
-Remove a tag from a transaction. For ephemeral tags (`needs-review`), the `note` is REQUIRED.
+Remove a tag from a transaction. A `note` is strongly recommended for ephemeral tags (`needs-review`) — it lands on the `tag_removed` annotation. Idempotent.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `transaction_id` | string | UUID or short ID |
 | `tag_slug` | string | Tag slug |
-| `note` | string | Required for ephemeral tags. Optional for persistent. |
+| `note` | string | Optional. Recommended for ephemeral tags so the rationale lands on the audit trail. |
 
 ### update_transactions (Write)
 
@@ -186,7 +186,7 @@ Each operation:
 | `transaction_id` | string | UUID or short ID. Required. |
 | `category_slug` | string | Optional category to set. Sets `category_override=true`. |
 | `tags_to_add` | array | `[{slug, note?}, ...]`. Auto-creates persistent tags. |
-| `tags_to_remove` | array | `[{slug, note?}, ...]`. `note` REQUIRED when the tag is ephemeral. |
+| `tags_to_remove` | array | `[{slug, note?}, ...]`. `note` is optional but strongly recommended for ephemeral tags — lands on the `tag_removed` annotation. |
 | `comment` | string | Optional comment annotation. |
 
 Use this to close a review entry: `set category + remove needs-review (with note) + comment` in one call.


### PR DESCRIPTION
## Summary

- Verified `docs/api-reference.md:119` — the stale "retired `/api/v1/reviews/*` endpoints have no REST successor" sentence is already absent in current `main`; no action needed there.
- Audited `docs/mcp-tools-reference.md` against `internal/mcp/server.go` and `internal/mcp/tools.go` for the new tag-world tools (`update_transactions`, `list_annotations`, `add_transaction_tag`, `remove_transaction_tag`). Descriptions and parameter schemas largely match. One drift found and fixed: docs claimed `note` is **REQUIRED** when removing an ephemeral tag (for both `remove_transaction_tag` and `update_transactions`), but the service layer only **recommends** it. Integration tests `TestRemoveTransactionTag_EphemeralNoNote` and `TestUpdateTransactions_EphemeralRemovalWithoutNote` explicitly assert that ephemeral removal without a note succeeds. Docs updated to "strongly recommended" language to match actual behavior.
- Same drift was also present in the "Tags & Reviews" blurb in `docs/api-reference.md`; fixed there too.
- Verified `docs/mcp-server.md` — no stale references, no edits.

Note: `internal/mcp/server.go:402` (the `update_transactions` tool description presented to agents) still says "Ephemeral tags (needs-review) REQUIRE a non-empty note on removal", which contradicts the tested service behavior. Flagging as follow-up — out of scope for this docs-only PR.

Closes #404

## Test plan

- [x] `go build ./...` passes (docs-only change, sanity check)
- [ ] Reviewer spot-checks the four tag-world tool descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)