### PR TITLE
chore(rules): small rule-engine code-quality cleanups

### DIFF
--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"breadbox/internal/slugs"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -986,6 +988,9 @@ func (s *Service) UpdateTransactionRule(ctx context.Context, id string, params U
 		actions = newActions
 	}
 
+	// existing.Trigger is sourced from a NOT NULL DEFAULT column, and
+	// normalizeTrigger guarantees a non-empty value on update — no fallback
+	// needed here.
 	trigger := existing.Trigger
 	if params.Trigger != nil {
 		t, err := normalizeTrigger(*params.Trigger)
@@ -993,9 +998,6 @@ func (s *Service) UpdateTransactionRule(ctx context.Context, id string, params U
 			return nil, err
 		}
 		trigger = t
-	}
-	if trigger == "" {
-		trigger = "on_create"
 	}
 
 	priority := int32(existing.Priority)
@@ -2064,7 +2066,7 @@ func (s *Service) materializeRuleTagAdd(ctx context.Context, tx pgx.Tx, txnID pg
 			INSERT INTO tags (slug, display_name, lifecycle)
 			VALUES ($1, $2, 'persistent')
 			ON CONFLICT (slug) DO UPDATE SET updated_at = tags.updated_at
-			RETURNING id`, slug, titleCaseSlug(slug)).Scan(&tagID); err2 != nil {
+			RETURNING id`, slug, slugs.TitleCase(slug)).Scan(&tagID); err2 != nil {
 			return false, fmt.Errorf("get or create tag %q: %w", slug, err2)
 		}
 	}
@@ -2148,35 +2150,6 @@ func (s *Service) materializeRuleTagRemove(ctx context.Context, tx pgx.Tx, txnID
 		return true, fmt.Errorf("annotate tag_removed: %w", err)
 	}
 	return true, nil
-}
-
-// buildActionSetClause converts rule actions into SQL SET clause components.
-// Returns setClauses (e.g., ["category_id = $1"]), args, and error. Only
-// set_category materializes here — add_tag / remove_tag / add_comment are
-// persisted via separate helpers (materializeRuleTagAdd / Remove) since they
-// don't fit a single UPDATE row. add_comment stays sync-only by design.
-func (s *Service) buildActionSetClause(ctx context.Context, actions []RuleAction) ([]string, []any, error) {
-	var setClauses []string
-	var args []any
-	argN := 1
-
-	for _, a := range actions {
-		switch a.Type {
-		case "set_category":
-			catID, err := s.categorySlugToUUID(ctx, a.CategorySlug)
-			if err != nil {
-				return nil, nil, err
-			}
-			if catID.Valid {
-				setClauses = append(setClauses, fmt.Sprintf("category_id = $%d", argN))
-				args = append(args, catID)
-				argN++
-			}
-			// "add_tag" / "add_comment" are sync-only; skip for retroactive apply.
-		}
-	}
-
-	return setClauses, args, nil
 }
 
 // categorySlugToUUID resolves a category slug to its UUID via the service-layer

--- a/internal/service/tags.go
+++ b/internal/service/tags.go
@@ -10,6 +10,7 @@ import (
 
 	"breadbox/internal/db"
 	"breadbox/internal/shortid"
+	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -67,21 +68,6 @@ func validateLifecycle(lifecycle string) error {
 		return fmt.Errorf("%w: lifecycle must be 'persistent' or 'ephemeral'", ErrInvalidParameter)
 	}
 	return nil
-}
-
-// titleCaseSlug converts a slug ("needs-review") to a title-cased display name
-// ("Needs Review"). Used as the default display_name for auto-created tags.
-func titleCaseSlug(slug string) string {
-	parts := strings.FieldsFunc(slug, func(r rune) bool {
-		return r == '-' || r == ':' || r == '_'
-	})
-	for i, p := range parts {
-		if p == "" {
-			continue
-		}
-		parts[i] = strings.ToUpper(p[:1]) + p[1:]
-	}
-	return strings.Join(parts, " ")
 }
 
 // CreateTag validates and inserts a new tag record. Slug regex:
@@ -288,7 +274,7 @@ func (s *Service) getOrCreateTagBySlug(ctx context.Context, q *db.Queries, slug 
 	// Auto-create
 	created, err := q.InsertTag(ctx, db.InsertTagParams{
 		Slug:        slug,
-		DisplayName: titleCaseSlug(slug),
+		DisplayName: slugs.TitleCase(slug),
 		Lifecycle:   "persistent",
 	})
 	if err != nil {

--- a/internal/slugs/slugs.go
+++ b/internal/slugs/slugs.go
@@ -1,0 +1,24 @@
+// Package slugs contains small string helpers for working with slug
+// identifiers used across Breadbox (tags, categories, and similar). It lives
+// in a neutral leaf package so both service and sync can import it without
+// creating a dependency cycle.
+package slugs
+
+import "strings"
+
+// TitleCase converts a slug ("needs-review") to a title-cased display name
+// ("Needs Review"). Separators recognized: '-', ':', '_'. Used as the default
+// display_name when auto-creating tags from a slug (e.g., during sync when a
+// rule's add_tag action references a slug that hasn't been registered yet).
+func TitleCase(slug string) string {
+	parts := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == ':' || r == '_'
+	})
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -13,6 +13,7 @@ import (
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
+	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -631,6 +632,12 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 	if !isNew {
 		if slugs, err := e.loadTagSlugsInTx(ctx, tx, dbTxn.ID); err == nil {
 			tctx.Tags = slugs
+		} else {
+			// Don't fail the whole sync over a tag-read glitch; rules that
+			// depend on tag conditions simply won't match this pass. Surfacing
+			// the error lets operators notice repeated failures.
+			e.logger.Warn("load tag slugs for rule evaluation failed; continuing without tag context",
+				"transaction_id", pgconv.FormatUUID(dbTxn.ID), "err", err)
 		}
 	}
 
@@ -642,6 +649,14 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 	// Build quick lookup of Source rule-metadata by (field, value) so the tag /
 	// comment / category persistence below can attach the right rule_id, name,
 	// and short_id to each annotation.
+	//
+	// First-wins on duplicate (field, value) keys: when multiple rules emit
+	// the same action (e.g., two rules both add_tag "needs-review"), the
+	// annotation is credited to the highest-priority rule that fired — because
+	// ResolveWithContext orders Sources by pipeline stage then priority, the
+	// first occurrence here is that rule. Lower-priority duplicates are
+	// dropped rather than overwriting, which matches the "winner takes the
+	// annotation" story the admin UI surfaces.
 	type ruleRef struct {
 		ruleID      pgtype.UUID
 		ruleShortID string
@@ -778,7 +793,7 @@ func (e *Engine) applyTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.U
 			INSERT INTO tags (slug, display_name, lifecycle)
 			VALUES ($1, $2, 'persistent')
 			ON CONFLICT (slug) DO UPDATE SET updated_at = tags.updated_at
-			RETURNING id`, slug, titleCaseSlugForRule(slug)).Scan(&tagID)
+			RETURNING id`, slug, slugs.TitleCase(slug)).Scan(&tagID)
 		if err2 != nil {
 			return fmt.Errorf("get or create tag %q: %w", slug, err2)
 		}
@@ -895,31 +910,6 @@ func (e *Engine) applyCommentFromRule(ctx context.Context, tx pgx.Tx, txnID pgty
 		return fmt.Errorf("annotate rule comment: %w", err)
 	}
 	return nil
-}
-
-// titleCaseSlugForRule converts a slug ("needs-review") to a display name
-// ("Needs Review") for auto-created tags during sync. Mirrors
-// service.titleCaseSlug; duplicated here to keep sync → service dependency
-// direction one-way.
-func titleCaseSlugForRule(slug string) string {
-	out := make([]byte, 0, len(slug))
-	capitalize := true
-	for i := 0; i < len(slug); i++ {
-		c := slug[i]
-		if c == '-' || c == ':' || c == '_' {
-			out = append(out, ' ')
-			capitalize = true
-			continue
-		}
-		if capitalize && c >= 'a' && c <= 'z' {
-			out = append(out, c-32)
-			capitalize = false
-			continue
-		}
-		out = append(out, c)
-		capitalize = false
-	}
-	return string(out)
 }
 
 // writeSyncAnnotationParams is the sync-package-local mirror of


### PR DESCRIPTION
## Summary
- Delete `buildActionSetClause` in `internal/service/rules.go` — dead after Phase 2.
- Log (instead of silently dropping) errors from `loadTagSlugsInTx` in `internal/sync/engine.go`. Behavior unchanged otherwise.
- Extract `titleCaseSlug` / `titleCaseSlugForRule` into a neutral `internal/slugs` package so `internal/service` and `internal/sync` share one implementation.
- Remove unreachable `if trigger == ""` branch from `UpdateTransactionRule` (column is `NOT NULL DEFAULT`, `normalizeTrigger` guarantees non-empty).
- Document the first-wins semantic for duplicate `(field, value)` keys in `sourceByKey` so the comment matches observable behavior.

Skipped from the issue:
- `rule_applied` payload-size cleanup (non-trivial schema change; left as follow-up, per issue notes).
- Integration-test suggestion (covered separately by #433).

Closes #434

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make test-integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)