### PR TITLE
refactor(ui): extract tx-row-compact partial, migrate dashboard recent txns

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -771,6 +771,7 @@ var templatePartials = []string{
 	"partials/skeletons.html",
 	"partials/breadcrumb.html",
 	"partials/tx_row.html",
+	"partials/tx_row_compact.html",
 	"partials/tx_results.html",
 	"partials/tag_chip.html",
 	"partials/condition_row.html",

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -253,53 +253,7 @@
     {{if .RecentTransactions}}
     <div class="px-3 sm:px-4 py-2">
       {{range .RecentTransactions}}
-      <a href="/transactions/{{.ID}}" class="flex items-center gap-3 py-2.5 px-1 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
-        <div class="relative shrink-0">
-          {{if .CategoryIcon}}
-          <div class="bb-tx-avatar bb-tx-avatar--sm" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
-            <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5"></i>
-          </div>
-          {{else}}
-          <div class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
-            <span>{{firstChar .Name}}</span>
-          </div>
-          {{end}}
-        </div>
-        <div class="min-w-0 flex-1">
-          <div class="flex items-center gap-1.5 min-w-0">
-            <span class="text-sm font-medium truncate">{{.Name}}</span>
-            {{if .Pending}}<span class="text-[0.6rem] font-medium text-warning/80 bg-warning/10 px-1.5 py-0.5 rounded-full leading-none shrink-0">Pending</span>{{end}}
-          </div>
-          <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 overflow-hidden">
-            {{if .UserName}}
-            {{if .EffectiveUserID}}
-            <img src="{{avatarURL .EffectiveUserID}}" alt="" class="w-4 h-4 rounded-full object-cover shrink-0" title="{{.UserName}}">
-            {{else}}
-            <span class="w-4 h-4 rounded-full bg-primary/10 inline-flex items-center justify-center shrink-0" title="{{.UserName}}">
-              <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
-            </span>
-            {{end}}
-            {{end}}
-            <span class="truncate shrink min-w-0">{{.AccountName}} · {{relativeDate .Date}}</span>
-            {{if .CategoryDisplayName}}
-            <span class="text-base-content/20 shrink-0 hidden sm:inline">&middot;</span>
-            <span class="items-center gap-1 shrink-0 hidden sm:inline-flex">
-              <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
-              <span class="text-base-content/50 truncate max-w-24">{{deref .CategoryDisplayName}}</span>
-            </span>
-            {{end}}
-            {{if .AgentReviewed}}
-            <span class="text-base-content/20 shrink-0">&middot;</span>
-            <span class="inline-flex items-center gap-0.5 text-primary/60 shrink-0" title="Categorized by AI agent">
-              <i data-lucide="bot" class="w-3 h-3"></i>
-            </span>
-            {{end}}
-          </div>
-        </div>
-        <span class="bb-tx-amount shrink-0{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
-          {{formatAmount .Amount}}
-        </span>
-      </a>
+      {{template "tx-row-compact" .}}
       {{end}}
     </div>
     {{else}}

--- a/internal/templates/partials/tx_row_compact.html
+++ b/internal/templates/partials/tx_row_compact.html
@@ -1,0 +1,61 @@
+{{define "tx-row-compact"}}
+<!-- Compact transaction row — lightweight sibling of `tx-row`.
+     Used in dense contexts (dashboard recent txns, rule detail tables) where
+     selection, inline category picker, and expand panels are not needed.
+     Input: service.AdminTransactionRow as dot. -->
+<a href="/transactions/{{.ID}}" class="bb-tx-row-compact flex items-center gap-3 py-2.5 px-2 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
+  <!-- Category avatar (same style as tx-row, smaller size) -->
+  <div class="relative shrink-0">
+    {{if .CategoryIcon}}
+    <div class="bb-tx-avatar bb-tx-avatar--sm" style="--avatar-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}oklch(0.65 0 0){{end}}">
+      <i data-lucide="{{deref .CategoryIcon}}" class="w-3.5 h-3.5"></i>
+    </div>
+    {{else}}
+    <div class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
+      <span>{{firstChar .Name}}</span>
+    </div>
+    {{end}}
+  </div>
+
+  <!-- Name + meta line -->
+  <div class="min-w-0 flex-1">
+    <div class="flex items-center gap-1.5 min-w-0">
+      <span class="text-sm font-medium truncate">{{.Name}}</span>
+      {{if .Pending}}<span class="badge badge-soft badge-xs badge-warning rounded-md shrink-0">Pending</span>{{end}}
+    </div>
+    <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 overflow-hidden">
+      {{if .UserName}}
+      {{if .EffectiveUserID}}
+      <img src="{{avatarURL .EffectiveUserID}}" alt="" class="w-4 h-4 rounded-full object-cover shrink-0" title="{{.UserName}}">
+      {{else}}
+      <span class="w-4 h-4 rounded-full bg-primary/10 inline-flex items-center justify-center shrink-0" title="{{.UserName}}">
+        <span class="text-[0.5rem] font-semibold text-primary/70 leading-none">{{firstChar .UserName}}</span>
+      </span>
+      {{end}}
+      {{end}}
+      <span class="truncate shrink min-w-0">{{.AccountName}}</span>
+      {{if .CategoryDisplayName}}
+      <span class="text-base-content/20 shrink-0 hidden sm:inline">&middot;</span>
+      <span class="items-center gap-1 shrink-0 hidden sm:inline-flex">
+        <span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{if .CategoryColor}}{{safeCSS (deref .CategoryColor)}}{{else}}{{safeCSS "oklch(0.65 0 0)"}}{{end}}"></span>
+        <span class="text-base-content/50 truncate max-w-24">{{deref .CategoryDisplayName}}</span>
+      </span>
+      {{end}}
+      {{if .AgentReviewed}}
+      <span class="text-base-content/20 shrink-0">&middot;</span>
+      <span class="inline-flex items-center gap-0.5 text-primary/60 shrink-0" title="Categorized by AI agent">
+        <i data-lucide="bot" class="w-3 h-3"></i>
+      </span>
+      {{end}}
+    </div>
+  </div>
+
+  <!-- Date + Amount (right-aligned stack) -->
+  <div class="shrink-0 text-right flex flex-col items-end gap-0.5">
+    <span class="bb-tx-amount tabular-nums{{if lt .Amount 0.0}} bb-tx-amount--income{{end}}">
+      {{formatAmount .Amount}}
+    </span>
+    <span class="text-[0.65rem] text-base-content/40 tabular-nums">{{relativeDate .Date}}</span>
+  </div>
+</a>
+{{end}}


### PR DESCRIPTION
## Summary

- Introduces `tx-row-compact` — a lightweight sibling of `tx-row` for dense contexts (dashboard recent txns, soon rule detail tables). No checkbox, no inline category picker, no expand panel.
- Takes `service.AdminTransactionRow` as dot — no new DTO, matches the type the dashboard already passes.
- Migrates the dashboard "Recent Transactions" widget (`pages/dashboard.html`) off its bespoke avatar-pill + inline-text block to `{{template "tx-row-compact" .}}`. Saves ~45 lines and stops two nearly-identical row renderers drifting.

Partial fix for #435. This is **PR 1 of 3**. Follow-ups (separate PRs):
- PR 2 — migrate `rule_detail.html` matched/preview transaction tables to `tx-row-compact`.
- PR 3 — introduce a `TransactionSummary` DTO and refactor palette + rule-preview call sites.

## Layout notes

Layout matches the spec in #435:
- Category avatar (reuses `.bb-tx-avatar` / `.bb-tx-avatar--sm`) on the left.
- Name + optional `Pending` badge (now the shared DaisyUI `badge-soft badge-xs badge-warning` style, consistent with `tx-row`).
- Meta line: user avatar · account · category (with colored dot) · optional `bot` indicator.
- Right column: amount on top, relative date below. Previously the date was jammed into the meta line.

## Before / after (desktop, 1280w)

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/d2nb8rygnq.jpg" width="400" alt="dashboard — before"></td>
    <td><img src="https://i.img402.dev/gksf6ry5z0.jpg" width="400" alt="dashboard — after"></td>
  </tr>
</table>

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Visual: rendered locally at `http://localhost:8081/`, captured dashboard recent txns widget before/after (see above)
- [ ] Reviewer: sanity-check on mobile (`390w`) — meta line collapses hidden-on-small category chip as before
- [ ] Reviewer: confirm no regression for pending badge + bot (agent-reviewed) indicator rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)