### PR TITLE
refactor(rules): unify rule_applied/category_set annotation writes

### DIFF
--- a/internal/ruleapply/annotations.go
+++ b/internal/ruleapply/annotations.go
@@ -1,0 +1,130 @@
+// Package ruleapply provides shared helpers for writing rule-driven annotation
+// rows. Both the sync engine (internal/sync) and the retroactive apply paths
+// (internal/service) need to emit identical annotation shapes for
+// `rule_applied` and `category_set` rows; keeping the payload construction in
+// one place avoids the drift we saw before the helpers existed.
+//
+// This package depends only on the database driver and is positioned as a
+// neutral leaf that both service and sync can import without creating a
+// dependency cycle (sync must not import service).
+package ruleapply
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// AppliedBy values communicate the write origin in the annotation payload. The
+// admin UI branches on these strings when rendering the activity timeline.
+const (
+	AppliedBySync        = "sync"
+	AppliedByRetroactive = "retroactive"
+)
+
+// Rule carries just enough rule metadata to attribute an annotation. Callers
+// pass short_id + name for the actor columns and the UUID for the rule_id FK.
+type Rule struct {
+	ID      pgtype.UUID
+	ShortID string
+	Name    string
+}
+
+// WriteRuleApplied writes a `rule_applied` annotation for a single rule firing
+// on a single transaction. Canonical payload shape:
+//
+//	{ rule_id, rule_name, action_field, action_value, applied_by }
+//
+// All five keys are always emitted so downstream consumers (admin UI
+// `internal/admin/transactions.go`, analytics, etc.) see a stable shape —
+// action_field / action_value may be empty strings when the caller is
+// recording a rule-level audit without a specific action specialization.
+func WriteRuleApplied(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, rule Rule, actionField, actionValue, appliedBy string) error {
+	payload := map[string]any{
+		"rule_id":      rule.ShortID,
+		"rule_name":    rule.Name,
+		"action_field": actionField,
+		"action_value": actionValue,
+		"applied_by":   appliedBy,
+	}
+	return writeAnnotation(ctx, tx, annotationRow{
+		TransactionID: txnID,
+		Kind:          "rule_applied",
+		ActorType:     "system",
+		ActorID:       rule.ShortID,
+		ActorName:     rule.Name,
+		Payload:       payload,
+		RuleID:        rule.ID,
+	})
+}
+
+// WriteCategorySet writes a `category_set` annotation for a rule that applied
+// a category to a transaction. Canonical payload shape:
+//
+//	{ category_slug, source: "rule", applied_by, rule_id, rule_name }
+//
+// Callers supply the slug (already validated upstream) and the appliedBy
+// origin. The annotation is attributed to the winning rule.
+func WriteCategorySet(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, rule Rule, slug, appliedBy string) error {
+	payload := map[string]any{
+		"category_slug": slug,
+		"source":        "rule",
+		"applied_by":    appliedBy,
+		"rule_id":       rule.ShortID,
+		"rule_name":     rule.Name,
+	}
+	return writeAnnotation(ctx, tx, annotationRow{
+		TransactionID: txnID,
+		Kind:          "category_set",
+		ActorType:     "system",
+		ActorID:       rule.ShortID,
+		ActorName:     rule.Name,
+		Payload:       payload,
+		RuleID:        rule.ID,
+	})
+}
+
+// annotationRow is the minimum column set required to insert an annotation
+// attributed to a rule. Other callers (comments, manual category changes, tag
+// writes) still use their own helpers in the service and sync packages.
+type annotationRow struct {
+	TransactionID pgtype.UUID
+	Kind          string
+	ActorType     string
+	ActorID       string
+	ActorName     string
+	Payload       map[string]any
+	TagID         pgtype.UUID
+	RuleID        pgtype.UUID
+}
+
+func writeAnnotation(ctx context.Context, tx pgx.Tx, r annotationRow) error {
+	var payloadJSON []byte
+	if r.Payload == nil {
+		payloadJSON = []byte(`{}`)
+	} else {
+		b, err := json.Marshal(r.Payload)
+		if err != nil {
+			return fmt.Errorf("marshal annotation payload: %w", err)
+		}
+		payloadJSON = b
+	}
+
+	actorID := pgtype.Text{}
+	if r.ActorID != "" {
+		actorID = pgtype.Text{String: r.ActorID, Valid: true}
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO annotations (transaction_id, kind, actor_type, actor_id, actor_name, session_id, payload, tag_id, rule_id)
+		VALUES ($1, $2, $3, $4, $5, NULL, $6::jsonb, $7, $8)`,
+		r.TransactionID, r.Kind, r.ActorType, actorID, r.ActorName, payloadJSON,
+		r.TagID, r.RuleID,
+	); err != nil {
+		return fmt.Errorf("insert %s annotation: %w", r.Kind, err)
+	}
+	return nil
+}

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"breadbox/internal/slugs"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -986,6 +988,9 @@ func (s *Service) UpdateTransactionRule(ctx context.Context, id string, params U
 		actions = newActions
 	}
 
+	// existing.Trigger is sourced from a NOT NULL DEFAULT column, and
+	// normalizeTrigger guarantees a non-empty value on update — no fallback
+	// needed here.
 	trigger := existing.Trigger
 	if params.Trigger != nil {
 		t, err := normalizeTrigger(*params.Trigger)
@@ -993,9 +998,6 @@ func (s *Service) UpdateTransactionRule(ctx context.Context, id string, params U
 			return nil, err
 		}
 		trigger = t
-	}
-	if trigger == "" {
-		trigger = "on_create"
 	}
 
 	priority := int32(existing.Priority)
@@ -2064,7 +2066,7 @@ func (s *Service) materializeRuleTagAdd(ctx context.Context, tx pgx.Tx, txnID pg
 			INSERT INTO tags (slug, display_name, lifecycle)
 			VALUES ($1, $2, 'persistent')
 			ON CONFLICT (slug) DO UPDATE SET updated_at = tags.updated_at
-			RETURNING id`, slug, titleCaseSlug(slug)).Scan(&tagID); err2 != nil {
+			RETURNING id`, slug, slugs.TitleCase(slug)).Scan(&tagID); err2 != nil {
 			return false, fmt.Errorf("get or create tag %q: %w", slug, err2)
 		}
 	}
@@ -2148,35 +2150,6 @@ func (s *Service) materializeRuleTagRemove(ctx context.Context, tx pgx.Tx, txnID
 		return true, fmt.Errorf("annotate tag_removed: %w", err)
 	}
 	return true, nil
-}
-
-// buildActionSetClause converts rule actions into SQL SET clause components.
-// Returns setClauses (e.g., ["category_id = $1"]), args, and error. Only
-// set_category materializes here — add_tag / remove_tag / add_comment are
-// persisted via separate helpers (materializeRuleTagAdd / Remove) since they
-// don't fit a single UPDATE row. add_comment stays sync-only by design.
-func (s *Service) buildActionSetClause(ctx context.Context, actions []RuleAction) ([]string, []any, error) {
-	var setClauses []string
-	var args []any
-	argN := 1
-
-	for _, a := range actions {
-		switch a.Type {
-		case "set_category":
-			catID, err := s.categorySlugToUUID(ctx, a.CategorySlug)
-			if err != nil {
-				return nil, nil, err
-			}
-			if catID.Valid {
-				setClauses = append(setClauses, fmt.Sprintf("category_id = $%d", argN))
-				args = append(args, catID)
-				argN++
-			}
-			// "add_tag" / "add_comment" are sync-only; skip for retroactive apply.
-		}
-	}
-
-	return setClauses, args, nil
 }
 
 // categorySlugToUUID resolves a category slug to its UUID via the service-layer

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"breadbox/internal/ruleapply"
 	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
@@ -1280,7 +1281,6 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		if err != nil {
 			return totalMatched, fmt.Errorf("begin retroactive apply tx: %w", err)
 		}
-		qtx := s.Queries.WithTx(tx)
 
 		// set_category: bulk UPDATE for matching non-overridden rows.
 		if categorySetCatID.Valid {
@@ -1293,23 +1293,9 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 				return totalMatched, fmt.Errorf("update transactions: %w", err)
 			}
 			// Annotation per touched row.
+			rule := ruleapply.Rule{ID: ruleUUID, ShortID: ruleShortID, Name: ruleName}
 			for _, txnID := range matchIDs {
-				payload := map[string]any{
-					"category_slug": categorySetSlug,
-					"source":        "rule",
-					"applied_by":    "retroactive",
-					"rule_id":       ruleShortID,
-					"rule_name":     ruleName,
-				}
-				if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
-					TransactionID: txnID,
-					Kind:          "category_set",
-					ActorType:     "system",
-					ActorID:       ruleShortID,
-					ActorName:     ruleName,
-					Payload:       payload,
-					RuleID:        ruleUUID,
-				}); err != nil {
+				if err := ruleapply.WriteCategorySet(ctx, tx, txnID, rule, categorySetSlug, ruleapply.AppliedByRetroactive); err != nil {
 					tx.Rollback(ctx)
 					return totalMatched, fmt.Errorf("annotate category_set: %w", err)
 				}
@@ -1333,28 +1319,14 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		}
 
 		// rule_applied audit trail — one per action intent per matched txn.
+		appliedRule := ruleapply.Rule{ID: ruleUUID, ShortID: ruleShortID, Name: ruleName}
 		for _, action := range rule.Actions {
 			field, value := actionAuditFields(action)
 			if field == "" || field == "comment" {
 				continue
 			}
 			for _, txnID := range matchIDs {
-				payload := map[string]any{
-					"rule_id":      ruleShortID,
-					"rule_name":    ruleName,
-					"action_field": field,
-					"action_value": value,
-					"applied_by":   "retroactive",
-				}
-				if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
-					TransactionID: txnID,
-					Kind:          "rule_applied",
-					ActorType:     "system",
-					ActorID:       ruleShortID,
-					ActorName:     ruleName,
-					Payload:       payload,
-					RuleID:        ruleUUID,
-				}); err != nil {
+				if err := ruleapply.WriteRuleApplied(ctx, tx, txnID, appliedRule, field, value, ruleapply.AppliedByRetroactive); err != nil {
 					tx.Rollback(ctx)
 					return totalMatched, fmt.Errorf("annotate rule_applied: %w", err)
 				}
@@ -1570,7 +1542,6 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 		if err != nil {
 			return hitCounts, fmt.Errorf("begin apply-all tx: %w", err)
 		}
-		qtx := s.Queries.WithTx(tx)
 		aborted := false
 
 		// Group category updates by (catID) for batched UPDATEs.
@@ -1593,22 +1564,10 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 		for _, it := range intents {
 			// category_set annotation (one per touched row, owned by the winning rule).
 			if it.catRule != nil {
-				payload := map[string]any{
-					"category_slug": it.catSlug,
-					"source":        "rule",
-					"applied_by":    "retroactive",
-					"rule_id":       it.catRule.shortID,
-					"rule_name":     it.catRule.name,
-				}
-				if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
-					TransactionID: it.txnID,
-					Kind:          "category_set",
-					ActorType:     "system",
-					ActorID:       it.catRule.shortID,
-					ActorName:     it.catRule.name,
-					Payload:       payload,
-					RuleID:        it.catRule.uuid,
-				}); err != nil {
+				if err := ruleapply.WriteCategorySet(ctx, tx, it.txnID,
+					ruleapply.Rule{ID: it.catRule.uuid, ShortID: it.catRule.shortID, Name: it.catRule.name},
+					it.catSlug, ruleapply.AppliedByRetroactive,
+				); err != nil {
 					aborted = true
 					break
 				}
@@ -1633,21 +1592,16 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 			}
 
 			// rule_applied audit: one per matching rule per txn.
+			//
+			// Unlike ApplyRuleRetroactively, this path emits one annotation per
+			// (matching rule, txn) without per-action specialization — callers
+			// get a rule-level audit, so action_field / action_value are left
+			// empty. Shape still matches the canonical 5-key payload.
 			for _, cr := range it.matchingRules {
-				payload := map[string]any{
-					"rule_id":    cr.shortID,
-					"rule_name":  cr.name,
-					"applied_by": "retroactive",
-				}
-				if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
-					TransactionID: it.txnID,
-					Kind:          "rule_applied",
-					ActorType:     "system",
-					ActorID:       cr.shortID,
-					ActorName:     cr.name,
-					Payload:       payload,
-					RuleID:        cr.uuid,
-				}); err != nil {
+				if err := ruleapply.WriteRuleApplied(ctx, tx, it.txnID,
+					ruleapply.Rule{ID: cr.uuid, ShortID: cr.shortID, Name: cr.name},
+					"", "", ruleapply.AppliedByRetroactive,
+				); err != nil {
 					aborted = true
 					break
 				}
@@ -2019,33 +1973,6 @@ func (s *Service) convertRuleRows(ctx context.Context, scanned []ruleRow) []Tran
 		rules[i] = resp
 	}
 	return rules
-}
-
-// recordRuleApplications writes a rule_applied annotation per transaction —
-// the canonical record of which rules touched which transactions.
-func (s *Service) recordRuleApplications(ctx context.Context, ruleID pgtype.UUID, txnIDs []pgtype.UUID, actionField, actionValue, appliedBy string) {
-	// Look up rule metadata for annotation actor fields.
-	var ruleShortID, ruleName string
-	_ = s.Pool.QueryRow(ctx, `SELECT short_id, name FROM transaction_rules WHERE id = $1`, ruleID).Scan(&ruleShortID, &ruleName)
-
-	for _, txnID := range txnIDs {
-		payload := map[string]interface{}{
-			"rule_id":      ruleShortID,
-			"rule_name":    ruleName,
-			"action_field": actionField,
-			"action_value": actionValue,
-			"applied_by":   appliedBy,
-		}
-		_ = writeAnnotation(ctx, s.Queries, writeAnnotationParams{
-			TransactionID: txnID,
-			Kind:          "rule_applied",
-			ActorType:     "system",
-			ActorID:       ruleShortID,
-			ActorName:     ruleName,
-			Payload:       payload,
-			RuleID:        ruleID,
-		})
-	}
 }
 
 // materializeRuleTagAdd applies an add_tag action retroactively: auto-creates

--- a/internal/service/tags.go
+++ b/internal/service/tags.go
@@ -10,6 +10,7 @@ import (
 
 	"breadbox/internal/db"
 	"breadbox/internal/shortid"
+	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -67,21 +68,6 @@ func validateLifecycle(lifecycle string) error {
 		return fmt.Errorf("%w: lifecycle must be 'persistent' or 'ephemeral'", ErrInvalidParameter)
 	}
 	return nil
-}
-
-// titleCaseSlug converts a slug ("needs-review") to a title-cased display name
-// ("Needs Review"). Used as the default display_name for auto-created tags.
-func titleCaseSlug(slug string) string {
-	parts := strings.FieldsFunc(slug, func(r rune) bool {
-		return r == '-' || r == ':' || r == '_'
-	})
-	for i, p := range parts {
-		if p == "" {
-			continue
-		}
-		parts[i] = strings.ToUpper(p[:1]) + p[1:]
-	}
-	return strings.Join(parts, " ")
 }
 
 // CreateTag validates and inserts a new tag record. Slug regex:
@@ -288,7 +274,7 @@ func (s *Service) getOrCreateTagBySlug(ctx context.Context, q *db.Queries, slug 
 	// Auto-create
 	created, err := q.InsertTag(ctx, db.InsertTagParams{
 		Slug:        slug,
-		DisplayName: titleCaseSlug(slug),
+		DisplayName: slugs.TitleCase(slug),
 		Lifecycle:   "persistent",
 	})
 	if err != nil {

--- a/internal/slugs/slugs.go
+++ b/internal/slugs/slugs.go
@@ -1,0 +1,24 @@
+// Package slugs contains small string helpers for working with slug
+// identifiers used across Breadbox (tags, categories, and similar). It lives
+// in a neutral leaf package so both service and sync can import it without
+// creating a dependency cycle.
+package slugs
+
+import "strings"
+
+// TitleCase converts a slug ("needs-review") to a title-cased display name
+// ("Needs Review"). Separators recognized: '-', ':', '_'. Used as the default
+// display_name when auto-creating tags from a slug (e.g., during sync when a
+// rule's add_tag action references a slug that hasn't been registered yet).
+func TitleCase(slug string) string {
+	parts := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == ':' || r == '_'
+	})
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -13,6 +13,7 @@ import (
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
+	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -631,6 +632,12 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 	if !isNew {
 		if slugs, err := e.loadTagSlugsInTx(ctx, tx, dbTxn.ID); err == nil {
 			tctx.Tags = slugs
+		} else {
+			// Don't fail the whole sync over a tag-read glitch; rules that
+			// depend on tag conditions simply won't match this pass. Surfacing
+			// the error lets operators notice repeated failures.
+			e.logger.Warn("load tag slugs for rule evaluation failed; continuing without tag context",
+				"transaction_id", pgconv.FormatUUID(dbTxn.ID), "err", err)
 		}
 	}
 
@@ -642,6 +649,14 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 	// Build quick lookup of Source rule-metadata by (field, value) so the tag /
 	// comment / category persistence below can attach the right rule_id, name,
 	// and short_id to each annotation.
+	//
+	// First-wins on duplicate (field, value) keys: when multiple rules emit
+	// the same action (e.g., two rules both add_tag "needs-review"), the
+	// annotation is credited to the highest-priority rule that fired — because
+	// ResolveWithContext orders Sources by pipeline stage then priority, the
+	// first occurrence here is that rule. Lower-priority duplicates are
+	// dropped rather than overwriting, which matches the "winner takes the
+	// annotation" story the admin UI surfaces.
 	type ruleRef struct {
 		ruleID      pgtype.UUID
 		ruleShortID string
@@ -778,7 +793,7 @@ func (e *Engine) applyTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.U
 			INSERT INTO tags (slug, display_name, lifecycle)
 			VALUES ($1, $2, 'persistent')
 			ON CONFLICT (slug) DO UPDATE SET updated_at = tags.updated_at
-			RETURNING id`, slug, titleCaseSlugForRule(slug)).Scan(&tagID)
+			RETURNING id`, slug, slugs.TitleCase(slug)).Scan(&tagID)
 		if err2 != nil {
 			return fmt.Errorf("get or create tag %q: %w", slug, err2)
 		}
@@ -895,31 +910,6 @@ func (e *Engine) applyCommentFromRule(ctx context.Context, tx pgx.Tx, txnID pgty
 		return fmt.Errorf("annotate rule comment: %w", err)
 	}
 	return nil
-}
-
-// titleCaseSlugForRule converts a slug ("needs-review") to a display name
-// ("Needs Review") for auto-created tags during sync. Mirrors
-// service.titleCaseSlug; duplicated here to keep sync → service dependency
-// direction one-way.
-func titleCaseSlugForRule(slug string) string {
-	out := make([]byte, 0, len(slug))
-	capitalize := true
-	for i := 0; i < len(slug); i++ {
-		c := slug[i]
-		if c == '-' || c == ':' || c == '_' {
-			out = append(out, ' ')
-			capitalize = true
-			continue
-		}
-		if capitalize && c >= 'a' && c <= 'z' {
-			out = append(out, c-32)
-			capitalize = false
-			continue
-		}
-		out = append(out, c)
-		capitalize = false
-	}
-	return string(out)
 }
 
 // writeSyncAnnotationParams is the sync-package-local mirror of

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -13,6 +13,7 @@ import (
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
+	"breadbox/internal/ruleapply"
 	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
@@ -370,22 +371,10 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		// user|agent|system — rule_id in the dedicated column carries the rule
 		// back-reference).
 		for _, app := range ruleApplications {
-			payload := map[string]any{
-				"rule_id":      app.ruleShortID,
-				"rule_name":    app.ruleName,
-				"action_field": app.actionField,
-				"action_value": app.actionValue,
-				"applied_by":   "sync",
-			}
-			if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
-				TransactionID: app.txnID,
-				Kind:          "rule_applied",
-				ActorType:     "system",
-				ActorID:       app.ruleShortID,
-				ActorName:     app.ruleName,
-				Payload:       payload,
-				RuleID:        app.ruleID,
-			}); err != nil {
+			if err := ruleapply.WriteRuleApplied(ctx, tx, app.txnID,
+				ruleapply.Rule{ID: app.ruleID, ShortID: app.ruleShortID, Name: app.ruleName},
+				app.actionField, app.actionValue, ruleapply.AppliedBySync,
+			); err != nil {
 				logger.Error("insert rule_applied annotation", "transaction_id", app.txnID, "rule_id", app.ruleID, "error", err)
 			}
 		}
@@ -690,18 +679,10 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 			}
 
 			src := sourceByKey["category|"+result.CategorySlug]
-			if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
-				TransactionID: dbTxn.ID,
-				Kind:          "category_set",
-				ActorType:     "system",
-				ActorID:       src.ruleShortID,
-				ActorName:     src.ruleName,
-				Payload: map[string]any{
-					"category_slug": result.CategorySlug,
-					"source":        "rule",
-				},
-				RuleID: src.ruleID,
-			}); err != nil {
+			if err := ruleapply.WriteCategorySet(ctx, tx, dbTxn.ID,
+				ruleapply.Rule{ID: src.ruleID, ShortID: src.ruleShortID, Name: src.ruleName},
+				result.CategorySlug, ruleapply.AppliedBySync,
+			); err != nil {
 				return result.Sources, fmt.Errorf("annotate category_set: %w", err)
 			}
 		}


### PR DESCRIPTION
## Summary
Builds on #440. Extracts rule-driven annotation construction into a new `internal/ruleapply` leaf package so the sync engine and both retroactive-apply paths stop drifting on payload shape.

- `ruleapply.WriteRuleApplied` — single writer for `rule_applied` annotations.
- `ruleapply.WriteCategorySet` — single writer for `category_set` annotations authored by a rule.
- `ruleapply` is a leaf (pgx + pgtype only), so `internal/sync` can import it without crossing the one-way `sync -> service` boundary.
- Canonical payload shapes:
  - `rule_applied`: `{ rule_id, rule_name, action_field, action_value, applied_by }`
  - `category_set` (rule-sourced): `{ category_slug, source:"rule", applied_by, rule_id, rule_name }`
- Named origin constants `AppliedBySync` / `AppliedByRetroactive`.
- Drops the dead `recordRuleApplications` helper in `internal/service/rules.go` (no callers).

`materializeRuleTagAdd` / `materializeRuleTagRemove` stayed in the service package — the tag auto-create SQL uses service-local helpers (`slugs.TitleCase`) and pulling them into `ruleapply` would drag the tag-creation + validation machinery along, which the issue explicitly marks as acceptable to skip.

`grep` for `Kind: "rule_applied"` and `Kind: "category_set"` now only matches `internal/ruleapply/annotations.go` (and one manual `category_set` writer in `update_transactions.go`, which is out of scope — that path writes `source=manual`, not a rule).

Closes #432

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make test-integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)