### PR TITLE
test(rules): add missing audit §D coverage

### DIFF
--- a/internal/ruleapply/annotations.go
+++ b/internal/ruleapply/annotations.go
@@ -1,0 +1,130 @@
+// Package ruleapply provides shared helpers for writing rule-driven annotation
+// rows. Both the sync engine (internal/sync) and the retroactive apply paths
+// (internal/service) need to emit identical annotation shapes for
+// `rule_applied` and `category_set` rows; keeping the payload construction in
+// one place avoids the drift we saw before the helpers existed.
+//
+// This package depends only on the database driver and is positioned as a
+// neutral leaf that both service and sync can import without creating a
+// dependency cycle (sync must not import service).
+package ruleapply
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// AppliedBy values communicate the write origin in the annotation payload. The
+// admin UI branches on these strings when rendering the activity timeline.
+const (
+	AppliedBySync        = "sync"
+	AppliedByRetroactive = "retroactive"
+)
+
+// Rule carries just enough rule metadata to attribute an annotation. Callers
+// pass short_id + name for the actor columns and the UUID for the rule_id FK.
+type Rule struct {
+	ID      pgtype.UUID
+	ShortID string
+	Name    string
+}
+
+// WriteRuleApplied writes a `rule_applied` annotation for a single rule firing
+// on a single transaction. Canonical payload shape:
+//
+//	{ rule_id, rule_name, action_field, action_value, applied_by }
+//
+// All five keys are always emitted so downstream consumers (admin UI
+// `internal/admin/transactions.go`, analytics, etc.) see a stable shape —
+// action_field / action_value may be empty strings when the caller is
+// recording a rule-level audit without a specific action specialization.
+func WriteRuleApplied(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, rule Rule, actionField, actionValue, appliedBy string) error {
+	payload := map[string]any{
+		"rule_id":      rule.ShortID,
+		"rule_name":    rule.Name,
+		"action_field": actionField,
+		"action_value": actionValue,
+		"applied_by":   appliedBy,
+	}
+	return writeAnnotation(ctx, tx, annotationRow{
+		TransactionID: txnID,
+		Kind:          "rule_applied",
+		ActorType:     "system",
+		ActorID:       rule.ShortID,
+		ActorName:     rule.Name,
+		Payload:       payload,
+		RuleID:        rule.ID,
+	})
+}
+
+// WriteCategorySet writes a `category_set` annotation for a rule that applied
+// a category to a transaction. Canonical payload shape:
+//
+//	{ category_slug, source: "rule", applied_by, rule_id, rule_name }
+//
+// Callers supply the slug (already validated upstream) and the appliedBy
+// origin. The annotation is attributed to the winning rule.
+func WriteCategorySet(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, rule Rule, slug, appliedBy string) error {
+	payload := map[string]any{
+		"category_slug": slug,
+		"source":        "rule",
+		"applied_by":    appliedBy,
+		"rule_id":       rule.ShortID,
+		"rule_name":     rule.Name,
+	}
+	return writeAnnotation(ctx, tx, annotationRow{
+		TransactionID: txnID,
+		Kind:          "category_set",
+		ActorType:     "system",
+		ActorID:       rule.ShortID,
+		ActorName:     rule.Name,
+		Payload:       payload,
+		RuleID:        rule.ID,
+	})
+}
+
+// annotationRow is the minimum column set required to insert an annotation
+// attributed to a rule. Other callers (comments, manual category changes, tag
+// writes) still use their own helpers in the service and sync packages.
+type annotationRow struct {
+	TransactionID pgtype.UUID
+	Kind          string
+	ActorType     string
+	ActorID       string
+	ActorName     string
+	Payload       map[string]any
+	TagID         pgtype.UUID
+	RuleID        pgtype.UUID
+}
+
+func writeAnnotation(ctx context.Context, tx pgx.Tx, r annotationRow) error {
+	var payloadJSON []byte
+	if r.Payload == nil {
+		payloadJSON = []byte(`{}`)
+	} else {
+		b, err := json.Marshal(r.Payload)
+		if err != nil {
+			return fmt.Errorf("marshal annotation payload: %w", err)
+		}
+		payloadJSON = b
+	}
+
+	actorID := pgtype.Text{}
+	if r.ActorID != "" {
+		actorID = pgtype.Text{String: r.ActorID, Valid: true}
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO annotations (transaction_id, kind, actor_type, actor_id, actor_name, session_id, payload, tag_id, rule_id)
+		VALUES ($1, $2, $3, $4, $5, NULL, $6::jsonb, $7, $8)`,
+		r.TransactionID, r.Kind, r.ActorType, actorID, r.ActorName, payloadJSON,
+		r.TagID, r.RuleID,
+	); err != nil {
+		return fmt.Errorf("insert %s annotation: %w", r.Kind, err)
+	}
+	return nil
+}

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"breadbox/internal/slugs"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -986,6 +988,9 @@ func (s *Service) UpdateTransactionRule(ctx context.Context, id string, params U
 		actions = newActions
 	}
 
+	// existing.Trigger is sourced from a NOT NULL DEFAULT column, and
+	// normalizeTrigger guarantees a non-empty value on update — no fallback
+	// needed here.
 	trigger := existing.Trigger
 	if params.Trigger != nil {
 		t, err := normalizeTrigger(*params.Trigger)
@@ -993,9 +998,6 @@ func (s *Service) UpdateTransactionRule(ctx context.Context, id string, params U
 			return nil, err
 		}
 		trigger = t
-	}
-	if trigger == "" {
-		trigger = "on_create"
 	}
 
 	priority := int32(existing.Priority)
@@ -2064,7 +2066,7 @@ func (s *Service) materializeRuleTagAdd(ctx context.Context, tx pgx.Tx, txnID pg
 			INSERT INTO tags (slug, display_name, lifecycle)
 			VALUES ($1, $2, 'persistent')
 			ON CONFLICT (slug) DO UPDATE SET updated_at = tags.updated_at
-			RETURNING id`, slug, titleCaseSlug(slug)).Scan(&tagID); err2 != nil {
+			RETURNING id`, slug, slugs.TitleCase(slug)).Scan(&tagID); err2 != nil {
 			return false, fmt.Errorf("get or create tag %q: %w", slug, err2)
 		}
 	}
@@ -2148,35 +2150,6 @@ func (s *Service) materializeRuleTagRemove(ctx context.Context, tx pgx.Tx, txnID
 		return true, fmt.Errorf("annotate tag_removed: %w", err)
 	}
 	return true, nil
-}
-
-// buildActionSetClause converts rule actions into SQL SET clause components.
-// Returns setClauses (e.g., ["category_id = $1"]), args, and error. Only
-// set_category materializes here — add_tag / remove_tag / add_comment are
-// persisted via separate helpers (materializeRuleTagAdd / Remove) since they
-// don't fit a single UPDATE row. add_comment stays sync-only by design.
-func (s *Service) buildActionSetClause(ctx context.Context, actions []RuleAction) ([]string, []any, error) {
-	var setClauses []string
-	var args []any
-	argN := 1
-
-	for _, a := range actions {
-		switch a.Type {
-		case "set_category":
-			catID, err := s.categorySlugToUUID(ctx, a.CategorySlug)
-			if err != nil {
-				return nil, nil, err
-			}
-			if catID.Valid {
-				setClauses = append(setClauses, fmt.Sprintf("category_id = $%d", argN))
-				args = append(args, catID)
-				argN++
-			}
-			// "add_tag" / "add_comment" are sync-only; skip for retroactive apply.
-		}
-	}
-
-	return setClauses, args, nil
 }
 
 // categorySlugToUUID resolves a category slug to its UUID via the service-layer

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"breadbox/internal/ruleapply"
 	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
@@ -1280,7 +1281,6 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		if err != nil {
 			return totalMatched, fmt.Errorf("begin retroactive apply tx: %w", err)
 		}
-		qtx := s.Queries.WithTx(tx)
 
 		// set_category: bulk UPDATE for matching non-overridden rows.
 		if categorySetCatID.Valid {
@@ -1293,23 +1293,9 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 				return totalMatched, fmt.Errorf("update transactions: %w", err)
 			}
 			// Annotation per touched row.
+			rule := ruleapply.Rule{ID: ruleUUID, ShortID: ruleShortID, Name: ruleName}
 			for _, txnID := range matchIDs {
-				payload := map[string]any{
-					"category_slug": categorySetSlug,
-					"source":        "rule",
-					"applied_by":    "retroactive",
-					"rule_id":       ruleShortID,
-					"rule_name":     ruleName,
-				}
-				if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
-					TransactionID: txnID,
-					Kind:          "category_set",
-					ActorType:     "system",
-					ActorID:       ruleShortID,
-					ActorName:     ruleName,
-					Payload:       payload,
-					RuleID:        ruleUUID,
-				}); err != nil {
+				if err := ruleapply.WriteCategorySet(ctx, tx, txnID, rule, categorySetSlug, ruleapply.AppliedByRetroactive); err != nil {
 					tx.Rollback(ctx)
 					return totalMatched, fmt.Errorf("annotate category_set: %w", err)
 				}
@@ -1333,28 +1319,14 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		}
 
 		// rule_applied audit trail — one per action intent per matched txn.
+		appliedRule := ruleapply.Rule{ID: ruleUUID, ShortID: ruleShortID, Name: ruleName}
 		for _, action := range rule.Actions {
 			field, value := actionAuditFields(action)
 			if field == "" || field == "comment" {
 				continue
 			}
 			for _, txnID := range matchIDs {
-				payload := map[string]any{
-					"rule_id":      ruleShortID,
-					"rule_name":    ruleName,
-					"action_field": field,
-					"action_value": value,
-					"applied_by":   "retroactive",
-				}
-				if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
-					TransactionID: txnID,
-					Kind:          "rule_applied",
-					ActorType:     "system",
-					ActorID:       ruleShortID,
-					ActorName:     ruleName,
-					Payload:       payload,
-					RuleID:        ruleUUID,
-				}); err != nil {
+				if err := ruleapply.WriteRuleApplied(ctx, tx, txnID, appliedRule, field, value, ruleapply.AppliedByRetroactive); err != nil {
 					tx.Rollback(ctx)
 					return totalMatched, fmt.Errorf("annotate rule_applied: %w", err)
 				}
@@ -1570,7 +1542,6 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 		if err != nil {
 			return hitCounts, fmt.Errorf("begin apply-all tx: %w", err)
 		}
-		qtx := s.Queries.WithTx(tx)
 		aborted := false
 
 		// Group category updates by (catID) for batched UPDATEs.
@@ -1593,22 +1564,10 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 		for _, it := range intents {
 			// category_set annotation (one per touched row, owned by the winning rule).
 			if it.catRule != nil {
-				payload := map[string]any{
-					"category_slug": it.catSlug,
-					"source":        "rule",
-					"applied_by":    "retroactive",
-					"rule_id":       it.catRule.shortID,
-					"rule_name":     it.catRule.name,
-				}
-				if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
-					TransactionID: it.txnID,
-					Kind:          "category_set",
-					ActorType:     "system",
-					ActorID:       it.catRule.shortID,
-					ActorName:     it.catRule.name,
-					Payload:       payload,
-					RuleID:        it.catRule.uuid,
-				}); err != nil {
+				if err := ruleapply.WriteCategorySet(ctx, tx, it.txnID,
+					ruleapply.Rule{ID: it.catRule.uuid, ShortID: it.catRule.shortID, Name: it.catRule.name},
+					it.catSlug, ruleapply.AppliedByRetroactive,
+				); err != nil {
 					aborted = true
 					break
 				}
@@ -1633,21 +1592,16 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 			}
 
 			// rule_applied audit: one per matching rule per txn.
+			//
+			// Unlike ApplyRuleRetroactively, this path emits one annotation per
+			// (matching rule, txn) without per-action specialization — callers
+			// get a rule-level audit, so action_field / action_value are left
+			// empty. Shape still matches the canonical 5-key payload.
 			for _, cr := range it.matchingRules {
-				payload := map[string]any{
-					"rule_id":    cr.shortID,
-					"rule_name":  cr.name,
-					"applied_by": "retroactive",
-				}
-				if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
-					TransactionID: it.txnID,
-					Kind:          "rule_applied",
-					ActorType:     "system",
-					ActorID:       cr.shortID,
-					ActorName:     cr.name,
-					Payload:       payload,
-					RuleID:        cr.uuid,
-				}); err != nil {
+				if err := ruleapply.WriteRuleApplied(ctx, tx, it.txnID,
+					ruleapply.Rule{ID: cr.uuid, ShortID: cr.shortID, Name: cr.name},
+					"", "", ruleapply.AppliedByRetroactive,
+				); err != nil {
 					aborted = true
 					break
 				}
@@ -2019,33 +1973,6 @@ func (s *Service) convertRuleRows(ctx context.Context, scanned []ruleRow) []Tran
 		rules[i] = resp
 	}
 	return rules
-}
-
-// recordRuleApplications writes a rule_applied annotation per transaction —
-// the canonical record of which rules touched which transactions.
-func (s *Service) recordRuleApplications(ctx context.Context, ruleID pgtype.UUID, txnIDs []pgtype.UUID, actionField, actionValue, appliedBy string) {
-	// Look up rule metadata for annotation actor fields.
-	var ruleShortID, ruleName string
-	_ = s.Pool.QueryRow(ctx, `SELECT short_id, name FROM transaction_rules WHERE id = $1`, ruleID).Scan(&ruleShortID, &ruleName)
-
-	for _, txnID := range txnIDs {
-		payload := map[string]interface{}{
-			"rule_id":      ruleShortID,
-			"rule_name":    ruleName,
-			"action_field": actionField,
-			"action_value": actionValue,
-			"applied_by":   appliedBy,
-		}
-		_ = writeAnnotation(ctx, s.Queries, writeAnnotationParams{
-			TransactionID: txnID,
-			Kind:          "rule_applied",
-			ActorType:     "system",
-			ActorID:       ruleShortID,
-			ActorName:     ruleName,
-			Payload:       payload,
-			RuleID:        ruleID,
-		})
-	}
 }
 
 // materializeRuleTagAdd applies an add_tag action retroactively: auto-creates

--- a/internal/service/rules_integration_test.go
+++ b/internal/service/rules_integration_test.go
@@ -1361,3 +1361,296 @@ func TestApplyRuleRetroactively_HitCountMatchesSync(t *testing.T) {
 func init() {
 	_ = db.InsertCategoryParams{}
 }
+
+// --- Audit §D retroactive coverage ---
+
+// TestApplyRuleRetroactively_Expired_Rejected verifies that calling
+// ApplyRuleRetroactively on a rule whose expires_at is in the past returns
+// ErrInvalidParameter and leaves the DB untouched.
+func TestApplyRuleRetroactively_Expired_Rejected(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	_ = mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_exp_1", "Starbucks Coffee", 500, "2025-01-15")
+
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:         "Expired Coffee Rule",
+		CategorySlug: "food_and_drink",
+		Conditions:   service.Condition{Field: "name", Op: "contains", Value: "Starbucks"},
+		Priority:     10,
+		Actor:        service.Actor{Type: "system", Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	// Backdate expires_at so the rule is expired.
+	if _, err := pool.Exec(ctx,
+		"UPDATE transaction_rules SET expires_at = NOW() - INTERVAL '1 hour' WHERE id = $1::uuid",
+		rule.ID,
+	); err != nil {
+		t.Fatalf("expire rule: %v", err)
+	}
+
+	matched, err := svc.ApplyRuleRetroactively(ctx, rule.ID)
+	if err == nil {
+		t.Fatal("expected error for expired rule, got nil")
+	}
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got %v", err)
+	}
+	if matched != 0 {
+		t.Errorf("expected matched=0, got %d", matched)
+	}
+
+	// DB untouched.
+	var annCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM annotations WHERE rule_id = $1::uuid`, rule.ID,
+	).Scan(&annCount); err != nil {
+		t.Fatalf("count annotations: %v", err)
+	}
+	if annCount != 0 {
+		t.Errorf("expected 0 annotations for rejected rule, got %d", annCount)
+	}
+}
+
+// TestApplyRuleRetroactively_Disabled_Rejected verifies that calling
+// ApplyRuleRetroactively on a disabled rule returns ErrInvalidParameter.
+func TestApplyRuleRetroactively_Disabled_Rejected(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	_ = mustCreateCategory(t, queries, "food_and_drink", "Food & Drink")
+
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_dis_1", "Starbucks Coffee", 500, "2025-01-15")
+
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:         "Disabled Coffee Rule",
+		CategorySlug: "food_and_drink",
+		Conditions:   service.Condition{Field: "name", Op: "contains", Value: "Starbucks"},
+		Priority:     10,
+		Actor:        service.Actor{Type: "system", Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	enabled := false
+	if _, err := svc.UpdateTransactionRule(ctx, rule.ID, service.UpdateTransactionRuleParams{
+		Enabled: &enabled,
+	}); err != nil {
+		t.Fatalf("disable rule: %v", err)
+	}
+
+	matched, err := svc.ApplyRuleRetroactively(ctx, rule.ID)
+	if err == nil {
+		t.Fatal("expected error for disabled rule, got nil")
+	}
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got %v", err)
+	}
+	if matched != 0 {
+		t.Errorf("expected matched=0, got %d", matched)
+	}
+
+	var annCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM annotations WHERE rule_id = $1::uuid`, rule.ID,
+	).Scan(&annCount); err != nil {
+		t.Fatalf("count annotations: %v", err)
+	}
+	if annCount != 0 {
+		t.Errorf("expected 0 annotations for rejected rule, got %d", annCount)
+	}
+}
+
+// TestApplyAllRulesRetroactively_SamePriorityTie verifies that when two rules
+// share the same priority and target the same transaction with set_category,
+// the ordering tie-break (created_at ASC → later rule processed last → last
+// writer wins) produces a deterministic winner.
+func TestApplyAllRulesRetroactively_SamePriorityTie(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	catA := mustCreateCategory(t, queries, "cat_a", "Cat A")
+	catB := mustCreateCategory(t, queries, "cat_b", "Cat B")
+
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_tie", "Starbucks Coffee", 500, "2025-01-15")
+
+	// Rule A created first, Rule B created second. Same priority. ListActive
+	// orders by created_at ASC within a priority bucket, so Rule B runs last
+	// and wins set_category under last-writer-wins.
+	ruleA, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:         "Rule A (first)",
+		CategorySlug: "cat_a",
+		Conditions:   service.Condition{Field: "name", Op: "contains", Value: "Starbucks"},
+		Priority:     50,
+		Actor:        service.Actor{Type: "system", Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("create rule A: %v", err)
+	}
+	// Brief sleep so created_at ordering is unambiguous between the two rules.
+	if _, err := pool.Exec(ctx, "SELECT pg_sleep(0.05)"); err != nil {
+		t.Fatalf("pg_sleep: %v", err)
+	}
+	ruleB, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:         "Rule B (second)",
+		CategorySlug: "cat_b",
+		Conditions:   service.Condition{Field: "name", Op: "contains", Value: "Starbucks"},
+		Priority:     50,
+		Actor:        service.Actor{Type: "system", Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("create rule B: %v", err)
+	}
+	_ = ruleA
+
+	hitCounts, err := svc.ApplyAllRulesRetroactively(ctx)
+	if err != nil {
+		t.Fatalf("ApplyAllRulesRetroactively: %v", err)
+	}
+
+	// Both rules matched. hitCounts is keyed by rule.ID (UUID string).
+	if hitCounts[ruleA.ID] != 1 {
+		t.Errorf("rule A hit count: got %d, want 1", hitCounts[ruleA.ID])
+	}
+	if hitCounts[ruleB.ID] != 1 {
+		t.Errorf("rule B hit count: got %d, want 1", hitCounts[ruleB.ID])
+	}
+
+	// Later-created rule B wins the category assignment.
+	var winningCat pgtype.UUID
+	if err := pool.QueryRow(ctx,
+		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_tie'",
+	).Scan(&winningCat); err != nil {
+		t.Fatalf("query winning category: %v", err)
+	}
+	if winningCat != catB.ID {
+		t.Errorf("same-priority tie winner: got %v, want catB=%v (catA=%v)", winningCat, catB.ID, catA.ID)
+	}
+}
+
+// TestPreviewRule_DoesNotModify verifies that PreviewRule is pure-read: it
+// returns match counts without touching transactions, annotations, or
+// transaction_tags.
+func TestPreviewRule_DoesNotModify(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_p_1", "Starbucks Coffee", 500, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_p_2", "Starbucks Reserve", 700, "2025-01-16")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_p_3", "Shell Gas", 3000, "2025-01-17")
+
+	// Snapshot baseline counts.
+	var txnsBefore, annsBefore, tagsBefore int
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM transactions WHERE category_id IS NOT NULL").Scan(&txnsBefore); err != nil {
+		t.Fatalf("count categorized txns before: %v", err)
+	}
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM annotations").Scan(&annsBefore); err != nil {
+		t.Fatalf("count annotations before: %v", err)
+	}
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM transaction_tags").Scan(&tagsBefore); err != nil {
+		t.Fatalf("count transaction_tags before: %v", err)
+	}
+
+	result, err := svc.PreviewRule(ctx,
+		service.Condition{Field: "name", Op: "contains", Value: "Starbucks"}, 10,
+	)
+	if err != nil {
+		t.Fatalf("PreviewRule: %v", err)
+	}
+	if result.MatchCount != 2 {
+		t.Errorf("match count: got %d, want 2", result.MatchCount)
+	}
+
+	// Nothing should have changed.
+	var txnsAfter, annsAfter, tagsAfter int
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM transactions WHERE category_id IS NOT NULL").Scan(&txnsAfter); err != nil {
+		t.Fatalf("count categorized txns after: %v", err)
+	}
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM annotations").Scan(&annsAfter); err != nil {
+		t.Fatalf("count annotations after: %v", err)
+	}
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM transaction_tags").Scan(&tagsAfter); err != nil {
+		t.Fatalf("count transaction_tags after: %v", err)
+	}
+	if txnsAfter != txnsBefore {
+		t.Errorf("PreviewRule modified transactions: categorized rows before=%d after=%d", txnsBefore, txnsAfter)
+	}
+	if annsAfter != annsBefore {
+		t.Errorf("PreviewRule wrote annotations: before=%d after=%d", annsBefore, annsAfter)
+	}
+	if tagsAfter != tagsBefore {
+		t.Errorf("PreviewRule wrote transaction_tags: before=%d after=%d", tagsBefore, tagsAfter)
+	}
+}
+
+// TestPreviewRuleForDetail_ExcludesAlreadyApplied verifies that after a rule
+// has been applied retroactively, calling PreviewRuleForDetail with that
+// rule's id excludes the already-applied transactions from the match count.
+func TestPreviewRuleForDetail_ExcludesAlreadyApplied(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+
+	_ = mustCreateCategory(t, queries, "coffee", "Coffee")
+
+	acctID := seedTxnFixture(t, queries)
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_d_1", "Starbucks Coffee", 500, "2025-01-15")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_d_2", "Starbucks Reserve", 700, "2025-01-16")
+	testutil.MustCreateTransaction(t, queries, acctID, "txn_d_3", "Starbucks Drive", 450, "2025-01-17")
+
+	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
+		Name:         "Starbucks → coffee",
+		CategorySlug: "coffee",
+		Conditions:   service.Condition{Field: "name", Op: "contains", Value: "Starbucks"},
+		Priority:     10,
+		Actor:        service.Actor{Type: "system", Name: "test"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTransactionRule: %v", err)
+	}
+
+	// Baseline: preview-for-detail matches all three (none applied yet).
+	initial, err := svc.PreviewRuleForDetail(ctx, rule.ID, rule.Conditions, 10)
+	if err != nil {
+		t.Fatalf("PreviewRuleForDetail (baseline): %v", err)
+	}
+	if initial.MatchCount != 3 {
+		t.Fatalf("baseline match count: got %d, want 3", initial.MatchCount)
+	}
+
+	matched, err := svc.ApplyRuleRetroactively(ctx, rule.ID)
+	if err != nil {
+		t.Fatalf("ApplyRuleRetroactively: %v", err)
+	}
+	if matched != 3 {
+		t.Fatalf("retroactive match count: got %d, want 3", matched)
+	}
+
+	// All three now have a rule_applied annotation for this rule, so
+	// PreviewRuleForDetail excludes them — the preview now matches zero.
+	after, err := svc.PreviewRuleForDetail(ctx, rule.ID, rule.Conditions, 10)
+	if err != nil {
+		t.Fatalf("PreviewRuleForDetail (after apply): %v", err)
+	}
+	if after.MatchCount != 0 {
+		t.Errorf("after-apply match count: got %d, want 0 (already-applied txns should be excluded)", after.MatchCount)
+	}
+
+	// Sanity: regular PreviewRule (no rule context) still sees all three.
+	plain, err := svc.PreviewRule(ctx, rule.Conditions, 10)
+	if err != nil {
+		t.Fatalf("PreviewRule (plain): %v", err)
+	}
+	if plain.MatchCount != 3 {
+		t.Errorf("plain preview after apply: got %d, want 3 (should not filter)", plain.MatchCount)
+	}
+}

--- a/internal/service/tags.go
+++ b/internal/service/tags.go
@@ -10,6 +10,7 @@ import (
 
 	"breadbox/internal/db"
 	"breadbox/internal/shortid"
+	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -67,21 +68,6 @@ func validateLifecycle(lifecycle string) error {
 		return fmt.Errorf("%w: lifecycle must be 'persistent' or 'ephemeral'", ErrInvalidParameter)
 	}
 	return nil
-}
-
-// titleCaseSlug converts a slug ("needs-review") to a title-cased display name
-// ("Needs Review"). Used as the default display_name for auto-created tags.
-func titleCaseSlug(slug string) string {
-	parts := strings.FieldsFunc(slug, func(r rune) bool {
-		return r == '-' || r == ':' || r == '_'
-	})
-	for i, p := range parts {
-		if p == "" {
-			continue
-		}
-		parts[i] = strings.ToUpper(p[:1]) + p[1:]
-	}
-	return strings.Join(parts, " ")
 }
 
 // CreateTag validates and inserts a new tag record. Slug regex:
@@ -288,7 +274,7 @@ func (s *Service) getOrCreateTagBySlug(ctx context.Context, q *db.Queries, slug 
 	// Auto-create
 	created, err := q.InsertTag(ctx, db.InsertTagParams{
 		Slug:        slug,
-		DisplayName: titleCaseSlug(slug),
+		DisplayName: slugs.TitleCase(slug),
 		Lifecycle:   "persistent",
 	})
 	if err != nil {

--- a/internal/slugs/slugs.go
+++ b/internal/slugs/slugs.go
@@ -1,0 +1,24 @@
+// Package slugs contains small string helpers for working with slug
+// identifiers used across Breadbox (tags, categories, and similar). It lives
+// in a neutral leaf package so both service and sync can import it without
+// creating a dependency cycle.
+package slugs
+
+import "strings"
+
+// TitleCase converts a slug ("needs-review") to a title-cased display name
+// ("Needs Review"). Separators recognized: '-', ':', '_'. Used as the default
+// display_name when auto-creating tags from a slug (e.g., during sync when a
+// rule's add_tag action references a slug that hasn't been registered yet).
+func TitleCase(slug string) string {
+	parts := strings.FieldsFunc(slug, func(r rune) bool {
+		return r == '-' || r == ':' || r == '_'
+	})
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -13,6 +13,7 @@ import (
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
+	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -631,6 +632,12 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 	if !isNew {
 		if slugs, err := e.loadTagSlugsInTx(ctx, tx, dbTxn.ID); err == nil {
 			tctx.Tags = slugs
+		} else {
+			// Don't fail the whole sync over a tag-read glitch; rules that
+			// depend on tag conditions simply won't match this pass. Surfacing
+			// the error lets operators notice repeated failures.
+			e.logger.Warn("load tag slugs for rule evaluation failed; continuing without tag context",
+				"transaction_id", pgconv.FormatUUID(dbTxn.ID), "err", err)
 		}
 	}
 
@@ -642,6 +649,14 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 	// Build quick lookup of Source rule-metadata by (field, value) so the tag /
 	// comment / category persistence below can attach the right rule_id, name,
 	// and short_id to each annotation.
+	//
+	// First-wins on duplicate (field, value) keys: when multiple rules emit
+	// the same action (e.g., two rules both add_tag "needs-review"), the
+	// annotation is credited to the highest-priority rule that fired — because
+	// ResolveWithContext orders Sources by pipeline stage then priority, the
+	// first occurrence here is that rule. Lower-priority duplicates are
+	// dropped rather than overwriting, which matches the "winner takes the
+	// annotation" story the admin UI surfaces.
 	type ruleRef struct {
 		ruleID      pgtype.UUID
 		ruleShortID string
@@ -778,7 +793,7 @@ func (e *Engine) applyTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.U
 			INSERT INTO tags (slug, display_name, lifecycle)
 			VALUES ($1, $2, 'persistent')
 			ON CONFLICT (slug) DO UPDATE SET updated_at = tags.updated_at
-			RETURNING id`, slug, titleCaseSlugForRule(slug)).Scan(&tagID)
+			RETURNING id`, slug, slugs.TitleCase(slug)).Scan(&tagID)
 		if err2 != nil {
 			return fmt.Errorf("get or create tag %q: %w", slug, err2)
 		}
@@ -895,31 +910,6 @@ func (e *Engine) applyCommentFromRule(ctx context.Context, tx pgx.Tx, txnID pgty
 		return fmt.Errorf("annotate rule comment: %w", err)
 	}
 	return nil
-}
-
-// titleCaseSlugForRule converts a slug ("needs-review") to a display name
-// ("Needs Review") for auto-created tags during sync. Mirrors
-// service.titleCaseSlug; duplicated here to keep sync → service dependency
-// direction one-way.
-func titleCaseSlugForRule(slug string) string {
-	out := make([]byte, 0, len(slug))
-	capitalize := true
-	for i := 0; i < len(slug); i++ {
-		c := slug[i]
-		if c == '-' || c == ':' || c == '_' {
-			out = append(out, ' ')
-			capitalize = true
-			continue
-		}
-		if capitalize && c >= 'a' && c <= 'z' {
-			out = append(out, c-32)
-			capitalize = false
-			continue
-		}
-		out = append(out, c)
-		capitalize = false
-	}
-	return string(out)
 }
 
 // writeSyncAnnotationParams is the sync-package-local mirror of

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -13,6 +13,7 @@ import (
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
+	"breadbox/internal/ruleapply"
 	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
@@ -370,22 +371,10 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		// user|agent|system — rule_id in the dedicated column carries the rule
 		// back-reference).
 		for _, app := range ruleApplications {
-			payload := map[string]any{
-				"rule_id":      app.ruleShortID,
-				"rule_name":    app.ruleName,
-				"action_field": app.actionField,
-				"action_value": app.actionValue,
-				"applied_by":   "sync",
-			}
-			if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
-				TransactionID: app.txnID,
-				Kind:          "rule_applied",
-				ActorType:     "system",
-				ActorID:       app.ruleShortID,
-				ActorName:     app.ruleName,
-				Payload:       payload,
-				RuleID:        app.ruleID,
-			}); err != nil {
+			if err := ruleapply.WriteRuleApplied(ctx, tx, app.txnID,
+				ruleapply.Rule{ID: app.ruleID, ShortID: app.ruleShortID, Name: app.ruleName},
+				app.actionField, app.actionValue, ruleapply.AppliedBySync,
+			); err != nil {
 				logger.Error("insert rule_applied annotation", "transaction_id", app.txnID, "rule_id", app.ruleID, "error", err)
 			}
 		}
@@ -690,18 +679,10 @@ func (e *Engine) applyRulesToTransaction(ctx context.Context, tx pgx.Tx, txn *pr
 			}
 
 			src := sourceByKey["category|"+result.CategorySlug]
-			if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
-				TransactionID: dbTxn.ID,
-				Kind:          "category_set",
-				ActorType:     "system",
-				ActorID:       src.ruleShortID,
-				ActorName:     src.ruleName,
-				Payload: map[string]any{
-					"category_slug": result.CategorySlug,
-					"source":        "rule",
-				},
-				RuleID: src.ruleID,
-			}); err != nil {
+			if err := ruleapply.WriteCategorySet(ctx, tx, dbTxn.ID,
+				ruleapply.Rule{ID: src.ruleID, ShortID: src.ruleShortID, Name: src.ruleName},
+				result.CategorySlug, ruleapply.AppliedBySync,
+			); err != nil {
 				return result.Sources, fmt.Errorf("annotate category_set: %w", err)
 			}
 		}

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -1670,3 +1670,358 @@ func TestRule_TypedActions_SetCategory_RespectsOverride(t *testing.T) {
 		t.Errorf("rule overwrote category_override=true; expected %v, got %v", other.ID, finalCatID)
 	}
 }
+
+// --- Audit §D rule tests ---
+
+// TestRule_ExpiredRule_NotFired verifies that rules past their expires_at time
+// are excluded by ListActiveRulesForSync and do not fire during sync. The
+// transaction lands uncategorized and no rule_applied annotation is written.
+func TestRule_ExpiredRule_NotFired(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategoriesWithFood(t, queries)
+
+	rule := testutil.MustCreateTransactionRule(
+		t, queries, "Expired Rule",
+		[]byte(`{"field":"name","op":"contains","value":"Coffee"}`),
+		[]byte(`[{"type":"set_category","category_slug":"food_and_drink"}]`),
+		"on_create",
+	)
+
+	// Backdate expires_at so ListActiveRulesForSync filters this rule out.
+	if _, err := pool.Exec(ctx,
+		"UPDATE transaction_rules SET expires_at = NOW() - INTERVAL '1 hour' WHERE id = $1",
+		rule.ID,
+	); err != nil {
+		t.Fatalf("expire rule: %v", err)
+	}
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added: []provider.Transaction{{
+				ExternalID:        "txn_expired",
+				AccountExternalID: "ext_acct_1",
+				Amount:            decimal.NewFromFloat(5.00),
+				Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+				Name:              "Coffee Shop",
+				ISOCurrencyCode:   "USD",
+			}},
+			Cursor: "cursor_1",
+		},
+	}
+
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	var catID pgtype.UUID
+	if err := pool.QueryRow(ctx,
+		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_expired'",
+	).Scan(&catID); err != nil {
+		t.Fatalf("query transaction: %v", err)
+	}
+	if catID.Valid {
+		t.Errorf("expired rule fired; expected category_id=NULL, got %v", catID)
+	}
+
+	var annCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM annotations WHERE kind = 'rule_applied' AND rule_id = $1`,
+		rule.ID,
+	).Scan(&annCount); err != nil {
+		t.Fatalf("count rule_applied annotations: %v", err)
+	}
+	if annCount != 0 {
+		t.Errorf("expected 0 rule_applied annotations for expired rule, got %d", annCount)
+	}
+
+	var hitCount int
+	if err := pool.QueryRow(ctx,
+		"SELECT hit_count FROM transaction_rules WHERE id = $1", rule.ID,
+	).Scan(&hitCount); err != nil {
+		t.Fatalf("query hit count: %v", err)
+	}
+	if hitCount != 0 {
+		t.Errorf("expected hit_count 0 for expired rule, got %d", hitCount)
+	}
+}
+
+// TestRule_DisabledRule_NotFired_DuringSync verifies that rules with
+// enabled=false are excluded by ListActiveRulesForSync and do not fire during
+// sync.
+func TestRule_DisabledRule_NotFired_DuringSync(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategoriesWithFood(t, queries)
+
+	rule := testutil.MustCreateTransactionRule(
+		t, queries, "Disabled Rule",
+		[]byte(`{"field":"name","op":"contains","value":"Coffee"}`),
+		[]byte(`[{"type":"set_category","category_slug":"food_and_drink"}]`),
+		"on_create",
+	)
+
+	// Disable the rule after creation.
+	if _, err := pool.Exec(ctx,
+		"UPDATE transaction_rules SET enabled = FALSE WHERE id = $1", rule.ID,
+	); err != nil {
+		t.Fatalf("disable rule: %v", err)
+	}
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added: []provider.Transaction{{
+				ExternalID:        "txn_disabled",
+				AccountExternalID: "ext_acct_1",
+				Amount:            decimal.NewFromFloat(5.00),
+				Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+				Name:              "Coffee Shop",
+				ISOCurrencyCode:   "USD",
+			}},
+			Cursor: "cursor_1",
+		},
+	}
+
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	var catID pgtype.UUID
+	if err := pool.QueryRow(ctx,
+		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_disabled'",
+	).Scan(&catID); err != nil {
+		t.Fatalf("query transaction: %v", err)
+	}
+	if catID.Valid {
+		t.Errorf("disabled rule fired; expected category_id=NULL, got %v", catID)
+	}
+
+	var annCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM annotations WHERE kind = 'rule_applied' AND rule_id = $1`,
+		rule.ID,
+	).Scan(&annCount); err != nil {
+		t.Fatalf("count rule_applied annotations: %v", err)
+	}
+	if annCount != 0 {
+		t.Errorf("expected 0 rule_applied annotations for disabled rule, got %d", annCount)
+	}
+}
+
+// TestRule_OverrideSuppressesSetCategoryButNotOthers verifies that when a
+// transaction has category_override=TRUE, a rule that set_category + add_tag
+// still applies the tag — override only suppresses the category write.
+func TestRule_OverrideSuppressesSetCategoryButNotOthers(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	_, food := seedCategoriesWithFood(t, queries)
+	overrideCat, err := queries.InsertCategory(ctx, db.InsertCategoryParams{
+		Slug: "user_pick", DisplayName: "User Pick",
+	})
+	if err != nil {
+		t.Fatalf("create override category: %v", err)
+	}
+
+	rule := testutil.MustCreateTransactionRule(
+		t, queries, "Coffee combo",
+		[]byte(`{"field":"name","op":"contains","value":"Coffee"}`),
+		[]byte(`[{"type":"set_category","category_slug":"food_and_drink"},{"type":"add_tag","tag_slug":"caffeine"}]`),
+		"always",
+	)
+	_ = rule
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	// First sync inserts the transaction; rule fires normally and picks up both
+	// actions on the new row.
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added: []provider.Transaction{{
+				ExternalID:        "txn_override_combo",
+				AccountExternalID: "ext_acct_1",
+				Amount:            decimal.NewFromFloat(5.00),
+				Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+				Name:              "Coffee Shop",
+				ISOCurrencyCode:   "USD",
+				Pending:           true,
+			}},
+			Cursor: "cursor_1",
+		},
+	}
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	// Pin a manual override on the row, swap the user's category, and remove
+	// the tag so the second sync has a clean slate to re-apply it.
+	if _, err := pool.Exec(ctx,
+		"UPDATE transactions SET category_id = $1, category_override = TRUE WHERE external_transaction_id = 'txn_override_combo'",
+		overrideCat.ID,
+	); err != nil {
+		t.Fatalf("set override: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`DELETE FROM transaction_tags WHERE transaction_id = (SELECT id FROM transactions WHERE external_transaction_id = 'txn_override_combo')`,
+	); err != nil {
+		t.Fatalf("clear tags: %v", err)
+	}
+
+	// Second sync modifies the transaction so the "always" rule re-evaluates.
+	mock.syncResult = provider.SyncResult{
+		Modified: []provider.Transaction{{
+			ExternalID:        "txn_override_combo",
+			AccountExternalID: "ext_acct_1",
+			Amount:            decimal.NewFromFloat(5.00),
+			Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+			Name:              "Coffee Shop",
+			ISOCurrencyCode:   "USD",
+			Pending:           false, // changed field triggers isChanged=true
+		}},
+		Cursor: "cursor_2",
+	}
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	// Category override should still be pointing at the user's choice, not
+	// the rule's food_and_drink.
+	var finalCatID pgtype.UUID
+	if err := pool.QueryRow(ctx,
+		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_override_combo'",
+	).Scan(&finalCatID); err != nil {
+		t.Fatalf("query transaction: %v", err)
+	}
+	if finalCatID != overrideCat.ID {
+		t.Errorf("override suppressed failed; expected %v, got %v (food=%v)", overrideCat.ID, finalCatID, food.ID)
+	}
+
+	// But the add_tag action should have still run — tag is attached.
+	var tagAttached int
+	if err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM transaction_tags tt
+		JOIN tags t ON tt.tag_id = t.id
+		JOIN transactions tr ON tt.transaction_id = tr.id
+		WHERE tr.external_transaction_id = 'txn_override_combo' AND t.slug = 'caffeine'`,
+	).Scan(&tagAttached); err != nil {
+		t.Fatalf("count tag attachment: %v", err)
+	}
+	if tagAttached != 1 {
+		t.Errorf("expected add_tag to succeed despite category override, got %d attachments", tagAttached)
+	}
+}
+
+// TestRule_HitCountMatchesWrites_TagOnly verifies a rule whose only action is
+// add_tag increments hit_count on match, and the rule_applied annotation's
+// action_field records "tag".
+func TestRule_HitCountMatchesWrites_TagOnly(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategories(t, queries)
+
+	rule := testutil.MustCreateTransactionRule(
+		t, queries, "Tag-only Rule",
+		[]byte(`{"field":"name","op":"contains","value":"Tagged"}`),
+		[]byte(`[{"type":"add_tag","tag_slug":"auto-tagged"}]`),
+		"on_create",
+	)
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added: []provider.Transaction{
+				{
+					ExternalID:        "txn_tag_1",
+					AccountExternalID: "ext_acct_1",
+					Amount:            decimal.NewFromFloat(1.00),
+					Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+					Name:              "Tagged Purchase A",
+					ISOCurrencyCode:   "USD",
+				},
+				{
+					ExternalID:        "txn_tag_2",
+					AccountExternalID: "ext_acct_1",
+					Amount:            decimal.NewFromFloat(2.00),
+					Date:              time.Date(2025, 3, 2, 0, 0, 0, 0, time.UTC),
+					Name:              "Tagged Purchase B",
+					ISOCurrencyCode:   "USD",
+				},
+				{
+					ExternalID:        "txn_ignore",
+					AccountExternalID: "ext_acct_1",
+					Amount:            decimal.NewFromFloat(3.00),
+					Date:              time.Date(2025, 3, 3, 0, 0, 0, 0, time.UTC),
+					Name:              "Other Thing",
+					ISOCurrencyCode:   "USD",
+				},
+			},
+			Cursor: "cursor_1",
+		},
+	}
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	// hit_count reflects only matches, not the non-matching txn.
+	var hitCount int
+	if err := pool.QueryRow(ctx,
+		"SELECT hit_count FROM transaction_rules WHERE id = $1", rule.ID,
+	).Scan(&hitCount); err != nil {
+		t.Fatalf("query hit count: %v", err)
+	}
+	if hitCount != 2 {
+		t.Errorf("expected hit_count=2 (two matches), got %d", hitCount)
+	}
+
+	// rule_applied annotation written with action_field=tag for both matches.
+	var appliedWithTag int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM annotations
+		 WHERE kind = 'rule_applied'
+		   AND rule_id = $1
+		   AND payload->>'action_field' = 'tag'`,
+		rule.ID,
+	).Scan(&appliedWithTag); err != nil {
+		t.Fatalf("count rule_applied annotations: %v", err)
+	}
+	if appliedWithTag != 2 {
+		t.Errorf("expected 2 rule_applied rows with action_field=tag, got %d", appliedWithTag)
+	}
+}
+
+// TestRule_AllActionsAtomicInSyncTx is a placeholder: the sync engine currently
+// logs rule-application errors but does not abort the per-connection tx on a
+// rule-write failure, so the "force failure + assert rollback" shape isn't
+// achievable from test fixtures alone. Re-introduce this test if the sync
+// engine gains opt-in strict-mode error propagation.
+//
+// See #433 — skipped with reason documented here.
+func TestRule_AllActionsAtomicInSyncTx(t *testing.T) {
+	t.Skip("sync engine logs rule errors without tx rollback; atomicity is per-row upsert, not per-rule-action. Needs production code change to assert cleanly.")
+}

--- a/internal/sync/rule_resolver_test.go
+++ b/internal/sync/rule_resolver_test.go
@@ -1475,3 +1475,102 @@ func TestHitCountsJSON_IntegrationWithResolveWithContext(t *testing.T) {
 		t.Errorf("expected 3 hits, got %d", parsed[ruleIDStr])
 	}
 }
+
+// --- Audit §D resolver coverage ---
+
+// TestResolveWithContext_AddCommentAccumulation_Dedup pins the current
+// accumulator behavior for duplicate comment content across rules: comments
+// are appended in rule order with no dedup. The test doubles as regression
+// cover — if we ever add dedup, this will fail loudly and needs updating.
+func TestResolveWithContext_AddCommentAccumulation_Dedup(t *testing.T) {
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:        testUUID(10),
+				shortID:   "rule0001",
+				name:      "rule-A",
+				actions:   []typedAction{{Type: "add_comment", Content: "same-text"}},
+				trigger:   "always",
+				condition: mustCompile(t, &Condition{Field: "name", Op: "contains", Value: "x"}),
+			},
+			{
+				id:        testUUID(11),
+				shortID:   "rule0002",
+				name:      "rule-B",
+				actions:   []typedAction{{Type: "add_comment", Content: "same-text"}},
+				trigger:   "always",
+				condition: mustCompile(t, &Condition{Field: "provider", Op: "eq", Value: "plaid"}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	result := r.ResolveWithContext("plaid", TransactionContext{Name: "x thing", Provider: "plaid"}, true)
+	if result == nil {
+		t.Fatal("expected result")
+	}
+
+	// Current behavior: both rules contribute their identical comment text;
+	// Comments is an append-only accumulator (no dedup).
+	if len(result.Comments) != 2 {
+		t.Fatalf("expected 2 comments (no dedup on identical content), got %d (%v)", len(result.Comments), result.Comments)
+	}
+	for _, c := range result.Comments {
+		if c != "same-text" {
+			t.Errorf("unexpected comment content: %q", c)
+		}
+	}
+
+	// Every comment carries a Source so the sync persist path can attribute
+	// each write to its originating rule. With two comments there must be two
+	// comment-flavored sources.
+	commentSources := 0
+	for _, s := range result.Sources {
+		if s.ActionField == "comment" {
+			commentSources++
+		}
+	}
+	if commentSources != 2 {
+		t.Errorf("expected 2 comment sources (one per rule firing), got %d", commentSources)
+	}
+}
+
+// TestResolveWithContext_RuleWithOnlyTagAction_NoCategoryWrite verifies that
+// a matching rule whose only action is add_tag does not populate
+// CategorySlug — the resolver must not silently synthesize a category from a
+// tag-only rule.
+func TestResolveWithContext_RuleWithOnlyTagAction_NoCategoryWrite(t *testing.T) {
+	r := &RuleResolver{
+		hitCounts: make(map[[16]byte]int),
+		rules: []compiledRule{
+			{
+				id:        testUUID(42),
+				shortID:   "rule00tg",
+				name:      "tag-only",
+				actions:   []typedAction{{Type: "add_tag", TagSlug: "review"}},
+				trigger:   "always",
+				condition: mustCompile(t, &Condition{Field: "name", Op: "contains", Value: "coffee"}),
+			},
+		},
+		uncategorizedID: testUUID(99),
+	}
+
+	result := r.ResolveWithContext("plaid", TransactionContext{Name: "Coffee Shop"}, true)
+	if result == nil {
+		t.Fatal("expected non-nil result (rule matched)")
+	}
+	if result.CategorySlug != "" {
+		t.Errorf("tag-only rule populated CategorySlug %q; expected empty", result.CategorySlug)
+	}
+	if len(result.TagsToAdd) != 1 || result.TagsToAdd[0] != "review" {
+		t.Errorf("expected TagsToAdd=[review], got %v", result.TagsToAdd)
+	}
+	// No Source should carry ActionField="category" — the audit trail would
+	// otherwise imply a category write that never happened.
+	for _, s := range result.Sources {
+		if s.ActionField == "category" {
+			t.Errorf("unexpected category source emitted for tag-only rule: %+v", s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Builds on #440 and #444. Adds the integration, retroactive, and unit tests called out in issue #433 for audit §D.

**Sync integration (`internal/sync/engine_integration_test.go`):**
- `TestRule_ExpiredRule_NotFired` — backdates `expires_at`; verifies the rule is excluded by `ListActiveRulesForSync`.
- `TestRule_DisabledRule_NotFired_DuringSync` — disables the rule; verifies no annotation / hit count.
- `TestRule_OverrideSuppressesSetCategoryButNotOthers` — pins that `category_override=TRUE` blocks `set_category` but leaves `add_tag` free to apply.
- `TestRule_HitCountMatchesWrites_TagOnly` — verifies a tag-only rule increments `hit_count` on each match and writes `rule_applied` rows with `action_field='tag'`.
- `TestRule_AllActionsAtomicInSyncTx` — **skipped** with a reason. The sync engine currently logs rule errors and does not roll back the per-connection tx on a rule-write failure, so a "force failure + assert rollback" assertion isn't reachable from test fixtures alone. Left as a placeholder to re-enable if/when the sync engine gains strict-mode error propagation.

**Retroactive service integration (`internal/service/rules_integration_test.go`):**
- `TestApplyRuleRetroactively_Expired_Rejected` — returns `ErrInvalidParameter`, DB untouched.
- `TestApplyRuleRetroactively_Disabled_Rejected` — same, via `UpdateTransactionRule(Enabled: &false)`.
- `TestApplyAllRulesRetroactively_SamePriorityTie` — documents the `created_at ASC` tie-break within a priority bucket.
- `TestPreviewRule_DoesNotModify` — snapshots transaction / annotation / tag counts before and after; asserts zero delta.
- `TestPreviewRuleForDetail_ExcludesAlreadyApplied` — verifies the `NOT EXISTS (SELECT 1 FROM annotations ... rule_id = ...)` filter drops already-applied txns from the preview count.

**Resolver unit (`internal/sync/rule_resolver_test.go`):**
- `TestResolveWithContext_AddCommentAccumulation_Dedup` — pins current no-dedup behavior for identical comment text across rules (regression cover if we later introduce dedup).
- `TestResolveWithContext_RuleWithOnlyTagAction_NoCategoryWrite` — verifies a tag-only rule leaves `CategorySlug` empty and emits no category-flavored source.

### Skipped
- `TestRule_AllActionsAtomicInSyncTx` — reason documented above.

Closes #433

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make test-integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)