### PR TITLE
docs(claude): prefer Chrome DevTools MCP for localhost browser automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,10 @@ Prefer `make dev-watch` for UI work. See `.claude/rules/ui.md` for the hot-reloa
 - Worktrees (`claude -w`): `.worktreeinclude` copies build artifacts; `.claude/hooks/session-start.sh` assigns a port from 8081–8099 and injects env via `CLAUDE_ENV_FILE`. Main repo uses 8080.
 - Stop all dev servers: `make dev-stop`.
 
+## Browser automation
+
+For validating UI on `localhost`, use the **Chrome DevTools MCP** (`mcp__plugin_chrome-devtools-mcp_chrome-devtools__*`) — pre-allowed, no prompts. Prefer it over `claude-in-chrome`, which is slower and requires permission approvals.
+
 ## Releases
 
 - `main` is branch-protected — PR-only, CI must pass.


### PR DESCRIPTION
## Summary
- Adds a short Browser automation section to CLAUDE.md directing agents to prefer the Chrome DevTools MCP (`mcp__plugin_chrome-devtools-mcp_chrome-devtools__*`) over `claude-in-chrome` for localhost UI validation.

## Test plan
- [x] CLAUDE.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)