### PR TITLE
feat(reports): render agent reports as messages + polish detail controls

### DIFF
--- a/input.css
+++ b/input.css
@@ -2406,4 +2406,48 @@
     }
   }
 
+  /* Agent report markdown body — lean, design-system-aligned rendering.
+     No separator lines under headings; rely on weight + spacing. */
+  .bb-report-body {
+    @apply text-sm text-base-content/85 leading-relaxed;
+  }
+  .bb-report-body > :first-child { @apply mt-0; }
+  .bb-report-body h1 { @apply text-lg font-semibold text-base-content mt-6 mb-2; }
+  .bb-report-body h2 { @apply text-base font-semibold text-base-content mt-5 mb-2; }
+  .bb-report-body h3 {
+    @apply text-[0.7rem] font-semibold uppercase tracking-wider text-base-content/50 mt-5 mb-1.5;
+  }
+  .bb-report-body h4 { @apply text-sm font-semibold text-base-content/80 mt-4 mb-1; }
+  .bb-report-body p  { @apply mb-3; }
+  .bb-report-body ul { @apply list-disc pl-5 space-y-1 my-2; }
+  .bb-report-body ol { @apply list-decimal pl-5 space-y-1 my-2; }
+  .bb-report-body li { @apply marker:text-base-content/30; }
+  .bb-report-body strong { @apply font-semibold text-base-content; }
+  .bb-report-body em { @apply italic; }
+  .bb-report-body a  { @apply text-primary underline decoration-primary/30 hover:decoration-primary underline-offset-2; }
+  .bb-report-body a[href^="/transactions/"] {
+    @apply rounded bg-primary/5 px-1 py-px no-underline hover:bg-primary/10;
+  }
+  .bb-report-body code:not(pre code) {
+    @apply bg-base-200/70 text-[0.8em] px-1 py-px rounded font-mono;
+  }
+  .bb-report-body pre {
+    @apply bg-base-200/60 rounded-xl p-3 my-3 overflow-x-auto text-xs font-mono border border-base-300/60;
+  }
+  .bb-report-body pre code { @apply bg-transparent p-0; }
+  .bb-report-body blockquote {
+    @apply border-l-2 border-base-300 pl-3 my-3 text-base-content/60;
+  }
+  .bb-report-body hr { @apply hidden; } /* discourage HR as decorative separator */
+  .bb-report-body table {
+    @apply w-full my-3 text-sm border-collapse;
+  }
+  .bb-report-body thead th {
+    @apply text-left font-semibold text-[0.7rem] uppercase tracking-wider text-base-content/50 px-3 py-2 border-b border-base-300;
+  }
+  .bb-report-body tbody td {
+    @apply px-3 py-2 border-b border-base-200;
+  }
+  .bb-report-body tbody tr:last-child td { @apply border-b-0; }
+
 }

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -379,17 +379,11 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		if err != nil {
 			a.Logger.Error("list unread agent reports", "error", err)
 		}
-		totalUnreadCount, err := svc.CountUnreadAgentReports(ctx)
-		if err != nil {
-			a.Logger.Error("count unread agent reports", "error", err)
-		}
-		totalUnread := int(totalUnreadCount)
+		// Reuse the unread count already fetched by NavBadgesMiddleware —
+		// avoids a second COUNT(*) round-trip on every dashboard load.
+		totalUnread := int(getNavBadges(ctx).UnreadReports)
 		for _, r := range rawReports {
 			t, _ := time.Parse(time.RFC3339, r.CreatedAt)
-			displayAuthor := r.CreatedByName
-			if r.Author != nil && *r.Author != "" {
-				displayAuthor = *r.Author
-			}
 			agentReports = append(agentReports, DashboardReport{
 				ID:            r.ID,
 				Title:         r.Title,
@@ -397,11 +391,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				CreatedByName: r.CreatedByName,
 				Priority:      r.Priority,
 				Tags:          r.Tags,
-				DisplayAuthor: displayAuthor,
+				DisplayAuthor: reportDisplayAuthor(r.CreatedByName, r.Author),
 				CreatedAt:     relativeTime(t),
 			})
 		}
-		hasMoreReports := totalUnread > len(agentReports)
 		moreReportsCount := totalUnread - len(agentReports)
 
 		// Quick stats for the status bar.
@@ -464,7 +457,6 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"AttentionCount":    attentionCount,
 			"HasAttentionItems": attentionCount > 0,
 			"AgentReports":       agentReports,
-			"HasMoreReports":     hasMoreReports,
 			"MoreReportsCount":   moreReportsCount,
 			"TotalUnreadReports": totalUnread,
 		}

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -373,20 +373,19 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			DisplayAuthor string
 			CreatedAt     string // relative time
 		}
+		const dashboardReportsVisible = 8
 		var agentReports []DashboardReport
-		var totalUnread int
-		rawReports, err := svc.ListUnreadAgentReports(ctx, 50)
+		rawReports, err := svc.ListUnreadAgentReports(ctx, dashboardReportsVisible)
 		if err != nil {
 			a.Logger.Error("list unread agent reports", "error", err)
 		}
-		totalUnread = len(rawReports)
-		now := time.Now()
-		for i, r := range rawReports {
+		totalUnreadCount, err := svc.CountUnreadAgentReports(ctx)
+		if err != nil {
+			a.Logger.Error("count unread agent reports", "error", err)
+		}
+		totalUnread := int(totalUnreadCount)
+		for _, r := range rawReports {
 			t, _ := time.Parse(time.RFC3339, r.CreatedAt)
-			// Show first 5, plus any additional within 24 hours
-			if i >= 5 && now.Sub(t) > 24*time.Hour {
-				continue
-			}
 			displayAuthor := r.CreatedByName
 			if r.Author != nil && *r.Author != "" {
 				displayAuthor = *r.Author
@@ -403,6 +402,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			})
 		}
 		hasMoreReports := totalUnread > len(agentReports)
+		moreReportsCount := totalUnread - len(agentReports)
 
 		// Quick stats for the status bar.
 		accountCount, err := a.Queries.CountAccounts(ctx)
@@ -465,6 +465,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			"HasAttentionItems": attentionCount > 0,
 			"AgentReports":       agentReports,
 			"HasMoreReports":     hasMoreReports,
+			"MoreReportsCount":   moreReportsCount,
 			"TotalUnreadReports": totalUnread,
 		}
 		tr.Render(w, r, "dashboard.html", data)

--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -3,6 +3,8 @@ package admin
 import (
 	"encoding/json"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"breadbox/internal/app"
@@ -11,6 +13,43 @@ import (
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
 )
+
+// markdown-preview scrubbing: replace links [text](url) with their text, drop bold/italic/code markers.
+var (
+	previewLinkRe   = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
+	previewItalicRe = regexp.MustCompile(`\*([^*\n]+)\*`)
+)
+
+// bodyPreview returns a short, plain-text preview of a markdown report body:
+// strips common markdown markers, collapses whitespace, and trims to ~160 chars.
+func bodyPreview(body string) string {
+	var sb strings.Builder
+	for _, line := range strings.Split(body, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "|") || strings.HasPrefix(trimmed, "```") {
+			continue
+		}
+		trimmed = strings.TrimPrefix(trimmed, "- ")
+		trimmed = strings.TrimPrefix(trimmed, "* ")
+		trimmed = strings.ReplaceAll(trimmed, "**", "")
+		trimmed = strings.ReplaceAll(trimmed, "`", "")
+		// Convert markdown links and italics to plain text.
+		trimmed = previewLinkRe.ReplaceAllString(trimmed, "$1")
+		trimmed = previewItalicRe.ReplaceAllString(trimmed, "$1")
+		if sb.Len() > 0 {
+			sb.WriteString(" · ")
+		}
+		sb.WriteString(trimmed)
+		if sb.Len() >= 200 {
+			break
+		}
+	}
+	out := sb.String()
+	if len(out) > 160 {
+		out = strings.TrimSpace(out[:160]) + "…"
+	}
+	return out
+}
 
 // ReportsPageHandler handles GET /reports.
 func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
@@ -50,6 +89,7 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 			ID            string
 			Title         string
 			Body          string
+			Preview       string
 			Priority      string
 			Tags          []string
 			DisplayAuthor string
@@ -67,6 +107,7 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 				ID:            r.ID,
 				Title:         r.Title,
 				Body:          r.Body,
+				Preview:       bodyPreview(r.Body),
 				Priority:      r.Priority,
 				Tags:          r.Tags,
 				DisplayAuthor: displayAuthor,
@@ -151,6 +192,20 @@ func MarkReportReadAdminHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		if err := svc.MarkAgentReportRead(r.Context(), id); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	}
+}
+
+// MarkReportUnreadAdminHandler handles POST /-/reports/{id}/unread.
+func MarkReportUnreadAdminHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.MarkAgentReportUnread(r.Context(), id); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 			return

--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -171,12 +171,6 @@ func ReportDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 			IsRead:        report.ReadAt != nil,
 		}
 
-		// Auto-mark as read when viewing.
-		if report.ReadAt == nil {
-			_ = svc.MarkAgentReportRead(ctx, reportID)
-			detail.IsRead = true
-		}
-
 		data := BaseTemplateData(r, sm, "reports", report.Title)
 		data["Report"] = detail
 		data["Breadcrumbs"] = []Breadcrumb{

--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -3,8 +3,6 @@ package admin
 import (
 	"encoding/json"
 	"net/http"
-	"regexp"
-	"strings"
 	"time"
 
 	"breadbox/internal/app"
@@ -14,41 +12,13 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// markdown-preview scrubbing: replace links [text](url) with their text, drop bold/italic/code markers.
-var (
-	previewLinkRe   = regexp.MustCompile(`\[([^\]]+)\]\([^)]+\)`)
-	previewItalicRe = regexp.MustCompile(`\*([^*\n]+)\*`)
-)
-
-// bodyPreview returns a short, plain-text preview of a markdown report body:
-// strips common markdown markers, collapses whitespace, and trims to ~160 chars.
-func bodyPreview(body string) string {
-	var sb strings.Builder
-	for _, line := range strings.Split(body, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "|") || strings.HasPrefix(trimmed, "```") {
-			continue
-		}
-		trimmed = strings.TrimPrefix(trimmed, "- ")
-		trimmed = strings.TrimPrefix(trimmed, "* ")
-		trimmed = strings.ReplaceAll(trimmed, "**", "")
-		trimmed = strings.ReplaceAll(trimmed, "`", "")
-		// Convert markdown links and italics to plain text.
-		trimmed = previewLinkRe.ReplaceAllString(trimmed, "$1")
-		trimmed = previewItalicRe.ReplaceAllString(trimmed, "$1")
-		if sb.Len() > 0 {
-			sb.WriteString(" · ")
-		}
-		sb.WriteString(trimmed)
-		if sb.Len() >= 200 {
-			break
-		}
+// reportDisplayAuthor returns the preferred display name for a report,
+// falling back to the creator's actor name when the agent didn't set a custom author.
+func reportDisplayAuthor(createdByName string, author *string) string {
+	if author != nil && *author != "" {
+		return *author
 	}
-	out := sb.String()
-	if len(out) > 160 {
-		out = strings.TrimSpace(out[:160]) + "…"
-	}
-	return out
+	return createdByName
 }
 
 // ReportsPageHandler handles GET /reports.
@@ -58,7 +28,6 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 
 		statusFilter := r.URL.Query().Get("status") // "", "unread", "read"
 
-		// Fetch reports based on filter.
 		var rawReports []service.AgentReportResponse
 		var err error
 		switch statusFilter {
@@ -73,7 +42,7 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 			return
 		}
 
-		// Filter "read" in Go since we don't have a dedicated query for it.
+		// "read" has no dedicated query; filter in Go.
 		if statusFilter == "read" {
 			var filtered []service.AgentReportResponse
 			for _, r := range rawReports {
@@ -84,12 +53,10 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 			rawReports = filtered
 		}
 
-		// Build template-friendly structs.
 		type ReportItem struct {
 			ID            string
 			Title         string
 			Body          string
-			Preview       string
 			Priority      string
 			Tags          []string
 			DisplayAuthor string
@@ -99,18 +66,13 @@ func ReportsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager
 		var reports []ReportItem
 		for _, r := range rawReports {
 			t, _ := time.Parse(time.RFC3339, r.CreatedAt)
-			displayAuthor := r.CreatedByName
-			if r.Author != nil && *r.Author != "" {
-				displayAuthor = *r.Author
-			}
 			reports = append(reports, ReportItem{
 				ID:            r.ID,
 				Title:         r.Title,
 				Body:          r.Body,
-				Preview:       bodyPreview(r.Body),
 				Priority:      r.Priority,
 				Tags:          r.Tags,
-				DisplayAuthor: displayAuthor,
+				DisplayAuthor: reportDisplayAuthor(r.CreatedByName, r.Author),
 				CreatedAt:     relativeTime(t),
 				IsRead:        r.ReadAt != nil,
 			})
@@ -142,10 +104,6 @@ func ReportDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 		}
 
 		t, _ := time.Parse(time.RFC3339, report.CreatedAt)
-		displayAuthor := report.CreatedByName
-		if report.Author != nil && *report.Author != "" {
-			displayAuthor = *report.Author
-		}
 
 		type ReportDetail struct {
 			ID            string
@@ -165,7 +123,7 @@ func ReportDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 			Body:          report.Body,
 			Priority:      report.Priority,
 			Tags:          report.Tags,
-			DisplayAuthor: displayAuthor,
+			DisplayAuthor: reportDisplayAuthor(report.CreatedByName, report.Author),
 			CreatedAt:     t.Format("Jan 2, 2006 at 3:04 PM"),
 			CreatedAtRel:  relativeTime(t),
 			IsRead:        report.ReadAt != nil,

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -335,6 +335,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 
 			// Agent reports
 			r.Post("/reports/{id}/read", MarkReportReadAdminHandler(svc))
+			r.Post("/reports/{id}/unread", MarkReportUnreadAdminHandler(svc))
 			r.Post("/reports/read-all", MarkAllReportsReadAdminHandler(svc))
 
 			// Login account management

--- a/internal/db/queries/agent_reports.sql
+++ b/internal/db/queries/agent_reports.sql
@@ -18,5 +18,8 @@ SELECT COUNT(*) FROM agent_reports WHERE read_at IS NULL;
 -- name: MarkAgentReportRead :exec
 UPDATE agent_reports SET read_at = NOW() WHERE id = $1 AND read_at IS NULL;
 
+-- name: MarkAgentReportUnread :exec
+UPDATE agent_reports SET read_at = NULL WHERE id = $1;
+
 -- name: MarkAllAgentReportsRead :exec
 UPDATE agent_reports SET read_at = NOW() WHERE read_at IS NULL;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -167,12 +167,19 @@ Plaid:
 // User-editable via the MCP Settings page.
 const DefaultReportFormat = `Always submit a report when you finish your work using submit_report.
 
-REPORT TITLE:
-The title appears as a dashboard notification — make it self-contained and scannable. A family member should understand what happened without expanding the report.
-- Good: "Reviewed 47 transactions — 3 recategorized, no suspicious activity"
-- Good: "March spending: $4,200 total, dining up 25% from February"
-- Bad: "Review Complete" (says nothing)
-- Bad: "Transaction Review Report for Week of March 15-21, 2026" (too long, no substance)
+REPORT TITLE — this IS the message your user sees:
+The title is rendered as the primary message in the dashboard feed, like a direct message from you. Most users will only read the title. Write a complete sentence (or two) addressed to the user, past tense, specific numbers and outcomes.
+
+Think: if they only read this line, did they get the answer?
+
+- Good: "Reviewed 47 transactions this week — 3 need your eyes on unusual dining charges."
+- Good: "March spending came in at $4,218. Dining is up 25% vs February, everything else flat."
+- Good: "Possible fraud: $1,240 at ELECTRONICS WAREHOUSE — not a merchant you've used before."
+- Bad: "Review Complete" (empty label, not a message)
+- Bad: "Weekly Review Report — 2026-03-15 to 2026-03-21" (filename, not a message)
+- Bad: "I have completed reviewing your transactions." (no information)
+
+The body is where structure, headers, and detail go — the title must stand alone.
 
 REPORT BODY:
 Use markdown with headers, bullets, and transaction links: [Transaction Name](/transactions/ID)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -181,13 +181,20 @@ Think: if they only read this line, did they get the answer?
 
 The body is where structure, headers, and detail go — the title must stand alone.
 
-REPORT BODY:
-Use markdown with headers, bullets, and transaction links: [Transaction Name](/transactions/ID)
+REPORT BODY — keep it tight and scannable:
+The body is rendered with standard markdown. The UI renders ## headers, bullet lists, tables, and inline transaction links cleanly — don't reach for decorative structure.
 
-Standard sections (include what's relevant to your task):
-- Summary: key numbers (transactions processed, rules created, amounts)
-- Actions Taken: what you did (rules created, categories changed)
-- Flagged Items: transactions needing human attention with links and reasons
+- Use "##" for section headers (Summary, Actions Taken, Flagged Items, Observations). Skip "#" entirely.
+- Don't add horizontal rules ("---"), emoji icons, bolded-label-only lines, or ASCII dividers — the UI gives the body its structure.
+- Prefer short bullet lists over long paragraphs. One fact per bullet.
+- Use tables only for genuinely tabular data (category breakdowns, merchant summaries). Don't force two columns where bullets work.
+- Link specific transactions with markdown links: [Transaction Name](/transactions/ID). These get styled as pill chips in the UI.
+- Aim for 3–6 sections max. A report longer than a screen is usually a sign the title isn't doing enough work.
+
+Standard sections (include only what applies to your task):
+- Summary: key numbers
+- Actions Taken: what you did
+- Flagged Items: transactions needing human attention, with links and reasons
 - Observations: trends, patterns, or recommendations
 
 PRIORITY:

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -158,6 +158,15 @@ func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) erro
 	return s.Queries.MarkAgentReportRead(ctx, uid)
 }
 
+// MarkAgentReportUnread clears read_at on a single report, returning it to the unread queue.
+func (s *Service) MarkAgentReportUnread(ctx context.Context, reportID string) error {
+	uid, err := parseUUID(reportID)
+	if err != nil {
+		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
+	}
+	return s.Queries.MarkAgentReportUnread(ctx, uid)
+}
+
 // MarkAllAgentReportsRead marks all unread reports as read.
 func (s *Service) MarkAllAgentReportsRead(ctx context.Context) error {
 	return s.Queries.MarkAllAgentReportsRead(ctx)

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -235,7 +235,7 @@
         </div>
       </div>
       {{end}}
-      {{if .HasMoreReports}}
+      {{if .MoreReportsCount}}
       <div class="pt-3 border-t border-base-200/60 text-center">
         <a href="/reports?status=unread" class="text-xs text-primary/70 hover:text-primary transition-colors">{{.MoreReportsCount}} more unread &rarr;</a>
       </div>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -190,9 +190,10 @@
       </div>
       <div class="flex items-center gap-3">
         {{if .AgentReports}}
-        <button type="button" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer"
-          @click="markAllRead()">
-          Mark all read
+        <button type="button" class="flex items-center gap-1 text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer"
+          @click="markAllRead()" title="Mark all reports as read">
+          <i data-lucide="check-check" class="w-3.5 h-3.5"></i>
+          <span>Mark all read</span>
         </button>
         {{end}}
         <a href="/reports" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
@@ -221,7 +222,10 @@
               {{else if eq .Priority "warning"}}
               <span class="w-2 h-2 rounded-full bg-warning shrink-0"></span>
               {{end}}
-              <button @click.stop="markRead('{{.ID}}')" class="text-[0.65rem] text-base-content/30 hover:text-success transition-colors cursor-pointer ml-auto shrink-0">Mark read</button>
+              <button @click.stop="markRead('{{.ID}}')" title="Mark as read"
+                class="ml-auto shrink-0 w-5 h-5 rounded-md flex items-center justify-center text-base-content/30 hover:text-success hover:bg-success/10 transition-colors cursor-pointer">
+                <i data-lucide="check" class="w-3.5 h-3.5"></i>
+              </button>
             </div>
             <a href="/reports/{{.ID}}" class="rounded-2xl rounded-tl-sm shadow-sm px-3.5 py-2.5 inline-block max-w-full no-underline group bg-base-200/70 hover:bg-base-200/90 transition-colors">
               <p class="text-sm leading-relaxed text-base-content/80 group-hover:text-base-content transition-colors">{{.Title}}</p>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -223,10 +223,7 @@
               {{end}}
               <button @click.stop="markRead('{{.ID}}')" class="text-[0.65rem] text-base-content/30 hover:text-success transition-colors cursor-pointer ml-auto shrink-0">Mark read</button>
             </div>
-            <a href="/reports/{{.ID}}" class="rounded-2xl rounded-tl-sm shadow-sm px-3.5 py-2.5 inline-block max-w-full no-underline group transition-colors
-              {{if eq .Priority "critical"}}bg-error/10 hover:bg-error/15
-              {{else if eq .Priority "warning"}}bg-warning/10 hover:bg-warning/15
-              {{else}}bg-base-200/70 hover:bg-base-200/90{{end}}">
+            <a href="/reports/{{.ID}}" class="rounded-2xl rounded-tl-sm shadow-sm px-3.5 py-2.5 inline-block max-w-full no-underline group bg-base-200/70 hover:bg-base-200/90 transition-colors">
               <p class="text-sm leading-relaxed text-base-content/80 group-hover:text-base-content transition-colors">{{.Title}}</p>
               <span class="text-xs text-base-content/30 group-hover:text-primary/60 transition-colors">View report &rarr;</span>
             </a>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -179,10 +179,10 @@
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
 
   <!-- Agent Reports -->
-  <div class="bb-card" x-data="{ ...agentReports() }">
+  <div class="bb-card overflow-hidden" x-data="{ ...agentReports() }">
     <div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
       <div class="flex items-center gap-2">
-        <i data-lucide="bot" class="w-4 h-4 text-primary/70"></i>
+        <i data-lucide="inbox" class="w-4 h-4 text-primary/70"></i>
         <h2 class="text-sm font-semibold text-base-content/80">Agent Reports</h2>
         {{if .AgentReports}}
         <span class="text-[0.65rem] font-semibold px-2 py-0.5 rounded-full bg-primary/15 text-primary">{{.TotalUnreadReports}} unread</span>
@@ -190,56 +190,71 @@
       </div>
       <div class="flex items-center gap-3">
         {{if .AgentReports}}
-        <span class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer"
+        <button type="button" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer"
           @click="markAllRead()">
           Mark all read
-        </span>
+        </button>
         {{end}}
         <a href="/reports" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
       </div>
     </div>
 
     {{if .AgentReports}}
-    <div class="px-4 sm:px-5 py-4 space-y-3">
+    <div class="divide-y divide-base-200/60">
       {{range .AgentReports}}
-      <div class="transition-all duration-300"
-        :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !my-0' : ''"
+      <a href="/reports/{{.ID}}"
+        class="group relative flex items-start gap-3 px-4 sm:px-5 py-3.5 hover:bg-base-200/40 transition-colors no-underline
+          {{if eq .Priority "critical"}}border-l-[3px] border-l-error/80{{else if eq .Priority "warning"}}border-l-[3px] border-l-warning/80{{else}}border-l-[3px] border-l-transparent{{end}}
+          transition-all duration-300"
+        :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !py-0 !border-l-0' : ''"
         id="report-{{.ID}}">
-        <div class="flex items-start gap-2.5">
-          <div class="w-7 h-7 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-0.5">
-            <i data-lucide="bot" class="w-3.5 h-3.5 text-primary"></i>
+        <div class="relative shrink-0 mt-0.5">
+          <div class="w-9 h-9 rounded-xl flex items-center justify-center
+            {{if eq .Priority "critical"}}bg-error/15 text-error{{else if eq .Priority "warning"}}bg-warning/15 text-warning{{else}}bg-primary/10 text-primary{{end}}">
+            <i data-lucide="bot" class="w-4 h-4"></i>
           </div>
-          <div class="flex-1 min-w-0">
-            <div class="flex items-center gap-2 mb-1">
-              <span class="text-xs font-semibold text-base-content/70">{{.DisplayAuthor}}</span>
-              <span class="text-[0.65rem] text-base-content/30">{{.CreatedAt}}</span>
-              {{if eq .Priority "critical"}}
-              <span class="flex w-2 h-2"><span class="animate-ping absolute w-2 h-2 rounded-full bg-error/60"></span><span class="relative w-2 h-2 rounded-full bg-error"></span></span>
-              {{else if eq .Priority "warning"}}
-              <span class="w-2 h-2 rounded-full bg-warning shrink-0"></span>
-              {{end}}
-              <button @click.stop="markRead('{{.ID}}')" class="text-[0.65rem] text-base-content/30 hover:text-success transition-colors cursor-pointer ml-auto shrink-0 mr-1">Mark read</button>
-            </div>
-            <a href="/reports/{{.ID}}" class="rounded-2xl rounded-tl-sm bg-base-200/70 shadow-sm px-3.5 py-2.5 hover:bg-base-200/90 transition-colors inline-block max-w-full no-underline group">
-              <p class="text-sm text-base-content/80 leading-relaxed group-hover:text-base-content transition-colors">{{.Title}}</p>
-              <span class="text-xs text-base-content/30 group-hover:text-primary/60 transition-colors">View report &rarr;</span>
-            </a>
-          </div>
+          {{if eq .Priority "critical"}}
+          <span class="absolute -top-0.5 -right-0.5 flex w-2.5 h-2.5">
+            <span class="animate-ping absolute inline-flex w-full h-full rounded-full bg-error/60"></span>
+            <span class="relative inline-flex w-2.5 h-2.5 rounded-full bg-error ring-2 ring-base-100"></span>
+          </span>
+          {{end}}
         </div>
-      </div>
-      {{end}}
-      {{if .HasMoreReports}}
-      <div class="pt-3 border-t border-base-200/60 text-center">
-        <a href="/reports" class="text-xs text-primary/70 hover:text-primary transition-colors">View all {{.TotalUnreadReports}} unread reports &rarr;</a>
-      </div>
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 mb-0.5 text-[0.7rem]">
+            <span class="font-semibold text-base-content/70 truncate">{{.DisplayAuthor}}</span>
+            {{if eq .Priority "critical"}}
+            <span class="text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full bg-error/10 text-error/90 shrink-0">CRITICAL</span>
+            {{else if eq .Priority "warning"}}
+            <span class="text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full bg-warning/15 text-warning shrink-0">WARNING</span>
+            {{end}}
+            <span class="text-base-content/30 shrink-0 ml-auto">{{.CreatedAt}}</span>
+          </div>
+          <p class="text-[0.95rem] leading-snug text-base-content/90 group-hover:text-base-content transition-colors">{{.Title}}</p>
+        </div>
+        <button type="button"
+          @click.prevent.stop="markRead('{{.ID}}')"
+          title="Mark as read"
+          class="shrink-0 self-center opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity w-7 h-7 rounded-lg hover:bg-success/15 hover:text-success text-base-content/30 flex items-center justify-center cursor-pointer">
+          <i data-lucide="check" class="w-4 h-4"></i>
+        </button>
+      </a>
       {{end}}
     </div>
+    {{if .HasMoreReports}}
+    <a href="/reports?status=unread" class="flex items-center justify-center gap-1.5 px-5 py-3 text-xs font-medium text-primary/80 hover:text-primary hover:bg-primary/5 transition-colors border-t border-base-200/60 no-underline">
+      <i data-lucide="arrow-down" class="w-3.5 h-3.5"></i>
+      {{.MoreReportsCount}} more unread
+    </a>
+    {{end}}
     {{else}}
-    <div class="px-5 py-8 text-center">
-      <i data-lucide="bot" class="w-8 h-8 mx-auto mb-2 text-base-content/15"></i>
-      <p class="text-sm text-base-content/40 mb-1">No unread reports</p>
-      <p class="text-xs text-base-content/30">Agent reports appear here when AI agents submit findings about your finances.</p>
-      <a href="/agents" class="text-xs text-primary/60 hover:text-primary transition-colors mt-2 inline-block">Set up an agent &rarr;</a>
+    <div class="px-5 py-10 text-center">
+      <div class="w-12 h-12 rounded-2xl bg-base-200/50 mx-auto mb-3 flex items-center justify-center">
+        <i data-lucide="inbox" class="w-5 h-5 text-base-content/25"></i>
+      </div>
+      <p class="text-sm font-medium text-base-content/60 mb-1">Inbox zero</p>
+      <p class="text-xs text-base-content/40 max-w-[18rem] mx-auto">Messages from your AI agents will land here when they finish a task or spot something worth sharing.</p>
+      <a href="/agents" class="text-xs text-primary/70 hover:text-primary transition-colors mt-3 inline-block font-medium">Set up an agent &rarr;</a>
     </div>
     {{end}}
   </div>

--- a/internal/templates/pages/dashboard.html
+++ b/internal/templates/pages/dashboard.html
@@ -179,10 +179,10 @@
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
 
   <!-- Agent Reports -->
-  <div class="bb-card overflow-hidden" x-data="{ ...agentReports() }">
+  <div class="bb-card" x-data="{ ...agentReports() }">
     <div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
       <div class="flex items-center gap-2">
-        <i data-lucide="inbox" class="w-4 h-4 text-primary/70"></i>
+        <i data-lucide="bot" class="w-4 h-4 text-primary/70"></i>
         <h2 class="text-sm font-semibold text-base-content/80">Agent Reports</h2>
         {{if .AgentReports}}
         <span class="text-[0.65rem] font-semibold px-2 py-0.5 rounded-full bg-primary/15 text-primary">{{.TotalUnreadReports}} unread</span>
@@ -200,61 +200,52 @@
     </div>
 
     {{if .AgentReports}}
-    <div class="divide-y divide-base-200/60">
+    <div class="px-4 sm:px-5 py-4 space-y-4">
       {{range .AgentReports}}
-      <a href="/reports/{{.ID}}"
-        class="group relative flex items-start gap-3 px-4 sm:px-5 py-3.5 hover:bg-base-200/40 transition-colors no-underline
-          {{if eq .Priority "critical"}}border-l-[3px] border-l-error/80{{else if eq .Priority "warning"}}border-l-[3px] border-l-warning/80{{else}}border-l-[3px] border-l-transparent{{end}}
-          transition-all duration-300"
-        :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !py-0 !border-l-0' : ''"
+      <div class="transition-all duration-300"
+        :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !my-0' : ''"
         id="report-{{.ID}}">
-        <div class="relative shrink-0 mt-0.5">
-          <div class="w-9 h-9 rounded-xl flex items-center justify-center
-            {{if eq .Priority "critical"}}bg-error/15 text-error{{else if eq .Priority "warning"}}bg-warning/15 text-warning{{else}}bg-primary/10 text-primary{{end}}">
-            <i data-lucide="bot" class="w-4 h-4"></i>
+        <div class="flex items-start gap-2.5">
+          <div class="w-7 h-7 rounded-full flex items-center justify-center shrink-0 mt-0.5 bg-primary/10 text-primary">
+            <i data-lucide="bot" class="w-3.5 h-3.5"></i>
           </div>
-          {{if eq .Priority "critical"}}
-          <span class="absolute -top-0.5 -right-0.5 flex w-2.5 h-2.5">
-            <span class="animate-ping absolute inline-flex w-full h-full rounded-full bg-error/60"></span>
-            <span class="relative inline-flex w-2.5 h-2.5 rounded-full bg-error ring-2 ring-base-100"></span>
-          </span>
-          {{end}}
-        </div>
-        <div class="flex-1 min-w-0">
-          <div class="flex items-center gap-2 mb-0.5 text-[0.7rem]">
-            <span class="font-semibold text-base-content/70 truncate">{{.DisplayAuthor}}</span>
-            {{if eq .Priority "critical"}}
-            <span class="text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full bg-error/10 text-error/90 shrink-0">CRITICAL</span>
-            {{else if eq .Priority "warning"}}
-            <span class="text-[0.6rem] font-semibold px-1.5 py-0.5 rounded-full bg-warning/15 text-warning shrink-0">WARNING</span>
-            {{end}}
-            <span class="text-base-content/30 shrink-0 ml-auto">{{.CreatedAt}}</span>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-1">
+              <span class="text-xs font-semibold text-base-content/70">{{.DisplayAuthor}}</span>
+              <span class="text-[0.65rem] text-base-content/30">{{.CreatedAt}}</span>
+              {{if eq .Priority "critical"}}
+              <span class="relative inline-flex w-2 h-2 shrink-0">
+                <span class="animate-ping absolute inline-flex w-full h-full rounded-full bg-error/60"></span>
+                <span class="relative inline-flex w-2 h-2 rounded-full bg-error"></span>
+              </span>
+              {{else if eq .Priority "warning"}}
+              <span class="w-2 h-2 rounded-full bg-warning shrink-0"></span>
+              {{end}}
+              <button @click.stop="markRead('{{.ID}}')" class="text-[0.65rem] text-base-content/30 hover:text-success transition-colors cursor-pointer ml-auto shrink-0">Mark read</button>
+            </div>
+            <a href="/reports/{{.ID}}" class="rounded-2xl rounded-tl-sm shadow-sm px-3.5 py-2.5 inline-block max-w-full no-underline group transition-colors
+              {{if eq .Priority "critical"}}bg-error/10 hover:bg-error/15
+              {{else if eq .Priority "warning"}}bg-warning/10 hover:bg-warning/15
+              {{else}}bg-base-200/70 hover:bg-base-200/90{{end}}">
+              <p class="text-sm leading-relaxed text-base-content/80 group-hover:text-base-content transition-colors">{{.Title}}</p>
+              <span class="text-xs text-base-content/30 group-hover:text-primary/60 transition-colors">View report &rarr;</span>
+            </a>
           </div>
-          <p class="text-[0.95rem] leading-snug text-base-content/90 group-hover:text-base-content transition-colors">{{.Title}}</p>
         </div>
-        <button type="button"
-          @click.prevent.stop="markRead('{{.ID}}')"
-          title="Mark as read"
-          class="shrink-0 self-center opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity w-7 h-7 rounded-lg hover:bg-success/15 hover:text-success text-base-content/30 flex items-center justify-center cursor-pointer">
-          <i data-lucide="check" class="w-4 h-4"></i>
-        </button>
-      </a>
+      </div>
+      {{end}}
+      {{if .HasMoreReports}}
+      <div class="pt-3 border-t border-base-200/60 text-center">
+        <a href="/reports?status=unread" class="text-xs text-primary/70 hover:text-primary transition-colors">{{.MoreReportsCount}} more unread &rarr;</a>
+      </div>
       {{end}}
     </div>
-    {{if .HasMoreReports}}
-    <a href="/reports?status=unread" class="flex items-center justify-center gap-1.5 px-5 py-3 text-xs font-medium text-primary/80 hover:text-primary hover:bg-primary/5 transition-colors border-t border-base-200/60 no-underline">
-      <i data-lucide="arrow-down" class="w-3.5 h-3.5"></i>
-      {{.MoreReportsCount}} more unread
-    </a>
-    {{end}}
     {{else}}
-    <div class="px-5 py-10 text-center">
-      <div class="w-12 h-12 rounded-2xl bg-base-200/50 mx-auto mb-3 flex items-center justify-center">
-        <i data-lucide="inbox" class="w-5 h-5 text-base-content/25"></i>
-      </div>
-      <p class="text-sm font-medium text-base-content/60 mb-1">Inbox zero</p>
-      <p class="text-xs text-base-content/40 max-w-[18rem] mx-auto">Messages from your AI agents will land here when they finish a task or spot something worth sharing.</p>
-      <a href="/agents" class="text-xs text-primary/70 hover:text-primary transition-colors mt-3 inline-block font-medium">Set up an agent &rarr;</a>
+    <div class="px-5 py-8 text-center">
+      <i data-lucide="bot" class="w-8 h-8 mx-auto mb-2 text-base-content/15"></i>
+      <p class="text-sm text-base-content/40 mb-1">No unread reports</p>
+      <p class="text-xs text-base-content/30">Agent reports appear here when AI agents submit findings about your finances.</p>
+      <a href="/agents" class="text-xs text-primary/60 hover:text-primary transition-colors mt-2 inline-block">Set up an agent &rarr;</a>
     </div>
     {{end}}
   </div>

--- a/internal/templates/pages/report_detail.html
+++ b/internal/templates/pages/report_detail.html
@@ -47,7 +47,7 @@
     <!-- Action toolbar -->
     <div class="flex items-center gap-1 px-3 sm:px-4 py-2 border-t border-base-200/60 bg-base-200/20 rounded-b-2xl">
       <button type="button" @click="toggleRead()" class="btn btn-ghost btn-xs rounded-lg text-xs">
-        <i :data-lucide="isRead ? 'mail' : 'mail-open'" class="w-3.5 h-3.5"></i>
+        <i :data-lucide="isRead ? 'rotate-ccw' : 'check'" class="w-3.5 h-3.5"></i>
         <span x-text="isRead ? 'Mark unread' : 'Mark read'"></span>
       </button>
       <button type="button" @click="copyLink()" class="btn btn-ghost btn-xs rounded-lg text-xs">

--- a/internal/templates/pages/report_detail.html
+++ b/internal/templates/pages/report_detail.html
@@ -1,35 +1,128 @@
 {{define "content"}}
 {{template "breadcrumb" .}}
 
-<div class="bb-page-header">
-  <div>
-    <h1 class="bb-page-title">{{.Report.Title}}</h1>
-    <div class="flex items-center flex-wrap gap-2 mt-1.5">
-      <span class="text-sm text-base-content/50">{{.Report.DisplayAuthor}}</span>
-      <span class="text-base-content/20">&middot;</span>
-      <span class="text-sm text-base-content/40" title="{{.Report.CreatedAt}}">{{.Report.CreatedAtRel}}</span>
-      {{if eq .Report.Priority "critical"}}
-      <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-error/10 text-error/80">critical</span>
-      {{else if eq .Report.Priority "warning"}}
-      <span class="text-xs font-medium px-2 py-0.5 rounded-full bg-warning/10 text-warning">warning</span>
-      {{end}}
-      {{range .Report.Tags}}
-      <span class="text-xs px-2 py-0.5 rounded-full bg-base-200/80 text-base-content/50">{{.}}</span>
-      {{end}}
+<div x-data="reportDetail('{{.Report.ID}}', {{.Report.IsRead}})" class="max-w-4xl">
+  <!-- Toast for copy + mark-unread feedback -->
+  <div class="toast toast-top toast-center z-50" x-show="toast" x-cloak x-transition.opacity>
+    <div class="alert alert-success text-xs rounded-xl shadow-md">
+      <i data-lucide="check" class="w-3.5 h-3.5"></i>
+      <span x-text="toast"></span>
+    </div>
+  </div>
+
+  <!-- Message header card -->
+  <div class="bb-card overflow-hidden mb-5
+    {{if eq .Report.Priority "critical"}}border-l-[3px] border-l-error/80
+    {{else if eq .Report.Priority "warning"}}border-l-[3px] border-l-warning/80
+    {{else}}border-l-[3px] border-l-primary/40{{end}}">
+
+    <div class="px-5 sm:px-6 pt-5 pb-4">
+      <!-- Author row -->
+      <div class="flex items-start gap-3 mb-4">
+        <div class="relative shrink-0">
+          <div class="w-12 h-12 rounded-2xl flex items-center justify-center
+            {{if eq .Report.Priority "critical"}}bg-error/15 text-error
+            {{else if eq .Report.Priority "warning"}}bg-warning/15 text-warning
+            {{else}}bg-primary/10 text-primary{{end}}">
+            <i data-lucide="bot" class="w-5 h-5"></i>
+          </div>
+          {{if eq .Report.Priority "critical"}}
+          <span class="absolute -top-1 -right-1 flex w-3 h-3">
+            <span class="animate-ping absolute inline-flex w-full h-full rounded-full bg-error/60"></span>
+            <span class="relative inline-flex w-3 h-3 rounded-full bg-error ring-2 ring-base-100"></span>
+          </span>
+          {{end}}
+        </div>
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center flex-wrap gap-2 mb-0.5">
+            <span class="font-semibold text-base-content">{{.Report.DisplayAuthor}}</span>
+            {{if eq .Report.Priority "critical"}}
+            <span class="text-[0.65rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-error/10 text-error/90">Critical</span>
+            {{else if eq .Report.Priority "warning"}}
+            <span class="text-[0.65rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-warning/15 text-warning">Warning</span>
+            {{end}}
+            {{range .Report.Tags}}
+            <span class="text-[0.65rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/50">{{.}}</span>
+            {{end}}
+          </div>
+          <p class="text-xs text-base-content/50" title="{{.Report.CreatedAt}}">
+            Sent {{.Report.CreatedAtRel}}
+          </p>
+        </div>
+      </div>
+
+      <!-- Title: rendered as the message -->
+      <h1 class="text-xl sm:text-2xl font-semibold text-base-content leading-snug">{{.Report.Title}}</h1>
+    </div>
+
+    <!-- Action toolbar -->
+    <div class="flex items-center gap-1 px-3 sm:px-4 py-2 border-t border-base-200/60 bg-base-200/20">
+      <button type="button" @click="toggleRead()" class="btn btn-ghost btn-xs rounded-lg text-xs">
+        <i :data-lucide="isRead ? 'mail' : 'mail-open'" class="w-3.5 h-3.5"></i>
+        <span x-text="isRead ? 'Mark unread' : 'Mark read'"></span>
+      </button>
+      <button type="button" @click="copyLink()" class="btn btn-ghost btn-xs rounded-lg text-xs">
+        <i data-lucide="link" class="w-3.5 h-3.5"></i>
+        <span>Copy link</span>
+      </button>
+      <div class="ml-auto">
+        <a href="/agents?tab=settings#report-format" class="btn btn-ghost btn-xs rounded-lg text-xs no-underline" title="Edit the guidelines agents follow when writing reports">
+          <i data-lucide="sliders-horizontal" class="w-3.5 h-3.5"></i>
+          <span class="hidden sm:inline">Manage report format</span>
+          <span class="sm:hidden">Format</span>
+          <i data-lucide="arrow-up-right" class="w-3 h-3 opacity-60"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <!-- Body card -->
+  <div class="bb-card">
+    <div class="px-5 sm:px-7 py-5 sm:py-6">
+      <div class="bb-report-body prose prose-sm sm:prose max-w-none text-base-content/85 leading-relaxed" data-markdown="{{.Report.Body}}"></div>
     </div>
   </div>
 </div>
 
-<div class="bb-card">
-  <div class="p-5 sm:p-6">
-    <div class="bb-report-body prose prose-sm max-w-none text-base-content/80 leading-relaxed" data-markdown="{{.Report.Body}}"></div>
-  </div>
-</div>
-
-<!-- Markdown rendering -->
+<!-- Alpine component + Markdown rendering -->
 <script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
 <script>
+function reportDetail(id, initialRead) {
+  return {
+    id: id,
+    isRead: initialRead,
+    toast: '',
+    _toastTimer: null,
+    flash(msg) {
+      this.toast = msg;
+      clearTimeout(this._toastTimer);
+      this._toastTimer = setTimeout(() => { this.toast = ''; }, 1800);
+    },
+    async toggleRead() {
+      const endpoint = this.isRead ? 'unread' : 'read';
+      try {
+        const res = await fetch('/-/reports/' + this.id + '/' + endpoint, { method: 'POST' });
+        if (!res.ok) throw new Error(String(res.status));
+        this.isRead = !this.isRead;
+        this.flash(this.isRead ? 'Marked as read' : 'Marked as unread');
+        // Re-render the icon for the toggled state.
+        this.$nextTick(() => window.lucide && window.lucide.createIcons && window.lucide.createIcons());
+      } catch (e) {
+        this.flash('Could not update — try again');
+      }
+    },
+    copyLink() {
+      try {
+        navigator.clipboard.writeText(window.location.href);
+        this.flash('Link copied');
+      } catch (e) {
+        this.flash('Copy failed');
+      }
+    }
+  };
+}
+
 document.addEventListener('DOMContentLoaded', function() {
   document.querySelectorAll('.bb-report-body').forEach(function(el) {
     var md = el.getAttribute('data-markdown');
@@ -49,13 +142,17 @@ document.addEventListener('DOMContentLoaded', function() {
       list.classList.add('list-decimal', 'pl-5', 'space-y-1', 'my-2');
     });
     el.querySelectorAll('p').forEach(function(p) {
-      p.classList.add('mb-2');
+      p.classList.add('mb-3');
     });
     el.querySelectorAll('strong').forEach(function(s) {
       s.classList.add('text-base-content', 'font-semibold');
     });
     el.querySelectorAll('h1, h2, h3, h4').forEach(function(h) {
-      h.classList.add('text-base-content', 'font-semibold', 'mt-3', 'mb-1');
+      h.classList.add('text-base-content', 'font-semibold', 'mt-5', 'mb-2', 'pb-1', 'border-b', 'border-base-200/70');
+    });
+    el.querySelectorAll('h3, h4').forEach(function(h) {
+      h.classList.remove('border-b', 'border-base-200/70', 'pb-1');
+      h.classList.add('text-sm', 'uppercase', 'tracking-wider', 'text-base-content/60');
     });
     el.querySelectorAll('code').forEach(function(c) {
       if (c.parentElement.tagName !== 'PRE') {
@@ -63,10 +160,22 @@ document.addEventListener('DOMContentLoaded', function() {
       }
     });
     el.querySelectorAll('pre').forEach(function(pre) {
-      pre.classList.add('bg-base-200/40', 'rounded-lg', 'p-3', 'my-2', 'overflow-x-auto', 'text-xs');
+      pre.classList.add('bg-base-200/40', 'rounded-xl', 'p-4', 'my-3', 'overflow-x-auto', 'text-xs', 'border', 'border-base-200/60');
     });
     el.querySelectorAll('blockquote').forEach(function(bq) {
-      bq.classList.add('border-l-2', 'border-primary/30', 'pl-3', 'my-2', 'text-base-content/60', 'italic');
+      bq.classList.add('border-l-2', 'border-primary/30', 'pl-3', 'my-3', 'text-base-content/60', 'italic');
+    });
+    el.querySelectorAll('table').forEach(function(tbl) {
+      tbl.classList.add('w-full', 'my-3', 'text-sm', 'border-collapse');
+      tbl.querySelectorAll('th').forEach(function(th) {
+        th.classList.add('text-left', 'font-semibold', 'text-base-content/70', 'text-xs', 'uppercase', 'tracking-wider', 'px-3', 'py-2', 'border-b', 'border-base-200');
+      });
+      tbl.querySelectorAll('td').forEach(function(td) {
+        td.classList.add('px-3', 'py-2', 'border-b', 'border-base-200/60');
+      });
+    });
+    el.querySelectorAll('hr').forEach(function(hr) {
+      hr.classList.add('my-5', 'border-base-200/60');
     });
     var lastChild = el.lastElementChild;
     if (lastChild) lastChild.classList.add('!mb-0');

--- a/internal/templates/pages/report_detail.html
+++ b/internal/templates/pages/report_detail.html
@@ -11,27 +11,12 @@
   </div>
 
   <!-- Message header card -->
-  <div class="bb-card overflow-hidden mb-5
-    {{if eq .Report.Priority "critical"}}border-l-[3px] border-l-error/80
-    {{else if eq .Report.Priority "warning"}}border-l-[3px] border-l-warning/80
-    {{else}}border-l-[3px] border-l-primary/40{{end}}">
-
+  <div class="bb-card mb-5">
     <div class="px-5 sm:px-6 pt-5 pb-4">
       <!-- Author row -->
-      <div class="flex items-start gap-3 mb-4">
-        <div class="relative shrink-0">
-          <div class="w-12 h-12 rounded-2xl flex items-center justify-center
-            {{if eq .Report.Priority "critical"}}bg-error/15 text-error
-            {{else if eq .Report.Priority "warning"}}bg-warning/15 text-warning
-            {{else}}bg-primary/10 text-primary{{end}}">
-            <i data-lucide="bot" class="w-5 h-5"></i>
-          </div>
-          {{if eq .Report.Priority "critical"}}
-          <span class="absolute -top-1 -right-1 flex w-3 h-3">
-            <span class="animate-ping absolute inline-flex w-full h-full rounded-full bg-error/60"></span>
-            <span class="relative inline-flex w-3 h-3 rounded-full bg-error ring-2 ring-base-100"></span>
-          </span>
-          {{end}}
+      <div class="flex items-center gap-3 mb-3">
+        <div class="w-10 h-10 rounded-full flex items-center justify-center shrink-0 bg-primary/10 text-primary">
+          <i data-lucide="bot" class="w-4.5 h-4.5"></i>
         </div>
         <div class="flex-1 min-w-0">
           <div class="flex items-center flex-wrap gap-2 mb-0.5">
@@ -51,12 +36,19 @@
         </div>
       </div>
 
-      <!-- Title: rendered as the message -->
-      <h1 class="text-xl sm:text-2xl font-semibold text-base-content leading-snug">{{.Report.Title}}</h1>
+      <!-- Title as the message bubble -->
+      <div class="pl-[3.25rem]">
+        <div class="inline-block max-w-full rounded-2xl rounded-tl-sm shadow-sm px-4 py-3
+          {{if eq .Report.Priority "critical"}}bg-error/10
+          {{else if eq .Report.Priority "warning"}}bg-warning/10
+          {{else}}bg-base-200/70{{end}}">
+          <p class="text-base sm:text-lg font-medium text-base-content leading-snug">{{.Report.Title}}</p>
+        </div>
+      </div>
     </div>
 
     <!-- Action toolbar -->
-    <div class="flex items-center gap-1 px-3 sm:px-4 py-2 border-t border-base-200/60 bg-base-200/20">
+    <div class="flex items-center gap-1 px-3 sm:px-4 py-2 border-t border-base-200/60 bg-base-200/20 rounded-b-2xl">
       <button type="button" @click="toggleRead()" class="btn btn-ghost btn-xs rounded-lg text-xs">
         <i :data-lucide="isRead ? 'mail' : 'mail-open'" class="w-3.5 h-3.5"></i>
         <span x-text="isRead ? 'Mark unread' : 'Mark read'"></span>
@@ -79,7 +71,7 @@
   <!-- Body card -->
   <div class="bb-card">
     <div class="px-5 sm:px-7 py-5 sm:py-6">
-      <div class="bb-report-body prose prose-sm sm:prose max-w-none text-base-content/85 leading-relaxed" data-markdown="{{.Report.Body}}"></div>
+      <div class="bb-report-body" data-markdown="{{.Report.Body}}"></div>
     </div>
   </div>
 </div>
@@ -123,59 +115,20 @@ function reportDetail(id, initialRead) {
   };
 }
 
+// Styling handled in input.css via .bb-report-body rules. Script only handles
+// external-link targeting and secure noopener. No separator lines under headings,
+// no heavy custom styling — keeps standard markdown rendering clean.
 document.addEventListener('DOMContentLoaded', function() {
   document.querySelectorAll('.bb-report-body').forEach(function(el) {
     var md = el.getAttribute('data-markdown');
     if (!md) return;
     el.innerHTML = DOMPurify.sanitize(marked.parse(md));
     el.querySelectorAll('a').forEach(function(a) {
-      a.classList.add('link', 'link-primary');
-      if (a.href && !a.href.startsWith(window.location.origin) && !a.getAttribute('href').startsWith('/')) {
+      var href = a.getAttribute('href') || '';
+      if (a.href && !a.href.startsWith(window.location.origin) && !href.startsWith('/')) {
         a.setAttribute('target', '_blank');
         a.setAttribute('rel', 'noopener');
       }
-    });
-    el.querySelectorAll('ul').forEach(function(list) {
-      list.classList.add('list-disc', 'pl-5', 'space-y-1', 'my-2');
-    });
-    el.querySelectorAll('ol').forEach(function(list) {
-      list.classList.add('list-decimal', 'pl-5', 'space-y-1', 'my-2');
-    });
-    el.querySelectorAll('p').forEach(function(p) {
-      p.classList.add('mb-3');
-    });
-    el.querySelectorAll('strong').forEach(function(s) {
-      s.classList.add('text-base-content', 'font-semibold');
-    });
-    el.querySelectorAll('h1, h2, h3, h4').forEach(function(h) {
-      h.classList.add('text-base-content', 'font-semibold', 'mt-5', 'mb-2', 'pb-1', 'border-b', 'border-base-200/70');
-    });
-    el.querySelectorAll('h3, h4').forEach(function(h) {
-      h.classList.remove('border-b', 'border-base-200/70', 'pb-1');
-      h.classList.add('text-sm', 'uppercase', 'tracking-wider', 'text-base-content/60');
-    });
-    el.querySelectorAll('code').forEach(function(c) {
-      if (c.parentElement.tagName !== 'PRE') {
-        c.classList.add('bg-base-200/60', 'px-1.5', 'py-0.5', 'rounded', 'text-xs', 'font-mono');
-      }
-    });
-    el.querySelectorAll('pre').forEach(function(pre) {
-      pre.classList.add('bg-base-200/40', 'rounded-xl', 'p-4', 'my-3', 'overflow-x-auto', 'text-xs', 'border', 'border-base-200/60');
-    });
-    el.querySelectorAll('blockquote').forEach(function(bq) {
-      bq.classList.add('border-l-2', 'border-primary/30', 'pl-3', 'my-3', 'text-base-content/60', 'italic');
-    });
-    el.querySelectorAll('table').forEach(function(tbl) {
-      tbl.classList.add('w-full', 'my-3', 'text-sm', 'border-collapse');
-      tbl.querySelectorAll('th').forEach(function(th) {
-        th.classList.add('text-left', 'font-semibold', 'text-base-content/70', 'text-xs', 'uppercase', 'tracking-wider', 'px-3', 'py-2', 'border-b', 'border-base-200');
-      });
-      tbl.querySelectorAll('td').forEach(function(td) {
-        td.classList.add('px-3', 'py-2', 'border-b', 'border-base-200/60');
-      });
-    });
-    el.querySelectorAll('hr').forEach(function(hr) {
-      hr.classList.add('my-5', 'border-base-200/60');
     });
     var lastChild = el.lastElementChild;
     if (lastChild) lastChild.classList.add('!mb-0');

--- a/internal/templates/pages/report_detail.html
+++ b/internal/templates/pages/report_detail.html
@@ -39,7 +39,7 @@
       <!-- Title as the message bubble -->
       <div class="pl-[3.25rem]">
         <div class="inline-block max-w-full rounded-2xl rounded-tl-sm shadow-sm px-4 py-3 bg-base-200/70">
-          <p class="text-base sm:text-lg font-medium text-base-content leading-snug">{{.Report.Title}}</p>
+          <p class="text-sm leading-relaxed text-base-content">{{.Report.Title}}</p>
         </div>
       </div>
     </div>

--- a/internal/templates/pages/report_detail.html
+++ b/internal/templates/pages/report_detail.html
@@ -38,10 +38,7 @@
 
       <!-- Title as the message bubble -->
       <div class="pl-[3.25rem]">
-        <div class="inline-block max-w-full rounded-2xl rounded-tl-sm shadow-sm px-4 py-3
-          {{if eq .Report.Priority "critical"}}bg-error/10
-          {{else if eq .Report.Priority "warning"}}bg-warning/10
-          {{else}}bg-base-200/70{{end}}">
+        <div class="inline-block max-w-full rounded-2xl rounded-tl-sm shadow-sm px-4 py-3 bg-base-200/70">
           <p class="text-base sm:text-lg font-medium text-base-content leading-snug">{{.Report.Title}}</p>
         </div>
       </div>

--- a/internal/templates/pages/report_detail.html
+++ b/internal/templates/pages/report_detail.html
@@ -112,9 +112,7 @@ function reportDetail(id, initialRead) {
   };
 }
 
-// Styling handled in input.css via .bb-report-body rules. Script only handles
-// external-link targeting and secure noopener. No separator lines under headings,
-// no heavy custom styling — keeps standard markdown rendering clean.
+// External-link targeting only — styling lives in .bb-report-body (input.css).
 document.addEventListener('DOMContentLoaded', function() {
   document.querySelectorAll('.bb-report-body').forEach(function(el) {
     var md = el.getAttribute('data-markdown');

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -68,9 +68,7 @@
           <!-- Title as message bubble -->
           <div class="inline-block max-w-full rounded-2xl rounded-tl-sm shadow-sm px-3.5 py-2.5 bg-base-200/70 group-hover:bg-base-200/90 transition-colors">
             <p class="text-sm leading-relaxed {{if .IsRead}}text-base-content/70{{else}}text-base-content{{end}} group-hover:text-base-content transition-colors">{{.Title}}</p>
-            {{if .Preview}}
-            <p class="text-xs text-base-content/40 mt-1 line-clamp-1">{{.Preview}}</p>
-            {{end}}
+            <span class="text-xs text-base-content/30 group-hover:text-primary/60 transition-colors">View report &rarr;</span>
           </div>
         </div>
 

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -27,59 +27,65 @@
 
 <!-- Reports Inbox -->
 {{if .Reports}}
-<div class="bb-card overflow-hidden bb-stagger" x-data="reportsPage()">
+<div class="bb-card bb-stagger" x-data="reportsPage()">
   <div class="divide-y divide-base-200/60">
     {{range .Reports}}
     <a href="/reports/{{.ID}}"
-      class="group relative flex items-start gap-3 px-4 sm:px-5 py-4 hover:bg-base-200/40 transition-all duration-300 no-underline
-        {{if eq .Priority "critical"}}border-l-[3px] border-l-error/80
-        {{else if eq .Priority "warning"}}border-l-[3px] border-l-warning/80
-        {{else if not .IsRead}}border-l-[3px] border-l-primary/60
-        {{else}}border-l-[3px] border-l-transparent{{end}}"
-      :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !p-0 !border-l-0' : ''"
+      class="group relative block px-4 sm:px-5 py-4 hover:bg-base-200/30 transition-all duration-300 no-underline"
+      :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !p-0' : ''"
       id="report-{{.ID}}">
+      <div class="flex items-start gap-3">
 
-      <!-- Avatar -->
-      <div class="relative shrink-0 mt-0.5">
-        <div class="w-10 h-10 rounded-xl flex items-center justify-center
-          {{if eq .Priority "critical"}}bg-error/15 text-error
-          {{else if eq .Priority "warning"}}bg-warning/15 text-warning
-          {{else}}bg-primary/10 text-primary{{end}}">
+        <!-- Avatar -->
+        <div class="w-9 h-9 rounded-full flex items-center justify-center shrink-0 mt-0.5 bg-primary/10 text-primary">
           <i data-lucide="bot" class="w-4 h-4"></i>
         </div>
-        {{if not .IsRead}}
-        <span class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-primary ring-2 ring-base-100"></span>
-        {{end}}
-      </div>
 
-      <!-- Message content -->
-      <div class="flex-1 min-w-0">
-        <div class="flex items-center flex-wrap gap-2 text-xs mb-1">
-          <span class="font-semibold text-base-content/80">{{.DisplayAuthor}}</span>
-          {{if eq .Priority "critical"}}
-          <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-error/10 text-error/90">Critical</span>
-          {{else if eq .Priority "warning"}}
-          <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-warning/15 text-warning">Warning</span>
-          {{end}}
-          {{range .Tags}}
-          <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/50">{{.}}</span>
-          {{end}}
-          <span class="ml-auto text-base-content/30 shrink-0">{{.CreatedAt}}</span>
+        <!-- Message content -->
+        <div class="flex-1 min-w-0">
+          <!-- Meta row -->
+          <div class="flex items-center flex-wrap gap-2 text-xs mb-1.5">
+            <span class="font-semibold text-base-content/80">{{.DisplayAuthor}}</span>
+            <span class="text-base-content/30">{{.CreatedAt}}</span>
+            {{if eq .Priority "critical"}}
+            <span class="relative inline-flex w-2 h-2 shrink-0">
+              <span class="animate-ping absolute inline-flex w-full h-full rounded-full bg-error/60"></span>
+              <span class="relative inline-flex w-2 h-2 rounded-full bg-error"></span>
+            </span>
+            <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-error/10 text-error/90">Critical</span>
+            {{else if eq .Priority "warning"}}
+            <span class="w-2 h-2 rounded-full bg-warning shrink-0"></span>
+            <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-warning/15 text-warning">Warning</span>
+            {{end}}
+            {{range .Tags}}
+            <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/50">{{.}}</span>
+            {{end}}
+            {{if not .IsRead}}
+            <span class="w-1.5 h-1.5 rounded-full bg-primary shrink-0" title="Unread"></span>
+            {{end}}
+          </div>
+
+          <!-- Title as message bubble -->
+          <div class="inline-block max-w-full rounded-2xl rounded-tl-sm shadow-sm px-3.5 py-2.5 transition-colors
+            {{if eq .Priority "critical"}}bg-error/10 group-hover:bg-error/15
+            {{else if eq .Priority "warning"}}bg-warning/10 group-hover:bg-warning/15
+            {{else}}bg-base-200/70 group-hover:bg-base-200/90{{end}}">
+            <p class="text-sm leading-relaxed {{if .IsRead}}text-base-content/70{{else}}text-base-content{{end}} group-hover:text-base-content transition-colors">{{.Title}}</p>
+            {{if .Preview}}
+            <p class="text-xs text-base-content/40 mt-1 line-clamp-1">{{.Preview}}</p>
+            {{end}}
+          </div>
         </div>
-        <p class="text-[0.975rem] leading-snug {{if .IsRead}}text-base-content/70{{else}}text-base-content font-medium{{end}} group-hover:text-base-content transition-colors">{{.Title}}</p>
-        {{if .Preview}}
-        <p class="text-xs text-base-content/40 mt-1 line-clamp-1">{{.Preview}}</p>
-        {{end}}
-      </div>
 
-      <!-- Actions -->
-      <div class="flex items-center gap-1 shrink-0 self-center">
-        {{if not .IsRead}}
-        <button @click.prevent.stop="markRead('{{.ID}}')" class="btn btn-ghost btn-xs rounded-lg cursor-pointer text-base-content/40 hover:text-success hover:bg-success/10" title="Mark as read">
-          <i data-lucide="check" class="w-4 h-4"></i>
-        </button>
-        {{end}}
-        <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/25 group-hover:text-base-content/50 transition-colors"></i>
+        <!-- Actions -->
+        <div class="flex items-center gap-1 shrink-0 self-center">
+          {{if not .IsRead}}
+          <button @click.prevent.stop="markRead('{{.ID}}')" class="btn btn-ghost btn-xs rounded-lg cursor-pointer text-base-content/40 hover:text-success hover:bg-success/10" title="Mark as read">
+            <i data-lucide="check" class="w-4 h-4"></i>
+          </button>
+          {{end}}
+          <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/25 group-hover:text-base-content/50 transition-colors"></i>
+        </div>
       </div>
     </a>
     {{end}}

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -27,8 +27,8 @@
 
 <!-- Reports Inbox -->
 {{if .Reports}}
-<div class="bb-card bb-stagger" x-data="reportsPage()">
-  <div class="divide-y divide-base-200/60">
+<div class="bb-card" x-data="reportsPage()">
+  <div class="divide-y divide-base-200/60 bb-stagger">
     {{range .Reports}}
     <a href="/reports/{{.ID}}"
       class="group relative block px-4 sm:px-5 py-4 hover:bg-base-200/30 transition-all duration-300 no-underline"

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -2,7 +2,13 @@
 <div class="bb-page-header">
   <div>
     <h1 class="bb-page-title">Agent Reports</h1>
-    <p class="text-sm text-base-content/50 mt-0.5 hidden sm:block">Summaries and findings from AI agents</p>
+    <p class="text-sm text-base-content/50 mt-0.5 hidden sm:block">Messages from your AI agents — their work, flagged items, and findings</p>
+  </div>
+  <div class="flex items-center gap-2">
+    <a href="/agents?tab=settings#report-format" class="btn btn-ghost btn-sm rounded-xl text-xs no-underline" title="Customize how agents write reports">
+      <i data-lucide="sliders-horizontal" class="w-3.5 h-3.5"></i>
+      <span class="hidden sm:inline">Manage format</span>
+    </a>
   </div>
 </div>
 
@@ -19,52 +25,73 @@
   </button>
 </div>
 
-<!-- Reports List -->
+<!-- Reports Inbox -->
 {{if .Reports}}
-<div class="space-y-3 bb-stagger" x-data="reportsPage()">
-  {{range .Reports}}
-  <a href="/reports/{{.ID}}" class="bb-card block no-underline transition-all duration-300 hover:shadow-md {{if not .IsRead}}border-l-2 border-l-primary/40{{end}}"
-    :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !p-0 !m-0 !border-0' : ''"
-    id="report-{{.ID}}">
-    <div class="px-5 py-3.5 flex items-start gap-3">
-      <!-- Priority dot -->
-      <span class="w-2.5 h-2.5 rounded-full shrink-0 mt-1.5 {{if eq .Priority "critical"}}bg-error{{else if eq .Priority "warning"}}bg-warning{{else}}bg-base-content/20{{end}}"></span>
+<div class="bb-card overflow-hidden bb-stagger" x-data="reportsPage()">
+  <div class="divide-y divide-base-200/60">
+    {{range .Reports}}
+    <a href="/reports/{{.ID}}"
+      class="group relative flex items-start gap-3 px-4 sm:px-5 py-4 hover:bg-base-200/40 transition-all duration-300 no-underline
+        {{if eq .Priority "critical"}}border-l-[3px] border-l-error/80
+        {{else if eq .Priority "warning"}}border-l-[3px] border-l-warning/80
+        {{else if not .IsRead}}border-l-[3px] border-l-primary/60
+        {{else}}border-l-[3px] border-l-transparent{{end}}"
+      :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !p-0 !border-l-0' : ''"
+      id="report-{{.ID}}">
+
+      <!-- Avatar -->
+      <div class="relative shrink-0 mt-0.5">
+        <div class="w-10 h-10 rounded-xl flex items-center justify-center
+          {{if eq .Priority "critical"}}bg-error/15 text-error
+          {{else if eq .Priority "warning"}}bg-warning/15 text-warning
+          {{else}}bg-primary/10 text-primary{{end}}">
+          <i data-lucide="bot" class="w-4 h-4"></i>
+        </div>
+        {{if not .IsRead}}
+        <span class="absolute -top-0.5 -right-0.5 w-2.5 h-2.5 rounded-full bg-primary ring-2 ring-base-100"></span>
+        {{end}}
+      </div>
+
       <!-- Message content -->
       <div class="flex-1 min-w-0">
         <div class="flex items-center flex-wrap gap-2 text-xs mb-1">
-          <span class="font-semibold text-base-content/70">{{.DisplayAuthor}}</span>
-          <span class="text-base-content/30">&middot;</span>
-          <span class="text-base-content/30">{{.CreatedAt}}</span>
-          {{if not .IsRead}}<span class="w-1.5 h-1.5 rounded-full bg-primary shrink-0"></span>{{end}}
+          <span class="font-semibold text-base-content/80">{{.DisplayAuthor}}</span>
           {{if eq .Priority "critical"}}
-          <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full bg-error/10 text-error/80">critical</span>
+          <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-error/10 text-error/90">Critical</span>
           {{else if eq .Priority "warning"}}
-          <span class="text-[0.6rem] font-medium px-1.5 py-0.5 rounded-full bg-warning/10 text-warning">warning</span>
+          <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-warning/15 text-warning">Warning</span>
           {{end}}
           {{range .Tags}}
-          <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/40">{{.}}</span>
+          <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/50">{{.}}</span>
           {{end}}
+          <span class="ml-auto text-base-content/30 shrink-0">{{.CreatedAt}}</span>
         </div>
-        <p class="text-sm font-medium text-base-content/80 leading-relaxed">{{.Title}}</p>
+        <p class="text-[0.975rem] leading-snug {{if .IsRead}}text-base-content/70{{else}}text-base-content font-medium{{end}} group-hover:text-base-content transition-colors">{{.Title}}</p>
+        {{if .Preview}}
+        <p class="text-xs text-base-content/40 mt-1 line-clamp-1">{{.Preview}}</p>
+        {{end}}
       </div>
+
       <!-- Actions -->
-      <div class="flex items-center gap-1 shrink-0">
+      <div class="flex items-center gap-1 shrink-0 self-center">
         {{if not .IsRead}}
-        <button @click.prevent.stop="markRead('{{.ID}}')" class="btn btn-success btn-ghost btn-xs rounded-lg cursor-pointer" title="Mark as read">
+        <button @click.prevent.stop="markRead('{{.ID}}')" class="btn btn-ghost btn-xs rounded-lg cursor-pointer text-base-content/40 hover:text-success hover:bg-success/10" title="Mark as read">
           <i data-lucide="check" class="w-4 h-4"></i>
         </button>
         {{end}}
-        <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/25"></i>
+        <i data-lucide="chevron-right" class="w-4 h-4 text-base-content/25 group-hover:text-base-content/50 transition-colors"></i>
       </div>
-    </div>
-  </a>
-  {{end}}
+    </a>
+    {{end}}
+  </div>
 </div>
 {{else}}
-<div class="flex flex-col items-center justify-center py-16 text-base-content/40">
-  <i data-lucide="file-text" class="w-12 h-12 mb-3 opacity-30"></i>
-  <p class="text-sm font-medium">No reports{{if eq .FilterStatus "unread"}} unread{{else if eq .FilterStatus "read"}} read{{end}}</p>
-  <p class="text-xs mt-1 text-base-content/30">Reports submitted by AI agents will appear here</p>
+<div class="bb-card px-5 py-16 text-center">
+  <div class="w-14 h-14 rounded-2xl bg-base-200/50 mx-auto mb-4 flex items-center justify-center">
+    <i data-lucide="inbox" class="w-6 h-6 text-base-content/25"></i>
+  </div>
+  <p class="text-base font-medium text-base-content/70 mb-1">No{{if eq .FilterStatus "unread"}} unread{{else if eq .FilterStatus "read"}} read{{end}} reports</p>
+  <p class="text-sm text-base-content/40 max-w-md mx-auto">{{if eq .FilterStatus "unread"}}You're all caught up. New agent messages will appear here.{{else}}Reports submitted by AI agents will appear here as messages.{{end}}</p>
 </div>
 {{end}}
 

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -60,9 +60,6 @@
             {{range .Tags}}
             <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/50">{{.}}</span>
             {{end}}
-            {{if not .IsRead}}
-            <span class="w-1.5 h-1.5 rounded-full bg-primary shrink-0" title="Unread"></span>
-            {{end}}
           </div>
 
           <!-- Title as message bubble -->

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -66,10 +66,7 @@
           </div>
 
           <!-- Title as message bubble -->
-          <div class="inline-block max-w-full rounded-2xl rounded-tl-sm shadow-sm px-3.5 py-2.5 transition-colors
-            {{if eq .Priority "critical"}}bg-error/10 group-hover:bg-error/15
-            {{else if eq .Priority "warning"}}bg-warning/10 group-hover:bg-warning/15
-            {{else}}bg-base-200/70 group-hover:bg-base-200/90{{end}}">
+          <div class="inline-block max-w-full rounded-2xl rounded-tl-sm shadow-sm px-3.5 py-2.5 bg-base-200/70 group-hover:bg-base-200/90 transition-colors">
             <p class="text-sm leading-relaxed {{if .IsRead}}text-base-content/70{{else}}text-base-content{{end}} group-hover:text-base-content transition-colors">{{.Title}}</p>
             {{if .Preview}}
             <p class="text-xs text-base-content/40 mt-1 line-clamp-1">{{.Preview}}</p>


### PR DESCRIPTION
## Summary

Reframes agent reports around the idea that **the title IS the message the user sees**. The dashboard widget, `/reports` list, and `/reports/:id` detail page now share a message-inbox visual language. The MCP `DefaultReportFormat` is updated to tell agents to write titles as complete sentences addressed to the user.

## What changed

**UI**
- **Dashboard widget** — priority accent rail, colored avatar with critical pulse, title as the `0.95rem` headline (not small grey body text), compact author + priority pill + time meta row, hover-reveal mark-read button, explicit "+ N more unread" row instead of silently hiding reports after 24 hours.
- **`/reports`** — same language scaled up for the list, with a plain-text body preview under each title and a "Manage format" deeplink pill in the header.
- **`/reports/:id`** — message header card (avatar, "Sent X ago", tags, priority) + action toolbar: **Mark unread · Copy link · Manage report format** (deeplinks `/agents?tab=settings#report-format`). Markdown prose styling upgraded — tables, code blocks, headings, blockquotes all rendered.

**Backend**
- New `MarkAgentReportUnread` query + service method + `POST /-/reports/{id}/unread` admin handler.
- Dashboard handler now shows up to 8 unread (was 5 plus anything <24h old) and uses `CountUnreadAgentReports` for an accurate total — old unread reports no longer disappear silently.
- `bodyPreview()` helper strips markdown markers and inline links so list previews read as plain prose.

**MCP**
- `DefaultReportFormat` — `REPORT TITLE` section rewritten. Title is now explicitly framed as the primary message rendered in the dashboard feed. Agents should write a complete sentence addressed to the user, past tense, with specific numbers. Includes concrete good/bad examples and the _"if they only read this line, did they get the answer?"_ test.

## Before / After

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td colspan="2"><strong>Dashboard — agent reports widget</strong></td></tr>
<tr>
  <td><img src="https://i.img402.dev/uw9hkoi66l.jpg" width="480" alt="dashboard before"></td>
  <td><img src="https://i.img402.dev/y96ychl0i0.jpg" width="480" alt="dashboard after"></td>
</tr>
<tr><td colspan="2"><strong>/reports — list</strong></td></tr>
<tr>
  <td><img src="https://i.img402.dev/hhjikltkv0.jpg" width="480" alt="reports list before"></td>
  <td><img src="https://i.img402.dev/93rh7ibrum.jpg" width="480" alt="reports list after"></td>
</tr>
<tr><td colspan="2"><strong>/reports/:id — detail</strong></td></tr>
<tr>
  <td><img src="https://i.img402.dev/g1stt0mogd.jpg" width="480" alt="report detail before"></td>
  <td><img src="https://i.img402.dev/edpj0u6u1f.jpg" width="480" alt="report detail after"></td>
</tr>
</tbody>
</table>

_Screenshots hosted on img402.dev, 7-day retention._

## Test plan

- [x] \`go build ./...\` — passes.
- [x] \`sqlc generate\` — new \`MarkAgentReportUnread\` function generated.
- [x] Dashboard, \`/reports\`, \`/reports/:id\` visually validated at 1280×800 via Chrome DevTools MCP.
- [ ] Click through mark-read / mark-unread / copy-link on \`/reports/:id\`.
- [ ] Confirm "+ N more unread" affordance appears on dashboard when unread count > 8.
- [ ] Deeplink \`Manage report format\` lands on \`/agents?tab=settings#report-format\` with the Report Format card expanded.
- [ ] Mobile (390×844) spot-check for the list + detail pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)