### PR TITLE
polish(rules): rework /rules list, rule detail, and rule form UI

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -283,6 +283,31 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return false
 				}
 			},
+			"conditionCount": func(c any) int {
+				count := func(v service.Condition) int {
+					if len(v.And) > 0 {
+						return len(v.And)
+					}
+					if len(v.Or) > 0 {
+						return len(v.Or)
+					}
+					if v.Field != "" {
+						return 1
+					}
+					return 0
+				}
+				switch v := c.(type) {
+				case service.Condition:
+					return count(v)
+				case *service.Condition:
+					if v == nil {
+						return 0
+					}
+					return count(*v)
+				default:
+					return 0
+				}
+			},
 			"actionsSummary": func(rule any) string {
 				if r, ok := rule.(*service.TransactionRuleResponse); ok && r != nil {
 					name := ""

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -797,18 +797,20 @@ func ruleOrderByClause(sortBy, sortDir string) string {
 			nullsOrder = "NULLS LAST"
 		}
 		return " ORDER BY tr.last_hit_at " + dir + " " + nullsOrder + ", tr.id DESC"
-	case "priority":
-		if sortDir == "" {
-			dir = "ASC" // pipeline stages read left-to-right
-		}
-		return " ORDER BY tr.priority " + dir + ", tr.created_at DESC, tr.id DESC"
+	case "created_at":
+		return " ORDER BY tr.created_at " + dir + ", tr.id DESC"
 	case "name":
 		if sortDir == "" {
 			dir = "ASC"
 		}
 		return " ORDER BY LOWER(tr.name) " + dir + ", tr.id DESC"
 	default:
-		return " ORDER BY tr.created_at DESC, tr.id DESC"
+		// Default: pipeline stage ASC — rules execute in priority order,
+		// so that's the most useful reading order for the list.
+		if sortDir == "" {
+			dir = "ASC"
+		}
+		return " ORDER BY tr.priority " + dir + ", tr.created_at DESC, tr.id DESC"
 	}
 }
 
@@ -2278,7 +2280,7 @@ func TriggerLabel(trigger string) string {
 	case "on_change", "on_update":
 		return "On sync change"
 	case "always":
-		return "Every sync"
+		return "On sync create or change"
 	default:
 		return trigger
 	}

--- a/internal/service/rules_test.go
+++ b/internal/service/rules_test.go
@@ -444,7 +444,7 @@ func TestTriggerLabel(t *testing.T) {
 		"on_create": "On sync create",
 		"on_change": "On sync change",
 		"on_update": "On sync change", // legacy alias
-		"always":    "Every sync",
+		"always":    "On sync create or change",
 		"weird":     "weird",
 	}
 	for in, want := range tests {

--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -243,47 +243,17 @@
       {{range .ApplicationTxns}}
       {{$meta := index $.ApplicationMeta .ID}}
       <div>
-        <!-- Action strip: prominent "what the rule did" line above the tx-row. -->
-        <div class="flex items-center flex-wrap gap-2 px-4 pt-3 pb-2 bg-base-200/30 text-xs">
-          {{if eq $meta.ActionField "category"}}
-          <span class="inline-flex items-center gap-1.5 font-medium text-base-content/70">
-            <i data-lucide="tag" class="w-3.5 h-3.5"></i>
-            <span>Set category</span>
-          </span>
-          <i data-lucide="arrow-right" class="w-3 h-3 text-base-content/30"></i>
-          <span class="inline-flex items-center gap-1.5 badge badge-sm bg-base-100 border-base-300 rounded-md gap-1">
-            {{if $meta.ActionCategoryColor}}
-            <span class="w-2 h-2 rounded-full shrink-0" style="background-color: {{safeCSS (deref $meta.ActionCategoryColor)}}"></span>
-            {{end}}
-            <span class="font-medium">{{$meta.ActionDisplay}}</span>
-          </span>
-          {{else if eq $meta.ActionField "tag"}}
-          <span class="inline-flex items-center gap-1.5 font-medium text-base-content/70">
-            <i data-lucide="hash" class="w-3.5 h-3.5 text-warning"></i>
-            <span>Added tag</span>
-          </span>
-          <i data-lucide="arrow-right" class="w-3 h-3 text-base-content/30"></i>
-          <span class="badge badge-soft badge-warning badge-sm rounded-md font-medium">{{$meta.ActionDisplay}}</span>
-          {{else if eq $meta.ActionField "comment"}}
-          <span class="inline-flex items-center gap-1.5 font-medium text-base-content/70">
-            <i data-lucide="message-square" class="w-3.5 h-3.5 text-info"></i>
-            <span>Added comment</span>
-          </span>
-          {{if $meta.ActionValue}}
-          <i data-lucide="arrow-right" class="w-3 h-3 text-base-content/30"></i>
-          <span class="text-base-content/60 italic truncate max-w-xs">&ldquo;{{$meta.ActionValue}}&rdquo;</span>
-          {{end}}
-          {{else}}
-          <span class="inline-flex items-center gap-1.5 text-base-content/50">
-            <i data-lucide="zap" class="w-3.5 h-3.5"></i>
-            <span>Rule matched</span>
-          </span>
-          {{end}}
-          <span class="ml-auto inline-flex items-center gap-1 text-[0.65rem] uppercase tracking-wider text-base-content/40">
-            <i data-lucide="{{if eq $meta.AppliedBy "retroactive"}}rewind{{else}}refresh-cw{{end}}" class="w-3 h-3"></i>
-            {{if eq $meta.AppliedBy "sync"}}via sync{{else if eq $meta.AppliedBy "retroactive"}}retroactive{{else}}manual{{end}}
+        {{if ne $meta.AppliedBy "sync"}}
+        <!-- The rule's action is already described in the "Then" card above,
+             so don't repeat it per row. Only surface how the row got here
+             when it wasn't the default ("via sync"). -->
+        <div class="flex items-center justify-end px-4 pt-2 text-[0.65rem] uppercase tracking-wider text-base-content/40">
+          <span class="inline-flex items-center gap-1">
+            <i data-lucide="{{if eq $meta.AppliedBy "retroactive"}}rewind{{else}}wrench{{end}}" class="w-3 h-3"></i>
+            {{if eq $meta.AppliedBy "retroactive"}}retroactive{{else}}{{$meta.AppliedBy}}{{end}}
           </span>
         </div>
+        {{end}}
         {{template "tx-row" .}}
       </div>
       {{end}}

--- a/internal/templates/pages/rule_form.html
+++ b/internal/templates/pages/rule_form.html
@@ -39,11 +39,65 @@
       </div>
     </div>
 
-    <!-- Conditions section -->
+    <!-- When section: trigger + (advanced) pipeline stage. Stage stays
+         collapsed by default since most rules keep the Standard stage;
+         it auto-opens when editing a rule that already has a non-default
+         stage so the current value is visible. -->
+    <div class="border-t border-base-300 p-5 sm:p-6" x-data="{ stageOpen: form.priority !== 10 }">
+      <div class="mb-3">
+        <h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/60">When</h3>
+        <p class="text-xs text-base-content/40 mt-1">Which sync events trigger this rule.</p>
+      </div>
+      <div>
+        <label class="sr-only" for="rule-trigger">Trigger</label>
+        <select id="rule-trigger" x-model="form.trigger" class="bb-form-select select-sm">
+          <option value="on_create">On sync create</option>
+          <option value="on_change">On sync change</option>
+          <option value="always">On sync create or change</option>
+        </select>
+      </div>
+
+      <!-- Pipeline stage (advanced, collapsed by default). The expanded
+           field block is indented with a soft left rule so it reads as a
+           nested sub-option of the trigger rather than a standalone
+           control. -->
+      <div class="mt-3">
+        <button type="button" @click="stageOpen = !stageOpen" class="group w-full flex items-center justify-between gap-3 text-left -mx-2 px-2 py-1.5 rounded-lg hover:bg-base-200/50 transition-colors">
+          <div class="inline-flex items-center gap-2 text-xs text-base-content/50 group-hover:text-base-content/70 transition-colors">
+            <i data-lucide="layers" class="w-3.5 h-3.5"></i>
+            <span>Pipeline stage</span>
+            <span class="text-base-content/40 group-hover:text-base-content/60 transition-colors" x-text="'· ' + (priorityPresets.find(p => p.value === form.priority)?.label || form.priority)"></span>
+          </div>
+          <i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/40 group-hover:text-base-content/60 transition-all shrink-0" :class="stageOpen ? 'rotate-180' : ''"></i>
+        </button>
+        <div x-show="stageOpen" x-cloak x-collapse class="mt-3 ml-2 pl-4 border-l border-base-300/70">
+          <div class="flex items-center gap-1 bg-base-200/60 rounded-xl p-1">
+            <template x-for="preset in priorityPresets" :key="preset.value">
+              <button type="button"
+                class="flex-1 text-xs font-medium py-1 px-2 rounded-lg transition-colors"
+                :class="form.priority === preset.value ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/50 hover:text-base-content/70'"
+                @click="form.priority = preset.value"
+                :title="preset.hint"
+                x-text="preset.label"></button>
+            </template>
+          </div>
+          <div class="flex items-center justify-between gap-2 mt-2">
+            <p class="text-xs text-base-content/40 min-w-0 truncate" x-text="priorityLabel(form.priority)"></p>
+            <input id="rule-priority" type="number" x-model.number="form.priority"
+                   class="input input-bordered input-xs rounded-lg bg-base-200/50 w-20 shrink-0" min="0" max="1000" />
+          </div>
+        </div>
+        <p class="text-xs text-base-content/40 mt-2">Lower stages run first. Higher stages run later and win set_category conflicts — tags accumulate across all stages.</p>
+      </div>
+    </div>
+
+    <!-- Match section: condition tree. "Match" reads better than "When"
+         now that the timing controls own that header; it also mirrors the
+         subtitle copy ("Match transactions where…"). -->
     <div class="border-t border-base-300 p-5 sm:p-6">
       <div class="flex items-center justify-between mb-2">
         <div>
-          <h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/60">When</h3>
+          <h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/60">Match</h3>
           <p class="text-xs text-base-content/40 mt-1">
             <span x-show="form.conditions.length === 0">No conditions &mdash; this rule fires on <strong>every transaction</strong></span>
             <span x-show="form.conditions.length === 1">Match transactions where</span>
@@ -144,7 +198,20 @@
               <option value="false">false</option>
             </select>
             <input type="number" x-model="cond.value" step="0.01" x-show="cond.field && fieldType(cond.field) === 'numeric'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 w-24 shrink-0" placeholder="0.00" />
-            <input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'string'" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" placeholder="value..." />
+            <!-- Category (assigned) with eq/neq — show the same category
+                 picker we use in actions instead of a free-text slug input.
+                 For contains/matches/in we fall back to text so power users
+                 can still do substring/regex matches on category slugs. -->
+            <select x-model="cond.value"
+                    x-show="cond.field === 'category' && (cond.op === 'eq' || cond.op === 'neq')"
+                    @change="syncToJson()"
+                    class="select select-bordered select-xs rounded-lg bg-base-100 flex-1 min-w-0">
+              <option value="">Category...</option>
+              {{range .FlatCategories}}
+              <option value="{{.Slug}}">{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
+              {{end}}
+            </select>
+            <input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'string' && !(cond.field === 'category' && (cond.op === 'eq' || cond.op === 'neq'))" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" placeholder="value..." />
             <input type="text" x-model="cond.value" x-show="cond.field && fieldType(cond.field) === 'tags'" list="bb-tag-slugs" @input="syncToJson()" class="input input-bordered input-xs rounded-lg bg-base-100 flex-1 min-w-0" :placeholder="cond.op === 'in' ? 'slug1, slug2, ...' : 'tag-slug'" />
             <!-- Remove -->
             <button type="button" class="btn btn-ghost btn-xs btn-square rounded-lg shrink-0" @click="removeCondition(idx)" :title="form.conditions.length === 1 ? 'Remove (rule will match all transactions)' : 'Remove'">
@@ -183,12 +250,10 @@
 
       <div class="space-y-2">
         <template x-for="(action, idx) in form.actions" :key="idx">
-          <div class="flex items-start gap-2 p-2.5 rounded-xl border transition-colors"
-               :class="action.field === 'tag_remove' ? 'bg-error/5 border-error/25' : 'bg-base-200/50 border-base-300/70'">
+          <div class="flex items-start gap-2 p-2.5 rounded-xl bg-base-200/50 border border-base-content/10">
             <!-- Action type selector -->
             <select x-model="action.field" @change="onActionTypeChange(idx)"
-                    class="select select-bordered select-xs rounded-lg bg-base-100 w-36 shrink-0 mt-px"
-                    :class="action.field === 'tag_remove' ? 'text-error font-medium' : ''">
+                    class="select select-bordered select-xs rounded-lg bg-base-100 w-36 shrink-0 mt-px">
               <option value="">Action...</option>
               <option value="category"   :disabled="action.field !== 'category'   && isActionUsed('category')">Set category</option>
               <option value="tag"        :disabled="action.field !== 'tag'        && isActionUsed('tag')">Add tag</option>
@@ -217,13 +282,12 @@
             <template x-if="action.field === 'tag' || action.field === 'tag_remove'">
               <div class="flex-1 min-w-0">
                 <input type="text" x-model="action.value" @input="validateTagSlug(idx)" list="bb-tag-slugs"
-                  class="input input-bordered input-xs rounded-lg w-full mt-px"
-                  :class="action.field === 'tag_remove' ? 'bg-error/[0.04] border-error/30 text-error placeholder:text-error/40 focus:border-error/50' : 'bg-base-100'"
+                  class="input input-bordered input-xs rounded-lg w-full mt-px bg-base-100"
                   placeholder="needs-review, subscription:monthly, ..."
                   pattern="^[a-z0-9][a-z0-9\-:]*[a-z0-9]$" />
                 <p x-show="action.error" x-cloak class="text-[0.65rem] text-error mt-1" x-text="action.error"></p>
                 <p x-show="!action.error && action.field === 'tag'" class="text-[0.65rem] text-base-content/40 mt-1">Lowercase, hyphens or colons. e.g. <code>needs-review</code></p>
-                <p x-show="!action.error && action.field === 'tag_remove'" class="text-[0.65rem] text-error/70 mt-1 inline-flex items-center gap-1"><i data-lucide="minus-circle" class="w-3 h-3"></i>Tag to remove from matching transactions</p>
+                <p x-show="!action.error && action.field === 'tag_remove'" class="text-[0.65rem] text-base-content/40 mt-1">Tag to remove from matching transactions.</p>
               </div>
             </template>
 
@@ -269,50 +333,6 @@
 
       <div x-show="form.actions.length === 0" class="text-xs text-base-content/40 text-center py-4">
         No actions configured. Click "Add action" to add one.
-      </div>
-    </div>
-
-    <!-- Settings section -->
-    <div class="border-t border-base-300 p-5 sm:p-6">
-      <h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/60 mb-3">Settings</h3>
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <div>
-          <label class="block text-xs font-medium text-base-content/50 mb-1.5" for="rule-trigger">Trigger</label>
-          <select id="rule-trigger" x-model="form.trigger" class="bb-form-select select-sm">
-            <option value="on_create">On sync create</option>
-            <option value="on_change">On sync change</option>
-            <option value="always">Every sync</option>
-          </select>
-          <p class="text-xs text-base-content/40 mt-1.5" x-show="form.trigger === 'on_create'">Fires when a provider first syncs the transaction.</p>
-          <p class="text-xs text-base-content/40 mt-1.5" x-show="form.trigger === 'on_change' || form.trigger === 'on_update'">Fires when a provider re-syncs and the transaction changed.</p>
-          <p class="text-xs text-warning/80 mt-1.5" x-show="form.trigger === 'always'" x-cloak>
-            <i data-lucide="alert-triangle" class="w-3 h-3 inline-block -mt-0.5 mr-0.5"></i>
-            Fires on every provider sync that touches this transaction &mdash; use sparingly.
-          </p>
-        </div>
-        <div>
-          <label class="flex items-center gap-1.5 text-xs font-medium text-base-content/50 mb-1.5" for="rule-priority">
-            <span>Pipeline stage</span>
-            <span class="tooltip tooltip-left" data-tip="Lower stages run first (baseline). Higher stages run later and win set_category. Tags accumulate across all stages.">
-              <i data-lucide="info" class="w-3 h-3 text-base-content/30"></i>
-            </span>
-          </label>
-          <div class="flex items-center gap-1 bg-base-200/60 rounded-xl p-1">
-            <template x-for="preset in priorityPresets" :key="preset.value">
-              <button type="button"
-                class="flex-1 text-xs font-medium py-1 px-2 rounded-lg transition-colors"
-                :class="form.priority === preset.value ? 'bg-base-100 shadow-sm text-base-content' : 'text-base-content/50 hover:text-base-content/70'"
-                @click="form.priority = preset.value"
-                :title="preset.hint"
-                x-text="preset.label"></button>
-            </template>
-          </div>
-          <div class="flex items-center gap-2 mt-1.5">
-            <input id="rule-priority" type="number" x-model.number="form.priority"
-                   class="input input-bordered input-xs rounded-lg bg-base-200/50 w-20" min="0" max="1000" />
-            <p class="text-xs text-base-content/40" x-text="priorityLabel(form.priority)"></p>
-          </div>
-        </div>
       </div>
     </div>
 
@@ -534,7 +554,11 @@ function ruleForm() {
     // Condition helpers
     onFieldChange(idx) {
       const cond = this.form.conditions[idx];
-      cond.op = defaultOps[this.fieldType(cond.field)] || 'contains';
+      // Assigned-category bias: default to eq so the value input renders as
+      // the category dropdown rather than a substring match. Power users can
+      // still flip to contains/matches/in for slug-based matching.
+      if (cond.field === 'category') cond.op = 'eq';
+      else cond.op = defaultOps[this.fieldType(cond.field)] || 'contains';
       if (this.fieldType(cond.field) === 'bool') cond.value = 'true';
       else cond.value = '';
       this.syncToJson();

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -13,69 +13,19 @@
 
 <div x-data="rulesPage()">
 
-<!-- Filters Card -->
-<div class="bb-card mb-6" x-data="{ filtersOpen: {{if or .SearchFilter .CategoryFilter .EnabledFilter}}true{{else}}false{{end}} }">
-  <div class="p-0">
-    <button type="button" class="bb-filter-toggle" @click="filtersOpen = !filtersOpen">
-      <div class="flex items-center gap-2">
-        <i data-lucide="sliders-horizontal" class="w-4 h-4 text-base-content/60"></i>
-        <span>Filters</span>
-        {{if or .SearchFilter .CategoryFilter .EnabledFilter}}
-        <span class="badge badge-primary badge-xs">Active</span>
-        {{end}}
-      </div>
-      <i data-lucide="chevron-down" class="w-4 h-4 text-base-content/40 transition-transform duration-200" :class="filtersOpen ? 'rotate-180' : ''"></i>
-    </button>
-
-    <form method="GET" action="/rules" x-show="filtersOpen" x-cloak x-collapse
-      class="bb-filter-form px-4 pb-4 pt-2">
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 mb-3">
-        <label class="bb-filter-label">
-          Search
-          <input type="text" name="search" placeholder="Search by name..." value="{{.SearchFilter}}" class="input input-sm input-bordered w-full">
-        </label>
-        <label class="bb-filter-label">
-          Category
-          <select name="category_slug" class="select select-sm select-bordered w-full">
-            <option value="">All Categories</option>
-            {{range .FlatCategories}}
-            <option value="{{.Slug}}"{{if eq $.CategoryFilter .Slug}} selected{{end}}>{{if .ParentDisplayName}}{{.ParentDisplayName}} &gt; {{end}}{{.DisplayName}}</option>
-            {{end}}
-          </select>
-        </label>
-        <label class="bb-filter-label">
-          Status
-          <select name="enabled" class="select select-sm select-bordered w-full">
-            <option value="">All</option>
-            <option value="true"{{if eq .EnabledFilter "true"}} selected{{end}}>Enabled</option>
-            <option value="false"{{if eq .EnabledFilter "false"}} selected{{end}}>Disabled</option>
-          </select>
-        </label>
-      </div>
-      <div class="bb-filter-actions">
-        {{if or .SearchFilter .CategoryFilter .EnabledFilter}}<a href="/rules" class="btn btn-sm btn-ghost rounded-xl">Reset</a>{{end}}
-        <button type="submit" class="btn btn-sm btn-primary rounded-xl">
-          <i data-lucide="search" class="w-3.5 h-3.5"></i>
-          Apply Filters
-        </button>
-      </div>
-    </form>
-  </div>
-</div>
-
 <!-- Rules count + sort -->
 <div class="flex items-center justify-between flex-wrap gap-3 mb-4 px-1">
   <div class="text-sm text-base-content/40">
     {{if gt .TotalPages 1}}Showing {{.ShowingStart}}&ndash;{{.ShowingEnd}} of {{end}}{{.Total}} rule{{if ne .Total 1}}s{{end}} found
   </div>
   {{if .Rules}}
-  <label class="flex items-center gap-2 text-xs text-base-content/40">
+  <label class="flex items-center gap-2 text-xs text-base-content/40 whitespace-nowrap">
     <span class="hidden sm:inline">Sort by</span>
     <select onchange="bbSetRulesSort(this.value)" class="select select-bordered select-xs rounded-lg bg-base-100 min-w-32 tabular-nums">
-      <option value=""            {{if eq .SortBy ""}}selected{{end}}>Newest first</option>
+      <option value=""            {{if or (eq .SortBy "") (eq .SortBy "priority")}}selected{{end}}>Pipeline stage</option>
       <option value="hit_count"   {{if eq .SortBy "hit_count"}}selected{{end}}>Most hits</option>
       <option value="last_hit_at" {{if eq .SortBy "last_hit_at"}}selected{{end}}>Recently active</option>
-      <option value="priority"    {{if eq .SortBy "priority"}}selected{{end}}>Pipeline stage</option>
+      <option value="created_at"  {{if eq .SortBy "created_at"}}selected{{end}}>Newest first</option>
       <option value="name"        {{if eq .SortBy "name"}}selected{{end}}>Name (A–Z)</option>
     </select>
   </label>
@@ -102,8 +52,8 @@
 {{range .Rules}}
 {{$matchAll := isMatchAllCondition .Conditions}}
 {{$isSystem := eq .CreatedByType "system"}}
-<div class="bb-card p-0 overflow-hidden cursor-pointer hover:shadow-md transition-shadow{{if not .Enabled}} opacity-60{{end}}" x-data="{deleting: false}" @click="window.location.href='/rules/{{.ID}}'">
-  <div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3 sm:py-4">
+<div class="bb-card p-0 overflow-hidden cursor-pointer hover:bg-base-200/30 transition-colors{{if not .Enabled}} opacity-60{{end}}" x-data="{deleting: false}" @click="window.location.href='/rules/{{.ID}}'">
+  <div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-4 sm:py-5">
     <!-- Avatar (category icon when set, else action-type icon) -->
     <div class="flex-shrink-0">
       {{if and .CategoryIcon .Enabled (not (and .ExpiresAt (expired .ExpiresAt)))}}
@@ -133,88 +83,70 @@
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-2 flex-wrap">
         <span class="font-semibold text-sm truncate">{{.Name}}</span>
+        <!-- Badges collapse at narrow widths — the avatar already carries
+             system/disabled/expired state, and the row opacity encodes
+             disabled. Bring them back once there's room. -->
         {{if $isSystem}}
-        <span class="badge badge-soft badge-info badge-xs gap-1" title="Built-in system rule">
+        <span class="hidden sm:inline-flex badge badge-soft badge-info badge-xs gap-1" title="Built-in system rule">
           <i data-lucide="shield" class="w-2.5 h-2.5"></i>
           System
         </span>
         {{end}}
         {{if .Enabled}}
           {{if and .ExpiresAt (expired .ExpiresAt)}}
-          <span class="badge badge-warning badge-xs">Expired</span>
+          <span class="hidden sm:inline-flex badge badge-warning badge-xs">Expired</span>
           {{end}}
         {{else}}
-        <span class="badge badge-ghost badge-xs">Disabled</span>
+        <span class="hidden sm:inline-flex badge badge-ghost badge-xs">Disabled</span>
         {{end}}
       </div>
-      <div class="text-xs text-base-content/40 mt-0.5 truncate flex items-center gap-1.5" title="{{conditionSummary .Conditions}}">
-        {{if $matchAll}}
-        <i data-lucide="infinity" class="w-3 h-3 text-base-content/40"></i>
-        <span class="italic">All transactions</span>
-        {{else}}
-        <span>{{conditionSummary .Conditions}}</span>
-        {{end}}
-      </div>
-      <!-- Mobile-only: action summary + stats inline -->
-      <div class="flex items-center gap-2 mt-1.5 sm:hidden flex-wrap">
-        <span class="text-xs text-base-content/60">{{actionsSummary .}}</span>
-        <span class="text-xs text-base-content/30">&middot;</span>
-        <span class="text-xs text-base-content/40 tabular-nums">{{.HitCount}} hits</span>
-        <span class="text-xs text-base-content/30">&middot;</span>
-        <span class="text-xs text-base-content/40 tabular-nums">p{{.Priority}}</span>
-        {{if .LastHitAt}}
-        <span class="text-xs text-base-content/30">&middot;</span>
-        <span class="text-xs text-base-content/40">{{relativeTime .LastHitAt}}</span>
-        {{end}}
+
+      <!-- Compact counts subtitle at every width. The full condition/action
+           summary text lives on the detail page; the list view only needs to
+           communicate scale (how many conditions, how many actions, how
+           often it's fired) without fighting the title for horizontal room. -->
+      <div class="flex items-center gap-2 mt-0.5 text-xs text-base-content/40 whitespace-nowrap overflow-hidden">
+        <span class="inline-flex items-center gap-1 shrink-0" title="{{conditionSummary .Conditions}}">
+          {{if $matchAll}}
+          <i data-lucide="infinity" class="w-3 h-3"></i>
+          <span class="italic">All</span>
+          {{else}}
+          <i data-lucide="list-filter" class="w-3 h-3"></i>
+          <span class="tabular-nums">{{conditionCount .Conditions}} cond.</span>
+          {{end}}
+        </span>
+        <span class="text-base-content/30 shrink-0">&middot;</span>
+        <span class="inline-flex items-center gap-1 shrink-0 tabular-nums" title="{{actionsSummary .}}">
+          <i data-lucide="zap" class="w-3 h-3"></i>
+          {{len .Actions}} action{{if ne (len .Actions) 1}}s{{end}}
+        </span>
+        <span class="text-base-content/30 shrink-0">&middot;</span>
+        <span class="tabular-nums shrink-0">{{.HitCount}} hits</span>
       </div>
     </div>
 
-    <!-- Action summary (tablet+) -->
-    <div class="hidden sm:flex flex-col items-end gap-0.5 flex-shrink-0 max-w-48 min-w-32">
-      <span class="text-xs font-medium text-base-content/70 truncate text-right" title="{{actionsSummary .}}">{{actionsSummary .}}</span>
-      <span class="text-[0.65rem] text-base-content/40 uppercase tracking-wider">{{triggerLabel .Trigger}}</span>
-    </div>
-
-    <!-- Stats (desktop+) -->
-    <div class="hidden md:flex items-center gap-4 text-xs text-base-content/40 flex-shrink-0">
-      <div class="text-center min-w-10">
-        <div class="font-semibold text-sm tabular-nums {{if ge .HitCount 50}}text-primary{{else if ge .HitCount 10}}text-base-content/70{{else}}text-base-content/50{{end}}">{{.HitCount}}</div>
-        <div>hits</div>
-      </div>
-      <div class="text-center min-w-10">
+    <!-- Right-side stats (desktop+). Condition/action/hit counts already
+         appear in the subtitle, so the right column just adds the two
+         fields the subtitle doesn't carry: pipeline stage and last-active
+         recency. -->
+    <div class="hidden lg:flex items-center gap-4 text-xs text-base-content/40 flex-shrink-0">
+      <div class="w-12 text-center">
         <div class="font-semibold text-sm text-base-content/50 tabular-nums">{{.Priority}}</div>
-        <div>priority</div>
+        <div>stage</div>
       </div>
-      {{if .LastHitAt}}
-      <div class="text-center min-w-16">
+      <div class="w-20 text-center">
+        {{if .LastHitAt}}
         <div class="font-medium text-xs text-base-content/50">{{relativeTime .LastHitAt}}</div>
         <div>last active</div>
+        {{else}}
+        <div class="font-medium text-xs text-base-content/30">&mdash;</div>
+        <div>last active</div>
+        {{end}}
       </div>
-      {{end}}
-    </div>
-
-    <!-- Creator badge (large desktop+) -->
-    <div class="hidden lg:flex items-center gap-1 flex-shrink-0">
-      {{if eq .CreatedByType "agent"}}
-      <span class="bb-rule-creator-badge bb-rule-creator-badge--agent" title="Created by {{.CreatedByName}}">
-        <i data-lucide="bot" class="w-3 h-3"></i>
-        agent
-      </span>
-      {{else if eq .CreatedByType "user"}}
-      <span class="bb-rule-creator-badge bb-rule-creator-badge--user" title="Created by {{.CreatedByName}}">
-        <i data-lucide="user" class="w-3 h-3"></i>
-        user
-      </span>
-      {{else}}
-      <span class="bb-rule-creator-badge" title="Created by system">
-        <i data-lucide="shield" class="w-3 h-3"></i>
-        system
-      </span>
-      {{end}}
     </div>
 
     <!-- Actions -->
-    <div class="flex items-center gap-0.5 flex-shrink-0">
+    <div class="flex items-center justify-end gap-0.5 flex-shrink-0 w-24">
       <button class="btn btn-ghost btn-xs btn-square rounded-lg" title="{{if .Enabled}}Disable{{else}}Enable{{end}}" @click.stop="toggleRule('{{.ID}}')">
         {{if .Enabled}}<i data-lucide="pause" class="w-3.5 h-3.5"></i>{{else}}<i data-lucide="play" class="w-3.5 h-3.5"></i>{{end}}
       </button>


### PR DESCRIPTION
## Summary

Polish pass across the three rules pages.

### `/rules` list
- Counts-based subtitle (`{N} cond. · {N} actions · {N} hits`) at every width — replaces the verbose condition text and the mid-row squish between title and stats.
- Right-side stats reduced to stage + last-active (hits is in the subtitle), pinned to fixed widths so columns stop drifting between rows. Action-summary column removed (redundant with subtitle).
- Badges (System / Disabled / Expired) collapse on `<sm` (avatar + row opacity already carry that state); right stats collapse on `<lg` so the title stops truncating at tablet widths.
- Default sort is now **Pipeline stage** (service default changed to `ORDER BY priority ASC, created_at DESC`, "Newest first" moved to an explicit `created_at` option).
- "Sort by" label gets `whitespace-nowrap` (no more "by" wrapping onto a second line).
- Filters card removed; hover swapped to `hover:bg-base-200/30 transition-colors` to match the rest of the admin.

### `/rules/:id`
- Recent Applications: dropped the per-row action strip — the "Then" card above already describes the rule's action. A small retroactive marker renders only when `applied_by` is non-default.

### `/rules/new` and `/rules/:id/edit`
- Reordered sections: **Rule details → When → Match → Then**.
  - **When** now owns the trigger; Pipeline stage is a collapsible "advanced" toggle nested inside, indented with a soft left rule. Collapsed by default; auto-opens when editing a rule with a non-default stage.
  - Pipeline stage footer row: numeric input pinned right, hint text on the left.
  - "Lower stages run first…" help line sits below the collapsible so it's always visible.
- **Match** (renamed from "When") — matches the subtitle copy ("Match transactions where…").
- **Category (assigned)** conditions now render a category dropdown (same picker as actions); op defaults to `equals` when the field is picked.
- Trigger labels: `always` → **"On sync create or change"** (replaces "Every sync"), matching the `on_create` / `on_change` naming pattern. Helper paragraphs under the select removed — option labels are self-explanatory now.
- Then action rows: border matched to Match section (`border-base-content/10`), destructive red styling on `Remove tag` removed — Add/Remove tag now read as the same neutral card.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/service` (TriggerLabel expectation updated)
- [ ] `/rules` at desktop + mobile
- [ ] `/rules/:id` with a rule that has Recent Applications (both sync and retroactive)
- [ ] `/rules/new` — toggle trigger, expand Pipeline stage, pick Category (assigned) condition
- [ ] Editing an existing rule with a non-default stage auto-opens the stage toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)