### PR TITLE
fix(tx list): collapse tag chips through small desktop, not just mobile

### DIFF
--- a/input.css
+++ b/input.css
@@ -504,11 +504,13 @@
     height: 0.65rem;
   }
 
-  /* On mobile (<sm), transaction-row tag chips collapse into a single icon +
-     count pill rendered beside the container (see data-tx-tag-mobile in
-     tx_row.html). Chips stay in the DOM so the bulk picker's
+  /* Below xl, transaction-row tag chips collapse into a single icon + count
+     pill rendered beside the container (see data-tx-tag-mobile in tx_row.html).
+     The pill renders cleanly on phones, tablets, and small desktops where the
+     full chip list would otherwise crowd the meta line and overflow into the
+     adjacent Category column. Chips stay in the DOM so the bulk picker's
      computeAppliedCounts() can still read them; they're just visually hidden. */
-  @media (max-width: 639.98px) {
+  @media (max-width: 1279.98px) {
     .bb-tx-tag-container .bb-tag {
       display: none;
     }

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -200,7 +200,7 @@
   <div class="bb-table-header">
     <div class="w-9"></div>
     <div class="flex-1 min-w-0">Name</div>
-    <div class="hidden sm:block shrink-0">Category</div>
+    <div class="hidden xl:block shrink-0">Category</div>
     <div class="w-24 text-right hidden sm:block">Date</div>
     <div class="w-24 text-right pl-3">Amount</div>
     <div class="w-4 hidden sm:block"></div>

--- a/internal/templates/partials/tx_results.html
+++ b/internal/templates/partials/tx_results.html
@@ -36,7 +36,7 @@
           <div class="w-5"></div>
           <div class="w-9"></div>
           <div class="flex-1 min-w-0">Name</div>
-          <div class="hidden sm:block shrink-0">Category</div>
+          <div class="hidden xl:block shrink-0">Category</div>
           <div class="w-24 text-right hidden sm:block">Date</div>
           <div class="w-24 text-right pl-3">Amount</div>
           <div class="w-4 hidden sm:block"></div>

--- a/internal/templates/partials/tx_row.html
+++ b/internal/templates/partials/tx_row.html
@@ -54,8 +54,8 @@
         {{end}}
         <span class="truncate min-w-0">{{.AccountName}}</span>
         {{if and .MerchantName (not (eqFold .Name (deref .MerchantName)))}}
-        <span class="text-base-content/20 hidden sm:inline">&middot;</span>
-        <span class="text-base-content/40 truncate hidden sm:inline">{{titleCase (deref .MerchantName)}}</span>
+        <span class="text-base-content/20 hidden xl:inline">&middot;</span>
+        <span class="text-base-content/40 truncate hidden xl:inline">{{titleCase (deref .MerchantName)}}</span>
         {{end}}
         {{if .AgentReviewed}}
         <span class="text-base-content/20">&middot;</span>
@@ -70,17 +70,18 @@
              the mobile-only count pill below takes their place. -->
         <span class="bb-tx-tag-container contents" data-tx-tag-container>
           {{if .Tags}}
-          <span class="text-base-content/20 hidden sm:inline" data-tx-tag-sep>&middot;</span>
+          <span class="text-base-content/20 hidden xl:inline" data-tx-tag-sep>&middot;</span>
           {{range .Tags}}
           {{template "tag-chip-sm" .}}
           {{end}}
           {{end}}
         </span>
-        <!-- Mobile tag indicator: single pill with tag icon + count. Kept in
-             sync by updateRowTags(). Rendered only when tags exist so the
-             leading middot doesn't orphan. -->
+        <!-- Compact tag indicator: single pill with tag icon + count. Shown
+             below xl where the inline chips would crowd the meta line and
+             overflow into the Category column (fits roughly: phones, tablets,
+             and small desktops with the sidebar open). -->
         {{if .Tags}}
-        <span class="sm:hidden inline-flex items-center gap-0.5 text-base-content/40 shrink-0"
+        <span class="xl:hidden inline-flex items-center gap-0.5 text-base-content/40 shrink-0"
               data-tx-tag-mobile
               title="{{len .Tags}} tag{{if ne (len .Tags) 1}}s{{end}}">
           <span class="text-base-content/20 mr-0.5">&middot;</span>
@@ -88,24 +89,26 @@
           <span class="text-[0.65rem] tabular-nums font-medium" data-tx-tag-count>{{len .Tags}}</span>
         </span>
         {{end}}
-        <!-- Mobile category label (hidden on desktop where the picker column shows).
-             Separator lives inside the conditional so it never orphans when the
-             meta line is empty. -->
+        <!-- Compact category label (shown below xl where the inline picker
+             column is hidden). Separator lives inside the conditional so it
+             never orphans when the meta line is empty. -->
         {{if .CategoryDisplayName}}
-        <span class="sm:hidden text-base-content/20 shrink-0">&middot;</span>
-        <span class="sm:hidden inline-flex items-center gap-1 shrink min-w-0">
+        <span class="xl:hidden text-base-content/20 shrink-0">&middot;</span>
+        <span class="xl:hidden inline-flex items-center gap-1 shrink min-w-0">
           {{if .CategoryColor}}<span class="w-1.5 h-1.5 rounded-full shrink-0" style="background-color: {{safeCSS (deref .CategoryColor)}}"></span>{{end}}
           <span class="text-base-content/50 truncate">{{deref .CategoryDisplayName}}</span>
         </span>
         {{else}}
-        <span class="sm:hidden text-base-content/20 shrink-0">&middot;</span>
-        <span class="sm:hidden text-base-content/25 truncate shrink-0">Uncategorized</span>
+        <span class="xl:hidden text-base-content/20 shrink-0">&middot;</span>
+        <span class="xl:hidden text-base-content/25 truncate shrink-0">Uncategorized</span>
         {{end}}
       </div>
     </div>
 
-    <!-- Category Picker (inline column) -->
-    <div class="shrink-0 hidden sm:block" @click.stop>
+    <!-- Category Picker (inline column) — shown at xl+ where there's room
+         for chips + picker without overflow. Below xl the compact category
+         label appears in the meta line above. -->
+    <div class="shrink-0 hidden xl:block" @click.stop>
       <div class="bb-cat-picker" data-picker-source="tx-cat-{{.ID}}" x-data="categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '{{if .CategoryID}}{{.CategoryID}}{{end}}', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', sourceId: 'tx-cat-{{.ID}}'})" x-init="$watch('selectedId', (v, old) => { if (old !== undefined && v !== old && !($store.bulk && $store.bulk.processing)) { quickSetCategory('{{.ID}}', v) } })">
         <button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
           <template x-if="displayColor"><span class="bb-cat-dot" :style="'background-color:' + displayColor"></span></template>


### PR DESCRIPTION
## Summary
- Tag chips on transaction rows now collapse to the icon+count pill below `xl:` instead of `sm:`, so tablet (768) and small desktops (sidebar visible) stop overflowing tags into the adjacent Category column.
- Account name no longer truncates to a single character (`P...`) on `/transactions` and `/accounts/:id` at tablet width when a row has 2-3 tags.
- Pure responsive sweep — chip DOM still present (bulk picker reads it), pill/picker/category-text breakpoints flipped together so they always swap as a unit.

## Before / After

<table>
<tr><th>Viewport</th><th>Before</th><th>After</th></tr>
<tr><td>Desktop (1280×800)</td><td><img src="https://i.img402.dev/94o4rv741f.jpg" width="400"></td><td><img src="https://i.img402.dev/qd6t6bkrla.jpg" width="400"></td></tr>
<tr><td>Tablet (768×1024)</td><td><img src="https://i.img402.dev/74uw19k4k1.jpg" width="400"></td><td><img src="https://i.img402.dev/cqv49133yd.jpg" width="400"></td></tr>
<tr><td>Mobile (390×844)</td><td><img src="https://i.img402.dev/2qcnu6r1e5.jpg" width="400"></td><td><img src="https://i.img402.dev/bh5yxgxoi1.jpg" width="400"></td></tr>
</table>

## Test plan
- [ ] Verify at all three breakpoints
- [ ] No regression at intermediate widths (sm/md/lg) — pill stays visible until xl
- [ ] /transactions and /accounts/:id still render rows with full account name + category line at tablet

🤖 Generated with [Claude Code](https://claude.com/claude-code)