### PR TITLE
fix(reports): responsive polish for reports list and detail

### DIFF
--- a/internal/templates/pages/report_detail.html
+++ b/internal/templates/pages/report_detail.html
@@ -37,7 +37,7 @@
       </div>
 
       <!-- Title as the message bubble -->
-      <div class="pl-[3.25rem]">
+      <div class="pl-0 sm:pl-[3.25rem]">
         <div class="inline-block max-w-full rounded-2xl rounded-tl-sm shadow-sm px-4 py-3 bg-base-200/70">
           <p class="text-sm leading-relaxed text-base-content">{{.Report.Title}}</p>
         </div>

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -14,15 +14,18 @@
 
 <!-- Filter Tabs + Actions -->
 <div class="flex items-center gap-1 border-b border-base-200/80 mb-6">
-  <a href="/reports" class="px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus ""}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">All</a>
-  <a href="/reports?status=unread" class="px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus "unread"}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">Unread</a>
-  <a href="/reports?status=read" class="px-3 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus "read"}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">Read</a>
-  <span class="ml-auto text-xs text-base-content/30 hidden sm:inline">{{.TotalCount}} report{{if ne .TotalCount 1}}s{{end}}</span>
-  <button class="ml-auto sm:ml-2 btn btn-ghost btn-sm rounded-xl text-xs cursor-pointer"
-    onclick="fetch('/-/reports/read-all', {method:'POST'}).then(function(){window.location.reload()})">
-    <i data-lucide="check-check" class="w-3.5 h-3.5"></i>
-    <span class="hidden sm:inline">Mark all read</span>
-  </button>
+  <a href="/reports" class="px-2.5 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus ""}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">All</a>
+  <a href="/reports?status=unread" class="px-2.5 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus "unread"}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">Unread</a>
+  <a href="/reports?status=read" class="px-2.5 sm:px-4 py-2.5 text-sm font-medium border-b-2 -mb-px transition-colors no-underline {{if eq .FilterStatus "read"}}text-base-content border-primary{{else}}text-base-content/40 border-transparent hover:text-base-content/60{{end}}">Read</a>
+  <div class="ml-auto flex items-center gap-2">
+    <span class="text-xs text-base-content/30 hidden sm:inline">{{.TotalCount}} report{{if ne .TotalCount 1}}s{{end}}</span>
+    <button class="btn btn-ghost btn-sm rounded-xl text-xs cursor-pointer"
+      onclick="fetch('/-/reports/read-all', {method:'POST'}).then(function(){window.location.reload()})"
+      title="Mark all read">
+      <i data-lucide="check-check" class="w-3.5 h-3.5"></i>
+      <span class="hidden sm:inline">Mark all read</span>
+    </button>
+  </div>
 </div>
 
 <!-- Reports Inbox -->
@@ -31,34 +34,34 @@
   <div class="divide-y divide-base-200/60 bb-stagger">
     {{range .Reports}}
     <a href="/reports/{{.ID}}"
-      class="group relative block px-4 sm:px-5 py-4 hover:bg-base-200/30 transition-all duration-300 no-underline"
+      class="group relative block px-3 sm:px-5 py-4 hover:bg-base-200/30 transition-all duration-300 no-underline"
       :class="dismissed['{{.ID}}'] ? 'opacity-0 h-0 overflow-hidden !p-0' : ''"
       id="report-{{.ID}}">
-      <div class="flex items-start gap-3">
+      <div class="flex items-start gap-2.5 sm:gap-3">
 
         <!-- Avatar -->
-        <div class="w-9 h-9 rounded-full flex items-center justify-center shrink-0 mt-0.5 bg-primary/10 text-primary">
+        <div class="w-8 h-8 sm:w-9 sm:h-9 rounded-full flex items-center justify-center shrink-0 mt-0.5 bg-primary/10 text-primary">
           <i data-lucide="bot" class="w-4 h-4"></i>
         </div>
 
         <!-- Message content -->
         <div class="flex-1 min-w-0">
           <!-- Meta row -->
-          <div class="flex items-center flex-wrap gap-2 text-xs mb-1.5">
-            <span class="font-semibold text-base-content/80">{{.DisplayAuthor}}</span>
-            <span class="text-base-content/30">{{.CreatedAt}}</span>
+          <div class="flex items-center flex-wrap gap-x-2 gap-y-1 text-xs mb-1.5">
+            <span class="font-semibold text-base-content/80 truncate max-w-[60%] sm:max-w-none">{{.DisplayAuthor}}</span>
+            <span class="text-base-content/30 shrink-0">{{.CreatedAt}}</span>
             {{if eq .Priority "critical"}}
             <span class="relative inline-flex w-2 h-2 shrink-0">
               <span class="animate-ping absolute inline-flex w-full h-full rounded-full bg-error/60"></span>
               <span class="relative inline-flex w-2 h-2 rounded-full bg-error"></span>
             </span>
-            <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-error/10 text-error/90">Critical</span>
+            <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-error/10 text-error/90 shrink-0">Critical</span>
             {{else if eq .Priority "warning"}}
             <span class="w-2 h-2 rounded-full bg-warning shrink-0"></span>
-            <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-warning/15 text-warning">Warning</span>
+            <span class="text-[0.6rem] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded-full bg-warning/15 text-warning shrink-0">Warning</span>
             {{end}}
-            {{range .Tags}}
-            <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/50">{{.}}</span>
+            {{range $i, $tag := .Tags}}
+            <span class="text-[0.6rem] px-1.5 py-0.5 rounded-full bg-base-200/80 text-base-content/50 shrink-0 {{if gt $i 0}}hidden sm:inline{{end}}">{{$tag}}</span>
             {{end}}
           </div>
 


### PR DESCRIPTION
## Summary
- Reports list: collapse low-signal tag chips to the first one on mobile, show the full set from tablet (`sm`) up — keeps the meta row to a single line on narrow widths.
- Reports list: tighter row/avatar padding on mobile, truncate long author names, add `shrink-0` to priority pills so they never break.
- Reports list: group count + Mark-all-read in one `ml-auto` cluster so the icon-only button sits flush on mobile.
- Report detail: drop the fixed `3.25rem` left-indent on the title bubble below `sm` so the message fills the mobile viewport.

## Before / After

<table>
<tr><th>Viewport</th><th>Before</th><th>After</th></tr>
<tr><td>Desktop (1280×800)</td><td><img src="https://i.img402.dev/2lyhykc99y.jpg" width="400"></td><td><img src="https://i.img402.dev/ykjfgnwnqq.jpg" width="400"></td></tr>
<tr><td>Tablet (768×1024)</td><td><img src="https://i.img402.dev/uc7udmtpba.jpg" width="400"></td><td><img src="https://i.img402.dev/lonx5pkzz2.jpg" width="400"></td></tr>
<tr><td>Mobile (390×844)</td><td><img src="https://i.img402.dev/v6qwva78r6.jpg" width="400"></td><td><img src="https://i.img402.dev/y1raotoig3.jpg" width="400"></td></tr>
</table>

## Test plan
- [ ] Verify at all three breakpoints
- [ ] No regression at intermediate widths (sm/md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)