### PR TITLE
fix(access): keep section header on one line on narrow viewports

### DIFF
--- a/internal/templates/pages/access.html
+++ b/internal/templates/pages/access.html
@@ -8,17 +8,17 @@
 
 <!-- OAuth Clients Section -->
 <div id="oauth-clients" class="mb-8">
-  <div class="flex items-center justify-between mb-3">
-    <div class="flex items-center gap-2">
-      <i data-lucide="fingerprint" class="w-4 h-4 text-primary"></i>
-      <h2 class="text-sm font-semibold">OAuth Clients</h2>
+  <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">
+    <div class="flex items-center gap-2 min-w-0 flex-1">
+      <i data-lucide="fingerprint" class="w-4 h-4 text-primary shrink-0"></i>
+      <h2 class="text-sm font-semibold shrink-0">OAuth Clients</h2>
       {{if .Clients}}
-      <span class="text-xs text-base-content/40">{{len .ActiveClients}} active{{if .RevokedClients}}, {{len .RevokedClients}} revoked{{end}}</span>
+      <span class="text-xs text-base-content/40 truncate">{{len .ActiveClients}} active{{if .RevokedClients}}, {{len .RevokedClients}} revoked{{end}}</span>
       {{else}}
-      <span class="text-xs text-base-content/40">External connector access (e.g., Claude)</span>
+      <span class="text-xs text-base-content/40 truncate">External connector access (e.g., Claude)</span>
       {{end}}
     </div>
-    <a href="/oauth-clients/new" class="btn btn-primary btn-sm btn-soft rounded-xl">
+    <a href="/oauth-clients/new" class="btn btn-primary btn-sm btn-soft rounded-xl shrink-0">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Create Client
     </a>
@@ -114,17 +114,17 @@
 
 <!-- API Keys Section -->
 <div id="api-keys">
-  <div class="flex items-center justify-between mb-3">
-    <div class="flex items-center gap-2">
-      <i data-lucide="key" class="w-4 h-4 text-primary"></i>
-      <h2 class="text-sm font-semibold">API Keys</h2>
+  <div class="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 mb-3">
+    <div class="flex items-center gap-2 min-w-0 flex-1">
+      <i data-lucide="key" class="w-4 h-4 text-primary shrink-0"></i>
+      <h2 class="text-sm font-semibold shrink-0">API Keys</h2>
       {{if .Keys}}
-      <span class="text-xs text-base-content/40">{{len .ActiveKeys}} active{{if .RevokedKeys}}, {{len .RevokedKeys}} revoked{{end}}</span>
+      <span class="text-xs text-base-content/40 truncate">{{len .ActiveKeys}} active{{if .RevokedKeys}}, {{len .RevokedKeys}} revoked{{end}}</span>
       {{else}}
-      <span class="text-xs text-base-content/40">Direct REST API and MCP access</span>
+      <span class="text-xs text-base-content/40 truncate">Direct REST API and MCP access</span>
       {{end}}
     </div>
-    <a href="/api-keys/new" class="btn btn-primary btn-sm btn-soft rounded-xl">
+    <a href="/api-keys/new" class="btn btn-primary btn-sm btn-soft rounded-xl shrink-0">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Create Key
     </a>


### PR DESCRIPTION
## Summary
- OAuth Clients / API Keys section headers wrapped the title to two lines and squeezed the caption out of view on 390px viewports because the right-aligned button competed with the title row for space.
- Allow the header row to `flex-wrap`, mark the icon/title/button `shrink-0`, and let the caption `truncate`. Title and button stay on one line; caption gracefully ellipses when there isn't room.
- No layout change at tablet (768px) or desktop (1280px) — the caption fits without truncation.

## Before / After

<table>
<tr><th>Viewport</th><th>Before</th><th>After</th></tr>
<tr><td>Desktop (1280×800)</td><td><img src="https://i.img402.dev/578dpcncz5.jpg" width="400"></td><td><img src="https://i.img402.dev/kn5rszu5kl.jpg" width="400"></td></tr>
<tr><td>Tablet (768×1024)</td><td><img src="https://i.img402.dev/7i2f5j2rsj.jpg" width="400"></td><td><img src="https://i.img402.dev/5fq7s2i9a6.jpg" width="400"></td></tr>
<tr><td>Mobile (390×844)</td><td><img src="https://i.img402.dev/jc1oh78eow.jpg" width="400"></td><td><img src="https://i.img402.dev/2zv3lm8cl6.jpg" width="400"></td></tr>
</table>

## Test plan
- [ ] Verify at all three breakpoints
- [ ] No regression at intermediate widths (sm/md)
- [ ] Verify with populated OAuth clients / API keys (active count caption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)