### PR TITLE
chore: fix staticcheck findings across admin, service, provider

### DIFF
--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -390,9 +390,7 @@ func flattenCategories(tree []service.CategoryResponse) []service.CategoryRespon
 	var flat []service.CategoryResponse
 	for _, parent := range tree {
 		flat = append(flat, parent)
-		for _, child := range parent.Children {
-			flat = append(flat, child)
-		}
+		flat = append(flat, parent.Children...)
 	}
 	return flat
 }

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -493,15 +493,12 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 		}
 		dayMap := make(map[string]*DaySync)
 		now := time.Now()
-		var daySyncs []DaySync
 		for i := 13; i >= 0; i-- {
 			day := now.AddDate(0, 0, -i)
 			key := day.Format("2006-01-02")
 			label := day.Format("Jan 2")
 			shortLabel := day.Format("2")
-			ds := &DaySync{Date: key, Label: label, ShortLabel: shortLabel}
-			dayMap[key] = ds
-			daySyncs = append(daySyncs, *ds)
+			dayMap[key] = &DaySync{Date: key, Label: label, ShortLabel: shortLabel}
 		}
 
 		for _, log := range allSyncLogs {
@@ -558,8 +555,8 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 			successRate = float64(successSyncs) / float64(totalSyncs) * 100
 		}
 
-		// Rebuild daySyncs from the map (map was modified in-place).
-		daySyncs = nil
+		// Build the ordered daySyncs slice from the (now-populated) map.
+		var daySyncs []DaySync
 		for i := 13; i >= 0; i-- {
 			day := now.AddDate(0, 0, -i)
 			key := day.Format("2006-01-02")

--- a/internal/provider/plaid/validate.go
+++ b/internal/provider/plaid/validate.go
@@ -28,7 +28,7 @@ func ValidateCredentials(ctx context.Context, clientID, secret, env string) erro
 			}
 		}
 		if plaidErr != nil {
-			return fmt.Errorf("Plaid error: %s", plaidErr.GetErrorMessage())
+			return fmt.Errorf("plaid error: %s", plaidErr.GetErrorMessage())
 		}
 		return fmt.Errorf("could not connect to Plaid: %v", err)
 	}

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -67,28 +67,12 @@ func timestampStr(ts pgtype.Timestamptz) *string {
 	return &s
 }
 
-func timestampPtr(ts pgtype.Timestamptz) *time.Time {
-	if !ts.Valid {
-		return nil
-	}
-	t := ts.Time.UTC()
-	return &t
-}
-
 func dateStr(d pgtype.Date) *string {
 	if !d.Valid {
 		return nil
 	}
 	s := d.Time.Format("2006-01-02")
 	return &s
-}
-
-func datePtr(d pgtype.Date) *time.Time {
-	if !d.Valid {
-		return nil
-	}
-	t := d.Time
-	return &t
 }
 
 func nullConnStatusPtr(s db.NullConnectionStatus) *string {

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -642,10 +642,6 @@ const ruleSelectQuery = `SELECT tr.id, tr.short_id, tr.name, tr.conditions, tr.a
 	tr.hit_count, tr.last_hit_at, tr.created_at, tr.updated_at
 	FROM transaction_rules tr`
 
-// ruleSelectColumnCount is the number of columns in ruleSelectQuery (excluding
-// JOINs). Used to bound scanDest() for INSERT/UPDATE RETURNING.
-const ruleSelectColumnCount = 16
-
 // CreateTransactionRule creates a new transaction rule.
 //
 // Category info is derived from actions[{type:"set_category"}] at response
@@ -1197,9 +1193,8 @@ const transactionContextGroupBy = ` GROUP BY t.id, t.name, t.merchant_name, t.am
 
 // transactionContextRow holds a scanned transaction row for rule evaluation.
 type transactionContextRow struct {
-	id        pgtype.UUID
-	tctx      TransactionContext
-	accountID pgtype.UUID
+	id   pgtype.UUID
+	tctx TransactionContext
 }
 
 func scanTransactionContextRow(dest []any) *transactionContextRow {
@@ -1554,9 +1549,7 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 						}
 						// If a prior-stage remove queued this slug, the later
 						// add cancels the remove.
-						if _, was := intent.tagRemoves[a.TagSlug]; was {
-							delete(intent.tagRemoves, a.TagSlug)
-						}
+						delete(intent.tagRemoves, a.TagSlug)
 						if _, exists := intent.tagAdds[a.TagSlug]; !exists {
 							intent.tagAdds[a.TagSlug] = cr
 						}

--- a/internal/service/transaction_summary_test.go
+++ b/internal/service/transaction_summary_test.go
@@ -1,13 +1,14 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
 
 func TestGetTransactionSummary_InvalidGroupBy(t *testing.T) {
 	svc := &Service{} // no pool needed for validation check
-	_, err := svc.GetTransactionSummary(nil, TransactionSummaryParams{GroupBy: "invalid"})
+	_, err := svc.GetTransactionSummary(context.Background(), TransactionSummaryParams{GroupBy: "invalid"})
 	if err == nil {
 		t.Fatal("expected error for invalid group_by")
 	}


### PR DESCRIPTION
## Summary

Cleanup pass driven by `staticcheck ./...` — removes dead code, a real
bug in `connections.go`, and fixes lint-level nits. No behavior change
except where noted.

## Findings addressed

| Location | Check | Fix |
|---|---|---|
| `internal/admin/categories.go:393` | S1011 | Collapse inner range-append into `append(flat, parent.Children...)` |
| `internal/admin/connections.go:504` | SA4010 | Drop the first loop's discarded append — `daySyncs` was already rebuilt from `dayMap` after mutation, so the initial append of stale copies was dead |
| `internal/provider/plaid/validate.go:31` | ST1005 | Lowercase `"plaid error: ..."` error wrap |
| `internal/service/convert.go:70,86` | U1000 | Remove unused `timestampPtr` and `datePtr` helpers. `timestampStr` / `dateStr` remain (still used) |
| `internal/service/rules.go:647` | U1000 | Remove unused `ruleSelectColumnCount` const |
| `internal/service/rules.go:1202` | U1000 | Remove unused `accountID` field on `transactionContextRow` |
| `internal/service/rules.go:1557` | S1033 | Drop redundant guard around `delete(intent.tagRemoves, ...)` — `delete` on a missing key is a no-op |
| `internal/service/transaction_summary_test.go:10` | SA1012 | Pass `context.Background()` instead of nil |

The `connections.go` change is the only one with user-visible intent:
the code built `daySyncs`, then mutated `dayMap` in place, then
*rebuilt* `daySyncs` from the map. The first build was unused. Now
there's a single rebuild after mutation.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `make test-integration` equivalent on `internal/service`, `internal/admin`, `internal/api`
- [x] `staticcheck ./...` clean after changes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)