### PR TITLE
refactor(api): consolidate JSON body decoding into decodeJSON helper

### DIFF
--- a/internal/api/account_links.go
+++ b/internal/api/account_links.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -32,8 +31,7 @@ func CreateAccountLinkHandler(svc *service.Service) http.HandlerFunc {
 			MatchStrategy      string `json:"match_strategy"`
 			MatchToleranceDays int    `json:"match_tolerance_days"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 
@@ -92,8 +90,7 @@ func UpdateAccountLinkHandler(svc *service.Service) http.HandlerFunc {
 			MatchToleranceDays *int    `json:"match_tolerance_days"`
 			Enabled            *bool   `json:"enabled"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 
@@ -206,8 +203,7 @@ func ManualMatchHandler(svc *service.Service) http.HandlerFunc {
 			PrimaryTransactionID   string `json:"primary_transaction_id"`
 			DependentTransactionID string `json:"dependent_transaction_id"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 

--- a/internal/api/categories.go
+++ b/internal/api/categories.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -55,8 +54,7 @@ type createCategoryRequest struct {
 func CreateCategoryHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var input createCategoryRequest
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 
@@ -100,8 +98,7 @@ func UpdateCategoryHandler(svc *service.Service) http.HandlerFunc {
 		id := chi.URLParam(r, "id")
 
 		var input updateCategoryRequest
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 
@@ -163,8 +160,7 @@ func MergeCategoriesHandler(svc *service.Service) http.HandlerFunc {
 		id := chi.URLParam(r, "id")
 
 		var input mergeCategoriesRequest
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 

--- a/internal/api/comments.go
+++ b/internal/api/comments.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -39,8 +38,7 @@ func CreateCommentHandler(svc *service.Service) http.HandlerFunc {
 		var input struct {
 			Content string `json:"content"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 
@@ -76,8 +74,7 @@ func UpdateCommentHandler(svc *service.Service) http.HandlerFunc {
 		var input struct {
 			Content string `json:"content"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 

--- a/internal/api/reports.go
+++ b/internal/api/reports.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
 
 	mw "breadbox/internal/middleware"
@@ -44,8 +43,7 @@ func CreateReportHandler(svc *service.Service) http.HandlerFunc {
 			Tags     []string `json:"tags"`
 			Author   string   `json:"author"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid JSON body")
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+
+	mw "breadbox/internal/middleware"
 )
 
 // writeJSON writes v as JSON with the given HTTP status code.
@@ -15,4 +17,15 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 // writeData writes v as JSON with HTTP 200 OK.
 func writeData(w http.ResponseWriter, v any) {
 	writeJSON(w, http.StatusOK, v)
+}
+
+// decodeJSON decodes the JSON request body into v. On failure it writes a
+// standard 400 INVALID_BODY error envelope and returns false; callers should
+// return immediately when this returns false.
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		return false
+	}
+	return true
 }

--- a/internal/api/rules.go
+++ b/internal/api/rules.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -66,8 +65,7 @@ func CreateRuleHandler(svc *service.Service) http.HandlerFunc {
 			Priority  int    `json:"priority"`
 			ExpiresIn string `json:"expires_in"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 
@@ -150,8 +148,7 @@ func UpdateRuleHandler(svc *service.Service) http.HandlerFunc {
 			Enabled   *bool   `json:"enabled,omitempty"`
 			ExpiresAt *string `json:"expires_at,omitempty"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 
@@ -255,8 +252,7 @@ func PreviewRuleHandler(svc *service.Service) http.HandlerFunc {
 			Conditions service.Condition `json:"conditions"`
 			SampleSize int               `json:"sample_size"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 
@@ -18,8 +17,7 @@ func TriggerSyncHandler(svc *service.Service) http.HandlerFunc {
 			var body struct {
 				ConnectionID *string `json:"connection_id"`
 			}
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			if !decodeJSON(w, r, &body) {
 				return
 			}
 			connectionID = body.ConnectionID

--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
@@ -389,8 +388,7 @@ func SetTransactionCategoryHandler(svc *service.Service) http.HandlerFunc {
 		var input struct {
 			CategoryID string `json:"category_id"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 		if input.CategoryID == "" {
@@ -436,8 +434,7 @@ func BatchCategorizeHandler(svc *service.Service) http.HandlerFunc {
 		var input struct {
 			Items []service.BatchCategorizeItem `json:"items"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 
@@ -471,8 +468,7 @@ func BulkRecategorizeHandler(svc *service.Service) http.HandlerFunc {
 			Search             string   `json:"search"`
 			NameContains       string   `json:"name_contains"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 


### PR DESCRIPTION
## Summary

- Sixteen REST handlers across `internal/api/` duplicated the same `json.NewDecoder(r.Body).Decode(&input)` + `mw.WriteError(w, 400, "...", "Invalid JSON body")` pattern. Three different error codes (`INVALID_BODY`, `INVALID_JSON`, `INVALID_REQUEST`) were used for the identical condition.
- Extracted a shared `decodeJSON(w, r, &input) bool` helper in [response.go](internal/api/response.go) and normalized every callsite to the dominant `INVALID_BODY` code, matching the api.md guidance to use response.go helpers and not hand-roll envelopes.
- No behavior change beyond the two outlier error codes (`INVALID_JSON` in categories, `INVALID_REQUEST` in reports) being normalized — these were undocumented inconsistencies. Net: +29 / -39 LOC.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/api/...`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)