### PR TITLE
test(slugs): add unit coverage for TitleCase

### DIFF
--- a/internal/slugs/slugs_test.go
+++ b/internal/slugs/slugs_test.go
@@ -1,0 +1,36 @@
+package slugs
+
+import "testing"
+
+func TestTitleCase(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"single word lowercase", "review", "Review"},
+		{"single word already capitalized", "Review", "Review"},
+		{"hyphen separator", "needs-review", "Needs Review"},
+		{"colon separator", "subscription:monthly", "Subscription Monthly"},
+		{"underscore separator", "user_name", "User Name"},
+		{"mixed separators", "needs-review:urgent_now", "Needs Review Urgent Now"},
+		{"multiple words", "very-long-tag-name", "Very Long Tag Name"},
+		{"leading separator", "-review", "Review"},
+		{"trailing separator", "review-", "Review"},
+		{"consecutive separators", "needs--review", "Needs Review"},
+		{"all caps preserved past first char", "API-key", "API Key"},
+		{"single character", "a", "A"},
+		{"only separators", "---", ""},
+		{"unicode word", "café-bar", "Café Bar"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TitleCase(tc.in)
+			if got != tc.want {
+				t.Errorf("TitleCase(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/slugs/slugs_test.go` covering `TitleCase` end-to-end: every recognized separator (`-`, `:`, `_`), mixed separators, leading/trailing/consecutive separators, single character, only-separators input, unicode, and preservation of pre-existing capitalization.
- `TitleCase` is used by `internal/sync/engine.go`, `internal/service/tags.go`, and `internal/service/rules.go` to derive a display name when auto-creating a tag from a slug. Untested until now, so any regression would silently produce malformed tag labels during sync or rule application.

## Test plan
- [x] `go test ./internal/slugs/ -v` — 15 subtests pass
- [x] `go test ./...` — full unit suite still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)