### PR TITLE
refactor(pgconv): consolidate UUID parsing + de-duplicate formatting

### DIFF
--- a/internal/admin/oauth.go
+++ b/internal/admin/oauth.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
@@ -518,10 +519,7 @@ func isForwardedHTTPS(r *http.Request) bool {
 }
 
 func parseUUID(s string) (pgtype.UUID, error) {
-	// Re-use existing parse logic. This is a local version to avoid import cycle.
-	var uuid pgtype.UUID
-	err := uuid.Scan(s)
-	return uuid, err
+	return pgconv.ParseUUID(s)
 }
 
 func generateState() string {

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -17,3 +17,11 @@ func FormatUUID(u pgtype.UUID) string {
 	b := u.Bytes
 	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
+
+// ParseUUID parses a UUID string into a pgtype.UUID. Accepts any format
+// pgx's UUID.Scan accepts (canonical 36-char with dashes, or 32-char without).
+func ParseUUID(s string) (pgtype.UUID, error) {
+	var u pgtype.UUID
+	err := u.Scan(s)
+	return u, err
+}

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -49,3 +49,32 @@ func TestFormatUUID_MaxBytes(t *testing.T) {
 		t.Errorf("FormatUUID(max) = %q, want %q", got, want)
 	}
 }
+
+func TestParseUUID_Canonical(t *testing.T) {
+	got, err := ParseUUID("550e8400-e29b-41d4-a716-446655440000")
+	if err != nil {
+		t.Fatalf("ParseUUID: unexpected error: %v", err)
+	}
+	if !got.Valid {
+		t.Fatal("ParseUUID: expected Valid=true")
+	}
+	if FormatUUID(got) != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Errorf("ParseUUID roundtrip mismatch: got %q", FormatUUID(got))
+	}
+}
+
+func TestParseUUID_NoDashes(t *testing.T) {
+	got, err := ParseUUID("550e8400e29b41d4a716446655440000")
+	if err != nil {
+		t.Fatalf("ParseUUID: unexpected error: %v", err)
+	}
+	if FormatUUID(got) != "550e8400-e29b-41d4-a716-446655440000" {
+		t.Errorf("ParseUUID roundtrip mismatch: got %q", FormatUUID(got))
+	}
+}
+
+func TestParseUUID_Invalid(t *testing.T) {
+	if _, err := ParseUUID("not-a-uuid"); err == nil {
+		t.Error("ParseUUID: expected error for invalid input")
+	}
+}

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -165,7 +166,5 @@ func accountFromGetRow(r db.GetAccountRow) AccountResponse {
 }
 
 func parseUUID(s string) (pgtype.UUID, error) {
-	var u pgtype.UUID
-	err := u.Scan(s)
-	return u, err
+	return pgconv.ParseUUID(s)
 }

--- a/internal/service/overview.go
+++ b/internal/service/overview.go
@@ -124,7 +124,7 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		if err := userRows.Scan(&id, &u.Name); err != nil {
 			return nil, fmt.Errorf("scan user: %w", err)
 		}
-		u.ID = fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", id.Bytes[0:4], id.Bytes[4:6], id.Bytes[6:8], id.Bytes[8:10], id.Bytes[10:16])
+		u.ID = formatUUID(id)
 		stats.Users = append(stats.Users, u)
 	}
 	if err := userRows.Err(); err != nil {
@@ -170,7 +170,7 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		if err := connRows.Scan(&id, &c.Provider, &instName, &c.Status, &lastSynced, &c.AccountCount); err != nil {
 			return nil, fmt.Errorf("scan connection: %w", err)
 		}
-		c.ID = fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", id.Bytes[0:4], id.Bytes[4:6], id.Bytes[6:8], id.Bytes[8:10], id.Bytes[10:16])
+		c.ID = formatUUID(id)
 		c.InstitutionName = instName
 		if lastSynced != nil {
 			s := lastSynced.UTC().Format(time.RFC3339)


### PR DESCRIPTION
## Summary

- Add `pgconv.ParseUUID(s)` alongside the existing `pgconv.FormatUUID`, with unit tests for canonical, dash-less, and invalid inputs.
- Collapse the duplicate `parseUUID` helpers in `internal/service/accounts.go` and `internal/admin/oauth.go` to thin delegators. The admin copy carried a stale *\"avoid import cycle\"* comment — `pgconv` has no deps so there was never a cycle to avoid.
- Replace two inline `fmt.Sprintf(\"%08x-%04x-...\", id.Bytes[0:4], ...)` calls in `internal/service/overview.go` with the existing `formatUUID` helper so the canonical layout lives in one place.

Pure refactor — no behavior change.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (unit)
- [x] \`go test -tags integration -count=1 -p 1 ./internal/service/ -run 'Overview|Accounts'\`
- [x] \`go test -tags integration -count=1 -p 1 ./internal/admin/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)