### PR TITLE
refactor(admin): consolidate response helpers in dedicated response.go

### DIFF
--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -169,12 +169,12 @@ func CreateCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 			SortOrder   int32   `json:"sort_order"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeCategoryError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		req.DisplayName = strings.TrimSpace(req.DisplayName)
 		if req.DisplayName == "" {
-			writeCategoryError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Display name is required")
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Display name is required")
 			return
 		}
 
@@ -205,12 +205,12 @@ func UpdateCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 			Hidden      bool    `json:"hidden"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeCategoryError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		req.DisplayName = strings.TrimSpace(req.DisplayName)
 		if req.DisplayName == "" {
-			writeCategoryError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Display name is required")
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Display name is required")
 			return
 		}
 
@@ -250,11 +250,11 @@ func MergeCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 			TargetID string `json:"target_id"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeCategoryError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		if req.TargetID == "" {
-			writeCategoryError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "target_id is required")
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "target_id is required")
 			return
 		}
 
@@ -270,26 +270,16 @@ func MergeCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 func handleCategoryError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, service.ErrCategoryNotFound):
-		writeCategoryError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
 	case errors.Is(err, service.ErrCategoryUndeletable):
-		writeCategoryError(w, http.StatusConflict, "UNDELETABLE", "This category cannot be deleted")
+		writeError(w, http.StatusConflict, "UNDELETABLE", "This category cannot be deleted")
 	case errors.Is(err, service.ErrSlugConflict):
-		writeCategoryError(w, http.StatusConflict, "SLUG_CONFLICT", "A category with this name already exists")
+		writeError(w, http.StatusConflict, "SLUG_CONFLICT", "A category with this name already exists")
 	case errors.Is(err, service.ErrInvalidParameter):
-		writeCategoryError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+		writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
 	default:
-		writeCategoryError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred")
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "An unexpected error occurred")
 	}
-}
-
-// writeCategoryError writes a JSON error envelope.
-func writeCategoryError(w http.ResponseWriter, status int, code, message string) {
-	writeJSON(w, status, map[string]any{
-		"error": map[string]string{
-			"code":    code,
-			"message": message,
-		},
-	})
 }
 
 // SetTransactionCategoryAdminHandler handles POST /admin/api/transactions/{id}/category.
@@ -300,23 +290,23 @@ func SetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 			CategoryID string `json:"category_id"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeCategoryError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		if req.CategoryID == "" {
-			writeCategoryError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "category_id is required")
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "category_id is required")
 			return
 		}
 		if err := svc.SetTransactionCategory(r.Context(), id, req.CategoryID); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				writeCategoryError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
 			}
 			if errors.Is(err, service.ErrCategoryNotFound) {
-				writeCategoryError(w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+				writeError(w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
 				return
 			}
-			writeCategoryError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to set category")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to set category")
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -329,10 +319,10 @@ func ResetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerFunc
 		id := chi.URLParam(r, "id")
 		if err := svc.ResetTransactionCategory(r.Context(), id); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				writeCategoryError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
 			}
-			writeCategoryError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reset category")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reset category")
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -350,15 +340,15 @@ func BatchSetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerF
 			} `json:"items"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeCategoryError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		if len(req.Items) == 0 {
-			writeCategoryError(w, http.StatusBadRequest, "VALIDATION_ERROR", "items array is required")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "items array is required")
 			return
 		}
 		if len(req.Items) > 500 {
-			writeCategoryError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Maximum 500 items per batch")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Maximum 500 items per batch")
 			return
 		}
 

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -1187,10 +1187,4 @@ func formatSyncStatusDuration(ms int32) string {
 	return fmt.Sprintf("%dm %ds", mins, secs)
 }
 
-// writeJSON writes a JSON response with the given status code.
-func writeJSON(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
-}
 

--- a/internal/admin/response.go
+++ b/internal/admin/response.go
@@ -1,0 +1,22 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+
+	mw "breadbox/internal/middleware"
+)
+
+// writeJSON writes v as JSON with the given HTTP status code.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+// writeError writes the canonical {"error": {"code", "message"}} envelope.
+// Thin wrapper around middleware.WriteError so admin handlers share the same
+// shape as the REST API without pulling the middleware import into every file.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	mw.WriteError(w, status, code, message)
+}

--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -96,13 +96,13 @@ func CreateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Lifecycle   string  `json:"lifecycle"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"code": "INVALID_REQUEST", "message": "Invalid request body"}})
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		req.Slug = strings.TrimSpace(req.Slug)
 		req.DisplayName = strings.TrimSpace(req.DisplayName)
 		if req.Slug == "" || req.DisplayName == "" {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{"error": map[string]any{"code": "VALIDATION_ERROR", "message": "slug and display_name are required"}})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "slug and display_name are required")
 			return
 		}
 
@@ -134,7 +134,7 @@ func UpdateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Lifecycle   *string `json:"lifecycle"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"code": "INVALID_REQUEST", "message": "Invalid request body"}})
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		result, err := svc.UpdateTag(r.Context(), id, service.UpdateTagParams{
@@ -248,11 +248,11 @@ func RemoveTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *s
 func handleTagError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, service.ErrNotFound):
-		writeJSON(w, http.StatusNotFound, map[string]any{"error": map[string]any{"code": "NOT_FOUND", "message": "Tag not found"}})
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "Tag not found")
 	case errors.Is(err, service.ErrInvalidParameter):
-		writeJSON(w, http.StatusUnprocessableEntity, map[string]any{"error": map[string]any{"code": "VALIDATION_ERROR", "message": err.Error()}})
+		writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", err.Error())
 	default:
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": map[string]any{"code": "INTERNAL_ERROR", "message": err.Error()}})
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Moves the generic `writeJSON` helper out of `connections.go` (where it was misplaced alongside feature-specific code) into a new `internal/admin/response.go`.
- Adds a `writeError` helper that delegates to `middleware.WriteError`, so admin handlers emit the same canonical `{\"error\":{\"code\",\"message\"}}` envelope as the REST API (per [.claude/rules/api.md](.claude/rules/api.md)).
- Removes the now-redundant `writeCategoryError` helper in `categories.go` and collapses inline `map[string]any{\"error\":{...}}` literals in `tags.go` (`CreateTag`, `UpdateTag`, `handleTagError`).

Net: 4 files changed, 49 insertions, 43 deletions — smaller, more consistent, and the admin package no longer has a duplicated `writeJSON` sitting 1000 lines into a feature file.

### Explicitly out of scope

A handful of admin endpoints (`transactions.go` bulk ops, `rules.go` CRUD, `update.go`) still emit the non-canonical `{\"error\":\"string\"}` shape. I left those alone here to avoid changing the response contract consumed by the admin UI — they're a pre-existing inconsistency worth a separate pass.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go vet ./...\` passes
- [x] \`go test ./...\` — all unit tests pass (admin, api, middleware, service, etc.)
- [ ] No UI validation needed — pure refactor, no rendered output changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)