### PR TITLE
refactor(admin): unify tag error responses on canonical envelope

### DIFF
--- a/internal/admin/response.go
+++ b/internal/admin/response.go
@@ -1,0 +1,15 @@
+package admin
+
+import (
+	"net/http"
+
+	"breadbox/internal/middleware"
+)
+
+// writeError writes the canonical JSON error envelope documented in
+// .claude/rules/api.md: { "error": { "code": "...", "message": "..." } }.
+// Use this instead of hand-rolling map literals so admin responses stay
+// consistent with the REST API contract.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	middleware.WriteError(w, status, code, message)
+}

--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -96,13 +96,13 @@ func CreateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Lifecycle   string  `json:"lifecycle"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"code": "INVALID_REQUEST", "message": "Invalid request body"}})
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		req.Slug = strings.TrimSpace(req.Slug)
 		req.DisplayName = strings.TrimSpace(req.DisplayName)
 		if req.Slug == "" || req.DisplayName == "" {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{"error": map[string]any{"code": "VALIDATION_ERROR", "message": "slug and display_name are required"}})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "slug and display_name are required")
 			return
 		}
 
@@ -134,7 +134,7 @@ func UpdateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Lifecycle   *string `json:"lifecycle"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": map[string]any{"code": "INVALID_REQUEST", "message": "Invalid request body"}})
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		result, err := svc.UpdateTag(r.Context(), id, service.UpdateTagParams{
@@ -176,24 +176,24 @@ func AddTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *serv
 			Note string `json:"note,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid body"})
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		body.Slug = strings.TrimSpace(body.Slug)
 		if body.Slug == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "slug is required"})
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "slug is required")
 			return
 		}
 		added, alreadyPresent, err := svc.AddTransactionTag(r.Context(), txnID, body.Slug, actor, body.Note)
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrNotFound):
-				writeJSON(w, http.StatusNotFound, map[string]any{"error": "transaction not found"})
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 			case errors.Is(err, service.ErrInvalidParameter):
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+				writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
 			default:
 				a.Logger.Error("add transaction tag", "error", err)
-				writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal server error"})
+				writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Internal server error")
 			}
 			return
 		}
@@ -227,12 +227,12 @@ func RemoveTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *s
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrNotFound):
-				writeJSON(w, http.StatusNotFound, map[string]any{"error": "transaction not found"})
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 			case errors.Is(err, service.ErrInvalidParameter):
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+				writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
 			default:
 				a.Logger.Error("remove transaction tag", "error", err)
-				writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal server error"})
+				writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Internal server error")
 			}
 			return
 		}
@@ -248,11 +248,11 @@ func RemoveTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *s
 func handleTagError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, service.ErrNotFound):
-		writeJSON(w, http.StatusNotFound, map[string]any{"error": map[string]any{"code": "NOT_FOUND", "message": "Tag not found"}})
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "Tag not found")
 	case errors.Is(err, service.ErrInvalidParameter):
-		writeJSON(w, http.StatusUnprocessableEntity, map[string]any{"error": map[string]any{"code": "VALIDATION_ERROR", "message": err.Error()}})
+		writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", err.Error())
 	default:
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": map[string]any{"code": "INTERNAL_ERROR", "message": err.Error()}})
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error())
 	}
 }
 

--- a/internal/admin/tags_integration_test.go
+++ b/internal/admin/tags_integration_test.go
@@ -132,6 +132,41 @@ func TestDeleteTagAdmin(t *testing.T) {
 	}
 }
 
+// TestCreateTagAdmin_ErrorEnvelope verifies the error response matches the
+// canonical envelope shape documented in .claude/rules/api.md:
+// { "error": { "code": "...", "message": "..." } }.
+func TestCreateTagAdmin_ErrorEnvelope(t *testing.T) {
+	svc := newTestSvc(t)
+	r := chi.NewRouter()
+	r.Post("/-/tags", CreateTagAdminHandler(svc))
+
+	// Missing display_name triggers VALIDATION_ERROR.
+	body := []byte(`{"slug":"incomplete"}`)
+	req := httptest.NewRequest(http.MethodPost, "/-/tags", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("expected 422, got %d: %s", w.Code, w.Body.String())
+	}
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, w.Body.String())
+	}
+	if env.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected code=VALIDATION_ERROR, got %q", env.Error.Code)
+	}
+	if env.Error.Message == "" {
+		t.Errorf("expected non-empty message, got empty")
+	}
+}
+
 // TestTagsPageRenders is a smoke test that the page handler renders the tag list.
 func TestTagsPageRenders(t *testing.T) {
 	svc := newTestSvc(t)

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -470,7 +470,7 @@ function tagManager() {
           showToast('Tag removed.', 'success');
           location.reload();
         } else {
-          showToast(r.body.error || 'Failed to remove tag.');
+          showToast((r.body.error && r.body.error.message) || 'Failed to remove tag.');
         }
       })
       .catch(function() { showToast('Network error.'); });

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -1136,7 +1136,7 @@ function removeTag(el, txnId, slug, displayName) {
       setTimeout(function() { el.remove(); }, 160);
       window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: displayName + ' removed', type:'success'}}));
     } else {
-      window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error || 'Failed to remove tag', type:'error'}}));
+      window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: (d.error && d.error.message) || 'Failed to remove tag', type:'error'}}));
     }
   });
 }


### PR DESCRIPTION
## Summary

- Admin tag handlers mixed two error response shapes: the canonical `{ "error": { code, message } }` envelope documented in [.claude/rules/api.md](.claude/rules/api.md) and a flat `{ "error": "string" }` literal. Fourteen hand-rolled `map[string]any{...}` literals scattered across [internal/admin/tags.go](internal/admin/tags.go) made it impossible for JS consumers to know which shape to read.
- Extract a small `writeError(w, status, code, message)` helper in a new [internal/admin/response.go](internal/admin/response.go) that delegates to `middleware.WriteError`. Migrate every error path in `tags.go` to it, converting all non-envelope sites to the canonical shape with meaningful `code` values (`INVALID_REQUEST`, `VALIDATION_ERROR`, `NOT_FOUND`, `INTERNAL_ERROR`).
- Update the two template JS consumers ([transactions.html:1139](internal/templates/pages/transactions.html), [transaction_detail.html:473](internal/templates/pages/transaction_detail.html)) that were reading `d.error` as a string to read `d.error.message` with a default fallback. Other JS consumers of these endpoints (`base.html` inline tag create, `tag_form.html`) already handled the envelope shape.
- Add an integration test (`TestCreateTagAdmin_ErrorEnvelope`) that pins the envelope shape so future handlers can't drift back.

No behavior change beyond the response shape — status codes and logged errors unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit)
- [x] `DATABASE_URL=... go test -tags integration -run TestCreateTagAdmin ./internal/admin/` — all 4 tag tests pass including the new envelope assertion
- [ ] Manual: remove a tag from the transaction list and transaction detail page, confirm the happy path still works and error toasts show a message

🤖 Generated with [Claude Code](https://claude.com/claude-code)