### PR TITLE
chore: clean up staticcheck warnings

### DIFF
--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -390,9 +390,7 @@ func flattenCategories(tree []service.CategoryResponse) []service.CategoryRespon
 	var flat []service.CategoryResponse
 	for _, parent := range tree {
 		flat = append(flat, parent)
-		for _, child := range parent.Children {
-			flat = append(flat, child)
-		}
+		flat = append(flat, parent.Children...)
 	}
 	return flat
 }

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -493,15 +493,12 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 		}
 		dayMap := make(map[string]*DaySync)
 		now := time.Now()
-		var daySyncs []DaySync
 		for i := 13; i >= 0; i-- {
 			day := now.AddDate(0, 0, -i)
 			key := day.Format("2006-01-02")
 			label := day.Format("Jan 2")
 			shortLabel := day.Format("2")
-			ds := &DaySync{Date: key, Label: label, ShortLabel: shortLabel}
-			dayMap[key] = ds
-			daySyncs = append(daySyncs, *ds)
+			dayMap[key] = &DaySync{Date: key, Label: label, ShortLabel: shortLabel}
 		}
 
 		for _, log := range allSyncLogs {
@@ -558,8 +555,8 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 			successRate = float64(successSyncs) / float64(totalSyncs) * 100
 		}
 
-		// Rebuild daySyncs from the map (map was modified in-place).
-		daySyncs = nil
+		// Flatten the day map into a chronologically ordered slice.
+		var daySyncs []DaySync
 		for i := 13; i >= 0; i-- {
 			day := now.AddDate(0, 0, -i)
 			key := day.Format("2006-01-02")

--- a/internal/provider/plaid/validate.go
+++ b/internal/provider/plaid/validate.go
@@ -28,7 +28,7 @@ func ValidateCredentials(ctx context.Context, clientID, secret, env string) erro
 			}
 		}
 		if plaidErr != nil {
-			return fmt.Errorf("Plaid error: %s", plaidErr.GetErrorMessage())
+			return fmt.Errorf("plaid error: %s", plaidErr.GetErrorMessage())
 		}
 		return fmt.Errorf("could not connect to Plaid: %v", err)
 	}

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -67,28 +67,12 @@ func timestampStr(ts pgtype.Timestamptz) *string {
 	return &s
 }
 
-func timestampPtr(ts pgtype.Timestamptz) *time.Time {
-	if !ts.Valid {
-		return nil
-	}
-	t := ts.Time.UTC()
-	return &t
-}
-
 func dateStr(d pgtype.Date) *string {
 	if !d.Valid {
 		return nil
 	}
 	s := d.Time.Format("2006-01-02")
 	return &s
-}
-
-func datePtr(d pgtype.Date) *time.Time {
-	if !d.Valid {
-		return nil
-	}
-	t := d.Time
-	return &t
 }
 
 func nullConnStatusPtr(s db.NullConnectionStatus) *string {

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -642,10 +642,6 @@ const ruleSelectQuery = `SELECT tr.id, tr.short_id, tr.name, tr.conditions, tr.a
 	tr.hit_count, tr.last_hit_at, tr.created_at, tr.updated_at
 	FROM transaction_rules tr`
 
-// ruleSelectColumnCount is the number of columns in ruleSelectQuery (excluding
-// JOINs). Used to bound scanDest() for INSERT/UPDATE RETURNING.
-const ruleSelectColumnCount = 16
-
 // CreateTransactionRule creates a new transaction rule.
 //
 // Category info is derived from actions[{type:"set_category"}] at response
@@ -1197,9 +1193,8 @@ const transactionContextGroupBy = ` GROUP BY t.id, t.name, t.merchant_name, t.am
 
 // transactionContextRow holds a scanned transaction row for rule evaluation.
 type transactionContextRow struct {
-	id        pgtype.UUID
-	tctx      TransactionContext
-	accountID pgtype.UUID
+	id   pgtype.UUID
+	tctx TransactionContext
 }
 
 func scanTransactionContextRow(dest []any) *transactionContextRow {
@@ -1554,9 +1549,7 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 						}
 						// If a prior-stage remove queued this slug, the later
 						// add cancels the remove.
-						if _, was := intent.tagRemoves[a.TagSlug]; was {
-							delete(intent.tagRemoves, a.TagSlug)
-						}
+						delete(intent.tagRemoves, a.TagSlug)
 						if _, exists := intent.tagAdds[a.TagSlug]; !exists {
 							intent.tagAdds[a.TagSlug] = cr
 						}

--- a/internal/service/transaction_summary_test.go
+++ b/internal/service/transaction_summary_test.go
@@ -1,13 +1,14 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
 
 func TestGetTransactionSummary_InvalidGroupBy(t *testing.T) {
 	svc := &Service{} // no pool needed for validation check
-	_, err := svc.GetTransactionSummary(nil, TransactionSummaryParams{GroupBy: "invalid"})
+	_, err := svc.GetTransactionSummary(context.Background(), TransactionSummaryParams{GroupBy: "invalid"})
 	if err == nil {
 		t.Fatal("expected error for invalid group_by")
 	}


### PR DESCRIPTION
## Summary

Cleans up the full set of `staticcheck ./...` findings. Pure cleanup, no behavior changes — with one exception called out below.

- **admin/connections** — drop dead `append` to `daySyncs` in the init loop. The slice was rebuilt from the map a few lines later, so the first `append` was discarded on every request. Flagged as `SA4010` (this result of append is never used).
- **admin/categories** — collapse inner `for _, child := range parent.Children` into `append(flat, parent.Children...)` (`S1011`).
- **provider/plaid/validate** — lowercase error string (`ST1005`).
- **service/convert** — remove unused `timestampPtr` and `datePtr` helpers (`U1000`).
- **service/rules** — drop unused `ruleSelectColumnCount` const and unused `accountID` field on `transactionContextRow` (`U1000`); simplify a `delete`-guard (delete on a missing key is a no-op) (`S1033`).
- **service/transaction_summary_test** — pass `context.Background()` instead of a nil context (`SA1012`).

### Note on the connections.go change

The first `append` in the 14-day sync-timeline loop was dead code, not just style — the struct copies appended there were never seen by callers because the slice is rebuilt from the (mutated) map further down. Dropping the redundant `var daySyncs` at the top makes the flow clearer: populate the map, mutate it in-place while iterating sync logs, then flatten in chronological order.

### Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `staticcheck ./...` — now zero findings (was 9)
- `go test ./...` — all packages pass

No UI changes — the connections.go fix doesn't alter rendered output because the dead `append` wasn't reaching the template; only downstream deletion of an unused intermediate slice.

## Test plan

- [x] Unit tests pass
- [x] `staticcheck` is clean
- [ ] Confirm `/connections/:id` still renders the 14-day sync timeline (no visual regression — the map-backed code path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)