### PR TITLE
refactor(api): add writeError helper, drop middleware import from handlers

### DIFF
--- a/internal/api/account_links.go
+++ b/internal/api/account_links.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -16,7 +15,7 @@ func ListAccountLinksHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		links, err := svc.ListAccountLinks(r.Context())
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list account links")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list account links")
 			return
 		}
 		writeData(w, links)
@@ -33,12 +32,12 @@ func CreateAccountLinkHandler(svc *service.Service) http.HandlerFunc {
 			MatchToleranceDays int    `json:"match_tolerance_days"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
 		if input.PrimaryAccountID == "" || input.DependentAccountID == "" {
-			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "primary_account_id and dependent_account_id are required")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "primary_account_id and dependent_account_id are required")
 			return
 		}
 
@@ -50,14 +49,14 @@ func CreateAccountLinkHandler(svc *service.Service) http.HandlerFunc {
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+				writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
 				return
 			}
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create account link")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create account link")
 			return
 		}
 
@@ -72,10 +71,10 @@ func GetAccountLinkHandler(svc *service.Service) http.HandlerFunc {
 		link, err := svc.GetAccountLink(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get account link")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get account link")
 			return
 		}
 		writeData(w, link)
@@ -93,7 +92,7 @@ func UpdateAccountLinkHandler(svc *service.Service) http.HandlerFunc {
 			Enabled            *bool   `json:"enabled"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
@@ -104,10 +103,10 @@ func UpdateAccountLinkHandler(svc *service.Service) http.HandlerFunc {
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update account link")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update account link")
 			return
 		}
 		writeData(w, link)
@@ -120,10 +119,10 @@ func DeleteAccountLinkHandler(svc *service.Service) http.HandlerFunc {
 		id := chi.URLParam(r, "id")
 		if err := svc.DeleteAccountLink(r.Context(), id); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete account link")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete account link")
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -137,10 +136,10 @@ func ReconcileAccountLinkHandler(svc *service.Service) http.HandlerFunc {
 		result, err := svc.RunMatchReconciliation(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reconcile")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reconcile")
 			return
 		}
 		writeData(w, result)
@@ -156,10 +155,10 @@ func ListTransactionMatchesHandler(svc *service.Service) http.HandlerFunc {
 		matches, err := svc.ListTransactionMatches(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Account link not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list matches")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list matches")
 			return
 		}
 		writeData(w, matches)
@@ -172,10 +171,10 @@ func ConfirmMatchHandler(svc *service.Service) http.HandlerFunc {
 		id := chi.URLParam(r, "id")
 		if err := svc.ConfirmMatch(r.Context(), id); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Match not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Match not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to confirm match")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to confirm match")
 			return
 		}
 		writeData(w, map[string]string{"status": "confirmed"})
@@ -188,10 +187,10 @@ func RejectMatchHandler(svc *service.Service) http.HandlerFunc {
 		id := chi.URLParam(r, "id")
 		if err := svc.RejectMatch(r.Context(), id); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Match not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Match not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reject match")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reject match")
 			return
 		}
 		writeData(w, map[string]string{"status": "rejected"})
@@ -207,26 +206,26 @@ func ManualMatchHandler(svc *service.Service) http.HandlerFunc {
 			DependentTransactionID string `json:"dependent_transaction_id"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
 		if input.LinkID == "" || input.PrimaryTransactionID == "" || input.DependentTransactionID == "" {
-			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "link_id, primary_transaction_id, and dependent_transaction_id are required")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "link_id, primary_transaction_id, and dependent_transaction_id are required")
 			return
 		}
 
 		match, err := svc.ManualMatch(r.Context(), input.LinkID, input.PrimaryTransactionID, input.DependentTransactionID)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
+				writeError(w, http.StatusNotFound, "NOT_FOUND", err.Error())
 				return
 			}
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create match")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create match")
 			return
 		}
 

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -21,7 +20,7 @@ func ListAccountsHandler(svc *service.Service) http.HandlerFunc {
 
 		accounts, err := svc.ListAccounts(r.Context(), userIDPtr)
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list accounts")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list accounts")
 			return
 		}
 
@@ -37,10 +36,10 @@ func GetAccountHandler(svc *service.Service) http.HandlerFunc {
 		account, err := svc.GetAccount(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Account not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get account")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get account")
 			return
 		}
 

--- a/internal/api/categories.go
+++ b/internal/api/categories.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -16,7 +15,7 @@ func ListCategoriesHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		categories, err := svc.ListCategoryTree(r.Context())
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list categories")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list categories")
 			return
 		}
 		writeData(w, categories)
@@ -31,10 +30,10 @@ func GetCategoryHandler(svc *service.Service) http.HandlerFunc {
 		category, err := svc.GetCategory(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrCategoryNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get category")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get category")
 			return
 		}
 
@@ -56,12 +55,12 @@ func CreateCategoryHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var input createCategoryRequest
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
 			return
 		}
 
 		if input.DisplayName == "" {
-			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "display_name is required")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "display_name is required")
 			return
 		}
 
@@ -75,10 +74,10 @@ func CreateCategoryHandler(svc *service.Service) http.HandlerFunc {
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrSlugConflict) {
-				mw.WriteError(w, http.StatusConflict, "SLUG_CONFLICT", "A category with this slug already exists")
+				writeError(w, http.StatusConflict, "SLUG_CONFLICT", "A category with this slug already exists")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create category")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create category")
 			return
 		}
 
@@ -101,12 +100,12 @@ func UpdateCategoryHandler(svc *service.Service) http.HandlerFunc {
 
 		var input updateCategoryRequest
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
 			return
 		}
 
 		if input.DisplayName == "" {
-			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "display_name is required")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "display_name is required")
 			return
 		}
 
@@ -119,10 +118,10 @@ func UpdateCategoryHandler(svc *service.Service) http.HandlerFunc {
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrCategoryNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update category")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update category")
 			return
 		}
 
@@ -138,14 +137,14 @@ func DeleteCategoryHandler(svc *service.Service) http.HandlerFunc {
 		affected, err := svc.DeleteCategory(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrCategoryNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
 				return
 			}
 			if errors.Is(err, service.ErrCategoryUndeletable) {
-				mw.WriteError(w, http.StatusConflict, "CATEGORY_UNDELETABLE", "This category cannot be deleted")
+				writeError(w, http.StatusConflict, "CATEGORY_UNDELETABLE", "This category cannot be deleted")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete category")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete category")
 			return
 		}
 
@@ -164,26 +163,26 @@ func MergeCategoriesHandler(svc *service.Service) http.HandlerFunc {
 
 		var input mergeCategoriesRequest
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_JSON", "Invalid JSON body")
 			return
 		}
 
 		if input.TargetID == "" {
-			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "target_id is required")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "target_id is required")
 			return
 		}
 
 		err := svc.MergeCategories(r.Context(), id, input.TargetID)
 		if err != nil {
 			if errors.Is(err, service.ErrCategoryNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
 				return
 			}
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+				writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to merge categories")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to merge categories")
 			return
 		}
 

--- a/internal/api/category_bulk.go
+++ b/internal/api/category_bulk.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"net/http"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 )
 
@@ -13,7 +12,7 @@ func ExportCategoriesTSVHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		tsv, err := svc.ExportCategoriesTSV(r.Context())
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to export categories")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to export categories")
 			return
 		}
 		w.Header().Set("Content-Type", "text/tab-separated-values")
@@ -27,11 +26,11 @@ func ImportCategoriesTSVHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Failed to read request body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Failed to read request body")
 			return
 		}
 		if len(body) == 0 {
-			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Request body is empty")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Request body is empty")
 			return
 		}
 
@@ -39,7 +38,7 @@ func ImportCategoriesTSVHandler(svc *service.Service) http.HandlerFunc {
 
 		result, err := svc.ImportCategoriesTSV(r.Context(), string(body), replaceMode)
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "IMPORT_ERROR", err.Error())
+			writeError(w, http.StatusBadRequest, "IMPORT_ERROR", err.Error())
 			return
 		}
 		writeData(w, result)

--- a/internal/api/comments.go
+++ b/internal/api/comments.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strings"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -20,10 +19,10 @@ func ListCommentsHandler(svc *service.Service) http.HandlerFunc {
 		comments, err := svc.ListComments(r.Context(), txnID)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list comments")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list comments")
 			return
 		}
 
@@ -40,7 +39,7 @@ func CreateCommentHandler(svc *service.Service) http.HandlerFunc {
 			Content string `json:"content"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
@@ -53,14 +52,14 @@ func CreateCommentHandler(svc *service.Service) http.HandlerFunc {
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
 			}
 			if strings.Contains(err.Error(), "content must be") {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create comment")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create comment")
 			return
 		}
 
@@ -77,7 +76,7 @@ func UpdateCommentHandler(svc *service.Service) http.HandlerFunc {
 			Content string `json:"content"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
@@ -89,18 +88,18 @@ func UpdateCommentHandler(svc *service.Service) http.HandlerFunc {
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Comment not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Comment not found")
 				return
 			}
 			if errors.Is(err, service.ErrForbidden) {
-				mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "You can only edit your own comments")
+				writeError(w, http.StatusForbidden, "FORBIDDEN", "You can only edit your own comments")
 				return
 			}
 			if strings.Contains(err.Error(), "content must be") {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update comment")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update comment")
 			return
 		}
 
@@ -116,14 +115,14 @@ func DeleteCommentHandler(svc *service.Service) http.HandlerFunc {
 
 		if err := svc.DeleteComment(r.Context(), commentID, actor); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Comment not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Comment not found")
 				return
 			}
 			if errors.Is(err, service.ErrForbidden) {
-				mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "You can only delete your own comments")
+				writeError(w, http.StatusForbidden, "FORBIDDEN", "You can only delete your own comments")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete comment")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete comment")
 			return
 		}
 

--- a/internal/api/connections.go
+++ b/internal/api/connections.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"net/http"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -21,7 +20,7 @@ func ListConnectionsHandler(svc *service.Service) http.HandlerFunc {
 
 		connections, err := svc.ListConnections(r.Context(), userIDPtr)
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list connections")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list connections")
 			return
 		}
 
@@ -37,10 +36,10 @@ func GetConnectionStatusHandler(svc *service.Service) http.HandlerFunc {
 		status, err := svc.GetConnectionStatus(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get connection status")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get connection status")
 			return
 		}
 

--- a/internal/api/reports.go
+++ b/internal/api/reports.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -15,7 +14,7 @@ func ListReportsHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		reports, err := svc.ListAgentReports(r.Context(), 50)
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list reports")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list reports")
 			return
 		}
 		writeData(w, reports)
@@ -27,7 +26,7 @@ func UnreadReportCountHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		count, err := svc.CountUnreadAgentReports(r.Context())
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to count unread reports")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to count unread reports")
 			return
 		}
 		writeData(w, map[string]int64{"unread_count": count})
@@ -45,14 +44,14 @@ func CreateReportHandler(svc *service.Service) http.HandlerFunc {
 			Author   string   `json:"author"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid JSON body")
 			return
 		}
 
 		actor := service.ActorFromContext(r.Context())
 		report, err := svc.CreateAgentReport(r.Context(), req.Title, req.Body, actor, req.Priority, req.Tags, req.Author, "")
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
@@ -65,7 +64,7 @@ func MarkReportReadHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		if err := svc.MarkAgentReportRead(r.Context(), id); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 		writeData(w, map[string]bool{"ok": true})

--- a/internal/api/response.go
+++ b/internal/api/response.go
@@ -3,6 +3,8 @@ package api
 import (
 	"encoding/json"
 	"net/http"
+
+	mw "breadbox/internal/middleware"
 )
 
 // writeJSON writes v as JSON with the given HTTP status code.
@@ -15,4 +17,11 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 // writeData writes v as JSON with HTTP 200 OK.
 func writeData(w http.ResponseWriter, v any) {
 	writeJSON(w, http.StatusOK, v)
+}
+
+// writeError writes the standard JSON error envelope with the given HTTP
+// status code. Thin wrapper around middleware.WriteError so handlers don't
+// need to import the middleware package just to emit error responses.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	mw.WriteError(w, status, code, message)
 }

--- a/internal/api/rules.go
+++ b/internal/api/rules.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -18,13 +17,13 @@ func ListRulesHandler(svc *service.Service) http.HandlerFunc {
 
 		limit, err := parseIntParam(q, "limit", 50, 1, 500)
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
 		enabled, err := parseBoolParam(q, "enabled")
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
@@ -39,10 +38,10 @@ func ListRulesHandler(svc *service.Service) http.HandlerFunc {
 		result, err := svc.ListTransactionRules(r.Context(), params)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidCursor) {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid cursor")
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid cursor")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list rules")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list rules")
 			return
 		}
 
@@ -67,16 +66,16 @@ func CreateRuleHandler(svc *service.Service) http.HandlerFunc {
 			ExpiresIn string `json:"expires_in"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
 		if input.Name == "" {
-			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "name is required")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "name is required")
 			return
 		}
 		if len(input.Actions) == 0 && input.CategorySlug == "" {
-			mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "either actions or category_slug is required")
+			writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "either actions or category_slug is required")
 			return
 		}
 
@@ -99,14 +98,14 @@ func CreateRuleHandler(svc *service.Service) http.HandlerFunc {
 		rule, err := svc.CreateTransactionRule(r.Context(), params)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+				writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
 				return
 			}
 			if errors.Is(err, service.ErrCategoryNotFound) {
-				mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Category not found")
+				writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "Category not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create rule")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create rule")
 			return
 		}
 
@@ -122,10 +121,10 @@ func GetRuleHandler(svc *service.Service) http.HandlerFunc {
 		rule, err := svc.GetTransactionRule(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Rule not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Rule not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get rule")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get rule")
 			return
 		}
 
@@ -151,7 +150,7 @@ func UpdateRuleHandler(svc *service.Service) http.HandlerFunc {
 			ExpiresAt *string `json:"expires_at,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
@@ -168,14 +167,14 @@ func UpdateRuleHandler(svc *service.Service) http.HandlerFunc {
 		})
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Rule not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Rule not found")
 				return
 			}
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+				writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update rule")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update rule")
 			return
 		}
 
@@ -190,10 +189,10 @@ func DeleteRuleHandler(svc *service.Service) http.HandlerFunc {
 
 		if err := svc.DeleteTransactionRule(r.Context(), id); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Rule not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Rule not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete rule")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete rule")
 			return
 		}
 
@@ -209,14 +208,14 @@ func ApplyRuleHandler(svc *service.Service) http.HandlerFunc {
 		count, err := svc.ApplyRuleRetroactively(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Rule not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Rule not found")
 				return
 			}
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+				writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to apply rule")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to apply rule")
 			return
 		}
 
@@ -232,7 +231,7 @@ func ApplyAllRulesHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		results, err := svc.ApplyAllRulesRetroactively(r.Context())
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to apply rules")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to apply rules")
 			return
 		}
 
@@ -256,17 +255,17 @@ func PreviewRuleHandler(svc *service.Service) http.HandlerFunc {
 			SampleSize int               `json:"sample_size"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
 		result, err := svc.PreviewRule(r.Context(), input.Conditions, input.SampleSize)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+				writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to preview rule")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to preview rule")
 			return
 		}
 

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 )
 
@@ -19,7 +18,7 @@ func TriggerSyncHandler(svc *service.Service) http.HandlerFunc {
 				ConnectionID *string `json:"connection_id"`
 			}
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+				writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 				return
 			}
 			connectionID = body.ConnectionID
@@ -27,10 +26,10 @@ func TriggerSyncHandler(svc *service.Service) http.HandlerFunc {
 
 		if err := svc.TriggerSync(r.Context(), connectionID); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to trigger sync")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to trigger sync")
 			return
 		}
 

--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -30,18 +29,18 @@ func parseTransactionFilters(w http.ResponseWriter, r *http.Request) (
 
 	startDate, err = parseDateParam(q, "start_date")
 	if err != nil {
-		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
 	endDate, err = parseDateParam(q, "end_date")
 	if err != nil {
-		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
 	if startDate != nil && endDate != nil && !startDate.Before(*endDate) {
-		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "start_date must be before end_date")
+		writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "start_date must be before end_date")
 		return
 	}
 
@@ -51,36 +50,36 @@ func parseTransactionFilters(w http.ResponseWriter, r *http.Request) (
 
 	minAmount, err = parseFloatParam(q, "min_amount")
 	if err != nil {
-		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
 	maxAmount, err = parseFloatParam(q, "max_amount")
 	if err != nil {
-		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
 	if minAmount != nil && maxAmount != nil && *minAmount > *maxAmount {
-		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "min_amount must be less than or equal to max_amount")
+		writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "min_amount must be less than or equal to max_amount")
 		return
 	}
 
 	pending, err = parseBoolParam(q, "pending")
 	if err != nil {
-		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
 	search, err = parseMinLengthStringParam(q, "search", 2)
 	if err != nil {
-		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
 	if v := q.Get("search_mode"); v != "" {
 		if !service.ValidateSearchMode(v) {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "search_mode must be one of: contains, words, fuzzy")
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "search_mode must be one of: contains, words, fuzzy")
 			return
 		}
 		searchMode = &v
@@ -88,7 +87,7 @@ func parseTransactionFilters(w http.ResponseWriter, r *http.Request) (
 
 	excludeSearch, err = parseMinLengthStringParam(q, "exclude_search", 2)
 	if err != nil {
-		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+		writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
@@ -103,7 +102,7 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 
 		limit, err := parseIntParam(q, "limit", 100, 1, 500)
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
@@ -115,7 +114,7 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 		// Parse sort_by.
 		sortBy, err := parseEnumParam(q, "sort_by", []string{"date", "amount", "name"})
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
@@ -126,7 +125,7 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			case "asc", "desc":
 				sortOrder = &v
 			default:
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "sort_order must be asc or desc")
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "sort_order must be asc or desc")
 				return
 			}
 		}
@@ -152,17 +151,17 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 		// Parse fields for field selection.
 		fieldSet, err := service.ParseFields(q.Get("fields"))
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_FIELDS", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_FIELDS", err.Error())
 			return
 		}
 
 		result, err := svc.ListTransactions(r.Context(), params)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidCursor) {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_CURSOR", "The provided cursor is not valid")
+				writeError(w, http.StatusBadRequest, "INVALID_CURSOR", "The provided cursor is not valid")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list transactions")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list transactions")
 			return
 		}
 
@@ -208,7 +207,7 @@ func CountTransactionsHandler(svc *service.Service) http.HandlerFunc {
 
 		count, err := svc.CountTransactionsFiltered(r.Context(), params)
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to count transactions")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to count transactions")
 			return
 		}
 
@@ -223,17 +222,17 @@ func GetTransactionHandler(svc *service.Service) http.HandlerFunc {
 
 		fieldSet, err := service.ParseFields(r.URL.Query().Get("fields"))
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_FIELDS", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_FIELDS", err.Error())
 			return
 		}
 
 		txn, err := svc.GetTransaction(r.Context(), id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get transaction")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get transaction")
 			return
 		}
 
@@ -253,7 +252,7 @@ func TransactionSummaryHandler(svc *service.Service) http.HandlerFunc {
 
 		groupBy := q.Get("group_by")
 		if groupBy == "" {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "group_by is required (category, month, week, day, category_month)")
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "group_by is required (category, month, week, day, category_month)")
 			return
 		}
 
@@ -264,13 +263,13 @@ func TransactionSummaryHandler(svc *service.Service) http.HandlerFunc {
 		var err error
 		params.StartDate, err = parseDateParam(q, "start_date")
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
 		params.EndDate, err = parseDateParam(q, "end_date")
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
@@ -287,10 +286,10 @@ func TransactionSummaryHandler(svc *service.Service) http.HandlerFunc {
 		result, err := svc.GetTransactionSummary(r.Context(), params)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get transaction summary")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get transaction summary")
 			return
 		}
 
@@ -309,13 +308,13 @@ func MerchantSummaryHandler(svc *service.Service) http.HandlerFunc {
 
 		params.StartDate, err = parseDateParam(q, "start_date")
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
 		params.EndDate, err = parseDateParam(q, "end_date")
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
@@ -325,24 +324,24 @@ func MerchantSummaryHandler(svc *service.Service) http.HandlerFunc {
 
 		params.MinAmount, err = parseFloatParam(q, "min_amount")
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
 		params.MaxAmount, err = parseFloatParam(q, "max_amount")
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
 		params.Search, err = parseMinLengthStringParam(q, "search", 2)
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 		if v := q.Get("search_mode"); v != "" {
 			if !service.ValidateSearchMode(v) {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "search_mode must be one of: contains, words, fuzzy")
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "search_mode must be one of: contains, words, fuzzy")
 				return
 			}
 			params.SearchMode = &v
@@ -350,14 +349,14 @@ func MerchantSummaryHandler(svc *service.Service) http.HandlerFunc {
 
 		params.ExcludeSearch, err = parseMinLengthStringParam(q, "exclude_search", 2)
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
 		if v := q.Get("min_count"); v != "" {
 			n, parseErr := strconv.Atoi(v)
 			if parseErr != nil || n < 1 {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "min_count must be a positive integer")
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "min_count must be a positive integer")
 				return
 			}
 			params.MinCount = n
@@ -370,10 +369,10 @@ func MerchantSummaryHandler(svc *service.Service) http.HandlerFunc {
 		result, err := svc.GetMerchantSummary(r.Context(), params)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get merchant summary")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to get merchant summary")
 			return
 		}
 
@@ -390,23 +389,23 @@ func SetTransactionCategoryHandler(svc *service.Service) http.HandlerFunc {
 			CategoryID string `json:"category_id"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 		if input.CategoryID == "" {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "category_id is required")
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "category_id is required")
 			return
 		}
 		if err := svc.SetTransactionCategory(r.Context(), id, input.CategoryID); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
 			}
 			if errors.Is(err, service.ErrCategoryNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
+				writeError(w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to set transaction category")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to set transaction category")
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -420,10 +419,10 @@ func ResetTransactionCategoryHandler(svc *service.Service) http.HandlerFunc {
 		id := chi.URLParam(r, "id")
 		if err := svc.ResetTransactionCategory(r.Context(), id); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reset transaction category")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to reset transaction category")
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
@@ -437,17 +436,17 @@ func BatchCategorizeHandler(svc *service.Service) http.HandlerFunc {
 			Items []service.BatchCategorizeItem `json:"items"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
 		result, err := svc.BatchSetTransactionCategory(r.Context(), input.Items)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to batch categorize transactions")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to batch categorize transactions")
 			return
 		}
 
@@ -472,12 +471,12 @@ func BulkRecategorizeHandler(svc *service.Service) http.HandlerFunc {
 			NameContains       string   `json:"name_contains"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			writeError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
 			return
 		}
 
 		if input.TargetCategorySlug == "" {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "target_category_slug is required")
+			writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "target_category_slug is required")
 			return
 		}
 
@@ -491,7 +490,7 @@ func BulkRecategorizeHandler(svc *service.Service) http.HandlerFunc {
 		if input.StartDate != "" {
 			t, err := time.Parse("2006-01-02", input.StartDate)
 			if err != nil {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid start_date format")
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid start_date format")
 				return
 			}
 			params.StartDate = &t
@@ -499,7 +498,7 @@ func BulkRecategorizeHandler(svc *service.Service) http.HandlerFunc {
 		if input.EndDate != "" {
 			t, err := time.Parse("2006-01-02", input.EndDate)
 			if err != nil {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid end_date format")
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", "invalid end_date format")
 				return
 			}
 			params.EndDate = &t
@@ -523,14 +522,14 @@ func BulkRecategorizeHandler(svc *service.Service) http.HandlerFunc {
 		result, err := svc.BulkRecategorizeByFilter(r.Context(), params)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				writeError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 				return
 			}
 			if errors.Is(err, service.ErrCategoryNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "CATEGORY_NOT_FOUND", err.Error())
+				writeError(w, http.StatusNotFound, "CATEGORY_NOT_FOUND", err.Error())
 				return
 			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to bulk recategorize transactions")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to bulk recategorize transactions")
 			return
 		}
 

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -3,7 +3,6 @@ package api
 import (
 	"net/http"
 
-	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 )
 
@@ -12,7 +11,7 @@ func ListUsersHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		users, err := svc.ListUsers(r.Context())
 		if err != nil {
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list users")
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list users")
 			return
 		}
 


### PR DESCRIPTION
## Summary

- The `api.md` rule instructs handlers to "use `internal/api/response.go` helpers (`writeError`, `writeJSON`)" — but `writeError` never existed. Handlers reached into `middleware.WriteError` directly, forcing every handler file to import the middleware package just to emit the standard error envelope.
- Add a thin `writeError` wrapper in `response.go` and migrate the 152 call sites across 10 handler files to use it. Handler files that only imported middleware for `WriteError` drop the import entirely; `router.go` and the integration test still need middleware for auth/logging and keep it.
- No behavior change — `writeError` delegates to `middleware.WriteError`. The JSON error envelope, codes, and HTTP statuses are identical.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all unit tests pass
- [x] \`DATABASE_URL=... go test -tags integration -p 1 ./internal/api/...\` — all API integration tests pass
- [x] \`grep "mw\\." internal/api/\` shows only legitimate middleware uses remain (auth, logging, \`ErrorResponse\` in test assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)