### PR TITLE
refactor(admin): consolidate JSON body decoding into decodeJSON helper

### DIFF
--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -168,8 +168,7 @@ func CreateCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 			Color       *string `json:"color"`
 			SortOrder   int32   `json:"sort_order"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 		req.DisplayName = strings.TrimSpace(req.DisplayName)
@@ -204,8 +203,7 @@ func UpdateCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 			SortOrder   int32   `json:"sort_order"`
 			Hidden      bool    `json:"hidden"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 		req.DisplayName = strings.TrimSpace(req.DisplayName)
@@ -249,8 +247,7 @@ func MergeCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 		var req struct {
 			TargetID string `json:"target_id"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 		if req.TargetID == "" {
@@ -289,8 +286,7 @@ func SetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 		var req struct {
 			CategoryID string `json:"category_id"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 		if req.CategoryID == "" {
@@ -339,8 +335,7 @@ func BatchSetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerF
 				CategoryID    string `json:"category_id"`
 			} `json:"items"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 		if len(req.Items) == 0 {

--- a/internal/admin/response.go
+++ b/internal/admin/response.go
@@ -20,3 +20,14 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 func writeError(w http.ResponseWriter, status int, code, message string) {
 	mw.WriteError(w, status, code, message)
 }
+
+// decodeJSON decodes the JSON request body into v. On failure it writes a
+// standard 400 INVALID_REQUEST error envelope and returns false; callers should
+// return immediately when this returns false.
+func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return false
+	}
+	return true
+}

--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -95,8 +95,7 @@ func CreateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Icon        *string `json:"icon"`
 			Lifecycle   string  `json:"lifecycle"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 		req.Slug = strings.TrimSpace(req.Slug)
@@ -133,8 +132,7 @@ func UpdateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Icon        *string `json:"icon"`
 			Lifecycle   *string `json:"lifecycle"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 		result, err := svc.UpdateTag(r.Context(), id, service.UpdateTagParams{


### PR DESCRIPTION
## Summary

- Mirrors the `api` package refactor from #459: adds a shared `decodeJSON` helper to `internal/admin/response.go`.
- Replaces 7 inline `json.NewDecoder(r.Body).Decode(&req)` + `writeError(...)` sites across `categories.go` (5) and `tags.go` (2) with the helper.
- Leaves the legacy `{\"error\":\"...\"}` admin responses alone — those are consumed by template JS that expects a string payload, so unifying them is a larger, riskier change.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/admin/...` green
- [x] No behavior change: helper returns the same canonical error envelope the replaced call sites already produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)