### PR TITLE
chore(settings): allowlist read-only MCP tools and shared gh writes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,26 @@
   "enabledPlugins": {
     "mcp-server-dev@claude-plugins-official": true
   },
+  "permissions": {
+    "allow": [
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__take_screenshot",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__navigate_page",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__resize_page",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__wait_for",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__list_pages",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__take_snapshot",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__new_page",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__close_page",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__list_console_messages",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__list_network_requests",
+      "mcp__claude-in-chrome__navigate",
+      "mcp__claude-in-chrome__resize_window",
+      "mcp__claude-in-chrome__tabs_context_mcp",
+      "Bash(staticcheck *)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)"
+    ]
+  },
   "sandbox": {
     "enabled": true,
     "autoAllowBashIfSandboxed": true,


### PR DESCRIPTION
## Summary
- Add chrome-devtools-mcp and claude-in-chrome read/navigation tools to `.claude/settings.json` so they stop prompting across subagents
- Promote `Bash(gh pr:*)` and `Bash(gh issue:*)` from `.local.json` to shared settings (subagents don't inherit `.local.json`)
- Allowlist `Bash(staticcheck *)` for Go static analysis runs

Driven by scanning the 50 most-recent transcripts for high-frequency tool calls that were read-only/safe but still prompting.

## Test plan
- [ ] New session should no longer prompt for browser screenshots/navigation or `gh pr create`