### PR TITLE
docs(ui): document templ component workflow (#462)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,10 @@ Go 1.24+ single binary. PostgreSQL, chi/v5, pgx/v5 + sqlc, goose migrations, rob
 
 One HTTP server (`breadbox serve`) hosts everything: REST API (`/api/v1/...`), MCP, admin dashboard, webhooks (`/webhooks/:provider`). Bank providers are abstracted behind the `internal/provider.Provider` interface.
 
+### Templ components
+
+New admin UI pieces are authored as [`a-h/templ`](https://templ.guide) components under `internal/templates/components/*.templ` — type-safe Go that compiles to generated `*_templ.go` siblings (commit both). Existing `html/template` pages continue to work during the migration (#462) and can embed templ components via the `renderComponent` funcMap bridge. Run `templ generate` after editing a `.templ` file; `make generate` and `make dev-watch` do it automatically once the #462 infrastructure lands. Run `templ fmt .` before committing. Details in `docs/design-system.md`.
+
 ## Codebase Map
 
 - `internal/service/` — shared service layer. REST handlers and MCP tools call into here (no HTTP round-trip for MCP). Converts `pgtype.*` → Go primitives. See `.claude/rules/service.md`.

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -4,6 +4,8 @@
 
 The Breadbox admin dashboard uses **DaisyUI 5 + Tailwind CSS v4** with **Alpine.js v3** for interactivity. DaisyUI provides semantic component classes (drawer, table, badge, menu, modal) with built-in dark mode.
 
+**Component authoring:** new UI pieces are written as [`a-h/templ`](https://templ.guide) components in `internal/templates/components/*.templ` — this is the target pattern going forward (issue #462). Existing `html/template` pages and partials continue to work during the migration and can call templ components via the `renderComponent` funcMap bridge. See §13 below for the workflow.
+
 **Constraints:**
 - No Node.js, no npm, no bundler — uses `tailwindcss-extra` standalone binary
 - Single `make css` build step (like `sqlc generate` or `go generate`)
@@ -724,3 +726,48 @@ Flash messages (`partials/flash.html`) and inline alerts follow the same pattern
 ```
 
 Always pair with an `alert-circle` icon so the error reads at a glance. This is the canonical pattern for inline Alpine-driven form validation errors.
+
+## 13. Templ Components
+
+Admin UI is migrating from `html/template` to [`a-h/templ`](https://templ.guide) (issue #462). Both coexist during the migration — don't rewrite a whole page to templ unless the migration plan calls for it.
+
+### Where components live
+
+`internal/templates/components/*.templ` — one component per file, named in `PascalCase`. Each `.templ` file produces a generated `*_templ.go` sibling; commit both.
+
+### Generating Go from `.templ`
+
+```
+templ generate      # regenerates all *_templ.go in the repo
+```
+
+`make generate` and `make dev-watch` invoke `templ generate` automatically (once the #462 infrastructure lands). If you edit a `.templ` file by hand, re-run generation before `go build` — the Go compiler only sees the generated files.
+
+Install the CLI with `go install github.com/a-h/templ/cmd/templ@latest` if it's missing from `$PATH`.
+
+### Dev-reload interaction
+
+`make dev-watch` rebuilds the Go binary on `.templ` changes via **air** — the generated `*_templ.go` files are part of the Go build graph, so a save triggers a ~1–2s restart, not the HTML-from-disk fast path used for `.html` edits. `BREADBOX_DEV_RELOAD=1` does **not** re-read templ components from disk; they're compiled in.
+
+If you're iterating rapidly on a templ component, expect a Go restart per save. Prefer `.html` for pure markup tweaks during the migration if restart latency matters.
+
+### Calling templ components from `.html` pages
+
+`.html` templates bridge to templ via the `renderComponent` funcMap helper. Register a component once in the bridge (see `internal/templates/components/bridge.go`) and call it from any `.html` block:
+
+```html
+{{renderComponent "StatusBadge" .Connection.Status}}
+```
+
+The helper invokes the component's `Render(ctx, w)` and returns `template.HTML` so the output isn't re-escaped. Pass simple Go values — the bridge signature is fixed per component.
+
+### Adding a new component
+
+1. Copy an existing component (e.g. `status_badge.templ`) — mirrors package, imports, and signature conventions.
+2. Edit the markup and params, then run `templ generate`.
+3. If the component will be called from a `.html` page, add an entry to the `renderComponent` bridge. Pure templ-to-templ calls don't need a bridge entry.
+4. `go build ./...` to confirm the generated code compiles.
+
+### `templ fmt`
+
+Run `templ fmt .` before committing — it normalizes whitespace and attribute order in `.templ` files. CI may enforce this. Many editors have a templ LSP that formats on save.


### PR DESCRIPTION
## Summary

- Add a **Templ components** subsection under Stack in `CLAUDE.md` with a one-paragraph orientation (where components live, generate/fmt commands, bridge, pointer to details).
- Add **§13 Templ Components** to `docs/design-system.md` covering: component location, `templ generate`, dev-reload interaction with air, the `renderComponent` funcMap bridge for calling templ from `.html` pages (with a snippet), steps to add a new component, and the `templ fmt` convention.
- Add a brief Overview note in `docs/design-system.md` flagging templ as the target pattern and linking to §13.

No code changes. This PR accompanies the #462 migration effort so workers have a single source of truth.

## Notes

- The task brief also called for appending a Templ section to `.claude/rules/ui.md`, but edits to that file were blocked in this harness across multiple attempts. The full workflow content was put in `docs/design-system.md` §13 instead (stable, discoverable, already the canonical design-system home). If `.claude/rules/ui.md` should mirror it, a follow-up PR can copy §13 across.
- Docs describe `templ generate` being wired into `make generate` / `make dev-watch` as happening "once the #462 infrastructure lands" — no Makefile/go.mod assumptions are baked in.
- Minor doc conflicts possible if other #462 workers also touch `CLAUDE.md` / `docs/design-system.md`; rebase should be trivial.

## Test plan

- [x] `git diff` — docs-only, two files changed, +51 lines
- [x] Proofread — no broken internal links, consistent voice with surrounding sections
- [x] `go build ./...` — only pre-existing `service/reports.go:167` error on `main` (unrelated)
- [ ] No e2e (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)