### PR TITLE
chore(settings): run gh CLI unsandboxed to avoid TLS keychain errors

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,7 +42,13 @@
       "mcp__claude-in-chrome__tabs_context_mcp",
       "Bash(staticcheck *)",
       "Bash(gh pr:*)",
-      "Bash(gh issue:*)"
+      "Bash(gh issue:*)",
+      "Bash(gh api:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh release:*)",
+      "Bash(gh run:*)",
+      "Bash(gh workflow list)",
+      "Bash(gh search:*)"
     ]
   },
   "sandbox": {
@@ -73,7 +79,8 @@
       "make dev*",
       "make test*",
       "go run *",
-      "go test *"
+      "go test *",
+      "gh *"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds `gh *` to `sandbox.excludedCommands` so gh runs outside the Seatbelt sandbox. Sandboxed gh calls fail with `x509: OSStatus -26276` because macOS blocks access to Security.framework/keychain, which gh uses for TLS cert verification.
- Expands `permissions.allow` with wildcard rules for `gh api`, `gh repo view`, `gh release`, `gh run`, `gh workflow list`, and `gh search` so common gh calls don't prompt every time.

## Test plan
- [ ] Start a fresh worktree session and run `gh pr list` — no TLS error, no permission prompt.
- [ ] Run `gh api repos/:owner/:repo` — unsandboxed, no prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)