### PR TITLE
refactor(admin): migrate flash partial to templ (#462)

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -49,6 +49,19 @@ func renderTemplComponent(name string, data any) template.HTML {
 			}
 		}
 		c = components.TxRow(tx)
+	case "Flash":
+		f, ok := data.(*Flash)
+		if !ok {
+			if v, ok := data.(Flash); ok {
+				f = &v
+			} else {
+				return template.HTML(fmt.Sprintf("<!-- renderComponent(%q): want *admin.Flash, got %T -->", name, data))
+			}
+		}
+		if f == nil {
+			return ""
+		}
+		c = components.Flash(f.Type, f.Message)
 	default:
 		return template.HTML(fmt.Sprintf("<!-- renderComponent(%q): unknown -->", name))
 	}

--- a/internal/templates/components/flash.templ
+++ b/internal/templates/components/flash.templ
@@ -1,0 +1,22 @@
+package components
+
+// Flash renders a one-time banner shown after a redirect.
+// Callers pass the type ("success", "error", anything else → "info") and
+// the human-readable message. The caller is responsible for the nil check
+// (the html/template facade short-circuits when .Flash is nil).
+templ Flash(flashType, message string) {
+	<div role="alert" class={ "alert", flashClass(flashType), "rounded-xl", "mb-6" }>
+		<span>{ message }</span>
+	</div>
+}
+
+func flashClass(t string) string {
+	switch t {
+	case "success":
+		return "alert-success"
+	case "error":
+		return "alert-error"
+	default:
+		return "alert-info"
+	}
+}

--- a/internal/templates/partials/flash.html
+++ b/internal/templates/partials/flash.html
@@ -1,7 +1,8 @@
-{{define "flash"}}
-{{if .Flash}}
-<div role="alert" class="alert {{if eq .Flash.Type "success"}}alert-success{{else if eq .Flash.Type "error"}}alert-error{{else}}alert-info{{end}} rounded-xl mb-6">
-  <span>{{.Flash.Message}}</span>
-</div>
-{{end}}
-{{end}}
+{{/*
+  Thin html/template facade around the templ component in
+  internal/templates/components/flash.templ. base.html + wizard.html call
+  {{template "flash" .}} with the full layout data; we short-circuit when
+  .Flash is nil so the component can accept a non-nil value directly.
+  See issue #462 for migration context.
+*/}}
+{{define "flash"}}{{if .Flash}}{{renderComponent "Flash" .Flash}}{{end}}{{end}}


### PR DESCRIPTION
## Summary
- Port `partials/flash.html` to `components/flash.templ` as a 2-arg templ component (`flashType`, `message`).
- Keep `partials/flash.html` as a one-line facade so every `{{template "flash" .}}` caller in `base.html` / `wizard.html` keeps working untouched.
- Extend the existing `renderTemplComponent` bridge in `internal/admin/templates.go` with a `"Flash"` case.

## Why
Follow-up to the #462 foundation (#473). Picks up the flash migration that was originally scoped in the first parallel batch but then closed in favor of the serial strategy.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] Ran dev server on :8084, logged in as admin@example.com, POSTed a mismatched password change via `/my-account/password`, confirmed the redirected `/my-account` page rendered `<div role="alert" class="alert alert-error rounded-xl mb-6"><span>New passwords do not match.</span></div>` from the templ component
- [ ] Visual screenshot — skipped; component diff is trivial and covered by the HTML check above

🤖 Generated with [Claude Code](https://claude.com/claude-code)