### PR TITLE
refactor(service): consolidate duration formatting helper

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -894,7 +894,7 @@ func SyncConnectionStatusHandler(a *app.App) http.HandlerFunc {
 		}
 		if hasDuration {
 			resp["duration_ms"] = durationMs
-			resp["duration_label"] = formatSyncStatusDuration(durationMs)
+			resp["duration_label"] = service.FormatDurationMs(int64(durationMs))
 		}
 		if log.ErrorMessage.Valid {
 			resp["error_message"] = log.ErrorMessage.String
@@ -1165,23 +1165,4 @@ func relativeTimeUntil(target, now time.Time) string {
 		return "in <1m"
 	}
 }
-
-// formatSyncStatusDuration mirrors the "formatDurationMs" template helper so
-// the sync-status JSON payload carries a preformatted label the client can
-// render without duplicating the formatting logic.
-func formatSyncStatusDuration(ms int32) string {
-	if ms < 1000 {
-		return fmt.Sprintf("%dms", ms)
-	}
-	if ms < 60000 {
-		return fmt.Sprintf("%.1fs", float64(ms)/1000)
-	}
-	mins := ms / 60000
-	secs := (ms % 60000) / 1000
-	if secs == 0 {
-		return fmt.Sprintf("%dm", mins)
-	}
-	return fmt.Sprintf("%dm %ds", mins, secs)
-}
-
 

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -162,7 +162,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return fmt.Sprintf("%.0fm", d.Minutes())
 			},
-			"formatDurationMs": formatSyncStatusDuration,
+			"formatDurationMs": func(ms int32) string { return service.FormatDurationMs(int64(ms)) },
 			"relativeTime": func(t interface{}) string {
 				switch v := t.(type) {
 				case time.Time:

--- a/internal/service/connections.go
+++ b/internal/service/connections.go
@@ -119,12 +119,12 @@ func (s *Service) GetConnectionStatus(ctx context.Context, id string) (*Connecti
 		}
 		if syncLog.DurationMs.Valid {
 			slResp.DurationMs = &syncLog.DurationMs.Int32
-			d := formatDurationMs(int64(syncLog.DurationMs.Int32))
+			d := FormatDurationMs(int64(syncLog.DurationMs.Int32))
 			slResp.Duration = &d
 		} else if syncLog.StartedAt.Valid && syncLog.CompletedAt.Valid {
 			ms := int32(syncLog.CompletedAt.Time.Sub(syncLog.StartedAt.Time).Milliseconds())
 			slResp.DurationMs = &ms
-			d := formatDurationMs(int64(ms))
+			d := FormatDurationMs(int64(ms))
 			slResp.Duration = &d
 		}
 		resp.LastSyncLog = &slResp

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -88,9 +88,9 @@ func connStatusPtr(s db.ConnectionStatus) *string {
 	return &str
 }
 
-// formatDurationMs converts milliseconds to a human-readable duration string.
+// FormatDurationMs converts milliseconds to a human-readable duration string.
 // Examples: 42ms, 1.2s, 2m 15s
-func formatDurationMs(ms int64) string {
+func FormatDurationMs(ms int64) string {
 	if ms < 1000 {
 		return fmt.Sprintf("%dms", ms)
 	}

--- a/internal/service/convert_test.go
+++ b/internal/service/convert_test.go
@@ -186,9 +186,9 @@ func TestFormatDurationMs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
-			got := formatDurationMs(tt.ms)
+			got := FormatDurationMs(tt.ms)
 			if got != tt.want {
-				t.Errorf("formatDurationMs(%d) = %q, want %q", tt.ms, got, tt.want)
+				t.Errorf("FormatDurationMs(%d) = %q, want %q", tt.ms, got, tt.want)
 			}
 		})
 	}

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -193,11 +193,11 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 
 		var duration *string
 		if durationMs.Valid {
-			d := formatDurationMs(int64(durationMs.Int32))
+			d := FormatDurationMs(int64(durationMs.Int32))
 			duration = &d
 		} else if startedAt.Valid && completedAt.Valid {
 			// Fallback for logs before the duration_ms column was backfilled.
-			d := formatDurationMs(completedAt.Time.Sub(startedAt.Time).Milliseconds())
+			d := FormatDurationMs(completedAt.Time.Sub(startedAt.Time).Milliseconds())
 			duration = &d
 		}
 


### PR DESCRIPTION
## Summary

- Export `service.FormatDurationMs` and remove the identical copy (`formatSyncStatusDuration`) in `internal/admin/connections.go`.
- Admin sync-status JSON payload and the `formatDurationMs` template helper now both delegate to the service-layer implementation — single source of truth, no drift risk.
- No behavior change: the formulas were already character-for-character identical (`42ms`, `1.2s`, `2m 15s`).

## Why

`internal/admin/connections.go:1169` had a verbatim copy of `internal/service/convert.go:93` with a comment explicitly flagging the duplication ("mirrors the formatDurationMs template helper"). The existing unit test in `service/convert_test.go` continues to cover the behavior for both callers.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/service/... ./internal/admin/...`

No UI surface changes — rendered duration strings are byte-for-byte identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)