### PR TITLE
refactor(admin): migrate tag_chip partial to templ (#462)

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -72,6 +72,28 @@ func renderTemplComponent(name string, data any) template.HTML {
 			}
 		}
 		c = components.TxRowCompact(tx)
+	case "TagChip", "TagChipSm":
+		var td components.TagChipData
+		switch v := data.(type) {
+		case service.TagResponse:
+			td = components.TagChipDataFromResponse(v)
+		case *service.TagResponse:
+			if v == nil {
+				return ""
+			}
+			td = components.TagChipDataFromResponse(*v)
+		case service.AdminTransactionTag:
+			td = components.TagChipDataFromTx(v)
+		case components.TagChipData:
+			td = v
+		default:
+			return template.HTML(fmt.Sprintf("<!-- renderComponent(%q): unsupported type %T -->", name, data))
+		}
+		if name == "TagChipSm" {
+			c = components.TagChipSm(td)
+		} else {
+			c = components.TagChip(td)
+		}
 	default:
 		return template.HTML(fmt.Sprintf("<!-- renderComponent(%q): unknown -->", name))
 	}

--- a/internal/templates/components/tag_chip.templ
+++ b/internal/templates/components/tag_chip.templ
@@ -2,13 +2,38 @@ package components
 
 import "breadbox/internal/service"
 
-// TagChipSm renders the compact tag chip used inside transaction rows.
-//
-// Mirrors the "tag-chip-sm" html/template partial. Styling lives in
-// input.css under .bb-tag / .bb-tag-sm.
-templ TagChipSm(tag service.AdminTransactionTag) {
+// TagChipData is the minimal shape both tag-chip variants need. Both
+// service.AdminTransactionTag (transaction rows) and service.TagResponse
+// (tags admin page) collapse to this via the two helpers below so the
+// component stays independent of the service layer's naming.
+type TagChipData struct {
+	Slug        string
+	DisplayName string
+	Color       *string
+	Icon        *string
+}
+
+func TagChipDataFromTx(t service.AdminTransactionTag) TagChipData {
+	return TagChipData{Slug: t.Slug, DisplayName: t.DisplayName, Color: t.Color, Icon: t.Icon}
+}
+
+func TagChipDataFromResponse(t service.TagResponse) TagChipData {
+	return TagChipData{Slug: t.Slug, DisplayName: t.DisplayName, Color: t.Color, Icon: t.Icon}
+}
+
+// TagChip renders the default-sized pill. Mirrors the "tag-chip" partial.
+templ TagChip(tag TagChipData) {
+	@tagChipBody("bb-tag", tag)
+}
+
+// TagChipSm renders the compact variant used inside transaction rows.
+templ TagChipSm(tag TagChipData) {
+	@tagChipBody("bb-tag bb-tag-sm", tag)
+}
+
+templ tagChipBody(class string, tag TagChipData) {
 	<span
-		class="bb-tag bb-tag-sm"
+		class={ class }
 		if tag.Color != nil {
 			style={ "--tag-color: " + deref(tag.Color) }
 		}

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -93,7 +93,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 						if len(tx.Tags) > 0 {
 							<span class="text-base-content/20 hidden xl:inline" data-tx-tag-sep>&middot;</span>
 							for _, tag := range tx.Tags {
-								@TagChipSm(tag)
+								@TagChipSm(TagChipDataFromTx(tag))
 							}
 						}
 					</span>

--- a/internal/templates/partials/tag_chip.html
+++ b/internal/templates/partials/tag_chip.html
@@ -1,25 +1,16 @@
 {{/*
-  Tag chip partials — canonical rendering for tags across the app.
-  Always pill-shaped (bb-tag) to differentiate from status badges.
-
-  Expects a tag value with .Slug, .DisplayName, .Color (*string), .Icon (*string).
-  Works with either service.TagResponse or any struct sharing those fields.
+  Tag chip partials — thin html/template facades around the templ
+  components in internal/templates/components/tag_chip.templ.
 
   Variants:
-    {{template "tag-chip"       .}}  — default size
-    {{template "tag-chip-sm"    .}}  — compact (for transaction rows / dense lists)
+    {{template "tag-chip"    .}}  — default pill (tags admin page)
+    {{template "tag-chip-sm" .}}  — compact (dense lists)
+
+  Expects any tag shape with .Slug, .DisplayName, .Color (*string), .Icon
+  (*string) — service.TagResponse and service.AdminTransactionTag both
+  match. See issue #462 for migration context.
 */}}
 
-{{define "tag-chip"}}
-<span class="bb-tag"{{if .Color}} style="--tag-color: {{safeCSS (deref .Color)}}"{{end}} title="{{.Slug}}">
-  {{if .Icon}}<i data-lucide="{{deref .Icon}}"></i>{{end}}
-  <span class="truncate">{{.DisplayName}}</span>
-</span>
-{{end}}
+{{define "tag-chip"}}{{renderComponent "TagChip" .}}{{end}}
 
-{{define "tag-chip-sm"}}
-<span class="bb-tag bb-tag-sm"{{if .Color}} style="--tag-color: {{safeCSS (deref .Color)}}"{{end}} title="{{.Slug}}">
-  {{if .Icon}}<i data-lucide="{{deref .Icon}}"></i>{{end}}
-  <span class="truncate">{{.DisplayName}}</span>
-</span>
-{{end}}
+{{define "tag-chip-sm"}}{{renderComponent "TagChipSm" .}}{{end}}


### PR DESCRIPTION
Serial follow-up to #488 (flash). #462 foundation: #473.

## Summary
- Wire the dormant `components.TagChipSm` (landed in #473 but unused) through the `renderComponent` funcMap bridge.
- Introduce `components.TagChip` (default-size) + a shared `tagChipBody` inner so both variants go through one templ function.
- Collapse `partials/tag_chip.html` to two one-line facades — all existing `{{template "tag-chip" .}}` / `{{template "tag-chip-sm" .}}` callers keep working.
- Update `components.TxRow` to pass `TagChipDataFromTx(tag)` to the new `TagChipSm(TagChipData)` signature.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] `/tags` — 5 default chips render via the bridge (correct `--tag-color`, `title="<slug>"`)
- [x] `/transactions?tags=needs-review` — 70 `.bb-tag.bb-tag-sm` chips render through `TxRow → TagChipSm`, no console errors

### Screenshots

<table>
  <tr><th><code>/tags</code></th><th><code>/transactions?tags=needs-review</code></th></tr>
  <tr>
    <td><img src="https://i.img402.dev/i35nctqczc.jpg" width="400" alt="tags page chips"></td>
    <td><img src="https://i.img402.dev/1prmy33429.jpg" width="400" alt="transactions page compact chips"></td>
  </tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)