### PR TITLE
refactor(admin): migrate breadcrumb partial to templ (#462)

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -94,6 +94,19 @@ func renderTemplComponent(name string, data any) template.HTML {
 		} else {
 			c = components.TagChip(td)
 		}
+	case "Breadcrumb":
+		crumbs, ok := data.([]Breadcrumb)
+		if !ok {
+			return template.HTML(fmt.Sprintf("<!-- renderComponent(%q): want []admin.Breadcrumb, got %T -->", name, data))
+		}
+		if len(crumbs) == 0 {
+			return ""
+		}
+		items := make([]components.Breadcrumb, len(crumbs))
+		for i, b := range crumbs {
+			items[i] = components.Breadcrumb{Label: b.Label, Href: b.Href}
+		}
+		c = components.BreadcrumbNav(items)
 	default:
 		return template.HTML(fmt.Sprintf("<!-- renderComponent(%q): unknown -->", name))
 	}

--- a/internal/templates/components/breadcrumb.templ
+++ b/internal/templates/components/breadcrumb.templ
@@ -1,0 +1,33 @@
+package components
+
+// Breadcrumb is one entry in a breadcrumb trail. An empty Href marks the
+// current page (rendered without a link). Kept in sync with
+// admin.Breadcrumb via the bridge in admin/templates.go.
+type Breadcrumb struct {
+	Label string
+	Href  string
+}
+
+// BreadcrumbNav renders a navigation breadcrumb trail. The last entry is
+// the current page (no link, bolder text). Separators are inline SVG
+// chevrons so we don't have to wait for lucide.createIcons() to run.
+templ BreadcrumbNav(items []Breadcrumb) {
+	if len(items) > 0 {
+		<nav aria-label="Breadcrumb" class="bb-breadcrumb">
+			for i, crumb := range items {
+				if i > 0 {
+					<span class="bb-breadcrumb-sep" aria-hidden="true">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"></path></svg>
+					</span>
+				}
+				if crumb.Href != "" {
+					<span class="bb-breadcrumb-item">
+						<a href={ templ.SafeURL(crumb.Href) }>{ crumb.Label }</a>
+					</span>
+				} else {
+					<span class="bb-breadcrumb-current">{ crumb.Label }</span>
+				}
+			}
+		</nav>
+	}
+}

--- a/internal/templates/partials/breadcrumb.html
+++ b/internal/templates/partials/breadcrumb.html
@@ -1,17 +1,8 @@
 {{/*
-  Breadcrumb partial — renders a clean navigation trail.
-
-  Usage: Pass .Breadcrumbs as a slice of maps with "label" and optional "href":
-    []map[string]string{{"label": "Connections", "href": "/connections"}, {"label": "Chase"}}
-
-  The last item is rendered as the current page (no link, bolder text).
-  A chevron-right SVG separator is used between items.
+  Thin html/template facade around the templ component in
+  internal/templates/components/breadcrumb.templ. Pages still call
+  {{template "breadcrumb" .}} and pass the full layout data; we
+  forward the .Breadcrumbs slice to the component. Empty slice renders
+  nothing. See issue #462 for migration context.
 */}}
-
-{{define "breadcrumb"}}
-{{if .Breadcrumbs}}
-<nav aria-label="Breadcrumb" class="bb-breadcrumb">
-  {{range $i, $crumb := .Breadcrumbs}}{{if $i}}<span class="bb-breadcrumb-sep" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg></span>{{end}}{{if $crumb.Href}}<span class="bb-breadcrumb-item"><a href="{{$crumb.Href}}">{{$crumb.Label}}</a></span>{{else}}<span class="bb-breadcrumb-current">{{$crumb.Label}}</span>{{end}}{{end}}
-</nav>
-{{end}}
-{{end}}
+{{define "breadcrumb"}}{{renderComponent "Breadcrumb" .Breadcrumbs}}{{end}}


### PR DESCRIPTION
Serial follow-up to #490. #462 foundation: #473.

## Summary
- Port `partials/breadcrumb.html` → `components/breadcrumb.templ` with `BreadcrumbNav([]Breadcrumb)`.
- Inline SVG chevron separator (no lucide dependency for the separator).
- Extend `renderTemplComponent` bridge with a `"Breadcrumb"` case that converts `[]admin.Breadcrumb` → `[]components.Breadcrumb`.
- `partials/breadcrumb.html` collapses to one line — all 18 pages that call `{{template "breadcrumb" .}}` keep working untouched.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] `/rules/new` renders `Rules > New Rule` with the chevron separator, no console errors

### Screenshot

<img src="https://i.img402.dev/fkw99iu8ke.jpg" width="800" alt="/rules/new breadcrumb after migration">

🤖 Generated with [Claude Code](https://claude.com/claude-code)