### PR TITLE
refactor(admin): migrate condition_row partial to templ (#462)

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -62,6 +62,25 @@ func renderTemplComponent(name string, data any) template.HTML {
 			return ""
 		}
 		c = components.Flash(f.Type, f.Message)
+	case "ConditionRow":
+		m, ok := data.(map[string]any)
+		if !ok {
+			return template.HTML(fmt.Sprintf("<!-- renderComponent(%q): want map[string]any{Cond, Idx, Conj}, got %T -->", name, data))
+		}
+		cond, ok := m["Cond"].(service.Condition)
+		if !ok {
+			return template.HTML(fmt.Sprintf("<!-- renderComponent(%q): Cond not service.Condition, got %T -->", name, m["Cond"]))
+		}
+		idx, _ := m["Idx"].(int)
+		conj, _ := m["Conj"].(string)
+		props := components.ConditionRowProps{
+			IsFirst:     idx == 0,
+			Conj:        conj,
+			FieldLabel:  ruleFieldLabel(cond.Field),
+			OpLabel:     ruleOpLabel(cond.Op, cond.Field),
+			ValueFormat: ruleValueFormat(cond.Value),
+		}
+		c = components.ConditionRow(props)
 	default:
 		return template.HTML(fmt.Sprintf("<!-- renderComponent(%q): unknown -->", name))
 	}

--- a/internal/templates/components/condition_row.templ
+++ b/internal/templates/components/condition_row.templ
@@ -1,0 +1,44 @@
+package components
+
+// ConditionRowProps carries the pre-formatted strings the bridge
+// computes from a service.Condition. The component stays oblivious to
+// the underlying condition shape so no admin↔components import cycle.
+type ConditionRowProps struct {
+	// IsFirst controls the "IF" prefix vs the AND/OR conjunction.
+	IsFirst bool
+	// Conj is "AND" or "OR" (ignored when IsFirst).
+	Conj string
+	// FieldLabel, OpLabel, ValueFormat are the pre-rendered strings from
+	// admin's ruleFieldLabel / ruleOpLabel / ruleValueFormat helpers.
+	FieldLabel  string
+	OpLabel     string
+	ValueFormat string
+}
+
+// ConditionRow renders one row in the rule-conditions list on the rule
+// detail page. Mirrors the "condition-row" html/template partial.
+templ ConditionRow(p ConditionRowProps) {
+	<div class="flex items-center gap-2 p-2.5 bg-base-200/50 border border-base-content/10 rounded-xl">
+		<!-- Conjunction / IF prefix -->
+		<div class="w-10 shrink-0 text-center">
+			if p.IsFirst {
+				<span class="text-[0.65rem] font-semibold tracking-wider text-base-content/30">IF</span>
+			} else {
+				<span class={ "text-[0.65rem]", "font-semibold", "tracking-wider", conjClass(p.Conj) }>{ p.Conj }</span>
+			}
+		</div>
+		<!-- Field -->
+		<span class="text-sm font-medium text-base-content/80 truncate">{ p.FieldLabel }</span>
+		<!-- Operator pill -->
+		<span class="inline-flex items-center px-2 py-0.5 rounded-md bg-base-100 border border-base-content/10 text-xs text-base-content/55 font-mono">{ p.OpLabel }</span>
+		<!-- Value -->
+		<span class="text-sm font-semibold text-base-content truncate" title={ p.ValueFormat }>{ p.ValueFormat }</span>
+	</div>
+}
+
+func conjClass(c string) string {
+	if c == "OR" {
+		return "text-warning"
+	}
+	return "text-base-content/30"
+}

--- a/internal/templates/partials/condition_row.html
+++ b/internal/templates/partials/condition_row.html
@@ -1,21 +1,7 @@
-{{define "condition-row"}}
-{{- $c := .Cond -}}
-{{- $isFirst := eq .Idx 0 -}}
-{{- $conj := .Conj -}}
-<div class="flex items-center gap-2 p-2.5 bg-base-200/50 border border-base-content/10 rounded-xl">
-  <!-- Conjunction / IF prefix -->
-  <div class="w-10 shrink-0 text-center">
-    {{if $isFirst}}
-    <span class="text-[0.65rem] font-semibold tracking-wider text-base-content/30">IF</span>
-    {{else}}
-    <span class="text-[0.65rem] font-semibold tracking-wider {{if eq $conj "OR"}}text-warning{{else}}text-base-content/30{{end}}">{{$conj}}</span>
-    {{end}}
-  </div>
-  <!-- Field -->
-  <span class="text-sm font-medium text-base-content/80 truncate">{{ruleFieldLabel $c.Field}}</span>
-  <!-- Operator pill -->
-  <span class="inline-flex items-center px-2 py-0.5 rounded-md bg-base-100 border border-base-content/10 text-xs text-base-content/55 font-mono">{{ruleOpLabel $c.Op $c.Field}}</span>
-  <!-- Value -->
-  <span class="text-sm font-semibold text-base-content truncate" title="{{ruleValueFormat $c.Value}}">{{ruleValueFormat $c.Value}}</span>
-</div>
-{{end}}
+{{/*
+  Thin html/template facade around the templ component in
+  internal/templates/components/condition_row.templ. Callers still pass
+  a dict with Cond, Idx, Conj — the bridge pre-formats the labels before
+  handing the component a typed ConditionRowProps. See issue #462.
+*/}}
+{{define "condition-row"}}{{renderComponent "ConditionRow" .}}{{end}}


### PR DESCRIPTION
Serial follow-up to #491. #462 foundation: #473.

## Summary
- Port `partials/condition_row.html` → `components/condition_row.templ` as `ConditionRow(ConditionRowProps)`.
- Bridge pre-formats the three label strings via `ruleFieldLabel` / `ruleOpLabel` / `ruleValueFormat` so the component stays decoupled from `service.Condition` (no admin ↔ components cycle).
- Facade collapses to one line — `rule_detail.html` still calls `{{template "condition-row" dict "Cond" $c "Idx" $i "Conj" "AND"}}` untouched.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` clean
- [x] `/rules/dc970a34-…` renders `IF Name contains orange` with the operator pill, value title attribute, no console errors

### Screenshot

<img src="https://i.img402.dev/v9gdatqs7l.jpg" width="800" alt="Rule detail — condition row after migration">

🤖 Generated with [Claude Code](https://claude.com/claude-code)