### PR TITLE
test(service): add unit coverage for Actor helpers

### DIFF
--- a/internal/service/actor_test.go
+++ b/internal/service/actor_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSystemActor(t *testing.T) {
+	got := SystemActor()
+	if got.Type != "system" {
+		t.Errorf("Type = %q, want %q", got.Type, "system")
+	}
+	if got.ID != "" {
+		t.Errorf("ID = %q, want empty", got.ID)
+	}
+	if got.Name != "Breadbox" {
+		t.Errorf("Name = %q, want %q", got.Name, "Breadbox")
+	}
+}
+
+func TestActorFromContext_Empty(t *testing.T) {
+	got := ActorFromContext(context.Background())
+	if got != SystemActor() {
+		t.Errorf("empty context: got %+v, want SystemActor()", got)
+	}
+}
+
+func TestActorFromContext_AgentWithAPIKey(t *testing.T) {
+	ctx := ContextWithAPIKey(context.Background(), "key-123", "CI bot")
+	got := ActorFromContext(ctx)
+
+	if got.Type != "agent" {
+		t.Errorf("Type = %q, want %q", got.Type, "agent")
+	}
+	if got.ID != "key-123" {
+		t.Errorf("ID = %q, want %q", got.ID, "key-123")
+	}
+	if got.Name != "CI bot" {
+		t.Errorf("Name = %q, want %q", got.Name, "CI bot")
+	}
+}
+
+func TestActorFromContext_BlankIDFallsBackToSystem(t *testing.T) {
+	// An empty API key ID should NOT promote the actor to agent — otherwise
+	// audit rows lose attribution. Falls back to system instead.
+	ctx := ContextWithAPIKey(context.Background(), "", "ignored")
+	got := ActorFromContext(ctx)
+	if got != SystemActor() {
+		t.Errorf("blank id: got %+v, want SystemActor()", got)
+	}
+}
+
+func TestContextWithAPIKey_DoesNotMutateParent(t *testing.T) {
+	parent := context.Background()
+	_ = ContextWithAPIKey(parent, "key-1", "one")
+	if ActorFromContext(parent) != SystemActor() {
+		t.Error("parent context was mutated by ContextWithAPIKey")
+	}
+}
+
+func TestContextWithAPIKey_NestedOverrides(t *testing.T) {
+	outer := ContextWithAPIKey(context.Background(), "key-outer", "outer")
+	inner := ContextWithAPIKey(outer, "key-inner", "inner")
+
+	if a := ActorFromContext(inner); a.ID != "key-inner" || a.Name != "inner" {
+		t.Errorf("inner actor = %+v, want id=key-inner name=inner", a)
+	}
+	if a := ActorFromContext(outer); a.ID != "key-outer" || a.Name != "outer" {
+		t.Errorf("outer actor = %+v, want id=key-outer name=outer", a)
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/service/actor.go` underpins audit attribution for mutations (rules, reports, comments) but had 0% coverage.
- Adds unit tests for `SystemActor`, `ContextWithAPIKey`, and `ActorFromContext`.
- Covers the blank-ID fallback (unauthenticated requests must not masquerade as agents), nested context overrides, and parent-context isolation.
- Brings `actor.go` to 100% statement coverage.

No production code changed — test-only addition.

## Test plan
- [x] `go test ./internal/service/` passes
- [x] `go build ./...` clean
- [x] `go test ./...` (unit) passes
- [x] `go tool cover -func` shows `actor.go` at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)