### PR TITLE
test(admin): cover titleCaseMerchant and rule label helpers

### DIFF
--- a/internal/admin/templates_test.go
+++ b/internal/admin/templates_test.go
@@ -1,0 +1,134 @@
+package admin
+
+import (
+	"testing"
+)
+
+func TestTitleCaseMerchant(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"all caps single word", "WALMART", "Walmart"},
+		{"all caps multi word", "WHOLE FOODS MARKET", "Whole Foods Market"},
+		{"all lower", "amazon prime", "Amazon Prime"},
+		{"mixed case left alone", "McDonald's", "McDonald's"},
+		{"mixed case name left alone", "iTunes", "iTunes"},
+		{"small words stay lowercase", "BANK OF AMERICA", "Bank of America"},
+		{"small word at start stays capitalized", "THE HOME DEPOT", "The Home Depot"},
+		{"two-letter abbreviations uppercased", "US ATM FEE", "US Atm Fee"},
+		{"two-letter small word stays lowercase mid-phrase", "UP AND AT EM", "UP and at EM"},
+		{"abbreviation with periods", "h.e.b.", "H.E.B."},
+		{"abbreviation with periods caps", "H.E.B.", "H.E.B."},
+		{"single small word capitalized as first", "the", "The"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := titleCaseMerchant(tc.in)
+			if got != tc.want {
+				t.Errorf("titleCaseMerchant(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRuleFieldLabel(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"name", "Name"},
+		{"merchant_name", "Merchant"},
+		{"amount", "Amount"},
+		{"pending", "Pending"},
+		{"category", "Category"},
+		{"category_primary", "Category (primary)"},
+		{"category_detailed", "Category (detail)"},
+		{"tags", "Tag"},
+		{"account_name", "Account"},
+		{"user_name", "Family member"},
+		{"provider", "Provider"},
+		{"", "—"},
+		// Unknown fields fall back to title-cased display.
+		{"some_custom_field", "Some Custom Field"},
+		{"foo", "Foo"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			got := ruleFieldLabel(tc.in)
+			if got != tc.want {
+				t.Errorf("ruleFieldLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRuleOpLabel(t *testing.T) {
+	tests := []struct {
+		name  string
+		op    string
+		field string
+		want  string
+	}{
+		{"contains on string", "contains", "name", "contains"},
+		{"contains on tags", "contains", "tags", "has"},
+		{"not_contains on string", "not_contains", "name", "does not contain"},
+		{"not_contains on tags", "not_contains", "tags", "does not have"},
+		{"in on string", "in", "name", "in"},
+		{"in on tags", "in", "tags", "has any of"},
+		{"matches regex", "matches", "name", "matches /regex/"},
+		{"eq on amount (numeric)", "eq", "amount", "="},
+		{"eq on pending (bool)", "eq", "pending", "is"},
+		{"eq on string", "eq", "name", "is"},
+		{"neq on amount (numeric)", "neq", "amount", "≠"},
+		{"neq on pending (bool)", "neq", "pending", "is not"},
+		{"neq on string", "neq", "name", "is not"},
+		{"gt", "gt", "amount", ">"},
+		{"gte", "gte", "amount", "≥"},
+		{"lt", "lt", "amount", "<"},
+		{"lte", "lte", "amount", "≤"},
+		{"empty op", "", "name", "—"},
+		{"unknown op passes through", "weirdly", "name", "weirdly"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ruleOpLabel(tc.op, tc.field)
+			if got != tc.want {
+				t.Errorf("ruleOpLabel(%q, %q) = %q, want %q", tc.op, tc.field, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRuleValueFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"nil", nil, ""},
+		{"string", "coffee", "coffee"},
+		{"empty string", "", ""},
+		{"bool true", true, "true"},
+		{"bool false", false, "false"},
+		{"int via default", 42, "42"},
+		{"float via default", 12.5, "12.5"},
+		{"slice of strings", []any{"a", "b", "c"}, "a, b, c"},
+		{"slice with mixed types", []any{"tag", 2, true}, "tag, 2, true"},
+		{"empty slice", []any{}, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ruleValueFormat(tc.in)
+			if got != tc.want {
+				t.Errorf("ruleValueFormat(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds unit coverage for four pure helpers in `internal/admin/templates.go` that had no tests: `titleCaseMerchant`, `ruleFieldLabel`, `ruleOpLabel`, `ruleValueFormat`.
- Covers the branchy edge cases that drive UI rendering for the rules pages and transaction list: all-caps vs mixed-case input, small-word handling, abbreviations (two-letter + period-separated), numeric vs bool vs tag-list field variants for operators, nil / slice / bool / default formatting for condition values.
- No behavior changes.

## Test plan
- [x] `go test ./internal/admin/` passes (new + existing)
- [x] `go test ./...` (unit) clean