### PR TITLE
fix(admin): alias /reviews → /transactions?tags=needs-review (#464)

### DIFF
--- a/internal/admin/reviews.go
+++ b/internal/admin/reviews.go
@@ -1,0 +1,11 @@
+package admin
+
+import "net/http"
+
+// ReviewsAliasHandler redirects `/reviews` to the transactions list filtered
+// to the `needs-review` tag. The review queue is tag-backed, not a separate
+// page — the alias keeps dashboard CTAs and the `gr` keyboard shortcut
+// pointing at a stable URL.
+func ReviewsAliasHandler(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/transactions?tags=needs-review", http.StatusMovedPermanently)
+}

--- a/internal/admin/reviews_redirect_test.go
+++ b/internal/admin/reviews_redirect_test.go
@@ -1,0 +1,25 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestReviewsAliasHandler guards the `/reviews` alias that the dashboard
+// "Attention" CTA and the `gr` keyboard shortcut both depend on. If someone
+// deletes the alias, those links 404.
+func TestReviewsAliasHandler(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/reviews", nil)
+	w := httptest.NewRecorder()
+	ReviewsAliasHandler(w, req)
+
+	if w.Code != http.StatusMovedPermanently {
+		t.Fatalf("expected 301, got %d", w.Code)
+	}
+	got := w.Header().Get("Location")
+	want := "/transactions?tags=needs-review"
+	if got != want {
+		t.Errorf("Location = %q, want %q", got, want)
+	}
+}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -80,6 +80,11 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Get("/transactions/{id}", TransactionDetailHandler(a, sm, tr, svc))
 		r.Get("/accounts/{id}", AccountDetailHandler(a, sm, tr, svc))
 
+		// The review queue is tag-backed — "needs-review" transactions. The
+		// `/reviews` alias exists so dashboard CTAs and the `gr` keyboard
+		// shortcut point at a stable, meaningful URL.
+		r.Get("/reviews", ReviewsAliasHandler)
+
 		// Member account self-service pages.
 		r.Get("/my-account", MyAccountHandler(a, sm, tr, svc))
 		r.Post("/my-account/password", MyAccountChangePasswordHandler(a, sm))


### PR DESCRIPTION
## Summary

- The dashboard \"Attention\" CTA and the \`gr\` keyboard shortcut both link to \`/reviews\`, which had no handler — every click landed on the 404 page.
- The review queue is just transactions tagged \`needs-review\`, so register a thin 301 alias instead of inventing a new page.
- Add a unit test on the named handler so deleting the alias surfaces at CI time, not via a user report.

Addresses proposal A in #464. Proposals B and C are moot (Insights page is deprecated per issue comment). Meta-ask (route ↔ href CI check) follows in a separate stacked PR.

## Evidence

\`\`\`
GET /reviews → 301 Location=/transactions?tags=needs-review
GET /reviews (follow) → final 200 url=/transactions?tags=needs-review
\`\`\`

Go unit test covers the redirect handler directly; full \`go test ./...\` clean.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean
- [x] Manual: authenticated GET /reviews follows 301 to /transactions?tags=needs-review and renders the review queue
- [ ] Optional follow-up: add route↔template-href drift check in CI (stacked PR)