### PR TITLE
chore: stop tracking breadbox-server build artifact (#462)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Binary
 /breadbox
+/breadbox-server
 breadbox.exe
 
 # Tailwind CSS standalone binary and generated CSS


### PR DESCRIPTION
## Summary
- Add `/breadbox-server` to `.gitignore` and `git rm --cached` the tracked 46MB binary. Drive-by flagged in #462 — every clone/worktree was pulling this.
- History is not rewritten here; the binary will stop growing the tree going forward. A `git filter-repo` purge before v0.1.0 is a separate call.

## Test plan
- [x] `git ls-files | grep breadbox-server` returns nothing.
- [x] Running `make build` (or any command that produces the binary) still works — the file is ignored, not blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)