### PR TITLE
chore(ui): pin CDN scripts to exact versions with SRI hashes (#462)

### DIFF
--- a/internal/templates/components/layout/wizard.templ
+++ b/internal/templates/components/layout/wizard.templ
@@ -61,7 +61,7 @@ templ Wizard(p WizardProps) {
 					Breadbox &mdash; Financial data for households
 				</p>
 			</div>
-			<script src="https://cdn.jsdelivr.net/npm/lucide@0.468.0/dist/umd/lucide.min.js"></script>
+			<script src="https://cdn.jsdelivr.net/npm/lucide@0.468.0/dist/umd/lucide.min.js" integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu" crossorigin="anonymous"></script>
 			<script>lucide.createIcons();</script>
 		</body>
 	</html>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -19,9 +19,9 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>body { font-family: 'Inter', system-ui, -apple-system, sans-serif; }</style>
-  <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3/dist/cdn.min.js"></script>
-  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3/dist/cdn.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.15.11/dist/cdn.min.js" integrity="sha384-NArNwzWsUSF+kY2lgW4YriEkjLqi+J+za6HrENUn/3nZqkBnWbxV22kCJEK5Uu6n" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.15.11/dist/cdn.min.js" integrity="sha384-WPtu0YHhJ3arcykfnv1JgUffWDSKRnqnDeTpJUbOc2os2moEmLkIdaeR0trPN4be" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1/dist/chart.umd.min.js" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
   {{if .CSRFToken}}<meta name="csrf-token" content="{{.CSRFToken}}">{{end}}
   <script>
     // Auto-inject CSRF token into all same-origin fetch requests.
@@ -686,7 +686,7 @@
     </div>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/lucide@0.468.0/dist/umd/lucide.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/lucide@0.468.0/dist/umd/lucide.min.js" integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu" crossorigin="anonymous"></script>
   <script>
     lucide.createIcons();
 

--- a/internal/templates/layout/wizard.html
+++ b/internal/templates/layout/wizard.html
@@ -41,7 +41,7 @@
     </p>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/lucide@0.468.0/dist/umd/lucide.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/lucide@0.468.0/dist/umd/lucide.min.js" integrity="sha384-uTYyvsSSUZeaPhb5RbKlQa0zY/WpX/QHfvg2mczXyBQOpkWPEDy9lczyp+w7SKXu" crossorigin="anonymous"></script>
   <script>lucide.createIcons();</script>
 </body>
 </html>

--- a/internal/templates/pages/prompt_builder.html
+++ b/internal/templates/pages/prompt_builder.html
@@ -643,5 +643,5 @@ function promptBuilder(initialBlocks) {
   };
 }
 </script>
-<script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
 {{end}}

--- a/internal/templates/pages/report_detail.html
+++ b/internal/templates/pages/report_detail.html
@@ -74,8 +74,8 @@
 </div>
 
 <!-- Alpine component + Markdown rendering -->
-<script src="https://cdn.jsdelivr.net/npm/marked@15/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js" integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7" crossorigin="anonymous"></script>
 <script>
 function reportDetail(id, initialRead) {
   return {


### PR DESCRIPTION
## Summary
- Pin every CDN-loaded script to an exact version and add `sha384` SRI + `crossorigin=\"anonymous\"`. Drive-by flagged in #462: unpinned + unverified jsdelivr loads are a real supply-chain surface for an app that touches bank data.
- Versions:
  - `alpinejs` \`3\` → \`3.15.11\`
  - `@alpinejs/collapse` \`3\` → \`3.15.11\`
  - `chart.js` \`4\` → \`4.5.1\`
  - `lucide` \`0.468.0\` (already pinned) — SRI added
  - `marked` \`15\` → \`15.0.12\`
  - `dompurify` \`3\` → \`3.4.0\`
- Files touched: `internal/templates/layout/base.html`, `layout/wizard.html`, `components/layout/wizard.templ`, `pages/report_detail.html`, `pages/prompt_builder.html`.

## Test plan
- [x] `go build ./...` and `templ generate` clean.
- [ ] Load admin dashboard and confirm Alpine, Chart.js, and Lucide still initialize (no SRI rejection in console).
- [ ] Load `/reports/{id}` and confirm `marked` + `dompurify` render the agent body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)