### PR TITLE
refactor(admin): consolidate funcMap formatters into components package

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -605,7 +605,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			},
 			"lower":     strings.ToLower,
 			"eqFold":    strings.EqualFold,
-			"titleCase": titleCaseMerchant,
+			"titleCase": components.TitleCase,
 			"syncLogFilterQuery": func(status, connID, trigger, dateFrom, dateTo string) template.URL {
 				params := url.Values{}
 				if status != "" {
@@ -716,21 +716,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return base
 			},
-			"firstChar": func(s string) string {
-				if s == "" {
-					return "?"
-				}
-				for _, r := range s {
-					c := strings.ToUpper(string(r))
-					if c >= "A" && c <= "Z" {
-						return c
-					}
-					if c >= "0" && c <= "9" {
-						return c
-					}
-				}
-				return strings.ToUpper(string([]rune(s)[0]))
-			},
+			"firstChar": components.FirstChar,
 			"firstWord": func(s string) string {
 				if s == "" {
 					return ""
@@ -754,15 +740,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return (value / max) * 100
 			},
-			"formatAmount": func(amount float64) string {
-				neg := amount < 0
-				abs := math.Abs(amount)
-				formatted := formatCurrency(abs)
-				if neg {
-					return "-" + formatted
-				}
-				return formatted
-			},
+			"formatAmount": components.FormatAmount,
 			"formatBalance": func(amount float64) string {
 				return components.FormatBalance(amount)
 			},
@@ -874,35 +852,8 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return ""
 				}
 			},
-			"formatDate": func(s string) string {
-				if t, err := time.Parse("2006-01-02", s); err == nil {
-					return t.Format("Jan 2, 2006")
-				}
-				return s
-			},
-			"relativeDate": func(s string) string {
-				t, err := time.Parse("2006-01-02", s)
-				if err != nil {
-					return s
-				}
-				now := time.Now()
-				today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-				d := t.In(now.Location())
-				dateOnly := time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, now.Location())
-				days := int(today.Sub(dateOnly).Hours() / 24)
-				switch {
-				case days == 0:
-					return "Today"
-				case days == 1:
-					return "Yesterday"
-				case days >= 2 && days <= 6:
-					return fmt.Sprintf("%d days ago", days)
-				case days >= 7 && days <= 13:
-					return "1 week ago"
-				default:
-					return t.Format("Jan 2, 2006")
-				}
-			},
+			"formatDate":   components.FormatDate,
+			"relativeDate": components.RelativeDate,
 			"formatNumeric": func(n pgtype.Numeric) string {
 				if !n.Valid {
 					return ""
@@ -1321,55 +1272,6 @@ func formatCurrency(abs float64) string {
 	return service.FormatCurrency(abs)
 }
 
-// titleCaseMerchant converts ALL-CAPS merchant names from bank feeds into
-// readable Title Case. Mixed-case input is returned as-is to avoid mangling
-// names that are already properly cased.
-func titleCaseMerchant(s string) string {
-	if s == "" {
-		return s
-	}
-	// Only transform if the string appears to be ALL CAPS or all lowercase.
-	// Mixed-case strings like "McDonald's" are left alone.
-	upper := strings.ToUpper(s)
-	lower := strings.ToLower(s)
-	if s != upper && s != lower {
-		return s // already mixed case — leave it alone
-	}
-
-	// Small words that should stay lowercase (unless first word).
-	smallWords := map[string]bool{
-		"a": true, "an": true, "and": true, "as": true, "at": true,
-		"by": true, "for": true, "in": true, "of": true, "on": true,
-		"or": true, "the": true, "to": true, "vs": true, "via": true,
-	}
-
-	words := strings.Fields(lower)
-	for i, w := range words {
-		// Abbreviations with periods (e.g., "h.e." → "H.E."): uppercase all parts.
-		if strings.Contains(w, ".") {
-			parts := strings.Split(w, ".")
-			for j, p := range parts {
-				if len(p) > 0 {
-					parts[j] = strings.ToUpper(p)
-				}
-			}
-			words[i] = strings.Join(parts, ".")
-			continue
-		}
-		// Short words (2 letters or less) that aren't articles: keep uppercase
-		// (likely abbreviations like "AB", "US", "ATM").
-		if len(w) <= 2 && !smallWords[w] {
-			words[i] = strings.ToUpper(w)
-			continue
-		}
-		// Always capitalize the first word; small words stay lowercase otherwise.
-		if i == 0 || !smallWords[w] {
-			words[i] = strings.ToUpper(w[:1]) + w[1:]
-		}
-	}
-	return strings.Join(words, " ")
-}
-
 // AdminUsername returns the username from the session for use in template data maps.
 func AdminUsername(r *http.Request, sm *scs.SessionManager) string {
 	return sm.GetString(r.Context(), sessionKeyAccountUsername)
@@ -1406,7 +1308,7 @@ func ruleFieldLabel(field string) string {
 		if field == "" {
 			return "—"
 		}
-		return titleCaseMerchant(strings.ReplaceAll(field, "_", " "))
+		return components.TitleCase(strings.ReplaceAll(field, "_", " "))
 	}
 }
 

--- a/internal/templates/components/helpers.go
+++ b/internal/templates/components/helpers.go
@@ -218,3 +218,31 @@ func AvatarURLVersioned(id, version string) string {
 	}
 	return base + "?v=" + version
 }
+
+// Exported wrappers for the shared formatting helpers. Used by the admin
+// funcMap (internal/admin/templates.go) and other packages so there's one
+// canonical implementation. Keep these in lock-step with their lowercase
+// counterparts above — drift surfaces as different rows between pages.
+
+// FirstChar returns the first A–Z/0–9 rune of s uppercased, or "?" when s has
+// none. See firstChar.
+func FirstChar(s string) string { return firstChar(s) }
+
+// FormatDate formats a "2006-01-02" date string as "Jan 2, 2006". Returns the
+// input unchanged if it doesn't parse. See formatDate.
+func FormatDate(s string) string { return formatDate(s) }
+
+// RelativeDate renders a "2006-01-02" date as "Today", "Yesterday", etc.
+// See relativeDate.
+func RelativeDate(s string) string { return relativeDate(s) }
+
+// FormatAmount renders a signed amount with currency prefix (e.g. "-$1.50").
+// See formatAmount.
+func FormatAmount(amount float64) string { return formatAmount(amount) }
+
+// TitleCase rewrites ALL-CAPS or all-lowercase input to Title Case, leaving
+// mixed-case input untouched. See titleCase.
+func TitleCase(s string) string { return titleCase(s) }
+
+// PluralS returns "" for n == 1, else "s". See pluralS.
+func PluralS(n int) string { return pluralS(n) }

--- a/internal/templates/components/helpers_test.go
+++ b/internal/templates/components/helpers_test.go
@@ -172,6 +172,31 @@ func TestPluralS(t *testing.T) {
 	}
 }
 
+func TestExportedWrappersDelegate(t *testing.T) {
+	// Each exported wrapper must return the same value as its lowercase
+	// counterpart so the admin funcMap and .templ files stay in lock-step.
+	if got, want := FirstChar("apple"), firstChar("apple"); got != want {
+		t.Errorf("FirstChar = %q, want %q", got, want)
+	}
+	if got, want := FormatDate("2024-03-15"), formatDate("2024-03-15"); got != want {
+		t.Errorf("FormatDate = %q, want %q", got, want)
+	}
+	if got, want := FormatAmount(-1.5), formatAmount(-1.5); got != want {
+		t.Errorf("FormatAmount = %q, want %q", got, want)
+	}
+	if got, want := TitleCase("STARBUCKS"), titleCase("STARBUCKS"); got != want {
+		t.Errorf("TitleCase = %q, want %q", got, want)
+	}
+	if got, want := PluralS(2), pluralS(2); got != want {
+		t.Errorf("PluralS = %q, want %q", got, want)
+	}
+	// RelativeDate goes through time.Now() — just assert it returns non-empty
+	// for a valid date.
+	if got := RelativeDate("2024-01-01"); got == "" {
+		t.Error("RelativeDate returned empty string for valid input")
+	}
+}
+
 func TestAmount2f(t *testing.T) {
 	tests := []struct {
 		in   float64

--- a/internal/templates/components/pages/dashboard.templ
+++ b/internal/templates/components/pages/dashboard.templ
@@ -433,7 +433,7 @@ templ dashConnectionRow(c ConnectionHealthRow) {
 			if c.Status != "active" && c.ErrorMessage != "" {
 				<div class="text-[0.6rem] text-error/60 truncate mt-0.5 font-mono max-w-full" title={ c.ErrorMessage }>{ c.ErrorMessage }</div>
 			} else {
-				<div class="text-[0.6rem] text-base-content/30 mt-0.5">{ fmt.Sprintf("%d account%s · synced %s", c.AccountCount, pluralS(int(c.AccountCount)), c.LastSyncedAt) }</div>
+				<div class="text-[0.6rem] text-base-content/30 mt-0.5">{ fmt.Sprintf("%d account%s · synced %s", c.AccountCount, components.PluralS(int(c.AccountCount)), c.LastSyncedAt) }</div>
 			}
 		</div>
 		<div class="shrink-0">
@@ -532,13 +532,6 @@ templ dashScripts() {
 }
 
 // ── Helpers ──────────────────────────────────────────────────
-
-func pluralS(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
-}
 
 func dashAllocSegStyle(s AllocationSlice) string {
 	return fmt.Sprintf("width: %.1f%%; background: %s; opacity: 0.7;", s.Percent, s.Color)


### PR DESCRIPTION
## Summary

Continues the helper consolidation from [#503](https://github.com/canalesb93/breadbox/pull/503). Admin's `funcMap` in `internal/admin/templates.go` had inline duplicates of formatters already defined in `internal/templates/components/helpers.go` — each copy drifted every time either side was touched.

- Export `FirstChar`, `FormatDate`, `RelativeDate`, `FormatAmount`, `TitleCase`, `PluralS` from `components/helpers.go` as thin wrappers over the existing lowercase implementations (canonical source of truth).
- Update admin funcMap entries (`firstChar`, `formatDate`, `relativeDate`, `formatAmount`, `titleCase`) to delegate to the components exports.
- Delete duplicate `titleCaseMerchant` (47 lines) from `admin/templates.go`; `ruleFieldLabel` now calls `components.TitleCase`.
- Delete duplicate `pluralS` from `pages/dashboard.templ`; its single call site now uses `components.PluralS`.
- Add `TestExportedWrappersDelegate` to lock in the wrapper contract so the admin funcMap and `.templ` files stay in lock-step.

Net: -52 lines across admin + dashboard, single source of truth for formatting helpers. No behavioral changes — pure consolidation.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all unit tests pass)
- [x] `make test-integration` (all integration tests pass)
- [x] `templ generate` is clean (no drift in generated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)