### PR TITLE
fix(ui): stop page-header buttons stretching full-width on mobile

### DIFF
--- a/input.css
+++ b/input.css
@@ -618,8 +618,10 @@
   }
 
   /* ── Page header pattern ── */
+  /* items-start on mobile so single-child buttons keep their intrinsic width
+     instead of stretching edge-to-edge when the header wraps to a column. */
   .bb-page-header {
-    @apply flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6;
+    @apply flex flex-col items-start sm:flex-row sm:items-center justify-between gap-3 mb-6;
   }
 
   .bb-page-title {


### PR DESCRIPTION
## Summary

`.bb-page-header` (used by most admin pages) wraps to `flex-col` on mobile. The default `align-items: stretch` caused single-child action buttons to fill the container edge-to-edge, which looks oddly heavy and fragments the header visually.

**Examples visible before the fix:**

- `/users` — the "Add Member" button spans the entire width of the page under the title.
- `/oauth-clients/new` — the "← Access" back-link becomes a full-width centered bar.
- Any other page that uses `bb-page-header` with a single direct-child button (e.g. `/connections/new`).

## Change

One-line CSS utility change in `input.css`:

```diff
   .bb-page-header {
-    @apply flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-6;
+    @apply flex flex-col items-start sm:flex-row sm:items-center justify-between gap-3 mb-6;
   }
```

Adding `items-start` on the mobile side lets children keep their intrinsic width, left-aligned under the title. `sm:items-center` overrides it on tablet+ so the existing single-row layout (button right-aligned) is unchanged.

## Scope / safety

- **Pages that use `bb-page-header` with a single child button** — now look right on mobile (no more full-width stretch).
- **Pages with a multi-button flex group as the header's second child** (e.g. `/transactions`, `/categories`, `/rules`) — the wrapper div was already an intrinsic-width flex row, so behavior is unchanged.
- **Pages with no second child** — trivially unaffected.
- **Pages with their own custom header layout** (e.g. `/connections`) — use their own classes, unaffected.

## Before / After

Screenshots captured at Chrome DevTools MCP's controlled widths (mobile 500x844 — DevTools clamps to a 500px minimum; the target breakpoint is `sm` at 640px so real iPhone behavior matches — tablet 820x1180, desktop 1440x900).

Target page: `/users` (Household).

| Width | Before | After |
| --- | --- | --- |
| Mobile | ![Before mobile](https://i.img402.dev/ldncs8dkey.jpg) — "Add Member" stretched edge-to-edge under the subtitle | ![After mobile](https://i.img402.dev/v0ooazvi0x.jpg) — "Add Member" at natural size, left-aligned under subtitle |
| Tablet | ![Before tablet](https://i.img402.dev/marl6lwp51.jpg) — button right-aligned in header row | ![After tablet](https://i.img402.dev/chy37bd8d5.jpg) — identical (no change) |
| Desktop | ![Before desktop](https://i.img402.dev/rffjaus3iq.jpg) — button right-aligned in header row | ![After desktop](https://i.img402.dev/g1urhlodyv.jpg) — identical (no change) |

Also spot-checked `/oauth-clients/new` — the "← Access" back link is no longer a full-width centered bar on mobile:

![After oauth-clients/new mobile](https://i.img402.dev/hi6k2w1vsv.jpg)

`/rules`, `/transactions`, and `/connections` were also verified to have no visual regressions.

## Test plan

- [x] `go build ./...` passes.
- [x] `make css` rebuilt successfully.
- [x] `/users` at 500x844, 820x1180, 1440x900 — mobile fix applied, tablet/desktop unchanged.
- [x] `/oauth-clients/new` at 500x844 — "← Access" back-link no longer stretched.
- [x] `/rules`, `/transactions`, `/connections` at 500x844 — no visual regressions.
- [ ] Reviewer: sanity check on any other page using `bb-page-header` (38 files grep hit).
