### PR TITLE
fix(connections): stack header actions below title on mobile

### DIFF
--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -3,14 +3,14 @@
      x-init="$watch('tab', function(v) { var u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); })">
 
 <!-- Page Header -->
-<div class="flex items-center justify-between mb-6">
-  <div class="flex items-baseline gap-3">
+<div class="flex flex-col items-start sm:flex-row sm:items-center justify-between gap-3 mb-6">
+  <div class="flex items-baseline gap-3 flex-wrap">
     <h1 class="bb-page-title">Connections</h1>
     {{if .Connections}}
     <span class="text-sm text-base-content/40" x-show="tab === 'connections'">{{len .Connections}} bank{{if ne (len .Connections) 1}}s{{end}}</span>
     {{end}}
   </div>
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2 flex-wrap">
     <div x-show="tab === 'connections'" x-cloak class="flex items-center gap-2">
       {{if .Connections}}
       <div x-data="syncAllBtn()">


### PR DESCRIPTION
## Summary

The `/connections` page uses its own inline flex header (not `bb-page-header`), with `flex items-center justify-between` and no responsive fallback. At narrow widths, "Connections N banks" competes with "Sync All" + "+ Connect Bank" on the same row.

**Measured at 500px viewport (before):**
- Title group ("Connections 2 banks"): 181px
- Actions group (Sync All + Connect Bank): 234px
- Gap between them: only ~52px

At a real iPhone viewport (~390px) or with a larger bank count ("12 banks"), the two groups overlap. At 500px with long title text the header already overflows (documentElement.scrollWidth jumped from 500 to 516 in a synthetic test).

## Fix

Apply the same mobile stacking pattern the rest of the admin UI uses:

```diff
-<div class="flex items-center justify-between mb-6">
-  <div class="flex items-baseline gap-3">
+<div class="flex flex-col items-start sm:flex-row sm:items-center justify-between gap-3 mb-6">
+  <div class="flex items-baseline gap-3 flex-wrap">
     <h1 class="bb-page-title">Connections</h1>
     ...
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-2 flex-wrap">
```

- `flex-col items-start sm:flex-row sm:items-center` stacks rows below 640px, side-by-side above.
- `flex-wrap` on both the title group and the actions group handles edge cases if content grows.
- Existing `gap-3` provides vertical spacing automatically.

## Before / After

Screenshots captured with Chrome DevTools MCP at mobile 500x844, tablet 820x1180, desktop 1440x900.

| Width | Before | After |
| --- | --- | --- |
| Mobile (500px) | ![Before mobile](https://i.img402.dev/8nlffmtcjb.png) | ![After mobile](https://i.img402.dev/hqj9migrou.png) |
| Tablet (820px) | ![Before tablet](https://i.img402.dev/1g7bcvkt4j.png) | ![After tablet](https://i.img402.dev/emkglen7rl.png) |
| Desktop (1440px) | ![Before desktop](https://i.img402.dev/xjg5ic6udk.png) | ![After desktop](https://i.img402.dev/3kb548g9wu.png) |

Account Links tab also stacks cleanly on mobile:

![After mobile — Account Links tab](https://i.img402.dev/jw3ezfrqj2.png)

## Test plan

- [x] `go build ./...` passes
- [x] Mobile 500x844 — header stacks on two rows, both tabs (Connections and Account Links)
- [x] Tablet 820x1180 — single-row layout preserved
- [x] Desktop 1440x900 — single-row layout preserved
- [ ] Reviewer: sanity-check at a real iPhone width (<= 428px) — sm breakpoint is 640px so behavior below that is identical

## Scope

One file, 3 additions / 3 deletions. No JS, no other pages touched. Does not conflict with PR #512 (rule editor) or PR #514 (`bb-page-header` items-start) — this page has always used its own header markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
