### PR TITLE
test: cover untested branches in Decrypt and FilterTransactionFields

### DIFF
--- a/internal/crypto/encrypt_test.go
+++ b/internal/crypto/encrypt_test.go
@@ -107,3 +107,18 @@ func TestEncryptInvalidKeySize(t *testing.T) {
 		}
 	}
 }
+
+func TestDecryptInvalidKeySize(t *testing.T) {
+	// Produce a valid ciphertext first so the input is otherwise well-formed —
+	// this ensures the error comes from the key, not the ciphertext shape.
+	ciphertext, err := Encrypt([]byte("test"), validKey(t))
+	if err != nil {
+		t.Fatalf("setup Encrypt: %v", err)
+	}
+	for _, size := range []int{0, 15, 31, 33, 64} {
+		key := make([]byte, size)
+		if _, err := Decrypt(ciphertext, key); err == nil {
+			t.Errorf("expected error for key size %d", size)
+		}
+	}
+}

--- a/internal/service/fields_test.go
+++ b/internal/service/fields_test.go
@@ -288,3 +288,97 @@ func TestFilterTransactionFields_UserNameUsesAttribution(t *testing.T) {
 		t.Errorf("expected user_name to be 'Ricardo' after normalization, got %v", result["user_name"])
 	}
 }
+
+// When normalization hasn't run yet (e.g. REST path that skips it),
+// FilterTransactionFields must still prefer AttributedUserName over UserName.
+func TestFilterTransactionFields_UserNameAttributionWithoutNormalization(t *testing.T) {
+	owner := "Alice"
+	attributed := "Ricardo"
+	txn := TransactionResponse{
+		ID:                 "txn-1",
+		UserName:           &owner,
+		AttributedUserName: &attributed,
+	}
+
+	fields := map[string]bool{"id": true, "user_name": true}
+	result := FilterTransactionFields(txn, fields)
+
+	name, ok := result["user_name"].(*string)
+	if !ok || *name != "Ricardo" {
+		t.Errorf("expected user_name to be 'Ricardo', got %v", result["user_name"])
+	}
+}
+
+// When AttributedUserName is unset, the owner's UserName must pass through.
+func TestFilterTransactionFields_UserNameFallsBackToOwner(t *testing.T) {
+	owner := "Alice"
+	txn := TransactionResponse{
+		ID:       "txn-1",
+		UserName: &owner,
+	}
+
+	fields := map[string]bool{"id": true, "user_name": true}
+	result := FilterTransactionFields(txn, fields)
+
+	name, ok := result["user_name"].(*string)
+	if !ok || *name != "Alice" {
+		t.Errorf("expected user_name to be 'Alice', got %v", result["user_name"])
+	}
+}
+
+// When AccountShortID is set, filtering account_id must also emit account_short_id.
+func TestFilterTransactionFields_AccountShortIDIncluded(t *testing.T) {
+	accountID := "acct-uuid-123"
+	accountShort := "Ab12CdEf"
+	txn := TransactionResponse{
+		ID:             "txn-1",
+		AccountID:      &accountID,
+		AccountShortID: &accountShort,
+	}
+
+	fields := map[string]bool{"id": true, "account_id": true}
+	result := FilterTransactionFields(txn, fields)
+
+	if gotID, _ := result["account_id"].(*string); gotID == nil || *gotID != accountID {
+		t.Errorf("expected account_id %q, got %v", accountID, result["account_id"])
+	}
+	gotShort, ok := result["account_short_id"].(*string)
+	if !ok || *gotShort != accountShort {
+		t.Errorf("expected account_short_id %q, got %v", accountShort, result["account_short_id"])
+	}
+}
+
+// When AccountShortID is nil, account_short_id must be absent from the result
+// (the key is omitted entirely, not set to a nil pointer).
+func TestFilterTransactionFields_AccountShortIDOmittedWhenNil(t *testing.T) {
+	accountID := "acct-uuid-123"
+	txn := TransactionResponse{
+		ID:        "txn-1",
+		AccountID: &accountID,
+	}
+
+	fields := map[string]bool{"id": true, "account_id": true}
+	result := FilterTransactionFields(txn, fields)
+
+	if _, present := result["account_short_id"]; present {
+		t.Error("account_short_id should be omitted when AccountShortID is nil")
+	}
+}
+
+// Normalizing a transaction with only AttributedUserName set (no owner UserName)
+// must promote it to UserName rather than leaving it nil.
+func TestNormalizeTransactionAttribution_NilOwner(t *testing.T) {
+	attributed := "Ricardo"
+	txn := TransactionResponse{
+		ID:                 "txn-1",
+		AttributedUserName: &attributed,
+	}
+	NormalizeTransactionAttribution(&txn)
+
+	if txn.UserName == nil || *txn.UserName != "Ricardo" {
+		t.Errorf("expected user_name to be 'Ricardo', got %v", txn.UserName)
+	}
+	if txn.AttributedUserName != nil {
+		t.Error("expected attributed_user_name to be cleared")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `TestDecryptInvalidKeySize` mirroring the existing `TestEncryptInvalidKeySize` so invalid key sizes are explicitly rejected on both sides of the AES-GCM pair.
- Cover three previously untested branches in `service.FilterTransactionFields`: attribution priority on non-normalized input (the existing `…_UserNameUsesAttribution` test normalized first, so the inline priority branch was effectively dead), owner-name fallback, and the `account_short_id` emission path.
- Cover the nil-owner case in `NormalizeTransactionAttribution` (`AttributedUserName` set, `UserName` nil) to confirm the attributed name is promoted rather than silently lost.

All tests are pure-function — no DB or integration dependencies, no product decisions, no behavior changes.

## Test plan
- [x] `go test ./internal/crypto/... ./internal/service/...` — all pass
- [x] `go test ./...` (unit) — all green
- [x] `go build ./...` — clean