### PR TITLE
fix(dashboard): unclutter Agent Reports header on mobile

### DIFF
--- a/internal/templates/components/pages/dashboard.templ
+++ b/internal/templates/components/pages/dashboard.templ
@@ -206,19 +206,19 @@ templ dashConnDot(status string) {
 
 templ dashAgentReportsCard(p DashboardProps) {
 	<div class="bb-card" x-data="{ ...agentReports() }">
-		<div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
-			<div class="flex items-center gap-2">
-				<i data-lucide="bot" class="w-4 h-4 text-primary/70"></i>
+		<div class="px-5 py-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-b border-base-200/60">
+			<div class="flex items-center gap-2 min-w-0">
+				<i data-lucide="bot" class="w-4 h-4 text-primary/70 shrink-0"></i>
 				<h2 class="text-sm font-semibold text-base-content/80">Agent Reports</h2>
 				if len(p.AgentReports) > 0 {
-					<span class="text-[0.65rem] font-semibold px-2 py-0.5 rounded-full bg-primary/15 text-primary">{ fmt.Sprintf("%d unread", p.TotalUnreadReports) }</span>
+					<span class="text-[0.65rem] font-semibold px-2 py-0.5 rounded-full bg-primary/15 text-primary shrink-0">{ fmt.Sprintf("%d unread", p.TotalUnreadReports) }</span>
 				}
 			</div>
-			<div class="flex items-center gap-3">
+			<div class="flex items-center gap-3 ml-auto">
 				if len(p.AgentReports) > 0 {
 					<button type="button" class="flex items-center gap-1 text-xs text-base-content/40 hover:text-base-content/60 transition-colors cursor-pointer" @click="markAllRead()" title="Mark all reports as read">
 						<i data-lucide="check-check" class="w-3.5 h-3.5"></i>
-						<span>Mark all read</span>
+						<span class="hidden sm:inline">Mark all read</span>
 					</button>
 				}
 				<a href="/reports" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>


### PR DESCRIPTION
## Problem

On the home dashboard, the **Agent Reports** card header runs the title, the `N unread` pill, the **Mark all read** button, and **View all** all on one line. At narrow widths (~500px, and desktop 3-column layouts where the card itself is ~400px wide) the content crowds. With a 3-digit unread count the header is effectively maxed out.

## Fix

Smallest possible change in `internal/templates/components/pages/dashboard.templ`:

- `flex-wrap` + `gap-x-3 gap-y-2` on the header row so the action group can wrap below the title if space runs out, instead of jamming.
- `ml-auto` on the action group keeps it right-aligned when wrapped.
- `min-w-0` on the left group + `shrink-0` on the icon and pill keep the pill from being squeezed.
- Hide the **Mark all read** text on sub-`sm` viewports (`hidden sm:inline`) — the check-check icon remains and its `title="Mark all reports as read"` tooltip preserves the affordance.

Desktop (>=640px) is visually unchanged — "Mark all read" label still shows.

## Screenshots

| Width | Before | After |
|---|---|---|
| 500px (mobile) | ![Before mobile](https://i.img402.dev/8w2i7hbyl0.png) | ![After mobile](https://i.img402.dev/zj972fxwxn.png) |
| 820px (tablet) | ![Before tablet](https://i.img402.dev/e0napwnn4a.png) | ![After tablet](https://i.img402.dev/7iturba44v.png) |
| 1440px (desktop) | ![Before desktop](https://i.img402.dev/fhjtbn6257.png) | ![After desktop](https://i.img402.dev/6fy4v76jfl.png) |

The 500px before/after were captured with 124 unread reports (temp fixture, cleaned up) to show the worst-case crowding; the normal 4-unread state verifies nothing regresses for the common case.

## Test plan

- [ ] View dashboard at ~500px with unread agent reports — header reads cleanly: title + pill left, check-check icon + "View all" right.
- [ ] Grow unread count into 3-digit territory (e.g. 124 unread) — pill stays intact; action group wraps below the title if needed, no horizontal overflow.
- [ ] At >=640px the full "Mark all read" label is visible and layout matches the pre-PR desktop behavior.
- [ ] "Mark all read" button still fires the Alpine `markAllRead()` handler (icon-only on mobile).

## Related

This page was fixed for the old `dashboard.html` template in #295 — that fix got lost during the templ migration (#462). This PR restores the behavior in the templ component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
