### PR TITLE
fix(transactions): stretch Filters toggle to full width when open

### DIFF
--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -86,9 +86,9 @@
       </div>
     </div>
 
-    <!-- Filter toggle button (always pinned right) -->
-    <button type="button" class="btn rounded-xl gap-2 shrink-0 ml-auto h-10 min-h-0 px-4"
-      :class="filtersOpen ? 'btn-primary' : 'btn-ghost'"
+    <!-- Filter toggle button (pinned right when collapsed; full-width header when open) -->
+    <button type="button" class="btn rounded-xl gap-2 h-10 min-h-0 px-4"
+      :class="filtersOpen ? 'btn-primary w-full justify-between' : 'btn-ghost shrink-0 ml-auto'"
       @click="filtersOpen = !filtersOpen">
       <i data-lucide="sliders-horizontal" class="w-3.5 h-3.5"></i>
       <span>Filters</span>


### PR DESCRIPTION
## Problem
On the `/transactions` page, when the filter panel is expanded (or pre-opened because filters are active), the quick-search input collapses away and the Filters toggle button is left orphaned on its own row, right-aligned, with a large empty gap to its left. At mobile width (500px) this looks like a visual dead zone above the panel.

## Fix
Keep the closed-state layout identical (search input + compact Filters button pinned right). In the open state, stretch the Filters button to `w-full` with `justify-between`, so it reads as a deliberate collapsible header for the panel immediately below.

Single-file change: `internal/templates/pages/transactions.html`.

## Screenshots

| Width | Before (filters open) | After (filters open) |
|---|---|---|
| Mobile (500px) | ![Before mobile](https://i.img402.dev/6d2cye1oe4.png) | ![After mobile](https://i.img402.dev/6ni2kwoy3w.png) |
| Tablet (820px) | ![Before tablet](https://i.img402.dev/3wm9py9z1d.png) | ![After tablet](https://i.img402.dev/z1387n3vec.png) |
| Desktop (1440px) | ![Before desktop](https://i.img402.dev/aacd9ewzqk.png) | ![After desktop](https://i.img402.dev/2ryjl3vzar.png) |

Closed state (mobile) — unchanged:

![After mobile — filters closed](https://i.img402.dev/p50jvxjqkv.png)

## Test plan
- [ ] Visit `/transactions` at 500px — confirm closed state shows search input + compact Filters button, open state shows full-width Filters header
- [ ] Confirm tablet/desktop still render correctly with the full-width header
- [ ] Confirm toggling filters open/closed animates smoothly and the state persists via localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
