### PR TITLE
test: fix admin build, expand matcher and titleCase coverage

### DIFF
--- a/internal/admin/templates_test.go
+++ b/internal/admin/templates_test.go
@@ -4,36 +4,9 @@ import (
 	"testing"
 )
 
-func TestTitleCaseMerchant(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{"empty", "", ""},
-		{"all caps single word", "WALMART", "Walmart"},
-		{"all caps multi word", "WHOLE FOODS MARKET", "Whole Foods Market"},
-		{"all lower", "amazon prime", "Amazon Prime"},
-		{"mixed case left alone", "McDonald's", "McDonald's"},
-		{"mixed case name left alone", "iTunes", "iTunes"},
-		{"small words stay lowercase", "BANK OF AMERICA", "Bank of America"},
-		{"small word at start stays capitalized", "THE HOME DEPOT", "The Home Depot"},
-		{"two-letter abbreviations uppercased", "US ATM FEE", "US Atm Fee"},
-		{"two-letter small word stays lowercase mid-phrase", "UP AND AT EM", "UP and at EM"},
-		{"abbreviation with periods", "h.e.b.", "H.E.B."},
-		{"abbreviation with periods caps", "H.E.B.", "H.E.B."},
-		{"single small word capitalized as first", "the", "The"},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := titleCaseMerchant(tc.in)
-			if got != tc.want {
-				t.Errorf("titleCaseMerchant(%q) = %q, want %q", tc.in, got, tc.want)
-			}
-		})
-	}
-}
+// titleCaseMerchant coverage moved to internal/templates/components.TestTitleCase
+// after PR #513 consolidated the helper. Don't reintroduce a wrapper test here
+// — extend TestTitleCase in the components package instead.
 
 func TestRuleFieldLabel(t *testing.T) {
 	tests := []struct {

--- a/internal/sync/matcher_test.go
+++ b/internal/sync/matcher_test.go
@@ -1,81 +1,263 @@
 package sync
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// nameSimilarityCase is shared by both scoring variants so behavior stays
+// in lock-step (nameSimilarityScoreLowered is purely an allocation
+// optimization of nameSimilarityScore and must score identically).
+type nameSimilarityCase struct {
+	name         string
+	depName      string
+	depMerchant  string
+	priName      string
+	priMerchant  string
+	wantScore    int
+	wantFieldLen int
+	wantField    string // first matched field, if any
+}
+
+var nameSimilarityCases = []nameSimilarityCase{
+	{
+		name:         "exact merchant match",
+		depName:      "STARBUCKS #1234",
+		depMerchant:  "Starbucks",
+		priName:      "STARBUCKS STORE #1234",
+		priMerchant:  "Starbucks",
+		wantScore:    3,
+		wantFieldLen: 1,
+		wantField:    "merchant_name",
+	},
+	{
+		name:         "merchant contains match",
+		depName:      "AMAZON MARKETPLACE",
+		depMerchant:  "Amazon",
+		priName:      "AMZN MKTP US",
+		priMerchant:  "Amazon.com",
+		wantScore:    2,
+		wantFieldLen: 1,
+		wantField:    "merchant_name",
+	},
+	{
+		name:         "merchant contains reversed (pri shorter)",
+		depName:      "AMAZON.COM PURCHASE",
+		depMerchant:  "Amazon.com",
+		priName:      "AMZN",
+		priMerchant:  "Amazon",
+		wantScore:    2,
+		wantFieldLen: 1,
+		wantField:    "merchant_name",
+	},
+	{
+		name:         "exact name match no merchant",
+		depName:      "TRADER JOE'S #123",
+		depMerchant:  "",
+		priName:      "TRADER JOE'S #123",
+		priMerchant:  "",
+		wantScore:    2,
+		wantFieldLen: 1,
+		wantField:    "name",
+	},
+	{
+		name:         "exact name match case insensitive",
+		depName:      "Trader Joe's #123",
+		depMerchant:  "",
+		priName:      "TRADER JOE'S #123",
+		priMerchant:  "",
+		wantScore:    2,
+		wantFieldLen: 1,
+		wantField:    "name",
+	},
+	{
+		name:         "name contains match",
+		depName:      "DOORDASH CHIPOTLE",
+		depMerchant:  "",
+		priName:      "DD *DOORDASH CHIPOTLE SAN FRANCISCO",
+		priMerchant:  "",
+		wantScore:    1,
+		wantFieldLen: 1,
+		wantField:    "name",
+	},
+	{
+		name:         "name contains reversed (pri shorter)",
+		depName:      "DD *DOORDASH CHIPOTLE SAN FRANCISCO",
+		depMerchant:  "",
+		priName:      "DOORDASH CHIPOTLE",
+		priMerchant:  "",
+		wantScore:    1,
+		wantFieldLen: 1,
+		wantField:    "name",
+	},
+	{
+		name:         "name contains case insensitive",
+		depName:      "doordash chipotle",
+		depMerchant:  "",
+		priName:      "DD *DOORDASH CHIPOTLE SAN FRANCISCO",
+		priMerchant:  "",
+		wantScore:    1,
+		wantFieldLen: 1,
+		wantField:    "name",
+	},
+	{
+		name:         "no match at all",
+		depName:      "UBER TRIP",
+		depMerchant:  "Uber",
+		priName:      "LYFT RIDE",
+		priMerchant:  "Lyft",
+		wantScore:    0,
+		wantFieldLen: 0,
+	},
+	{
+		name:         "case insensitive merchant exact",
+		depName:      "COSTCO WHOLESALE",
+		depMerchant:  "COSTCO WHOLESALE",
+		priName:      "COSTCO WHSE #1234",
+		priMerchant:  "Costco Wholesale",
+		wantScore:    3,
+		wantFieldLen: 1,
+		wantField:    "merchant_name",
+	},
+	{
+		name:         "dep merchant empty skips merchant branches",
+		depName:      "STARBUCKS STORE",
+		depMerchant:  "",
+		priName:      "STARBUCKS STORE",
+		priMerchant:  "Starbucks",
+		wantScore:    2,
+		wantFieldLen: 1,
+		wantField:    "name",
+	},
+	{
+		name:         "pri merchant empty skips merchant branches",
+		depName:      "STARBUCKS STORE",
+		depMerchant:  "Starbucks",
+		priName:      "STARBUCKS STORE",
+		priMerchant:  "",
+		wantScore:    2,
+		wantFieldLen: 1,
+		wantField:    "name",
+	},
+	{
+		name:         "different merchants still exact name match",
+		depName:      "AMAZON PAYMENTS",
+		depMerchant:  "Amazon",
+		priName:      "AMAZON PAYMENTS",
+		priMerchant:  "Stripe",
+		wantScore:    2,
+		wantFieldLen: 1,
+		wantField:    "name",
+	},
+	{
+		name:         "different merchants name contains",
+		depName:      "PAYPAL TRANSFER FROM ACME CO",
+		depMerchant:  "PayPal",
+		priName:      "ACME CO",
+		priMerchant:  "Acme",
+		wantScore:    1,
+		wantFieldLen: 1,
+		wantField:    "name",
+	},
+	{
+		name:         "merchant wins over name even when name also exact",
+		depName:      "STARBUCKS #1234",
+		depMerchant:  "Starbucks",
+		priName:      "STARBUCKS #1234",
+		priMerchant:  "Starbucks",
+		wantScore:    3,
+		wantFieldLen: 1,
+		wantField:    "merchant_name",
+	},
+}
 
 func TestNameSimilarityScore(t *testing.T) {
-	tests := []struct {
-		name         string
-		depName      string
-		depMerchant  string
-		priName      string
-		priMerchant  string
-		wantScore    int
-		wantFieldLen int // expected number of matched fields
-	}{
-		{
-			name:         "exact merchant match",
-			depName:      "STARBUCKS #1234",
-			depMerchant:  "Starbucks",
-			priName:      "STARBUCKS STORE #1234",
-			priMerchant:  "Starbucks",
-			wantScore:    3,
-			wantFieldLen: 1,
-		},
-		{
-			name:         "merchant contains match",
-			depName:      "AMAZON MARKETPLACE",
-			depMerchant:  "Amazon",
-			priName:      "AMZN MKTP US",
-			priMerchant:  "Amazon.com",
-			wantScore:    2,
-			wantFieldLen: 1,
-		},
-		{
-			name:         "exact name match no merchant",
-			depName:      "TRADER JOE'S #123",
-			depMerchant:  "",
-			priName:      "TRADER JOE'S #123",
-			priMerchant:  "",
-			wantScore:    2,
-			wantFieldLen: 1,
-		},
-		{
-			name:         "name contains match",
-			depName:      "DOORDASH CHIPOTLE",
-			depMerchant:  "",
-			priName:      "DD *DOORDASH CHIPOTLE SAN FRANCISCO",
-			priMerchant:  "",
-			wantScore:    1,
-			wantFieldLen: 1,
-		},
-		{
-			name:         "no match at all",
-			depName:      "UBER TRIP",
-			depMerchant:  "Uber",
-			priName:      "LYFT RIDE",
-			priMerchant:  "Lyft",
-			wantScore:    0,
-			wantFieldLen: 0,
-		},
-		{
-			name:         "case insensitive merchant",
-			depName:      "COSTCO WHOLESALE",
-			depMerchant:  "COSTCO WHOLESALE",
-			priName:      "COSTCO WHSE #1234",
-			priMerchant:  "Costco Wholesale",
-			wantScore:    3,
-			wantFieldLen: 1,
-		},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range nameSimilarityCases {
 		t.Run(tt.name, func(t *testing.T) {
 			score, fields := nameSimilarityScore(tt.depName, tt.depMerchant, tt.priName, tt.priMerchant)
 			if score != tt.wantScore {
 				t.Errorf("score = %d, want %d", score, tt.wantScore)
 			}
 			if len(fields) != tt.wantFieldLen {
-				t.Errorf("matched fields = %v (len %d), want len %d", fields, len(fields), tt.wantFieldLen)
+				t.Fatalf("matched fields = %v (len %d), want len %d", fields, len(fields), tt.wantFieldLen)
+			}
+			if tt.wantField != "" && fields[0] != tt.wantField {
+				t.Errorf("matched field = %q, want %q", fields[0], tt.wantField)
+			}
+		})
+	}
+}
+
+// TestNameSimilarityScoreLowered_ParityWithUnlowered asserts the lowered
+// variant returns identical results to the canonical function for every
+// case. The lowered form is purely an allocation optimization; any
+// behavioral divergence is a bug.
+func TestNameSimilarityScoreLowered_ParityWithUnlowered(t *testing.T) {
+	for _, tt := range nameSimilarityCases {
+		t.Run(tt.name, func(t *testing.T) {
+			wantScore, wantFields := nameSimilarityScore(tt.depName, tt.depMerchant, tt.priName, tt.priMerchant)
+			gotScore, gotFields := nameSimilarityScoreLowered(
+				tt.depName, strings.ToLower(tt.depName),
+				tt.depMerchant, strings.ToLower(tt.depMerchant),
+				tt.priName, tt.priMerchant,
+			)
+			if gotScore != wantScore {
+				t.Errorf("lowered score = %d, canonical = %d", gotScore, wantScore)
+			}
+			if len(gotFields) != len(wantFields) {
+				t.Fatalf("lowered fields = %v, canonical = %v", gotFields, wantFields)
+			}
+			for i := range gotFields {
+				if gotFields[i] != wantFields[i] {
+					t.Errorf("lowered fields[%d] = %q, canonical = %q", i, gotFields[i], wantFields[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildMatchedOn(t *testing.T) {
+	tests := []struct {
+		name        string
+		depName     string
+		depMerchant string
+		priName     string
+		priMerchant string
+		want        []string
+	}{
+		{
+			name:        "merchant exact",
+			depName:     "STARBUCKS #1",
+			depMerchant: "Starbucks",
+			priName:     "STARBUCKS #2",
+			priMerchant: "Starbucks",
+			want:        []string{"merchant_name"},
+		},
+		{
+			name:    "name exact",
+			depName: "TRADER JOE'S",
+			priName: "TRADER JOE'S",
+			want:    []string{"name"},
+		},
+		{
+			name:        "no similarity returns nil",
+			depName:     "UBER TRIP",
+			depMerchant: "Uber",
+			priName:     "LYFT RIDE",
+			priMerchant: "Lyft",
+			want:        nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildMatchedOn(tt.depName, tt.depMerchant, tt.priName, tt.priMerchant)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
 			}
 		})
 	}
@@ -90,6 +272,13 @@ func TestPickBestCandidate(t *testing.T) {
 		wantNil     bool
 		wantIdx     int // expected index if not nil
 	}{
+		{
+			name:        "empty candidates returns nil",
+			depName:     "STARBUCKS",
+			depMerchant: "",
+			candidates:  nil,
+			wantNil:     true,
+		},
 		{
 			name:        "single candidate returns it",
 			depName:     "STARBUCKS",
@@ -131,6 +320,41 @@ func TestPickBestCandidate(t *testing.T) {
 			},
 			wantNil: true, // both score 0, ambiguous
 		},
+		{
+			name:        "three candidates one clear winner at top score",
+			depName:     "STARBUCKS #123",
+			depMerchant: "Starbucks",
+			candidates: []matchCandidate{
+				{Name: "STARBUCKS RESERVE", MerchantName: "Starbucks"}, // 3
+				{Name: "SOME OTHER STARBUCKS", MerchantName: "Peet's"}, // 1 (name contains)
+				{Name: "UNRELATED", MerchantName: "Dunkin"},            // 0
+			},
+			wantNil: false,
+			wantIdx: 0,
+		},
+		{
+			name:        "three candidates last one wins",
+			depName:     "AMAZON MARKETPLACE",
+			depMerchant: "Amazon",
+			candidates: []matchCandidate{
+				{Name: "UNRELATED ONE", MerchantName: ""},      // 0
+				{Name: "AMZN MKTP", MerchantName: "Amazon.com"}, // 2 (merchant contains)
+				{Name: "AMAZON.COM", MerchantName: "Amazon"},    // 3 (merchant exact)
+			},
+			wantNil: false,
+			wantIdx: 2,
+		},
+		{
+			name:        "three-way tie at top score returns nil",
+			depName:     "PAYMENT",
+			depMerchant: "",
+			candidates: []matchCandidate{
+				{Name: "PAYMENT RECEIVED", MerchantName: ""},
+				{Name: "PAYMENT SENT", MerchantName: ""},
+				{Name: "PAYMENT REFUND", MerchantName: ""},
+			},
+			wantNil: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -151,3 +375,4 @@ func TestPickBestCandidate(t *testing.T) {
 		})
 	}
 }
+

--- a/internal/templates/components/helpers_test.go
+++ b/internal/templates/components/helpers_test.go
@@ -139,12 +139,20 @@ func TestTitleCase(t *testing.T) {
 		{"all caps becomes title case", "STARBUCKS COFFEE", "Starbucks Coffee"},
 		{"all lowercase becomes title case", "starbucks coffee", "Starbucks Coffee"},
 		{"mixed case left untouched", "McDonald's", "McDonald's"},
+		{"mixed case name like iTunes left untouched", "iTunes", "iTunes"},
 		{"short non-article words uppercased", "us bank", "US Bank"},
 		{"small words stay lowercase in middle", "BANK OF AMERICA", "Bank of America"},
 		{"first small word capitalized", "the coffee shop", "The Coffee Shop"},
+		{"first small word capitalized from all caps", "THE HOME DEPOT", "The Home Depot"},
 		{"abbreviations with periods uppercased", "h.e.b grocery", "H.E.B Grocery"},
+		{"abbreviation with trailing period", "h.e.b.", "H.E.B."},
+		{"abbreviation already capitalized stays", "H.E.B.", "H.E.B."},
 		{"single word all caps", "WALMART", "Walmart"},
+		{"all caps multi word", "WHOLE FOODS MARKET", "Whole Foods Market"},
 		{"two-letter acronym uppercased", "ab pharmacy", "AB Pharmacy"},
+		{"three-letter acronym title-cased not all-uppered", "US ATM FEE", "US Atm Fee"},
+		{"two-letter small words stay lowercase mid-phrase", "UP AND AT EM", "UP and at EM"},
+		{"single small word at start gets capitalized", "the", "The"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Unblock CI on `main`** — `internal/admin/templates_test.go` still references `titleCaseMerchant`, which was deleted when the helper moved to `internal/templates/components.TitleCase` in #513. Drop the orphaned test (canonical coverage already lives in `components.TestTitleCase`) and port its unique cases into that test so we don't lose any assertions. CI has been red on `main` since #513 — the last 4 pushes show `failure`/`cancelled`.
- **Expand sync matcher coverage** — fill the remaining gaps in the pure-function helpers that drive cross-account transaction reconciliation. New tests for empty-merchant edges, case-insensitive name matching, contains-reversed, an explicit \"merchant wins over name\" assertion, a parity test asserting `nameSimilarityScoreLowered` returns the same `(score, fields)` as `nameSimilarityScore` for every case (the lowered form is purely an allocation optimization), a direct test for `buildMatchedOn`, and `pickBestCandidate` cases for empty input, three-way ties, and clear winners among 3+ candidates.
- Coverage of `internal/sync/matcher.go` pure functions goes from 66.7% → 100%.

No production code changes — tests only.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `go test -coverprofile=cov.out ./internal/sync/... && go tool cover -func=cov.out` shows the four matcher helpers at 100% (`nameSimilarityScore`, `nameSimilarityScoreLowered`, `buildMatchedOn`, `pickBestCandidate`)
- [ ] CI green (validates the admin-build fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)