### PR TITLE
fix(agents): keep tab switcher on one line with scroll on mobile

### DIFF
--- a/internal/templates/pages/agents.html
+++ b/internal/templates/pages/agents.html
@@ -9,29 +9,29 @@
   </div>
 </div>
 
-<!-- Tab Switcher -->
-<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit">
+<!-- Tab Switcher: horizontally scrollable on mobile so labels stay on one line -->
+<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit max-w-full overflow-x-auto">
   <button @click="tab = 'guide'"
     :class="tab === 'guide' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
-    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    class="px-3 sm:px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2 whitespace-nowrap shrink-0">
     <i data-lucide="rocket" class="w-3.5 h-3.5"></i>
     Getting Started
   </button>
   <button @click="tab = 'wizard'"
     :class="tab === 'wizard' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
-    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    class="px-3 sm:px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2 whitespace-nowrap shrink-0">
     <i data-lucide="wand-sparkles" class="w-3.5 h-3.5"></i>
     Prompt Library
   </button>
   <button @click="tab = 'settings'"
     :class="tab === 'settings' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
-    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2">
+    class="px-3 sm:px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2 whitespace-nowrap shrink-0">
     <i data-lucide="settings" class="w-3.5 h-3.5"></i>
     MCP Settings
   </button>
   <a href="/agents?tab=activity"
     :class="tab === 'activity' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
-    class="px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2 no-underline">
+    class="px-3 sm:px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2 no-underline whitespace-nowrap shrink-0">
     <i data-lucide="scroll-text" class="w-3.5 h-3.5"></i>
     Activity
   </a>


### PR DESCRIPTION
## Problem
At mobile widths the Agents tab switcher was `w-fit` with no overflow handling, so the four tab labels ("Getting Started", "Prompt Library", "MCP Settings", "Activity") wrapped to two lines. This produced uneven tab heights and a cramped row that looks broken.

## Fix
Add `max-w-full overflow-x-auto` to the tab container and `whitespace-nowrap shrink-0` (plus slightly tighter `px-3 sm:px-4`) to each tab pill so:
- Labels stay on a single line.
- Tabs scroll horizontally when they don't fit (mobile) rather than wrapping.
- Tablet and desktop behaviour is unchanged (still fits on one line without scroll).

Single surgical change to `internal/templates/pages/agents.html`. No CSS regeneration needed (standard Tailwind utilities).

## Screenshots

### Before

| Mobile (500px) | Tablet (820px) | Desktop (1440px) |
|---|---|---|
| ![](https://i.img402.dev/s71jo359d2.png) | ![](https://i.img402.dev/7cmor5s8je.png) | ![](https://i.img402.dev/n1n0w1thm8.png) |

### After

| Mobile (500px) | Tablet (820px) | Desktop (1440px) |
|---|---|---|
| ![](https://i.img402.dev/2s5b8dhzg7.png) | ![](https://i.img402.dev/ht7ym3i1lf.png) | ![](https://i.img402.dev/gc91yyfpgo.png) |

## Test plan
- [x] Mobile (500px): tabs on one line, horizontally scrollable
- [x] Tablet (820px): all four tabs visible on one line, no scroll
- [x] Desktop (1440px): unchanged
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
