### PR TITLE
refactor: consolidate string-slice tag helpers into internal/sliceutil

### DIFF
--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"breadbox/internal/ruleapply"
+	"breadbox/internal/sliceutil"
 	"breadbox/internal/slugs"
 
 	"github.com/jackc/pgx/v5"
@@ -1553,7 +1554,7 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 						if _, exists := intent.tagAdds[a.TagSlug]; !exists {
 							intent.tagAdds[a.TagSlug] = cr
 						}
-						if !stringSliceHasFold(tctx.Tags, a.TagSlug) {
+						if !sliceutil.ContainsFold(tctx.Tags, a.TagSlug) {
 							tctx.Tags = append(tctx.Tags, a.TagSlug)
 						}
 					case "remove_tag":
@@ -1563,12 +1564,12 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 						// If a prior-stage add queued this slug, cancel it.
 						if _, was := intent.tagAdds[a.TagSlug]; was {
 							delete(intent.tagAdds, a.TagSlug)
-						} else if stringSliceHasFold(tctx.Tags, a.TagSlug) {
+						} else if sliceutil.ContainsFold(tctx.Tags, a.TagSlug) {
 							if _, exists := intent.tagRemoves[a.TagSlug]; !exists {
 								intent.tagRemoves[a.TagSlug] = cr
 							}
 						}
-						tctx.Tags = stringSliceDropFold(tctx.Tags, a.TagSlug)
+						tctx.Tags = sliceutil.DropFold(tctx.Tags, a.TagSlug)
 					}
 				}
 			}
@@ -1684,27 +1685,6 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 	}
 
 	return hitCounts, nil
-}
-
-// stringSliceHasFold returns true if slice contains s (case-insensitive).
-func stringSliceHasFold(slice []string, s string) bool {
-	for _, v := range slice {
-		if strings.EqualFold(v, s) {
-			return true
-		}
-	}
-	return false
-}
-
-// stringSliceDropFold returns slice with all case-insensitive matches of s removed.
-func stringSliceDropFold(slice []string, s string) []string {
-	out := slice[:0]
-	for _, v := range slice {
-		if !strings.EqualFold(v, s) {
-			out = append(out, v)
-		}
-	}
-	return out
 }
 
 // RulePreviewMatch contains a sample transaction that matched a rule preview.

--- a/internal/sliceutil/sliceutil.go
+++ b/internal/sliceutil/sliceutil.go
@@ -1,0 +1,55 @@
+// Package sliceutil provides small, dependency-free helpers for operating on
+// []string. It exists so sync and service layers share one implementation of
+// the case-insensitive tag/slug operations used during rule evaluation.
+package sliceutil
+
+import "strings"
+
+// Contains reports whether slice contains target (case-sensitive).
+func Contains(slice []string, target string) bool {
+	for _, s := range slice {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsFold reports whether slice contains target (case-insensitive).
+// An empty target never matches — callers comparing tag slugs should treat
+// "no tag" as absent rather than matching empty strings in the slice.
+func ContainsFold(slice []string, target string) bool {
+	if target == "" {
+		return false
+	}
+	for _, s := range slice {
+		if strings.EqualFold(s, target) {
+			return true
+		}
+	}
+	return false
+}
+
+// IndexFold returns the index of target in slice (case-insensitive),
+// or -1 if not present.
+func IndexFold(slice []string, target string) int {
+	for i, v := range slice {
+		if strings.EqualFold(v, target) {
+			return i
+		}
+	}
+	return -1
+}
+
+// DropFold returns slice with all case-insensitive matches of target removed.
+// The returned slice shares backing storage with the input; callers must not
+// rely on the original contents after calling.
+func DropFold(slice []string, target string) []string {
+	out := slice[:0]
+	for _, v := range slice {
+		if !strings.EqualFold(v, target) {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/internal/sliceutil/sliceutil_test.go
+++ b/internal/sliceutil/sliceutil_test.go
@@ -1,0 +1,98 @@
+package sliceutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestContains(t *testing.T) {
+	cases := []struct {
+		name   string
+		slice  []string
+		target string
+		want   bool
+	}{
+		{"present exact", []string{"a", "b", "c"}, "b", true},
+		{"absent", []string{"a", "b"}, "z", false},
+		{"case mismatch", []string{"Alpha"}, "alpha", false},
+		{"empty slice", nil, "x", false},
+		{"empty target present", []string{"", "a"}, "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Contains(tc.slice, tc.target); got != tc.want {
+				t.Fatalf("Contains(%v, %q) = %v, want %v", tc.slice, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestContainsFold(t *testing.T) {
+	cases := []struct {
+		name   string
+		slice  []string
+		target string
+		want   bool
+	}{
+		{"case-insensitive match", []string{"Alpha", "Beta"}, "alpha", true},
+		{"absent", []string{"Alpha"}, "gamma", false},
+		{"empty target never matches", []string{"", "a"}, "", false},
+		{"empty slice", nil, "x", false},
+		{"unicode fold", []string{"Éclair"}, "éclair", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ContainsFold(tc.slice, tc.target); got != tc.want {
+				t.Fatalf("ContainsFold(%v, %q) = %v, want %v", tc.slice, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIndexFold(t *testing.T) {
+	cases := []struct {
+		name   string
+		slice  []string
+		target string
+		want   int
+	}{
+		{"first match", []string{"Alpha", "Beta"}, "alpha", 0},
+		{"later match", []string{"Alpha", "Beta"}, "BETA", 1},
+		{"absent", []string{"Alpha"}, "gamma", -1},
+		{"empty slice", nil, "x", -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IndexFold(tc.slice, tc.target); got != tc.want {
+				t.Fatalf("IndexFold(%v, %q) = %d, want %d", tc.slice, tc.target, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDropFold(t *testing.T) {
+	cases := []struct {
+		name   string
+		slice  []string
+		target string
+		want   []string
+	}{
+		{"drops single match", []string{"a", "B", "c"}, "b", []string{"a", "c"}},
+		{"drops all matches", []string{"x", "X", "y", "x"}, "X", []string{"y"}},
+		{"no match returns equivalent", []string{"a", "b"}, "z", []string{"a", "b"}},
+		{"empty slice", nil, "x", nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clone so we can assert behavior without cross-case aliasing via shared backing storage.
+			input := append([]string(nil), tc.slice...)
+			got := DropFold(input, tc.target)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("DropFold(%v, %q) = %v, want %v", tc.slice, tc.target, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/sync/rule_resolver.go
+++ b/internal/sync/rule_resolver.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"breadbox/internal/pgconv"
+	"breadbox/internal/sliceutil"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -471,11 +472,11 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 				// If a prior-stage rule's remove_tag had queued this slug,
 				// the later add cancels it — strip from TagsToRemove and
 				// drop the prior remove source.
-				if i := stringSliceIndex(result.TagsToRemove, a.TagSlug); i >= 0 {
+				if i := sliceutil.IndexFold(result.TagsToRemove, a.TagSlug); i >= 0 {
 					result.TagsToRemove = append(result.TagsToRemove[:i], result.TagsToRemove[i+1:]...)
 					result.Sources = dropTagSource(result.Sources, "tag_remove", a.TagSlug)
 				}
-				if !stringSliceContains(result.TagsToAdd, a.TagSlug) {
+				if !sliceutil.Contains(result.TagsToAdd, a.TagSlug) {
 					result.TagsToAdd = append(result.TagsToAdd, a.TagSlug)
 					result.Sources = append(result.Sources, RuleActionSource{
 						RuleID:      rule.id,
@@ -487,7 +488,7 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 				}
 				// Mirror into live context so later rules' tags conditions
 				// can observe the addition.
-				if !stringSliceContains(tctx.Tags, a.TagSlug) {
+				if !sliceutil.Contains(tctx.Tags, a.TagSlug) {
 					tctx.Tags = append(tctx.Tags, a.TagSlug)
 				}
 			case "remove_tag":
@@ -497,14 +498,14 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 				// If a same-pass earlier-stage rule added this slug, cancel
 				// that add rather than queueing a delete. The net effect is
 				// no DB write for this slug.
-				if i := stringSliceIndex(result.TagsToAdd, a.TagSlug); i >= 0 {
+				if i := sliceutil.IndexFold(result.TagsToAdd, a.TagSlug); i >= 0 {
 					result.TagsToAdd = append(result.TagsToAdd[:i], result.TagsToAdd[i+1:]...)
 					result.Sources = dropTagSource(result.Sources, "tag", a.TagSlug)
-				} else if stringSliceContains(tctx.Tags, a.TagSlug) {
+				} else if sliceutil.Contains(tctx.Tags, a.TagSlug) {
 					// Only queue a delete if the slug is actually present on
 					// the transaction (loaded initial tags). Otherwise the
 					// remove is a no-op.
-					if !stringSliceContains(result.TagsToRemove, a.TagSlug) {
+					if !sliceutil.Contains(result.TagsToRemove, a.TagSlug) {
 						result.TagsToRemove = append(result.TagsToRemove, a.TagSlug)
 						result.Sources = append(result.Sources, RuleActionSource{
 							RuleID:      rule.id,
@@ -516,7 +517,7 @@ func (r *RuleResolver) ResolveWithContext(providerName string, txn TransactionCo
 					}
 				}
 				// Mirror into live context so later rules see the slug gone.
-				if i := stringSliceIndex(tctx.Tags, a.TagSlug); i >= 0 {
+				if i := sliceutil.IndexFold(tctx.Tags, a.TagSlug); i >= 0 {
 					tctx.Tags = append(tctx.Tags[:i], tctx.Tags[i+1:]...)
 				}
 			case "add_comment":
@@ -570,17 +571,6 @@ func dropTagSource(src []RuleActionSource, field, value string) []RuleActionSour
 		kept = append(kept, s)
 	}
 	return kept
-}
-
-// stringSliceIndex returns the index of s in slice (case-insensitive),
-// or -1 if not present.
-func stringSliceIndex(slice []string, s string) int {
-	for i, v := range slice {
-		if strings.EqualFold(v, s) {
-			return i
-		}
-	}
-	return -1
 }
 
 // triggerMatches reports whether a rule with the given trigger should fire
@@ -773,16 +763,16 @@ func evaluateBool(c *compiledCondition, fieldVal bool) bool {
 func evaluateTags(c *compiledCondition, tags []string) bool {
 	switch c.op {
 	case "contains":
-		return stringSliceContainsFold(tags, toString(c.value))
+		return sliceutil.ContainsFold(tags, toString(c.value))
 	case "not_contains":
-		return !stringSliceContainsFold(tags, toString(c.value))
+		return !sliceutil.ContainsFold(tags, toString(c.value))
 	case "in":
 		list, ok := c.value.([]interface{})
 		if !ok {
 			return false
 		}
 		for _, item := range list {
-			if stringSliceContainsFold(tags, toString(item)) {
+			if sliceutil.ContainsFold(tags, toString(item)) {
 				return true
 			}
 		}
@@ -869,25 +859,3 @@ func stringInList(fieldVal string, v interface{}) bool {
 	}
 }
 
-// stringSliceContains reports whether slice contains target (case-sensitive).
-func stringSliceContains(slice []string, target string) bool {
-	for _, s := range slice {
-		if s == target {
-			return true
-		}
-	}
-	return false
-}
-
-// stringSliceContainsFold reports whether slice contains target (case-insensitive).
-func stringSliceContainsFold(slice []string, target string) bool {
-	if target == "" {
-		return false
-	}
-	for _, s := range slice {
-		if strings.EqualFold(s, target) {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
## Summary
- Extract the four duplicate string-slice helpers that `internal/sync/rule_resolver.go` and `internal/service/rules.go` each maintained (case-sensitive `Contains`, case-insensitive `ContainsFold` / `HasFold`, `IndexFold`, `DropFold`) into a new leaf package `internal/sliceutil`.
- Replace call sites to use the shared helpers. Behavior is preserved, including the empty-target guard in `ContainsFold` (callers already skip empty tag slugs before reaching the helper).
- Add unit coverage for all four helpers, including previously untested cases like unicode folding and repeated-match removal.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go build -tags integration ./...`
- [x] `go test ./...` (all packages pass; new `internal/sliceutil` tests cover every helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)