### PR TITLE
fix(csv import): soften bb-card padding on mobile wizard steps

### DIFF
--- a/internal/templates/pages/csv_import.html
+++ b/internal/templates/pages/csv_import.html
@@ -14,7 +14,7 @@
 <!-- Step indicator -->
 <div x-data="{step: {{if .ConnectionID}}1{{else}}1{{end}}}" x-init="window._csvWizard = {setStep: (s) => { step = s; }}">
 
-  <div class="flex items-center gap-0 mb-8 max-w-xl" id="step-indicator">
+  <div class="flex items-center gap-0 mb-6 sm:mb-8 max-w-xl" id="step-indicator">
     <template x-for="(s, i) in [{n:1, label:'Upload'}, {n:2, label:'Map Columns'}, {n:3, label:'Confirm'}, {n:4, label:'Done'}]" :key="i">
       <div class="flex items-center" :class="i < 3 ? 'flex-1' : ''">
         <div class="flex items-center gap-2">
@@ -36,7 +36,7 @@
 
   <!-- Step 1: Upload -->
   <div id="step-1" x-show="step === 1" x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0" {{if .ConnectionID}}{{end}}>
-    <div class="bb-card p-8 max-w-2xl">
+    <div class="bb-card p-5 sm:p-8 max-w-2xl">
       <div class="flex items-center gap-3 mb-6">
         <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
           <i data-lucide="upload" class="w-5 h-5 text-primary"></i>
@@ -85,7 +85,7 @@
 
   <!-- Step 2: Map Columns -->
   <div id="step-2" x-show="step === 2" x-cloak x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0">
-    <div class="bb-card p-8 max-w-3xl">
+    <div class="bb-card p-5 sm:p-8 max-w-3xl">
       <div class="flex items-center gap-3 mb-6">
         <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-accent/8">
           <i data-lucide="columns" class="w-5 h-5 text-accent"></i>
@@ -215,7 +215,7 @@
 
   <!-- Step 3: Confirm -->
   <div id="step-3" x-show="step === 3" x-cloak x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0">
-    <div class="bb-card p-8 max-w-lg">
+    <div class="bb-card p-5 sm:p-8 max-w-lg">
       <div class="flex items-center gap-3 mb-6">
         <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-warning/8">
           <i data-lucide="file-check" class="w-5 h-5 text-warning"></i>
@@ -255,7 +255,7 @@
 
   <!-- Step 4: Complete -->
   <div id="step-4" x-show="step === 4" x-cloak x-transition:enter="transition ease-out duration-200" x-transition:enter-start="opacity-0 translate-y-2" x-transition:enter-end="opacity-100 translate-y-0">
-    <div class="bb-card p-8 max-w-lg">
+    <div class="bb-card p-5 sm:p-8 max-w-lg">
       <div class="flex flex-col items-center text-center mb-8">
         <div class="w-16 h-16 rounded-xl bg-success/10 flex items-center justify-center mb-4">
           <i data-lucide="check-circle-2" class="w-8 h-8 text-success"></i>


### PR DESCRIPTION
## Problem

On mobile (500px), the CSV import wizard's four step cards use `p-8` (32px padding on all sides). That eats 64px of horizontal space inside a ~468px card, leaving file inputs, selects, and the split debit/credit grid feeling cramped. The step indicator also uses a flat `mb-8` (32px) which adds unnecessary vertical rhythm on small screens.

## Fix

Scoped to `internal/templates/pages/csv_import.html`:

- All 4 wizard cards: `bb-card p-8` → `bb-card p-5 sm:p-8` — 20px padding below 640px, 32px from sm: up. Recovers ~24px of content width per step on mobile.
- Step indicator: `mb-8` → `mb-6 sm:mb-8` — tightens vertical rhythm on mobile only.

No desktop or tablet behavior changes (sm: breakpoint = 640px).

## Screenshots

### Before

| Mobile (500px) | Tablet (820px) | Desktop (1440px) |
|---|---|---|
| ![](https://i.img402.dev/s5m2btv5ti.png) | ![](https://i.img402.dev/rjvxchc4ia.png) | ![](https://i.img402.dev/l6e9g7txr1.png) |

### After

| Mobile (500px) | Tablet (820px) | Desktop (1440px) |
|---|---|---|
| ![](https://i.img402.dev/w8ldjx8f6r.png) | ![](https://i.img402.dev/v3kvwmwwwx.png) | ![](https://i.img402.dev/duio88m4d4.png) |

## Test plan

- [x] `go build ./...`
- [x] Mobile 500x844: step 1 card padding measured 20px (was 32px), select input now 426px wide (was ~402px)
- [x] Tablet 820x1180 and desktop 1440x900: unchanged (sm: breakpoint keeps p-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
