### PR TITLE
fix(tx filters): pair Search selects on one row on mobile

### DIFF
--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -170,24 +170,24 @@
 
     <!-- Search within filters -->
     <div class="border-t border-base-200 pt-4 mb-4" x-data="{ mode: '{{if .FilterSearchMode}}{{.FilterSearchMode}}{{else}}contains{{end}}' }">
-      <div class="grid grid-cols-1 sm:grid-cols-[1fr_auto_auto] gap-x-3 gap-y-1">
+      <div class="grid grid-cols-2 sm:grid-cols-[1fr_auto_auto] gap-x-3 gap-y-1">
         <div class="text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2 hidden sm:flex">
           <i data-lucide="search" class="w-3.5 h-3.5 text-base-content/40"></i>
           Search
         </div>
         <div class="text-[0.65rem] text-base-content/40 hidden sm:block">Search in</div>
         <div class="text-[0.65rem] text-base-content/40 hidden sm:block">Match type</div>
-        <div class="text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2 sm:hidden mb-1">
+        <div class="col-span-2 sm:hidden text-xs font-medium text-base-content/50 uppercase tracking-wider flex items-center gap-2 mb-1">
           <i data-lucide="search" class="w-3.5 h-3.5 text-base-content/40"></i>
           Search
         </div>
-        <input type="text" name="search" value="{{.FilterSearch}}" placeholder="Search transactions..." class="input input-sm input-bordered w-full">
-        <select name="search_field" class="select select-sm select-bordered">
+        <input type="text" name="search" value="{{.FilterSearch}}" placeholder="Search transactions..." class="input input-sm input-bordered w-full col-span-2 sm:col-span-1">
+        <select name="search_field" class="select select-sm select-bordered w-full">
           <option value="all"{{if or (eq .FilterSearchField "all") (not .FilterSearchField)}} selected{{end}}>Name &amp; Merchant</option>
           <option value="name"{{if eq .FilterSearchField "name"}} selected{{end}}>Name only</option>
           <option value="merchant"{{if eq .FilterSearchField "merchant"}} selected{{end}}>Merchant only</option>
         </select>
-        <select name="search_mode" class="select select-sm select-bordered" x-model="mode">
+        <select name="search_mode" class="select select-sm select-bordered w-full" x-model="mode">
           <option value="contains">Contains</option>
           <option value="words">All words</option>
           <option value="fuzzy">Fuzzy match</option>


### PR DESCRIPTION
## Problem

Inside the Transactions filter panel, the inner **Search** row (Search input + scope select + match-mode select) stacked all three controls as full-width rows on mobile. A single logical filter chewed up three vertical rows:

- Search input
- Scope select (Name & Merchant / Name only / Merchant only)
- Match-mode select (Contains / All words / Fuzzy)

## Fix

Promote the mobile grid from `grid-cols-1` to `grid-cols-2`:

- Search input spans both columns (`col-span-2 sm:col-span-1`) on its own row.
- The two selects each take one column on the next row.
- Desktop layout (`sm:grid-cols-[1fr_auto_auto]`) is unchanged — all three controls still share one line at `sm:` and up.

The mobile "Search" label is given `col-span-2 sm:hidden` so it sits on its own row above the input on mobile, and the selects now stretch with `w-full` so they share the paired row evenly.

Touched only the inner Search row — does not alter the outer transactions filter panel layout addressed by #520.

## Screenshots

### Before

| Mobile (500px) | Tablet (820px) | Desktop (1440px) |
|---|---|---|
| ![](https://i.img402.dev/7rzkxsbjam.png) | ![](https://i.img402.dev/wcvunjneef.png) | ![](https://i.img402.dev/4y0z4k0l4w.png) |

### After

| Mobile (500px) | Tablet (820px) | Desktop (1440px) |
|---|---|---|
| ![](https://i.img402.dev/5zhx3x7qrv.png) | ![](https://i.img402.dev/69cjmqa31s.png) | ![](https://i.img402.dev/hy3b6ccm43.png) |

## Test plan

- [ ] At <640px, Search input is full-width on its own row and the two selects sit side-by-side on the second row.
- [ ] At >=640px, the three controls share one row with the input flexible and the two selects auto-sized.
- [ ] Submitting the search form with any combination of scope/mode still round-trips correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
