### PR TITLE
refactor(admin): route JSON decode through decodeJSON helper

### DIFF
--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 
@@ -20,8 +19,7 @@ func CreateAPIKeyHandler(svc *service.Service) http.HandlerFunc {
 			Name  string `json:"name"`
 			Scope string `json:"scope"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 		req.Name = strings.TrimSpace(req.Name)

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"net/http"
@@ -284,8 +283,7 @@ type linkTokenResponse struct {
 func LinkTokenHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req linkTokenRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 
@@ -348,8 +346,7 @@ type exchangeTokenResponse struct {
 func ExchangeTokenHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req exchangeTokenRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 
@@ -941,8 +938,7 @@ func UpdateAccountExcludedHandler(a *app.App, sm *scs.SessionManager) http.Handl
 		var req struct {
 			Excluded bool `json:"excluded"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 
@@ -974,8 +970,7 @@ func UpdateAccountDisplayNameHandler(a *app.App, sm *scs.SessionManager) http.Ha
 		var req struct {
 			DisplayName *string `json:"display_name"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 
@@ -1012,8 +1007,7 @@ func UpdateConnectionPausedHandler(a *app.App, sm *scs.SessionManager) http.Hand
 		var req struct {
 			Paused bool `json:"paused"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 
@@ -1045,8 +1039,7 @@ func UpdateConnectionSyncIntervalHandler(a *app.App, sm *scs.SessionManager) htt
 		var req struct {
 			Minutes *int32 `json:"minutes"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 

--- a/internal/admin/csv_import.go
+++ b/internal/admin/csv_import.go
@@ -187,8 +187,7 @@ func CSVPreviewHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 			DateFormat      string         `json:"date_format"`
 			HasDebitCredit  bool           `json:"has_debit_credit"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 
@@ -320,8 +319,7 @@ func CSVImportHandler(a *app.App, sm *scs.SessionManager, svc *service.Service) 
 			ConnectionID    string         `json:"connection_id"`
 			HasDebitCredit  bool           `json:"has_debit_credit"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 

--- a/internal/admin/members.go
+++ b/internal/admin/members.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"net/http"
 	"net/mail"
 	"strings"
@@ -27,8 +26,7 @@ type createLoginAccountRequest struct {
 func CreateLoginAccountHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req createLoginAccountRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 
@@ -112,8 +110,7 @@ func UpdateLoginAccountRoleHandler(svc *service.Service, sm *scs.SessionManager)
 		var req struct {
 			Role string `json:"role"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
@@ -325,8 +324,7 @@ func CreateRuleAdminHandler(svc *service.Service, sm *scs.SessionManager) http.H
 			Priority     int                   `json:"priority"`
 			ExpiresIn    string                `json:"expires_in"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid request body"})
+		if !decodeJSON(w, r, &body) {
 			return
 		}
 
@@ -381,8 +379,7 @@ func UpdateRuleAdminHandler(svc *service.Service, sm *scs.SessionManager) http.H
 			Enabled      *bool                  `json:"enabled,omitempty"`
 			ExpiresAt    *string                `json:"expires_at,omitempty"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid request body"})
+		if !decodeJSON(w, r, &body) {
 			return
 		}
 
@@ -468,8 +465,7 @@ func PreviewRuleAdminHandler(svc *service.Service) http.HandlerFunc {
 			Conditions service.Condition `json:"conditions"`
 			SampleSize int               `json:"sample_size"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid request body"})
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 

--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -173,8 +173,7 @@ func AddTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *serv
 			Slug string `json:"slug"`
 			Note string `json:"note,omitempty"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid body"})
+		if !decodeJSON(w, r, &body) {
 			return
 		}
 		body.Slug = strings.TrimSpace(body.Slug)

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -932,8 +932,7 @@ func CreateTransactionCommentHandler(a *app.App, sm *scs.SessionManager, svc *se
 		var input struct {
 			Content string `json:"content"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &input) {
 			return
 		}
 
@@ -1070,8 +1069,7 @@ func BulkUpdateTransactionsAdminHandler(a *app.App, sm *scs.SessionManager, svc 
 			} `json:"operations"`
 			OnError string `json:"on_error,omitempty"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid body"})
+		if !decodeJSON(w, r, &body) {
 			return
 		}
 		if len(body.Operations) == 0 {

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"errors"
 	"math"
 	"net/http"
@@ -234,8 +233,7 @@ type createUserRequest struct {
 func CreateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req createUserRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 
@@ -305,8 +303,7 @@ func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		}
 
 		var req updateUserRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+		if !decodeJSON(w, r, &req) {
 			return
 		}
 


### PR DESCRIPTION
## Summary

- Replaces 19 copies of the manual `json.NewDecoder(r.Body).Decode(&req)` + ad-hoc error idiom across 8 admin handlers with the existing `decodeJSON()` helper in [response.go](internal/admin/response.go:27).
- All decode-failure responses now emit the canonical `{error:{code,message}}` envelope documented in [.claude/rules/api.md](.claude/rules/api.md), instead of the inconsistent mix of flat `{error:"..."}` strings and slightly varying messages (`"Invalid request body"`, `"invalid body"`, `"invalid request body"`).
- Drops now-unused `encoding/json` imports from `apikeys.go`, `members.go`, `users.go`, `connections.go`, `rules.go`.

Net: **19 insertions, 43 deletions** across 8 files.

Out of scope (intentionally): `oauth.go` (RFC 6749 error envelope), `setup.go` and `update.go` (mixed body decode + additional validation in one branch), and the optional decode at `tags.go:220` (error is deliberately ignored).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass
- [x] Confirmed no test asserts on the replaced strings (`Invalid request body` / `invalid body` / `invalid request body` / `INVALID_REQUEST`)

No UI changes; admin API contract only shifts on the unhappy path (invalid JSON body), where the body is now the canonical envelope rather than a flat string. Admin UI JS that reads `data.error` as a string still falls through to its default error message in that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)