### PR TITLE
fix(category picker): bump mobile tap target and de-clutter list rows

### DIFF
--- a/input.css
+++ b/input.css
@@ -1709,6 +1709,25 @@
            text-[0.6rem] font-medium text-base-content/40 bg-base-200 border border-base-300 rounded mx-0.5;
   }
 
+  /* Mobile list polish: meet the 44px tap target, tighten the indent gutter,
+     and drop the echoed parent label while browsing (the hierarchy is already
+     obvious from the indentation). Parent labels still show while searching,
+     where results appear out of hierarchy context. */
+  @media (max-width: 640px) {
+    .bb-catpicker-item {
+      @apply py-2.5;
+      min-height: 2.75rem;
+    }
+
+    .bb-catpicker-item--indent {
+      @apply pl-7;
+    }
+
+    .bb-catpicker-list[data-searching="false"] .bb-catpicker-item__parent-label {
+      display: none;
+    }
+  }
+
   /* ─── Global Tag Picker Overlay ─── */
   /*
    * Mirrors the category picker shell (backdrop, dialog, input, footer) but the body is a

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -356,6 +356,7 @@
 
       <!-- Results list -->
       <div class="bb-catpicker-list" x-ref="catPickerList"
+           :data-searching="search ? 'true' : 'false'"
            x-effect="filteredList; $nextTick(() => { if (typeof lucide !== 'undefined' && $refs.catPickerList) lucide.createIcons({ nodes: [$refs.catPickerList] }); })">
         <div class="py-1">
           <template x-for="(item, idx) in filteredList" :key="item.slug + '-' + idx">
@@ -373,7 +374,7 @@
               </template>
               <span x-text="item.label" class="truncate"></span>
               <template x-if="item.indent && item.parentLabel">
-                <span class="text-xs text-base-content/30 ml-auto truncate" x-text="item.parentLabel"></span>
+                <span class="bb-catpicker-item__parent-label text-xs text-base-content/30 ml-auto truncate" x-text="item.parentLabel"></span>
               </template>
             </div>
           </template>


### PR DESCRIPTION
## Problem

On mobile (≤640px) the global category picker's list items rendered at only 36px tall — below the iOS 44px tap-target guideline — and every indented subcategory echoed its parent name on the right edge. With 106 indented entries and the indent gutter eating 36px of horizontal space, the list felt cramped and the right-side echo added visual noise where the hierarchy was already visible via indentation.

## Fix

Three mobile-only (`max-width: 640px`) CSS tweaks plus one small template change:

- `.bb-catpicker-item` — `py-2.5` + `min-height: 2.75rem` so every row is a clean 44px tap target.
- `.bb-catpicker-item--indent` — `pl-9` → `pl-7` to reclaim horizontal space.
- `.bb-catpicker-list[data-searching="false"] .bb-catpicker-item__parent-label` — hide the echoed parent label while browsing. Keep it when searching, where results appear out of hierarchy context and the label disambiguates (e.g., typing "savings" → "Savings" under both Transfers In and Transfers Out).

`data-searching` is bound to the Alpine `search` state on the list, so CSS alone drives visibility.

Desktop and tablet (≥641px) are unchanged.

### Before

| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/n910bvow4k.png" width="260" alt="before mobile"> | <img src="https://i.img402.dev/vzfaiwsv0o.png" width="260" alt="before tablet"> | <img src="https://i.img402.dev/c95bd8i456.png" width="260" alt="before desktop"> |

### After

| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/b8h6hf6z64.png" width="260" alt="after mobile"> | <img src="https://i.img402.dev/gzo5pxir0l.png" width="260" alt="after tablet"> | <img src="https://i.img402.dev/rxuw3h4euz.png" width="260" alt="after desktop"> |

Local fallback paths: `/tmp/claude/mobile-polish-iter12/{before,after}-{mobile,tablet,desktop}.png`.

## Test plan

- [x] Verified item height = 44px and indent padding = 28px on mobile via DevTools.
- [x] Verified parent labels hidden in default browse, visible when searching (typed "gro" → "Food & Drink" label visible).
- [x] Verified no visual change on tablet/desktop.
- [x] `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)