### PR TITLE
docs(workflow): introduce stacked-PR workflow via Graphite (gt)

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -177,6 +177,24 @@ if ! make css 2>&1; then
   echo "WARN: make css failed"
 fi
 
+# --- Graphite CLI (for stacked PRs) ---
+# Installed eagerly so /stack is ready without a second round-trip. Skip
+# silently if npm isn't available — single-PR work doesn't need gt.
+if command -v npm &>/dev/null; then
+  echo "==> Installing Graphite CLI..."
+  if ! command -v gt &>/dev/null; then
+    npm install -g @withgraphite/graphite-cli@stable >/dev/null 2>&1 \
+      && echo "    gt installed" \
+      || echo "WARN: gt install failed — /stack will not work until fixed"
+  else
+    echo "    gt already installed"
+  fi
+  # Initialize repo metadata (idempotent).
+  if command -v gt &>/dev/null && [ ! -f .graphite_repo_config ]; then
+    gt repo init --trunk main >/dev/null 2>&1 || true
+  fi
+fi
+
 # --- Test database ---
 echo "==> Setting up test database..."
 if command -v pg_isready &>/dev/null; then

--- a/.claude/rules/stacked-prs.md
+++ b/.claude/rules/stacked-prs.md
@@ -1,0 +1,54 @@
+# Stacked PRs
+
+Use stacks only when the change is large enough to justify the overhead. Default to a single PR.
+
+Full spec: `docs/stacked-prs.md`.
+
+## When to stack
+
+Stack if any of these apply; otherwise ship a single PR:
+
+- Change touches more than one layer (migration + service + handler + UI).
+- Diff would exceed ~400 LOC and splits cleanly.
+- Parts can merge in stages without blocking the rest.
+- A reviewer would reasonably want to approve early pieces first.
+
+Do not stack a single bug fix, single UI tweak, or any change whose pieces only make sense together.
+
+## Branch naming
+
+`stack/<topic>/<NN>-<slug>` — topic is kebab-case, `NN` is a two-digit position, `slug` describes this PR. Always pass `-b` to `gt create` so the branch gets the right name.
+
+## Commands to use
+
+Always use `gt` for branch/PR operations when in a stack:
+
+- `gt sync` before starting — pulls `main`, restacks open stacks, prunes merged branches.
+- `gt create -b stack/<topic>/<NN>-<slug> -am "..."` for each new branch in the stack.
+- `gt submit --stack --no-interactive` to push everything and open/update PRs in one shot.
+- `gt modify --amend` for mid-stack edits (never `git commit --amend` + force-push).
+- `gt land` to merge the bottom PR and auto-restack the rest.
+
+Never `git push` or `git checkout -b` directly once you're on a stack — it desynchronizes `gt`'s metadata.
+
+## PR body
+
+`gt submit` inserts and maintains a `<!-- Graphite stack -->` block at the top of each PR body. Do not hand-edit it. Write the rest of the description as usual; the first line should be a one-sentence standalone justification for this PR.
+
+## Review iteration
+
+If a reviewer requests changes on a middle PR:
+
+1. `gt checkout <branch>`
+2. Edit files.
+3. `gt modify --amend` — this restacks all descendants.
+4. `gt submit --stack --no-interactive` — force-with-lease push for each affected PR.
+
+Comment anchors on later PRs are preserved because `gt` uses `--force-with-lease`.
+
+## Don't
+
+- Don't stack for the sake of stacking. A small change belongs in one PR.
+- Don't target `main` for mid-stack PRs — `gt` sets the base automatically.
+- Don't squash-merge out of order. Land the bottom first.
+- Don't mix unrelated work into a stack. One topic per stack.

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -84,6 +84,8 @@ Write the new phase following the format in [format-reference.md](format-referen
 - Tasks should be self-contained: one package, one endpoint group, one page, etc.
 - Break large features into sub-phases (e.g., 18A, 18B) if they exceed 10 tasks
 
+**Flag stacked-PR candidates:** When a phase touches multiple layers (migration + service + handler + UI) or is likely to exceed ~400 LOC, note in the phase description that it's a good candidate for a stacked PR split and reference `docs/stacked-prs.md`. This lets the implementing agent invoke `/stack plan <topic>` up front instead of discovering mid-implementation that the diff has outgrown a single PR.
+
 ### Spec Files for New Phases
 
 For non-trivial features, create a **spec document** in `docs/` alongside the roadmap entry. This serves two purposes: it gives the implementing agent detailed context without bloating the roadmap, and it becomes permanent documentation for the feature.

--- a/.claude/skills/stack/SKILL.md
+++ b/.claude/skills/stack/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: stack
+description: Plan, start, submit, and land stacked PRs using Graphite (`gt`). Invoke when the change is large enough to benefit from splitting into reviewable pieces. Do NOT invoke for small single-PR work.
+argument-hint: "[plan|start|next|submit|status|land] [args...]"
+---
+
+# Stacked PR Workflow (Graphite)
+
+This skill wraps [Graphite](https://graphite.dev) (`gt`) with Breadbox conventions. It assumes `gt` is installed and the repo is initialized (`gt repo init --trunk main`) — the session-start hook handles both.
+
+**When to use a stack:** only when the change is large and splits cleanly. See `docs/stacked-prs.md` for the decision rule. Default to a single PR.
+
+## Modes
+
+Based on `$ARGUMENTS`, run one of:
+
+- `plan <topic>` — propose a split. No git actions.
+- `start <topic>` — sync `main`, prep for the first branch.
+- `next <slug>` — create the next stacked branch.
+- `submit` — push and open/update PRs for the whole stack.
+- `status` — show the current stack.
+- `land` — merge the bottom PR and auto-restack the rest.
+
+If `$ARGUMENTS` is empty or unrecognized, ask which mode to run.
+
+---
+
+## Plan Mode
+
+Take a feature description and propose how to split it into independently reviewable PRs.
+
+### Steps
+
+1. Ask for (or use the passed) feature description if not already clear.
+2. Skim the relevant code layers to understand what the change will touch (use `Explore` agent if more than a handful of files).
+3. Propose a numbered list of 2–6 PRs, each with:
+   - A short title
+   - The files/packages it touches
+   - A one-sentence "why this PR exists on its own" justification
+   - Dependencies on prior PRs in the stack
+4. Ask the user to confirm or revise.
+5. If fewer than 2 independently reviewable pieces exist, **recommend a single PR instead** and stop.
+
+Do not create branches or run `gt` commands in this mode.
+
+---
+
+## Start Mode
+
+Set up the worktree for a new stack.
+
+```bash
+gt sync                                  # pull main, restack open stacks, prune merged branches
+gt checkout main
+```
+
+Report the current `gt log short` so the user sees existing stacks, and confirm the topic name to use (`<topic>`). The first branch will be created with `next`.
+
+---
+
+## Next Mode
+
+Create the next branch in the current stack. Requires `<slug>` as an argument.
+
+### Steps
+
+1. Determine the topic. If on `main`, ask the user (or infer from the last `start` call). If already on a `stack/<topic>/*` branch, reuse that topic.
+2. Determine the next position number by listing existing `stack/<topic>/*` branches and taking `max(NN) + 1` (zero-padded to 2 digits). First branch is `01`.
+3. Verify there are staged or uncommitted changes; if not, stop and ask the user to stage the work first.
+4. Run:
+
+```bash
+gt create -b stack/<topic>/<NN>-<slug> -am "<topic>: <one-line commit msg>"
+```
+
+5. Confirm the new branch is the tip of the stack via `gt log short`.
+
+---
+
+## Submit Mode
+
+Push everything and open/update PRs.
+
+```bash
+gt submit --stack --no-interactive --no-edit
+```
+
+After submit:
+
+1. Capture the PR URLs from the command output.
+2. Print them in order (bottom to top) so the user can start review from the base.
+3. If any PR body lacks a "why this PR exists" line under the `<!-- Graphite stack -->` block, offer to fill it in via `mcp__github__update_pull_request`.
+
+---
+
+## Status Mode
+
+Show the state of the current stack.
+
+```bash
+gt log short
+```
+
+Then, for each branch in the stack, fetch its PR state via `mcp__github__pull_request_read` and print a compact table:
+
+| Position | Branch | PR | CI | Review |
+|---|---|---|---|---|
+| 01 | stack/review-ui/01-migration | #201 | ✅ | approved |
+| 02 | stack/review-ui/02-service | #202 | ⏳ | pending |
+
+---
+
+## Land Mode
+
+Merge the bottom PR and auto-restack the remainder.
+
+### Pre-flight checks
+
+Before calling `gt land`:
+
+1. Confirm the bottom PR has approving review and green CI (via `mcp__github__pull_request_read`).
+2. Confirm no unresolved review threads on the bottom PR.
+3. Refuse to proceed if any of the above fail; surface the blocker to the user.
+
+### Execute
+
+```bash
+gt checkout <bottom-branch>
+gt land --no-interactive
+```
+
+After a successful land, run `gt log short` and report which PR is next in line.
+
+---
+
+## Guardrails
+
+- **Never** run `git push`, `git commit --amend`, `git checkout -b`, or `git rebase` manually while on a stacked branch. Always go through `gt`.
+- **Never** squash-merge a mid-stack PR directly via `mcp__github__merge_pull_request` — use `gt land` so the rest of the stack restacks correctly.
+- If `gt` reports a merge conflict during `gt sync` or `gt modify`, stop and surface the conflict files to the user; don't try to resolve autonomously unless the conflict is trivial (whitespace-only, a single line in a single file).
+- The `<!-- Graphite stack -->` block in each PR body is owned by `gt`. Don't edit it via `mcp__github__update_pull_request`.
+
+## Installation check
+
+If `gt --version` fails, run:
+
+```bash
+npm install -g @withgraphite/graphite-cli@stable
+```
+
+The session-start hook already does this for remote sessions; this check is only for manual invocations in environments where the hook didn't run.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,12 @@ Prefer `make dev-watch` for UI work. See `.claude/rules/ui.md` for the hot-reloa
 
 For validating UI on `localhost`, use the **Chrome DevTools MCP** (`mcp__plugin_chrome-devtools-mcp_chrome-devtools__*`) — pre-allowed, no prompts. Prefer it over `claude-in-chrome`, which is slower and requires permission approvals.
 
+## Stacked PRs
+
+Default to a single PR. Stack **only when reasonable** — i.e., the change is large (touches >1 layer or ~400+ LOC) and splits cleanly into independently reviewable pieces. Don't stack a single bug fix or UI tweak.
+
+When stacking, use [Graphite](https://graphite.dev) (`gt`) — never raw `git push`, `git checkout -b`, or `git commit --amend` on a stacked branch. Invoke `/stack plan <topic>` before writing code to propose the split; use `/stack next`, `/stack submit`, and `/stack land` to execute. Full spec in `docs/stacked-prs.md`; guardrails in `.claude/rules/stacked-prs.md`.
+
 ## Releases
 
 - `main` is branch-protected — PR-only, CI must pass.
@@ -108,6 +114,7 @@ Canonical specs in `docs/`:
 - `design-system.md` — CSS framework, components, icons
 - `plaid-integration.md`, `teller-integration.md`, `csv-import.md` — provider specifics
 - `admin-dashboard.md`, `mcp-server.md`, `rest-api.md`, `backup.md` — subsystem details
+- `stacked-prs.md` — when and how to split work across stacked PRs using `gt`
 
 Scoped rules in `.claude/rules/` load when you touch matching files:
 
@@ -119,3 +126,4 @@ Scoped rules in `.claude/rules/` load when you touch matching files:
 - `providers.md` — provider integrations
 - `sync.md` — sync engine patterns
 - `ui.md` — admin UI, CSS, Alpine, icons
+- `stacked-prs.md` — `gt` workflow and stack conventions (read before creating a stack)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,24 @@ make css        # Compile input.css -> static/css/styles.css
 make css-watch  # Watch mode for development
 ```
 
+## Pull Requests
+
+Default to a single PR per change. Use stacked PRs (via [Graphite](https://graphite.dev)) **only when the change is large and splits cleanly** — e.g., touches >1 layer, exceeds ~400 LOC, or has pieces that can merge in stages. Don't stack a single bug fix or UI tweak.
+
+When stacking:
+
+```bash
+npm install -g @withgraphite/graphite-cli@stable
+gt repo init --trunk main           # one-time, per clone
+gt sync                             # before starting
+gt create -b stack/<topic>/01-<slug> -am "..."
+# ...repeat gt create for each subsequent PR...
+gt submit --stack --no-interactive  # push and open/update PRs
+gt land                             # merge bottom PR, auto-restacks the rest
+```
+
+Never `git push`, `git checkout -b`, or `git commit --amend` on a stacked branch — it desyncs `gt`'s metadata. See `docs/stacked-prs.md` for the full policy.
+
 ## Code Style
 
 - Error codes: `UPPER_SNAKE_CASE` in JSON envelope `{ "error": { "code": "...", "message": "..." } }`

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -1,0 +1,131 @@
+# Stacked PRs
+
+A stacked PR is a chain of small PRs where each builds on the previous one. We use [Graphite](https://graphite.dev) (`gt`) as the tool of record for creating and managing stacks.
+
+## When to stack
+
+Stacks have real overhead — more branches, more restacks, more PRs to review. Use them **only when reasonable**. Default to a single PR.
+
+**Stack when any of these apply:**
+
+- The change touches more than one layer — e.g., migration + service + handler + UI.
+- The diff would exceed ~400 LOC and can be split into independently reviewable chunks.
+- Work can be usefully merged in stages (e.g., ship the migration first so other agents can build on it while you finish the UI).
+- A reviewer will reasonably want to approve part of the work before the rest.
+
+**Don't stack when:**
+
+- The change is a single bug fix, a single UI tweak, or a single test addition.
+- The pieces only make sense together (e.g., a service method and its only caller) — that's one PR.
+- You'd have to artificially split the work to meet a line-count target.
+
+A good rule of thumb: if you can't write a short, standalone "why this PR exists" description for each PR in the stack, don't stack.
+
+## Conventions
+
+### Branch naming
+
+When stacking, name branches `stack/<topic>/<NN>-<slug>`:
+
+```
+stack/review-ui/01-add-migration
+stack/review-ui/02-service-methods
+stack/review-ui/03-handlers
+stack/review-ui/04-templates
+```
+
+`<topic>` is a short kebab-case identifier for the overall feature. `<NN>` is a two-digit position (01, 02, ...). `<slug>` describes the specific PR.
+
+Pass the name explicitly to `gt`:
+
+```bash
+gt create -b stack/review-ui/01-add-migration -am "review-ui: add reviews table"
+```
+
+### Stack metadata in PR bodies
+
+`gt submit` inserts and maintains a `<!-- Graphite stack -->` comment block at the top of each PR body listing all PRs in the stack and marking the current position. Do not hand-edit this block — `gt` will overwrite it.
+
+Write the rest of the PR body as you normally would. The first line under the Graphite block should be a one-sentence "why this PR exists" that stands on its own.
+
+### Base branch
+
+The first PR in a stack targets `main`. Subsequent PRs target their parent branch (not `main`) — `gt submit` handles this automatically.
+
+## Workflow with `gt`
+
+### Starting a stack
+
+```bash
+gt sync                                          # pull main, restack, prune merged branches
+gt create -b stack/<topic>/01-<slug> -am "..."   # create branch + commit as one step
+# implement, test
+gt create -b stack/<topic>/02-<slug> -am "..."   # stack next branch on top
+# implement, test
+gt submit --stack --no-interactive               # push all, open/update PRs
+```
+
+### Amending a branch mid-stack
+
+Check out the branch, edit, then:
+
+```bash
+gt modify --amend                                # amend current branch's commit and restack dependents
+gt submit --stack --no-interactive               # update all affected PRs
+```
+
+Never `git commit --amend` + `git push --force` on a stacked branch — `gt modify` is what preserves the stack state.
+
+### Keeping up with `main`
+
+Other PRs will land on `main` while your stack is open:
+
+```bash
+gt sync                                          # pulls main, restacks your entire stack onto the new tip
+gt submit --stack --no-interactive               # force-with-lease the restacked branches
+```
+
+### Landing (merging)
+
+Once the bottom PR is approved and CI is green:
+
+```bash
+gt land                                          # merges bottom PR, auto-restacks rest
+```
+
+Repeat from the bottom upward. Don't squash-merge out of order.
+
+### Navigating
+
+```bash
+gt log short                                     # compact view of current stack
+gt log long                                      # full view across all stacks
+gt up / gt down                                  # move one branch up/down the stack
+gt checkout <branch>                             # jump to any branch
+```
+
+## Review etiquette
+
+- Reviewers start at the bottom of the stack and approve upward. The Graphite block in each PR body links to adjacent PRs for navigation.
+- If a reviewer requests a change on a middle PR, use `gt modify` (not manual rebase) so comments on later PRs remain anchored. After restack, `gt submit` force-pushes each affected branch with `--force-with-lease`.
+- If the stack has diverged significantly from `main` (days old), `gt sync` before requesting re-review.
+
+## CI
+
+Each PR in a stack runs CI independently against its own tip. There's no merge-queue coordination — if you need the bottom PR's changes to make the middle PR's CI green, that's the correct behavior; merge the bottom first.
+
+`gt land` waits on CI for the branch being landed, not the rest of the stack.
+
+## Cheat sheet
+
+| Task | Command |
+|---|---|
+| Start fresh from main | `gt sync && gt trunk` |
+| New branch stacked on current | `gt create -b <name> -am "<msg>"` |
+| Push + open/update all PRs | `gt submit --stack --no-interactive` |
+| Amend current branch | `gt modify --amend` |
+| Pull main and restack | `gt sync` |
+| See the stack | `gt log short` |
+| Merge the bottom PR | `gt land` |
+
+See the [Graphite docs](https://graphite.dev/docs) for everything else.


### PR DESCRIPTION
## Summary

- Adds opt-in stacked-PR workflow using [Graphite](https://graphite.dev) (`gt`) while keeping single-PR as the default. Stacks are reserved for large changes that touch multiple layers or exceed ~400 LOC and split cleanly.
- Introduces a `/stack` slash command (`plan`, `start`, `next`, `submit`, `status`, `land`) so agents can drive the workflow end-to-end without learning `gt` directly.
- Session-start hook installs `gt` for remote (web) sessions so `/stack` is ready without a round-trip.

## Changes

- `docs/stacked-prs.md` — canonical spec: when to stack, branch naming (`stack/<topic>/<NN>-<slug>`), `gt` workflow, review etiquette, cheat sheet.
- `.claude/rules/stacked-prs.md` — concise scoped rule for agents creating a stack.
- `.claude/skills/stack/SKILL.md` — `/stack` slash command with six modes and guardrails (never `git push`/`--amend` on a stacked branch; never squash-merge mid-stack).
- `CLAUDE.md` — new "Stacked PRs" section with the stack-only-when-reasonable policy; references the spec and rule.
- `CONTRIBUTING.md` — human-facing "Pull Requests" section covering the `gt` flow.
- `.claude/hooks/session-start.sh` — installs `@withgraphite/graphite-cli` and runs `gt repo init --trunk main` on remote sessions (idempotent; silent skip if `npm` unavailable).
- `.claude/skills/roadmap/SKILL.md` — flags multi-layer / large phases as stack candidates during scoping.

## Notes

- Not hoisting the `gt` install to local worktree sessions by default — the assumption is that on a local machine you already have `npm` and can install `gt` yourself. Easy to add if we want it.
- Skipped updating the autonomous iteration commands (ux-improve, qa-bugs, sync-improve, insights-improve, ux-qa-mobile) since those are being deprecated.

## Test plan

- [ ] Open a fresh cloud session; verify `gt --version` works after session-start.
- [ ] `/stack plan <topic>` produces a reasonable split proposal without running git commands.
- [ ] `/stack start <topic>` runs `gt sync` and leaves us on `main`.
- [ ] `/stack next <slug>` creates `stack/<topic>/01-<slug>` with the staged commit.
- [ ] `/stack submit` pushes and opens PRs; the Graphite block appears in each PR body.
- [ ] `/stack land` merges the bottom PR and auto-restacks the remainder.
- [ ] Local worktree still starts fine (no regression from the hook changes).

https://claude.ai/code/session_01PrMKZgpeTUY3Ukb5bLBwDH