### PR TITLE
chore(sandbox): allow graphite state paths

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,6 +58,8 @@
       "allowWrite": [
         "~/go",
         "~/Library/Caches/go-build",
+        "~/.local/share/graphite",
+        "~/.config/graphite",
         "/tmp",
         "/var/folders"
       ]


### PR DESCRIPTION
Short infra PR to unblock the stacked-PR workflow (#533).

`gt` writes to `~/.local/share/graphite` (state) and `~/.config/graphite` (user config). Without these paths in the harness sandbox allowlist, every `gt` invocation fails with `EPERM`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)