### PR TITLE
refactor(rules): drop tagSliceContains dup, use sliceutil.ContainsFold

### DIFF
--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -352,29 +352,16 @@ func evaluateLeaf(c *CompiledCondition, tctx TransactionContext) bool {
 func evalTags(c *CompiledCondition, tags []string) bool {
 	switch c.Op {
 	case "contains":
-		return tagSliceContains(tags, c.lowerValue)
+		return sliceutil.ContainsFold(tags, c.lowerValue)
 	case "not_contains":
-		return !tagSliceContains(tags, c.lowerValue)
+		return !sliceutil.ContainsFold(tags, c.lowerValue)
 	case "in":
 		for _, v := range c.lowerInSet {
-			if tagSliceContains(tags, v) {
+			if sliceutil.ContainsFold(tags, v) {
 				return true
 			}
 		}
 		return false
-	}
-	return false
-}
-
-// tagSliceContains reports whether tags contains target (case-insensitive).
-func tagSliceContains(tags []string, target string) bool {
-	if target == "" {
-		return false
-	}
-	for _, t := range tags {
-		if strings.EqualFold(t, target) {
-			return true
-		}
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

- `internal/service/rules.go` carried a local `tagSliceContains` helper with semantics identical to `sliceutil.ContainsFold` (empty-target short-circuit + case-insensitive scan).
- The sync-side rule resolver already routes tag `contains` / `in` through `sliceutil.ContainsFold` ([rule_resolver.go:766](https://github.com/canalesb93/breadbox/blob/main/internal/sync/rule_resolver.go#L766)). This brings the service-side evaluator in line.
- `sliceutil` was already imported in this file for the tag action-execution path, so no new imports.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all unit tests pass
- [x] `TestEvaluateCondition_TagsField` (contains / not_contains / in, case-insensitive, empty tags) covers every call site

🤖 Generated with [Claude Code](https://claude.com/claude-code)