### PR TITLE
Fix `gt` CLI flags: positional branch name, `--publish --ai` on submit

### DIFF
--- a/.claude/rules/stacked-prs.md
+++ b/.claude/rules/stacked-prs.md
@@ -17,16 +17,17 @@ Do not stack a single bug fix, single UI tweak, or any change whose pieces only 
 
 ## Branch naming
 
-`stack/<topic>/<NN>-<slug>` — topic is kebab-case, `NN` is a two-digit position, `slug` describes this PR. Always pass `-b` to `gt create` so the branch gets the right name.
+`stack/<topic>/<NN>-<slug>` — topic is kebab-case, `NN` is a two-digit position, `slug` describes this PR. Pass the name positionally: `gt create <name>`. The `-b` flag is not accepted by this version of the CLI.
 
 ## Commands to use
 
 Always use `gt` for branch/PR operations when in a stack:
 
 - `gt sync` before starting — pulls `main`, restacks open stacks, prunes merged branches.
-- `gt create -b stack/<topic>/<NN>-<slug> -am "..."` for each new branch in the stack.
-- `gt submit --stack --no-interactive` to push everything and open/update PRs in one shot.
-- `gt modify --amend` for mid-stack edits (never `git commit --amend` + force-push).
+- `gt create stack/<topic>/<NN>-<slug> -am "..."` for each new branch in the stack. Positional branch name; `-am` stages all and commits in one step (if nothing is staged, creates an empty branch to fill in later).
+- **First submit:** `gt submit --stack --publish --ai --no-interactive`. `--ai` populates title + body from the commit; `--publish` opens as ready-for-review (not draft); `--no-interactive` keeps it harness-safe.
+- **Subsequent pushes:** `gt submit --stack --publish --no-interactive` — no `--ai` (it only fires on initial PR creation).
+- `gt modify -u` for mid-stack edits — amends the current branch's commit (the default behavior; `-u` stages all tracked updates) and auto-restacks descendants. Never `git commit --amend` + force-push.
 - `gt land` to merge the bottom PR and auto-restack the rest.
 
 Never `git push` or `git checkout -b` directly once you're on a stack — it desynchronizes `gt`'s metadata.
@@ -35,14 +36,16 @@ Never `git push` or `git checkout -b` directly once you're on a stack — it des
 
 `gt submit` inserts and maintains a `<!-- Graphite stack -->` block at the top of each PR body. Do not hand-edit it. Write the rest of the description as usual; the first line should be a one-sentence standalone justification for this PR.
 
+**If `--ai`-generated output isn't rich enough** (needs screenshots, cross-PR checklists, hand-curated test plan), pre-write `body-NN.md` files during the implementation phase and after submit run `gh pr edit <pr-number> --body-file body-NN.md`. Never call `gt submit --no-interactive` without either `--ai` or a follow-up `gh pr edit` — the bare non-interactive form leaves the repo's PR template as the body, which reads as empty in review.
+
 ## Review iteration
 
 If a reviewer requests changes on a middle PR:
 
 1. `gt checkout <branch>`
 2. Edit files.
-3. `gt modify --amend` — this restacks all descendants.
-4. `gt submit --stack --no-interactive` — force-with-lease push for each affected PR.
+3. `gt modify -u` — amends the current commit (default) and restacks all descendants.
+4. `gt submit --stack --publish --no-interactive` — force-with-lease push for each affected PR.
 
 Comment anchors on later PRs are preserved because `gt` uses `--force-with-lease`.
 

--- a/.claude/skills/stack/SKILL.md
+++ b/.claude/skills/stack/SKILL.md
@@ -70,8 +70,10 @@ Create the next branch in the current stack. Requires `<slug>` as an argument.
 4. Run:
 
 ```bash
-gt create -b stack/<topic>/<NN>-<slug> -am "<topic>: <one-line commit msg>"
+gt create stack/<topic>/<NN>-<slug> -am "<topic>: <one-line commit msg>"
 ```
+
+Note: pass the branch name positionally. The `-b` flag shown in some Graphite docs isn't accepted by the current CLI — it errors with `Unknown argument: b`.
 
 5. Confirm the new branch is the tip of the stack via `gt log short`.
 
@@ -79,17 +81,37 @@ gt create -b stack/<topic>/<NN>-<slug> -am "<topic>: <one-line commit msg>"
 
 ## Submit Mode
 
-Push everything and open/update PRs.
+Push everything and open/update PRs. The flag combination depends on whether PRs already exist.
+
+**First submit (PRs don't exist yet):**
 
 ```bash
-gt submit --stack --no-interactive --no-edit
+gt submit --stack --publish --ai --no-interactive
 ```
+
+- `--ai` populates title + description from each commit + diff. Only works on initial PR creation — it's a no-op on already-open PRs.
+- `--publish` opens as ready-for-review instead of draft (the default when `--no-interactive` is set).
+- `--no-interactive` keeps it harness-safe (no inline prompts, no stalled stdin).
+
+**Subsequent pushes (PRs already exist):**
+
+```bash
+gt submit --stack --publish --no-interactive
+```
+
+Drop `--ai` — title and body are already set; AI won't re-generate them, and including the flag just burns time.
+
+**What NOT to use:** `gt submit --stack --no-interactive` on its own. That leaves the PR body as the repo's `.github/pull_request_template.md` placeholder, which reads as empty in review.
 
 After submit:
 
 1. Capture the PR URLs from the command output.
 2. Print them in order (bottom to top) so the user can start review from the base.
-3. If any PR body lacks a "why this PR exists" line under the `<!-- Graphite stack -->` block, offer to fill it in via `mcp__github__update_pull_request`.
+3. Spot-check the bodies: if `--ai` produced something thin (no "why this PR exists" line, no test plan, no screenshots for a UI PR), either:
+   - Pre-write a `body-NN.md` file and apply via `gh pr edit <num> --body-file body-NN.md`, or
+   - Use `mcp__github__update_pull_request` to fill in the sections that matter.
+
+Leave the `<!-- Graphite stack -->` block alone — `gt` owns it and will overwrite hand edits on the next submit.
 
 ---
 
@@ -127,6 +149,7 @@ Before calling `gt land`:
 ```bash
 gt checkout <bottom-branch>
 gt land --no-interactive
+gt submit --stack --publish --no-interactive  # after land, restack + force-push the remainder
 ```
 
 After a successful land, run `gt log short` and report which PR is next in line.

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -39,8 +39,20 @@ stack/review-ui/04-templates
 Pass the name explicitly to `gt`:
 
 ```bash
-gt create -b stack/review-ui/01-add-migration -am "review-ui: add reviews table"
+gt create stack/review-ui/01-add-migration -am "review-ui: add reviews table"
 ```
+
+### PR titles and bodies
+
+`gt submit` picks up PR metadata one of three ways. Pick one; don't mix:
+
+**Option 1 — `--ai` (default in this repo).** Graphite generates the title and body from the commit subject, body, and diff. This is the lowest-friction path for agent-driven stacks and is what the command line above uses. Re-running `gt submit --ai` on an already-open PR does **not** regenerate — `--ai` only populates the first time.
+
+**Option 2 — Commit-driven (no `--ai`, no `--no-interactive`).** In an interactive TTY, `gt submit` prompts inline and seeds the prompts with the commit subject + body. This is the humans-at-keyboards default and is what the Graphite docs assume.
+
+**Option 3 — Pre-written body files (any mode).** Drop a `.github/pull_request_template/stack-<topic>-<NN>.md` (or any convenient file) per PR and apply them after submit with `gh pr edit <num> --body-file …`. Use this when the body needs to be richer than what `--ai` produces (e.g., screenshots, cross-PR checklists, hand-curated test plans).
+
+**What NOT to use:** `gt submit --no-interactive` by itself leaves the PR body as the repo's `.github/pull_request_template.md` placeholder — empty from a reviewer's perspective. Always pair `--no-interactive` with either `--ai` or a follow-up `gh pr edit --body-file`.
 
 ### Stack metadata in PR bodies
 
@@ -58,11 +70,11 @@ The first PR in a stack targets `main`. Subsequent PRs target their parent branc
 
 ```bash
 gt sync                                          # pull main, restack, prune merged branches
-gt create -b stack/<topic>/01-<slug> -am "..."   # create branch + commit as one step
+gt create stack/<topic>/01-<slug> -am "..."   # create branch + commit as one step
 # implement, test
-gt create -b stack/<topic>/02-<slug> -am "..."   # stack next branch on top
+gt create stack/<topic>/02-<slug> -am "..."   # stack next branch on top
 # implement, test
-gt submit --stack --no-interactive               # push all, open/update PRs
+gt submit --stack --publish --ai --no-interactive  # push all, open/update PRs
 ```
 
 ### Amending a branch mid-stack
@@ -70,8 +82,8 @@ gt submit --stack --no-interactive               # push all, open/update PRs
 Check out the branch, edit, then:
 
 ```bash
-gt modify --amend                                # amend current branch's commit and restack dependents
-gt submit --stack --no-interactive               # update all affected PRs
+gt modify -u                                       # amend current branch's commit (default) + restack dependents; -u stages tracked updates
+gt submit --stack --publish --no-interactive       # update already-open PRs (no --ai needed; bodies already set)
 ```
 
 Never `git commit --amend` + `git push --force` on a stacked branch — `gt modify` is what preserves the stack state.
@@ -81,8 +93,8 @@ Never `git commit --amend` + `git push --force` on a stacked branch — `gt modi
 Other PRs will land on `main` while your stack is open:
 
 ```bash
-gt sync                                          # pulls main, restacks your entire stack onto the new tip
-gt submit --stack --no-interactive               # force-with-lease the restacked branches
+gt sync                                            # pulls main, restacks your entire stack onto the new tip
+gt submit --stack --publish --no-interactive       # force-with-lease the restacked branches
 ```
 
 ### Landing (merging)
@@ -121,9 +133,10 @@ Each PR in a stack runs CI independently against its own tip. There's no merge-q
 | Task | Command |
 |---|---|
 | Start fresh from main | `gt sync && gt trunk` |
-| New branch stacked on current | `gt create -b <name> -am "<msg>"` |
-| Push + open/update all PRs | `gt submit --stack --no-interactive` |
-| Amend current branch | `gt modify --amend` |
+| New branch stacked on current | `gt create <name> -am "<msg>"` |
+| Push + open all PRs (first submit) | `gt submit --stack --publish --ai --no-interactive` |
+| Push updates to already-open PRs | `gt submit --stack --publish --no-interactive` |
+| Amend current branch | `gt modify -u` |
 | Pull main and restack | `gt sync` |
 | See the stack | `gt log short` |
 | Merge the bottom PR | `gt land` |


### PR DESCRIPTION
## Summary

Fixes the `gt create` invocation across all docs and skill files — the `-b` flag is not accepted by the current Graphite CLI version and errors with `Unknown argument: b`. Branch name is now passed positionally. Also tightens the `gt submit` guidance to distinguish first-submit (use `--ai --publish`) from subsequent pushes (drop `--ai`), and adds an explicit warning that bare `--no-interactive` without `--ai` or a follow-up `gh pr edit` leaves PR bodies as empty template placeholders.

## Changes

- Replace `gt create -b <name>` with `gt create <name>` (positional) everywhere it appears.
- Split `gt submit` into two documented forms: `--stack --publish --ai --no-interactive` for initial PR creation and `--stack --publish --no-interactive` for subsequent pushes.
- Add `--publish` to all `gt submit` calls so PRs open as ready-for-review rather than draft when `--no-interactive` is set.
- Document that `--ai` is a no-op on already-open PRs and should be dropped on re-submits.
- Add explicit guidance that `gt submit --no-interactive` alone leaves the PR body as the repo's pull request template placeholder; pair it with `--ai` or a follow-up `gh pr edit --body-file`.
- Add `gt submit --stack --publish --no-interactive` after `gt land` to restack and force-push the remainder of the stack.
- Update the cheat-sheet table to split the single "push + open/update" row into first-submit and subsequent-push rows.

## Evidence

This PR itself was opened via the new flag combo (`gt submit --stack --publish --ai --no-interactive`) — the AI-generated title, Summary, and Changes sections above are the unmodified `--ai` output. This description was then edited via `gh pr edit --body-file` to add this Evidence + Related sections, demonstrating the "pre-written body-file escape hatch" documented in the PR.

## Testing

Docs-only change; no code paths touched.

## Related

Builds on #533 (the initial stacked-PR spec). Feeds back into the stack experiment tracked across #538–#541 (first real stacked PRs in the repo).
