### PR TITLE
fix(breadcrumbs): stop spurious vertical scroll on breadcrumb bar

### DIFF
--- a/input.css
+++ b/input.css
@@ -184,6 +184,13 @@
   /* ── Breadcrumbs: shadcn-style navigation trail ── */
   .bb-breadcrumb {
     @apply flex items-center gap-1.5 text-sm mb-6 overflow-x-auto whitespace-nowrap;
+    /* With overflow-x:auto the CSS spec forces overflow-y to also compute
+       as auto (visible can't coexist with a scroll container). That means
+       any sub-pixel row-height mismatch between the SVG chevrons and the
+       text baseline produces a spurious vertical scroll region. Pin Y to
+       clip so a long trail still scrolls horizontally, but vertical
+       overflow never becomes scrollable. */
+    overflow-y: clip;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;        /* Firefox */
     -ms-overflow-style: none;     /* IE/Edge */


### PR DESCRIPTION
## Problem

The breadcrumb bar (`.bb-breadcrumb`) sets `overflow-x: auto` so long trails can scroll horizontally on narrow viewports — that part works as intended. But the CSS spec says: when one axis of `overflow` is anything other than `visible` (or `clip`), the other axis also computes as `auto`. So `overflow-x: auto` silently makes `overflow-y: auto` too.

The result: any sub-pixel row-height mismatch (e.g. the inline SVG chevron reporting a slightly different height than the surrounding text baseline) turns the breadcrumb into a vertical scroll container. In Chrome the computed `overflow-y` comes back as `auto` and the bar becomes scrollable vertically even though it clearly shouldn't be — scroll-wheeling the breadcrumb moves it by a pixel or two.

## Fix

Pin `overflow-y: clip` on `.bb-breadcrumb`. One line in `input.css`. The horizontal scroll behaviour for long trails is unchanged, but the browser can no longer create a vertical scroll region for the breadcrumb.

`clip` (rather than `hidden`) is preferred because it doesn't create a new scroll container — it just clips. Chrome, Safari 16+, Firefox 81+ all support it; older engines fall back to `hidden`, which still fixes the bug.

## Verification

- Computed `overflow-y` on `.bb-breadcrumb` is now `hidden` (Chrome normalises `clip` → `hidden` in computed styles); previously it was `auto`.
- Long breadcrumb trails still scroll horizontally (verified by injecting a 5-level trail at 500px width).
- No visible clipping of descenders or chevrons at normal row height.

### Before
| Mobile (500) | Tablet (820) | Desktop (1440) |
|---|---|---|
| ![](https://i.img402.dev/0z3s0yq4u6.png) | ![](https://i.img402.dev/x2zs5p3ccp.png) | ![](https://i.img402.dev/0hcga242tr.png) |

### After
| Mobile (500) | Tablet (820) | Desktop (1440) |
|---|---|---|
| ![](https://i.img402.dev/r2mu9hss88.png) | ![](https://i.img402.dev/9lo4xfpwf2.png) | ![](https://i.img402.dev/r3951r7grx.png) |

## Test plan
- [ ] Visit a page with breadcrumbs (e.g. `/rules/:id/edit`, a transaction detail page).
- [ ] Confirm breadcrumb bar cannot be scrolled vertically (scroll-wheeling the breadcrumb does nothing).
- [ ] At a narrow viewport (e.g. 375px) with a long trail, confirm the breadcrumb still scrolls horizontally.
- [ ] No clipping of chevron SVGs or text descenders at default row height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)