### PR TITLE
Replace `gt land` with `gh pr merge --auto` + `gt sync` workflow

### DIFF
--- a/.claude/rules/stacked-prs.md
+++ b/.claude/rules/stacked-prs.md
@@ -28,7 +28,7 @@ Always use `gt` for branch/PR operations when in a stack:
 - **First submit:** `gt submit --stack --publish --ai --no-interactive`. `--ai` populates title + body from the commit; `--publish` opens as ready-for-review (not draft); `--no-interactive` keeps it harness-safe.
 - **Subsequent pushes:** `gt submit --stack --publish --no-interactive` — no `--ai` (it only fires on initial PR creation).
 - `gt modify -u` for mid-stack edits — amends the current branch's commit (the default behavior; `-u` stages all tracked updates) and auto-restacks descendants. Never `git commit --amend` + force-push.
-- `gt land` to merge the bottom PR and auto-restack the rest.
+- Landing: `gt land` is not in the installed CLI. Either pass `--merge-when-ready` on the submit (queues GitHub auto-merge for every PR in the stack) or run `gh pr merge <bottom-pr> --auto --squash`. After each merge: `gt sync` + re-submit to restack the tail.
 
 Never `git push` or `git checkout -b` directly once you're on a stack — it desynchronizes `gt`'s metadata.
 

--- a/.claude/skills/stack/SKILL.md
+++ b/.claude/skills/stack/SKILL.md
@@ -134,32 +134,43 @@ Then, for each branch in the stack, fetch its PR state via `mcp__github__pull_re
 
 ## Land Mode
 
-Merge the bottom PR and auto-restack the remainder.
+Merge the bottom PR and auto-restack the remainder. The installed Graphite CLI doesn't ship `gt land`; use GitHub's auto-merge instead.
 
 ### Pre-flight checks
 
-Before calling `gt land`:
+Before queuing the merge:
 
-1. Confirm the bottom PR has approving review and green CI (via `mcp__github__pull_request_read`).
+1. Confirm the bottom PR has approving review and green (or in-progress) CI (via `mcp__github__pull_request_read`).
 2. Confirm no unresolved review threads on the bottom PR.
 3. Refuse to proceed if any of the above fail; surface the blocker to the user.
 
 ### Execute
 
+**Option A — queue auto-merge for the whole stack at submit time:**
+
 ```bash
-gt checkout <bottom-branch>
-gt land --no-interactive
-gt submit --stack --publish --no-interactive  # after land, restack + force-push the remainder
+gt submit --stack --publish --merge-when-ready --no-interactive
 ```
 
-After a successful land, run `gt log short` and report which PR is next in line.
+This marks every PR in the stack for auto-merge. GitHub squashes them in order as approvals/CI clear.
+
+**Option B — queue the bottom PR alone, then re-sync:**
+
+```bash
+gh pr merge <bottom-pr-number> --auto --squash
+# wait for it to land
+gt sync                                        # pulls main, prunes the merged branch, restacks the tail
+gt submit --stack --publish --no-interactive   # force-with-lease the restacked tail
+```
+
+After a successful land, run `gt log short` and report which PR is next in line. Never merge a mid-stack PR manually via `mcp__github__merge_pull_request` — the squash drops the lower-stack diff into `main`, which breaks later branches' diffs.
 
 ---
 
 ## Guardrails
 
 - **Never** run `git push`, `git commit --amend`, `git checkout -b`, or `git rebase` manually while on a stacked branch. Always go through `gt`.
-- **Never** squash-merge a mid-stack PR directly via `mcp__github__merge_pull_request` — use `gt land` so the rest of the stack restacks correctly.
+- **Never** squash-merge a mid-stack PR out of order (via `mcp__github__merge_pull_request`, `gh pr merge` without waiting, or the GitHub UI) — the squash drops the lower-stack diff into `main`, which breaks later branches' diffs. Land the bottom first, then `gt sync` + re-submit.
 - If `gt` reports a merge conflict during `gt sync` or `gt modify`, stop and surface the conflict files to the user; don't try to resolve autonomously unless the conflict is trivial (whitespace-only, a single line in a single file).
 - The `<!-- Graphite stack -->` block in each PR body is owned by `gt`. Don't edit it via `mcp__github__update_pull_request`.
 

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -99,13 +99,30 @@ gt submit --stack --publish --no-interactive       # force-with-lease the restac
 
 ### Landing (merging)
 
-Once the bottom PR is approved and CI is green:
+The installed Graphite CLI doesn't ship `gt land`. Use one of these instead:
+
+**Option 1 — queue at submit time:**
 
 ```bash
-gt land                                          # merges bottom PR, auto-restacks rest
+gt submit --stack --publish --merge-when-ready --no-interactive
 ```
 
-Repeat from the bottom upward. Don't squash-merge out of order.
+`--merge-when-ready` marks every PR in the stack as auto-merge; GitHub squash-merges them in order as approvals come in and CI clears. Respects branch protection.
+
+**Option 2 — queue the bottom PR directly:**
+
+```bash
+gh pr merge <bottom-PR-number> --auto --squash
+```
+
+Then after it lands:
+
+```bash
+gt sync                                            # pulls main, prunes the merged bottom, restacks the rest
+gt submit --stack --publish --no-interactive       # force-with-lease the restacked tail
+```
+
+Repeat from the bottom upward. Never squash-merge a mid-stack PR manually — the GitHub merge squashes the diff from `main`, which includes all lower PRs' changes, which breaks later PRs' diffs. Always land the bottom first.
 
 ### Navigating
 
@@ -126,7 +143,7 @@ gt checkout <branch>                             # jump to any branch
 
 Each PR in a stack runs CI independently against its own tip. There's no merge-queue coordination — if you need the bottom PR's changes to make the middle PR's CI green, that's the correct behavior; merge the bottom first.
 
-`gt land` waits on CI for the branch being landed, not the rest of the stack.
+GitHub's auto-merge (via `--merge-when-ready` or `gh pr merge --auto`) waits on CI for the branch being landed, not the rest of the stack.
 
 ## Cheat sheet
 
@@ -139,6 +156,7 @@ Each PR in a stack runs CI independently against its own tip. There's no merge-q
 | Amend current branch | `gt modify -u` |
 | Pull main and restack | `gt sync` |
 | See the stack | `gt log short` |
-| Merge the bottom PR | `gt land` |
+| Queue auto-merge for the whole stack | `gt submit --stack --publish --merge-when-ready --no-interactive` |
+| Queue auto-merge for a single PR | `gh pr merge <pr> --auto --squash` |
 
 See the [Graphite docs](https://graphite.dev/docs) for everything else.


### PR DESCRIPTION
## Summary

`gt land` is not available in the installed Graphite CLI. This replaces all references to `gt land` with the two supported alternatives: passing `--merge-when-ready` at submit time to queue auto-merge for the entire stack, or using `gh pr merge <pr> --auto --squash` to queue the bottom PR individually followed by `gt sync` + re-submit to restack the tail.

## Changes

- Replaced `gt land` in the stacked-PRs rule, skill, and docs with `--merge-when-ready` and `gh pr merge --auto --squash` workflows
- Clarified that CI only needs to be green or in-progress (not fully complete) before queuing auto-merge
- Expanded the guardrail against out-of-order mid-stack merges to cover `gh pr merge` and the GitHub UI, not just `mcp__github__merge_pull_request`
- Updated the cheat sheet to list both queue-whole-stack and queue-single-PR commands
- Replaced the `gt land` CI note with the equivalent note about GitHub's auto-merge behavior

## Testing

- [ ] Unit tests pass (`go test ./...`)
- [ ] Integration tests pass (`make test-integration`) — if applicable
- [ ] Build succeeds (`go build ./cmd/breadbox`)

## Related issues

Closes #