### PR TITLE
docs(stack): drop --ai from recommended flow; add label convention

### DIFF
--- a/.claude/rules/stacked-prs.md
+++ b/.claude/rules/stacked-prs.md
@@ -25,8 +25,9 @@ Always use `gt` for branch/PR operations when in a stack:
 
 - `gt sync` before starting — pulls `main`, restacks open stacks, prunes merged branches.
 - `gt create stack/<topic>/<NN>-<slug> -am "..."` for each new branch in the stack. Positional branch name; `-am` stages all and commits in one step (if nothing is staged, creates an empty branch to fill in later).
-- **First submit:** `gt submit --stack --publish --ai --no-interactive`. `--ai` populates title + body from the commit; `--publish` opens as ready-for-review (not draft); `--no-interactive` keeps it harness-safe.
-- **Subsequent pushes:** `gt submit --stack --publish --no-interactive` — no `--ai` (it only fires on initial PR creation).
+- **First submit:** `gt submit --stack --publish --no-interactive`. `--publish` opens as ready-for-review (not draft); `--no-interactive` keeps it harness-safe. Follow up **per PR** with `gh pr edit <num> --title "..." --body-file /tmp/body-<num>.md --add-label stacked --add-label "stack/<topic>"` to set metadata + labels yourself.
+- **Subsequent pushes:** `gt submit --stack --publish --no-interactive`. Title, body, and labels persist from the initial submit.
+- **Do not use `--ai`.** It ships diffs + related codebase context to Graphite's AI subprocessors (Anthropic, OpenAI) and has produced inaccurate titles in practice (see #546). Both reasons — privacy and accuracy — are spelled out in `docs/stacked-prs.md`.
 - `gt modify -u` for mid-stack edits — amends the current branch's commit (the default behavior; `-u` stages all tracked updates) and auto-restacks descendants. Never `git commit --amend` + force-push.
 - Landing: `gt land` is not in the installed CLI. Either pass `--merge-when-ready` on the submit (queues GitHub auto-merge for every PR in the stack) or run `gh pr merge <bottom-pr> --auto --squash`. After each merge: `gt sync` + re-submit to restack the tail.
 
@@ -36,7 +37,20 @@ Never `git push` or `git checkout -b` directly once you're on a stack — it des
 
 `gt submit` inserts and maintains a `<!-- Graphite stack -->` block at the top of each PR body. Do not hand-edit it. Write the rest of the description as usual; the first line should be a one-sentence standalone justification for this PR.
 
-**If `--ai`-generated output isn't rich enough** (needs screenshots, cross-PR checklists, hand-curated test plan), pre-write `body-NN.md` files during the implementation phase and after submit run `gh pr edit <pr-number> --body-file body-NN.md`. Never call `gt submit --no-interactive` without either `--ai` or a follow-up `gh pr edit` — the bare non-interactive form leaves the repo's PR template as the body, which reads as empty in review.
+**Bare `gt submit --no-interactive` leaves the body as the repo's PR template** (empty from a reviewer's perspective). Always pair it with a follow-up `gh pr edit <pr> --body-file /tmp/body-<pr>.md` per PR. Author the body files during the implementation phase.
+
+## Labeling
+
+Every PR in a real stack (2+ PRs) gets two labels in the GitHub dashboard, applied right after submit:
+
+1. **`stacked`** — catches every stacked PR across topics. Already exists in the repo.
+2. **`stack/<topic>`** — per-topic grouping (mirrors the branch prefix, e.g. `stack/templ-wizard`). If missing, create it:
+   ```bash
+   gh label create "stack/<topic>" --repo canalesb93/breadbox --color B866F8 \
+     --description "PRs in the <topic> stack" 2>/dev/null || true
+   ```
+
+Apply via `gh pr edit <pr> --add-label stacked --add-label "stack/<topic>"` in the same loop as the body-file fixup. Single-PR submits don't get `stacked` — it's reserved for actual multi-PR stacks.
 
 ## Review iteration
 

--- a/.claude/skills/stack/SKILL.md
+++ b/.claude/skills/stack/SKILL.md
@@ -81,37 +81,53 @@ Note: pass the branch name positionally. The `-b` flag shown in some Graphite do
 
 ## Submit Mode
 
-Push everything and open/update PRs. The flag combination depends on whether PRs already exist.
-
-**First submit (PRs don't exist yet):**
-
-```bash
-gt submit --stack --publish --ai --no-interactive
-```
-
-- `--ai` populates title + description from each commit + diff. Only works on initial PR creation — it's a no-op on already-open PRs.
-- `--publish` opens as ready-for-review instead of draft (the default when `--no-interactive` is set).
-- `--no-interactive` keeps it harness-safe (no inline prompts, no stalled stdin).
-
-**Subsequent pushes (PRs already exist):**
+Push everything and open/update PRs. Same flag combination whether PRs are new or already open:
 
 ```bash
 gt submit --stack --publish --no-interactive
 ```
 
-Drop `--ai` — title and body are already set; AI won't re-generate them, and including the flag just burns time.
+- `--publish` opens as ready-for-review (not draft — the default when `--no-interactive` is set).
+- `--no-interactive` keeps it harness-safe (no inline prompts, no stalled stdin).
 
-**What NOT to use:** `gt submit --stack --no-interactive` on its own. That leaves the PR body as the repo's `.github/pull_request_template.md` placeholder, which reads as empty in review.
+**Do NOT pass `--ai`.** Graphite's `--ai` flag ships each commit's code + "related or similar parts of your codebase" to their AI subprocessors (Anthropic, OpenAI). Two problems for Breadbox: (1) observed inaccuracy — see [#546](https://github.com/canalesb93/breadbox/pull/546), where `--ai` produced a title that emphasized the PR's secondary recommendation and omitted the primary; (2) privacy — we don't ship source for a self-hosted financial app. Write titles and bodies yourself.
 
-After submit:
+### After submit — metadata + labels per PR
 
-1. Capture the PR URLs from the command output.
-2. Print them in order (bottom to top) so the user can start review from the base.
-3. Spot-check the bodies: if `--ai` produced something thin (no "why this PR exists" line, no test plan, no screenshots for a UI PR), either:
-   - Pre-write a `body-NN.md` file and apply via `gh pr edit <num> --body-file body-NN.md`, or
-   - Use `mcp__github__update_pull_request` to fill in the sections that matter.
+Bare `gt submit --no-interactive` leaves each PR body as the repo's PR template placeholder. Close the gap in a single loop:
 
-Leave the `<!-- Graphite stack -->` block alone — `gt` owns it and will overwrite hand edits on the next submit.
+```bash
+# Ensure the topic label exists (idempotent; create once per topic)
+gh label create "stack/<topic>" --repo canalesb93/breadbox --color B866F8 \
+  --description "PRs in the <topic> stack" 2>/dev/null || true
+
+# For each PR the submit just opened (bottom to top):
+for pr in <n1> <n2> <n3>; do
+  gh pr edit "$pr" \
+    --title "<topic>: <clear human-written title>" \
+    --body-file "/tmp/body-$pr.md" \
+    --add-label stacked \
+    --add-label "stack/<topic>"
+done
+```
+
+Author the `body-<pr>.md` files during the implementation phase, not after — the context is fresher. Keep them in `/tmp` (throwaway per session).
+
+**Single-PR submits** (one branch, not a stack) skip the `stacked` + `stack/<topic>` labels — they're reserved for actual multi-PR stacks so the dashboard filter stays meaningful.
+
+**On subsequent submits** (re-pushing amended branches), skip the title/body/label step — they persist across `gt submit`.
+
+### Print the stack state
+
+Capture the PR numbers from the submit output and print URLs bottom-to-top so the user can start review from the base:
+
+```
+#<n1>  (stack/<topic>/01-<slug>)  — bottom
+#<n2>  (stack/<topic>/02-<slug>)
+#<n3>  (stack/<topic>/03-<slug>)  — top
+```
+
+**Leave the `<!-- Graphite stack -->` block alone** — `gt` owns it and will overwrite hand edits on the next submit.
 
 ---
 

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -44,15 +44,44 @@ gt create stack/review-ui/01-add-migration -am "review-ui: add reviews table"
 
 ### PR titles and bodies
 
-`gt submit` picks up PR metadata one of three ways. Pick one; don't mix:
+**Write them yourself.** `gt submit --no-interactive` on its own leaves the PR body as the repo's `.github/pull_request_template.md` placeholder, which reads as empty in review. Close the gap with pre-written body files and a post-submit fixup pass:
 
-**Option 1 — `--ai` (default in this repo).** Graphite generates the title and body from the commit subject, body, and diff. This is the lowest-friction path for agent-driven stacks and is what the command line above uses. Re-running `gt submit --ai` on an already-open PR does **not** regenerate — `--ai` only populates the first time.
+```bash
+gt submit --stack --publish --no-interactive
+# For each new PR the submit produced (bottom to top):
+gh pr edit <pr> --title "<topic>: <clear title>" --body-file /tmp/body-<pr>.md
+```
 
-**Option 2 — Commit-driven (no `--ai`, no `--no-interactive`).** In an interactive TTY, `gt submit` prompts inline and seeds the prompts with the commit subject + body. This is the humans-at-keyboards default and is what the Graphite docs assume.
+The body files are drafted during the implementation phase (one per PR) and kept in `/tmp/` or another scratch location — they're throwaway artifacts of the submit step.
 
-**Option 3 — Pre-written body files (any mode).** Drop a `.github/pull_request_template/stack-<topic>-<NN>.md` (or any convenient file) per PR and apply them after submit with `gh pr edit <num> --body-file …`. Use this when the body needs to be richer than what `--ai` produces (e.g., screenshots, cross-PR checklists, hand-curated test plans).
+**Do not use `--ai`.** Graphite's `--ai` flag ships each commit's code + related codebase context to their AI subprocessors (Anthropic, OpenAI) and returns a generated title and body. Two reasons this is off for Breadbox:
 
-**What NOT to use:** `gt submit --no-interactive` by itself leaves the PR body as the repo's `.github/pull_request_template.md` placeholder — empty from a reviewer's perspective. Always pair `--no-interactive` with either `--ai` or a follow-up `gh pr edit --body-file`.
+1. **Accuracy.** The AI summarizes what it sees in the diff, which in practice means latching onto a salient detail and inflating it. [#546](https://github.com/canalesb93/breadbox/pull/546) landed with an AI title that picked the PR's secondary recommendation and omitted the primary — technically sourced from the diff, functionally misleading. Human-written titles don't have that failure mode.
+2. **Privacy.** Breadbox is self-hosted financial-data infrastructure. There's no reason to ship source to Graphite → an LLM provider. Their [AI privacy doc](https://graphite.com/docs/ai-privacy-and-security) confirms this is opt-in per-command for exactly this kind of concern.
+
+**Interactive alternative (not used in this harness).** In a real TTY, `gt submit` without `--no-interactive` prompts inline and seeds each prompt with the commit subject + body. Humans-at-keyboards default; doesn't work in the agent harness because there's no stdin.
+
+### Labeling stacked PRs
+
+Every PR that's part of a stack gets two GitHub labels so they're easy to filter from the PR dashboard:
+
+1. **`stacked`** — catches every stacked PR across all topics. Filter link: [`label:stacked`](https://github.com/canalesb93/breadbox/pulls?q=is%3Apr+label%3Astacked).
+2. **`stack/<topic>`** — per-topic grouping (e.g. `stack/templ-wizard`). Matches the branch prefix. If the label doesn't exist yet, create it during submit:
+
+```bash
+gh label create "stack/<topic>" --repo canalesb93/breadbox --color "B866F8" \
+  --description "PRs in the <topic> stack" 2>/dev/null || true
+```
+
+Apply both to every new PR in the stack, in the same loop as the body-file fixup:
+
+```bash
+for pr in <n1> <n2> <n3>; do
+  gh pr edit "$pr" --add-label stacked --add-label "stack/<topic>"
+done
+```
+
+Single-PR submits (not multi-PR stacks) do **not** get the `stacked` label — it's reserved for actual stacks of 2+ PRs where the dashboard view benefits from the filter.
 
 ### Stack metadata in PR bodies
 
@@ -74,7 +103,7 @@ gt create stack/<topic>/01-<slug> -am "..."   # create branch + commit as one st
 # implement, test
 gt create stack/<topic>/02-<slug> -am "..."   # stack next branch on top
 # implement, test
-gt submit --stack --publish --ai --no-interactive  # push all, open/update PRs
+gt submit --stack --publish --no-interactive       # push all, open/update PRs; follow up with gh pr edit per PR (title + body + labels)
 ```
 
 ### Amending a branch mid-stack
@@ -83,7 +112,7 @@ Check out the branch, edit, then:
 
 ```bash
 gt modify -u                                       # amend current branch's commit (default) + restack dependents; -u stages tracked updates
-gt submit --stack --publish --no-interactive       # update already-open PRs (no --ai needed; bodies already set)
+gt submit --stack --publish --no-interactive       # update already-open PRs; title, body, and labels persist
 ```
 
 Never `git commit --amend` + `git push --force` on a stacked branch — `gt modify` is what preserves the stack state.
@@ -151,7 +180,7 @@ GitHub's auto-merge (via `--merge-when-ready` or `gh pr merge --auto`) waits on 
 |---|---|
 | Start fresh from main | `gt sync && gt trunk` |
 | New branch stacked on current | `gt create <name> -am "<msg>"` |
-| Push + open all PRs (first submit) | `gt submit --stack --publish --ai --no-interactive` |
+| Push + open all PRs (first submit) | `gt submit --stack --publish --no-interactive` then per-PR `gh pr edit <num> --title "..." --body-file body-<num>.md --add-label stacked --add-label "stack/<topic>"` |
 | Push updates to already-open PRs | `gt submit --stack --publish --no-interactive` |
 | Amend current branch | `gt modify -u` |
 | Pull main and restack | `gt sync` |


### PR DESCRIPTION
## Summary

Two related workflow changes to the stacked-PR instructions, validated against Graphite's canonical docs at [graphite.com/docs/llms.txt](https://graphite.com/docs/llms.txt) and the behavior observed across #544 / #546 / this PR.

**(1) Drop `--ai` from the recommended `gt submit` flow.**

- **Accuracy:** `--ai` produced an inaccurate title on #546 (it picked the PR's *secondary* recommendation and omitted the primary). The mode is prone to this on multi-option docs.
- **Privacy:** Graphite's [AI Privacy and Security](https://graphite.com/docs/ai-privacy-and-security) doc confirms `--ai` sends the PR's code and "related or similar parts of your codebase" to their subprocessors (Anthropic, OpenAI). Not training data, but still outbound. Unnecessary for a self-hosted financial app.
- **Replacement:** `gt submit --stack --publish --no-interactive`, then per PR `gh pr edit <pr> --title "..." --body-file /tmp/body-<pr>.md`. Bodies authored during implementation, kept in `/tmp`.

**(2) Add a labeling convention so stacked PRs are filterable from the GitHub dashboard.**

Every PR in a real multi-PR stack gets two labels applied right after submit:

- `stacked` — catches every stacked PR across all topics ([filter link](https://github.com/canalesb93/breadbox/pulls?q=is%3Apr+label%3Astacked)).
- `stack/<topic>` — per-topic grouping (mirrors the branch prefix, e.g. `stack/templ-wizard`).

Single-PR submits do **not** get either label — the filter is only meaningful for actual stacks of 2+ PRs.

## Changes

- `docs/stacked-prs.md` — rewrite the "PR titles and bodies" section, add a "Labeling stacked PRs" section, scrub `--ai` from the workflow snippets and cheat sheet.
- `.claude/rules/stacked-prs.md` — same updates in the scoped rule (loaded when touching stack files).
- `.claude/skills/stack/SKILL.md` — update Submit Mode to use the new `gh pr edit` + `--add-label` loop; keep `--ai` only as an explicit "do not use" warning.

## Infra already applied

- Created the `stacked` label (purple, `#7057ff`) and `stack/templ-wizard` label (`#B866F8`).
- Backfilled both labels on #538–#541 (the templ-wizard stack), so the dashboard filter is useful starting now.
- #544 and #546 remain unlabeled — they were single-PR submits, not stacks.

## This PR as a live demonstration

This PR was submitted with `gt submit --stack --publish --no-interactive` (no `--ai`), and this body + title were set via `gh pr edit --body-file` after submit. No labels applied because it's a single-PR submit.

## Testing

- [x] Title + body human-authored (this document).
- [x] Label backfill verified: `label:stacked` dashboard filter shows #538–#541 only.
