### PR TITLE
fix(build): rebuild CSS when input.css is newer (report body typography)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,18 @@ TAILWIND_BIN := ./tailwindcss-extra
 
 PORT ?= 8080
 
-# generate ensures gitignored build artifacts exist.
-# Skips if artifacts are already present (e.g., copied by .worktreeinclude).
+# generate ensures gitignored build artifacts exist and are up to date.
+# - sqlc: only rebuilds if the generated models file is missing (queries are
+#   regenerated out-of-band via `make sqlc` when queries change).
+# - css: rebuilds whenever styles.css is missing OR older than input.css, so
+#   editing input.css and running `make dev` picks up the change without a
+#   manual `make css`. Previously this used `-f` existence only, which caused
+#   plain `make dev` to serve stale embedded CSS whenever input.css had been
+#   edited since the last full build.
 # Run 'make sqlc', 'make templ', or 'make css' directly to force regeneration.
 generate: templ
 	@if [ ! -f internal/db/models.go ]; then $(MAKE) sqlc; fi
-	@if [ ! -f static/css/styles.css ]; then $(MAKE) css; fi
+	@if [ ! -f static/css/styles.css ] || [ input.css -nt static/css/styles.css ]; then $(MAKE) css; fi
 
 # templ-install pulls the templ CLI if it's missing. Pinned via go.mod so the
 # version the CLI understands always matches the runtime lib the binary


### PR DESCRIPTION
Fixes #547

## Summary

`make dev` was serving stale compiled CSS whenever `input.css` had been edited since the last full build. The `.bb-report-body` typography rules were authored in `input.css` but never reached the served stylesheet, so agent reports rendered as a flat wall of text — no heading hierarchy, no bullets, no paragraph spacing.

## Root cause

`Makefile`'s `generate` target only ran `make css` if `static/css/styles.css` was **missing**:

```make
@if [ ! -f static/css/styles.css ]; then $(MAKE) css; fi
```

Once the file existed from a prior build, `make dev` would happily start the server with a stale compiled CSS regardless of how much `input.css` had changed. The Dockerfile unconditionally rebuilds CSS in its build stage, so prod was fine — only the local dev loop was broken.

## Fix

Add a "source newer than artifact" check:

```make
@if [ ! -f static/css/styles.css ] || [ input.css -nt static/css/styles.css ]; then $(MAKE) css; fi
```

- Idempotent: second `make generate` is a no-op.
- Still skips the rebuild when the file already exists and is up to date (preserving the worktree `.worktreeinclude` fast path).
- `make dev-watch` is unaffected — it already runs `tailwindcss-extra --watch` in parallel.

This fixes the local-dev manifestation of #547. The deeper symptom — the committed `static/css/styles.css` artifact being stale — doesn't apply here because the file is gitignored (`static/embed.go` embeds it at build time, and the Dockerfile compiles it fresh). So the issue's "rebuild + commit" proposal was overridden: committing the artifact would fight the existing `.gitignore` and the "don't commit `styles.css` changes" rule in `.claude/rules/ui.md`. The real bug is the stale-detection gap in `Makefile`.

## Before / after

Before: agent report body renders with no typography — headings same size as body, bullets missing, no paragraph spacing. After: proper heading hierarchy, bullets, spacing.

<table>
<tr>
<th>Mobile (500×844)</th>
<th>Tablet (820×1180)</th>
<th>Desktop (1440×900)</th>
</tr>
<tr>
<td><img src="https://i.img402.dev/otd5pvm6jo.png" width="280" alt="before-mobile"></td>
<td><img src="https://i.img402.dev/8tktr29dq7.png" width="280" alt="before-tablet"></td>
<td><img src="https://i.img402.dev/77su3w5pyj.png" width="280" alt="before-desktop"></td>
</tr>
<tr>
<td><img src="https://i.img402.dev/fjduilp3d8.png" width="280" alt="after-mobile"></td>
<td><img src="https://i.img402.dev/5i6rxqmmhx.png" width="280" alt="after-tablet"></td>
<td><img src="https://i.img402.dev/8qohnd270t.png" width="280" alt="after-desktop"></td>
</tr>
</table>

## Verification

- [x] `go build ./...` passes.
- [x] `make generate` with a newly-touched `input.css` rebuilds `static/css/styles.css`.
- [x] Second `make generate` is a no-op (idempotent).
- [x] `grep -c bb-report-body static/css/styles.css` > 0 after rebuild.
- [x] Local `breadbox serve` with `BREADBOX_DEV_RELOAD=1` serves styled report body at all three viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)