### PR TITLE
refactor(mcp): extract optStr + parseOptionalDate helpers

### DIFF
--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -1,0 +1,30 @@
+package mcp
+
+import (
+	"fmt"
+	"time"
+)
+
+// optStr returns a pointer to s when non-empty, else nil. Used to forward
+// MCP tool input strings into service-layer params that treat nil as "no
+// filter" and ignore empty-string values.
+func optStr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// parseOptionalDate parses a YYYY-MM-DD string into a time pointer. Returns
+// (nil, nil) when value is empty. The field name is used in the error message
+// so callers can surface it back to the MCP client without wrapping.
+func parseOptionalDate(field, value string) (*time.Time, error) {
+	if value == "" {
+		return nil, nil
+	}
+	t, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s: %w", field, err)
+	}
+	return &t, nil
+}

--- a/internal/mcp/helpers_test.go
+++ b/internal/mcp/helpers_test.go
@@ -1,0 +1,62 @@
+package mcp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOptStr(t *testing.T) {
+	if optStr("") != nil {
+		t.Error("optStr(\"\") should return nil")
+	}
+	p := optStr("hello")
+	if p == nil {
+		t.Fatal("optStr(non-empty) should return non-nil pointer")
+	}
+	if *p != "hello" {
+		t.Errorf("expected %q, got %q", "hello", *p)
+	}
+}
+
+func TestParseOptionalDate(t *testing.T) {
+	t.Run("empty returns nil without error", func(t *testing.T) {
+		got, err := parseOptionalDate("start_date", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("valid date parses", func(t *testing.T) {
+		got, err := parseOptionalDate("start_date", "2024-03-15")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected non-nil pointer")
+		}
+		want := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Errorf("expected %v, got %v", want, *got)
+		}
+	})
+
+	t.Run("invalid date returns wrapped error with field name", func(t *testing.T) {
+		_, err := parseOptionalDate("end_date", "not-a-date")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if msg := err.Error(); !strings.Contains(msg, "end_date") {
+			t.Errorf("expected error to mention field name, got: %q", msg)
+		}
+		// Ensure the underlying time.Parse error is wrapped so callers can unwrap.
+		var parseErr *time.ParseError
+		if !errors.As(err, &parseErr) {
+			t.Errorf("expected wrapped *time.ParseError, got: %v", err)
+		}
+	})
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"breadbox/internal/service"
 
@@ -186,12 +185,7 @@ func (s *MCPServer) handleCreateSession(reqCtx context.Context, _ *mcpsdk.CallTo
 
 func (s *MCPServer) handleListAccounts(_ context.Context, _ *mcpsdk.CallToolRequest, input listAccountsInput) (*mcpsdk.CallToolResult, any, error) {
 	ctx := context.Background()
-	var userID *string
-	if input.UserID != "" {
-		userID = &input.UserID
-	}
-
-	accounts, err := s.svc.ListAccounts(ctx, userID)
+	accounts, err := s.svc.ListAccounts(ctx, optStr(input.UserID))
 	if err != nil {
 		return errorResult(err), nil, nil
 	}
@@ -202,65 +196,34 @@ func (s *MCPServer) handleListAccounts(_ context.Context, _ *mcpsdk.CallToolRequ
 func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToolRequest, input queryTransactionsInput) (*mcpsdk.CallToolResult, any, error) {
 	ctx := context.Background()
 	params := service.TransactionListParams{
-		Cursor: input.Cursor,
-		Limit:  input.Limit,
+		Cursor:        input.Cursor,
+		Limit:         input.Limit,
+		AccountID:     optStr(input.AccountID),
+		UserID:        optStr(input.UserID),
+		CategorySlug:  optStr(input.CategorySlug),
+		MinAmount:     input.MinAmount,
+		MaxAmount:     input.MaxAmount,
+		Pending:       input.Pending,
+		Search:        optStr(input.Search),
+		ExcludeSearch: optStr(input.ExcludeSearch),
+		Tags:          input.Tags,
+		AnyTag:        input.AnyTag,
+		SortBy:        optStr(input.SortBy),
+		SortOrder:     optStr(input.SortOrder),
 	}
 
-	if input.StartDate != "" {
-		t, err := time.Parse("2006-01-02", input.StartDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid start_date: %w", err)), nil, nil
-		}
-		params.StartDate = &t
+	var err error
+	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
+		return errorResult(err), nil, nil
 	}
-	if input.EndDate != "" {
-		t, err := time.Parse("2006-01-02", input.EndDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid end_date: %w", err)), nil, nil
-		}
-		params.EndDate = &t
-	}
-	if input.AccountID != "" {
-		params.AccountID = &input.AccountID
-	}
-	if input.UserID != "" {
-		params.UserID = &input.UserID
-	}
-	if input.CategorySlug != "" {
-		params.CategorySlug = &input.CategorySlug
-	}
-	if input.MinAmount != nil {
-		params.MinAmount = input.MinAmount
-	}
-	if input.MaxAmount != nil {
-		params.MaxAmount = input.MaxAmount
-	}
-	if input.Pending != nil {
-		params.Pending = input.Pending
-	}
-	if input.Search != "" {
-		params.Search = &input.Search
+	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+		return errorResult(err), nil, nil
 	}
 	if input.SearchMode != "" {
 		if !service.ValidateSearchMode(input.SearchMode) {
 			return errorResult(fmt.Errorf("invalid search_mode: %s. Must be one of: contains, words, fuzzy", input.SearchMode)), nil, nil
 		}
 		params.SearchMode = &input.SearchMode
-	}
-	if input.ExcludeSearch != "" {
-		params.ExcludeSearch = &input.ExcludeSearch
-	}
-	if len(input.Tags) > 0 {
-		params.Tags = input.Tags
-	}
-	if len(input.AnyTag) > 0 {
-		params.AnyTag = input.AnyTag
-	}
-	if input.SortBy != "" {
-		params.SortBy = &input.SortBy
-	}
-	if input.SortOrder != "" {
-		params.SortOrder = &input.SortOrder
 	}
 
 	fieldSet, err := service.ParseFields(input.Fields)
@@ -298,57 +261,31 @@ func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToo
 
 func (s *MCPServer) handleCountTransactions(_ context.Context, _ *mcpsdk.CallToolRequest, input countTransactionsInput) (*mcpsdk.CallToolResult, any, error) {
 	ctx := context.Background()
-	params := service.TransactionCountParams{}
+	params := service.TransactionCountParams{
+		AccountID:     optStr(input.AccountID),
+		UserID:        optStr(input.UserID),
+		CategorySlug:  optStr(input.CategorySlug),
+		MinAmount:     input.MinAmount,
+		MaxAmount:     input.MaxAmount,
+		Pending:       input.Pending,
+		Search:        optStr(input.Search),
+		ExcludeSearch: optStr(input.ExcludeSearch),
+		Tags:          input.Tags,
+		AnyTag:        input.AnyTag,
+	}
 
-	if input.StartDate != "" {
-		t, err := time.Parse("2006-01-02", input.StartDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid start_date: %w", err)), nil, nil
-		}
-		params.StartDate = &t
+	var err error
+	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
+		return errorResult(err), nil, nil
 	}
-	if input.EndDate != "" {
-		t, err := time.Parse("2006-01-02", input.EndDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid end_date: %w", err)), nil, nil
-		}
-		params.EndDate = &t
-	}
-	if input.AccountID != "" {
-		params.AccountID = &input.AccountID
-	}
-	if input.UserID != "" {
-		params.UserID = &input.UserID
-	}
-	if input.CategorySlug != "" {
-		params.CategorySlug = &input.CategorySlug
-	}
-	if input.MinAmount != nil {
-		params.MinAmount = input.MinAmount
-	}
-	if input.MaxAmount != nil {
-		params.MaxAmount = input.MaxAmount
-	}
-	if input.Pending != nil {
-		params.Pending = input.Pending
-	}
-	if input.Search != "" {
-		params.Search = &input.Search
+	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+		return errorResult(err), nil, nil
 	}
 	if input.SearchMode != "" {
 		if !service.ValidateSearchMode(input.SearchMode) {
 			return errorResult(fmt.Errorf("invalid search_mode: %s. Must be one of: contains, words, fuzzy", input.SearchMode)), nil, nil
 		}
 		params.SearchMode = &input.SearchMode
-	}
-	if input.ExcludeSearch != "" {
-		params.ExcludeSearch = &input.ExcludeSearch
-	}
-	if len(input.Tags) > 0 {
-		params.Tags = input.Tags
-	}
-	if len(input.AnyTag) > 0 {
-		params.AnyTag = input.AnyTag
 	}
 
 	count, err := s.svc.CountTransactionsFiltered(ctx, params)
@@ -393,10 +330,7 @@ func (s *MCPServer) handleTriggerSync(ctx context.Context, _ *mcpsdk.CallToolReq
 		return errorResult(err), nil, nil
 	}
 	ctx = context.Background()
-	var connectionID *string
-	if input.ConnectionID != "" {
-		connectionID = &input.ConnectionID
-	}
+	connectionID := optStr(input.ConnectionID)
 
 	if err := s.svc.TriggerSync(ctx, connectionID); err != nil {
 		return errorResult(err), nil, nil
@@ -498,31 +432,18 @@ func (s *MCPServer) handleTransactionSummary(_ context.Context, _ *mcpsdk.CallTo
 	ctx := context.Background()
 
 	params := service.TransactionSummaryParams{
-		GroupBy: input.GroupBy,
+		GroupBy:   input.GroupBy,
+		AccountID: optStr(input.AccountID),
+		UserID:    optStr(input.UserID),
+		Category:  optStr(input.Category),
 	}
 
-	if input.StartDate != "" {
-		t, err := time.Parse("2006-01-02", input.StartDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid start_date: %w", err)), nil, nil
-		}
-		params.StartDate = &t
+	var err error
+	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
+		return errorResult(err), nil, nil
 	}
-	if input.EndDate != "" {
-		t, err := time.Parse("2006-01-02", input.EndDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid end_date: %w", err)), nil, nil
-		}
-		params.EndDate = &t
-	}
-	if input.AccountID != "" {
-		params.AccountID = &input.AccountID
-	}
-	if input.UserID != "" {
-		params.UserID = &input.UserID
-	}
-	if input.Category != "" {
-		params.Category = &input.Category
+	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+		return errorResult(err), nil, nil
 	}
 	if input.IncludePending != nil && *input.IncludePending {
 		params.IncludePending = true
@@ -540,49 +461,28 @@ func (s *MCPServer) handleMerchantSummary(_ context.Context, _ *mcpsdk.CallToolR
 	ctx := context.Background()
 
 	params := service.MerchantSummaryParams{
-		MinCount: input.MinCount,
+		MinCount:      input.MinCount,
+		AccountID:     optStr(input.AccountID),
+		UserID:        optStr(input.UserID),
+		CategorySlug:  optStr(input.CategorySlug),
+		MinAmount:     input.MinAmount,
+		MaxAmount:     input.MaxAmount,
+		Search:        optStr(input.Search),
+		ExcludeSearch: optStr(input.ExcludeSearch),
 	}
 
-	if input.StartDate != "" {
-		t, err := time.Parse("2006-01-02", input.StartDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid start_date: %w", err)), nil, nil
-		}
-		params.StartDate = &t
+	var err error
+	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
+		return errorResult(err), nil, nil
 	}
-	if input.EndDate != "" {
-		t, err := time.Parse("2006-01-02", input.EndDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid end_date: %w", err)), nil, nil
-		}
-		params.EndDate = &t
-	}
-	if input.AccountID != "" {
-		params.AccountID = &input.AccountID
-	}
-	if input.UserID != "" {
-		params.UserID = &input.UserID
-	}
-	if input.CategorySlug != "" {
-		params.CategorySlug = &input.CategorySlug
-	}
-	if input.MinAmount != nil {
-		params.MinAmount = input.MinAmount
-	}
-	if input.MaxAmount != nil {
-		params.MaxAmount = input.MaxAmount
-	}
-	if input.Search != "" {
-		params.Search = &input.Search
+	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+		return errorResult(err), nil, nil
 	}
 	if input.SearchMode != "" {
 		if !service.ValidateSearchMode(input.SearchMode) {
 			return errorResult(fmt.Errorf("invalid search_mode: %s. Must be one of: contains, words, fuzzy", input.SearchMode)), nil, nil
 		}
 		params.SearchMode = &input.SearchMode
-	}
-	if input.ExcludeSearch != "" {
-		params.ExcludeSearch = &input.ExcludeSearch
 	}
 	if input.SpendingOnly != nil && *input.SpendingOnly {
 		params.SpendingOnly = true
@@ -743,17 +643,11 @@ func (s *MCPServer) handleListTransactionRules(_ context.Context, _ *mcpsdk.Call
 	ctx := context.Background()
 
 	params := service.TransactionRuleListParams{
-		Limit:  input.Limit,
-		Cursor: input.Cursor,
-	}
-	if input.CategorySlug != "" {
-		params.CategorySlug = &input.CategorySlug
-	}
-	if input.Enabled != nil {
-		params.Enabled = input.Enabled
-	}
-	if input.Search != "" {
-		params.Search = &input.Search
+		Limit:        input.Limit,
+		Cursor:       input.Cursor,
+		CategorySlug: optStr(input.CategorySlug),
+		Enabled:      input.Enabled,
+		Search:       optStr(input.Search),
 	}
 	if input.SearchMode != "" {
 		if !service.ValidateSearchMode(input.SearchMode) {
@@ -1014,45 +908,22 @@ func (s *MCPServer) handleBulkRecategorize(ctx context.Context, _ *mcpsdk.CallTo
 
 	params := service.BulkRecategorizeParams{
 		TargetCategorySlug: toCategory,
+		AccountID:          optStr(input.AccountID),
+		UserID:             optStr(input.UserID),
+		CategorySlug:       optStr(fromCategory),
+		MinAmount:          input.MinAmount,
+		MaxAmount:          input.MaxAmount,
+		Pending:            input.Pending,
+		Search:             optStr(input.Search),
+		NameContains:       optStr(input.NameContains),
 	}
 
-	if input.StartDate != "" {
-		t, err := time.Parse("2006-01-02", input.StartDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid start_date: %w", err)), nil, nil
-		}
-		params.StartDate = &t
+	var err error
+	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
+		return errorResult(err), nil, nil
 	}
-	if input.EndDate != "" {
-		t, err := time.Parse("2006-01-02", input.EndDate)
-		if err != nil {
-			return errorResult(fmt.Errorf("invalid end_date: %w", err)), nil, nil
-		}
-		params.EndDate = &t
-	}
-	if input.AccountID != "" {
-		params.AccountID = &input.AccountID
-	}
-	if input.UserID != "" {
-		params.UserID = &input.UserID
-	}
-	if fromCategory != "" {
-		params.CategorySlug = &fromCategory
-	}
-	if input.MinAmount != nil {
-		params.MinAmount = input.MinAmount
-	}
-	if input.MaxAmount != nil {
-		params.MaxAmount = input.MaxAmount
-	}
-	if input.Pending != nil {
-		params.Pending = input.Pending
-	}
-	if input.Search != "" {
-		params.Search = &input.Search
-	}
-	if input.NameContains != "" {
-		params.NameContains = &input.NameContains
+	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+		return errorResult(err), nil, nil
 	}
 
 	result, err := s.svc.BulkRecategorizeByFilter(ctx, params)


### PR DESCRIPTION
## Summary

MCP tool handlers in `internal/mcp/tools.go` repeated two boilerplate patterns at nearly every filter-accepting callsite:

```go
if input.X != "" { params.X = &input.X }
```

and a 7-line date-parse-or-error block:

```go
if input.StartDate != "" {
    t, err := time.Parse("2006-01-02", input.StartDate)
    if err != nil {
        return errorResult(fmt.Errorf("invalid start_date: %w", err)), nil, nil
    }
    params.StartDate = &t
}
```

Together these patterns appeared 25+ times and drowned the actual per-handler logic.

This PR introduces two small helpers in a new [internal/mcp/helpers.go](internal/mcp/helpers.go):

- `optStr(s string) *string` — nil for empty, pointer otherwise
- `parseOptionalDate(field, value string) (*time.Time, error)` — parses `YYYY-MM-DD` with a field-aware error message; returns `(nil, nil)` on empty input

Then migrates all applicable callsites in `handleListAccounts`, `handleQueryTransactions`, `handleCountTransactions`, `handleTriggerSync`, `handleTransactionSummary`, `handleMerchantSummary`, `handleListTransactionRules`, and `handleBulkRecategorize`.

**Behavior is preserved:**
- Service-layer params treat `nil` and `"set-to-pointer-of-empty-string-guarded-by-if"` identically — all consumers check `params.X != nil`.
- Error messages keep the same `"invalid <field>: <parse error>"` shape, so MCP clients see no change.
- No public API or tool-schema changes.

## Stats

- `internal/mcp/tools.go`: -129 LOC net
- New: [internal/mcp/helpers.go](internal/mcp/helpers.go) (30 LOC), [internal/mcp/helpers_test.go](internal/mcp/helpers_test.go) (unit tests for both helpers)

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./...\` passes (unit suite)
- [x] New unit tests cover empty/valid/invalid cases for both helpers, including `errors.As` unwrapping of the underlying `*time.ParseError`
- [ ] Integration suite (DB-backed) — not touched by this change; MCP handler tests in `tools_bench_test.go` and `server_test.go` already cover the affected paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)