### PR TITLE
fix(rules): register ConditionRow adapter in template bridge

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -114,6 +114,40 @@ var componentRegistry = map[string]componentAdapter{
 		}
 		return components.TxResults(txResultsPropsFromData(m)), nil
 	},
+	"ConditionRow": func(data any) (templ.Component, error) {
+		m, ok := data.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("want map[string]any, got %T", data)
+		}
+		var cond service.Condition
+		switch c := m["Cond"].(type) {
+		case service.Condition:
+			cond = c
+		case *service.Condition:
+			if c != nil {
+				cond = *c
+			}
+		default:
+			return nil, fmt.Errorf("ConditionRow: want service.Condition in Cond, got %T", m["Cond"])
+		}
+		idx := 0
+		switch v := m["Idx"].(type) {
+		case int:
+			idx = v
+		case int32:
+			idx = int(v)
+		case int64:
+			idx = int(v)
+		}
+		conj, _ := m["Conj"].(string)
+		return components.ConditionRow(components.ConditionRowProps{
+			IsFirst:     idx == 0,
+			Conj:        conj,
+			FieldLabel:  ruleFieldLabel(cond.Field),
+			OpLabel:     ruleOpLabel(cond.Op, cond.Field),
+			ValueFormat: ruleValueFormat(cond.Value),
+		}), nil
+	},
 }
 
 // assertAdminTxRow extracts a service.AdminTransactionRow from data,


### PR DESCRIPTION
Fixes #557

Registers a `ConditionRow` adapter in `componentRegistry` so the html/template partial at `internal/templates/partials/condition_row.html` — which forwards to `{{renderComponent "ConditionRow" .}}` — actually resolves to the already-existing templ component. Before this fix, every call emitted `<!-- renderComponent("ConditionRow"): unknown -->` and logged `renderTemplComponent: unknown component "ConditionRow"`, so the rule detail page's WHEN section rendered empty.

The adapter reads the dict (`Cond`, `Idx`, `Conj`) passed by `rule_detail.html`, pre-formats the labels via the existing `ruleFieldLabel` / `ruleOpLabel` / `ruleValueFormat` helpers, and derives `IsFirst` from `Idx == 0`. Works for the And, Or, and bare single-condition shapes the template already iterates.

### Verification

Repro rule: `/rules/3510a039-1257-42d7-8bec-986cc7476b52` (`PR2 Preview Test - Zelle`, condition `Name contains zelle`).

Server log after fix: zero occurrences of `unknown component "ConditionRow"`.

### Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| Mobile (500×844) | ![before-mobile](https://i.img402.dev/zb0471quxv.png) | ![after-mobile](https://i.img402.dev/ioh6y3r3lg.png) |
| Tablet (820×1180) | ![before-tablet](https://i.img402.dev/y5deatn847.png) | ![after-tablet](https://i.img402.dev/nz3zac7s1c.png) |
| Desktop (1440×900) | ![before-desktop](https://i.img402.dev/rveoo6u199.png) | ![after-desktop](https://i.img402.dev/verd0lf54u.png) |

### Test plan

- [x] `go build ./...` passes
- [x] `templ generate` regenerated clean (no changes)
- [x] Rule detail WHEN section renders condition rows (bare single-condition shape verified on 3 reproducing rules)
- [x] No `unknown component "ConditionRow"` log entries after reload
- [ ] Manually verify And/Or shapes render multiple rows with correct conjunction prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)