### PR TITLE
refactor(config): extract appconfig helpers for app_config reads

### DIFF
--- a/cmd/breadbox/main.go
+++ b/cmd/breadbox/main.go
@@ -9,13 +9,13 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"breadbox/internal/api"
 	"breadbox/internal/app"
+	"breadbox/internal/appconfig"
 	"breadbox/internal/config"
 	"breadbox/internal/db"
 	breadboxmcp "breadbox/internal/mcp"
@@ -566,11 +566,10 @@ func runSeed() error {
 func runScheduledBackup(bs *service.BackupService, queries *db.Queries, logger *slog.Logger) {
 	ctx := context.Background()
 
-	row, err := queries.GetAppConfig(ctx, "backup_schedule")
-	if err != nil || !row.Value.Valid || row.Value.String == "" {
+	schedule := appconfig.String(ctx, queries, "backup_schedule", "")
+	if schedule == "" {
 		return // Backups not scheduled
 	}
-	schedule := row.Value.String
 
 	now := time.Now()
 	hour := now.Hour()
@@ -604,12 +603,9 @@ func runScheduledBackup(bs *service.BackupService, queries *db.Queries, logger *
 	logger.Info("scheduled backup completed", "filename", filename)
 
 	// Clean up old backups based on retention setting.
-	retentionDays := 7 // default
-	retRow, err := queries.GetAppConfig(ctx, "backup_retention_days")
-	if err == nil && retRow.Value.Valid && retRow.Value.String != "" {
-		if d, parseErr := strconv.Atoi(retRow.Value.String); parseErr == nil && d > 0 {
-			retentionDays = d
-		}
+	retentionDays := appconfig.Int(ctx, queries, "backup_retention_days", 7)
+	if retentionDays <= 0 {
+		retentionDays = 7
 	}
 
 	deleted, err := bs.CleanupOldBackups(retentionDays)

--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"breadbox/internal/app"
+	"breadbox/internal/appconfig"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
@@ -21,7 +22,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 		ctx := r.Context()
 
 		// Redirect to getting-started page if onboarding is not dismissed.
-		if !GetConfigBool(ctx, a.Queries, "onboarding_dismissed") {
+		if !appconfig.Bool(ctx, a.Queries, "onboarding_dismissed", false) {
 			http.Redirect(w, r, "/getting-started", http.StatusSeeOther)
 			return
 		}
@@ -60,7 +61,7 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 				a.Logger.Debug("version check failed", "error", err)
 			}
 			if updateAvailable != nil && *updateAvailable && latest != nil {
-				if GetConfigString(ctx, a.Queries, "update_dismissed_version") != latest.Version {
+				if appconfig.String(ctx, a.Queries, "update_dismissed_version", "") != latest.Version {
 					showUpdateBanner = true
 					latestVersion = latest.Version
 					latestURL = latest.URL

--- a/internal/admin/getting_started.go
+++ b/internal/admin/getting_started.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"breadbox/internal/app"
+	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 
 	"github.com/alexedwards/scs/v2"
@@ -77,7 +78,7 @@ func GettingStartedHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRende
 		}
 
 		// Check if onboarding is dismissed (for the nav badge display).
-		dismissed := GetConfigBool(ctx, a.Queries, "onboarding_dismissed")
+		dismissed := appconfig.Bool(ctx, a.Queries, "onboarding_dismissed", false)
 
 		data := BaseTemplateData(r, sm, "getting-started", "Getting Started")
 		data["HasMember"] = hasMember

--- a/internal/admin/helpers.go
+++ b/internal/admin/helpers.go
@@ -1,11 +1,8 @@
 package admin
 
 import (
-	"context"
 	"strings"
 	"time"
-
-	"breadbox/internal/db"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -22,26 +19,6 @@ func splitCSV(s string) []string {
 		}
 	}
 	return out
-}
-
-// GetConfigBool reads a boolean config key from app_config.
-// Returns false if the key doesn't exist, has a null value, or can't be parsed.
-func GetConfigBool(ctx context.Context, queries *db.Queries, key string) bool {
-	cfg, err := queries.GetAppConfig(ctx, key)
-	if err != nil {
-		return false
-	}
-	return cfg.Value.Valid && cfg.Value.String == "true"
-}
-
-// GetConfigString reads a string config key from app_config.
-// Returns empty string if the key doesn't exist or has a null value.
-func GetConfigString(ctx context.Context, queries *db.Queries, key string) string {
-	cfg, err := queries.GetAppConfig(ctx, key)
-	if err != nil || !cfg.Value.Valid {
-		return ""
-	}
-	return cfg.Value.String
 }
 
 // BalanceTotals holds aggregated asset/liability/net-worth values.

--- a/internal/admin/middleware.go
+++ b/internal/admin/middleware.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 
 	"github.com/alexedwards/scs/v2"
@@ -52,7 +53,7 @@ func NavBadgesMiddleware(queries *db.Queries, logger *slog.Logger) func(http.Han
 			}
 
 			// Check if getting started guide should show in nav.
-			badges.ShowGettingStarted = !GetConfigBool(ctx, queries, "onboarding_dismissed")
+			badges.ShowGettingStarted = !appconfig.Bool(ctx, queries, "onboarding_dismissed", false)
 
 			ctx = context.WithValue(ctx, navBadgesKey, badges)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"breadbox/internal/app"
+	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 	"breadbox/internal/templates/components/pages"
 
@@ -48,7 +49,7 @@ func SettingsGetHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer
 		syncLogCount, _ := a.Service.CountSyncLogs(ctx)
 
 		// Check onboarding dismissed state for help section.
-		onboardingDismissed := GetConfigBool(ctx, a.Queries, "onboarding_dismissed")
+		onboardingDismissed := appconfig.Bool(ctx, a.Queries, "onboarding_dismissed", false)
 
 		nextSyncTime := ""
 		if a.Scheduler != nil {

--- a/internal/appconfig/read.go
+++ b/internal/appconfig/read.go
@@ -1,0 +1,73 @@
+// Package appconfig provides typed read helpers for the app_config DB table.
+//
+// The service, admin, sync, and command layers all need to read individual
+// app_config rows with defaults. Each caller was repeating the same
+// queries.GetAppConfig + row.Value.Valid + empty-string + parse dance. These
+// helpers centralize that pattern so the rest of the codebase can ask for a
+// string, bool, or int with a default in one call.
+//
+// For startup-time config loading (env + DB merge into a single Config
+// struct), see internal/config — that package is concerned with process
+// boot; this one is concerned with runtime reads of individual keys.
+package appconfig
+
+import (
+	"context"
+	"strconv"
+
+	"breadbox/internal/db"
+)
+
+// Reader is the minimal query surface used by these helpers. *db.Queries
+// satisfies it; tests and callers with a narrower type can implement their
+// own.
+type Reader interface {
+	GetAppConfig(ctx context.Context, key string) (db.AppConfig, error)
+}
+
+// Read returns the raw string value stored at key and whether a usable value
+// was found. A missing row, a row with a NULL value, or a query error all
+// return ("", false).
+func Read(ctx context.Context, r Reader, key string) (string, bool) {
+	row, err := r.GetAppConfig(ctx, key)
+	if err != nil || !row.Value.Valid {
+		return "", false
+	}
+	return row.Value.String, true
+}
+
+// String returns the value at key, or def when missing or empty.
+func String(ctx context.Context, r Reader, key, def string) string {
+	v, ok := Read(ctx, r, key)
+	if !ok || v == "" {
+		return def
+	}
+	return v
+}
+
+// Bool returns true when the value at key is the literal string "true".
+// Missing keys, NULL values, and any other string return def. The strict
+// match mirrors the values the admin UI writes — widening this to accept
+// "1"/"yes"/etc. would change behavior elsewhere.
+func Bool(ctx context.Context, r Reader, key string, def bool) bool {
+	v, ok := Read(ctx, r, key)
+	if !ok {
+		return def
+	}
+	return v == "true"
+}
+
+// Int returns the parsed integer value at key, or def when the key is
+// missing, empty, or unparseable. No range clamping — callers that reject
+// specific values (negative, zero) apply their own check after the call.
+func Int(ctx context.Context, r Reader, key string, def int) int {
+	v, ok := Read(ctx, r, key)
+	if !ok || v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}

--- a/internal/appconfig/read_test.go
+++ b/internal/appconfig/read_test.go
@@ -1,0 +1,143 @@
+package appconfig
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type stubReader struct {
+	rows map[string]db.AppConfig
+	err  error
+}
+
+func (s stubReader) GetAppConfig(_ context.Context, key string) (db.AppConfig, error) {
+	if s.err != nil {
+		return db.AppConfig{}, s.err
+	}
+	row, ok := s.rows[key]
+	if !ok {
+		return db.AppConfig{}, errors.New("not found")
+	}
+	return row, nil
+}
+
+func makeRow(value string, valid bool) db.AppConfig {
+	return db.AppConfig{
+		Key:   "k",
+		Value: pgtype.Text{String: value, Valid: valid},
+	}
+}
+
+func TestRead(t *testing.T) {
+	ctx := context.Background()
+	r := stubReader{rows: map[string]db.AppConfig{
+		"present": makeRow("abc", true),
+		"null":    makeRow("", false),
+		"empty":   makeRow("", true),
+	}}
+
+	if v, ok := Read(ctx, r, "present"); !ok || v != "abc" {
+		t.Errorf("Read(present) = (%q, %v), want (abc, true)", v, ok)
+	}
+	if _, ok := Read(ctx, r, "null"); ok {
+		t.Error("Read(null) should return ok=false for NULL value")
+	}
+	if v, ok := Read(ctx, r, "empty"); !ok || v != "" {
+		t.Errorf("Read(empty) = (%q, %v), want (\"\", true)", v, ok)
+	}
+	if _, ok := Read(ctx, r, "missing"); ok {
+		t.Error("Read(missing) should return ok=false for missing key")
+	}
+	if _, ok := Read(ctx, stubReader{err: errors.New("boom")}, "x"); ok {
+		t.Error("Read should return ok=false when query errors")
+	}
+}
+
+func TestString(t *testing.T) {
+	ctx := context.Background()
+	r := stubReader{rows: map[string]db.AppConfig{
+		"set":   makeRow("abc", true),
+		"empty": makeRow("", true),
+		"null":  makeRow("", false),
+	}}
+
+	cases := []struct {
+		key, def, want string
+	}{
+		{"set", "D", "abc"},
+		{"empty", "D", "D"},
+		{"null", "D", "D"},
+		{"missing", "D", "D"},
+	}
+	for _, c := range cases {
+		if got := String(ctx, r, c.key, c.def); got != c.want {
+			t.Errorf("String(%q) = %q, want %q", c.key, got, c.want)
+		}
+	}
+}
+
+func TestBool(t *testing.T) {
+	ctx := context.Background()
+	r := stubReader{rows: map[string]db.AppConfig{
+		"true_val":  makeRow("true", true),
+		"false_val": makeRow("false", true),
+		"junk":      makeRow("yes", true),
+		"empty":     makeRow("", true),
+		"null":      makeRow("", false),
+	}}
+
+	cases := []struct {
+		key  string
+		def  bool
+		want bool
+	}{
+		{"true_val", false, true},
+		{"false_val", true, false},
+		{"junk", true, false},
+		{"empty", true, false},
+		{"null", true, true},
+		{"missing", false, false},
+		{"missing", true, true},
+	}
+	for _, c := range cases {
+		if got := Bool(ctx, r, c.key, c.def); got != c.want {
+			t.Errorf("Bool(%q, def=%v) = %v, want %v", c.key, c.def, got, c.want)
+		}
+	}
+}
+
+func TestInt(t *testing.T) {
+	ctx := context.Background()
+	r := stubReader{rows: map[string]db.AppConfig{
+		"int":    makeRow("42", true),
+		"zero":   makeRow("0", true),
+		"neg":    makeRow("-5", true),
+		"junk":   makeRow("abc", true),
+		"empty":  makeRow("", true),
+		"null":   makeRow("", false),
+	}}
+
+	cases := []struct {
+		key  string
+		def  int
+		want int
+	}{
+		{"int", 7, 42},
+		{"zero", 7, 0},
+		{"neg", 7, -5},
+		{"junk", 7, 7},
+		{"empty", 7, 7},
+		{"null", 7, 7},
+		{"missing", 7, 7},
+	}
+	for _, c := range cases {
+		if got := Int(ctx, r, c.key, c.def); got != c.want {
+			t.Errorf("Int(%q, def=%d) = %d, want %d", c.key, c.def, got, c.want)
+		}
+	}
+}

--- a/internal/service/backup.go
+++ b/internal/service/backup.go
@@ -15,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"breadbox/internal/appconfig"
 )
 
 // BackupInfo describes a backup file on disk.
@@ -482,28 +484,14 @@ func FormatBytes(bytes int64) string {
 // GetBackupSchedule returns the backup schedule from app_config.
 // Returns empty string if not configured (disabled).
 func (s *Service) GetBackupSchedule(ctx context.Context) string {
-	row, err := s.Queries.GetAppConfig(ctx, "backup_schedule")
-	if err != nil {
-		return ""
-	}
-	if !row.Value.Valid || row.Value.String == "" {
-		return ""
-	}
-	return row.Value.String
+	return appconfig.String(ctx, s.Queries, "backup_schedule", "")
 }
 
 // GetBackupRetentionDays returns the backup retention days from app_config.
-// Returns default of 7 if not configured.
+// Returns default of 7 if not configured or negative.
 func (s *Service) GetBackupRetentionDays(ctx context.Context) int {
-	row, err := s.Queries.GetAppConfig(ctx, "backup_retention_days")
-	if err != nil {
-		return 7
-	}
-	if !row.Value.Valid || row.Value.String == "" {
-		return 7
-	}
-	days, err := strconv.Atoi(row.Value.String)
-	if err != nil || days < 0 {
+	days := appconfig.Int(ctx, s.Queries, "backup_retention_days", 7)
+	if days < 0 {
 		return 7
 	}
 	return days

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strconv"
 	"time"
 
+	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 	bsync "breadbox/internal/sync"
 
@@ -362,18 +362,10 @@ func (s *Service) CleanupSyncLogs(ctx context.Context, retentionDays int) (int64
 }
 
 // GetSyncLogRetentionDays reads the sync_log_retention_days setting from app_config.
-// Returns 90 (default) if not set.
+// Returns 90 (default) if not set or not a positive value.
 func (s *Service) GetSyncLogRetentionDays(ctx context.Context) (int, error) {
-	row, err := s.Queries.GetAppConfig(ctx, "sync_log_retention_days")
-	if err != nil {
-		return 90, nil // default if not found
-	}
-	if !row.Value.Valid || row.Value.String == "" {
-		return 90, nil
-	}
-
-	days, err := strconv.Atoi(row.Value.String)
-	if err != nil || days <= 0 {
+	days := appconfig.Int(ctx, s.Queries, "sync_log_retention_days", 90)
+	if days <= 0 {
 		return 90, nil
 	}
 	return days, nil

--- a/internal/sync/scheduler.go
+++ b/internal/sync/scheduler.go
@@ -3,9 +3,9 @@ package sync
 import (
 	"context"
 	"log/slog"
-	"strconv"
 	"time"
 
+	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 
@@ -218,13 +218,9 @@ const defaultRetentionDays = 90
 // Reads sync_log_retention_days from app_config (default: 90 days).
 // A value of 0 disables cleanup.
 func (s *Scheduler) cleanupSyncLogs(ctx context.Context) {
-	retentionDays := defaultRetentionDays
-
-	row, err := s.queries.GetAppConfig(ctx, "sync_log_retention_days")
-	if err == nil && row.Value.Valid && row.Value.String != "" {
-		if days, parseErr := strconv.Atoi(row.Value.String); parseErr == nil && days >= 0 {
-			retentionDays = days
-		}
+	retentionDays := appconfig.Int(ctx, s.queries, "sync_log_retention_days", defaultRetentionDays)
+	if retentionDays < 0 {
+		retentionDays = defaultRetentionDays
 	}
 
 	if retentionDays == 0 {


### PR DESCRIPTION
## Summary

- The pattern `queries.GetAppConfig(ctx, key)` + `row.Value.Valid` + empty/parse + default was duplicated across `internal/admin`, `internal/service`, `internal/sync`, and `cmd/breadbox`. This PR consolidates it into a new `internal/appconfig` package with `String`, `Bool`, `Int`, and `Read` helpers that each take a default value.
- Six call sites migrated: `admin.GetConfigBool`/`GetConfigString` (removed — four callers updated), `service.GetBackupSchedule`, `service.GetBackupRetentionDays`, `service.GetSyncLogRetentionDays`, `sync.Scheduler.cleanupSyncLogs`, and `cmd/breadbox.runScheduledBackup` (two reads).
- Behavior is preserved at each call site: same defaults, same negative/zero clamp rules. Units for the new package cover missing rows, NULL values, empty strings, parse failures, and custom defaults.

Net diff: **+245 / −76 across 11 files** (mostly the new package + test; call-site changes are small).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all unit suites pass)
- [x] `go test -tags=integration -run "TestGetSyncLogRetentionDays|TestGetBackup" ./internal/service/...` (integration coverage for migrated service methods)

🤖 Generated with [Claude Code](https://claude.com/claude-code)