### PR TITLE
fix(categories): repoint category form breadcrumbs to /categories

### DIFF
--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -127,7 +127,7 @@ func CategoryNewPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Te
 		data["IsEdit"] = false
 		data["Categories"] = categories
 		data["Breadcrumbs"] = []Breadcrumb{
-			{Label: "Rules & Categories", Href: "/rules?tab=categories"},
+			{Label: "Categories", Href: "/categories"},
 			{Label: "Add Category"},
 		}
 		tr.Render(w, r, "category_form.html", data)
@@ -151,7 +151,7 @@ func CategoryEditPageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 		data["IsEdit"] = true
 		data["Category"] = category
 		data["Breadcrumbs"] = []Breadcrumb{
-			{Label: "Rules & Categories", Href: "/rules?tab=categories"},
+			{Label: "Categories", Href: "/categories"},
 			{Label: category.DisplayName},
 		}
 		tr.Render(w, r, "category_form.html", data)

--- a/internal/templates/pages/category_form.html
+++ b/internal/templates/pages/category_form.html
@@ -147,7 +147,7 @@
 
     <!-- Sticky action row -->
     <div class="bb-action-row">
-      <a href="/rules?tab=categories" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
+      <a href="/categories" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
       <button type="submit" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32" :disabled="submitting || !displayName">
         <span x-show="!submitting" class="inline-flex items-center gap-1.5">
           <i data-lucide="save" class="w-3.5 h-3.5"></i>
@@ -237,7 +237,7 @@ function categoryForm() {
       })
       .then(function(res) {
         if (res.ok) {
-          window.location.href = '/rules?tab=categories';
+          window.location.href = '/categories';
           return;
         }
         return res.json().then(function(data) {


### PR DESCRIPTION
Fixes #558

The breadcrumb on `/categories/new` and `/categories/{id}/edit` linked to `/rules?tab=categories` — a stale route from an older combined page. Click landed on `/rules` (the tab param is ignored), not back on Categories. This swaps the breadcrumb, Cancel button, and post-delete redirect to `/categories` so every back-exit matches the left-nav.

## Before / After

| Viewport | Before | After |
| --- | --- | --- |
| Mobile (500x844) | ![before-mobile](https://i.img402.dev/tr52n28t0d.png) | ![after-mobile](https://i.img402.dev/y6ii0dp1k5.png) |
| Tablet (820x1180) | ![before-tablet](https://i.img402.dev/v10pcq7qei.png) | ![after-tablet](https://i.img402.dev/h1fblunmt6.png) |
| Desktop (1440x900) | ![before-desktop](https://i.img402.dev/m0zxps151v.png) | ![after-desktop](https://i.img402.dev/jjcko8l5bt.png) |

## Notes

- Fix extends slightly beyond the proposed scope: the same stale `/rules?tab=categories` URL was also used by the Cancel button in `category_form.html` and the post-delete redirect. Both now point to `/categories` for consistency.
- `go build ./...` passes.