### PR TITLE
refactor(admin): extract queryPage + queryPageSize helpers

### DIFF
--- a/internal/admin/agents_page.go
+++ b/internal/admin/agents_page.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"net/http"
-	"strconv"
 
 	breadboxmcp "breadbox/internal/mcp"
 	"breadbox/internal/service"
@@ -223,10 +222,7 @@ func AgentsPageHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer, s
 
 		// === Activity tab data ===
 		if tab == "activity" {
-			page := 1
-			if p, err := strconv.Atoi(r.URL.Query().Get("page")); err == nil && p > 0 {
-				page = p
-			}
+			page := queryPage(r, "page")
 			sessions, total, _ := svc.ListMCPSessions(ctx, page, 25)
 			data["Sessions"] = sessions
 			data["SessionsTotal"] = int(total)

--- a/internal/admin/helpers.go
+++ b/internal/admin/helpers.go
@@ -1,11 +1,41 @@
 package admin
 
 import (
+	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// queryPage reads a 1-based page number from a named query-string key.
+// Missing, non-numeric, or sub-1 values collapse to 1 so handlers never
+// issue a paginated query with page=0.
+func queryPage(r *http.Request, key string) int {
+	page, _ := strconv.Atoi(r.URL.Query().Get(key))
+	if page < 1 {
+		page = 1
+	}
+	return page
+}
+
+// queryPageSize reads ?per_page and rejects any value not in allowed,
+// returning defaultSize on missing, malformed, or disallowed input.
+// Whitelisting is mandatory — page size drives SQL LIMIT and must not be
+// attacker-controlled.
+func queryPageSize(r *http.Request, defaultSize int, allowed ...int) int {
+	v, err := strconv.Atoi(r.URL.Query().Get("per_page"))
+	if err != nil {
+		return defaultSize
+	}
+	for _, a := range allowed {
+		if v == a {
+			return v
+		}
+	}
+	return defaultSize
+}
 
 // splitCSV splits a comma-separated string into trimmed non-empty entries.
 // Used by URL params that accept multi-value lists (e.g. ?tags=a,b,c).

--- a/internal/admin/helpers_test.go
+++ b/internal/admin/helpers_test.go
@@ -1,11 +1,62 @@
 package admin
 
 import (
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+func TestQueryPage(t *testing.T) {
+	cases := []struct {
+		name string
+		url  string
+		key  string
+		want int
+	}{
+		{"missing collapses to 1", "/?", "page", 1},
+		{"empty collapses to 1", "/?page=", "page", 1},
+		{"zero collapses to 1", "/?page=0", "page", 1},
+		{"negative collapses to 1", "/?page=-4", "page", 1},
+		{"non-numeric collapses to 1", "/?page=abc", "page", 1},
+		{"positive preserved", "/?page=3", "page", 3},
+		{"custom key honored", "/?wh_page=5&page=1", "wh_page", 5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", tc.url, nil)
+			if got := queryPage(r, tc.key); got != tc.want {
+				t.Errorf("queryPage(%q, %q) = %d, want %d", tc.url, tc.key, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestQueryPageSize(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		def     int
+		allowed []int
+		want    int
+	}{
+		{"missing → default", "/?", 50, []int{25, 50, 100}, 50},
+		{"non-numeric → default", "/?per_page=abc", 50, []int{25, 50, 100}, 50},
+		{"not in allowlist → default", "/?per_page=7", 50, []int{25, 50, 100}, 50},
+		{"hostile large value → default", "/?per_page=99999", 50, []int{25, 50, 100}, 50},
+		{"allowed value preserved", "/?per_page=25", 50, []int{25, 50, 100}, 25},
+		{"allowed top-of-range preserved", "/?per_page=100", 50, []int{25, 50, 100}, 100},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", tc.url, nil)
+			if got := queryPageSize(r, tc.def, tc.allowed...); got != tc.want {
+				t.Errorf("queryPageSize(%q) = %d, want %d", tc.url, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestSplitCSV(t *testing.T) {
 	tests := []struct {

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"net/http"
-	"strconv"
 	"time"
 
 	"breadbox/internal/app"
@@ -30,13 +29,8 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 
 		// Always fetch sync logs data.
 		{
-			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-			if page < 1 {
-				page = 1
-			}
-
 			params := service.SyncLogListParams{
-				Page:     page,
+				Page:     queryPage(r, "page"),
 				PageSize: 25,
 			}
 
@@ -147,13 +141,8 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 
 		// Always fetch webhook events data.
 		{
-			page, _ := strconv.Atoi(r.URL.Query().Get("wh_page"))
-			if page < 1 {
-				page = 1
-			}
-
 			params := service.WebhookEventListParams{
-				Page:     page,
+				Page:     queryPage(r, "wh_page"),
 				PageSize: 25,
 			}
 

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -19,22 +19,9 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
-		pageSize := 50
-		if v, err := strconv.Atoi(r.URL.Query().Get("per_page")); err == nil {
-			switch v {
-			case 25, 50, 100:
-				pageSize = v
-			}
-		}
-
 		params := service.TransactionRuleListParams{
-			Page:     page,
-			PageSize: pageSize,
+			Page:     queryPage(r, "page"),
+			PageSize: queryPageSize(r, 50, 25, 50, 100),
 		}
 
 		if v := r.URL.Query().Get("search"); v != "" {

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
 	"breadbox/internal/app"
@@ -19,13 +18,8 @@ func SyncLogsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, s
 		ctx := r.Context()
 
 		// Parse query params.
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
 		params := service.SyncLogListParams{
-			Page:     page,
+			Page:     queryPage(r, "page"),
 			PageSize: 25,
 		}
 

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -99,22 +99,9 @@ func TransactionListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRend
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
-		pageSize := 50
-		if v, err := strconv.Atoi(r.URL.Query().Get("per_page")); err == nil {
-			switch v {
-			case 25, 50, 100:
-				pageSize = v
-			}
-		}
-
 		params := service.AdminTransactionListParams{
-			Page:     page,
-			PageSize: pageSize,
+			Page:     queryPage(r, "page"),
+			PageSize: queryPageSize(r, 50, 25, 50, 100),
 		}
 
 		if v := r.URL.Query().Get("start_date"); v != "" {
@@ -291,22 +278,9 @@ func TransactionSearchHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
-		pageSize := 50
-		if v, err := strconv.Atoi(r.URL.Query().Get("per_page")); err == nil {
-			switch v {
-			case 25, 50, 100:
-				pageSize = v
-			}
-		}
-
 		params := service.AdminTransactionListParams{
-			Page:     page,
-			PageSize: pageSize,
+			Page:     queryPage(r, "page"),
+			PageSize: queryPageSize(r, 50, 25, 50, 100),
 		}
 
 		if v := r.URL.Query().Get("start_date"); v != "" {
@@ -438,13 +412,8 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 		}
 
 		// Fetch transactions for this account.
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
 		txParams := service.AdminTransactionListParams{
-			Page:      page,
+			Page:      queryPage(r, "page"),
 			PageSize:  50,
 			AccountID: &idStr,
 		}

--- a/internal/admin/webhook_events.go
+++ b/internal/admin/webhook_events.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"net/http"
-	"strconv"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -15,13 +14,8 @@ func WebhookEventsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
 		params := service.WebhookEventListParams{
-			Page:     page,
+			Page:     queryPage(r, "page"),
 			PageSize: 25,
 		}
 


### PR DESCRIPTION
## Summary

Seven admin handlers copy-pasted the same pagination-param parsing:

```go
page, _ := strconv.Atoi(r.URL.Query().Get("page"))
if page < 1 { page = 1 }

pageSize := 50
if v, err := strconv.Atoi(r.URL.Query().Get("per_page")); err == nil {
    switch v {
    case 25, 50, 100:
        pageSize = v
    }
}
```

Extracted into two helpers in `internal/admin/helpers.go`:

- `queryPage(r, key)` — reads a named page key (`page`, `wh_page`, …) and floors sub-1 values to 1.
- `queryPageSize(r, default, allowed...)` — enforces a `per_page` whitelist, rejecting hostile values (it drives SQL LIMIT and cannot be attacker-controlled).

Refactored call sites across `rules.go`, `transactions.go` (×3), `synclogs.go`, `webhook_events.go`, `logs.go` (×2), `agents_page.go`. No behavior change — new unit tests cover the helper contracts and pin the whitelist guard.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages pass, including new `TestQueryPage` / `TestQueryPageSize`)
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)