### PR TITLE
a11y(reports): add aria-label to icon-only buttons on mobile

### DIFF
--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -5,7 +5,7 @@
     <p class="text-sm text-base-content/50 mt-0.5 hidden sm:block">Messages from your AI agents — their work, flagged items, and findings</p>
   </div>
   <div class="flex items-center gap-2">
-    <a href="/agents?tab=settings#report-format" class="btn btn-ghost btn-sm rounded-xl text-xs no-underline" title="Customize how agents write reports">
+    <a href="/agents?tab=settings#report-format" class="btn btn-ghost btn-sm rounded-xl text-xs no-underline" aria-label="Manage report format" title="Customize how agents write reports">
       <i data-lucide="sliders-horizontal" class="w-3.5 h-3.5"></i>
       <span class="hidden sm:inline">Manage format</span>
     </a>
@@ -21,6 +21,7 @@
     <span class="text-xs text-base-content/30 hidden sm:inline">{{.TotalCount}} report{{if ne .TotalCount 1}}s{{end}}</span>
     <button class="btn btn-ghost btn-sm rounded-xl text-xs cursor-pointer"
       onclick="fetch('/-/reports/read-all', {method:'POST'}).then(function(){window.location.reload()})"
+      aria-label="Mark all reports read"
       title="Mark all read">
       <i data-lucide="check-check" class="w-3.5 h-3.5"></i>
       <span class="hidden sm:inline">Mark all read</span>


### PR DESCRIPTION
Fixes #550

The "Manage format" link and "Mark all read" button collapse to bare icons below the `sm` breakpoint but only provided a `title` tooltip — unreliable on touch and not a replacement for `aria-label`. Added explicit `aria-label` to both so assistive tech announces the action (confirmed via Chrome DevTools a11y tree: "Manage report format" / "Mark all reports read").

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| Mobile (500×844) | ![before-mobile](https://i.img402.dev/kxmi3m1fav.png) | ![after-mobile](https://i.img402.dev/kgkzgh7h1t.png) |
| Tablet (820×1180) | ![before-tablet](https://i.img402.dev/qrw3nddila.png) | ![after-tablet](https://i.img402.dev/2cuqyz3i31.png) |
| Desktop (1440×900) | ![before-desktop](https://i.img402.dev/sk83dufgrv.png) | ![after-desktop](https://i.img402.dev/zldkhnfsaz.png) |

## Test plan
- [x] `go build ./...` passes
- [x] Both elements expose correct accessible name via a11y tree
- [x] Visible label still renders at `sm+` (no regression)
- [x] Elements remain keyboard-focusable (tabIndex 0, semantic `<a>` / `<button>`)

Generated with [Claude Code](https://claude.com/claude-code)