### PR TITLE
fix(tags): register TagRow adapter in TagChip templ bridge

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -173,6 +173,13 @@ func assertTagChipData(data any) (components.TagChipData, error) {
 			return components.TagChipData{}, nil
 		}
 		return components.TagChipDataFromResponse(*v), nil
+	case TagRow:
+		return components.TagChipDataFromResponse(v.TagResponse), nil
+	case *TagRow:
+		if v == nil {
+			return components.TagChipData{}, nil
+		}
+		return components.TagChipDataFromResponse(v.TagResponse), nil
 	case service.AdminTransactionTag:
 		return components.TagChipDataFromTx(v), nil
 	case components.TagChipData:


### PR DESCRIPTION
Fixes #567

Register `admin.TagRow` (and `*TagRow`) in `assertTagChipData` so the `/tags` list renders chips instead of an HTML-comment placeholder. `TagRow` embeds `service.TagResponse`, but Go's nominal type assertion does not treat the outer struct as the inner type, so the bridge fell through to the default branch. Forward to the embedded `TagResponse` and reuse the existing `TagChipDataFromResponse` adapter — no handler or template changes needed.

## Before / After

| Viewport | Before | After |
|---|---|---|
| Mobile (500x844) | ![before mobile](https://i.img402.dev/j8mclcv0ic.png) | ![after mobile](https://i.img402.dev/h4vdj593af.png) |
| Tablet (820x1180) | ![before tablet](https://i.img402.dev/bly9d8rc6l.png) | ![after tablet](https://i.img402.dev/18xjlhn5lr.png) |
| Desktop (1440x900) | ![before desktop](https://i.img402.dev/iasuaiwg0z.png) | ![after desktop](https://i.img402.dev/pekq44avvb.png) |

## Test plan
- [x] `go build ./...`
- [x] `/tags` renders chip for every row at mobile, tablet, desktop (Apples, Decent, Needs Enrichment, Needs Review, Suspicious)
- [x] No `renderComponent(...)` comment placeholders in page source
- [x] Chip style matches `/transactions/:id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)