### PR TITLE
refactor(mcp): extract parseSearchMode helper

### DIFF
--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"fmt"
 	"time"
+
+	"breadbox/internal/service"
 )
 
 // optStr returns a pointer to s when non-empty, else nil. Used to forward
@@ -27,4 +29,19 @@ func parseOptionalDate(field, value string) (*time.Time, error) {
 		return nil, fmt.Errorf("invalid %s: %w", field, err)
 	}
 	return &t, nil
+}
+
+// parseSearchMode validates an MCP search_mode input and returns a pointer
+// suitable for service-layer params. Empty input returns (nil, nil) —
+// service layer falls back to its own default. Unknown modes return an
+// error whose message mirrors the one previously duplicated across tool
+// handlers so agents see a consistent hint.
+func parseSearchMode(mode string) (*string, error) {
+	if mode == "" {
+		return nil, nil
+	}
+	if !service.ValidateSearchMode(mode) {
+		return nil, fmt.Errorf("invalid search_mode: %s. Must be one of: contains, words, fuzzy", mode)
+	}
+	return &mode, nil
 }

--- a/internal/mcp/helpers_test.go
+++ b/internal/mcp/helpers_test.go
@@ -20,6 +20,43 @@ func TestOptStr(t *testing.T) {
 	}
 }
 
+func TestParseSearchMode(t *testing.T) {
+	t.Run("empty returns nil without error", func(t *testing.T) {
+		got, err := parseSearchMode("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil, got %q", *got)
+		}
+	})
+
+	t.Run("valid modes round-trip", func(t *testing.T) {
+		for _, mode := range []string{"contains", "words", "fuzzy"} {
+			got, err := parseSearchMode(mode)
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", mode, err)
+			}
+			if got == nil || *got != mode {
+				t.Errorf("expected pointer to %q, got %v", mode, got)
+			}
+		}
+	})
+
+	t.Run("invalid mode returns error listing valid options", func(t *testing.T) {
+		_, err := parseSearchMode("regex")
+		if err == nil {
+			t.Fatal("expected error for invalid mode")
+		}
+		msg := err.Error()
+		for _, want := range []string{"regex", "contains", "words", "fuzzy"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("expected error to mention %q, got: %q", want, msg)
+			}
+		}
+	})
+}
+
 func TestParseOptionalDate(t *testing.T) {
 	t.Run("empty returns nil without error", func(t *testing.T) {
 		got, err := parseOptionalDate("start_date", "")

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -219,11 +219,8 @@ func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToo
 	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
-	if input.SearchMode != "" {
-		if !service.ValidateSearchMode(input.SearchMode) {
-			return errorResult(fmt.Errorf("invalid search_mode: %s. Must be one of: contains, words, fuzzy", input.SearchMode)), nil, nil
-		}
-		params.SearchMode = &input.SearchMode
+	if params.SearchMode, err = parseSearchMode(input.SearchMode); err != nil {
+		return errorResult(err), nil, nil
 	}
 
 	fieldSet, err := service.ParseFields(input.Fields)
@@ -281,11 +278,8 @@ func (s *MCPServer) handleCountTransactions(_ context.Context, _ *mcpsdk.CallToo
 	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
-	if input.SearchMode != "" {
-		if !service.ValidateSearchMode(input.SearchMode) {
-			return errorResult(fmt.Errorf("invalid search_mode: %s. Must be one of: contains, words, fuzzy", input.SearchMode)), nil, nil
-		}
-		params.SearchMode = &input.SearchMode
+	if params.SearchMode, err = parseSearchMode(input.SearchMode); err != nil {
+		return errorResult(err), nil, nil
 	}
 
 	count, err := s.svc.CountTransactionsFiltered(ctx, params)
@@ -478,11 +472,8 @@ func (s *MCPServer) handleMerchantSummary(_ context.Context, _ *mcpsdk.CallToolR
 	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
-	if input.SearchMode != "" {
-		if !service.ValidateSearchMode(input.SearchMode) {
-			return errorResult(fmt.Errorf("invalid search_mode: %s. Must be one of: contains, words, fuzzy", input.SearchMode)), nil, nil
-		}
-		params.SearchMode = &input.SearchMode
+	if params.SearchMode, err = parseSearchMode(input.SearchMode); err != nil {
+		return errorResult(err), nil, nil
 	}
 	if input.SpendingOnly != nil && *input.SpendingOnly {
 		params.SpendingOnly = true
@@ -649,11 +640,9 @@ func (s *MCPServer) handleListTransactionRules(_ context.Context, _ *mcpsdk.Call
 		Enabled:      input.Enabled,
 		Search:       optStr(input.Search),
 	}
-	if input.SearchMode != "" {
-		if !service.ValidateSearchMode(input.SearchMode) {
-			return errorResult(fmt.Errorf("invalid search_mode: %s. Must be one of: contains, words, fuzzy", input.SearchMode)), nil, nil
-		}
-		params.SearchMode = &input.SearchMode
+	var err error
+	if params.SearchMode, err = parseSearchMode(input.SearchMode); err != nil {
+		return errorResult(err), nil, nil
 	}
 
 	result, err := s.svc.ListTransactionRules(ctx, params)


### PR DESCRIPTION
## Summary
- Four MCP tool handlers (`handleQueryTransactions`, `handleCountTransactions`, `handleMerchantSummary`, `handleListTransactionRules`) repeated the same five-line `search_mode` validation + pointer-assignment block verbatim.
- Consolidate into `parseSearchMode` in `internal/mcp/helpers.go` alongside the existing `optStr` / `parseOptionalDate` helpers (following the pattern set by #554).
- Adds a unit test covering the empty, valid, and invalid cases so the error message agents see stays pinned.

Net: -20 / +63 (most of which is the new test).

## Test plan
- [x] `go test ./...`
- [x] `go build ./...`