### PR TITLE
a11y(transactions): name remove-tag buttons with their tag (#568)

### DIFF
--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -173,7 +173,8 @@
             <a :href="'/transactions?tags=' + t.slug" class="hover:underline" x-text="t.displayName || t.slug"></a>
             <button type="button" class="bb-tag-remove"
               @click.prevent.stop="t.lifecycle === 'ephemeral' ? (showRemoveNote = !showRemoveNote) : removeTag(t, '')"
-              title="Remove tag">
+              :aria-label="'Remove tag ' + (t.displayName || t.slug)"
+              :title="'Remove tag ' + (t.displayName || t.slug)">
               <i data-lucide="x" ></i>
             </button>
             <div x-show="showRemoveNote && t.lifecycle === 'ephemeral'" x-cloak


### PR DESCRIPTION
Fixes #568

Each tag chip's × button shared the generic `Remove tag` accessible name, so screen-reader users heard identical announcements for every chip with no way to tell which tag would be removed. Binds `aria-label` (and `title`) to include the tag's `displayName || slug` — matches the proposed fix in the issue.

Verified in Chrome DevTools a11y tree: two distinct accessible names after the change.

Before:
```
button "Remove tag"
button "Remove tag"
```
After:
```
button "Remove tag Needs Review"
button "Remove tag Needs Enrichment"
```

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| Mobile (500×844) | ![before-mobile](https://i.img402.dev/xkcsqx17db.png) | ![after-mobile](https://i.img402.dev/2xaarytxip.png) |
| Tablet (820×1180) | ![before-tablet](https://i.img402.dev/dfku2tk7jf.png) | ![after-tablet](https://i.img402.dev/wlbgh6fslp.png) |
| Desktop (1440×900) | ![before-desktop](https://i.img402.dev/fxdedfg10j.png) | ![after-desktop](https://i.img402.dev/j60lw0kk31.png) |

(Visuals are unchanged — this is a screen-reader/hover-tooltip fix. The difference is in the accessible name and the hover title text.)

## Test plan
- [x] `go build ./...`
- [x] DOM snapshot on a transaction with 2+ tags shows distinct `aria-label` values per chip
- [x] Hover title matches the aria-label
- [x] No layout/style change at mobile, tablet, desktop