### PR TITLE
fix(transactions): dedup rule-sourced tag events in activity timeline

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -844,6 +844,13 @@ func buildActivityTimeline(annotations []service.Annotation) []service.ActivityE
 			})
 
 		case "tag_added":
+			source, _ := a.Payload["source"].(string)
+			if source == "rule" {
+				// Represented separately via the rule_applied annotation
+				// written alongside tag_added during sync. Skip to avoid
+				// double-rendering. Mirrors the category_set dedup below.
+				continue
+			}
 			slug, _ := a.Payload["slug"].(string)
 			note, _ := a.Payload["note"].(string)
 			summary := "Added tag " + slug
@@ -863,6 +870,13 @@ func buildActivityTimeline(annotations []service.Annotation) []service.ActivityE
 			entries = append(entries, entry)
 
 		case "tag_removed":
+			source, _ := a.Payload["source"].(string)
+			if source == "rule" {
+				// Future-proof: if a rule ever emits a rule-sourced tag_removed
+				// alongside a rule_applied annotation, dedup the same way as
+				// tag_added / category_set so the timeline stays symmetric.
+				continue
+			}
 			slug, _ := a.Payload["slug"].(string)
 			note, _ := a.Payload["note"].(string)
 			summary := "Removed tag " + slug

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -117,6 +117,82 @@ func TestBuildActivityTimeline_FreeStandingCommentStillEmitted(t *testing.T) {
 	}
 }
 
+// Rule-sourced tag_added annotations are represented by the paired
+// rule_applied annotation that sync writes alongside them. The timeline
+// must dedup the tag_added so rule-driven tag applications do not render
+// twice (once as "Added tag X" and once as "Rule '…' added tag X").
+// Mirrors the existing category_set dedup.
+func TestBuildActivityTimeline_RuleSourcedTagAddedDeduped(t *testing.T) {
+	ruleID := "rule-1"
+	annotations := []service.Annotation{
+		{
+			ID:        "ann-tag",
+			Kind:      "tag_added",
+			ActorName: "Auto-tag new transactions for review",
+			ActorType: "system",
+			ActorID:   &ruleID,
+			Payload: map[string]interface{}{
+				"slug":      "needs-review",
+				"source":    "rule",
+				"rule_id":   ruleID,
+				"rule_name": "Auto-tag new transactions for review",
+			},
+			CreatedAt: "2026-04-04T12:00:00Z",
+		},
+		{
+			ID:        "ann-rule",
+			Kind:      "rule_applied",
+			ActorName: "Auto-tag new transactions for review",
+			ActorType: "system",
+			ActorID:   &ruleID,
+			Payload: map[string]interface{}{
+				"rule_name": "Auto-tag new transactions for review",
+				"how":       "tag_added",
+				"slug":      "needs-review",
+			},
+			CreatedAt: "2026-04-04T12:00:00Z",
+		},
+	}
+
+	entries := buildActivityTimeline(annotations)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (rule_applied only), got %d", len(entries))
+	}
+	if entries[0].Type != "rule" {
+		t.Errorf("expected the surviving entry to be a rule entry, got type=%q", entries[0].Type)
+	}
+}
+
+// User-authored tag additions must still render as regular "Added tag …" entries.
+func TestBuildActivityTimeline_UserTagAddedStillEmitted(t *testing.T) {
+	userID := "user-1"
+	annotations := []service.Annotation{{
+		ID:        "ann-user-tag",
+		Kind:      "tag_added",
+		ActorName: "Alice",
+		ActorType: "user",
+		ActorID:   &userID,
+		Payload: map[string]interface{}{
+			"slug": "vacation",
+			// no "source" field — user-authored
+		},
+		CreatedAt: "2026-04-05T09:00:00Z",
+	}}
+
+	entries := buildActivityTimeline(annotations)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 tag entry, got %d", len(entries))
+	}
+	if entries[0].Type != "tag" {
+		t.Errorf("expected tag entry, got type=%q", entries[0].Type)
+	}
+	if entries[0].TagSlug != "vacation" {
+		t.Errorf("expected TagSlug=vacation, got %q", entries[0].TagSlug)
+	}
+}
+
 func TestBuildActivityTimeline_LegacyPrefixCommentSuppressed(t *testing.T) {
 	annotations := []service.Annotation{{
 		ID:        "ann-legacy",


### PR DESCRIPTION
Fixes #569

Rule-driven tag applications were rendering twice in the transaction activity timeline: once as a generic `Added tag X` entry and again as the paired `Rule '…' added tag X` entry. The parallel `category_set` case already dedupes rule-sourced rows; `tag_added` now mirrors that guard, and `tag_removed` gets the same treatment so future rule-sourced removals stay symmetric. The `N events` counter is driven by the processed entries slice and corrects itself automatically.

Repro txn (`/transactions/3ShjS3no`) — 2 underlying rule-tag applications that previously rendered as 4 rows:

| Viewport | Before | After |
| --- | --- | --- |
| Mobile 500x844 | ![before-mobile](https://i.img402.dev/d89uomtmzt.png) | ![after-mobile](https://i.img402.dev/dqgnf8j3wm.png) |
| Tablet 820x1180 | ![before-tablet](https://i.img402.dev/y138qb1fua.png) | ![after-tablet](https://i.img402.dev/xw4m5jrcd6.png) |
| Desktop 1440x900 | ![before-desktop](https://i.img402.dev/dlnsm1cire.png) | ![after-desktop](https://i.img402.dev/ec5qntbv6n.png) |

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/admin/...` — added `TestBuildActivityTimeline_RuleSourcedTagAddedDeduped` and `TestBuildActivityTimeline_UserTagAddedStillEmitted` to lock the dedup behavior and guard user-authored tag adds from regressing.
- [x] Live repro on dev DB: `/transactions/3ShjS3no` now reads `2 events` with just the two `Rule '…' added tag …` rows across mobile/tablet/desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)