### PR TITLE
refactor(pgconv): add NumericToFloat helper, drop admin duplicate

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -102,7 +102,7 @@ func ConnectionsListHandler(a *app.App, svc *service.Service, sm *scs.SessionMan
 				for _, acct := range accounts {
 					ca := ConnectionAccount{Account: acct}
 					if acct.BalanceCurrent.Valid {
-						if f, err := numericToFloat(acct.BalanceCurrent); err == nil {
+						if f, ok := pgconv.NumericToFloat(acct.BalanceCurrent); ok {
 							ca.HasBalance = true
 							cwa.HasBalance = true
 							hasAnyBalance = true
@@ -567,8 +567,7 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 		var hasBalance bool
 		for _, acct := range accounts {
 			if acct.BalanceCurrent.Valid {
-				n, err := numericToFloat(acct.BalanceCurrent)
-				if err == nil {
+				if n, ok := pgconv.NumericToFloat(acct.BalanceCurrent); ok {
 					totalBalance += n
 					hasBalance = true
 				}
@@ -617,18 +616,6 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 		}
 		tr.Render(w, r, "connection_detail.html", data)
 	}
-}
-
-// numericToFloat converts a pgtype.Numeric to float64.
-func numericToFloat(n pgtype.Numeric) (float64, error) {
-	if !n.Valid {
-		return 0, fmt.Errorf("null numeric")
-	}
-	f, err := n.Float64Value()
-	if err != nil {
-		return 0, err
-	}
-	return f.Float64, nil
 }
 
 // ConnectionReauthHandler serves GET /admin/connections/{id}/reauth.

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -890,14 +890,11 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			"formatDate":   components.FormatDate,
 			"relativeDate": components.RelativeDate,
 			"formatNumeric": func(n pgtype.Numeric) string {
-				if !n.Valid {
+				f, ok := pgconv.NumericToFloat(n)
+				if !ok {
 					return ""
 				}
-				f, err := n.Float64Value()
-				if err != nil || !f.Valid {
-					return ""
-				}
-				return service.FormatCurrency(math.Abs(f.Float64))
+				return service.FormatCurrency(math.Abs(f))
 			},
 			"fmtBalance": func(v interface{}) string {
 				var f float64

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -77,8 +77,7 @@ func UsersListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) 
 				}
 				eu.ConnectionCount = int64(len(connSet))
 				for _, acct := range accounts {
-					bal, err := numericToFloat(acct.BalanceCurrent)
-					hasBal := err == nil
+					bal, hasBal := pgconv.NumericToFloat(acct.BalanceCurrent)
 					subtype := ""
 					if acct.Subtype.Valid {
 						// Clean up subtype for display (e.g. "credit_card" -> "Credit Card")

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -25,3 +25,17 @@ func ParseUUID(s string) (pgtype.UUID, error) {
 	err := u.Scan(s)
 	return u, err
 }
+
+// NumericToFloat returns the float64 value of a pgtype.Numeric. Returns
+// (0, false) when the numeric is NULL, NaN, or fails to convert (e.g. overflow).
+// Callers that need to distinguish those cases should use Float64Value directly.
+func NumericToFloat(n pgtype.Numeric) (float64, bool) {
+	if !n.Valid || n.NaN {
+		return 0, false
+	}
+	f, err := n.Float64Value()
+	if err != nil || !f.Valid {
+		return 0, false
+	}
+	return f.Float64, true
+}

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -78,3 +78,64 @@ func TestParseUUID_Invalid(t *testing.T) {
 		t.Error("ParseUUID: expected error for invalid input")
 	}
 }
+
+func TestNumericToFloat_Valid(t *testing.T) {
+	var n pgtype.Numeric
+	if err := n.Scan("123.45"); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	got, ok := NumericToFloat(n)
+	if !ok {
+		t.Fatal("NumericToFloat: expected ok=true")
+	}
+	if got != 123.45 {
+		t.Errorf("NumericToFloat = %v, want 123.45", got)
+	}
+}
+
+func TestNumericToFloat_Negative(t *testing.T) {
+	var n pgtype.Numeric
+	if err := n.Scan("-42.5"); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	got, ok := NumericToFloat(n)
+	if !ok {
+		t.Fatal("NumericToFloat: expected ok=true")
+	}
+	if got != -42.5 {
+		t.Errorf("NumericToFloat = %v, want -42.5", got)
+	}
+}
+
+func TestNumericToFloat_Zero(t *testing.T) {
+	var n pgtype.Numeric
+	if err := n.Scan("0"); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	got, ok := NumericToFloat(n)
+	if !ok {
+		t.Fatal("NumericToFloat: expected ok=true for zero")
+	}
+	if got != 0 {
+		t.Errorf("NumericToFloat = %v, want 0", got)
+	}
+}
+
+func TestNumericToFloat_Null(t *testing.T) {
+	n := pgtype.Numeric{Valid: false}
+	got, ok := NumericToFloat(n)
+	if ok {
+		t.Error("NumericToFloat: expected ok=false for NULL")
+	}
+	if got != 0 {
+		t.Errorf("NumericToFloat = %v, want 0", got)
+	}
+}
+
+func TestNumericToFloat_NaN(t *testing.T) {
+	n := pgtype.Numeric{NaN: true, Valid: true}
+	_, ok := NumericToFloat(n)
+	if ok {
+		t.Error("NumericToFloat: expected ok=false for NaN")
+	}
+}


### PR DESCRIPTION
## Summary

Four call sites in \`internal/admin\` open-coded the same \`pgtype.Numeric\` → \`float64\` conversion:

- \`connections.go\` — three call sites (balance totaling in list + detail, liability classification) plus the local \`numericToFloat\` helper itself.
- \`users.go\` — balance accumulation per user.
- \`templates.go\` — \`formatNumeric\` template funcMap closure.

All four wanted the same thing: \"if valid and convertible, give me the float.\" Consolidate on a single \`pgconv.NumericToFloat(n) (float64, bool)\` that also rejects \`NaN\` up front (the old helper didn't guard this — a NaN would have returned through \`Float64Value\` with \`Valid=true\`). Drop the admin-local \`numericToFloat\` and its \`\"null numeric\"\` error (callers always discarded it anyway).

No behavior change for any user-facing surface: the admin-local helper was only ever used with \`err == nil\` as a boolean, and \`formatNumeric\` returned \`\"\"\` on any failure — semantics preserved.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` — new \`TestNumericToFloat_{Valid,Negative,Zero,Null,NaN}\` cover the helper contract