### PR TITLE
fix(reports): use short label in report detail breadcrumb

### DIFF
--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -131,9 +131,13 @@ func ReportDetailHandler(a *app.App, svc *service.Service, sm *scs.SessionManage
 
 		data := BaseTemplateData(r, sm, "reports", report.Title)
 		data["Report"] = detail
+		// Use a short, fixed label for the current-page crumb. Agent report
+		// titles can be full sentences; interpolating them into the breadcrumb
+		// overflows on mobile/tablet and visually competes with the header
+		// card below, which already shows the full title.
 		data["Breadcrumbs"] = []Breadcrumb{
 			{Label: "Reports", Href: "/reports"},
-			{Label: report.Title},
+			{Label: "Report"},
 		}
 		tr.Render(w, r, "report_detail.html", data)
 	}


### PR DESCRIPTION
Fixes #548

Swap the interpolated `report.Title` in the report-detail breadcrumb for a fixed `"Report"` label. Agent report titles can be full sentences (e.g. "Possible fraud: $1,240 at \"ELECTRONICS WAREHOUSE\" — not a merchant you have history with."), which overflows the breadcrumb on mobile/tablet and visually competes with the header card below that already shows the full title.

## Screenshots

| Viewport | Before | After |
|---|---|---|
| Mobile (500×844) | ![before-mobile](https://i.img402.dev/0hnfoyr6u9.png) | ![after-mobile](https://i.img402.dev/e37go7wn2a.png) |
| Tablet (820×1180) | ![before-tablet](https://i.img402.dev/kge6r70y8o.png) | ![after-tablet](https://i.img402.dev/a0qa1i4516.png) |
| Desktop (1440×900) | ![before-desktop](https://i.img402.dev/wpj119kcd2.png) | ![after-desktop](https://i.img402.dev/gkkdex1cf8.png) |

## Test plan

- [x] `go build ./...` passes
- [x] Breadcrumb renders as `Reports > Report` on the long-title report at all three viewports
- [x] No change to the header card below, which still shows the full title
- [x] Short-title reports unaffected (same fixed label either way)

🤖 Generated with [Claude Code](https://claude.com/claude-code)