### PR TITLE
a11y(connections): split nested <button> out of wrapping <a> on cards

### DIFF
--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -103,80 +103,80 @@
 <div class="flex flex-col gap-4 bb-stagger">
   {{range .Connections}}
   <div class="bb-card overflow-hidden" x-show="filterUser === 'all' || filterUser === '{{formatUUID .UserID}}'">
-    <!-- Connection Header — clickable -->
-    <a href="/connections/{{formatUUID .ID}}" class="block no-underline group">
-      <div class="px-4 py-3 sm:px-5 sm:py-4 flex items-center justify-between gap-3 sm:gap-4">
-        <div class="flex items-center gap-3 sm:gap-4 min-w-0">
-          <div class="hidden sm:flex w-10 h-10 rounded-lg bg-base-200/60 items-center justify-center shrink-0">
-            {{if eq (printf "%s" .Provider) "plaid"}}
-            <i data-lucide="building-2" class="w-5 h-5 text-info"></i>
-            {{else if eq (printf "%s" .Provider) "teller"}}
-            <i data-lucide="landmark" class="w-5 h-5 text-success"></i>
+    <!-- Connection Header — non-nested interactives (a11y: link + sibling button) -->
+    <div class="group px-4 py-3 sm:px-5 sm:py-4 flex items-center justify-between gap-3 sm:gap-4">
+      <a href="/connections/{{formatUUID .ID}}" class="flex items-center gap-3 sm:gap-4 min-w-0 flex-1 no-underline" aria-label="Open {{.InstitutionName.String}} connection">
+        <div class="hidden sm:flex w-10 h-10 rounded-lg bg-base-200/60 items-center justify-center shrink-0">
+          {{if eq (printf "%s" .Provider) "plaid"}}
+          <i data-lucide="building-2" class="w-5 h-5 text-info"></i>
+          {{else if eq (printf "%s" .Provider) "teller"}}
+          <i data-lucide="landmark" class="w-5 h-5 text-success"></i>
+          {{else}}
+          <i data-lucide="file-spreadsheet" class="w-5 h-5 text-warning"></i>
+          {{end}}
+        </div>
+        <div class="min-w-0">
+          <div class="flex items-center gap-2 flex-wrap">
+            <h3 class="font-semibold text-sm sm:text-base group-hover:text-primary transition-colors truncate max-w-[10rem] sm:max-w-none">{{.InstitutionName.String}}</h3>
+            {{if .IsStale}}
+            <span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-warning/10 text-warning">Stale</span>
+            {{else if and (eq .LastSyncStatus "error") (eq (printf "%s" .Status) "active")}}
+            <span class="relative group/err">
+              <span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
+              {{if .LastSyncErrorMessage.Valid}}
+              <span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
+                <span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>
+                <span class="text-base-content/70">{{.LastSyncErrorMessage.String}}</span>
+              </span>
+              {{end}}
+            </span>
             {{else}}
-            <i data-lucide="file-spreadsheet" class="w-5 h-5 text-warning"></i>
+            {{statusBadge (printf "%s" .Status)}}
+            {{end}}
+            {{if .Paused}}<span class="badge badge-ghost badge-xs">Paused</span>{{end}}
+          </div>
+          <div class="flex items-center gap-2 text-xs text-base-content/40 mt-0.5">
+            <span>{{.UserName.String}}</span>
+            <span class="text-base-content/20">&middot;</span>
+            <span class="capitalize">{{printf "%s" .Provider}}</span>
+            <span class="text-base-content/20">&middot;</span>
+            {{if .LastSyncedAt.Valid}}
+            <span>{{relativeTime .LastSyncedAt.Time}}</span>
+            {{else}}
+            <span>Never synced</span>
             {{end}}
           </div>
-          <div class="min-w-0">
-            <div class="flex items-center gap-2 flex-wrap">
-              <h3 class="font-semibold text-sm sm:text-base group-hover:text-primary transition-colors truncate max-w-[10rem] sm:max-w-none">{{.InstitutionName.String}}</h3>
-              {{if .IsStale}}
-              <span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-warning/10 text-warning">Stale</span>
-              {{else if and (eq .LastSyncStatus "error") (eq (printf "%s" .Status) "active")}}
-              <span class="relative group/err">
-                <span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
-                {{if .LastSyncErrorMessage.Valid}}
-                <span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
-                  <span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>
-                  <span class="text-base-content/70">{{.LastSyncErrorMessage.String}}</span>
-                </span>
-                {{end}}
-              </span>
-              {{else}}
-              {{statusBadge (printf "%s" .Status)}}
-              {{end}}
-              {{if .Paused}}<span class="badge badge-ghost badge-xs">Paused</span>{{end}}
-            </div>
-            <div class="flex items-center gap-2 text-xs text-base-content/40 mt-0.5">
-              <span>{{.UserName.String}}</span>
-              <span class="text-base-content/20">&middot;</span>
-              <span class="capitalize">{{printf "%s" .Provider}}</span>
-              <span class="text-base-content/20">&middot;</span>
-              {{if .LastSyncedAt.Valid}}
-              <span>{{relativeTime .LastSyncedAt.Time}}</span>
-              {{else}}
-              <span>Never synced</span>
-              {{end}}
-            </div>
-          </div>
         </div>
-        <div class="flex items-center gap-2 sm:gap-3 shrink-0">
-          <!-- Sync Now button (non-CSV active connections only) -->
-          {{if and (ne (printf "%s" .Provider) "csv") (eq (printf "%s" .Status) "active")}}
-          <div x-data="syncBtn('{{formatUUID .ID}}')" @click.prevent.stop>
-            <button class="w-8 h-8 rounded-full flex items-center justify-center text-base-content/30 hover:text-primary hover:bg-primary/10 transition-colors"
-                    :disabled="state !== 'idle'"
-                    @click="triggerSync()"
-                    :title="state === 'syncing' ? 'Syncing...' : 'Sync Now'">
-              <i data-lucide="refresh-cw" class="w-4 h-4" x-show="state === 'idle'" :class="state === 'idle' ? '' : 'hidden'"></i>
-              <span class="loading loading-spinner loading-xs" x-show="state === 'syncing'" x-cloak></span>
-              <i data-lucide="check" class="w-4 h-4 text-success" x-show="state === 'done'" x-cloak></i>
-            </button>
-          </div>
-          {{end}}
-          <!-- Connection total balance -->
-          {{if .HasBalance}}
-          <div class="text-right">
-            <div class="text-base sm:text-lg font-semibold tabular-nums tracking-tight">{{formatAmount .TotalBalance}}</div>
-            <div class="text-xs text-base-content/40">{{.AccountCount}} <span class="hidden sm:inline">account{{if ne .AccountCount 1}}s{{end}}</span><span class="sm:hidden">acct{{if ne .AccountCount 1}}s{{end}}</span></div>
-          </div>
-          {{else}}
-          <div class="text-right">
-            <div class="text-xs text-base-content/40">{{.AccountCount}} <span class="hidden sm:inline">account{{if ne .AccountCount 1}}s{{end}}</span><span class="sm:hidden">acct{{if ne .AccountCount 1}}s{{end}}</span></div>
-          </div>
-          {{end}}
+      </a>
+      <div class="flex items-center gap-2 sm:gap-3 shrink-0">
+        <!-- Sync Now button (non-CSV active connections only) -->
+        {{if and (ne (printf "%s" .Provider) "csv") (eq (printf "%s" .Status) "active")}}
+        <div x-data="syncBtn('{{formatUUID .ID}}')">
+          <button type="button"
+                  class="w-8 h-8 rounded-full flex items-center justify-center text-base-content/30 hover:text-primary hover:bg-primary/10 transition-colors"
+                  :disabled="state !== 'idle'"
+                  @click="triggerSync()"
+                  :aria-label="state === 'syncing' ? 'Syncing...' : 'Sync {{.InstitutionName.String}} now'"
+                  :title="state === 'syncing' ? 'Syncing...' : 'Sync Now'">
+            <i data-lucide="refresh-cw" class="w-4 h-4" x-show="state === 'idle'" :class="state === 'idle' ? '' : 'hidden'"></i>
+            <span class="loading loading-spinner loading-xs" x-show="state === 'syncing'" x-cloak></span>
+            <i data-lucide="check" class="w-4 h-4 text-success" x-show="state === 'done'" x-cloak></i>
+          </button>
         </div>
+        {{end}}
+        <!-- Connection total balance -->
+        {{if .HasBalance}}
+        <a href="/connections/{{formatUUID .ID}}" class="text-right no-underline text-inherit" tabindex="-1" aria-hidden="true">
+          <div class="text-base sm:text-lg font-semibold tabular-nums tracking-tight">{{formatAmount .TotalBalance}}</div>
+          <div class="text-xs text-base-content/40">{{.AccountCount}} <span class="hidden sm:inline">account{{if ne .AccountCount 1}}s{{end}}</span><span class="sm:hidden">acct{{if ne .AccountCount 1}}s{{end}}</span></div>
+        </a>
+        {{else}}
+        <a href="/connections/{{formatUUID .ID}}" class="text-right no-underline text-inherit" tabindex="-1" aria-hidden="true">
+          <div class="text-xs text-base-content/40">{{.AccountCount}} <span class="hidden sm:inline">account{{if ne .AccountCount 1}}s{{end}}</span><span class="sm:hidden">acct{{if ne .AccountCount 1}}s{{end}}</span></div>
+        </a>
+        {{end}}
       </div>
-    </a>
+    </div>
 
     <!-- Connection-level error message (e.g. reauth needed) -->
     {{if .ErrorMessage.Valid}}


### PR DESCRIPTION
Fixes #577

Split the connection card header into non-nested interactives — the outer `<a href="/connections/:id">` no longer wraps the Sync Now `<button>`. Icon + metadata are wrapped in the link (`aria-label="Open <institution> connection"`); the Sync Now button is a sibling (`aria-label="Sync <institution> now"`, `type="button"`). The balance cluster keeps a click-to-open affordance via a small `aria-hidden`, `tabindex="-1"` link so it doesn't clutter the tab order.

Verified with Chrome DevTools MCP:
- A11y snapshot now shows `link "Open CapitalOne connection"` and `button "Sync CapitalOne now"` as separate nodes.
- `document.querySelectorAll('a button, a a').length === 0`.
- Tab from the card link advances to the Sync button next (keyboard order preserved).

## Before / After

| | Before | After |
|---|---|---|
| Mobile (500×844) | ![](https://i.img402.dev/k30h0i9sp8.png) | ![](https://i.img402.dev/oqsji9rp2y.png) |
| Tablet (820×1180) | ![](https://i.img402.dev/s3xrxm890b.png) | ![](https://i.img402.dev/vaajb4jsbf.png) |
| Desktop (1440×900) | ![](https://i.img402.dev/qz4gnar219.png) | ![](https://i.img402.dev/76513n0e38.png) |

## Test plan

- [ ] Tap/click the header area of a connection card → navigates to `/connections/:id`.
- [ ] Tap/click the Sync Now icon → triggers sync, does NOT navigate.
- [ ] Tab through the list: link, then Sync button, then the next card's link; Enter on link navigates; Enter/Space on button triggers sync.
- [ ] Screen reader announces the link and Sync button as separate controls.
- [ ] No visual regression at mobile/tablet/desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)