### PR TITLE
refactor(mcp): extract parseDateRange helper for paired date filters

### DIFF
--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -28,3 +28,19 @@ func parseOptionalDate(field, value string) (*time.Time, error) {
 	}
 	return &t, nil
 }
+
+// parseDateRange parses a paired start_date/end_date YYYY-MM-DD input into
+// time pointers. Either or both may be empty. Tool handlers accept these as
+// a bounded window filter and nearly always parse them together, so bundling
+// the two calls keeps handler bodies focused on the filter being built.
+func parseDateRange(start, end string) (*time.Time, *time.Time, error) {
+	startT, err := parseOptionalDate("start_date", start)
+	if err != nil {
+		return nil, nil, err
+	}
+	endT, err := parseOptionalDate("end_date", end)
+	if err != nil {
+		return nil, nil, err
+	}
+	return startT, endT, nil
+}

--- a/internal/mcp/helpers_test.go
+++ b/internal/mcp/helpers_test.go
@@ -60,3 +60,59 @@ func TestParseOptionalDate(t *testing.T) {
 		}
 	})
 }
+
+func TestParseDateRange(t *testing.T) {
+	t.Run("both empty returns nil pair", func(t *testing.T) {
+		start, end, err := parseDateRange("", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if start != nil || end != nil {
+			t.Errorf("expected nil pair, got start=%v end=%v", start, end)
+		}
+	})
+
+	t.Run("only start parses", func(t *testing.T) {
+		start, end, err := parseDateRange("2024-03-15", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if start == nil || end != nil {
+			t.Fatalf("expected start set, end nil; got start=%v end=%v", start, end)
+		}
+		want := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+		if !start.Equal(want) {
+			t.Errorf("expected %v, got %v", want, *start)
+		}
+	})
+
+	t.Run("both set parse", func(t *testing.T) {
+		start, end, err := parseDateRange("2024-01-01", "2024-12-31")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if start == nil || end == nil {
+			t.Fatal("expected both non-nil")
+		}
+	})
+
+	t.Run("invalid start surfaces field name", func(t *testing.T) {
+		_, _, err := parseDateRange("nope", "2024-12-31")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "start_date") {
+			t.Errorf("expected start_date in error, got: %q", err.Error())
+		}
+	})
+
+	t.Run("invalid end surfaces field name", func(t *testing.T) {
+		_, _, err := parseDateRange("2024-01-01", "nope")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "end_date") {
+			t.Errorf("expected end_date in error, got: %q", err.Error())
+		}
+	})
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -213,10 +213,7 @@ func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToo
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 	if input.SearchMode != "" {
@@ -275,10 +272,7 @@ func (s *MCPServer) handleCountTransactions(_ context.Context, _ *mcpsdk.CallToo
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 	if input.SearchMode != "" {
@@ -439,10 +433,7 @@ func (s *MCPServer) handleTransactionSummary(_ context.Context, _ *mcpsdk.CallTo
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 	if input.IncludePending != nil && *input.IncludePending {
@@ -472,10 +463,7 @@ func (s *MCPServer) handleMerchantSummary(_ context.Context, _ *mcpsdk.CallToolR
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 	if input.SearchMode != "" {
@@ -919,10 +907,7 @@ func (s *MCPServer) handleBulkRecategorize(ctx context.Context, _ *mcpsdk.CallTo
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 


### PR DESCRIPTION
## Summary

- Every MCP tool that accepts `start_date`/`end_date` was parsing the pair with two back-to-back `parseOptionalDate` calls plus error-return blocks. Five call sites collapse from six lines to three by folding the pair into a single `parseDateRange` helper.
- Keeps the existing `parseOptionalDate` primitive (still exercised by the new helper) so the field-named error messages agents already see stay identical.
- Adds unit coverage for the new helper alongside the existing tests.

No behavior change — same errors, same params populated.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/mcp/ -run 'TestParseOptionalDate|TestParseDateRange|TestOptStr' -v`
- [x] `go test ./internal/mcp/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)