### PR TITLE
fix(forms): drop duplicate back link under page header on new/reauth forms

### DIFF
--- a/internal/templates/pages/api_key_new.html
+++ b/internal/templates/pages/api_key_new.html
@@ -6,9 +6,6 @@
     <h1 class="bb-page-title">Create API Key</h1>
     <p class="text-sm text-base-content/50 mt-1">Generate a new key for API or MCP access</p>
   </div>
-  <a href="/access" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> Access
-  </a>
 </div>
 
 <div class="bb-card p-6 max-w-lg">

--- a/internal/templates/pages/connection_new.html
+++ b/internal/templates/pages/connection_new.html
@@ -6,9 +6,6 @@
     <h1 class="bb-page-title">Connect New Bank</h1>
     <p class="text-sm text-base-content/50 mt-1">Link a bank account to start syncing transactions</p>
   </div>
-  <a href="/connections" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> Connections
-  </a>
 </div>
 
 {{if not (or .HasPlaid .HasTeller)}}

--- a/internal/templates/pages/connection_reauth.html
+++ b/internal/templates/pages/connection_reauth.html
@@ -12,9 +12,6 @@
     <h1 class="bb-page-title">Re-authenticate</h1>
     <p class="text-sm text-base-content/50 mt-1">{{.Connection.InstitutionName.String}} needs to be re-connected</p>
   </div>
-  <a href="/connections/{{.ConnID}}" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> Back to Connection
-  </a>
 </div>
 
 <div class="bb-card p-8 max-w-lg">

--- a/internal/templates/pages/csv_import.html
+++ b/internal/templates/pages/csv_import.html
@@ -6,9 +6,6 @@
     <h1 class="bb-page-title">Import CSV</h1>
     <p class="text-sm text-base-content/50 mt-1">Import transactions from a CSV, TSV, or TXT file</p>
   </div>
-  <a href="/connections" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> Connections
-  </a>
 </div>
 
 <!-- Step indicator -->

--- a/internal/templates/pages/oauth_client_new.html
+++ b/internal/templates/pages/oauth_client_new.html
@@ -6,9 +6,6 @@
     <h1 class="bb-page-title">Create OAuth Client</h1>
     <p class="text-sm text-base-content/50 mt-1">Generate credentials for an external connector (e.g., Claude)</p>
   </div>
-  <a href="/access" class="btn btn-sm btn-ghost rounded-xl gap-2">
-    <i data-lucide="arrow-left" class="w-4 h-4"></i> Access
-  </a>
 </div>
 
 <div class="bb-card p-6 max-w-lg">


### PR DESCRIPTION
Fixes #579

Removes the secondary `← <Parent>` link from `.bb-page-header` on the five new/reauth form pages. The breadcrumb at the top of every page already provides back navigation; on mobile and tablet the secondary link's `btn btn-sm` styling stretched full-width and centered, which visually duplicated the breadcrumb and outweighed the primary CTA.

Files:
- `internal/templates/pages/api_key_new.html`
- `internal/templates/pages/oauth_client_new.html`
- `internal/templates/pages/connection_new.html`
- `internal/templates/pages/connection_reauth.html`
- `internal/templates/pages/csv_import.html`

All validated on `/api-keys/new` (same pattern across the five files).

## Before / After

| Viewport | Before | After |
|---|---|---|
| Mobile 500×844 | ![before-mobile](https://i.img402.dev/op6i7sdi9d.png) | ![after-mobile](https://i.img402.dev/c9pqsl5mae.png) |
| Tablet 820×1180 | ![before-tablet](https://i.img402.dev/ra5y49fv35.png) | ![after-tablet](https://i.img402.dev/30mq1qlojp.png) |
| Desktop 1440×900 | ![before-desktop](https://i.img402.dev/cohwutuyrw.png) | ![after-desktop](https://i.img402.dev/sgytdy36d8.png) |

## Test plan
- [x] `go build ./...` passes
- [x] Mobile/tablet/desktop screenshots captured on `/api-keys/new`
- [x] Breadcrumb still renders and provides parent nav
- [x] Page title + subtitle layout preserved