### PR TITLE
refactor(admin): extract page/date query-param parsing helpers

### DIFF
--- a/internal/admin/agents_page.go
+++ b/internal/admin/agents_page.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"net/http"
-	"strconv"
 
 	breadboxmcp "breadbox/internal/mcp"
 	"breadbox/internal/service"
@@ -223,10 +222,7 @@ func AgentsPageHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer, s
 
 		// === Activity tab data ===
 		if tab == "activity" {
-			page := 1
-			if p, err := strconv.Atoi(r.URL.Query().Get("page")); err == nil && p > 0 {
-				page = p
-			}
+			page := parsePage(r)
 			sessions, total, _ := svc.ListMCPSessions(ctx, page, 25)
 			data["Sessions"] = sessions
 			data["SessionsTotal"] = int(total)

--- a/internal/admin/csv_export.go
+++ b/internal/admin/csv_export.go
@@ -18,21 +18,12 @@ func ExportTransactionsCSVHandler(a *app.App, svc *service.Service) http.Handler
 		ctx := r.Context()
 
 		params := service.AdminTransactionListParams{
-			Page:     1,
-			PageSize: -1, // Export all matching rows (no pagination).
+			Page:      1,
+			PageSize:  -1, // Export all matching rows (no pagination).
+			StartDate: parseDateParam(r, "start_date"),
+			EndDate:   parseInclusiveDateParam(r, "end_date"),
 		}
 
-		if v := r.URL.Query().Get("start_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				params.StartDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("end_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				t = t.AddDate(0, 0, 1)
-				params.EndDate = &t
-			}
-		}
 		if v := r.URL.Query().Get("account_id"); v != "" {
 			params.AccountID = &v
 		}

--- a/internal/admin/helpers.go
+++ b/internal/admin/helpers.go
@@ -1,11 +1,78 @@
 package admin
 
 import (
+	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// parsePage returns the 1-indexed page from ?page=, flooring at 1 when the
+// param is missing, non-numeric, or less than 1.
+func parsePage(r *http.Request) int {
+	return parsePageKey(r, "page")
+}
+
+// parsePageKey is like parsePage but reads from an arbitrary query-param name.
+// Useful on pages that host multiple independent lists (e.g. ?page=1&wh_page=2).
+func parsePageKey(r *http.Request, key string) int {
+	page, _ := strconv.Atoi(r.URL.Query().Get(key))
+	if page < 1 {
+		page = 1
+	}
+	return page
+}
+
+// parsePerPage returns the validated ?per_page= value. It falls back to
+// defaultSize when the param is missing, non-numeric, or not in allowed.
+// An empty allowed list means any positive integer is accepted.
+func parsePerPage(r *http.Request, defaultSize int, allowed ...int) int {
+	v, err := strconv.Atoi(r.URL.Query().Get("per_page"))
+	if err != nil {
+		return defaultSize
+	}
+	if len(allowed) == 0 {
+		if v > 0 {
+			return v
+		}
+		return defaultSize
+	}
+	for _, a := range allowed {
+		if v == a {
+			return v
+		}
+	}
+	return defaultSize
+}
+
+// parseDateParam parses the YYYY-MM-DD value of r.URL.Query().Get(key) into a
+// *time.Time. Returns nil when the param is missing or malformed, matching the
+// "silently drop invalid filters" convention used across admin handlers.
+func parseDateParam(r *http.Request, key string) *time.Time {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return nil
+	}
+	t, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// parseInclusiveDateParam behaves like parseDateParam but adds one day so the
+// parsed value can be used as an exclusive upper bound that still includes the
+// entire given calendar date (e.g. `date < end+1 day`).
+func parseInclusiveDateParam(r *http.Request, key string) *time.Time {
+	t := parseDateParam(r, key)
+	if t == nil {
+		return nil
+	}
+	next := t.AddDate(0, 0, 1)
+	return &next
+}
 
 // splitCSV splits a comma-separated string into trimmed non-empty entries.
 // Used by URL params that accept multi-value lists (e.g. ?tags=a,b,c).

--- a/internal/admin/helpers_test.go
+++ b/internal/admin/helpers_test.go
@@ -1,11 +1,115 @@
 package admin
 
 import (
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+func TestParsePage(t *testing.T) {
+	tests := []struct {
+		query string
+		want  int
+	}{
+		{"", 1},
+		{"page=", 1},
+		{"page=abc", 1},
+		{"page=0", 1},
+		{"page=-5", 1},
+		{"page=1", 1},
+		{"page=7", 7},
+	}
+	for _, tc := range tests {
+		t.Run(tc.query, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/?"+tc.query, nil)
+			if got := parsePage(r); got != tc.want {
+				t.Errorf("parsePage(%q) = %d, want %d", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParsePageKey(t *testing.T) {
+	r := httptest.NewRequest("GET", "/?page=2&wh_page=9", nil)
+	if got := parsePageKey(r, "wh_page"); got != 9 {
+		t.Errorf("parsePageKey(wh_page) = %d, want 9", got)
+	}
+	if got := parsePageKey(r, "missing"); got != 1 {
+		t.Errorf("parsePageKey(missing) = %d, want 1", got)
+	}
+}
+
+func TestParsePerPage(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		def     int
+		allowed []int
+		want    int
+	}{
+		{"missing returns default", "", 25, []int{25, 50}, 25},
+		{"non-numeric returns default", "per_page=abc", 25, []int{25, 50}, 25},
+		{"in allowed", "per_page=50", 25, []int{25, 50, 100}, 50},
+		{"not in allowed returns default", "per_page=33", 25, []int{25, 50}, 25},
+		{"no allowlist accepts positive", "per_page=200", 25, nil, 200},
+		{"no allowlist rejects zero", "per_page=0", 25, nil, 25},
+		{"no allowlist rejects negative", "per_page=-1", 25, nil, 25},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/?"+tc.query, nil)
+			if got := parsePerPage(r, tc.def, tc.allowed...); got != tc.want {
+				t.Errorf("parsePerPage = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseDateParam(t *testing.T) {
+	r := httptest.NewRequest("GET", "/?d=2026-04-19&bad=2026/04/19", nil)
+
+	got := parseDateParam(r, "d")
+	if got == nil {
+		t.Fatal("parseDateParam(d) = nil, want 2026-04-19")
+	}
+	want := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("parseDateParam(d) = %v, want %v", got, want)
+	}
+
+	if parseDateParam(r, "bad") != nil {
+		t.Error("parseDateParam(bad) should return nil for malformed input")
+	}
+	if parseDateParam(r, "missing") != nil {
+		t.Error("parseDateParam(missing) should return nil")
+	}
+}
+
+func TestParseInclusiveDateParam(t *testing.T) {
+	r := httptest.NewRequest("GET", "/?d=2026-04-19", nil)
+
+	got := parseInclusiveDateParam(r, "d")
+	if got == nil {
+		t.Fatal("parseInclusiveDateParam = nil")
+	}
+	want := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(want) {
+		t.Errorf("parseInclusiveDateParam = %v, want %v (end-date shifted by +1 day)", got, want)
+	}
+
+	// Verify the original param isn't mutated: re-parsing returns the
+	// un-shifted date.
+	orig := parseDateParam(r, "d")
+	if orig == nil || !orig.Equal(time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("parseDateParam(d) after inclusive parse = %v, want 2026-04-19", orig)
+	}
+
+	if parseInclusiveDateParam(r, "missing") != nil {
+		t.Error("parseInclusiveDateParam(missing) should return nil")
+	}
+}
 
 func TestSplitCSV(t *testing.T) {
 	tests := []struct {

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -2,8 +2,6 @@ package admin
 
 import (
 	"net/http"
-	"strconv"
-	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -30,14 +28,11 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 
 		// Always fetch sync logs data.
 		{
-			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-			if page < 1 {
-				page = 1
-			}
-
 			params := service.SyncLogListParams{
-				Page:     page,
+				Page:     parsePage(r),
 				PageSize: 25,
+				DateFrom: parseDateParam(r, "date_from"),
+				DateTo:   parseInclusiveDateParam(r, "date_to"),
 			}
 
 			if connID := r.URL.Query().Get("connection_id"); connID != "" {
@@ -48,17 +43,6 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 			}
 			if trigger := r.URL.Query().Get("trigger"); trigger != "" {
 				params.Trigger = &trigger
-			}
-			if v := r.URL.Query().Get("date_from"); v != "" {
-				if t, err := time.Parse("2006-01-02", v); err == nil {
-					params.DateFrom = &t
-				}
-			}
-			if v := r.URL.Query().Get("date_to"); v != "" {
-				if t, err := time.Parse("2006-01-02", v); err == nil {
-					t = t.AddDate(0, 0, 1)
-					params.DateTo = &t
-				}
 			}
 
 			result, err := svc.ListSyncLogsPaginated(ctx, params)
@@ -147,13 +131,8 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 
 		// Always fetch webhook events data.
 		{
-			page, _ := strconv.Atoi(r.URL.Query().Get("wh_page"))
-			if page < 1 {
-				page = 1
-			}
-
 			params := service.WebhookEventListParams{
-				Page:     page,
+				Page:     parsePageKey(r, "wh_page"),
 				PageSize: 25,
 			}
 

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -19,22 +19,9 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
-		pageSize := 50
-		if v, err := strconv.Atoi(r.URL.Query().Get("per_page")); err == nil {
-			switch v {
-			case 25, 50, 100:
-				pageSize = v
-			}
-		}
-
 		params := service.TransactionRuleListParams{
-			Page:     page,
-			PageSize: pageSize,
+			Page:     parsePage(r),
+			PageSize: parsePerPage(r, 50, 25, 50, 100),
 		}
 
 		if v := r.URL.Query().Get("search"); v != "" {

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -3,8 +3,6 @@ package admin
 import (
 	"net/http"
 	"net/url"
-	"strconv"
-	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -19,14 +17,11 @@ func SyncLogsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, s
 		ctx := r.Context()
 
 		// Parse query params.
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
 		params := service.SyncLogListParams{
-			Page:     page,
+			Page:     parsePage(r),
 			PageSize: 25,
+			DateFrom: parseDateParam(r, "date_from"),
+			DateTo:   parseInclusiveDateParam(r, "date_to"),
 		}
 
 		if connID := r.URL.Query().Get("connection_id"); connID != "" {
@@ -37,18 +32,6 @@ func SyncLogsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, s
 		}
 		if trigger := r.URL.Query().Get("trigger"); trigger != "" {
 			params.Trigger = &trigger
-		}
-		if v := r.URL.Query().Get("date_from"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				params.DateFrom = &t
-			}
-		}
-		if v := r.URL.Query().Get("date_to"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				// Add one day so the end date is inclusive.
-				t = t.AddDate(0, 0, 1)
-				params.DateTo = &t
-			}
 		}
 
 		// Fetch paginated sync logs.

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -99,36 +99,13 @@ func TransactionListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRend
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
-		pageSize := 50
-		if v, err := strconv.Atoi(r.URL.Query().Get("per_page")); err == nil {
-			switch v {
-			case 25, 50, 100:
-				pageSize = v
-			}
-		}
-
 		params := service.AdminTransactionListParams{
-			Page:     page,
-			PageSize: pageSize,
+			Page:      parsePage(r),
+			PageSize:  parsePerPage(r, 50, 25, 50, 100),
+			StartDate: parseDateParam(r, "start_date"),
+			EndDate:   parseInclusiveDateParam(r, "end_date"),
 		}
 
-		if v := r.URL.Query().Get("start_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				params.StartDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("end_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				// Add one day so the end date is inclusive.
-				t = t.AddDate(0, 0, 1)
-				params.EndDate = &t
-			}
-		}
 		if v := r.URL.Query().Get("account_id"); v != "" {
 			params.AccountID = &v
 		}
@@ -291,35 +268,13 @@ func TransactionSearchHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
-		pageSize := 50
-		if v, err := strconv.Atoi(r.URL.Query().Get("per_page")); err == nil {
-			switch v {
-			case 25, 50, 100:
-				pageSize = v
-			}
-		}
-
 		params := service.AdminTransactionListParams{
-			Page:     page,
-			PageSize: pageSize,
+			Page:      parsePage(r),
+			PageSize:  parsePerPage(r, 50, 25, 50, 100),
+			StartDate: parseDateParam(r, "start_date"),
+			EndDate:   parseInclusiveDateParam(r, "end_date"),
 		}
 
-		if v := r.URL.Query().Get("start_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				params.StartDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("end_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				t = t.AddDate(0, 0, 1)
-				params.EndDate = &t
-			}
-		}
 		if v := r.URL.Query().Get("account_id"); v != "" {
 			params.AccountID = &v
 		}
@@ -438,15 +393,12 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 		}
 
 		// Fetch transactions for this account.
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
 		txParams := service.AdminTransactionListParams{
-			Page:      page,
+			Page:      parsePage(r),
 			PageSize:  50,
 			AccountID: &idStr,
+			StartDate: parseDateParam(r, "start_date"),
+			EndDate:   parseInclusiveDateParam(r, "end_date"),
 		}
 
 		// Scope transaction query to viewer's user. Editors+ see all.
@@ -454,17 +406,6 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 			txParams.UserID = &memberUID
 		}
 
-		if v := r.URL.Query().Get("start_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				txParams.StartDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("end_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				t = t.AddDate(0, 0, 1)
-				txParams.EndDate = &t
-			}
-		}
 		if v := r.URL.Query().Get("search"); v != "" {
 			txParams.Search = &v
 		}

--- a/internal/admin/webhook_events.go
+++ b/internal/admin/webhook_events.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"net/http"
-	"strconv"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -15,13 +14,8 @@ func WebhookEventsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
-		if page < 1 {
-			page = 1
-		}
-
 		params := service.WebhookEventListParams{
-			Page:     page,
+			Page:     parsePage(r),
 			PageSize: 25,
 		}
 


### PR DESCRIPTION
## Summary

Pagination (`page`, `per_page`) and `YYYY-MM-DD` date-filter parsing were copy-pasted across seven admin handlers. This PR consolidates those patterns into four helpers in [internal/admin/helpers.go](internal/admin/helpers.go):

- `parsePage(r)` / `parsePageKey(r, key)` — returns the 1-indexed page, flooring at 1 when missing/invalid.
- `parsePerPage(r, default, allowed...)` — returns a whitelisted `per_page` value (falls back to default).
- `parseDateParam(r, key)` — returns `*time.Time` from `YYYY-MM-DD`, `nil` on missing/malformed.
- `parseInclusiveDateParam(r, key)` — same but adds one day for exclusive upper-bound comparisons.

Call sites updated: [transactions.go](internal/admin/transactions.go), [rules.go](internal/admin/rules.go), [logs.go](internal/admin/logs.go), [synclogs.go](internal/admin/synclogs.go), [webhook_events.go](internal/admin/webhook_events.go), [csv_export.go](internal/admin/csv_export.go), [agents_page.go](internal/admin/agents_page.go) — ~60 lines of boilerplate removed at call sites; behavior preserved exactly (same defaults, same allowed per-page whitelist `{25, 50, 100}`, same inclusive-end-date semantics).

Added unit tests in [helpers_test.go](internal/admin/helpers_test.go) covering missing / empty / non-numeric / out-of-range inputs, the `wh_page` multi-list case, the per-page whitelist, and the +1-day inclusive shift.

Net diff: +197 / −155 lines across 9 files.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing unit tests + new helper tests green)
- [x] `go vet ./...` clean
- [ ] Manual sanity check on `/admin/transactions`, `/admin/logs`, `/admin/sync-logs` query-param filtering (pagination, date range, per-page dropdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)