### PR TITLE
fix(connections): show Sync Error pill on detail header when last sync failed

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -472,6 +472,15 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 			syncLogs = syncLogs[:10]
 		}
 
+		// Latest sync status + error message — mirror the list query so the
+		// header badge on the detail page matches the list (issue #578).
+		var lastSyncStatus string
+		var lastSyncErrorMessage pgtype.Text
+		if len(allSyncLogs) > 0 {
+			lastSyncStatus = string(allSyncLogs[0].Status)
+			lastSyncErrorMessage = allSyncLogs[0].ErrorMessage
+		}
+
 		// Compute sync health stats from all logs.
 		var totalSyncs, successSyncs, errorSyncs int
 		var totalAdded, totalModified, totalRemoved int
@@ -614,6 +623,9 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 			"HasBalance":          hasBalance,
 			// Next sync schedule
 			"NextSync":            nextSync,
+			// Latest sync log status (for header badge — matches list page).
+			"LastSyncStatus":       lastSyncStatus,
+			"LastSyncErrorMessage": lastSyncErrorMessage,
 		}
 		tr.Render(w, r, "connection_detail.html", data)
 	}

--- a/internal/templates/pages/connection_detail.html
+++ b/internal/templates/pages/connection_detail.html
@@ -45,7 +45,19 @@
     <div class="min-w-0">
       <div class="flex items-center gap-2.5 flex-wrap">
         <h1 class="bb-page-title truncate">{{.Connection.InstitutionName.String}}</h1>
+        {{if and (eq .LastSyncStatus "error") (eq (printf "%s" .Connection.Status) "active")}}
+        <span class="relative group/err">
+          <span class="text-[0.7rem] font-medium px-2 py-0.5 rounded-full bg-error/10 text-error cursor-help">Sync Error</span>
+          {{if .LastSyncErrorMessage.Valid}}
+          <span class="absolute left-0 top-full mt-1.5 z-50 hidden group-hover/err:block w-64 sm:w-80 px-3 py-2.5 rounded-lg bg-base-300 text-xs shadow-lg border border-error/20 leading-relaxed">
+            <span class="flex items-center gap-1.5 text-error font-medium mb-1"><i data-lucide="alert-circle" class="w-3 h-3"></i>Last sync failed</span>
+            <span class="text-base-content/70">{{.LastSyncErrorMessage.String}}</span>
+          </span>
+          {{end}}
+        </span>
+        {{else}}
         {{statusBadge (printf "%s" .Connection.Status)}}
+        {{end}}
         {{if .Connection.Paused}}<span class="badge badge-ghost badge-sm">Paused</span>{{end}}
       </div>
       <div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40">


### PR DESCRIPTION
Fixes #578

The `/connections` list already shows a red "Sync Error" pill when the most recent sync failed but the underlying `connection.status` is still `active`. The detail page header was rendering a green `Active` pill unconditionally, contradicting the "Last error N hours ago" strip directly below it.

This mirrors the list's branching in the detail header so both surfaces agree. `LastSyncStatus` / `LastSyncErrorMessage` are derived from the already-fetched sync logs in the handler, so no new query is added.

## Screenshots

| Viewport | Before (green `Active`) | After (red `Sync Error`) |
| --- | --- | --- |
| Mobile (500×844) | ![before-mobile](https://i.img402.dev/tgmpzrxlw3.png) | ![after-mobile](https://i.img402.dev/lngnh8p47j.png) |
| Tablet (820×1180) | ![before-tablet](https://i.img402.dev/b8701q8dlg.png) | ![after-tablet](https://i.img402.dev/hcgx26v7tr.png) |
| Desktop (1440×900) | ![before-desktop](https://i.img402.dev/7hbx5bbp2j.png) | ![after-desktop](https://i.img402.dev/ve85ka5yvo.png) |

## Test plan

- [x] `go build ./...` passes
- [x] Connection with `status=active` + `last_sync_status=error` shows red `Sync Error` pill on `/connections/:id` (matches list)
- [x] `Paused` badge still renders alongside the status pill when applicable
- [x] Reauth banner (for `status=error`/`pending_reauth`) unaffected

Generated with Claude Code.