### PR TITLE
ux(categories): compact chips for zero-activity expanded parents

### DIFF
--- a/internal/templates/pages/categories.html
+++ b/internal/templates/pages/categories.html
@@ -116,9 +116,38 @@
           </div>
 
           {{if .Children}}
+          {{/* Determine whether the parent and every child have zero activity in the selected period.
+               When true we render a single "No activity" hint with subcategory chips instead of
+               a wall of em-dashes for each subcategory. */}}
+          {{$allZero := eq $spending.TransactionCount 0}}
+          {{if $allZero}}
+            {{range .Children}}
+              {{$cs := index $.SpendingByCategory .DisplayName}}
+              {{if gt $cs.TransactionCount 0}}{{$allZero = false}}{{end}}
+            {{end}}
+          {{end}}
           <!-- Children -->
           <div x-show="open" x-cloak x-collapse>
             <div class="border-t border-base-300/30 bg-base-200/20">
+              {{if $allZero}}
+              <!-- Zero-activity compact hint: chips instead of a wall of em-dashes -->
+              <div class="pl-10 sm:pl-14 pr-4 sm:pr-5 py-3">
+                <p class="text-xs text-base-content/50 mb-2">
+                  <i data-lucide="info" class="inline-block w-3 h-3 mr-1 -mt-0.5 align-middle"></i>
+                  No activity in last {{$.SpendingDays}}d &middot; {{len .Children}} subcategories available
+                </p>
+                <div class="flex flex-wrap gap-1.5">
+                  {{range .Children}}
+                  <a href="/categories/{{.ID}}/edit"
+                    class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-base-100 border border-base-300/60 text-base-content/60 hover:text-base-content hover:border-base-content/30 transition-colors {{if .Hidden}}italic text-base-content/40{{end}}"
+                    title="Edit {{.DisplayName}}">
+                    {{if .Icon}}<i data-lucide="{{.Icon}}" class="w-3 h-3"{{if .Color}} style="color: {{safeCSS .Color}}"{{end}}></i>{{end}}
+                    <span>{{.DisplayName}}</span>
+                  </a>
+                  {{end}}
+                </div>
+              </div>
+              {{else}}
               {{range .Children}}
               {{$childSpending := index $.SpendingByCategory .DisplayName}}
               <div class="group grid grid-cols-[auto_1fr_auto_auto] sm:grid-cols-[auto_1fr_auto_auto_auto_auto] items-center gap-3 sm:gap-4 pl-10 sm:pl-14 pr-4 sm:pr-5 py-2.5 hover:bg-base-200/30 transition-colors duration-150">
@@ -179,6 +208,7 @@
                   </div>
                 </div>
               </div>
+              {{end}}
               {{end}}
             </div>
           </div>


### PR DESCRIPTION
Fixes #559

When an expanded parent category and all of its children have zero spending in the selected period, replace the wall of em-dash rows with a single "No activity in last Xd" hint and render the subcategories as inline chips. Mixed parents (some children with spending) continue to show full rows with amounts/counts/%.

## Before / After

| Viewport | Before | After |
| --- | --- | --- |
| Mobile (500x844) | ![before mobile](https://i.img402.dev/7hmbvhop3n.png) | ![after mobile](https://i.img402.dev/37e4iej5t2.png) |
| Tablet (820x1180) | ![before tablet](https://i.img402.dev/2kyjs044vq.png) | ![after tablet](https://i.img402.dev/mvggq3qd2i.png) |
| Desktop (1440x900) | ![before desktop](https://i.img402.dev/972uoie30y.png) | ![after desktop](https://i.img402.dev/ait9q8tr72.png) |

Regression-checked a mixed-state parent (Food & Drink: Groceries has spending, others don't) — full rows still render, no change to non-zero behavior.

## Test plan
- [x] `go build ./...`
- [x] Shopping (14 subcategories, 0 txns) expands to chip grid
- [x] Mixed parent (Food & Drink) still shows full row layout with amounts
- [x] Non-expanded rows unchanged
- [x] Screenshots captured at mobile/tablet/desktop

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>