### PR TITLE
fix(ui): design consistency and mobile layout improvements

### DIFF
--- a/internal/templates/pages/backups.html
+++ b/internal/templates/pages/backups.html
@@ -20,7 +20,7 @@
 <div class="grid gap-6 bb-stagger">
 
   <!-- Encryption Key Warning -->
-  <div class="alert alert-warning shadow-sm">
+  <div class="alert alert-warning rounded-xl">
     <i data-lucide="shield-alert" class="w-5 h-5 flex-shrink-0"></i>
     <div>
       <h3 class="font-semibold text-sm">Back up your ENCRYPTION_KEY separately</h3>
@@ -40,14 +40,14 @@
   </div>
 
   {{if .Error}}
-  <div class="alert alert-error shadow-sm">
+  <div class="alert alert-error rounded-xl">
     <i data-lucide="alert-circle" class="w-5 h-5 flex-shrink-0"></i>
     <span class="text-sm">{{.Error}}</span>
   </div>
   {{else}}
 
   {{if not .PreflightOK}}
-  <div class="alert alert-error shadow-sm">
+  <div class="alert alert-error rounded-xl">
     <i data-lucide="alert-circle" class="w-5 h-5 flex-shrink-0"></i>
     <div>
       <h3 class="font-semibold text-sm">Backups unavailable</h3>
@@ -57,22 +57,22 @@
   {{end}}
 
   <!-- Stats -->
-  <div class="flex flex-wrap gap-4">
-    <div class="bb-card p-4 flex-1 min-w-[140px]">
+  <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
+    <div class="bb-card p-4">
       <div class="text-xs text-base-content/40 mb-1">Backups</div>
       <div class="text-2xl font-bold tabular-nums">{{.BackupCount}}</div>
     </div>
-    <div class="bb-card p-4 flex-1 min-w-[140px]">
+    <div class="bb-card p-4">
       <div class="text-xs text-base-content/40 mb-1">Total Size</div>
       <div class="text-2xl font-bold tabular-nums">{{.TotalSize}}</div>
     </div>
-    <div class="bb-card p-4 flex-1 min-w-[140px]">
+    <div class="bb-card p-4">
       <div class="text-xs text-base-content/40 mb-1">Schedule</div>
       <div class="text-2xl font-bold">
         {{if eq .Schedule ""}}Off{{else if eq .Schedule "daily_2am"}}Daily 2am{{else if eq .Schedule "daily_3am"}}Daily 3am{{else if eq .Schedule "daily_4am"}}Daily 4am{{else if eq .Schedule "weekly"}}Weekly{{else}}{{.Schedule}}{{end}}
       </div>
     </div>
-    <div class="bb-card p-4 flex-1 min-w-[140px]">
+    <div class="bb-card p-4">
       <div class="text-xs text-base-content/40 mb-1">Retention</div>
       <div class="text-2xl font-bold tabular-nums">{{.RetentionDays}}d</div>
     </div>

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -3,7 +3,7 @@
      x-init="$watch('tab', function(v) { var u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); })">
 
 <!-- Page Header -->
-<div class="flex flex-col items-start sm:flex-row sm:items-center justify-between gap-3 mb-6">
+<div class="bb-page-header">
   <div class="flex items-baseline gap-3 flex-wrap">
     <h1 class="bb-page-title">Connections</h1>
     {{if .Connections}}
@@ -196,7 +196,7 @@
     {{/* Error message communicated via badge tooltip on hover */}}
 
     {{if .NewAccountsAvailable}}
-    <div class="mx-6 mb-4 flex items-center gap-2 text-xs text-info bg-info/10 rounded-lg px-3 py-2">
+    <div class="mx-4 sm:mx-6 mb-4 flex items-center gap-2 text-xs text-info bg-info/10 rounded-lg px-3 py-2">
       <i data-lucide="plus-circle" class="w-3.5 h-3.5 shrink-0"></i>
       <span>New accounts available to link</span>
     </div>
@@ -255,7 +255,7 @@
     </div>
     <h3 class="text-lg font-semibold mb-1">No bank connections yet</h3>
     <p class="text-sm text-base-content/60 max-w-sm mb-4">Connect your first bank to start syncing transactions and tracking your finances.</p>
-    <a href="/connections/new" class="btn btn-primary rounded-xl">
+    <a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">
       <i data-lucide="plus" class="w-4 h-4"></i>
       Connect Your First Bank
     </a>

--- a/internal/templates/pages/providers.html
+++ b/internal/templates/pages/providers.html
@@ -28,7 +28,7 @@
           <span class="badge badge-soft badge-success badge-sm">Healthy</span>
         {{end}}
         {{if .PlaidConfigured}}
-          <span class="badge badge-success badge-sm">Configured</span>
+          <span class="badge badge-soft badge-success badge-sm">Configured</span>
         {{else}}
           <span class="badge badge-ghost badge-sm">Not Configured</span>
         {{end}}
@@ -154,7 +154,7 @@
           <span class="badge badge-soft badge-success badge-sm">Healthy</span>
         {{end}}
         {{if .TellerConfigured}}
-          <span class="badge badge-success badge-sm">Configured</span>
+          <span class="badge badge-soft badge-success badge-sm">Configured</span>
         {{else}}
           <span class="badge badge-ghost badge-sm">Not Configured</span>
         {{end}}
@@ -298,7 +298,7 @@
           <p class="text-xs text-base-content/40 truncate">Import transactions from bank-exported files</p>
         </div>
       </div>
-      <span class="badge badge-success badge-sm flex-shrink-0">Always Available</span>
+      <span class="badge badge-soft badge-success badge-sm flex-shrink-0">Always Available</span>
     </div>
 
     <div class="px-4 sm:px-5 py-4 space-y-4">

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -88,7 +88,7 @@
 </div>
 {{else}}
 <div class="bb-card px-5 py-16 text-center">
-  <div class="w-14 h-14 rounded-2xl bg-base-200/50 mx-auto mb-4 flex items-center justify-center">
+  <div class="w-14 h-14 rounded-xl bg-base-200/50 mx-auto mb-4 flex items-center justify-center">
     <i data-lucide="inbox" class="w-6 h-6 text-base-content/25"></i>
   </div>
   <p class="text-base font-medium text-base-content/70 mb-1">No{{if eq .FilterStatus "unread"}} unread{{else if eq .FilterStatus "read"}} read{{end}} reports</p>

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -8,7 +8,7 @@
 
 <!-- Summary Stats -->
 {{if .Stats}}
-<div class="grid grid-cols-3 gap-3 mb-6 bb-stagger">
+<div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6 bb-stagger">
   <!-- Success Rate -->
   <div class="bb-card p-4">
     <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Audited the admin UI against the design system spec (`docs/design-system.md`) and fixed eight design consistency issues across five pages, prioritizing mobile layout breakages first.

### Mobile layout fixes (high impact)
- **Sync logs stat cards**: `grid-cols-3` → `grid-cols-1 sm:grid-cols-3` — three stat cards were cramming into a single row on mobile, making text like "Success rate" and "Avg duration" unreadable on phones
- **Backups stat cards**: `flex-wrap` with `min-w-[140px]` → `grid grid-cols-2 sm:grid-cols-4` — predictable 2×2 grid on mobile instead of unpredictable wrapping behavior
- **Connections "new accounts" banner**: `mx-6` → `mx-4 sm:mx-6` — now matches the error banner directly above it, preventing horizontal overflow on narrow screens

### Design system consistency fixes
- **Connections page header**: inline flex classes → `bb-page-header` class (every other page uses the standard class)
- **Connections empty state CTA**: added missing `btn-sm` — was the only oversized primary button in the app
- **Reports empty state icon**: `rounded-2xl` → `rounded-xl` per design system §4
- **Backups alerts**: replaced `shadow-sm` with `rounded-xl` per design system §12 (3 alerts)
- **Providers badges**: "Configured" and "Always Available" badges now use `badge-soft` to match the "Healthy" / "Sync Error" badges on the same page

## Test plan
- [ ] Verify sync logs page renders stat cards stacked on mobile, 3-col on desktop
- [ ] Verify backups page renders stat cards as 2×2 on mobile, 4-col on desktop
- [ ] Verify connections page header aligns with other pages
- [ ] Verify provider badges have soft styling matching nearby status badges
- [ ] Spot-check dark mode on affected pages

https://claude.ai/code/session_017EkCUqD3qw5NZuq8n9h2ts