### PR TITLE
refactor(admin): extract query-string parse helpers

### DIFF
--- a/internal/admin/csv_export.go
+++ b/internal/admin/csv_export.go
@@ -17,52 +17,26 @@ func ExportTransactionsCSVHandler(a *app.App, svc *service.Service) http.Handler
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		q := r.URL.Query()
 		params := service.AdminTransactionListParams{
-			Page:     1,
-			PageSize: -1, // Export all matching rows (no pagination).
+			Page:         1,
+			PageSize:     -1, // Export all matching rows (no pagination).
+			StartDate:    optDateQuery(q, "start_date"),
+			EndDate:      optEndDateQuery(q, "end_date"),
+			AccountID:    optStrQuery(q, "account_id"),
+			UserID:       optStrQuery(q, "user_id"),
+			ConnectionID: optStrQuery(q, "connection_id"),
+			CategorySlug: optStrQuery(q, "category"),
+			MinAmount:    optFloatQuery(q, "min_amount"),
+			MaxAmount:    optFloatQuery(q, "max_amount"),
+			Search:       optStrQuery(q, "search"),
 		}
 
-		if v := r.URL.Query().Get("start_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				params.StartDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("end_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				t = t.AddDate(0, 0, 1)
-				params.EndDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("account_id"); v != "" {
-			params.AccountID = &v
-		}
-		if v := r.URL.Query().Get("user_id"); v != "" {
-			params.UserID = &v
-		}
-		if v := r.URL.Query().Get("connection_id"); v != "" {
-			params.ConnectionID = &v
-		}
-		if v := r.URL.Query().Get("category"); v != "" {
-			params.CategorySlug = &v
-		}
-		if v := r.URL.Query().Get("min_amount"); v != "" {
-			if f, err := strconv.ParseFloat(v, 64); err == nil {
-				params.MinAmount = &f
-			}
-		}
-		if v := r.URL.Query().Get("max_amount"); v != "" {
-			if f, err := strconv.ParseFloat(v, 64); err == nil {
-				params.MaxAmount = &f
-			}
-		}
-		if v := r.URL.Query().Get("pending"); v != "" {
+		if v := q.Get("pending"); v != "" {
 			b := v == "true"
 			params.Pending = &b
 		}
-		if v := r.URL.Query().Get("search"); v != "" {
-			params.Search = &v
-		}
-		if v := r.URL.Query().Get("sort"); v == "asc" {
+		if q.Get("sort") == "asc" {
 			params.SortOrder = "asc"
 		}
 

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"net/http"
 	"strconv"
-	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -30,35 +29,20 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 
 		// Always fetch sync logs data.
 		{
-			page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+			q := r.URL.Query()
+			page, _ := strconv.Atoi(q.Get("page"))
 			if page < 1 {
 				page = 1
 			}
 
 			params := service.SyncLogListParams{
-				Page:     page,
-				PageSize: 25,
-			}
-
-			if connID := r.URL.Query().Get("connection_id"); connID != "" {
-				params.ConnectionID = &connID
-			}
-			if status := r.URL.Query().Get("status"); status != "" {
-				params.Status = &status
-			}
-			if trigger := r.URL.Query().Get("trigger"); trigger != "" {
-				params.Trigger = &trigger
-			}
-			if v := r.URL.Query().Get("date_from"); v != "" {
-				if t, err := time.Parse("2006-01-02", v); err == nil {
-					params.DateFrom = &t
-				}
-			}
-			if v := r.URL.Query().Get("date_to"); v != "" {
-				if t, err := time.Parse("2006-01-02", v); err == nil {
-					t = t.AddDate(0, 0, 1)
-					params.DateTo = &t
-				}
+				Page:         page,
+				PageSize:     25,
+				ConnectionID: optStrQuery(q, "connection_id"),
+				Status:       optStrQuery(q, "status"),
+				Trigger:      optStrQuery(q, "trigger"),
+				DateFrom:     optDateQuery(q, "date_from"),
+				DateTo:       optEndDateQuery(q, "date_to"),
 			}
 
 			result, err := svc.ListSyncLogsPaginated(ctx, params)

--- a/internal/admin/queryparse.go
+++ b/internal/admin/queryparse.go
@@ -1,0 +1,64 @@
+package admin
+
+import (
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// Helpers for parsing optional query-string parameters in admin handlers.
+//
+// Admin pages use silent-failure semantics: a malformed value is treated the
+// same as an absent one so users don't get a 400 from a stale URL. The REST
+// API takes a stricter approach (see internal/api/queryparse.go), which is why
+// these helpers live here separately.
+
+// optStrQuery returns a pointer to the query value, or nil when the parameter
+// is absent or empty.
+func optStrQuery(q url.Values, key string) *string {
+	v := q.Get(key)
+	if v == "" {
+		return nil
+	}
+	return &v
+}
+
+// optDateQuery parses a YYYY-MM-DD query value. Returns nil when the parameter
+// is absent, empty, or malformed.
+func optDateQuery(q url.Values, key string) *time.Time {
+	v := q.Get(key)
+	if v == "" {
+		return nil
+	}
+	t, err := time.Parse("2006-01-02", v)
+	if err != nil {
+		return nil
+	}
+	return &t
+}
+
+// optEndDateQuery parses a YYYY-MM-DD query value and shifts it forward one
+// day so the end date is inclusive in `date >= start AND date < end` filters.
+// Returns nil when the parameter is absent, empty, or malformed.
+func optEndDateQuery(q url.Values, key string) *time.Time {
+	t := optDateQuery(q, key)
+	if t == nil {
+		return nil
+	}
+	next := t.AddDate(0, 0, 1)
+	return &next
+}
+
+// optFloatQuery parses a floating-point query value. Returns nil when the
+// parameter is absent, empty, or malformed.
+func optFloatQuery(q url.Values, key string) *float64 {
+	v := q.Get(key)
+	if v == "" {
+		return nil
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return nil
+	}
+	return &f
+}

--- a/internal/admin/queryparse_test.go
+++ b/internal/admin/queryparse_test.go
@@ -1,0 +1,104 @@
+package admin
+
+import (
+	"net/url"
+	"testing"
+	"time"
+)
+
+func TestOptStrQuery(t *testing.T) {
+	q := url.Values{"a": {"hello"}, "b": {""}}
+
+	if got := optStrQuery(q, "a"); got == nil || *got != "hello" {
+		t.Errorf("present key: got %v, want pointer to 'hello'", got)
+	}
+	if got := optStrQuery(q, "b"); got != nil {
+		t.Errorf("empty value: got %v, want nil", got)
+	}
+	if got := optStrQuery(q, "missing"); got != nil {
+		t.Errorf("absent key: got %v, want nil", got)
+	}
+}
+
+func TestOptDateQuery(t *testing.T) {
+	want := time.Date(2026, 4, 19, 0, 0, 0, 0, time.UTC)
+
+	cases := map[string]struct {
+		value string
+		want  *time.Time
+	}{
+		"valid date":      {"2026-04-19", &want},
+		"empty":           {"", nil},
+		"malformed":       {"not-a-date", nil},
+		"wrong format":    {"04/19/2026", nil},
+		"datetime string": {"2026-04-19T00:00:00Z", nil},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			q := url.Values{"d": {tc.value}}
+			got := optDateQuery(q, "d")
+			if tc.want == nil {
+				if got != nil {
+					t.Errorf("got %v, want nil", got)
+				}
+				return
+			}
+			if got == nil || !got.Equal(*tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// Absent key behaves the same as empty.
+	if got := optDateQuery(url.Values{}, "d"); got != nil {
+		t.Errorf("absent key: got %v, want nil", got)
+	}
+}
+
+func TestOptEndDateQuery(t *testing.T) {
+	q := url.Values{"d": {"2026-04-19"}}
+	got := optEndDateQuery(q, "d")
+	want := time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC)
+	if got == nil || !got.Equal(want) {
+		t.Errorf("got %v, want %v (one day after input)", got, want)
+	}
+
+	if got := optEndDateQuery(url.Values{"d": {"bogus"}}, "d"); got != nil {
+		t.Errorf("malformed value: got %v, want nil", got)
+	}
+	if got := optEndDateQuery(url.Values{}, "d"); got != nil {
+		t.Errorf("absent key: got %v, want nil", got)
+	}
+}
+
+func TestOptFloatQuery(t *testing.T) {
+	cases := map[string]struct {
+		value string
+		want  *float64
+	}{
+		"integer":   {"42", ptrFloat(42)},
+		"decimal":   {"12.5", ptrFloat(12.5)},
+		"negative":  {"-3.14", ptrFloat(-3.14)},
+		"empty":     {"", nil},
+		"malformed": {"abc", nil},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			q := url.Values{"f": {tc.value}}
+			got := optFloatQuery(q, "f")
+			if tc.want == nil {
+				if got != nil {
+					t.Errorf("got %v, want nil", got)
+				}
+				return
+			}
+			if got == nil || *got != *tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func ptrFloat(f float64) *float64 { return &f }

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -32,20 +32,16 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 			}
 		}
 
+		q := r.URL.Query()
 		params := service.TransactionRuleListParams{
-			Page:     page,
-			PageSize: pageSize,
+			Page:         page,
+			PageSize:     pageSize,
+			Search:       optStrQuery(q, "search"),
+			CategorySlug: optStrQuery(q, "category_slug"),
 		}
 
-		if v := r.URL.Query().Get("search"); v != "" {
-			params.Search = &v
-		}
-		if v := r.URL.Query().Get("category_slug"); v != "" {
-			params.CategorySlug = &v
-		}
-		if v := r.URL.Query().Get("enabled"); v != "" {
-			b, err := strconv.ParseBool(v)
-			if err == nil {
+		if v := q.Get("enabled"); v != "" {
+			if b, err := strconv.ParseBool(v); err == nil {
 				params.Enabled = &b
 			}
 		}

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -19,36 +18,20 @@ func SyncLogsHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, s
 		ctx := r.Context()
 
 		// Parse query params.
-		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		q := r.URL.Query()
+		page, _ := strconv.Atoi(q.Get("page"))
 		if page < 1 {
 			page = 1
 		}
 
 		params := service.SyncLogListParams{
-			Page:     page,
-			PageSize: 25,
-		}
-
-		if connID := r.URL.Query().Get("connection_id"); connID != "" {
-			params.ConnectionID = &connID
-		}
-		if status := r.URL.Query().Get("status"); status != "" {
-			params.Status = &status
-		}
-		if trigger := r.URL.Query().Get("trigger"); trigger != "" {
-			params.Trigger = &trigger
-		}
-		if v := r.URL.Query().Get("date_from"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				params.DateFrom = &t
-			}
-		}
-		if v := r.URL.Query().Get("date_to"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				// Add one day so the end date is inclusive.
-				t = t.AddDate(0, 0, 1)
-				params.DateTo = &t
-			}
+			Page:         page,
+			PageSize:     25,
+			ConnectionID: optStrQuery(q, "connection_id"),
+			Status:       optStrQuery(q, "status"),
+			Trigger:      optStrQuery(q, "trigger"),
+			DateFrom:     optDateQuery(q, "date_from"),
+			DateTo:       optEndDateQuery(q, "date_to"),
 		}
 
 		// Fetch paginated sync logs.

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -112,67 +112,40 @@ func TransactionListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRend
 			}
 		}
 
+		q := r.URL.Query()
 		params := service.AdminTransactionListParams{
-			Page:     page,
-			PageSize: pageSize,
+			Page:         page,
+			PageSize:     pageSize,
+			StartDate:    optDateQuery(q, "start_date"),
+			EndDate:      optEndDateQuery(q, "end_date"),
+			AccountID:    optStrQuery(q, "account_id"),
+			UserID:       optStrQuery(q, "user_id"),
+			ConnectionID: optStrQuery(q, "connection_id"),
+			CategorySlug: optStrQuery(q, "category"),
+			MinAmount:    optFloatQuery(q, "min_amount"),
+			MaxAmount:    optFloatQuery(q, "max_amount"),
+			Search:       optStrQuery(q, "search"),
 		}
 
-		if v := r.URL.Query().Get("start_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				params.StartDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("end_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				// Add one day so the end date is inclusive.
-				t = t.AddDate(0, 0, 1)
-				params.EndDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("account_id"); v != "" {
-			params.AccountID = &v
-		}
-		if v := r.URL.Query().Get("user_id"); v != "" {
-			params.UserID = &v
-		}
-		if v := r.URL.Query().Get("connection_id"); v != "" {
-			params.ConnectionID = &v
-		}
-		if v := r.URL.Query().Get("category"); v != "" {
-			params.CategorySlug = &v
-		}
-		if v := r.URL.Query().Get("min_amount"); v != "" {
-			if f, err := strconv.ParseFloat(v, 64); err == nil {
-				params.MinAmount = &f
-			}
-		}
-		if v := r.URL.Query().Get("max_amount"); v != "" {
-			if f, err := strconv.ParseFloat(v, 64); err == nil {
-				params.MaxAmount = &f
-			}
-		}
-		if v := r.URL.Query().Get("pending"); v != "" {
+		if v := q.Get("pending"); v != "" {
 			b := v == "true"
 			params.Pending = &b
 		}
-		if v := r.URL.Query().Get("search"); v != "" {
-			params.Search = &v
-		}
-		if v := r.URL.Query().Get("search_mode"); v != "" && service.ValidateSearchMode(v) {
+		if v := q.Get("search_mode"); v != "" && service.ValidateSearchMode(v) {
 			params.SearchMode = &v
 		}
-		if v := r.URL.Query().Get("search_field"); v != "" && service.ValidateSearchField(v) {
+		if v := q.Get("search_field"); v != "" && service.ValidateSearchField(v) {
 			params.SearchField = &v
 		}
-		if v := r.URL.Query().Get("sort"); v == "asc" {
+		if q.Get("sort") == "asc" {
 			params.SortOrder = "asc"
 		}
 
 		// Tag filters. ?tags=needs-review,foo (AND) and ?any_tag=a,b (OR).
-		if v := r.URL.Query().Get("tags"); v != "" {
+		if v := q.Get("tags"); v != "" {
 			params.Tags = splitCSV(v)
 		}
-		if v := r.URL.Query().Get("any_tag"); v != "" {
+		if v := q.Get("any_tag"); v != "" {
 			params.AnyTag = splitCSV(v)
 		}
 
@@ -296,8 +269,9 @@ func TransactionSearchHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			page = 1
 		}
 
+		q := r.URL.Query()
 		pageSize := 50
-		if v, err := strconv.Atoi(r.URL.Query().Get("per_page")); err == nil {
+		if v, err := strconv.Atoi(q.Get("per_page")); err == nil {
 			switch v {
 			case 25, 50, 100:
 				pageSize = v
@@ -305,64 +279,37 @@ func TransactionSearchHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 		}
 
 		params := service.AdminTransactionListParams{
-			Page:     page,
-			PageSize: pageSize,
+			Page:         page,
+			PageSize:     pageSize,
+			StartDate:    optDateQuery(q, "start_date"),
+			EndDate:      optEndDateQuery(q, "end_date"),
+			AccountID:    optStrQuery(q, "account_id"),
+			UserID:       optStrQuery(q, "user_id"),
+			ConnectionID: optStrQuery(q, "connection_id"),
+			CategorySlug: optStrQuery(q, "category"),
+			MinAmount:    optFloatQuery(q, "min_amount"),
+			MaxAmount:    optFloatQuery(q, "max_amount"),
+			Search:       optStrQuery(q, "search"),
 		}
 
-		if v := r.URL.Query().Get("start_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				params.StartDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("end_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				t = t.AddDate(0, 0, 1)
-				params.EndDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("account_id"); v != "" {
-			params.AccountID = &v
-		}
-		if v := r.URL.Query().Get("user_id"); v != "" {
-			params.UserID = &v
-		}
-		if v := r.URL.Query().Get("connection_id"); v != "" {
-			params.ConnectionID = &v
-		}
-		if v := r.URL.Query().Get("category"); v != "" {
-			params.CategorySlug = &v
-		}
-		if v := r.URL.Query().Get("min_amount"); v != "" {
-			if f, err := strconv.ParseFloat(v, 64); err == nil {
-				params.MinAmount = &f
-			}
-		}
-		if v := r.URL.Query().Get("max_amount"); v != "" {
-			if f, err := strconv.ParseFloat(v, 64); err == nil {
-				params.MaxAmount = &f
-			}
-		}
-		if v := r.URL.Query().Get("pending"); v != "" {
+		if v := q.Get("pending"); v != "" {
 			b := v == "true"
 			params.Pending = &b
 		}
-		if v := r.URL.Query().Get("search"); v != "" {
-			params.Search = &v
-		}
-		if v := r.URL.Query().Get("search_mode"); v != "" && service.ValidateSearchMode(v) {
+		if v := q.Get("search_mode"); v != "" && service.ValidateSearchMode(v) {
 			params.SearchMode = &v
 		}
-		if v := r.URL.Query().Get("search_field"); v != "" && service.ValidateSearchField(v) {
+		if v := q.Get("search_field"); v != "" && service.ValidateSearchField(v) {
 			params.SearchField = &v
 		}
-		if v := r.URL.Query().Get("sort"); v == "asc" {
+		if q.Get("sort") == "asc" {
 			params.SortOrder = "asc"
 		}
 
-		if v := r.URL.Query().Get("tags"); v != "" {
+		if v := q.Get("tags"); v != "" {
 			params.Tags = splitCSV(v)
 		}
-		if v := r.URL.Query().Get("any_tag"); v != "" {
+		if v := q.Get("any_tag"); v != "" {
 			params.AnyTag = splitCSV(v)
 		}
 
@@ -454,24 +401,12 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 			txParams.UserID = &memberUID
 		}
 
-		if v := r.URL.Query().Get("start_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				txParams.StartDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("end_date"); v != "" {
-			if t, err := time.Parse("2006-01-02", v); err == nil {
-				t = t.AddDate(0, 0, 1)
-				txParams.EndDate = &t
-			}
-		}
-		if v := r.URL.Query().Get("search"); v != "" {
-			txParams.Search = &v
-		}
-		if v := r.URL.Query().Get("category"); v != "" {
-			txParams.CategorySlug = &v
-		}
-		if v := r.URL.Query().Get("pending"); v != "" {
+		q := r.URL.Query()
+		txParams.StartDate = optDateQuery(q, "start_date")
+		txParams.EndDate = optEndDateQuery(q, "end_date")
+		txParams.Search = optStrQuery(q, "search")
+		txParams.CategorySlug = optStrQuery(q, "category")
+		if v := q.Get("pending"); v != "" {
 			b := v == "true"
 			txParams.Pending = &b
 		}
@@ -488,16 +423,16 @@ func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 
 		// Build export URL for this account's transactions.
 		acctExportURL := "/-/transactions/export-csv?account_id=" + idStr
-		if sd := r.URL.Query().Get("start_date"); sd != "" {
+		if sd := q.Get("start_date"); sd != "" {
 			acctExportURL += "&start_date=" + sd
 		}
-		if ed := r.URL.Query().Get("end_date"); ed != "" {
+		if ed := q.Get("end_date"); ed != "" {
 			acctExportURL += "&end_date=" + ed
 		}
-		if cat := r.URL.Query().Get("category"); cat != "" {
+		if cat := q.Get("category"); cat != "" {
 			acctExportURL += "&category=" + cat
 		}
-		if search := r.URL.Query().Get("search"); search != "" {
+		if search := q.Get("search"); search != "" {
 			acctExportURL += "&search=" + search
 		}
 


### PR DESCRIPTION
## Summary

Admin handlers repeated the "get optional query param, fall back silently on empty/malformed" pattern at 40+ sites across transactions, sync logs, logs, rules, and CSV export. Each filter group produced the same 4–8 line block — string pointer, date parse + error swallow, end-date + 1-day inclusivity shift, float parse — drowning the actual per-handler logic.

Introduces [internal/admin/queryparse.go](internal/admin/queryparse.go) with four small helpers:

- \`optStrQuery(q url.Values, key string) *string\`
- \`optDateQuery(q url.Values, key string) *time.Time\` — YYYY-MM-DD, silent failure
- \`optEndDateQuery(q url.Values, key string) *time.Time\` — same, +1 day for inclusive ranges
- \`optFloatQuery(q url.Values, key string) *float64\`

All use silent-failure semantics (malformed == absent), matching how the admin UI has always behaved. The REST API's stricter, error-returning variants in [internal/api/queryparse.go](internal/api/queryparse.go) stay as-is — different callers, different contracts, so a shared package would end up lossy.

Call-site migrations in:

- [internal/admin/transactions.go](internal/admin/transactions.go) — three filter blocks
- [internal/admin/csv_export.go](internal/admin/csv_export.go)
- [internal/admin/synclogs.go](internal/admin/synclogs.go)
- [internal/admin/logs.go](internal/admin/logs.go)
- [internal/admin/rules.go](internal/admin/rules.go)

## Stats

- Handler files: **−128 LOC** boilerplate removed (**+90 / −218**)
- New: [queryparse.go](internal/admin/queryparse.go) (64) + [queryparse_test.go](internal/admin/queryparse_test.go) (104)
- Net: **+40 LOC** total for a much clearer intent at the call sites

Mirrors the MCP helper extraction from [#554](https://github.com/canalesb93/breadbox/pull/554).

## Behavior preservation

- Service-layer params already treat \`nil\` and "pointer-to-empty-string-guarded-by-if" identically — all consumers check \`params.X != nil\`.
- The \`+1 day\` end-date semantic (for inclusive \`date >= start AND date < end\` filters) is preserved via \`optEndDateQuery\`.
- Strict-parseable-bool \`enabled\` (rules) and tri-state "true"-string \`pending\` (transactions/csv) cases kept inline — their semantics differ from the generic helpers and aren't worth overloading.
- No public API or URL contract changes.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go vet ./...\` passes
- [x] \`go test ./...\` passes (unit suite — admin + all packages)
- [x] New unit tests cover empty / present / malformed / absent cases for each helper
- [ ] Integration suite (DB-backed) — not touched by this change; admin list/filter/export paths behave identically at the SQL level

🤖 Generated with [Claude Code](https://claude.com/claude-code)