### PR TITLE
fix(transactions): hide avatar slot in mobile select mode

### DIFF
--- a/input.css
+++ b/input.css
@@ -887,6 +887,20 @@
   }
 
   /*
+   * While bulk-selection mode is active, the per-row checkbox is injected at
+   * the start of the row. On mobile there isn't enough horizontal room to
+   * also keep the decorative category avatar — the name column would lose
+   * ~40px and merchant names truncate (#593). Hide the avatar slot below the
+   * `sm` breakpoint so the checkbox effectively reuses that space. Tablet and
+   * desktop keep both.
+   */
+  @media (max-width: 639px) {
+    body.bb-tx-selecting .bb-tx-avatar-slot {
+      display: none;
+    }
+  }
+
+  /*
    * DaisyUI 5's `.checkbox` ships with `transition: all`, which animated every
    * property change (including nearby paint invalidations from unrelated CSS).
    * Clamp the transition to the properties that actually drive the check draw.

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -42,8 +42,10 @@ templ TxRow(tx service.AdminTransactionRow) {
 					@change={ fmt.Sprintf("$store.bulk.toggle('%s')", tx.ID) }
 				/>
 			</label>
-			<!-- Category icon / merchant-initial avatar -->
-			<div class="relative shrink-0">
+			<!-- Category icon / merchant-initial avatar. The `bb-tx-avatar-slot`
+			     class lets CSS hide the slot on mobile while selection mode is on
+			     so the bulk-select checkbox doesn't squeeze the name column. -->
+			<div class="relative shrink-0 bb-tx-avatar-slot">
 				if tx.CategoryIcon != nil {
 					<div class="bb-tx-avatar" style={ txAvatarColorStyle(tx.CategoryColor) }>
 						<i data-lucide={ deref(tx.CategoryIcon) } class="w-4 h-4"></i>

--- a/internal/templates/pages/transactions.html
+++ b/internal/templates/pages/transactions.html
@@ -766,11 +766,15 @@ document.addEventListener('alpine:init', function() {
     // Show/hide the per-row checkbox labels when selection mode toggles.
     // Done once globally instead of 50 reactive x-show bindings.
     // Set display explicitly (not '') so inline style wins over Tailwind `.flex`.
+    // Also toggles a body-level class so CSS can hide the per-row avatar slot
+    // at mobile breakpoints (the checkbox reuses that slot's width instead of
+    // appending to it, which was truncating merchant names — see #593).
     _updateRowVisibility() {
       var on = this.selecting;
       document.querySelectorAll('.bb-tx-checkbox').forEach(function(el) {
         el.style.display = on ? 'flex' : 'none';
       });
+      document.body.classList.toggle('bb-tx-selecting', on);
     },
 
     // Update a single row's checkbox + selected attribute without touching others.


### PR DESCRIPTION
Fixes #593

On mobile (<sm), injecting the bulk-select checkbox in front of every transaction row pushed the name column ~40px narrower, so merchant names like "International Wire Transfer", "Electronic Withdrawal", and "Monthly Water Bill" truncated the moment a user entered select mode — the exact scenario they're in select mode to act on.

## Change

- `internal/templates/components/tx_row.templ`: tag the category-avatar wrapper with `bb-tx-avatar-slot` so CSS can target it.
- `internal/templates/pages/transactions.html`: `_updateRowVisibility()` also toggles a `bb-tx-selecting` class on `<body>`.
- `input.css`: below the `sm` breakpoint, hide `.bb-tx-avatar-slot` while `body.bb-tx-selecting` is active. Tablet and desktop keep the avatar alongside the checkbox.

Net effect: the checkbox reuses the avatar's slot on mobile instead of stealing it from the name column. Normal (non-select) mobile layout is untouched; tablet + desktop are untouched.

## Before / after

### Mobile 500x844 (select mode ON)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://i.img402.dev/iqhkxoi4ci.jpg" width="400" alt="mobile before"></td>
<td><img src="https://i.img402.dev/e2mzxtzlqx.jpg" width="400" alt="mobile after"></td>
</tr>
</table>

Before: "International Wire Tran…", "Essential Sa…", "Platinum Ca…" all truncate. After: full names render.

### Tablet 820x1180 (select mode ON)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://i.img402.dev/evw2a47di1.jpg" width="400" alt="tablet before"></td>
<td><img src="https://i.img402.dev/l3qj1y2wb5.jpg" width="400" alt="tablet after"></td>
</tr>
</table>

No regression — avatars still render alongside the checkbox.

### Desktop 1440x900 (select mode ON)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://i.img402.dev/qlfpalutj0.jpg" width="400" alt="desktop before"></td>
<td><img src="https://i.img402.dev/g6vy3jw64o.jpg" width="400" alt="desktop after"></td>
</tr>
</table>

No regression.

## Acceptance check

- Mobile 500x844 select mode: "International Wire Transfer", "Monthly Water Bill", "Electronic Withdrawal", "Point of Sale - Monthly" render without truncation.
- Mobile 500x844 normal mode: unchanged (avatars back in, same layout as main).
- Tablet 820x1180 + desktop 1440x900: unchanged in both modes.
- Checkbox tap target: still rendered by the untouched `label.bb-tx-checkbox` (44+px via DaisyUI `.checkbox`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)