### PR TITLE
fix(auth): align login error copy with 'Email' label (#591)

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -78,12 +78,12 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, _ *TemplateRender
 		password := r.FormValue("password")
 
 		if username == "" || password == "" {
-			renderLogin(w, r, sm, username, "Invalid username or password")
+			renderLogin(w, r, sm, username, "Invalid email or password")
 			return
 		}
 
 		renderLoginError := func() {
-			renderLogin(w, r, sm, username, "Invalid username or password")
+			renderLogin(w, r, sm, username, "Invalid email or password")
 		}
 
 		// Single table lookup.

--- a/internal/admin/setup.go
+++ b/internal/admin/setup.go
@@ -53,11 +53,11 @@ func CreateAdminHandler(a *app.App, sm *scs.SessionManager, _ *TemplateRenderer)
 		}
 
 		if username == "" {
-			errors["Username"] = "Email is required"
+			errors["Email"] = "Email is required"
 		} else if _, err := mail.ParseAddress(username); err != nil {
-			errors["Username"] = "Please enter a valid email address"
+			errors["Email"] = "Please enter a valid email address"
 		} else if len(username) > 64 {
-			errors["Username"] = "Email must be 64 characters or fewer"
+			errors["Email"] = "Email must be 64 characters or fewer"
 		}
 
 		if len(password) < 8 {

--- a/internal/templates/components/pages/setup_create_admin.templ
+++ b/internal/templates/components/pages/setup_create_admin.templ
@@ -4,7 +4,7 @@ import "breadbox/internal/templates/components/layout"
 
 // CreateAdminProps carries the data the first-run admin setup page needs.
 // Rendered at GET/POST /setup when no auth accounts exist yet. Error is the
-// top-level banner; FieldErrors keys "Name", "Username", "Password" drive
+// top-level banner; FieldErrors keys "Name", "Email", "Password" drive
 // per-field styling and messages.
 type CreateAdminProps struct {
 	PageTitle   string
@@ -65,10 +65,10 @@ templ CreateAdmin(p CreateAdminProps) {
 					required
 					autocomplete="email"
 					placeholder="you@example.com"
-					class={ "input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200", templ.KV("input-error", p.FieldErrors["Username"] != "") }
+					class={ "input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200", templ.KV("input-error", p.FieldErrors["Email"] != "") }
 				/>
-				if p.FieldErrors["Username"] != "" {
-					<p class="text-xs text-error mt-1.5">{ p.FieldErrors["Username"] }</p>
+				if p.FieldErrors["Email"] != "" {
+					<p class="text-xs text-error mt-1.5">{ p.FieldErrors["Email"] }</p>
 				}
 			</div>
 			<div>


### PR DESCRIPTION
Fixes #591

Align the user-visible copy with the form label. The login form uses `type="email"` / `autocomplete="email"` and labels the field "Email", but the failure banner said "Invalid username or password". The setup page had the same mismatch — `FieldErrors` were keyed as `Username` under an `Email` label. For an open-source launch this reads as sloppy on the first screen a new user sees.

## Changes

- `internal/admin/auth.go`: banner text `Invalid username or password` → `Invalid email or password` (both call sites — empty-field guard and the unified `renderLoginError` path)
- `internal/admin/setup.go`: three `errors["Username"]` writes → `errors["Email"]`
- `internal/templates/components/pages/setup_create_admin.templ`: three `FieldErrors["Username"]` reads → `FieldErrors["Email"]` and updated doc comment

The HTML `name="username"` and backing session field are unchanged, so session and auth-account logic is untouched. `grep "Invalid username or password" internal/` returns no hits.

## Screenshots

| Viewport | Before | After |
|----------|--------|-------|
| Mobile (500×844)   | ![before mobile](https://i.img402.dev/zoj0fjyfjt.png)   | ![after mobile](https://i.img402.dev/cli18unndj.png)   |
| Tablet (820×1180)  | ![before tablet](https://i.img402.dev/2ynbao0l21.png)   | ![after tablet](https://i.img402.dev/lava18j30d.png)   |
| Desktop (1440×900) | ![before desktop](https://i.img402.dev/1t04b1tqha.png)  | ![after desktop](https://i.img402.dev/inqxqobmy9.png)  |

## Test plan

- [x] Build clean: `go build ./...`
- [x] `/login` with bad creds at 500×844, 820×1180, 1440×900 → banner reads "Invalid email or password"
- [x] `grep -r "Invalid username or password" internal/` → no matches
- [ ] `/setup` first-run with bad email → per-field error under the Email input (reviewer: verify; can't hit without wiping auth_accounts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)