### PR TITLE
docs: daily maintenance pass (2026-04-19)

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -16,7 +16,7 @@ All error responses use:
 ```
 
 - Codes are **stable contracts** — treat them as API surface. Don't rename on a whim.
-- Use `internal/api/response.go` helpers (`writeError`, `writeJSON`) — don't hand-roll.
+- REST handlers use `internal/api/response.go` helpers (`writeError`, `writeJSON`). Admin handlers use `internal/admin/response.go` equivalents. Don't hand-roll either.
 - 4xx for client errors, 5xx only for actual server bugs. Validation errors are 400 with a specific code like `INVALID_DATE_RANGE`.
 
 ## Auth
@@ -81,7 +81,7 @@ Split for orchestrators:
 
 ## Admin-only endpoints
 
-Prefixed `/-/` to disambiguate from user-facing routes. Examples: `POST /-/reports/{id}/read`, `POST /-/reports/read-all`. CSRF + session required.
+Prefixed `/-/` to disambiguate from user-facing routes. Examples: `POST /-/reports/{id}/read`, `POST /-/reports/{id}/unread`, `POST /-/reports/read-all`. CSRF + session required.
 
 ## Webhooks
 


### PR DESCRIPTION
## Docs updated

**`.claude/rules/api.md`** — two fixes driven by commits that landed today:

1. **Response helpers** (`d8e9dde` — refactor(admin): consolidate response helpers in dedicated response.go): `internal/admin/response.go` was created with its own `writeJSON`/`writeError` helpers for admin handlers. The rule previously only referenced `internal/api/response.go`, which only applies to REST handlers. Updated to distinguish the two.

2. **Admin-only endpoint examples** (`af3b49a` — feat(reports): render agent reports as messages + polish detail controls): `POST /-/reports/{id}/unread` was added as a new admin endpoint. Added it alongside the existing `read` and `read-all` examples.

No other drift found. Docs updated by the same PRs that introduced changes (rule-dsl.md, api-reference.md, mcp-tools-reference.md, CLAUDE.md) are current.

https://claude.ai/code/session_01TJ8zL8q5maRZU8D1NsnDAr