### PR TITLE
refactor(mcp): add parseDateRange helper for start_date/end_date pairs

### DIFF
--- a/internal/mcp/helpers.go
+++ b/internal/mcp/helpers.go
@@ -31,6 +31,22 @@ func parseOptionalDate(field, value string) (*time.Time, error) {
 	return &t, nil
 }
 
+// parseDateRange parses optional start_date + end_date strings in one call.
+// Nearly every tool that accepts a date window does so with the same
+// YYYY-MM-DD pair, so handlers share the field names ("start_date", "end_date")
+// and the parseOptionalDate error format. Empty inputs yield nil pointers.
+func parseDateRange(start, end string) (*time.Time, *time.Time, error) {
+	s, err := parseOptionalDate("start_date", start)
+	if err != nil {
+		return nil, nil, err
+	}
+	e, err := parseOptionalDate("end_date", end)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s, e, nil
+}
+
 // parseSearchMode validates an MCP search_mode input and returns a pointer
 // suitable for service-layer params. Empty input returns (nil, nil) —
 // service layer falls back to its own default. Unknown modes return an

--- a/internal/mcp/helpers_test.go
+++ b/internal/mcp/helpers_test.go
@@ -97,3 +97,63 @@ func TestParseOptionalDate(t *testing.T) {
 		}
 	})
 }
+
+func TestParseDateRange(t *testing.T) {
+	t.Run("both empty returns nil pointers without error", func(t *testing.T) {
+		start, end, err := parseDateRange("", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if start != nil || end != nil {
+			t.Errorf("expected both nil, got start=%v end=%v", start, end)
+		}
+	})
+
+	t.Run("both valid parse", func(t *testing.T) {
+		start, end, err := parseDateRange("2024-01-01", "2024-02-01")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		wantStart := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		wantEnd := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+		if start == nil || !start.Equal(wantStart) {
+			t.Errorf("expected start=%v, got %v", wantStart, start)
+		}
+		if end == nil || !end.Equal(wantEnd) {
+			t.Errorf("expected end=%v, got %v", wantEnd, end)
+		}
+	})
+
+	t.Run("invalid start surfaces start_date in error", func(t *testing.T) {
+		_, _, err := parseDateRange("bogus", "2024-02-01")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "start_date") {
+			t.Errorf("expected error to mention start_date, got: %q", err.Error())
+		}
+	})
+
+	t.Run("invalid end surfaces end_date in error", func(t *testing.T) {
+		_, _, err := parseDateRange("2024-01-01", "bogus")
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "end_date") {
+			t.Errorf("expected error to mention end_date, got: %q", err.Error())
+		}
+	})
+
+	t.Run("mixed empty and valid parses the valid side", func(t *testing.T) {
+		start, end, err := parseDateRange("", "2024-02-01")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if start != nil {
+			t.Errorf("expected nil start, got %v", start)
+		}
+		if end == nil {
+			t.Fatal("expected non-nil end")
+		}
+	})
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -213,10 +213,7 @@ func (s *MCPServer) handleQueryTransactions(_ context.Context, _ *mcpsdk.CallToo
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 	if params.SearchMode, err = parseSearchMode(input.SearchMode); err != nil {
@@ -272,10 +269,7 @@ func (s *MCPServer) handleCountTransactions(_ context.Context, _ *mcpsdk.CallToo
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 	if params.SearchMode, err = parseSearchMode(input.SearchMode); err != nil {
@@ -433,10 +427,7 @@ func (s *MCPServer) handleTransactionSummary(_ context.Context, _ *mcpsdk.CallTo
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 	if input.IncludePending != nil && *input.IncludePending {
@@ -466,10 +457,7 @@ func (s *MCPServer) handleMerchantSummary(_ context.Context, _ *mcpsdk.CallToolR
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 	if params.SearchMode, err = parseSearchMode(input.SearchMode); err != nil {
@@ -908,10 +896,7 @@ func (s *MCPServer) handleBulkRecategorize(ctx context.Context, _ *mcpsdk.CallTo
 	}
 
 	var err error
-	if params.StartDate, err = parseOptionalDate("start_date", input.StartDate); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if params.EndDate, err = parseOptionalDate("end_date", input.EndDate); err != nil {
+	if params.StartDate, params.EndDate, err = parseDateRange(input.StartDate, input.EndDate); err != nil {
 		return errorResult(err), nil, nil
 	}
 


### PR DESCRIPTION
## Summary

Every MCP tool that accepts a date window does so with the same YYYY-MM-DD pair and the same `parseOptionalDate` error format. Extract a tiny `parseDateRange` helper and collapse the two-line parse/check idiom into a single call across the five handlers that use it:

- `handleQueryTransactions`
- `handleCountTransactions`
- `handleTransactionSummary`
- `handleMerchantSummary`
- `handleBulkRecategorize`

Behavior is unchanged — same field names in errors, same nil-pointer-on-empty semantics. Follows the same pattern as [#571](https://github.com/canalesb93/breadbox/pull/571) (`parseSearchMode`) and [#554](https://github.com/canalesb93/breadbox/pull/554) (`optStr`, `parseOptionalDate`).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — including new `TestParseDateRange` covering empty/valid/invalid-start/invalid-end/mixed cases
- [x] Existing `parseOptionalDate` tests still pass (helper is used internally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)