### PR TITLE
a11y(agents): restore labels + aria-name on agent selector buttons

### DIFF
--- a/internal/templates/pages/mcp_guide.html
+++ b/internal/templates/pages/mcp_guide.html
@@ -91,9 +91,10 @@
                     :class="tab === t.id ? 'btn-primary' : 'btn-ghost'"
                     @click="switchTab(t.id)"
                     role="tab"
-                    :aria-selected="tab === t.id">
+                    :aria-selected="tab === t.id"
+                    :aria-label="t.label">
               <i :data-lucide="t.icon" class="w-3.5 h-3.5"></i>
-              <span x-text="t.label" class="hidden sm:inline"></span>
+              <span x-text="t.label"></span>
             </button>
           </template>
         </div>


### PR DESCRIPTION
Fixes #598

Below 640px the client-selector buttons (Claude Desktop, Claude Code, ChatGPT, Other) hid their span via `hidden sm:inline`, leaving four unlabeled icons with no accessible name. This drops the `hidden` class so the existing `flex-wrap` container wraps labels to a second row on mobile, and binds `aria-label` to the tab label as a backstop.

## Before / After

| Viewport | Before | After |
|---|---|---|
| Mobile 500x844 | ![before mobile](https://i.img402.dev/xuyzo4tkd3.png) | ![after mobile](https://i.img402.dev/jc1fehczyq.png) |
| Tablet 820x1180 | ![before tablet](https://i.img402.dev/l79jl40qou.png) | ![after tablet](https://i.img402.dev/ncbdf06pm3.png) |
| Desktop 1440x900 | ![before desktop](https://i.img402.dev/wzehc2pxvq.png) | ![after desktop](https://i.img402.dev/h7u9nu8u6v.png) |

## Test plan

- [x] Mobile (500x844): labels visible; row wraps (Other wraps below)
- [x] Tablet (820x1180): all four tabs on one line with Guide/Config toggle aligned right
- [x] Desktop (1440x900): unchanged single-line pill group
- [x] `aria-label` bound on every button for screen-reader backstop
- [x] `role="tab"` + `aria-selected` still toggle on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)