### PR TITLE
fix(agents): wrap tab strip on mobile so Activity label stays visible

### DIFF
--- a/internal/templates/pages/agents.html
+++ b/internal/templates/pages/agents.html
@@ -9,8 +9,8 @@
   </div>
 </div>
 
-<!-- Tab Switcher: horizontally scrollable on mobile so labels stay on one line -->
-<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-fit max-w-full overflow-x-auto">
+<!-- Tab Switcher: wraps to a second row on mobile so all labels stay visible; stays single-line from sm and up. -->
+<div class="flex flex-wrap sm:flex-nowrap items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 mb-6 w-full sm:w-fit max-w-full sm:overflow-x-auto">
   <button @click="tab = 'guide'"
     :class="tab === 'guide' ? 'bg-base-100 text-base-content shadow-sm' : 'text-base-content/40 hover:text-base-content/60'"
     class="px-3 sm:px-4 py-1.5 text-sm font-medium rounded-md transition-all duration-150 flex items-center gap-2 whitespace-nowrap shrink-0">


### PR DESCRIPTION
Fixes #597

On mobile (<640px) the Agents page tab strip overflowed its container, clipping the Activity tab so only its icon was visible — no label, no scroll indicator. Switched the mobile layout from a silent `overflow-x-auto` scroll to `flex-wrap`, so all four tabs stay on screen (Activity drops to a second row). From the `sm` breakpoint up, the original single-line pill group is preserved via `sm:flex-nowrap`.

## Before / After

| Viewport | Before | After |
|---|---|---|
| Mobile 500x844 | ![before mobile](https://i.img402.dev/bgaxroduej.png) | ![after mobile](https://i.img402.dev/eg8ao7mldy.png) |
| Tablet 820x1180 | ![before tablet](https://i.img402.dev/d53sfnhh6r.png) | ![after tablet](https://i.img402.dev/0azx97mg5n.png) |
| Desktop 1440x900 | ![before desktop](https://i.img402.dev/j7pj81rb1a.png) | ![after desktop](https://i.img402.dev/8v3ufpkghm.png) |

## Test plan
- [x] Mobile 500x844: all four tab labels visible (Activity wraps to second row)
- [x] Tablet 820x1180: single-line pill group preserved
- [x] Desktop 1440x900: single-line pill group preserved
- [x] No horizontal page scrollbar introduced
- [x] `tab=` query param / Alpine `$watch` state behavior unchanged (only the container classes were touched)

Generated with [Claude Code](https://claude.com/claude-code)