### PR TITLE
refactor(components): unify pluralS helper with generics

### DIFF
--- a/internal/templates/components/helpers.go
+++ b/internal/templates/components/helpers.go
@@ -133,7 +133,13 @@ func titleCase(s string) string {
 	return strings.Join(words, " ")
 }
 
-func pluralS(n int) string {
+// pluralInt constrains pluralS to signed int types so the same helper works
+// for `len(slice)` (int) and sqlc-derived counts (int64) without casting.
+type pluralInt interface {
+	~int | ~int32 | ~int64
+}
+
+func pluralS[T pluralInt](n T) string {
 	if n == 1 {
 		return ""
 	}
@@ -245,4 +251,4 @@ func FormatAmount(amount float64) string { return formatAmount(amount) }
 func TitleCase(s string) string { return titleCase(s) }
 
 // PluralS returns "" for n == 1, else "s". See pluralS.
-func PluralS(n int) string { return pluralS(n) }
+func PluralS[T pluralInt](n T) string { return pluralS(n) }

--- a/internal/templates/components/helpers_test.go
+++ b/internal/templates/components/helpers_test.go
@@ -178,6 +178,21 @@ func TestPluralS(t *testing.T) {
 			t.Errorf("pluralS(%d) = %q, want %q", tc.n, got, tc.want)
 		}
 	}
+	// int64 path — sqlc-derived counts (e.g. transaction totals) hit this
+	// branch of the generic and must produce the same output as int.
+	int64Cases := []struct {
+		n    int64
+		want string
+	}{
+		{0, "s"},
+		{1, ""},
+		{2, "s"},
+	}
+	for _, tc := range int64Cases {
+		if got := pluralS(tc.n); got != tc.want {
+			t.Errorf("pluralS(int64=%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
 }
 
 func TestExportedWrappersDelegate(t *testing.T) {

--- a/internal/templates/components/pages/dashboard.templ
+++ b/internal/templates/components/pages/dashboard.templ
@@ -433,7 +433,7 @@ templ dashConnectionRow(c ConnectionHealthRow) {
 			if c.Status != "active" && c.ErrorMessage != "" {
 				<div class="text-[0.6rem] text-error/60 truncate mt-0.5 font-mono max-w-full" title={ c.ErrorMessage }>{ c.ErrorMessage }</div>
 			} else {
-				<div class="text-[0.6rem] text-base-content/30 mt-0.5">{ fmt.Sprintf("%d account%s · synced %s", c.AccountCount, components.PluralS(int(c.AccountCount)), c.LastSyncedAt) }</div>
+				<div class="text-[0.6rem] text-base-content/30 mt-0.5">{ fmt.Sprintf("%d account%s · synced %s", c.AccountCount, components.PluralS(c.AccountCount), c.LastSyncedAt) }</div>
 			}
 		</div>
 		<div class="shrink-0">

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -45,7 +45,7 @@ templ txPageHeader(p TransactionsProps) {
 			<h1 class="bb-page-title">Transactions</h1>
 			if p.Total > 0 {
 				<span class="text-sm text-base-content/40 tabular-nums">
-					{ fmt.Sprintf("%d transaction%s", p.Total, pluralSuffix(p.Total)) }
+					{ fmt.Sprintf("%d transaction%s", p.Total, components.PluralS(p.Total)) }
 				</span>
 			}
 		</div>
@@ -376,13 +376,6 @@ templ txPageScripts(p TransactionsProps) {
 }
 
 // ── Helpers ──────────────────────────────────────────────────
-
-func pluralSuffix(n int64) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
-}
 
 // accountSelectLabel mirrors the admin funcMap "accountLabel" helper: combine
 // a name with an optional last-4 mask so ambiguous accounts stay addressable.


### PR DESCRIPTION
## Summary
- Make `pluralS`/`PluralS` in `internal/templates/components/helpers.go` generic over `int | int32 | int64`, so the same helper works for both `len(slice)` (int) and sqlc-derived counts (int64) without callers casting.
- Remove the duplicate local `pluralSuffix(n int64)` from `pages/transactions.templ` — it now calls the shared `components.PluralS(p.Total)` directly.
- Drop the `int(c.AccountCount)` cast in `pages/dashboard.templ` for the same reason.
- Extend `TestPluralS` with an `int64` case so the generic instantiation stays covered.

Pure refactor — rendered output is byte-identical.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/templates/components/...`
- [x] `go test ./...` (unit suite)
- [x] `templ generate` regenerates cleanly
- [x] `templ fmt .` no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)