### PR TITLE
fix(oauth): show real MCP server URL on client-created page

### DIFF
--- a/internal/admin/agents_page.go
+++ b/internal/admin/agents_page.go
@@ -22,18 +22,7 @@ func AgentsPageHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer, s
 		data["Tab"] = tab
 
 		// === Getting Started data ===
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
-		}
-		if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
-			scheme = proto
-		}
-		host := r.Host
-		if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
-			host = fwdHost
-		}
-		data["MCPServerURL"] = scheme + "://" + host + "/mcp"
+		data["MCPServerURL"] = mcpServerURL(r)
 
 		var hasAPIKeys, hasOAuthClients bool
 		if keys, err := svc.ListAPIKeys(ctx); err == nil {

--- a/internal/admin/mcp_guide.go
+++ b/internal/admin/mcp_guide.go
@@ -8,25 +8,31 @@ import (
 	"github.com/alexedwards/scs/v2"
 )
 
+// mcpServerURL derives the public MCP endpoint from the incoming request,
+// honoring X-Forwarded-Proto / X-Forwarded-Host when set by a reverse proxy.
+// Shared across admin pages that surface the URL to users.
+func mcpServerURL(r *http.Request) string {
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	}
+	host := r.Host
+	if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
+		host = fwdHost
+	}
+	return scheme + "://" + host + "/mcp"
+}
+
 // MCPGuideHandler serves GET /admin/mcp-getting-started.
 func MCPGuideHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		data := BaseTemplateData(r, sm, "mcp-getting-started", "Getting Started")
 
-		// Build MCP server URL from request.
-		scheme := "http"
-		if r.TLS != nil {
-			scheme = "https"
-		}
-		if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
-			scheme = proto
-		}
-		host := r.Host
-		if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
-			host = fwdHost
-		}
-		data["MCPServerURL"] = scheme + "://" + host + "/mcp"
+		data["MCPServerURL"] = mcpServerURL(r)
 
 		// Check for existing credentials.
 		var hasAPIKeys, hasOAuthClients bool

--- a/internal/admin/oauth.go
+++ b/internal/admin/oauth.go
@@ -425,6 +425,7 @@ func OAuthClientCreatedPageHandler(sm *scs.SessionManager, tr *TemplateRenderer)
 			"ClientID":     clientID,
 			"ClientSecret": clientSecret,
 			"ClientName":   name,
+			"MCPServerURL": mcpServerURL(r),
 			"CSRFToken":    GetCSRFToken(r),
 			"Breadcrumbs": []Breadcrumb{
 				{Label: "Access", Href: "/access"},

--- a/internal/templates/pages/oauth_client_created.html
+++ b/internal/templates/pages/oauth_client_created.html
@@ -8,7 +8,7 @@
   </div>
 </div>
 
-<div class="bb-card p-6 max-w-lg" x-data="{ copiedId: false, copiedSecret: false }">
+<div class="bb-card p-6 max-w-lg" x-data="{ copiedId: false, copiedSecret: false, copiedUrl: false }">
   <div class="flex items-center gap-3 mb-5">
     <div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center">
       <i data-lucide="check" class="w-5 h-5 text-success"></i>
@@ -55,8 +55,16 @@
       <a href="/access" class="btn btn-ghost btn-sm rounded-xl shrink-0">Done</a>
     </div>
     <div class="rounded-xl bg-base-200/50 p-3">
-      <div class="text-xs font-medium text-base-content/50 mb-1">MCP Server URL</div>
-      <code class="text-xs font-mono text-primary/70">https://your-breadbox-host/mcp</code>
+      <div class="text-xs font-medium text-base-content/50 mb-1.5">MCP Server URL</div>
+      <div class="flex gap-2">
+        <input type="text" value="{{.MCPServerURL}}" readonly id="oauth-mcp-url"
+               class="input input-sm font-mono flex-1 bg-base-100 border-base-300 rounded-xl text-xs text-primary/80">
+        <button class="btn btn-sm btn-ghost rounded-xl shrink-0 gap-1.5" :class="copiedUrl && '!text-success'" @click="navigator.clipboard.writeText(document.getElementById('oauth-mcp-url').value).then(function(){ $data.copiedUrl = true; setTimeout(function(){ $data.copiedUrl = false; }, 2000); })">
+          <i data-lucide="clipboard" class="w-3.5 h-3.5" x-show="!copiedUrl"></i>
+          <i data-lucide="check" class="w-3.5 h-3.5" x-show="copiedUrl" x-cloak></i>
+          <span x-text="copiedUrl ? 'Copied!' : 'Copy'"></span>
+        </button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #599

The OAuth "Client Created" page was showing a literal `https://your-breadbox-host/mcp` placeholder instead of the instance's actual endpoint. Replaced with a dynamically derived URL (honors `X-Forwarded-Proto`/`X-Forwarded-Host`) and added a Copy button matching the Client ID/Secret rows. Scheme/host derivation is now a shared `mcpServerURL` helper reused by the Agents, MCP Guide, and OAuth Client Created handlers.

## Before / After

| Viewport | Before | After |
| --- | --- | --- |
| Mobile (500x844) | ![before-mobile](https://i.img402.dev/vw51s8l4o0.png) | ![after-mobile](https://i.img402.dev/m8dqnuhn6e.png) |
| Tablet (820x1180) | ![before-tablet](https://i.img402.dev/f947672v2m.png) | ![after-tablet](https://i.img402.dev/57h4xo616s.png) |
| Desktop (1440x900) | ![before-desktop](https://i.img402.dev/8hzf3wvot1.png) | ![after-desktop](https://i.img402.dev/98zeeu8hp7.png) |

## Test plan

- [ ] Local dev at `http://localhost:<port>` -> page shows `http://localhost:<port>/mcp`
- [ ] Behind a TLS-terminating reverse proxy -> URL reflects `X-Forwarded-Proto`/`X-Forwarded-Host`
- [ ] Copy button copies the URL to clipboard (matches ID/Secret pattern)
- [ ] `grep -r your-breadbox-host` across the repo comes back empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)