### PR TITLE
refactor(pgconv): add TextPtr helper; simplify service numericFloat

### DIFF
--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -277,7 +277,7 @@ func CreateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		writeJSON(w, http.StatusCreated, map[string]any{
 			"id":         userID,
 			"name":       user.Name,
-			"email":      nullTextToPtr(user.Email),
+			"email":      pgconv.TextPtr(user.Email),
 			"created_at": user.CreatedAt.Time,
 			"updated_at": user.UpdatedAt.Time,
 		})
@@ -364,7 +364,7 @@ func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"id":         pgconv.FormatUUID(user.ID),
 			"name":       user.Name,
-			"email":      nullTextToPtr(user.Email),
+			"email":      pgconv.TextPtr(user.Email),
 			"created_at": user.CreatedAt.Time,
 			"updated_at": user.UpdatedAt.Time,
 		})
@@ -438,10 +438,3 @@ func CreateLoginPageHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 	}
 }
 
-// nullTextToPtr converts a pgtype.Text to a *string for JSON serialization.
-func nullTextToPtr(t pgtype.Text) *string {
-	if !t.Valid {
-		return nil
-	}
-	return &t.String
-}

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -39,3 +39,13 @@ func NumericToFloat(n pgtype.Numeric) (float64, bool) {
 	}
 	return f.Float64, true
 }
+
+// TextPtr converts a pgtype.Text to *string for JSON serialization. Returns
+// nil when the text is NULL; otherwise returns a pointer to the underlying
+// string value.
+func TextPtr(t pgtype.Text) *string {
+	if !t.Valid {
+		return nil
+	}
+	return &t.String
+}

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -139,3 +139,24 @@ func TestNumericToFloat_NaN(t *testing.T) {
 		t.Error("NumericToFloat: expected ok=false for NaN")
 	}
 }
+
+func TestTextPtr_Valid(t *testing.T) {
+	got := TextPtr(pgtype.Text{String: "hello", Valid: true})
+	if got == nil || *got != "hello" {
+		t.Errorf("TextPtr = %v, want &\"hello\"", got)
+	}
+}
+
+func TestTextPtr_Empty(t *testing.T) {
+	got := TextPtr(pgtype.Text{String: "", Valid: true})
+	if got == nil || *got != "" {
+		t.Errorf("TextPtr(empty valid) = %v, want &\"\"", got)
+	}
+}
+
+func TestTextPtr_Invalid(t *testing.T) {
+	got := TextPtr(pgtype.Text{Valid: false})
+	if got != nil {
+		t.Errorf("TextPtr(invalid) = %v, want nil", got)
+	}
+}

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"math/big"
 	"time"
 
 	"breadbox/internal/db"
@@ -24,39 +23,18 @@ func uuidPtr(u pgtype.UUID) *string {
 }
 
 func textPtr(t pgtype.Text) *string {
-	if !t.Valid {
-		return nil
-	}
-	return &t.String
+	return pgconv.TextPtr(t)
 }
 
 func numericFloat(n pgtype.Numeric) *float64 {
-	if !n.Valid {
-		return nil
-	}
-	// Construct the float from Int * 10^Exp
 	if n.Int == nil {
 		return nil
 	}
-	f := new(big.Float).SetInt(n.Int)
-	if n.Exp != 0 {
-		exp := new(big.Float).SetFloat64(1)
-		base := new(big.Float).SetFloat64(10)
-		e := int(n.Exp)
-		if e > 0 {
-			for i := 0; i < e; i++ {
-				exp.Mul(exp, base)
-			}
-		} else {
-			for i := 0; i < -e; i++ {
-				exp.Mul(exp, base)
-			}
-			exp = new(big.Float).Quo(new(big.Float).SetFloat64(1), exp)
-		}
-		f.Mul(f, exp)
+	f, ok := pgconv.NumericToFloat(n)
+	if !ok {
+		return nil
 	}
-	result, _ := f.Float64()
-	return &result
+	return &f
 }
 
 func timestampStr(ts pgtype.Timestamptz) *string {


### PR DESCRIPTION
## Summary

Small, mechanical consolidation of two patterns that had quietly duplicated across packages:

1. **`pgtype.Text → *string`** was implemented twice — `service/convert.go#textPtr` and `admin/users.go#nullTextToPtr` — with identical logic. Moved to `pgconv.TextPtr` (tested), and both private helpers now delegate or are removed.
2. **`numericFloat` in `service/convert.go`** re-implemented `pgtype.Numeric → float64` with a hand-rolled `math/big.Float` scaling loop. `pgconv.NumericToFloat` already does the same via `pgx`'s built-in `Float64Value()`. Service's `numericFloat` now delegates, dropping the `math/big` import and ~25 LOC.

Follows the pattern of [#574](https://github.com/canalesb93/breadbox/pull/574) (`NumericToFloat` to `pgconv`), [#595](https://github.com/canalesb93/breadbox/pull/595) (query-string helpers), [#603](https://github.com/canalesb93/breadbox/pull/603) (`parseDateRange`), and [#609](https://github.com/canalesb93/breadbox/pull/609) (`pluralS` generics).

## Scope

- `internal/pgconv/pgconv.go`: add `TextPtr(pgtype.Text) *string`
- `internal/pgconv/pgconv_test.go`: 3 new unit tests (valid, empty-valid, invalid)
- `internal/admin/users.go`: remove `nullTextToPtr`, replace 2 call sites with `pgconv.TextPtr`
- `internal/service/convert.go`: `textPtr` → `pgconv.TextPtr`; `numericFloat` → `pgconv.NumericToFloat` (preserves the existing `n.Int == nil` guard for the pre-existing test case)

No behavior changes; the existing `service/convert_test.go` suite (which tests `numericFloat` and `textPtr`) still passes unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all unit tests pass
- [x] `go test ./internal/pgconv/ ./internal/service/` — new `TextPtr` tests pass, existing `numericFloat` tests still pass against delegation
- [x] Integration tests pass for touched surface (`service` package: users / accounts / transactions flows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)