### PR TITLE
refactor(pgconv): consolidate Timestamptz/Date → string helpers

### DIFF
--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -3,6 +3,7 @@ package pgconv
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -48,4 +49,36 @@ func TextPtr(t pgtype.Text) *string {
 		return nil
 	}
 	return &t.String
+}
+
+// TimestampStr renders a pgtype.Timestamptz as an RFC3339 UTC string. Returns
+// an empty string when the timestamp is NULL. Use for NOT NULL columns where
+// an empty response field is acceptable for the rare invalid case.
+func TimestampStr(ts pgtype.Timestamptz) string {
+	if !ts.Valid {
+		return ""
+	}
+	return ts.Time.UTC().Format(time.RFC3339)
+}
+
+// TimestampStrPtr renders a pgtype.Timestamptz as an RFC3339 UTC string wrapped
+// in *string. Returns nil when the timestamp is NULL. Use for nullable columns
+// where JSON should serialize absent timestamps as null (and be omitted via
+// omitempty).
+func TimestampStrPtr(ts pgtype.Timestamptz) *string {
+	if !ts.Valid {
+		return nil
+	}
+	s := ts.Time.UTC().Format(time.RFC3339)
+	return &s
+}
+
+// DateStrPtr renders a pgtype.Date as a "2006-01-02" string wrapped in
+// *string. Returns nil when the date is NULL.
+func DateStrPtr(d pgtype.Date) *string {
+	if !d.Valid {
+		return nil
+	}
+	s := d.Time.Format("2006-01-02")
+	return &s
 }

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -2,6 +2,7 @@ package pgconv
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -158,5 +159,80 @@ func TestTextPtr_Invalid(t *testing.T) {
 	got := TextPtr(pgtype.Text{Valid: false})
 	if got != nil {
 		t.Errorf("TextPtr(invalid) = %v, want nil", got)
+	}
+}
+
+func TestTimestampStr_Valid(t *testing.T) {
+	ts := pgtype.Timestamptz{
+		Time:  time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),
+		Valid: true,
+	}
+	got := TimestampStr(ts)
+	want := "2024-03-15T14:30:00Z"
+	if got != want {
+		t.Errorf("TimestampStr = %q, want %q", got, want)
+	}
+}
+
+func TestTimestampStr_NonUTC(t *testing.T) {
+	loc, _ := time.LoadLocation("America/Los_Angeles")
+	ts := pgtype.Timestamptz{
+		Time:  time.Date(2024, 3, 15, 7, 30, 0, 0, loc),
+		Valid: true,
+	}
+	got := TimestampStr(ts)
+	want := "2024-03-15T14:30:00Z"
+	if got != want {
+		t.Errorf("TimestampStr(non-UTC) = %q, want %q (should be normalized to UTC)", got, want)
+	}
+}
+
+func TestTimestampStr_Invalid(t *testing.T) {
+	got := TimestampStr(pgtype.Timestamptz{Valid: false})
+	if got != "" {
+		t.Errorf("TimestampStr(invalid) = %q, want empty", got)
+	}
+}
+
+func TestTimestampStrPtr_Valid(t *testing.T) {
+	ts := pgtype.Timestamptz{
+		Time:  time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),
+		Valid: true,
+	}
+	got := TimestampStrPtr(ts)
+	if got == nil {
+		t.Fatal("TimestampStrPtr: expected non-nil")
+	}
+	want := "2024-03-15T14:30:00Z"
+	if *got != want {
+		t.Errorf("TimestampStrPtr = %q, want %q", *got, want)
+	}
+}
+
+func TestTimestampStrPtr_Invalid(t *testing.T) {
+	got := TimestampStrPtr(pgtype.Timestamptz{Valid: false})
+	if got != nil {
+		t.Errorf("TimestampStrPtr(invalid) = %v, want nil", got)
+	}
+}
+
+func TestDateStrPtr_Valid(t *testing.T) {
+	d := pgtype.Date{
+		Time:  time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC),
+		Valid: true,
+	}
+	got := DateStrPtr(d)
+	if got == nil {
+		t.Fatal("DateStrPtr: expected non-nil")
+	}
+	if *got != "2024-03-15" {
+		t.Errorf("DateStrPtr = %q, want 2024-03-15", *got)
+	}
+}
+
+func TestDateStrPtr_Invalid(t *testing.T) {
+	got := DateStrPtr(pgtype.Date{Valid: false})
+	if got != nil {
+		t.Errorf("DateStrPtr(invalid) = %v, want nil", got)
 	}
 }

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -110,7 +110,7 @@ func annotationFromRow(a db.Annotation) Annotation {
 		ActorType:     a.ActorType,
 		ActorID:       textPtr(a.ActorID),
 		ActorName:     a.ActorName,
-		CreatedAt:     a.CreatedAt.Time.UTC().Format(time.RFC3339),
+		CreatedAt:     pgconv.TimestampStr(a.CreatedAt),
 	}
 
 	if a.SessionID.Valid {

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -7,9 +7,9 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -63,8 +63,8 @@ func (s *Service) ListCategories(ctx context.Context) ([]CategoryResponse, error
 			SortOrder:         r.SortOrder,
 			IsSystem:          r.IsSystem,
 			Hidden:            r.Hidden,
-			CreatedAt:         r.CreatedAt.Time.UTC().Format(time.RFC3339),
-			UpdatedAt:         r.UpdatedAt.Time.UTC().Format(time.RFC3339),
+			CreatedAt:         pgconv.TimestampStr(r.CreatedAt),
+			UpdatedAt:         pgconv.TimestampStr(r.UpdatedAt),
 		})
 	}
 	return result, nil
@@ -124,8 +124,8 @@ func (s *Service) GetCategory(ctx context.Context, id string) (*CategoryResponse
 		SortOrder:   cat.SortOrder,
 		IsSystem:    cat.IsSystem,
 		Hidden:      cat.Hidden,
-		CreatedAt:   cat.CreatedAt.Time.UTC().Format(time.RFC3339),
-		UpdatedAt:   cat.UpdatedAt.Time.UTC().Format(time.RFC3339),
+		CreatedAt:   pgconv.TimestampStr(cat.CreatedAt),
+		UpdatedAt:   pgconv.TimestampStr(cat.UpdatedAt),
 	}, nil
 }
 
@@ -201,8 +201,8 @@ func (s *Service) CreateCategory(ctx context.Context, params CreateCategoryParam
 		SortOrder:   cat.SortOrder,
 		IsSystem:    cat.IsSystem,
 		Hidden:      cat.Hidden,
-		CreatedAt:   cat.CreatedAt.Time.UTC().Format(time.RFC3339),
-		UpdatedAt:   cat.UpdatedAt.Time.UTC().Format(time.RFC3339),
+		CreatedAt:   pgconv.TimestampStr(cat.CreatedAt),
+		UpdatedAt:   pgconv.TimestampStr(cat.UpdatedAt),
 	}, nil
 }
 
@@ -248,8 +248,8 @@ func (s *Service) UpdateCategory(ctx context.Context, id string, params UpdateCa
 		SortOrder:   cat.SortOrder,
 		IsSystem:    cat.IsSystem,
 		Hidden:      cat.Hidden,
-		CreatedAt:   cat.CreatedAt.Time.UTC().Format(time.RFC3339),
-		UpdatedAt:   cat.UpdatedAt.Time.UTC().Format(time.RFC3339),
+		CreatedAt:   pgconv.TimestampStr(cat.CreatedAt),
+		UpdatedAt:   pgconv.TimestampStr(cat.UpdatedAt),
 	}, nil
 }
 

--- a/internal/service/comments.go
+++ b/internal/service/comments.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -243,8 +243,8 @@ func commentFromAnnotation(a db.Annotation, content, reviewID string) CommentRes
 		AuthorID:      textPtr(a.ActorID),
 		AuthorName:    a.ActorName,
 		Content:       content,
-		CreatedAt:     a.CreatedAt.Time.UTC().Format(time.RFC3339),
-		UpdatedAt:     a.CreatedAt.Time.UTC().Format(time.RFC3339),
+		CreatedAt:     pgconv.TimestampStr(a.CreatedAt),
+		UpdatedAt:     pgconv.TimestampStr(a.CreatedAt),
 	}
 	if reviewID != "" {
 		rid := reviewID

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"fmt"
-	"time"
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
@@ -38,19 +37,11 @@ func numericFloat(n pgtype.Numeric) *float64 {
 }
 
 func timestampStr(ts pgtype.Timestamptz) *string {
-	if !ts.Valid {
-		return nil
-	}
-	s := ts.Time.UTC().Format(time.RFC3339)
-	return &s
+	return pgconv.TimestampStrPtr(ts)
 }
 
 func dateStr(d pgtype.Date) *string {
-	if !d.Valid {
-		return nil
-	}
-	s := d.Time.Format("2006-01-02")
-	return &s
+	return pgconv.DateStrPtr(d)
 }
 
 func nullConnStatusPtr(s db.NullConnectionStatus) *string {

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"breadbox/internal/pgconv"
 	"breadbox/internal/ruleapply"
 	"breadbox/internal/sliceutil"
 	"breadbox/internal/slugs"
@@ -1908,8 +1909,8 @@ func (r *ruleRow) toResponseBase() TransactionRuleResponse {
 		CreatedByName: r.createdByName,
 		HitCount:      int(r.hitCount),
 		LastHitAt:     timestampStr(r.lastHitAt),
-		CreatedAt:     r.createdAt.Time.UTC().Format(time.RFC3339),
-		UpdatedAt:     r.updatedAt.Time.UTC().Format(time.RFC3339),
+		CreatedAt:     pgconv.TimestampStr(r.createdAt),
+		UpdatedAt:     pgconv.TimestampStr(r.updatedAt),
 	}
 }
 
@@ -2370,9 +2371,7 @@ func (s *Service) ListRuleApplications(ctx context.Context, ruleID string, limit
 		if date.Valid {
 			r.Date = date.Time.Format("2006-01-02")
 		}
-		if appliedAt.Valid {
-			r.AppliedAt = appliedAt.Time.UTC().Format(time.RFC3339)
-		}
+		r.AppliedAt = pgconv.TimestampStr(appliedAt)
 		results = append(results, r)
 	}
 
@@ -2429,7 +2428,7 @@ func (s *Service) GetRuleSyncHistory(ctx context.Context, ruleID string, limit i
 
 		entry := map[string]any{
 			"sync_id":     formatUUID(id),
-			"started_at":  startedAt.Time.UTC().Format(time.RFC3339),
+			"started_at":  pgconv.TimestampStr(startedAt),
 			"status":      status,
 			"hit_count":   hits[ruleID],
 			"institution": textPtr(instName),
@@ -2485,9 +2484,7 @@ func (s *Service) ListRuleApplicationsByTransactionID(ctx context.Context, trans
 			return nil, fmt.Errorf("scan rule application: %w", err)
 		}
 		d.RuleID = formatUUID(ruleID)
-		if appliedAt.Valid {
-			d.AppliedAt = appliedAt.Time.UTC().Format(time.RFC3339)
-		}
+		d.AppliedAt = pgconv.TimestampStr(appliedAt)
 		results = append(results, d)
 	}
 

--- a/internal/service/tags.go
+++ b/internal/service/tags.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/shortid"
 	"breadbox/internal/slugs"
 
@@ -301,7 +301,7 @@ func tagFromRow(t db.Tag) TagResponse {
 		Color:       textPtr(t.Color),
 		Icon:        textPtr(t.Icon),
 		Lifecycle:   t.Lifecycle,
-		CreatedAt:   t.CreatedAt.Time.UTC().Format(time.RFC3339),
-		UpdatedAt:   t.UpdatedAt.Time.UTC().Format(time.RFC3339),
+		CreatedAt:   pgconv.TimestampStr(t.CreatedAt),
+		UpdatedAt:   pgconv.TimestampStr(t.UpdatedAt),
 	}
 }

--- a/internal/service/transaction_tags.go
+++ b/internal/service/transaction_tags.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -227,7 +227,7 @@ func (s *Service) ListTransactionTags(ctx context.Context, txnID string) ([]Tran
 			Color:       textPtr(color),
 			Icon:        textPtr(icon),
 			Lifecycle:   lifecycle,
-			AddedAt:     addedAt.Time.UTC().Format(time.RFC3339),
+			AddedAt:     pgconv.TimestampStr(addedAt),
 			AddedByType: addedByType,
 			AddedByName: addedByName,
 		})

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"breadbox/internal/pgconv"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -419,8 +421,8 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 			CategoryConfidence:  textPtr(categoryConfidence),
 			PaymentChannel:      textPtr(paymentChannel),
 			Pending:             pending,
-			CreatedAt:           createdAt.Time.UTC().Format(time.RFC3339),
-			UpdatedAt:           updatedAt.Time.UTC().Format(time.RFC3339),
+			CreatedAt:           pgconv.TimestampStr(createdAt),
+			UpdatedAt:           pgconv.TimestampStr(updatedAt),
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -965,8 +967,8 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			Pending:             pending,
 			AgentReviewed:       agentReviewed,
 			HasPendingReview:    hasPendingReview,
-			CreatedAt:           createdAt.Time.UTC().Format(time.RFC3339),
-			UpdatedAt:           updatedAt.Time.UTC().Format(time.RFC3339),
+			CreatedAt:           pgconv.TimestampStr(createdAt),
+			UpdatedAt:           pgconv.TimestampStr(updatedAt),
 		})
 	}
 	if err := rows.Err(); err != nil {
@@ -1151,8 +1153,8 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 			Pending:             pending,
 			AgentReviewed:       agentReviewed,
 			HasPendingReview:    hasPendingReview,
-			CreatedAt:           createdAt.Time.UTC().Format(time.RFC3339),
-			UpdatedAt:           updatedAt.Time.UTC().Format(time.RFC3339),
+			CreatedAt:           pgconv.TimestampStr(createdAt),
+			UpdatedAt:           pgconv.TimestampStr(updatedAt),
 		}
 		byID[row.ID] = row
 	}
@@ -1246,8 +1248,8 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		CategoryOverride:    txn.CategoryOverride,
 		PaymentChannel:      textPtr(txn.PaymentChannel),
 		Pending:             txn.Pending,
-		CreatedAt:           txn.CreatedAt.Time.UTC().Format(time.RFC3339),
-		UpdatedAt:           txn.UpdatedAt.Time.UTC().Format(time.RFC3339),
+		CreatedAt:           pgconv.TimestampStr(txn.CreatedAt),
+		UpdatedAt:           pgconv.TimestampStr(txn.UpdatedAt),
 	}
 
 	// Load structured category info if category_id is set
@@ -1296,7 +1298,7 @@ func (s *Service) GetCategoryBySlug(ctx context.Context, slug string) (*Category
 		SortOrder:   cat.SortOrder,
 		IsSystem:    cat.IsSystem,
 		Hidden:      cat.Hidden,
-		CreatedAt:   cat.CreatedAt.Time.UTC().Format(time.RFC3339),
-		UpdatedAt:   cat.UpdatedAt.Time.UTC().Format(time.RFC3339),
+		CreatedAt:   pgconv.TimestampStr(cat.CreatedAt),
+		UpdatedAt:   pgconv.TimestampStr(cat.UpdatedAt),
 	}, nil
 }


### PR DESCRIPTION
## Summary

Small, mechanical follow-up to [#611](https://github.com/canalesb93/breadbox/pull/611). Two patterns still duplicated across the service layer:

- 30 call sites inlined `x.Time.UTC().Format(time.RFC3339)` on NOT NULL `pgtype.Timestamptz` columns.
- `service.timestampStr` / `service.dateStr` reimplemented the nullable variants (`*string`).

Moved all three conversions into `pgconv`:

- `TimestampStr(pgtype.Timestamptz) string` — empty when invalid, else UTC RFC3339. Used for NOT NULL columns.
- `TimestampStrPtr(pgtype.Timestamptz) *string` — nil when invalid. `service.timestampStr` now delegates (mirrors `service.textPtr` from #611).
- `DateStrPtr(pgtype.Date) *string` — nil when invalid. `service.dateStr` now delegates.

## Scope

- `internal/pgconv/pgconv.go`: three new helpers + single `time` import
- `internal/pgconv/pgconv_test.go`: 7 unit tests (valid, non-UTC → UTC normalization, invalid)
- `internal/service/convert.go`: `timestampStr` / `dateStr` become thin wrappers; `time` import dropped
- `internal/service/{annotations,categories,comments,rules,tags,transaction_tags,transactions}.go`: 30 inline calls replaced with `pgconv.TimestampStr(…)`; now-unused `time` imports dropped from five of those files

No behavior change on the happy path. For the rare `!Valid` case on a NOT NULL column (which shouldn't happen in practice), output goes from `"0001-01-01T00:00:00Z"` to `""` — strictly better for an API response that would otherwise leak the zero date.

Follows the same pattern as [#574](https://github.com/canalesb93/breadbox/pull/574) (`NumericToFloat`), [#595](https://github.com/canalesb93/breadbox/pull/595) (query-string helpers), [#603](https://github.com/canalesb93/breadbox/pull/603) (`parseDateRange`), [#609](https://github.com/canalesb93/breadbox/pull/609) (`pluralS` generics), and [#611](https://github.com/canalesb93/breadbox/pull/611) (`TextPtr`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — unit tests pass
- [x] `DATABASE_URL=... go test -tags integration -count=1 -p 1 ./internal/service/` — all 65s of service integration tests pass against the touched response shapes (tags, categories, transactions, rules, comments, annotations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)