### PR TITLE
fix(tx list): chevron leaks onto mobile, squeezing tx name column

### DIFF
--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -160,9 +160,17 @@ templ TxRow(tx service.AdminTransactionRow) {
 				</span>
 			</div>
 			<!-- Expand chevron. Rotation lives on the wrapper because Lucide
-			     replaces the <i> with an <svg> at runtime. -->
+			     replaces the <i> with an <svg> at runtime. Below the `sm`
+			     breakpoint the chevron is hidden to reclaim ~20px of horizontal
+			     room on narrow phones — critical in selection mode and for
+			     long merchant names. Use `hidden sm:inline-flex` (one display
+			     utility at a time) rather than `inline-flex ... hidden sm:block`
+			     because Tailwind v4 emits `.inline-flex` *after* `.hidden` in
+			     the utilities layer, so combining both on one element resolves
+			     to `display: inline-flex` at every breakpoint and the chevron
+			     leaks onto mobile. -->
 			<span
-				class="inline-flex text-base-content/20 shrink-0 transition-transform duration-200 hidden sm:block"
+				class="hidden sm:inline-flex text-base-content/20 shrink-0 transition-transform duration-200"
 				:class="expanded ? 'rotate-90' : ''"
 			>
 				<i data-lucide="chevron-right" class="w-4 h-4"></i>


### PR DESCRIPTION
## Summary

The expand-chevron on each transaction row was rendering on every mobile width instead of being hidden below the `sm` breakpoint. On a 375px iPhone SE in selection mode this squeezed the name column enough to truncate "Caltrain" → "Caltr..." and "Zelle Payment" → "Zelle Paym...".

## Root cause

The chevron `<span>` had `class="inline-flex ... hidden sm:block"`. Combining two display utilities on one element is a Tailwind v4 footgun — the compiled CSS emits `.inline-flex` *after* `.hidden` in the utilities layer, so both rules apply with equal specificity and the later one (`inline-flex`) wins at every breakpoint. Result: the chevron was never hidden.

Traced the bug back to **PR #409** (commit [`fafde4e`](https://github.com/canalesb93/breadbox/commit/fafde4e)) — "tag picker modal, shared pill design, tx list polish" — which wrapped the bare `<i data-lucide="chevron-...">` in a `<span class="inline-flex ...">` for rotation styling. The old `<i>` had `display: inline` by default, so `hidden` won; the new span opted into `inline-flex` and silently broke the mobile layout. The templ migration in PR #473 carried the class across verbatim and nobody caught it.

## Fix

Use a single display utility per breakpoint: `hidden sm:inline-flex`. Below 640px only `.hidden` applies (display:none). At 640px+ the media-query-scoped `.sm\:inline-flex` takes over — it's declared later in the generated CSS, so it correctly wins.

One-file fix (`internal/templates/components/tx_row.templ`), plus a comment documenting the footgun for the next person.

## Before / after

### iPhone SE (375×667), default list

| Before | After |
|---|---|
| <img src="https://i.img402.dev/lr6oj5skgx.png" width="380" alt="before iphone se"> | <img src="https://i.img402.dev/aw11nomp5x.png" width="380" alt="after iphone se"> |

Chevron disappears below `sm`; "Zelle Payment" and "Dollar General" are no longer truncated and the account name line now has room to show ("P..", "E..").

### iPhone SE (375×667), selection mode

| Before | After |
|---|---|
| <img src="https://i.img402.dev/qsi2q1zygg.png" width="380" alt="before iphone se select"> | <img src="https://i.img402.dev/14whxtwl12.png" width="380" alt="after iphone se select"> |

Selection mode at 375px is the worst case: the avatar slot hide (PR #596) reclaimed ~40px, but the orphan chevron was still eating ~20px. With both issues fixed, full merchant names ("Caltrain", "Zelle Payment", "International Wire Transfer") fit without truncation.

### iPhone 14 (390×844), default list

| Before | After |
|---|---|
| <img src="https://i.img402.dev/o2io47yh73.png" width="380" alt="before iphone 14"> | <img src="https://i.img402.dev/tr7r8tqkh4.png" width="380" alt="after iphone 14"> |

### Mobile (500×844), default list

| Before | After |
|---|---|
| <img src="https://i.img402.dev/twhwfiko6s.png" width="380" alt="before 500"> | <img src="https://i.img402.dev/eby5f5ardv.png" width="380" alt="after 500"> |

### iPhone 14 (390×844), selection mode

| Before | After |
|---|---|
| <img src="https://i.img402.dev/bbzdgbhnec.png" width="380" alt="before iphone 14 select"> | <img src="https://i.img402.dev/5k5ue4e2eo.png" width="380" alt="after iphone 14 select"> |

Tablet (820px) and desktop (1440px) behavior is unchanged — chevron still renders in list mode, still rotates on expand. I captured those states too but they're byte-identical in layout to `main`.

## Test plan

- [x] Load `/transactions` at 375×667, 390×844, 500×844, 820×1180, 1440×900 and visually verify the chevron appears only at `sm+`.
- [x] Toggle selection mode at 375px and 390px — merchant names no longer truncate, avatar slot hides as intended (PR #596 continues to work), chevron is gone.
- [x] Verify chevron still rotates on row expand at `sm+` widths (Alpine `expanded` state binds to `rotate-90` utility).
- [ ] `go build ./...` + `templ generate` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)