### PR TITLE
fix(oauth): show redirect URI host and scope on consent screen

### DIFF
--- a/internal/templates/components/pages/oauth_authorize.templ
+++ b/internal/templates/components/pages/oauth_authorize.templ
@@ -1,6 +1,36 @@
 package pages
 
-import "breadbox/internal/templates/components/layout"
+import (
+	"net/url"
+
+	"breadbox/internal/templates/components/layout"
+)
+
+// redirectHost returns the host of a redirect URI for display on the OAuth
+// consent card. Falls back to the raw URI if parsing fails or the host is
+// empty (e.g. malformed or opaque URI) so the user can still eyeball where
+// the authorization code is headed.
+func redirectHost(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return raw
+	}
+	return u.Host
+}
+
+// scopeLabel maps the raw OAuth scope string to a short human-readable label
+// shown on the consent card. Keeps the word "scope" on-screen for users
+// comparing against the permission bullets below.
+func scopeLabel(scope string) string {
+	switch scope {
+	case "read_only":
+		return "Read only"
+	case "full_access", "":
+		return "Full access"
+	default:
+		return scope
+	}
+}
 
 // OAuthAuthorizeProps carries the data the OAuth consent page needs.
 // Rendered at GET /oauth/authorize when an admin session is active. Scope
@@ -38,9 +68,19 @@ templ OAuthAuthorize(p OAuthAuthorizeProps) {
 					<p class="text-sm text-base-content/50">
 						<strong>{ p.ClientName }</strong> wants to connect to your Breadbox instance.
 					</p>
+					if p.RedirectURI != "" {
+						<p class="text-xs text-base-content/40 mt-2 break-all">
+							Redirecting to <span class="font-mono text-base-content/60">{ redirectHost(p.RedirectURI) }</span>
+						</p>
+					}
 				</div>
 				<div class="rounded-xl bg-base-200/50 p-4 mb-6">
-					<div class="text-xs font-medium text-base-content/50 mb-2">This will allow the application to:</div>
+					<div class="flex items-center justify-between gap-2 mb-2">
+						<div class="text-xs font-medium text-base-content/50">This will allow the application to:</div>
+						<span class="badge badge-sm bg-base-100 border-base-300 text-base-content/70 font-medium shrink-0">
+							{ scopeLabel(p.Scope) }
+						</span>
+					</div>
 					<ul class="space-y-2">
 						<li class="flex items-center gap-2 text-sm">
 							<i data-lucide="check" class="w-4 h-4 text-success shrink-0"></i>


### PR DESCRIPTION
Fixes #600

## Summary

Show the redirect URI host and a scope label on the OAuth consent screen so the user has enough context to tell where the authorization code is actually headed before clicking Authorize.

- New `Redirecting to <host>` line under the client name (uses `break-all` + `font-mono` so long hosts wrap within the card at 500x844; falls back to the full URI if parsing fails).
- Compact `Full access` / `Read only` badge next to the "This will allow…" header so the requested scope is always labeled, not just implied by the bullet list.
- Redirect row is omitted when `redirect_uri` is empty, so a malformed request doesn't render an empty line.

## Before / After

| Viewport | Before | After |
| --- | --- | --- |
| Mobile (500x844) | ![before-mobile](https://i.img402.dev/stjahsx8s7.png) | ![after-mobile](https://i.img402.dev/d11glypl54.png) |
| Tablet (820x1180) | ![before-tablet](https://i.img402.dev/3dk7m38w1z.png) | ![after-tablet](https://i.img402.dev/4vo84637jn.png) |
| Desktop (1440x900) | ![before-desktop](https://i.img402.dev/notiaswvmn.png) | ![after-desktop](https://i.img402.dev/po81bq7l8p.png) |

Also verified long-host wrap + `read_only` scope on mobile (badge stays on one line, host wraps with `break-all`, only the "Read your transactions…" bullet is shown — no write-mode bullets).

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/templates/... ./internal/admin/...` passes
- [x] Consent card renders the redirect host for both registered clients and dynamic-registration clients (same handler path)
- [x] Long redirect URIs wrap within the card at 500x844 (no horizontal overflow)
- [x] Missing `redirect_uri` omits the row cleanly
- [x] `read_only` scope renders the "Read only" badge and hides the two write-mode bullets

🤖 Generated with [Claude Code](https://claude.com/claude-code)