### PR TITLE
refactor(admin): use response helpers, drop hand-rolled JSON encodes

### DIFF
--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -361,8 +360,7 @@ func BatchSetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerF
 			succeeded++
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
+		writeJSON(w, http.StatusOK, map[string]any{
 			"succeeded": succeeded,
 			"failed":    failed,
 			"total":     len(req.Items),

--- a/internal/admin/reports.go
+++ b/internal/admin/reports.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -148,12 +147,10 @@ func MarkReportReadAdminHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		if err := svc.MarkAgentReportRead(r.Context(), id); err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			writeError(w, http.StatusBadRequest, "MARK_READ_FAILED", err.Error())
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+		writeOK(w)
 	}
 }
 
@@ -162,12 +159,10 @@ func MarkReportUnreadAdminHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		if err := svc.MarkAgentReportUnread(r.Context(), id); err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			writeError(w, http.StatusBadRequest, "MARK_UNREAD_FAILED", err.Error())
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+		writeOK(w)
 	}
 }
 
@@ -175,11 +170,9 @@ func MarkReportUnreadAdminHandler(svc *service.Service) http.HandlerFunc {
 func MarkAllReportsReadAdminHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := svc.MarkAllAgentReportsRead(r.Context()); err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", err.Error())
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+		writeOK(w)
 	}
 }

--- a/internal/admin/response.go
+++ b/internal/admin/response.go
@@ -31,3 +31,9 @@ func decodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	}
 	return true
 }
+
+// writeOK writes a 200 OK response with the canonical `{"ok": true}` body used
+// by fire-and-forget admin mutation endpoints.
+func writeOK(w http.ResponseWriter) {
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"errors"
 	"math"
 	"net/http"
@@ -1176,8 +1175,7 @@ func QuickSearchTransactionsHandler(svc *service.Service) http.HandlerFunc {
 
 		result, err := svc.ListTransactionsAdmin(r.Context(), params)
 		if err != nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte("[]"))
+			writeJSON(w, http.StatusOK, []service.TransactionSummary{})
 			return
 		}
 
@@ -1186,7 +1184,6 @@ func QuickSearchTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			items = append(items, service.ToTransactionSummary(tx))
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(items)
+		writeJSON(w, http.StatusOK, items)
 	}
 }

--- a/internal/admin/update.go
+++ b/internal/admin/update.go
@@ -23,9 +23,7 @@ func DismissUpdateHandler(a *app.App) http.HandlerFunc {
 			Version string `json:"version"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Version == "" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]any{"error": "version is required"})
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "version is required")
 			return
 		}
 
@@ -34,8 +32,7 @@ func DismissUpdateHandler(a *app.App) http.HandlerFunc {
 			Value: pgtype.Text{String: body.Version, Valid: true},
 		})
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		writeOK(w)
 	}
 }
 
@@ -45,22 +42,17 @@ func DismissUpdateHandler(a *app.App) http.HandlerFunc {
 func TriggerUpdateHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !a.DockerSocketAvailable {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]any{"error": "Docker socket not available"})
+			writeError(w, http.StatusBadRequest, "DOCKER_UNAVAILABLE", "Docker socket not available")
 			return
 		}
 
 		if err := pullImage(r.Context(), "ghcr.io/canalesb93/breadbox", "latest"); err != nil {
 			a.Logger.Error("docker image pull failed", "error", err)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(map[string]any{"error": fmt.Sprintf("Failed to pull image: %v", err)})
+			writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", fmt.Sprintf("Failed to pull image: %v", err))
 			return
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
+		writeJSON(w, http.StatusOK, map[string]any{
 			"ok":      true,
 			"message": "Image pulled. Run 'docker compose up -d' to complete the update.",
 			"pulled":  true,


### PR DESCRIPTION
## Summary

- Admin handlers had been bypassing `internal/admin/response.go` and re-doing `Content-Type` + `WriteHeader` + `json.NewEncoder` by hand at ~10 call sites, with inconsistent error envelopes (flat `{"error": "..."}` strings instead of the canonical `{"error": {"code", "message"}}` envelope documented in `api.md`).
- Consolidate the call sites in `reports.go`, `update.go`, `categories.go`, and `transactions.go` to use `writeJSON` / `writeError`, and add a small `writeOK` helper for the ubiquitous fire-and-forget `{"ok": true}` reply.
- Drops `encoding/json` import from three files that no longer needed it.

## Why

`.claude/rules/api.md` explicitly says: *"Admin handlers use `internal/admin/response.go` equivalents. Don't hand-roll either."* These handlers predate the rule. Net -14 LOC, and error responses now share the same envelope as the REST API.

## Safety

The affected endpoints (`/-/reports/{id}/read|unread`, `/-/reports/read-all`, `/-/update/dismiss`, `/admin/api/update`, batch-category, quick-search) are admin-only and consumed fire-and-forget by the dashboard JS — no client reads the response body, so aligning the error shape to the canonical envelope doesn't break any caller. Grepped `internal/templates/` and `static/` to confirm.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all unit tests pass (admin, api, service, etc.)
- [ ] Smoke: reviewer can verify reports mark-read / mark-all-read buttons on dashboard still hide the card on click (fire-and-forget, so no response parsing involved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)