### PR TITLE
docs(claude): mention breadbox-site sibling repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,10 @@ When stacking, use [Graphite](https://graphite.dev) (`gt`) — never raw `git pu
 - Merge to `main` auto-deploys to `breadbox.exe.xyz` via SSH.
 - See `CHANGELOG.md` and `CONTRIBUTING.md`.
 
+## Landing site
+
+The public marketing site at [breadbox.sh](https://breadbox.sh) lives in a separate private repo at `~/dev/breadbox-site` (canalesb93/breadbox-site). Astro 5 static site, deployed to Cloudflare Workers Static Assets via auto-build on push to `main`. Anything visitor-facing (hero copy, install instructions, screenshots, OG/social, footer links) belongs there — not in this repo. The README here links to breadbox.sh once mkdocs is torn down (#583).
+
 ## References
 
 Canonical specs in `docs/`:


### PR DESCRIPTION
Brief pointer in CLAUDE.md so future sessions know the marketing site at [breadbox.sh](https://breadbox.sh) lives in `canalesb93/breadbox-site` (`~/dev/breadbox-site`), not this repo.

Sets the boundary: visitor-facing copy/screenshots/install instructions belong in the site repo; product code stays here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)