### PR TITLE
refactor(pgconv): add Text/TextFromPtr constructors; drop inline wraps

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -198,7 +197,7 @@ func SetupAccountHandler(sm *scs.SessionManager, queries *db.Queries, _ *Templat
 			return
 		}
 
-		account, err := queries.GetAuthAccountBySetupToken(r.Context(), pgtype.Text{String: token, Valid: true})
+		account, err := queries.GetAuthAccountBySetupToken(r.Context(), pgconv.Text(token))
 		if err != nil {
 			renderSetupError(w, r, sm, "This setup link is invalid or has expired.")
 			return

--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -143,7 +143,7 @@ func RegenerateUserAvatarHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 		if err := a.Queries.SetUserAvatarSeed(r.Context(), db.SetUserAvatarSeedParams{
-			ID: userID, AvatarSeed: pgtype.Text{String: seed, Valid: true},
+			ID: userID, AvatarSeed: pgconv.Text(seed),
 		}); err != nil {
 			a.Logger.Error("set avatar seed", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to regenerate"})
@@ -198,7 +198,7 @@ func RegenerateMyAvatarHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 			return
 		}
 		if err := a.Queries.SetUserAvatarSeed(r.Context(), db.SetUserAvatarSeedParams{
-			ID: userID, AvatarSeed: pgtype.Text{String: seed, Valid: true},
+			ID: userID, AvatarSeed: pgconv.Text(seed),
 		}); err != nil {
 			a.Logger.Error("set avatar seed", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to regenerate"})
@@ -248,7 +248,7 @@ func processAndStoreAvatar(a *app.App, w http.ResponseWriter, r *http.Request, u
 	if err := a.Queries.SetUserAvatar(r.Context(), db.SetUserAvatarParams{
 		ID:                userID,
 		AvatarData:        processed,
-		AvatarContentType: pgtype.Text{String: ct, Valid: true},
+		AvatarContentType: pgconv.Text(ct),
 	}); err != nil {
 		a.Logger.Error("store avatar", "error", err)
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to save avatar"})

--- a/internal/admin/backups.go
+++ b/internal/admin/backups.go
@@ -8,6 +8,7 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 
 	"github.com/alexedwards/scs/v2"
@@ -222,7 +223,7 @@ func BackupScheduleHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc 
 		// Save schedule.
 		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 			Key:   "backup_schedule",
-			Value: pgtype.Text{String: schedule, Valid: true},
+			Value: pgconv.Text(schedule),
 		}); err != nil {
 			a.Logger.Error("save backup schedule", "error", err)
 			SetFlash(ctx, sm, "error", "Failed to save backup schedule.")

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -384,9 +384,9 @@ func ExchangeTokenHandler(a *app.App) http.HandlerFunc {
 		bankConn, err := a.Queries.CreateBankConnection(r.Context(), db.CreateBankConnectionParams{
 			UserID:           userID,
 			Provider:         db.ProviderType(providerName),
-			InstitutionID:    pgtype.Text{String: req.InstitutionID, Valid: true},
-			InstitutionName:  pgtype.Text{String: req.InstitutionName, Valid: true},
-			ExternalID:           pgtype.Text{String: conn.ExternalID, Valid: true},
+			InstitutionID:    pgconv.Text(req.InstitutionID),
+			InstitutionName:  pgconv.Text(req.InstitutionName),
+			ExternalID:           pgconv.Text(conn.ExternalID),
 			EncryptedCredentials: conn.EncryptedCredentials,
 			Status:           db.ConnectionStatusActive,
 		})

--- a/internal/admin/getting_started.go
+++ b/internal/admin/getting_started.go
@@ -6,9 +6,9 @@ import (
 	"breadbox/internal/app"
 	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/alexedwards/scs/v2"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // GettingStartedHandler serves GET /getting-started — the setup walkthrough page.
@@ -104,7 +104,7 @@ func DismissGettingStartedHandler(a *app.App, sm *scs.SessionManager) http.Handl
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
 			Key:   "onboarding_dismissed",
-			Value: pgtype.Text{String: "true", Valid: true},
+			Value: pgconv.Text("true"),
 		}); err != nil {
 			a.Logger.Error("dismiss getting started: set app config", "error", err)
 			SetFlash(r.Context(), sm, "error", "Failed to dismiss guide. Please try again.")
@@ -122,7 +122,7 @@ func ReopenGettingStartedHandler(a *app.App, sm *scs.SessionManager) http.Handle
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
 			Key:   "onboarding_dismissed",
-			Value: pgtype.Text{String: "false", Valid: true},
+			Value: pgconv.Text("false"),
 		}); err != nil {
 			a.Logger.Error("reopen getting started: set app config", "error", err)
 			SetFlash(r.Context(), sm, "error", "Failed to re-open guide. Please try again.")

--- a/internal/admin/providers.go
+++ b/internal/admin/providers.go
@@ -11,6 +11,7 @@ import (
 	"breadbox/internal/app"
 	"breadbox/internal/crypto"
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	plaidprovider "breadbox/internal/provider/plaid"
 	tellerprovider "breadbox/internal/provider/teller"
 	"breadbox/internal/service"
@@ -132,9 +133,9 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 		}
 
 		entries := []db.SetAppConfigParams{
-			{Key: "plaid_client_id", Value: pgtype.Text{String: plaidClientID, Valid: true}},
-			{Key: "plaid_secret", Value: pgtype.Text{String: plaidSecret, Valid: true}},
-			{Key: "plaid_env", Value: pgtype.Text{String: plaidEnv, Valid: true}},
+			{Key: "plaid_client_id", Value: pgconv.Text(plaidClientID)},
+			{Key: "plaid_secret", Value: pgconv.Text(plaidSecret)},
+			{Key: "plaid_env", Value: pgconv.Text(plaidEnv)},
 			{Key: "webhook_url", Value: pgtype.Text{String: webhookURL, Valid: webhookURL != ""}},
 		}
 		for _, entry := range entries {
@@ -214,12 +215,12 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 
 		// Save app ID, env, webhook secret.
 		configEntries := []db.SetAppConfigParams{
-			{Key: "teller_app_id", Value: pgtype.Text{String: tellerAppID, Valid: true}},
-			{Key: "teller_env", Value: pgtype.Text{String: tellerEnv, Valid: true}},
+			{Key: "teller_app_id", Value: pgconv.Text(tellerAppID)},
+			{Key: "teller_env", Value: pgconv.Text(tellerEnv)},
 		}
 		if tellerWebhookSecret != "" {
 			configEntries = append(configEntries, db.SetAppConfigParams{
-				Key: "teller_webhook_secret", Value: pgtype.Text{String: tellerWebhookSecret, Valid: true},
+				Key: "teller_webhook_secret", Value: pgconv.Text(tellerWebhookSecret),
 			})
 		}
 		for _, entry := range configEntries {
@@ -280,14 +281,14 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 				keyB64 := base64.StdEncoding.EncodeToString(encKey)
 
 				if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
-					Key: "teller_cert_pem", Value: pgtype.Text{String: certB64, Valid: true},
+					Key: "teller_cert_pem", Value: pgconv.Text(certB64),
 				}); err != nil {
 					SetFlash(ctx, sm, "error", "Failed to save certificate.")
 					http.Redirect(w, r, "/providers", http.StatusSeeOther)
 					return
 				}
 				if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
-					Key: "teller_key_pem", Value: pgtype.Text{String: keyB64, Valid: true},
+					Key: "teller_key_pem", Value: pgconv.Text(keyB64),
 				}); err != nil {
 					SetFlash(ctx, sm, "error", "Failed to save private key.")
 					http.Redirect(w, r, "/providers", http.StatusSeeOther)

--- a/internal/admin/setup.go
+++ b/internal/admin/setup.go
@@ -11,12 +11,12 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	plaidprovider "breadbox/internal/provider/plaid"
 	"breadbox/internal/templates/components/pages"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -126,7 +126,7 @@ func createLinkedAdmin(ctx context.Context, a *app.App, name, username string, h
 
 	user, err := qtx.CreateUser(ctx, db.CreateUserParams{
 		Name:  name,
-		Email: pgtype.Text{String: username, Valid: true},
+		Email: pgconv.Text(username),
 	})
 	if err != nil {
 		return fmt.Errorf("create user: %w", err)
@@ -264,8 +264,8 @@ func ProgrammaticSetupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFu
 
 		// Store all config values.
 		configEntries := []db.SetAppConfigParams{
-			{Key: "sync_interval_minutes", Value: pgtype.Text{String: req.SyncIntervalMinutes, Valid: true}},
-			{Key: "webhook_url", Value: pgtype.Text{String: req.WebhookURL, Valid: true}},
+			{Key: "sync_interval_minutes", Value: pgconv.Text(req.SyncIntervalMinutes)},
+			{Key: "webhook_url", Value: pgconv.Text(req.WebhookURL)},
 		}
 		if req.PlaidClientID != "" {
 			plaidEnv := req.PlaidEnv
@@ -273,9 +273,9 @@ func ProgrammaticSetupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFu
 				plaidEnv = "sandbox"
 			}
 			configEntries = append(configEntries,
-				db.SetAppConfigParams{Key: "plaid_client_id", Value: pgtype.Text{String: req.PlaidClientID, Valid: true}},
-				db.SetAppConfigParams{Key: "plaid_secret", Value: pgtype.Text{String: req.PlaidSecret, Valid: true}},
-				db.SetAppConfigParams{Key: "plaid_env", Value: pgtype.Text{String: plaidEnv, Valid: true}},
+				db.SetAppConfigParams{Key: "plaid_client_id", Value: pgconv.Text(req.PlaidClientID)},
+				db.SetAppConfigParams{Key: "plaid_secret", Value: pgconv.Text(req.PlaidSecret)},
+				db.SetAppConfigParams{Key: "plaid_env", Value: pgconv.Text(plaidEnv)},
 			)
 		}
 

--- a/internal/admin/update.go
+++ b/internal/admin/update.go
@@ -10,8 +10,7 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/db"
-
-	"github.com/jackc/pgx/v5/pgtype"
+	"breadbox/internal/pgconv"
 )
 
 // DismissUpdateHandler handles POST /admin/api/update/dismiss.
@@ -29,7 +28,7 @@ func DismissUpdateHandler(a *app.App) http.HandlerFunc {
 
 		_ = a.Queries.SetAppConfig(r.Context(), db.SetAppConfigParams{
 			Key:   "update_dismissed_version",
-			Value: pgtype.Text{String: body.Version, Valid: true},
+			Value: pgconv.Text(body.Version),
 		})
 
 		writeOK(w)

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -51,6 +51,22 @@ func TextPtr(t pgtype.Text) *string {
 	return &t.String
 }
 
+// Text wraps a string as a non-NULL pgtype.Text. Empty strings are preserved
+// as valid (non-NULL) empty values — use TextFromPtr when an empty/missing
+// input should map to NULL.
+func Text(s string) pgtype.Text {
+	return pgtype.Text{String: s, Valid: true}
+}
+
+// TextFromPtr wraps *string as pgtype.Text: nil → NULL, non-nil → valid
+// (including the empty string). Mirrors TextPtr in reverse.
+func TextFromPtr(s *string) pgtype.Text {
+	if s == nil {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: *s, Valid: true}
+}
+
 // TimestampStr renders a pgtype.Timestamptz as an RFC3339 UTC string. Returns
 // an empty string when the timestamp is NULL. Use for NOT NULL columns where
 // an empty response field is acceptable for the rare invalid case.

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -162,6 +162,43 @@ func TestTextPtr_Invalid(t *testing.T) {
 	}
 }
 
+func TestText(t *testing.T) {
+	got := Text("hello")
+	if !got.Valid || got.String != "hello" {
+		t.Errorf("Text(hello) = %+v, want {hello true}", got)
+	}
+}
+
+func TestText_Empty(t *testing.T) {
+	got := Text("")
+	if !got.Valid || got.String != "" {
+		t.Errorf("Text(\"\") = %+v, want {\"\" true} — empty strings stay valid", got)
+	}
+}
+
+func TestTextFromPtr_Nil(t *testing.T) {
+	got := TextFromPtr(nil)
+	if got.Valid {
+		t.Errorf("TextFromPtr(nil) = %+v, want invalid", got)
+	}
+}
+
+func TestTextFromPtr_Valid(t *testing.T) {
+	s := "hello"
+	got := TextFromPtr(&s)
+	if !got.Valid || got.String != "hello" {
+		t.Errorf("TextFromPtr(&hello) = %+v, want {hello true}", got)
+	}
+}
+
+func TestTextFromPtr_EmptyPointer(t *testing.T) {
+	s := ""
+	got := TextFromPtr(&s)
+	if !got.Valid || got.String != "" {
+		t.Errorf("TextFromPtr(&\"\") = %+v, want {\"\" true}", got)
+	}
+}
+
 func TestTimestampStr_Valid(t *testing.T) {
 	ts := pgtype.Timestamptz{
 		Time:  time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),

--- a/internal/ruleapply/annotations.go
+++ b/internal/ruleapply/annotations.go
@@ -14,6 +14,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"breadbox/internal/pgconv"
+
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -115,7 +117,7 @@ func writeAnnotation(ctx context.Context, tx pgx.Tx, r annotationRow) error {
 
 	actorID := pgtype.Text{}
 	if r.ActorID != "" {
-		actorID = pgtype.Text{String: r.ActorID, Valid: true}
+		actorID = pgconv.Text(r.ActorID)
 	}
 
 	if _, err := tx.Exec(ctx,

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -60,7 +60,7 @@ func writeAnnotation(ctx context.Context, q *db.Queries, params writeAnnotationP
 
 	actorID := pgtype.Text{}
 	if params.ActorID != "" {
-		actorID = pgtype.Text{String: params.ActorID, Valid: true}
+		actorID = pgconv.Text(params.ActorID)
 	}
 
 	_, err := q.InsertAnnotation(ctx, db.InsertAnnotationParams{

--- a/internal/service/comments.go
+++ b/internal/service/comments.go
@@ -54,7 +54,7 @@ func (s *Service) CreateComment(ctx context.Context, params CreateCommentParams)
 
 	actorID := pgtype.Text{}
 	if params.Actor.ID != "" {
-		actorID = pgtype.Text{String: params.Actor.ID, Valid: true}
+		actorID = pgconv.Text(params.Actor.ID)
 	}
 
 	payloadBytes, err := json.Marshal(payload)

--- a/internal/service/csv_import.go
+++ b/internal/service/csv_import.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	csvpkg "breadbox/internal/provider/csv"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -85,8 +86,8 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 			UserID:               userID,
 			Provider:             db.ProviderTypeCsv,
 			InstitutionID:        pgtype.Text{},
-			InstitutionName:      pgtype.Text{String: params.AccountName, Valid: true},
-			ExternalID:           pgtype.Text{String: externalID, Valid: true},
+			InstitutionName:      pgconv.Text(params.AccountName),
+			ExternalID:           pgconv.Text(externalID),
 			EncryptedCredentials: nil,
 			Status:               db.ConnectionStatusActive,
 		})
@@ -100,8 +101,8 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 			ExternalAccountID: externalID,
 			Name:              params.AccountName,
 			Type:              "depository",
-			Subtype:           pgtype.Text{String: "checking", Valid: true},
-			IsoCurrencyCode:   pgtype.Text{String: "USD", Valid: true},
+			Subtype:           pgconv.Text("checking"),
+			IsoCurrencyCode:   pgconv.Text("USD"),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("create account: %w", err)
@@ -227,12 +228,12 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 			AccountID:             accountID,
 			ExternalTransactionID: externalTxnID,
 			Amount:                amountNumeric,
-			IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
+			IsoCurrencyCode:       pgconv.Text("USD"),
 			Date:                  pgtype.Date{Time: dateVal, Valid: true},
 			Name:                  desc,
 			MerchantName:          pgtype.Text{String: merchant, Valid: merchant != ""},
 			CategoryPrimary:       pgtype.Text{String: category, Valid: category != ""},
-			PaymentChannel:        pgtype.Text{String: "other", Valid: true},
+			PaymentChannel:        pgconv.Text("other"),
 			Pending:               false,
 			CategoryID:            categoryID,
 		})

--- a/internal/service/mcp_config.go
+++ b/internal/service/mcp_config.go
@@ -6,8 +6,7 @@ import (
 	"fmt"
 
 	"breadbox/internal/db"
-
-	"github.com/jackc/pgx/v5/pgtype"
+	"breadbox/internal/pgconv"
 )
 
 // MCPConfig represents the MCP permission and instruction settings.
@@ -68,7 +67,7 @@ func (s *Service) SaveMCPMode(ctx context.Context, mode string) error {
 	}
 	return s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 		Key:   "mcp_mode",
-		Value: pgtype.Text{String: mode, Valid: true},
+		Value: pgconv.Text(mode),
 	})
 }
 
@@ -83,7 +82,7 @@ func (s *Service) SaveMCPDisabledTools(ctx context.Context, tools []string) erro
 	}
 	return s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 		Key:   "mcp_disabled_tools",
-		Value: pgtype.Text{String: string(data), Valid: true},
+		Value: pgconv.Text(string(data)),
 	})
 }
 
@@ -94,7 +93,7 @@ func (s *Service) SaveMCPInstructions(ctx context.Context, instructions string) 
 	}
 	return s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 		Key:   "mcp_instructions",
-		Value: pgtype.Text{String: instructions, Valid: true},
+		Value: pgconv.Text(instructions),
 	})
 }
 
@@ -105,7 +104,7 @@ func (s *Service) SaveMCPReviewGuidelines(ctx context.Context, guidelines string
 	}
 	return s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 		Key:   "mcp_review_guidelines",
-		Value: pgtype.Text{String: guidelines, Valid: true},
+		Value: pgconv.Text(guidelines),
 	})
 }
 
@@ -116,6 +115,6 @@ func (s *Service) SaveMCPReportFormat(ctx context.Context, format string) error 
 	}
 	return s.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 		Key:   "mcp_report_format",
-		Value: pgtype.Text{String: format, Valid: true},
+		Value: pgconv.Text(format),
 	})
 }

--- a/internal/service/members.go
+++ b/internal/service/members.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -171,7 +172,7 @@ func (s *Service) generateSetupToken(ctx context.Context, accountID pgtype.UUID)
 
 	err := s.Queries.SetAuthAccountSetupToken(ctx, db.SetAuthAccountSetupTokenParams{
 		ID:                  accountID,
-		SetupToken:          pgtype.Text{String: token, Valid: true},
+		SetupToken:          pgconv.Text(token),
 		SetupTokenExpiresAt: pgtype.Timestamptz{Time: expiresAt, Valid: true},
 	})
 	if err != nil {

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -711,7 +711,7 @@ func (s *Service) CreateTransactionRule(ctx context.Context, params CreateTransa
 	}
 	var createdByID pgtype.Text
 	if params.Actor.ID != "" {
-		createdByID = pgtype.Text{String: params.Actor.ID, Valid: true}
+		createdByID = pgconv.Text(params.Actor.ID)
 	}
 
 	query := `INSERT INTO transaction_rules (name, conditions, actions, trigger, priority, enabled, expires_at, created_by_type, created_by_id, created_by_name)

--- a/internal/service/transaction_tags.go
+++ b/internal/service/transaction_tags.go
@@ -65,7 +65,7 @@ func (s *Service) AddTransactionTag(ctx context.Context, txnID, slug string, act
 	}
 	var addedByID pgtype.Text
 	if actor.ID != "" {
-		addedByID = pgtype.Text{String: actor.ID, Valid: true}
+		addedByID = pgconv.Text(actor.ID)
 	}
 
 	rows, err := qtx.AddTransactionTag(ctx, db.AddTransactionTagParams{

--- a/internal/service/update_transactions.go
+++ b/internal/service/update_transactions.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -224,7 +225,7 @@ func (s *Service) runUpdateOpInTx(ctx context.Context, tx pgx.Tx, op UpdateTrans
 		}
 		actorID := pgtype.Text{}
 		if actor.ID != "" {
-			actorID = pgtype.Text{String: actor.ID, Valid: true}
+			actorID = pgconv.Text(actor.ID)
 		}
 		rows, err := qtx.AddTransactionTag(ctx, db.AddTransactionTagParams{
 			TransactionID: txnUID,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -106,12 +106,12 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	var errMsg pgtype.Text
 	if syncErr != nil {
 		status = db.SyncStatusError
-		errMsg = pgtype.Text{String: syncErr.Error(), Valid: true}
+		errMsg = pgconv.Text(syncErr.Error())
 	}
 
 	var warnMsg pgtype.Text
 	if warningMsg != "" {
-		warnMsg = pgtype.Text{String: warningMsg, Valid: true}
+		warnMsg = pgconv.Text(warningMsg)
 	}
 
 	// Compute duration in milliseconds from started_at.
@@ -260,8 +260,8 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 				_ = e.db.UpdateBankConnectionStatus(ctx, db.UpdateBankConnectionStatusParams{
 					ID:           connectionID,
 					Status:       db.ConnectionStatusPendingReauth,
-					ErrorCode:    pgtype.Text{String: "ITEM_LOGIN_REQUIRED", Valid: true},
-					ErrorMessage: pgtype.Text{String: "Re-authentication required by institution", Valid: true},
+					ErrorCode:    pgconv.Text("ITEM_LOGIN_REQUIRED"),
+					ErrorMessage: pgconv.Text("Re-authentication required by institution"),
 				})
 				return 0, 0, 0, 0, nil, nil, "", syncErr
 			}
@@ -392,7 +392,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 		// Commit cursor.
 		if err := txQueries.UpdateBankConnectionCursor(ctx, db.UpdateBankConnectionCursorParams{
 			ID:         connectionID,
-			SyncCursor: pgtype.Text{String: result.Cursor, Valid: true},
+			SyncCursor: pgconv.Text(result.Cursor),
 		}); err != nil {
 			return added, modified, removed, unchanged, perAccount, nil, "", fmt.Errorf("update cursor: %w", err)
 		}
@@ -923,7 +923,7 @@ func writeSyncAnnotation(ctx context.Context, tx pgx.Tx, params writeSyncAnnotat
 
 	actorID := pgtype.Text{}
 	if params.ActorID != "" {
-		actorID = pgtype.Text{String: params.ActorID, Valid: true}
+		actorID = pgconv.Text(params.ActorID)
 	}
 
 	_, err := tx.Exec(ctx,

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/provider"
 	"breadbox/internal/sync"
 
@@ -67,7 +68,7 @@ func NewHandler(providers map[string]provider.Provider, engine *sync.Engine, que
 		// Look up the internal connection by provider + external ID.
 		conn, err := queries.GetBankConnectionByExternalID(r.Context(), db.GetBankConnectionByExternalIDParams{
 			Provider:   db.ProviderType(providerName),
-			ExternalID: pgtype.Text{String: event.ConnectionID, Valid: true},
+			ExternalID: pgconv.Text(event.ConnectionID),
 		})
 		if err != nil {
 			logger.Error("failed to look up connection", "error", err)


### PR DESCRIPTION
## Summary

Continues the `pgconv` consolidation from [#611](https://github.com/canalesb93/breadbox/pull/611) and [#613](https://github.com/canalesb93/breadbox/pull/613) by adding the **reverse** direction — primitive → `pgtype.Text`. Replaces 48 inline `pgtype.Text{String: s, Valid: true}` constructions with `pgconv.Text(s)`.

- **`Text(s string) pgtype.Text`** — always valid. Empty strings stay valid (use `TextFromPtr` when empty should map to NULL).
- **`TextFromPtr(s *string) pgtype.Text`** — nil → NULL, non-nil → valid (including empty). Mirrors `TextPtr` in reverse.

## Scope

- `internal/pgconv/pgconv.go` — two new helpers
- `internal/pgconv/pgconv_test.go` — 5 unit tests covering empty strings, nil pointers, and pointer-to-empty cases
- 19 files across `admin/`, `service/`, `sync/`, `webhook/`, `ruleapply/` updated to call `pgconv.Text(x)` instead of the inline literal
- Drops `pgtype` imports from 4 files (`admin/auth.go`, `admin/getting_started.go`, `admin/setup.go`, `admin/update.go`, `service/mcp_config.go`) that no longer need them

**Left untouched:** the handful of `if x != nil { y = pgtype.Text{String: *x, Valid: true} }` blocks that could migrate to `TextFromPtr`. Some conflate nil with empty string, so they need case-by-case review. A future pass can tackle those.

No behavior change.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes (unit)
- [x] `go test -tags integration -p 1 ./internal/service/... ./internal/sync/... ./internal/admin/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)