### PR TITLE
ux(transactions): chip row summarises active filters when panel collapsed

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -328,6 +328,10 @@ func renderTransactions(w http.ResponseWriter, r *http.Request, tr *TemplateRend
 		ExportURL:         in.exportURL,
 		Results:           results,
 	}
+	// Chip summary renders above the results when the filter panel is
+	// collapsed. Built after the rest of props so all lookup lists (names
+	// for connections/accounts/users/categories/tags) are already populated.
+	props.FilterChips = buildTransactionFilterChips(r, props)
 
 	data := map[string]any{
 		"PageTitle":   "Transactions",

--- a/internal/admin/transactions_filter_chips.go
+++ b/internal/admin/transactions_filter_chips.go
@@ -1,0 +1,231 @@
+package admin
+
+import (
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"breadbox/internal/service"
+	"breadbox/internal/templates/components/pages"
+)
+
+// buildTransactionFilterChips renders one TransactionsFilterChip per active
+// filter on /transactions. Chips are shown above the list when the filter
+// panel is collapsed so the user can see (and individually clear) what's
+// narrowing the view without having to open eight controls. Display labels
+// resolve IDs (connection/account/user/category/tag slugs) to human names
+// using the same dropdown option lists already hydrated for the form.
+//
+// Each chip's RemoveURL is the current request URL with that one query
+// param dropped (tags/any_tag chips remove a single slug from the CSV list).
+// page is always cleared so we don't land on a now-empty later page.
+func buildTransactionFilterChips(
+	r *http.Request,
+	props pages.TransactionsProps,
+) []pages.TransactionsFilterChip {
+	q := r.URL.Query()
+	var chips []pages.TransactionsFilterChip
+
+	add := func(label string, drop ...string) {
+		chips = append(chips, pages.TransactionsFilterChip{
+			Label:     label,
+			RemoveURL: removeFilterURL(q, drop...),
+		})
+	}
+
+	if props.FilterSearch != "" {
+		add("Search: "+props.FilterSearch, "search")
+	}
+	if props.FilterStartDate != "" {
+		add("From: "+props.FilterStartDate, "start_date")
+	}
+	if props.FilterEndDate != "" {
+		add("To: "+props.FilterEndDate, "end_date")
+	}
+	if props.FilterConnID != "" {
+		if name := lookupConnectionName(props.Connections, props.FilterConnID); name != "" {
+			add("Connection: "+name, "connection_id")
+		} else {
+			add("Connection", "connection_id")
+		}
+	}
+	if props.FilterAccountID != "" {
+		if name := lookupAccountName(props.Accounts, props.FilterAccountID); name != "" {
+			add("Account: "+name, "account_id")
+		} else {
+			add("Account", "account_id")
+		}
+	}
+	if props.FilterUserID != "" {
+		if name := lookupUserName(props.Users, props.FilterUserID); name != "" {
+			add("Member: "+name, "user_id")
+		} else {
+			add("Member", "user_id")
+		}
+	}
+	if props.FilterCategory != "" {
+		if name := lookupCategoryName(props.Categories, props.FilterCategory); name != "" {
+			add("Category: "+name, "category")
+		} else {
+			add("Category: "+props.FilterCategory, "category")
+		}
+	}
+	if props.FilterMinAmount != "" {
+		add("Min: "+formatAmountForChip(props.FilterMinAmount), "min_amount")
+	}
+	if props.FilterMaxAmount != "" {
+		add("Max: "+formatAmountForChip(props.FilterMaxAmount), "max_amount")
+	}
+	if props.FilterPending == "true" {
+		add("Pending: Yes", "pending")
+	} else if props.FilterPending == "false" {
+		add("Pending: No", "pending")
+	}
+
+	// Tag chips drop a single slug out of the CSV rather than clearing the
+	// whole list. "tags" and "any_tag" are exclusive in the UI but handled
+	// the same way either way.
+	for _, slug := range props.FilterTags {
+		label := lookupTagLabel(props.AllTags, slug)
+		chips = append(chips, pages.TransactionsFilterChip{
+			Label:     "Tag: " + label,
+			RemoveURL: removeTagFromCSV(q, "tags", slug),
+		})
+	}
+	for _, slug := range props.FilterAnyTag {
+		label := lookupTagLabel(props.AllTags, slug)
+		chips = append(chips, pages.TransactionsFilterChip{
+			Label:     "Tag: " + label,
+			RemoveURL: removeTagFromCSV(q, "any_tag", slug),
+		})
+	}
+
+	return chips
+}
+
+// removeFilterURL returns /transactions?<current-query-minus-keys>. Always
+// drops "page" so clearing a filter doesn't leave us on a now-empty page.
+func removeFilterURL(q url.Values, keys ...string) string {
+	next := cloneValues(q)
+	for _, k := range keys {
+		next.Del(k)
+	}
+	next.Del("page")
+	return "/transactions" + queryStringPrefix(next)
+}
+
+// removeTagFromCSV preserves the other comma-separated tag slugs and drops
+// just the one. If the list becomes empty the whole param is removed.
+func removeTagFromCSV(q url.Values, key, slug string) string {
+	next := cloneValues(q)
+	raw := next.Get(key)
+	if raw == "" {
+		next.Del(key)
+	} else {
+		parts := strings.Split(raw, ",")
+		kept := parts[:0]
+		for _, p := range parts {
+			if p != slug && p != "" {
+				kept = append(kept, p)
+			}
+		}
+		if len(kept) == 0 {
+			next.Del(key)
+		} else {
+			next.Set(key, strings.Join(kept, ","))
+		}
+	}
+	next.Del("page")
+	return "/transactions" + queryStringPrefix(next)
+}
+
+func cloneValues(q url.Values) url.Values {
+	out := make(url.Values, len(q))
+	for k, vs := range q {
+		cp := make([]string, len(vs))
+		copy(cp, vs)
+		out[k] = cp
+	}
+	return out
+}
+
+func queryStringPrefix(q url.Values) string {
+	if len(q) == 0 {
+		return ""
+	}
+	return "?" + q.Encode()
+}
+
+func lookupConnectionName(opts []pages.TransactionsConnectionOption, id string) string {
+	for _, o := range opts {
+		if o.ID == id {
+			return o.InstitutionName
+		}
+	}
+	return ""
+}
+
+func lookupAccountName(opts []pages.TransactionsAccountOption, id string) string {
+	for _, o := range opts {
+		if o.ID == id {
+			if o.Mask != "" {
+				return o.Name + " ••" + o.Mask
+			}
+			return o.Name
+		}
+	}
+	return ""
+}
+
+func lookupUserName(opts []pages.TransactionsUserOption, id string) string {
+	for _, o := range opts {
+		if o.ID == id {
+			return o.Name
+		}
+	}
+	return ""
+}
+
+// lookupCategoryName walks the two-level category tree and returns the
+// display name for a slug, including the parent for subcategories so the
+// chip is unambiguous.
+func lookupCategoryName(cats []service.CategoryResponse, slug string) string {
+	for _, parent := range cats {
+		if parent.Slug == slug {
+			return parent.DisplayName
+		}
+		for _, child := range parent.Children {
+			if child.Slug == slug {
+				return parent.DisplayName + " › " + child.DisplayName
+			}
+		}
+	}
+	return ""
+}
+
+func lookupTagLabel(tags []service.TagResponse, slug string) string {
+	for _, t := range tags {
+		if t.Slug == slug {
+			if t.DisplayName != "" {
+				return t.DisplayName
+			}
+			return t.Slug
+		}
+	}
+	return slug
+}
+
+// formatAmountForChip renders a compact amount label — "$50" if whole,
+// "$12.34" otherwise. The incoming string is already a user-supplied
+// decimal so a single ParseFloat is enough; on failure we echo the raw.
+func formatAmountForChip(raw string) string {
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return raw
+	}
+	if v == float64(int64(v)) {
+		return "$" + strconv.FormatInt(int64(v), 10)
+	}
+	return "$" + strconv.FormatFloat(v, 'f', 2, 64)
+}

--- a/internal/admin/transactions_filter_chips_test.go
+++ b/internal/admin/transactions_filter_chips_test.go
@@ -1,0 +1,162 @@
+package admin
+
+import (
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"breadbox/internal/service"
+	"breadbox/internal/templates/components/pages"
+)
+
+// TestBuildTransactionFilterChips covers the label-resolution and
+// remove-URL construction for every active-filter type. The chip row is
+// the only user-visible summary when the panel is collapsed (#592), so
+// the labels need to match the filter they represent *exactly* and the
+// × link must drop just that one param.
+func TestBuildTransactionFilterChips(t *testing.T) {
+	cats := []service.CategoryResponse{
+		{Slug: "food_and_drink", DisplayName: "Food & Drink", Children: []service.CategoryResponse{
+			{Slug: "food_and_drink_groceries", DisplayName: "Groceries"},
+		}},
+	}
+	tags := []service.TagResponse{
+		{Slug: "needs-review", DisplayName: "Needs Review"},
+	}
+	conns := []pages.TransactionsConnectionOption{
+		{ID: "conn-abc", InstitutionName: "Acme Bank"},
+	}
+	accts := []pages.TransactionsAccountOption{
+		{ID: "acct-abc", Name: "Checking", Mask: "1234"},
+	}
+	users := []pages.TransactionsUserOption{
+		{ID: "user-abc", Name: "Ricardo"},
+	}
+
+	tests := []struct {
+		name       string
+		url        string
+		props      pages.TransactionsProps
+		wantChips  []pages.TransactionsFilterChip
+		wantMinLen int
+	}{
+		{
+			name: "single search chip",
+			url:  "/transactions?search=payment",
+			props: pages.TransactionsProps{
+				FilterSearch: "payment",
+			},
+			wantChips: []pages.TransactionsFilterChip{
+				{Label: "Search: payment", RemoveURL: "/transactions"},
+			},
+		},
+		{
+			name: "three filters drop only one each",
+			url:  "/transactions?search=payment&min_amount=50&pending=false",
+			props: pages.TransactionsProps{
+				FilterSearch:    "payment",
+				FilterMinAmount: "50",
+				FilterPending:   "false",
+			},
+			wantChips: []pages.TransactionsFilterChip{
+				{Label: "Search: payment", RemoveURL: "/transactions?min_amount=50&pending=false"},
+				{Label: "Min: $50", RemoveURL: "/transactions?pending=false&search=payment"},
+				{Label: "Pending: No", RemoveURL: "/transactions?min_amount=50&search=payment"},
+			},
+		},
+		{
+			name: "resolves connection/account/user/category names",
+			url:  "/transactions?connection_id=conn-abc&account_id=acct-abc&user_id=user-abc&category=food_and_drink_groceries",
+			props: pages.TransactionsProps{
+				FilterConnID:    "conn-abc",
+				FilterAccountID: "acct-abc",
+				FilterUserID:    "user-abc",
+				FilterCategory:  "food_and_drink_groceries",
+				Connections:     conns,
+				Accounts:        accts,
+				Users:           users,
+				Categories:      cats,
+			},
+			wantChips: []pages.TransactionsFilterChip{
+				{Label: "Connection: Acme Bank", RemoveURL: "/transactions?account_id=acct-abc&category=food_and_drink_groceries&user_id=user-abc"},
+				{Label: "Account: Checking ••1234", RemoveURL: "/transactions?category=food_and_drink_groceries&connection_id=conn-abc&user_id=user-abc"},
+				{Label: "Member: Ricardo", RemoveURL: "/transactions?account_id=acct-abc&category=food_and_drink_groceries&connection_id=conn-abc"},
+				{Label: "Category: Food & Drink › Groceries", RemoveURL: "/transactions?account_id=acct-abc&connection_id=conn-abc&user_id=user-abc"},
+			},
+		},
+		{
+			name: "tag CSV drops single slug",
+			url:  "/transactions?tags=needs-review,foo",
+			props: pages.TransactionsProps{
+				FilterTags: []string{"needs-review", "foo"},
+				AllTags:    tags,
+			},
+			wantChips: []pages.TransactionsFilterChip{
+				{Label: "Tag: Needs Review", RemoveURL: "/transactions?tags=foo"},
+				{Label: "Tag: foo", RemoveURL: "/transactions?tags=needs-review"},
+			},
+		},
+		{
+			name: "empty when no filters",
+			url:  "/transactions",
+			props: pages.TransactionsProps{},
+		},
+		{
+			name: "page param is always dropped",
+			url:  "/transactions?search=a&page=7",
+			props: pages.TransactionsProps{
+				FilterSearch: "a",
+			},
+			wantChips: []pages.TransactionsFilterChip{
+				{Label: "Search: a", RemoveURL: "/transactions"},
+			},
+		},
+		{
+			name: "pending=true renders Yes",
+			url:  "/transactions?pending=true",
+			props: pages.TransactionsProps{
+				FilterPending: "true",
+			},
+			wantChips: []pages.TransactionsFilterChip{
+				{Label: "Pending: Yes", RemoveURL: "/transactions"},
+			},
+		},
+		{
+			name: "fractional amount formatted with decimals",
+			url:  "/transactions?min_amount=12.34",
+			props: pages.TransactionsProps{
+				FilterMinAmount: "12.34",
+			},
+			wantChips: []pages.TransactionsFilterChip{
+				{Label: "Min: $12.34", RemoveURL: "/transactions"},
+			},
+		},
+		{
+			name: "unknown category slug falls back to raw",
+			url:  "/transactions?category=weird-slug",
+			props: pages.TransactionsProps{
+				FilterCategory: "weird-slug",
+				Categories:     cats,
+			},
+			wantChips: []pages.TransactionsFilterChip{
+				{Label: "Category: weird-slug", RemoveURL: "/transactions"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", tt.url, nil)
+			got := buildTransactionFilterChips(r, tt.props)
+			if tt.wantChips == nil {
+				if len(got) != 0 {
+					t.Fatalf("expected no chips, got %+v", got)
+				}
+				return
+			}
+			if !reflect.DeepEqual(got, tt.wantChips) {
+				t.Fatalf("chips mismatch\nwant: %+v\n got: %+v", tt.wantChips, got)
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -305,6 +305,31 @@ templ txFilters(p TransactionsProps) {
 				</button>
 			</div>
 		</form>
+		if len(p.FilterChips) > 0 {
+			@txFilterChips(p.FilterChips)
+		}
+	</div>
+}
+
+// txFilterChips renders a row of removable chips summarising each active
+// filter. Shown only when the filter panel is collapsed (x-show="!filtersOpen")
+// so the chips and the expanded panel never duplicate each other. Each chip's
+// × link drops just that one param from the current URL.
+templ txFilterChips(chips []TransactionsFilterChip) {
+	<div x-show="!filtersOpen" x-cloak class="flex flex-wrap items-center gap-1.5 mt-3" aria-label="Active filters">
+		for _, chip := range chips {
+			<span class="inline-flex items-center gap-1 pl-2.5 pr-1 py-1 rounded-full bg-primary/10 text-primary text-xs font-medium">
+				<span>{ chip.Label }</span>
+				<a
+					href={ templ.SafeURL(chip.RemoveURL) }
+					class="inline-flex items-center justify-center w-4 h-4 rounded-full hover:bg-primary/20 transition-colors"
+					aria-label={ "Remove filter " + chip.Label }
+					title={ "Remove " + chip.Label }
+				>
+					<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg>
+				</a>
+			</span>
+		}
 	</div>
 }
 

--- a/internal/templates/components/pages/transactions_types.go
+++ b/internal/templates/components/pages/transactions_types.go
@@ -24,6 +24,16 @@ type TransactionsUserOption struct {
 	Name string
 }
 
+// TransactionsFilterChip describes one active-filter chip rendered above the
+// transaction list when the filter panel is collapsed. Each chip shows a
+// human-readable label and links to the current URL with just that one
+// filter dropped so the user can clear filters individually without having
+// to open the panel.
+type TransactionsFilterChip struct {
+	Label     string
+	RemoveURL string
+}
+
 // TransactionsProps is the full view model the transactions page renders.
 // Hosted inside base.html via TemplateRenderer.RenderWithTempl. The AJAX
 // tx-results fragment (TxResultsProps) is embedded so the same templ
@@ -58,6 +68,10 @@ type TransactionsProps struct {
 	FilterSort        string
 	FilterTags        []string
 	FilterAnyTag      []string
+
+	// Active-filter chip summary. Populated by the admin handler so the view
+	// can render one chip per applied filter when the panel is collapsed.
+	FilterChips []TransactionsFilterChip
 
 	// Export + pagination base URLs.
 	ExportURL string


### PR DESCRIPTION
Fixes #592.

## Summary
Renders a server-side chip row between the search input and the
transaction list whenever at least one filter is active and the filter
panel is collapsed. Each chip shows a human-readable label (e.g.
`Search: payment`, `Min: $50`, `Pending: No`, `Category: Food & Drink ›
Groceries`, `Tag: Needs Review`) with an × link that reloads the page
with just that one param dropped. The whole row is hidden when the
panel is open so nothing is duplicated, and it's not rendered at all
when no filters are active.

Label resolution (connection / account / member / category / tag) reuses
the option lists already hydrated for the filter form — no extra
queries. Tag CSVs drop a single slug rather than clearing the whole
list. `page=` is always stripped so clearing a filter doesn't land on
an empty later page.

## Before / After
`/transactions?search=payment&min_amount=50&pending=false` with the
filter panel collapsed.

<table>
<tr><th>Desktop 1440</th></tr>
<tr><td>Before<br><img src="https://i.img402.dev/weqpkw69g5.png" width="800" alt="desktop before"></td></tr>
<tr><td>After<br><img src="https://i.img402.dev/2u1a0i1a5b.png" width="800" alt="desktop after"></td></tr>
<tr><th>Tablet 820</th></tr>
<tr><td>Before<br><img src="https://i.img402.dev/8jhf7u4mkn.png" width="600" alt="tablet before"></td></tr>
<tr><td>After<br><img src="https://i.img402.dev/jqlr6ls65m.png" width="600" alt="tablet after"></td></tr>
<tr><th>Mobile 500</th></tr>
<tr><td>Before<br><img src="https://i.img402.dev/b5lvypbfjg.png" width="400" alt="mobile before"></td></tr>
<tr><td>After<br><img src="https://i.img402.dev/0l0am8fs4g.png" width="400" alt="mobile after"></td></tr>
</table>

## Test plan
- [x] `go test ./internal/admin/... -run TestBuildTransactionFilterChips -v` — 9 subtests cover search/date/amount/pending/tag/category/lookup-miss and the drop-just-one-param URL behaviour
- [x] `go test ./...` — full unit suite green
- [x] `templ generate` + `templ fmt .` no-op
- [x] Browser validation at 500×844 / 820×1180 / 1440×900 against a live
      server — chips appear when panel collapsed, hidden when expanded,
      × link removes that single filter, zero-filter state is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)