### PR TITLE
fix(reports): restore monotonic heading hierarchy in markdown body

### DIFF
--- a/input.css
+++ b/input.css
@@ -2414,16 +2414,16 @@
     @apply text-sm text-base-content/85 leading-relaxed;
   }
   .bb-report-body > :first-child { @apply mt-0; }
-  .bb-report-body h1 { @apply text-lg font-semibold text-base-content mt-6 mb-2; }
-  .bb-report-body h2 { @apply text-base font-semibold text-base-content mt-5 mb-2; }
-  .bb-report-body h3 {
-    @apply text-[0.7rem] font-semibold uppercase tracking-wider text-base-content/50 mt-5 mb-1.5;
+  .bb-report-body h1 { @apply text-xl font-semibold text-base-content mt-6 mb-2; }
+  .bb-report-body h2 { @apply text-lg font-semibold text-base-content mt-5 mb-2; }
+  .bb-report-body h3 { @apply text-base font-semibold text-base-content mt-5 mb-1.5; }
+  .bb-report-body h4 {
+    @apply text-sm font-semibold uppercase tracking-wider text-base-content/60 mt-4 mb-1;
   }
-  .bb-report-body h4 { @apply text-sm font-semibold text-base-content/80 mt-4 mb-1; }
   .bb-report-body p  { @apply mb-3; }
   .bb-report-body ul { @apply list-disc pl-5 space-y-1 my-2; }
   .bb-report-body ol { @apply list-decimal pl-5 space-y-1 my-2; }
-  .bb-report-body li { @apply marker:text-base-content/30; }
+  .bb-report-body li { @apply marker:text-base-content/60; }
   .bb-report-body strong { @apply font-semibold text-base-content; }
   .bb-report-body em { @apply italic; }
   .bb-report-body a  { @apply text-primary underline decoration-primary/30 hover:decoration-primary underline-offset-2; }


### PR DESCRIPTION
Fixes #616

Markdown H3 rendered as an 11.2px uppercase eyebrow — smaller than the 14px body text — inverting semantic hierarchy. H4 was flat against body, and ordered-list markers at `base-content/30` were nearly invisible despite being content.

New scale (per issue's proposed fix):

| Element | Before | After |
|---|---|---|
| `h1` | `text-lg font-semibold` | `text-xl font-semibold` |
| `h2` | `text-base font-semibold` | `text-lg font-semibold` |
| `h3` | `text-[0.7rem] font-semibold uppercase tracking-wider text-base-content/50` | `text-base font-semibold` |
| `h4` | `text-sm font-semibold text-base-content/80` | `text-sm font-semibold uppercase tracking-wider text-base-content/60` (takes over eyebrow role) |
| `li` marker | `marker:text-base-content/30` | `marker:text-base-content/60` |

Result: H1 > H2 > H3 = body, monotonic. H4 now owns the tiny-uppercase eyebrow slot (cleanly distinct from content headings). Ordered-list numbers readable.

## Before / After — typography kit injected into `.bb-report-body`

<table>
<tr><th>Viewport</th><th>Before</th><th>After</th></tr>
<tr><td>375</td>
<td><img src="https://i.img402.dev/z1p28hia9l.png" width="400" alt="before 375"></td>
<td><img src="https://i.img402.dev/kl35lwgwyr.png" width="400" alt="after 375"></td>
</tr>
<tr><td>500</td>
<td><img src="https://i.img402.dev/jyxo0ookns.png" width="400" alt="before 500"></td>
<td><img src="https://i.img402.dev/jgckztaugz.png" width="400" alt="after 500"></td>
</tr>
<tr><td>820</td>
<td><img src="https://i.img402.dev/26hya6ev4x.png" width="400" alt="before 820"></td>
<td><img src="https://i.img402.dev/6nwa6r7iv2.png" width="400" alt="after 820"></td>
</tr>
<tr><td>1440</td>
<td><img src="https://i.img402.dev/zcetjp5rp2.png" width="400" alt="before 1440"></td>
<td><img src="https://i.img402.dev/gl13y15dns.png" width="400" alt="after 1440"></td>
</tr>
</table>

## Test plan
- [x] Visual validation at 375/500/820/1440 via headless Chrome with typography kit injected into a real `/reports/:id` body
- [x] H1 > H2 > H3 ≥ body, monotonic
- [x] H3 no longer uppercase eyebrow
- [x] Ordered-list numbers legible
- [x] No changes to tables/blockquotes/code/links — only heading + marker utilities touched
- [x] `go build ./...` clean

## Notes
`static/css/styles.css` is gitignored (built at Docker stage / via `make css`), so this PR only ships the `input.css` source change.

Generated with [Claude Code](https://claude.com/claude-code)