### PR TITLE
fix(my-account): stack cards in single centered column on desktop

### DIFF
--- a/internal/templates/pages/my_account.html
+++ b/internal/templates/pages/my_account.html
@@ -1,4 +1,5 @@
 {{define "content"}}
+<div class="max-w-2xl mx-auto">
 <div class="bb-page-header">
   <div>
     <h1 class="bb-page-title">My Account</h1>
@@ -59,7 +60,7 @@
 </div>
 {{end}}
 
-<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+<div class="space-y-6">
   <!-- Change Password -->
   <div class="bb-card">
     <div class="p-5 border-b border-base-300">
@@ -154,6 +155,7 @@
       </template>
     </div>
   </div>
+</div>
 </div>
 
 {{if .UserID}}


### PR DESCRIPTION
Fixes #627

Wraps the `/my-account` content in `max-w-2xl mx-auto` and replaces the `lg:grid-cols-2` grid with a vertical `space-y-6` stack. Eliminates the 2-col-with-3-children jagged-ends layout, the ~300px empty gap under My Connections, and the mostly-empty full-width Profile Picture card. Mobile layout is unchanged (already single-column).

## Before / After — 1440

| Before | After |
| --- | --- |
| ![before 1440](https://i.img402.dev/m4mtquvfbh.png) | ![after 1440](https://i.img402.dev/ty7syz8qvt.png) |

## Before / After — 820

| Before | After |
| --- | --- |
| ![before 820](https://i.img402.dev/qc8e48izeq.png) | ![after 820](https://i.img402.dev/huda5th1oz.png) |

## Before / After — 375 (unchanged)

| Before | After |
| --- | --- |
| ![before 375](https://i.img402.dev/cldoa0x5jz.png) | ![after 375](https://i.img402.dev/pkulhoivh2.png) |

## Test plan
- [x] `go build ./...`
- [x] Visual: /my-account at 375, 500, 820, 1440 — cards stack in a single ~42 rem centered column on desktop
- [x] Mobile single-column layout is unchanged