### PR TITLE
refactor(tags): drop ephemeral-note requirement; deprecate lifecycle column

### DIFF
--- a/.claude/agents/breadbox-mcp-expert.md
+++ b/.claude/agents/breadbox-mcp-expert.md
@@ -60,7 +60,7 @@ You help the team:
 1. **Every tagged transaction must be individually assessed** — no auto-approve, no bulk-remove of a trigger tag without examination. Rules pre-categorize but agents still review in the vanilla setup.
 2. **Rules are forward-looking** — apply_retroactively=true only during initial setup, NEVER routine
 3. **apply_rules is dangerous** — NEVER during routine reviews, only explicit one-off bulk operations
-4. **Ephemeral tag removal requires a note** — the server enforces this for lifecycle=ephemeral tags (e.g., needs-review). The note is the audit trail. Agents should also read prior `list_annotations` output to respect existing feedback.
+4. **Tag-removal notes are optional but helpful** — when provided they land on the `tag_removed` annotation and form the audit trail. Agents should also read prior `list_annotations` output to respect existing feedback.
 5. **Skip rather than guess** — uncertain transactions should be left tagged, not removed with a fabricated category
 6. **Open system** — instructions are defaults, not requirements. Users can customize, disable, or replace everything. Never write instructions that assume a locked-in workflow.
 7. **Prefer compound operations** — `update_transactions` does set_category + tags_to_add + tags_to_remove + comment atomically per-op. Don't loop single-op tools when one compound call suffices.

--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -67,6 +67,6 @@ Good descriptions are load-bearing — they're the only documentation agents see
 
 The "review queue" is just transactions tagged `needs-review`. A seeded system rule (NULL conditions, `trigger=on_create`, action `add_tag: needs-review`) auto-tags every newly-synced transaction. Disable that rule to opt out of auto-review.
 
-Agents follow a uniform loop: `query_transactions(tags=["needs-review"])` to find work, `update_transactions(operations=[…])` to set category + remove the tag (with a required note since `needs-review` is ephemeral) atomically per transaction. Max 50 ops per call.
+Agents follow a uniform loop: `query_transactions(tags=["needs-review"])` to find work, `update_transactions(operations=[…])` to set category + remove the tag (an optional note lands on the `tag_removed` annotation) atomically per transaction. Max 50 ops per call.
 
 Tag/annotation tools: `list_tags`, `add_transaction_tag`, `remove_transaction_tag`, `list_annotations`, plus tag CRUD admin tools (`create_tag`, `update_tag`, `delete_tag`).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -114,7 +114,7 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 
 ## Tags & Reviews
 
-The review queue is a tag. Transactions carrying the seeded `needs-review` tag (or any operator-defined trigger tag) are the backlog. A seeded `on_create` system rule auto-attaches `needs-review` to every newly-synced transaction; disable that rule to opt out. When removing an ephemeral tag (lifecycle `ephemeral`), passing a rationale `note` is strongly recommended — it's recorded on the `tag_removed` annotation.
+The review queue is a tag. Transactions carrying the seeded `needs-review` tag (or any operator-defined trigger tag) are the backlog. A seeded `on_create` system rule auto-attaches `needs-review` to every newly-synced transaction; disable that rule to opt out. When removing a tag, passing a rationale `note` is optional — if provided, it's recorded on the `tag_removed` annotation.
 
 Tag management is exposed via the MCP tools (`list_tags`, `add_transaction_tag`, `remove_transaction_tag`, `create_tag`, `update_tag`, `delete_tag`, `update_transactions`, `list_annotations`) and the admin dashboard (`/tags`, `/transactions/:id/edit`, bulk actions on `/transactions`).
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -44,7 +44,7 @@ This document defines the complete PostgreSQL database schema for the Breadbox M
 | `sync_logs` | Immutable audit trail of every sync operation attempt. |
 | `api_keys` | Hashed API keys for REST API and MCP access. |
 | `app_config` | Key-value store for runtime configuration set during the first-run setup wizard. |
-| `tags` | Reusable labels attached to transactions (e.g. `needs-review`). Ephemeral tags require a note on removal. |
+| `tags` | Reusable labels attached to transactions (e.g. `needs-review`). |
 | `transaction_tags` | Many-to-many join between transactions and tags with attribution metadata. |
 | `annotations` | Unified activity timeline per transaction (comments, tag events, rule applications, category sets). |
 
@@ -627,7 +627,7 @@ The following keys are seeded during initial migration and used by the applicati
 | `description` | `TEXT` | No | `''` | Operator-facing description. |
 | `color` | `TEXT` | Yes | `NULL` | CSS color used when rendering the tag chip. |
 | `icon` | `TEXT` | Yes | `NULL` | Lucide icon name for chip rendering. |
-| `lifecycle` | `TEXT` | No | `'persistent'` | `persistent` or `ephemeral`. Ephemeral tags require a non-empty note on removal (enforced by service layer, recorded on the `tag_removed` annotation payload). |
+| `lifecycle` | `TEXT` | No | `'persistent'` | **Deprecated.** Legacy persistent/ephemeral distinction — no longer read or written by the app. Column remains in the schema for backwards compatibility; all new rows default to `persistent`. Notes on tag removal are optional and recorded on the `tag_removed` annotation payload regardless. |
 | `created_at` | `TIMESTAMPTZ` | No | `NOW()` | Record creation timestamp. |
 | `updated_at` | `TIMESTAMPTZ` | No | `NOW()` | Last modification timestamp. |
 
@@ -645,14 +645,14 @@ UNIQUE (short_id)
 #### Check Constraints
 
 ```sql
-CHECK (lifecycle IN ('persistent', 'ephemeral'))
+CHECK (lifecycle IN ('persistent', 'ephemeral')) -- deprecated, column no longer used
 ```
 
 #### Seeds
 
-| Slug | Display Name | Lifecycle | Purpose |
-|---|---|---|---|
-| `needs-review` | Needs Review | `ephemeral` | Marks transactions awaiting initial categorization review. The seeded `on_create` system rule auto-attaches this tag during sync. |
+| Slug | Display Name | Purpose |
+|---|---|---|
+| `needs-review` | Needs Review | Marks transactions awaiting initial categorization review. The seeded `on_create` system rule auto-attaches this tag during sync. |
 
 A companion seeded system rule on `transaction_rules` fires on every `on_create` event and attaches `needs-review` to newly-synced transactions. To opt out of the default review queue, disable that rule from `/rules` — this is the supported opt-out. System-seeded rules can't be deleted, only disabled.
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -162,13 +162,13 @@ Attach a tag to a transaction. Auto-creates a persistent tag if the slug is unkn
 
 ### remove_transaction_tag (Write)
 
-Remove a tag from a transaction. A `note` is strongly recommended for ephemeral tags (`needs-review`) — it lands on the `tag_removed` annotation. Idempotent.
+Remove a tag from a transaction. An optional `note` lands on the `tag_removed` annotation. Idempotent.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `transaction_id` | string | UUID or short ID |
 | `tag_slug` | string | Tag slug |
-| `note` | string | Optional. Recommended for ephemeral tags so the rationale lands on the audit trail. |
+| `note` | string | Optional rationale for removal — recorded on the audit trail. |
 
 ### update_transactions (Write)
 
@@ -185,8 +185,8 @@ Each operation:
 |-------|------|-------------|
 | `transaction_id` | string | UUID or short ID. Required. |
 | `category_slug` | string | Optional category to set. Sets `category_override=true`. |
-| `tags_to_add` | array | `[{slug, note?}, ...]`. Auto-creates persistent tags. |
-| `tags_to_remove` | array | `[{slug, note?}, ...]`. `note` is optional but strongly recommended for ephemeral tags — lands on the `tag_removed` annotation. |
+| `tags_to_add` | array | `[{slug, note?}, ...]`. Auto-creates tags if the slug is new. |
+| `tags_to_remove` | array | `[{slug, note?}, ...]`. `note` is optional — if provided, lands on the `tag_removed` annotation. |
 | `comment` | string | Optional comment annotation. |
 
 Use this to close a review entry: `set category + remove needs-review (with note) + comment` in one call.
@@ -197,7 +197,7 @@ Return the activity timeline for a transaction. Each row is one of: `comment`, `
 
 ### create_tag / update_tag / delete_tag (Write)
 
-Admin-only tag CRUD. Agents typically don't need these — `add_transaction_tag` auto-creates persistent tags. Use these to set display name, color, lifecycle, or cascade-delete a tag.
+Admin-only tag CRUD. Agents typically don't need these — `add_transaction_tag` auto-creates tags on demand. Use these to set display name, color, or cascade-delete a tag.
 
 ---
 

--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -132,7 +132,7 @@ Sets the transaction's assigned category. At most one `set_category` per rule.
 { "type": "add_tag", "tag_slug": "needs-review" }
 ```
 
-Adds a tag. The tag is auto-created with `lifecycle = persistent` if the slug doesn't exist yet. Idempotent — re-adding an existing tag is a no-op.
+Adds a tag. The tag is auto-created if the slug doesn't exist yet. Idempotent — re-adding an existing tag is a no-op.
 
 - Slug format: `^[a-z0-9][a-z0-9\-:]*[a-z0-9]$` (lowercase, digits, hyphens, colons; no leading/trailing punctuation).
 - Writes a `tag_added` annotation; deduped against prior annotations of the same tag on the same transaction.
@@ -145,7 +145,7 @@ Adds a tag. The tag is auto-created with `lifecycle = persistent` if the slug do
 
 Removes a tag from the transaction. No-op if the tag isn't attached. Slug validation matches `add_tag`.
 
-- Writes a `tag_removed` annotation. The rule's name is captured in the annotation payload as the removal note, so ephemeral-tag removal has a source attribution on the activity timeline.
+- Writes a `tag_removed` annotation. The rule's name is captured in the annotation payload as the removal note so the activity timeline carries a source attribution.
 - **Net-diff semantics in a pipeline.** If an earlier-stage rule's `add_tag` and a later-stage rule's `remove_tag` target the same slug in a single sync pass, they cancel — neither the INSERT nor the DELETE hits the DB, and no annotations are emitted. This keeps the timeline clean when rules compose.
 
 ### `add_comment`

--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -93,7 +93,6 @@ func CreateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Description string  `json:"description"`
 			Color       *string `json:"color"`
 			Icon        *string `json:"icon"`
-			Lifecycle   string  `json:"lifecycle"`
 		}
 		if !decodeJSON(w, r, &req) {
 			return
@@ -111,7 +110,6 @@ func CreateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Description: req.Description,
 			Color:       req.Color,
 			Icon:        req.Icon,
-			Lifecycle:   req.Lifecycle,
 		})
 		if err != nil {
 			handleTagError(w, err)
@@ -130,7 +128,6 @@ func UpdateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Description *string `json:"description"`
 			Color       *string `json:"color"`
 			Icon        *string `json:"icon"`
-			Lifecycle   *string `json:"lifecycle"`
 		}
 		if !decodeJSON(w, r, &req) {
 			return
@@ -140,7 +137,6 @@ func UpdateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Description: req.Description,
 			Color:       req.Color,
 			Icon:        req.Icon,
-			Lifecycle:   req.Lifecycle,
 		})
 		if err != nil {
 			handleTagError(w, err)
@@ -204,7 +200,8 @@ func AddTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *serv
 }
 
 // RemoveTransactionTagAdminHandler handles DELETE /-/transactions/{id}/tags/{slug}.
-// Query/body: note (REQUIRED for ephemeral tags). Accepts either form-encoded or JSON.
+// Query/body: optional note recorded on the tag_removed annotation. Accepts
+// either form-encoded or JSON.
 func RemoveTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		txnID := chi.URLParam(r, "id")

--- a/internal/admin/tags_integration_test.go
+++ b/internal/admin/tags_integration_test.go
@@ -35,7 +35,7 @@ func TestCreateTagAdmin_Success(t *testing.T) {
 	r := chi.NewRouter()
 	r.Post("/-/tags", CreateTagAdminHandler(svc))
 
-	body := []byte(`{"slug":"watchlist","display_name":"Watchlist","color":"#ff0000","lifecycle":"persistent"}`)
+	body := []byte(`{"slug":"watchlist","display_name":"Watchlist","color":"#ff0000"}`)
 	req := httptest.NewRequest(http.MethodPost, "/-/tags", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
@@ -136,7 +136,7 @@ func TestDeleteTagAdmin(t *testing.T) {
 func TestTagsPageRenders(t *testing.T) {
 	svc := newTestSvc(t)
 	ctx := context.Background()
-	if _, err := svc.CreateTag(ctx, service.CreateTagParams{Slug: "needs-review", DisplayName: "Needs Review", Lifecycle: "ephemeral"}); err != nil {
+	if _, err := svc.CreateTag(ctx, service.CreateTagParams{Slug: "needs-review", DisplayName: "Needs Review"}); err != nil {
 		t.Fatalf("CreateTag: %v", err)
 	}
 

--- a/internal/db/queries/tags.sql
+++ b/internal/db/queries/tags.sql
@@ -1,6 +1,6 @@
 -- name: InsertTag :one
-INSERT INTO tags (slug, display_name, description, color, icon, lifecycle)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO tags (slug, display_name, description, color, icon)
+VALUES ($1, $2, $3, $4, $5)
 RETURNING *;
 
 -- name: GetTagByID :one
@@ -21,7 +21,6 @@ SET display_name = $2,
     description = $3,
     color = $4,
     icon = $5,
-    lifecycle = $6,
     updated_at = NOW()
 WHERE id = $1
 RETURNING *;

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -24,7 +24,7 @@ DATA MODEL:
 - Transactions: individual financial transactions belonging to an account
 - Categories: 2-level hierarchy (primary → subcategory), identified by slug (e.g., food_and_drink_groceries)
 - Transaction Rules: pattern-matching conditions that pre-categorize new transactions during sync
-- Tags: open-ended labels attached to transactions. Each tag has a slug (stable identifier), display_name, and lifecycle ("persistent" or "ephemeral"). Tags coordinate work between agents and humans.
+- Tags: open-ended labels attached to transactions. Each tag has a slug (stable identifier) and a display_name. Tags coordinate work between agents and humans.
 - Annotations: the activity timeline for a transaction. Every tag change, category set, rule application, and comment is an annotation.
 
 AMOUNT CONVENTION (critical):
@@ -401,7 +401,7 @@ func (s *MCPServer) buildToolRegistry() {
 			s.handleSubmitReport, svc),
 		// --- Tags + annotations ---
 		makeToolDefLogged("list_tags", ToolRead,
-			"List all tags registered in the system. Each tag has a slug (stable identifier), display_name, and lifecycle ('persistent' or 'ephemeral'). Tags attached to transactions can be queried via the tags / any_tag filters on query_transactions.",
+			"List all tags registered in the system. Each tag has a slug (stable identifier) and a display_name. Tags attached to transactions can be queried via the tags / any_tag filters on query_transactions.",
 			s.handleListTags, svc),
 		makeToolDefLogged("list_annotations", ToolRead,
 			"List the activity timeline for a transaction. Each annotation is a single event: comment, tag_added, tag_removed, rule_applied, or category_set. Ordered by created_at ASC. Payload carries kind-specific fields (content for comments, slug for tags, rule_name for rule applications).",
@@ -413,13 +413,13 @@ func (s *MCPServer) buildToolRegistry() {
 			"Remove a tag from a transaction. A note is recommended (it's recorded on the tag_removed annotation for auditability) but not required. Idempotent: returns already_absent=true if the tag wasn't attached.",
 			s.handleRemoveTransactionTag, svc),
 		makeToolDefLogged("update_transactions", ToolWrite,
-			"Compound write for up to 50 transactions at once. Each operation can: set a category (category_slug), add tags (tags_to_add), remove tags (tags_to_remove), and attach a comment — all atomically per transaction, with annotations written for every change. The preferred tool for closing review work (set category + remove needs-review + explain) in one call. Example operation: {\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\",\"note\":\"clearly groceries\"}],\"comment\":\"Costco run\"}. on_error: 'continue' (default — each op in its own DB tx, partial failures OK) or 'abort' (one DB tx, rolls back on first error). Ephemeral tags (needs-review) REQUIRE a non-empty note on removal.",
+			"Compound write for up to 50 transactions at once. Each operation can: set a category (category_slug), add tags (tags_to_add), remove tags (tags_to_remove), and attach a comment — all atomically per transaction, with annotations written for every change. The preferred tool for closing review work (set category + remove needs-review + explain) in one call. Example operation: {\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\",\"note\":\"clearly groceries\"}],\"comment\":\"Costco run\"}. on_error: 'continue' (default — each op in its own DB tx, partial failures OK) or 'abort' (one DB tx, rolls back on first error). Notes on tag removal are optional but recommended for workflow tags like needs-review.",
 			s.handleUpdateTransactions, svc),
 		makeToolDefLogged("create_tag", ToolWrite,
-			"Register a new tag in the system. Admin-only write — agents can auto-create persistent tags implicitly via add_transaction_tag (pass a new slug), so use create_tag only when users need to set display_name/color/lifecycle up front. Slug regex: ^[a-z0-9][a-z0-9\\-:]*[a-z0-9]$. Lifecycle defaults to 'persistent' (user-defined, long-lived). Use 'ephemeral' for workflow trigger tags like needs-review.",
+			"Register a new tag in the system. Admin-only write — agents can auto-create tags implicitly via add_transaction_tag (pass a new slug), so use create_tag only when users need to set display_name/color/icon up front. Slug regex: ^[a-z0-9][a-z0-9\\-:]*[a-z0-9]$.",
 			s.handleCreateTag, svc),
 		makeToolDefLogged("update_tag", ToolWrite,
-			"Update a tag's mutable fields (display_name, description, color, icon, lifecycle). Slug is immutable — to rename, create a new tag + bulk re-tag + delete old. Identify the tag by UUID, short ID, or slug.",
+			"Update a tag's mutable fields (display_name, description, color, icon). Slug is immutable — to rename, create a new tag + bulk re-tag + delete old. Identify the tag by UUID, short ID, or slug.",
 			s.handleUpdateTag, svc),
 		makeToolDefLogged("delete_tag", ToolWrite,
 			"Delete a tag. Cascades to transaction_tags (removes the tag from every transaction). Annotations that reference the tag keep their rows with tag_id=NULL (preserves audit trail). Identify the tag by UUID, short ID, or slug.",

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -32,7 +32,7 @@ type removeTransactionTagInput struct {
 	WriteSessionContext
 	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
 	TagSlug       string `json:"tag_slug" jsonschema:"required,Tag slug to remove"`
-	Note          string `json:"note,omitempty" jsonschema:"Required when the tag's lifecycle is 'ephemeral'. Short rationale for removal."`
+	Note          string `json:"note,omitempty" jsonschema:"Optional rationale recorded on the tag_removed annotation."`
 }
 
 type createTagInput struct {
@@ -42,7 +42,6 @@ type createTagInput struct {
 	Description string  `json:"description,omitempty" jsonschema:"Optional description."`
 	Color       *string `json:"color,omitempty" jsonschema:"Optional CSS color (e.g. '#4f46e5') used for chip rendering."`
 	Icon        *string `json:"icon,omitempty" jsonschema:"Optional Lucide icon name (e.g. 'inbox')."`
-	Lifecycle   string  `json:"lifecycle,omitempty" jsonschema:"'persistent' (default) or 'ephemeral'. Ephemeral tags require a note on removal."`
 }
 
 type updateTagInput struct {
@@ -52,7 +51,6 @@ type updateTagInput struct {
 	Description *string `json:"description,omitempty" jsonschema:"New description."`
 	Color       *string `json:"color,omitempty" jsonschema:"New color (pass empty string to clear)."`
 	Icon        *string `json:"icon,omitempty" jsonschema:"New icon (pass empty string to clear)."`
-	Lifecycle   *string `json:"lifecycle,omitempty" jsonschema:"'persistent' or 'ephemeral'."`
 }
 
 type deleteTagInput struct {
@@ -139,7 +137,6 @@ func (s *MCPServer) handleCreateTag(ctx context.Context, _ *mcpsdk.CallToolReque
 		Description: input.Description,
 		Color:       input.Color,
 		Icon:        input.Icon,
-		Lifecycle:   input.Lifecycle,
 	}
 	tag, err := s.svc.CreateTag(context.Background(), params)
 	if err != nil {
@@ -160,7 +157,6 @@ func (s *MCPServer) handleUpdateTag(ctx context.Context, _ *mcpsdk.CallToolReque
 		Description: input.Description,
 		Color:       input.Color,
 		Icon:        input.Icon,
-		Lifecycle:   input.Lifecycle,
 	}
 	tag, err := s.svc.UpdateTag(context.Background(), input.ID, params)
 	if err != nil {

--- a/internal/prompts/blocks/review-depth-thorough.md
+++ b/internal/prompts/blocks/review-depth-thorough.md
@@ -6,7 +6,7 @@ REVIEW APPROACH:
 - Check list_annotations (or list_transaction_comments for comments only) to understand prior context before recategorizing — the timeline includes every tag add/remove, category set, rule application, and comment for a given transaction
 - For ambiguous transactions, use merchant_summary to check historical patterns for that merchant
 - Cross-reference with other transactions from the same merchant to ensure consistent categorization
-- When the decision is non-obvious, use update_transactions with a compound op: set_category + add a comment explaining the call + remove needs-review with a short reason. The note on the ephemeral-tag removal is stored on the audit trail.
+- When the decision is non-obvious, use update_transactions with a compound op: set_category + add a comment explaining the call + remove needs-review with a short reason. The note on tag removal is recorded on the audit trail.
 - Review pre-categorized transactions carefully — verify the rule's category is correct, don't just confirm
 - Create specific per-merchant rules when you notice patterns, not just broad category_primary rules
 - When uncertain, investigate rather than remove the tag — check the merchant name, amount patterns, and timing. Leaving a transaction tagged needs-review is equivalent to "skipping" — it stays in the queue for next time.

--- a/internal/prompts/blocks/transaction-comments.md
+++ b/internal/prompts/blocks/transaction-comments.md
@@ -2,14 +2,14 @@
 > Annotate transactions with reasoning and context
 
 THREE WRITE PATHS — pick the right one:
-- Compound review decision: call update_transactions with an operation that sets the category, removes the needs-review tag (with a required note), and optionally attaches a `comment`. Everything lands in one audit-atomic batch.
+- Compound review decision: call update_transactions with an operation that sets the category, removes the needs-review tag (with an optional note), and optionally attaches a `comment`. Everything lands in one audit-atomic batch.
 - Stand-alone note during review: include `comment` inside an update_transactions operation. It is written as an annotation with kind=comment attributed to you.
 - Free-standing narrative: call add_transaction_comment for context that isn't tied to a specific review or tag change — flagging a suspicious charge, cross-referencing related transactions, long-lived household notes.
 
 Don't double-write: if you have an update_transactions op with `tags_to_remove: [{slug: "needs-review", note: "..."}]`, the note you pass there captures "why I closed this review". Do NOT also call add_transaction_comment for the same narrative — you'll produce two annotations saying the same thing.
 
 WHEN TO ADD NARRATIVE:
-- Removing an ephemeral tag (needs-review): strongly recommended — the note lands on the audit trail explaining why the tag came off.
+- Removing a workflow tag (e.g. needs-review): recommended — the note lands on the audit trail explaining why the tag came off.
 - Confirming a non-obvious category — explain your reasoning
 - Flagging a transaction for human attention — explain what looks suspicious
 - An ambiguous transaction where you're making a judgment call

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -2008,8 +2008,8 @@ func (s *Service) materializeRuleTagAdd(ctx context.Context, tx pgx.Tx, txnID pg
 		// Auto-create on miss. ON CONFLICT DO UPDATE SET updated_at=... is a
 		// harmless no-op-returning-id dance so we always get the tag id back.
 		if err2 := tx.QueryRow(ctx, `
-			INSERT INTO tags (slug, display_name, lifecycle)
-			VALUES ($1, $2, 'persistent')
+			INSERT INTO tags (slug, display_name)
+			VALUES ($1, $2)
 			ON CONFLICT (slug) DO UPDATE SET updated_at = tags.updated_at
 			RETURNING id`, slug, slugs.TitleCase(slug)).Scan(&tagID); err2 != nil {
 			return false, fmt.Errorf("get or create tag %q: %w", slug, err2)

--- a/internal/service/rules_integration_test.go
+++ b/internal/service/rules_integration_test.go
@@ -1114,7 +1114,7 @@ func TestApplyRuleRetroactively_AddTagMaterialized(t *testing.T) {
 
 	// Pre-seed the dining tag so materializeRuleTagAdd resolves it directly
 	// rather than auto-creating.
-	tag := testutil.MustCreateTag(t, queries, "dining", "Dining", "persistent")
+	tag := testutil.MustCreateTag(t, queries, "dining", "Dining")
 
 	// Rule: name contains "Restaurant" → add_tag "dining".
 	rule, err := svc.CreateTransactionRule(ctx, service.CreateTransactionRuleParams{
@@ -1211,9 +1211,9 @@ func TestApplyRuleRetroactively_RemoveTagMaterialized(t *testing.T) {
 	txn1 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_sbx_1", "Starbucks Coffee", 500, "2025-06-01")
 	txn2 := testutil.MustCreateTransaction(t, queries, acct.ID, "txn_sbx_2", "Starbucks Reserve", 750, "2025-06-02")
 
-	// Pre-seed ephemeral needs-review tag and attach it to both transactions
+	// Pre-seed needs-review tag and attach it to both transactions
 	// directly (simulating user-applied review state).
-	tag := testutil.MustCreateTag(t, queries, "needs-review", "Needs Review", "ephemeral")
+	tag := testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
 	for _, txn := range []db.Transaction{txn1, txn2} {
 		_, err := pool.Exec(ctx, `
 			INSERT INTO transaction_tags (transaction_id, tag_id, added_by_type, added_by_name)

--- a/internal/service/tags.go
+++ b/internal/service/tags.go
@@ -25,7 +25,6 @@ type TagResponse struct {
 	Description string  `json:"description"`
 	Color       *string `json:"color,omitempty"`
 	Icon        *string `json:"icon,omitempty"`
-	Lifecycle   string  `json:"lifecycle"`
 	CreatedAt   string  `json:"created_at"`
 	UpdatedAt   string  `json:"updated_at"`
 }
@@ -37,7 +36,6 @@ type CreateTagParams struct {
 	Description string
 	Color       *string
 	Icon        *string
-	Lifecycle   string // "persistent" (default) | "ephemeral"
 }
 
 // UpdateTagParams holds parameters for updating an existing tag.
@@ -46,7 +44,6 @@ type UpdateTagParams struct {
 	Description *string
 	Color       *string
 	Icon        *string
-	Lifecycle   *string
 }
 
 // tagSlugRegex enforces the tag slug format: lowercase alphanumerics with
@@ -62,17 +59,8 @@ func validateTagSlug(slug string) error {
 	return nil
 }
 
-// validateLifecycle accepts "persistent" and "ephemeral".
-func validateLifecycle(lifecycle string) error {
-	if lifecycle != "persistent" && lifecycle != "ephemeral" {
-		return fmt.Errorf("%w: lifecycle must be 'persistent' or 'ephemeral'", ErrInvalidParameter)
-	}
-	return nil
-}
-
 // CreateTag validates and inserts a new tag record. Slug regex:
-// ^[a-z0-9][a-z0-9\-:]*[a-z0-9]$. display_name must be non-empty. Lifecycle
-// defaults to "persistent".
+// ^[a-z0-9][a-z0-9\-:]*[a-z0-9]$. display_name must be non-empty.
 func (s *Service) CreateTag(ctx context.Context, params CreateTagParams) (*TagResponse, error) {
 	if err := validateTagSlug(params.Slug); err != nil {
 		return nil, err
@@ -80,13 +68,6 @@ func (s *Service) CreateTag(ctx context.Context, params CreateTagParams) (*TagRe
 	displayName := strings.TrimSpace(params.DisplayName)
 	if displayName == "" {
 		return nil, fmt.Errorf("%w: display_name is required", ErrInvalidParameter)
-	}
-	lifecycle := params.Lifecycle
-	if lifecycle == "" {
-		lifecycle = "persistent"
-	}
-	if err := validateLifecycle(lifecycle); err != nil {
-		return nil, err
 	}
 
 	color := pgtype.Text{}
@@ -104,7 +85,6 @@ func (s *Service) CreateTag(ctx context.Context, params CreateTagParams) (*TagRe
 		Description: params.Description,
 		Color:       color,
 		Icon:        icon,
-		Lifecycle:   lifecycle,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("insert tag: %w", err)
@@ -208,14 +188,6 @@ func (s *Service) UpdateTag(ctx context.Context, id string, params UpdateTagPara
 		icon = pgtype.Text{String: *params.Icon, Valid: *params.Icon != ""}
 	}
 
-	lifecycle := existing.Lifecycle
-	if params.Lifecycle != nil {
-		if err := validateLifecycle(*params.Lifecycle); err != nil {
-			return nil, err
-		}
-		lifecycle = *params.Lifecycle
-	}
-
 	existingUID, _ := parseUUID(existing.ID)
 	tag, err := s.Queries.UpdateTag(ctx, db.UpdateTagParams{
 		ID:          existingUID,
@@ -223,7 +195,6 @@ func (s *Service) UpdateTag(ctx context.Context, id string, params UpdateTagPara
 		Description: description,
 		Color:       color,
 		Icon:        icon,
-		Lifecycle:   lifecycle,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -257,9 +228,9 @@ func (s *Service) DeleteTag(ctx context.Context, id string) error {
 }
 
 // getOrCreateTagBySlug returns the UUID+row of the tag with the given slug.
-// If the tag doesn't exist, it's auto-created with lifecycle=persistent and
-// display_name=title-cased slug. Safe to call from inside a DB tx — the passed
-// db.Queries handle is used for lookup + insert.
+// If the tag doesn't exist, it's auto-created with display_name=title-cased
+// slug. Safe to call from inside a DB tx — the passed db.Queries handle is
+// used for lookup + insert.
 func (s *Service) getOrCreateTagBySlug(ctx context.Context, q *db.Queries, slug string) (db.Tag, error) {
 	if err := validateTagSlug(slug); err != nil {
 		return db.Tag{}, err
@@ -275,7 +246,6 @@ func (s *Service) getOrCreateTagBySlug(ctx context.Context, q *db.Queries, slug 
 	created, err := q.InsertTag(ctx, db.InsertTagParams{
 		Slug:        slug,
 		DisplayName: slugs.TitleCase(slug),
-		Lifecycle:   "persistent",
 	})
 	if err != nil {
 		return db.Tag{}, fmt.Errorf("auto-create tag %q: %w", slug, err)
@@ -300,7 +270,6 @@ func tagFromRow(t db.Tag) TagResponse {
 		Description: t.Description,
 		Color:       textPtr(t.Color),
 		Icon:        textPtr(t.Icon),
-		Lifecycle:   t.Lifecycle,
 		CreatedAt:   pgconv.TimestampStr(t.CreatedAt),
 		UpdatedAt:   pgconv.TimestampStr(t.UpdatedAt),
 	}

--- a/internal/service/tags_integration_test.go
+++ b/internal/service/tags_integration_test.go
@@ -38,24 +38,8 @@ func TestCreateTag_SlugValidation(t *testing.T) {
 	}
 }
 
-// TestCreateTag_DefaultsLifecycle verifies lifecycle defaults to "persistent".
-func TestCreateTag_DefaultsLifecycle(t *testing.T) {
-	svc, _, _ := newService(t)
-	ctx := context.Background()
-	tag, err := svc.CreateTag(ctx, service.CreateTagParams{
-		Slug:        "work",
-		DisplayName: "Work",
-	})
-	if err != nil {
-		t.Fatalf("CreateTag: %v", err)
-	}
-	if tag.Lifecycle != "persistent" {
-		t.Errorf("expected lifecycle=persistent, got %q", tag.Lifecycle)
-	}
-}
-
 // TestAddTransactionTag_AutoCreatesTag verifies that adding a tag whose slug
-// doesn't exist creates it as persistent with a title-cased display name.
+// doesn't exist creates it with a title-cased display name.
 func TestAddTransactionTag_AutoCreatesTag(t *testing.T) {
 	svc, queries, _ := newService(t)
 	ctx := context.Background()
@@ -78,9 +62,6 @@ func TestAddTransactionTag_AutoCreatesTag(t *testing.T) {
 	tag, err := queries.GetTagBySlug(ctx, "vacation-2026")
 	if err != nil {
 		t.Fatalf("tag was not created: %v", err)
-	}
-	if tag.Lifecycle != "persistent" {
-		t.Errorf("expected persistent lifecycle, got %q", tag.Lifecycle)
 	}
 	if tag.DisplayName != "Vacation 2026" {
 		t.Errorf("expected display name 'Vacation 2026', got %q", tag.DisplayName)
@@ -118,15 +99,15 @@ func TestAddTransactionTag_WritesAnnotation(t *testing.T) {
 	}
 }
 
-// TestRemoveTransactionTag_EphemeralNoNote verifies that ephemeral tags
-// can be removed without a note (note is optional, not required).
-func TestRemoveTransactionTag_EphemeralNoNote(t *testing.T) {
+// TestRemoveTransactionTag_NoNote verifies that a tag can be removed without
+// a note — note is optional for all tags.
+func TestRemoveTransactionTag_NoNote(t *testing.T) {
 	svc, queries, _ := newService(t)
 	ctx := context.Background()
 	acctID := seedTxnFixture(t, queries)
 	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn3", "Coffee", 500, "2026-03-01")
 
-	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review", "ephemeral")
+	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
 
 	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", Name: "A"}, ""); err != nil {
 		t.Fatalf("AddTransactionTag: %v", err)
@@ -146,15 +127,15 @@ func TestRemoveTransactionTag_EphemeralNoNote(t *testing.T) {
 	}
 }
 
-// TestRemoveTransactionTag_NonEphemeralAcceptsEmptyNote verifies that
-// persistent tags can be removed without a note.
-func TestRemoveTransactionTag_NonEphemeralAcceptsEmptyNote(t *testing.T) {
+// TestRemoveTransactionTag_EmptyNoteSucceeds verifies tag removal works with
+// an empty note across regular tags.
+func TestRemoveTransactionTag_EmptyNoteSucceeds(t *testing.T) {
 	svc, queries, _ := newService(t)
 	ctx := context.Background()
 	acctID := seedTxnFixture(t, queries)
 	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn4", "Coffee", 500, "2026-03-01")
 
-	testutil.MustCreateTag(t, queries, "watchlist", "Watch", "persistent")
+	testutil.MustCreateTag(t, queries, "watchlist", "Watch")
 
 	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "watchlist", service.Actor{Type: "user", Name: "A"}, ""); err != nil {
 		t.Fatalf("AddTransactionTag: %v", err)
@@ -176,7 +157,7 @@ func TestRemoveTransactionTag_AlreadyAbsent_NoError(t *testing.T) {
 	acctID := seedTxnFixture(t, queries)
 	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn5", "Coffee", 500, "2026-03-01")
 
-	testutil.MustCreateTag(t, queries, "unused", "Unused", "persistent")
+	testutil.MustCreateTag(t, queries, "unused", "Unused")
 
 	removed, alreadyAbsent, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "unused", service.Actor{Type: "user", Name: "A"}, "")
 	if err != nil {

--- a/internal/service/transaction_tags.go
+++ b/internal/service/transaction_tags.go
@@ -14,13 +14,12 @@ import (
 )
 
 // TransactionTagResponse is the enriched per-transaction tag entry returned to
-// API/MCP consumers. Includes the tag's slug + lifecycle plus provenance info.
+// API/MCP consumers. Includes the tag's slug plus provenance info.
 type TransactionTagResponse struct {
 	Slug        string  `json:"slug"`
 	DisplayName string  `json:"display_name"`
 	Color       *string `json:"color,omitempty"`
 	Icon        *string `json:"icon,omitempty"`
-	Lifecycle   string  `json:"lifecycle"`
 	AddedAt     string  `json:"added_at"`
 	AddedByType string  `json:"added_by_type"`
 	AddedByName string  `json:"added_by_name"`
@@ -202,7 +201,7 @@ func (s *Service) ListTransactionTags(ctx context.Context, txnID string) ([]Tran
 	// We also need the added_by_* provenance from transaction_tags; a small
 	// dynamic query covers both in a single round-trip.
 	rows, err := s.Pool.Query(ctx, `
-		SELECT t.slug, t.display_name, t.color, t.icon, t.lifecycle,
+		SELECT t.slug, t.display_name, t.color, t.icon,
 		       tt.added_at, tt.added_by_type, tt.added_by_name
 		FROM tags t
 		JOIN transaction_tags tt ON tt.tag_id = t.id
@@ -215,10 +214,10 @@ func (s *Service) ListTransactionTags(ctx context.Context, txnID string) ([]Tran
 
 	var result []TransactionTagResponse
 	for rows.Next() {
-		var slug, displayName, lifecycle, addedByType, addedByName string
+		var slug, displayName, addedByType, addedByName string
 		var color, icon pgtype.Text
 		var addedAt pgtype.Timestamptz
-		if err := rows.Scan(&slug, &displayName, &color, &icon, &lifecycle, &addedAt, &addedByType, &addedByName); err != nil {
+		if err := rows.Scan(&slug, &displayName, &color, &icon, &addedAt, &addedByType, &addedByName); err != nil {
 			return nil, fmt.Errorf("scan transaction tag: %w", err)
 		}
 		result = append(result, TransactionTagResponse{
@@ -226,7 +225,6 @@ func (s *Service) ListTransactionTags(ctx context.Context, txnID string) ([]Tran
 			DisplayName: displayName,
 			Color:       textPtr(color),
 			Icon:        textPtr(icon),
-			Lifecycle:   lifecycle,
 			AddedAt:     pgconv.TimestampStr(addedAt),
 			AddedByType: addedByType,
 			AddedByName: addedByName,

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -988,7 +988,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		}
 		if len(ids) > 0 {
 			tagRows, err := s.Pool.Query(ctx, `
-				SELECT tt.transaction_id, t.slug, t.display_name, t.color, t.icon, t.lifecycle
+				SELECT tt.transaction_id, t.slug, t.display_name, t.color, t.icon
 				FROM transaction_tags tt
 				JOIN tags t ON t.id = tt.tag_id
 				WHERE tt.transaction_id = ANY($1)
@@ -997,9 +997,9 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 				defer tagRows.Close()
 				for tagRows.Next() {
 					var txnID pgtype.UUID
-					var slug, displayName, lifecycle string
+					var slug, displayName string
 					var color, icon pgtype.Text
-					if scanErr := tagRows.Scan(&txnID, &slug, &displayName, &color, &icon, &lifecycle); scanErr != nil {
+					if scanErr := tagRows.Scan(&txnID, &slug, &displayName, &color, &icon); scanErr != nil {
 						continue
 					}
 					tag := AdminTransactionTag{
@@ -1007,7 +1007,6 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 						DisplayName: displayName,
 						Color:       textPtr(color),
 						Icon:        textPtr(icon),
-						Lifecycle:   lifecycle,
 					}
 					if idx, ok := idIdx[formatUUID(txnID)]; ok {
 						transactions[idx].Tags = append(transactions[idx].Tags, tag)

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -324,7 +324,6 @@ type AdminTransactionTag struct {
 	DisplayName string
 	Color       *string
 	Icon        *string
-	Lifecycle   string
 }
 
 type AdminTransactionListResult struct {

--- a/internal/service/update_transactions_integration_test.go
+++ b/internal/service/update_transactions_integration_test.go
@@ -22,9 +22,9 @@ func TestUpdateTransactions_CompoundOp(t *testing.T) {
 	acctID := seedTxnFixture(t, queries)
 	txn := testutil.MustCreateTransaction(t, queries, acctID, "extu1", "Costco", 8732, "2026-04-01")
 
-	// Seed required category + ephemeral tag.
+	// Seed required category + needs-review tag.
 	mustCreateCategory(t, queries, "food_and_drink_groceries", "Groceries")
-	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review", "ephemeral")
+	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
 
 	// Pre-attach needs-review to mimic the seeded auto-rule.
 	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", ID: "u1", Name: "Tester"}, ""); err != nil {
@@ -175,15 +175,15 @@ func TestUpdateTransactions_AbortMode_RollsBack(t *testing.T) {
 	}
 }
 
-// TestUpdateTransactions_EphemeralRemovalWithoutNote verifies that removing
-// an ephemeral tag without a note succeeds (note is optional).
-func TestUpdateTransactions_EphemeralRemovalWithoutNote(t *testing.T) {
+// TestUpdateTransactions_TagRemovalWithoutNote verifies that tag removal
+// without a note succeeds — note is optional.
+func TestUpdateTransactions_TagRemovalWithoutNote(t *testing.T) {
 	svc, queries, _ := newService(t)
 	ctx := context.Background()
 	acctID := seedTxnFixture(t, queries)
 	txn := testutil.MustCreateTransaction(t, queries, acctID, "tx_c", "Subscription", 999, "2026-04-03")
 
-	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review", "ephemeral")
+	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
 	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", ID: "u1", Name: "Tester"}, ""); err != nil {
 		t.Fatalf("seed: %v", err)
 	}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -771,8 +771,8 @@ func (e *Engine) applyTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.U
 	if err != nil {
 		// Either no row (auto-create) or some other error.
 		err2 := tx.QueryRow(ctx, `
-			INSERT INTO tags (slug, display_name, lifecycle)
-			VALUES ($1, $2, 'persistent')
+			INSERT INTO tags (slug, display_name)
+			VALUES ($1, $2)
 			ON CONFLICT (slug) DO UPDATE SET updated_at = tags.updated_at
 			RETURNING id`, slug, slugs.TitleCase(slug)).Scan(&tagID)
 		if err2 != nil {
@@ -827,8 +827,8 @@ func (e *Engine) applyTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.U
 
 // removeTagFromRule deletes a (transaction, tag) row and writes the matching
 // tag_removed annotation. No-op if the tag slug doesn't exist. The rule's
-// name is used as the removal note so ephemeral-tag removal has a source
-// attribution visible in the activity timeline.
+// name is used as the removal note so the activity timeline carries a source
+// attribution.
 func (e *Engine) removeTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, slug string, ruleID pgtype.UUID, ruleShortID, ruleName string) error {
 	var tagID pgtype.UUID
 	err := tx.QueryRow(ctx, `SELECT id FROM tags WHERE slug = $1`, slug).Scan(&tagID)

--- a/internal/sync/tags_integration_test.go
+++ b/internal/sync/tags_integration_test.go
@@ -25,7 +25,7 @@ func TestSync_AddTagAction_PersistsTag(t *testing.T) {
 
 	// Seed a persistent "dining" tag so we don't rely on auto-create in this
 	// test — the auto-create path is covered by the seeded-rule test below.
-	tag := testutil.MustCreateTag(t, queries, "dining", "Dining", "persistent")
+	tag := testutil.MustCreateTag(t, queries, "dining", "Dining")
 
 	// Rule: name contains "Restaurant" → add_tag "dining".
 	testutil.MustCreateTransactionRule(
@@ -116,7 +116,7 @@ func TestSync_RemoveTagAction_DeletesTagAndAnnotates(t *testing.T) {
 	seedCategories(t, queries)
 
 	// Pre-seed tag and rule.
-	tag := testutil.MustCreateTag(t, queries, "needs-review", "Needs Review", "ephemeral")
+	tag := testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
 	testutil.MustCreateTransactionRule(
 		t, queries, "Clear review flag for coffee",
 		[]byte(`{"field":"name","op":"contains","value":"Starbucks"}`),
@@ -217,7 +217,7 @@ func TestSync_RemoveTagAction_DeletesTagAndAnnotates(t *testing.T) {
 //
 // Testutil truncates all tables between tests, so the migration's seeded
 // rows are wiped. We re-seed the tag + rule here mirroring the migration
-// exactly (same slug, same lifecycle, same action shape) to prove the
+// exactly (same slug, same action shape) to prove the
 // seeded behavior works end-to-end.
 func TestSync_SeededRule_TagsAllNewTransactions(t *testing.T) {
 	pool, queries := testutil.ServicePool(t)
@@ -226,7 +226,7 @@ func TestSync_SeededRule_TagsAllNewTransactions(t *testing.T) {
 	seedCategories(t, queries)
 
 	// Re-seed the needs-review tag + rule just like the migration.
-	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review", "ephemeral")
+	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
 	testutil.MustCreateTransactionRule(
 		t, queries, "Auto-tag new transactions for review",
 		nil, // match-all conditions

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -1186,7 +1186,7 @@
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
               slug: slug, display_name: displayName, description: '',
-              color: color, icon: null, lifecycle: 'persistent'
+              color: color, icon: null
             })
           })
           .then(function(r) { return r.json().then(function(d) { return {ok: r.ok, body: d}; }); })
@@ -1200,7 +1200,7 @@
             var tag = {
               id: t.id, slug: t.slug, display_name: t.display_name,
               description: t.description || '', color: t.color || color,
-              icon: t.icon || null, lifecycle: t.lifecycle || 'persistent'
+              icon: t.icon || null
             };
             if (window.__bbAllTags && !window.__bbAllTags.some(function(x) { return x.slug === tag.slug; })) {
               window.__bbAllTags.push(tag);

--- a/internal/templates/pages/tag_form.html
+++ b/internal/templates/pages/tag_form.html
@@ -93,27 +93,6 @@
           </div>
         </div>
 
-        <!-- Lifecycle -->
-        <div>
-          <label class="block text-xs font-medium text-base-content/50 mb-1.5">Lifecycle</label>
-          <div class="flex gap-2">
-            <label class="flex-1 cursor-pointer">
-              <input type="radio" x-model="lifecycle" value="persistent" class="peer sr-only">
-              <div class="border-2 border-base-300 peer-checked:border-primary peer-checked:bg-primary/5 rounded-xl p-3 transition-colors">
-                <div class="font-medium text-sm">Persistent</div>
-                <div class="text-xs text-base-content/50 mt-0.5">Long-lived label (subscription, shared)</div>
-              </div>
-            </label>
-            <label class="flex-1 cursor-pointer">
-              <input type="radio" x-model="lifecycle" value="ephemeral" class="peer sr-only">
-              <div class="border-2 border-base-300 peer-checked:border-warning peer-checked:bg-warning/5 rounded-xl p-3 transition-colors">
-                <div class="font-medium text-sm">Ephemeral</div>
-                <div class="text-xs text-base-content/50 mt-0.5">Workflow trigger, removal requires note</div>
-              </div>
-            </label>
-          </div>
-        </div>
-
         <template x-if="error">
           <div role="alert" class="bb-form-error">
             <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
@@ -146,8 +125,7 @@ function tagForm() {
     displayName: {{if .IsEdit}}{{toJSON .Tag.DisplayName}}{{else}}''{{end}},
     description: {{if .IsEdit}}{{toJSON .Tag.Description}}{{else}}''{{end}},
     color: {{if .IsEdit}}{{if .Tag.Color}}'{{deref .Tag.Color}}'{{else}}'#6366f1'{{end}}{{else}}'#6366f1'{{end}},
-    icon: {{if .IsEdit}}{{if .Tag.Icon}}'{{deref .Tag.Icon}}'{{else}}''{{end}}{{else}}''{{end}},
-    lifecycle: {{if .IsEdit}}'{{.Tag.Lifecycle}}'{{else}}'persistent'{{end}}
+    icon: {{if .IsEdit}}{{if .Tag.Icon}}'{{deref .Tag.Icon}}'{{else}}''{{end}}{{else}}''{{end}}
   };
   return {
     isEdit: isEdit,
@@ -157,7 +135,6 @@ function tagForm() {
     description: initial.description,
     color: initial.color,
     icon: initial.icon,
-    lifecycle: initial.lifecycle,
     submitting: false,
     error: '',
     presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c'],
@@ -191,8 +168,7 @@ function tagForm() {
           display_name: displayName,
           description: this.description || '',
           color: this.color || null,
-          icon: this.icon || null,
-          lifecycle: this.lifecycle
+          icon: this.icon || null
         };
       } else {
         url = '/-/tags';
@@ -202,8 +178,7 @@ function tagForm() {
           display_name: displayName,
           description: this.description || '',
           color: this.color || null,
-          icon: this.icon || null,
-          lifecycle: this.lifecycle
+          icon: this.icon || null
         };
       }
 

--- a/internal/templates/pages/tags.html
+++ b/internal/templates/pages/tags.html
@@ -25,17 +25,16 @@
   {{if .Tags}}
   <div class="bb-card overflow-hidden">
     <!-- Table header -->
-    <div class="hidden sm:grid grid-cols-[auto_1fr_auto_auto_auto] items-center gap-4 px-5 py-2.5 border-b border-base-300/50 text-xs font-medium text-base-content/40 uppercase tracking-wider">
+    <div class="hidden sm:grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 px-5 py-2.5 border-b border-base-300/50 text-xs font-medium text-base-content/40 uppercase tracking-wider">
       <div class="w-32">Chip</div>
       <div>Details</div>
       <div class="w-24 text-right">Transactions</div>
-      <div class="w-20">Lifecycle</div>
       <div class="w-20"></div>
     </div>
 
     <div class="divide-y divide-base-300/40">
       {{range .Tags}}
-      <div class="group grid grid-cols-[auto_1fr_auto] sm:grid-cols-[auto_1fr_auto_auto_auto] items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3"
+      <div class="group grid grid-cols-[auto_1fr_auto] sm:grid-cols-[auto_1fr_auto_auto] items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3"
         x-show="!filter || '{{.Slug}} {{.DisplayName}} {{.Description}}'.toLowerCase().includes(filter.toLowerCase())">
         <!-- Chip preview -->
         <div class="w-32 shrink-0">
@@ -56,14 +55,6 @@
           <a href="/transactions?tags={{.Slug}}" class="link link-hover">{{commaInt .TransactionCount}}</a>
           {{else}}
           <span class="text-base-content/25">&mdash;</span>
-          {{end}}
-        </div>
-        <!-- Lifecycle -->
-        <div class="w-20 hidden sm:block">
-          {{if eq .Lifecycle "ephemeral"}}
-          <span class="badge badge-soft badge-warning badge-xs">ephemeral</span>
-          {{else}}
-          <span class="badge badge-ghost badge-xs">persistent</span>
           {{end}}
         </div>
         <!-- Actions -->

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -166,27 +166,16 @@
       </div>
       <div class="flex flex-wrap gap-1.5 min-h-[1.5rem] items-center">
         <template x-for="t in tags" :key="t.slug">
-          <span class="bb-tag relative"
-            :style="t.color ? ('--tag-color:' + t.color) : ''"
-            x-data="{showRemoveNote: false, note: ''}">
+          <span class="bb-tag"
+            :style="t.color ? ('--tag-color:' + t.color) : ''">
             <template x-if="t.icon"><i :data-lucide="t.icon" ></i></template>
             <a :href="'/transactions?tags=' + t.slug" class="hover:underline" x-text="t.displayName || t.slug"></a>
             <button type="button" class="bb-tag-remove"
-              @click.prevent.stop="t.lifecycle === 'ephemeral' ? (showRemoveNote = !showRemoveNote) : removeTag(t, '')"
+              @click.prevent.stop="removeTag(t, '')"
               :aria-label="'Remove tag ' + (t.displayName || t.slug)"
               :title="'Remove tag ' + (t.displayName || t.slug)">
               <i data-lucide="x" ></i>
             </button>
-            <div x-show="showRemoveNote && t.lifecycle === 'ephemeral'" x-cloak
-              class="absolute left-0 top-full mt-1 bg-base-100 border border-base-300 rounded-xl p-2 shadow-lg z-10 w-64"
-              @click.outside="showRemoveNote = false">
-              <p class="text-xs text-warning mb-1.5">Removing ephemeral tag — note required:</p>
-              <input type="text" x-model="note" class="input input-bordered input-xs rounded-lg w-full mb-1.5" placeholder="Why removing?" @keydown.enter="if(note.trim()) { removeTag(t, note); showRemoveNote = false; }">
-              <div class="flex gap-1 justify-end">
-                <button type="button" class="btn btn-ghost btn-xs rounded-lg" @click="showRemoveNote = false">Cancel</button>
-                <button type="button" class="btn btn-error btn-xs rounded-lg" :disabled="!note.trim()" @click="if(note.trim()) { removeTag(t, note); showRemoveNote = false; }">Remove</button>
-              </div>
-            </div>
           </span>
         </template>
         <!-- Edit-tags chip sits in the same wrapping row as its siblings. Opens the
@@ -409,7 +398,6 @@ function tagManager() {
       displayName: t.display_name,
       color: t.color,
       icon: t.icon,
-      lifecycle: t.lifecycle,
     }; }),
     availableTags: {{toJSON .AvailableTags}} || [],
 
@@ -457,8 +445,7 @@ function tagManager() {
     },
 
     removeTag(tag, note) {
-      // Inline × on a tag chip — direct DELETE (keeps the note path for
-      // ephemeral tags, which the picker doesn't surface).
+      // Inline × on a tag chip — direct DELETE. Note is optional.
       var url = '/-/transactions/{{.TransactionID}}/tags/' + encodeURIComponent(tag.slug);
       fetch(url, {
         method: 'DELETE',

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -277,17 +277,12 @@ func MustCreateAPIKey(t *testing.T, q *db.Queries, name string) db.ApiKey {
 	return key
 }
 
-// MustCreateTag inserts a tag row and fatals on error. lifecycle defaults to
-// "persistent" if empty.
-func MustCreateTag(t *testing.T, q *db.Queries, slug, displayName, lifecycle string) db.Tag {
+// MustCreateTag inserts a tag row and fatals on error.
+func MustCreateTag(t *testing.T, q *db.Queries, slug, displayName string) db.Tag {
 	t.Helper()
-	if lifecycle == "" {
-		lifecycle = "persistent"
-	}
 	tag, err := q.InsertTag(context.Background(), db.InsertTagParams{
 		Slug:        slug,
 		DisplayName: displayName,
-		Lifecycle:   lifecycle,
 	})
 	if err != nil {
 		t.Fatalf("MustCreateTag(%q): %v", slug, err)


### PR DESCRIPTION
## Summary
- Removes the 'ephemeral tags require a note on removal' requirement everywhere (service, MCP, admin, UI, prompts, agent rules). Notes on `tag_removed` annotations are now simply optional for all tags.
- Strips the `lifecycle` field from every user-facing surface: `TagResponse`, `TransactionTagResponse`, `AdminTransactionTag`, `CreateTagParams`, `UpdateTagParams`, MCP tool inputs, admin request/response bodies, tag form, tags list, transaction-detail chip UI.
- Drops `lifecycle` from `InsertTag` / `UpdateTag` sqlc queries. Auto-create paths in `sync/engine.go` and `service/rules.go` stop setting it. The DB column stays (DEFAULT `'persistent'`) — no destructive migration, shared dev DB rule respected.
- Marks the column **Deprecated** in `docs/data-model.md`; updates api-reference / mcp-tools-reference / rule-dsl / prompts / `.claude/rules/mcp.md` / breadbox-mcp-expert agent.

## Test plan
- [x] `go build ./...`
- [x] `go build -tags integration ./...`
- [x] `make test-integration` — full suite green
- [ ] Manual: visit `/tags/new`, `/tags`, and a transaction detail page to confirm lifecycle UI is gone and tag removal works with no note prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)