### PR TITLE
fix(accounts): collapse redundant 'Credit Card · credit card' header

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -676,6 +676,26 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			"humanize": func(s string) string {
 				return strings.ReplaceAll(s, "_", " ")
 			},
+			// subtypeSuffix returns the humanized subtype for use after a type label
+			// (e.g. "savings" in "Bank Account · savings"), or "" when the subtype
+			// is an echo of the type label (e.g. "credit_card" under "Credit Card").
+			// Comparison strips spaces and underscores and is case-insensitive, so
+			// "Credit Card" vs "credit_card" collapses to the same token.
+			"subtypeSuffix": func(typeLabel, subtype string) string {
+				if subtype == "" {
+					return ""
+				}
+				normalize := func(s string) string {
+					s = strings.ToLower(s)
+					s = strings.ReplaceAll(s, "_", "")
+					s = strings.ReplaceAll(s, " ", "")
+					return s
+				}
+				if normalize(typeLabel) == normalize(subtype) {
+					return ""
+				}
+				return strings.ReplaceAll(subtype, "_", " ")
+			},
 			"pageRange": func(current, total int) []int {
 				// Returns page numbers to display: always include first, last,
 				// current, and neighbors. Use 0 as ellipsis sentinel.

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -12,7 +12,9 @@
     <div>
       <h1 class="bb-page-title">{{if .Account.DisplayName}}{{.Account.DisplayName}}{{else}}{{.Account.Name}}{{end}}</h1>
       <div class="flex items-center gap-2 mt-0.5">
-        <span class="text-xs text-base-content/40">{{accountTypeLabel .Account.Type ""}}{{if .Account.Subtype}} &middot; {{humanize .Account.Subtype}}{{end}}</span>
+        {{$typeLabel := accountTypeLabel .Account.Type ""}}
+        {{$subtype := ""}}{{if .Account.Subtype}}{{$subtype = subtypeSuffix $typeLabel .Account.Subtype}}{{end}}
+        <span class="text-xs text-base-content/40">{{$typeLabel}}{{if $subtype}} &middot; {{$subtype}}{{end}}</span>
         {{if .Account.Mask}}<span class="text-xs text-base-content/30">&bull;&bull;&bull;&bull;{{.Account.Mask}}</span>{{end}}
         {{if .Account.Excluded}}<span class="badge badge-ghost badge-xs">Excluded</span>{{end}}
         {{if and .Account.ConnectionStatus (ne (deref .Account.ConnectionStatus) "active")}}


### PR DESCRIPTION
Fixes #629

## Summary

The account-detail header rendered `{type} · {subtype}` even when the humanized subtype was an echo of the type label. On every credit-card page this produced "Credit Card · credit card ····6420". This adds a `subtypeSuffix` template helper that collapses the echo while preserving informative subtypes (e.g. "Bank Account · checking", "Investment · 401k").

Implemented per the issue's proposed fix: the helper lowercases both sides and strips spaces/underscores before comparing, so "Credit Card" and "credit_card" normalize to the same token and the subtype is suppressed.

## Before / After

### Credit card detail — desktop (1440)
| Before | After |
| --- | --- |
| ![before-cc-1440](https://i.img402.dev/gapr5ak82j.png) | ![after-cc-1440](https://i.img402.dev/xk2v16pzqg.png) |

### Credit card detail — mobile (375)
| Before | After |
| --- | --- |
| ![before-cc-375](https://i.img402.dev/hw5yhsgr0c.png) | ![after-cc-375](https://i.img402.dev/s8iovo7sk9.png) |

### Regression: bank account (checking) unchanged — desktop (1440)
| Before | After |
| --- | --- |
| ![before-bank-1440](https://i.img402.dev/n76ekc8cxm.png) | ![after-bank-1440](https://i.img402.dev/d4c9drtkg2.png) |

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/admin/...` passes
- [x] Credit-card detail shows "Credit Card ····6420" (subtype suppressed)
- [x] Bank-account detail still shows "Bank Account · checking ····0000"
- [x] Verified at 375 and 1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)