### PR TITLE
ux(accounts): Linked badge for dependent-linked accounts (#628)

### DIFF
--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -116,6 +116,7 @@ func accountFromAllRow(r db.ListAccountsRow) AccountResponse {
 		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		ConnectionStatus:  nullConnStatusPtr(r.ConnectionStatus),
+		IsDependentLinked: r.IsDependentLinked,
 	}
 }
 
@@ -139,6 +140,7 @@ func accountFromUserRow(r db.ListAccountsByUserRow) AccountResponse {
 		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		ConnectionStatus:  connStatusPtr(r.ConnectionStatus),
+		IsDependentLinked: r.IsDependentLinked,
 	}
 }
 
@@ -162,6 +164,7 @@ func accountFromGetRow(r db.GetAccountRow) AccountResponse {
 		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
 		ConnectionStatus:  nullConnStatusPtr(r.ConnectionStatus),
+		IsDependentLinked: r.IsDependentLinked,
 	}
 }
 

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -21,6 +21,7 @@ type AccountResponse struct {
 	CreatedAt         string   `json:"created_at"`
 	UpdatedAt         string   `json:"updated_at"`
 	ConnectionStatus  *string  `json:"connection_status,omitempty"`
+	IsDependentLinked bool     `json:"is_dependent_linked"`
 }
 
 type TransactionCategoryInfo struct {

--- a/internal/templates/pages/account_detail.html
+++ b/internal/templates/pages/account_detail.html
@@ -17,6 +17,7 @@
         <span class="text-xs text-base-content/40">{{$typeLabel}}{{if $subtype}} &middot; {{$subtype}}{{end}}</span>
         {{if .Account.Mask}}<span class="text-xs text-base-content/30">&bull;&bull;&bull;&bull;{{.Account.Mask}}</span>{{end}}
         {{if .Account.Excluded}}<span class="badge badge-ghost badge-xs">Excluded</span>{{end}}
+        {{if .Account.IsDependentLinked}}<span class="badge badge-soft badge-info badge-xs" title="Dependent-linked: balance and transactions are attributed to a linked user and excluded from this user's totals">Linked</span>{{end}}
         {{if and .Account.ConnectionStatus (ne (deref .Account.ConnectionStatus) "active")}}
         {{if eq (deref .Account.ConnectionStatus) "error"}}<span class="badge badge-soft badge-error badge-xs">Error</span>
         {{else if eq (deref .Account.ConnectionStatus) "pending_reauth"}}<span class="badge badge-soft badge-warning badge-xs">Reauth</span>
@@ -109,6 +110,15 @@
         <div>
           <p class="text-xs text-base-content/40 mb-1">Family Member</p>
           <p class="text-sm font-medium">{{.Account.UserName}}</p>
+        </div>
+        {{end}}
+        {{if .Account.IsDependentLinked}}
+        <div class="sm:col-span-2 lg:col-span-4">
+          <p class="text-xs text-base-content/40 mb-1">Attribution</p>
+          <div class="flex items-start gap-2 text-sm">
+            <span class="badge badge-soft badge-info badge-sm shrink-0">Linked</span>
+            <p class="text-base-content/70 leading-relaxed">This account is linked to a primary cardholder. Its balance and transactions are attributed to the linked user, so they are excluded from this user's totals. Manage links on the <a href="/connections?tab=links" class="link link-primary">Account Links</a> tab.</p>
+          </div>
         </div>
         {{end}}
       </div>

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -221,8 +221,13 @@
             {{end}}
           </div>
           <div class="min-w-0">
-            <div class="text-sm font-medium truncate group-hover/acct:text-primary transition-colors">
-              {{if .DisplayName.Valid}}{{.DisplayName.String}}{{else}}{{.Name}}{{end}}
+            <div class="flex items-center gap-1.5 flex-wrap">
+              <span class="text-sm font-medium truncate group-hover/acct:text-primary transition-colors">
+                {{if .DisplayName.Valid}}{{.DisplayName.String}}{{else}}{{.Name}}{{end}}
+              </span>
+              {{if .IsDependentLinked}}
+              <span class="badge badge-soft badge-info badge-xs" title="Dependent-linked: balance and transactions are attributed to a linked user and excluded from this user's totals">Linked</span>
+              {{end}}
             </div>
             <div class="text-xs text-base-content/40">
               {{if .Subtype.Valid}}<span class="capitalize">{{humanize .Subtype.String}}</span>{{end}}


### PR DESCRIPTION
Fixes #628

Surfaces dependent-linked accounts (`accounts.is_dependent_linked = TRUE`, introduced in migration 00027) with a visible badge so users can tell at a glance which accounts are attributed to a linked user and therefore excluded from their totals. Previously the flag had zero UI surface — the only signal was that totals silently omitted the balance.

## Changes

- **`internal/templates/pages/connections.html`** — renders `<span class="badge badge-soft badge-info badge-xs">Linked</span>` next to the account name inside each connection's account list. Badge carries a tooltip explaining the behavior.
- **`internal/templates/pages/account_detail.html`** — same badge in the detail-page header, plus a full-width explanatory row inside the "Account Settings" collapsible when the account is dependent-linked, with a link to the Account Links tab.
- **`internal/service/types.go`, `internal/service/accounts.go`** — adds `IsDependentLinked bool` to `AccountResponse` and populates it from `ListAccountsRow`, `ListAccountsByUserRow`, and `GetAccountRow`. This also means REST (`GET /api/v1/accounts`, `GET /api/v1/accounts/:id`) and MCP `list_accounts` now expose the flag.

Non-dependent-linked accounts are unchanged visually.

## Before / After

### Connections list (`/connections`)

| | Before | After |
|---|---|---|
| Desktop 1440 | ![](https://i.img402.dev/b062xeg12v.png) | ![](https://i.img402.dev/2wosxsllpn.png) |
| Tablet 820 | ![](https://i.img402.dev/9v93wrd5t0.png) | ![](https://i.img402.dev/a4h9xuk04y.png) |
| Mobile 500 | ![](https://i.img402.dev/8p1cgdqowi.png) | ![](https://i.img402.dev/tzeilkzw9z.png) |

### Account detail (`/accounts/:id`)

| | Before | After |
|---|---|---|
| Desktop 1440 | ![](https://i.img402.dev/v7ilqh5rtp.png) | ![](https://i.img402.dev/1psca7m6z2.png) |
| Tablet 820 | ![](https://i.img402.dev/g5ex7rtphk.png) | ![](https://i.img402.dev/mb0je1we6w.png) |
| Mobile 500 | ![](https://i.img402.dev/pcuzvpiuzh.png) | ![](https://i.img402.dev/5tnepn2h4u.png) |

## Test plan

- [x] `go build ./...` clean.
- [x] Visual verification at 500 / 820 / 1440 after creating an account link (which flips `is_dependent_linked=true` on the dependent account).
- [x] Badge disappears and explanatory row is hidden when the account is no longer dependent-linked (verified by deleting the link, which resets the flag per `internal/service/account_links.go`).
- [ ] Consider a follow-up to show the same badge in dashboard "family member" account rollups and in the Connections-tab list when a connection has *any* dependent-linked child (out of scope for this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)