### PR TITLE
fix(logs): stack Sync Logs stat cards on mobile to prevent overflow

### DIFF
--- a/internal/templates/pages/logs.html
+++ b/internal/templates/pages/logs.html
@@ -30,7 +30,7 @@
 
 <!-- Summary Stats -->
 {{if .Stats}}
-<div class="grid grid-cols-3 gap-3 mb-6 bb-stagger">
+<div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6 bb-stagger">
   <!-- Success Rate -->
   <div class="bb-card p-4">
     <div class="flex items-center gap-3">


### PR DESCRIPTION
Fixes #634

Hardcoded `grid-cols-3` forced three stat cards into narrow viewports on the Sync Logs tab, clipping the third card and triggering horizontal scroll at <=390px. Switched to `grid-cols-1 sm:grid-cols-3` so the cards stack on mobile and match the responsive pattern already used by the Webhooks tab on the same page.

### Before / After — 375×667

| Before | After |
|---|---|
| ![before 375](https://i.img402.dev/m0y9jdk0ow.png) | ![after 375](https://i.img402.dev/1rkv5kr9z7.png) |

### Before / After — 390×844

| Before | After |
|---|---|
| ![before 390](https://i.img402.dev/shzmcungfg.png) | ![after 390](https://i.img402.dev/grsqyy61k3.png) |

Desktop (>=640px) layout is unchanged — cards remain 3-across.

🤖 Generated with [Claude Code](https://claude.com/claude-code)