### PR TITLE
a11y(drawer): trap focus in mobile sidebar when open

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -65,16 +65,26 @@
       <!-- Mobile navbar -->
       <div class="bb-mobile-navbar lg:hidden">
         <div class="flex-none">
-          <label for="bb-drawer" class="btn btn-square btn-ghost">
-            <i data-lucide="menu" class="w-5 h-5"></i>
+          <label for="bb-drawer"
+                 id="bb-drawer-trigger"
+                 class="btn btn-square btn-ghost"
+                 role="button"
+                 tabindex="0"
+                 aria-label="Open navigation menu"
+                 aria-controls="bb-drawer-sidebar"
+                 aria-expanded="false">
+            <i data-lucide="menu" class="w-5 h-5" aria-hidden="true"></i>
           </label>
         </div>
         <div class="flex-1 min-w-0">
           <a href="/" class="text-sm font-semibold truncate">Breadbox</a>
         </div>
         <div class="flex-none">
-          <button class="btn btn-square btn-ghost" x-data @click="$dispatch('open-cmdk')" title="Search">
-            <i data-lucide="search" class="w-5 h-5"></i>
+          <button class="btn btn-square btn-ghost"
+                  x-data @click="$dispatch('open-cmdk')"
+                  aria-label="Search"
+                  title="Search">
+            <i data-lucide="search" class="w-5 h-5" aria-hidden="true"></i>
           </button>
         </div>
       </div>
@@ -91,9 +101,9 @@
     </div>
 
     <!-- Sidebar -->
-    <div class="drawer-side">
+    <div class="drawer-side" id="bb-drawer-sidebar">
       <label for="bb-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
-      <aside class="bb-sidebar">
+      <aside class="bb-sidebar" id="bb-sidebar" aria-label="Main navigation">
         <!-- Brand -->
         <a href="/" class="bb-sidebar-brand">
           <i data-lucide="package" class="w-5 h-5"></i>
@@ -746,16 +756,143 @@
       lucide.createIcons({ nodes: [btn] });
     };
 
-    // Auto-close sidebar on mobile when a nav link is tapped
+    // Mobile drawer: auto-close on nav tap + focus trap + aria management (#640)
+    //
+    // DaisyUI's checkbox-based drawer is visual-only — when opened on mobile it
+    // doesn't manage focus, so Tab escapes out to the topbar search button
+    // behind the overlay and screen readers can still navigate the page
+    // content. This IIFE scopes modal behavior to the drawer while it's open
+    // at <lg (<1024px), and leaves the persistent desktop sidebar alone.
     (function() {
       var toggle = document.getElementById('bb-drawer');
       if (!toggle) return;
-      var side = document.querySelector('.drawer-side');
-      if (!side) return;
-      side.querySelectorAll('a.bb-sidebar-link, button[type="submit"]').forEach(function(link) {
+      var drawerSide = document.getElementById('bb-drawer-sidebar');
+      var sidebar = document.getElementById('bb-sidebar');
+      var trigger = document.getElementById('bb-drawer-trigger');
+      var content = document.querySelector('.drawer-content');
+      if (!drawerSide || !sidebar) return;
+
+      var TABBABLE = [
+        'a[href]',
+        'button:not([disabled])',
+        'input:not([disabled]):not([type="hidden"])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])',
+      ].join(',');
+
+      function isMobile() { return window.innerWidth < 1024; }
+
+      function tabbableItems() {
+        return Array.prototype.filter.call(
+          sidebar.querySelectorAll(TABBABLE),
+          function(el) {
+            // Skip elements hidden via display:none/visibility
+            return el.offsetParent !== null || el === document.activeElement;
+          }
+        );
+      }
+
+      function setInertOutside(on) {
+        // Apply inert + aria-hidden to everything outside the drawer-side so
+        // the mobile navbar (search button) and main content don't swallow
+        // focus or get announced by screen readers.
+        [content, document.querySelector('.bb-mobile-navbar')].forEach(function(el) {
+          if (!el) return;
+          if (on) {
+            el.setAttribute('inert', '');
+            el.setAttribute('aria-hidden', 'true');
+          } else {
+            el.removeAttribute('inert');
+            el.removeAttribute('aria-hidden');
+          }
+        });
+      }
+
+      function onOpen() {
+        if (!isMobile()) return;
+        sidebar.setAttribute('role', 'dialog');
+        sidebar.setAttribute('aria-modal', 'true');
+        if (trigger) trigger.setAttribute('aria-expanded', 'true');
+        setInertOutside(true);
+        // Move focus into the drawer on next tick so the checkbox-driven
+        // CSS transition has started.
+        requestAnimationFrame(function() {
+          var items = tabbableItems();
+          if (items.length) items[0].focus();
+        });
+      }
+
+      function onClose() {
+        var wasModal = sidebar.hasAttribute('aria-modal');
+        sidebar.removeAttribute('role');
+        sidebar.removeAttribute('aria-modal');
+        if (trigger) trigger.setAttribute('aria-expanded', 'false');
+        setInertOutside(false);
+        // If focus was inside the drawer (e.g. a nav link was clicked on
+        // mobile), return it to the trigger so keyboard users don't lose
+        // their place. Skip if focus already moved elsewhere intentionally.
+        if (wasModal && trigger && (document.activeElement === document.body ||
+            sidebar.contains(document.activeElement))) {
+          trigger.focus();
+        }
+      }
+
+      toggle.addEventListener('change', function() {
+        if (toggle.checked) onOpen(); else onClose();
+      });
+
+      // Tab cycling — trap focus among drawer tabbables while open on mobile.
+      document.addEventListener('keydown', function(e) {
+        if (!toggle.checked || !isMobile()) return;
+        if (e.key === 'Tab') {
+          var items = tabbableItems();
+          if (!items.length) { e.preventDefault(); return; }
+          var first = items[0];
+          var last = items[items.length - 1];
+          var active = document.activeElement;
+          // Focus not inside drawer (e.g. body after click) → pull it in.
+          if (!sidebar.contains(active)) {
+            e.preventDefault();
+            (e.shiftKey ? last : first).focus();
+            return;
+          }
+          if (e.shiftKey && active === first) {
+            e.preventDefault();
+            last.focus();
+          } else if (!e.shiftKey && active === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        } else if (e.key === 'Escape') {
+          e.preventDefault();
+          toggle.checked = false;
+          // Manually fire 'change' so our onClose + screen readers update;
+          // setting .checked programmatically doesn't dispatch change.
+          toggle.dispatchEvent(new Event('change'));
+          if (trigger) trigger.focus();
+        }
+      });
+
+      // On resize across the lg breakpoint, clean up modal state so the
+      // persistent desktop sidebar isn't stuck in dialog/inert limbo.
+      window.addEventListener('resize', function() {
+        if (!isMobile()) {
+          sidebar.removeAttribute('role');
+          sidebar.removeAttribute('aria-modal');
+          if (trigger) trigger.setAttribute('aria-expanded', 'false');
+          setInertOutside(false);
+        } else if (toggle.checked) {
+          onOpen();
+        }
+      });
+
+      // Existing behavior: auto-close drawer on mobile when a nav link is tapped.
+      drawerSide.querySelectorAll('a.bb-sidebar-link, button[type="submit"]').forEach(function(link) {
         link.addEventListener('click', function() {
-          if (window.innerWidth < 1024) {
+          if (isMobile()) {
             toggle.checked = false;
+            toggle.dispatchEvent(new Event('change'));
           }
         });
       });


### PR DESCRIPTION
Fixes #640

## Summary
DaisyUI's checkbox-based drawer is visual-only — on mobile, opening it leaves focus reachable on the topbar search button and page content behind the overlay, so keyboard and screen-reader users can Tab out of the modal. This adds a scoped focus trap that only runs at <lg (<1024px): moves focus into the drawer on open, wraps Tab/Shift+Tab, marks `.drawer-content` + mobile navbar as `inert` + `aria-hidden`, sets `role="dialog"` / `aria-modal="true"` on the sidebar, and returns focus to the hamburger trigger on Escape or close. Desktop (`lg:drawer-open`) behavior is unchanged.

Also labels the hamburger and topbar search icons (`aria-label` + `aria-hidden` on the inner icons) so they're no longer announced as "unlabelled button."

## Behavior (375×667, drawer open)

| Before | After |
| --- | --- |
| Tab leaves drawer — focus lands on topbar Search button outside the overlay. | Tab cycles only inside the drawer (brand → search → Home → Transactions → …). |
| Escape does nothing; drawer stays open. | Escape closes the drawer and returns focus to the hamburger. |
| `.drawer-content` still exposes page content to AT. | `.drawer-content` + mobile navbar are `inert` + `aria-hidden="true"`. |
| Hamburger / search announced as "button, clickable" (no accessible name). | Announced as "Open navigation menu" / "Search"; `aria-expanded` reflects state. |

## Screenshots

### Before — Tab 1 (focused on unnamed topbar Search button, outside drawer)
![before tab 1](https://i.img402.dev/72i3cxif4r.png)

### Before — after 4 Tabs (still outside the drawer, cycling topbar controls)
![before tab 4](https://i.img402.dev/a5nb8gkzmt.png)

### After — Tab 1 (drawer brand link, inside the drawer)
![after tab 1](https://i.img402.dev/0d857v8mr4.png)

### After — Tab 4 (Transactions link, still inside the drawer)
![after tab 4](https://i.img402.dev/jny5t3a00n.png)

### Desktop (1440px) unchanged
![desktop 1440](https://i.img402.dev/z3638o5qva.png)

## Test plan
- [x] Verified at 375×667: Tab 20 times — focus never leaves the drawer.
- [x] Verified Shift+Tab from first drawer item wraps to last.
- [x] Verified Escape closes drawer (`checked=false`), sets `aria-expanded=false`, and moves focus back to the hamburger trigger.
- [x] Verified on open: sidebar has `role=dialog` + `aria-modal=true`; `.drawer-content` + `.bb-mobile-navbar` both get `inert` + `aria-hidden="true"`.
- [x] Verified on close: those attributes are removed.
- [x] Verified at 1440×900: sidebar has no dialog/modal role, no `inert` applied anywhere.
- [x] `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)