### PR TITLE
fix(backups): align empty state with preflight status

### DIFF
--- a/internal/templates/pages/backups.html
+++ b/internal/templates/pages/backups.html
@@ -9,7 +9,11 @@
     <form method="POST" action="/-/backups/create">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
       <button type="submit" class="btn btn-primary btn-sm rounded-xl" {{if not .PreflightOK}}disabled title="{{.PreflightMessage}}"{{end}}>
+        {{if .PreflightOK}}
         <i data-lucide="download" class="w-4 h-4"></i>
+        {{else}}
+        <i data-lucide="info" class="w-4 h-4"></i>
+        {{end}}
         Create Backup Now
       </button>
     </form>
@@ -146,7 +150,12 @@
     {{if eq .BackupCount 0}}
     <div class="px-4 sm:px-5 py-8 text-center text-sm text-base-content/40">
       <i data-lucide="database" class="w-8 h-8 mx-auto mb-2 opacity-30"></i>
+      {{if .PreflightOK}}
       <p>No backups yet. Click "Create Backup Now" to create your first backup.</p>
+      {{else}}
+      <p class="font-medium text-base-content/60">Backups are paused</p>
+      <p class="mt-1">Resolve the preflight issue shown above, then come back to create your first backup.</p>
+      {{end}}
     </div>
     {{else}}
     <div class="overflow-x-auto">


### PR DESCRIPTION
## Summary

Fixes #636

When the backup preflight fails (e.g. `pg_dump` version mismatch), the empty-state card on `/backups` used to tell the user to click \"Create Backup Now\" — a button that was disabled in that same state. It now acknowledges the paused state and points at the red alert above. The disabled button also gets a subtle `info` icon so its unavailable state is obvious without hovering for the `title` tooltip.

Surgical template-only change in `internal/templates/pages/backups.html` — branches the empty-state copy and the button icon on `.PreflightOK`.

## Before / After

### Desktop (1440×900)

| Before | After |
| --- | --- |
| ![before-desktop](https://i.img402.dev/ztj7y6oz7o.png) | ![after-desktop](https://i.img402.dev/vb79qthi34.png) |

### Mobile (375×667)

| Before | After |
| --- | --- |
| ![before-mobile](https://i.img402.dev/g6qyon7ex9.png) | ![after-mobile](https://i.img402.dev/e7moe4vtrg.png) |

## Test plan
- [x] Preflight-failure state: empty-state copy reads \"Backups are paused / Resolve the preflight issue shown above, then come back to create your first backup.\" (verified at 1440 and 375)
- [x] Disabled \"Create Backup Now\" button renders an `info` icon instead of the `download` icon, retains `title` tooltip with preflight message
- [ ] Preflight-OK + zero backups: existing \"No backups yet. Click 'Create Backup Now'...\" copy preserved (unchanged template branch)
- [ ] Preflight-OK + existing backups: no regression in the file list rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)