### PR TITLE
fix(nav): drop pending-reviews badge from sidebar Tags link

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -83,11 +83,7 @@ templ Nav(p NavProps) {
 		}
 		if p.IsEditor {
 			<a href="/tags" class={ "bb-sidebar-link", navActive(p.CurrentPage, "tags") }>
-				<i data-lucide="tags"></i>
-				<span class="flex-1">Tags</span>
-				if p.PendingReviews > 0 {
-					<span class="bb-nav-badge" title={ fmt.Sprintf("%d transactions tagged needs-review", p.PendingReviews) }>{ badgeCount(p.PendingReviews) }</span>
-				}
+				<i data-lucide="tags"></i> Tags
 			</a>
 		}
 		if p.IsAdmin {


### PR DESCRIPTION
## Summary
Removes the small count pill that rendered next to the **Tags** item in the admin sidebar. The review count is still surfaced on the Agents wizard page (the primary place reviews get triaged), so no signal is lost — just less badge noise in the nav chrome.

## Changes
- `internal/templates/components/nav.templ` — drop the `bb-nav-badge` span and the `PendingReviews > 0` guard from the `/tags` link; collapse the `<span class="flex-1">Tags</span>` back to the same simple `<i> Text` pattern used by the other unbadged nav items.
- `PendingReviews` stays on `NavProps` and middleware — still consumed by the Agents wizard.

## Before / After

<table>
  <tr><th>Before (Tags 99+)</th><th>After (Tags)</th></tr>
  <tr>
    <td><img src="https://github.com/canalesb93/breadbox/releases/download/screenshots-cdn/20260423-124301-tags-badge-before.jpeg" width="320" alt="sidebar before — Tags 99+"></td>
    <td><img src="https://github.com/canalesb93/breadbox/releases/download/screenshots-cdn/20260423-124301-tags-badge-after.jpeg" width="320" alt="sidebar after — Tags"></td>
  </tr>
</table>

## Test plan
- [ ] Load the admin on a role with `IsEditor = true` and a non-zero `PendingReviews` count; confirm the Tags sidebar link no longer shows the count pill.
- [ ] Confirm Reports (unread) and Connections (attention) badges are untouched.
- [ ] Navigate to `/agents` and confirm the review count is still displayed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
