### PR TITLE
fix(dashboard): drop attention, connections, and net worth sections

### DIFF
--- a/internal/templates/components/pages/dashboard.templ
+++ b/internal/templates/components/pages/dashboard.templ
@@ -3,29 +3,16 @@ package pages
 import (
 	"fmt"
 
-	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 )
 
-// Dashboard renders the admin home page: net worth hero, account grid,
-// agent reports, recent transactions, attention items, connection health.
+// Dashboard renders the admin home page: agent reports and recent transactions.
 // Hosted inside base.html via TemplateRenderer.RenderWithTempl.
 templ Dashboard(p DashboardProps) {
 	if p.ShowUpdateBanner {
 		@dashUpdateBanner(p)
 	}
-	if p.NeedsAttention > 0 {
-		<div role="alert" class="alert alert-warning rounded-xl mb-6">
-			<i data-lucide="alert-triangle" class="w-5 h-5"></i>
-			<div>
-				<strong>{ fmt.Sprintf("%d connection(s) need attention.", p.NeedsAttention) }</strong>
-				<a href="/connections" class="link ml-1">View connections &rarr;</a>
-			</div>
-		</div>
-	}
-	if len(p.Accounts) > 0 {
-		@dashNetWorthCard(p)
-	} else {
+	if len(p.Accounts) == 0 {
 		<div class="bb-card mb-6 p-8 text-center">
 			<i data-lucide="wallet" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
 			<h2 class="text-lg font-semibold mb-1">No accounts yet</h2>
@@ -39,10 +26,6 @@ templ Dashboard(p DashboardProps) {
 	<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
 		@dashAgentReportsCard(p)
 		@dashRecentTransactionsCard(p)
-	</div>
-	<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-		@dashAttentionCard(p)
-		@dashConnectionsCard(p)
 	</div>
 	@dashScripts()
 }
@@ -86,122 +69,6 @@ templ dashUpdateBanner(p DashboardProps) {
 			<button class="btn btn-sm btn-ghost" @click={ dashDismissUpdateScript(p.LatestVersion) }>Dismiss</button>
 		</div>
 	</div>
-}
-
-templ dashNetWorthCard(p DashboardProps) {
-	<div class="bb-card mb-6">
-		if len(p.AllocationSlices) > 0 {
-			<div class="p-5 sm:p-6">
-				<div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-4">
-					<div>
-						<div class="text-xs text-base-content/40 mb-0.5">Net Worth</div>
-						<div class="text-3xl sm:text-4xl font-bold tabular-nums tracking-tight">{ components.FormatBalance(p.NetWorth) }</div>
-					</div>
-					<div class="flex items-center gap-5 sm:text-right">
-						<div>
-							<div class="text-[0.65rem] text-base-content/35 uppercase tracking-wider">Assets</div>
-							<div class="text-sm font-semibold tabular-nums text-success/80">{ components.FormatBalance(p.TotalAssets) }</div>
-						</div>
-						<div>
-							<div class="text-[0.65rem] text-base-content/35 uppercase tracking-wider">Liabilities</div>
-							<div class="text-sm font-semibold tabular-nums text-error/70">{ components.FormatBalance(p.TotalLiabilities) }</div>
-						</div>
-					</div>
-				</div>
-				<div class="flex h-2.5 rounded-full overflow-hidden gap-0.5">
-					for _, s := range p.AllocationSlices {
-						<div class="h-full rounded-full transition-all duration-700 ease-out" style={ dashAllocSegStyle(s) } title={ fmt.Sprintf("%s: %s", s.Label, components.FormatBalance(s.Amount)) }></div>
-					}
-				</div>
-				<div class="flex items-center gap-4 flex-wrap mt-2.5">
-					for _, s := range p.AllocationSlices {
-						<span class="flex items-center gap-1.5 text-xs text-base-content/50">
-							<span class="w-2 h-2 rounded-full shrink-0" style={ dashAllocDotStyle(s) }></span>
-							{ s.Label }
-							<span class="tabular-nums font-medium text-base-content/70">{ components.FormatBalance(s.Amount) }</span>
-						</span>
-					}
-				</div>
-			</div>
-		}
-		@dashAccountsGrid(p)
-	</div>
-}
-
-templ dashAccountsGrid(p DashboardProps) {
-	<div class="border-t border-base-200/60" x-data="{ showAccounts: false }">
-		<button @click="showAccounts = !showAccounts" class="w-full px-4 sm:px-5 py-3 flex items-center justify-between cursor-pointer hover:bg-base-200/30 transition-colors">
-			<span class="flex items-center gap-2">
-				<span class="text-sm font-semibold text-base-content/70">{ fmt.Sprintf("%d Accounts", len(p.Accounts)) }</span>
-				<i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/30 transition-transform duration-200" :class="showAccounts ? 'rotate-180' : ''"></i>
-			</span>
-			<a href="/connections" @click.stop class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Manage</a>
-		</button>
-		<div x-show="showAccounts" x-cloak x-collapse>
-			<div class="px-4 sm:px-5 pb-4 sm:pb-5">
-				<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-					for _, a := range p.Accounts {
-						@dashAccountCard(a)
-					}
-				</div>
-			</div>
-		</div>
-	</div>
-}
-
-templ dashAccountCard(a DashboardAccount) {
-	<a href={ templ.SafeURL("/accounts/" + a.ID) } class="bb-card bb-card--interactive p-4 no-underline group block">
-		<div class="flex items-start justify-between mb-2">
-			<div class="min-w-0 flex-1">
-				<div class="flex items-center gap-1.5">
-					@dashConnDot(a.ConnectionStatus)
-					<span class="text-sm font-medium truncate group-hover:text-primary transition-colors">{ a.Name }</span>
-				</div>
-				<div class="text-[0.65rem] text-base-content/40 mt-0.5 truncate">
-					{ a.InstitutionName }
-					if a.Mask != "" {
-						· ····{ a.Mask }
-					}
-				</div>
-			</div>
-			<div class="w-7 h-7 rounded-lg bg-base-200/50 flex items-center justify-center shrink-0 ml-2">
-				<i data-lucide={ dashAccountIcon(a.Type) } class="w-3.5 h-3.5 text-base-content/35"></i>
-			</div>
-		</div>
-		if a.SparklineData != "" {
-			<div class="bb-sparkline w-full h-8 my-1.5" data-values={ a.SparklineData } data-liability={ fmt.Sprintf("%t", a.IsLiability) }></div>
-		} else {
-			<div class="h-8 my-1.5"></div>
-		}
-		<div class="flex items-end justify-between mt-1">
-			<div class={ "text-lg font-bold tabular-nums tracking-tight", templ.KV("text-error/80", a.IsLiability) }>
-				if a.IsLiability {
-					-
-				}
-				{ components.FormatBalance(a.BalanceCurrent) }
-			</div>
-			<div class="text-right">
-				if a.SpendingTotal > 0 {
-					<div class="text-[0.65rem] text-base-content/40 tabular-nums">{ components.FormatBalance(a.SpendingTotal) } spent</div>
-				} else {
-					<div class="text-[0.65rem] text-base-content/35">{ dashAccountLabel(a.Type, a.Subtype) }</div>
-				}
-			</div>
-		</div>
-	</a>
-}
-
-templ dashConnDot(status string) {
-	switch status {
-		case "active":
-			<span class="w-1.5 h-1.5 rounded-full bg-success/60 shrink-0" title="Connected"></span>
-		case "error":
-			<span class="w-1.5 h-1.5 rounded-full bg-error/70 shrink-0" title="Error"></span>
-		case "pending_reauth":
-			<span class="w-1.5 h-1.5 rounded-full bg-warning shrink-0" title="Needs reauth"></span>
-		case "disconnected":
-			<span class="w-1.5 h-1.5 rounded-full bg-base-300 shrink-0" title="Disconnected"></span>
-	}
 }
 
 templ dashAgentReportsCard(p DashboardProps) {
@@ -302,176 +169,6 @@ templ dashRecentTransactionsCard(p DashboardProps) {
 	</div>
 }
 
-templ dashAttentionCard(p DashboardProps) {
-	<div class="bb-card">
-		<div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
-			<div class="flex items-center gap-2">
-				<i data-lucide="bell" class="w-4 h-4 text-base-content/40"></i>
-				<h2 class="text-sm font-semibold text-base-content/80">Attention</h2>
-				if p.HasAttentionItems {
-					<span class="text-[0.65rem] font-semibold px-2 py-0.5 rounded-full bg-warning/15 text-warning">{ attentionBadge(p.AttentionCount) }</span>
-				}
-			</div>
-		</div>
-		if p.HasAttentionItems {
-			<div class="px-3 sm:px-4 py-2">
-				if p.UncategorizedCount > 0 {
-					@dashAttentionLink("/transactions?filter=uncategorized", "tag", "text-warning", "bg-warning/10",
-						fmt.Sprintf("%s uncategorized", components.CommaInt(p.UncategorizedCount)),
-						"Review and assign categories")
-				}
-				if p.ReviewsEnabled && p.ReviewPending > 0 {
-					@dashAttentionLink("/reviews", "clipboard-check", "text-info", "bg-info/10",
-						fmt.Sprintf("%s pending reviews", components.CommaInt(p.ReviewPending)),
-						"Awaiting your approval")
-				}
-				if p.ErrorCount > 0 {
-					@dashAttentionLink("/connections", "alert-circle", "text-error/70", "bg-error/10",
-						dashErrorLabel(p.ErrorCount),
-						"Authentication or sync errors")
-				}
-			</div>
-		} else {
-			<div class="px-5 py-8 text-center">
-				<i data-lucide="check-circle-2" class="w-8 h-8 mx-auto mb-2 text-success/30"></i>
-				<p class="text-sm text-base-content/40">All caught up</p>
-				<p class="text-xs text-base-content/30 mt-0.5">No items need your attention right now.</p>
-			</div>
-		}
-	</div>
-}
-
-templ dashAttentionLink(href, icon, textClass, bgClass, label, sub string) {
-	<a href={ templ.SafeURL(href) } class="flex items-center gap-3 py-2.5 px-2 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline group">
-		<div class={ "w-8 h-8 rounded-lg flex items-center justify-center shrink-0", bgClass }>
-			<i data-lucide={ icon } class={ "w-4 h-4", textClass }></i>
-		</div>
-		<div class="flex-1 min-w-0">
-			<div class="text-sm font-medium group-hover:text-primary transition-colors">{ label }</div>
-			<div class="text-[0.65rem] text-base-content/40 mt-0.5">{ sub }</div>
-		</div>
-		<i data-lucide="chevron-right" class="w-4 h-4 text-base-content/20 group-hover:text-base-content/40 transition-colors shrink-0"></i>
-	</a>
-}
-
-templ dashConnectionsCard(p DashboardProps) {
-	if len(p.ConnectionHealth) > 0 {
-		<div class="bb-card">
-			<div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
-				<div class="flex items-center gap-2">
-					<i data-lucide="link-2" class="w-4 h-4 text-base-content/40"></i>
-					<h2 class="text-sm font-semibold text-base-content/80">Connections</h2>
-				</div>
-				<a href="/connections" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">Manage</a>
-			</div>
-			if p.SyncHealth != nil {
-				@dashSyncHealthRow(p.SyncHealth)
-			}
-			<div class="px-3 sm:px-4 py-2">
-				for _, c := range p.ConnectionHealth {
-					@dashConnectionRow(c)
-				}
-			</div>
-		</div>
-	} else {
-		<div class="bb-card">
-			<div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
-				<div class="flex items-center gap-2">
-					<i data-lucide="link-2" class="w-4 h-4 text-base-content/40"></i>
-					<h2 class="text-sm font-semibold text-base-content/80">Connections</h2>
-				</div>
-			</div>
-			<div class="px-5 py-8 text-center">
-				<i data-lucide="link-2" class="w-8 h-8 mx-auto mb-2 text-base-content/15"></i>
-				<p class="text-sm text-base-content/40">No connections yet</p>
-				<a href="/connections/new" class="btn btn-primary btn-sm mt-3 rounded-xl">Connect a bank</a>
-			</div>
-		</div>
-	}
-}
-
-templ dashSyncHealthRow(s *service.SyncHealthSummary) {
-	<div class="flex items-center gap-5 flex-wrap px-5 py-3 text-xs text-base-content/50 border-b border-base-200/60">
-		if s.LastSyncTime != nil {
-			<span class="flex items-center gap-1.5">
-				<i data-lucide="clock" class="w-3 h-3 text-base-content/30"></i>
-				Synced { *s.LastSyncTime }
-			</span>
-		}
-		if s.RecentSyncCount > 0 {
-			<span class={ "flex items-center gap-1.5", syncRateColor(s.RecentSuccessRate) }>
-				<i data-lucide="bar-chart-3" class="w-3 h-3"></i>
-				{ fmt.Sprintf("%.0f%% success", s.RecentSuccessRate) }
-			</span>
-		}
-		if s.NextSyncTime != "" {
-			<span class="flex items-center gap-1.5 text-base-content/40">
-				<i data-lucide="timer" class="w-3 h-3"></i>
-				Next: { s.NextSyncTime }
-			</span>
-		}
-	</div>
-}
-
-templ dashConnectionRow(c ConnectionHealthRow) {
-	<a href={ templ.SafeURL("/connections/" + c.ID) } class="flex items-center gap-2.5 py-2.5 px-2 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline group">
-		<div class="relative shrink-0">
-			<div class={ "w-7 h-7 rounded-lg flex items-center justify-center", connStatusBg(c.Status, c.IsStale) }>
-				@dashConnStatusIcon(c.Status, c.IsStale)
-			</div>
-			if c.Paused {
-				<div class="absolute -top-0.5 -right-0.5 w-3 h-3 rounded-full bg-base-100 flex items-center justify-center">
-					<i data-lucide="pause" class="w-2 h-2 text-base-content/40"></i>
-				</div>
-			}
-		</div>
-		<div class="flex-1 min-w-0">
-			<div class="flex items-center gap-1.5">
-				<span class="text-xs font-medium truncate group-hover:text-primary transition-colors">{ c.Name }</span>
-				<span class="text-[0.6rem] text-base-content/25 shrink-0">{ c.Provider }</span>
-			</div>
-			if c.Status != "active" && c.ErrorMessage != "" {
-				<div class="text-[0.6rem] text-error/60 truncate mt-0.5 font-mono max-w-full" title={ c.ErrorMessage }>{ c.ErrorMessage }</div>
-			} else {
-				<div class="text-[0.6rem] text-base-content/30 mt-0.5">{ fmt.Sprintf("%d account%s · synced %s", c.AccountCount, components.PluralS(c.AccountCount), c.LastSyncedAt) }</div>
-			}
-		</div>
-		<div class="shrink-0">
-			@dashConnStatusBadge(c.Status, c.IsStale)
-		</div>
-	</a>
-}
-
-templ dashConnStatusIcon(status string, isStale bool) {
-	switch status {
-		case "error":
-			<i data-lucide="alert-circle" class="w-3.5 h-3.5 text-error/70"></i>
-		case "pending_reauth":
-			<i data-lucide="key" class="w-3.5 h-3.5 text-warning"></i>
-		default:
-			if isStale {
-				<i data-lucide="clock" class="w-3.5 h-3.5 text-warning/70"></i>
-			} else {
-				<i data-lucide="check-circle-2" class="w-3.5 h-3.5 text-success/70"></i>
-			}
-	}
-}
-
-templ dashConnStatusBadge(status string, isStale bool) {
-	switch status {
-		case "active":
-			if isStale {
-				<span class="text-[0.6rem] font-medium text-warning/70 bg-warning/8 px-1.5 py-0.5 rounded-full">stale</span>
-			} else {
-				<span class="w-1.5 h-1.5 rounded-full bg-success/50"></span>
-			}
-		case "error":
-			<span class="text-[0.6rem] font-medium text-error/70 bg-error/8 px-1.5 py-0.5 rounded-full">error</span>
-		case "pending_reauth":
-			<span class="text-[0.6rem] font-medium text-warning bg-warning/8 px-1.5 py-0.5 rounded-full">reauth</span>
-	}
-}
-
 templ dashScripts() {
 	<!-- Agent Reports: dismiss logic -->
 	<script>
@@ -493,134 +190,10 @@ templ dashScripts() {
 			};
 		}
 	</script>
-	<!-- Sparkline Rendering -->
-	<script>
-		document.addEventListener('DOMContentLoaded', function() {
-			var isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-			document.querySelectorAll('.bb-sparkline').forEach(function(el) {
-				try {
-					var values = JSON.parse(el.dataset.values);
-					var isLiability = el.dataset.liability === 'true';
-					if (!values || values.length === 0) return;
-					var max = Math.max.apply(null, values);
-					if (!(max > 0)) return;
-					var w = 200, h = 40, padding = 2;
-					var points = values.map(function(v, i) {
-						var x = padding + (i / (values.length - 1)) * (w - padding * 2);
-						var y = h - padding - ((v / max) * (h - padding * 2));
-						return x + ',' + y;
-					});
-					var pathD = 'M' + points.join(' L');
-					var fillD = pathD + ' L' + (w - padding) + ',' + h + ' L' + padding + ',' + h + ' Z';
-					var strokeColor, fillColor;
-					if (isLiability) {
-						strokeColor = isDark ? 'oklch(0.65 0.15 25)' : 'oklch(0.55 0.15 25)';
-						fillColor = isDark ? 'oklch(0.65 0.15 25 / 0.15)' : 'oklch(0.55 0.15 25 / 0.1)';
-					} else {
-						strokeColor = isDark ? 'oklch(0.65 0.02 250)' : 'oklch(0.45 0.02 250)';
-						fillColor = isDark ? 'oklch(0.65 0.02 250 / 0.15)' : 'oklch(0.45 0.02 250 / 0.1)';
-					}
-					var svg = '<svg viewBox="0 0 ' + w + ' ' + h + '" preserveAspectRatio="none" class="w-full h-full">' +
-						'<path d="' + fillD + '" fill="' + fillColor + '" />' +
-						'<polyline points="' + points.join(' ') + '" fill="none" stroke="' + strokeColor + '" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />' +
-						'</svg>';
-					el.innerHTML = svg;
-				} catch(e) { /* ignore */ }
-			});
-		});
-	</script>
 }
 
 // ── Helpers ──────────────────────────────────────────────────
 
-func dashAllocSegStyle(s AllocationSlice) string {
-	return fmt.Sprintf("width: %.1f%%; background: %s; opacity: 0.7;", s.Percent, s.Color)
-}
-
-func dashAllocDotStyle(s AllocationSlice) string {
-	return fmt.Sprintf("background: %s; opacity: 0.7;", s.Color)
-}
-
-func dashAccountIcon(accountType string) string {
-	switch accountType {
-	case "depository":
-		return "landmark"
-	case "credit":
-		return "credit-card"
-	case "loan":
-		return "file-text"
-	case "investment":
-		return "trending-up"
-	default:
-		return "wallet"
-	}
-}
-
-func dashAccountLabel(accountType, subtype string) string {
-	if subtype != "" {
-		labels := map[string]string{
-			"checking": "Checking", "savings": "Savings",
-			"credit card": "Credit Card", "credit_card": "Credit Card",
-			"money market": "Money Market", "money_market": "Money Market",
-			"cd": "CD", "paypal": "PayPal", "student": "Student Loan",
-			"mortgage": "Mortgage", "auto": "Auto Loan",
-			"401k": "401(k)", "ira": "IRA", "brokerage": "Brokerage",
-			"prepaid": "Prepaid", "hsa": "HSA",
-		}
-		if l, ok := labels[subtype]; ok {
-			return l
-		}
-		return subtype
-	}
-	labels := map[string]string{
-		"depository": "Bank Account", "credit": "Credit Card",
-		"loan": "Loan", "investment": "Investment",
-	}
-	if l, ok := labels[accountType]; ok {
-		return l
-	}
-	return accountType
-}
-
 func dashDismissUpdateScript(version string) string {
 	return fmt.Sprintf(`fetch('/-/update/dismiss', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({version: %q}) }).then(() => $el.closest('.alert').remove())`, version)
-}
-
-func syncRateColor(rate float64) string {
-	switch {
-	case rate >= 90:
-		return "text-success"
-	case rate >= 50:
-		return "text-warning"
-	default:
-		return "text-error/80"
-	}
-}
-
-func connStatusBg(status string, isStale bool) string {
-	switch status {
-	case "error":
-		return "bg-error/10"
-	case "pending_reauth":
-		return "bg-warning/10"
-	default:
-		if isStale {
-			return "bg-warning/8"
-		}
-		return "bg-success/8"
-	}
-}
-
-func attentionBadge(n int) string {
-	if n == 1 {
-		return "1 item"
-	}
-	return fmt.Sprintf("%d items", n)
-}
-
-func dashErrorLabel(n int) string {
-	if n == 1 {
-		return "1 connection needs attention"
-	}
-	return fmt.Sprintf("%d connections need attention", n)
 }


### PR DESCRIPTION
## Summary

Removes the **Attention**, **Connections**, and **Net Worth** sections from the dashboard. The page now shows just the update banner (when available), the empty-accounts CTA (when no accounts are linked), and the Agent Reports + Recent Transactions row.

## Before / After

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/ij3mh7mxut.jpg" width="420" alt="dashboard before"></td>
    <td><img src="https://i.img402.dev/wh1lkz5o6v.jpg" width="420" alt="dashboard after"></td>
  </tr>
</table>

## Changes

- Delete `dashNetWorthCard`, `dashAccountsGrid`, `dashAccountCard`, `dashConnDot` and the top-of-page "N connection(s) need attention" alert.
- Delete `dashAttentionCard` + `dashAttentionLink`.
- Delete `dashConnectionsCard`, `dashSyncHealthRow`, `dashConnectionRow`, `dashConnStatusIcon`, `dashConnStatusBadge`.
- Drop the now-unused sparkline `<script>` block and the helper funcs they relied on.
- Drop the `service` import (no longer referenced).

`DashboardProps` is left alone — the handler still populates it; the unused fields can be removed in a follow-up if desired.

## Test plan

- [x] `go build ./...` clean
- [x] `templ generate` + `templ fmt`
- [x] Loaded `/` in Chrome DevTools MCP against `localhost:8082`, verified Net Worth / Attention / Connections no longer render and Agent Reports + Recent Transactions still do.
