### PR TITLE
chore(skill): make img402 the primary PR image host

### DIFF
--- a/.claude/commands/quick-task.md
+++ b/.claude/commands/quick-task.md
@@ -27,7 +27,7 @@ Respect scoped `.claude/rules/*.md` for the files you're touching. Run `go build
 
 ## 4. AFTER state
 
-Reload the browser, snapshot + screenshot to `/tmp/quick-task-<slug>-after.jpg`. If you can't see the change, it didn't land — say so and debug. Upload both screenshots via the `github-image-hosting` skill for permanent URLs.
+Reload the browser, snapshot + screenshot to `/tmp/quick-task-<slug>-after.jpg`. If you can't see the change, it didn't land — say so and debug. Upload both screenshots via the `github-image-hosting` skill (defaults to img402.dev) and embed the resulting URLs inline in the PR body.
 
 ## 5. Ship
 

--- a/.claude/skills/github-image-hosting/SKILL.md
+++ b/.claude/skills/github-image-hosting/SKILL.md
@@ -1,87 +1,62 @@
 ---
 name: github-image-hosting
 description: >
-  Upload images to GitHub's native CDN for embedding in PRs, issues, and comments.
-  Uses `gh release upload` to a dedicated screenshots prerelease, giving permanent
-  github.com-hosted URLs with no third-party dependency. Falls back to img402.dev
-  if the gh approach isn't available.
+  Upload screenshots or mockups and get a hosted URL suitable for embedding in
+  PRs, issues, and comments. Defaults to img402.dev (ephemeral, 7-day, 1MB cap).
+  Falls back to a GitHub release-asset CDN only when explicitly requested or when
+  img402 is unreachable.
   Triggers: "screenshot this", "attach an image", "add a screenshot to the PR",
-  "upload this mockup", or any task producing an image for GitHub.
+  "upload this mockup", or any task producing an image for a PR/issue.
 metadata:
   openclaw:
     requires:
       bins:
+        - curl
         - gh
 ---
 
-# Image Upload for GitHub
+# PR Image Hosting
 
-Upload a screenshot or image to GitHub's native CDN and embed the URL in a PR or issue.
+Upload a screenshot or image and embed the resulting URL in a PR or issue.
 
-## Primary approach: GitHub Release Assets (preferred)
-
-Uses `gh` (already sandbox-exempt via `excludedCommands`) — no network allowlist changes
-needed, no third-party dependency, URLs are permanent GitHub-hosted links.
-
-### Quick reference
+## Primary: img402.dev
 
 ```bash
-# One-time setup: ensure the screenshots-cdn prerelease exists in this repo
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-gh release view screenshots-cdn 2>/dev/null || \
-  gh release create screenshots-cdn \
-    --prerelease \
-    --title "Screenshots CDN" \
-    --notes "Auto-uploaded PR validation screenshots. Assets may be overwritten between runs."
-
-# Upload (use a timestamped name to avoid collisions between concurrent PRs)
-FNAME="$(date +%Y%m%d-%H%M%S)-$(basename "$FILE")"
-cp "$FILE" "/tmp/$FNAME"
-gh release upload screenshots-cdn "/tmp/$FNAME" --clobber
-
-# Resulting URL
-IMG_URL="https://github.com/$REPO/releases/download/screenshots-cdn/$FNAME"
-echo "$IMG_URL"
+curl -s -X POST https://img402.dev/api/free -F image=@/tmp/screenshot.jpg
+# Response: {"url":"https://i.img402.dev/aBcDeFgHiJ.jpg","id":"aBcDeFgHiJ",...,"expiresAt":"..."}
 ```
 
-### Full workflow
+Extract `.url` with `jq -r .url` or `python3 -c "import sys,json;print(json.load(sys.stdin)['url'])"` and embed in the PR body as inline HTML so the width is controlled:
 
-1. **Capture** the screenshot (via Chrome DevTools MCP `take_screenshot`, saving to `/tmp/app-<page>.jpg`).
-
-2. **Verify size**: must be under 100MB for GitHub releases (practically never an issue).
-
-3. **Ensure the release exists** (idempotent — safe to run every time):
-   ```bash
-   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-   gh release view screenshots-cdn 2>/dev/null || \
-     gh release create screenshots-cdn \
-       --prerelease \
-       --title "Screenshots CDN" \
-       --notes "Auto-uploaded PR validation screenshots."
-   ```
-
-4. **Upload**:
-   ```bash
-   FNAME="$(date +%Y%m%d-%H%M%S)-$(basename /tmp/app-<page>.jpg)"
-   cp /tmp/app-<page>.jpg "/tmp/$FNAME"
-   gh release upload screenshots-cdn "/tmp/$FNAME" --clobber
-   IMG_URL="https://github.com/$REPO/releases/download/screenshots-cdn/$FNAME"
-   echo "$IMG_URL"
-   ```
-
-5. **Embed** in PR description or comment:
-   ```bash
-   # Inline HTML (preferred — controls display width)
-   gh pr comment <PR_NUMBER> --body "<img src=\"$IMG_URL\" width=\"800\" alt=\"<page>\">"
-
-   # Or in a PR body via --body-file with the full markdown
-   ```
-
-### Embed formats
-
-**Single screenshot:**
 ```html
-<img src="https://github.com/OWNER/REPO/releases/download/screenshots-cdn/FNAME.jpg" width="800" alt="<page> — after">
+<img src="https://i.img402.dev/aBcDeFgHiJ.jpg" width="800" alt="<page> — after">
+```
+
+**Constraints**: 1MB max per upload, 7-day expiry (long enough for PR review, short enough that stale screenshots disappear on their own), 1,000 uploads/day global limit. Requires `img402.dev` in the sandbox network allowlist — it is, by default in this project.
+
+If the upload exceeds 1MB: re-encode with lower quality (`cwebp -q 75` or `jpegoptim --max=85 --strip-all`) before retrying. Chrome DevTools MCP `take_screenshot` already supports `format: "jpeg", quality: 85` — use that first.
+
+## Fallback: GitHub release asset CDN
+
+Only use when explicitly requested or when img402 is unavailable (network error, rate-limited). GitHub-hosted URLs are permanent, which is usually undesirable — they clutter the repo's release assets and stick around forever. Ask the user before falling back.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh release view screenshots-cdn --repo "$REPO" >/dev/null 2>&1 || \
+  gh release create screenshots-cdn --repo "$REPO" --prerelease \
+    --title "Screenshots CDN" --notes "Auto-uploaded PR validation screenshots."
+
+FNAME="$(date +%Y%m%d-%H%M%S)-$(basename "$FILE")"
+cp "$FILE" "/tmp/$FNAME"
+gh release upload screenshots-cdn "/tmp/$FNAME" --clobber --repo "$REPO"
+IMG_URL="https://github.com/$REPO/releases/download/screenshots-cdn/$FNAME"
+```
+
+## Embed formats
+
+**Single:**
+```html
+<img src="$IMG_URL" width="800" alt="<page> — after">
 ```
 
 **Before/after table:**
@@ -89,40 +64,19 @@ echo "$IMG_URL"
 <table>
   <tr><th>Before</th><th>After</th></tr>
   <tr>
-    <td><img src="https://github.com/OWNER/REPO/releases/download/screenshots-cdn/before.jpg" width="400" alt="before"></td>
-    <td><img src="https://github.com/OWNER/REPO/releases/download/screenshots-cdn/after.jpg" width="400" alt="after"></td>
+    <td><img src="$BEFORE_URL" width="400" alt="before"></td>
+    <td><img src="$AFTER_URL" width="400" alt="after"></td>
   </tr>
 </table>
 ```
 
-**Mobile screenshot** (narrow — embed smaller):
+**Mobile** (narrow — embed smaller):
 ```html
-<img src="https://github.com/OWNER/REPO/releases/download/screenshots-cdn/mobile.jpg" width="320" alt="<page> — mobile">
+<img src="$IMG_URL" width="320" alt="<page> — mobile">
 ```
 
----
+## Notes
 
-## Fallback: img402.dev free tier
-
-Use this only if `gh` is unavailable or the release approach fails. Requires `img402.dev`
-to be in the sandbox network allowlist — check `settings.json` before using.
-
-```bash
-# Upload (multipart)
-curl -s -X POST https://img402.dev/api/free -F image=@/tmp/screenshot.png
-
-# Response
-# {"url":"https://i.img402.dev/aBcDeFgHiJ.png","id":"aBcDeFgHiJ",...,"expiresAt":"..."}
-```
-
-**Constraints**: 1MB max, 7-day expiry, 1,000 uploads/day global limit, requires network
-allowlist entry for `img402.dev`.
-
----
-
-## Tips
-
-- Use a descriptive, timestamped filename to avoid asset collisions between parallel PR runs.
-- The `screenshots-cdn` release is a prerelease — it won't appear on the repo's main releases
-  page. Assets persist indefinitely (or until manually deleted).
-- For quick local checks (not PR evidence), skip the upload step entirely.
+- Do NOT use `![alt](url)` — GitHub renders the native pixel size and tall captures become painful to review. Inline `<img width="…">` is the only format that renders sensibly.
+- `{width=…}` kramdown syntax and `style="…"` attributes are silently stripped by GitHub's sanitizer. Use the `width` attribute.
+- For quick local sanity checks (not PR evidence), skip uploading entirely.


### PR DESCRIPTION
## Summary

Flip the default in the `github-image-hosting` skill so **img402.dev** is the primary upload target and the **GitHub release-asset CDN** is the explicit fallback.

Why: GitHub-hosted screenshots stick around forever and accumulate on the repo's releases page. img402 expires in 7 days — long enough for PR review, short enough that stale screenshots disappear on their own. The skill was previously doing the opposite, which contradicted the intent in `.claude/rules/ui.md` ("Upload via the `github-image-hosting` skill (img402)").

## Changes

- `.claude/skills/github-image-hosting/SKILL.md` — rewrite so img402 is the primary path; keep the `gh release` flow as a clearly-marked fallback (with a note to ask before using it). Updated `description` so Claude picks up the new default.
- `.claude/commands/quick-task.md` — stop claiming the upload produces "permanent URLs"; point at img402 explicitly.

No code changes, no runtime impact — this is just guidance for Claude sessions.

## Test plan

- [x] Confirmed `.claude/rules/ui.md` still matches the new default (it already said img402).
- [x] Skill frontmatter still valid YAML; description unchanged enough that existing trigger phrases still match.
