### PR TITLE
feat(ui): add Alpine $store.device with isTouch/isMobile

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -50,6 +50,31 @@
       };
     })();
   </script>
+
+  <script>
+    // Alpine store: $store.device
+    //
+    // Exposes `isTouch` and `isMobile` for downstream UI code (keyboard-hint
+    // components, shortcut dispatchers) to branch on input capability without
+    // each call site re-running matchMedia. Evaluated once on Alpine init —
+    // breakpoint changes on resize are not currently observed because nothing
+    // in the UI depends on transitional values, and keeping the store static
+    // avoids forcing every consumer to use reactive getters.
+    //
+    // Detection:
+    //   isTouch — `(hover: none) and (pointer: coarse)` (true on phones, false
+    //             on most laptops/desktops even with touchscreens).
+    //   isMobile — viewport width < 1024px (matches the existing `lg:` breakpoint
+    //              used by the drawer + mobile navbar).
+    document.addEventListener('alpine:init', function() {
+      var mqTouch = window.matchMedia('(hover: none) and (pointer: coarse)');
+      var mqMobile = window.matchMedia('(max-width: 1023.98px)');
+      Alpine.store('device', {
+        isTouch: mqTouch.matches,
+        isMobile: mqMobile.matches,
+      });
+    });
+  </script>
 </head>
 <body>
   <!-- Navigation progress bar -->


### PR DESCRIPTION
First step of the keyboard-navigation sprint: registers an Alpine `$store.device` with `isTouch` and `isMobile` so subsequent PRs (kbd-hint component, shortcut dispatcher) can branch on input capability without re-running `matchMedia` at every call site.

## Summary
- Adds a new `<script>` block in `internal/templates/layout/base.html` that, on `alpine:init`, populates `Alpine.store('device', { isTouch, isMobile })`.
- `isTouch` derives from `matchMedia('(hover: none) and (pointer: coarse)')` — true on phones, false on most laptops/desktops including those with touchscreens.
- `isMobile` derives from `matchMedia('(max-width: 1023.98px)')` — matches the `lg:` breakpoint the drawer / mobile navbar already use.
- Detection is evaluated once; no reactive listeners. Nothing in the UI currently needs mid-session transitions and keeping the store static avoids forcing consumers into reactive getters.
- No visible UI change. The store has no callers yet — M0.2 (shortcut registry) and M0.4 (kbd templ component) will introduce them.

## Sprint plan
Tracked in `~/Documents/obsidian/Breadbox/planned-features/keyboard-nav-sprint.md` → **M0.1** of the `keyboard-nav` stack.

## Test plan
- [ ] `go build ./...` passes (verified locally).
- [ ] `go vet ./...` passes (verified locally).
- [ ] In browser DevTools console on any admin page: `Alpine.store('device')` returns `{ isTouch: false, isMobile: false }` on desktop; emulating a mobile device flips both to `true`.
