### PR TITLE
fix(csv-import): prevent step 4 clipping on narrow viewports

### DIFF
--- a/internal/templates/pages/csv_import.html
+++ b/internal/templates/pages/csv_import.html
@@ -11,24 +11,28 @@
 <!-- Step indicator -->
 <div x-data="{step: {{if .ConnectionID}}1{{else}}1{{end}}}" x-init="window._csvWizard = {setStep: (s) => { step = s; }}">
 
-  <div class="flex items-center gap-0 mb-6 sm:mb-8 max-w-xl" id="step-indicator">
-    <template x-for="(s, i) in [{n:1, label:'Upload'}, {n:2, label:'Map Columns'}, {n:3, label:'Confirm'}, {n:4, label:'Done'}]" :key="i">
-      <div class="flex items-center" :class="i < 3 ? 'flex-1' : ''">
-        <div class="flex items-center gap-2">
-          <div class="w-8 h-8 rounded-full flex items-center justify-center text-xs font-semibold transition-all duration-200"
-               :class="step > s.n ? 'bg-success text-success-content' : step === s.n ? 'bg-primary text-primary-content' : 'bg-base-200 text-base-content/40'">
-            <template x-if="step > s.n"><i data-lucide="check" class="w-4 h-4"></i></template>
-            <template x-if="step <= s.n"><span x-text="s.n"></span></template>
+  <div x-data="{steps: [{n:1, label:'Upload'}, {n:2, label:'Map Columns'}, {n:3, label:'Confirm'}, {n:4, label:'Done'}]}">
+    <div class="flex items-center gap-0 mb-2 sm:mb-8 max-w-xl" id="step-indicator">
+      <template x-for="(s, i) in steps" :key="i">
+        <div class="flex items-center" :class="i < 3 ? 'flex-1' : ''">
+          <div class="flex items-center gap-2">
+            <div class="w-8 h-8 rounded-full flex items-center justify-center text-xs font-semibold transition-all duration-200 shrink-0"
+                 :class="step > s.n ? 'bg-success text-success-content' : step === s.n ? 'bg-primary text-primary-content' : 'bg-base-200 text-base-content/40'">
+              <template x-if="step > s.n"><i data-lucide="check" class="w-4 h-4"></i></template>
+              <template x-if="step <= s.n"><span x-text="s.n"></span></template>
+            </div>
+            <span class="text-xs font-medium whitespace-nowrap transition-colors duration-200 hidden sm:inline"
+                  :class="step >= s.n ? 'text-base-content' : 'text-base-content/40'" x-text="s.label"></span>
           </div>
-          <span class="text-xs font-medium whitespace-nowrap transition-colors duration-200"
-                :class="step >= s.n ? 'text-base-content' : 'text-base-content/40'" x-text="s.label"></span>
+          <template x-if="i < 3">
+            <div class="flex-1 h-px mx-2 sm:mx-3 transition-colors duration-200"
+                 :class="step > s.n ? 'bg-success/40' : 'bg-base-200'"></div>
+          </template>
         </div>
-        <template x-if="i < 3">
-          <div class="flex-1 h-px mx-3 transition-colors duration-200"
-               :class="step > s.n ? 'bg-success/40' : 'bg-base-200'"></div>
-        </template>
-      </div>
-    </template>
+      </template>
+    </div>
+    <p class="text-xs font-medium text-base-content/70 sm:hidden mb-6"
+       x-text="'Step ' + step + ' of ' + steps.length + ': ' + steps[step-1].label"></p>
   </div>
 
   <!-- Step 1: Upload -->


### PR DESCRIPTION
Fixes #647

Hide step labels on `<sm` and render the active step label (`Step N of 4: Label`) below the dots. Keeps all four circles visible at 375px/390px so the Done step is discoverable; full labeled strip returns at `sm` and above.

## Before / After

| Viewport | Before | After |
|---|---|---|
| Mobile 375x667 | ![](https://i.img402.dev/vw1xc7fm6i.png) | ![](https://i.img402.dev/uh343unul3.png) |
| Mobile 390x844 | ![](https://i.img402.dev/rco4mmwjmg.png) | ![](https://i.img402.dev/fzyidv1mnb.png) |
| Mobile 500x844 | ![](https://i.img402.dev/8ds2ge5ndq.png) | ![](https://i.img402.dev/cluxvyx45g.png) |
| Tablet 820x1180 | ![](https://i.img402.dev/6z04pdm0pl.png) | ![](https://i.img402.dev/hlpqos3c7w.png) |
| Desktop 1440x900 | ![](https://i.img402.dev/8ud2le2s0b.png) | ![](https://i.img402.dev/3c09luxoc2.png) |

## Notes

Chose Option A from the issue (hide labels at `<sm`, add active-step caption) over Option B (horizontal scroll with fade) since a hidden scroll affordance was recently rejected in #597. Also reduced connector `mx-3` to `mx-2` at `<sm` so all four circles + connectors comfortably fit at 375px.

## Test plan

- [x] 375x667: all four circles visible, Step 1 of 4 caption shown under strip
- [x] 390x844: same
- [x] 500x844: all four circles visible
- [x] 820x1180: full labeled strip returns
- [x] 1440x900: unchanged from baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)