### PR TITLE
feat(kbd): add Kbd/KbdChord templ component (M0.4)

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -114,6 +114,20 @@ var componentRegistry = map[string]componentAdapter{
 		}
 		return components.TxResults(txResultsPropsFromData(m)), nil
 	},
+	"Kbd": func(data any) (templ.Component, error) {
+		key, ok := data.(string)
+		if !ok {
+			return nil, fmt.Errorf("Kbd: want string, got %T", data)
+		}
+		return components.Kbd(key), nil
+	},
+	"KbdChord": func(data any) (templ.Component, error) {
+		keys, ok := data.([]string)
+		if !ok {
+			return nil, fmt.Errorf("KbdChord: want []string, got %T", data)
+		}
+		return components.KbdChord(keys...), nil
+	},
 	"ConditionRow": func(data any) (templ.Component, error) {
 		m, ok := data.(map[string]any)
 		if !ok {

--- a/internal/templates/components/kbd.templ
+++ b/internal/templates/components/kbd.templ
@@ -1,0 +1,33 @@
+package components
+
+// Kbd renders a single keyboard-shortcut badge.
+//
+// The badge is hidden on touch devices two ways:
+//  1. CSS fallback: `hidden sm:inline-flex` keeps it invisible on small
+//     viewports even before Alpine initializes.
+//  2. Runtime via Alpine: `x-show="!$store.device.isTouch"` suppresses the
+//     hint on devices reporting `(hover: none) and (pointer: coarse)` —
+//     the same signal the global shortcut dispatcher uses to skip firing.
+//
+// Both guards are needed: `sm:` catches the common case, `$store.device`
+// catches touch-capable desktops/tablets on a wide viewport.
+templ Kbd(key string) {
+	<kbd class="bb-kbd hidden sm:inline-flex" x-show="!$store.device.isTouch">{ key }</kbd>
+}
+
+// KbdChord renders a sequence of keys separated by a faint "then" label,
+// mirroring the `.bb-shortcuts-kbd` + `.bb-shortcuts-then` styling used in
+// the help modal. The whole chord hides on touch via the same guards as
+// `Kbd`. Calling with 0 or 1 keys degrades gracefully.
+templ KbdChord(keys ...string) {
+	if len(keys) > 0 {
+		<span class="inline-flex items-center gap-1 hidden sm:inline-flex" x-show="!$store.device.isTouch">
+			for i, k := range keys {
+				if i > 0 {
+					<span class="bb-shortcuts-then">then</span>
+				}
+				<kbd class="bb-kbd">{ k }</kbd>
+			}
+		</span>
+	}
+}

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -362,14 +362,17 @@ templ txResultsShell(p TransactionsProps) {
 				</label>
 			</div>
 			<div class="flex-1"></div>
-			<!-- Keyboard shortcuts (desktop only) -->
+			<!-- Keyboard shortcuts (desktop only).
+			     `.hidden sm:flex` gives a pre-Alpine fallback; each @components.Kbd
+			     also guards on `$store.device.isTouch` to cover touch-capable
+			     large viewports. -->
 			<div class="hidden sm:flex items-center gap-2 text-xs text-base-content/30">
-				<span class="flex items-center gap-1"><kbd class="bb-kbd">j</kbd><kbd class="bb-kbd">k</kbd> navigate</span>
-				<span class="flex items-center gap-1"><kbd class="bb-kbd">Enter</kbd> open</span>
-				<span class="flex items-center gap-1"><kbd class="bb-kbd">c</kbd> category</span>
-				<span class="flex items-center gap-1"><kbd class="bb-kbd">t</kbd> tag</span>
-				<span class="flex items-center gap-1"><kbd class="bb-kbd">e</kbd> expand</span>
-				<span class="flex items-center gap-1"><kbd class="bb-kbd">x</kbd> select</span>
+				<span class="flex items-center gap-1">@components.Kbd("j")@components.Kbd("k") navigate</span>
+				<span class="flex items-center gap-1">@components.Kbd("Enter") open</span>
+				<span class="flex items-center gap-1">@components.Kbd("c") category</span>
+				<span class="flex items-center gap-1">@components.Kbd("t") tag</span>
+				<span class="flex items-center gap-1">@components.Kbd("e") expand</span>
+				<span class="flex items-center gap-1">@components.Kbd("x") select</span>
 			</div>
 		</div>
 		<div id="bb-tx-results">

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -395,7 +395,7 @@
         <div class="flex items-center gap-3">
           <span><kbd>&uarr;</kbd> <kbd>&darr;</kbd> navigate</span>
           <span><kbd>&crarr;</kbd> select</span>
-          <span><kbd>esc</kbd> close</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "Esc"}} close</span>
         </div>
       </div>
     </div>
@@ -529,7 +529,7 @@
           <template x-if="!canCreate">
             <span><kbd>&crarr;</kbd> apply</span>
           </template>
-          <span><kbd>esc</kbd> cancel</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "Esc"}} cancel</span>
         </div>
         <div class="flex items-center gap-2">
           <button type="button" class="btn btn-ghost btn-xs rounded-lg" @click="closePicker()">Cancel</button>


### PR DESCRIPTION
Standalone justification: centralizes the three duplicate `<kbd>` patterns in the admin UI behind one templ component so every shortcut hint hides on touch devices via the same guards the dispatcher uses.

## Summary

Part of the `stack/keyboard-nav` foundation (M0.4). Introduces `internal/templates/components/kbd.templ` with two helpers:

- **`Kbd(key)`** — renders one `<kbd class="bb-kbd hidden sm:inline-flex">KEY</kbd>` wrapped in `x-show="!$store.device.isTouch"`.
- **`KbdChord(keys…)`** — same guards, multiple keys separated by the `.bb-shortcuts-then` "then" label (mirrors the help modal's chord rendering).

Both hide on touch two ways:

1. **CSS fallback** — `hidden sm:inline-flex` keeps the badge invisible on small viewports before Alpine boots.
2. **Runtime** — `x-show="!$store.device.isTouch"` (M0.1's `Alpine.store('device')`) suppresses hints on touch-capable wide viewports where the media query alone can't tell.

Added a `renderComponent "Kbd"` (and `KbdChord`) bridge entry in `internal/admin/templates.go` so `html/template` pages can use the component during the ongoing templ migration.

### Migrated call sites (proof of concept)

- Transactions toolbar kbd hints (`internal/templates/components/pages/transactions.templ`).
- Category picker footer Esc hint (`internal/templates/layout/base.html`).
- Tag picker footer Esc hint (`internal/templates/layout/base.html`).

### Intentionally not touched

- **Shortcuts help modal** — already rendered dynamically in M0.3 (#662) with its own chord helper; keeping them divergent until the registry unification lands later.
- **Cmd+K palette rows** — M0.5 handles surfacing registry bindings inline.
- The three kbd CSS classes (`.bb-kbd`, `.bb-cmdk-kbd`, `.bb-shortcuts-kbd`) are left in place — deduping them is a follow-up.

## Test plan

- [ ] `go build ./...` and `go vet ./...` clean (verified locally).
- [ ] `templ generate` produces no diff on a clean tree.
- [ ] Open `/transactions` on desktop — `j/k/Enter/c/t/e/x` badges still visible in toolbar.
- [ ] Open the category picker (press `c` on any tx) — footer still shows `↑ ↓ navigate`, `↵ select`, and the new templ-rendered `Esc close`.
- [ ] Open the tag picker (press `t` on any tx) — footer shows templ-rendered `Esc cancel`.
- [ ] Emulate a touch device (`(hover: none) and (pointer: coarse)`) — all three migrated hint groups disappear while non-migrated entities like `↵` are unaffected.
- [ ] Narrow viewport to <640px — migrated hints hidden via `sm:` fallback even if Alpine hasn't booted.
