### PR TITLE
feat(transactions): keyboard shortcuts on detail page

### DIFF
--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -1,6 +1,14 @@
 {{define "content"}}
 {{template "category-picker-styles" .}}
 
+{{/*
+  Set the shortcut-registry scope so base.html's global dispatcher routes
+  c / t / e / Enter (registered below) to this page's handlers, and so the
+  ? help modal surfaces them under "This page". Reset to 'global' on
+  Alpine teardown so other pages don't inherit the scope.
+*/}}
+<div x-data x-init="$store.shortcuts.setScope('transaction-detail')" x-destroy="$store.shortcuts.setScope('global')"></div>
+
 {{template "breadcrumb" .}}
 
 <!-- Hero: Transaction name + amount -->
@@ -112,7 +120,7 @@
 
     <!-- Metadata (collapsed by default) -->
     <div class="mt-5 pt-4 border-t border-base-300" x-data="{open: false}">
-      <button class="flex items-center gap-1.5 text-xs text-base-content/30 hover:text-base-content/50 transition-colors" @click="open = !open">
+      <button id="bb-txd-system-details-toggle" class="flex items-center gap-1.5 text-xs text-base-content/30 hover:text-base-content/50 transition-colors" @click="open = !open">
         <i data-lucide="chevron-right" class="w-3 h-3 transition-transform" :class="open && 'rotate-90'"></i>
         <span>System details</span>
       </button>
@@ -207,7 +215,7 @@
   <!-- Add Note -->
   <div class="px-4 sm:px-5 pb-4">
     <div class="flex gap-2 items-center">
-      <input type="text" x-model="newComment" placeholder="Add a note..." class="input input-bordered input-sm h-9 flex-1 bg-base-200/50 rounded-xl" @keydown.enter.prevent="newComment.trim() && addComment()" />
+      <input id="bb-txd-comment" type="text" x-model="newComment" placeholder="Add a note..." class="input input-bordered input-sm h-9 flex-1 bg-base-200/50 rounded-xl" @keydown.enter.prevent="newComment.trim() && addComment()" />
       <button @click="addComment()" class="btn btn-sm h-9 rounded-xl btn-primary btn-square" :disabled="!newComment.trim()">
         <i data-lucide="send" class="w-3.5 h-3.5"></i>
       </button>
@@ -293,6 +301,67 @@
 <script>
 // Populate global tag cache so the picker works without a re-fetch.
 window.__bbAllTags = {{toJSON .AvailableTags}} || [];
+
+// Register transaction-detail scoped keyboard shortcuts in the global registry
+// (base.html). The dispatcher guards against touch, input focus, and open
+// overlays, so these handlers only need to care about "what does this key do".
+// Shortcuts surface automatically in the ? help modal (M0.3) under "This page".
+document.addEventListener('alpine:init', function() {
+  var reg = Alpine.store('shortcuts');
+  if (!reg) return;
+
+  reg.register({
+    id: 'transaction-detail.categorize',
+    keys: 'c',
+    description: 'Categorize transaction',
+    group: 'Actions',
+    scope: 'transaction-detail',
+    action: function() {
+      // Reuse the inline picker trigger — same contract as the click handler,
+      // so the categoryPicker's sourceId + listener wiring stays in one place.
+      var btn = document.querySelector('.bb-cat-picker[data-picker-source="txd-cat"] button');
+      if (btn) btn.click();
+    },
+  });
+
+  reg.register({
+    id: 'transaction-detail.tag',
+    keys: 't',
+    description: 'Edit tags',
+    group: 'Actions',
+    scope: 'transaction-detail',
+    action: function() {
+      // Click the "Add tag / Edit tags" chip so the tagManager component
+      // opens the picker with its current tag state (appliedCounts, etc.).
+      var btn = document.querySelector('.bb-tag-add');
+      if (btn) btn.click();
+    },
+  });
+
+  reg.register({
+    id: 'transaction-detail.focus-comment',
+    keys: 'Enter',
+    description: 'Focus comment',
+    group: 'Actions',
+    scope: 'transaction-detail',
+    action: function() {
+      var el = document.getElementById('bb-txd-comment');
+      if (el) el.focus();
+    },
+  });
+
+  reg.register({
+    id: 'transaction-detail.expand-system-details',
+    keys: 'e',
+    description: 'Toggle system details',
+    group: 'Actions',
+    scope: 'transaction-detail',
+    action: function() {
+      var btn = document.getElementById('bb-txd-system-details-toggle');
+      if (btn) btn.click();
+    },
+  });
+});
 
 function txCategoryEditor() {
   return {


### PR DESCRIPTION
## Summary

M2 of the keyboard-navigation sprint (`docs/planned-features/keyboard-nav-sprint.md`). Wires page-scoped shortcuts on `/transactions/{id}` through the M0 registry introduced in #661/#662:

- `c` — open the category picker (reuses the inline trigger; same `sourceId` / listener wiring).
- `t` — open the tag picker (clicks the existing "Add tag / Edit tags" chip so `tagManager.openTagPicker` builds the correct `appliedCounts`).
- `Enter` — focus the add-comment input when focus isn't already in an input (the global dispatcher guards against firing while typing, so this can't fight the input's own `@keydown.enter` submit).
- `e` — toggle the "System details" collapsible section.

Scope is set via `x-init="$store.shortcuts.setScope('transaction-detail')"` on a page-level stub, and reset via `x-destroy` so other pages don't inherit it. Shortcuts surface automatically in the `?` help modal under "This page" (M0.3) and are suppressed on touch devices by the dispatcher (M0.2 + M0.1).

`Esc` is already handled by the category/tag picker components themselves; no new binding.

## Skipped (flagged in the plan as needing backend support)

- `[` / `]` prev/next — requires neighbor resolution in the detail handler (no sibling links exist today). Skipped rather than adding a new service query for this PR.
- `r` rule — no "create rule from transaction" affordance currently exists on the page, and `/rules/new` has no transaction-id prefill. Skipped until that path exists; happy to revisit in a follow-up.

## Test plan

- [ ] Navigate to `/transactions/{id}`, press `?` — modal shows a "This page" section listing `c`, `t`, `Enter`, `e`.
- [ ] Press `c` — category picker overlay opens.
- [ ] Press `t` — tag picker overlay opens with this transaction's current tags marked as present.
- [ ] Focus off-input, press `Enter` — comment input receives focus; typing + Enter submits the comment without triggering the shortcut again.
- [ ] Press `e` — "System details" expands/collapses.
- [ ] Open the category picker, press `Esc` — closes. Confirm no double-handler.
- [ ] Emulate touch (`matchMedia('(hover: none)')`) — none of the page shortcuts fire.
- [ ] Navigate away — verify `$store.shortcuts.currentScope` resets, proving `x-destroy` fires.
