### PR TITLE
fix(agents/wizard): allow preset card badges to wrap on mobile (#646)

### DIFF
--- a/internal/templates/pages/agent_wizard.html
+++ b/internal/templates/pages/agent_wizard.html
@@ -26,9 +26,9 @@
             <i data-lucide="sparkles" class="w-5 h-5 text-primary"></i>
           </div>
           <div class="flex-1 px-4 py-3.5 min-w-0">
-            <div class="flex items-center gap-2 mb-0.5">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-0.5">
               <h3 class="font-semibold text-sm text-base-content group-hover:text-primary transition-colors">Initial Setup</h3>
-              <span class="badge badge-soft badge-primary badge-xs">First run</span>
+              <span class="badge badge-soft badge-primary badge-xs shrink-0">First run</span>
             </div>
             <p class="text-xs text-base-content/50 leading-relaxed">Establish rules and categories after connecting your first accounts. Creates broad category mappings per provider.</p>
           </div>
@@ -50,11 +50,11 @@
             <i data-lucide="layers" class="w-5 h-5 text-primary"></i>
           </div>
           <div class="flex-1 px-4 py-3.5 min-w-0">
-            <div class="flex items-center gap-2 mb-0.5">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-0.5">
               <h3 class="font-semibold text-sm text-base-content group-hover:text-primary transition-colors">Bulk Review</h3>
-              <span class="badge badge-soft badge-primary badge-xs">Thorough</span>
+              <span class="badge badge-soft badge-primary badge-xs shrink-0">Thorough</span>
               {{if gt $stats.PendingReviews 0}}
-              <span class="badge badge-primary badge-xs font-mono">{{$stats.PendingReviews}} waiting</span>
+              <span class="badge badge-primary badge-xs font-mono shrink-0">{{$stats.PendingReviews}} waiting</span>
               {{end}}
             </div>
             <p class="text-xs text-base-content/50 leading-relaxed">Review a large queue of pending transactions with careful categorization and rule creation.</p>
@@ -77,9 +77,9 @@
             <i data-lucide="zap" class="w-5 h-5 text-primary"></i>
           </div>
           <div class="flex-1 px-4 py-3.5 min-w-0">
-            <div class="flex items-center gap-2 mb-0.5">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-0.5">
               <h3 class="font-semibold text-sm text-base-content group-hover:text-primary transition-colors">Quick Review</h3>
-              <span class="badge badge-soft badge-primary badge-xs">Fast</span>
+              <span class="badge badge-soft badge-primary badge-xs shrink-0">Fast</span>
             </div>
             <p class="text-xs text-base-content/50 leading-relaxed">Rapidly clear a large queue using batch operations. Prioritizes speed with reasonable accuracy.</p>
           </div>
@@ -111,13 +111,13 @@
             <i data-lucide="repeat" class="w-5 h-5 text-success"></i>
           </div>
           <div class="flex-1 px-4 py-3.5 min-w-0">
-            <div class="flex items-center gap-2 mb-0.5">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-0.5">
               <h3 class="font-semibold text-sm text-base-content group-hover:text-success transition-colors">Routine Review</h3>
-              <span class="badge badge-soft badge-success badge-xs">Recurring</span>
+              <span class="badge badge-soft badge-success badge-xs shrink-0">Recurring</span>
               {{if gt $stats.TotalRules 0}}
-              <span class="text-xs text-base-content/40">{{$stats.TotalRules}} active rule{{if ne $stats.TotalRules 1}}s{{end}}</span>
+              <span class="text-xs text-base-content/40 shrink-0 whitespace-nowrap">{{$stats.TotalRules}} active rule{{if ne $stats.TotalRules 1}}s{{end}}</span>
               {{else}}
-              <span class="text-xs text-warning font-medium">No rules yet — run Initial Setup first</span>
+              <span class="text-xs text-warning font-medium shrink-0">No rules yet — run Initial Setup first</span>
               {{end}}
             </div>
             <p class="text-xs text-base-content/50 leading-relaxed">Review and categorize new transactions on a daily or weekly schedule. Creates rules for new patterns.</p>
@@ -140,11 +140,11 @@
             <i data-lucide="bar-chart-3" class="w-5 h-5 text-violet-500"></i>
           </div>
           <div class="flex-1 px-4 py-3.5 min-w-0">
-            <div class="flex items-center gap-2 mb-0.5">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-0.5">
               <h3 class="font-semibold text-sm text-base-content group-hover:text-violet-500 transition-colors">Spending Report</h3>
-              <span class="badge badge-xs bg-violet-500/15 text-violet-600 border-0">Recurring</span>
+              <span class="badge badge-xs bg-violet-500/15 text-violet-600 border-0 shrink-0">Recurring</span>
               {{if gt $stats.TotalAccounts 0}}
-              <span class="text-xs text-base-content/40">Across {{$stats.TotalAccounts}} account{{if ne $stats.TotalAccounts 1}}s{{end}}</span>
+              <span class="text-xs text-base-content/40 shrink-0 whitespace-nowrap">Across {{$stats.TotalAccounts}} account{{if ne $stats.TotalAccounts 1}}s{{end}}</span>
               {{end}}
             </div>
             <p class="text-xs text-base-content/50 leading-relaxed">Weekly or monthly summary of spending by category with trend analysis and anomaly callouts.</p>
@@ -177,9 +177,9 @@
             <i data-lucide="shield-alert" class="w-5 h-5 text-warning"></i>
           </div>
           <div class="flex-1 px-4 py-3.5 min-w-0">
-            <div class="flex items-center gap-2 mb-0.5">
+            <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-0.5">
               <h3 class="font-semibold text-sm text-base-content group-hover:text-warning transition-colors">Anomaly Detection</h3>
-              <span class="badge badge-soft badge-warning badge-xs">Monitoring</span>
+              <span class="badge badge-soft badge-warning badge-xs shrink-0">Monitoring</span>
             </div>
             <p class="text-xs text-base-content/50 leading-relaxed">Watch for unusual charges, duplicate transactions, or unexpected spending spikes across all accounts.</p>
           </div>
@@ -200,7 +200,7 @@
           <i data-lucide="plus" class="w-5 h-5 text-base-content/40"></i>
         </div>
         <div class="flex-1 px-4 py-3.5 min-w-0">
-          <div class="flex items-center gap-2 mb-0.5">
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-0.5">
             <h3 class="font-semibold text-sm text-base-content/70 group-hover:text-base-content transition-colors">Custom Agent</h3>
           </div>
           <p class="text-xs text-base-content/50 leading-relaxed">Start from scratch with your own goals and instructions. Full access to all prompt blocks.</p>


### PR DESCRIPTION
## Summary

Fixes #646 — on narrow viewports (<=500px) the preset-card headers on `/agents?tab=wizard` (Initial Setup, Bulk Review, Quick Review, Routine Review, Spending Report, Anomaly Detection) packed the title, variant badge and optional count badge into a single unwrapped flex row. Badges couldn't shrink, so on Bulk Review the two badges (Thorough + "N waiting") visibly overlapped, and on Initial Setup both the title and the "First run" badge wrapped mid-word.

## Fix

Switch each preset-card title row from `flex items-center gap-2` to `flex flex-wrap items-center gap-x-2 gap-y-1`, and add `shrink-0` (plus `whitespace-nowrap` on the longer meta spans) to badges/meta so they drop cleanly onto a second row instead of being squeezed. Desktop single-line layout is unchanged — flex-wrap only engages when there isn't enough horizontal room.

## Before / After

| Viewport | Before | After |
|---|---|---|
| Mobile 375x667 | ![before-m375](https://i.img402.dev/0puxx5vxjc.png) | ![after-m375](https://i.img402.dev/4a0nsti8c5.png) |
| Mobile 390x844 | ![before-m390](https://i.img402.dev/l7130uqzph.png) | ![after-m390](https://i.img402.dev/xqu47eftcm.png) |

## Test plan

- [x] `go build ./...` passes
- [x] Visual QA at 375, 390, 500, 820, 1440 — badges no longer overlap, titles no longer wrap mid-word, no horizontal scrollbar
- [x] Desktop (1440) layout unchanged — single-line card headers

Fixes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)