### PR TITLE
feat(reviews): keyboard shortcuts in review queue

### DIFF
--- a/internal/templates/components/pages/assets/reviews_scripts.js.html
+++ b/internal/templates/components/pages/assets/reviews_scripts.js.html
@@ -2,17 +2,18 @@
  * M3 — Reviews queue keyboard shortcuts.
  *
  * Rendered only when the transactions page is filtered to tags=needs-review
- * (see txReviewQueueShortcuts in transactions.templ). Registers the three
- * review-specific actions — approve (a), reject (r), skip (s) — at
- * `scope: 'reviews'` on top of the transactions list's existing j/k/Enter/c
- * handlers (still driven by the inline keydown in transactions_scripts.js.html
- * until M1 lands and ports them to the registry).
+ * (see txReviewQueueShortcuts in transactions.templ). Registers the single
+ * review-specific action — approve (a) — at `scope: 'reviews'` on top of the
+ * transactions list's existing j/k/Enter/c handlers (still driven by the
+ * inline keydown in transactions_scripts.js.html until M1 lands and ports
+ * them to the registry).
  *
- * Approve/reject both resolve the needs-review tag on the focused row: the
- * review system is tag-backed since the review_queue cutover (#... migration
- * 20260415083233_cutover_review_queue.sql) so there is no distinct "rejected"
- * state in the data model — only a different annotation / toast. Skip leaves
- * the tag intact and just advances focus so the reviewer can come back later.
+ * Reject and skip were considered but dropped: the review model is tag-backed
+ * (the needs-review tag is the queue), so there is no distinct "rejected"
+ * state to record — reject would be semantically identical to approve with
+ * different toast copy. Skip, without a tracked snooze-until mechanism, is
+ * just `j` (advance focus). We keep the transactions list free of custom
+ * logic that doesn't pull its weight.
  *
  * Guards (input focus, open overlays, touch devices) are owned by the global
  * dispatcher in base.html, so these handlers only need to care about "what
@@ -88,28 +89,6 @@
       group: 'Actions',
       scope: 'reviews',
       action: function () { resolveReview('approved'); }
-    });
-
-    reg.register({
-      id: 'reviews.reject',
-      keys: 'r',
-      description: 'Reject review',
-      group: 'Actions',
-      scope: 'reviews',
-      action: function () { resolveReview('rejected'); }
-    });
-
-    reg.register({
-      id: 'reviews.skip',
-      keys: 's',
-      description: 'Skip review',
-      group: 'Actions',
-      scope: 'reviews',
-      action: function () {
-        // Leaves the tag in place — the review stays queued. Advances focus
-        // so the reviewer can move on and come back to it later.
-        advanceFocus();
-      }
     });
   }
 

--- a/internal/templates/components/pages/assets/reviews_scripts.js.html
+++ b/internal/templates/components/pages/assets/reviews_scripts.js.html
@@ -1,0 +1,121 @@
+/*
+ * M3 — Reviews queue keyboard shortcuts.
+ *
+ * Rendered only when the transactions page is filtered to tags=needs-review
+ * (see txReviewQueueShortcuts in transactions.templ). Registers the three
+ * review-specific actions — approve (a), reject (r), skip (s) — at
+ * `scope: 'reviews'` on top of the transactions list's existing j/k/Enter/c
+ * handlers (still driven by the inline keydown in transactions_scripts.js.html
+ * until M1 lands and ports them to the registry).
+ *
+ * Approve/reject both resolve the needs-review tag on the focused row: the
+ * review system is tag-backed since the review_queue cutover (#... migration
+ * 20260415083233_cutover_review_queue.sql) so there is no distinct "rejected"
+ * state in the data model — only a different annotation / toast. Skip leaves
+ * the tag intact and just advances focus so the reviewer can come back later.
+ *
+ * Guards (input focus, open overlays, touch devices) are owned by the global
+ * dispatcher in base.html, so these handlers only need to care about "what
+ * does this key do" when it fires.
+ */
+(function () {
+  function focusedRow() {
+    var nav = window.Alpine && Alpine.store('txNav');
+    if (!nav) return null;
+    // Private helper on the store — the store exposes it via `_getRows`
+    // for j/k nav. Fall back to a DOM query if the store shape drifts.
+    var rows = typeof nav._getRows === 'function'
+      ? nav._getRows()
+      : Array.prototype.slice.call(document.querySelectorAll('.bb-tx-row'));
+    if (nav.focusedIdx < 0 || nav.focusedIdx >= rows.length) return null;
+    return rows[nav.focusedIdx];
+  }
+
+  function advanceFocus() {
+    var nav = window.Alpine && Alpine.store('txNav');
+    if (!nav) return;
+    nav.next();
+  }
+
+  // Resolve the needs-review tag on the focused row. Calls the same DELETE
+  // endpoint the tag chip's remove button uses so CSRF, annotations, and
+  // any other server-side side effects stay in one code path. On success,
+  // the row is removed from the view (mirrors removeTag's animation in
+  // transactions_scripts.js.html) and focus advances to the next row.
+  function resolveReview(verb) {
+    var row = focusedRow();
+    if (!row) return;
+    var txId = row.dataset.txId;
+    if (!txId) return;
+    fetch('/-/transactions/' + encodeURIComponent(txId) + '/tags/needs-review', {
+      method: 'DELETE',
+      headers: { 'Accept': 'application/json' }
+    })
+      .then(function (r) { return r.json().catch(function () { return {}; }); })
+      .then(function (d) {
+        if (d && (d.ok || d.removed)) {
+          // Advance focus BEFORE the row is gone so the focus ring lands on
+          // the row that slides up into its slot. txNav.next() is idempotent
+          // if already at the end, so no special-case for the last review.
+          advanceFocus();
+          row.style.transition = 'opacity 150ms';
+          row.style.opacity = '0';
+          setTimeout(function () { row.remove(); }, 160);
+          window.dispatchEvent(new CustomEvent('bb-toast', {
+            detail: { message: 'Review ' + verb, type: 'success' }
+          }));
+        } else {
+          window.dispatchEvent(new CustomEvent('bb-toast', {
+            detail: { message: (d && d.error) || 'Failed to resolve review', type: 'error' }
+          }));
+        }
+      })
+      .catch(function () {
+        window.dispatchEvent(new CustomEvent('bb-toast', {
+          detail: { message: 'Failed to resolve review', type: 'error' }
+        }));
+      });
+  }
+
+  function register() {
+    var reg = window.Alpine && Alpine.store('shortcuts');
+    if (!reg) return;
+
+    reg.register({
+      id: 'reviews.approve',
+      keys: 'a',
+      description: 'Approve review',
+      group: 'Actions',
+      scope: 'reviews',
+      action: function () { resolveReview('approved'); }
+    });
+
+    reg.register({
+      id: 'reviews.reject',
+      keys: 'r',
+      description: 'Reject review',
+      group: 'Actions',
+      scope: 'reviews',
+      action: function () { resolveReview('rejected'); }
+    });
+
+    reg.register({
+      id: 'reviews.skip',
+      keys: 's',
+      description: 'Skip review',
+      group: 'Actions',
+      scope: 'reviews',
+      action: function () {
+        // Leaves the tag in place — the review stays queued. Advances focus
+        // so the reviewer can move on and come back to it later.
+        advanceFocus();
+      }
+    });
+  }
+
+  if (window.Alpine) {
+    register();
+  } else {
+    document.addEventListener('alpine:init', register);
+  }
+})();

--- a/internal/templates/components/pages/reviews_scripts.go
+++ b/internal/templates/components/pages/reviews_scripts.go
@@ -1,0 +1,15 @@
+package pages
+
+import _ "embed"
+
+// reviewQueueScriptBody holds the inline <script> block rendered by
+// txReviewQueueShortcuts when the transactions list is filtered to the
+// needs-review tag (see transactions.templ). It registers the M3
+// review-queue keyboard shortcuts — approve (a), reject (r), skip (s) —
+// against the shortcut registry at `scope: 'reviews'`.
+//
+// The file lives alongside transactions_scripts.js.html under assets/ so
+// the two page-scoped script bundles stay discoverable in one place.
+//
+//go:embed assets/reviews_scripts.js.html
+var reviewQueueScriptBody string

--- a/internal/templates/components/pages/reviews_scripts.go
+++ b/internal/templates/components/pages/reviews_scripts.go
@@ -5,8 +5,8 @@ import _ "embed"
 // reviewQueueScriptBody holds the inline <script> block rendered by
 // txReviewQueueShortcuts when the transactions list is filtered to the
 // needs-review tag (see transactions.templ). It registers the M3
-// review-queue keyboard shortcuts — approve (a), reject (r), skip (s) —
-// against the shortcut registry at `scope: 'reviews'`.
+// review-queue keyboard shortcut — approve (a) — against the shortcut
+// registry at `scope: 'reviews'`.
 //
 // The file lives alongside transactions_scripts.js.html under assets/ so
 // the two page-scoped script bundles stay discoverable in one place.

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -32,14 +32,16 @@ templ Transactions(p TransactionsProps) {
 	}
 }
 
-// txReviewQueueShortcuts registers M3 review-queue keyboard shortcuts
-// (`a` approve, `r` reject, `s` skip) at `scope: 'reviews'` whenever the
-// transactions page is filtered to `tags=needs-review` — the review queue
-// view. The x-data wrapper flips the shortcut-registry scope on init so
-// the `?` help modal (M0.3) surfaces these under "This page", and resets
-// back to 'global' on teardown. j/k/Enter/c continue to fire via the
-// existing inline keydown handler in transactions_scripts.js.html; M3
-// only layers the review-specific actions on top.
+// txReviewQueueShortcuts registers the M3 review-queue keyboard shortcut
+// (`a` approve) at `scope: 'reviews'` whenever the transactions page is
+// filtered to `tags=needs-review` — the review queue view. The x-data
+// wrapper flips the shortcut-registry scope on init so the `?` help modal
+// (M0.3) surfaces approve under "This page", and resets back to 'global'
+// on teardown. j/k/Enter/c continue to fire via the existing inline keydown
+// handler in transactions_scripts.js.html; M3 only layers the approve
+// action on top. Reject and skip were dropped after review feedback —
+// reject had no data-model meaning (the queue is tag-backed, so there is
+// no "rejected" state), and skip was duplicative of `j`.
 templ txReviewQueueShortcuts() {
 	<div x-data x-init="$store.shortcuts.setScope('reviews')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	@templ.Raw("<script>" + reviewQueueScriptBody + "</script>")

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -27,6 +27,22 @@ templ Transactions(p TransactionsProps) {
 	<!-- Floating bulk action bar is created via JS in <body> to avoid parent transform breaking position:fixed -->
 	@components.CategoryPickerScript()
 	@txPageScripts(p)
+	if p.IsReviewQueue() {
+		@txReviewQueueShortcuts()
+	}
+}
+
+// txReviewQueueShortcuts registers M3 review-queue keyboard shortcuts
+// (`a` approve, `r` reject, `s` skip) at `scope: 'reviews'` whenever the
+// transactions page is filtered to `tags=needs-review` — the review queue
+// view. The x-data wrapper flips the shortcut-registry scope on init so
+// the `?` help modal (M0.3) surfaces these under "This page", and resets
+// back to 'global' on teardown. j/k/Enter/c continue to fire via the
+// existing inline keydown handler in transactions_scripts.js.html; M3
+// only layers the review-specific actions on top.
+templ txReviewQueueShortcuts() {
+	<div x-data x-init="$store.shortcuts.setScope('reviews')" x-destroy="$store.shortcuts.setScope('global')"></div>
+	@templ.Raw("<script>" + reviewQueueScriptBody + "</script>")
 }
 
 // TransactionsResults renders only the AJAX tx-results-partial fragment —

--- a/internal/templates/components/pages/transactions_types.go
+++ b/internal/templates/components/pages/transactions_types.go
@@ -106,3 +106,18 @@ func (p TransactionsProps) HasActiveFilters() bool {
 func (p TransactionsProps) HasAnyFilter() bool {
 	return p.HasActiveFilters() || p.FilterSearch != ""
 }
+
+// IsReviewQueue reports whether the current page view is the review queue —
+// transactions filtered to the needs-review tag. The `/reviews` admin alias
+// redirects to `/transactions?tags=needs-review`, so the reviews queue is
+// just this filtered view of the transactions list. Drives the M3 keyboard
+// shortcut scope (`scope: 'reviews'`) so the page registers approve/reject/
+// skip actions on top of the standard transactions navigation.
+func (p TransactionsProps) IsReviewQueue() bool {
+	for _, slug := range p.FilterTags {
+		if slug == "needs-review" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**Scope trimmed after review feedback:** reject and skip shortcuts have been removed; only `a` approve remains. Rationale in the commit and in the review-thread reply — reject had no data-model meaning (the queue is tag-backed, so there is no distinct "rejected" state), and skip was duplicative of `j` without a tracked snooze mechanism.

M3 of the keyboard navigation sprint (see `planned-features/keyboard-nav-sprint.md`). The review queue view (`/transactions?tags=needs-review`, the target of the `/reviews` admin alias) now registers a review-specific keyboard shortcut on top of the transactions list's existing j/k/Enter/c navigation.

## Summary
- New shortcut registered at `scope: 'reviews'`:
  - `a` approve — DELETE `needs-review` tag on the focused row and advance focus.
- Page wraps a templ component (`txReviewQueueShortcuts`) that only renders when `p.IsReviewQueue()` is true; `x-init` / `x-destroy` flip the shortcut-registry scope between `reviews` and `global`.
- The action calls the same `DELETE /-/transactions/:id/tags/needs-review` endpoint the tag chip's remove button uses — CSRF, annotations, and row-removal animation stay in one code path. No new API routes, no duplicated POST logic.
- j/k/Enter/c continue to fire via the existing inline keydown handler in `transactions_scripts.js.html` until M1 lands and ports those to the registry; M3 only layers the review-specific approve action.

## Scope notes
- The review system is tag-backed since the cutover migration (`20260415083233_cutover_review_queue.sql`) dropped the `review_queue` table — approve resolves the tag.
- Registered shortcuts surface in the `?` help modal and command palette once M0.3 / M0.5 land; on main today the hardcoded help body doesn't list them yet but the key fires correctly.

## Test plan
- [ ] Navigate to `/reviews` (redirects to `/transactions?tags=needs-review`); confirm j/k focus a row, then:
  - [ ] `a` removes the needs-review tag and advances focus, toast reads "Review approved".
- [ ] On a regular `/transactions` view (no tag filter), confirm `a` does nothing (scope stays `global`).
- [ ] `go build ./...` + `go vet ./...` clean (verified locally).
- [ ] Touch device: page-scoped shortcuts are suppressed by the dispatcher's `isTouch` guard — no new handler bypasses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
