### PR TITLE
feat(connections): keyboard shortcuts on list page

### DIFF
--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -1,4 +1,12 @@
 {{define "content"}}
+{{/*
+  Set the shortcut-registry scope so base.html's global dispatcher routes
+  j/k/s/e/Enter (registered below) to this page's handlers, and so the
+  ? help modal surfaces them under "This page". Reset to 'global' on
+  Alpine teardown so other pages don't inherit the scope.
+*/}}
+<div x-data x-init="$store.shortcuts.setScope('connections')" x-destroy="$store.shortcuts.setScope('global')"></div>
+
 <div x-data="{ tab: '{{.Tab}}', filterUser: 'all' }"
      x-init="$watch('tab', function(v) { var u = new URL(window.location); u.searchParams.set('tab', v); history.replaceState(null, '', u); })">
 
@@ -100,9 +108,14 @@
 {{end}}
 
 <!-- Connection Cards -->
-<div class="flex flex-col gap-4 bb-stagger">
+<div class="flex flex-col gap-4 bb-stagger" id="bb-connections-list">
   {{range .Connections}}
-  <div class="bb-card overflow-hidden" x-show="filterUser === 'all' || filterUser === '{{formatUUID .UserID}}'">
+  <div class="bb-card overflow-hidden bb-conn-row"
+       data-connection-row
+       data-open-url="/connections/{{formatUUID .ID}}"
+       data-edit-url="/connections/{{formatUUID .ID}}"
+       data-filter-user="{{formatUUID .UserID}}"
+       x-show="filterUser === 'all' || filterUser === '{{formatUUID .UserID}}'">
     <!-- Connection Header — non-nested interactives (a11y: link + sibling button) -->
     <div class="group px-4 py-3 sm:px-5 sm:py-4 flex items-center justify-between gap-3 sm:gap-4">
       <a href="/connections/{{formatUUID .ID}}" class="flex items-center gap-3 sm:gap-4 min-w-0 flex-1 no-underline" aria-label="Open {{.InstitutionName.String}} connection">
@@ -153,6 +166,7 @@
         {{if and (ne (printf "%s" .Provider) "csv") (eq (printf "%s" .Status) "active")}}
         <div x-data="syncBtn('{{formatUUID .ID}}')">
           <button type="button"
+                  data-sync-btn
                   class="w-8 h-8 rounded-full flex items-center justify-center text-base-content/30 hover:text-primary hover:bg-primary/10 transition-colors"
                   :disabled="state !== 'idle'"
                   @click="triggerSync()"
@@ -330,6 +344,127 @@ function syncBtn(connId) {
     }
   };
 }
+
+// Keyboard navigation for the connections list. Reads the DOM for visible
+// rows (respecting the family-member filter via data-filter-user + Alpine's
+// x-show display:none) instead of mirroring connection data into a store.
+// The base.html dispatcher already guards against input focus, overlays,
+// and touch devices, so these handlers just do the thing.
+var bbConnNav = {
+  focusedIdx: -1,
+  FOCUSED_CLASS: 'bb-tx-row--focused', // reuse the tx-list focus styling
+  visibleRows: function() {
+    var all = document.querySelectorAll('[data-connection-row]');
+    var out = [];
+    for (var i = 0; i < all.length; i++) {
+      // offsetParent is null when x-show has display:none'd the row
+      if (all[i].offsetParent !== null) out.push(all[i]);
+    }
+    return out;
+  },
+  clearFocus: function() {
+    var rows = document.querySelectorAll('[data-connection-row].' + this.FOCUSED_CLASS);
+    for (var i = 0; i < rows.length; i++) rows[i].classList.remove(this.FOCUSED_CLASS);
+  },
+  setFocus: function(idx) {
+    var rows = this.visibleRows();
+    if (!rows.length) { this.focusedIdx = -1; return; }
+    if (idx < 0) idx = 0;
+    if (idx >= rows.length) idx = rows.length - 1;
+    this.clearFocus();
+    rows[idx].classList.add(this.FOCUSED_CLASS);
+    this.focusedIdx = idx;
+    rows[idx].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  },
+  next: function() {
+    var rows = this.visibleRows();
+    if (!rows.length) return;
+    this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx + 1);
+  },
+  prev: function() {
+    var rows = this.visibleRows();
+    if (!rows.length) return;
+    this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx - 1);
+  },
+  currentRow: function() {
+    var rows = this.visibleRows();
+    if (this.focusedIdx < 0 || this.focusedIdx >= rows.length) return null;
+    return rows[this.focusedIdx];
+  },
+};
+
+document.addEventListener('alpine:init', function() {
+  var reg = Alpine.store('shortcuts');
+  if (!reg) return;
+
+  reg.register({
+    id: 'connections.next',
+    keys: 'j',
+    description: 'Move down',
+    group: 'Navigation',
+    scope: 'connections',
+    action: function() { bbConnNav.next(); },
+  });
+
+  reg.register({
+    id: 'connections.prev',
+    keys: 'k',
+    description: 'Move up',
+    group: 'Navigation',
+    scope: 'connections',
+    action: function() { bbConnNav.prev(); },
+  });
+
+  reg.register({
+    id: 'connections.open',
+    keys: 'Enter',
+    description: 'Open connection',
+    group: 'Actions',
+    scope: 'connections',
+    action: function() {
+      var row = bbConnNav.currentRow();
+      if (!row) return;
+      var url = row.getAttribute('data-open-url');
+      if (url) window.location.href = url;
+    },
+  });
+
+  reg.register({
+    id: 'connections.sync',
+    keys: 's',
+    description: 'Sync connection',
+    group: 'Actions',
+    scope: 'connections',
+    action: function() {
+      var row = bbConnNav.currentRow();
+      if (!row) return;
+      // Reuse the existing syncBtn Alpine component's click handler so CSRF,
+      // toast, and UI-state logic (disabled, spinner, 5s cooldown) stay in
+      // one place. Inactive and CSV connections don't render the button —
+      // no-op in that case.
+      var btn = row.querySelector('[data-sync-btn]');
+      if (btn) btn.click();
+    },
+  });
+
+  reg.register({
+    id: 'connections.edit',
+    keys: 'e',
+    description: 'Edit connection',
+    group: 'Actions',
+    scope: 'connections',
+    action: function() {
+      var row = bbConnNav.currentRow();
+      if (!row) return;
+      // No inline edit affordance on the list — the connection-detail page
+      // hosts rename, pause, and disconnect. Route 'e' there so the user
+      // lands on the edit surface directly. Same destination as Enter today;
+      // will diverge once an inline edit drawer lands.
+      var url = row.getAttribute('data-edit-url') || row.getAttribute('data-open-url');
+      if (url) window.location.href = url;
+    },
+  });
+});
 </script>
 
 </div><!-- /connections tab -->


### PR DESCRIPTION
Connections list picks up keyboard navigation — first rung of the `kbd-pages` stack (M4.1 of the keyboard-nav sprint).

## Summary

- Connections list (`/connections`) registers page-scoped shortcuts at `scope: 'connections'`:
  - `j` / `k` — move the row-focus cursor down / up.
  - `Enter` — open the focused connection's detail page.
  - `s` — sync the focused connection. Clicks the existing per-row `syncBtn` so CSRF, toast, spinner, and 5-second cooldown all reuse the same code path.
  - `e` — edit focused connection. Routes to the connection-detail page where rename / pause / disconnect live. Identical destination as Enter today; will diverge once an inline edit drawer lands.
- Focus highlight reuses `.bb-tx-row--focused` (already compiled; same inset-ring + bg-primary treatment as the transactions list) to avoid a Tailwind rebuild for a one-off class.
- DOM-backed nav (no Alpine store): a lightweight `bbConnNav` object reads `[data-connection-row]` and filters via `offsetParent !== null` so the family-member filter (`x-show`) hides rows from `j/k` automatically.
- Scope set/reset on the existing page root via `$store.shortcuts.setScope('connections')` + `x-destroy` back to `'global'`. Help modal (`?`) auto-surfaces these under "This page".

## Dispatcher guards covered by base.html

- Input focus (filter tabs, modal forms) skip the handler.
- Touch devices skip page-scoped shortcuts entirely.
- Open overlay (`[data-dialog-open]`) suppresses the handler — the Create Account Link modal is safe.

## Test plan

- [ ] `j` / `k` move a ring cursor through visible connection cards; wraps to edges (clamped).
- [ ] `Enter` on a focused row lands on `/connections/<id>`.
- [ ] `s` on a focused row triggers `/-/connections/<id>/sync` via the existing button; inactive / CSV rows are no-ops (no sync button rendered).
- [ ] `e` routes to the detail page.
- [ ] Filtering by family member hides those rows from `j`/`k`.
- [ ] `?` modal shows j, k, Enter, s, e under "This page" while on `/connections`.
- [ ] Touch device (DevTools device mode) — shortcuts do not fire.
- [ ] Typing into a filter / modal input — shortcuts do not fire.
