### PR TITLE
feat(rules): keyboard shortcuts on list page

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -2107,6 +2107,20 @@
 
       function hasChordStartingWith(reg, prefix) {
         var scope = reg.currentScope;
+        // If the active page scope has a single-key binding for this exact
+        // key, the page wins — don't start a chord sequence. This lets a
+        // page rebind a key that's otherwise a global chord prefix (e.g.
+        // the rules list using `n` for "New rule" instead of `n+_`).
+        if (scope && scope !== 'global') {
+          for (var j = 0; j < reg.items.length; j++) {
+            var ps = reg.items[j];
+            if (ps.scope !== scope) continue;
+            var pk = ps.keys;
+            var pageMatch = (typeof pk === 'string' && pk === prefix) ||
+              (Array.isArray(pk) && pk.length === 1 && pk[0] === prefix);
+            if (pageMatch) return false;
+          }
+        }
         for (var i = 0; i < reg.items.length; i++) {
           var s = reg.items[i];
           if (s.scope !== 'global' && s.scope !== scope) continue;

--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -1,11 +1,19 @@
 {{define "content"}}
+{{/*
+  Set the shortcut-registry scope so base.html's global dispatcher routes
+  j/k/Enter/n/Space/d (registered below) to this page's handlers, and so
+  the ? help modal surfaces them under "This page". Reset to 'global' on
+  Alpine teardown so other pages don't inherit the scope.
+*/}}
+<div x-data x-init="$store.shortcuts.setScope('rules')" x-destroy="$store.shortcuts.setScope('global')"></div>
+
 <div class="bb-page-header">
   <div>
     <h1 class="bb-page-title">Rules</h1>
     <p class="text-sm text-base-content/50 mt-1">Automatically categorize, tag, or comment on transactions during sync</p>
   </div>
   <div class="flex items-center gap-2">
-    <a href="/rules/new" class="btn btn-primary btn-sm rounded-xl">
+    <a href="/rules/new" class="btn btn-primary btn-sm rounded-xl" data-new-rule>
       <i data-lucide="plus" class="w-4 h-4"></i> New Rule
     </a>
   </div>
@@ -52,7 +60,13 @@
 {{range .Rules}}
 {{$matchAll := isMatchAllCondition .Conditions}}
 {{$isSystem := eq .CreatedByType "system"}}
-<div class="bb-card p-0 overflow-hidden cursor-pointer hover:bg-base-200/30 transition-colors{{if not .Enabled}} opacity-60{{end}}" x-data="{deleting: false}" @click="window.location.href='/rules/{{.ID}}'">
+<div class="bb-card p-0 overflow-hidden cursor-pointer hover:bg-base-200/30 transition-colors{{if not .Enabled}} opacity-60{{end}}"
+     data-rule-row
+     data-rule-id="{{.ID}}"
+     data-open-url="/rules/{{.ID}}"
+     data-edit-url="/rules/{{.ID}}/edit"
+     {{if not $isSystem}}data-can-delete="true"{{end}}
+     x-data="{deleting: false}" @click="window.location.href='/rules/{{.ID}}'">
   <div class="flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-4 sm:py-5">
     <!-- Avatar (category icon when set, else action-type icon) -->
     <div class="flex-shrink-0">
@@ -147,7 +161,7 @@
 
     <!-- Actions -->
     <div class="flex items-center justify-end gap-0.5 flex-shrink-0 w-24">
-      <button class="btn btn-ghost btn-xs btn-square rounded-lg" title="{{if .Enabled}}Disable{{else}}Enable{{end}}" @click.stop="toggleRule('{{.ID}}')">
+      <button class="btn btn-ghost btn-xs btn-square rounded-lg" data-toggle-enabled title="{{if .Enabled}}Disable{{else}}Enable{{end}}" @click.stop="toggleRule('{{.ID}}')">
         {{if .Enabled}}<i data-lucide="pause" class="w-3.5 h-3.5"></i>{{else}}<i data-lucide="play" class="w-3.5 h-3.5"></i>{{end}}
       </button>
       <a href="/rules/{{.ID}}/edit" class="btn btn-ghost btn-xs btn-square rounded-lg" title="Edit" @click.stop>
@@ -158,7 +172,7 @@
         <i data-lucide="shield" class="w-3.5 h-3.5"></i>
       </button>
       {{else}}
-      <button class="btn btn-ghost btn-xs btn-square rounded-lg text-error/60" title="Delete" :disabled="deleting" @click.stop="deleteRule('{{.ID}}', $el)">
+      <button class="btn btn-ghost btn-xs btn-square rounded-lg text-error/60" data-delete-action title="Delete" :disabled="deleting" @click.stop="deleteRule('{{.ID}}', $el)">
         <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
       </button>
       {{end}}
@@ -254,6 +268,142 @@ function rulesPage() {
     }
   };
 }
+
+// Keyboard navigation for the rules list. Reads the DOM for visible rows
+// (no filter exists today, but offsetParent !== null stays future-proof)
+// instead of mirroring rule data into a store. The base.html dispatcher
+// already guards against input focus, overlays, and touch devices.
+var bbRuleNav = {
+  focusedIdx: -1,
+  FOCUSED_CLASS: 'bb-tx-row--focused', // reuse the tx-list focus styling
+  visibleRows: function() {
+    var all = document.querySelectorAll('[data-rule-row]');
+    var out = [];
+    for (var i = 0; i < all.length; i++) {
+      if (all[i].offsetParent !== null) out.push(all[i]);
+    }
+    return out;
+  },
+  clearFocus: function() {
+    var rows = document.querySelectorAll('[data-rule-row].' + this.FOCUSED_CLASS);
+    for (var i = 0; i < rows.length; i++) rows[i].classList.remove(this.FOCUSED_CLASS);
+  },
+  setFocus: function(idx) {
+    var rows = this.visibleRows();
+    if (!rows.length) { this.focusedIdx = -1; return; }
+    if (idx < 0) idx = 0;
+    if (idx >= rows.length) idx = rows.length - 1;
+    this.clearFocus();
+    rows[idx].classList.add(this.FOCUSED_CLASS);
+    this.focusedIdx = idx;
+    rows[idx].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  },
+  next: function() {
+    var rows = this.visibleRows();
+    if (!rows.length) return;
+    this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx + 1);
+  },
+  prev: function() {
+    var rows = this.visibleRows();
+    if (!rows.length) return;
+    this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx - 1);
+  },
+  currentRow: function() {
+    var rows = this.visibleRows();
+    if (this.focusedIdx < 0 || this.focusedIdx >= rows.length) return null;
+    return rows[this.focusedIdx];
+  },
+};
+
+document.addEventListener('alpine:init', function() {
+  var reg = Alpine.store('shortcuts');
+  if (!reg) return;
+
+  reg.register({
+    id: 'rules.next',
+    keys: 'j',
+    description: 'Move down',
+    group: 'Navigation',
+    scope: 'rules',
+    action: function() { bbRuleNav.next(); },
+  });
+
+  reg.register({
+    id: 'rules.prev',
+    keys: 'k',
+    description: 'Move up',
+    group: 'Navigation',
+    scope: 'rules',
+    action: function() { bbRuleNav.prev(); },
+  });
+
+  reg.register({
+    id: 'rules.edit',
+    keys: 'Enter',
+    description: 'Edit rule',
+    group: 'Actions',
+    scope: 'rules',
+    action: function() {
+      var row = bbRuleNav.currentRow();
+      if (!row) return;
+      // Prefer the dedicated edit URL; fall back to the detail page (same
+      // destination as clicking the row).
+      var url = row.getAttribute('data-edit-url') || row.getAttribute('data-open-url');
+      if (url) window.location.href = url;
+    },
+  });
+
+  reg.register({
+    id: 'rules.new',
+    keys: 'n',
+    description: 'New rule',
+    group: 'Actions',
+    scope: 'rules',
+    // This shadows the global `n+_` chord while on /rules — see the
+    // hasChordStartingWith guard in base.html. Users can still use `g r`
+    // etc. to navigate; `n+r` chord lives everywhere else.
+    action: function() {
+      var btn = document.querySelector('[data-new-rule]');
+      if (btn) btn.click();
+    },
+  });
+
+  reg.register({
+    id: 'rules.toggle',
+    keys: ' ', // Space key — e.key is a literal space
+    description: 'Toggle enabled',
+    group: 'Actions',
+    scope: 'rules',
+    // Only fire when a row is focused, otherwise let the browser scroll.
+    // The dispatcher `when` predicate gates the match itself; if Space
+    // has no focused row, no shortcut matches and default scroll runs.
+    when: function() { return bbRuleNav.focusedIdx >= 0; },
+    action: function() {
+      var row = bbRuleNav.currentRow();
+      if (!row) return;
+      var btn = row.querySelector('[data-toggle-enabled]');
+      if (btn) btn.click();
+    },
+  });
+
+  reg.register({
+    id: 'rules.delete',
+    keys: 'd',
+    description: 'Delete rule',
+    group: 'Actions',
+    scope: 'rules',
+    // System rules render a disabled shield button instead of the delete
+    // button — data-delete-action is absent there, so `d` is a no-op on
+    // system rules. The existing deleteRule flow shows bbConfirm() before
+    // issuing the DELETE, so the confirm dialog still fires.
+    action: function() {
+      var row = bbRuleNav.currentRow();
+      if (!row) return;
+      var btn = row.querySelector('[data-delete-action]');
+      if (btn) btn.click();
+    },
+  });
+});
 </script>
 
 </div><!-- /rulesPage x-data -->


### PR DESCRIPTION
Wire the rules list to `$store.shortcuts` at `scope: 'rules'` — second PR in the `kbd-pages` stack; continues the per-page keyboard-nav rollout that M4.1 started on `/connections`.

## What lands

- `x-init="$store.shortcuts.setScope('rules')"` / `x-destroy` reset on a lightweight div at the top of the rules page, mirroring M4.1.
- DOM-backed `bbRuleNav` helper that reads `[data-rule-row]` and filters by `offsetParent !== null` (future-proof against any filter the page grows later). Focus ring reuses `.bb-tx-row--focused` to dodge a Tailwind rebuild, same pragmatic choice as iter 9 / M4.1.
- Row cards get `data-rule-row`, `data-open-url`, `data-edit-url`, and `data-can-delete`. Action buttons tagged with `data-toggle-enabled` and `data-delete-action` so shortcut handlers can click them and reuse the existing `rulesPage()` Alpine methods — no backend or UX divergence. The header "New Rule" CTA tagged with `data-new-rule`.

## Bindings (scope: `rules`)

| Key | Action |
|---|---|
| `j` / `k` | Move down / up through visible rows |
| `Enter` | Edit rule (`data-edit-url`, falls back to detail) |
| `n` | New rule (clicks the header CTA) |
| `Space` | Toggle enabled state on the focused row |
| `d` | Delete focused rule (runs the page's existing `bbConfirm` dialog — not bypassed) |

## Dispatcher tweak

`hasChordStartingWith` in `base.html` now short-circuits when the active page scope has a single-key binding for the same key. That lets `n` on `/rules` shadow the global `n+_` chord prefix without breaking chord behavior on any other page. Plan had flagged this — `N` (Shift+N) was the fallback, but page-scope shadowing keeps the key ergonomic and consistent with how `matchSingle` already prefers page scope.

## Space handling

The Space shortcut uses a `when: () => bbRuleNav.focusedIdx >= 0` predicate. Without a focused row the dispatcher's `shouldFire` returns false, so no `preventDefault` fires and the browser's default page-scroll still works. With a focused row Space clicks the per-row toggle button, reusing `toggleRule(id)` (CSRF, reload, etc.).

## Test plan

- [ ] `/rules` with >1 rule: `j`/`k` moves focus through cards, ring visible.
- [ ] `Enter` on a focused row opens `/rules/<id>/edit`.
- [ ] `n` from the list opens `/rules/new`.
- [ ] `Space` toggles the focused rule's enabled state (reloads page).
- [ ] `d` on a non-system rule shows the confirm dialog; Cancel aborts, Confirm deletes.
- [ ] `d` on a system rule is a no-op (system rules render a disabled shield instead of the delete button).
- [ ] `Space` with no row focused still scrolls the page.
- [ ] Global `g r`, `g c`, and other chord navigations still work from `/rules` (only `n+_` is shadowed on this page).
- [ ] `?` help modal on `/rules` surfaces these five bindings under "This page".
- [ ] Touch device: dispatcher's `isTouch` guard keeps page shortcuts from firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
