### PR TITLE
feat(rules): keyboard shortcuts on rule detail page

### DIFF
--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -1,7 +1,11 @@
 {{define "content"}}
 {{template "breadcrumb" .}}
 
-<div x-data="ruleDetail()">
+<div x-data="ruleDetail()"
+     x-init="$store.shortcuts && $store.shortcuts.setScope('rule-detail'); registerShortcuts()"
+     x-destroy="$store.shortcuts && $store.shortcuts.setScope('global'); unregisterShortcuts()"
+     @keydown.meta.enter.window.prevent="if (!showApplyModal) toggleRule()"
+     @keydown.ctrl.enter.window.prevent="if (!showApplyModal) toggleRule()">
 
 {{$isSystem := eq .Rule.CreatedByType "system"}}
 {{$matchAll := isMatchAllCondition .Rule.Conditions}}
@@ -319,7 +323,7 @@
 
   <div class="mt-4 flex items-center justify-between">
     <p class="text-xs text-base-content/40">Apply this rule to categorize these existing transactions</p>
-    <button class="btn btn-sm btn-outline rounded-xl" @click="openApplyModal()" :disabled="applying">
+    <button class="btn btn-sm btn-outline rounded-xl" data-apply-btn @click="openApplyModal()" :disabled="applying">
       <span x-show="applying" class="loading loading-spinner loading-xs"></span>
       <i data-lucide="play" class="w-3.5 h-3.5" x-show="!applying"></i>
       Categorize as {{if .ActionCategoryName}}{{.ActionCategoryName}}{{else}}matched category{{end}}
@@ -473,6 +477,56 @@ function ruleDetail() {
     applyError: '',
     showApplyModal: false,
     confirmApply: false,
+    // Register page-scoped shortcuts so they surface in the `?` help modal.
+    // `Cmd+Enter` (toggle) is wired via inline @keydown.meta.enter.window
+    // because the global dispatcher short-circuits on modifier keys; this
+    // registry entry is visible-only so the help modal advertises it.
+    // `Esc` closes the apply modal via @keydown.escape.window on the modal
+    // itself — registered here (visible-only) for discoverability.
+    registerShortcuts() {
+      if (!window.Alpine || !Alpine.store('shortcuts')) return;
+      var reg = Alpine.store('shortcuts');
+      var self = this;
+      reg.register({
+        id: 'rule-detail.save',
+        keys: 'cmd+enter',
+        description: 'Toggle rule (enable / disable)',
+        group: 'Actions',
+        scope: 'rule-detail',
+        visible: true
+        // no action — dispatched by inline @keydown.meta.enter on the page root
+      });
+      reg.register({
+        id: 'rule-detail.apply',
+        keys: 'a',
+        description: 'Apply rule to matching transactions',
+        group: 'Actions',
+        scope: 'rule-detail',
+        when: function() {
+          return !!document.querySelector('[data-apply-btn]');
+        },
+        action: function() {
+          var btn = document.querySelector('[data-apply-btn]');
+          if (btn) btn.click();
+        }
+      });
+      reg.register({
+        id: 'rule-detail.esc',
+        keys: 'Esc',
+        description: 'Close apply dialog',
+        group: 'Actions',
+        scope: 'rule-detail',
+        visible: true
+        // no action — handled by @keydown.escape.window on the modal itself
+      });
+    },
+    unregisterShortcuts() {
+      if (!window.Alpine || !Alpine.store('shortcuts')) return;
+      var reg = Alpine.store('shortcuts');
+      reg.unregister('rule-detail.save');
+      reg.unregister('rule-detail.apply');
+      reg.unregister('rule-detail.esc');
+    },
     openApplyModal() {
       this.confirmApply = false;
       this.applyError = '';


### PR DESCRIPTION
Register page-scoped keyboard shortcuts for the rule detail view so it mirrors the discoverability the rest of the kbd-pages stack added on the list views.

## Shortcuts (scope `rule-detail`)

- `a` — "Apply rule to matching transactions". Clicks the `[data-apply-btn]` on the pending-matches card (the "Categorize as …" button), which opens the existing confirmation modal. The spec's `when` predicate checks for the button in the DOM so the shortcut silently no-ops when a rule has nothing to apply (no matches, or only `add_comment` actions).
- `Cmd+Enter` / `Ctrl+Enter` — "Toggle rule (enable / disable)". Rule detail is a read-only view with no save form, so the closest "save"-shaped action is `toggleRule()`, which persists a state change via `POST /-/rules/{id}/toggle`. Wired via inline `@keydown.meta.enter.window` on the page root because the global dispatcher intentionally short-circuits on modifier keys (the same reason `Cmd+K` is handled by the command palette, not the registry). The registry entry is `visible: true`, action-less — it exists solely so the binding surfaces in the `?` help modal under "This page".
- `Esc` — "Close apply dialog". The modal already handles this via an inline `@keydown.escape.window="closeApplyModal()"`; registering it here (visible-only) just surfaces it in the help modal.

## Guards

- The `Cmd+Enter` handler skips when the apply modal is open (`if (!showApplyModal) toggleRule()`) so confirming an apply with Cmd+Enter can't accidentally flip the rule's enabled state.
- `a` goes through the existing button click, so the modal's confirmation checkbox still gates the destructive apply action.
- Standard kbd-pages-stack hygiene: `x-init` sets scope on mount, `x-destroy` resets to `global` on teardown; entries are unregistered so they don't leak to other pages.

## Out of scope

- No dispatcher changes. `allowInInput` was considered for `Cmd+Enter` (typical "submit form while typing" ergonomics) but isn't needed here — there's no form to submit on the detail page, and inline Alpine handlers already fire regardless of focus.
- The rule *edit* form (`/rules/{id}/edit`) doesn't get Cmd+Enter in this PR; adding a scope there is a separate small PR if desired.

Build + vet clean; browser verification deferred to review.
