### PR TITLE
chore(cli): remove api-keys subcommand

### DIFF
--- a/cmd/breadbox/main.go
+++ b/cmd/breadbox/main.go
@@ -39,7 +39,7 @@ var version = "dev"
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: breadbox <command>")
-		fmt.Fprintln(os.Stderr, "commands: serve, migrate, seed, mcp-stdio, api-keys, create-admin, reset-password, version")
+		fmt.Fprintln(os.Stderr, "commands: serve, migrate, seed, mcp-stdio, create-admin, reset-password, version")
 		os.Exit(1)
 	}
 
@@ -61,11 +61,6 @@ func main() {
 		}
 	case "mcp-stdio":
 		if err := runMCPStdio(); err != nil {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
-			os.Exit(1)
-		}
-	case "api-keys":
-		if err := runAPIKeys(); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
@@ -402,71 +397,6 @@ func runMCPStdio() error {
 
 	logger.Info("starting MCP stdio server", "version", version)
 	return server.Run(ctx, &mcpsdk.StdioTransport{})
-}
-
-func runAPIKeys() error {
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("load config: %w", err)
-	}
-
-	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, cfg.DatabaseURL)
-	if err != nil {
-		return fmt.Errorf("connect to database: %w", err)
-	}
-	defer pool.Close()
-
-	queries := db.New(pool)
-	svc := service.New(queries, pool, nil, slog.New(slog.NewTextHandler(os.Stderr, nil)))
-
-	// Sub-action: "create <name>" or default to "list"
-	action := "list"
-	if len(os.Args) > 2 {
-		action = os.Args[2]
-	}
-
-	switch action {
-	case "list":
-		keys, err := svc.ListAPIKeys(ctx)
-		if err != nil {
-			return fmt.Errorf("list api keys: %w", err)
-		}
-		if len(keys) == 0 {
-			fmt.Println("No API keys found. Create one with: breadbox api-keys create <name>")
-			return nil
-		}
-		fmt.Printf("%-38s  %-20s  %-12s  %-10s  %s\n", "ID", "NAME", "PREFIX", "STATUS", "LAST USED")
-		for _, k := range keys {
-			status := "active"
-			if k.RevokedAt != nil {
-				status = "revoked"
-			}
-			lastUsed := "never"
-			if k.LastUsedAt != nil {
-				lastUsed = *k.LastUsedAt
-			}
-			fmt.Printf("%-38s  %-20s  %-12s  %-10s  %s\n", k.ID, k.Name, k.KeyPrefix+"...", status, lastUsed)
-		}
-
-	case "create":
-		name := "cli"
-		if len(os.Args) > 3 {
-			name = os.Args[3]
-		}
-		result, err := svc.CreateAPIKey(ctx, name, "full_access")
-		if err != nil {
-			return fmt.Errorf("create api key: %w", err)
-		}
-		fmt.Printf("Created API key: %s\n", result.Name)
-		fmt.Printf("Key: %s\n", result.PlaintextKey)
-		fmt.Println("\nSave this key now — it cannot be retrieved again.")
-
-	default:
-		return fmt.Errorf("unknown api-keys action: %s (use 'list' or 'create <name>')", action)
-	}
-
-	return nil
 }
 
 func runResetPassword() error {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,16 +32,16 @@ breadbox serve           Start HTTP server with all components
 breadbox mcp-stdio       Start MCP server on stdio (local agent dev only)
 breadbox migrate         Run pending database migrations
 breadbox seed            Insert sandbox test data (development only)
-breadbox api-keys        List or create API keys (list | create <name>)
 breadbox create-admin    Create an admin account (interactive or --username/--password flags)
 breadbox reset-password  Reset the admin account password
 breadbox version         Print build version and exit
 ```
 
 > **Note:** There is no separate CLI client binary. All subcommands above are
-> part of the server binary (`cmd/breadbox/main.go`). The `api-keys`,
-> `create-admin`, and `reset-password` commands connect directly to the database
-> — they are administrative utilities, not API clients.
+> part of the server binary (`cmd/breadbox/main.go`). The `create-admin` and
+> `reset-password` commands connect directly to the database — they are
+> administrative utilities, not API clients. API keys are managed exclusively
+> via the admin dashboard at `/admin/api-keys`.
 
 `breadbox serve` is the production entry point. It initializes every component
 — HTTP router, sync engine, cron scheduler, webhook handler — and runs them


### PR DESCRIPTION
## Summary

- Drops the `breadbox api-keys` CLI subcommand (both `list` and `create <name>` actions) and its `runAPIKeys` helper in `cmd/breadbox/main.go`.
- Updates `docs/architecture.md` to reflect the new subcommand list and points to the admin dashboard as the sole surface for API key management.

## Why

API keys are already fully managed from the admin dashboard — creation (with scope selection), listing, and revocation all live under `/admin/api-keys`. The CLI path had drifted from the dashboard's UX (no scope selection, no revoke flow, simpler created-key display) and was redundant. Consolidating on the dashboard removes a second code path and a source of confusion.

The admin-side code (`internal/admin/apikeys.go`, `internal/service` methods, `internal/templates` pages) is untouched.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Smoke test in dev: `./breadbox api-keys` prints `unknown command: api-keys` (the default case) and exits non-zero.
- [ ] Confirm API keys can still be created, listed, and revoked from `/admin/api-keys` in the dashboard.