### PR TITLE
feat(a11y): register keyboard scope on remaining pages

### DIFF
--- a/internal/templates/components/pages/dashboard.templ
+++ b/internal/templates/components/pages/dashboard.templ
@@ -9,6 +9,12 @@ import (
 // Dashboard renders the admin home page: agent reports and recent transactions.
 // Hosted inside base.html via TemplateRenderer.RenderWithTempl.
 templ Dashboard(p DashboardProps) {
+	<!--
+		Set the shortcut-registry scope so the ? help modal reflects "This page"
+		accurately (dashboard has no custom shortcuts — navigation lives via the
+		g+_ chords already). Reset to 'global' on Alpine teardown.
+	-->
+	<div x-data x-init="$store.shortcuts.setScope('dashboard')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	if p.ShowUpdateBanner {
 		@dashUpdateBanner(p)
 	}

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -11,6 +11,13 @@ import (
 // typed props and the bridge drops the rendered HTML into base.html's
 // TemplContent slot.
 templ Settings(p SettingsProps) {
+	<!--
+		Set the shortcut-registry scope so the ? help modal reflects "This page"
+		accurately. Settings intentionally has no custom shortcuts — it's a
+		settings form and letter-key shortcuts would collide with form inputs.
+		Reset to 'global' on Alpine teardown.
+	-->
+	<div x-data x-init="$store.shortcuts.setScope('settings')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Settings</h1>

--- a/internal/templates/pages/backups.html
+++ b/internal/templates/pages/backups.html
@@ -1,4 +1,11 @@
 {{define "content"}}
+{{/*
+  Set the shortcut-registry scope so base.html's global dispatcher routes
+  n (registered below) to the Create Backup submit button, and so the
+  ? help modal surfaces it under "This page". Reset on Alpine teardown.
+*/}}
+<div x-data x-init="$store.shortcuts.setScope('backups')" x-destroy="$store.shortcuts.setScope('global')"></div>
+
 <div class="bb-page-header">
   <div>
     <h1 class="bb-page-title">Backups</h1>
@@ -8,7 +15,7 @@
     {{if not .Error}}
     <form method="POST" action="/-/backups/create">
       <input type="hidden" name="_csrf" value="{{.CSRFToken}}">
-      <button type="submit" class="btn btn-primary btn-sm rounded-xl" {{if not .PreflightOK}}disabled title="{{.PreflightMessage}}"{{end}}>
+      <button type="submit" data-new-backup class="btn btn-primary btn-sm rounded-xl" {{if not .PreflightOK}}disabled title="{{.PreflightMessage}}"{{end}}>
         {{if .PreflightOK}}
         <i data-lucide="download" class="w-4 h-4"></i>
         {{else}}
@@ -295,5 +302,25 @@
   var el = document.querySelector(location.hash);
   if (el) setTimeout(function() { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 100);
 })();
+
+// Register backups-scoped keyboard shortcuts. `n` clicks the Create Backup
+// submit button so the real POST form handles CSRF + preflight gating —
+// the shortcut is purely a UI affordance.
+document.addEventListener('alpine:init', function() {
+  var reg = Alpine.store('shortcuts');
+  if (!reg) return;
+
+  reg.register({
+    id: 'backups.new',
+    keys: 'n',
+    description: 'Create backup',
+    group: 'New',
+    scope: 'backups',
+    action: function() {
+      var btn = document.querySelector('[data-new-backup]');
+      if (btn && !btn.disabled) btn.click();
+    },
+  });
+});
 </script>
 {{end}}

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -1,4 +1,11 @@
 {{define "content"}}
+{{/*
+  Set the shortcut-registry scope so base.html's global dispatcher routes
+  r (registered below) to a reload, and so the ? help modal surfaces it
+  under "This page". Reset on Alpine teardown.
+*/}}
+<div x-data x-init="$store.shortcuts.setScope('reports')" x-destroy="$store.shortcuts.setScope('global')"></div>
+
 <div class="bb-page-header">
   <div>
     <h1 class="bb-page-title">Agent Reports</h1>
@@ -110,5 +117,23 @@ function reportsPage() {
 }
 </script>
 {{end}}
+
+<script>
+// Register reports-scoped keyboard shortcuts. No dedicated refresh button
+// on this page (it's a server-rendered inbox), so `r` reloads.
+document.addEventListener('alpine:init', function() {
+  var reg = Alpine.store('shortcuts');
+  if (!reg) return;
+
+  reg.register({
+    id: 'reports.refresh',
+    keys: 'r',
+    description: 'Refresh reports',
+    group: 'Actions',
+    scope: 'reports',
+    action: function() { window.location.reload(); },
+  });
+});
+</script>
 
 {{end}}

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -1,4 +1,11 @@
 {{define "content"}}
+{{/*
+  Set the shortcut-registry scope so base.html's global dispatcher routes
+  r (registered below) to this page's handler, and so the ? help modal
+  surfaces it under "This page". Reset to 'global' on Alpine teardown.
+*/}}
+<div x-data x-init="$store.shortcuts.setScope('sync-logs')" x-destroy="$store.shortcuts.setScope('global')"></div>
+
 <div class="bb-page-header">
   <div>
     <h1 class="bb-page-title">Sync Logs</h1>
@@ -287,4 +294,23 @@
   </div>
 </div>
 {{end}}
+
+<script>
+// Register sync-logs scoped keyboard shortcuts in the global registry.
+// No explicit "refresh" button on this page, so `r` reloads the page —
+// matches the user's mental model (list view, no client-side re-fetch yet).
+document.addEventListener('alpine:init', function() {
+  var reg = Alpine.store('shortcuts');
+  if (!reg) return;
+
+  reg.register({
+    id: 'sync-logs.refresh',
+    keys: 'r',
+    description: 'Refresh sync logs',
+    group: 'Actions',
+    scope: 'sync-logs',
+    action: function() { window.location.reload(); },
+  });
+});
+</script>
 {{end}}

--- a/internal/templates/pages/users.html
+++ b/internal/templates/pages/users.html
@@ -1,10 +1,17 @@
 {{define "content"}}
+{{/*
+  Set the shortcut-registry scope so base.html's global dispatcher routes
+  n (registered below) to the Add Member link, and so the ? help modal
+  surfaces it under "This page". Reset on Alpine teardown.
+*/}}
+<div x-data x-init="$store.shortcuts.setScope('users')" x-destroy="$store.shortcuts.setScope('global')"></div>
+
 <div class="bb-page-header">
   <div>
     <h1 class="bb-page-title">Household</h1>
     <p class="text-sm text-base-content/50 mt-1">Manage who has bank connections in Breadbox</p>
   </div>
-  <a href="/users/new" class="btn btn-primary btn-sm rounded-xl">
+  <a href="/users/new" data-new-user class="btn btn-primary btn-sm rounded-xl">
     <i data-lucide="plus" class="w-4 h-4"></i>
     Add Member
   </a>
@@ -215,4 +222,26 @@
   </div>
 </div>
 {{end}}
+
+<script>
+// Register users-scoped keyboard shortcuts. `n` clicks the Add Member
+// link (anchor tag). Using .click() respects the browser's normal
+// navigation so we don't need to duplicate the href here.
+document.addEventListener('alpine:init', function() {
+  var reg = Alpine.store('shortcuts');
+  if (!reg) return;
+
+  reg.register({
+    id: 'users.new',
+    keys: 'n',
+    description: 'Add member',
+    group: 'New',
+    scope: 'users',
+    action: function() {
+      var el = document.querySelector('[data-new-user]');
+      if (el) el.click();
+    },
+  });
+});
+</script>
 {{end}}


### PR DESCRIPTION
Register page-level keyboard scopes on the remaining admin pages so the `?` help modal reflects truth ("This page" no longer falsely inherits the previous scope), and add the few shortcuts that are obvious enough to clear the M3 bar.

## Summary

- **Sync logs** (`internal/templates/pages/sync_logs.html`): scope `sync-logs` + `r` → `window.location.reload()`. No explicit refresh button on this page, so reload is the honest action.
- **Backups** (`internal/templates/pages/backups.html`): scope `backups` + `n` → clicks the existing `Create Backup Now` form submit via a new `[data-new-backup]` hook. Preflight-disabled state is respected (guard on `btn.disabled`), so CSRF + preflight gating stay in the form.
- **Users** (`internal/templates/pages/users.html`): scope `users` + `n` → clicks the `Add Member` anchor (`[data-new-user]`), so the browser's normal navigation handles the route change.
- **Reports** (`internal/templates/pages/reports.html`): scope `reports` + `r` → reload. No dedicated refresh button on the inbox — matches sync logs behavior.
- **Dashboard** (`internal/templates/components/pages/dashboard.templ`): scope `dashboard` only. Navigation already lives in the `g+_` global chords; no custom bindings added.
- **Settings** (`internal/templates/components/pages/settings.templ`): scope `settings` only. Settings is a form-heavy surface where letter-key shortcuts would collide with inputs; the scope registration alone gives an honest empty "This page" section.

Pattern matches M2 (`transaction_detail.html`): a small `x-data x-init` scope div + a `document.addEventListener('alpine:init', ...)` block that calls `$store.shortcuts.register`. No dispatcher changes. No new Alpine components. No touch-device handling needed — the global dispatcher in base.html already suppresses page-level shortcuts on `$store.device.isTouch`.

Both templ files regenerated; `*_templ.go` stays gitignored. `go build ./...` and `go vet ./...` clean.

## Test plan

- [ ] Visit `/sync-logs` on desktop, press `?` — help modal "This page" section shows `R — Refresh sync logs`. Press `r` — page reloads.
- [ ] Visit `/backups`, press `?` — shows `N — Create backup`. Press `n` — confirms POST fires (page navigates to `/-/backups/create`). Disable preflight (e.g. fill disk) and confirm `n` no-ops while the button is disabled.
- [ ] Visit `/users`, press `?` — shows `N — Add member`. Press `n` — navigates to `/users/new`.
- [ ] Visit `/reports`, press `?` — shows `R — Refresh reports`. Press `r` — reloads.
- [ ] Visit `/` (dashboard) and `/settings`, press `?` — "This page" section is empty (only globals shown), confirming scope is set but no custom bindings.
- [ ] Touch device / narrow viewport: none of the above fire; `?` and `Cmd+K` still work.
- [ ] `go build ./...` + `go vet ./...` clean.

Plan: `/Users/canales/Documents/obsidian/Breadbox/planned-features/keyboard-nav-sprint.md`.
