### PR TITLE
fix(agent-wizard): inactive pill labels meet WCAG AA contrast

### DIFF
--- a/internal/templates/pages/prompt_builder.html
+++ b/internal/templates/pages/prompt_builder.html
@@ -50,7 +50,7 @@
           <button class="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-all duration-150 border-r border-base-300 last:border-r-0"
                   :class="block.enabled
                     ? 'bg-primary/10 text-primary'
-                    : 'bg-base-200/50 text-base-content/40 hover:text-base-content/60'"
+                    : 'bg-base-200/50 text-base-content/60 hover:text-base-content/80'"
                   @click="toggleBlock(block.id)">
             <span x-html="getBlockIcon(block.id)" class="flex-shrink-0 flex items-center"></span>
             <span x-text="block.title"></span>
@@ -63,7 +63,7 @@
       <button class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-150"
               :class="block.enabled
                 ? 'bg-primary/10 text-primary border border-primary/30 hover:bg-primary/15'
-                : 'bg-base-200/50 text-base-content/40 border border-base-300 hover:text-base-content/60 hover:border-base-content/20'"
+                : 'bg-base-200/50 text-base-content/60 border border-base-300 hover:text-base-content/80 hover:border-base-content/20'"
               @click="toggleBlock(block.id)">
         <span x-html="getBlockIcon(block.id)" class="flex-shrink-0 flex items-center"></span>
         <span x-text="block.title"></span>
@@ -72,7 +72,7 @@
       </button>
     </template>
     <!-- Custom instructions -->
-    <button class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-base-200/50 text-base-content/40 border border-dashed border-base-300 hover:text-base-content/60 hover:border-base-content/20 transition-all duration-150"
+    <button class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium bg-base-200/50 text-base-content/60 border border-dashed border-base-300 hover:text-base-content/80 hover:border-base-content/20 transition-all duration-150"
             @click="addCustomBlock()">
       <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z"/></svg>
       Custom Instructions


### PR DESCRIPTION
Fixes #678

Bumps inactive scope-pill label opacity from `text-base-content/40` (~3.3:1) to `/60` (>=4.5:1) so the Bulk Review / Agent Wizard pills meet WCAG AA on 12px normal-weight copy. Hover lifts from `/60` to `/80`. The active / enabled pill styling (`text-primary`) is unchanged.

## Before / After

### Mobile 375x667
| Before | After |
|---|---|
| ![before-375](https://i.img402.dev/2uae6dzczl.png) | ![after-375](https://i.img402.dev/3yj6ec2zo4.png) |

### Mobile 500x844
| Before | After |
|---|---|
| ![before-500](https://i.img402.dev/ivp41rr6yd.png) | ![after-500](https://i.img402.dev/ccyfic0efu.png) |

### Tablet 820x1180
| Before | After |
|---|---|
| ![before-820](https://i.img402.dev/81x3htg3ef.png) | ![after-820](https://i.img402.dev/setks6vyuv.png) |

### Desktop 1440x900
| Before | After |
|---|---|
| ![before-1440](https://i.img402.dev/724hbu2bpr.png) | ![after-1440](https://i.img402.dev/ihkyuewhp7.png) |

File touched: `internal/templates/pages/prompt_builder.html`

Applies to the inactive side of the exclusive `Review Depth` toggle, every non-enabled scope pill (Gmail Integration, Account Linking, Category System, Sync Management, Transaction Comments & Annotations, Merchant Analysis, etc.), and the dashed `Custom Instructions` add-pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)