### PR TITLE
refactor(kbd): drop low-value and risky shortcuts per sprint review

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -52,7 +52,6 @@ Each page calls `$store.shortcuts.setScope('<page>')` in its root `x-init` and r
 | `t` | Tag focused row |
 | `e` | Expand / collapse row |
 | `x` | Toggle selection on focused row |
-| `Shift+J` / `Shift+K` | Extend selection down / up |
 | `/` | Focus the quick-search input |
 | `Esc` | Clear selection, then exit select mode, then clear focus |
 
@@ -62,7 +61,6 @@ Each page calls `$store.shortcuts.setScope('<page>')` in its root `x-init` and r
 | --- | --- |
 | `c` | Categorize transaction (opens inline picker) |
 | `t` | Edit tags (opens tag picker) |
-| `Enter` | Focus the comment input |
 | `e` | Toggle system details |
 
 ### Reviews queue — scope `reviews`
@@ -82,7 +80,6 @@ The review queue reuses the transactions list UI, so `j/k/Enter/c/t/Esc` all wor
 | `j` / `k` | Move focus down / up (skips hidden rows) |
 | `Enter` | Open connection detail |
 | `s` | Sync focused connection (respects 5 s cooldown) |
-| `e` | Edit connection (routes to detail page) |
 
 ### Rules list — scope `rules`
 
@@ -110,18 +107,6 @@ Expand/collapse is handled inline via Alpine `@keydown.enter` / `@keydown.space`
 | --- | --- |
 | `j` / `k` | Move focus down / up through visible rows |
 | `n` | Add a new category (clicks the Add link; shadows global `n+_`) |
-
-### Sync logs — scope `sync-logs`
-
-| Keys | Action |
-| --- | --- |
-| `r` | Reload the page |
-
-### Reports — scope `reports`
-
-| Keys | Action |
-| --- | --- |
-| `r` | Reload the page |
 
 ### Backups — scope `backups`
 

--- a/internal/templates/components/pages/assets/transactions_scripts.js.html
+++ b/internal/templates/components/pages/assets/transactions_scripts.js.html
@@ -756,25 +756,6 @@ document.addEventListener('alpine:init', function() {
       Alpine.store('bulk').toggle(id);
     },
 
-    // Shift+J / Shift+K — extend the bulk selection while moving the focus ring.
-    // Mirrors Gmail/Linear: the row the cursor *arrives at* gets (de)selected,
-    // which feels like "drag-select with the keyboard".
-    _extendSelection(dir) {
-      var rows = this._getRows();
-      if (!rows.length) return;
-      // Enter selection mode implicitly — matches the behavior of `x` which
-      // also bootstraps selection mode when a row first gets toggled.
-      if (!Alpine.store('bulk').selecting) Alpine.store('bulk').toggleMode();
-      if (dir > 0) this.next(); else this.prev();
-      var row = rows[this.focusedIdx] || this._getRows()[this.focusedIdx];
-      if (!row) return;
-      var id = row.dataset.txId;
-      if (!id) return;
-      Alpine.store('bulk').toggle(id);
-    },
-    extendSelectionDown() { this._extendSelection(1); },
-    extendSelectionUp() { this._extendSelection(-1); },
-
     // Jump the keyboard focus ring onto the clicked row so j/k continues from there.
     focusRow(row) {
       var rows = this._getRows();
@@ -857,14 +838,6 @@ document.addEventListener('alpine:init', function() {
   reg.register({ id: 'transactions.select', keys: 'x', description: 'Toggle selection',
     group: 'Selection', scope: 'transactions', when: txFocusedNotInPicker,
     action: function() { Alpine.store('txNav').toggleSelect(); } });
-  reg.register({ id: 'transactions.select-extend-down', keys: 'J',
-    description: 'Extend selection down',
-    group: 'Selection', scope: 'transactions', when: txNotInPicker,
-    action: function() { Alpine.store('txNav').extendSelectionDown(); } });
-  reg.register({ id: 'transactions.select-extend-up', keys: 'K',
-    description: 'Extend selection up',
-    group: 'Selection', scope: 'transactions', when: txNotInPicker,
-    action: function() { Alpine.store('txNav').extendSelectionUp(); } });
   reg.register({ id: 'transactions.focus-search', keys: '/',
     description: 'Focus search',
     group: 'Actions', scope: 'transactions', when: txNotInPicker,

--- a/internal/templates/pages/connections.html
+++ b/internal/templates/pages/connections.html
@@ -447,23 +447,6 @@ document.addEventListener('alpine:init', function() {
     },
   });
 
-  reg.register({
-    id: 'connections.edit',
-    keys: 'e',
-    description: 'Edit connection',
-    group: 'Actions',
-    scope: 'connections',
-    action: function() {
-      var row = bbConnNav.currentRow();
-      if (!row) return;
-      // No inline edit affordance on the list — the connection-detail page
-      // hosts rename, pause, and disconnect. Route 'e' there so the user
-      // lands on the edit surface directly. Same destination as Enter today;
-      // will diverge once an inline edit drawer lands.
-      var url = row.getAttribute('data-edit-url') || row.getAttribute('data-open-url');
-      if (url) window.location.href = url;
-    },
-  });
 });
 </script>
 

--- a/internal/templates/pages/reports.html
+++ b/internal/templates/pages/reports.html
@@ -118,22 +118,4 @@ function reportsPage() {
 </script>
 {{end}}
 
-<script>
-// Register reports-scoped keyboard shortcuts. No dedicated refresh button
-// on this page (it's a server-rendered inbox), so `r` reloads.
-document.addEventListener('alpine:init', function() {
-  var reg = Alpine.store('shortcuts');
-  if (!reg) return;
-
-  reg.register({
-    id: 'reports.refresh',
-    keys: 'r',
-    description: 'Refresh reports',
-    group: 'Actions',
-    scope: 'reports',
-    action: function() { window.location.reload(); },
-  });
-});
-</script>
-
 {{end}}

--- a/internal/templates/pages/sync_logs.html
+++ b/internal/templates/pages/sync_logs.html
@@ -295,22 +295,4 @@
 </div>
 {{end}}
 
-<script>
-// Register sync-logs scoped keyboard shortcuts in the global registry.
-// No explicit "refresh" button on this page, so `r` reloads the page —
-// matches the user's mental model (list view, no client-side re-fetch yet).
-document.addEventListener('alpine:init', function() {
-  var reg = Alpine.store('shortcuts');
-  if (!reg) return;
-
-  reg.register({
-    id: 'sync-logs.refresh',
-    keys: 'r',
-    description: 'Refresh sync logs',
-    group: 'Actions',
-    scope: 'sync-logs',
-    action: function() { window.location.reload(); },
-  });
-});
-</script>
 {{end}}

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -3,7 +3,7 @@
 
 {{/*
   Set the shortcut-registry scope so base.html's global dispatcher routes
-  c / t / e / Enter (registered below) to this page's handlers, and so the
+  c / t / e (registered below) to this page's handlers, and so the
   ? help modal surfaces them under "This page". Reset to 'global' on
   Alpine teardown so other pages don't inherit the scope.
 */}}
@@ -335,18 +335,6 @@ document.addEventListener('alpine:init', function() {
       // opens the picker with its current tag state (appliedCounts, etc.).
       var btn = document.querySelector('.bb-tag-add');
       if (btn) btn.click();
-    },
-  });
-
-  reg.register({
-    id: 'transaction-detail.focus-comment',
-    keys: 'Enter',
-    description: 'Focus comment',
-    group: 'Actions',
-    scope: 'transaction-detail',
-    action: function() {
-      var el = document.getElementById('bb-txd-comment');
-      if (el) el.focus();
     },
   });
 


### PR DESCRIPTION
Post-sprint usability cleanup of the keyboard-nav sprint. A critical review flagged four shortcuts as low-value or actively risky — this PR removes them so the canonical help modal, docs, and per-page registrations stay honest.

## Changes

- **Transactions list** (#666): drop `Shift+J` / `Shift+K` extend-selection. It collided with typing shifted characters (e.g. `J` in a search box before focus escape), and the `x`-then-`j/k`-then-`x` pattern already covers keyboard multi-select without overloading shift. Removes the `_extendSelection` helper and both shortcut registrations.
- **Transaction detail** (#667): drop `Enter` focus-comment. `Enter` opens detail on list views; overloading it for a Tab-reachable input is the same-key-different-behavior footgun the sprint was trying to eliminate. Users can Tab or click into the comment field.
- **Sync logs + Reports** (#679): drop `r` reload on both pages. `Cmd+R` already reloads in every browser, and `r` was stepping on the reject/rules mnemonic space we use elsewhere.
- **Connections list** (#670): drop `e` edit. It routed to the same destination as `Enter` on the focused row — zero added behavior.

All four relevant branches were already merged to `main`, so this goes in as a single standalone cleanup PR (no fixups to open branches needed).

## Docs

`docs/keyboard-shortcuts.md` updated to match the new registered set — the `?` help modal is runtime-driven so it auto-updates.

## Test plan

- [ ] `go build ./...` + `go vet ./...` clean (verified locally)
- [ ] On transactions list: `x` still enters select mode and toggles the focused row; `j`/`k` still move the focus ring; `Shift+J`/`Shift+K` now type a capital letter in focused inputs instead of triggering selection.
- [ ] On transaction detail: `Enter` no longer hijacks focus to the comment input; pressing it while scope is `transaction-detail` is a no-op; Tab still reaches the comment field.
- [ ] On sync logs / reports: `r` does nothing (Cmd+R reload still works).
- [ ] On connections list: `e` does nothing on the focused row; `Enter` still opens detail.
- [ ] `?` help modal on each page reflects only the remaining bindings.