### PR TITLE
fix(rules): stack preview footer vertically on mobile (<=640px)

### DIFF
--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -321,9 +321,9 @@
   <p class="text-xs text-base-content/40 mt-2">Showing 10 of {{commaInt .Preview.MatchCount}}</p>
   {{end}}
 
-  <div class="mt-4 flex items-center justify-between">
+  <div class="mt-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
     <p class="text-xs text-base-content/40">Apply this rule to categorize these existing transactions</p>
-    <button class="btn btn-sm btn-outline rounded-xl" data-apply-btn @click="openApplyModal()" :disabled="applying">
+    <button class="btn btn-sm btn-outline rounded-xl w-full sm:w-auto" data-apply-btn @click="openApplyModal()" :disabled="applying">
       <span x-show="applying" class="loading loading-spinner loading-xs"></span>
       <i data-lucide="play" class="w-3.5 h-3.5" x-show="!applying"></i>
       Categorize as {{if .ActionCategoryName}}{{.ActionCategoryName}}{{else}}matched category{{end}}


### PR DESCRIPTION
Fixes #677

Switch the rule-preview footer from `flex items-center justify-between` to `flex-col sm:flex-row` with `gap-3`, and make the button `w-full sm:w-auto`. At <=640px the helper text now reads naturally on its own line with a full-width "Categorize as ..." button below it. sm+ layouts keep the existing horizontal row.

## Before / After at 375x667

| Before | After |
|---|---|
| ![before-375](https://i.img402.dev/1u4eapou79.png) | ![after-375](https://i.img402.dev/vv1tpsbiat.png) |

## Before / After at 390x844

| Before | After |
|---|---|
| ![before-390](https://i.img402.dev/k81xk5z9mw.png) | ![after-390](https://i.img402.dev/5j8imusdsm.png) |

## Desktop unchanged (1440x900)

![after-1440](https://i.img402.dev/4rp5iuoy3j.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)