### PR TITLE
feat(dashboard): fill recent transactions card on desktop

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -41,10 +41,13 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			reviewPending = 0
 		}
 
-		// Recent transactions (last 8).
+		// Recent transactions (last 12).
+		// Fetched at 12 so the card fills the sibling Agent Reports card's
+		// height on desktop; the card scrolls internally if the list still
+		// runs longer than the Reports column on a given day.
 		recentTx, err := svc.ListTransactionsAdmin(ctx, service.AdminTransactionListParams{
 			Page:     1,
-			PageSize: 8,
+			PageSize: 12,
 		})
 		if err != nil {
 			a.Logger.Error("recent transactions", "error", err)

--- a/internal/templates/components/pages/dashboard.templ
+++ b/internal/templates/components/pages/dashboard.templ
@@ -78,8 +78,8 @@ templ dashUpdateBanner(p DashboardProps) {
 }
 
 templ dashAgentReportsCard(p DashboardProps) {
-	<div class="bb-card" x-data="{ ...agentReports() }">
-		<div class="px-5 py-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-b border-base-200/60">
+	<div class="bb-card flex flex-col h-full" x-data="{ ...agentReports() }">
+		<div class="px-5 py-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-b border-base-200/60 shrink-0">
 			<div class="flex items-center gap-2 min-w-0">
 				<i data-lucide="bot" class="w-4 h-4 text-primary/70 shrink-0"></i>
 				<h2 class="text-sm font-semibold text-base-content/80">Agent Reports</h2>
@@ -98,7 +98,7 @@ templ dashAgentReportsCard(p DashboardProps) {
 			</div>
 		</div>
 		if len(p.AgentReports) > 0 {
-			<div class="px-4 sm:px-5 py-4 space-y-4">
+			<div class="px-4 sm:px-5 py-4 space-y-4 flex-1 min-h-0 overflow-y-auto">
 				for _, r := range p.AgentReports {
 					@dashReportItem(r)
 				}
@@ -109,7 +109,7 @@ templ dashAgentReportsCard(p DashboardProps) {
 				}
 			</div>
 		} else {
-			<div class="px-5 py-8 text-center">
+			<div class="px-5 py-8 text-center flex-1 flex flex-col items-center justify-center">
 				<i data-lucide="bot" class="w-8 h-8 mx-auto mb-2 text-base-content/15"></i>
 				<p class="text-sm text-base-content/40 mb-1">No unread reports</p>
 				<p class="text-xs text-base-content/30">Agent reports appear here when AI agents submit findings about your finances.</p>
@@ -152,19 +152,19 @@ templ dashReportItem(r DashboardReport) {
 }
 
 templ dashRecentTransactionsCard(p DashboardProps) {
-	<div class="bb-card">
-		<div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60">
+	<div class="bb-card flex flex-col h-full">
+		<div class="px-5 py-4 flex items-center justify-between border-b border-base-200/60 shrink-0">
 			<h2 class="text-sm font-semibold text-base-content/80">Recent Transactions</h2>
 			<a href="/transactions" class="text-xs text-base-content/40 hover:text-base-content/60 transition-colors">View all</a>
 		</div>
 		if len(p.RecentTransactions) > 0 {
-			<div class="px-3 sm:px-4 py-2">
+			<div class="px-3 sm:px-4 py-2 flex-1 min-h-0 overflow-y-auto">
 				for _, tx := range p.RecentTransactions {
 					@components.TxRowCompact(tx)
 				}
 			</div>
 		} else {
-			<div class="flex items-center justify-center py-8 text-base-content/40">
+			<div class="flex-1 flex items-center justify-center py-8 text-base-content/40">
 				<div class="text-center">
 					<i data-lucide="receipt" class="w-8 h-8 mx-auto mb-2 opacity-40"></i>
 					<p class="text-sm">No transactions yet</p>


### PR DESCRIPTION
Eliminates the empty band at the bottom of the Recent Transactions card when Agent Reports runs taller on desktop.

## Before / After

### Desktop (1280×900)

| Before | After |
|---|---|
| <img src="https://i.img402.dev/iukuo8qnql.jpg" width="420" alt="dashboard — before: empty space below recent transactions"> | <img src="https://i.img402.dev/jx8bv15pl1.jpg" width="420" alt="dashboard — after: card filled with 12 rows"> |

## Changes

- Bump recent-transactions fetch from 8 → 12 in `internal/admin/dashboard.go` so the list usually drives the grid row height on desktop instead of trailing it.
- Wrap both the Agent Reports card and the Recent Transactions card in `flex flex-col h-full` and promote each scrollable content region to `flex-1 min-h-0 overflow-y-auto`. Whichever card has less content gets stretched to match the sibling; whichever has more scrolls internally.
- Mobile (`grid-cols-1`) unaffected — `h-full` equals natural height when the card is alone in its grid row.

## Test plan

- [x] `templ generate` + `go build ./...` clean.
- [x] Loaded `/` at 1280×900 in Chrome DevTools MCP — Recent Transactions card now fills to the same height as Agent Reports, no empty band.
- [x] Loaded `/` at 390×844 — cards stack and take natural height, no unexpected scrollbars or clipping.