### PR TITLE
docs(api): reconcile response envelopes with spec (#684)

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -17,7 +17,7 @@ All error responses use:
 
 - Codes are **stable contracts** — treat them as API surface. Don't rename on a whim.
 - REST handlers use `internal/api/response.go` helpers (`writeError`, `writeJSON`). Admin handlers use `internal/admin/response.go` equivalents. Don't hand-roll either.
-- 4xx for client errors, 5xx only for actual server bugs. Validation errors are 400 with a specific code like `INVALID_DATE_RANGE`.
+- 4xx for client errors, 5xx only for actual server bugs. Validation errors on the public REST API return **`400`** with either `VALIDATION_ERROR` or a more specific code like `INVALID_PARAMETER` / `INVALID_CURSOR` / `INVALID_DATE_RANGE`. Admin form submissions under `/admin/api/*` return `422 VALIDATION_ERROR` instead (classic browser-form convention) — don't conflate the two.
 
 ## Auth
 
@@ -48,15 +48,31 @@ Filtering happens in handlers via `service.FilterFields(response, parsedFields)`
 
 Query endpoints (`/api/v1/transactions`, `/rules`, `/reviews`, `/merchants`) share a filter vocabulary built on positional `$N` SQL. See `internal/service/` for the composable filter builders. Handlers just parse query params and pass them in.
 
+## List response envelopes
+
+Two shapes, picked per-resource:
+
+- **Bounded resources** (households are small: accounts, users, connections, categories, agent reports) return a **bare JSON array**. No pagination metadata, no wrapper.
+
+  ```json
+  [ { "id": "...", ... }, { "id": "...", ... } ]
+  ```
+
+- **Paginated resources** (transactions, rules, reviews, merchants, sync logs) return a **resource-keyed object**:
+
+  ```json
+  { "transactions": [...], "next_cursor": "opaque-string-or-null", "has_more": false, "limit": 50 }
+  ```
+
+  The list key matches the resource (`transactions`, `rules`, `reviews`, etc.). Pagination metadata fields (`next_cursor`, `has_more`, `total`, `limit`) are included when meaningful for that endpoint.
+
+There is **no** `{ "data": [...] }` envelope. Old drafts of `docs/rest-api.md` showed one; reality is resource-keyed. When adding a new paginated list endpoint, pick a resource key and follow the paginated shape above.
+
 ## Pagination
 
-Cursor pagination (not OFFSET) for transactions, rules, reviews. Response envelope:
+Cursor pagination (not OFFSET) for the public REST API. Pass `cursor=...` from a previous response's `next_cursor` to fetch the next page. Only works with the default sort (date DESC) for transactions.
 
-```json
-{ "data": [...], "next_cursor": "opaque-string-or-null" }
-```
-
-Pass `cursor=...` on the next request. Only works with default sort (date DESC) for transactions.
+`TransactionRuleListResult` additionally carries offset fields (`page`, `page_size`, `total_pages`) — these are populated **only** when the admin UI calls the service layer with `Page > 0` and are consumed by the admin template, not emitted by the REST handler. The public `/api/v1/rules` endpoint uses cursor pagination exclusively; the offset fields stay zero-valued and are elided via `omitempty`.
 
 ## Search modes
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -189,10 +189,31 @@ AI agents can submit summaries and flag transactions for human review.
 
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
-| GET | `/reports` | Read | List all reports |
+| GET | `/reports` | Read | List all reports (bare array, bounded) |
 | GET | `/reports/unread-count` | Read | Count of unread reports |
-| POST | `/reports` | Write | Submit a report (title + markdown body) |
+| POST | `/reports` | Write | Submit a report |
 | PATCH | `/reports/{id}/read` | Write | Mark a report as read |
+
+### `POST /reports` body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `title` | string | Yes | Short headline shown in the reports list. |
+| `body` | string | Yes | Markdown body. May include transaction references, tables, etc. |
+| `priority` | string | No | `low`, `normal` (default), `high`. Surfaced in the admin list view. |
+| `tags` | string[] | No | Free-form labels for filtering (e.g., `["monthly-summary", "groceries"]`). |
+| `author` | string | No | Override display name for the report author. Defaults to the authenticated actor (API key name). |
+
+### `POST /rules/apply-all` response
+
+```json
+{
+  "rules_applied": { "<rule_id>": 17, "<rule_id>": 4 },
+  "total_affected": 21
+}
+```
+
+`rules_applied` is an object keyed by rule ID, mapping to the number of transactions updated by that rule in this retroactive pass. Order is not guaranteed. `total_affected` is the sum across all rules.
 
 ## OAuth / MCP Auth
 
@@ -205,21 +226,27 @@ OAuth 2.1 endpoints for MCP client authentication:
 | POST | `/oauth/token` | No | Token exchange |
 | POST | `/oauth/register` | No | Dynamic client registration |
 
-## Pagination
+## List Response Envelopes
 
-List endpoints use cursor-based pagination:
+Two shapes, picked per-resource:
 
-```json
-{
-  "data": [...],
-  "pagination": {
-    "next_cursor": "eyJ...",
-    "has_more": true
-  }
-}
-```
+- **Bounded resources** (small by design: accounts, users, connections, categories, reports) return a **bare JSON array**:
 
-Pass the `next_cursor` value as the `cursor` query parameter to get the next page. Cursor pagination only works with the default date sort.
+  ```json
+  [ { "id": "...", ... }, { "id": "...", ... } ]
+  ```
+
+- **Paginated resources** (transactions, rules) return a **resource-keyed envelope** with cursor pagination:
+
+  ```json
+  { "transactions": [...], "next_cursor": "eyJ...", "has_more": true, "limit": 50 }
+  ```
+
+  ```json
+  { "rules": [...], "next_cursor": "eyJ...", "has_more": true, "total": 248 }
+  ```
+
+The list key matches the resource name. Pass the `next_cursor` value as the `cursor` query parameter to fetch the next page. Cursor pagination only works with the default date sort on transactions.
 
 ## Error Format
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -152,21 +152,32 @@ Cursors are not guaranteed to be stable across schema changes or server restarts
 
 ### Response Shape
 
-All paginated list responses share this envelope:
+Paginated list responses use a **resource-keyed** envelope. The list key matches the resource name:
 
 ```json
 {
-  "data": [ ... ],
+  "transactions": [ ... ],
   "next_cursor": "eyJkYXRlIjoiMjAyNS0xMi0xNSIsImlkIjoiYWJjZGVmIn0",
-  "has_more": true
+  "has_more": true,
+  "limit": 50
 }
+```
+
+Rules use `"rules"`:
+
+```json
+{ "rules": [ ... ], "next_cursor": "...", "has_more": true, "total": 248 }
 ```
 
 | Field | Type | Description |
 |---|---|---|
-| `data` | array | The page of results. May be empty. |
-| `next_cursor` | string \| null | Cursor to pass as `cursor` in the next request. `null` when there are no more results. |
+| `<resource>` | array | The page of results. May be empty. Key name matches the resource (`transactions`, `rules`, etc.). |
+| `next_cursor` | string \| null | Cursor to pass as `cursor` in the next request. `null` or omitted when there are no more results. |
 | `has_more` | boolean | `true` if additional pages exist. Equivalent to `next_cursor != null`. |
+| `limit` | integer | Echoed back so clients can detect when their requested limit was clamped (transactions only). |
+| `total` | integer | Total count across all pages (rules only). Not populated for high-cardinality resources where counting is expensive. |
+
+**Bounded resources** — `GET /api/v1/accounts`, `/users`, `/connections`, `/categories`, `/reports` — are not paginated and return a **bare JSON array** rather than an envelope. See each endpoint's example in [Section 5](#5-endpoint-specifications).
 
 ### Fetching All Pages
 
@@ -206,15 +217,19 @@ All errors return a consistent JSON body with an HTTP status code in the 4xx or 
 | HTTP Status | Code | Description |
 |---|---|---|
 | `400 Bad Request` | `INVALID_PARAMETER` | A query parameter or request body field has an invalid value (wrong type, out of range, bad format). The `message` field identifies which parameter. |
+| `400 Bad Request` | `INVALID_BODY` | The request body is not valid JSON. |
 | `400 Bad Request` | `INVALID_CURSOR` | The provided `cursor` value is malformed or no longer valid. |
+| `400 Bad Request` | `VALIDATION_ERROR` | A required field is missing, empty, or fails semantic validation (e.g., unknown category slug, missing rule name). The `message` field describes the issue. |
 | `401 Unauthorized` | `MISSING_API_KEY` | `X-API-Key` header was not provided. |
 | `401 Unauthorized` | `INVALID_API_KEY` | The provided key is malformed or does not match any active key. |
 | `401 Unauthorized` | `REVOKED_API_KEY` | The key exists but has been revoked. |
+| `403 Forbidden` | `INSUFFICIENT_SCOPE` | Read-only API key attempted a write endpoint. |
 | `404 Not Found` | `NOT_FOUND` | The requested resource does not exist. |
 | `409 Conflict` | `SYNC_IN_PROGRESS` | A sync is already running for the requested connection. |
-| `422 Unprocessable Entity` | `VALIDATION_ERROR` | The request body failed validation. The `message` field describes the issue. |
 | `500 Internal Server Error` | `INTERNAL_ERROR` | An unexpected server-side error. Check server logs. |
 | `503 Service Unavailable` | `DATABASE_UNAVAILABLE` | The database connection is not healthy. |
+
+> **Note:** Validation failures on the public `/api/v1/*` API return `400`, not `422`. Admin form submissions under `/admin/api/*` return `422` for form-validation failures (classic browser-form convention) — see [Section 8](#8-admin-api).
 
 ### Example Error Response
 
@@ -307,48 +322,46 @@ This endpoint returns **all accounts** without pagination — the total number o
 
 **Response — 200 OK**
 
-```json
-{
-  "data": [
-    {
-      "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-      "connection_id": "c9d8e7f6-a5b4-3210-fedc-ba0987654321",
-      "user_id": "u1a2b3c4-d5e6-f789-0abc-def123456789",
-      "name": "Platinum Checking",
-      "official_name": "Chase Total Checking®",
-      "type": "depository",
-      "subtype": "checking",
-      "mask": "4821",
-      "iso_currency_code": "USD",
-      "balance_current": 3241.87,
-      "balance_available": 3191.87,
-      "balance_limit": null,
-      "institution_name": "Chase",
-      "created_at": "2025-11-01T09:00:00Z",
-      "updated_at": "2026-02-28T14:30:00Z"
-    },
-    {
-      "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-      "connection_id": "c9d8e7f6-a5b4-3210-fedc-ba0987654321",
-      "user_id": "u1a2b3c4-d5e6-f789-0abc-def123456789",
-      "name": "Sapphire Reserve",
-      "official_name": "Chase Sapphire Reserve®",
-      "type": "credit",
-      "subtype": "credit card",
-      "mask": "7743",
-      "iso_currency_code": "USD",
-      "balance_current": 1842.50,
-      "balance_available": 18157.50,
-      "balance_limit": 20000.00,
-      "institution_name": "Chase",
-      "created_at": "2025-11-01T09:00:00Z",
-      "updated_at": "2026-02-28T14:30:00Z"
-    }
-  ]
-}
-```
+Returns a bare JSON array — this endpoint does not paginate.
 
-The response is not wrapped in a pagination envelope because this endpoint does not paginate.
+```json
+[
+  {
+    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "connection_id": "c9d8e7f6-a5b4-3210-fedc-ba0987654321",
+    "user_id": "u1a2b3c4-d5e6-f789-0abc-def123456789",
+    "name": "Platinum Checking",
+    "official_name": "Chase Total Checking®",
+    "type": "depository",
+    "subtype": "checking",
+    "mask": "4821",
+    "iso_currency_code": "USD",
+    "balance_current": 3241.87,
+    "balance_available": 3191.87,
+    "balance_limit": null,
+    "institution_name": "Chase",
+    "created_at": "2025-11-01T09:00:00Z",
+    "updated_at": "2026-02-28T14:30:00Z"
+  },
+  {
+    "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+    "connection_id": "c9d8e7f6-a5b4-3210-fedc-ba0987654321",
+    "user_id": "u1a2b3c4-d5e6-f789-0abc-def123456789",
+    "name": "Sapphire Reserve",
+    "official_name": "Chase Sapphire Reserve®",
+    "type": "credit",
+    "subtype": "credit card",
+    "mask": "7743",
+    "iso_currency_code": "USD",
+    "balance_current": 1842.50,
+    "balance_available": 18157.50,
+    "balance_limit": 20000.00,
+    "institution_name": "Chase",
+    "created_at": "2025-11-01T09:00:00Z",
+    "updated_at": "2026-02-28T14:30:00Z"
+  }
+]
+```
 
 **Error Cases**
 
@@ -449,7 +462,7 @@ All filters are combined with `AND` logic. See [Section 6](#6-filtering-and-sear
 
 ```json
 {
-  "data": [
+  "transactions": [
     {
       "id": "t1a2b3c4-d5e6-f789-0abc-def123456789",
       "account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
@@ -515,7 +528,8 @@ All filters are combined with `AND` logic. See [Section 6](#6-filtering-and-sear
     }
   ],
   "next_cursor": "eyJkYXRlIjoiMjAyNi0wMi0yNSIsImlkIjoidDNjNGQ1ZTYtZjdhOC05MDFiLWNkZWYtMTIzNDU2Nzg5MDEyIn0",
-  "has_more": true
+  "has_more": true,
+  "limit": 50
 }
 ```
 
@@ -661,28 +675,26 @@ None.
 
 **Response — 200 OK**
 
-```json
-{
-  "data": [
-    {
-      "id": "u1a2b3c4-d5e6-f789-0abc-def123456789",
-      "name": "Alex Canales",
-      "email": "alex@example.com",
-      "created_at": "2025-11-01T09:00:00Z",
-      "updated_at": "2025-11-01T09:00:00Z"
-    },
-    {
-      "id": "u2b3c4d5-e6f7-890a-bcde-f12345678901",
-      "name": "Jordan Canales",
-      "email": null,
-      "created_at": "2025-11-15T12:00:00Z",
-      "updated_at": "2025-11-15T12:00:00Z"
-    }
-  ]
-}
-```
+Returns a bare JSON array — this endpoint does not paginate.
 
-The response is not wrapped in a pagination envelope.
+```json
+[
+  {
+    "id": "u1a2b3c4-d5e6-f789-0abc-def123456789",
+    "name": "Alex Canales",
+    "email": "alex@example.com",
+    "created_at": "2025-11-01T09:00:00Z",
+    "updated_at": "2025-11-01T09:00:00Z"
+  },
+  {
+    "id": "u2b3c4d5-e6f7-890a-bcde-f12345678901",
+    "name": "Jordan Canales",
+    "email": null,
+    "created_at": "2025-11-15T12:00:00Z",
+    "updated_at": "2025-11-15T12:00:00Z"
+  }
+]
+```
 
 **Error Cases**
 
@@ -709,41 +721,41 @@ Returns a list of all bank connections (Plaid Items), including their current st
 
 **Response — 200 OK**
 
+Returns a bare JSON array — this endpoint does not paginate.
+
 ```json
-{
-  "data": [
-    {
-      "id": "c9d8e7f6-a5b4-3210-fedc-ba0987654321",
-      "institution_id": "ins_3",
-      "institution_name": "Chase",
-      "provider": "plaid",
-      "status": "active",
-      "error_code": null,
-      "error_message": null,
-      "last_synced_at": "2026-02-28T14:30:00Z",
-      "last_attempted_sync_at": "2026-02-28T14:30:00Z",
-      "user_id": "u1a2b3c4-d5e6-f789-0abc-def123456789",
-      "user_name": "Alex Canales",
-      "created_at": "2025-11-01T09:00:00Z",
-      "updated_at": "2026-02-28T14:30:00Z"
-    },
-    {
-      "id": "d8e9f0a1-b2c3-4567-efab-cd9012345678",
-      "institution_id": "ins_11",
-      "institution_name": "Bank of America",
-      "provider": "plaid",
-      "status": "error",
-      "error_code": "ITEM_LOGIN_REQUIRED",
-      "error_message": "the login details of this item have changed",
-      "last_synced_at": "2026-01-15T08:00:00Z",
-      "last_attempted_sync_at": "2026-02-28T14:31:00Z",
-      "user_id": "u2b3c4d5-e6f7-890a-bcde-f12345678901",
-      "user_name": "Jordan Canales",
-      "created_at": "2025-12-01T11:00:00Z",
-      "updated_at": "2026-02-28T14:31:00Z"
-    }
-  ]
-}
+[
+  {
+    "id": "c9d8e7f6-a5b4-3210-fedc-ba0987654321",
+    "institution_id": "ins_3",
+    "institution_name": "Chase",
+    "provider": "plaid",
+    "status": "active",
+    "error_code": null,
+    "error_message": null,
+    "last_synced_at": "2026-02-28T14:30:00Z",
+    "last_attempted_sync_at": "2026-02-28T14:30:00Z",
+    "user_id": "u1a2b3c4-d5e6-f789-0abc-def123456789",
+    "user_name": "Alex Canales",
+    "created_at": "2025-11-01T09:00:00Z",
+    "updated_at": "2026-02-28T14:30:00Z"
+  },
+  {
+    "id": "d8e9f0a1-b2c3-4567-efab-cd9012345678",
+    "institution_id": "ins_11",
+    "institution_name": "Bank of America",
+    "provider": "plaid",
+    "status": "error",
+    "error_code": "ITEM_LOGIN_REQUIRED",
+    "error_message": "the login details of this item have changed",
+    "last_synced_at": "2026-01-15T08:00:00Z",
+    "last_attempted_sync_at": "2026-02-28T14:31:00Z",
+    "user_id": "u2b3c4d5-e6f7-890a-bcde-f12345678901",
+    "user_name": "Jordan Canales",
+    "created_at": "2025-12-01T11:00:00Z",
+    "updated_at": "2026-02-28T14:31:00Z"
+  }
+]
 ```
 
 **Connection Status Values**
@@ -924,23 +936,23 @@ No parameters.
 
 **Response — 200 OK**
 
+Returns a bare JSON array — this endpoint does not paginate.
+
 ```json
-{
-  "data": [
-    {
-      "primary": "FOOD_AND_DRINK",
-      "detailed": "FOOD_AND_DRINK_GROCERIES"
-    },
-    {
-      "primary": "FOOD_AND_DRINK",
-      "detailed": "FOOD_AND_DRINK_RESTAURANTS"
-    },
-    {
-      "primary": "TRANSPORTATION",
-      "detailed": "TRANSPORTATION_GAS"
-    }
-  ]
-}
+[
+  {
+    "primary": "FOOD_AND_DRINK",
+    "detailed": "FOOD_AND_DRINK_GROCERIES"
+  },
+  {
+    "primary": "FOOD_AND_DRINK",
+    "detailed": "FOOD_AND_DRINK_RESTAURANTS"
+  },
+  {
+    "primary": "TRANSPORTATION",
+    "detailed": "TRANSPORTATION_GAS"
+  }
+]
 ```
 
 | Field | Type | Description |


### PR DESCRIPTION
Closes #684.

## Direction: amend the spec to match reality

Handlers stay as-is; docs are updated to describe current shipping shapes as canonical. The alternative — migrating handlers to a uniform `{data: [...]}` envelope — would be a breaking change for any consumer that's already integrated (admin UI, MCP docs, alpha users).

## What changed per deviation

1. **Bare arrays vs keyed envelopes** — canonicalize both. `.claude/rules/api.md` gets a new "List response envelopes" section: bounded resources (`accounts`, `users`, `connections`, `categories`, `reports`) return bare JSON arrays; paginated resources (`transactions`, `rules`, and future lists) return resource-keyed envelopes (`{transactions: [...]}`, `{rules: [...]}`). `docs/rest-api.md` and `docs/api-reference.md` examples are updated to match. Removed stale "data envelope" language.

2. **Dual pagination on `TransactionRuleListResult`** — left as-is in code, documented in the spec. Why: the offset fields (`page`, `page_size`, `total_pages`) are marked `omitempty` and only populated when `params.Page > 0`, which only the admin UI sets. The admin UI consumes the struct via Go template data — not via JSON round-trip. The REST `/api/v1/rules` handler uses the cursor path exclusively, so API clients never see offset fields on the wire. No refactor needed; just clarify in the spec.

3. **`rules_applied` map on `/rules/apply-all`** — documented in `docs/api-reference.md` rather than reshaped. Grep showed callers are admin/MCP only; neither relies on array ordering. Low traffic, low stakes.

4. **`POST /reports` body fields** — `priority`, `tags`, `author` are now documented in `docs/api-reference.md` with types and defaults. They're real features (priority surfaces in the admin list; tags/author are used by agent-generated summaries), so they deserved documentation, not deletion.

5. **Error-code status (400 vs 422)** — handlers consistently return `400` for public-API validation; `.claude/rules/api.md` already said `400`. The drift was in `docs/rest-api.md` Standard Error Codes table which claimed `422 VALIDATION_ERROR`. Fixed to `400 VALIDATION_ERROR` and added a note distinguishing public API (`400`) from admin form endpoints (`422`, classic browser-form convention). The `422` mentions deeper in `docs/rest-api.md` (sections 8.x admin setup, users, members) are correct — admin handlers do return 422.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` passes (unit, no DB)
- Docs-only change — no integration tests affected

## Deferred

- None. All six items from the issue addressed either by doc edit or by documenting intentional current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)