### PR TITLE
feat(api): REST tag endpoints for V1 parity (#624)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -65,6 +65,8 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 | `exclude_search` | string | Exclude matching name/merchant (min 2 chars) |
 | `search_mode` | string | `contains` (default), `words`, `fuzzy` |
 | `pending` | bool | Filter by pending status |
+| `tags` | string | Comma-separated slugs; result transactions must carry **every** slug (AND) |
+| `any_tag` | string | Comma-separated slugs; result transactions must carry **at least one** slug (OR) |
 | `sort_by` | string | `date` (default), `amount`, `name` |
 | `sort_order` | string | `desc` (default), `asc` |
 | `fields` | string | Field selection. Aliases: `minimal`, `core`, `category`, `timestamps` |
@@ -116,7 +118,15 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 
 The review queue is a tag. Transactions carrying the seeded `needs-review` tag (or any operator-defined trigger tag) are the backlog. A seeded `on_create` system rule auto-attaches `needs-review` to every newly-synced transaction; disable that rule to opt out. When removing a tag, passing a rationale `note` is optional — if provided, it's recorded on the `tag_removed` annotation.
 
-Tag management is exposed via the MCP tools (`list_tags`, `add_transaction_tag`, `remove_transaction_tag`, `create_tag`, `update_tag`, `delete_tag`, `update_transactions`, `list_annotations`) and the admin dashboard (`/tags`, `/transactions/:id/edit`, bulk actions on `/transactions`).
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/tags` | Read | List all registered tags |
+| POST | `/transactions/{id}/tags` | Write | Attach a tag to a transaction (body: `{"slug":"...","note":"..."}`). Auto-creates the tag if the slug is not yet registered. Idempotent — returns `already_present: true` on repeat calls. |
+| DELETE | `/transactions/{id}/tags/{slug}` | Write | Detach a tag from a transaction. Optional `?note=...` or JSON body `{"note":"..."}` recorded on the `tag_removed` annotation. Idempotent — returns `already_absent: true` when the tag isn't attached. |
+
+Tag CRUD (create/update/delete tag records themselves) remains on the admin dashboard and MCP (`create_tag`, `update_tag`, `delete_tag`) for now; REST CRUD is tracked as a follow-up. For filtering, pass `tags=slug1,slug2` (AND) or `any_tag=slug1,slug2` (OR) to `/transactions` and `/transactions/count`.
+
+Additional tag-touching operations exposed via MCP: `list_tags`, `add_transaction_tag`, `remove_transaction_tag`, `create_tag`, `update_tag`, `delete_tag`, `update_transactions`, `list_annotations`. The admin dashboard covers the same ground at `/tags`, `/transactions/:id/edit`, and bulk actions on `/transactions`.
 
 ## Transaction Rules
 

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -115,6 +115,7 @@ func buildTestRouter(svc *service.Service) http.Handler {
 		r.Get("/account-links/{id}/matches", ListTransactionMatchesHandler(svc))
 		r.Get("/reports", ListReportsHandler(svc))
 		r.Get("/reports/unread-count", UnreadReportCountHandler(svc))
+		r.Get("/tags", ListTagsHandler(svc))
 
 		// Write endpoints — require full_access scope
 		r.Group(func(r chi.Router) {
@@ -143,6 +144,8 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Post("/transaction-matches/manual", ManualMatchHandler(svc))
 			r.Post("/reports", CreateReportHandler(svc))
 			r.Patch("/reports/{id}/read", MarkReportReadHandler(svc))
+			r.Post("/transactions/{id}/tags", AddTransactionTagHandler(svc))
+			r.Delete("/transactions/{id}/tags/{slug}", RemoveTransactionTagHandler(svc))
 		})
 	})
 	return r

--- a/internal/api/queryparse.go
+++ b/internal/api/queryparse.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -108,6 +109,32 @@ func parseEnumParam(q url.Values, key string, allowed []string) (*string, error)
 		}
 	}
 	return nil, fmt.Errorf("%s must be one of: %s", key, joinStrings(allowed))
+}
+
+// parseCSVParam collects a repeatable/comma-separated query parameter into a
+// de-duplicated, trimmed slice. Accepts both ?tags=a,b and ?tags=a&tags=b.
+// Returns nil when the parameter is absent or contains only empty tokens.
+func parseCSVParam(q url.Values, key string) []string {
+	raw := q[key]
+	if len(raw) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, v := range raw {
+		for _, token := range strings.Split(v, ",") {
+			t := strings.TrimSpace(token)
+			if t == "" {
+				continue
+			}
+			if _, ok := seen[t]; ok {
+				continue
+			}
+			seen[t] = struct{}{}
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // joinStrings joins strings with ", " for error messages.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -63,6 +63,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/account-links/{id}/matches", ListTransactionMatchesHandler(svc))
 		r.Get("/reports", ListReportsHandler(svc))
 		r.Get("/reports/unread-count", UnreadReportCountHandler(svc))
+		r.Get("/tags", ListTagsHandler(svc))
 
 		// Write endpoints — full_access API keys only.
 		r.Group(func(r chi.Router) {
@@ -95,6 +96,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/transaction-matches/manual", ManualMatchHandler(svc))
 			r.Post("/reports", CreateReportHandler(svc))
 			r.Patch("/reports/{id}/read", MarkReportReadHandler(svc))
+			r.Post("/transactions/{id}/tags", AddTransactionTagHandler(svc))
+			r.Delete("/transactions/{id}/tags/{slug}", RemoveTransactionTagHandler(svc))
 		})
 	})
 

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ListTagsHandler returns all registered tags.
+// GET /api/v1/tags — mirrors the list_tags MCP tool.
+func ListTagsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tags, err := svc.ListTags(r.Context())
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list tags")
+			return
+		}
+		writeData(w, map[string]any{"tags": tags})
+	}
+}
+
+// AddTransactionTagHandler attaches a tag to a transaction. Auto-creates the
+// tag if the slug is not yet registered. Mirrors the admin-side handler.
+// POST /api/v1/transactions/{id}/tags — body: {"slug":"...", "note":"..."}.
+func AddTransactionTagHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		txnID := chi.URLParam(r, "id")
+
+		var body struct {
+			Slug string `json:"slug"`
+			Note string `json:"note,omitempty"`
+		}
+		if !decodeJSON(w, r, &body) {
+			return
+		}
+		body.Slug = strings.TrimSpace(body.Slug)
+		if body.Slug == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "slug is required")
+			return
+		}
+
+		actor := service.ActorFromContext(r.Context())
+		added, alreadyPresent, err := svc.AddTransactionTag(r.Context(), txnID, body.Slug, actor, body.Note)
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrNotFound):
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+			case errors.Is(err, service.ErrInvalidParameter):
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			default:
+				mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to add transaction tag")
+			}
+			return
+		}
+		writeData(w, map[string]any{
+			"added":           added,
+			"already_present": alreadyPresent,
+			"slug":            body.Slug,
+			"transaction_id":  txnID,
+		})
+	}
+}
+
+// RemoveTransactionTagHandler removes a tag from a transaction.
+// DELETE /api/v1/transactions/{id}/tags/{slug} — optional ?note=... or JSON
+// body {"note":"..."} recorded on the tag_removed annotation.
+func RemoveTransactionTagHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		txnID := chi.URLParam(r, "id")
+		slug := chi.URLParam(r, "slug")
+
+		note := strings.TrimSpace(r.URL.Query().Get("note"))
+		if note == "" && r.ContentLength > 0 {
+			var body struct {
+				Note string `json:"note"`
+			}
+			if !decodeJSON(w, r, &body) {
+				return
+			}
+			note = strings.TrimSpace(body.Note)
+		}
+
+		actor := service.ActorFromContext(r.Context())
+		removed, alreadyAbsent, err := svc.RemoveTransactionTag(r.Context(), txnID, slug, actor, note)
+		if err != nil {
+			switch {
+			case errors.Is(err, service.ErrNotFound):
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+			case errors.Is(err, service.ErrInvalidParameter):
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			default:
+				mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to remove transaction tag")
+			}
+			return
+		}
+		writeData(w, map[string]any{
+			"removed":        removed,
+			"already_absent": alreadyAbsent,
+			"slug":           slug,
+			"transaction_id": txnID,
+		})
+	}
+}

--- a/internal/api/tags_integration_test.go
+++ b/internal/api/tags_integration_test.go
@@ -1,0 +1,285 @@
+//go:build integration
+
+// Integration tests for REST tag endpoints and the tags filter on
+// /api/v1/transactions. Run with:
+//   DATABASE_URL="postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable" \
+//   go test -tags integration -count=1 -p 1 -v ./internal/api/... -run TestAPI_Tag
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// TestAPI_ListTags_Empty returns an empty list when no tags are registered.
+func TestAPI_ListTags_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/tags")
+	assertStatus(t, resp, http.StatusOK)
+
+	var body struct {
+		Tags []map[string]any `json:"tags"`
+	}
+	parseJSON(t, resp, &body)
+	if len(body.Tags) != 0 {
+		t.Fatalf("want empty tags list, got %d entries", len(body.Tags))
+	}
+}
+
+// TestAPI_ListTags_WithData returns registered tags.
+func TestAPI_ListTags_WithData(t *testing.T) {
+	env := setupTestEnv(t)
+
+	if _, err := env.Service.CreateTag(t.Context(), service.CreateTagParams{
+		Slug:        "needs-review",
+		DisplayName: "Needs Review",
+	}); err != nil {
+		t.Fatalf("create tag: %v", err)
+	}
+
+	resp := env.doGet(t, "/api/v1/tags")
+	assertStatus(t, resp, http.StatusOK)
+
+	var body struct {
+		Tags []struct {
+			Slug        string `json:"slug"`
+			DisplayName string `json:"display_name"`
+		} `json:"tags"`
+	}
+	parseJSON(t, resp, &body)
+	if len(body.Tags) != 1 {
+		t.Fatalf("want 1 tag, got %d", len(body.Tags))
+	}
+	if body.Tags[0].Slug != "needs-review" {
+		t.Fatalf("want slug needs-review, got %q", body.Tags[0].Slug)
+	}
+	if body.Tags[0].DisplayName != "Needs Review" {
+		t.Fatalf("want display_name %q, got %q", "Needs Review", body.Tags[0].DisplayName)
+	}
+}
+
+// TestAPI_AddTransactionTag_Success attaches a tag to a transaction and
+// confirms the response envelope. The tag is auto-created by the service.
+func TestAPI_AddTransactionTag_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/tags", map[string]string{
+		"slug": "needs-review",
+		"note": "flagged by bot",
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var body struct {
+		Added          bool   `json:"added"`
+		AlreadyPresent bool   `json:"already_present"`
+		Slug           string `json:"slug"`
+	}
+	parseJSON(t, resp, &body)
+	if !body.Added || body.AlreadyPresent {
+		t.Fatalf("want added=true already_present=false, got %+v", body)
+	}
+	if body.Slug != "needs-review" {
+		t.Fatalf("want slug needs-review, got %q", body.Slug)
+	}
+}
+
+// TestAPI_AddTransactionTag_Idempotent returns already_present=true on the
+// second identical call, matching the MCP tool's semantics.
+func TestAPI_AddTransactionTag_Idempotent(t *testing.T) {
+	env := setupTestEnv(t)
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	first := env.doPost(t, "/api/v1/transactions/"+txnID+"/tags", map[string]string{"slug": "x-flag"})
+	assertStatus(t, first, http.StatusOK)
+	first.Body.Close()
+
+	second := env.doPost(t, "/api/v1/transactions/"+txnID+"/tags", map[string]string{"slug": "x-flag"})
+	assertStatus(t, second, http.StatusOK)
+
+	var body struct {
+		Added          bool `json:"added"`
+		AlreadyPresent bool `json:"already_present"`
+	}
+	parseJSON(t, second, &body)
+	if body.Added || !body.AlreadyPresent {
+		t.Fatalf("want added=false already_present=true, got %+v", body)
+	}
+}
+
+// TestAPI_AddTransactionTag_MissingSlug rejects an empty slug.
+func TestAPI_AddTransactionTag_MissingSlug(t *testing.T) {
+	env := setupTestEnv(t)
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/tags", map[string]string{})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// TestAPI_AddTransactionTag_TransactionNotFound returns 404 for unknown
+// short IDs. A bogus short ID routes through resolveTransactionID and yields
+// ErrNotFound (a UUID that is merely well-formed but absent would bypass
+// resolution and surface an FK error from the DB insert instead — a separate
+// concern tracked in the service layer).
+func TestAPI_AddTransactionTag_TransactionNotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/transactions/zzzzzzzz/tags", map[string]string{
+		"slug": "needs-review",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// TestAPI_AddTransactionTag_ReadOnlyBlocked confirms write-scope enforcement.
+func TestAPI_AddTransactionTag_ReadOnlyBlocked(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/tags", map[string]string{
+		"slug": "needs-review",
+	})
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+// TestAPI_RemoveTransactionTag_Success detaches a previously attached tag.
+func TestAPI_RemoveTransactionTag_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	add := env.doPost(t, "/api/v1/transactions/"+txnID+"/tags", map[string]string{"slug": "needs-review"})
+	assertStatus(t, add, http.StatusOK)
+	add.Body.Close()
+
+	del := env.doDelete(t, "/api/v1/transactions/"+txnID+"/tags/needs-review")
+	assertStatus(t, del, http.StatusOK)
+
+	var body struct {
+		Removed       bool `json:"removed"`
+		AlreadyAbsent bool `json:"already_absent"`
+	}
+	parseJSON(t, del, &body)
+	if !body.Removed || body.AlreadyAbsent {
+		t.Fatalf("want removed=true already_absent=false, got %+v", body)
+	}
+}
+
+// TestAPI_RemoveTransactionTag_AlreadyAbsent is a no-op when the tag isn't
+// attached — mirrors the MCP tool's already_absent contract.
+func TestAPI_RemoveTransactionTag_AlreadyAbsent(t *testing.T) {
+	env := setupTestEnv(t)
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doDelete(t, "/api/v1/transactions/"+txnID+"/tags/never-attached")
+	assertStatus(t, resp, http.StatusOK)
+
+	var body struct {
+		Removed       bool `json:"removed"`
+		AlreadyAbsent bool `json:"already_absent"`
+	}
+	parseJSON(t, resp, &body)
+	if body.Removed || !body.AlreadyAbsent {
+		t.Fatalf("want removed=false already_absent=true, got %+v", body)
+	}
+}
+
+// TestAPI_ListTransactions_TagsFilter_AND ensures the tags filter applies
+// AND semantics (transaction must have every listed tag).
+func TestAPI_ListTransactions_TagsFilter_AND(t *testing.T) {
+	env := setupTestEnv(t)
+
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "item_1")
+	acct := testutil.MustCreateAccount(t, env.Queries, conn.ID, "ext_acct_1", "Checking")
+	txnA := testutil.MustCreateTransaction(t, env.Queries, acct.ID, "ext_txn_A", "Coffee", 450, "2025-03-15")
+	txnB := testutil.MustCreateTransaction(t, env.Queries, acct.ID, "ext_txn_B", "Grocery", 1200, "2025-03-14")
+
+	txnAID := pgconv.FormatUUID(txnA.ID)
+	txnBID := pgconv.FormatUUID(txnB.ID)
+
+	// txnA has both tags, txnB has only "needs-review".
+	mustAddTag(t, env, txnAID, "needs-review")
+	mustAddTag(t, env, txnAID, "urgent")
+	mustAddTag(t, env, txnBID, "needs-review")
+
+	// tags=needs-review,urgent must return txnA only (AND).
+	resp := env.doGet(t, "/api/v1/transactions?tags=needs-review,urgent")
+	assertStatus(t, resp, http.StatusOK)
+	var body struct {
+		Transactions []struct {
+			ID string `json:"id"`
+		} `json:"transactions"`
+	}
+	parseJSON(t, resp, &body)
+	if len(body.Transactions) != 1 {
+		t.Fatalf("want 1 transaction, got %d (body=%+v)", len(body.Transactions), body)
+	}
+	if body.Transactions[0].ID != txnAID {
+		t.Fatalf("want txn %s, got %s", txnAID, body.Transactions[0].ID)
+	}
+}
+
+// TestAPI_ListTransactions_AnyTagFilter_OR ensures any_tag applies OR
+// semantics (at least one listed tag).
+func TestAPI_ListTransactions_AnyTagFilter_OR(t *testing.T) {
+	env := setupTestEnv(t)
+
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "item_1")
+	acct := testutil.MustCreateAccount(t, env.Queries, conn.ID, "ext_acct_1", "Checking")
+	txnA := testutil.MustCreateTransaction(t, env.Queries, acct.ID, "ext_txn_A", "Coffee", 450, "2025-03-15")
+	txnB := testutil.MustCreateTransaction(t, env.Queries, acct.ID, "ext_txn_B", "Grocery", 1200, "2025-03-14")
+	// txnC has no tags — must be excluded.
+	_ = testutil.MustCreateTransaction(t, env.Queries, acct.ID, "ext_txn_C", "Rent", 90000, "2025-03-13")
+
+	txnAID := pgconv.FormatUUID(txnA.ID)
+	txnBID := pgconv.FormatUUID(txnB.ID)
+
+	mustAddTag(t, env, txnAID, "needs-review")
+	mustAddTag(t, env, txnBID, "urgent")
+
+	resp := env.doGet(t, "/api/v1/transactions?any_tag=needs-review,urgent")
+	assertStatus(t, resp, http.StatusOK)
+
+	var body struct {
+		Transactions []struct {
+			ID string `json:"id"`
+		} `json:"transactions"`
+	}
+	parseJSON(t, resp, &body)
+	if len(body.Transactions) != 2 {
+		t.Fatalf("want 2 transactions, got %d (body=%+v)", len(body.Transactions), body)
+	}
+	ids := map[string]bool{}
+	for _, tx := range body.Transactions {
+		ids[tx.ID] = true
+	}
+	if !ids[txnAID] || !ids[txnBID] {
+		t.Fatalf("expected txnA and txnB in results, got %+v", ids)
+	}
+}
+
+// mustAddTag attaches a tag via the REST endpoint or fails the test. Keeps
+// individual tests focused on the assertion under test.
+func mustAddTag(t *testing.T, env *testEnv, txnID, slug string) {
+	t.Helper()
+	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/tags", map[string]string{"slug": slug})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+}

--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -21,6 +21,7 @@ func parseTransactionFilters(w http.ResponseWriter, r *http.Request) (
 	minAmount, maxAmount *float64,
 	pending *bool,
 	search, searchMode, excludeSearch *string,
+	tags, anyTag []string,
 	ok bool,
 ) {
 	q := r.URL.Query()
@@ -91,6 +92,9 @@ func parseTransactionFilters(w http.ResponseWriter, r *http.Request) (
 		return
 	}
 
+	tags = parseCSVParam(q, "tags")
+	anyTag = parseCSVParam(q, "any_tag")
+
 	ok = true
 	return
 }
@@ -106,7 +110,7 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 
-		startDate, endDate, accountID, userID, categorySlug, minAmount, maxAmount, pending, search, searchMode, excludeSearch, ok := parseTransactionFilters(w, r)
+		startDate, endDate, accountID, userID, categorySlug, minAmount, maxAmount, pending, search, searchMode, excludeSearch, tags, anyTag, ok := parseTransactionFilters(w, r)
 		if !ok {
 			return
 		}
@@ -146,6 +150,8 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			ExcludeSearch: excludeSearch,
 			SortBy:        sortBy,
 			SortOrder:     sortOrder,
+			Tags:          tags,
+			AnyTag:        anyTag,
 		}
 
 		// Parse fields for field selection.
@@ -186,7 +192,7 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 // CountTransactionsHandler returns the number of transactions matching optional filters.
 func CountTransactionsHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		startDate, endDate, accountID, userID, categorySlug, minAmount, maxAmount, pending, search, searchMode, excludeSearch, ok := parseTransactionFilters(w, r)
+		startDate, endDate, accountID, userID, categorySlug, minAmount, maxAmount, pending, search, searchMode, excludeSearch, tags, anyTag, ok := parseTransactionFilters(w, r)
 		if !ok {
 			return
 		}
@@ -203,6 +209,8 @@ func CountTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			Search:        search,
 			SearchMode:    searchMode,
 			ExcludeSearch: excludeSearch,
+			Tags:          tags,
+			AnyTag:        anyTag,
 		}
 
 		count, err := svc.CountTransactionsFiltered(r.Context(), params)


### PR DESCRIPTION
## Summary

Closes #624. Adds the four REST tag endpoints needed for V1 parity with MCP. Agents using `X-API-Key` auth can now list tags, filter transactions by tag, and assign/unassign tags — no more forcing them to the MCP endpoint for tag work.

- `GET /api/v1/tags` — mirrors the `list_tags` MCP tool.
- `POST /api/v1/transactions/{id}/tags` — attaches a tag (body: `{"slug":"...","note":"..."}`). Auto-creates unknown slugs. Idempotent — `already_present: true` on repeats.
- `DELETE /api/v1/transactions/{id}/tags/{slug}` — detaches; optional `?note=` or JSON body lands on the `tag_removed` annotation. Idempotent via `already_absent`.
- `tags=a,b` (AND) and `any_tag=a,b` (OR) query params added to `/transactions` and `/transactions/count`, matching the `query_transactions` filter vocabulary.

All routes reuse the existing `service.Service` methods (`ListTags`, `AddTransactionTag`, `RemoveTransactionTag`) — no new sqlc queries, no migrations. Writes flow through `service.ActorFromContext`, so annotations carry the agent identity.

Integration tests exercise: empty+populated `list_tags`, happy-path add, idempotent add, missing-slug validation, not-found routing via short ID, read-only scope enforcement, happy-path remove, already-absent remove, AND filter, OR filter.

## Scope / deferrals

- **Out of scope — deferred to follow-up:** tag CRUD over REST (`POST/PUT/DELETE /api/v1/tags`). Tag-record management stays on the admin dashboard and MCP (`create_tag`, `update_tag`, `delete_tag`) for now, which is where the issue's P2 bucket lives.
- **Tracked separately:** the docs gap flagged as "(2)" in #624 (coverage in the MCP tools reference) lives in the `canalesb93/breadbox-docs` repo and will be addressed there; it's not a Breadbox-repo change.

## Test plan

- [x] `go test ./...` — unit tests pass
- [x] `go vet ./...` — clean
- [x] New integration tests pass: `DATABASE_URL=... go test -tags integration -count=1 -p 1 -v -run "TestAPI_ListTags|TestAPI_AddTransactionTag|TestAPI_RemoveTransactionTag|TestAPI_ListTransactions_TagsFilter|TestAPI_ListTransactions_AnyTagFilter" ./internal/api/...`
- [x] `docs/api-reference.md` updated with the four endpoints and the two new query params