### PR TITLE
feat(cli): add breadbox doctor pre-flight command

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,15 @@ breadbox serve           Start the server (API, MCP, dashboard, webhooks, cron)
 breadbox create-admin    Create an admin user
 breadbox mcp-stdio       Start MCP server on stdin/stdout
 breadbox migrate         Run pending database migrations
+breadbox doctor          Validate config and connectivity without booting the server
 breadbox version         Print version
 ```
+
+Run `breadbox doctor` if the server fails to start or something feels off — it
+surfaces bad `DATABASE_URL`/`ENCRYPTION_KEY`, missing migrations, unreadable
+Teller certs, a missing admin account, and unreachable `PUBLIC_URL` in a single
+pass. See [Doctor](docs/doctor.md) for the full check list and `--json` /
+`--skip-external` flags.
 
 ## Documentation
 
@@ -193,6 +200,7 @@ breadbox version         Print version
 - [Admin Dashboard](docs/admin-dashboard.md) -- dashboard pages and features
 - [Design System](docs/design-system.md) -- UI framework and component reference
 - [Backup & Restore](docs/backup.md) -- database backup strategies
+- [Doctor](docs/doctor.md) -- `breadbox doctor` pre-flight / readiness check
 
 ## Contributing
 

--- a/cmd/breadbox/doctor.go
+++ b/cmd/breadbox/doctor.go
@@ -1,0 +1,679 @@
+package main
+
+import (
+	"context"
+	"crypto/aes"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"breadbox/internal/config"
+	"breadbox/internal/crypto"
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pressly/goose/v3"
+	"github.com/robfig/cron/v3"
+)
+
+// Check statuses for the doctor command.
+const (
+	doctorStatusPass = "pass"
+	doctorStatusFail = "fail"
+	doctorStatusSkip = "skip"
+	doctorStatusWarn = "warn"
+)
+
+// doctorCheck is the structured result of a single preflight check.
+type doctorCheck struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	Message     string `json:"message"`
+	Remediation string `json:"remediation,omitempty"`
+}
+
+// doctorReport is the structured output for --json mode.
+type doctorReport struct {
+	Checks []doctorCheck `json:"checks"`
+	OK     bool          `json:"ok"`
+}
+
+// runDoctor validates configuration and connectivity without booting the server.
+// Exits non-zero if any check fails so install scripts can gate on it.
+func runDoctor() error {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	jsonOut := fs.Bool("json", false, "emit structured JSON instead of a pretty table")
+	skipExternal := fs.Bool("skip-external", false, "skip DNS/HTTP reachability checks (air-gapped installs)")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	cfg, cfgErr := config.Load()
+	checks := []doctorCheck{}
+
+	// Config parse
+	if cfgErr != nil {
+		checks = append(checks, doctorCheck{
+			Name:        "config load",
+			Status:      doctorStatusFail,
+			Message:     cfgErr.Error(),
+			Remediation: "fix the offending environment variable or .local.env entry",
+		})
+		return emitDoctor(checks, *jsonOut)
+	}
+	checks = append(checks, doctorCheck{
+		Name:    "config load",
+		Status:  doctorStatusPass,
+		Message: fmt.Sprintf("environment=%s", cfg.Environment),
+	})
+
+	// DATABASE_URL + connectivity + migrations
+	dbCheck, migCheck, pool := checkDatabase(ctx, cfg)
+	checks = append(checks, dbCheck, migCheck)
+	if pool != nil {
+		defer pool.Close()
+	}
+
+	// After DB is up, merge app_config values so provider checks see the full picture.
+	if pool != nil {
+		if err := config.LoadWithDB(ctx, cfg, pool); err != nil {
+			checks = append(checks, doctorCheck{
+				Name:    "app_config",
+				Status:  doctorStatusWarn,
+				Message: "could not merge app_config: " + err.Error(),
+			})
+		}
+	}
+
+	// ENCRYPTION_KEY
+	checks = append(checks, checkEncryptionKey(cfg))
+
+	// Providers (only if configured)
+	if cfg.PlaidClientID != "" {
+		checks = append(checks, checkPlaid(cfg))
+	}
+	if cfg.TellerAppID != "" {
+		checks = append(checks, checkTeller(cfg))
+	}
+
+	// Provider credential decrypt: only meaningful when both the key and DB are up.
+	if pool != nil && cfg.EncryptionKey != nil {
+		checks = append(checks, checkProviderCredentialsDecrypt(ctx, pool, cfg))
+	}
+
+	// Admin account
+	if pool != nil {
+		checks = append(checks, checkAdminAccount(ctx, pool))
+	}
+
+	// Scheduler/cron config
+	checks = append(checks, checkCronConfig(cfg))
+
+	// DOMAIN / PUBLIC_URL reachability
+	checks = append(checks, checkPublicURL(*skipExternal))
+
+	return emitDoctor(checks, *jsonOut)
+}
+
+// emitDoctor writes the report and returns a non-nil error when any check failed
+// so main() exits non-zero. json mode still returns an error on failure.
+func emitDoctor(checks []doctorCheck, asJSON bool) error {
+	ok := true
+	for _, c := range checks {
+		if c.Status == doctorStatusFail {
+			ok = false
+		}
+	}
+
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(doctorReport{Checks: checks, OK: ok})
+	} else {
+		renderDoctorTable(checks)
+		fmt.Println()
+		if ok {
+			fmt.Println("OK — all checks passed.")
+		} else {
+			fmt.Println("FAIL — one or more checks failed. See remediation hints above.")
+		}
+	}
+
+	if !ok {
+		return fmt.Errorf("doctor: one or more checks failed")
+	}
+	return nil
+}
+
+// renderDoctorTable prints a padded table with status symbols, names, and messages.
+func renderDoctorTable(checks []doctorCheck) {
+	nameW := len("Check")
+	for _, c := range checks {
+		if len(c.Name) > nameW {
+			nameW = len(c.Name)
+		}
+	}
+	fmt.Printf("  %s  %-*s  %s\n", " ", nameW, "Check", "Status")
+	fmt.Printf("  %s  %s  %s\n", "-", strings.Repeat("-", nameW), strings.Repeat("-", 40))
+	for _, c := range checks {
+		sym := statusSymbol(c.Status)
+		fmt.Printf("  %s  %-*s  %s\n", sym, nameW, c.Name, c.Message)
+		if c.Status == doctorStatusFail && c.Remediation != "" {
+			fmt.Printf("     %s  → %s\n", strings.Repeat(" ", nameW), c.Remediation)
+		}
+	}
+}
+
+func statusSymbol(status string) string {
+	switch status {
+	case doctorStatusPass:
+		return "✓" // ✓
+	case doctorStatusFail:
+		return "✗" // ✗
+	case doctorStatusSkip:
+		return "⊘" // ⊘
+	case doctorStatusWarn:
+		return "!"
+	default:
+		return "?"
+	}
+}
+
+// checkDatabase validates DATABASE_URL, reachability, and migration version.
+// Returns the DB-check result, the migrations-check result, and the open pool
+// (so subsequent checks can reuse it). Pool is nil if connect failed.
+func checkDatabase(ctx context.Context, cfg *config.Config) (doctorCheck, doctorCheck, *pgxpool.Pool) {
+	if cfg.DatabaseURL == "" {
+		return doctorCheck{
+				Name:        "database",
+				Status:      doctorStatusFail,
+				Message:     "DATABASE_URL is not set",
+				Remediation: "export DATABASE_URL=postgres://user:pass@host:5432/breadbox?sslmode=disable",
+			}, doctorCheck{
+				Name:    "migrations",
+				Status:  doctorStatusSkip,
+				Message: "skipped — no database connection",
+			}, nil
+	}
+
+	connectCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(connectCtx, cfg.DatabaseURL)
+	if err != nil {
+		return doctorCheck{
+			Name:        "database",
+			Status:      doctorStatusFail,
+			Message:     "connect failed: " + err.Error(),
+			Remediation: "verify DATABASE_URL and that Postgres is running",
+		}, doctorCheck{Name: "migrations", Status: doctorStatusSkip, Message: "skipped — no database connection"}, nil
+	}
+	if err := pool.Ping(connectCtx); err != nil {
+		pool.Close()
+		return doctorCheck{
+			Name:        "database",
+			Status:      doctorStatusFail,
+			Message:     "ping failed: " + err.Error(),
+			Remediation: "verify DATABASE_URL and that Postgres is running",
+		}, doctorCheck{Name: "migrations", Status: doctorStatusSkip, Message: "skipped — no database connection"}, nil
+	}
+
+	dbCheck := doctorCheck{
+		Name:    "database",
+		Status:  doctorStatusPass,
+		Message: "connected and reachable",
+	}
+
+	migCheck := checkMigrations(ctx, cfg.DatabaseURL)
+	return dbCheck, migCheck, pool
+}
+
+// checkMigrations compares the applied goose_db_version against embedded migration files.
+func checkMigrations(ctx context.Context, databaseURL string) doctorCheck {
+	latest, err := latestEmbeddedMigration()
+	if err != nil {
+		return doctorCheck{
+			Name:        "migrations",
+			Status:      doctorStatusFail,
+			Message:     "could not read embedded migrations: " + err.Error(),
+			Remediation: "rebuild the binary — embedded migrations are corrupt",
+		}
+	}
+
+	goose.SetBaseFS(db.Migrations)
+	sqlDB, err := goose.OpenDBWithDriver("pgx", databaseURL)
+	if err != nil {
+		return doctorCheck{
+			Name:        "migrations",
+			Status:      doctorStatusFail,
+			Message:     "open: " + err.Error(),
+			Remediation: "verify DATABASE_URL",
+		}
+	}
+	defer sqlDB.Close()
+
+	if err := goose.SetDialect("postgres"); err != nil {
+		return doctorCheck{
+			Name:    "migrations",
+			Status:  doctorStatusFail,
+			Message: "set dialect: " + err.Error(),
+		}
+	}
+
+	applied, err := goose.GetDBVersionContext(ctx, sqlDB)
+	if err != nil {
+		return doctorCheck{
+			Name:        "migrations",
+			Status:      doctorStatusFail,
+			Message:     "could not read goose_db_version: " + err.Error(),
+			Remediation: "run 'breadbox migrate' to initialize the schema",
+		}
+	}
+
+	if applied < latest {
+		return doctorCheck{
+			Name:        "migrations",
+			Status:      doctorStatusFail,
+			Message:     fmt.Sprintf("applied=%d, embedded=%d (behind by %d)", applied, latest, latest-applied),
+			Remediation: "run 'breadbox migrate' to apply pending migrations",
+		}
+	}
+	if applied > latest {
+		return doctorCheck{
+			Name:        "migrations",
+			Status:      doctorStatusWarn,
+			Message:     fmt.Sprintf("applied=%d, embedded=%d — db is ahead (downgraded binary?)", applied, latest),
+			Remediation: "upgrade the binary to the version matching your schema",
+		}
+	}
+	return doctorCheck{
+		Name:    "migrations",
+		Status:  doctorStatusPass,
+		Message: fmt.Sprintf("up-to-date (version %d)", applied),
+	}
+}
+
+// latestEmbeddedMigration returns the highest numeric prefix among embedded migrations.
+func latestEmbeddedMigration() (int64, error) {
+	entries, err := fs.ReadDir(db.Migrations, "migrations")
+	if err != nil {
+		return 0, err
+	}
+	prefix := regexp.MustCompile(`^(\d+)_`)
+	var versions []int64
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		m := prefix.FindStringSubmatch(e.Name())
+		if len(m) != 2 {
+			continue
+		}
+		var v int64
+		_, err := fmt.Sscanf(m[1], "%d", &v)
+		if err != nil {
+			continue
+		}
+		versions = append(versions, v)
+	}
+	if len(versions) == 0 {
+		return 0, fmt.Errorf("no migrations found")
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+	return versions[len(versions)-1], nil
+}
+
+// checkEncryptionKey validates ENCRYPTION_KEY is set and hex-decodes to 32 bytes.
+// TODO(#688): once we persist a key fingerprint, compare it against the live key here
+// to catch silent key rotations that would break decrypt for existing connections.
+func checkEncryptionKey(cfg *config.Config) doctorCheck {
+	raw := os.Getenv("ENCRYPTION_KEY")
+	providerConfigured := cfg.PlaidClientID != "" || cfg.TellerAppID != ""
+
+	if raw == "" {
+		if providerConfigured {
+			return doctorCheck{
+				Name:        "encryption key",
+				Status:      doctorStatusFail,
+				Message:     "ENCRYPTION_KEY is required when a bank provider is configured",
+				Remediation: "generate one with: openssl rand -hex 32",
+			}
+		}
+		return doctorCheck{
+			Name:    "encryption key",
+			Status:  doctorStatusSkip,
+			Message: "not set (no bank provider configured)",
+		}
+	}
+
+	key, err := hex.DecodeString(raw)
+	if err != nil {
+		return doctorCheck{
+			Name:        "encryption key",
+			Status:      doctorStatusFail,
+			Message:     "ENCRYPTION_KEY is not valid hex",
+			Remediation: "regenerate with: openssl rand -hex 32",
+		}
+	}
+	if len(key) != 32 {
+		return doctorCheck{
+			Name:        "encryption key",
+			Status:      doctorStatusFail,
+			Message:     fmt.Sprintf("ENCRYPTION_KEY must decode to 32 bytes, got %d", len(key)),
+			Remediation: "regenerate with: openssl rand -hex 32",
+		}
+	}
+	if _, err := aes.NewCipher(key); err != nil {
+		return doctorCheck{
+			Name:        "encryption key",
+			Status:      doctorStatusFail,
+			Message:     "key rejected by AES cipher: " + err.Error(),
+			Remediation: "regenerate with: openssl rand -hex 32",
+		}
+	}
+	return doctorCheck{
+		Name:    "encryption key",
+		Status:  doctorStatusPass,
+		Message: "set and 32 bytes",
+	}
+}
+
+// checkPlaid validates that PLAID_ENV is a recognized value and client/secret are present.
+func checkPlaid(cfg *config.Config) doctorCheck {
+	if cfg.PlaidSecret == "" {
+		return doctorCheck{
+			Name:        "plaid",
+			Status:      doctorStatusFail,
+			Message:     "PLAID_CLIENT_ID is set but PLAID_SECRET is missing",
+			Remediation: "set PLAID_SECRET or remove PLAID_CLIENT_ID",
+		}
+	}
+	env := cfg.PlaidEnv
+	switch env {
+	case "sandbox", "development", "production":
+		return doctorCheck{
+			Name:    "plaid",
+			Status:  doctorStatusPass,
+			Message: "client/secret set, env=" + env,
+		}
+	case "":
+		return doctorCheck{
+			Name:        "plaid",
+			Status:      doctorStatusFail,
+			Message:     "PLAID_ENV is empty",
+			Remediation: "set PLAID_ENV to sandbox, development, or production",
+		}
+	default:
+		return doctorCheck{
+			Name:        "plaid",
+			Status:      doctorStatusFail,
+			Message:     "PLAID_ENV=" + env + " is not one of sandbox/development/production",
+			Remediation: "set PLAID_ENV to sandbox, development, or production",
+		}
+	}
+}
+
+// checkTeller validates Teller env and that any cert/key paths exist and are readable.
+func checkTeller(cfg *config.Config) doctorCheck {
+	env := cfg.TellerEnv
+	switch env {
+	case "sandbox", "development", "production":
+	default:
+		return doctorCheck{
+			Name:        "teller",
+			Status:      doctorStatusFail,
+			Message:     "TELLER_ENV=" + env + " is not one of sandbox/development/production",
+			Remediation: "set TELLER_ENV appropriately",
+		}
+	}
+
+	// If file paths are set, they must be readable.
+	for _, p := range []struct {
+		label string
+		path  string
+	}{
+		{"TELLER_CERT_PATH", cfg.TellerCertPath},
+		{"TELLER_KEY_PATH", cfg.TellerKeyPath},
+	} {
+		if p.path == "" {
+			continue
+		}
+		abs, _ := filepath.Abs(p.path)
+		f, err := os.Open(p.path)
+		if err != nil {
+			return doctorCheck{
+				Name:        "teller",
+				Status:      doctorStatusFail,
+				Message:     fmt.Sprintf("%s=%s is not readable: %v", p.label, abs, err),
+				Remediation: "verify the file exists and the process can read it",
+			}
+		}
+		f.Close()
+	}
+
+	// Either env paths are set OR the PEM bytes came from the DB (populated by LoadWithDB).
+	if cfg.TellerCertPath == "" && cfg.TellerKeyPath == "" && len(cfg.TellerCertPEM) == 0 && len(cfg.TellerKeyPEM) == 0 {
+		return doctorCheck{
+			Name:        "teller",
+			Status:      doctorStatusFail,
+			Message:     "TELLER_APP_ID is set but no cert/key material is available",
+			Remediation: "set TELLER_CERT_PATH and TELLER_KEY_PATH, or upload certificates via the admin dashboard",
+		}
+	}
+
+	return doctorCheck{
+		Name:    "teller",
+		Status:  doctorStatusPass,
+		Message: "cert/key present, env=" + env,
+	}
+}
+
+// checkProviderCredentialsDecrypt walks all active bank_connections and verifies
+// encrypted_credentials decrypts cleanly with the current ENCRYPTION_KEY. Any
+// decryption failure is a hard fail — it means the stored key no longer matches
+// the data it was supposed to protect.
+func checkProviderCredentialsDecrypt(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config) doctorCheck {
+	rows, err := pool.Query(ctx, `
+		SELECT id::text, provider, encrypted_credentials
+		FROM bank_connections
+		WHERE status != 'disconnected' AND encrypted_credentials IS NOT NULL
+	`)
+	if err != nil {
+		return doctorCheck{
+			Name:    "provider credentials",
+			Status:  doctorStatusWarn,
+			Message: "could not query bank_connections: " + err.Error(),
+		}
+	}
+	defer rows.Close()
+
+	var total, failed int
+	var firstFailID, firstFailProvider string
+	for rows.Next() {
+		var id, provider string
+		var cred []byte
+		if err := rows.Scan(&id, &provider, &cred); err != nil {
+			return doctorCheck{
+				Name:    "provider credentials",
+				Status:  doctorStatusWarn,
+				Message: "scan error: " + err.Error(),
+			}
+		}
+		total++
+		if _, err := crypto.Decrypt(cred, cfg.EncryptionKey); err != nil {
+			failed++
+			if firstFailID == "" {
+				firstFailID = id
+				firstFailProvider = provider
+			}
+		}
+	}
+
+	if total == 0 {
+		return doctorCheck{
+			Name:    "provider credentials",
+			Status:  doctorStatusSkip,
+			Message: "no active bank connections to check",
+		}
+	}
+	if failed > 0 {
+		return doctorCheck{
+			Name:        "provider credentials",
+			Status:      doctorStatusFail,
+			Message:     fmt.Sprintf("%d/%d connections failed to decrypt (first: %s %s)", failed, total, firstFailProvider, firstFailID),
+			Remediation: "ENCRYPTION_KEY appears to have changed since these connections were created — restore the original key or re-link the affected connections",
+		}
+	}
+	return doctorCheck{
+		Name:    "provider credentials",
+		Status:  doctorStatusPass,
+		Message: fmt.Sprintf("%d connection(s) decrypt cleanly", total),
+	}
+}
+
+// checkAdminAccount verifies at least one admin row exists in auth_accounts.
+func checkAdminAccount(ctx context.Context, pool *pgxpool.Pool) doctorCheck {
+	q := db.New(pool)
+	count, err := q.CountAuthAccounts(ctx)
+	if err != nil {
+		return doctorCheck{
+			Name:        "admin account",
+			Status:      doctorStatusFail,
+			Message:     "could not query auth_accounts: " + err.Error(),
+			Remediation: "check database connectivity and that migrations ran",
+		}
+	}
+	if count == 0 {
+		return doctorCheck{
+			Name:        "admin account",
+			Status:      doctorStatusFail,
+			Message:     "no admin account exists",
+			Remediation: "visit /setup in the running server or run 'breadbox create-admin'",
+		}
+	}
+	return doctorCheck{
+		Name:    "admin account",
+		Status:  doctorStatusPass,
+		Message: fmt.Sprintf("%d account(s) present", count),
+	}
+}
+
+// checkCronConfig verifies the sync interval and any BACKUP_SCHEDULE-style cron values parse.
+// SYNC_INTERVAL_MINUTES isn't a cron expression, but we validate it's a positive int if set.
+func checkCronConfig(cfg *config.Config) doctorCheck {
+	// SyncIntervalMinutes is always positive once LoadWithDB ran; defend anyway.
+	if cfg.SyncIntervalMinutes < 0 {
+		return doctorCheck{
+			Name:        "scheduler",
+			Status:      doctorStatusFail,
+			Message:     fmt.Sprintf("sync_interval_minutes=%d is negative", cfg.SyncIntervalMinutes),
+			Remediation: "set sync_interval_minutes to a positive integer in app_config",
+		}
+	}
+
+	// Validate any explicit cron expressions set via env (backup schedule, custom crons).
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow)
+	for _, envVar := range []string{"BACKUP_CRON", "SYNC_CRON"} {
+		spec := os.Getenv(envVar)
+		if spec == "" {
+			continue
+		}
+		if _, err := parser.Parse(spec); err != nil {
+			return doctorCheck{
+				Name:        "scheduler",
+				Status:      doctorStatusFail,
+				Message:     fmt.Sprintf("%s=%q does not parse: %v", envVar, spec, err),
+				Remediation: "use a standard 5-field cron expression, e.g. '0 2 * * *'",
+			}
+		}
+	}
+
+	return doctorCheck{
+		Name:    "scheduler",
+		Status:  doctorStatusPass,
+		Message: fmt.Sprintf("sync every %dm; cron expressions valid", cfg.SyncIntervalMinutes),
+	}
+}
+
+// checkPublicURL resolves DOMAIN / PUBLIC_URL and probes /health/ready over HTTP.
+// Skipped entirely if --skip-external or neither env is set.
+func checkPublicURL(skipExternal bool) doctorCheck {
+	publicURL := strings.TrimSpace(os.Getenv("PUBLIC_URL"))
+	domain := strings.TrimSpace(os.Getenv("DOMAIN"))
+	if publicURL == "" && domain == "" {
+		return doctorCheck{
+			Name:    "public url",
+			Status:  doctorStatusSkip,
+			Message: "neither PUBLIC_URL nor DOMAIN set",
+		}
+	}
+	if skipExternal {
+		return doctorCheck{
+			Name:    "public url",
+			Status:  doctorStatusSkip,
+			Message: "--skip-external set",
+		}
+	}
+
+	target := publicURL
+	if target == "" {
+		target = "https://" + domain
+	}
+	u, err := url.Parse(target)
+	if err != nil || u.Host == "" {
+		return doctorCheck{
+			Name:        "public url",
+			Status:      doctorStatusFail,
+			Message:     fmt.Sprintf("invalid URL %q", target),
+			Remediation: "set PUBLIC_URL to a full URL like https://breadbox.example.com",
+		}
+	}
+
+	host := u.Hostname()
+	if _, err := net.LookupHost(host); err != nil {
+		return doctorCheck{
+			Name:        "public url",
+			Status:      doctorStatusFail,
+			Message:     fmt.Sprintf("DNS lookup for %s failed: %v", host, err),
+			Remediation: "verify your DNS A/AAAA records point at this host",
+		}
+	}
+
+	readyURL := strings.TrimRight(target, "/") + "/health/ready"
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(readyURL)
+	if err != nil {
+		return doctorCheck{
+			Name:        "public url",
+			Status:      doctorStatusFail,
+			Message:     fmt.Sprintf("GET %s failed: %v", readyURL, err),
+			Remediation: "ensure the server is running and reachable from this host, or pass --skip-external",
+		}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return doctorCheck{
+			Name:        "public url",
+			Status:      doctorStatusFail,
+			Message:     fmt.Sprintf("%s returned HTTP %d", readyURL, resp.StatusCode),
+			Remediation: "check server logs for why /health/ready is failing",
+		}
+	}
+	return doctorCheck{
+		Name:    "public url",
+		Status:  doctorStatusPass,
+		Message: fmt.Sprintf("DNS resolves, %s → %d", readyURL, resp.StatusCode),
+	}
+}

--- a/cmd/breadbox/doctor_test.go
+++ b/cmd/breadbox/doctor_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"breadbox/internal/config"
+)
+
+func TestCheckEncryptionKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		envKey     string
+		cfg        *config.Config
+		wantStatus string
+		wantMsgSub string
+	}{
+		{
+			name:       "unset and no provider skips",
+			envKey:     "",
+			cfg:        &config.Config{},
+			wantStatus: doctorStatusSkip,
+		},
+		{
+			name:       "unset with plaid fails",
+			envKey:     "",
+			cfg:        &config.Config{PlaidClientID: "id"},
+			wantStatus: doctorStatusFail,
+			wantMsgSub: "ENCRYPTION_KEY is required",
+		},
+		{
+			name:       "invalid hex fails",
+			envKey:     "zzzz",
+			cfg:        &config.Config{},
+			wantStatus: doctorStatusFail,
+			wantMsgSub: "not valid hex",
+		},
+		{
+			name:       "wrong length fails",
+			envKey:     "deadbeef",
+			cfg:        &config.Config{},
+			wantStatus: doctorStatusFail,
+			wantMsgSub: "must decode to 32 bytes",
+		},
+		{
+			name:       "valid 32-byte hex passes",
+			envKey:     strings.Repeat("ab", 32),
+			cfg:        &config.Config{},
+			wantStatus: doctorStatusPass,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("ENCRYPTION_KEY", tc.envKey)
+			got := checkEncryptionKey(tc.cfg)
+			if got.Status != tc.wantStatus {
+				t.Fatalf("status: got %q, want %q (msg=%q)", got.Status, tc.wantStatus, got.Message)
+			}
+			if tc.wantMsgSub != "" && !strings.Contains(got.Message, tc.wantMsgSub) {
+				t.Fatalf("message: got %q, want substring %q", got.Message, tc.wantMsgSub)
+			}
+		})
+	}
+}
+
+func TestCheckPlaid(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		wantStatus string
+	}{
+		{"missing secret", &config.Config{PlaidClientID: "id", PlaidEnv: "sandbox"}, doctorStatusFail},
+		{"empty env", &config.Config{PlaidClientID: "id", PlaidSecret: "s"}, doctorStatusFail},
+		{"bogus env", &config.Config{PlaidClientID: "id", PlaidSecret: "s", PlaidEnv: "staging"}, doctorStatusFail},
+		{"sandbox ok", &config.Config{PlaidClientID: "id", PlaidSecret: "s", PlaidEnv: "sandbox"}, doctorStatusPass},
+		{"production ok", &config.Config{PlaidClientID: "id", PlaidSecret: "s", PlaidEnv: "production"}, doctorStatusPass},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := checkPlaid(tc.cfg).Status; got != tc.wantStatus {
+				t.Fatalf("status: got %q, want %q", got, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestCheckTeller(t *testing.T) {
+	// Create a readable temp file to stand in as a cert path.
+	tmpCert := t.TempDir() + "/cert.pem"
+	if err := writeFile(tmpCert, []byte("-----BEGIN CERT-----\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name       string
+		cfg        *config.Config
+		wantStatus string
+	}{
+		{
+			name:       "bad env",
+			cfg:        &config.Config{TellerAppID: "id", TellerEnv: "weird"},
+			wantStatus: doctorStatusFail,
+		},
+		{
+			name:       "no cert material",
+			cfg:        &config.Config{TellerAppID: "id", TellerEnv: "sandbox"},
+			wantStatus: doctorStatusFail,
+		},
+		{
+			name:       "missing file fails",
+			cfg:        &config.Config{TellerAppID: "id", TellerEnv: "sandbox", TellerCertPath: "/nope/nonexistent.pem"},
+			wantStatus: doctorStatusFail,
+		},
+		{
+			name:       "readable cert path passes",
+			cfg:        &config.Config{TellerAppID: "id", TellerEnv: "sandbox", TellerCertPath: tmpCert, TellerKeyPath: tmpCert},
+			wantStatus: doctorStatusPass,
+		},
+		{
+			name:       "DB-stored PEM passes",
+			cfg:        &config.Config{TellerAppID: "id", TellerEnv: "sandbox", TellerCertPEM: []byte("x"), TellerKeyPEM: []byte("y")},
+			wantStatus: doctorStatusPass,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := checkTeller(tc.cfg).Status; got != tc.wantStatus {
+				t.Fatalf("status: got %q, want %q", got, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestCheckCronConfig(t *testing.T) {
+	t.Run("valid default sync interval", func(t *testing.T) {
+		got := checkCronConfig(&config.Config{SyncIntervalMinutes: 60})
+		if got.Status != doctorStatusPass {
+			t.Fatalf("status: got %q, want pass (msg=%q)", got.Status, got.Message)
+		}
+	})
+	t.Run("invalid BACKUP_CRON fails", func(t *testing.T) {
+		t.Setenv("BACKUP_CRON", "not-a-cron")
+		got := checkCronConfig(&config.Config{SyncIntervalMinutes: 60})
+		if got.Status != doctorStatusFail {
+			t.Fatalf("status: got %q, want fail", got.Status)
+		}
+	})
+	t.Run("valid BACKUP_CRON passes", func(t *testing.T) {
+		t.Setenv("BACKUP_CRON", "0 2 * * *")
+		got := checkCronConfig(&config.Config{SyncIntervalMinutes: 60})
+		if got.Status != doctorStatusPass {
+			t.Fatalf("status: got %q, want pass (msg=%q)", got.Status, got.Message)
+		}
+	})
+}
+
+func TestCheckPublicURL(t *testing.T) {
+	t.Run("unset skips", func(t *testing.T) {
+		t.Setenv("PUBLIC_URL", "")
+		t.Setenv("DOMAIN", "")
+		if got := checkPublicURL(false).Status; got != doctorStatusSkip {
+			t.Fatalf("status: got %q, want skip", got)
+		}
+	})
+	t.Run("skip-external flag short-circuits", func(t *testing.T) {
+		t.Setenv("PUBLIC_URL", "https://example.com")
+		if got := checkPublicURL(true).Status; got != doctorStatusSkip {
+			t.Fatalf("status: got %q, want skip", got)
+		}
+	})
+}
+
+func TestLatestEmbeddedMigration(t *testing.T) {
+	v, err := latestEmbeddedMigration()
+	if err != nil {
+		t.Fatalf("latestEmbeddedMigration: %v", err)
+	}
+	if v <= 0 {
+		t.Fatalf("expected a positive version, got %d", v)
+	}
+}
+
+// helpers
+
+func writeFile(path string, data []byte) error {
+	return os.WriteFile(path, data, 0600)
+}

--- a/cmd/breadbox/main.go
+++ b/cmd/breadbox/main.go
@@ -39,7 +39,7 @@ var version = "dev"
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "usage: breadbox <command>")
-		fmt.Fprintln(os.Stderr, "commands: serve, migrate, seed, mcp-stdio, create-admin, reset-password, version")
+		fmt.Fprintln(os.Stderr, "commands: serve, migrate, seed, mcp-stdio, create-admin, reset-password, doctor, version")
 		os.Exit(1)
 	}
 
@@ -72,6 +72,12 @@ func main() {
 	case "reset-password":
 		if err := runResetPassword(); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	case "doctor":
+		if err := runDoctor(); err != nil {
+			// runDoctor already printed the report; exit non-zero without the
+			// "error:" prefix other commands use.
 			os.Exit(1)
 		}
 	case "version":

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,80 @@
+# `breadbox doctor`
+
+A pre-flight + readiness command that validates configuration and connectivity
+**without booting the server**. Use it as the first diagnostic when something
+"feels off", and let install scripts gate on its exit code.
+
+```
+breadbox doctor [--json] [--skip-external]
+```
+
+- Exit code `0` — all checks pass (or were skipped).
+- Exit code `1` — one or more checks failed. Remediation hints are printed next
+  to each failure.
+
+## Flags
+
+| Flag | Description |
+| --- | --- |
+| `--json` | Emit a structured `{"checks": [...], "ok": bool}` document instead of a pretty table. Useful in CI and install scripts. |
+| `--skip-external` | Skip DNS and outbound HTTP checks (DNS lookup + `GET /health/ready` against `PUBLIC_URL`/`DOMAIN`). Use this on air-gapped installs or when the box is still behind a firewall. |
+
+## Checks
+
+| Name | What it validates |
+| --- | --- |
+| `config load` | `.local.env` / `.docker.env` parse cleanly and required env vars decode. |
+| `database` | `DATABASE_URL` is set, Postgres accepts a connection, and `Ping` succeeds. |
+| `migrations` | The `goose_db_version` in the DB matches the highest numeric prefix among embedded migrations. Reports "behind" (needs `breadbox migrate`) or "ahead" (binary downgrade). |
+| `encryption key` | `ENCRYPTION_KEY` is set (required if Plaid or Teller is configured), hex-decodes to exactly 32 bytes, and is accepted by AES. |
+| `plaid` | When `PLAID_CLIENT_ID` is set: `PLAID_SECRET` is present and `PLAID_ENV` is one of `sandbox`/`development`/`production`. |
+| `teller` | When `TELLER_APP_ID` is set: `TELLER_ENV` is valid, cert/key paths (if any) exist and are readable, or PEM bytes are available via `app_config`. |
+| `provider credentials` | Walks every non-disconnected `bank_connections` row and verifies `encrypted_credentials` decrypts with the current key. Catches silent `ENCRYPTION_KEY` rotations. |
+| `admin account` | `auth_accounts` contains at least one row — otherwise the setup wizard hasn't run. |
+| `scheduler` | `sync_interval_minutes` is positive; any `BACKUP_CRON` / `SYNC_CRON` env value parses as a 5-field cron expression. |
+| `public url` | When `PUBLIC_URL` or `DOMAIN` is set (and `--skip-external` isn't): DNS resolves and `GET /health/ready` returns < 400. |
+
+> **Encryption-key fingerprint vs stored hash:** deferred to issue #688. Once
+> the fingerprint is persisted at setup, `doctor` will compare it against the
+> key in the environment to catch rotations even before any bank connection
+> exists. Until then, the credential-decrypt walk is the proxy.
+
+## Example output
+
+```text
+     Check                 Status
+  -  --------------------  ----------------------------------------
+  ✓  config load           environment=local
+  ✓  database              connected and reachable
+  ✓  migrations            up-to-date (version 20260417032707)
+  ✓  encryption key        set and 32 bytes
+  ✓  plaid                 client/secret set, env=sandbox
+  ✓  teller                cert/key present, env=sandbox
+  ✓  provider credentials  3 connection(s) decrypt cleanly
+  ✓  admin account         1 account(s) present
+  ✓  scheduler             sync every 720m; cron expressions valid
+  ⊘  public url            neither PUBLIC_URL nor DOMAIN set
+
+OK — all checks passed.
+```
+
+## CI / install-script use
+
+```bash
+breadbox doctor --json --skip-external > doctor.json
+jq -e '.ok == true' doctor.json
+```
+
+A future one-liner installer (issue #686) is expected to run `breadbox doctor`
+after launching the process to surface configuration problems before handing
+the operator a URL. This PR does not yet wire doctor into `install.sh`.
+
+## What doctor intentionally does **not** do
+
+- **Does not mutate state.** Read-only across the board. Running it repeatedly
+  is safe.
+- **Does not boot the HTTP server.** Use `breadbox serve` for that — doctor is
+  designed to diagnose startup failures without needing startup to succeed.
+- **Does not probe provider APIs.** A healthy Plaid env var doesn't guarantee
+  the credentials are valid with Plaid itself; the credential-decrypt walk is
+  strictly a local AES check.


### PR DESCRIPTION
## Summary

Adds a read-only `breadbox doctor` subcommand that validates config and connectivity **without booting the server**. The goal is to surface bad `DATABASE_URL`, missing migrations, `ENCRYPTION_KEY` problems, unreadable Teller certs, a missing admin account, invalid cron specs, and unreachable `PUBLIC_URL` in one pass — so install scripts can gate on the exit code and operators have a single command to run when something feels off.

## Checks

- **config load** — `.local.env`/`.docker.env` parse and required env vars decode
- **database** — `DATABASE_URL` set, Postgres connects, `Ping` succeeds
- **migrations** — `goose_db_version` matches the highest embedded migration prefix (reports "behind" or "ahead")
- **encryption key** — set when any provider is configured, hex-decodes to 32 bytes, AES-compatible
- **plaid** — `PLAID_SECRET` present, `PLAID_ENV` ∈ {sandbox, development, production}
- **teller** — `TELLER_ENV` valid, cert/key paths (if set) exist and are readable, or PEM from `app_config` is available
- **provider credentials** — walks non-disconnected `bank_connections` and confirms `encrypted_credentials` decrypts with the current key (catches silent `ENCRYPTION_KEY` rotations)
- **admin account** — `auth_accounts` has ≥1 row
- **scheduler** — `sync_interval_minutes` positive; any `BACKUP_CRON`/`SYNC_CRON` env parses as a 5-field cron expression
- **public url** — when `PUBLIC_URL`/`DOMAIN` is set: DNS resolves and `GET /health/ready` returns <400

## Flags

- `--json` — structured `{"checks": [...], "ok": bool}` output for CI/install scripts
- `--skip-external` — skips DNS + outbound HTTP for air-gapped installs

Exits non-zero if any check fails so install scripts can gate.

## Deferred

- **Encryption-key fingerprint vs stored hash** — issue #688 owns the fingerprint storage. Until then the credential-decrypt walk is the proxy; a `// TODO(#688)` points at the spot.
- **Wiring into `install.sh`** — explicitly owned by issue #686.

## Test plan

- [x] `go test ./cmd/breadbox/...` — new `doctor_test.go` covers encryption-key, plaid, teller, cron, public-url, and embedded-migration helpers
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Manual smoke: `breadbox doctor`, `breadbox doctor --json`, `breadbox doctor --skip-external` all render correctly against a real DB
- [x] Non-zero exit verified on failure

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)