### PR TITLE
fix(deploy): correct installer bugs and preserve version pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,13 +115,13 @@ make dev
 
 ### Production deployment
 
-For production with automatic HTTPS via Caddy, use the one-liner install script:
+For production, use the one-liner install script:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/install.sh | sudo bash
 ```
 
-This installs Docker if needed, downloads the deployment files, generates secrets, and starts Breadbox with Caddy for automatic TLS. See [`deploy/`](deploy/) for details.
+The script checks for Docker (and offers to install it on Linux via `get.docker.com`), downloads the deployment files, prompts for an optional public domain, generates secrets, and starts Breadbox. If you supply a domain it also starts Caddy for automatic TLS; otherwise the install is localhost-only and does not bind ports 80/443. See [`deploy/`](deploy/) for details, including version-pinned updates via `update.sh`.
 
 ## MCP Integration
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,10 +11,13 @@ Caddy handles automatic HTTPS via Let's Encrypt. Breadbox is a single Go binary 
 
 ## Prerequisites
 
-- A Linux VM (Ubuntu 22.04+ or Debian 12+ recommended)
-- A domain name pointing to your VM's IP address
-- Docker and Docker Compose (installed automatically by the install script if missing)
-- Ports 80, 443 open for HTTPS, port 22 for SSH
+- A Linux VM (Ubuntu 22.04+ or Debian 12+ recommended) or macOS with Docker Desktop
+- Docker and Docker Compose
+  - On Linux the installer can install Docker for you (`--install-docker`, uses `https://get.docker.com`).
+  - On macOS install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/) manually first.
+- Optional: a domain name pointing to your VM's IP address (for HTTPS via Caddy). If you don't
+  configure a domain the installer performs a localhost-only install and does **not** bind
+  ports 80/443.
 
 ## Quick Install (One-Liner)
 
@@ -23,18 +26,38 @@ curl -sSL https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/inst
 ```
 
 The script will:
-1. Verify Docker and Docker Compose are installed
+1. Verify Docker / Docker Compose (offer to install Docker on Linux if missing)
 2. Fetch the latest release tag from GitHub
 3. Download `docker-compose.prod.yml` and `Caddyfile`, pinned to that release
-4. Generate an `ENCRYPTION_KEY` and database password
-5. Create a `.env` file (will not overwrite an existing one)
-6. Start all services and wait for a healthy status
+4. Write `.breadbox-version` so `update.sh` preserves the pin
+5. Prompt for an optional public domain (leave blank for localhost-only)
+6. Generate `ENCRYPTION_KEY` and database password
+7. Create a `.env` file (will not overwrite an existing one)
+8. Start Breadbox + Postgres. Caddy is started only if you configured a domain
+   (via the `caddy` compose profile).
 
-After installation, visit `http://localhost:8080/setup` to create your admin account.
+After installation, visit `http://localhost:8080/setup` (or `https://<your-domain>/setup`) to
+create your admin account.
 
-Options:
-- `INSTALL_DIR=./my-dir bash install.sh` -- install to a custom directory (default: `./breadbox`)
-- `bash install.sh --uninstall` -- stop containers and remove installed files (preserves database volume)
+### Options
+
+| Flag | Purpose |
+| --- | --- |
+| `--yes, -y` | Non-interactive mode: accept defaults, no prompts. |
+| `--domain=HOST` | Configure HTTPS via Caddy for `HOST`. Also enables the `caddy` compose profile. |
+| `--install-docker` | Install Docker automatically on Linux via `https://get.docker.com` (no prompt). |
+| `--uninstall` | Stop containers and remove installed files (preserves database volume). |
+
+### `INSTALL_DIR` default
+
+`INSTALL_DIR` follows a consistent convention across install and update:
+
+- **Root / `sudo bash install.sh`** → `/opt/breadbox`
+- **Regular user** → `$HOME/.breadbox`
+- Override: `INSTALL_DIR=/custom/path bash install.sh`
+
+`update.sh` resolves `INSTALL_DIR` with the same rules, so `sudo ./update.sh` and `./update.sh`
+target the same directory as their matching install.
 
 ## Manual Setup
 
@@ -81,9 +104,20 @@ Key variables:
 
 ### 5. Start Services
 
+Localhost-only (no HTTPS, no Caddy, no ports 80/443 bound):
+
 ```bash
 docker compose up -d
 ```
+
+With public HTTPS via Caddy (requires `DOMAIN` in `.env`):
+
+```bash
+docker compose --profile caddy up -d
+```
+
+The `caddy` service is gated behind a compose profile so it **only** starts when you opt in.
+This avoids port 80/443 conflicts on localhost-only installs.
 
 ### 6. Verify
 
@@ -120,11 +154,23 @@ When a new version is published on GitHub, the admin dashboard shows an update b
 ### CLI Update
 
 ```bash
-cd /opt/breadbox
+cd /opt/breadbox    # or $HOME/.breadbox for user installs
 sudo ./update.sh
 ```
 
-Or manually:
+`update.sh` respects the version pin recorded in `.breadbox-version`. If you installed
+`v0.3.1`, the script will pull `v0.3.1` on every run — it will **not** silently roll
+you forward to `main` / `latest`. To explicitly change the pin:
+
+```bash
+./update.sh --bump=v0.4.0    # pin to a specific release
+./update.sh --bump=latest    # opt in to rolling updates
+```
+
+If `.env` has `DOMAIN` set, the script passes `--profile caddy` to `docker compose`
+automatically so the reverse proxy restarts alongside the app.
+
+Manual update (not recommended — skips the pin check):
 
 ```bash
 cd /opt/breadbox

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -42,9 +42,16 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # Caddy is gated behind the `caddy` compose profile. It is only started when
+  # a public domain is configured. Localhost-only installs do not start Caddy,
+  # so ports 80/443 are not bound on the host.
+  #
+  # Enable with: docker compose --profile caddy up -d
+  # (install.sh toggles this automatically when DOMAIN is set.)
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
+    profiles: ["caddy"]
     ports:
       - "80:80"
       - "443:443"

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -2,14 +2,32 @@
 set -eu
 
 # Breadbox Install Script
-# Usage: curl -sSL https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/install.sh | bash
-# Or: bash install.sh [--uninstall]
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/install.sh | bash
+#   bash install.sh [--uninstall] [--yes] [--domain=...] [--install-docker]
+#
+# INSTALL_DIR convention:
+#   - System install  (running as root or EUID 0) → /opt/breadbox
+#   - User install    (default)                   → $HOME/.breadbox
+# Override with: INSTALL_DIR=/custom/path bash install.sh
+#
+# Caddy (HTTPS reverse proxy) is gated behind the `caddy` compose profile.
+# It is only started when a DOMAIN is configured, so localhost-only installs
+# never bind ports 80/443.
 
 REPO="canalesb93/breadbox"
 GITHUB_RAW="https://raw.githubusercontent.com/${REPO}"
 GITHUB_API="https://api.github.com/repos/${REPO}"
-INSTALL_DIR="${INSTALL_DIR:-./breadbox}"
 COMPOSE_FILE="docker-compose.prod.yml"
+
+# Pick a consistent default INSTALL_DIR based on privilege.
+if [ -z "${INSTALL_DIR:-}" ]; then
+    if [ "$(id -u 2>/dev/null || echo 1000)" = "0" ]; then
+        INSTALL_DIR="/opt/breadbox"
+    else
+        INSTALL_DIR="${HOME:-.}/.breadbox"
+    fi
+fi
 
 # ---------------------------------------------------------------------------
 # Color helpers (disabled when not a terminal or NO_COLOR is set)
@@ -66,7 +84,11 @@ do_uninstall() {
     # Stop containers if compose file exists
     if [ -f "$COMPOSE_FILE" ]; then
         info "Stopping containers..."
-        docker compose -f "$COMPOSE_FILE" down 2>/dev/null || true
+        # Pass --profile caddy so the Caddy service (if it was started) is
+        # included in the stop. Profiles not in use are silently ignored.
+        docker compose --profile caddy -f "$COMPOSE_FILE" down 2>/dev/null \
+            || docker compose -f "$COMPOSE_FILE" down 2>/dev/null \
+            || true
     fi
 
     printf "\n"
@@ -74,6 +96,7 @@ do_uninstall() {
     printf "  ${INSTALL_DIR}/${COMPOSE_FILE}\n"
     printf "  ${INSTALL_DIR}/Caddyfile\n"
     printf "  ${INSTALL_DIR}/.env\n"
+    printf "  ${INSTALL_DIR}/.breadbox-version\n"
     printf "\n"
     printf "${YELLOW}Docker volumes (postgres_data, caddy_data, caddy_config) are NOT removed.${NC}\n"
     printf "To remove volumes: docker volume rm breadbox_postgres_data breadbox_caddy_data breadbox_caddy_config\n"
@@ -89,6 +112,7 @@ do_uninstall() {
     rm -f "$INSTALL_DIR/$COMPOSE_FILE"
     rm -f "$INSTALL_DIR/Caddyfile"
     rm -f "$INSTALL_DIR/.env"
+    rm -f "$INSTALL_DIR/.breadbox-version"
 
     # Remove directory if empty
     rmdir "$INSTALL_DIR" 2>/dev/null || true
@@ -106,9 +130,59 @@ check_command() {
     command -v "$1" >/dev/null 2>&1
 }
 
+# Prompt for a yes/no answer. Returns 0 for yes, 1 for no.
+# Respects AUTO_YES (treats "yes" as the default when non-interactive).
+prompt_yn() {
+    question="$1"
+    default="${2:-n}"
+
+    if [ "${AUTO_YES:-0}" = "1" ]; then
+        [ "$default" = "y" ] && return 0
+        return 1
+    fi
+
+    if [ ! -t 0 ]; then
+        # Non-interactive (piped). Use default.
+        [ "$default" = "y" ] && return 0
+        return 1
+    fi
+
+    if [ "$default" = "y" ]; then
+        printf "%s [Y/n] " "$question"
+    else
+        printf "%s [y/N] " "$question"
+    fi
+    read -r ans
+    ans=${ans:-$default}
+    case "$ans" in
+        [yY]|[yY][eE][sS]) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Prompt for a free-text value with a default.
+prompt_value() {
+    question="$1"
+    default="${2:-}"
+
+    if [ "${AUTO_YES:-0}" = "1" ] || [ ! -t 0 ]; then
+        printf "%s" "$default"
+        return
+    fi
+
+    if [ -n "$default" ]; then
+        printf "%s [%s]: " "$question" "$default" >&2
+    else
+        printf "%s: " "$question" >&2
+    fi
+    read -r ans
+    printf "%s" "${ans:-$default}"
+}
+
 # Fetch the latest release tag from GitHub API.
 # Falls back to "latest" if the API call fails.
 get_latest_tag() {
+    tag=""
     if check_command curl; then
         tag=$(curl -fsSL "${GITHUB_API}/releases/latest" 2>/dev/null \
             | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')
@@ -132,19 +206,62 @@ download() {
     fi
 }
 
+# Try to install Docker via https://get.docker.com.
+# Only Linux. Best-effort — if it fails, surface the error.
+try_install_docker() {
+    os=$(uname -s 2>/dev/null || echo unknown)
+    case "$os" in
+        Linux)
+            info "Installing Docker via https://get.docker.com ..."
+            if check_command curl; then
+                curl -fsSL https://get.docker.com | sh
+            elif check_command wget; then
+                wget -qO- https://get.docker.com | sh
+            else
+                die "Cannot install Docker: neither curl nor wget is available."
+            fi
+
+            # Add the invoking user to the docker group for non-sudo use,
+            # when we are running via sudo.
+            if [ -n "${SUDO_USER:-}" ]; then
+                usermod -aG docker "$SUDO_USER" 2>/dev/null || true
+                warn "Added ${SUDO_USER} to the 'docker' group. Log out and back in for this to take effect."
+            fi
+            ;;
+        Darwin)
+            die "Automatic Docker install is not supported on macOS. Install Docker Desktop from https://docs.docker.com/desktop/install/mac-install/ and re-run this script."
+            ;;
+        *)
+            die "Automatic Docker install is not supported on ${os}. Install Docker manually from https://docs.docker.com/get-docker/ and re-run this script."
+            ;;
+    esac
+}
+
 # ---------------------------------------------------------------------------
 # Parse arguments
 # ---------------------------------------------------------------------------
+AUTO_YES=0
+INSTALL_DOCKER=0
+DOMAIN_ARG=""
+
 for arg in "$@"; do
     case "$arg" in
         --uninstall) do_uninstall ;;
+        --yes|-y) AUTO_YES=1 ;;
+        --install-docker) INSTALL_DOCKER=1 ;;
+        --domain=*) DOMAIN_ARG="${arg#--domain=}" ;;
         --help|-h)
             printf "Usage: install.sh [OPTIONS]\n\n"
             printf "Options:\n"
-            printf "  --uninstall   Stop containers and remove installed files\n"
-            printf "  --help, -h    Show this help message\n"
+            printf "  --uninstall         Stop containers and remove installed files\n"
+            printf "  --yes, -y           Skip interactive prompts; accept defaults\n"
+            printf "  --install-docker    Install Docker automatically (Linux only)\n"
+            printf "  --domain=HOST       Configure the install for HTTPS at HOST (enables Caddy)\n"
+            printf "  --help, -h          Show this help message\n"
             printf "\nEnvironment:\n"
-            printf "  INSTALL_DIR   Installation directory (default: ./breadbox)\n"
+            printf "  INSTALL_DIR   Installation directory\n"
+            printf "                Default (root):        /opt/breadbox\n"
+            printf "                Default (regular user): \$HOME/.breadbox\n"
             printf "  NO_COLOR      Disable colored output\n"
             exit 0
             ;;
@@ -158,11 +275,18 @@ banner
 
 # --- Pre-flight checks ---
 
+info "Install directory: ${INSTALL_DIR}"
 info "Checking prerequisites..."
 
 # Docker
 if ! check_command docker; then
-    die "Docker is not installed. Install it from https://docs.docker.com/get-docker/ and re-run this script."
+    warn "Docker is not installed."
+    if [ "$INSTALL_DOCKER" = "1" ] || prompt_yn "Install Docker now via https://get.docker.com?" "n"; then
+        try_install_docker
+        check_command docker || die "Docker install did not make 'docker' available on PATH."
+    else
+        die "Docker is required. Install it from https://docs.docker.com/get-docker/ and re-run this script."
+    fi
 fi
 success "Docker found"
 
@@ -212,6 +336,26 @@ else
     ENV_EXISTS=0
 fi
 
+# --- Domain prompt ---
+
+DOMAIN_VALUE="$DOMAIN_ARG"
+if [ -z "$DOMAIN_VALUE" ] && [ "$ENV_EXISTS" = "0" ]; then
+    printf "\n"
+    info "Optional: configure a public domain for automatic HTTPS via Caddy."
+    info "Leave blank for a localhost-only install (ports 80/443 not bound)."
+    DOMAIN_VALUE=$(prompt_value "Public domain (e.g. breadbox.example.com)" "")
+fi
+
+if [ -n "$DOMAIN_VALUE" ]; then
+    info "Configuring for domain: ${DOMAIN_VALUE}"
+    CADDY_PROFILE="--profile caddy"
+else
+    info "Localhost-only install (no HTTPS, no Caddy)"
+    CADDY_PROFILE=""
+fi
+
+printf "\n"
+
 # --- Create install directory ---
 
 mkdir -p "$INSTALL_DIR"
@@ -247,6 +391,10 @@ if [ "$IMAGE_TAG" != "latest" ]; then
     info "Pinned image to ghcr.io/${REPO}:${IMAGE_TAG}"
 fi
 
+# Record the pinned tag so update.sh can preserve it across upgrades.
+# "latest" signals the user explicitly wants rolling updates.
+printf "%s\n" "$IMAGE_TAG" > "${INSTALL_DIR}/.breadbox-version"
+
 # --- Generate .env ---
 
 if [ "$ENV_EXISTS" -eq 0 ]; then
@@ -254,6 +402,14 @@ if [ "$ENV_EXISTS" -eq 0 ]; then
 
     ENCRYPTION_KEY=$(openssl rand -hex 32)
     POSTGRES_PASSWORD=$(openssl rand -hex 24)
+
+    # Emit DOMAIN= (commented when not set) so users can flip it later without
+    # hand-editing adjacent lines.
+    if [ -n "$DOMAIN_VALUE" ]; then
+        DOMAIN_LINE="DOMAIN=${DOMAIN_VALUE}"
+    else
+        DOMAIN_LINE="# DOMAIN=breadbox.example.com"
+    fi
 
     cat > "${INSTALL_DIR}/.env" <<ENVEOF
 # Breadbox Configuration
@@ -274,8 +430,10 @@ SERVER_PORT=8080
 ENVIRONMENT=docker
 
 # --- Domain (for Caddy HTTPS) ---
-# Uncomment and set your domain to enable automatic TLS.
-# DOMAIN=breadbox.example.com
+# Uncomment to enable automatic TLS. Also re-run the install with the
+# --domain flag or start the caddy profile manually:
+#   docker compose --profile caddy -f ${COMPOSE_FILE} up -d
+${DOMAIN_LINE}
 
 # --- Plaid (optional, configure via dashboard at /providers) ---
 # PLAID_CLIENT_ID=
@@ -302,7 +460,10 @@ printf "\n"
 
 info "Starting Breadbox..."
 cd "$INSTALL_DIR"
-docker compose -f "$COMPOSE_FILE" up -d
+# Intentionally unquoted: CADDY_PROFILE is either empty or "--profile caddy"
+# and we want the empty case to contribute no argument.
+# shellcheck disable=SC2086
+docker compose $CADDY_PROFILE -f "$COMPOSE_FILE" up -d
 
 printf "\n"
 
@@ -328,15 +489,27 @@ if [ "$healthy" -eq 1 ]; then
     printf "    Breadbox is running!\n"
     printf "  =========================================\n"
     printf "${NC}\n"
-    info "Setup wizard:  ${BOLD}http://localhost:8080/setup${NC}"
+    if [ -n "$DOMAIN_VALUE" ]; then
+        info "Public URL:    ${BOLD}https://${DOMAIN_VALUE}${NC}"
+        info "Setup wizard:  ${BOLD}https://${DOMAIN_VALUE}/setup${NC}"
+    else
+        info "Setup wizard:  ${BOLD}http://localhost:8080/setup${NC}"
+    fi
     info "Config file:   ${INSTALL_DIR}/.env"
-    info "View logs:     cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} logs -f"
-    info "Update:        cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} pull && docker compose -f ${COMPOSE_FILE} up -d"
+    info "Version pin:   ${INSTALL_DIR}/.breadbox-version (${IMAGE_TAG})"
+    if [ -n "$CADDY_PROFILE" ]; then
+        info "View logs:     cd ${INSTALL_DIR} && docker compose --profile caddy -f ${COMPOSE_FILE} logs -f"
+    else
+        info "View logs:     cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} logs -f"
+    fi
+    info "Update:        cd ${INSTALL_DIR} && ./update.sh   (preserves your pinned version)"
     info "Uninstall:     ${0} --uninstall"
     printf "\n"
-    printf "${DIM}For HTTPS, set DOMAIN in .env and restart:${NC}\n"
-    printf "${DIM}  cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} up -d${NC}\n"
-    printf "\n"
+    if [ -z "$DOMAIN_VALUE" ]; then
+        printf "${DIM}To enable HTTPS later, edit .env to set DOMAIN=, then:${NC}\n"
+        printf "${DIM}  cd ${INSTALL_DIR} && docker compose --profile caddy -f ${COMPOSE_FILE} up -d${NC}\n"
+        printf "\n"
+    fi
 else
     error "Breadbox did not become healthy within 60 seconds."
     error "Check logs: cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} logs"

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Breadbox Update Script
+#
+# Preserves the version pin written by install.sh (.breadbox-version).
+# If the user installed v0.3.1, `update.sh` will pull v0.3.1 again, NOT
+# silently roll them forward to main. Run `update.sh --bump vX.Y.Z` or
+# `update.sh --bump latest` to explicitly change the pin.
+
 # --- Color helpers ---
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -13,17 +20,48 @@ warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
 error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 success() { echo -e "${GREEN}[OK]${NC} $*"; }
 
+REPO="canalesb93/breadbox"
+
 # --- Parse flags ---
 AUTO_YES=false
+BUMP_TARGET=""
 for arg in "$@"; do
     case "$arg" in
         --yes|-y) AUTO_YES=true ;;
+        --bump=*) BUMP_TARGET="${arg#--bump=}" ;;
+        --bump)
+            error "--bump requires a value, e.g. --bump=v0.4.0 or --bump=latest"
+            exit 2
+            ;;
+        --help|-h)
+            cat <<EOF
+Usage: update.sh [OPTIONS]
+
+Pulls the Breadbox image pinned in .breadbox-version and restarts the stack.
+
+Options:
+  --yes, -y          Skip confirmation prompt
+  --bump=<tag>       Explicitly change the pinned version (e.g. --bump=v0.4.0,
+                     --bump=latest). Rewrites .breadbox-version and the image
+                     tag in docker-compose.prod.yml.
+  --help, -h         Show this message
+EOF
+            exit 0
+            ;;
     esac
 done
 
 # --- Determine install directory ---
-INSTALL_DIR="${INSTALL_DIR:-/opt/breadbox}"
+# Mirror install.sh's convention: root → /opt/breadbox, user → $HOME/.breadbox.
+if [[ -z "${INSTALL_DIR:-}" ]]; then
+    if [[ "$(id -u)" = "0" ]]; then
+        INSTALL_DIR="/opt/breadbox"
+    else
+        INSTALL_DIR="${HOME:-.}/.breadbox"
+    fi
+fi
 COMPOSE_FILE="$INSTALL_DIR/docker-compose.prod.yml"
+VERSION_FILE="$INSTALL_DIR/.breadbox-version"
 
 if [[ ! -f "$COMPOSE_FILE" ]]; then
     error "Breadbox installation not found at $INSTALL_DIR"
@@ -33,17 +71,63 @@ fi
 
 cd "$INSTALL_DIR"
 
+# --- Resolve target tag ---
+# Precedence: --bump=X > .breadbox-version > "latest" (with a warning).
+if [[ -n "$BUMP_TARGET" ]]; then
+    TARGET_TAG="$BUMP_TARGET"
+    info "Bumping pinned version to: $TARGET_TAG"
+elif [[ -f "$VERSION_FILE" ]]; then
+    TARGET_TAG=$(tr -d '[:space:]' < "$VERSION_FILE")
+    if [[ -z "$TARGET_TAG" ]]; then
+        warn "$VERSION_FILE is empty; falling back to 'latest'"
+        TARGET_TAG="latest"
+    fi
+    info "Target version from .breadbox-version: $TARGET_TAG"
+else
+    warn "No .breadbox-version file; defaulting to 'latest'"
+    warn "Run with --bump=vX.Y.Z to pin to a specific release"
+    TARGET_TAG="latest"
+fi
+
+# --- Rewrite compose image tag if bumping or repairing drift ---
+# This is the CRITICAL fix: previously `docker compose pull` on an unpinned
+# compose file would silently yank users forward. Now we rewrite the image
+# line to match the pinned tag before pulling, so `pull` is always for the
+# intended version.
+if grep -Eq "^[[:space:]]*image: ghcr.io/${REPO}:" "$COMPOSE_FILE"; then
+    CURRENT_IMAGE_TAG=$(grep -Eo "ghcr.io/${REPO}:[^\"'[:space:]]+" "$COMPOSE_FILE" | head -1 | sed "s|ghcr.io/${REPO}:||")
+    if [[ "$CURRENT_IMAGE_TAG" != "$TARGET_TAG" ]]; then
+        info "Rewriting compose image: ghcr.io/${REPO}:${CURRENT_IMAGE_TAG} → :${TARGET_TAG}"
+        tmpfile="${COMPOSE_FILE}.tmp"
+        # POSIX-portable (BSD vs GNU sed): write to temp, move over.
+        sed "s|ghcr.io/${REPO}:${CURRENT_IMAGE_TAG}|ghcr.io/${REPO}:${TARGET_TAG}|g" \
+            "$COMPOSE_FILE" > "$tmpfile"
+        mv "$tmpfile" "$COMPOSE_FILE"
+    fi
+fi
+
+# Persist the pin (create it if this is a legacy install that never had one).
+printf "%s\n" "$TARGET_TAG" > "$VERSION_FILE"
+
+# --- Detect caddy profile ---
+# If the .env has DOMAIN set, assume caddy was started with --profile caddy.
+CADDY_PROFILE=()
+if [[ -f "$INSTALL_DIR/.env" ]] && grep -Eq '^[[:space:]]*DOMAIN=.+' "$INSTALL_DIR/.env"; then
+    CADDY_PROFILE=(--profile caddy)
+fi
+
 # --- Get current version ---
 CURRENT_VERSION="unknown"
 if curl -sf http://localhost:8080/health/ready > /dev/null 2>&1; then
     CURRENT_VERSION=$(curl -sf http://localhost:8080/api/v1/version 2>/dev/null | grep -o '"version":"[^"]*"' | cut -d'"' -f4 || echo "unknown")
 fi
 
-info "Current version: ${CURRENT_VERSION}"
+info "Current running version: ${CURRENT_VERSION}"
+info "Target version:          ${TARGET_TAG}"
 
 # --- Confirm update ---
 if [[ "$AUTO_YES" != true ]]; then
-    read -rp "Pull latest images and restart? [Y/n]: " confirm
+    read -rp "Pull ${TARGET_TAG} and restart? [Y/n]: " confirm
     confirm="${confirm:-Y}"
     if [[ "${confirm,,}" != "y" ]]; then
         info "Update cancelled."
@@ -52,18 +136,18 @@ if [[ "$AUTO_YES" != true ]]; then
 fi
 
 # --- Pull and restart ---
-info "Pulling latest images..."
-docker compose -f docker-compose.prod.yml pull
+info "Pulling image..."
+docker compose "${CADDY_PROFILE[@]}" -f docker-compose.prod.yml pull
 
 info "Restarting services..."
-docker compose -f docker-compose.prod.yml up -d
+docker compose "${CADDY_PROFILE[@]}" -f docker-compose.prod.yml up -d
 
 # --- Wait for healthy ---
 info "Waiting for Breadbox to become healthy..."
-for i in $(seq 1 60); do
+for _ in $(seq 1 60); do
     if curl -sf http://localhost:8080/health/ready > /dev/null 2>&1; then
         NEW_VERSION=$(curl -sf http://localhost:8080/api/v1/version 2>/dev/null | grep -o '"version":"[^"]*"' | cut -d'"' -f4 || echo "unknown")
-        success "Updated: ${CURRENT_VERSION} → ${NEW_VERSION}"
+        success "Updated: ${CURRENT_VERSION} → ${NEW_VERSION} (pinned: ${TARGET_TAG})"
         exit 0
     fi
     sleep 1


### PR DESCRIPTION
Correct the existing Docker installer before layering cross-platform support on top — gives us a solid foundation for the rest of the stack.

## Summary

- **Caddy is now gated behind a `caddy` compose profile.** Localhost-only installs no longer unconditionally bind ports 80/443. `install.sh` passes `--profile caddy` only when a DOMAIN is configured; `update.sh` auto-detects via `DOMAIN=` in `.env`.
- **DOMAIN prompt added.** `install.sh` asks for an optional public domain (or accepts `--domain=HOST`). Blank answer = localhost-only install. `.env` gets `DOMAIN=` pre-filled.
- **`INSTALL_DIR` default is now consistent across `install.sh` and `update.sh`:** root → `/opt/breadbox`, regular user → `$HOME/.breadbox`. Override via the `INSTALL_DIR` env var.
- **Optional Docker auto-install on Linux** via `https://get.docker.com` — opt-in through a prompt or `--install-docker`. macOS still requires Docker Desktop manually (previously the installer lied about installing Docker itself; README corrected).
- **Version-pin preservation in `update.sh`.** `install.sh` writes the resolved tag to `.breadbox-version`; `update.sh` reads it and pulls that exact tag, rewriting the compose file's image line before pulling. No more silent rollforwards. New `--bump=vX.Y.Z` (or `--bump=latest`) to explicitly change the pin.
- **README accuracy fixes** in both the root README and `deploy/README.md`.

## Test plan

- [x] `bash -n deploy/install.sh` / `sh -n deploy/install.sh` / `bash -n deploy/update.sh` — syntax clean
- [x] `sh deploy/install.sh --help` / `sh deploy/update.sh --help` show updated flags
- [x] `INSTALL_DIR=/tmp/bb sh deploy/install.sh --yes --no-register-daemon` dry-runs through platform detection and stops at Docker-daemon-not-running (Docker Desktop off on the test machine)
- [ ] Full end-to-end install on Ubuntu 22.04 with `--domain=` set (requires reviewer to validate in a VM)
- [ ] Full end-to-end install on Ubuntu 22.04 without domain, verifying ports 80/443 are NOT bound

## Breaking changes

- Existing installs that relied on the Caddy service starting unconditionally will need to either set `DOMAIN` in `.env` or re-run the installer. The old `docker compose up -d` no longer starts Caddy; use `docker compose --profile caddy up -d` or let `install.sh` / `update.sh` handle it.
- `update.sh`'s default `INSTALL_DIR` changed from `/opt/breadbox` (hardcoded) to privilege-aware (`/opt/breadbox` for root, `$HOME/.breadbox` for user). Users with existing `/opt/breadbox` installs running `sudo ./update.sh` are unaffected.

Part of #686
