### PR TITLE
feat(deploy): cross-platform detection and daemon registration

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -46,7 +46,28 @@ create your admin account.
 | `--yes, -y` | Non-interactive mode: accept defaults, no prompts. |
 | `--domain=HOST` | Configure HTTPS via Caddy for `HOST`. Also enables the `caddy` compose profile. |
 | `--install-docker` | Install Docker automatically on Linux via `https://get.docker.com` (no prompt). |
+| `--register-daemon` | Register a launchd agent (macOS) or systemd unit (Linux) so Breadbox restarts on boot. |
+| `--no-register-daemon` | Skip the daemon registration prompt entirely. |
 | `--uninstall` | Stop containers and remove installed files (preserves database volume). |
+
+### Platform support
+
+The installer detects OS / arch / distro / package manager / init system via
+`deploy/detect.sh` and adapts:
+
+| Platform | Docker install | openssl install | Daemon registration |
+| --- | --- | --- | --- |
+| Linux (Debian/Ubuntu) | `get.docker.com` | `apt-get install -y openssl` | systemd unit at `/etc/systemd/system/breadbox.service` |
+| Linux (Fedora/RHEL) | `get.docker.com` | `dnf install -y openssl` | systemd unit |
+| Linux (Arch) | `get.docker.com` | `pacman -S openssl` | systemd unit |
+| Linux (Alpine) | `get.docker.com` | `apk add openssl` | systemd (when present) |
+| macOS | Manual (Docker Desktop link) | `brew install openssl` | user-level launchd agent at `~/Library/LaunchAgents/sh.breadbox.plist` |
+
+Official Docker images are published for `linux/amd64` and `linux/arm64`. Other
+architectures may work under emulation; the installer warns but proceeds.
+
+You can run `deploy/detect.sh` directly to print what the installer sees, and
+`deploy/detect.sh --test` to run self-tests.
 
 ### `INSTALL_DIR` default
 

--- a/deploy/daemon/breadbox.service.tmpl
+++ b/deploy/daemon/breadbox.service.tmpl
@@ -1,0 +1,20 @@
+[Unit]
+Description=Breadbox (Docker Compose)
+Documentation=https://github.com/canalesb93/breadbox
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=__INSTALL_DIR__
+# Preserve the caddy profile when DOMAIN is configured.
+ExecStart=/bin/sh -c '__COMPOSE_CMD__ up -d'
+ExecStop=/bin/sh -c '__COMPOSE_CMD__ down'
+# Restart-on-failure doesn't apply to oneshot; the Docker daemon restarts
+# containers via `restart: unless-stopped` in docker-compose.prod.yml.
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/daemon/sh.breadbox.plist.tmpl
+++ b/deploy/daemon/sh.breadbox.plist.tmpl
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>sh.breadbox</string>
+
+    <key>WorkingDirectory</key>
+    <string>__INSTALL_DIR__</string>
+
+    <!--
+        Run the compose command at load time. Docker Desktop must be running
+        on macOS; we do NOT try to launch Docker Desktop ourselves because
+        doing so from launchd without a GUI session is unreliable.
+    -->
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>__COMPOSE_CMD__ up -d</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Relaunch if the oneshot exits abnormally. -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__INSTALL_DIR__/breadbox.launchd.log</string>
+    <key>StandardErrorPath</key>
+    <string>__INSTALL_DIR__/breadbox.launchd.log</string>
+</dict>
+</plist>

--- a/deploy/detect.sh
+++ b/deploy/detect.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# detect.sh — platform detection helpers for the Breadbox installer.
+#
+# Sourced by install.sh. Sets the following variables when run:
+#
+#   BB_OS            linux | darwin | unknown
+#   BB_ARCH          amd64 | arm64 | <raw uname -m>
+#   BB_DISTRO        debian | ubuntu | fedora | rhel | arch | alpine | macos | unknown
+#   BB_DISTRO_VERSION version string from /etc/os-release (best effort)
+#   BB_PKG_MANAGER   apt | dnf | yum | pacman | apk | brew | none
+#   BB_INIT_SYSTEM   systemd | launchd | none
+#
+# All variables are non-empty on exit; unknown values are literal "unknown"
+# or "none". The detector does not touch the network and is safe to dot-source.
+#
+# CLI: running `deploy/detect.sh` directly prints the detected values and
+# exits 0. `deploy/detect.sh --test` runs the self-tests at the bottom of
+# this file.
+
+# shellcheck disable=SC2034  # variables are consumed by dot-sourcing caller.
+
+detect_os() {
+    case "$(uname -s 2>/dev/null || echo unknown)" in
+        Linux) BB_OS=linux ;;
+        Darwin) BB_OS=darwin ;;
+        *) BB_OS=unknown ;;
+    esac
+}
+
+detect_arch() {
+    raw=$(uname -m 2>/dev/null || echo unknown)
+    case "$raw" in
+        x86_64|amd64) BB_ARCH=amd64 ;;
+        aarch64|arm64) BB_ARCH=arm64 ;;
+        armv7l|armv7|armhf) BB_ARCH=armv7 ;;
+        *) BB_ARCH="$raw" ;;
+    esac
+}
+
+detect_distro() {
+    BB_DISTRO=unknown
+    BB_DISTRO_VERSION=unknown
+
+    if [ "$BB_OS" = "darwin" ]; then
+        BB_DISTRO=macos
+        BB_DISTRO_VERSION=$(sw_vers -productVersion 2>/dev/null || echo unknown)
+        return
+    fi
+
+    # /etc/os-release is the standard across modern Linux distros.
+    if [ -r /etc/os-release ]; then
+        # Parse ID= and VERSION_ID= without sourcing (avoid shell surprises).
+        id_raw=$(grep -E '^ID=' /etc/os-release | head -1 | sed 's/^ID=//;s/"//g')
+        ver_raw=$(grep -E '^VERSION_ID=' /etc/os-release | head -1 | sed 's/^VERSION_ID=//;s/"//g')
+
+        case "$id_raw" in
+            debian|ubuntu|fedora|arch|alpine)
+                BB_DISTRO="$id_raw"
+                ;;
+            rhel|centos|rocky|almalinux)
+                BB_DISTRO=rhel
+                ;;
+            *)
+                # Fall back to ID_LIKE for derivatives.
+                like_raw=$(grep -E '^ID_LIKE=' /etc/os-release | head -1 | sed 's/^ID_LIKE=//;s/"//g')
+                case "$like_raw" in
+                    *debian*|*ubuntu*) BB_DISTRO=debian ;;
+                    *rhel*|*fedora*) BB_DISTRO=rhel ;;
+                    *arch*) BB_DISTRO=arch ;;
+                    *) BB_DISTRO=unknown ;;
+                esac
+                ;;
+        esac
+
+        [ -n "$ver_raw" ] && BB_DISTRO_VERSION="$ver_raw"
+    fi
+}
+
+detect_pkg_manager() {
+    if [ "$BB_OS" = "darwin" ]; then
+        if command -v brew >/dev/null 2>&1; then
+            BB_PKG_MANAGER=brew
+        else
+            BB_PKG_MANAGER=none
+        fi
+        return
+    fi
+
+    # Order matters: prefer dnf over yum, apt over nothing, etc.
+    for candidate in apt dnf yum pacman apk; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            BB_PKG_MANAGER="$candidate"
+            return
+        fi
+    done
+    BB_PKG_MANAGER=none
+}
+
+detect_init_system() {
+    case "$BB_OS" in
+        darwin)
+            BB_INIT_SYSTEM=launchd
+            ;;
+        linux)
+            # systemd is the de facto default on modern distros.
+            # `systemctl --version` succeeding is the cleanest signal.
+            if command -v systemctl >/dev/null 2>&1 && systemctl --version >/dev/null 2>&1; then
+                BB_INIT_SYSTEM=systemd
+            else
+                BB_INIT_SYSTEM=none
+            fi
+            ;;
+        *)
+            BB_INIT_SYSTEM=none
+            ;;
+    esac
+}
+
+# Install a package via the detected package manager. Best-effort; callers
+# should check $? and fall through to a manual-install message on failure.
+#
+# Usage: bb_pkg_install <package-name>
+bb_pkg_install() {
+    pkg="$1"
+    [ -z "$pkg" ] && return 2
+    case "$BB_PKG_MANAGER" in
+        apt)
+            DEBIAN_FRONTEND=noninteractive apt-get update -qq \
+              && DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$pkg"
+            ;;
+        dnf)  dnf install -y "$pkg" ;;
+        yum)  yum install -y "$pkg" ;;
+        pacman) pacman -S --noconfirm "$pkg" ;;
+        apk)  apk add --no-cache "$pkg" ;;
+        brew) brew install "$pkg" ;;
+        *) return 1 ;;
+    esac
+}
+
+bb_detect_all() {
+    detect_os
+    detect_arch
+    detect_distro
+    detect_pkg_manager
+    detect_init_system
+}
+
+# If invoked directly, print the detected values (or run self-tests).
+if [ "$(basename "${0:-}")" = "detect.sh" ]; then
+    bb_detect_all
+
+    if [ "${1:-}" = "--test" ]; then
+        # Minimal self-tests: every variable must be non-empty, and the OS
+        # must be a recognised value (the fallback to "unknown" is allowed,
+        # but the variable itself must be set).
+        fail=0
+        for var in BB_OS BB_ARCH BB_DISTRO BB_DISTRO_VERSION BB_PKG_MANAGER BB_INIT_SYSTEM; do
+            eval "val=\${$var:-}"
+            if [ -z "$val" ]; then
+                printf "FAIL: %s is empty\n" "$var" >&2
+                fail=1
+            fi
+        done
+        # OS should be one of the known values.
+        case "$BB_OS" in
+            linux|darwin|unknown) ;;
+            *) printf "FAIL: BB_OS=%s is not one of {linux,darwin,unknown}\n" "$BB_OS" >&2; fail=1 ;;
+        esac
+        # Arch should be non-empty and not start with "unknown"-as-prefix oddities.
+        [ -z "$BB_ARCH" ] && { printf "FAIL: BB_ARCH empty\n" >&2; fail=1; }
+
+        if [ "$fail" = "0" ]; then
+            printf "ok: all detect.sh self-tests passed\n"
+            exit 0
+        else
+            exit 1
+        fi
+    fi
+
+    printf "BB_OS=%s\n" "$BB_OS"
+    printf "BB_ARCH=%s\n" "$BB_ARCH"
+    printf "BB_DISTRO=%s\n" "$BB_DISTRO"
+    printf "BB_DISTRO_VERSION=%s\n" "$BB_DISTRO_VERSION"
+    printf "BB_PKG_MANAGER=%s\n" "$BB_PKG_MANAGER"
+    printf "BB_INIT_SYSTEM=%s\n" "$BB_INIT_SYSTEM"
+fi

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -20,6 +20,47 @@ GITHUB_RAW="https://raw.githubusercontent.com/${REPO}"
 GITHUB_API="https://api.github.com/repos/${REPO}"
 COMPOSE_FILE="docker-compose.prod.yml"
 
+# Load platform detection. When install.sh is piped into `bash`, the local
+# detect.sh file does not exist — fetch it into a temp location and source
+# from there so the one-liner path works too.
+_bb_load_detect() {
+    # Try the local copy first (git checkout / manual install).
+    script_dir=""
+    if [ -n "${BASH_SOURCE:-}" ]; then
+        script_dir=$(cd "$(dirname "${BASH_SOURCE:-$0}")" 2>/dev/null && pwd || echo "")
+    fi
+    if [ -n "$script_dir" ] && [ -r "$script_dir/detect.sh" ]; then
+        # shellcheck disable=SC1090,SC1091
+        . "$script_dir/detect.sh"
+        return
+    fi
+    # Fetch from GitHub. Use a temp file; silently skip if we can't.
+    _detect_tmp="${TMPDIR:-/tmp}/breadbox-detect.$$.sh"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "${GITHUB_RAW}/main/deploy/detect.sh" -o "$_detect_tmp" 2>/dev/null || return 0
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$_detect_tmp" "${GITHUB_RAW}/main/deploy/detect.sh" 2>/dev/null || return 0
+    else
+        return 0
+    fi
+    if [ -r "$_detect_tmp" ]; then
+        # shellcheck disable=SC1090
+        . "$_detect_tmp"
+        rm -f "$_detect_tmp"
+    fi
+}
+_bb_load_detect
+# Populate BB_* if detect.sh is available; otherwise tolerate absence.
+if command -v bb_detect_all >/dev/null 2>&1; then
+    bb_detect_all
+fi
+: "${BB_OS:=unknown}"
+: "${BB_ARCH:=unknown}"
+: "${BB_DISTRO:=unknown}"
+: "${BB_DISTRO_VERSION:=unknown}"
+: "${BB_PKG_MANAGER:=none}"
+: "${BB_INIT_SYSTEM:=none}"
+
 # Pick a consistent default INSTALL_DIR based on privilege.
 if [ -z "${INSTALL_DIR:-}" ]; then
     if [ "$(id -u 2>/dev/null || echo 1000)" = "0" ]; then
@@ -209,10 +250,9 @@ download() {
 # Try to install Docker via https://get.docker.com.
 # Only Linux. Best-effort — if it fails, surface the error.
 try_install_docker() {
-    os=$(uname -s 2>/dev/null || echo unknown)
-    case "$os" in
-        Linux)
-            info "Installing Docker via https://get.docker.com ..."
+    case "$BB_OS" in
+        linux)
+            info "Installing Docker via https://get.docker.com (detected: ${BB_DISTRO} ${BB_DISTRO_VERSION}, ${BB_ARCH}) ..."
             if check_command curl; then
                 curl -fsSL https://get.docker.com | sh
             elif check_command wget; then
@@ -228,11 +268,100 @@ try_install_docker() {
                 warn "Added ${SUDO_USER} to the 'docker' group. Log out and back in for this to take effect."
             fi
             ;;
-        Darwin)
+        darwin)
             die "Automatic Docker install is not supported on macOS. Install Docker Desktop from https://docs.docker.com/desktop/install/mac-install/ and re-run this script."
             ;;
         *)
-            die "Automatic Docker install is not supported on ${os}. Install Docker manually from https://docs.docker.com/get-docker/ and re-run this script."
+            die "Automatic Docker install is not supported on ${BB_OS}. Install Docker manually from https://docs.docker.com/get-docker/ and re-run this script."
+            ;;
+    esac
+}
+
+# Install openssl via the detected package manager if available. Skipped on
+# systems where we don't know the package manager — the user can install it
+# manually and re-run.
+try_install_openssl() {
+    case "$BB_PKG_MANAGER" in
+        none)
+            die "openssl is not installed and no supported package manager was detected. Install openssl manually and re-run this script."
+            ;;
+    esac
+    info "Installing openssl via ${BB_PKG_MANAGER}..."
+    if ! bb_pkg_install openssl; then
+        die "Failed to install openssl via ${BB_PKG_MANAGER}. Install it manually and re-run."
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Daemon registration (opt-in)
+# ---------------------------------------------------------------------------
+
+register_daemon_systemd() {
+    unit_template_url="${GITHUB_RAW}/main/deploy/daemon/breadbox.service.tmpl"
+    unit_dest="/etc/systemd/system/breadbox.service"
+
+    if [ "$(id -u)" != "0" ]; then
+        warn "Registering a systemd unit requires root. Re-run with sudo to enable this feature."
+        return 1
+    fi
+
+    tmp_unit="${TMPDIR:-/tmp}/breadbox.service.$$"
+    # Prefer local file if present (git checkout install).
+    if [ -r "$(dirname "$0")/daemon/breadbox.service.tmpl" ]; then
+        cp "$(dirname "$0")/daemon/breadbox.service.tmpl" "$tmp_unit"
+    else
+        download "$unit_template_url" "$tmp_unit" || { warn "Could not fetch systemd unit template"; return 1; }
+    fi
+
+    compose_cmd="docker compose ${CADDY_PROFILE} -f ${INSTALL_DIR}/${COMPOSE_FILE}"
+    sed -e "s|__INSTALL_DIR__|${INSTALL_DIR}|g" \
+        -e "s|__COMPOSE_CMD__|${compose_cmd}|g" \
+        "$tmp_unit" > "$unit_dest"
+    rm -f "$tmp_unit"
+
+    systemctl daemon-reload
+    systemctl enable breadbox.service >/dev/null 2>&1 || true
+    success "Registered systemd unit: ${unit_dest} (enabled at boot)"
+    info "Start: systemctl start breadbox    Stop: systemctl stop breadbox"
+}
+
+register_daemon_launchd() {
+    plist_template_url="${GITHUB_RAW}/main/deploy/daemon/sh.breadbox.plist.tmpl"
+    # User-level LaunchAgent — does not need root.
+    plist_dest="${HOME}/Library/LaunchAgents/sh.breadbox.plist"
+    mkdir -p "${HOME}/Library/LaunchAgents"
+
+    tmp_plist="${TMPDIR:-/tmp}/sh.breadbox.plist.$$"
+    if [ -r "$(dirname "$0")/daemon/sh.breadbox.plist.tmpl" ]; then
+        cp "$(dirname "$0")/daemon/sh.breadbox.plist.tmpl" "$tmp_plist"
+    else
+        download "$plist_template_url" "$tmp_plist" || { warn "Could not fetch launchd template"; return 1; }
+    fi
+
+    compose_cmd="docker compose ${CADDY_PROFILE} -f ${INSTALL_DIR}/${COMPOSE_FILE}"
+    sed -e "s|__INSTALL_DIR__|${INSTALL_DIR}|g" \
+        -e "s|__COMPOSE_CMD__|${compose_cmd}|g" \
+        "$tmp_plist" > "$plist_dest"
+    rm -f "$tmp_plist"
+
+    # bootout is the modern replacement for `launchctl unload`; tolerate
+    # "not currently loaded" errors.
+    launchctl bootout "gui/$(id -u)" "$plist_dest" >/dev/null 2>&1 || true
+    if launchctl bootstrap "gui/$(id -u)" "$plist_dest" 2>/dev/null; then
+        success "Registered launchd agent: ${plist_dest}"
+    else
+        warn "launchctl bootstrap failed. The plist is in place at ${plist_dest};"
+        warn "run 'launchctl bootstrap gui/\$(id -u) ${plist_dest}' from a login shell to finish."
+    fi
+}
+
+register_daemon() {
+    case "$BB_INIT_SYSTEM" in
+        systemd) register_daemon_systemd ;;
+        launchd) register_daemon_launchd ;;
+        *)
+            warn "No supported init system detected (BB_INIT_SYSTEM=${BB_INIT_SYSTEM}). Skipping daemon registration."
+            warn "Breadbox will still start now via 'docker compose up', but won't be re-started automatically on boot."
             ;;
     esac
 }
@@ -242,6 +371,8 @@ try_install_docker() {
 # ---------------------------------------------------------------------------
 AUTO_YES=0
 INSTALL_DOCKER=0
+REGISTER_DAEMON=0
+NO_REGISTER_DAEMON=0
 DOMAIN_ARG=""
 
 for arg in "$@"; do
@@ -249,15 +380,19 @@ for arg in "$@"; do
         --uninstall) do_uninstall ;;
         --yes|-y) AUTO_YES=1 ;;
         --install-docker) INSTALL_DOCKER=1 ;;
+        --register-daemon) REGISTER_DAEMON=1 ;;
+        --no-register-daemon) NO_REGISTER_DAEMON=1 ;;
         --domain=*) DOMAIN_ARG="${arg#--domain=}" ;;
         --help|-h)
             printf "Usage: install.sh [OPTIONS]\n\n"
             printf "Options:\n"
-            printf "  --uninstall         Stop containers and remove installed files\n"
-            printf "  --yes, -y           Skip interactive prompts; accept defaults\n"
-            printf "  --install-docker    Install Docker automatically (Linux only)\n"
-            printf "  --domain=HOST       Configure the install for HTTPS at HOST (enables Caddy)\n"
-            printf "  --help, -h          Show this help message\n"
+            printf "  --uninstall            Stop containers and remove installed files\n"
+            printf "  --yes, -y              Skip interactive prompts; accept defaults\n"
+            printf "  --install-docker       Install Docker automatically (Linux only)\n"
+            printf "  --domain=HOST          Configure the install for HTTPS at HOST (enables Caddy)\n"
+            printf "  --register-daemon      Register launchd (macOS) or systemd (Linux) unit\n"
+            printf "  --no-register-daemon   Skip daemon registration (no boot-time autostart)\n"
+            printf "  --help, -h             Show this help message\n"
             printf "\nEnvironment:\n"
             printf "  INSTALL_DIR   Installation directory\n"
             printf "                Default (root):        /opt/breadbox\n"
@@ -275,8 +410,26 @@ banner
 
 # --- Pre-flight checks ---
 
+info "Platform: ${BB_OS}/${BB_ARCH} (${BB_DISTRO} ${BB_DISTRO_VERSION}, pkg=${BB_PKG_MANAGER}, init=${BB_INIT_SYSTEM})"
 info "Install directory: ${INSTALL_DIR}"
 info "Checking prerequisites..."
+
+# Hard-stop on unsupported OS.
+case "$BB_OS" in
+    linux|darwin) ;;
+    *)
+        die "Unsupported OS '${BB_OS}' (uname -s = $(uname -s 2>/dev/null || echo '?')). Supported: Linux, macOS."
+        ;;
+esac
+
+# Warn on exotic architectures. We only ship amd64 + arm64 images.
+case "$BB_ARCH" in
+    amd64|arm64) ;;
+    *)
+        warn "Detected arch '${BB_ARCH}'. Official images are built for amd64 and arm64."
+        warn "Installation may fail or run under emulation."
+        ;;
+esac
 
 # Docker
 if ! check_command docker; then
@@ -304,7 +457,13 @@ success "Docker daemon is running"
 
 # openssl (for key generation)
 if ! check_command openssl; then
-    die "openssl is not installed. It is needed to generate encryption keys."
+    warn "openssl is not installed (needed for encryption key + db password generation)."
+    if [ "$AUTO_YES" = "1" ] || prompt_yn "Install openssl via ${BB_PKG_MANAGER}?" "y"; then
+        try_install_openssl
+        check_command openssl || die "openssl still not available after install."
+    else
+        die "openssl is required. Install it and re-run this script."
+    fi
 fi
 success "openssl found"
 
@@ -484,6 +643,16 @@ done
 printf "\n"
 
 if [ "$healthy" -eq 1 ]; then
+    # Optional daemon registration
+    if [ "$NO_REGISTER_DAEMON" = "1" ]; then
+        :  # user opted out
+    elif [ "$REGISTER_DAEMON" = "1" ] \
+        || { [ "$BB_INIT_SYSTEM" != "none" ] \
+             && prompt_yn "Register a ${BB_INIT_SYSTEM} unit so Breadbox restarts on boot?" "n"; }; then
+        printf "\n"
+        register_daemon
+    fi
+
     printf "${GREEN}${BOLD}"
     printf "  =========================================\n"
     printf "    Breadbox is running!\n"


### PR DESCRIPTION
Teach the installer to adapt to the host environment instead of assuming a particular Linux distribution. Builds on #693 and sets up the one-liner landing in the next PR.

## Summary

- **New `deploy/detect.sh` library.** Detects OS (linux/darwin), arch (amd64/arm64/armv7), Linux distro family (debian/ubuntu/fedora/rhel/arch/alpine) and version via `/etc/os-release`, package manager (apt/dnf/yum/pacman/apk/brew), and init system (systemd/launchd). Sourced by `install.sh` when local, fetched from GitHub when the installer is piped through `curl`. Includes a `--test` self-check and prints detected values when invoked directly.

- **`install.sh` adapts:**
  - Surfaces the detected platform up front.
  - Hard-stops on unsupported OS; warns for non-amd64/non-arm64 arch.
  - Installs `openssl` via the detected package manager when missing (was previously a hard error).
  - Detects `launchd` vs `systemd` and offers boot-time unit registration (opt-in via prompt, forced with `--register-daemon`, skipped with `--no-register-daemon`).

- **Daemon templates** under `deploy/daemon/`:
  - `breadbox.service.tmpl` — systemd oneshot wrapping `docker compose up -d`/`down`, placeholders filled in at install time.
  - `sh.breadbox.plist.tmpl` — user-level launchd agent with `KeepAlive` on abnormal exit.

## Test plan

- [x] `sh deploy/detect.sh --test` passes on darwin/arm64
- [x] `sh deploy/detect.sh` prints expected values on darwin/arm64:
      ```
      BB_OS=darwin BB_ARCH=arm64 BB_DISTRO=macos
      BB_PKG_MANAGER=brew BB_INIT_SYSTEM=launchd
      ```
- [x] `bash -n` / `sh -n` syntax clean on install.sh
- [ ] `sh deploy/detect.sh --test` on Ubuntu 22.04, Debian 12, Fedora, Arch, Alpine (reviewer to validate in VMs)
- [ ] `install.sh --register-daemon` on Ubuntu 22.04 drops a working systemd unit (reviewer to validate)
- [ ] `install.sh --register-daemon` on macOS bootstraps a working launchd agent

## Explicitly unverified

Linux-side detection, `get.docker.com` Docker install path, systemd unit generation, and package-manager-based `openssl` install are all exercised in code review only. None of them run on the macOS test machine.

Part of #686
