### PR TITLE
feat(deploy): Openclaw-style one-liner + docs restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,45 @@ Breadbox syncs your bank data into a PostgreSQL database you control, then expos
 
 ## Installation
 
-### Docker (recommended)
+### One-liner (recommended)
 
-No need to clone the repo. This pulls the pre-built image from GHCR and starts Breadbox with PostgreSQL:
+```bash
+curl -fsSL https://breadbox.sh/install.sh | bash
+```
+
+This is the primary install path. It detects your OS (Linux or macOS) and arch
+(amd64 or arm64), checks for Docker (and offers to install it on Linux via
+`get.docker.com`), prompts for an optional public domain (leave blank for a
+localhost-only install), writes a version-pinned `docker-compose.prod.yml`,
+generates an `ENCRYPTION_KEY` and database password, and starts the stack.
+
+On success it offers to register a launchd agent (macOS) or systemd unit
+(Linux) so Breadbox restarts on boot, and calls `breadbox doctor` to verify
+configuration.
+
+Common variations:
+
+```bash
+# Non-interactive install with a public domain (enables Caddy + HTTPS)
+curl -fsSL https://breadbox.sh/install.sh | bash -s -- --yes --domain=breadbox.example.com
+
+# Installer without breadbox.sh (straight from GitHub)
+curl -fsSL https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/install.sh | bash
+```
+
+Install directory:
+
+- Root (`sudo bash ...`) → `/opt/breadbox`
+- Regular user → `$HOME/.breadbox`
+- Override: `INSTALL_DIR=/custom/path bash install.sh`
+
+Updates respect the installed version pin. `./update.sh` in the install
+directory pulls the same tag on every run; `./update.sh --bump=v0.4.0` (or
+`--bump=latest`) explicitly changes it. Full docs in [`deploy/`](deploy/).
+
+### Docker Compose (manual)
+
+No need to clone the repo. This pulls the pre-built image from GHCR and starts Breadbox with PostgreSQL directly — useful if you want full control over the compose file:
 
 ```bash
 mkdir breadbox && cd breadbox
@@ -55,11 +91,14 @@ EOF
 Start the services:
 
 ```bash
+# Localhost-only (no HTTPS, no Caddy, no 80/443 bindings)
 docker compose up -d breadbox db
-# Visit http://localhost:8080 to start the setup wizard
+
+# With public HTTPS via Caddy (requires DOMAIN= in .env)
+docker compose --profile caddy up -d
 ```
 
-> **Note:** This starts Breadbox and PostgreSQL without the Caddy reverse proxy, exposing port 8080 directly. For production with automatic HTTPS, run `docker compose up -d` (all services) and configure your domain in the Caddyfile -- see [Production Deployment](#production-deployment) below.
+Caddy is gated behind the `caddy` compose profile, so localhost-only installs never bind ports 80/443.
 
 To pin a specific version instead of `latest`, edit `docker-compose.yml` and change the image tag:
 
@@ -113,15 +152,7 @@ make dev
 # Visit http://localhost:8080
 ```
 
-### Production deployment
-
-For production, use the one-liner install script:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/install.sh | sudo bash
-```
-
-The script checks for Docker (and offers to install it on Linux via `get.docker.com`), downloads the deployment files, prompts for an optional public domain, generates secrets, and starts Breadbox. If you supply a domain it also starts Caddy for automatic TLS; otherwise the install is localhost-only and does not bind ports 80/443. See [`deploy/`](deploy/) for details, including version-pinned updates via `update.sh`.
+For production deployment details (domain setup, Caddy, daemon registration, backups), see the [`deploy/README.md`](deploy/README.md).
 
 ## MCP Integration
 

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -21,9 +21,23 @@ Caddy handles automatic HTTPS via Let's Encrypt. Breadbox is a single Go binary 
 
 ## Quick Install (One-Liner)
 
+Recommended — the bootstrap at `breadbox.sh` pins to a known-good installer:
+
 ```bash
-curl -sSL https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/install.sh | bash
+curl -fsSL https://breadbox.sh/install.sh | bash
 ```
+
+Straight-from-GitHub alternative (no CDN layer):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/canalesb93/breadbox/main/deploy/install.sh | bash
+```
+
+The `breadbox.sh/install.sh` endpoint is a tiny shim (source in this repo at
+[`deploy/bootstrap.sh`](./bootstrap.sh)) that fetches the real installer and
+execs it with your arguments. That lets bug fixes to the installer land in
+one place (`deploy/install.sh`) without needing to redeploy the landing
+site. Pin a specific ref with `BB_INSTALL_REF=v0.4.0 curl ... | bash`.
 
 The script will:
 1. Verify Docker / Docker Compose (offer to install Docker on Linux if missing)

--- a/deploy/bootstrap.sh
+++ b/deploy/bootstrap.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+# Breadbox bootstrap
+#
+# This is the tiny shim hosted at https://breadbox.sh/install.sh. It does
+# nothing more than fetch the real installer from GitHub and execute it,
+# forwarding any arguments. Canonical source for this file lives in the
+# Breadbox repo at deploy/bootstrap.sh; it is copied into the landing-site
+# repo (breadbox-site) on release. Keep them in sync.
+#
+# Usage:
+#   curl -fsSL https://breadbox.sh/install.sh | bash
+#   curl -fsSL https://breadbox.sh/install.sh | bash -s -- --domain=my.example.com
+#
+# We deliberately don't do any work here beyond fetch + exec so that
+# bug fixes to the installer land in one place (deploy/install.sh).
+
+set -eu
+
+REPO="canalesb93/breadbox"
+# BB_INSTALL_REF pins the installer to a specific branch or tag. Defaults to
+# main. Set e.g. BB_INSTALL_REF=v0.4.0 to bootstrap from a specific release.
+REF="${BB_INSTALL_REF:-main}"
+URL="https://raw.githubusercontent.com/${REPO}/${REF}/deploy/install.sh"
+
+echo "==> Fetching Breadbox installer from ${URL}"
+
+if command -v curl >/dev/null 2>&1; then
+    # -f = fail on HTTP errors; -s = silent; -S = show errors; -L = follow redirects.
+    tmpfile="${TMPDIR:-/tmp}/breadbox-install.$$.sh"
+    trap 'rm -f "$tmpfile"' EXIT INT TERM
+    curl -fsSL "$URL" -o "$tmpfile"
+    sh "$tmpfile" "$@"
+elif command -v wget >/dev/null 2>&1; then
+    tmpfile="${TMPDIR:-/tmp}/breadbox-install.$$.sh"
+    trap 'rm -f "$tmpfile"' EXIT INT TERM
+    wget -qO "$tmpfile" "$URL"
+    sh "$tmpfile" "$@"
+else
+    echo "error: neither curl nor wget found. Install one of them and retry." >&2
+    exit 1
+fi

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -679,6 +679,20 @@ if [ "$healthy" -eq 1 ]; then
         printf "${DIM}  cd ${INSTALL_DIR} && docker compose --profile caddy -f ${COMPOSE_FILE} up -d${NC}\n"
         printf "\n"
     fi
+
+    # --- Post-install: breadbox doctor handoff ---
+    # `breadbox doctor` is a planned pre-flight command (tracked in issue
+    # #687). When it lands, running it against the fresh install catches
+    # misconfiguration before the user hits runtime errors. If the binary
+    # inside the container doesn't support `doctor` yet, tolerate the
+    # failure quietly so the installer doesn't regress on older images.
+    if docker compose -f "$COMPOSE_FILE" exec -T breadbox /app/breadbox doctor 2>/dev/null; then
+        :  # doctor printed its own summary; nothing more to say.
+    else
+        printf "${DIM}Run 'docker compose -f %s exec breadbox /app/breadbox doctor' when available${NC}\n" "$COMPOSE_FILE"
+        printf "${DIM}to verify configuration (see issue #687).${NC}\n"
+        printf "\n"
+    fi
 else
     error "Breadbox did not become healthy within 60 seconds."
     error "Check logs: cd ${INSTALL_DIR} && docker compose -f ${COMPOSE_FILE} logs"


### PR DESCRIPTION
Makes the one-liner the lead install path for Breadbox. Top of the #686 stack.

## Summary

- **`deploy/bootstrap.sh`** — the tiny shim that will be hosted at `https://breadbox.sh/install.sh`. Fetches the real installer from GitHub and execs it with forwarded arguments. Canonical source lives in this repo; the landing-site repo copies it on release. Keeping the shim thin means installer bug fixes land in one place. Supports `BB_INSTALL_REF=<tag|branch>` to pin the bootstrapped installer.
- **`breadbox doctor` handoff.** `install.sh` calls `breadbox doctor` inside the running container as its final step. `doctor` is planned in #687 and may not have shipped yet; when the image doesn't support the subcommand, the call fails silently and the installer prints a pointer to the issue.
- **Root README restructured** to lead with the one-liner:
    ```bash
    curl -fsSL https://breadbox.sh/install.sh | bash
    ```
  Docker Compose manual install, binary download, `go install`, and from-source move to secondary options. The `caddy` compose-profile split from the bottom PR is also documented in the Docker Compose section.
- **`deploy/README.md`** shows both the `breadbox.sh` and the direct-GitHub forms with a note on the bootstrap indirection and the `BB_INSTALL_REF` pin.

## Test plan

- [x] `bash -n deploy/bootstrap.sh` / `sh -n deploy/bootstrap.sh` — syntax clean
- [x] End-to-end dry-run of `install.sh` on macOS darwin/arm64: platform detection, prerequisites check, openssl detection, stops cleanly at the Docker-daemon health gate when Docker Desktop isn't running
- [ ] Full end-to-end one-liner on a fresh Ubuntu 22.04 VM via `breadbox.sh/install.sh` (requires the landing site to host `bootstrap.sh` — this PR includes the source but does not deploy it)
- [ ] Full end-to-end one-liner on macOS 15 with Docker Desktop running

## Follow-ups

- `breadbox doctor` itself is tracked in #687. The handoff in this PR is tolerant and does not block installs.
- The landing site (`~/dev/breadbox-site`) needs to copy `deploy/bootstrap.sh` into its static assets and serve it at `/install.sh`. That's a separate repo change, not in scope here.

Closes #686
