### PR TITLE
fix(404): anonymous 404/500 no longer leaks admin sidebar

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -1285,15 +1285,36 @@ func BaseTemplateData(r *http.Request, sm *scs.SessionManager, currentPage, page
 	}
 }
 
-// RenderNotFound renders the styled 404 page within the app layout.
+// RenderNotFound renders the styled 404 page. For authenticated sessions the
+// page lives inside the admin shell (so the user can navigate away); for
+// anonymous visitors it renders standalone in the wizard layout so the admin
+// sidebar and 'Administrator' footer don't leak to logged-out users.
 func (tr *TemplateRenderer) RenderNotFound(w http.ResponseWriter, r *http.Request) {
+	if !IsViewer(tr.sm, r) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusNotFound)
+		if err := pages.NotFoundPublic().Render(r.Context(), w); err != nil {
+			log.Printf("templ render error (NotFoundPublic): %v", err)
+		}
+		return
+	}
 	w.WriteHeader(http.StatusNotFound)
 	data := BaseTemplateData(r, tr.sm, "", "Page Not Found")
 	tr.RenderWithTempl(w, r, data, pages.NotFound())
 }
 
-// RenderError renders the styled 500 page within the app layout.
+// RenderError renders the styled 500 page. Matches RenderNotFound's branching:
+// anonymous visitors get a standalone wizard-layout page; authenticated users
+// get the full admin shell.
 func (tr *TemplateRenderer) RenderError(w http.ResponseWriter, r *http.Request) {
+	if !IsViewer(tr.sm, r) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusInternalServerError)
+		if err := pages.InternalErrorPublic().Render(r.Context(), w); err != nil {
+			log.Printf("templ render error (InternalErrorPublic): %v", err)
+		}
+		return
+	}
 	w.WriteHeader(http.StatusInternalServerError)
 	data := BaseTemplateData(r, tr.sm, "", "Error")
 	tr.RenderWithTempl(w, r, data, pages.InternalError())

--- a/internal/templates/components/pages/errors.templ
+++ b/internal/templates/components/pages/errors.templ
@@ -1,5 +1,7 @@
 package pages
 
+import "breadbox/internal/templates/components/layout"
+
 // NotFound renders the 404 page body hosted inside the base layout via
 // TemplateRenderer.RenderWithTempl. The handler passes no props.
 templ NotFound() {
@@ -37,4 +39,50 @@ templ InternalError() {
 			</a>
 		</div>
 	</div>
+}
+
+// NotFoundPublic renders the 404 page for unauthenticated visitors — no admin
+// shell, wizard-style standalone layout with a 'Back to sign in' CTA. Used
+// when someone hits an unknown path without a session (OSS visitors, stale
+// links, typos).
+templ NotFoundPublic() {
+	@layout.Wizard(layout.WizardProps{PageTitle: "Page Not Found"}) {
+		<div class="bb-error-page">
+			<p class="bb-error-code">404</p>
+			<div class="bb-error-icon bg-base-200/80">
+				<i data-lucide="compass" class="w-7 h-7 text-base-content/40"></i>
+			</div>
+			<h1 class="bb-error-title">Page not found</h1>
+			<p class="bb-error-message">The page you're looking for doesn't exist or has been moved.</p>
+			<a href="/login" class="btn btn-primary rounded-xl px-6">
+				<i data-lucide="arrow-left" class="w-4 h-4"></i>
+				Back to sign in
+			</a>
+		</div>
+	}
+}
+
+// InternalErrorPublic renders the 500 page for unauthenticated visitors — no
+// admin shell, wizard-style standalone layout. Keeps anonymous error pages
+// from leaking the admin sidebar and role labels.
+templ InternalErrorPublic() {
+	@layout.Wizard(layout.WizardProps{PageTitle: "Error"}) {
+		<div class="bb-error-page">
+			<p class="bb-error-code">500</p>
+			<div class="bb-error-icon bg-error/10">
+				<i data-lucide="alert-triangle" class="w-7 h-7 text-error/60"></i>
+			</div>
+			<h1 class="bb-error-title">Something went wrong</h1>
+			<p class="bb-error-message">An unexpected error occurred. Please try again.</p>
+			<div class="flex items-center gap-3">
+				<a href="javascript:location.reload()" class="btn btn-primary rounded-xl px-6">
+					<i data-lucide="refresh-cw" class="w-4 h-4"></i>
+					Try Again
+				</a>
+				<a href="/login" class="btn btn-ghost rounded-xl px-6">
+					Back to sign in
+				</a>
+			</div>
+		</div>
+	}
 }


### PR DESCRIPTION
Fixes #635

## Summary

Anonymous 404/500 responses rendered the full admin shell (sidebar, \"Administrator\" footer) because `BaseTemplateData` defaults the session role to `RoleAdmin` when no session exists. `RenderNotFound` / `RenderError` now branch on `IsViewer`: anonymous visitors get a new standalone `NotFoundPublic` / `InternalErrorPublic` component inside the wizard layout (same shell as `/login`), with a \"Back to sign in\" CTA. Authenticated users keep the in-shell error pages — no regression.

## Before / After — anonymous 404

| Viewport | Before | After |
|---|---|---|
| Desktop 1440×900 | ![before 1440](https://i.img402.dev/oju895cte4.png) | ![after 1440](https://i.img402.dev/palxxk3z46.png) |
| Tablet 820×1180 | ![before 820](https://i.img402.dev/6893a0sjt1.png) | ![after 820](https://i.img402.dev/cdqtpax2js.png) |
| Mobile 500×844 | ![before 500](https://i.img402.dev/9t4ud6vnhf.png) | ![after 500](https://i.img402.dev/mdxmd2gymg.png) |
| Mobile 390×844 | ![before 390](https://i.img402.dev/9e9s7h2iku.png) | ![after 390](https://i.img402.dev/110pes9swg.png) |
| Mobile 375×667 | ![before 375](https://i.img402.dev/42sfi8hs8y.png) | ![after 375](https://i.img402.dev/jkgr0f4top.png) |

## No regression — authenticated 404

Signed-in users still see the full admin shell and the \"Back to Dashboard\" CTA:

![authed 1440](https://i.img402.dev/uygtf6s8oh.png)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/admin/...` — pass
- [x] Anonymous `GET /this-page-does-not-exist` → 404 with wizard layout, brand mark, and \"Back to sign in\" link to `/login`; grep confirms no `bb-sidebar`, no `Administrator`, no nav items
- [x] Authenticated `GET /this-page-does-not-exist` → 404 with admin shell, real user email in footer, \"Back to Dashboard\" CTA
- [x] 500 handler mirrors the same branching (`InternalErrorPublic` rendered when anonymous)

🤖 Generated with [Claude Code](https://claude.com/claude-code)