### PR TITLE
refactor(kbd): touch suppression + help modal polish

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -2143,9 +2143,11 @@
 
         var key = e.key;
 
-        // Touch device guard — page-level specs don't fire on touch.
-        // Globals (`?`, `/`, `g+_`, `n+_`) still run; the per-spec filter
-        // happens when we resolve the match below.
+        // Touch device guard — page-level specs don't fire on touch, and
+        // two-key chord prefixes (`g+_`, `n+_`) are suppressed entirely since
+        // users can't reasonably type chords on a soft keyboard. Single-key
+        // globals (`?`, `/`, Cmd+K, Esc) still run — they're non-destructive
+        // and occasionally reachable from mobile hardware keyboards.
         var isTouch = (Alpine.store('device') || {}).isTouch === true;
 
         function shouldFire(spec) {
@@ -2156,7 +2158,13 @@
         }
 
         // Chord resolution: if we have a pending prefix, match second key now.
+        // On touch the prefix shouldn't have been acquired (see below), but
+        // bail defensively if it somehow was.
         if (pendingPrefix) {
+          if (isTouch) {
+            clearPrefix();
+            return;
+          }
           var prefix = pendingPrefix;
           clearPrefix();
           var chordSpec = matchChord(reg, prefix, key);
@@ -2168,7 +2176,10 @@
         }
 
         // Start a chord sequence if any registered spec begins with this key.
-        if (hasChordStartingWith(reg, key)) {
+        // Skipped on touch so `g`/`n` don't swallow a keystroke waiting for a
+        // second key that will never come — and the chord itself is unusable
+        // on mobile anyway.
+        if (!isTouch && hasChordStartingWith(reg, key)) {
           pendingPrefix = key;
           prefixTimeout = setTimeout(function() {
             pendingPrefix = null;


### PR DESCRIPTION
## Summary

Touch-device polish for the global keyboard dispatcher, flagged during the keyboard-shortcut sprint critique.

Global chord prefixes (`g+_`, `n+_`) were still being acquired on touch devices. Users can't reasonably type a two-key chord on a soft keyboard, so pressing `g` or `n` on mobile just swallowed the event waiting for a second key that never comes. This PR suppresses chord-prefix acquisition (and defensively, chord resolution) when `$store.device.isTouch` is true. Non-destructive single-key globals — `?`, `/`, `Cmd+K`, `Esc` — still fire, since they're occasionally reachable from mobile hardware keyboards and are low-risk.

## Changes

- `internal/templates/layout/base.html`:
  - In the dispatcher's keydown listener, guard `hasChordStartingWith` acquisition on `!isTouch`.
  - Also bail out of the `pendingPrefix` resolution branch on touch (defensive — acquisition is now blocked, but this keeps us honest if a pending prefix survives a device mode flip).
  - Clarify the touch-guard comment so future readers understand the single-key / chord-prefix split.

No registry API changes. Page-level scope suppression was already handled by `shouldFire`'s existing `spec.scope !== 'global'` filter; only the chord-prefix gap is new here.

## Sprint item 2 (help-modal ambiguity)

The sprint also flagged ambiguous "Actions" group headings between global and page-scoped shortcuts. That concern is already being addressed by the open #699 (`refactor(kbd): show page shortcuts above globals in ? modal`), which flips section order and prefixes the page section heading with the current scope name (`Transactions`, `Transaction detail`, etc.). No additional change needed in this PR — shipping that fix twice would just conflict with #699.

## Test plan

- [ ] Desktop (`$store.device.isTouch === false`): `g+h` still navigates home, `n+t` still opens new-transaction, `?` opens help modal. Behavior unchanged from current main.
- [ ] Mobile / touch viewport (DevTools device emulation or actual phone): pressing `g` or `n` on any page does NOT stall with a pending prefix. Typing `g` followed by `h` does NOT navigate — chord is fully inert.
- [ ] Mobile: `?` still opens the help modal; `/` still focuses the command-palette trigger; `Esc` still closes overlays. Single-key globals unchanged.
- [ ] Mobile: page-level specs (e.g. transactions `j`/`k`) still suppressed by the pre-existing `shouldFire` filter.
- [ ] `go build ./...` + `go vet ./...` clean (verified).
