### PR TITLE
fix(transactions): graceful fallback for rule-applied timeline rows

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -690,8 +690,15 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			a.Logger.Error("list transaction annotations", "error", err)
 		}
 
+		// Load category tree early so the activity timeline can humanize
+		// category slugs (rule_applied + category_set rows).
+		categoryTree, err := svc.ListCategoryTree(ctx)
+		if err != nil {
+			a.Logger.Error("list categories for transaction detail", "error", err)
+		}
+
 		// Build unified activity timeline from annotations.
-		activity := buildActivityTimeline(annotations)
+		activity := buildActivityTimeline(annotations, categoryDisplayLookup(categoryTree))
 
 		// Load tags currently attached + the registered-tag list (for the inline
 		// add-tag suggestion datalist). Also derive HasPendingReview from the
@@ -757,11 +764,8 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			userName = *txn.UserName
 		}
 
-		// Load category tree for inline category picker.
-		categoryTree, err := svc.ListCategoryTree(ctx)
-		if err != nil {
-			a.Logger.Error("list categories for transaction detail", "error", err)
-		}
+		// categoryTree already loaded above for the activity timeline; reused
+		// for the inline category picker.
 
 		// Build breadcrumbs: Transactions > Account Name > Transaction Name
 		breadcrumbs := []Breadcrumb{
@@ -798,11 +802,40 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 	}
 }
 
+// categoryDisplayLookup returns a slug→"Parent › Child" formatter for the
+// given category tree. Falls back to the raw slug when a match can't be
+// found (e.g. the category was deleted after the annotation was written).
+func categoryDisplayLookup(tree []service.CategoryResponse) func(string) string {
+	names := make(map[string]string, 64)
+	for _, parent := range tree {
+		names[parent.Slug] = parent.DisplayName
+		for _, child := range parent.Children {
+			names[child.Slug] = parent.DisplayName + " › " + child.DisplayName
+		}
+	}
+	return func(slug string) string {
+		if slug == "" {
+			return ""
+		}
+		if name, ok := names[slug]; ok {
+			return name
+		}
+		return slug
+	}
+}
+
 // buildActivityTimeline produces a sorted activity list from annotations.
 // Review lifecycle events surface as tag_added/tag_removed on the
 // needs-review tag. Comment annotations originally authored as review notes
 // (identified by payload.review_id) render inline on their resolution event.
-func buildActivityTimeline(annotations []service.Annotation) []service.ActivityEntry {
+//
+// categoryDisplay maps a category slug to a human-readable name
+// ("Food & Drink › Groceries"). Pass a no-op (returning slug unchanged) in
+// tests that don't need humanization.
+func buildActivityTimeline(annotations []service.Annotation, categoryDisplay func(string) string) []service.ActivityEntry {
+	if categoryDisplay == nil {
+		categoryDisplay = func(s string) string { return s }
+	}
 	var entries []service.ActivityEntry
 
 	// Annotations.
@@ -835,14 +868,29 @@ func buildActivityTimeline(annotations []service.Annotation) []service.ActivityE
 			field, _ := a.Payload["action_field"].(string)
 			value, _ := a.Payload["action_value"].(string)
 			appliedBy, _ := a.Payload["applied_by"].(string)
-			summary := "Rule \"" + ruleName + "\" applied"
+			// Older rows (and any future bug) can land here with rule_name
+			// empty and rule_id empty — render a generic subject instead of
+			// `Rule "" set category to food_and_drink_groceries`. The
+			// template already skips the /rules/<id> link when RuleID is
+			// empty, so the fallback text renders as plain copy.
+			subject := `Rule "` + ruleName + `"`
+			if ruleName == "" {
+				subject = "A rule"
+			}
+			// Humanize the action value for category actions so we render
+			// "Food & Drink › Groceries" rather than the raw slug.
+			displayValue := value
+			if field == "category" {
+				displayValue = categoryDisplay(value)
+			}
+			summary := subject + " applied"
 			switch field {
 			case "category":
-				summary = "Rule \"" + ruleName + "\" set category to " + value
+				summary = subject + " set category to " + displayValue
 			case "tag":
-				summary = "Rule \"" + ruleName + "\" added tag " + value
+				summary = subject + " added tag " + value
 			case "comment":
-				summary = "Rule \"" + ruleName + "\" added a comment"
+				summary = subject + " added a comment"
 			}
 			how := "during sync"
 			if appliedBy == "retroactive" {
@@ -913,20 +961,21 @@ func buildActivityTimeline(annotations []service.Annotation) []service.ActivityE
 		case "category_set":
 			slug, _ := a.Payload["category_slug"].(string)
 			source, _ := a.Payload["source"].(string)
-			summary := "Category set to " + slug
 			if source == "rule" {
 				// Represented separately via the rule_applied annotation
 				// written alongside category_set during sync. Skip to avoid
 				// double-rendering.
 				continue
 			}
+			displaySlug := categoryDisplay(slug)
+			summary := "Category set to " + displaySlug
 			entry := service.ActivityEntry{
-				Type:      "category",
-				Timestamp: a.CreatedAt,
-				ActorName: a.ActorName,
-				ActorType: a.ActorType,
-				Summary:   summary,
-				CategoryName: slug,
+				Type:         "category",
+				Timestamp:    a.CreatedAt,
+				ActorName:    a.ActorName,
+				ActorType:    a.ActorType,
+				Summary:      summary,
+				CategoryName: displaySlug,
 			}
 			if a.ActorID != nil && *a.ActorID != "" {
 				id := *a.ActorID

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -104,7 +104,7 @@ func TestBuildActivityTimeline_FreeStandingCommentStillEmitted(t *testing.T) {
 		CreatedAt: "2026-04-04T12:00:00Z",
 	}}
 
-	entries := buildActivityTimeline(annotations)
+	entries := buildActivityTimeline(annotations, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
@@ -154,7 +154,7 @@ func TestBuildActivityTimeline_RuleSourcedTagAddedDeduped(t *testing.T) {
 		},
 	}
 
-	entries := buildActivityTimeline(annotations)
+	entries := buildActivityTimeline(annotations, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry (rule_applied only), got %d", len(entries))
@@ -180,7 +180,7 @@ func TestBuildActivityTimeline_UserTagAddedStillEmitted(t *testing.T) {
 		CreatedAt: "2026-04-05T09:00:00Z",
 	}}
 
-	entries := buildActivityTimeline(annotations)
+	entries := buildActivityTimeline(annotations, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 tag entry, got %d", len(entries))
@@ -190,6 +190,88 @@ func TestBuildActivityTimeline_UserTagAddedStillEmitted(t *testing.T) {
 	}
 	if entries[0].TagSlug != "vacation" {
 		t.Errorf("expected TagSlug=vacation, got %q", entries[0].TagSlug)
+	}
+}
+
+// Older rule_applied rows can have empty rule_name/rule_id (pre-ruleapply
+// helper retroactive runs). Render a generic subject instead of the raw
+// `Rule "" set category to food_and_drink_groceries` copy that #704 reported.
+func TestBuildActivityTimeline_RuleAppliedEmptyNameFallsBack(t *testing.T) {
+	annotations := []service.Annotation{{
+		ID:        "ann-rule-empty",
+		Kind:      "rule_applied",
+		ActorName: "",
+		ActorType: "system",
+		Payload: map[string]interface{}{
+			"rule_id":       "",
+			"rule_name":     "",
+			"applied_by":    "retroactive",
+			"action_field":  "category",
+			"action_value":  "food_and_drink_groceries",
+		},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+
+	categoryDisplay := func(slug string) string {
+		if slug == "food_and_drink_groceries" {
+			return "Food & Drink › Groceries"
+		}
+		return slug
+	}
+
+	entries := buildActivityTimeline(annotations, categoryDisplay)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	want := `A rule set category to Food & Drink › Groceries`
+	if entries[0].Summary != want {
+		t.Errorf("summary = %q, want %q", entries[0].Summary, want)
+	}
+	if entries[0].RuleID != "" {
+		t.Errorf("expected empty RuleID so template skips /rules/<id> link, got %q", entries[0].RuleID)
+	}
+}
+
+// Named rule rows must keep their quoted-name subject and the link-eligible
+// RuleID — the fallback is only for the empty-name edge case.
+func TestBuildActivityTimeline_RuleAppliedNamedStillQuoted(t *testing.T) {
+	ruleID := "rule-1"
+	annotations := []service.Annotation{{
+		ID:        "ann-rule-named",
+		Kind:      "rule_applied",
+		ActorName: "Walgreens auto-categorize",
+		ActorType: "system",
+		ActorID:   &ruleID,
+		RuleID:    &ruleID,
+		Payload: map[string]interface{}{
+			"rule_id":      ruleID,
+			"rule_name":    "Walgreens auto-categorize",
+			"applied_by":   "sync",
+			"action_field": "category",
+			"action_value": "shopping",
+		},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+
+	categoryDisplay := func(slug string) string {
+		if slug == "shopping" {
+			return "Shopping"
+		}
+		return slug
+	}
+
+	entries := buildActivityTimeline(annotations, categoryDisplay)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	want := `Rule "Walgreens auto-categorize" set category to Shopping`
+	if entries[0].Summary != want {
+		t.Errorf("summary = %q, want %q", entries[0].Summary, want)
+	}
+	if entries[0].RuleID != ruleID {
+		t.Errorf("expected RuleID=%q, got %q", ruleID, entries[0].RuleID)
 	}
 }
 
@@ -206,7 +288,7 @@ func TestBuildActivityTimeline_LegacyPrefixCommentSuppressed(t *testing.T) {
 		CreatedAt: "2026-03-01T00:00:00Z",
 	}}
 
-	entries := buildActivityTimeline(annotations)
+	entries := buildActivityTimeline(annotations, nil)
 
 	if len(entries) != 0 {
 		t.Fatalf("expected legacy [Review: ...] comment to be suppressed, got %d entries", len(entries))


### PR DESCRIPTION
Closes #704.

## Summary

Activity timeline rows on `/transactions/{id}` could render literally `Rule "" set category to food_and_drink_groceries` for older rule-applied annotations whose payload carries empty `rule_name` + `rule_id` (retroactive runs that predate the `ruleapply` helper). Two defects in one row: empty quoted name and raw category slug.

- `buildActivityTimeline` now falls back to `"A rule"` when `rule_name` is empty. The detail template already skips the `<a href="/rules/{RuleID}">` wrap when `RuleID` is empty, so the fallback renders as plain copy — no template change needed.
- Category slugs are humanized via the category tree on both the `rule_applied` and `category_set` cases. `/transactions/{id}` now loads `categoryTree` once (previously loaded only for the inline picker) and threads a `slug → "Parent › Child"` lookup into the timeline builder.
- Named rule rows keep their quoted-name subject and `/rules/{id}` anchor — fallback is only for the empty-name edge case.

After the fix the Zelle Payment (`yZbfXGcx`) row reads:

> A rule set category to Food & Drink › Groceries

and unchanged neighbors still read, e.g.:

> Rule "General -> Needs Enrichment" added tag needs-enrichment
> Rule "Auto-tag new transactions for review" added tag needs-review

## Deferred

A server-side guard in `ruleapply.WriteRuleApplied` that refuses to write `rule_applied` annotations with both `rule.ID` zero and `rule.Name == ""` is intentionally out of scope (per the issue) — old rows remain in shared dev DBs regardless.

## Test plan

- `go test ./...` — passes (two new unit tests cover empty-name fallback + named-rule regression).
- `make test-integration` — passes.
- Verified against the reported transaction on `localhost:8083`: rendered HTML contains `A rule set category to Food & Drink › Groceries` inside a plain `<span>` (no `/rules/` anchor, since RuleID is empty), zero occurrences of the literal `Rule ""` string, and named rule rows still render as anchored quoted names.

Note: screenshots were not attached — Chrome DevTools MCP was unavailable in this session and browser-automation fallbacks were declined. End-to-end validation was done via authenticated `curl` + HTML assertions against the same transaction as the issue's repro.