### PR TITLE
fix(rules): make disabled 'Apply to N' button visible with soft warning tint

### DIFF
--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -368,7 +368,10 @@
       </div>
       <div class="flex items-center justify-end gap-2 mt-5">
         <button type="button" class="btn btn-sm btn-ghost rounded-xl" @click="closeApplyModal()">Cancel</button>
-        <button type="button" class="btn btn-sm btn-warning rounded-xl" :disabled="!confirmApply || applying" @click="applyRetroactively()">
+        <button type="button"
+                class="btn btn-sm rounded-xl btn-warning disabled:bg-warning/40 disabled:text-warning disabled:border-transparent disabled:!opacity-100"
+                :disabled="!confirmApply || applying"
+                @click="applyRetroactively()">
           <span x-show="applying" class="loading loading-spinner loading-xs"></span>
           <i data-lucide="play" class="w-3.5 h-3.5" x-show="!applying"></i>
           Apply to {{commaInt .Preview.MatchCount}}


### PR DESCRIPTION
Fixes #700

daisyUI's default `:disabled` styles strip the warning background and drop opacity, making the retroactive-apply confirm button visually equivalent to the modal card fill. Users read the modal and often miss the primary action entirely, or assume it's already fired. Swap to explicit `disabled:bg-warning/40 disabled:text-warning disabled:border-transparent disabled:!opacity-100` so the button stays clearly warning-tinted while disabled; once the acknowledgement checkbox is ticked it transitions to the full `btn-warning` orange with no layout shift.

## Before / After

| Viewport | Before (disabled) | After (disabled) |
|---|---|---|
| 1440 | <img src="https://i.img402.dev/nfhsna46kt.png" width="420" /> | <img src="https://i.img402.dev/7k1svrsl99.png" width="420" /> |
| 820  | <img src="https://i.img402.dev/vk6vdzv9gt.png" width="420" /> | <img src="https://i.img402.dev/0hvoc2j4zv.png" width="420" /> |
| 500  | <img src="https://i.img402.dev/ki3v7doos8.png" width="420" /> | <img src="https://i.img402.dev/rn0jgh4wm8.png" width="420" /> |
| 375  | <img src="https://i.img402.dev/ro4c9p4igi.png" width="420" /> | <img src="https://i.img402.dev/bazmvs6pp7.png" width="420" /> |

Enabled state (checkbox ticked) still pops with full warning orange:

<img src="https://i.img402.dev/5pcnvh3u8g.png" width="600" />

## Test plan

- [x] `go build ./...` clean
- [x] Disabled button has visible warning-tinted background at 375/500/820/1440 px
- [x] Button still reads as disabled (reduced text contrast vs. active state, pointer blocked via native `:disabled`)
- [x] Checkbox toggle → full `btn-warning` orange, no layout shift
- [x] Cancel (ghost) no longer out-weights the primary action

🤖 Generated with [Claude Code](https://claude.com/claude-code)