### PR TITLE
fix(transactions): populate CommentID from annotation short_id (#703)

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -820,9 +820,7 @@ func buildActivityTimeline(annotations []service.Annotation) []service.ActivityE
 				ActorName: a.ActorName,
 				ActorType: a.ActorType,
 				Detail:    content,
-			}
-			if cid, _ := a.Payload["comment_id"].(string); cid != "" {
-				entry.CommentID = cid
+				CommentID: a.ShortID,
 			}
 			if a.ActorID != nil && *a.ActorID != "" {
 				id := *a.ActorID

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -92,14 +92,17 @@ func searchString(s, sub string) bool {
 // not a distinct timeline event type.
 
 func TestBuildActivityTimeline_FreeStandingCommentStillEmitted(t *testing.T) {
+	// CommentID must be populated from the annotation's own short_id — the
+	// write path never sets payload.comment_id, so the template-gated delete
+	// button only renders when we surface ShortID here. See #703.
 	annotations := []service.Annotation{{
 		ID:        "ann-free",
+		ShortID:   "ax9Ku7Qp",
 		Kind:      "comment",
 		ActorName: "Alice",
 		ActorType: "user",
 		Payload: map[string]interface{}{
-			"content":    "split with Bob",
-			"comment_id": "comment-free",
+			"content": "split with Bob",
 		},
 		CreatedAt: "2026-04-04T12:00:00Z",
 	}}
@@ -112,8 +115,8 @@ func TestBuildActivityTimeline_FreeStandingCommentStillEmitted(t *testing.T) {
 	if entries[0].Type != "comment" {
 		t.Errorf("expected comment entry, got type=%q", entries[0].Type)
 	}
-	if entries[0].CommentID != "comment-free" {
-		t.Errorf("expected CommentID=comment-free, got %q", entries[0].CommentID)
+	if entries[0].CommentID != "ax9Ku7Qp" {
+		t.Errorf("expected CommentID to come from annotation ShortID (ax9Ku7Qp), got %q", entries[0].CommentID)
 	}
 }
 


### PR DESCRIPTION
Closes #703

## Why

`/transactions/{id}` activity timeline never rendered the per-row delete button on comment entries. `buildActivityTimeline` was reading `payload.comment_id` from the annotation, but the write path (`service.CreateComment`) never sets that key — so `CommentID` was always empty and the template gate (`{{if .CommentID}}`) always suppressed the trash button.

## What

Replace the `payload.comment_id` lookup with `a.ShortID` — the annotation's own 8-char short_id, which already flows through `resolveAnnotationID` in the delete handler. Single-line behavior change; no API surface affected.

- `internal/admin/transactions.go` — stop reading `payload.comment_id`, use `a.ShortID` instead.
- `internal/admin/transactions_test.go` — updated `TestBuildActivityTimeline_FreeStandingCommentStillEmitted` to assert `CommentID` is sourced from `ShortID`, with a comment anchoring the intent to #703.

## Validation

- `go test ./...` green (existing activity-timeline tests updated and passing).
- Ran locally against the dev DB on `/transactions/e950fza1` (Walgreens repro). The three freestanding user comments in the activity timeline now render with a trash button each; DOM inspection shows the buttons wire `deleteComment('<short_id>')` with 8-char base62 values (e.g., `Bcn3ysbu`, `pMB2mx1c`, `NeRUaDAF`), and the existing delete handler already resolves those via `resolveAnnotationID`, so the click path is end-to-end correct.

## Deferred

The issue floats a follow-up of hiding the trash UI when `ActorID != sessionUserID`. Skipping here — the server already enforces via `ErrForbidden`, and the cleanup isn't needed to close this bug.
