### PR TITLE
fix(csv-import): humanize CSV parse errors and surface them in an alert

### DIFF
--- a/internal/admin/csv_import.go
+++ b/internal/admin/csv_import.go
@@ -1,7 +1,9 @@
 package admin
 
 import (
+	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +17,46 @@ import (
 	"github.com/alexedwards/scs/v2"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// humanizeCSVError converts low-level `encoding/csv` parser errors into
+// plain-English messages suitable for the import wizard UI. Unknown errors
+// fall through with their prefix stripped so we never expose the Go
+// `fmt.Errorf("parse CSV: ...")` wrapper or the word "fields" (the stdlib's
+// term for CSV columns).
+func humanizeCSVError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var parseErr *csv.ParseError
+	if errors.As(err, &parseErr) {
+		line := parseErr.Line
+		if line <= 0 {
+			line = parseErr.StartLine
+		}
+		switch {
+		case errors.Is(parseErr.Err, csv.ErrFieldCount):
+			return fmt.Sprintf(
+				"We couldn't parse this file. Row %d has a different number of columns than the header row. Check that no commas appear inside values without quotes, or re-export from your bank with consistent columns.",
+				line,
+			)
+		case errors.Is(parseErr.Err, csv.ErrBareQuote):
+			return fmt.Sprintf(
+				"We couldn't parse this file. Row %d contains an unescaped quote character. Make sure any values containing quotes are wrapped in double quotes with inner quotes doubled (e.g., \"she said \"\"hi\"\"\").",
+				line,
+			)
+		case errors.Is(parseErr.Err, csv.ErrQuote):
+			return fmt.Sprintf(
+				"We couldn't parse this file. Row %d has a quoted value that is never closed. Make sure every opening \" has a matching closing \".",
+				line,
+			)
+		}
+	}
+	// Strip the "parse CSV: " wrapper added in internal/provider/csv/parser.go
+	// before surfacing anything unexpected to the user.
+	msg := err.Error()
+	msg = strings.TrimPrefix(msg, "parse CSV: ")
+	return msg
+}
 
 const maxCSVUploadSize = 10 << 20 // 10MB
 
@@ -94,7 +136,8 @@ func CSVUploadHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 
 		parsed, err := csvpkg.ParseFile(raw)
 		if err != nil {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
+			a.Logger.Debug("csv upload parse failed", "error", err)
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": humanizeCSVError(err)})
 			return
 		}
 

--- a/internal/admin/csv_import_test.go
+++ b/internal/admin/csv_import_test.go
@@ -1,0 +1,117 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// readAllCSV reads every record from `raw` and returns the first non-EOF
+// error. Used to obtain a real *csv.ParseError for the tests below.
+func readAllCSV(raw string) error {
+	r := csv.NewReader(bytes.NewReader([]byte(raw)))
+	for {
+		_, err := r.Read()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func TestHumanizeCSVError(t *testing.T) {
+	t.Parallel()
+
+	// Real encoding/csv field-count error: header has 3 columns, row 2 has 2.
+	fieldCountErr := readAllCSV("a,b,c\nx,y\n")
+	if fieldCountErr == nil {
+		t.Fatal("expected ErrFieldCount from mismatched rows")
+	}
+	// Wrap the way internal/provider/csv.ParseFile does.
+	wrappedFieldCount := fmt.Errorf("parse CSV: %w", fieldCountErr)
+
+	// Real bare-quote error: quote appearing mid-field without LazyQuotes.
+	bareQuoteErr := readAllCSV("a,b\nfoo\",bar\n")
+	if bareQuoteErr == nil {
+		t.Fatal("expected a bare-quote error")
+	}
+	wrappedBareQuote := fmt.Errorf("parse CSV: %w", bareQuoteErr)
+
+	// Real extraneous/unclosed quote: opening " with no closing match.
+	quoteErr := readAllCSV("a,b\n\"oops,bar\n")
+	if quoteErr == nil {
+		t.Fatal("expected a quote error")
+	}
+	wrappedQuote := fmt.Errorf("parse CSV: %w", quoteErr)
+
+	tests := []struct {
+		name         string
+		err          error
+		wantContains []string
+		wantMissing  []string
+	}{
+		{
+			name: "nil returns empty",
+			err:  nil,
+		},
+		{
+			name:         "field count surfaces row and plain language",
+			err:          wrappedFieldCount,
+			wantContains: []string{"Row 2", "different number of columns", "re-export"},
+			wantMissing:  []string{"parse CSV", "wrong number of fields", "field"},
+		},
+		{
+			name:         "bare quote",
+			err:          wrappedBareQuote,
+			wantContains: []string{"unescaped quote"},
+			wantMissing:  []string{"parse CSV", "bare \""},
+		},
+		{
+			name:         "unclosed quote",
+			err:          wrappedQuote,
+			wantContains: []string{"never closed"},
+			wantMissing:  []string{"parse CSV"},
+		},
+		{
+			name:         "unknown error strips parse CSV prefix",
+			err:          fmt.Errorf("parse CSV: %w", errors.New("file is empty")),
+			wantContains: []string{"file is empty"},
+			wantMissing:  []string{"parse CSV:"},
+		},
+		{
+			name:         "sentinel fallback still readable",
+			err:          errors.New("file must have at least 2 rows (header + 1 data row)"),
+			wantContains: []string{"at least 2 rows"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := humanizeCSVError(tt.err)
+			if tt.err == nil {
+				if got != "" {
+					t.Fatalf("want empty string, got %q", got)
+				}
+				return
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("result %q missing expected substring %q", got, want)
+				}
+			}
+			for _, dontWant := range tt.wantMissing {
+				if strings.Contains(got, dontWant) {
+					t.Errorf("result %q contains disallowed substring %q", got, dontWant)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/pages/csv_import.html
+++ b/internal/templates/pages/csv_import.html
@@ -75,11 +75,16 @@
         <p class="text-xs text-base-content/40 mt-2">Supported: CSV, TSV, TXT files up to 10MB. Max 50,000 rows.</p>
       </fieldset>
 
+      <div id="upload-alert" role="alert" class="hidden mb-4 flex items-start gap-3 rounded-xl bg-error/10 text-error px-4 py-3 text-sm">
+        <i data-lucide="alert-circle" class="w-4 h-4 shrink-0 mt-0.5"></i>
+        <span id="upload-status"></span>
+      </div>
+
       <div class="flex items-center gap-3 pt-2">
         <button type="button" id="upload-btn" class="btn btn-primary btn-sm rounded-xl" onclick="uploadFile()">
           <i data-lucide="upload" class="w-4 h-4"></i> Upload &amp; Parse
         </button>
-        <p id="upload-status" class="text-sm text-error"></p>
+        <p id="upload-progress" class="text-sm text-base-content/60"></p>
       </div>
     </div>
   </div>
@@ -309,27 +314,44 @@
   var detectedDateFormat = "";
   var totalRows = 0;
 
+  function showUploadError(msg) {
+    var alert = document.getElementById("upload-alert");
+    var status = document.getElementById("upload-status");
+    status.textContent = msg;
+    alert.classList.remove("hidden");
+    if (typeof lucide !== 'undefined') lucide.createIcons();
+  }
+
+  function clearUploadError() {
+    var alert = document.getElementById("upload-alert");
+    var status = document.getElementById("upload-status");
+    status.textContent = "";
+    alert.classList.add("hidden");
+  }
+
   window.uploadFile = function() {
     var fileInput = document.getElementById("csv-file");
-    var status = document.getElementById("upload-status");
+    var progress = document.getElementById("upload-progress");
     var btn = document.getElementById("upload-btn");
 
+    clearUploadError();
+
     if (!fileInput.files.length) {
-      status.textContent = "Please select a file.";
+      showUploadError("Please select a file.");
       return;
     }
 
     {{if not .ConnectionID}}
     var userSelect = document.getElementById("csv-user-id");
     if (!userSelect.value) {
-      status.textContent = "Please select a family member.";
+      showUploadError("Please select a family member.");
       return;
     }
     {{end}}
 
     btn.disabled = true;
     btn.classList.add("btn-disabled");
-    status.textContent = "Uploading...";
+    progress.textContent = "Uploading...";
 
     var formData = new FormData();
     formData.append("file", fileInput.files[0]);
@@ -343,19 +365,20 @@
     .then(function(res) {
       btn.disabled = false;
       btn.classList.remove("btn-disabled");
+      progress.textContent = "";
       if (!res.ok) {
-        status.textContent = res.data.error || "Upload failed.";
+        showUploadError(res.data.error || "Upload failed.");
         return;
       }
       uploadData = res.data;
       totalRows = res.data.total_rows;
-      status.textContent = "";
       setupStep2(res.data);
     })
     .catch(function() {
       btn.disabled = false;
       btn.classList.remove("btn-disabled");
-      status.textContent = "Network error.";
+      progress.textContent = "";
+      showUploadError("Network error.");
     });
   };
 


### PR DESCRIPTION
Fixes #648

## Summary

Replace the raw `encoding/csv` error that used to leak verbatim into the CSV import wizard ("parse CSV: record on line 2: wrong number of fields") with a plain-English message rendered inside a proper `role="alert"` box.

- Added `humanizeCSVError` in `internal/admin/csv_import.go` that maps `csv.ErrFieldCount`, `csv.ErrBareQuote`, and `csv.ErrQuote` to user-facing copy (names the row, gives remediation). Unknown errors still surface but with the `parse CSV: ` wrapper stripped.
- Upload handler logs the raw error at debug level before responding, so troubleshooters still have the full message in server logs.
- Templates: replaced the inline `<p class="text-sm text-error">` with a standard `bg-error/10` alert container with an `alert-circle` icon; progress text ("Uploading...") now lives in a separate neutral line so it doesn't fight with the alert styling.
- Added `TestHumanizeCSVError` exercising real `csv.ParseError` values (not string matches) so the mapping keeps working if Go reformats its error messages.

## Before / After (Row 2 has more columns than the header)

| Viewport | Before | After |
|---|---|---|
| 1440x900 | ![before](https://i.img402.dev/ptrnpwqtu7.png) | ![after](https://i.img402.dev/3qtfb6xo6a.png) |
| 820x1180 | ![before](https://i.img402.dev/cdvxd0bjhj.png) | ![after](https://i.img402.dev/qn7uz0dh6b.png) |
| 390x844 | ![before](https://i.img402.dev/jfr74gav2a.png) | ![after](https://i.img402.dev/lrjduy4r5c.png) |

## Test plan

- [x] `go test ./internal/admin/ ./internal/provider/csv/` passes.
- [x] Headless browser repro at 390/820/1440: upload a CSV whose row 2 has a different column count than the header; observe the alert box with plain-English copy instead of `parse CSV: record on line 2: wrong number of fields`.
- [x] Happy-path: uploading a well-formed CSV still advances to step 2 with no alert visible.

## Scope notes

The issue also suggested detecting duplicate header names and surfacing a non-blocking warning on step 2 (File 3 in the proposed fix). Keeping this PR focused on the acute UX bug (raw Go error leak) so it can land quickly; the duplicate-header warning can be a small follow-up once the alert container is in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)