### PR TITLE
fix(transactions): group activity timeline by day and polish mobile rows

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -699,6 +699,7 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 
 		// Build unified activity timeline from annotations.
 		activity := buildActivityTimeline(annotations, categoryDisplayLookup(categoryTree))
+		activityDays := groupActivityByDay(activity)
 
 		// Load tags currently attached + the registered-tag list (for the inline
 		// add-tag suggestion datalist). Also derive HasPendingReview from the
@@ -792,6 +793,7 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			"ConnectionID":    connectionID,
 			"Account":         account,
 			"Activity":          activity,
+			"ActivityDays":      activityDays,
 			"HasPendingReview":  hasPendingReview,
 			"CurrentTags":       currentTags,
 			"AvailableTags":     availableTags,
@@ -989,6 +991,73 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 	})
 
 	return entries
+}
+
+// ActivityDayGroup holds activity entries grouped by calendar day (in the
+// server's local timezone) for rendering day separators on the transaction
+// detail timeline.
+type ActivityDayGroup struct {
+	Date   string                  // ISO date, e.g. "2026-04-16"
+	Label  string                  // Human-friendly: "Today", "Yesterday", "Thursday, April 16"
+	Events []service.ActivityEntry // events for this day, newest first (order preserved)
+}
+
+// groupActivityByDay groups a sorted-desc activity list into per-day buckets.
+// Timestamp is an RFC3339 string on ActivityEntry; entries with unparseable
+// timestamps are skipped (they're dropped rather than mis-bucketed). Each
+// returned group preserves the relative ordering of the input slice.
+func groupActivityByDay(entries []service.ActivityEntry) []ActivityDayGroup {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
+
+	var groups []ActivityDayGroup
+	groupIdx := map[string]int{}
+
+	for _, e := range entries {
+		t, err := time.Parse(time.RFC3339, e.Timestamp)
+		if err != nil {
+			continue
+		}
+		date := t.Local().Format("2006-01-02")
+
+		idx, ok := groupIdx[date]
+		if !ok {
+			groups = append(groups, ActivityDayGroup{
+				Date:  date,
+				Label: activityDayLabel(date, today, yesterday),
+			})
+			idx = len(groups) - 1
+			groupIdx[date] = idx
+		}
+		groups[idx].Events = append(groups[idx].Events, e)
+	}
+
+	return groups
+}
+
+// activityDayLabel returns "Today", "Yesterday", or "Thursday, April 16" /
+// "Thursday, April 16, 2025" for older dates. The long-form weekday/month
+// mirrors GitHub's timeline convention and reads well at mobile widths.
+func activityDayLabel(dateStr, today, yesterday string) string {
+	if dateStr == today {
+		return "Today"
+	}
+	if dateStr == yesterday {
+		return "Yesterday"
+	}
+	t, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return dateStr
+	}
+	if t.Year() == time.Now().Year() {
+		return t.Format("Monday, January 2")
+	}
+	return t.Format("Monday, January 2, 2006")
 }
 
 // derefOr returns *p if non-nil, else def.

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -278,6 +278,67 @@ func TestBuildActivityTimeline_RuleAppliedNamedStillQuoted(t *testing.T) {
 	}
 }
 
+// groupActivityByDay buckets the sorted-desc activity slice into per-day
+// groups so the template can render day separators. Entries without a
+// parseable timestamp are dropped. Ordering within a day is preserved.
+func TestGroupActivityByDay_BucketsByLocalDate(t *testing.T) {
+	// Use times far from midnight so the UTC→local conversion lands on the
+	// same calendar date regardless of the server's timezone offset.
+	entries := []service.ActivityEntry{
+		{Type: "comment", Timestamp: "2026-04-16T15:00:00Z", Summary: "a"},
+		{Type: "comment", Timestamp: "2026-04-16T14:00:00Z", Summary: "b"},
+		{Type: "comment", Timestamp: "2026-04-14T15:00:00Z", Summary: "c"},
+	}
+
+	groups := groupActivityByDay(entries)
+
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 day groups, got %d", len(groups))
+	}
+	if len(groups[0].Events) != 2 {
+		t.Errorf("expected 2 events in first group, got %d", len(groups[0].Events))
+	}
+	if len(groups[1].Events) != 1 {
+		t.Errorf("expected 1 event in second group, got %d", len(groups[1].Events))
+	}
+	// Input order (desc) is preserved within a bucket.
+	if groups[0].Events[0].Summary != "a" || groups[0].Events[1].Summary != "b" {
+		t.Errorf("expected events in input order, got %v, %v", groups[0].Events[0].Summary, groups[0].Events[1].Summary)
+	}
+	// Labels are non-empty.
+	for i, g := range groups {
+		if g.Label == "" {
+			t.Errorf("group %d has empty Label", i)
+		}
+		if g.Date == "" {
+			t.Errorf("group %d has empty Date", i)
+		}
+	}
+}
+
+func TestGroupActivityByDay_EmptyInput(t *testing.T) {
+	if groups := groupActivityByDay(nil); groups != nil {
+		t.Errorf("expected nil for nil input, got %v", groups)
+	}
+	if groups := groupActivityByDay([]service.ActivityEntry{}); groups != nil {
+		t.Errorf("expected nil for empty input, got %v", groups)
+	}
+}
+
+func TestGroupActivityByDay_DropsUnparseableTimestamps(t *testing.T) {
+	entries := []service.ActivityEntry{
+		{Type: "comment", Timestamp: "2026-04-16T09:00:00Z", Summary: "ok"},
+		{Type: "comment", Timestamp: "not-a-date", Summary: "bad"},
+	}
+	groups := groupActivityByDay(entries)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 day group, got %d", len(groups))
+	}
+	if len(groups[0].Events) != 1 || groups[0].Events[0].Summary != "ok" {
+		t.Errorf("expected only the parseable entry to survive, got %+v", groups[0].Events)
+	}
+}
+
 func TestBuildActivityTimeline_LegacyPrefixCommentSuppressed(t *testing.T) {
 	annotations := []service.Annotation{{
 		ID:        "ann-legacy",

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -223,16 +223,40 @@
     </div>
   </div>
 
-  {{if .Activity}}
+  {{if .ActivityDays}}
   <div class="px-4 sm:px-5 border-t border-base-200 space-y-0">
-    {{range .Activity}}
-    <div class="flex items-start gap-3 py-3 border-b border-base-200/50 last:border-b-0 group">
-      <!-- Icon -->
-      {{if eq .Type "rule"}}
+    {{range .ActivityDays}}
+    <div class="pt-4 pb-1 first:pt-3">
+      <h3 class="text-[11px] font-semibold uppercase tracking-wide text-base-content/40">{{.Label}}</h3>
+    </div>
+    {{range .Events}}
+    {{if and (eq .Type "rule") .RuleID}}
+    <a href="/rules/{{.RuleID}}" class="flex items-start gap-3 py-3 border-b border-base-300/60 dark:border-base-200 last:border-b-0 group -mx-1 px-1 rounded-lg hover:bg-base-200/40 transition-colors">
       <div class="w-8 h-8 rounded-full bg-info/10 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
         <i data-lucide="zap" class="w-4 h-4 text-info" aria-hidden="true"></i>
       </div>
-      {{else if eq .Type "review"}}
+      <div class="flex-1 min-w-0">
+        {{if .Summary}}
+        <p class="text-sm">
+          <span class="font-medium line-clamp-2 sm:line-clamp-none group-hover:text-primary break-words">{{.Summary}}</span>
+        </p>
+        {{end}}
+        {{if .Detail}}
+        <p class="text-sm text-base-content/60 mt-1 whitespace-pre-wrap leading-relaxed">{{.Detail}}</p>
+        {{end}}
+        <div class="flex items-center gap-1.5 mt-1 flex-wrap">
+          {{if .ActorName}}<span class="text-xs text-base-content/40">{{.ActorName}}</span>{{end}}
+          {{if .Timestamp}}
+          <span class="text-xs text-base-content/30" aria-hidden="true">&middot;</span>
+          <time datetime="{{.Timestamp}}" class="text-xs text-base-content/30" title="{{formatDateTime .Timestamp}}">{{relativeTime .Timestamp}}</time>
+          {{end}}
+        </div>
+      </div>
+    </a>
+    {{else}}
+    <div class="flex items-start gap-3 py-3 border-b border-base-300/60 dark:border-base-200 last:border-b-0 group">
+      <!-- Icon -->
+      {{if eq .Type "review"}}
       <div class="w-8 h-8 rounded-full flex items-center justify-center shrink-0 mt-0.5
         {{if eq .ReviewStatus "approved"}}bg-success/10
         {{else if eq .ReviewStatus "rejected"}}bg-error/10
@@ -259,11 +283,7 @@
       <div class="flex-1 min-w-0">
         {{if .Summary}}
         <p class="text-sm">
-          {{if and (eq .Type "rule") .RuleID}}
-          <a href="/rules/{{.RuleID}}" class="font-medium hover:text-primary">{{.Summary}}</a>
-          {{else}}
-          <span class="font-medium">{{.Summary}}</span>
-          {{end}}
+          <span class="font-medium break-words">{{.Summary}}</span>
         </p>
         {{end}}
         {{if .Detail}}
@@ -293,6 +313,8 @@
       </button>
       {{end}}
     </div>
+    {{end}}
+    {{end}}
     {{end}}
   </div>
   {{end}}


### PR DESCRIPTION
Fixes #711

The activity timeline on `/transactions/{id}` presented same-day events as a visually merged wall of rows with no chronological structure, weak dividers, and sub-44px tap targets on mobile. This PR surfaces per-day structure and addresses the other mobile polish items called out in the issue.

## Changes

- **Server-side day grouping** — new `ActivityDayGroup` + `groupActivityByDay` helper in `internal/admin/transactions.go` buckets activity entries by local calendar day with labels `Today`, `Yesterday`, `Monday, January 2`. Mirrors the existing `groupTransactionsByDate` pattern used on the transactions list.
- **Day headers** — the template renders a subtle uppercase header above each day cluster so 10+ same-day events are visually grouped.
- **Stronger dividers** — swapped `border-base-200/50` → `border-base-300/60 dark:border-base-200` so row separators remain visible in dark mode on mobile.
- **Full-row rule links** — the entire row is the anchor for `tag="rule"` events with a `RuleID`, giving a 44px+ tap target instead of the previous ~18px summary-only link.
- **Rule name truncation** — `line-clamp-2 sm:line-clamp-none` + `break-words` on the rule-row summary prevents awkward mid-word line breaks at 375px.

## Test plan

- [x] `go test ./internal/admin/...` — new unit tests cover bucketing, empty input, and unparseable timestamps
- [x] Manual visual check at 375×667, 820×1180, 1440×900 via headless Chrome
- [ ] Verify the full-row rule link still navigates to `/rules/{id}` when tapping near the timestamp

## Screenshots

| Viewport | Before | After |
|---|---|---|
| Mobile 375×667 | ![before-375](https://i.img402.dev/4khtpo32hg.png) | ![after-375](https://i.img402.dev/0nm78owio2.png) |
| Tablet 820×1180 | ![before-820](https://i.img402.dev/hy13ab29l0.png) | ![after-820](https://i.img402.dev/545bk576wf.png) |
| Desktop 1440×900 | ![before-1440](https://i.img402.dev/t1ls2me0lh.png) | ![after-1440](https://i.img402.dev/j5ban2n7zv.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)