### PR TITLE
fix(agents): add CTAs to Activity tab empty state

### DIFF
--- a/internal/templates/pages/agents.html
+++ b/internal/templates/pages/agents.html
@@ -107,10 +107,20 @@
   {{end}}
 {{else}}
   <div class="card bg-base-100 shadow-sm">
-    <div class="card-body items-center text-center py-12">
-      <i data-lucide="scroll-text" class="w-12 h-12 text-base-content/20 mb-3"></i>
-      <h3 class="font-medium text-base-content/70">No agent sessions yet</h3>
-      <p class="text-sm text-base-content/50 max-w-md">When AI agents use the MCP tools with sessions enabled, their activity will appear here.</p>
+    <div class="card-body items-center text-center py-12 gap-4">
+      <i data-lucide="scroll-text" class="w-12 h-12 text-base-content/20 mb-1"></i>
+      <div>
+        <h3 class="font-medium text-base-content/70">No agent sessions yet</h3>
+        <p class="text-sm text-base-content/50 max-w-md mt-1">Agent activity appears here once an MCP client connects to Breadbox. Start by configuring your first agent.</p>
+      </div>
+      <div class="flex flex-wrap items-center justify-center gap-2">
+        <a href="/agents?tab=guide" class="btn btn-primary btn-sm rounded-xl">
+          <i data-lucide="rocket" class="w-4 h-4"></i> Connect your first agent
+        </a>
+        <a href="/agents?tab=wizard" class="btn btn-ghost btn-sm rounded-xl">
+          <i data-lucide="wand-sparkles" class="w-4 h-4"></i> Browse prompt library
+        </a>
+      </div>
     </div>
   </div>
 {{end}}


### PR DESCRIPTION
Fixes #649

## Summary
Turn the passive "No agent sessions yet" dead-end into an actionable empty state with primary/secondary buttons that link to the Getting Started guide and Prompt Library tabs, matching the CTA pattern used in other empty states.

## Before / After

| Viewport | Before | After |
|---|---|---|
| Desktop 1440x900 | ![before](https://i.img402.dev/e2f17uvfe8.png) | ![after](https://i.img402.dev/7o5bj7d8e0.png) |
| Mobile 375x667 | ![before](https://i.img402.dev/pwend25olq.png) | ![after](https://i.img402.dev/ry2pv3y8to.png) |

(The content-area dimming at wider widths appears in both before and after screenshots; it is a puppeteer headless rendering artefact, not a regression.)

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/admin/... ./internal/templates/...`
- [x] Manual screenshots at 375, 500, 820, 1440; buttons wrap onto two lines at 375 without horizontal overflow
- [x] Populated-list path unchanged (still only renders inside `{{else}}` branch of `{{if .Sessions}}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)