### PR TITLE
fix(transactions): activity timeline empty state (#708)

### DIFF
--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -207,9 +207,7 @@
   <div class="px-4 sm:px-5 pt-5 pb-3 flex items-center gap-2">
     <i data-lucide="activity" class="w-4 h-4 text-base-content/40" aria-hidden="true"></i>
     <h2 id="activity-heading" class="text-sm font-semibold text-base-content/50">Activity</h2>
-    {{if .Activity}}
-    <span class="text-xs text-base-content/30">{{len .Activity}} events</span>
-    {{end}}
+    <span class="text-xs text-base-content/30">{{if .Activity}}{{len .Activity}}{{else}}0{{end}} events</span>
   </div>
 
   <!-- Add Note -->
@@ -316,6 +314,12 @@
     {{end}}
     {{end}}
     {{end}}
+  </div>
+  {{else}}
+  <div class="px-4 sm:px-5 border-t border-base-200 py-8 text-center">
+    <i data-lucide="clock" class="w-6 h-6 text-base-content/20 mx-auto" aria-hidden="true"></i>
+    <p class="text-sm text-base-content/40 mt-2">No activity yet.</p>
+    <p class="text-xs text-base-content/30 mt-1">Comments, tag changes, and rule hits will appear here.</p>
   </div>
   {{end}}
 </section>


### PR DESCRIPTION
> Stacked on top of #721. Base this PR on that branch so the diff is just the empty-state change.

Fixes #708

## Summary
- Activity card header always shows `N events` (including `0 events`) so the meter isn't hidden on empty transactions.
- When there are no annotations, render a muted empty state with a clock icon and short copy ("No activity yet. Comments, tag changes, and rule hits will appear here.") in place of the silent gap below the note input.

## Why
Before this change the card just ended after the `Add a note…` input when a transaction had nothing tagged, commented, or rule-applied. New transactions (e.g. `PybjGDM0`) looked like the card was broken.

## Test plan
- [x] `go build ./...`
- [ ] Visual check: open a brand-new transaction and confirm the empty state renders with consistent card padding.
- [ ] Visual check: open a rich-activity transaction (e.g. `e950fza1`) and confirm the header still shows the real event count and all rows render.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>