### PR TITLE
fix(transactions): rule rows stop imitating users (#706)

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -899,11 +899,16 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 			entries = append(entries, service.ActivityEntry{
 				Type:      "rule",
 				Timestamp: a.CreatedAt,
-				ActorName: how,
+				// Rules aren't actors — keep the actor slot empty so the
+				// template's actor-meta span is skipped. Origin carries the
+				// "during sync" / "retroactively" qualifier as a subordinate
+				// meta pill next to the timestamp.
+				ActorName: "",
 				ActorType: "system",
 				Summary:   summary,
 				RuleName:  ruleName,
 				RuleID:    derefOr(a.RuleID, ""),
+				Origin:    how,
 			})
 
 		case "tag_added":

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -234,6 +234,14 @@ func TestBuildActivityTimeline_RuleAppliedEmptyNameFallsBack(t *testing.T) {
 	if entries[0].RuleID != "" {
 		t.Errorf("expected empty RuleID so template skips /rules/<id> link, got %q", entries[0].RuleID)
 	}
+	// Rule rows must not overload ActorName with a verb phrase.
+	if entries[0].ActorName != "" {
+		t.Errorf("rule row ActorName should be empty, got %q", entries[0].ActorName)
+	}
+	// Origin carries the retroactively/during-sync qualifier instead.
+	if entries[0].Origin != "retroactively" {
+		t.Errorf("Origin = %q, want %q", entries[0].Origin, "retroactively")
+	}
 }
 
 // Named rule rows must keep their quoted-name subject and the link-eligible
@@ -275,6 +283,12 @@ func TestBuildActivityTimeline_RuleAppliedNamedStillQuoted(t *testing.T) {
 	}
 	if entries[0].RuleID != ruleID {
 		t.Errorf("expected RuleID=%q, got %q", ruleID, entries[0].RuleID)
+	}
+	if entries[0].ActorName != "" {
+		t.Errorf("rule row ActorName should be empty, got %q", entries[0].ActorName)
+	}
+	if entries[0].Origin != "during sync" {
+		t.Errorf("Origin = %q, want %q", entries[0].Origin, "during sync")
 	}
 }
 

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -406,6 +406,12 @@ type ActivityEntry struct {
 	RuleID       string `json:"rule_id,omitempty"`
 	CommentID    string `json:"comment_id,omitempty"`
 	TagSlug      string `json:"tag_slug,omitempty"` // for tag_added / tag_removed entries
+
+	// Origin describes how a rule-sourced entry was applied ("during sync",
+	// "retroactively"). Rule-applied rows previously overloaded ActorName
+	// with this phrase; Origin keeps the actor slot empty for system rows
+	// and lets the template render origin as a subordinate meta pill.
+	Origin string `json:"origin,omitempty"`
 }
 
 type Condition struct {

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -244,6 +244,9 @@
         {{end}}
         <div class="flex items-center gap-1.5 mt-1 flex-wrap">
           {{if .ActorName}}<span class="text-xs text-base-content/40">{{.ActorName}}</span>{{end}}
+          {{if .Origin}}
+          <span class="text-xs text-base-content/40 italic">Applied {{.Origin}}</span>
+          {{end}}
           {{if .Timestamp}}
           <span class="text-xs text-base-content/30" aria-hidden="true">&middot;</span>
           <time datetime="{{.Timestamp}}" class="text-xs text-base-content/30" title="{{formatDateTime .Timestamp}}">{{relativeTime .Timestamp}}</time>
@@ -271,6 +274,10 @@
       </div>
       {{else if and (eq .ActorType "user") .ActorID}}
       <img src="{{avatarURL (deref .ActorID)}}" alt="{{.ActorName}} avatar" class="w-8 h-8 rounded-full object-cover shrink-0 mt-0.5" title="{{.ActorName}}">
+      {{else if eq .Type "rule"}}
+      <div class="w-8 h-8 rounded-full bg-info/10 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
+        <i data-lucide="zap" class="w-4 h-4 text-info" aria-hidden="true"></i>
+      </div>
       {{else}}
       <div class="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
         <span class="text-xs font-semibold text-primary leading-none">{{firstChar .ActorName}}</span>
@@ -293,6 +300,9 @@
         {{end}}
         <div class="flex items-center gap-1.5 mt-1 flex-wrap">
           {{if .ActorName}}<span class="text-xs text-base-content/40">{{.ActorName}}</span>{{end}}
+          {{if .Origin}}
+          <span class="text-xs text-base-content/40 italic">Applied {{.Origin}}</span>
+          {{end}}
           {{if and (eq .Type "review") (eq .ReviewStatus "pending") .Detail}}
           <span class="text-xs text-base-content/30">&middot;</span>
           <span class="text-xs text-info font-medium">{{.Detail}}</span>


### PR DESCRIPTION
> Stacked on top of #730 (which is stacked on #721). Set this PR's base branch to \`fix/issue-708-activity-empty-state\`.

Fixes #706

## Summary
- Split rule-attribution: \`ActivityEntry.ActorName\` is now empty for rule rows; a new \`Origin\` field (\"during sync\" | \"retroactively\") carries the applied-when qualifier.
- Template renders \`Origin\` as a muted italic \"Applied during sync\" pill in the meta row, next to the timestamp, rather than in the actor slot.
- Rule rows without a \`RuleID\` (older retroactive applications) now render with the zap icon instead of a blank first-char avatar.

## Why
Readers were scanning timeline rows like \`during sync \u00b7 8 days ago\` under a rule summary and mistaking \`during sync\` for a person's name — the text lived in the exact slot user rows use for their email.

## Test plan
- [x] \`go build ./...\`
- [x] Unit: \`TestBuildActivityTimeline_RuleApplied*\` now asserts \`ActorName == \"\"\` and \`Origin\` matches the expected phrase.
- [ ] Visual: rule rows on \`/transactions/e950fza1\` show the italic \"Applied during sync\" pill next to the timestamp, not in the user-name slot.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>