### PR TITLE
fix(transactions): dedup tag-note + twin comment rows (#713)

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -826,6 +826,55 @@ func categoryDisplayLookup(tree []service.CategoryResponse) func(string) string 
 	}
 }
 
+// isDuplicateOfAdjacentTagNote reports whether a comment annotation exactly
+// duplicates a tag_added.note from the same actor within ±2 seconds — the
+// signature of a single update_transactions call that wrote both a tag with
+// a note and a standalone comment. Timestamps outside RFC3339-parseable
+// range are treated as non-matching (fail open, never over-dedup).
+func isDuplicateOfAdjacentTagNote(all []service.Annotation, c service.Annotation, content string) bool {
+	if content == "" {
+		return false
+	}
+	cT, err := time.Parse(time.RFC3339Nano, c.CreatedAt)
+	if err != nil {
+		return false
+	}
+	const window = 2 * time.Second
+	for _, a := range all {
+		if a.Kind != "tag_added" {
+			continue
+		}
+		note, _ := a.Payload["note"].(string)
+		if note != content {
+			continue
+		}
+		// Match only if both rows share the same actor id (when available);
+		// fall back to actor name for system/agent rows without an id.
+		sameActor := false
+		switch {
+		case a.ActorID != nil && c.ActorID != nil && *a.ActorID != "" && *a.ActorID == *c.ActorID:
+			sameActor = true
+		case (a.ActorID == nil || *a.ActorID == "") && (c.ActorID == nil || *c.ActorID == "") && a.ActorName == c.ActorName:
+			sameActor = true
+		}
+		if !sameActor {
+			continue
+		}
+		aT, err := time.Parse(time.RFC3339Nano, a.CreatedAt)
+		if err != nil {
+			continue
+		}
+		diff := cT.Sub(aT)
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff <= window {
+			return true
+		}
+	}
+	return false
+}
+
 // buildActivityTimeline produces a sorted activity list from annotations.
 // Review lifecycle events surface as tag_added/tag_removed on the
 // needs-review tag. Comment annotations originally authored as review notes
@@ -847,6 +896,15 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 			content, _ := a.Payload["content"].(string)
 			// Filter legacy [Review: ...] prefix duplicates from pre-consolidation imports.
 			if strings.HasPrefix(content, "[Review: ") {
+				continue
+			}
+			// Dedup: suppress a comment that exactly duplicates a same-actor
+			// tag_added.note written within ±2s. update_transactions (MCP
+			// and REST) can write a tag-with-note AND a standalone comment
+			// in one call; the resulting rows land within a few ms of each
+			// other and render as twin adjacent events. The tag row already
+			// inlines the note via .Detail — the comment is redundant.
+			if isDuplicateOfAdjacentTagNote(annotations, a, content) {
 				continue
 			}
 			entry := service.ActivityEntry{

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -353,6 +353,113 @@ func TestGroupActivityByDay_DropsUnparseableTimestamps(t *testing.T) {
 	}
 }
 
+// update_transactions can write a tag_added with a note AND a standalone
+// comment in the same call. The timeline should collapse the duplicate
+// comment (the note already renders inline on the tag row) so users don't
+// see twin near-identical rows.
+func TestBuildActivityTimeline_TagNoteAndDuplicateCommentDeduped(t *testing.T) {
+	actor := "user-1"
+	note := "Please review this one again"
+	annotations := []service.Annotation{
+		{
+			ID:        "ann-tag",
+			Kind:      "tag_added",
+			ActorID:   &actor,
+			ActorName: "admin@example.com",
+			ActorType: "user",
+			Payload: map[string]interface{}{
+				"slug": "needs-review",
+				"note": note,
+			},
+			CreatedAt: "2026-04-16T03:39:34.502794Z",
+		},
+		{
+			ID:        "ann-comment",
+			Kind:      "comment",
+			ActorID:   &actor,
+			ActorName: "admin@example.com",
+			ActorType: "user",
+			Payload: map[string]interface{}{
+				"content": note,
+			},
+			CreatedAt: "2026-04-16T03:39:34.513524Z",
+		},
+	}
+
+	entries := buildActivityTimeline(annotations, nil)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (duplicate comment suppressed), got %d", len(entries))
+	}
+	if entries[0].Type != "tag" {
+		t.Errorf("expected the tag entry to survive, got type=%q", entries[0].Type)
+	}
+	if entries[0].Detail != note {
+		t.Errorf("expected note to render inline as Detail, got %q", entries[0].Detail)
+	}
+}
+
+// A standalone comment with no matching tag note must still be emitted.
+func TestBuildActivityTimeline_StandaloneCommentNotDeduped(t *testing.T) {
+	actor := "user-1"
+	annotations := []service.Annotation{{
+		ID:        "ann-standalone",
+		Kind:      "comment",
+		ActorID:   &actor,
+		ActorName: "admin@example.com",
+		ActorType: "user",
+		Payload: map[string]interface{}{
+			"content": "Just a standalone note",
+		},
+		CreatedAt: "2026-04-16T03:39:34Z",
+	}}
+
+	entries := buildActivityTimeline(annotations, nil)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Type != "comment" {
+		t.Errorf("expected comment type, got %q", entries[0].Type)
+	}
+}
+
+// A comment far outside the ±2s window of a matching tag_added note must NOT
+// be deduped — users can legitimately comment the same text later.
+func TestBuildActivityTimeline_DistantCommentNotDeduped(t *testing.T) {
+	actor := "user-1"
+	note := "duplicate text"
+	annotations := []service.Annotation{
+		{
+			ID:        "ann-tag",
+			Kind:      "tag_added",
+			ActorID:   &actor,
+			ActorName: "admin@example.com",
+			ActorType: "user",
+			Payload: map[string]interface{}{
+				"slug": "needs-review",
+				"note": note,
+			},
+			CreatedAt: "2026-04-16T03:39:34Z",
+		},
+		{
+			ID:        "ann-comment-later",
+			Kind:      "comment",
+			ActorID:   &actor,
+			ActorName: "admin@example.com",
+			ActorType: "user",
+			Payload: map[string]interface{}{
+				"content": note,
+			},
+			CreatedAt: "2026-04-16T03:40:34Z", // 60s later
+		},
+	}
+
+	entries := buildActivityTimeline(annotations, nil)
+	if len(entries) != 2 {
+		t.Fatalf("expected both entries to survive (distant timestamps), got %d", len(entries))
+	}
+}
+
 func TestBuildActivityTimeline_LegacyPrefixCommentSuppressed(t *testing.T) {
 	annotations := []service.Annotation{{
 		ID:        "ann-legacy",


### PR DESCRIPTION
> Stacked on top of #731 (which stacks on #730 and #721). Base this PR on \`fix/issue-706-activity-actor-slot\`.

Fixes #713

## Summary
- \`buildActivityTimeline\` suppresses a \`comment\` entry whose content exactly matches a \`tag_added.payload.note\` written within ±2s by the same actor.
- The tag row already inlines the note via \`.Detail\`, so the standalone comment is redundant. Event count drops from N to N-1 for affected transactions (e.g. \`e950fza1\` goes from 13 to 12 events).
- Three new unit tests: same-call dedup, standalone-comment preserved, distant-comment preserved.

## Why
\`update_transactions\` (MCP and REST) lets a single call write a \`tags_to_add[{slug, note}]\` AND a \`comment\` with the same text. The resulting pair of annotations lands within a few ms and renders as two adjacent, near-identical rows — confusing and noisy. Agents calling \`add_transaction_tag\` + \`add_transaction_comment\` produce the same pattern.

## Approach
Option B from the issue body (client-side / buildActivityTimeline-level dedup). This also handles legacy data already in the DB without a backfill migration.

## Test plan
- [x] \`go build ./...\` clean.
- [x] Unit tests pass (\`TestBuildActivityTimeline_TagNoteAndDuplicateCommentDeduped\`, \`_StandaloneCommentNotDeduped\`, \`_DistantCommentNotDeduped\`).
- [ ] Visual: \`/transactions/e950fza1\` header reads \"12 events\" and the twin \"Please review this one again\" comment row is gone; the note still renders inline on the \`Added tag needs-review\` row.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>