### PR TITLE
fix(transactions): per-type icons + tag chips on timeline (#709)

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -698,7 +698,15 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 		}
 
 		// Build unified activity timeline from annotations.
-		activity := buildActivityTimeline(annotations, categoryDisplayLookup(categoryTree))
+		// Load registered-tag list early so tag chip rendering in the
+		// timeline has display names + colors without a per-row query.
+		timelineTags, err := svc.ListTags(ctx)
+		if err != nil {
+			a.Logger.Error("list tags for activity timeline", "error", err)
+			timelineTags = nil
+		}
+
+		activity := buildActivityTimeline(annotations, categoryDisplayLookup(categoryTree), tagDisplayLookup(timelineTags))
 		activityDays := groupActivityByDay(activity)
 
 		// Load tags currently attached + the registered-tag list (for the inline
@@ -875,6 +883,35 @@ func isDuplicateOfAdjacentTagNote(all []service.Annotation, c service.Annotation
 	return false
 }
 
+// tagDisplay carries presentation metadata for rendering a tag chip on a
+// timeline row. See tagDisplayLookup and the tag_added / tag_removed cases
+// in buildActivityTimeline.
+type tagDisplay struct {
+	DisplayName string
+	Color       *string
+}
+
+// tagDisplayLookup returns a slug -> presentation lookup built from the
+// registered-tag list. Slugs without a registered tag fall back to the
+// slug itself with a nil color so the template renders a plain chip.
+func tagDisplayLookup(tags []service.TagResponse) func(string) tagDisplay {
+	by := make(map[string]tagDisplay, len(tags))
+	for _, t := range tags {
+		by[t.Slug] = tagDisplay{DisplayName: t.DisplayName, Color: t.Color}
+	}
+	return func(slug string) tagDisplay {
+		if slug == "" {
+			return tagDisplay{}
+		}
+		if d, ok := by[slug]; ok {
+			return d
+		}
+		// Fall back to the slug as the display name — preserves legibility
+		// for tags that have since been deleted.
+		return tagDisplay{DisplayName: slug}
+	}
+}
+
 // buildActivityTimeline produces a sorted activity list from annotations.
 // Review lifecycle events surface as tag_added/tag_removed on the
 // needs-review tag. Comment annotations originally authored as review notes
@@ -883,9 +920,16 @@ func isDuplicateOfAdjacentTagNote(all []service.Annotation, c service.Annotation
 // categoryDisplay maps a category slug to a human-readable name
 // ("Food & Drink › Groceries"). Pass a no-op (returning slug unchanged) in
 // tests that don't need humanization.
-func buildActivityTimeline(annotations []service.Annotation, categoryDisplay func(string) string) []service.ActivityEntry {
+//
+// tagDisplayFn maps a tag slug to its display name + color for rendering a
+// tag chip on tag_added / tag_removed rows. Pass nil in tests that don't
+// exercise tag presentation.
+func buildActivityTimeline(annotations []service.Annotation, categoryDisplay func(string) string, tagDisplayFn func(string) tagDisplay) []service.ActivityEntry {
 	if categoryDisplay == nil {
 		categoryDisplay = func(s string) string { return s }
+	}
+	if tagDisplayFn == nil {
+		tagDisplayFn = func(slug string) tagDisplay { return tagDisplay{DisplayName: slug} }
 	}
 	var entries []service.ActivityEntry
 
@@ -979,15 +1023,18 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 			}
 			slug, _ := a.Payload["slug"].(string)
 			note, _ := a.Payload["note"].(string)
-			summary := "Added tag " + slug
+			td := tagDisplayFn(slug)
 			entry := service.ActivityEntry{
-				Type:      "tag",
-				Timestamp: a.CreatedAt,
-				ActorName: a.ActorName,
-				ActorType: a.ActorType,
-				Summary:   summary,
-				Detail:    note,
-				TagSlug:   slug,
+				Type:           "tag",
+				Timestamp:      a.CreatedAt,
+				ActorName:      a.ActorName,
+				ActorType:      a.ActorType,
+				Summary:        "Added tag",
+				Detail:         note,
+				TagSlug:        slug,
+				TagDisplayName: td.DisplayName,
+				TagColor:       td.Color,
+				TagAction:      "added",
 			}
 			if a.ActorID != nil && *a.ActorID != "" {
 				id := *a.ActorID
@@ -1005,15 +1052,18 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 			}
 			slug, _ := a.Payload["slug"].(string)
 			note, _ := a.Payload["note"].(string)
-			summary := "Removed tag " + slug
+			td := tagDisplayFn(slug)
 			entry := service.ActivityEntry{
-				Type:      "tag",
-				Timestamp: a.CreatedAt,
-				ActorName: a.ActorName,
-				ActorType: a.ActorType,
-				Summary:   summary,
-				Detail:    note,
-				TagSlug:   slug,
+				Type:           "tag",
+				Timestamp:      a.CreatedAt,
+				ActorName:      a.ActorName,
+				ActorType:      a.ActorType,
+				Summary:        "Removed tag",
+				Detail:         note,
+				TagSlug:        slug,
+				TagDisplayName: td.DisplayName,
+				TagColor:       td.Color,
+				TagAction:      "removed",
 			}
 			if a.ActorID != nil && *a.ActorID != "" {
 				id := *a.ActorID

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -107,7 +107,7 @@ func TestBuildActivityTimeline_FreeStandingCommentStillEmitted(t *testing.T) {
 		CreatedAt: "2026-04-04T12:00:00Z",
 	}}
 
-	entries := buildActivityTimeline(annotations, nil)
+	entries := buildActivityTimeline(annotations, nil, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
@@ -157,7 +157,7 @@ func TestBuildActivityTimeline_RuleSourcedTagAddedDeduped(t *testing.T) {
 		},
 	}
 
-	entries := buildActivityTimeline(annotations, nil)
+	entries := buildActivityTimeline(annotations, nil, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry (rule_applied only), got %d", len(entries))
@@ -183,7 +183,7 @@ func TestBuildActivityTimeline_UserTagAddedStillEmitted(t *testing.T) {
 		CreatedAt: "2026-04-05T09:00:00Z",
 	}}
 
-	entries := buildActivityTimeline(annotations, nil)
+	entries := buildActivityTimeline(annotations, nil, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 tag entry, got %d", len(entries))
@@ -222,7 +222,7 @@ func TestBuildActivityTimeline_RuleAppliedEmptyNameFallsBack(t *testing.T) {
 		return slug
 	}
 
-	entries := buildActivityTimeline(annotations, categoryDisplay)
+	entries := buildActivityTimeline(annotations, categoryDisplay, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
@@ -272,7 +272,7 @@ func TestBuildActivityTimeline_RuleAppliedNamedStillQuoted(t *testing.T) {
 		return slug
 	}
 
-	entries := buildActivityTimeline(annotations, categoryDisplay)
+	entries := buildActivityTimeline(annotations, categoryDisplay, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
@@ -386,7 +386,7 @@ func TestBuildActivityTimeline_TagNoteAndDuplicateCommentDeduped(t *testing.T) {
 		},
 	}
 
-	entries := buildActivityTimeline(annotations, nil)
+	entries := buildActivityTimeline(annotations, nil, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry (duplicate comment suppressed), got %d", len(entries))
@@ -414,7 +414,7 @@ func TestBuildActivityTimeline_StandaloneCommentNotDeduped(t *testing.T) {
 		CreatedAt: "2026-04-16T03:39:34Z",
 	}}
 
-	entries := buildActivityTimeline(annotations, nil)
+	entries := buildActivityTimeline(annotations, nil, nil)
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
 	}
@@ -454,9 +454,93 @@ func TestBuildActivityTimeline_DistantCommentNotDeduped(t *testing.T) {
 		},
 	}
 
-	entries := buildActivityTimeline(annotations, nil)
+	entries := buildActivityTimeline(annotations, nil, nil)
 	if len(entries) != 2 {
 		t.Fatalf("expected both entries to survive (distant timestamps), got %d", len(entries))
+	}
+}
+
+// Tag timeline rows now carry display name + color for chip rendering and a
+// TagAction discriminator for the plus/minus icon overlay.
+func TestBuildActivityTimeline_TagRowHasChipMetadata(t *testing.T) {
+	color := "#ff9800"
+	lookup := func(slug string) tagDisplay {
+		if slug == "needs-review" {
+			return tagDisplay{DisplayName: "Needs Review", Color: &color}
+		}
+		return tagDisplay{DisplayName: slug}
+	}
+	annotations := []service.Annotation{
+		{
+			ID:        "ann-add",
+			Kind:      "tag_added",
+			ActorName: "admin@example.com",
+			ActorType: "user",
+			Payload: map[string]interface{}{
+				"slug": "needs-review",
+			},
+			CreatedAt: "2026-04-16T03:39:34Z",
+		},
+		{
+			ID:        "ann-rem",
+			Kind:      "tag_removed",
+			ActorName: "admin@example.com",
+			ActorType: "user",
+			Payload: map[string]interface{}{
+				"slug": "needs-review",
+			},
+			CreatedAt: "2026-04-16T04:00:00Z",
+		},
+		{
+			ID:        "ann-unknown",
+			Kind:      "tag_added",
+			ActorName: "admin@example.com",
+			ActorType: "user",
+			Payload: map[string]interface{}{
+				"slug": "deleted-tag-slug",
+			},
+			CreatedAt: "2026-04-16T05:00:00Z",
+		},
+	}
+
+	entries := buildActivityTimeline(annotations, nil, lookup)
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 tag entries, got %d", len(entries))
+	}
+	byKey := map[string]service.ActivityEntry{}
+	for _, e := range entries {
+		if e.Type != "tag" {
+			t.Fatalf("expected type=tag, got %q", e.Type)
+		}
+		byKey[e.TagAction+"/"+e.TagSlug] = e
+	}
+
+	added := byKey["added/needs-review"]
+	if added.TagDisplayName != "Needs Review" {
+		t.Errorf("added.TagDisplayName = %q, want %q", added.TagDisplayName, "Needs Review")
+	}
+	if added.TagColor == nil || *added.TagColor != color {
+		t.Errorf("added.TagColor not propagated, got %v", added.TagColor)
+	}
+	if added.Summary != "Added tag" {
+		t.Errorf("added.Summary = %q, want just \"Added tag\" (chip renders the name)", added.Summary)
+	}
+
+	removed := byKey["removed/needs-review"]
+	if removed.TagAction != "removed" {
+		t.Errorf("removed.TagAction = %q", removed.TagAction)
+	}
+	if removed.TagColor == nil || *removed.TagColor != color {
+		t.Errorf("removed.TagColor not propagated, got %v", removed.TagColor)
+	}
+
+	// Unknown/deleted tag falls back to slug as display name, no color.
+	unknown := byKey["added/deleted-tag-slug"]
+	if unknown.TagDisplayName != "deleted-tag-slug" {
+		t.Errorf("unknown tag fallback DisplayName = %q, want slug", unknown.TagDisplayName)
+	}
+	if unknown.TagColor != nil {
+		t.Errorf("unknown tag should have nil color, got %v", unknown.TagColor)
 	}
 }
 
@@ -473,7 +557,7 @@ func TestBuildActivityTimeline_LegacyPrefixCommentSuppressed(t *testing.T) {
 		CreatedAt: "2026-03-01T00:00:00Z",
 	}}
 
-	entries := buildActivityTimeline(annotations, nil)
+	entries := buildActivityTimeline(annotations, nil, nil)
 
 	if len(entries) != 0 {
 		t.Fatalf("expected legacy [Review: ...] comment to be suppressed, got %d entries", len(entries))

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -407,6 +407,15 @@ type ActivityEntry struct {
 	CommentID    string `json:"comment_id,omitempty"`
 	TagSlug      string `json:"tag_slug,omitempty"` // for tag_added / tag_removed entries
 
+	// TagDisplayName and TagColor drive the rendered tag-chip on
+	// tag_added / tag_removed timeline rows. Empty/nil when the tag no
+	// longer exists in the registry (deleted tags still show their slug).
+	TagDisplayName string  `json:"tag_display_name,omitempty"`
+	TagColor       *string `json:"tag_color,omitempty"`
+	// TagAction distinguishes "added" vs "removed" so the template can
+	// render a plus / minus overlay on tag rows.
+	TagAction string `json:"tag_action,omitempty"` // "added" | "removed"
+
 	// Origin describes how a rule-sourced entry was applied ("during sync",
 	// "retroactively"). Rule-applied rows previously overloaded ActorName
 	// with this phrase; Origin keeps the actor slot empty for system rows

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -268,6 +268,20 @@
         {{else if eq .ReviewStatus "skipped"}}<i data-lucide="skip-forward" class="w-4 h-4 text-warning" aria-hidden="true"></i>
         {{else}}<i data-lucide="scan-search" class="w-4 h-4 text-base-content/40" aria-hidden="true"></i>{{end}}
       </div>
+      {{else if eq .Type "tag"}}
+      <div class="relative w-8 h-8 shrink-0 mt-0.5" aria-hidden="true">
+        <div class="w-8 h-8 rounded-full {{if eq .TagAction "removed"}}bg-base-200{{else}}bg-primary/10{{end}} flex items-center justify-center">
+          <i data-lucide="tag" class="w-4 h-4 {{if eq .TagAction "removed"}}text-base-content/50{{else}}text-primary{{end}}"></i>
+        </div>
+        <div class="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 rounded-full border border-base-100 flex items-center justify-center {{if eq .TagAction "removed"}}bg-error/80{{else}}bg-success/80{{end}}">
+          {{if eq .TagAction "removed"}}<i data-lucide="minus" class="w-2 h-2 text-base-100"></i>
+          {{else}}<i data-lucide="plus" class="w-2 h-2 text-base-100"></i>{{end}}
+        </div>
+      </div>
+      {{else if eq .Type "category"}}
+      <div class="w-8 h-8 rounded-full bg-warning/10 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
+        <i data-lucide="folder" class="w-4 h-4 text-warning" aria-hidden="true"></i>
+      </div>
       {{else if eq .ActorType "agent"}}
       <div class="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
         <i data-lucide="bot" class="w-4 h-4 text-primary" aria-hidden="true"></i>
@@ -289,6 +303,11 @@
         {{if .Summary}}
         <p class="text-sm">
           <span class="font-medium break-words">{{.Summary}}</span>
+          {{if and (eq .Type "tag") .TagSlug}}
+          <span class="bb-tag bb-tag-sm ml-1 align-middle{{if eq .TagAction "removed"}} line-through opacity-70{{end}}"{{if .TagColor}} style="--tag-color: {{deref .TagColor}}"{{end}} title="{{.TagSlug}}">
+            <span class="truncate">{{if .TagDisplayName}}{{.TagDisplayName}}{{else}}{{.TagSlug}}{{end}}</span>
+          </span>
+          {{end}}
         </p>
         {{end}}
         {{if .Detail}}


### PR DESCRIPTION
> Stacked on top of #732 (which stacks on #731, #730, #721). Base this PR on \`fix/issue-713-dedup-tag-note-comment\`.

Fixes #709

## Summary
- \`ActivityEntry\` gains \`TagDisplayName\`, \`TagColor\` (*string), and \`TagAction\` (\"added\"|\"removed\"). Populated via a new \`tagDisplayLookup(svc.ListTags())\` passed into \`buildActivityTimeline\`. Missing tags fall back to the slug.
- Tag rows now render:
  - a primary **tag icon** with a **green plus / red minus** overlay instead of the acting user's avatar,
  - the **\`bb-tag bb-tag-sm\` chip** (color + display name) inline in the summary instead of the raw slug,
  - line-through on the chip when \`.TagAction == \"removed\"\` so add vs remove is distinguishable at a glance.
- Category rows get a **folder** icon on a warning-tinted background. Category display-name humanization (\`Food & Drink › Groceries\`) already landed via #704/#715, so this PR just adds the icon.
- User avatar is still reachable in the meta row via \`.ActorName\` text — fine for now; the issue's \"avatar in meta row\" polish can be a follow-up.

## Drift / already-landed notes
- #704 shipped as PR #715, so the raw-slug category case is already resolved. This PR only addresses the tag chip and per-type icon portion of #709.

## Test plan
- [x] \`go build ./...\`
- [x] New unit test \`TestBuildActivityTimeline_TagRowHasChipMetadata\` covers added/removed propagation + unknown-slug fallback.
- [x] Existing admin test suite still green.
- [ ] Visual: \`/transactions/e950fza1\` shows differentiated rows (tag chip + plus/minus, folder icon for category) at 375/820/1440.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>