### PR TITLE
fix(transactions): same-day timeline rows show clock time (#707)

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -892,6 +892,42 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return ""
 				}
 			},
+			// clockTime renders the local clock portion of a timestamp
+			// ("2:03 AM"). Paired with a same-day day separator on the
+			// activity timeline it disambiguates 10 events that would all
+			// otherwise read "8 days ago" (#707).
+			"clockTime": func(t interface{}) string {
+				format := func(tm time.Time) string {
+					return tm.Local().Format("3:04 PM")
+				}
+				switch v := t.(type) {
+				case time.Time:
+					return format(v)
+				case *time.Time:
+					if v == nil {
+						return ""
+					}
+					return format(*v)
+				case string:
+					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
+						return format(parsed)
+					}
+					if parsed, err := time.Parse(time.RFC3339Nano, v); err == nil {
+						return format(parsed)
+					}
+					return v
+				case *string:
+					if v == nil {
+						return ""
+					}
+					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
+						return format(parsed)
+					}
+					return *v
+				default:
+					return ""
+				}
+			},
 			"formatDateShort": func(t interface{}) string {
 				format := func(tm time.Time) string {
 					return tm.Local().Format("Jan 2, 3:04 PM")

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -249,7 +249,7 @@
           {{end}}
           {{if .Timestamp}}
           <span class="text-xs text-base-content/30" aria-hidden="true">&middot;</span>
-          <time datetime="{{.Timestamp}}" class="text-xs text-base-content/30" title="{{formatDateTime .Timestamp}}">{{relativeTime .Timestamp}}</time>
+          <time datetime="{{.Timestamp}}" class="text-xs text-base-content/30" title="{{formatDateTime .Timestamp}}">{{clockTime .Timestamp}}</time>
           {{end}}
         </div>
       </div>
@@ -328,7 +328,7 @@
           {{end}}
           {{if .Timestamp}}
           <span class="text-xs text-base-content/30" aria-hidden="true">&middot;</span>
-          <time datetime="{{.Timestamp}}" class="text-xs text-base-content/30" title="{{formatDateTime .Timestamp}}">{{relativeTime .Timestamp}}</time>
+          <time datetime="{{.Timestamp}}" class="text-xs text-base-content/30" title="{{formatDateTime .Timestamp}}">{{clockTime .Timestamp}}</time>
           {{end}}
         </div>
       </div>


### PR DESCRIPTION
> Stacked on top of #733 (which stacks on #732, #731, #730, #721). Base this PR on \`fix/issue-709-activity-icons-chips\`.

Fixes #707

## Summary
- New template helper \`clockTime\` formats a timestamp as a local clock string (\"2:03 AM\").
- Timeline rows inside \`ActivityDays\` now render the clock time instead of \"8 days ago\" — the day is already given by the group's separator header (landed via #721), so a relative label within a day was redundant and lossy.
- \`<time datetime=\"...\" title=\"{{formatDateTime ...}}\">\` wrapper is unchanged from #718, so the a11y / hover-absolute-time story stays intact.

## Drift
- The hover-reveals-absolute-time and \`datetime\` attribute portions of the issue were already satisfied when #718 (a11y landmarks) landed, so this PR only addresses the \"10 rows all reading 8 days ago\" chronology problem.

## Test plan
- [x] \`go build ./...\`
- [x] Full \`go test ./internal/admin/\` passes.
- [ ] Visual: on \`/transactions/e950fza1\`, events within the Apr 16 group show distinct \"2:03 AM\", \"3:39 AM\" clock times; the group's header separator still reads \"Thursday, April 16\".

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>