### PR TITLE
feat(kbd): blended pill rendering for modifier combos

### DIFF
--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -118,7 +118,7 @@ document.addEventListener('alpine:init', function () {
 
 Never add a fresh `addEventListener('keydown', ...)` for a UI shortcut — the global dispatcher in `base.html` already handles input-field short-circuiting, overlay suppression, touch-device gating, and chord state. Raw listeners bypass all of it.
 
-Visible `kbd` hints must use the `Kbd` / `KbdChord` components in `internal/templates/components/kbd.templ` (or guard with `x-show="!$store.device.isTouch"`) so they disappear on touch devices. Don't hand-roll new `<kbd>` spans in new code.
+Visible `kbd` hints must use the `Kbd` (single key), `KbdChord` (sequential "g then d"), or `KbdCombo` (blended modifier pill like `⌘K`) components in `internal/templates/components/kbd.templ` (or guard with `x-show="!$store.device.isTouch"`) so they disappear on touch devices. Don't hand-roll new `<kbd>` spans in new code. Symbol mapping (`cmd` → ⌘, `shift` → ⇧, `enter` → ↵, `up`/`down`/`left`/`right` → arrows, etc.) is handled by the shared `kbdGlyph` Go helper and its JS twin `bbKbdGlyph` — keep those in lock-step when adding new glyphs.
 
 Full reference, including the canonical global + per-page shortcut tables and architecture notes, lives in `docs/keyboard-shortcuts.md`.
 

--- a/input.css
+++ b/input.css
@@ -2173,6 +2173,39 @@
     }
   }
 
+  /* Blended modifier pill: ⌘│K rendered as one tight badge with a hairline
+     divider between cells and only the outer corners rounded. Inherits the
+     background / border palette from .bb-kbd so light/dark mode stays in
+     sync — only the shape is different (no per-cell rounding). */
+  .bb-kbd-combo {
+    @apply inline-flex items-center h-[1.25rem] rounded overflow-hidden
+           font-mono font-medium text-[0.6rem] leading-none;
+    background: oklch(0.97 0 0);
+    color: oklch(0.4 0 0);
+    border: 1px solid oklch(0.9 0 0);
+    box-shadow: 0 1px 0 oklch(0.88 0 0);
+  }
+
+  .bb-kbd-combo__key {
+    @apply inline-flex items-center justify-center min-w-[1.25rem] px-1 h-full;
+  }
+
+  .bb-kbd-combo__key + .bb-kbd-combo__key {
+    border-left: 1px solid oklch(0.9 0 0);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-kbd-combo {
+      background: oklch(0.25 0 0);
+      color: oklch(0.7 0 0);
+      border-color: oklch(0.35 0 0);
+      box-shadow: 0 1px 0 oklch(0.15 0 0);
+    }
+    .bb-kbd-combo__key + .bb-kbd-combo__key {
+      border-left-color: oklch(0.35 0 0);
+    }
+  }
+
   /* ── Triage mode: compact review rows ── */
   .bb-triage-row {
     @apply relative;

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -128,6 +128,13 @@ var componentRegistry = map[string]componentAdapter{
 		}
 		return components.KbdChord(keys...), nil
 	},
+	"KbdCombo": func(data any) (templ.Component, error) {
+		keys, err := toStringSlice(data)
+		if err != nil {
+			return nil, fmt.Errorf("KbdCombo: %w", err)
+		}
+		return components.KbdCombo(keys...), nil
+	},
 	"ConditionRow": func(data any) (templ.Component, error) {
 		m, ok := data.(map[string]any)
 		if !ok {
@@ -193,6 +200,31 @@ func assertTagChipData(data any) (components.TagChipData, error) {
 		return v, nil
 	default:
 		return components.TagChipData{}, fmt.Errorf("unsupported tag chip type %T", data)
+	}
+}
+
+// toStringSlice coerces the value passed via renderComponent into a
+// []string. Accepts []string directly (from Go call sites) and []any
+// (produced by the template-side `strs` funcmap). Keeps component
+// adapters tolerant of both paths without caring which one fed them.
+func toStringSlice(v any) ([]string, error) {
+	switch s := v.(type) {
+	case []string:
+		return s, nil
+	case []any:
+		out := make([]string, 0, len(s))
+		for i, item := range s {
+			str, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("element %d: want string, got %T", i, item)
+			}
+			out = append(out, str)
+		}
+		return out, nil
+	case nil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("want []string or []any, got %T", v)
 	}
 }
 
@@ -363,6 +395,10 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 		funcMap: template.FuncMap{
 			"sub": func(a, b int) int { return a - b },
 			"add": func(a, b int) int { return a + b },
+			// strs collects variadic string args into a []string so
+			// templates can pass slices through `renderComponent`
+			// (e.g. `{{renderComponent "KbdCombo" (strs "cmd" "k")}}`).
+			"strs": func(vals ...string) []string { return vals },
 			"commaInt": func(n any) string {
 				var s string
 				switch v := n.(type) {

--- a/internal/templates/components/helpers_test.go
+++ b/internal/templates/components/helpers_test.go
@@ -332,3 +332,38 @@ func TestAmount2f(t *testing.T) {
 		}
 	}
 }
+
+func TestKbdGlyph(t *testing.T) {
+	// Covers modifier names (case-insensitive), arrows, special keys, and
+	// the single-letter uppercase fallback. Must stay in lock-step with the
+	// JS twin `bbKbdGlyph` in internal/templates/layout/base.html.
+	tests := []struct {
+		in, want string
+	}{
+		{"cmd", "⌘"},
+		{"CMD", "⌘"},
+		{"meta", "⌘"},
+		{"shift", "⇧"},
+		{"ctrl", "⌃"},
+		{"alt", "⌥"},
+		{"option", "⌥"},
+		{"opt", "⌥"},
+		{"enter", "↵"},
+		{"return", "↵"},
+		{"esc", "esc"},
+		{"tab", "⇥"},
+		{"space", "␣"},
+		{"up", "↑"},
+		{"down", "↓"},
+		{"left", "←"},
+		{"right", "→"},
+		{"k", "K"}, // single-letter → uppercase keycap
+		{"?", "?"},
+		{"F2", "F2"}, // multi-char pass-through
+	}
+	for _, tc := range tests {
+		if got := kbdGlyph(tc.in); got != tc.want {
+			t.Errorf("kbdGlyph(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/templates/components/kbd.templ
+++ b/internal/templates/components/kbd.templ
@@ -1,5 +1,7 @@
 package components
 
+import "strings"
+
 // Kbd renders a single keyboard-shortcut badge.
 //
 // The badge is hidden on touch devices two ways:
@@ -12,7 +14,7 @@ package components
 // Both guards are needed: `sm:` catches the common case, `$store.device`
 // catches touch-capable desktops/tablets on a wide viewport.
 templ Kbd(key string) {
-	<kbd class="bb-kbd hidden sm:inline-flex" x-show="!$store.device.isTouch">{ key }</kbd>
+	<kbd class="bb-kbd hidden sm:inline-flex" x-show="!$store.device.isTouch">{ kbdGlyph(key) }</kbd>
 }
 
 // KbdChord renders a sequence of keys separated by a faint "then" label,
@@ -26,8 +28,71 @@ templ KbdChord(keys ...string) {
 				if i > 0 {
 					<span class="bb-shortcuts-then">then</span>
 				}
-				<kbd class="bb-kbd">{ k }</kbd>
+				<kbd class="bb-kbd">{ kbdGlyph(k) }</kbd>
 			}
 		</span>
 	}
+}
+
+// KbdCombo renders a modifier-style combo as a single blended pill.
+// Each key becomes an inner cell with a hairline divider between siblings
+// and only the OUTER corners rounded. Example: `KbdCombo("cmd","k")`
+// renders one pill with ⌘│K fused together.
+//
+// Hides on touch via the same two-layer guard as `Kbd`.
+//
+// With zero keys the component renders nothing; with one key it degrades
+// to a single inner cell — callers can pass variable-length slices without
+// a pre-check.
+templ KbdCombo(keys ...string) {
+	if len(keys) > 0 {
+		<span class="bb-kbd-combo hidden sm:inline-flex" x-show="!$store.device.isTouch">
+			for _, k := range keys {
+				<span class="bb-kbd-combo__key">{ kbdGlyph(k) }</span>
+			}
+		</span>
+	}
+}
+
+// kbdGlyph maps a key-name string to its on-screen glyph. Shared by
+// `Kbd`, `KbdChord`, and `KbdCombo` so a "cmd" token always renders the
+// same whether it appears alone, inside a chord, or fused in a combo.
+//
+// The JS counterpart in `base.html` (`bbKbdGlyph()`) must mirror this
+// map so dynamic renderers (help modal, cmdk palette) produce identical
+// HTML to the server-rendered components.
+func kbdGlyph(s string) string {
+	switch strings.ToLower(s) {
+	case "cmd", "meta":
+		return "⌘" // ⌘
+	case "shift":
+		return "⇧" // ⇧
+	case "ctrl":
+		return "⌃" // ⌃
+	case "alt", "option", "opt":
+		return "⌥" // ⌥
+	case "enter", "return":
+		return "↵" // ↵
+	case "esc":
+		return "esc"
+	case "tab":
+		return "⇥" // ⇥
+	case "space":
+		return "␣" // ␣
+	case "up":
+		return "↑" // ↑
+	case "down":
+		return "↓" // ↓
+	case "left":
+		return "←" // ←
+	case "right":
+		return "→" // →
+	}
+	// Single-letter alphanumerics render uppercase so they read like a
+	// key cap (`k` → `K`). Multi-char labels like "F2" or "?" pass
+	// through unchanged.
+	if len(s) == 1 {
+		return strings.ToUpper(s)
+	}
+	return s
 }

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -148,7 +148,7 @@ templ Nav(p NavProps) {
 				<span class="badge badge-ghost badge-xs">dev</span>
 			}
 			<span class="ml-auto hidden lg:inline" style="cursor:pointer;opacity:0.5" @click="$dispatch('open-shortcuts')" title="Keyboard shortcuts">
-				<kbd class="bb-shortcuts-kbd" style="font-size:0.5rem;min-width:1rem;height:1rem;padding:0 0.25rem">?</kbd>
+				<kbd class="bb-kbd" style="font-size:0.5rem;min-width:1rem;height:1rem;padding:0 0.25rem">?</kbd>
 			</span>
 		</div>
 	</div>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -77,6 +77,41 @@
   </script>
 
   <script>
+    // bbKbdGlyph(key) → display string for a keyboard-shortcut token.
+    //
+    // Mirrors the Go-side `kbdGlyph` in internal/templates/components/kbd.templ.
+    // Both must stay in lock-step so a help-modal entry, a cmdk hint, and a
+    // server-rendered Kbd/KbdCombo component all render the exact same glyph
+    // for a given registered key (e.g. 'cmd' → '⌘'). Shared by
+    // `toTokens()` (help modal) and `shortcutKeyTokens()` (palette).
+    window.bbKbdGlyph = function(key) {
+      if (key == null) return '';
+      var s = String(key);
+      switch (s.toLowerCase()) {
+        case 'cmd':
+        case 'meta':    return '⌘';         // ⌘
+        case 'shift':   return '⇧';         // ⇧
+        case 'ctrl':    return '⌃';         // ⌃
+        case 'alt':
+        case 'option':
+        case 'opt':     return '⌥';         // ⌥
+        case 'enter':
+        case 'return':  return '↵';         // ↵
+        case 'esc':     return 'esc';
+        case 'tab':     return '⇥';         // ⇥
+        case 'space':   return '␣';         // ␣
+        case 'up':      return '↑';         // ↑
+        case 'down':    return '↓';         // ↓
+        case 'left':    return '←';         // ←
+        case 'right':   return '→';         // →
+      }
+      // Single-letter alphanumerics render uppercase so they read like a
+      // key cap (`k` → `K`). Longer labels (`F2`, `?`) pass through.
+      return s.length === 1 ? s.toUpperCase() : s;
+    };
+  </script>
+
+  <script>
     // Alpine store: $store.shortcuts
     //
     // Central registry for all keyboard shortcuts. Pages declare their bindings
@@ -226,7 +261,7 @@
           <i data-lucide="search"></i>
           <span>Search...</span>
           <span class="bb-sidebar-search-hint">
-            <kbd>&#8984;</kbd><kbd>K</kbd>
+            {{renderComponent "KbdCombo" (strs "cmd" "k")}}
           </span>
         </div>
         {{template "nav" .}}
@@ -355,7 +390,7 @@
         </template>
       </div>
       <div class="bb-shortcuts-footer">
-        Press <kbd class="bb-shortcuts-kbd" style="display:inline-flex;vertical-align:middle;">?</kbd> anytime to toggle this panel
+        Press {{renderComponent "Kbd" "?"}} anytime to toggle this panel
       </div>
     </div>
   </div>
@@ -423,9 +458,9 @@
       <!-- Footer -->
       <div class="bb-catpicker-footer">
         <div class="flex items-center gap-3">
-          <span><kbd>&uarr;</kbd> <kbd>&darr;</kbd> navigate</span>
-          <span><kbd>&crarr;</kbd> select</span>
-          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "Esc"}} close</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "up"}} {{renderComponent "Kbd" "down"}} navigate</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "enter"}} select</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "esc"}} close</span>
         </div>
       </div>
     </div>
@@ -510,7 +545,7 @@
             <span>Create</span>
             <code class="font-mono bg-base-100/60 px-1.5 py-0.5 rounded text-[0.7rem]" x-text="normalizedQuery"></code>
             <span x-show="!creating" class="ml-auto text-[0.65rem] text-base-content/40">
-              <kbd>&crarr;</kbd>
+              <kbd class="bb-kbd">&crarr;</kbd>
             </span>
             <span x-show="creating" class="ml-auto loading loading-spinner loading-xs"></span>
           </button>
@@ -554,12 +589,12 @@
       <div class="bb-catpicker-footer">
         <div class="flex items-center gap-3 flex-wrap">
           <template x-if="canCreate">
-            <span><kbd>&crarr;</kbd> create</span>
+            <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "enter"}} create</span>
           </template>
           <template x-if="!canCreate">
-            <span><kbd>&crarr;</kbd> apply</span>
+            <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "enter"}} apply</span>
           </template>
-          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "Esc"}} cancel</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "esc"}} cancel</span>
         </div>
         <div class="flex items-center gap-2">
           <button type="button" class="btn btn-ghost btn-xs rounded-lg" @click="closePicker()">Cancel</button>
@@ -704,7 +739,17 @@
                         <template x-for="(tok, ti) in shortcutTokensFor(item)" :key="ti">
                           <span>
                             <span x-show="tok.then" class="bb-cmdk-then">then</span>
-                            <span x-show="!tok.then" class="bb-cmdk-kbd" x-text="tok.label"></span>
+                            <!-- Blended combo pill: renders ⌘│K as one tight
+                                 badge so modifier combos don't read as two
+                                 disconnected keycaps (see .bb-kbd-combo). -->
+                            <template x-if="tok.combo">
+                              <span class="bb-kbd-combo">
+                                <template x-for="(k, ki) in tok.combo" :key="ki">
+                                  <span class="bb-kbd-combo__key" x-text="k"></span>
+                                </template>
+                              </span>
+                            </template>
+                            <span x-show="!tok.then && !tok.combo" class="bb-cmdk-kbd" x-text="tok.label"></span>
                           </span>
                         </template>
                       </div>
@@ -720,10 +765,10 @@
       <!-- Footer hints -->
       <div class="bb-cmdk-footer">
         <div class="flex items-center gap-3">
-          <span><kbd>&uarr;</kbd> <kbd>&darr;</kbd> navigate</span>
-          <span><kbd>&crarr;</kbd> open</span>
-          <span><kbd>esc</kbd> close</span>
-          <span><kbd>?</kbd> shortcuts</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "up"}} {{renderComponent "Kbd" "down"}} navigate</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "enter"}} open</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "esc"}} close</span>
+          <span class="inline-flex items-center gap-1">{{renderComponent "Kbd" "?"}} shortcuts</span>
         </div>
       </div>
     </div>
@@ -1429,37 +1474,36 @@
       ];
 
       // Turn a spec's `keys` into flat tokens for rendering:
-      //   'cmd+k'               → [{label:'⌘'}, {label:'K'}]
+      //   'cmd+k'               → [{combo:['⌘','K']}]
       //   '?'                   → [{label:'?'}]
       //   { chord: ['g','d'] }  → [{label:'g'}, {then:true}, {label:'d'}]
-      // Mirrors shortcutsHelp.toTokens() (M0.3). Duplicated on purpose —
-      // keeping the two renderers independent means a palette tweak can't
-      // break the help modal and vice versa.
+      // Symbol mapping goes through the shared `bbKbdGlyph` helper defined
+      // at the top of this file so the palette, help modal, and server-
+      // rendered Kbd/KbdCombo components all speak the same glyph vocabulary.
       function shortcutKeyTokens(keys) {
         if (!keys) return [];
         if (keys.chord && Array.isArray(keys.chord)) {
           var out = [];
           keys.chord.forEach(function(k, i) {
             if (i > 0) out.push({ then: true });
-            out.push({ label: String(k) });
+            out.push({ label: bbKbdGlyph(k) });
           });
           return out;
         }
+        // Array form collapses into a blended pill — the keys are meant to
+        // be pressed simultaneously so visually they belong in one badge.
         if (Array.isArray(keys)) {
-          return keys.map(function(k) { return { label: String(k) }; });
+          return [{ combo: keys.map(function(k) { return bbKbdGlyph(k); }) }];
         }
         if (typeof keys === 'string') {
           if (keys.indexOf('+') !== -1 && keys.length > 1) {
-            return keys.split('+').map(function(part) {
-              var p = part.toLowerCase();
-              if (p === 'cmd' || p === 'meta') return { label: '⌘' };
-              if (p === 'ctrl')                return { label: 'Ctrl' };
-              if (p === 'shift')               return { label: '⇧' };
-              if (p === 'alt' || p === 'opt')  return { label: '⌥' };
-              return { label: part.length === 1 ? part.toUpperCase() : part };
-            });
+            return [{
+              combo: keys.split('+').map(function(part) {
+                return bbKbdGlyph(part);
+              }),
+            }];
           }
-          return [{ label: keys }];
+          return [{ label: bbKbdGlyph(keys) }];
         }
         return [];
       }
@@ -1707,8 +1751,11 @@
 
       // Turn a spec's `keys` into a flat list of render tokens:
       //   [{ label: 'g' }, { then: true }, { label: 'd' }]
+      //   [{ combo: ['⌘', 'K'] }]                         ← modifier combo
       // Supports: single string ('?', '/', 'c'), modifier combo ('cmd+k',
       // 'ctrl+shift+p'), array-of-one (['c']), and chord ({ chord: ['g','d'] }).
+      // Combos become a single `combo` token so the renderer can emit one
+      // blended pill (.bb-kbd-combo) instead of adjacent standalone kbds.
       function toTokens(keys) {
         if (!keys) return [];
         // Chord: sequential keys joined by "then".
@@ -1716,29 +1763,27 @@
           var out = [];
           keys.chord.forEach(function(k, i) {
             if (i > 0) out.push({ then: true });
-            out.push({ label: esc(k) });
+            out.push({ label: esc(bbKbdGlyph(k)) });
           });
           return out;
         }
-        // Array form — treat as simultaneous chord (no "then" separator).
+        // Array form — treat as simultaneous chord rendered as a single
+        // blended pill so the keys read as a unit rather than two
+        // standalone keycaps side-by-side.
         if (Array.isArray(keys)) {
-          return keys.map(function(k) { return { label: esc(k) }; });
+          return [{ combo: keys.map(function(k) { return esc(bbKbdGlyph(k)); }) }];
         }
         if (typeof keys === 'string') {
           // Modifier combo like 'cmd+k' or 'ctrl+shift+p'. Plus as a shortcut
           // for itself (a lone '+') is not something we register today.
           if (keys.indexOf('+') !== -1 && keys.length > 1) {
-            return keys.split('+').map(function(part) {
-              var p = part.toLowerCase();
-              if (p === 'cmd' || p === 'meta') return { label: '&#8984;' };
-              if (p === 'ctrl')                return { label: 'Ctrl' };
-              if (p === 'shift')               return { label: '&#8679;' };
-              if (p === 'alt' || p === 'opt')  return { label: '&#8997;' };
-              // Render a single-letter key uppercase so it reads like a key cap.
-              return { label: esc(part.length === 1 ? part.toUpperCase() : part) };
-            });
+            return [{
+              combo: keys.split('+').map(function(part) {
+                return esc(bbKbdGlyph(part));
+              }),
+            }];
           }
-          return [{ label: esc(keys) }];
+          return [{ label: esc(bbKbdGlyph(keys)) }];
         }
         return [];
       }
@@ -1747,6 +1792,13 @@
         if (!tokens || !tokens.length) return '';
         return tokens.map(function(t) {
           if (t.then) return '<span class="bb-shortcuts-then">then</span>';
+          if (t.combo) {
+            return '<span class="bb-kbd-combo">' +
+              t.combo.map(function(k) {
+                return '<span class="bb-kbd-combo__key">' + k + '</span>';
+              }).join('') +
+              '</span>';
+          }
           return '<kbd class="bb-shortcuts-kbd">' + t.label + '</kbd>';
         }).join('');
       }


### PR DESCRIPTION
## Summary

Polish `<kbd>` rendering across the admin UI so modifier combos (Cmd+K, Shift+J, Cmd+Enter, ...) render as a **single blended pill** — keys touch with a hairline divider, only the outer corners rounded — instead of two adjacent standalone keycaps. Chord sequences (`g` then `d`, `C` then `L`) keep the existing two-pill "then" rendering.

## Screenshots

### Help modal (`?`)

`⌘K` renders as a single blended combo pill (outer rounded border, inner hairline divider between keys); chord sequences (`G` then `D`, ...) keep two separate pills with the word "then" between.

<img src="https://i.img402.dev/3fdaqmq4v5.jpg" width="800" alt="Keyboard shortcuts help modal with blended Cmd+K combo pill">

### Command palette (`Cmd+K`)

Palette rows show trailing chord hints (`G` then `D`, etc.) with the same two-pill rendering; footer uses the updated kbd styles (`↑`, `↓`, `↵`, `esc`, `?`).

<img src="https://i.img402.dev/0iqdygv049.jpg" width="800" alt="Cmd+K command palette with chord keycap hints">

## Changes

- **New `KbdCombo(keys ...string)` templ component** (`internal/templates/components/kbd.templ`) emitting `.bb-kbd-combo` → `.bb-kbd-combo__key`. Inherits background / border from `.bb-kbd` so light/dark mode stay in sync; only the shape is different.
- **Shared symbol mapping**: new `kbdGlyph` Go helper + JS twin `window.bbKbdGlyph` used by `Kbd`, `KbdChord`, `KbdCombo`, the help modal's `renderTokens()`, and the cmdk palette's `shortcutKeyTokens()`. `cmd` → ⌘, `shift` → ⇧, `ctrl` → ⌃, `alt` → ⌥, `enter` → ↵, `tab` → ⇥, `space` → ␣, arrows → ↑↓←→, `esc` stays textual, single letters uppercase to read as keycaps.
- **Help modal + cmdk palette** now emit a `{combo: [...]}` token shape for modifier combos and render it as `.bb-kbd-combo`. Chord tokens (`{then: true}`) still render the `then` separator. Array-form keys (e.g. `['cmd','shift','p']`) collapse into a single combo pill.
- **Raw `<kbd>` migration**: sidebar search hint (now `KbdCombo "cmd" "k"`), global category-picker footer, global tag-picker footer, cmdk palette footer, shortcuts-modal footer, and the nav `?` badge all migrated to `Kbd` / `KbdCombo` or the `.bb-kbd` class. 11 raw tags migrated; the one remaining hand-rolled `<kbd>` is the `&crarr;` inside the tag-picker "Create" button, which now carries `.bb-kbd` for visual consistency.
- **Funcmap helper**: `strs "cmd" "k"` builds a `[]string` so `renderComponent "KbdCombo"` can take a slice; adapter accepts both `[]string` and `[]any` for forward-compat.
- **Unit test** covers `kbdGlyph` for every mapped glyph plus the uppercase fallback and multi-char pass-through.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./...` (unit tier) — all packages pass, new `TestKbdGlyph` green.
- [x] Visual verification via `validate-ui` — Playwright against a local `breadbox serve` on the branch. `⌘K` renders as a blended combo pill on the `?` help modal; chord keys (`G then D`, ...) keep the two-pill "then" layout on both the help modal and the Cmd+K palette. Screenshots above.
- [x] Help modal (`?`) — combos render as single pills, chords as two pills with "then".
- [x] Cmdk palette (`⌘K`) — hints on nav rows (`G` then `D`, etc.) and any modifier-combo bindings render with the new blended pill.
- [x] Sidebar search hint — `⌘K` reads as one tight badge.
- [x] Touch-device guard intact (component hides via `$store.device.isTouch`; CSS `sm:inline-flex` still applies on narrow viewports).

## Follow-ups (out of scope)

- `.bb-kbd` (badge), `.bb-cmdk-kbd` (palette), `.bb-shortcuts-kbd` (help modal) still coexist with slightly different sizes. Safe to consolidate once a designer passes on the three surfaces together.
