### PR TITLE
fix(transactions): distinguish Pending indicator from tag pills

### DIFF
--- a/input.css
+++ b/input.css
@@ -979,6 +979,20 @@
     }
   }
 
+  /* Pending transactions: the amount is provisional, so we soften it (dimmed
+     glyph + leading clock icon via the row template) instead of tacking a
+     warning chip onto the name line where it competes with tag pills.
+     No italic / no underline — just a quieter number. */
+  .bb-tx-amount--pending {
+    opacity: 0.55;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-tx-amount--pending {
+      opacity: 0.65;
+    }
+  }
+
   /* ── Rule category badge ── */
   .bb-rule-cat-badge {
     @apply inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full;

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -60,9 +60,6 @@ templ TxRow(tx service.AdminTransactionRow) {
 			<div class="flex-1 min-w-0">
 				<div class="flex items-center gap-2">
 					<a href={ templ.URL("/transactions/" + tx.ID) } @click.stop class="font-medium text-sm hover:text-primary transition-colors truncate">{ tx.Name }</a>
-					if tx.Pending {
-						<span class="badge badge-soft badge-xs badge-warning rounded-md shrink-0">Pending</span>
-					}
 				</div>
 				<div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 min-w-0">
 					if tx.UserName != "" {
@@ -153,9 +150,22 @@ templ TxRow(tx service.AdminTransactionRow) {
 			<div class="text-xs text-base-content/40 tabular-nums shrink-0 hidden sm:block w-24 text-right bb-tx-date">
 				{ formatDate(tx.Date) }
 			</div>
-			<!-- Amount -->
-			<div class="w-20 sm:w-24 text-right shrink-0 pl-2 sm:pl-3">
-				<span class={ "bb-tx-amount tabular-nums", templ.KV("bb-tx-amount--income", tx.Amount < 0) }>
+			<!-- Amount. Pending transactions render a small clock icon flush
+			     against the amount and soften the glyph (bb-tx-amount pending
+			     modifier). The flex+justify-end layout keeps the right edge
+			     locked and the row height stable across pending and settled. -->
+			<div class="w-20 sm:w-24 shrink-0 pl-2 sm:pl-3 flex items-center justify-end gap-1">
+				if tx.Pending {
+					<i
+						data-lucide="clock"
+						class="w-3 h-3 shrink-0 text-warning/70"
+						title="Pending — not yet posted"
+					></i>
+					<span class="sr-only">(pending)</span>
+				}
+				<span class={ "bb-tx-amount tabular-nums",
+					templ.KV("bb-tx-amount--income", tx.Amount < 0),
+					templ.KV("bb-tx-amount--pending", tx.Pending) }>
 					{ formatAmount(tx.Amount) }
 				</span>
 			</div>

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -23,9 +23,6 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 		<div class="min-w-0 flex-1">
 			<div class="flex items-center gap-1.5 min-w-0">
 				<span class="text-sm font-medium truncate">{ tx.Name }</span>
-				if tx.Pending {
-					<span class="badge badge-soft badge-xs badge-warning rounded-md shrink-0">Pending</span>
-				}
 			</div>
 			<div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 overflow-hidden">
 				if tx.UserName != "" {
@@ -53,11 +50,24 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 				}
 			</div>
 		</div>
-		<!-- Date + Amount -->
+		<!-- Date + Amount. Pending rows get a small clock icon left of the
+		     amount plus a softer glyph color; row height stays stable. -->
 		<div class="shrink-0 text-right flex flex-col items-end gap-0.5">
-			<span class={ "bb-tx-amount tabular-nums", templ.KV("bb-tx-amount--income", tx.Amount < 0) }>
-				{ formatAmount(tx.Amount) }
-			</span>
+			<div class="flex items-center justify-end gap-1">
+				if tx.Pending {
+					<i
+						data-lucide="clock"
+						class="w-3 h-3 shrink-0 text-warning/70"
+						title="Pending — not yet posted"
+					></i>
+					<span class="sr-only">(pending)</span>
+				}
+				<span class={ "bb-tx-amount tabular-nums",
+					templ.KV("bb-tx-amount--income", tx.Amount < 0),
+					templ.KV("bb-tx-amount--pending", tx.Pending) }>
+					{ formatAmount(tx.Amount) }
+				</span>
+			</div>
 			<span class="text-[0.65rem] text-base-content/40 tabular-nums">{ relativeDate(tx.Date) }</span>
 		</div>
 	</a>

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -25,13 +25,15 @@
         <span class="text-xs text-base-content/30">&middot;</span>
         <span class="text-xs text-base-content/40">{{titleCase (deref .Transaction.MerchantName)}}</span>
         {{end}}
-        {{if .Transaction.Pending}}<span class="badge badge-soft badge-warning badge-xs ml-1">Pending</span>{{end}}
+        {{if .Transaction.Pending}}<span class="inline-flex items-center gap-1 px-1.5 py-0 text-[0.65rem] border border-dashed border-warning/60 text-warning rounded-md ml-1" title="Not yet posted"><i data-lucide="clock" class="w-2.5 h-2.5"></i>pending</span>{{end}}
       </div>
     </div>
   </div>
   <div class="sm:text-right">
-    <p class="text-3xl font-semibold tabular-nums{{if lt .Transaction.Amount 0.0}} text-success{{end}}">
-      {{formatAmount .Transaction.Amount}}
+    <p class="text-3xl font-semibold tabular-nums inline-flex items-center gap-2 justify-end{{if lt .Transaction.Amount 0.0}} text-success{{end}}"
+       {{if .Transaction.Pending}}title="Pending — not yet posted"{{end}}>
+      {{if .Transaction.Pending}}<i data-lucide="clock" class="w-5 h-5 shrink-0 text-warning/70"></i>{{end}}
+      <span class="{{if .Transaction.Pending}}bb-tx-amount--pending{{end}}">{{formatAmount .Transaction.Amount}}</span>
     </p>
     {{if .Transaction.IsoCurrencyCode}}<p class="text-xs text-base-content/30 mt-0.5">{{deref .Transaction.IsoCurrencyCode}}</p>{{end}}
   </div>


### PR DESCRIPTION
## Summary

- Replaces the soft-warning `Pending` chip on the merchant-name line with a small `clock` icon flush-left of the amount plus a softened glyph via `bb-tx-amount--pending`. The old chip was visually indistinguishable from the adjacent tag pills — same pill shape, same soft-tint treatment — so "pending" read as "just another tag" rather than a status.
- Co-locating the cue with the amount matches the semantics: it's the amount that's provisional. Row height and right-edge alignment are preserved: the amount column becomes `flex items-center justify-end gap-1`, so the clock + number render as a right-aligned unit inside the same fixed-width column. No breakpoint-specific behavior changes.
- Applied in three places: `tx_row.templ` (full transactions list), `tx_row_compact.templ` (dashboard recents, rule-detail lists), and `transaction_detail.html` (detail view — big amount gets the treatment; the header chip was swapped for a dashed-outline variant that can't be confused with a tag).

## Design exploration

Options discussed before settling on this approach:
1. Inline text next to the name — pushed the amount horizontally.
2. Stacked under the amount — added row-height variance.
3. Italic + dashed-underline on the amount — felt noisy.
4. ✅ Clock icon + softer amount color — no layout shift at any breakpoint, reads semantically ("this number is provisional"), visually distinct from tags.

## Test plan

- [x] Local dev (`http://localhost:8081/transactions`) with pending + settled rows — right-edge alignment preserved, row heights identical.
- [x] Visually approved by author in live admin UI.
- [ ] Reviewer to spot-check mobile (390px) and dark mode.
- [ ] Detail page `/transactions/<id>` on a pending row — clock beside the `text-3xl` amount and dashed-outline chip in the header.

<sub>Note: automated screenshot capture was blocked in this session (the MCP Chrome instance was locked by a prior process and the agent couldn't kill it). The change was validated interactively with the author on localhost; adding a still here requires a screenshot run outside this branch session.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)