### PR TITLE
fix(rules): show retroactive-apply error inside modal, use toast for success (#701)

### DIFF
--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -359,12 +359,6 @@
     </button>
   </div>
 
-  <div x-show="applyResult" x-cloak role="alert" class="alert alert-success text-sm mt-3 rounded-xl">
-    <span x-text="applyResult"></span>
-  </div>
-  <div x-show="applyError" x-cloak role="alert" class="alert alert-error text-sm mt-3 rounded-xl">
-    <span x-text="applyError"></span>
-  </div>
   {{end}}
   {{else}}
   <!-- 0-match empty state: matches the tone of other empty cards (e.g. the
@@ -415,6 +409,15 @@
             </label>
           </div>
         </div>
+      </div>
+      <!-- Inline error alert lives *inside* the modal so it's visible while
+           the dialog is still open. The old in-card alert (above the
+           category button) was rendered behind the z-50 backdrop and
+           therefore invisible whenever apply failed — see #701. -->
+      <div x-show="applyError" x-cloak role="alert"
+           class="alert alert-error text-xs mt-4 rounded-xl">
+        <i data-lucide="alert-circle" class="w-4 h-4 shrink-0"></i>
+        <span x-text="applyError"></span>
       </div>
       <div class="flex items-center justify-end gap-2 mt-5">
         <button type="button" class="btn btn-sm btn-ghost rounded-xl" @click="closeApplyModal()">Cancel</button>
@@ -527,7 +530,6 @@ function quickSetCategory(txId, categoryId) {
 function ruleDetail() {
   return {
     applying: false,
-    applyResult: '',
     applyError: '',
     showApplyModal: false,
     confirmApply: false,
@@ -584,7 +586,6 @@ function ruleDetail() {
     openApplyModal() {
       this.confirmApply = false;
       this.applyError = '';
-      this.applyResult = '';
       this.showApplyModal = true;
     },
     closeApplyModal() {
@@ -594,7 +595,6 @@ function ruleDetail() {
     async applyRetroactively() {
       if (!this.confirmApply) return;
       this.applying = true;
-      this.applyResult = '';
       this.applyError = '';
       try {
         const resp = await fetch('/-/rules/{{.Rule.ID}}/apply', { method: 'POST' });
@@ -604,10 +604,14 @@ function ruleDetail() {
           this.applying = false;
           return;
         }
-        this.applyResult = 'Applied to ' + (data.affected_count || 0) + ' transactions';
+        // Promote success to the global toast (see base.html) so it persists
+        // through the reload window and isn't clipped by the closing modal.
+        const msg = 'Applied to ' + (data.affected_count || 0) + ' transactions';
+        showToast(msg, 'success');
         this.applying = false;
         this.showApplyModal = false;
-        setTimeout(() => location.reload(), 1500);
+        // Reload so the updated application list and hit counts show up.
+        setTimeout(() => location.reload(), 800);
       } catch (e) {
         this.applyError = 'Network error: ' + e.message;
         this.applying = false;


### PR DESCRIPTION
## Summary

Fix `/rules/{id}` retroactive-apply error alert rendering behind the
modal backdrop.

- Move the error alert **inside** the modal (above Cancel/Apply) so
  users see it while the dialog is still open and can retry or cancel.
- Promote the success message to the global `bb-toast` stream so it
  survives the reload window (the old inline success alert flashed for
  ~1.5s before `location.reload()` wiped it).
- Drop the unused `applyResult` Alpine state now that success routes
  through the toast.

Fixes #701.

## UI evidence

Simulated via request interception returning `500 { error: "…" }` on
`POST /-/rules/{id}/apply`.

<table>
  <tr><th>Viewport</th><th>Before</th><th>After</th></tr>
  <tr>
    <td>Desktop (1440)</td>
    <td><img src="https://i.img402.dev/0wnp6q9xor.png" width="400" alt="before desktop"></td>
    <td><img src="https://i.img402.dev/w3a40r7mzv.png" width="400" alt="after desktop"></td>
  </tr>
  <tr>
    <td>Tablet (820)</td>
    <td><img src="https://i.img402.dev/5vxap0c1vz.png" width="400" alt="before tablet"></td>
    <td><img src="https://i.img402.dev/mzqgb4knsg.png" width="400" alt="after tablet"></td>
  </tr>
  <tr>
    <td>Mobile (500)</td>
    <td><img src="https://i.img402.dev/zjh1eg9zav.png" width="400" alt="before mobile"></td>
    <td><img src="https://i.img402.dev/xzug2pf4sp.png" width="400" alt="after mobile"></td>
  </tr>
</table>

On the "before" shots, the error alert is the red banner below the
preview card — visually hidden behind the z-50 modal backdrop.
On the "after" shots, it's inline inside the dialog above the action
buttons, so the user can read it, retry, or cancel without dismissing
the modal first.

## Testing

- [x] `go build ./...`
- [x] `go test ./...` passes
- [x] Manual puppeteer flow on 500/820/1440: confirm 500-response path
      surfaces inline error; no layout regression in the initial and
      modal-open states.

## Related issues

Closes #701
