### PR TITLE
refactor(admin): align category error codes with REST/MCP

### DIFF
--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -185,9 +185,9 @@ func MergeCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 func handleCategoryError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, service.ErrCategoryNotFound):
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "Category not found")
+		writeError(w, http.StatusNotFound, "CATEGORY_NOT_FOUND", "Category not found")
 	case errors.Is(err, service.ErrCategoryUndeletable):
-		writeError(w, http.StatusConflict, "UNDELETABLE", "This category cannot be deleted")
+		writeError(w, http.StatusConflict, "CATEGORY_UNDELETABLE", "This category cannot be deleted")
 	case errors.Is(err, service.ErrSlugConflict):
 		writeError(w, http.StatusConflict, "SLUG_CONFLICT", "A category with this name already exists")
 	case errors.Is(err, service.ErrInvalidParameter):


### PR DESCRIPTION
## Summary

- `handleCategoryError` in `internal/admin/categories.go` emitted `NOT_FOUND` and `UNDELETABLE` for category errors while the REST API (`internal/api/categories.go`, `internal/api/transactions.go`) and MCP (`internal/mcp/errors.go`) both use `CATEGORY_NOT_FOUND` and `CATEGORY_UNDELETABLE` for the same service sentinels (`service.ErrCategoryNotFound`, `service.ErrCategoryUndeletable`).
- Aligning admin with the canonical codes gives clients a single, consistent contract for these error conditions across all three surfaces.

## Why it's safe

- No admin UI code, template, or test switches on these particular codes — they are returned in JSON but never compared by a consumer. A repo-wide `grep "UNDELETABLE"` and `grep "CATEGORY_NOT_FOUND"` confirms the admin handler is the only caller using the diverging strings.
- The admin package's own tests continue to pass (`go test ./internal/admin/...`).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/admin/...`
- [x] `go test ./internal/admin/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)