### PR TITLE
refactor(admin): use canonical error envelope in rule handlers

### DIFF
--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -312,11 +312,11 @@ func CreateRuleAdminHandler(svc *service.Service, sm *scs.SessionManager) http.H
 		}
 
 		if body.Name == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "name is required"})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "name is required")
 			return
 		}
 		if len(body.Actions) == 0 && body.CategorySlug == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "either actions or category_slug is required"})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "either actions or category_slug is required")
 			return
 		}
 
@@ -335,11 +335,7 @@ func CreateRuleAdminHandler(svc *service.Service, sm *scs.SessionManager) http.H
 
 		rule, err := svc.CreateTransactionRule(r.Context(), params)
 		if err != nil {
-			if errors.Is(err, service.ErrInvalidParameter) {
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
-				return
-			}
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "failed to create rule"})
+			handleRuleError(w, err, "Failed to create rule")
 			return
 		}
 
@@ -377,14 +373,7 @@ func UpdateRuleAdminHandler(svc *service.Service, sm *scs.SessionManager) http.H
 			ExpiresAt:    body.ExpiresAt,
 		})
 		if err != nil {
-			switch {
-			case errors.Is(err, service.ErrNotFound):
-				writeJSON(w, http.StatusNotFound, map[string]any{"error": "rule not found"})
-			case errors.Is(err, service.ErrInvalidParameter):
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
-			default:
-				writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "failed to update rule"})
-			}
+			handleRuleError(w, err, "Failed to update rule")
 			return
 		}
 
@@ -398,11 +387,7 @@ func DeleteRuleAdminHandler(svc *service.Service) http.HandlerFunc {
 		id := chi.URLParam(r, "id")
 
 		if err := svc.DeleteTransactionRule(r.Context(), id); err != nil {
-			if errors.Is(err, service.ErrNotFound) {
-				writeJSON(w, http.StatusNotFound, map[string]any{"error": "rule not found"})
-				return
-			}
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "failed to delete rule"})
+			handleRuleError(w, err, "Failed to delete rule")
 			return
 		}
 
@@ -418,11 +403,7 @@ func ToggleRuleAdminHandler(svc *service.Service) http.HandlerFunc {
 		// Get current state
 		existing, err := svc.GetTransactionRule(r.Context(), id)
 		if err != nil {
-			if errors.Is(err, service.ErrNotFound) {
-				writeJSON(w, http.StatusNotFound, map[string]any{"error": "rule not found"})
-				return
-			}
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "failed to get rule"})
+			handleRuleError(w, err, "Failed to get rule")
 			return
 		}
 
@@ -431,7 +412,7 @@ func ToggleRuleAdminHandler(svc *service.Service) http.HandlerFunc {
 			Enabled: &newEnabled,
 		})
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "failed to toggle rule"})
+			handleRuleError(w, err, "Failed to toggle rule")
 			return
 		}
 
@@ -454,11 +435,7 @@ func PreviewRuleAdminHandler(svc *service.Service) http.HandlerFunc {
 
 		result, err := svc.PreviewRule(r.Context(), input.Conditions, input.SampleSize)
 		if err != nil {
-			if errors.Is(err, service.ErrInvalidParameter) {
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
-				return
-			}
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "failed to preview rule"})
+			handleRuleError(w, err, "Failed to preview rule")
 			return
 		}
 
@@ -473,15 +450,7 @@ func ApplyRuleAdminHandler(svc *service.Service) http.HandlerFunc {
 
 		count, err := svc.ApplyRuleRetroactively(r.Context(), id)
 		if err != nil {
-			if errors.Is(err, service.ErrNotFound) {
-				writeJSON(w, http.StatusNotFound, map[string]any{"error": "rule not found"})
-				return
-			}
-			if errors.Is(err, service.ErrInvalidParameter) {
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
-				return
-			}
-			writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "failed to apply rule"})
+			handleRuleError(w, err, "Failed to apply rule")
 			return
 		}
 
@@ -489,5 +458,19 @@ func ApplyRuleAdminHandler(svc *service.Service) http.HandlerFunc {
 			"rule_id":        id,
 			"affected_count": count,
 		})
+	}
+}
+
+// handleRuleError maps service-layer errors returned by rule mutations to the
+// canonical {"error": {"code", "message"}} envelope. `fallback` is the
+// human-readable message used when the error isn't a recognized sentinel.
+func handleRuleError(w http.ResponseWriter, err error, fallback string) {
+	switch {
+	case errors.Is(err, service.ErrNotFound):
+		writeError(w, http.StatusNotFound, "NOT_FOUND", "Rule not found")
+	case errors.Is(err, service.ErrInvalidParameter):
+		writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
+	default:
+		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", fallback)
 	}
 }

--- a/internal/templates/pages/rule_detail.html
+++ b/internal/templates/pages/rule_detail.html
@@ -600,7 +600,7 @@ function ruleDetail() {
         const resp = await fetch('/-/rules/{{.Rule.ID}}/apply', { method: 'POST' });
         const data = await resp.json();
         if (!resp.ok) {
-          this.applyError = data.error || 'Failed to apply rule';
+          this.applyError = data.error?.message || data.error || 'Failed to apply rule';
           this.applying = false;
           return;
         }


### PR DESCRIPTION
## Summary

- `internal/admin/rules.go` hand-rolled `{"error": "<string>"}` responses across 6 handlers (create/update/delete/toggle/preview/apply), diverging from the canonical `{"error": {"code", "message"}}` envelope documented in `.claude/rules/api.md`.
- The REST counterpart (`internal/api/rules.go`) and sibling admin handler (`internal/admin/categories.go`) both use the canonical envelope via `writeError()`.
- Introduce `handleRuleError(w, err, fallback)` — a local mirror of `handleCategoryError` — to map `ErrNotFound` → 404 `NOT_FOUND`, `ErrInvalidParameter` → 400 `VALIDATION_ERROR`, and everything else → 500 `INTERNAL_ERROR` with a caller-supplied fallback message.
- Pre-service required-field validation now returns 422 `VALIDATION_ERROR` per the admin-form convention.

## JS consumers

Most callers already handle both shapes (`data.error?.message || data.error`). The one flat-shape-only caller — the apply-rule toast in `rule_detail.html` — is updated to read `data.error?.message` first, with the old flat string as a fallback.

The toggle/delete callers in `rules.html` don't read the error body (they only check `resp.ok`), so they need no change.

## Why it's safe

- Build + `go test ./...` pass.
- `go test ./internal/admin/...` passes.
- No consumer in the codebase asserts on the old `error: <string>` shape.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/admin/...`
- [x] `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)