### PR TITLE
transactions-rename: schema + sqlc + internal Go rename

### DIFF
--- a/internal/db/migrations/20260424184638_rename_provider_columns.sql
+++ b/internal/db/migrations/20260424184638_rename_provider_columns.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+-- Rename raw-provider columns on transactions to use an explicit provider_* prefix,
+-- and add provider_raw for storing the unmodified provider payload per transaction.
+-- This is a pre-1.0 rename ahead of public release; the intent is that every column
+-- that may be enriched later carries a provider_ prefix to make "raw vs enriched"
+-- unambiguous at the schema level.
+
+DROP INDEX IF EXISTS transactions_category_primary_idx;
+DROP INDEX IF EXISTS transactions_name_merchant_gin_idx;
+DROP INDEX IF EXISTS transactions_external_transaction_id_idx;
+
+ALTER TABLE transactions RENAME COLUMN external_transaction_id  TO provider_transaction_id;
+ALTER TABLE transactions RENAME COLUMN pending_transaction_id   TO provider_pending_transaction_id;
+ALTER TABLE transactions RENAME COLUMN name                     TO provider_name;
+ALTER TABLE transactions RENAME COLUMN merchant_name            TO provider_merchant_name;
+ALTER TABLE transactions RENAME COLUMN category_primary         TO provider_category_primary;
+ALTER TABLE transactions RENAME COLUMN category_detailed        TO provider_category_detailed;
+ALTER TABLE transactions RENAME COLUMN category_confidence      TO provider_category_confidence;
+ALTER TABLE transactions RENAME COLUMN payment_channel          TO provider_payment_channel;
+
+ALTER TABLE transactions ADD COLUMN provider_raw JSONB NULL;
+
+CREATE INDEX transactions_provider_transaction_id_idx ON transactions (provider_transaction_id);
+CREATE INDEX transactions_provider_category_primary_idx ON transactions (provider_category_primary);
+CREATE INDEX transactions_provider_name_merchant_gin_idx
+  ON transactions USING gin (provider_name gin_trgm_ops, provider_merchant_name gin_trgm_ops);
+
+-- +goose Down
+DROP INDEX IF EXISTS transactions_provider_name_merchant_gin_idx;
+DROP INDEX IF EXISTS transactions_provider_category_primary_idx;
+DROP INDEX IF EXISTS transactions_provider_transaction_id_idx;
+
+ALTER TABLE transactions DROP COLUMN IF EXISTS provider_raw;
+
+ALTER TABLE transactions RENAME COLUMN provider_payment_channel         TO payment_channel;
+ALTER TABLE transactions RENAME COLUMN provider_category_confidence     TO category_confidence;
+ALTER TABLE transactions RENAME COLUMN provider_category_detailed       TO category_detailed;
+ALTER TABLE transactions RENAME COLUMN provider_category_primary        TO category_primary;
+ALTER TABLE transactions RENAME COLUMN provider_merchant_name           TO merchant_name;
+ALTER TABLE transactions RENAME COLUMN provider_name                    TO name;
+ALTER TABLE transactions RENAME COLUMN provider_pending_transaction_id  TO pending_transaction_id;
+ALTER TABLE transactions RENAME COLUMN provider_transaction_id          TO external_transaction_id;
+
+CREATE INDEX transactions_external_transaction_id_idx ON transactions (external_transaction_id);
+CREATE INDEX transactions_category_primary_idx ON transactions (category_primary);
+CREATE INDEX transactions_name_merchant_gin_idx
+  ON transactions USING gin (name gin_trgm_ops, merchant_name gin_trgm_ops);

--- a/internal/db/queries/transaction_matches.sql
+++ b/internal/db/queries/transaction_matches.sql
@@ -18,8 +18,8 @@ SELECT * FROM transaction_matches WHERE dependent_transaction_id = $1;
 
 -- name: ListTransactionMatchesByLink :many
 SELECT tm.*,
-       pt.name AS primary_txn_name, pt.amount AS primary_txn_amount, pt.date AS primary_txn_date, pt.merchant_name AS primary_txn_merchant,
-       dt.name AS dependent_txn_name, dt.amount AS dependent_txn_amount, dt.date AS dependent_txn_date, dt.merchant_name AS dependent_txn_merchant
+       pt.provider_name AS primary_txn_name, pt.amount AS primary_txn_amount, pt.date AS primary_txn_date, pt.provider_merchant_name AS primary_txn_merchant,
+       dt.provider_name AS dependent_txn_name, dt.amount AS dependent_txn_amount, dt.date AS dependent_txn_date, dt.provider_merchant_name AS dependent_txn_merchant
 FROM transaction_matches tm
 JOIN transactions pt ON tm.primary_transaction_id = pt.id
 JOIN transactions dt ON tm.dependent_transaction_id = dt.id

--- a/internal/db/queries/transactions.sql
+++ b/internal/db/queries/transactions.sql
@@ -3,30 +3,31 @@ SELECT COUNT(*) FROM transactions WHERE deleted_at IS NULL;
 
 -- name: UpsertTransaction :one
 INSERT INTO transactions (
-  account_id, external_transaction_id, pending_transaction_id,
+  account_id, provider_transaction_id, provider_pending_transaction_id,
   amount, iso_currency_code, date, authorized_date,
-  datetime, authorized_datetime, name, merchant_name,
-  category_primary, category_detailed, category_confidence,
-  payment_channel, pending, category_id
+  datetime, authorized_datetime, provider_name, provider_merchant_name,
+  provider_category_primary, provider_category_detailed, provider_category_confidence,
+  provider_payment_channel, pending, category_id, provider_raw
 ) VALUES (
-  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17
+  $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18
 )
-ON CONFLICT (external_transaction_id) DO UPDATE SET
+ON CONFLICT (provider_transaction_id) DO UPDATE SET
   account_id = EXCLUDED.account_id,
-  pending_transaction_id = EXCLUDED.pending_transaction_id,
+  provider_pending_transaction_id = EXCLUDED.provider_pending_transaction_id,
   amount = EXCLUDED.amount,
   iso_currency_code = EXCLUDED.iso_currency_code,
   date = EXCLUDED.date,
   authorized_date = EXCLUDED.authorized_date,
   datetime = EXCLUDED.datetime,
   authorized_datetime = EXCLUDED.authorized_datetime,
-  name = EXCLUDED.name,
-  merchant_name = EXCLUDED.merchant_name,
-  category_primary = EXCLUDED.category_primary,
-  category_detailed = EXCLUDED.category_detailed,
-  category_confidence = EXCLUDED.category_confidence,
-  payment_channel = EXCLUDED.payment_channel,
+  provider_name = EXCLUDED.provider_name,
+  provider_merchant_name = EXCLUDED.provider_merchant_name,
+  provider_category_primary = EXCLUDED.provider_category_primary,
+  provider_category_detailed = EXCLUDED.provider_category_detailed,
+  provider_category_confidence = EXCLUDED.provider_category_confidence,
+  provider_payment_channel = EXCLUDED.provider_payment_channel,
   pending = EXCLUDED.pending,
+  provider_raw = COALESCE(EXCLUDED.provider_raw, transactions.provider_raw),
   category_id = CASE
     WHEN transactions.category_override THEN transactions.category_id
     WHEN EXCLUDED.category_id IS NOT NULL THEN EXCLUDED.category_id
@@ -35,11 +36,11 @@ ON CONFLICT (external_transaction_id) DO UPDATE SET
   deleted_at = NULL,
   updated_at = CASE
     WHEN transactions.amount IS DISTINCT FROM EXCLUDED.amount
-      OR transactions.name IS DISTINCT FROM EXCLUDED.name
+      OR transactions.provider_name IS DISTINCT FROM EXCLUDED.provider_name
       OR transactions.pending IS DISTINCT FROM EXCLUDED.pending
-      OR transactions.merchant_name IS DISTINCT FROM EXCLUDED.merchant_name
-      OR transactions.category_primary IS DISTINCT FROM EXCLUDED.category_primary
-      OR transactions.category_detailed IS DISTINCT FROM EXCLUDED.category_detailed
+      OR transactions.provider_merchant_name IS DISTINCT FROM EXCLUDED.provider_merchant_name
+      OR transactions.provider_category_primary IS DISTINCT FROM EXCLUDED.provider_category_primary
+      OR transactions.provider_category_detailed IS DISTINCT FROM EXCLUDED.provider_category_detailed
       OR transactions.deleted_at IS NOT NULL
     THEN NOW()
     ELSE transactions.updated_at
@@ -47,7 +48,7 @@ ON CONFLICT (external_transaction_id) DO UPDATE SET
 RETURNING *;
 
 -- name: SoftDeleteTransactionByExternalID :exec
-UPDATE transactions SET deleted_at = NOW() WHERE external_transaction_id = $1 AND deleted_at IS NULL;
+UPDATE transactions SET deleted_at = NOW() WHERE provider_transaction_id = $1 AND deleted_at IS NULL;
 
 -- name: SoftDeleteTransactionsByConnectionID :execrows
 UPDATE transactions SET deleted_at = NOW()

--- a/internal/provider/plaid/sync.go
+++ b/internal/provider/plaid/sync.go
@@ -2,6 +2,7 @@ package plaid
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -183,6 +184,11 @@ func mapTransaction(txn plaidgo.Transaction) provider.Transaction {
 		if conf, ok := pfc.GetConfidenceLevelOk(); ok && conf != nil {
 			t.CategoryConfidence = conf
 		}
+	}
+
+	// Store the raw Plaid transaction as JSON for audit / future use.
+	if raw, err := json.Marshal(txn); err == nil {
+		t.Raw = raw
 	}
 
 	return t

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -88,6 +88,7 @@ type Transaction struct {
 	PaymentChannel     string // online, in store, other
 	Pending            bool
 	ISOCurrencyCode    string
+	Raw                []byte // provider raw JSON payload; nil if unavailable
 }
 
 type WebhookPayload struct {

--- a/internal/provider/teller/sync.go
+++ b/internal/provider/teller/sync.go
@@ -195,6 +195,11 @@ func mapTellerTransaction(txn tellerTransaction, currencyMap map[string]string, 
 		t.MerchantName = &name
 	}
 
+	// Store the raw Teller transaction as JSON for audit / future use.
+	if raw, err := json.Marshal(txn); err == nil {
+		t.Raw = raw
+	}
+
 	return t, nil
 }
 

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -105,7 +105,7 @@ ON CONFLICT (id) DO NOTHING;
 `
 
 const transactionsSQL = `
-INSERT INTO transactions (account_id, external_transaction_id, amount, iso_currency_code, date, name, merchant_name, category_primary, category_detailed, payment_channel, pending) VALUES
+INSERT INTO transactions (account_id, provider_transaction_id, amount, iso_currency_code, date, provider_name, provider_merchant_name, provider_category_primary, provider_category_detailed, provider_payment_channel, pending) VALUES
   -- Alice / Chase Checking (seed_acct_1)
   ('00000000-0000-0000-0000-000000000021', 'seed_txn_001', 4.50,    'USD', CURRENT_DATE - INTERVAL '1 day',  'Starbucks Coffee',       'Starbucks',      'FOOD_AND_DRINK',  'COFFEE_SHOPS',     'in_store', false),
   ('00000000-0000-0000-0000-000000000021', 'seed_txn_002', 42.15,   'USD', CURRENT_DATE - INTERVAL '2 days', 'Shell Gas Station',      'Shell',          'TRANSPORTATION',  'GAS_STATIONS',     'in_store', false),
@@ -167,7 +167,7 @@ INSERT INTO transactions (account_id, external_transaction_id, amount, iso_curre
   ('00000000-0000-0000-0000-000000000023', 'seed_txn_048', -2800.00,'USD', CURRENT_DATE - INTERVAL '35 days','Direct Deposit',         NULL,             'INCOME',          'WAGES',            'other',    false),
   ('00000000-0000-0000-0000-000000000023', 'seed_txn_049', 1500.00, 'USD', CURRENT_DATE - INTERVAL '36 days','Rent',                   NULL,             'RENT_AND_UTILITIES', 'RENT',          'other',    false),
   ('00000000-0000-0000-0000-000000000023', 'seed_txn_050', 95.00,   'USD', CURRENT_DATE - INTERVAL '40 days','Kroger',                 'Kroger',         'FOOD_AND_DRINK',  'GROCERIES',        'in_store', false)
-ON CONFLICT (external_transaction_id) DO NOTHING;
+ON CONFLICT (provider_transaction_id) DO NOTHING;
 `
 
 const syncLogsSQL = `
@@ -191,7 +191,7 @@ ON CONFLICT (id) DO NOTHING;
 `
 
 const tellerTransactionsSQL = `
-INSERT INTO transactions (account_id, external_transaction_id, amount, iso_currency_code, date, name, merchant_name, category_primary, category_detailed, payment_channel, pending) VALUES
+INSERT INTO transactions (account_id, provider_transaction_id, amount, iso_currency_code, date, provider_name, provider_merchant_name, provider_category_primary, provider_category_detailed, provider_payment_channel, pending) VALUES
   -- Alice / Wells Fargo Checking (seed_acct_t1)
   ('00000000-0000-0000-0000-000000000025', 'seed_txn_t01', 12.50,   'USD', CURRENT_DATE - INTERVAL '1 day',  'Taco Bell',              'Taco Bell',      'FOOD_AND_DRINK',  NULL, 'other', false),
   ('00000000-0000-0000-0000-000000000025', 'seed_txn_t02', 45.00,   'USD', CURRENT_DATE - INTERVAL '3 days', 'Chevron Gas',            'Chevron',        'TRANSPORTATION',  NULL, 'other', false),
@@ -201,7 +201,7 @@ INSERT INTO transactions (account_id, external_transaction_id, amount, iso_curre
   -- Alice / Wells Fargo Savings (seed_acct_t2)
   ('00000000-0000-0000-0000-000000000026', 'seed_txn_t05', -300.00, 'USD', CURRENT_DATE - INTERVAL '2 days', 'Transfer from Checking', NULL,             'TRANSFER_IN',     NULL, 'other', false),
   ('00000000-0000-0000-0000-000000000026', 'seed_txn_t06', 0.18,    'USD', CURRENT_DATE - INTERVAL '30 days','Interest Payment',       NULL,             'INCOME',          NULL, 'other', false)
-ON CONFLICT (external_transaction_id) DO NOTHING;
+ON CONFLICT (provider_transaction_id) DO NOTHING;
 `
 
 const tellerSyncLogSQL = `

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -613,7 +613,7 @@ func (s *Service) BulkRecategorizeByFilter(ctx context.Context, params BulkRecat
 	}
 
 	if params.NameContains != nil {
-		query += fmt.Sprintf(" AND t.name ILIKE '%%' || $%d || '%%'", argN)
+		query += fmt.Sprintf(" AND t.provider_name ILIKE '%%' || $%d || '%%'", argN)
 		args = append(args, *params.NameContains)
 		argN++
 	}

--- a/internal/service/category_integration_test.go
+++ b/internal/service/category_integration_test.go
@@ -51,11 +51,11 @@ func mustCreateTransactionWithCategory(t *testing.T, q *db.Queries, acctID, catI
 	t.Helper()
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
-		ExternalTransactionID: extID,
+		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
-		Name:                  name,
+		ProviderName:          name,
 		CategoryID:            catID,
 	})
 	if err != nil {
@@ -371,7 +371,7 @@ func TestDeleteCategory_ReassignsTransactionsToUncategorized(t *testing.T) {
 
 	// Transaction should now be uncategorized
 	var gotCatID pgtype.UUID
-	err = pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_doomed'").Scan(&gotCatID)
+	err = pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_doomed'").Scan(&gotCatID)
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
@@ -440,7 +440,7 @@ func TestMergeCategories_Success(t *testing.T) {
 	// Transaction should be in target
 	tgtUID, _ := parseUUIDForTest(target.ID)
 	var gotCatID pgtype.UUID
-	err = pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_merge'").Scan(&gotCatID)
+	err = pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_merge'").Scan(&gotCatID)
 	if err != nil {
 		t.Fatalf("query: %v", err)
 	}
@@ -595,7 +595,7 @@ func TestMergeCategories_ParentWithChildren(t *testing.T) {
 	// All three transactions should be reassigned to target.
 	for _, extID := range []string{"txn_parent", "txn_child1", "txn_child2"} {
 		var gotCatID pgtype.UUID
-		err := pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE external_transaction_id = $1", extID).Scan(&gotCatID)
+		err := pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE provider_transaction_id = $1", extID).Scan(&gotCatID)
 		if err != nil {
 			t.Fatalf("query %s: %v", extID, err)
 		}
@@ -793,7 +793,7 @@ func TestBulkRecategorizeByFilter_ByNameSearch(t *testing.T) {
 
 	// Walmart should be unchanged
 	var walmartCatID pgtype.UUID
-	pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE external_transaction_id = 'bulk_txn_3'").Scan(&walmartCatID)
+	pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE provider_transaction_id = 'bulk_txn_3'").Scan(&walmartCatID)
 	if walmartCatID != uncat.ID {
 		t.Errorf("Walmart should still be uncategorized")
 	}

--- a/internal/service/csv_import.go
+++ b/internal/service/csv_import.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -224,18 +225,25 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 		// Set to uncategorized — transaction rules will categorize on next sync.
 		categoryID := uncategorizedID
 
+		// Marshal raw CSV row as JSON for audit purposes.
+		var providerRaw []byte
+		if raw, err := json.Marshal(row); err == nil {
+			providerRaw = raw
+		}
+
 		txn, err := s.Queries.UpsertTransaction(ctx, db.UpsertTransactionParams{
-			AccountID:             accountID,
-			ExternalTransactionID: externalTxnID,
-			Amount:                amountNumeric,
-			IsoCurrencyCode:       pgconv.Text("USD"),
-			Date:                  pgtype.Date{Time: dateVal, Valid: true},
-			Name:                  desc,
-			MerchantName:          pgtype.Text{String: merchant, Valid: merchant != ""},
-			CategoryPrimary:       pgtype.Text{String: category, Valid: category != ""},
-			PaymentChannel:        pgconv.Text("other"),
-			Pending:               false,
-			CategoryID:            categoryID,
+			AccountID:               accountID,
+			ProviderTransactionID:   externalTxnID,
+			Amount:                  amountNumeric,
+			IsoCurrencyCode:         pgconv.Text("USD"),
+			Date:                    pgtype.Date{Time: dateVal, Valid: true},
+			ProviderName:            desc,
+			ProviderMerchantName:    pgtype.Text{String: merchant, Valid: merchant != ""},
+			ProviderCategoryPrimary: pgtype.Text{String: category, Valid: category != ""},
+			ProviderPaymentChannel:  pgconv.Text("other"),
+			Pending:                 false,
+			CategoryID:              categoryID,
+			ProviderRaw:             providerRaw,
 		})
 		if err != nil {
 			result.SkippedCount++

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -741,11 +741,11 @@ func TestImportCategoriesTSV_MergeInto(t *testing.T) {
 
 	_, err = queries.UpsertTransaction(ctx, db.UpsertTransactionParams{
 		AccountID:             acct.ID,
-		ExternalTransactionID: "txn_merge_1",
+		ProviderTransactionID: "txn_merge_1",
 		Amount:                pgtype.Numeric{Int: big.NewInt(550), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgtype.Date{Time: testutil.MustParseDate("2025-01-15"), Valid: true},
-		Name:                  "Starbucks",
+		ProviderName:          "Starbucks",
 		CategoryID:            sourceCat.ID,
 	})
 	if err != nil {
@@ -778,7 +778,7 @@ func TestImportCategoriesTSV_MergeInto(t *testing.T) {
 	// Verify transaction was reassigned to target.
 	var gotCatID pgtype.UUID
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_merge_1'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_merge_1'",
 	).Scan(&gotCatID)
 	if err != nil {
 		t.Fatalf("query transaction: %v", err)
@@ -981,7 +981,7 @@ func TestBatchSetTransactionCategory_Success(t *testing.T) {
 
 	// Verify txn3 is unchanged (no category_id set)
 	var gotCatIDNullable pgtype.UUID
-	err = pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_batch_3'").Scan(&gotCatIDNullable)
+	err = pool.QueryRow(ctx, "SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_batch_3'").Scan(&gotCatIDNullable)
 	if err != nil {
 		t.Fatalf("query txn3 category: %v", err)
 	}
@@ -1075,7 +1075,7 @@ func TestBulkRecategorizeByFilter_SearchFilter(t *testing.T) {
 
 	// Verify UBER transactions got the target category and category_override=true
 	rows, err := pool.Query(ctx,
-		"SELECT external_transaction_id, category_id, category_override FROM transactions WHERE name ILIKE '%UBER%' ORDER BY external_transaction_id")
+		"SELECT provider_transaction_id, category_id, category_override FROM transactions WHERE provider_name ILIKE '%UBER%' ORDER BY provider_transaction_id")
 	if err != nil {
 		t.Fatalf("query UBER txns: %v", err)
 	}
@@ -1098,7 +1098,7 @@ func TestBulkRecategorizeByFilter_SearchFilter(t *testing.T) {
 	// Verify non-UBER transactions are unchanged
 	var unchangedCount int
 	err = pool.QueryRow(ctx,
-		"SELECT COUNT(*) FROM transactions WHERE name NOT ILIKE '%UBER%' AND category_id IS NULL").Scan(&unchangedCount)
+		"SELECT COUNT(*) FROM transactions WHERE provider_name NOT ILIKE '%UBER%' AND category_id IS NULL").Scan(&unchangedCount)
 	if err != nil {
 		t.Fatalf("query unchanged: %v", err)
 	}
@@ -1198,7 +1198,7 @@ func TestApplyRuleRetroactively_MatchesAndSkipsOverrides(t *testing.T) {
 	for _, extID := range []string{"txn_sb_1", "txn_sb_2"} {
 		var catID pgtype.UUID
 		err = pool.QueryRow(ctx,
-			"SELECT category_id FROM transactions WHERE external_transaction_id = $1", extID).Scan(&catID)
+			"SELECT category_id FROM transactions WHERE provider_transaction_id = $1", extID).Scan(&catID)
 		if err != nil {
 			t.Fatalf("query %s: %v", extID, err)
 		}
@@ -1210,7 +1210,7 @@ func TestApplyRuleRetroactively_MatchesAndSkipsOverrides(t *testing.T) {
 	// Verify txn_sb_3 still has override category (not changed)
 	var overrideCatID pgtype.UUID
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_sb_3'").Scan(&overrideCatID)
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_sb_3'").Scan(&overrideCatID)
 	if err != nil {
 		t.Fatalf("query txn_sb_3: %v", err)
 	}
@@ -1222,7 +1222,7 @@ func TestApplyRuleRetroactively_MatchesAndSkipsOverrides(t *testing.T) {
 	for _, extID := range []string{"txn_other_1", "txn_other_2"} {
 		var catID pgtype.UUID
 		err = pool.QueryRow(ctx,
-			"SELECT category_id FROM transactions WHERE external_transaction_id = $1", extID).Scan(&catID)
+			"SELECT category_id FROM transactions WHERE provider_transaction_id = $1", extID).Scan(&catID)
 		if err != nil {
 			t.Fatalf("query %s: %v", extID, err)
 		}
@@ -1308,7 +1308,7 @@ func TestApplyAllRulesRetroactively_PriorityWins(t *testing.T) {
 	// Verify "Starbucks Coffee" got coffee category (higher priority rule won)
 	var catID pgtype.UUID
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_sb'").Scan(&catID)
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_sb'").Scan(&catID)
 	if err != nil {
 		t.Fatalf("query txn_sb: %v", err)
 	}
@@ -1318,7 +1318,7 @@ func TestApplyAllRulesRetroactively_PriorityWins(t *testing.T) {
 
 	// Verify "Shell Gas" got gas category
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_gas'").Scan(&catID)
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_gas'").Scan(&catID)
 	if err != nil {
 		t.Fatalf("query txn_gas: %v", err)
 	}
@@ -1329,7 +1329,7 @@ func TestApplyAllRulesRetroactively_PriorityWins(t *testing.T) {
 	// Verify "Amazon Purchase" is unchanged
 	var unrelatedCatID pgtype.UUID
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_unrelated'").Scan(&unrelatedCatID)
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_unrelated'").Scan(&unrelatedCatID)
 	if err != nil {
 		t.Fatalf("query txn_unrelated: %v", err)
 	}

--- a/internal/service/overview.go
+++ b/internal/service/overview.go
@@ -216,11 +216,11 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		}
 
 		catRows, err := s.Pool.Query(ctx, `
-			SELECT COALESCE(t.category_primary, 'UNCATEGORIZED'), SUM(t.amount), COUNT(*)
+			SELECT COALESCE(t.provider_category_primary, 'UNCATEGORIZED'), SUM(t.amount), COUNT(*)
 			FROM transactions t
 			JOIN accounts a ON t.account_id = a.id
 			WHERE t.deleted_at IS NULL AND t.pending = false AND t.date >= $1 AND t.amount > 0 AND (a.is_dependent_linked = FALSE OR NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id))
-			GROUP BY t.category_primary
+			GROUP BY t.provider_category_primary
 			ORDER BY SUM(t.amount) DESC
 			LIMIT 5`, thirtyDaysAgo)
 		if err != nil {

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -1164,8 +1164,8 @@ func (s *Service) ListActiveRulesForSync(ctx context.Context) ([]TransactionRule
 // rows. The `set_category` UPDATE below enforces its own
 // `category_override = FALSE` guard so overridden rows keep their user-pinned
 // category.
-const transactionContextQuery = `SELECT t.id, t.name, COALESCE(t.merchant_name, ''), t.amount,
-	COALESCE(t.category_primary, ''), COALESCE(t.category_detailed, ''),
+const transactionContextQuery = `SELECT t.id, t.provider_name, COALESCE(t.provider_merchant_name, ''), t.amount,
+	COALESCE(t.provider_category_primary, ''), COALESCE(t.provider_category_detailed, ''),
 	t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, ''),
 	COALESCE(array_agg(DISTINCT tag.slug) FILTER (WHERE tag.slug IS NOT NULL), ARRAY[]::text[])
 	FROM transactions t
@@ -1178,7 +1178,7 @@ const transactionContextQuery = `SELECT t.id, t.name, COALESCE(t.merchant_name, 
 	AND (a.is_dependent_linked = FALSE OR NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id))`
 
 // transactionContextGroupBy is the GROUP BY clause matching transactionContextQuery.
-const transactionContextGroupBy = ` GROUP BY t.id, t.name, t.merchant_name, t.amount, t.category_primary, t.category_detailed, t.pending, bc.provider, t.account_id, u.id, u.name`
+const transactionContextGroupBy = ` GROUP BY t.id, t.provider_name, t.provider_merchant_name, t.amount, t.provider_category_primary, t.provider_category_detailed, t.pending, bc.provider, t.account_id, u.id, u.name`
 
 // transactionContextRow holds a scanned transaction row for rule evaluation.
 type transactionContextRow struct {
@@ -1731,8 +1731,8 @@ func (s *Service) previewRuleInternal(ctx context.Context, excludeRuleID *pgtype
 	// Must match the same filters as transactionContextQuery (used by ApplyRuleRetroactively):
 	// - category_override = FALSE (rules don't overwrite manual overrides)
 	// - exclude matched dependent transactions (dedup'd via account links)
-	baseQuery := `SELECT t.id, t.name, COALESCE(t.merchant_name, ''), t.amount,
-		COALESCE(t.category_primary, ''), COALESCE(t.category_detailed, ''),
+	baseQuery := `SELECT t.id, t.provider_name, COALESCE(t.provider_merchant_name, ''), t.amount,
+		COALESCE(t.provider_category_primary, ''), COALESCE(t.provider_category_detailed, ''),
 		t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, ''),
 		t.date, COALESCE(c.slug, '')
 		FROM transactions t
@@ -2317,7 +2317,7 @@ func (s *Service) ListRuleApplications(ctx context.Context, ruleID string, limit
 		limit = 100
 	}
 
-	query := `SELECT ann.id, ann.transaction_id, t.name, t.amount, t.date,
+	query := `SELECT ann.id, ann.transaction_id, t.provider_name, t.amount, t.date,
 		COALESCE(ann.payload->>'action_field', ''),
 		COALESCE(ann.payload->>'action_value', ''),
 		COALESCE(ann.payload->>'applied_by', 'sync'),

--- a/internal/service/rules_integration_test.go
+++ b/internal/service/rules_integration_test.go
@@ -1144,10 +1144,10 @@ func TestApplyRuleRetroactively_AddTagMaterialized(t *testing.T) {
 			SELECT added_by_type FROM transaction_tags
 			WHERE transaction_id = $1 AND tag_id = $2`, txn.ID, tag.ID).Scan(&addedByType)
 		if err != nil {
-			t.Fatalf("query transaction_tags for %s: %v", txn.ExternalTransactionID, err)
+			t.Fatalf("query transaction_tags for %s: %v", txn.ProviderTransactionID, err)
 		}
 		if addedByType != "rule" {
-			t.Errorf("%s: added_by_type got %q, want 'rule'", txn.ExternalTransactionID, addedByType)
+			t.Errorf("%s: added_by_type got %q, want 'rule'", txn.ProviderTransactionID, addedByType)
 		}
 
 		// tag_added annotation with rule_id set and tag_id matching.
@@ -1158,10 +1158,10 @@ func TestApplyRuleRetroactively_AddTagMaterialized(t *testing.T) {
 			  AND tag_id = $2 AND rule_id = $3`,
 			txn.ID, tag.ID, rule.ID).Scan(&annCount)
 		if err != nil {
-			t.Fatalf("count tag_added annotations for %s: %v", txn.ExternalTransactionID, err)
+			t.Fatalf("count tag_added annotations for %s: %v", txn.ProviderTransactionID, err)
 		}
 		if annCount != 1 {
-			t.Errorf("%s: tag_added annotations with rule_id: got %d, want 1", txn.ExternalTransactionID, annCount)
+			t.Errorf("%s: tag_added annotations with rule_id: got %d, want 1", txn.ProviderTransactionID, annCount)
 		}
 	}
 
@@ -1219,7 +1219,7 @@ func TestApplyRuleRetroactively_RemoveTagMaterialized(t *testing.T) {
 			INSERT INTO transaction_tags (transaction_id, tag_id, added_by_type, added_by_name)
 			VALUES ($1, $2, 'user', 'test')`, txn.ID, tag.ID)
 		if err != nil {
-			t.Fatalf("seed transaction_tags for %s: %v", txn.ExternalTransactionID, err)
+			t.Fatalf("seed transaction_tags for %s: %v", txn.ProviderTransactionID, err)
 		}
 	}
 
@@ -1250,10 +1250,10 @@ func TestApplyRuleRetroactively_RemoveTagMaterialized(t *testing.T) {
 		if err := pool.QueryRow(ctx,
 			`SELECT COUNT(*) FROM transaction_tags WHERE transaction_id = $1 AND tag_id = $2`,
 			txn.ID, tag.ID).Scan(&ttCount); err != nil {
-			t.Fatalf("count transaction_tags for %s: %v", txn.ExternalTransactionID, err)
+			t.Fatalf("count transaction_tags for %s: %v", txn.ProviderTransactionID, err)
 		}
 		if ttCount != 0 {
-			t.Errorf("%s: transaction_tags should be empty, got %d rows", txn.ExternalTransactionID, ttCount)
+			t.Errorf("%s: transaction_tags should be empty, got %d rows", txn.ProviderTransactionID, ttCount)
 		}
 
 		var note string
@@ -1264,11 +1264,11 @@ func TestApplyRuleRetroactively_RemoveTagMaterialized(t *testing.T) {
 			  AND tag_id = $2 AND rule_id = $3`,
 			txn.ID, tag.ID, rule.ID).Scan(&note)
 		if err != nil {
-			t.Fatalf("query tag_removed annotation for %s: %v", txn.ExternalTransactionID, err)
+			t.Fatalf("query tag_removed annotation for %s: %v", txn.ProviderTransactionID, err)
 		}
 		if !strings.Contains(note, rule.Name) {
 			t.Errorf("%s: tag_removed payload note %q does not reference rule name %q",
-				txn.ExternalTransactionID, note, rule.Name)
+				txn.ProviderTransactionID, note, rule.Name)
 		}
 	}
 
@@ -1528,7 +1528,7 @@ func TestApplyAllRulesRetroactively_SamePriorityTie(t *testing.T) {
 	// Later-created rule B wins the category assignment.
 	var winningCat pgtype.UUID
 	if err := pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_tie'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_tie'",
 	).Scan(&winningCat); err != nil {
 		t.Fatalf("query winning category: %v", err)
 	}

--- a/internal/service/search.go
+++ b/internal/service/search.go
@@ -343,10 +343,10 @@ func estimateExcludeSize(numCols, numTerms int, columns []string, nullableColumn
 }
 
 // TransactionSearchColumns are the standard columns searched for transactions.
-var TransactionSearchColumns = []string{"t.name", "t.merchant_name"}
+var TransactionSearchColumns = []string{"t.provider_name", "t.provider_merchant_name"}
 
 // TransactionNullableColumns marks which transaction search columns are nullable.
-var TransactionNullableColumns = map[string]bool{"t.merchant_name": true}
+var TransactionNullableColumns = map[string]bool{"t.provider_merchant_name": true}
 
 // validSearchFields lists recognized search_field values.
 var validSearchFields = map[string]bool{
@@ -367,9 +367,9 @@ func resolveSearchField(field *string) ([]string, map[string]bool) {
 	}
 	switch *field {
 	case "name":
-		return []string{"t.name"}, map[string]bool{}
+		return []string{"t.provider_name"}, map[string]bool{}
 	case "merchant":
-		return []string{"t.merchant_name"}, map[string]bool{"t.merchant_name": true}
+		return []string{"t.provider_merchant_name"}, map[string]bool{"t.provider_merchant_name": true}
 	default:
 		return TransactionSearchColumns, TransactionNullableColumns
 	}

--- a/internal/service/transaction_query_integration_test.go
+++ b/internal/service/transaction_query_integration_test.go
@@ -1033,11 +1033,11 @@ func upsertTxnWithCategory(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 	t.Helper()
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
-		ExternalTransactionID: extID,
+		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
-		Name:                  name,
+		ProviderName:          name,
 		CategoryID:            categoryID,
 	})
 	if err != nil {
@@ -1050,11 +1050,11 @@ func upsertTxnPending(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID, na
 	t.Helper()
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
-		ExternalTransactionID: extID,
+		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
-		Name:                  name,
+		ProviderName:          name,
 		Pending:               true,
 	})
 	if err != nil {
@@ -1191,11 +1191,11 @@ func upsertTxnWithAmount(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID,
 	t.Helper()
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
-		ExternalTransactionID: extID,
+		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
-		Name:                  name,
+		ProviderName:          name,
 	})
 	if err != nil {
 		t.Fatalf("upsertTxnWithAmount(%q): %v", name, err)
@@ -1212,12 +1212,12 @@ func upsertTxnWithMerchant(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 	t.Helper()
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
-		ExternalTransactionID: extID,
+		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
-		Name:                  name,
-		MerchantName:          pgtype.Text{String: merchant, Valid: true},
+		ProviderName:          name,
+		ProviderMerchantName:  pgtype.Text{String: merchant, Valid: true},
 	})
 	if err != nil {
 		t.Fatalf("upsertTxnWithMerchant(%q): %v", name, err)

--- a/internal/service/transaction_summary.go
+++ b/internal/service/transaction_summary.go
@@ -82,8 +82,8 @@ func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionS
 	joinCategories := false
 	switch params.GroupBy {
 	case "category":
-		selectCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.category_primary, '_', ' ')), 'Uncategorized') AS category, cat.icon AS category_icon, cat.color AS category_color, t.iso_currency_code"
-		groupCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.category_primary, '_', ' ')), 'Uncategorized'), cat.icon, cat.color, t.iso_currency_code"
+		selectCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.provider_category_primary, '_', ' ')), 'Uncategorized') AS category, cat.icon AS category_icon, cat.color AS category_color, t.iso_currency_code"
+		groupCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.provider_category_primary, '_', ' ')), 'Uncategorized'), cat.icon, cat.color, t.iso_currency_code"
 		orderCols = "SUM(t.amount) DESC"
 		joinCategories = true
 	case "month":
@@ -99,8 +99,8 @@ func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionS
 		groupCols = "t.date, t.iso_currency_code"
 		orderCols = "t.date DESC"
 	case "category_month":
-		selectCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.category_primary, '_', ' ')), 'Uncategorized') AS category, cat.icon AS category_icon, cat.color AS category_color, to_char(date_trunc('month', t.date), 'YYYY-MM') AS period, t.iso_currency_code"
-		groupCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.category_primary, '_', ' ')), 'Uncategorized'), cat.icon, cat.color, date_trunc('month', t.date), t.iso_currency_code"
+		selectCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.provider_category_primary, '_', ' ')), 'Uncategorized') AS category, cat.icon AS category_icon, cat.color AS category_color, to_char(date_trunc('month', t.date), 'YYYY-MM') AS period, t.iso_currency_code"
+		groupCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.provider_category_primary, '_', ' ')), 'Uncategorized'), cat.icon, cat.color, date_trunc('month', t.date), t.iso_currency_code"
 		orderCols = "date_trunc('month', t.date) DESC, SUM(t.amount) DESC"
 		joinCategories = true
 	}
@@ -160,7 +160,7 @@ func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionS
 	}
 
 	if params.Category != nil {
-		buf.WriteString(" AND t.category_primary = $")
+		buf.WriteString(" AND t.provider_category_primary = $")
 		buf.WriteString(strconv.Itoa(argN))
 		args = append(args, *params.Category)
 		argN++ //nolint:ineffassign // kept for consistency with other filters
@@ -255,7 +255,7 @@ func (s *Service) GetMerchantSummary(ctx context.Context, params MerchantSummary
 	args := make([]any, 0, 12)
 	argN := 1
 
-	buf.WriteString(`SELECT COALESCE(t.merchant_name, t.name) AS merchant,
+	buf.WriteString(`SELECT COALESCE(t.provider_merchant_name, t.provider_name) AS merchant,
 		COUNT(*) AS transaction_count,
 		SUM(t.amount) AS total_amount,
 		AVG(t.amount) AS avg_amount,
@@ -369,7 +369,7 @@ LEFT JOIN bank_connections bc ON a.connection_id = bc.id`)
 		argN = ec.ArgN
 	}
 
-	buf.WriteString(" GROUP BY COALESCE(t.merchant_name, t.name), t.iso_currency_code")
+	buf.WriteString(" GROUP BY COALESCE(t.provider_merchant_name, t.provider_name), t.iso_currency_code")
 	buf.WriteString(" HAVING COUNT(*) >= $")
 	buf.WriteString(strconv.Itoa(argN))
 	args = append(args, params.MinCount)

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -99,11 +99,11 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 	args := make([]any, 0, 16)
 	argN := 1
 
-	buf.WriteString("SELECT t.id, t.short_id, t.account_id, t.external_transaction_id, t.pending_transaction_id, " +
+	buf.WriteString("SELECT t.id, t.short_id, t.account_id, t.provider_transaction_id, t.provider_pending_transaction_id, " +
 		"t.amount, t.iso_currency_code, t.unofficial_currency_code, t.date, t.authorized_date, " +
-		"t.datetime, t.authorized_datetime, t.name, t.merchant_name, " +
-		"t.category_primary, t.category_detailed, t.category_confidence, " +
-		"t.payment_channel, t.pending, t.deleted_at, t.created_at, t.updated_at, " +
+		"t.datetime, t.authorized_datetime, t.provider_name, t.provider_merchant_name, " +
+		"t.provider_category_primary, t.provider_category_detailed, t.provider_category_confidence, " +
+		"t.provider_payment_channel, t.pending, t.deleted_at, t.created_at, t.updated_at, " +
 		"COALESCE(a.display_name, a.name) AS account_name, " +
 		"a.short_id AS account_short_id, " +
 		"COALESCE(au.name, u.name) AS user_name, " +
@@ -282,7 +282,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		case "amount":
 			sortCol = "t.amount"
 		case "name":
-			sortCol = "t.name"
+			sortCol = "t.provider_name"
 		case "date":
 			sortCol = "t.date"
 		}
@@ -667,7 +667,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 
 	buf.WriteString("SELECT t.id, t.account_id, COALESCE(a.display_name, a.name, ''), " +
 		"COALESCE(bc.institution_name, ''), COALESCE(au.name, u.name, ''), " +
-		"t.date, t.name, t.merchant_name, t.amount, t.iso_currency_code, " +
+		"t.date, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, " +
 		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, " +
 		// "Agent reviewed" is inferred from a category_set annotation authored
@@ -1059,7 +1059,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 
 	query := "SELECT t.id, t.account_id, COALESCE(a.display_name, a.name, ''), " +
 		"COALESCE(bc.institution_name, ''), COALESCE(au.name, u.name, ''), " +
-		"t.date, t.name, t.merchant_name, t.amount, t.iso_currency_code, " +
+		"t.date, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, " +
 		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, " +
 		"EXISTS(SELECT 1 FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'category_set' AND ann.actor_type = 'agent') AS agent_reviewed, " +
@@ -1184,7 +1184,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 
 func (s *Service) ListDistinctCategories(ctx context.Context) ([]CategoryPair, error) {
 	rows, err := s.Pool.Query(ctx,
-		"SELECT DISTINCT category_primary, category_detailed FROM transactions WHERE deleted_at IS NULL AND category_primary IS NOT NULL ORDER BY category_primary, category_detailed")
+		"SELECT DISTINCT provider_category_primary, provider_category_detailed FROM transactions WHERE deleted_at IS NULL AND provider_category_primary IS NOT NULL ORDER BY provider_category_primary, provider_category_detailed")
 	if err != nil {
 		return nil, fmt.Errorf("list distinct categories: %w", err)
 	}
@@ -1239,13 +1239,13 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		AuthorizedDate:      dateStr(txn.AuthorizedDate),
 		Datetime:            timestampStr(txn.Datetime),
 		AuthorizedDatetime:  timestampStr(txn.AuthorizedDatetime),
-		Name:                txn.Name,
-		MerchantName:        textPtr(txn.MerchantName),
-		CategoryPrimaryRaw:  textPtr(txn.CategoryPrimary),
-		CategoryDetailedRaw: textPtr(txn.CategoryDetailed),
-		CategoryConfidence:  textPtr(txn.CategoryConfidence),
+		Name:                txn.ProviderName,
+		MerchantName:        textPtr(txn.ProviderMerchantName),
+		CategoryPrimaryRaw:  textPtr(txn.ProviderCategoryPrimary),
+		CategoryDetailedRaw: textPtr(txn.ProviderCategoryDetailed),
+		CategoryConfidence:  textPtr(txn.ProviderCategoryConfidence),
 		CategoryOverride:    txn.CategoryOverride,
-		PaymentChannel:      textPtr(txn.PaymentChannel),
+		PaymentChannel:      textPtr(txn.ProviderPaymentChannel),
 		Pending:             txn.Pending,
 		CreatedAt:           pgconv.TimestampStr(txn.CreatedAt),
 		UpdatedAt:           pgconv.TimestampStr(txn.UpdatedAt),

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -550,22 +550,23 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 	}
 
 	params := db.UpsertTransactionParams{
-		AccountID:             accountID,
-		ExternalTransactionID: txn.ExternalID,
-		PendingTransactionID:  optionalText(txn.PendingExternalID),
-		Amount:                decimalToNumeric(txn.Amount),
-		IsoCurrencyCode:       pgtype.Text{String: txn.ISOCurrencyCode, Valid: txn.ISOCurrencyCode != ""},
-		Date:                  pgtype.Date{Time: txn.Date, Valid: true},
-		AuthorizedDate:        optionalDate(txn.AuthorizedDate),
-		Datetime:              optionalTimestamptz(txn.Datetime),
-		AuthorizedDatetime:    optionalTimestamptz(txn.AuthorizedDatetime),
-		Name:                  txn.Name,
-		MerchantName:          optionalText(txn.MerchantName),
-		CategoryPrimary:       optionalText(txn.CategoryPrimary),
-		CategoryDetailed:      optionalText(txn.CategoryDetailed),
-		CategoryConfidence:    optionalText(txn.CategoryConfidence),
-		PaymentChannel:        pgtype.Text{String: txn.PaymentChannel, Valid: txn.PaymentChannel != ""},
-		Pending:               txn.Pending,
+		AccountID:                    accountID,
+		ProviderTransactionID:        txn.ExternalID,
+		ProviderPendingTransactionID: optionalText(txn.PendingExternalID),
+		Amount:                       decimalToNumeric(txn.Amount),
+		IsoCurrencyCode:              pgtype.Text{String: txn.ISOCurrencyCode, Valid: txn.ISOCurrencyCode != ""},
+		Date:                         pgtype.Date{Time: txn.Date, Valid: true},
+		AuthorizedDate:               optionalDate(txn.AuthorizedDate),
+		Datetime:                     optionalTimestamptz(txn.Datetime),
+		AuthorizedDatetime:           optionalTimestamptz(txn.AuthorizedDatetime),
+		ProviderName:                 txn.Name,
+		ProviderMerchantName:         optionalText(txn.MerchantName),
+		ProviderCategoryPrimary:      optionalText(txn.CategoryPrimary),
+		ProviderCategoryDetailed:     optionalText(txn.CategoryDetailed),
+		ProviderCategoryConfidence:   optionalText(txn.CategoryConfidence),
+		ProviderPaymentChannel:       pgtype.Text{String: txn.PaymentChannel, Valid: txn.PaymentChannel != ""},
+		Pending:                      txn.Pending,
+		ProviderRaw:                  txn.Raw,
 	}
 
 	return q.UpsertTransaction(ctx, params)
@@ -1020,8 +1021,8 @@ func (e *Engine) cleanStalePending(ctx context.Context, tx pgx.Tx, connectionID 
 		  AND date <= $3
 		  AND pending = true
 		  AND deleted_at IS NULL
-		  AND external_transaction_id != ALL($4)
-		RETURNING external_transaction_id`
+		  AND provider_transaction_id != ALL($4)
+		RETURNING provider_transaction_id`
 
 	rows, err := tx.Query(ctx, query, connectionID, fromDate, toDate, returnedIDs)
 	if err != nil {
@@ -1037,7 +1038,7 @@ func (e *Engine) cleanStalePending(ctx context.Context, tx pgx.Tx, connectionID 
 			logger.Error("scan stale pending transaction", "error", err)
 			continue
 		}
-		logger.Info("soft-deleted stale pending transaction", "external_transaction_id", externalID)
+		logger.Info("soft-deleted stale pending transaction", "provider_transaction_id", externalID)
 		count++
 	}
 	if rows.Err() != nil {

--- a/internal/sync/engine_integration_test.go
+++ b/internal/sync/engine_integration_test.go
@@ -315,7 +315,7 @@ func TestSync_ModifyTransactions(t *testing.T) {
 	var name string
 	var pending bool
 	err := pool.QueryRow(ctx,
-		"SELECT name, pending FROM transactions WHERE external_transaction_id = 'txn_1'",
+		"SELECT provider_name, pending FROM transactions WHERE provider_transaction_id = 'txn_1'",
 	).Scan(&name, &pending)
 	if err != nil {
 		t.Fatalf("query transaction: %v", err)
@@ -369,7 +369,7 @@ func TestSync_RemoveTransactions(t *testing.T) {
 	// Verify transaction was soft-deleted.
 	var deletedAt pgtype.Timestamptz
 	err := pool.QueryRow(ctx,
-		"SELECT deleted_at FROM transactions WHERE external_transaction_id = 'txn_1'",
+		"SELECT deleted_at FROM transactions WHERE provider_transaction_id = 'txn_1'",
 	).Scan(&deletedAt)
 	if err != nil {
 		t.Fatalf("query transaction: %v", err)
@@ -667,7 +667,7 @@ func TestSync_RuleCategoryDuringSync(t *testing.T) {
 	// Verify category was resolved via transaction rule.
 	var categoryID pgtype.UUID
 	err := pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_food'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_food'",
 	).Scan(&categoryID)
 	if err != nil {
 		t.Fatalf("query transaction: %v", err)
@@ -939,7 +939,7 @@ func TestSync_BalanceUpdateFailure_NonFatal(t *testing.T) {
 	// Transaction should still be created.
 	var count int
 	err := pool.QueryRow(ctx,
-		"SELECT count(*) FROM transactions WHERE external_transaction_id = 'txn_1'",
+		"SELECT count(*) FROM transactions WHERE provider_transaction_id = 'txn_1'",
 	).Scan(&count)
 	if err != nil {
 		t.Fatalf("count transactions: %v", err)
@@ -1020,7 +1020,7 @@ func TestSync_TellerStalePendingCleanup(t *testing.T) {
 	// Stale pending transaction should be soft-deleted.
 	var staleDeletedAt pgtype.Timestamptz
 	err = pool.QueryRow(ctx,
-		"SELECT deleted_at FROM transactions WHERE external_transaction_id = 'stale_pending_1'",
+		"SELECT deleted_at FROM transactions WHERE provider_transaction_id = 'stale_pending_1'",
 	).Scan(&staleDeletedAt)
 	if err != nil {
 		t.Fatalf("query stale txn: %v", err)
@@ -1032,7 +1032,7 @@ func TestSync_TellerStalePendingCleanup(t *testing.T) {
 	// Posted transaction should NOT be deleted.
 	var postedDeletedAt pgtype.Timestamptz
 	err = pool.QueryRow(ctx,
-		"SELECT deleted_at FROM transactions WHERE external_transaction_id = 'posted_1'",
+		"SELECT deleted_at FROM transactions WHERE provider_transaction_id = 'posted_1'",
 	).Scan(&postedDeletedAt)
 	if err != nil {
 		t.Fatalf("query posted txn: %v", err)
@@ -1131,7 +1131,7 @@ func TestSync_RuleBasedCategorization(t *testing.T) {
 	// Verify the transaction was categorized by the rule.
 	var categoryID pgtype.UUID
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_coffee'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_coffee'",
 	).Scan(&categoryID)
 	if err != nil {
 		t.Fatalf("query transaction: %v", err)
@@ -1261,7 +1261,7 @@ func TestSync_UnchangedTransactions_SkipRuleReapplication(t *testing.T) {
 	err = pool.QueryRow(ctx,
 		`SELECT created_at FROM annotations
 		 WHERE kind = 'rule_applied'
-		   AND transaction_id = (SELECT id FROM transactions WHERE external_transaction_id = 'txn_coffee')
+		   AND transaction_id = (SELECT id FROM transactions WHERE provider_transaction_id = 'txn_coffee')
 		 ORDER BY created_at ASC
 		 LIMIT 1`,
 	).Scan(&appliedAt1)
@@ -1300,7 +1300,7 @@ func TestSync_UnchangedTransactions_SkipRuleReapplication(t *testing.T) {
 	err = pool.QueryRow(ctx,
 		`SELECT COUNT(*), MIN(created_at) FROM annotations
 		 WHERE kind = 'rule_applied'
-		   AND transaction_id = (SELECT id FROM transactions WHERE external_transaction_id = 'txn_coffee')`,
+		   AND transaction_id = (SELECT id FROM transactions WHERE provider_transaction_id = 'txn_coffee')`,
 	).Scan(&annotationCount, &appliedAt2)
 	if err != nil {
 		t.Fatalf("query rule annotation after second sync: %v", err)
@@ -1391,7 +1391,7 @@ func TestRule_NullConditions_MatchesAll(t *testing.T) {
 
 	var categoryID pgtype.UUID
 	err := pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_match_all'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_match_all'",
 	).Scan(&categoryID)
 	if err != nil {
 		t.Fatalf("query transaction: %v", err)
@@ -1458,7 +1458,7 @@ func TestRule_Trigger_OnCreate_SkipsOnUpdate(t *testing.T) {
 	// Verify rule fired on create.
 	var initialCatID pgtype.UUID
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_on_create'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_on_create'",
 	).Scan(&initialCatID)
 	if err != nil {
 		t.Fatalf("query transaction after first sync: %v", err)
@@ -1470,7 +1470,7 @@ func TestRule_Trigger_OnCreate_SkipsOnUpdate(t *testing.T) {
 	// Manually move the transaction to a different category so we can detect
 	// re-fires (an on_update fire would overwrite our manual move).
 	_, err = pool.Exec(ctx,
-		"UPDATE transactions SET category_id = $1 WHERE external_transaction_id = 'txn_on_create'",
+		"UPDATE transactions SET category_id = $1 WHERE provider_transaction_id = 'txn_on_create'",
 		other.ID,
 	)
 	if err != nil {
@@ -1500,7 +1500,7 @@ func TestRule_Trigger_OnCreate_SkipsOnUpdate(t *testing.T) {
 	// on_create rule should NOT have re-fired — manual category should remain.
 	var finalCatID pgtype.UUID
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_on_create'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_on_create'",
 	).Scan(&finalCatID)
 	if err != nil {
 		t.Fatalf("query transaction after second sync: %v", err)
@@ -1555,7 +1555,7 @@ func TestRule_Trigger_OnUpdate_SkipsOnCreate(t *testing.T) {
 	// Rule did NOT fire on create — category should remain NULL.
 	var categoryID pgtype.UUID
 	err := pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_only_on_update'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_only_on_update'",
 	).Scan(&categoryID)
 	if err != nil {
 		t.Fatalf("query transaction: %v", err)
@@ -1619,7 +1619,7 @@ func TestRule_TypedActions_SetCategory_RespectsOverride(t *testing.T) {
 	// Sanity: rule fired on initial insert.
 	var initialCatID pgtype.UUID
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_override'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_override'",
 	).Scan(&initialCatID)
 	if err != nil {
 		t.Fatalf("query transaction after first sync: %v", err)
@@ -1630,7 +1630,7 @@ func TestRule_TypedActions_SetCategory_RespectsOverride(t *testing.T) {
 
 	// Set a manual override pointing at the other category.
 	_, err = pool.Exec(ctx,
-		"UPDATE transactions SET category_id = $1, category_override = TRUE WHERE external_transaction_id = 'txn_override'",
+		"UPDATE transactions SET category_id = $1, category_override = TRUE WHERE provider_transaction_id = 'txn_override'",
 		other.ID,
 	)
 	if err != nil {
@@ -1661,7 +1661,7 @@ func TestRule_TypedActions_SetCategory_RespectsOverride(t *testing.T) {
 
 	var finalCatID pgtype.UUID
 	err = pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_override'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_override'",
 	).Scan(&finalCatID)
 	if err != nil {
 		t.Fatalf("query transaction after second sync: %v", err)
@@ -1724,7 +1724,7 @@ func TestRule_ExpiredRule_NotFired(t *testing.T) {
 
 	var catID pgtype.UUID
 	if err := pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_expired'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_expired'",
 	).Scan(&catID); err != nil {
 		t.Fatalf("query transaction: %v", err)
 	}
@@ -1804,7 +1804,7 @@ func TestRule_DisabledRule_NotFired_DuringSync(t *testing.T) {
 
 	var catID pgtype.UUID
 	if err := pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_disabled'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_disabled'",
 	).Scan(&catID); err != nil {
 		t.Fatalf("query transaction: %v", err)
 	}
@@ -1876,13 +1876,13 @@ func TestRule_OverrideSuppressesSetCategoryButNotOthers(t *testing.T) {
 	// Pin a manual override on the row, swap the user's category, and remove
 	// the tag so the second sync has a clean slate to re-apply it.
 	if _, err := pool.Exec(ctx,
-		"UPDATE transactions SET category_id = $1, category_override = TRUE WHERE external_transaction_id = 'txn_override_combo'",
+		"UPDATE transactions SET category_id = $1, category_override = TRUE WHERE provider_transaction_id = 'txn_override_combo'",
 		overrideCat.ID,
 	); err != nil {
 		t.Fatalf("set override: %v", err)
 	}
 	if _, err := pool.Exec(ctx,
-		`DELETE FROM transaction_tags WHERE transaction_id = (SELECT id FROM transactions WHERE external_transaction_id = 'txn_override_combo')`,
+		`DELETE FROM transaction_tags WHERE transaction_id = (SELECT id FROM transactions WHERE provider_transaction_id = 'txn_override_combo')`,
 	); err != nil {
 		t.Fatalf("clear tags: %v", err)
 	}
@@ -1908,7 +1908,7 @@ func TestRule_OverrideSuppressesSetCategoryButNotOthers(t *testing.T) {
 	// the rule's food_and_drink.
 	var finalCatID pgtype.UUID
 	if err := pool.QueryRow(ctx,
-		"SELECT category_id FROM transactions WHERE external_transaction_id = 'txn_override_combo'",
+		"SELECT category_id FROM transactions WHERE provider_transaction_id = 'txn_override_combo'",
 	).Scan(&finalCatID); err != nil {
 		t.Fatalf("query transaction: %v", err)
 	}
@@ -1922,7 +1922,7 @@ func TestRule_OverrideSuppressesSetCategoryButNotOthers(t *testing.T) {
 		SELECT COUNT(*) FROM transaction_tags tt
 		JOIN tags t ON tt.tag_id = t.id
 		JOIN transactions tr ON tt.transaction_id = tr.id
-		WHERE tr.external_transaction_id = 'txn_override_combo' AND t.slug = 'caffeine'`,
+		WHERE tr.provider_transaction_id = 'txn_override_combo' AND t.slug = 'caffeine'`,
 	).Scan(&tagAttached); err != nil {
 		t.Fatalf("count tag attachment: %v", err)
 	}

--- a/internal/sync/matcher.go
+++ b/internal/sync/matcher.go
@@ -51,7 +51,7 @@ func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, 
 
 	// Find unmatched dependent transactions.
 	unmatchedQuery := `
-		SELECT t.id, t.date, t.amount, t.name, COALESCE(t.merchant_name, '') AS merchant_name
+		SELECT t.id, t.date, t.amount, t.provider_name, COALESCE(t.provider_merchant_name, '') AS provider_merchant_name
 		FROM transactions t
 		WHERE t.account_id = $1
 		  AND t.deleted_at IS NULL
@@ -96,7 +96,7 @@ func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, 
 	for _, dep := range unmatched {
 		// Find candidate primary transactions: same amount, date within tolerance, not already matched.
 		candidateQuery := `
-			SELECT t.id, t.name, COALESCE(t.merchant_name, '') AS merchant_name
+			SELECT t.id, t.provider_name, COALESCE(t.provider_merchant_name, '') AS provider_merchant_name
 			FROM transactions t
 			WHERE t.account_id = $1
 			  AND t.deleted_at IS NULL

--- a/internal/sync/tags_integration_test.go
+++ b/internal/sync/tags_integration_test.go
@@ -66,7 +66,7 @@ func TestSync_AddTagAction_PersistsTag(t *testing.T) {
 	err := pool.QueryRow(ctx, `
 		SELECT COUNT(*) FROM transaction_tags tt
 		JOIN transactions t ON tt.transaction_id = t.id
-		WHERE t.external_transaction_id = 'txn_tagged' AND tt.tag_id = $1`, tag.ID).Scan(&count)
+		WHERE t.provider_transaction_id = 'txn_tagged' AND tt.tag_id = $1`, tag.ID).Scan(&count)
 	if err != nil {
 		t.Fatalf("count transaction_tags: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestSync_AddTagAction_PersistsTag(t *testing.T) {
 	err = pool.QueryRow(ctx, `
 		SELECT COUNT(*) FROM annotations a
 		JOIN transactions t ON a.transaction_id = t.id
-		WHERE t.external_transaction_id = 'txn_tagged'
+		WHERE t.provider_transaction_id = 'txn_tagged'
 		  AND a.kind = 'tag_added'
 		  AND a.tag_id = $1
 		  AND a.rule_id IS NOT NULL`, tag.ID).Scan(&annCount)
@@ -95,7 +95,7 @@ func TestSync_AddTagAction_PersistsTag(t *testing.T) {
 	err = pool.QueryRow(ctx, `
 		SELECT added_by_type FROM transaction_tags tt
 		JOIN transactions t ON tt.transaction_id = t.id
-		WHERE t.external_transaction_id = 'txn_tagged' AND tt.tag_id = $1`, tag.ID).Scan(&addedByType)
+		WHERE t.provider_transaction_id = 'txn_tagged' AND tt.tag_id = $1`, tag.ID).Scan(&addedByType)
 	if err != nil {
 		t.Fatalf("query added_by_type: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestSync_RemoveTagAction_DeletesTagAndAnnotates(t *testing.T) {
 	_, err := pool.Exec(ctx, `
 		INSERT INTO transaction_tags (transaction_id, tag_id, added_by_type, added_by_name)
 		SELECT t.id, $1, 'user', 'Alice'
-		FROM transactions t WHERE t.external_transaction_id = 'txn_sbx'`, tag.ID)
+		FROM transactions t WHERE t.provider_transaction_id = 'txn_sbx'`, tag.ID)
 	if err != nil {
 		t.Fatalf("attach needs-review: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestSync_RemoveTagAction_DeletesTagAndAnnotates(t *testing.T) {
 	err = pool.QueryRow(ctx, `
 		SELECT COUNT(*) FROM transaction_tags tt
 		JOIN transactions t ON tt.transaction_id = t.id
-		WHERE t.external_transaction_id = 'txn_sbx' AND tt.tag_id = $1`, tag.ID).Scan(&ttCount)
+		WHERE t.provider_transaction_id = 'txn_sbx' AND tt.tag_id = $1`, tag.ID).Scan(&ttCount)
 	if err != nil {
 		t.Fatalf("count transaction_tags: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestSync_RemoveTagAction_DeletesTagAndAnnotates(t *testing.T) {
 	err = pool.QueryRow(ctx, `
 		SELECT COUNT(*) FROM annotations a
 		JOIN transactions t ON a.transaction_id = t.id
-		WHERE t.external_transaction_id = 'txn_sbx'
+		WHERE t.provider_transaction_id = 'txn_sbx'
 		  AND a.kind = 'tag_removed'
 		  AND a.tag_id = $1
 		  AND a.rule_id IS NOT NULL`, tag.ID).Scan(&annCount)
@@ -276,7 +276,7 @@ func TestSync_SeededRule_TagsAllNewTransactions(t *testing.T) {
 		JOIN transaction_tags tt ON tt.transaction_id = t.id
 		JOIN tags tag ON tag.id = tt.tag_id
 		WHERE tag.slug = 'needs-review'
-		  AND t.external_transaction_id IN ('txn_seeded_1', 'txn_seeded_2')`).Scan(&taggedCount)
+		  AND t.provider_transaction_id IN ('txn_seeded_1', 'txn_seeded_2')`).Scan(&taggedCount)
 	if err != nil {
 		t.Fatalf("count tagged transactions: %v", err)
 	}

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -180,11 +180,11 @@ func MustCreateTransaction(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 	t.Helper()
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
-		ExternalTransactionID: extID,
+		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgtype.Date{Time: MustParseDate(date), Valid: true},
-		Name:                  name,
+		ProviderName:          name,
 	})
 	if err != nil {
 		t.Fatalf("MustCreateTransaction(%q): %v", name, err)


### PR DESCRIPTION
Renames 8 raw-provider columns on `transactions` to an explicit `provider_*` prefix, adds a `provider_raw JSONB` column for the unmodified provider payload per transaction, and propagates the rename through every Go call site. First of 3 PRs doing a pre-1.0 cleanup of the transactions schema.

Previously this was the first of two PRs (schema-only vs internal rename) but CI runs `go vet` per-PR independently — a PR that renames columns without also fixing the Go references does not compile at its tip. Folded the follow-up back in so each PR in the stack is independently green.

## Summary

### Schema

- Migration `20260424184638_rename_provider_columns.sql` renames `external_transaction_id`, `pending_transaction_id`, `name`, `merchant_name`, `category_primary`, `category_detailed`, `category_confidence`, `payment_channel` to their `provider_*` equivalents, plus the indexes that embedded those names. Matching goose `Down` reverses everything.
- Adds `provider_raw JSONB NULL` for the unmodified provider payload. Populated by the Plaid, Teller, and CSV adapters on upsert.

### sqlc + queries

- `internal/db/queries/transactions.sql` and `internal/db/queries/transaction_matches.sql` updated to use the new column identifiers. sqlc regenerates clean.

### Internal Go rename (mechanical)

- Service layer: rename reads from renamed sqlc fields; rename column identifiers in dynamic SQL (`transactions.go`, `rules.go`, `search.go`, `categories.go`, `overview.go`, `transaction_summary.go`, `csv_import.go`).
- Sync engine + matcher: rename `UpsertTransactionParams` fields; rename column identifiers in stale-pending cleanup and matcher queries.
- Provider adapters (Plaid, Teller, CSV): marshal the raw provider payload via `json.Marshal` and populate the new `ProviderRaw` column on upsert. New `Raw []byte` field on the `provider.Transaction` abstraction.
- Seed + testutil updated.

## Intentionally unchanged

- Wire JSON shape on REST + MCP responses is **byte-identical** at this PR's tip. `TransactionResponse` in `internal/service/types.go` keeps its field names and `json:` tags.
- Rule DSL field identifiers (`name`, `merchant_name`, etc. inside rule JSON) are kept. Both get renamed in the next PR along with a data migration rewriting existing rule JSONB.
- `AdminTransactionRow` internal struct fields (`.Name`, `.MerchantName`) are kept — that struct represents "display name" in the admin list, which may swap to an enriched source later while keeping its API.

## Why

We're approaching the first public release and several columns that are unmodified provider data (name, merchant, categories) have been consumed throughout the codebase as if they were "the" transaction fields, even though future features will enrich these (especially `name`). The `provider_*` prefix makes "raw vs enriched" unambiguous at the schema level, and `provider_raw` gives us a durable place to hang the full payload for debugging, replay, and future enrichment flows.

## Important

**Destructive migration on the shared dev DB.** Column renames will break any other `breadbox serve` running against the shared `breadbox` database mid-session. Coordinate before applying locally (`make migrate`). CI and prod are unaffected until release — CI uses ephemeral `breadbox_test`.

## Delegation note

Internal Go rename was generated by a Sonnet subagent with a precise rename map and `go build ./...` as the feedback loop. Verified locally: vet + build + `go test ./...` (unit) all green.

## Test plan

- [ ] `sqlc generate` runs clean
- [ ] `go vet ./...` clean
- [ ] `go build ./...` green
- [ ] `go test ./...` (unit) green
- [ ] Migration applies cleanly (`goose up`) in an empty DB
- [ ] Down migration is symmetric (`goose down`)
- [ ] REST + MCP wire shape unchanged at this PR's tip (`go test ./internal/mcp/... -run ResponseShape`)
