### PR TITLE
transactions-rename: internal Go rename + provider_raw population

### DIFF
--- a/internal/provider/plaid/sync.go
+++ b/internal/provider/plaid/sync.go
@@ -2,6 +2,7 @@ package plaid
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -183,6 +184,11 @@ func mapTransaction(txn plaidgo.Transaction) provider.Transaction {
 		if conf, ok := pfc.GetConfidenceLevelOk(); ok && conf != nil {
 			t.CategoryConfidence = conf
 		}
+	}
+
+	// Store the raw Plaid transaction as JSON for audit / future use.
+	if raw, err := json.Marshal(txn); err == nil {
+		t.Raw = raw
 	}
 
 	return t

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -88,6 +88,7 @@ type Transaction struct {
 	PaymentChannel     string // online, in store, other
 	Pending            bool
 	ISOCurrencyCode    string
+	Raw                []byte // provider raw JSON payload; nil if unavailable
 }
 
 type WebhookPayload struct {

--- a/internal/provider/teller/sync.go
+++ b/internal/provider/teller/sync.go
@@ -195,6 +195,11 @@ func mapTellerTransaction(txn tellerTransaction, currencyMap map[string]string, 
 		t.MerchantName = &name
 	}
 
+	// Store the raw Teller transaction as JSON for audit / future use.
+	if raw, err := json.Marshal(txn); err == nil {
+		t.Raw = raw
+	}
+
 	return t, nil
 }
 

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -105,7 +105,7 @@ ON CONFLICT (id) DO NOTHING;
 `
 
 const transactionsSQL = `
-INSERT INTO transactions (account_id, external_transaction_id, amount, iso_currency_code, date, name, merchant_name, category_primary, category_detailed, payment_channel, pending) VALUES
+INSERT INTO transactions (account_id, provider_transaction_id, amount, iso_currency_code, date, provider_name, provider_merchant_name, provider_category_primary, provider_category_detailed, provider_payment_channel, pending) VALUES
   -- Alice / Chase Checking (seed_acct_1)
   ('00000000-0000-0000-0000-000000000021', 'seed_txn_001', 4.50,    'USD', CURRENT_DATE - INTERVAL '1 day',  'Starbucks Coffee',       'Starbucks',      'FOOD_AND_DRINK',  'COFFEE_SHOPS',     'in_store', false),
   ('00000000-0000-0000-0000-000000000021', 'seed_txn_002', 42.15,   'USD', CURRENT_DATE - INTERVAL '2 days', 'Shell Gas Station',      'Shell',          'TRANSPORTATION',  'GAS_STATIONS',     'in_store', false),
@@ -167,7 +167,7 @@ INSERT INTO transactions (account_id, external_transaction_id, amount, iso_curre
   ('00000000-0000-0000-0000-000000000023', 'seed_txn_048', -2800.00,'USD', CURRENT_DATE - INTERVAL '35 days','Direct Deposit',         NULL,             'INCOME',          'WAGES',            'other',    false),
   ('00000000-0000-0000-0000-000000000023', 'seed_txn_049', 1500.00, 'USD', CURRENT_DATE - INTERVAL '36 days','Rent',                   NULL,             'RENT_AND_UTILITIES', 'RENT',          'other',    false),
   ('00000000-0000-0000-0000-000000000023', 'seed_txn_050', 95.00,   'USD', CURRENT_DATE - INTERVAL '40 days','Kroger',                 'Kroger',         'FOOD_AND_DRINK',  'GROCERIES',        'in_store', false)
-ON CONFLICT (external_transaction_id) DO NOTHING;
+ON CONFLICT (provider_transaction_id) DO NOTHING;
 `
 
 const syncLogsSQL = `
@@ -191,7 +191,7 @@ ON CONFLICT (id) DO NOTHING;
 `
 
 const tellerTransactionsSQL = `
-INSERT INTO transactions (account_id, external_transaction_id, amount, iso_currency_code, date, name, merchant_name, category_primary, category_detailed, payment_channel, pending) VALUES
+INSERT INTO transactions (account_id, provider_transaction_id, amount, iso_currency_code, date, provider_name, provider_merchant_name, provider_category_primary, provider_category_detailed, provider_payment_channel, pending) VALUES
   -- Alice / Wells Fargo Checking (seed_acct_t1)
   ('00000000-0000-0000-0000-000000000025', 'seed_txn_t01', 12.50,   'USD', CURRENT_DATE - INTERVAL '1 day',  'Taco Bell',              'Taco Bell',      'FOOD_AND_DRINK',  NULL, 'other', false),
   ('00000000-0000-0000-0000-000000000025', 'seed_txn_t02', 45.00,   'USD', CURRENT_DATE - INTERVAL '3 days', 'Chevron Gas',            'Chevron',        'TRANSPORTATION',  NULL, 'other', false),
@@ -201,7 +201,7 @@ INSERT INTO transactions (account_id, external_transaction_id, amount, iso_curre
   -- Alice / Wells Fargo Savings (seed_acct_t2)
   ('00000000-0000-0000-0000-000000000026', 'seed_txn_t05', -300.00, 'USD', CURRENT_DATE - INTERVAL '2 days', 'Transfer from Checking', NULL,             'TRANSFER_IN',     NULL, 'other', false),
   ('00000000-0000-0000-0000-000000000026', 'seed_txn_t06', 0.18,    'USD', CURRENT_DATE - INTERVAL '30 days','Interest Payment',       NULL,             'INCOME',          NULL, 'other', false)
-ON CONFLICT (external_transaction_id) DO NOTHING;
+ON CONFLICT (provider_transaction_id) DO NOTHING;
 `
 
 const tellerSyncLogSQL = `

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -613,7 +613,7 @@ func (s *Service) BulkRecategorizeByFilter(ctx context.Context, params BulkRecat
 	}
 
 	if params.NameContains != nil {
-		query += fmt.Sprintf(" AND t.name ILIKE '%%' || $%d || '%%'", argN)
+		query += fmt.Sprintf(" AND t.provider_name ILIKE '%%' || $%d || '%%'", argN)
 		args = append(args, *params.NameContains)
 		argN++
 	}

--- a/internal/service/csv_import.go
+++ b/internal/service/csv_import.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -224,18 +225,25 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 		// Set to uncategorized — transaction rules will categorize on next sync.
 		categoryID := uncategorizedID
 
+		// Marshal raw CSV row as JSON for audit purposes.
+		var providerRaw []byte
+		if raw, err := json.Marshal(row); err == nil {
+			providerRaw = raw
+		}
+
 		txn, err := s.Queries.UpsertTransaction(ctx, db.UpsertTransactionParams{
-			AccountID:             accountID,
-			ExternalTransactionID: externalTxnID,
-			Amount:                amountNumeric,
-			IsoCurrencyCode:       pgconv.Text("USD"),
-			Date:                  pgtype.Date{Time: dateVal, Valid: true},
-			Name:                  desc,
-			MerchantName:          pgtype.Text{String: merchant, Valid: merchant != ""},
-			CategoryPrimary:       pgtype.Text{String: category, Valid: category != ""},
-			PaymentChannel:        pgconv.Text("other"),
-			Pending:               false,
-			CategoryID:            categoryID,
+			AccountID:               accountID,
+			ProviderTransactionID:   externalTxnID,
+			Amount:                  amountNumeric,
+			IsoCurrencyCode:         pgconv.Text("USD"),
+			Date:                    pgtype.Date{Time: dateVal, Valid: true},
+			ProviderName:            desc,
+			ProviderMerchantName:    pgtype.Text{String: merchant, Valid: merchant != ""},
+			ProviderCategoryPrimary: pgtype.Text{String: category, Valid: category != ""},
+			ProviderPaymentChannel:  pgconv.Text("other"),
+			Pending:                 false,
+			CategoryID:              categoryID,
+			ProviderRaw:             providerRaw,
 		})
 		if err != nil {
 			result.SkippedCount++

--- a/internal/service/overview.go
+++ b/internal/service/overview.go
@@ -216,11 +216,11 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		}
 
 		catRows, err := s.Pool.Query(ctx, `
-			SELECT COALESCE(t.category_primary, 'UNCATEGORIZED'), SUM(t.amount), COUNT(*)
+			SELECT COALESCE(t.provider_category_primary, 'UNCATEGORIZED'), SUM(t.amount), COUNT(*)
 			FROM transactions t
 			JOIN accounts a ON t.account_id = a.id
 			WHERE t.deleted_at IS NULL AND t.pending = false AND t.date >= $1 AND t.amount > 0 AND (a.is_dependent_linked = FALSE OR NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id))
-			GROUP BY t.category_primary
+			GROUP BY t.provider_category_primary
 			ORDER BY SUM(t.amount) DESC
 			LIMIT 5`, thirtyDaysAgo)
 		if err != nil {

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -1164,8 +1164,8 @@ func (s *Service) ListActiveRulesForSync(ctx context.Context) ([]TransactionRule
 // rows. The `set_category` UPDATE below enforces its own
 // `category_override = FALSE` guard so overridden rows keep their user-pinned
 // category.
-const transactionContextQuery = `SELECT t.id, t.name, COALESCE(t.merchant_name, ''), t.amount,
-	COALESCE(t.category_primary, ''), COALESCE(t.category_detailed, ''),
+const transactionContextQuery = `SELECT t.id, t.provider_name, COALESCE(t.provider_merchant_name, ''), t.amount,
+	COALESCE(t.provider_category_primary, ''), COALESCE(t.provider_category_detailed, ''),
 	t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, ''),
 	COALESCE(array_agg(DISTINCT tag.slug) FILTER (WHERE tag.slug IS NOT NULL), ARRAY[]::text[])
 	FROM transactions t
@@ -1178,7 +1178,7 @@ const transactionContextQuery = `SELECT t.id, t.name, COALESCE(t.merchant_name, 
 	AND (a.is_dependent_linked = FALSE OR NOT EXISTS (SELECT 1 FROM transaction_matches tm WHERE tm.dependent_transaction_id = t.id))`
 
 // transactionContextGroupBy is the GROUP BY clause matching transactionContextQuery.
-const transactionContextGroupBy = ` GROUP BY t.id, t.name, t.merchant_name, t.amount, t.category_primary, t.category_detailed, t.pending, bc.provider, t.account_id, u.id, u.name`
+const transactionContextGroupBy = ` GROUP BY t.id, t.provider_name, t.provider_merchant_name, t.amount, t.provider_category_primary, t.provider_category_detailed, t.pending, bc.provider, t.account_id, u.id, u.name`
 
 // transactionContextRow holds a scanned transaction row for rule evaluation.
 type transactionContextRow struct {
@@ -1731,8 +1731,8 @@ func (s *Service) previewRuleInternal(ctx context.Context, excludeRuleID *pgtype
 	// Must match the same filters as transactionContextQuery (used by ApplyRuleRetroactively):
 	// - category_override = FALSE (rules don't overwrite manual overrides)
 	// - exclude matched dependent transactions (dedup'd via account links)
-	baseQuery := `SELECT t.id, t.name, COALESCE(t.merchant_name, ''), t.amount,
-		COALESCE(t.category_primary, ''), COALESCE(t.category_detailed, ''),
+	baseQuery := `SELECT t.id, t.provider_name, COALESCE(t.provider_merchant_name, ''), t.amount,
+		COALESCE(t.provider_category_primary, ''), COALESCE(t.provider_category_detailed, ''),
 		t.pending, bc.provider, t.account_id::text, COALESCE(u.id::text, ''), COALESCE(u.name, ''),
 		t.date, COALESCE(c.slug, '')
 		FROM transactions t
@@ -2317,7 +2317,7 @@ func (s *Service) ListRuleApplications(ctx context.Context, ruleID string, limit
 		limit = 100
 	}
 
-	query := `SELECT ann.id, ann.transaction_id, t.name, t.amount, t.date,
+	query := `SELECT ann.id, ann.transaction_id, t.provider_name, t.amount, t.date,
 		COALESCE(ann.payload->>'action_field', ''),
 		COALESCE(ann.payload->>'action_value', ''),
 		COALESCE(ann.payload->>'applied_by', 'sync'),

--- a/internal/service/search.go
+++ b/internal/service/search.go
@@ -343,10 +343,10 @@ func estimateExcludeSize(numCols, numTerms int, columns []string, nullableColumn
 }
 
 // TransactionSearchColumns are the standard columns searched for transactions.
-var TransactionSearchColumns = []string{"t.name", "t.merchant_name"}
+var TransactionSearchColumns = []string{"t.provider_name", "t.provider_merchant_name"}
 
 // TransactionNullableColumns marks which transaction search columns are nullable.
-var TransactionNullableColumns = map[string]bool{"t.merchant_name": true}
+var TransactionNullableColumns = map[string]bool{"t.provider_merchant_name": true}
 
 // validSearchFields lists recognized search_field values.
 var validSearchFields = map[string]bool{
@@ -367,9 +367,9 @@ func resolveSearchField(field *string) ([]string, map[string]bool) {
 	}
 	switch *field {
 	case "name":
-		return []string{"t.name"}, map[string]bool{}
+		return []string{"t.provider_name"}, map[string]bool{}
 	case "merchant":
-		return []string{"t.merchant_name"}, map[string]bool{"t.merchant_name": true}
+		return []string{"t.provider_merchant_name"}, map[string]bool{"t.provider_merchant_name": true}
 	default:
 		return TransactionSearchColumns, TransactionNullableColumns
 	}

--- a/internal/service/transaction_summary.go
+++ b/internal/service/transaction_summary.go
@@ -82,8 +82,8 @@ func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionS
 	joinCategories := false
 	switch params.GroupBy {
 	case "category":
-		selectCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.category_primary, '_', ' ')), 'Uncategorized') AS category, cat.icon AS category_icon, cat.color AS category_color, t.iso_currency_code"
-		groupCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.category_primary, '_', ' ')), 'Uncategorized'), cat.icon, cat.color, t.iso_currency_code"
+		selectCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.provider_category_primary, '_', ' ')), 'Uncategorized') AS category, cat.icon AS category_icon, cat.color AS category_color, t.iso_currency_code"
+		groupCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.provider_category_primary, '_', ' ')), 'Uncategorized'), cat.icon, cat.color, t.iso_currency_code"
 		orderCols = "SUM(t.amount) DESC"
 		joinCategories = true
 	case "month":
@@ -99,8 +99,8 @@ func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionS
 		groupCols = "t.date, t.iso_currency_code"
 		orderCols = "t.date DESC"
 	case "category_month":
-		selectCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.category_primary, '_', ' ')), 'Uncategorized') AS category, cat.icon AS category_icon, cat.color AS category_color, to_char(date_trunc('month', t.date), 'YYYY-MM') AS period, t.iso_currency_code"
-		groupCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.category_primary, '_', ' ')), 'Uncategorized'), cat.icon, cat.color, date_trunc('month', t.date), t.iso_currency_code"
+		selectCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.provider_category_primary, '_', ' ')), 'Uncategorized') AS category, cat.icon AS category_icon, cat.color AS category_color, to_char(date_trunc('month', t.date), 'YYYY-MM') AS period, t.iso_currency_code"
+		groupCols = "COALESCE(cat.display_name, INITCAP(REPLACE(t.provider_category_primary, '_', ' ')), 'Uncategorized'), cat.icon, cat.color, date_trunc('month', t.date), t.iso_currency_code"
 		orderCols = "date_trunc('month', t.date) DESC, SUM(t.amount) DESC"
 		joinCategories = true
 	}
@@ -160,7 +160,7 @@ func (s *Service) GetTransactionSummary(ctx context.Context, params TransactionS
 	}
 
 	if params.Category != nil {
-		buf.WriteString(" AND t.category_primary = $")
+		buf.WriteString(" AND t.provider_category_primary = $")
 		buf.WriteString(strconv.Itoa(argN))
 		args = append(args, *params.Category)
 		argN++ //nolint:ineffassign // kept for consistency with other filters
@@ -255,7 +255,7 @@ func (s *Service) GetMerchantSummary(ctx context.Context, params MerchantSummary
 	args := make([]any, 0, 12)
 	argN := 1
 
-	buf.WriteString(`SELECT COALESCE(t.merchant_name, t.name) AS merchant,
+	buf.WriteString(`SELECT COALESCE(t.provider_merchant_name, t.provider_name) AS merchant,
 		COUNT(*) AS transaction_count,
 		SUM(t.amount) AS total_amount,
 		AVG(t.amount) AS avg_amount,
@@ -369,7 +369,7 @@ LEFT JOIN bank_connections bc ON a.connection_id = bc.id`)
 		argN = ec.ArgN
 	}
 
-	buf.WriteString(" GROUP BY COALESCE(t.merchant_name, t.name), t.iso_currency_code")
+	buf.WriteString(" GROUP BY COALESCE(t.provider_merchant_name, t.provider_name), t.iso_currency_code")
 	buf.WriteString(" HAVING COUNT(*) >= $")
 	buf.WriteString(strconv.Itoa(argN))
 	args = append(args, params.MinCount)

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -99,11 +99,11 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 	args := make([]any, 0, 16)
 	argN := 1
 
-	buf.WriteString("SELECT t.id, t.short_id, t.account_id, t.external_transaction_id, t.pending_transaction_id, " +
+	buf.WriteString("SELECT t.id, t.short_id, t.account_id, t.provider_transaction_id, t.provider_pending_transaction_id, " +
 		"t.amount, t.iso_currency_code, t.unofficial_currency_code, t.date, t.authorized_date, " +
-		"t.datetime, t.authorized_datetime, t.name, t.merchant_name, " +
-		"t.category_primary, t.category_detailed, t.category_confidence, " +
-		"t.payment_channel, t.pending, t.deleted_at, t.created_at, t.updated_at, " +
+		"t.datetime, t.authorized_datetime, t.provider_name, t.provider_merchant_name, " +
+		"t.provider_category_primary, t.provider_category_detailed, t.provider_category_confidence, " +
+		"t.provider_payment_channel, t.pending, t.deleted_at, t.created_at, t.updated_at, " +
 		"COALESCE(a.display_name, a.name) AS account_name, " +
 		"a.short_id AS account_short_id, " +
 		"COALESCE(au.name, u.name) AS user_name, " +
@@ -282,7 +282,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		case "amount":
 			sortCol = "t.amount"
 		case "name":
-			sortCol = "t.name"
+			sortCol = "t.provider_name"
 		case "date":
 			sortCol = "t.date"
 		}
@@ -667,7 +667,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 
 	buf.WriteString("SELECT t.id, t.account_id, COALESCE(a.display_name, a.name, ''), " +
 		"COALESCE(bc.institution_name, ''), COALESCE(au.name, u.name, ''), " +
-		"t.date, t.name, t.merchant_name, t.amount, t.iso_currency_code, " +
+		"t.date, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, " +
 		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, " +
 		// "Agent reviewed" is inferred from a category_set annotation authored
@@ -1059,7 +1059,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 
 	query := "SELECT t.id, t.account_id, COALESCE(a.display_name, a.name, ''), " +
 		"COALESCE(bc.institution_name, ''), COALESCE(au.name, u.name, ''), " +
-		"t.date, t.name, t.merchant_name, t.amount, t.iso_currency_code, " +
+		"t.date, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, " +
 		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, " +
 		"EXISTS(SELECT 1 FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'category_set' AND ann.actor_type = 'agent') AS agent_reviewed, " +
@@ -1184,7 +1184,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 
 func (s *Service) ListDistinctCategories(ctx context.Context) ([]CategoryPair, error) {
 	rows, err := s.Pool.Query(ctx,
-		"SELECT DISTINCT category_primary, category_detailed FROM transactions WHERE deleted_at IS NULL AND category_primary IS NOT NULL ORDER BY category_primary, category_detailed")
+		"SELECT DISTINCT provider_category_primary, provider_category_detailed FROM transactions WHERE deleted_at IS NULL AND provider_category_primary IS NOT NULL ORDER BY provider_category_primary, provider_category_detailed")
 	if err != nil {
 		return nil, fmt.Errorf("list distinct categories: %w", err)
 	}
@@ -1239,13 +1239,13 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		AuthorizedDate:      dateStr(txn.AuthorizedDate),
 		Datetime:            timestampStr(txn.Datetime),
 		AuthorizedDatetime:  timestampStr(txn.AuthorizedDatetime),
-		Name:                txn.Name,
-		MerchantName:        textPtr(txn.MerchantName),
-		CategoryPrimaryRaw:  textPtr(txn.CategoryPrimary),
-		CategoryDetailedRaw: textPtr(txn.CategoryDetailed),
-		CategoryConfidence:  textPtr(txn.CategoryConfidence),
+		Name:                txn.ProviderName,
+		MerchantName:        textPtr(txn.ProviderMerchantName),
+		CategoryPrimaryRaw:  textPtr(txn.ProviderCategoryPrimary),
+		CategoryDetailedRaw: textPtr(txn.ProviderCategoryDetailed),
+		CategoryConfidence:  textPtr(txn.ProviderCategoryConfidence),
 		CategoryOverride:    txn.CategoryOverride,
-		PaymentChannel:      textPtr(txn.PaymentChannel),
+		PaymentChannel:      textPtr(txn.ProviderPaymentChannel),
 		Pending:             txn.Pending,
 		CreatedAt:           pgconv.TimestampStr(txn.CreatedAt),
 		UpdatedAt:           pgconv.TimestampStr(txn.UpdatedAt),

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -550,22 +550,23 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 	}
 
 	params := db.UpsertTransactionParams{
-		AccountID:             accountID,
-		ExternalTransactionID: txn.ExternalID,
-		PendingTransactionID:  optionalText(txn.PendingExternalID),
-		Amount:                decimalToNumeric(txn.Amount),
-		IsoCurrencyCode:       pgtype.Text{String: txn.ISOCurrencyCode, Valid: txn.ISOCurrencyCode != ""},
-		Date:                  pgtype.Date{Time: txn.Date, Valid: true},
-		AuthorizedDate:        optionalDate(txn.AuthorizedDate),
-		Datetime:              optionalTimestamptz(txn.Datetime),
-		AuthorizedDatetime:    optionalTimestamptz(txn.AuthorizedDatetime),
-		Name:                  txn.Name,
-		MerchantName:          optionalText(txn.MerchantName),
-		CategoryPrimary:       optionalText(txn.CategoryPrimary),
-		CategoryDetailed:      optionalText(txn.CategoryDetailed),
-		CategoryConfidence:    optionalText(txn.CategoryConfidence),
-		PaymentChannel:        pgtype.Text{String: txn.PaymentChannel, Valid: txn.PaymentChannel != ""},
-		Pending:               txn.Pending,
+		AccountID:                    accountID,
+		ProviderTransactionID:        txn.ExternalID,
+		ProviderPendingTransactionID: optionalText(txn.PendingExternalID),
+		Amount:                       decimalToNumeric(txn.Amount),
+		IsoCurrencyCode:              pgtype.Text{String: txn.ISOCurrencyCode, Valid: txn.ISOCurrencyCode != ""},
+		Date:                         pgtype.Date{Time: txn.Date, Valid: true},
+		AuthorizedDate:               optionalDate(txn.AuthorizedDate),
+		Datetime:                     optionalTimestamptz(txn.Datetime),
+		AuthorizedDatetime:           optionalTimestamptz(txn.AuthorizedDatetime),
+		ProviderName:                 txn.Name,
+		ProviderMerchantName:         optionalText(txn.MerchantName),
+		ProviderCategoryPrimary:      optionalText(txn.CategoryPrimary),
+		ProviderCategoryDetailed:     optionalText(txn.CategoryDetailed),
+		ProviderCategoryConfidence:   optionalText(txn.CategoryConfidence),
+		ProviderPaymentChannel:       pgtype.Text{String: txn.PaymentChannel, Valid: txn.PaymentChannel != ""},
+		Pending:                      txn.Pending,
+		ProviderRaw:                  txn.Raw,
 	}
 
 	return q.UpsertTransaction(ctx, params)
@@ -1020,8 +1021,8 @@ func (e *Engine) cleanStalePending(ctx context.Context, tx pgx.Tx, connectionID 
 		  AND date <= $3
 		  AND pending = true
 		  AND deleted_at IS NULL
-		  AND external_transaction_id != ALL($4)
-		RETURNING external_transaction_id`
+		  AND provider_transaction_id != ALL($4)
+		RETURNING provider_transaction_id`
 
 	rows, err := tx.Query(ctx, query, connectionID, fromDate, toDate, returnedIDs)
 	if err != nil {
@@ -1037,7 +1038,7 @@ func (e *Engine) cleanStalePending(ctx context.Context, tx pgx.Tx, connectionID 
 			logger.Error("scan stale pending transaction", "error", err)
 			continue
 		}
-		logger.Info("soft-deleted stale pending transaction", "external_transaction_id", externalID)
+		logger.Info("soft-deleted stale pending transaction", "provider_transaction_id", externalID)
 		count++
 	}
 	if rows.Err() != nil {

--- a/internal/sync/matcher.go
+++ b/internal/sync/matcher.go
@@ -51,7 +51,7 @@ func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, 
 
 	// Find unmatched dependent transactions.
 	unmatchedQuery := `
-		SELECT t.id, t.date, t.amount, t.name, COALESCE(t.merchant_name, '') AS merchant_name
+		SELECT t.id, t.date, t.amount, t.provider_name, COALESCE(t.provider_merchant_name, '') AS provider_merchant_name
 		FROM transactions t
 		WHERE t.account_id = $1
 		  AND t.deleted_at IS NULL
@@ -96,7 +96,7 @@ func (m *Matcher) ReconcileLink(ctx context.Context, link db.AccountLink) (int, 
 	for _, dep := range unmatched {
 		// Find candidate primary transactions: same amount, date within tolerance, not already matched.
 		candidateQuery := `
-			SELECT t.id, t.name, COALESCE(t.merchant_name, '') AS merchant_name
+			SELECT t.id, t.provider_name, COALESCE(t.provider_merchant_name, '') AS provider_merchant_name
 			FROM transactions t
 			WHERE t.account_id = $1
 			  AND t.deleted_at IS NULL

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -180,11 +180,11 @@ func MustCreateTransaction(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 	t.Helper()
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
-		ExternalTransactionID: extID,
+		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgtype.Date{Time: MustParseDate(date), Valid: true},
-		Name:                  name,
+		ProviderName:          name,
 	})
 	if err != nil {
 		t.Fatalf("MustCreateTransaction(%q): %v", name, err)


### PR DESCRIPTION
Mechanical follow-up to the schema rename in PR 01 — updates every call site in `internal/service/`, `internal/sync/`, `internal/provider/`, `internal/seed/`, and `internal/testutil/` to use the new `Provider*` sqlc field names and the new `provider_*` column identifiers in hand-rolled dynamic SQL. Also adds provider-raw population in the three provider adapters.

## Summary

- Service layer: rename reads from renamed sqlc fields; rename column identifiers in dynamic SQL (`internal/service/transactions.go`, `rules.go`, `search.go`, `categories.go`, `overview.go`, `transaction_summary.go`, `csv_import.go`).
- Sync engine + matcher: rename `UpsertTransactionParams` fields; rename column identifiers in stale-pending cleanup and matcher queries (`internal/sync/engine.go`, `matcher.go`).
- Provider adapters (Plaid, Teller, CSV): marshal the raw provider payload via `json.Marshal` and populate the new `ProviderRaw` column on upsert. New `Raw []byte` field on the `provider.Transaction` abstraction.
- Seed + testutil updated.

## Intentionally unchanged

- Wire JSON shape on REST + MCP responses is **byte-identical to before**. `TransactionResponse` in `internal/service/types.go` keeps its field names and `json:` tags.
- Rule DSL field identifiers (`name`, `merchant_name`, etc. as strings inside rule JSON) are kept. Both get renamed in PR 03 with a matching data migration.
- `AdminTransactionRow` internal struct fields (`.Name`, `.MerchantName`) are kept — that struct represents "display name" in the admin list, which may swap to an enriched source later while keeping its API.

## Delegation note

This PR was generated by a Sonnet subagent with a precise rename map and `go build ./...` as the feedback loop. Verified locally: build clean, `go test ./...` (unit) green, `go vet` clean.

## Test plan

- [ ] `go build ./...` green
- [ ] `go test ./...` (unit) green
- [ ] Integration tests still compile (not run in this session — shared DB)
- [ ] REST + MCP wire shape unchanged under `go test ./internal/mcp/... -run ResponseShape`
