### PR TITLE
transactions-rename: docs + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Breadbox will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Breaking Changes (Pre-1.0)
+
+- **Renamed provider-data fields on transactions table.** Raw data fields from bank providers are now prefixed with `provider_` to clarify they are unmodified provider data, not Breadbox assignments. This affects:
+  - Database columns: `external_transaction_id` → `provider_transaction_id`, `pending_transaction_id` → `provider_pending_transaction_id`, `name` → `provider_name`, `merchant_name` → `provider_merchant_name`, `category_primary` → `provider_category_primary`, `category_detailed` → `provider_category_detailed`, `category_confidence` → `provider_category_confidence`, `payment_channel` → `provider_payment_channel`
+  - REST API / MCP response keys: `name` → `provider_name`, `merchant_name` → `provider_merchant_name`, `category_primary_raw` → `provider_category_primary`, `category_detailed_raw` → `provider_category_detailed`, `category_confidence` → `provider_category_confidence`, `payment_channel` → `provider_payment_channel`
+  - Rule DSL condition field identifiers: `name` → `provider_name`, `merchant_name` → `provider_merchant_name`, `category_primary` → `provider_category_primary`, `category_detailed` → `provider_category_detailed` (assignment `category` field unchanged)
+  - Field selector aliases: `minimal` expands to `provider_name, amount, date` (was `name, amount, date`); `core` expands to `id, date, amount, provider_name, iso_currency_code`; `category` expands to `category, provider_category_primary, provider_category_detailed`
+  - Sort parameter: `sort_by=name` → `sort_by=provider_name` (`date`, `amount` unchanged)
+  - New `provider_raw JSONB` column stores the unmodified provider payload for each transaction
+- **Rule DSL field renames.** Rules condition trees now use `provider_name`, `provider_merchant_name`, `provider_category_primary`, `provider_category_detailed` instead of the unqualified versions.
+
 ## [0.1.0] - 2026-04-XX
 
 ### Added

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -67,7 +67,7 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 | `pending` | bool | Filter by pending status |
 | `tags` | string | Comma-separated slugs; result transactions must carry **every** slug (AND) |
 | `any_tag` | string | Comma-separated slugs; result transactions must carry **at least one** slug (OR) |
-| `sort_by` | string | `date` (default), `amount`, `name` |
+| `sort_by` | string | `date` (default), `amount`, `provider_name` |
 | `sort_order` | string | `desc` (default), `asc` |
 | `fields` | string | Field selection. Aliases: `minimal`, `core`, `category`, `timestamps` |
 | `cursor` | string | Pagination cursor (only with date sort) |
@@ -151,13 +151,13 @@ Rules use a recursive JSON condition tree supporting AND/OR/NOT logic:
 {
   "type": "and",
   "conditions": [
-    { "field": "name", "operator": "contains", "value": "AMAZON" },
+    { "field": "provider_name", "operator": "contains", "value": "AMAZON" },
     { "field": "amount", "operator": "gt", "value": 50 }
   ]
 }
 ```
 
-**Available fields:** `name`, `merchant_name`, `amount`, `category_primary`, `category_detailed`, `pending`, `provider`, `account_id`, `user_id`, `user_name`
+**Available fields:** `provider_name`, `provider_merchant_name`, `amount`, `provider_category_primary`, `provider_category_detailed`, `pending`, `provider`, `account_id`, `user_id`, `user_name`
 
 **String operators:** `eq`, `neq`, `contains`, `not_contains`, `matches` (regex), `in`
 

--- a/docs/csv-import.md
+++ b/docs/csv-import.md
@@ -198,7 +198,7 @@ This avoids the MM/DD vs DD/MM ambiguity problem — if all dates parse as both,
 
 ### Hash Algorithm
 
-Each imported transaction gets a deterministic `external_transaction_id`:
+Each imported transaction gets a deterministic `provider_transaction_id`:
 
 ```
 SHA-256(account_id | date | amount | description)
@@ -213,7 +213,7 @@ Where:
 
 ### Upsert Behavior
 
-The generated `external_transaction_id` is passed to the existing `UpsertTransaction` query, which uses `ON CONFLICT (external_transaction_id) DO UPDATE`. This means:
+The generated `provider_transaction_id` is passed to the existing `UpsertTransaction` query, which uses `ON CONFLICT (provider_transaction_id) DO UPDATE`. This means:
 
 - **First import**: all rows are inserted as new transactions
 - **Re-import same file**: all rows match existing transactions, counts as "updated" (no-op in practice since values are identical)

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -133,20 +133,21 @@ This document defines the complete PostgreSQL database schema for the Breadbox M
                             │──────────────────────│
                             │ id (PK)              │
                             │ account_id (FK)      │
-                            │ external_transaction_id│
-                            │ pending_transaction_id│
+                            │ provider_transaction_id│
+                            │ provider_pending_transaction_id│
                             │ amount               │
                             │ iso_currency_code    │
                             │ date                 │
                             │ authorized_date      │
                             │ datetime             │
                             │ authorized_datetime  │
-                            │ name                 │
-                            │ merchant_name        │
-                            │ category_primary     │
-                            │ category_detailed    │
-                            │ category_confidence  │
-                            │ payment_channel      │
+                            │ provider_name        │
+                            │ provider_merchant_name│
+                            │ provider_category_primary│
+                            │ provider_category_detailed│
+                            │ provider_category_confidence│
+                            │ provider_payment_channel│
+                            │ provider_raw (JSONB) │
                             │ pending              │
                             │ deleted_at           │
                             │ created_at           │
@@ -400,8 +401,8 @@ Plaid `account_id` values are globally unique across all items and institutions.
 |---|---|---|---|---|
 | `id` | `UUID` | No | `gen_random_uuid()` | Primary key. Internal Breadbox identifier. |
 | `account_id` | `UUID` | Yes | `NULL` | FK to `accounts.id`. SET NULL on account delete. Nullable so transactions are preserved for historical queries if the parent account is removed. |
-| `external_transaction_id` | `TEXT` | No | — | Provider-assigned transaction identifier. For Plaid: `transaction_id`. Case-sensitive. Stable for posted transactions; pending transactions may receive a new `transaction_id` when they post. Used for upsert during sync. |
-| `pending_transaction_id` | `TEXT` | Yes | `NULL` | For a posted transaction that was previously pending, this is the `transaction_id` of that original pending transaction. Plaid sets this field to link the posted record back to the pending record it replaced. The application uses this to locate and soft-delete the superseded pending row. |
+| `provider_transaction_id` | `TEXT` | No | — | Provider-assigned transaction identifier. For Plaid: `transaction_id`. Case-sensitive. Stable for posted transactions; pending transactions may receive a new `transaction_id` when they post. Used for upsert during sync. |
+| `provider_pending_transaction_id` | `TEXT` | Yes | `NULL` | For a posted transaction that was previously pending, this is the `transaction_id` of that original pending transaction. Plaid sets this field to link the posted record back to the pending record it replaced. The application uses this to locate and soft-delete the superseded pending row. |
 | `amount` | `NUMERIC(12,2)` | No | — | Transaction amount in the account's currency. **Sign convention (Plaid passthrough):** Positive values represent money leaving the account (debits, purchases, payments). Negative values represent money entering the account (credits, refunds, deposits). This matches Plaid's native convention exactly — Breadbox does not invert the sign. See Section 4 for full rationale. |
 | `iso_currency_code` | `TEXT` | Yes | `NULL` | ISO-4217 currency code for this transaction (e.g., `USD`). `NULL` if Plaid returns an unofficial currency code. Never silently aggregate across currencies. |
 | `unofficial_currency_code` | `TEXT` | Yes | `NULL` | Non-standard currency code (e.g., cryptocurrency). Mutually exclusive with `iso_currency_code` — Plaid guarantees at most one is non-null. |
@@ -409,12 +410,13 @@ Plaid `account_id` values are globally unique across all items and institutions.
 | `authorized_date` | `DATE` | Yes | `NULL` | Date the transaction was authorized by the user (e.g., when a card was swiped). Earlier than or equal to `date` for posted transactions. Not always available. |
 | `datetime` | `TIMESTAMPTZ` | Yes | `NULL` | Full timestamp of the posted transaction, if provided by the institution. Only available for select institutions. `NULL` for most transactions. |
 | `authorized_datetime` | `TIMESTAMPTZ` | Yes | `NULL` | Full timestamp of authorization, if provided by the institution. `NULL` for most transactions. |
-| `name` | `TEXT` | No | — | Merchant name or transaction description as returned by Plaid (sourced from the raw financial institution description). This is the primary human-readable description of the transaction. Plaid marks this field as deprecated in favor of `merchant_name` but it remains populated and is the most reliable description field. |
-| `merchant_name` | `TEXT` | Yes | `NULL` | Plaid-enriched merchant name, cleaned and normalized from the `name` field (e.g., "McDonald's" instead of "MCDONALDS 00321 CARD PURCH"). `NULL` when Plaid cannot identify the merchant. |
-| `category_primary` | `TEXT` | Yes | `NULL` | High-level personal finance category from Plaid's `personal_finance_category.primary` (e.g., `FOOD_AND_DRINK`, `TRANSPORTATION`, `INCOME`). Part of Plaid's enriched categorization taxonomy (v2). |
-| `category_detailed` | `TEXT` | Yes | `NULL` | Granular subcategory from Plaid's `personal_finance_category.detailed` (e.g., `FOOD_AND_DRINK_RESTAURANTS`, `TRANSPORTATION_GAS_AND_FUEL`). Can be used as a stable identifier. |
-| `category_confidence` | `TEXT` | Yes | `NULL` | Plaid's confidence in the category assignment. One of: `VERY_HIGH`, `HIGH`, `MEDIUM`, `LOW`, `UNKNOWN`. |
-| `payment_channel` | `TEXT` | Yes | `NULL` | Channel used to make the payment. One of: `online`, `in store`, `other`. `NULL` if Plaid does not provide this field. |
+| `provider_name` | `TEXT` | No | — | Merchant name or transaction description as returned by the provider (sourced from the raw financial institution description). This is the primary human-readable description of the transaction. Plaid marks this field as deprecated in favor of `merchant_name` but it remains populated and is the most reliable description field. |
+| `provider_merchant_name` | `TEXT` | Yes | `NULL` | Provider-enriched merchant name, cleaned and normalized from the provider name field (e.g., "McDonald's" instead of "MCDONALDS 00321 CARD PURCH"). `NULL` when the provider cannot identify the merchant. |
+| `provider_category_primary` | `TEXT` | Yes | `NULL` | High-level personal finance category from the provider's categorization (e.g., `FOOD_AND_DRINK`, `TRANSPORTATION`, `INCOME` for Plaid). Part of the provider's enriched categorization taxonomy. |
+| `provider_category_detailed` | `TEXT` | Yes | `NULL` | Granular subcategory from the provider (e.g., `FOOD_AND_DRINK_RESTAURANTS`, `TRANSPORTATION_GAS_AND_FUEL` for Plaid). Can be used as a stable identifier. |
+| `provider_category_confidence` | `TEXT` | Yes | `NULL` | Provider's confidence in the category assignment. One of: `VERY_HIGH`, `HIGH`, `MEDIUM`, `LOW`, `UNKNOWN`. |
+| `provider_payment_channel` | `TEXT` | Yes | `NULL` | Channel used to make the payment. One of: `online`, `in store`, `other`. `NULL` if the provider does not provide this field. |
+| `provider_raw` | `JSONB` | Yes | `NULL` | Unmodified provider payload for this transaction. Populated by the Plaid, Teller, and CSV adapters during upsert. Useful for debugging, replaying enrichment, and accessing fields that Breadbox does not yet model as typed columns. Large — do not `SELECT *` it on list endpoints. |
 | `pending` | `BOOLEAN` | No | `FALSE` | Whether the transaction has settled. `TRUE` = pending (not yet cleared). `FALSE` = posted. Pending transactions may change details or be replaced entirely when they post. |
 | `deleted_at` | `TIMESTAMPTZ` | Yes | `NULL` | Soft-delete timestamp. `NULL` means the transaction is active. Set to the current time when Plaid includes this `transaction_id` in the `removed` array of a `/transactions/sync` response. Soft-deleted transactions are excluded from API responses by default but are never hard-deleted. |
 | `created_at` | `TIMESTAMPTZ` | No | `NOW()` | Timestamp when this row was first inserted into Breadbox. |
@@ -435,10 +437,10 @@ FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE SET NULL
 #### Unique Constraints
 
 ```sql
-UNIQUE (external_transaction_id)
+UNIQUE (provider_transaction_id)
 ```
 
-Enables `INSERT ... ON CONFLICT (external_transaction_id) DO UPDATE` upsert pattern for all sync operations. Plaid `transaction_id` values are globally unique.
+Enables `INSERT ... ON CONFLICT (provider_transaction_id) DO UPDATE` upsert pattern for all sync operations. Plaid `transaction_id` values are globally unique.
 
 #### Indexes
 
@@ -447,13 +449,13 @@ See Section 5 for full index rationale. Summary:
 | Index | Columns | Type | Rationale |
 |---|---|---|---|
 | `transactions_pkey` | `id` | B-tree (implicit PK) | Primary key lookup. |
-| `transactions_external_transaction_id_idx` | `external_transaction_id` | B-tree | Upsert lookup during sync. Enforces unique constraint. |
+| `transactions_provider_transaction_id_idx` | `provider_transaction_id` | B-tree | Upsert lookup during sync. Enforces unique constraint. |
 | `transactions_account_id_date_idx` | `account_id, date DESC` | B-tree | Primary query pattern: all transactions for an account ordered by date. |
 | `transactions_account_id_date_active_idx` | `account_id, date DESC` WHERE `deleted_at IS NULL` | Partial B-tree | Same as above but excludes soft-deleted rows. Most API queries use this path. |
 | `transactions_date_idx` | `date DESC` | B-tree | Date-range queries spanning multiple accounts (e.g., agent asking "all transactions last 30 days"). |
 | `transactions_pending_idx` | `pending` | B-tree | Filter pending/posted transactions. Low cardinality; effective when combined with other predicates. |
-| `transactions_category_primary_idx` | `category_primary` | B-tree | Filter by spending category (e.g., all `FOOD_AND_DRINK` transactions). |
-| `transactions_name_merchant_gin_idx` | `name, merchant_name` | GIN (pg_trgm) | Full-text trigram search on transaction description and merchant name. Supports `ILIKE '%query%'` efficiently. |
+| `transactions_provider_category_primary_idx` | `provider_category_primary` | B-tree | Filter by spending category (e.g., all `FOOD_AND_DRINK` transactions). |
+| `transactions_provider_name_merchant_gin_idx` | `provider_name, provider_merchant_name` | GIN (pg_trgm) | Full-text trigram search on transaction description and merchant name. Supports `ILIKE '%query%'` efficiently. |
 | `transactions_account_id_idx` | `account_id` | B-tree | Join path from accounts to transactions; supports CASCADE DELETE FK. |
 
 ---

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -37,7 +37,7 @@ Query transactions with composable filters and cursor pagination.
 | `pending` | bool | Filter by pending status |
 | `tags` | array | AND filter — must have every slug. Use `["needs-review"]` to fetch the review backlog. |
 | `any_tag` | array | OR filter — must have at least one slug. |
-| `sort_by` | string | `date` (default), `amount`, `name` |
+| `sort_by` | string | `date` (default), `amount`, `provider_name` |
 | `sort_order` | string | `desc` (default), `asc` |
 | `fields` | string | Field selection. Aliases: `minimal`, `core`, `category`, `timestamps` |
 | `cursor` | string | Pagination cursor |
@@ -271,7 +271,7 @@ Example pipeline (3 rules that chain):
     {
       "name": "Tag coffee shops",
       "stage": "baseline",
-      "conditions": { "field": "merchant_name", "op": "contains", "value": "starbucks" },
+      "conditions": { "field": "provider_merchant_name", "op": "contains", "value": "starbucks" },
       "actions": [ { "type": "add_tag", "tag_slug": "coffee" } ]
     },
     {

--- a/docs/plaid-integration.md
+++ b/docs/plaid-integration.md
@@ -296,18 +296,18 @@ Each object in the `added` and `modified` arrays contains:
 
 | Plaid Field | Breadbox Column | Type | Notes |
 |-------------|-----------------|------|-------|
-| `transaction_id` | `external_transaction_id` | string | Stable Plaid ID; used as upsert key |
-| `pending_transaction_id` | `pending_transaction_id` | string | Non-null when this posted tx replaces a pending tx |
+| `transaction_id` | `provider_transaction_id` | string | Stable Plaid ID; used as upsert key |
+| `pending_transaction_id` | `provider_pending_transaction_id` | string | Non-null when this posted tx replaces a pending tx |
 | `account_id` | (join to `accounts.external_account_id`) | string | Link to account |
 | `amount` | `amount` | NUMERIC(12,2) | Positive = debit (money out); negative = credit (money in) |
 | `iso_currency_code` | `iso_currency_code` | string | ISO 4217; may be null if `unofficial_currency_code` is set |
 | `date` | `date` | date | Posted date (or expected posted date for pending) |
 | `authorized_date` | `authorized_date` | date | Date transaction was authorized; may be null |
-| `name` | `name` | string | Plaid-cleaned merchant/payee name |
-| `merchant_name` | `merchant_name` | string | Further-normalized merchant name; may be null |
-| `personal_finance_category.primary` | `category_primary` | string | e.g., `FOOD_AND_DRINK`, `TRANSPORTATION` |
-| `personal_finance_category.detailed` | `category_detailed` | string | e.g., `FOOD_AND_DRINK_RESTAURANTS` |
-| `payment_channel` | `payment_channel` | string | `online`, `in store`, `other` |
+| `name` | `provider_name` | string | Plaid-cleaned merchant/payee name |
+| `merchant_name` | `provider_merchant_name` | string | Further-normalized merchant name; may be null |
+| `personal_finance_category.primary` | `provider_category_primary` | string | e.g., `FOOD_AND_DRINK`, `TRANSPORTATION` |
+| `personal_finance_category.detailed` | `provider_category_detailed` | string | e.g., `FOOD_AND_DRINK_RESTAURANTS` |
+| `payment_channel` | `provider_payment_channel` | string | `online`, `in store`, `other` |
 | `pending` | `pending` | boolean | True if transaction has not posted |
 | `transaction_type` | — | string | Deprecated; use `personal_finance_category` instead |
 
@@ -369,15 +369,15 @@ function syncConnection(connectionID):
 For each object in `response.added`:
 
 1. Look up the `account_id` in `accounts` table by `external_account_id`.
-2. Upsert into `transactions` on conflict `(external_transaction_id)`:
+2. Upsert into `transactions` on conflict `(provider_transaction_id)`:
    - On insert: populate all columns from the transaction object.
    - On conflict: update all mutable fields (name, amount, date, category, pending, etc.).
    - Never update `created_at`; always update `updated_at`.
-3. If `pending_transaction_id` is non-null, check whether the referenced pending transaction exists in the database. If it does and has `deleted_at` set (it will have been soft-deleted by `processRemoved` in this same batch or a prior sync), record the link for historical continuity. The posted transaction carries the lineage via its `pending_transaction_id` column.
+3. If `provider_pending_transaction_id` is non-null, check whether the referenced pending transaction exists in the database. If it does and has `deleted_at` set (it will have been soft-deleted by `processRemoved` in this same batch or a prior sync), record the link for historical continuity. The posted transaction carries the lineage via its `provider_pending_transaction_id` column.
 
 ### 3.5 Processing Modified Transactions
 
-For each object in `response.modified`: update the existing row in `transactions` by `external_transaction_id`. Apply the same field updates as the upsert above. If the row does not exist (possible in edge cases), insert it as in Section 3.4.
+For each object in `response.modified`: update the existing row in `transactions` by `provider_transaction_id`. Apply the same field updates as the upsert above. If the row does not exist (possible in edge cases), insert it as in Section 3.4.
 
 ### 3.6 Processing Removed Transactions
 
@@ -385,7 +385,7 @@ For each object in `response.removed` (each contains only `transaction_id`):
 
 1. Set `deleted_at = NOW()` on the matching `transactions` row (soft delete).
 2. The REST API excludes rows with `deleted_at IS NOT NULL` by default.
-3. Do not hard-delete; the `pending_transaction_id` on posted transactions may reference these removed pending IDs.
+3. Do not hard-delete; the `provider_pending_transaction_id` on posted transactions may reference these removed pending IDs.
 
 ### 3.7 Pending to Posted Transition
 
@@ -395,11 +395,11 @@ When a pending transaction posts at the institution:
 2. Plaid adds a new posted transaction to `response.added` with:
    - A new, different `transaction_id`
    - `pending: false`
-   - `pending_transaction_id` set to the old pending `transaction_id`
+   - `provider_pending_transaction_id` set to the old pending `transaction_id`
 
 Breadbox handling:
 1. `processRemoved` soft-deletes the pending transaction row (sets `deleted_at`).
-2. `processAdded` inserts the new posted transaction with `pending_transaction_id` referencing the old ID.
+2. `processAdded` inserts the new posted transaction with `provider_pending_transaction_id` referencing the old ID.
 3. The old pending row remains queryable with `include_deleted=true` for audit purposes.
 4. The REST API transaction list returns only the posted transaction by default.
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -447,13 +447,13 @@ Soft-deleted transactions (where `deleted_at` is non-null) are excluded from all
 | `end_date` | string (ISO 8601 date) | No | — | Exclusive upper bound on `date`. Format: `YYYY-MM-DD`. A transaction with `date == end_date` is excluded. |
 | `account_id` | UUID | No | — | Filter to a single account. |
 | `user_id` | UUID | No | — | Filter to all accounts belonging to a specific family member. |
-| `category` | string | No | — | Exact match on `category_primary` (e.g., `"FOOD_AND_DRINK"`, `"TRANSPORTATION"`). Case-sensitive. |
-| `category_detailed` | string | No | — | Exact match on `category_detailed` (e.g., `"FOOD_AND_DRINK_GROCERIES"`). Case-sensitive. |
+| `category` | string | No | — | Exact match on `provider_category_primary` (e.g., `"FOOD_AND_DRINK"`, `"TRANSPORTATION"`). Case-sensitive. |
+| `category_detailed` | string | No | — | Exact match on `provider_category_detailed` (e.g., `"FOOD_AND_DRINK_GROCERIES"`). Case-sensitive. |
 | `min_amount` | number | No | — | Inclusive lower bound on `amount`. Uses Plaid sign convention (positive = debit). |
 | `max_amount` | number | No | — | Inclusive upper bound on `amount`. |
 | `pending` | boolean | No | — | If `true`, return only pending transactions. If `false`, return only posted transactions. If omitted, return both. |
-| `search` | string | No | — | Text search applied to `name` and `merchant_name`. Case-insensitive. Uses PostgreSQL `pg_trgm` similarity or `ILIKE`. Min length: 2 characters. |
-| `sort_by` | string | No | `date` | Sort field. Valid values: `date`, `amount`, `name`. |
+| `search` | string | No | — | Text search applied to `provider_name` and `provider_merchant_name`. Case-insensitive. Uses PostgreSQL `pg_trgm` similarity or `ILIKE`. Min length: 2 characters. |
+| `sort_by` | string | No | `date` | Sort field. Valid values: `date`, `amount`, `provider_name`. |
 | `sort_order` | string | No | `desc` | Sort direction. Valid values: `asc`, `desc`. Cursor pagination only works with `date` sort. |
 
 All filters are combined with `AND` logic. See [Section 6](#6-filtering-and-search) for detailed filter semantics.
@@ -466,8 +466,8 @@ All filters are combined with `AND` logic. See [Section 6](#6-filtering-and-sear
     {
       "id": "t1a2b3c4-d5e6-f789-0abc-def123456789",
       "account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-      "external_transaction_id": "lPNZkR5o3Vh1qWxYuEj2dM7fKtS9gA",
-      "pending_transaction_id": null,
+      "provider_transaction_id": "lPNZkR5o3Vh1qWxYuEj2dM7fKtS9gA",
+      "provider_pending_transaction_id": null,
       "amount": 67.43,
       "iso_currency_code": "USD",
       "unofficial_currency_code": null,
@@ -475,11 +475,11 @@ All filters are combined with `AND` logic. See [Section 6](#6-filtering-and-sear
       "datetime": "2026-02-27T10:23:00Z",
       "authorized_date": "2026-02-26",
       "authorized_datetime": "2026-02-26T19:45:00Z",
-      "name": "WHOLE FOODS MARKET #10452",
-      "merchant_name": "Whole Foods Market",
-      "category_primary": "FOOD_AND_DRINK",
-      "category_detailed": "FOOD_AND_DRINK_GROCERIES",
-      "payment_channel": "in store",
+      "provider_name": "WHOLE FOODS MARKET #10452",
+      "provider_merchant_name": "Whole Foods Market",
+      "provider_category_primary": "FOOD_AND_DRINK",
+      "provider_category_detailed": "FOOD_AND_DRINK_GROCERIES",
+      "provider_payment_channel": "in store",
       "pending": false,
       "created_at": "2026-02-27T08:15:00Z",
       "updated_at": "2026-02-27T08:15:00Z"
@@ -487,8 +487,8 @@ All filters are combined with `AND` logic. See [Section 6](#6-filtering-and-sear
     {
       "id": "t2b3c4d5-e6f7-890a-bcde-f12345678901",
       "account_id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-      "external_transaction_id": "mQoZjS4p2Wg0rVyXtFk3eN8hLuT1bB",
-      "pending_transaction_id": null,
+      "provider_transaction_id": "mQoZjS4p2Wg0rVyXtFk3eN8hLuT1bB",
+      "provider_pending_transaction_id": null,
       "amount": 14.00,
       "iso_currency_code": "USD",
       "unofficial_currency_code": null,
@@ -496,11 +496,11 @@ All filters are combined with `AND` logic. See [Section 6](#6-filtering-and-sear
       "datetime": null,
       "authorized_date": "2026-02-26",
       "authorized_datetime": null,
-      "name": "NETFLIX.COM",
-      "merchant_name": "Netflix",
-      "category_primary": "ENTERTAINMENT",
-      "category_detailed": "ENTERTAINMENT_STREAMING_SERVICES",
-      "payment_channel": "online",
+      "provider_name": "NETFLIX.COM",
+      "provider_merchant_name": "Netflix",
+      "provider_category_primary": "ENTERTAINMENT",
+      "provider_category_detailed": "ENTERTAINMENT_STREAMING_SERVICES",
+      "provider_payment_channel": "online",
       "pending": false,
       "created_at": "2026-02-26T22:00:00Z",
       "updated_at": "2026-02-26T22:00:00Z"
@@ -508,8 +508,8 @@ All filters are combined with `AND` logic. See [Section 6](#6-filtering-and-sear
     {
       "id": "t3c4d5e6-f7a8-901b-cdef-123456789012",
       "account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-      "external_transaction_id": "nRpAkT5q3Xh1sWzYvGl4fO9iMvU2cC",
-      "pending_transaction_id": null,
+      "provider_transaction_id": "nRpAkT5q3Xh1sWzYvGl4fO9iMvU2cC",
+      "provider_pending_transaction_id": null,
       "amount": -2500.00,
       "iso_currency_code": "USD",
       "unofficial_currency_code": null,
@@ -517,11 +517,11 @@ All filters are combined with `AND` logic. See [Section 6](#6-filtering-and-sear
       "datetime": null,
       "authorized_date": null,
       "authorized_datetime": null,
-      "name": "EMPLOYER DIRECT DEPOSIT",
-      "merchant_name": null,
-      "category_primary": "INCOME",
-      "category_detailed": "INCOME_WAGES",
-      "payment_channel": "other",
+      "provider_name": "EMPLOYER DIRECT DEPOSIT",
+      "provider_merchant_name": null,
+      "provider_category_primary": "INCOME",
+      "provider_category_detailed": "INCOME_WAGES",
+      "provider_payment_channel": "other",
       "pending": false,
       "created_at": "2026-02-25T06:00:00Z",
       "updated_at": "2026-02-25T06:00:00Z"
@@ -575,11 +575,11 @@ Returns the total count of transactions matching the given filters. Accepts the 
 | `end_date` | string (ISO 8601 date) | No | — | Exclusive upper bound on `date`. Format: `YYYY-MM-DD`. |
 | `account_id` | UUID | No | — | Filter to a single account. |
 | `user_id` | UUID | No | — | Filter to all accounts belonging to a specific family member. |
-| `category` | string | No | — | Exact match on `category_primary`. Case-sensitive. |
+| `category` | string | No | — | Exact match on `provider_category_primary`. Case-sensitive. |
 | `min_amount` | number | No | — | Inclusive lower bound on `amount`. |
 | `max_amount` | number | No | — | Inclusive upper bound on `amount`. |
 | `pending` | boolean | No | — | If `true`, count only pending transactions. If `false`, count only posted. If omitted, count both. |
-| `search` | string | No | — | Text search applied to `name` and `merchant_name`. Min length: 2 characters. |
+| `search` | string | No | — | Text search applied to `provider_name` and `provider_merchant_name`. Min length: 2 characters. |
 
 All filters are combined with `AND` logic. Soft-deleted transactions are excluded.
 
@@ -628,8 +628,8 @@ Returns a single transaction by its Breadbox UUID.
 {
   "id": "t1a2b3c4-d5e6-f789-0abc-def123456789",
   "account_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-  "external_transaction_id": "lPNZkR5o3Vh1qWxYuEj2dM7fKtS9gA",
-  "pending_transaction_id": null,
+  "provider_transaction_id": "lPNZkR5o3Vh1qWxYuEj2dM7fKtS9gA",
+  "provider_pending_transaction_id": null,
   "amount": 67.43,
   "iso_currency_code": "USD",
   "unofficial_currency_code": null,
@@ -637,11 +637,11 @@ Returns a single transaction by its Breadbox UUID.
   "datetime": "2026-02-27T10:23:00Z",
   "authorized_date": "2026-02-26",
   "authorized_datetime": "2026-02-26T19:45:00Z",
-  "name": "WHOLE FOODS MARKET #10452",
-  "merchant_name": "Whole Foods Market",
-  "category_primary": "FOOD_AND_DRINK",
-  "category_detailed": "FOOD_AND_DRINK_GROCERIES",
-  "payment_channel": "in store",
+  "provider_name": "WHOLE FOODS MARKET #10452",
+  "provider_merchant_name": "Whole Foods Market",
+  "provider_category_primary": "FOOD_AND_DRINK",
+  "provider_category_detailed": "FOOD_AND_DRINK_GROCERIES",
+  "provider_payment_channel": "in store",
   "pending": false,
   "created_at": "2026-02-27T08:15:00Z",
   "updated_at": "2026-02-27T08:15:00Z"

--- a/docs/rule-dsl.md
+++ b/docs/rule-dsl.md
@@ -9,7 +9,7 @@ A rule is a JSON document with four parts:
 ```json
 {
   "name": "Dining out categorization",
-  "conditions": { "field": "merchant_name", "op": "contains", "value": "Starbucks" },
+  "conditions": { "field": "provider_merchant_name", "op": "contains", "value": "Starbucks" },
   "actions": [ { "type": "set_category", "category_slug": "food_and_drink_coffee" } ],
   "trigger": "on_create",
   "priority": 10
@@ -45,11 +45,11 @@ Combinators nest. Max depth: **10**. Empty / zero-value condition (`{}`) means *
   "or": [
     {
       "and": [
-        { "field": "merchant_name", "op": "contains", "value": "Starbucks" },
+        { "field": "provider_merchant_name", "op": "contains", "value": "Starbucks" },
         { "field": "amount", "op": "gte", "value": 5 }
       ]
     },
-    { "field": "name", "op": "matches", "value": "^COFFEE.*" }
+    { "field": "provider_name", "op": "matches", "value": "^COFFEE.*" }
   ]
 }
 ```
@@ -58,11 +58,11 @@ Combinators nest. Max depth: **10**. Empty / zero-value condition (`{}`) means *
 
 | Field               | Type    | Source                                                          |
 | ------------------- | ------- | --------------------------------------------------------------- |
-| `name`              | string  | Transaction name                                                |
-| `merchant_name`     | string  | Merchant display name (may be empty for CSV / no-enrich rows)   |
+| `provider_name`     | string  | Transaction name (raw provider)                                 |
+| `provider_merchant_name` | string | Merchant display name (may be empty for CSV / no-enrich rows)   |
 | `amount`            | numeric | Transaction amount (positive = debit, negative = credit)        |
-| `category_primary`  | string  | **Raw provider** primary category (Plaid/Teller classification) |
-| `category_detailed` | string  | **Raw provider** detailed category                              |
+| `provider_category_primary` | string | **Raw provider** primary category (Plaid/Teller classification) |
+| `provider_category_detailed` | string | **Raw provider** detailed category                              |
 | `category`          | string  | **Assigned** category slug (reflects Breadbox/rule/user writes) |
 | `pending`           | bool    | Provider-reported pending flag                                  |
 | `provider`          | string  | `plaid`, `teller`, or `csv`                                     |
@@ -72,7 +72,7 @@ Combinators nest. Max depth: **10**. Empty / zero-value condition (`{}`) means *
 | `user_name`         | string  | Family member display name                                      |
 | `tags`              | tags    | List of current transaction tag slugs (special, see below)      |
 
-> **Raw vs assigned category.** `category_primary` / `category_detailed` are the provider's classification — they don't change when Breadbox, a rule, or the user reassigns. Use `category` when you want to react to the *current* category, including mid-pass rule updates (see "Rule chaining" below).
+> **Raw vs assigned category.** `provider_category_primary` / `provider_category_detailed` are the provider's classification — they don't change when Breadbox, a rule, or the user reassigns. Use `category` when you want to react to the *current* category, including mid-pass rule updates (see "Rule chaining" below).
 
 ### Operators per field type
 
@@ -101,7 +101,7 @@ Rules evaluate in pipeline order — lower `priority` runs first. As each matchi
 
 This enables composition. For example, a pipeline of three rules:
 
-1. `priority: 0`, `name contains "starbucks"` → `add_tag: coffee`
+1. `priority: 0`, `provider_name contains "starbucks"` → `add_tag: coffee`
 2. `priority: 10`, `tags contains "coffee"` → `set_category: food_and_drink_coffee`
 3. `priority: 50`, `category eq "food_and_drink_coffee"` → `add_tag: dining`
 
@@ -164,7 +164,7 @@ A rule can carry multiple actions of different types. Override (`category_overri
 
 ```json
 {
-  "conditions": { "field": "merchant_name", "op": "contains", "value": "Uber" },
+  "conditions": { "field": "provider_merchant_name", "op": "contains", "value": "Uber" },
   "actions": [
     { "type": "set_category", "category_slug": "transportation_rideshare" },
     { "type": "add_tag", "tag_slug": "recurring" }

--- a/docs/teller-integration.md
+++ b/docs/teller-integration.md
@@ -299,20 +299,20 @@ Continue fetching until fewer than `count` transactions are returned.
 
 | Teller Field | Breadbox Field | Notes |
 |---|---|---|
-| `id` | `external_transaction_id` | Stable across most pending→posted transitions |
+| `id` | `provider_transaction_id` | Stable across most pending→posted transitions |
 | `account_id` | `account_external_id` | Resolved to internal account UUID by sync engine |
 | `amount` | `amount` | Parse string to decimal, **negate sign** (see 3.4) |
 | `date` | `date` | ISO 8601 date string `YYYY-MM-DD` |
-| `description` | `name` | Raw bank statement text |
+| `description` | `provider_name` | Raw bank statement text |
 | `status` | `pending` | `"pending"` → `true`, `"posted"` → `false` |
-| `details.category` | `category_primary` | Via category mapping table (Section 7) |
-| `details.counterparty.name` | `merchant_name` | Nullable |
+| `details.category` | `provider_category_primary` | Via category mapping table (Section 7) |
+| `details.counterparty.name` | `provider_merchant_name` | Nullable |
 | (not available) | `authorized_date` | `NULL` |
 | (not available) | `datetime` | `NULL` |
-| (not available) | `category_detailed` | `NULL` |
-| (not available) | `category_confidence` | `NULL` |
-| (not available) | `payment_channel` | `"other"` |
-| (not available) | `pending_transaction_id` | `NULL` (Teller has no explicit linkage) |
+| (not available) | `provider_category_detailed` | `NULL` |
+| (not available) | `provider_category_confidence` | `NULL` |
+| (not available) | `provider_payment_channel` | `"other"` |
+| (not available) | `provider_pending_transaction_id` | `NULL` (Teller has no explicit linkage) |
 | `currency` | `iso_currency_code` | From parent account's `currency` field |
 
 ### 3.4 Amount Sign Convention
@@ -353,7 +353,7 @@ WHERE account_id IN (... accounts for this connection ...)
   AND date >= $from_date
   AND date <= $to_date
   AND pending = true
-  AND external_transaction_id NOT IN (... returned IDs ...)
+  AND provider_transaction_id NOT IN (... returned IDs ...)
   AND deleted_at IS NULL;
 ```
 
@@ -573,7 +573,7 @@ active   →  pending_reauth      (credentials invalid, MFA required)
 Teller provides a single-level category in `details.category`. Breadbox
 normalizes these to primary categories compatible with Plaid's taxonomy.
 
-| Teller Category | Breadbox `category_primary` |
+| Teller Category | Breadbox `provider_category_primary` |
 |---|---|
 | `accommodation` | `TRAVEL` |
 | `advertising` | `GENERAL_SERVICES` |
@@ -607,7 +607,7 @@ normalizes these to primary categories compatible with Plaid's taxonomy.
 ### 7.2 Unmapped Categories
 
 If a Teller category is not in the mapping table (e.g., a new category added
-by Teller), default to `GENERAL_MERCHANDISE`. The `category_detailed` field is
+by Teller), default to `GENERAL_MERCHANDISE`. The `provider_category_detailed` field is
 always `NULL` for Teller transactions since Teller has no sub-categories.
 
 ---
@@ -626,7 +626,7 @@ always `NULL` for Teller transactions since Teller has no sub-categories.
 | **Balances** | All accounts in one call per item | One call per account | Loop over accounts in `GetBalances` |
 | **Webhooks** | JWT/ES256, `Plaid-Verification` header | HMAC-SHA256, `Teller-Signature` header | Provider-specific verification in `HandleWebhook` |
 | **Webhook data** | Notification only (sync separately) | `transactions.processed` includes tx data | Trigger full sync regardless (consistency) |
-| **Categories** | Two-level (primary + detailed) | Single-level (~27 categories) | Map to primary, `category_detailed = NULL` |
+| **Categories** | Two-level (primary + detailed) | Single-level (~27 categories) | Map to primary, `provider_category_detailed = NULL` |
 | **Amount sign** | Positive = debit | Negative = debit | Negate Teller amounts |
 | **Authorized date** | Separate `authorized_date` field | Not provided | `NULL` for Teller |
 | **Account types** | depository, credit, loan, investment | depository, credit only | Subset, no mapping needed |


### PR DESCRIPTION
Docs sweep closing the `transactions-rename` stack. No code changes.

## Summary

- `docs/data-model.md` — renamed columns in the ER diagram and the transactions column spec; added `provider_raw JSONB` row.
- `docs/rule-dsl.md` — updated the Fields reference table, example condition JSON, and the "Raw vs assigned category" note.
- `docs/api-reference.md`, `docs/rest-api.md`, `docs/mcp-tools-reference.md` — field selector docs, `sort_by` values, example request/response bodies.
- `docs/plaid-integration.md`, `docs/teller-integration.md` — provider field mapping tables and sync-algorithm references.
- `docs/csv-import.md` — narrative refs to the DB column only; CSV's own input-column vocabulary (`merchant_name` as a CSV header) is intentionally unchanged.
- `CHANGELOG.md` — pre-1.0 breaking-change entry under `[Unreleased]` covering columns, REST/MCP wire keys, rule DSL, field selector aliases, `sort_by`, and the new `provider_raw` column.

## Delegation note

Generated by a Haiku subagent with a precise rename map and file list. Spot-checked the output locally; added the missing `provider_raw` row to `data-model.md` manually since the subagent omitted it.

## Test plan

- [ ] No code changes — CI should pass cleanly
- [ ] Skim each doc page to confirm renames are consistent and nothing user-facing still references the old identifiers
- [ ] CHANGELOG entry is accurate for the stack's final state
