### PR TITLE
fix(admin): restore 404/500 rendering for rules and agent-wizard routes

### DIFF
--- a/internal/admin/prompt_builder.go
+++ b/internal/admin/prompt_builder.go
@@ -50,7 +50,7 @@ func PromptBuilderHandler(sm *scs.SessionManager, tr *TemplateRenderer) http.Han
 
 		cfg, ok := prompts.GetAgentConfig(agentType)
 		if !ok {
-			tr.Render(w, r, "404.html", BaseTemplateData(r, sm, "", "Not Found"))
+			tr.RenderNotFound(w, r)
 			return
 		}
 

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -40,7 +40,7 @@ func RulesPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Template
 
 		result, err := svc.ListTransactionRules(ctx, params)
 		if err != nil {
-			tr.Render(w, r, "500.html", map[string]any{"PageTitle": "Error", "CurrentPage": "rules"})
+			tr.RenderError(w, r)
 			return
 		}
 
@@ -128,10 +128,10 @@ func RuleFormPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Templ
 			rule, err := svc.GetTransactionRule(ctx, id)
 			if err != nil {
 				if errors.Is(err, service.ErrNotFound) {
-					tr.Render(w, r, "404.html", map[string]any{"PageTitle": "Not Found", "CurrentPage": "rules"})
+					tr.RenderNotFound(w, r)
 					return
 				}
-				tr.Render(w, r, "500.html", map[string]any{"PageTitle": "Error", "CurrentPage": "rules"})
+				tr.RenderError(w, r)
 				return
 			}
 			data["Rule"] = rule
@@ -156,10 +156,10 @@ func RuleDetailPageHandler(svc *service.Service, sm *scs.SessionManager, tr *Tem
 		rule, err := svc.GetTransactionRule(ctx, id)
 		if err != nil {
 			if errors.Is(err, service.ErrNotFound) {
-				tr.Render(w, r, "404.html", map[string]any{"PageTitle": "Not Found", "CurrentPage": "rules"})
+				tr.RenderNotFound(w, r)
 				return
 			}
-			tr.Render(w, r, "500.html", map[string]any{"PageTitle": "Error", "CurrentPage": "rules"})
+			tr.RenderError(w, r)
 			return
 		}
 


### PR DESCRIPTION
Fixes #741

The #462 templ migration removed the `404.html` and `500.html` template files, but `internal/admin/rules.go` and `internal/admin/prompt_builder.go` still referenced them by name through `tr.Render(w, r, "404.html", …)`. When a rule ID or agent-wizard type failed to resolve, the template registry logged `template not found: 404.html` and returned a 500 instead of the intended 404.

Switches all 6 callsites (rules.go ×5, prompt_builder.go ×1) to the `RenderNotFound` / `RenderError` helpers introduced in #698, which already handle the `IsViewer` branching between the public wizard-layout error page and the in-shell admin variant.

Note: the issue body called out 5 callsites in `rules.go`; grep surfaced an additional 500.html caller at `rules.go:43` (the list-page error path), fixed in the same commit for consistency.

## Before

| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/wxh4muvh4q.png" width="260" alt="rules — before — mobile"> | <img src="https://i.img402.dev/okknwe4nvs.png" width="260" alt="rules — before — tablet"> | <img src="https://i.img402.dev/9geggf2fok.png" width="260" alt="rules — before — desktop"> |
| <img src="https://i.img402.dev/iv1cv2p6o2.png" width="260" alt="agent-wizard — before — mobile"> | <img src="https://i.img402.dev/gwtmo4eli9.png" width="260" alt="agent-wizard — before — tablet"> | <img src="https://i.img402.dev/j2ongr4j1e.png" width="260" alt="agent-wizard — before — desktop"> |

`/rules/does-not-exist` and `/agent-wizard/does-not-exist` render as an empty 500 page (server returns HTTP 500 after logging `template not found`).

## After

| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/ow9qulnbe7.png" width="260" alt="rules — after — mobile"> | <img src="https://i.img402.dev/oeaeykx1iv.png" width="260" alt="rules — after — tablet"> | <img src="https://i.img402.dev/7ypta03utt.png" width="260" alt="rules — after — desktop"> |
| <img src="https://i.img402.dev/vfbv49e923.png" width="260" alt="agent-wizard — after — mobile"> | <img src="https://i.img402.dev/k10rtiy93u.png" width="260" alt="agent-wizard — after — tablet"> | <img src="https://i.img402.dev/cboctg92oe.png" width="260" alt="agent-wizard — after — desktop"> |

Both routes now return HTTP 404 and render the styled templ 404 page inside the admin shell.

## Notes

- Verified via puppeteer captures at 500/820/1440 for both `/rules/{missing}` and `/agent-wizard/{missing}` while authenticated as the admin user.
- Server access log confirms status transition: 500 → 404 for the same URLs after the change.
- No behaviour change for callers that already resolve successfully.
