### PR TITLE
fix(admin/sessions): add error/status summary to session detail header

### DIFF
--- a/internal/service/mcp_sessions.go
+++ b/internal/service/mcp_sessions.go
@@ -43,7 +43,10 @@ type ToolCallLogResponse struct {
 // MCPSessionDetailResponse is a session with its tool calls.
 type MCPSessionDetailResponse struct {
 	MCPSessionResponse
-	ToolCalls []ToolCallLogResponse `json:"tool_calls"`
+	ToolCalls  []ToolCallLogResponse `json:"tool_calls"`
+	ErrorCount int                   `json:"error_count"`
+	WriteCount int                   `json:"write_count"`
+	ReadCount  int                   `json:"read_count"`
 }
 
 // ToolCallLogInput is the input for logging a tool call.
@@ -197,11 +200,34 @@ func (s *Service) GetMCPSessionDetail(ctx context.Context, idOrShort string) (MC
 	}
 
 	session.ToolCallCount = int64(len(calls))
+	errorCount, writeCount, readCount := summarizeToolCalls(calls)
 
 	return MCPSessionDetailResponse{
 		MCPSessionResponse: session,
 		ToolCalls:          calls,
+		ErrorCount:         errorCount,
+		WriteCount:         writeCount,
+		ReadCount:          readCount,
 	}, nil
+}
+
+// summarizeToolCalls aggregates error / write / read counts across tool calls.
+// Calls with classifications other than "write" or "read" are not counted in
+// the split (and thus won't distort the header pill); errors are counted
+// independently of classification so a failed write still surfaces.
+func summarizeToolCalls(calls []ToolCallLogResponse) (errorCount, writeCount, readCount int) {
+	for _, c := range calls {
+		if c.IsError {
+			errorCount++
+		}
+		switch c.Classification {
+		case "write":
+			writeCount++
+		case "read":
+			readCount++
+		}
+	}
+	return errorCount, writeCount, readCount
 }
 
 // ResolveSessionUUID resolves a session ID string (UUID or short_id) to pgtype.UUID.

--- a/internal/service/mcp_sessions_test.go
+++ b/internal/service/mcp_sessions_test.go
@@ -1,0 +1,64 @@
+package service
+
+import "testing"
+
+func TestSummarizeToolCalls(t *testing.T) {
+	tests := []struct {
+		name                                       string
+		calls                                      []ToolCallLogResponse
+		wantErrors, wantWrites, wantReads          int
+	}{
+		{
+			name:  "empty",
+			calls: nil,
+		},
+		{
+			name: "mixed classifications and errors",
+			calls: []ToolCallLogResponse{
+				{Classification: "read"},
+				{Classification: "write"},
+				{Classification: "write", IsError: true},
+				{Classification: "read"},
+				{Classification: "read", IsError: true},
+			},
+			wantErrors: 2,
+			wantWrites: 2,
+			wantReads:  3,
+		},
+		{
+			name: "unknown classification is ignored in split but error still counted",
+			calls: []ToolCallLogResponse{
+				{Classification: "other", IsError: true},
+				{Classification: "", IsError: false},
+				{Classification: "read"},
+			},
+			wantErrors: 1,
+			wantWrites: 0,
+			wantReads:  1,
+		},
+		{
+			name: "all clean",
+			calls: []ToolCallLogResponse{
+				{Classification: "read"},
+				{Classification: "write"},
+			},
+			wantWrites: 1,
+			wantReads:  1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotErr, gotWrite, gotRead := summarizeToolCalls(tc.calls)
+			if gotErr != tc.wantErrors {
+				t.Errorf("errors = %d, want %d", gotErr, tc.wantErrors)
+			}
+			if gotWrite != tc.wantWrites {
+				t.Errorf("writes = %d, want %d", gotWrite, tc.wantWrites)
+			}
+			if gotRead != tc.wantReads {
+				t.Errorf("reads = %d, want %d", gotRead, tc.wantReads)
+			}
+		})
+	}
+}

--- a/internal/templates/pages/session_detail.html
+++ b/internal/templates/pages/session_detail.html
@@ -7,7 +7,7 @@
       <span>Session</span>
     </div>
     <h1 class="bb-page-title">{{.Session.Purpose}}</h1>
-    <div class="flex items-center gap-4 text-sm text-base-content/50 mt-1">
+    <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-base-content/50 mt-1">
       {{if .Session.AgentName}}
         <span class="flex items-center gap-1">
           <i data-lucide="bot" class="w-3.5 h-3.5"></i>
@@ -21,6 +21,15 @@
       {{end}}
       <span>{{relativeTime .Session.CreatedAt}}</span>
       <span>{{.Session.ToolCallCount}} tool calls</span>
+      {{if .Session.ErrorCount}}
+        <span class="inline-flex items-center gap-1 badge badge-sm badge-error">
+          <i data-lucide="alert-triangle" class="w-3 h-3"></i>
+          {{.Session.ErrorCount}} error{{if ne .Session.ErrorCount 1}}s{{end}}
+        </span>
+      {{end}}
+      {{if or .Session.WriteCount .Session.ReadCount}}
+        <span class="text-base-content/60">{{.Session.WriteCount}} write · {{.Session.ReadCount}} read</span>
+      {{end}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Adds an error pill and a write/read split next to the existing "N tool calls" count on `/agents/sessions/{id}`. Auditors can now tell at a glance whether a session needs attention without scrolling the full tool-call list. Counts are aggregated from the already-loaded tool calls via a small `summarizeToolCalls` helper (covered by a new unit test). The header metadata row is now `flex-wrap` so the pill drops to its own line cleanly on mobile widths instead of pushing the breadcrumb.

## Before / After

<table>
  <tr><th>Desktop — Before</th><th>Desktop — After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/olzrhk7p30.png" width="400" alt="desktop before"></td>
    <td><img src="https://i.img402.dev/oiun5gaswv.png" width="400" alt="desktop after"></td>
  </tr>
  <tr><th>Tablet — Before</th><th>Tablet — After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/tkhsaejvjg.png" width="400" alt="tablet before"></td>
    <td><img src="https://i.img402.dev/agj0zm4ucc.png" width="400" alt="tablet after"></td>
  </tr>
  <tr><th>Mobile — Before</th><th>Mobile — After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/trgbyiwhga.png" width="300" alt="mobile before"></td>
    <td><img src="https://i.img402.dev/k52wdc52k0.png" width="300" alt="mobile after"></td>
  </tr>
</table>

## Testing

- [x] `go build ./...`
- [x] `go test ./internal/service/...` (includes new `TestSummarizeToolCalls` table test covering empty / mixed / unknown-classification / all-clean cases)
- [x] Manual verification at 390, 820, 1440 widths against a seeded 10-call session with 2 errored writes: header now renders `10 tool calls · 2 errors · 5 write · 5 read`; sessions with zero errors do not render the pill.

## Related issues

Fixes #726