### PR TITLE
docs(stacks): each stacked PR must independently pass CI

### DIFF
--- a/.claude/rules/stacked-prs.md
+++ b/.claude/rules/stacked-prs.md
@@ -15,6 +15,18 @@ Stack if any of these apply; otherwise ship a single PR:
 
 Do not stack a single bug fix, single UI tweak, or any change whose pieces only make sense together.
 
+## Every PR must independently pass CI — non-negotiable
+
+The point of stacking is **smaller, easier-to-review units** — not splitting an atomic change into intermediate states that don't compile. At every branch tip in the stack, `go build ./...`, `go vet ./...`, and `go test ./...` must all pass.
+
+CI runs per-PR. There is no merge-queue coordination, no cross-PR CI. A PR whose tip fails `go vet` because "the next PR fixes it" will be red and blocked, and "merge the bottom first" does not rescue a broken bottom either.
+
+**Canonical trap — a schema-only PR.** Renaming a DB column without the matching Go rename in the same PR looks clean but fails `go vet` at the tip. Don't do this split. Schema + the Go references that read it belong in one PR.
+
+**If you've already split it wrong**, fold the next branch back in with `gt fold` so the combined branch is self-contained, then `gt submit --stack` to update the rest.
+
+Before pushing a stack: checkout each branch top-to-bottom, run `go build ./... && go vet ./... && go test ./...`, and only `gt submit` once every tip is green.
+
 ## Branch naming
 
 `stack/<topic>/<NN>-<slug>` — topic is kebab-case, `NN` is a two-digit position, `slug` describes this PR. Pass the name positionally: `gt create <name>`. The `-b` flag is not accepted by this version of the CLI.

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -21,6 +21,14 @@ Stacks have real overhead — more branches, more restacks, more PRs to review. 
 
 A good rule of thumb: if you can't write a short, standalone "why this PR exists" description for each PR in the stack, don't stack.
 
+### Every PR in a stack must independently pass CI
+
+The purpose of stacking is to produce **smaller, easier-to-review** changes — not to split a single atomic change into intermediate states that don't compile. Each PR's tip must build, vet, and test cleanly on its own.
+
+A migration + code rename is the canonical trap: landing the column rename without the matching Go references looks like a clean "schema PR," but `go vet` at its tip is broken until the next PR lands. CI runs per-PR; stacking does not help. The split was wrong.
+
+**Rule:** at every branch tip in the stack, `go build ./...`, `go vet ./...`, and `go test ./...` must all pass. If they don't, fold the next PR back in (`gt fold`) until the tip is green. Split by review size and review shape — not by whether the compiler is temporarily broken.
+
 ## Conventions
 
 ### Branch naming
@@ -170,9 +178,11 @@ gt checkout <branch>                             # jump to any branch
 
 ## CI
 
-Each PR in a stack runs CI independently against its own tip. There's no merge-queue coordination — if you need the bottom PR's changes to make the middle PR's CI green, that's the correct behavior; merge the bottom first.
+Each PR in a stack runs CI independently against its own tip. There is **no merge-queue coordination and no cross-PR CI**. A middle PR that only compiles once the bottom PR is merged is *not* acceptable — its CI will be red and will block it, and "merge the bottom first" does not rescue a bottom PR that itself depends on downstream code changes to compile (see "Every PR in a stack must independently pass CI" above).
 
-GitHub's auto-merge (via `--merge-when-ready` or `gh pr merge --auto`) waits on CI for the branch being landed, not the rest of the stack.
+If you've already opened the stack and realize a PR's tip is broken, the fix is to fold the next branch back in with `gt fold` so the combined branch is self-contained, then `gt submit --stack` to update the remaining PRs.
+
+GitHub's auto-merge (via `--merge-when-ready` or `gh pr merge --auto`) waits on CI for the branch being landed, not the rest of the stack — which is exactly why each branch must already be green on its own.
 
 ## Cheat sheet
 


### PR DESCRIPTION
## Summary

Rewrites the stacked-PRs guidance to make explicit what the `transactions-rename` stack (#744, #746, #747 — after #745 was folded in) taught us the hard way: **CI runs per-PR with no cross-PR coordination**, so every branch tip in the stack must build, vet, and test cleanly on its own. The point of stacking is smaller review units, not splitting an atomic change into intermediate states that don't compile.

- Adds an "Every PR in a stack must independently pass CI" section to `docs/stacked-prs.md` with the canonical trap (schema rename separated from the Go references that read the columns).
- Rewrites the existing CI section, which previously implied a broken middle PR was fine because "merge the bottom first" — misleading, since a broken bottom PR itself blocks on CI.
- Updates `.claude/rules/stacked-prs.md` so the rule loads into agent context whenever a stack workflow starts. Adds an "if you split wrong, `gt fold` the next branch back in" recovery note.

No code or runtime behavior change.

## Test plan

- [ ] Skim the two rewritten sections to check the guidance is unambiguous
- [ ] `docs/stacked-prs.md` renders cleanly on GitHub