### PR TITLE
fix(transactions): drop redundant clock chip on detail page

### DIFF
--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -25,7 +25,10 @@
         <span class="text-xs text-base-content/30">&middot;</span>
         <span class="text-xs text-base-content/40">{{titleCase (deref .Transaction.MerchantName)}}</span>
         {{end}}
-        {{if .Transaction.Pending}}<span class="inline-flex items-center gap-1 px-1.5 py-0 text-[0.65rem] border border-dashed border-warning/60 text-warning rounded-md ml-1" title="Not yet posted"><i data-lucide="clock" class="w-2.5 h-2.5"></i>pending</span>{{end}}
+        {{if .Transaction.Pending}}
+        <span class="text-xs text-base-content/30">&middot;</span>
+        <span class="text-xs text-warning/70" title="Not yet posted">Pending</span>
+        {{end}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Follow-up to #739. The detail page already shows a `clock` icon next to the big amount for pending rows; the dashed-outline chip in the subtitle repeated the same cue. Swap the chip for an interpunct + muted `Pending` word that flows with the existing `date · merchant` separators.

## Test plan

- [x] `/transactions/<id>` on a pending row — subtitle reads `<date> · <merchant> · Pending`; big amount still has the clock.
- [x] `/transactions/<id>` on a settled row — subtitle unchanged, amount unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)