### PR TITLE
fix(categories): always-visible kebab menu on category row actions (#752)

### DIFF
--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -367,33 +367,17 @@ templ categoryTileInner(c service.CategoryResponse, child bool) {
 	}
 }
 
-// categoryRowActions emits the trailing edit/delete controls — desktop
-// uses inline ghost buttons, mobile collapses to an overflow menu.
+// categoryRowActions emits the trailing edit/delete controls as a single
+// always-visible kebab menu so actions are reachable on every viewport
+// (mouse, touch, keyboard). Matches the pattern used on /tags (PR #728).
 templ categoryRowActions(c service.CategoryResponse, child bool) {
-	<div class="hidden sm:flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-		<a href={ templ.SafeURL(fmt.Sprintf("/categories/%s/edit", c.ID)) } class="btn btn-ghost btn-xs rounded-lg" title="Edit">
-			<i data-lucide="pencil" class="w-3.5 h-3.5"></i>
-		</a>
-		if !c.IsSystem {
-			<button
-				type="button"
-				class="btn btn-ghost btn-xs rounded-lg text-error"
-				data-id={ c.ID }
-				data-name={ c.DisplayName }
-				@click.prevent="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
-				title="Delete"
-			>
-				<i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
-			</button>
-		}
-	</div>
-	<div class="dropdown dropdown-end sm:hidden">
-		<div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-square rounded-lg">
+	<div class="dropdown dropdown-end">
+		<div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-square rounded-lg" aria-label={ fmt.Sprintf("Category %s actions", c.DisplayName) }>
 			<i data-lucide="ellipsis-vertical" class="w-4 h-4"></i>
 		</div>
 		<ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-40 p-1">
 			<li>
-				<a href={ templ.SafeURL(fmt.Sprintf("/categories/%s/edit", c.ID)) }>
+				<a href={ templ.SafeURL(fmt.Sprintf("/categories/%s/edit", c.ID)) } aria-label={ fmt.Sprintf("Edit category %s", c.DisplayName) }>
 					<i data-lucide="pencil" class="w-3.5 h-3.5"></i> Edit
 				</a>
 			</li>
@@ -404,6 +388,7 @@ templ categoryRowActions(c service.CategoryResponse, child bool) {
 						class="text-error"
 						data-id={ c.ID }
 						data-name={ c.DisplayName }
+						aria-label={ fmt.Sprintf("Delete category %s", c.DisplayName) }
 						@click="$dispatch('delete-category', {id: $el.dataset.id, name: $el.dataset.name})"
 					>
 						<i data-lucide="trash-2" class="w-3.5 h-3.5"></i> Delete


### PR DESCRIPTION
Fixes #752

Subcategory rows on `/categories` had no visible action affordance at idle on tablet or desktop — the inline edit/delete cluster was `opacity-0 group-hover:opacity-100` (hover-only) and the dropdown fallback was `sm:hidden`. Tablet touch and any non-hover `≥640 px` pointer couldn't reach Edit or Delete. This PR replaces both branches with a single always-visible `dropdown dropdown-end` kebab, mirroring the tags fix from #728. Trigger and menu items carry `aria-label` so assistive tech announces which category is being acted on.

## Before
| Mobile (500) | Tablet (820) | Desktop (1440) |
|---|---|---|
| <img src="https://i.img402.dev/wzbghihk3z.png" width="260"> | <img src="https://i.img402.dev/kaplkg6nfk.png" width="260"> | <img src="https://i.img402.dev/3i9am0xt6j.png" width="260"> |

## After
| Mobile (500) | Tablet (820) | Desktop (1440) |
|---|---|---|
| <img src="https://i.img402.dev/al142vulqu.png" width="260"> | <img src="https://i.img402.dev/i18o4k0zjd.png" width="260"> | <img src="https://i.img402.dev/bnz0xcw4kb.png" width="260"> |

## Notes
- `categoryRowActions` is used for both parent and subcategory rows; the kebab now appears on both for consistency. Parents still double as expand/collapse targets — the kebab sits at the row's right edge and doesn't intercept the row click.
- `grep "opacity-0 group-hover:opacity-100" internal/templates/components/pages/categories.templ` returns 0 matches after the change.
- `templ generate` + `templ fmt` re-run; `_templ.go` is gitignored so only `.templ` is committed.
