### PR TITLE
chore(env): document DOMAIN and clarify POSTGRES_* scope

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ ENVIRONMENT=local
 # Default: "info" for docker, "debug" for local
 # LOG_LEVEL=info
 
+# Public hostname for HTTPS via Caddy (Docker prod only). Leave unset for
+# localhost-only installs — Caddy is gated behind the `caddy` compose profile
+# and only starts when DOMAIN is set.
+# DOMAIN=breadbox.example.com
+
 # --- Plaid ---
 # These can also be set via the admin setup wizard (stored in app_config table).
 # Env vars override app_config values.
@@ -61,7 +66,10 @@ PLAID_ENV=sandbox
 # Per-connection sync timeout in seconds (default: 300 = 5 minutes)
 # SYNC_TIMEOUT_SECONDS=300
 
-# --- Docker Compose (used by db service) ---
+# --- Docker Compose (read by the postgres image, NOT the breadbox binary) ---
+# Only relevant when running the bundled compose stack. The postgres container
+# uses these to initialize the database on first boot and the healthcheck to
+# verify it. Keep them in sync with DATABASE_URL above.
 POSTGRES_USER=breadbox
 # IMPORTANT: Change this in production! Generate with: openssl rand -base64 32
 POSTGRES_PASSWORD=breadbox


### PR DESCRIPTION
## Summary

Two small `.env.example` improvements ahead of the OSS launch:

- Add a commented `DOMAIN=` template under server config so users setting up HTTPS-with-Caddy don't have to dig through `install.sh` to discover the var name.
- Clarify the `POSTGRES_*` block: it's read by the postgres image (and the healthcheck) — not by the breadbox binary. They came up in an audit as "unread by binary" but they're load-bearing for the bundled compose stack.

## Test plan
- [ ] Diff renders cleanly on GitHub
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)