### PR TITLE
chore(tests): use strings.Contains instead of hand-rolled substring helpers

### DIFF
--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"breadbox/internal/service"
@@ -48,12 +49,12 @@ func TestBuildPaginationBase_URLEncodesValues(t *testing.T) {
 			result := buildPaginationBase(req)
 
 			if tt.contains != "" {
-				if !containsSubstring(result, tt.contains) {
+				if !strings.Contains(result, tt.contains) {
 					t.Errorf("expected result to contain %q, got %q", tt.contains, result)
 				}
 			}
 			if tt.excludes != "" {
-				if containsSubstring(result, tt.excludes) {
+				if strings.Contains(result, tt.excludes) {
 					t.Errorf("expected result NOT to contain %q, got %q", tt.excludes, result)
 				}
 			}
@@ -65,26 +66,13 @@ func TestBuildExportURL_URLEncodesValues(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/transactions?search=foo%26bar", nil)
 	result := buildExportURL(req)
 
-	if !containsSubstring(result, "search=foo%26bar") {
+	if !strings.Contains(result, "search=foo%26bar") {
 		t.Errorf("expected URL-encoded ampersand in export URL, got %q", result)
 	}
 	// The raw ampersand should not appear as a parameter separator within the value
-	if containsSubstring(result, "search=foo&bar") {
+	if strings.Contains(result, "search=foo&bar") {
 		t.Errorf("raw ampersand should be encoded in export URL, got %q", result)
 	}
-}
-
-func containsSubstring(s, sub string) bool {
-	return len(s) >= len(sub) && searchString(s, sub)
-}
-
-func searchString(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }
 
 // The activity timeline is built purely from annotations — comments,

--- a/internal/provider/teller/errors_test.go
+++ b/internal/provider/teller/errors_test.go
@@ -3,6 +3,7 @@ package teller
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"breadbox/internal/provider"
@@ -56,7 +57,7 @@ func TestClassifyHTTPError_ServerAndRateLimitErrors_NoSyncRetryable(t *testing.T
 			if errors.Is(err, provider.ErrReauthRequired) {
 				t.Errorf("errors.Is(err, ErrReauthRequired) = true for status %d, want false", tt.statusCode)
 			}
-			if !containsSubstring(err.Error(), tt.wantSubstr) {
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
 				t.Errorf("error %q does not contain %q", err.Error(), tt.wantSubstr)
 			}
 		})
@@ -102,20 +103,8 @@ func TestClassifyHTTPError_ContainsOperationContext(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 	msg := err.Error()
-	if !containsSubstring(msg, "balance get") {
+	if !strings.Contains(msg, "balance get") {
 		t.Errorf("error message %q does not contain operation name 'balance get'", msg)
 	}
 }
 
-func containsSubstring(s, substr string) bool {
-	return len(s) >= len(substr) && searchSubstring(s, substr)
-}
-
-func searchSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
## Summary

Two test files each shipped a pair of helpers (\`containsSubstring\` + \`searchString\` / \`searchSubstring\`) that walked the string byte-by-byte to find a match — exactly what \`strings.Contains\` does, faster and clearer.

- [\`internal/admin/transactions_test.go\`](https://github.com/canalesb93/breadbox/blob/main/internal/admin/transactions_test.go) had \`containsSubstring\` + \`searchString\` (12 lines).
- [\`internal/provider/teller/errors_test.go\`](https://github.com/canalesb93/breadbox/blob/main/internal/provider/teller/errors_test.go) had \`containsSubstring\` + \`searchSubstring\` (12 lines).

Drop both helper pairs, import \`strings\`, and use \`strings.Contains\` at the call sites. Net -23 lines. No behavior change — the hand-rolled helpers are semantically equivalent to \`strings.Contains\`, just slower and harder to read.

## Why

- Tests-only churn, zero production-code impact.
- Removes two pieces of reinvented-wheel code that a reader has to trace to confirm they do what their name says.
- Makes any future grep for string-matching in tests land on \`strings.Contains\`, the obvious place.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/admin/ ./internal/provider/teller/\` — both packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)