### PR TITLE
fix(toasts): add dismiss, aria-live, collision-proof ids

### DIFF
--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -305,26 +305,45 @@
        bulk action bar), which dispatching bb-toast from a DOMContentLoaded
        handler is too early to deliver reliably. -->
   <div class="fixed bottom-8 left-1/2 z-50 -translate-x-1/2 flex flex-col items-center gap-2 pointer-events-none"
-       x-data="{ toasts: [] }"
-       @bb-toast.window="
-         toasts.push({ message: $event.detail.message, type: $event.detail.type || 'success', id: Date.now() });
-         setTimeout(() => { toasts = toasts.filter(t2 => t2.id !== toasts[0]?.id); }, 3500)
-       ">
+       role="region"
+       aria-live="polite"
+       aria-label="Notifications"
+       x-data="{
+         toasts: [],
+         nextId: 0,
+         add(detail) {
+           const id = (typeof crypto !== 'undefined' && crypto.randomUUID)
+             ? crypto.randomUUID()
+             : ('t-' + (++this.nextId) + '-' + Math.random().toString(36).slice(2));
+           const toast = { message: detail.message, type: detail.type || 'success', id: id };
+           this.toasts.push(toast);
+           setTimeout(() => { this.toasts = this.toasts.filter(t2 => t2.id !== id); }, 3500);
+         },
+         dismiss(id) { this.toasts = this.toasts.filter(t2 => t2.id !== id); },
+       }"
+       @bb-toast.window="add($event.detail)">
     <template x-for="t in toasts" :key="t.id">
       <div x-data="{ show: false }" x-init="$nextTick(() => { show = true; lucide.createIcons({nodes:[$el]}); setTimeout(() => show = false, 3000) })"
            x-show="show"
+           :role="t.type === 'error' ? 'alert' : 'status'"
            x-transition:enter="transition ease-out duration-200"
            x-transition:enter-start="opacity-0 translate-y-2 scale-95"
            x-transition:enter-end="opacity-100 translate-y-0 scale-100"
            x-transition:leave="transition ease-in duration-150"
            x-transition:leave-start="opacity-100 translate-y-0"
            x-transition:leave-end="opacity-0 translate-y-2"
-           class="bg-base-100 border border-base-300 rounded-xl shadow-lg px-4 py-2.5 flex items-center gap-2 pointer-events-auto">
+           class="bg-base-100 border border-base-300 rounded-xl shadow-lg px-4 py-2.5 flex items-center gap-2 pointer-events-auto max-w-[calc(100vw-2rem)]">
         <template x-if="t.type === 'success'"><i data-lucide="check" class="w-4 h-4 text-success shrink-0"></i></template>
         <template x-if="t.type === 'error'"><i data-lucide="x-circle" class="w-4 h-4 text-error shrink-0"></i></template>
         <template x-if="t.type === 'warning'"><i data-lucide="alert-triangle" class="w-4 h-4 text-warning shrink-0"></i></template>
         <template x-if="t.type === 'info'"><i data-lucide="info" class="w-4 h-4 text-info shrink-0"></i></template>
         <span class="text-sm font-medium" x-text="t.message"></span>
+        <button type="button"
+                class="ml-1 -mr-1 p-1 rounded-lg text-base-content/40 hover:text-base-content hover:bg-base-200 transition-colors shrink-0"
+                aria-label="Dismiss notification"
+                @click="dismiss(t.id)">
+          <i data-lucide="x" class="w-3.5 h-3.5"></i>
+        </button>
       </div>
     </template>
   </div>


### PR DESCRIPTION
Fixes #753

Global toast pill is now accessible and dismissable, and rapid-fire toasts no longer collide on the `Date.now()` id.

- Wrapper gets `role="region"` + `aria-live="polite"` + `aria-label="Notifications"` so screen readers announce messages. Per-toast `role` is `alert` for `type: 'error'`, `status` otherwise.
- Toast ids use `crypto.randomUUID()` with a counter+random fallback — three toasts dispatched in the same tick now all render and survive Alpine's `:key` dedup.
- Per-push cleanup closure captures its own id instead of always targeting `toasts[0]`, so toasts dismiss independently rather than collapsing together at `t+3500`.
- Each toast has a visible `×` close button (`aria-label="Dismiss notification"`) that removes just that toast immediately.
- Added `max-w-[calc(100vw-2rem)]` so long messages wrap inside the viewport on mobile instead of clipping against the edges.

Repro used for the captures (console of any authed page):

```js
['success','error','warning'].forEach(t => window.dispatchEvent(
  new CustomEvent('bb-toast', { detail: { message: t + ': sample notification message for capture', type: t } })));
```

## Before

| Mobile (375) | Tablet (820) | Desktop (1440) |
|---|---|---|
| <img src="https://i.img402.dev/2ry285yea1.png" width="300" alt="before mobile"> | <img src="https://i.img402.dev/zgmuz4762k.png" width="500" alt="before tablet"> | <img src="https://i.img402.dev/9596j8hl6j.png" width="800" alt="before desktop"> |

Only the last of three simultaneously dispatched toasts survives — id collision drops the others.

## After

| Mobile (375) | Tablet (820) | Desktop (1440) |
|---|---|---|
| <img src="https://i.img402.dev/4i8rbvlet5.png" width="300" alt="after mobile"> | <img src="https://i.img402.dev/rju0v7t3do.png" width="500" alt="after tablet"> | <img src="https://i.img402.dev/254mv0xl7d.png" width="800" alt="after desktop"> |

All three render stacked, each with its own dismiss `×`, and mobile stays within `calc(100vw - 2rem)`.

## Acceptance criteria

- [x] Dispatching three toasts in the same tick renders all three stacked pills at 375/820/1440 (captured).
- [x] Each pill has a visible close `×` button; click removes only that pill.
- [x] Container has `aria-live="polite"`; error toasts render with `role="alert"` for assertive announcements.
- [x] `grep "Date.now()" internal/templates/layout/base.html` returns 0 hits.
- [x] At 375, long-message toast stays within `calc(100vw - 2rem)` and wraps cleanly.
