### PR TITLE
fix(rules): collapse 3-icon row cluster into kebab dropdown

### DIFF
--- a/internal/templates/pages/rules.html
+++ b/internal/templates/pages/rules.html
@@ -60,7 +60,7 @@
 {{range .Rules}}
 {{$matchAll := isMatchAllCondition .Conditions}}
 {{$isSystem := eq .CreatedByType "system"}}
-<div class="bb-card p-0 overflow-hidden cursor-pointer hover:bg-base-200/30 transition-colors{{if not .Enabled}} opacity-60{{end}}"
+<div class="bb-card p-0 cursor-pointer hover:bg-base-200/30 transition-colors relative focus-within:z-30 has-[:focus-within]:z-30{{if not .Enabled}} opacity-60{{end}}"
      data-rule-row
      data-rule-id="{{.ID}}"
      data-open-url="/rules/{{.ID}}"
@@ -159,23 +159,40 @@
       </div>
     </div>
 
-    <!-- Actions -->
-    <div class="flex items-center justify-end gap-0.5 flex-shrink-0 w-24">
-      <button class="btn btn-ghost btn-xs btn-square rounded-lg" data-toggle-enabled title="{{if .Enabled}}Disable{{else}}Enable{{end}}" @click.stop="toggleRule('{{.ID}}')">
-        {{if .Enabled}}<i data-lucide="pause" class="w-3.5 h-3.5"></i>{{else}}<i data-lucide="play" class="w-3.5 h-3.5"></i>{{end}}
-      </button>
-      <a href="/rules/{{.ID}}/edit" class="btn btn-ghost btn-xs btn-square rounded-lg" title="Edit" @click.stop>
+    <!-- Actions — Edit stays as the always-visible primary action (most
+         frequent operation in a rules list); Enable/Disable and Delete
+         move into a kebab dropdown to free up width on mobile and put
+         destructive Delete behind a label instead of flush against Edit.
+         Matches the pattern used on /tags (#728). -->
+    <div class="flex items-center justify-end gap-0.5 flex-shrink-0">
+      <a href="/rules/{{.ID}}/edit" class="btn btn-ghost btn-xs btn-square rounded-lg" title="Edit" aria-label="Edit rule {{.Name}}" @click.stop>
         <i data-lucide="pencil" class="w-3.5 h-3.5"></i>
       </a>
-      {{if $isSystem}}
-      <button class="btn btn-ghost btn-xs btn-square rounded-lg text-base-content/20 cursor-not-allowed" title="System rules cannot be deleted (you can disable them instead)" disabled>
-        <i data-lucide="shield" class="w-3.5 h-3.5"></i>
-      </button>
-      {{else}}
-      <button class="btn btn-ghost btn-xs btn-square rounded-lg text-error/60" data-delete-action title="Delete" :disabled="deleting" @click.stop="deleteRule('{{.ID}}', $el)">
-        <i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
-      </button>
-      {{end}}
+      <div class="dropdown dropdown-end" @click.stop>
+        <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-square rounded-lg" aria-label="Rule {{.Name}} actions">
+          <i data-lucide="ellipsis-vertical" class="w-4 h-4"></i>
+        </div>
+        <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-xl shadow-lg border border-base-300 z-50 w-44 p-1">
+          <li>
+            <button type="button" data-toggle-enabled aria-label="{{if .Enabled}}Disable{{else}}Enable{{end}} rule {{.Name}}" @click.stop="toggleRule('{{.ID}}'); document.activeElement && document.activeElement.blur()">
+              {{if .Enabled}}<i data-lucide="pause" class="w-3.5 h-3.5"></i> Disable{{else}}<i data-lucide="play" class="w-3.5 h-3.5"></i> Enable{{end}}
+            </button>
+          </li>
+          {{if $isSystem}}
+          <li class="disabled">
+            <span class="text-base-content/40 cursor-not-allowed" title="System rules cannot be deleted — disable instead">
+              <i data-lucide="shield" class="w-3.5 h-3.5"></i> System (no delete)
+            </span>
+          </li>
+          {{else}}
+          <li>
+            <button type="button" class="text-error" data-delete-action aria-label="Delete rule {{.Name}}" :disabled="deleting" @click.stop="deleteRule('{{.ID}}', $el); document.activeElement && document.activeElement.blur()">
+              <i data-lucide="trash-2" class="w-3.5 h-3.5"></i> Delete
+            </button>
+          </li>
+          {{end}}
+        </ul>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #751

Collapses the 3-icon row cluster on `/rules` (toggle / edit / delete) into Edit + a kebab dropdown that surfaces Enable/Disable and Delete as labelled menu items. Frees up width on mobile so the rule name and `{N hits}` metric no longer truncate, and puts destructive Delete behind a label instead of flush against the primary Edit button. Matches the dropdown pattern used on `/tags` ([#728](https://github.com/canalesb93/breadbox/pull/728)).

Implementation notes:
- Edit stays as the always-visible primary action — most-frequent operation in a rules list.
- Toggle (Enable/Disable) and Delete move into a `dropdown dropdown-end` with `ellipsis-vertical` trigger and labelled items. Destructive Delete keeps `text-error`. System rules show a disabled "System (no delete)" item in place of Delete.
- `data-toggle-enabled` / `data-delete-action` attributes are preserved on the new menu items so the existing `space` and `d` keyboard shortcuts (which do `row.querySelector(...)`) keep working without changes.
- Removed `overflow-hidden` and added `relative has-[:focus-within]:z-30` on the row card so the open dropdown isn't clipped or covered by the next row.

## Before — 3 icons crammed into `w-24`, name and hits truncated on mobile
<table>
<tr><th>Mobile 375</th><th>Mobile 500</th></tr>
<tr><td><img src="https://i.img402.dev/513zqiqy0e.png" width="380" alt="before mobile 375"></td><td><img src="https://i.img402.dev/cwox6uswlb.png" width="380" alt="before mobile 500"></td></tr>
<tr><th>Tablet 820</th><th>Desktop 1440</th></tr>
<tr><td><img src="https://i.img402.dev/rk34a0bj6m.png" width="380" alt="before tablet 820"></td><td><img src="https://i.img402.dev/g4xz3vapty.png" width="380" alt="before desktop 1440"></td></tr>
</table>

## After — Edit + kebab; rule name and hits fully visible at 375
<table>
<tr><th>Mobile 375</th><th>Mobile 500</th></tr>
<tr><td><img src="https://i.img402.dev/vak2pqa4x1.png" width="380" alt="after mobile 375"></td><td><img src="https://i.img402.dev/vy75ir3uu1.png" width="380" alt="after mobile 500"></td></tr>
<tr><th>Tablet 820</th><th>Desktop 1440</th></tr>
<tr><td><img src="https://i.img402.dev/myxwphhh4l.png" width="380" alt="after tablet 820"></td><td><img src="https://i.img402.dev/31c5bf5n4b.png" width="380" alt="after desktop 1440"></td></tr>
</table>

## Menu open — Disable + Delete (820, non-system rule)
<img src="https://i.img402.dev/rx4p04eucg.png" width="800" alt="kebab menu open showing Disable and Delete">

## Notes
- `bb-card` previously used `overflow-hidden`. Dropping it doesn't change the visual layout of any row content (the card is still `rounded-xl` from `bb-card`, and no inner element extends past its rounded edge); it only stops the dropdown from being clipped.
- `static/css/styles.css` is regenerated to include the `has-[:focus-within]:z-30` and `focus-within:z-30` utilities introduced by the row card change.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean
- [x] 375 / 500 / 820 / 1440 — Edit + kebab visible at idle
- [x] Kebab opens to reveal Disable + Delete (or Disable + "System (no delete)" for system rules)
- [x] Rule name and `{N hits}` no longer truncate at 375

🤖 Generated with [Claude Code](https://claude.com/claude-code)
