### PR TITLE
refactor(admin): canonical error envelope in tag/bulk handlers

### DIFF
--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -179,19 +179,19 @@ func AddTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *serv
 		}
 		body.Slug = strings.TrimSpace(body.Slug)
 		if body.Slug == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "slug is required"})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "slug is required")
 			return
 		}
 		added, alreadyPresent, err := svc.AddTransactionTag(r.Context(), txnID, body.Slug, actor, body.Note)
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrNotFound):
-				writeJSON(w, http.StatusNotFound, map[string]any{"error": "transaction not found"})
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 			case errors.Is(err, service.ErrInvalidParameter):
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+				writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", err.Error())
 			default:
 				a.Logger.Error("add transaction tag", "error", err)
-				writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal server error"})
+				writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error")
 			}
 			return
 		}
@@ -226,12 +226,12 @@ func RemoveTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *s
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrNotFound):
-				writeJSON(w, http.StatusNotFound, map[string]any{"error": "transaction not found"})
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 			case errors.Is(err, service.ErrInvalidParameter):
-				writeJSON(w, http.StatusBadRequest, map[string]any{"error": err.Error()})
+				writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", err.Error())
 			default:
 				a.Logger.Error("remove transaction tag", "error", err)
-				writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal server error"})
+				writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "internal server error")
 			}
 			return
 		}

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -1331,11 +1331,11 @@ func BulkUpdateTransactionsAdminHandler(a *app.App, sm *scs.SessionManager, svc 
 			return
 		}
 		if len(body.Operations) == 0 {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "operations required"})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "operations required")
 			return
 		}
 		if len(body.Operations) > 50 {
-			writeJSON(w, http.StatusBadRequest, map[string]any{"error": "maximum 50 operations per batch"})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "maximum 50 operations per batch")
 			return
 		}
 


### PR DESCRIPTION
## Summary

- Convert the remaining 9 admin handlers from the legacy \`{\"error\": \"string\"}\` shape to \`writeError()\` with the canonical \`{\"error\": {\"code\", \"message\"}}\` envelope.
- Affects \`AddTransactionTagAdminHandler\`, \`RemoveTransactionTagAdminHandler\`, and the bulk \`UpdateTransactions\` endpoint validation.
- Continues alignment with [#742](https://github.com/canalesb93/breadbox/pull/742) (categories), [#743](https://github.com/canalesb93/breadbox/pull/743) (rules), and [#754](https://github.com/canalesb93/breadbox/pull/754) (oauth writeJSON helper).

## Codes used

Per \`.claude/rules/api.md\`, admin form-style endpoints under \`/-/...\` use:
- 422 \`VALIDATION_ERROR\` for validation failures (slug missing, empty operations, batch limit exceeded, invalid params)
- 404 \`NOT_FOUND\` for missing transactions
- 500 \`INTERNAL_ERROR\` for unexpected errors

After this change, no \`writeJSON(w, ..., map[string]any{\"error\": ...})\` callsites remain in \`internal/admin/\`.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go vet ./...\` passes
- [x] \`go test ./...\` passes (all packages)
- No UI changes; no browser validation required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)