### PR TITLE
fix(agents/session): add sequence + offset to tool-call rows

### DIFF
--- a/internal/service/mcp_sessions.go
+++ b/internal/service/mcp_sessions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"breadbox/internal/db"
 	"breadbox/internal/shortid"
@@ -38,6 +39,12 @@ type ToolCallLogResponse struct {
 	ActorName      string           `json:"actor_name"`
 	DurationMs     *int32           `json:"duration_ms,omitempty"`
 	CreatedAt      string           `json:"created_at"`
+	// Sequence is the 1-based ordinal of this call within the session.
+	Sequence int `json:"sequence,omitempty"`
+	// OffsetLabel is a compact human-readable delta from the session's first
+	// recorded tool call (e.g. "+0.0s", "+2.1s", "+1m12s"). Empty when there
+	// is no reference call yet.
+	OffsetLabel string `json:"offset_label,omitempty"`
 }
 
 // MCPSessionDetailResponse is a session with its tool calls.
@@ -195,8 +202,14 @@ func (s *Service) GetMCPSessionDetail(ctx context.Context, idOrShort string) (MC
 	}
 
 	calls := make([]ToolCallLogResponse, len(rows))
+	var base time.Time
+	if len(rows) > 0 {
+		base = rows[0].CreatedAt.Time
+	}
 	for i, r := range rows {
 		calls[i] = toolCallFromRow(r)
+		calls[i].Sequence = i + 1
+		calls[i].OffsetLabel = formatOffset(r.CreatedAt.Time.Sub(base))
 	}
 
 	session.ToolCallCount = int64(len(calls))
@@ -209,6 +222,29 @@ func (s *Service) GetMCPSessionDetail(ctx context.Context, idOrShort string) (MC
 		WriteCount:         writeCount,
 		ReadCount:          readCount,
 	}, nil
+}
+
+// formatOffset renders a duration relative to the session's first tool call
+// as a compact label suitable for inline display next to tool-call rows.
+// Negative values clamp to "+0.0s" so the first row always reads "+0.0s"
+// even if clock skew makes d slightly negative.
+func formatOffset(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	total := d.Seconds()
+	switch {
+	case total < 60:
+		return fmt.Sprintf("+%.1fs", total)
+	case total < 3600:
+		m := int(total) / 60
+		s := int(total) % 60
+		return fmt.Sprintf("+%dm%02ds", m, s)
+	default:
+		h := int(total) / 3600
+		m := (int(total) % 3600) / 60
+		return fmt.Sprintf("+%dh%02dm", h, m)
+	}
 }
 
 // summarizeToolCalls aggregates error / write / read counts across tool calls.

--- a/internal/service/mcp_sessions_test.go
+++ b/internal/service/mcp_sessions_test.go
@@ -1,6 +1,35 @@
 package service
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatOffset(t *testing.T) {
+	tests := []struct {
+		name string
+		d    time.Duration
+		want string
+	}{
+		{"zero", 0, "+0.0s"},
+		{"negative clamped", -5 * time.Second, "+0.0s"},
+		{"sub-second", 100 * time.Millisecond, "+0.1s"},
+		{"seconds with tenths", 2100 * time.Millisecond, "+2.1s"},
+		{"just under a minute", 59500 * time.Millisecond, "+59.5s"},
+		{"one minute exact", 60 * time.Second, "+1m00s"},
+		{"minute and seconds", 72 * time.Second, "+1m12s"},
+		{"just under an hour", 59*time.Minute + 59*time.Second, "+59m59s"},
+		{"one hour exact", time.Hour, "+1h00m"},
+		{"hours and minutes", 2*time.Hour + 5*time.Minute, "+2h05m"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatOffset(tc.d); got != tc.want {
+				t.Errorf("formatOffset(%v) = %q, want %q", tc.d, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestSummarizeToolCalls(t *testing.T) {
 	tests := []struct {

--- a/internal/templates/pages/session_detail.html
+++ b/internal/templates/pages/session_detail.html
@@ -55,12 +55,14 @@
           <span class="badge badge-sm badge-error shrink-0">error</span>
         {{end}}
 
-        <!-- Trailing cluster: keep duration + caret always visible; hide relative time on mobile -->
+        <!-- Trailing cluster: sequence (always distinguishes rows) + offset (timing delta from the first call). Relative time moves to the expanded block. -->
         <span class="flex items-center gap-2 shrink-0 whitespace-nowrap">
+          {{if .Sequence}}
+            <span class="text-xs text-base-content/60 font-mono tabular-nums" title="{{relativeTime .CreatedAt}}">#{{.Sequence}}{{if .OffsetLabel}} <span class="text-base-content/40">{{.OffsetLabel}}</span>{{end}}</span>
+          {{end}}
           {{if .DurationMs}}
             <span class="text-xs text-base-content/40 tabular-nums">{{derefInt32 .DurationMs}}ms</span>
           {{end}}
-          <span class="text-xs text-base-content/40 hidden sm:inline">{{relativeTime .CreatedAt}}</span>
           <i data-lucide="chevron-down" class="w-3.5 h-3.5 text-base-content/30 transition-transform" :class="expanded && 'rotate-180'"></i>
         </span>
       </div>


### PR DESCRIPTION
Fixes #727

Adds a sequence index (`#1`…`#N`) and a delta-from-first-call offset (`+2.1s`, `+1m12s`) to every tool-call row on `/agents/sessions/{id}`, so an auditor can reconstruct the trace even when every `CreatedAt` rounds to the same relative label.

## What changed

- `internal/service/mcp_sessions.go` — `ToolCallLogResponse` now carries `Sequence` and `OffsetLabel`. `GetMCPSessionDetail` populates them once per session using `rows[0].CreatedAt` as the base.
- `formatOffset` — compact helper: `+2.1s` below a minute, `+1m12s` below an hour, `+1h02m` above. Clamps negatives (clock-skew safety) to `+0.0s`.
- `internal/templates/pages/session_detail.html` — collapsed trailing cluster drops the mobile-hidden relative-time span and shows `#N +offset` instead. Relative time is preserved as a `title=` hover; absolute `<time datetime="…">` remains in the expanded block.
- Unit test covers the boundary cases (sub-second, exact minute, hour rollover, negative-clamp).

## Deviations from the proposed fix

Issue suggested either a sequence index **or** a delta offset. Went with **both**. In our seed data (and in practice whenever calls log within the same millisecond) every offset collapses to `+0.0s`, so offset alone would still read as ten identical rows. `#N` guarantees distinguishability; the offset stays useful for real multi-second sessions.

## Before
| Mobile (390) | Tablet (820) | Desktop (1440) |
|---|---|---|
| <img src="https://i.img402.dev/dpm88cypyy.png" width="280" alt="before — mobile"> | <img src="https://i.img402.dev/2p5xfo0d82.png" width="280" alt="before — tablet"> | <img src="https://i.img402.dev/t9yqy2nc1d.png" width="280" alt="before — desktop"> |

## After
| Mobile (390) | Tablet (820) | Desktop (1440) |
|---|---|---|
| <img src="https://i.img402.dev/47rngspzdk.png" width="280" alt="after — mobile"> | <img src="https://i.img402.dev/4g2u0d9s5f.png" width="280" alt="after — tablet"> | <img src="https://i.img402.dev/og7wwo0jpn.png" width="280" alt="after — desktop"> |

## Acceptance criteria

- [x] Collapsed row shows a distinguishable marker per call — `#1`…`#N` plus offset.
- [x] Expanded row shows absolute time wrapped in `<time datetime=…>` (unchanged from existing markup).
- [x] Header still shows one relative time for the session itself (unchanged).
- [x] Mobile/tablet/desktop all fit the new token without re-introducing the wrap problem from #723 — screenshots above.
