### PR TITLE
chore(admin): reuse components.CommaInt/CommaAmount in funcMap

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -400,26 +400,14 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 			// (e.g. `{{renderComponent "KbdCombo" (strs "cmd" "k")}}`).
 			"strs": func(vals ...string) []string { return vals },
 			"commaInt": func(n any) string {
-				var s string
 				switch v := n.(type) {
 				case int:
-					s = fmt.Sprintf("%d", v)
+					return components.CommaInt(int64(v))
 				case int64:
-					s = fmt.Sprintf("%d", v)
+					return components.CommaInt(v)
 				default:
-					s = fmt.Sprintf("%v", v)
+					return fmt.Sprintf("%v", v)
 				}
-				if len(s) <= 3 {
-					return s
-				}
-				result := ""
-				for i, c := range s {
-					if i > 0 && (len(s)-i)%3 == 0 {
-						result += ","
-					}
-					result += string(c)
-				}
-				return result
 			},
 			"subf": func(a, b float64) float64 { return a - b },
 			"mulf": func(a, b float64) float64 { return a * b },
@@ -1015,24 +1003,9 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				default:
 					return ""
 				}
-				neg := f < 0
-				abs := math.Abs(f)
-				whole := int(abs)
-				cents := int(math.Round((abs - float64(whole)) * 100))
-				s := fmt.Sprintf("%d", whole)
-				if len(s) > 3 {
-					result := ""
-					for i, c := range s {
-						if i > 0 && (len(s)-i)%3 == 0 {
-							result += ","
-						}
-						result += string(c)
-					}
-					s = result
-				}
-				formatted := fmt.Sprintf("$%s.%02d", s, cents)
-				if neg {
-					formatted = "-" + formatted
+				formatted := "$" + components.CommaAmount(math.Abs(f))
+				if f < 0 {
+					return "-" + formatted
 				}
 				return formatted
 			},

--- a/internal/admin/templates_test.go
+++ b/internal/admin/templates_test.go
@@ -8,6 +8,75 @@ import (
 // after PR #513 consolidated the helper. Don't reintroduce a wrapper test here
 // — extend TestTitleCase in the components package instead.
 
+// TestFuncMapCommaInt locks in the commaInt funcMap entry's behavior across the
+// supported argument types. The implementation delegates to
+// components.CommaInt, but the type-switch wrapper is admin-package-specific.
+func TestFuncMapCommaInt(t *testing.T) {
+	tr, err := NewTemplateRenderer(nil)
+	if err != nil {
+		t.Fatalf("NewTemplateRenderer: %v", err)
+	}
+	fn, ok := tr.funcMap["commaInt"].(func(any) string)
+	if !ok {
+		t.Fatalf("commaInt funcMap entry missing or wrong signature")
+	}
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"int small", int(42), "42"},
+		{"int four digits", int(1234), "1,234"},
+		{"int64 large", int64(1234567), "1,234,567"},
+		{"int zero", int(0), "0"},
+		{"unknown type falls back to %v", float64(1.5), "1.5"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fn(tc.in); got != tc.want {
+				t.Errorf("commaInt(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFuncMapFmtBalance locks in the fmtBalance funcMap entry's behavior. It
+// always emits "$X,XXX.XX" with cents and a leading sign for negatives, and
+// returns "" for nil pointers or unsupported types.
+func TestFuncMapFmtBalance(t *testing.T) {
+	tr, err := NewTemplateRenderer(nil)
+	if err != nil {
+		t.Fatalf("NewTemplateRenderer: %v", err)
+	}
+	fn, ok := tr.funcMap["fmtBalance"].(func(interface{}) string)
+	if !ok {
+		t.Fatalf("fmtBalance funcMap entry missing or wrong signature")
+	}
+	f := func(v float64) *float64 { return &v }
+	tests := []struct {
+		name string
+		in   interface{}
+		want string
+	}{
+		{"float64 zero", float64(0), "$0.00"},
+		{"float64 small", float64(12.34), "$12.34"},
+		{"float64 thousands", float64(1234.56), "$1,234.56"},
+		{"float64 millions", float64(1_234_567.89), "$1,234,567.89"},
+		{"float64 negative", float64(-1234.56), "-$1,234.56"},
+		{"*float64 value", f(99.5), "$99.50"},
+		{"*float64 negative", f(-1000), "-$1,000.00"},
+		{"*float64 nil", (*float64)(nil), ""},
+		{"unsupported type", "1234", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fn(tc.in); got != tc.want {
+				t.Errorf("fmtBalance(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRuleFieldLabel(t *testing.T) {
 	tests := []struct {
 		in   string

--- a/internal/templates/components/helpers.go
+++ b/internal/templates/components/helpers.go
@@ -246,6 +246,10 @@ func RelativeDate(s string) string { return relativeDate(s) }
 // See formatAmount.
 func FormatAmount(amount float64) string { return formatAmount(amount) }
 
+// CommaAmount formats a non-negative float as "1,234.56" (no currency prefix
+// or sign). See commaAmount.
+func CommaAmount(f float64) string { return commaAmount(f) }
+
 // TitleCase rewrites ALL-CAPS or all-lowercase input to Title Case, leaving
 // mixed-case input untouched. See titleCase.
 func TitleCase(s string) string { return titleCase(s) }


### PR DESCRIPTION
## Summary

- Two admin funcMap entries (`commaInt`, `fmtBalance`) each hand-rolled the same thousands-separator loop that already exists, tested, in `internal/templates/components/helpers.go` as `CommaInt` / `commaAmount`.
- Export `CommaAmount` and route both funcMap entries through the existing helpers so the formatting logic lives in one place. No rendered output changes.
- Add funcMap-level tests pinning the public behavior — signed dollars, nil-pointer + unknown-type fallbacks for `fmtBalance`; type-switch + `%v` fallback for `commaInt` — so future churn in the helpers package can't silently drift the templates.

Net: -33 / +79 lines (the +46 are mostly new test cases).

## Test plan

- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/admin/ -run TestFuncMap` — new tests pass
- [x] `go test ./internal/templates/components/` — pre-existing `CommaInt` / `CommaAmount` / `FormatBalance` coverage still green
- [x] `go test ./...` — full unit suite green
- No template HTML changed, no rendered output changed; UI validation not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)