### PR TITLE
chore(api): use strings.Join in parseEnumParam, cover parseCSVParam

### DIFF
--- a/internal/api/queryparse.go
+++ b/internal/api/queryparse.go
@@ -108,7 +108,7 @@ func parseEnumParam(q url.Values, key string, allowed []string) (*string, error)
 			return &v, nil
 		}
 	}
-	return nil, fmt.Errorf("%s must be one of: %s", key, joinStrings(allowed))
+	return nil, fmt.Errorf("%s must be one of: %s", key, strings.Join(allowed, ", "))
 }
 
 // parseCSVParam collects a repeatable/comma-separated query parameter into a
@@ -135,19 +135,4 @@ func parseCSVParam(q url.Values, key string) []string {
 		}
 	}
 	return out
-}
-
-// joinStrings joins strings with ", " for error messages.
-func joinStrings(ss []string) string {
-	switch len(ss) {
-	case 0:
-		return ""
-	case 1:
-		return ss[0]
-	}
-	result := ss[0]
-	for _, s := range ss[1:] {
-		result += ", " + s
-	}
-	return result
 }

--- a/internal/api/queryparse_test.go
+++ b/internal/api/queryparse_test.go
@@ -286,23 +286,40 @@ func TestParseEnumParam(t *testing.T) {
 	}
 }
 
-func TestJoinStrings(t *testing.T) {
+func TestParseCSVParam(t *testing.T) {
 	tests := []struct {
-		name string
-		ss   []string
-		want string
+		name  string
+		query string
+		key   string
+		want  []string
 	}{
-		{"empty", nil, ""},
-		{"single", []string{"a"}, "a"},
-		{"two", []string{"a", "b"}, "a, b"},
-		{"three", []string{"date", "amount", "name"}, "date, amount, name"},
+		{"absent returns nil", "", "tags", nil},
+		{"empty value returns nil", "tags=", "tags", nil},
+		{"only commas returns nil", "tags=,,,", "tags", nil},
+		{"only whitespace returns nil", "tags=%20%20,%20", "tags", nil},
+		{"single value", "tags=alpha", "tags", []string{"alpha"}},
+		{"comma-separated", "tags=a,b,c", "tags", []string{"a", "b", "c"}},
+		{"trims whitespace", "tags=%20a%20,%20b%20,c", "tags", []string{"a", "b", "c"}},
+		{"drops empty tokens", "tags=a,,b,", "tags", []string{"a", "b"}},
+		{"repeated param", "tags=a&tags=b", "tags", []string{"a", "b"}},
+		{"repeated and comma combined", "tags=a,b&tags=c", "tags", []string{"a", "b", "c"}},
+		{"dedupes across tokens", "tags=a,b,a", "tags", []string{"a", "b"}},
+		{"dedupes across repeated params", "tags=a&tags=a&tags=b", "tags", []string{"a", "b"}},
+		{"preserves inner spaces", "tags=foo%20bar,baz", "tags", []string{"foo bar", "baz"}},
+		{"different key", "any_tag=x,y", "any_tag", []string{"x", "y"}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := joinStrings(tt.ss)
-			if got != tt.want {
-				t.Errorf("joinStrings() = %q, want %q", got, tt.want)
+			q, _ := url.ParseQuery(tt.query)
+			got := parseCSVParam(q, tt.key)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseCSVParam() = %q, want %q", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseCSVParam()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Drop the in-house `joinStrings` helper in `internal/api/queryparse.go`. `strings.Join(allowed, \", \")` is identical for the empty/single/multi cases this code feeds it, so the custom function and its dedicated test were dead weight.
- Add a `TestParseCSVParam` table to fill a coverage gap: `parseCSVParam` was the only helper in this file without unit tests despite being on the hot path for `?tags=` / `?any_tag=` filters on the public REST API.

No behavior change. The new `strings.Join` call produces byte-identical error messages for `parseEnumParam`.

## Test plan

- [x] \`go build ./... && go vet ./...\`
- [x] \`go test ./internal/api/...\` — all green, including the new \`TestParseCSVParam\` cases (dedup across repeated params, comma-split, whitespace trimming, empty-token drop).
- [x] Full \`go test ./...\` unit suite passes.