### PR TITLE
chore(admin): use writeError for canonical error envelopes

### DIFF
--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -24,9 +24,7 @@ func CreateAPIKeyHandler(svc *service.Service) http.HandlerFunc {
 		}
 		req.Name = strings.TrimSpace(req.Name)
 		if req.Name == "" {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Name is required"},
-			})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Name is required")
 			return
 		}
 		if req.Scope == "" {
@@ -34,7 +32,7 @@ func CreateAPIKeyHandler(svc *service.Service) http.HandlerFunc {
 		}
 		result, err := svc.CreateAPIKey(r.Context(), req.Name, req.Scope)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to create API key"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create API key")
 			return
 		}
 		writeJSON(w, http.StatusCreated, result)
@@ -46,7 +44,7 @@ func ListAPIKeysHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		keys, err := svc.ListAPIKeys(r.Context())
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to list API keys"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list API keys")
 			return
 		}
 		writeJSON(w, http.StatusOK, keys)
@@ -58,7 +56,7 @@ func RevokeAPIKeyHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		if err := svc.RevokeAPIKey(r.Context(), id); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to revoke API key"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to revoke API key")
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -328,9 +328,7 @@ func ImportCategoriesTSVAdminHandler(svc *service.Service) http.HandlerFunc {
 
 		result, err := svc.ImportCategoriesTSV(r.Context(), string(body), replaceMode)
 		if err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]any{
-				"error": map[string]string{"code": "IMPORT_ERROR", "message": err.Error()},
-			})
+			writeError(w, http.StatusBadRequest, "IMPORT_ERROR", err.Error())
 			return
 		}
 		writeJSON(w, http.StatusOK, result)

--- a/internal/admin/members.go
+++ b/internal/admin/members.go
@@ -32,31 +32,23 @@ func CreateLoginAccountHandler(svc *service.Service, sm *scs.SessionManager) htt
 
 		req.Username = strings.TrimSpace(req.Username)
 		if req.Username == "" {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Email is required"},
-			})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Email is required")
 			return
 		}
 
 		// Validate email format since username = email.
 		if _, err := mail.ParseAddress(req.Username); err != nil {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Please enter a valid email address"},
-			})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Please enter a valid email address")
 			return
 		}
 
 		if len(req.Username) > 64 {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Email must be 64 characters or fewer"},
-			})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Email must be 64 characters or fewer")
 			return
 		}
 
 		if req.UserID == "" {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Family member (user_id) is required"},
-			})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Family member (user_id) is required")
 			return
 		}
 
@@ -71,18 +63,14 @@ func CreateLoginAccountHandler(svc *service.Service, sm *scs.SessionManager) htt
 		})
 		if err != nil {
 			if strings.Contains(err.Error(), "username already taken") {
-				writeJSON(w, http.StatusConflict, map[string]any{
-					"error": map[string]string{"code": "EMAIL_TAKEN", "message": "This email is already in use as a login"},
-				})
+				writeError(w, http.StatusConflict, "EMAIL_TAKEN", "This email is already in use as a login")
 				return
 			}
 			if strings.Contains(err.Error(), "already has a login account") {
-				writeJSON(w, http.StatusConflict, map[string]any{
-					"error": map[string]string{"code": "DUPLICATE_MEMBER", "message": "This family member already has a login account"},
-				})
+				writeError(w, http.StatusConflict, "DUPLICATE_MEMBER", "This family member already has a login account")
 				return
 			}
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to create login account"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create login account")
 			return
 		}
 
@@ -95,7 +83,7 @@ func ListLoginAccountsHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		members, err := svc.ListLoginAccounts(r.Context())
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to list login accounts"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list login accounts")
 			return
 		}
 		writeJSON(w, http.StatusOK, members)
@@ -115,9 +103,7 @@ func UpdateLoginAccountRoleHandler(svc *service.Service, sm *scs.SessionManager)
 		}
 
 		if err := svc.UpdateLoginAccountRole(r.Context(), id, req.Role); err != nil {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-				"error": map[string]string{"code": "VALIDATION_ERROR", "message": err.Error()},
-			})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", err.Error())
 			return
 		}
 
@@ -131,7 +117,7 @@ func DeleteLoginAccountHandler(svc *service.Service, sm *scs.SessionManager) htt
 		id := chi.URLParam(r, "id")
 
 		if err := svc.DeleteLoginAccount(r.Context(), id); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to delete login account"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete login account")
 			return
 		}
 
@@ -147,12 +133,10 @@ func RegenerateSetupTokenHandler(svc *service.Service, sm *scs.SessionManager) h
 		token, err := svc.RegenerateSetupToken(r.Context(), id)
 		if err != nil {
 			if strings.Contains(err.Error(), "already has a password") {
-				writeJSON(w, http.StatusConflict, map[string]any{
-					"error": map[string]string{"code": "PASSWORD_ALREADY_SET", "message": "This account already has a password set"},
-				})
+				writeError(w, http.StatusConflict, "PASSWORD_ALREADY_SET", "This account already has a password set")
 				return
 			}
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to regenerate setup token"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to regenerate setup token")
 			return
 		}
 
@@ -170,7 +154,7 @@ func WipeUserDataHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		txnCount, err := a.Service.WipeUserData(r.Context(), id)
 		if err != nil {
 			a.Logger.Error("wipe user data", "error", err, "user_id", id)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to wipe user data"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to wipe user data")
 			return
 		}
 

--- a/internal/admin/oauth.go
+++ b/internal/admin/oauth.go
@@ -452,19 +452,17 @@ func CreateOAuthClientHandler(svc *service.Service) http.HandlerFunc {
 			Scope string `json:"scope"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid request body"})
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
 			return
 		}
 		req.Name = strings.TrimSpace(req.Name)
 		if req.Name == "" {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Name is required"},
-			})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Name is required")
 			return
 		}
 		result, err := svc.CreateOAuthClient(r.Context(), req.Name, req.Scope)
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to create OAuth client"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create OAuth client")
 			return
 		}
 		writeJSON(w, http.StatusCreated, result)
@@ -475,7 +473,7 @@ func ListOAuthClientsHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		clients, err := svc.ListOAuthClients(r.Context())
 		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to list OAuth clients"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list OAuth clients")
 			return
 		}
 		writeJSON(w, http.StatusOK, clients)
@@ -486,7 +484,7 @@ func RevokeOAuthClientHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		if err := svc.RevokeOAuthClient(r.Context(), id); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to revoke OAuth client"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to revoke OAuth client")
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -238,18 +238,14 @@ func CreateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 
 		req.Name = strings.TrimSpace(req.Name)
 		if req.Name == "" {
-			writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-				"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Name is required"},
-			})
+			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Name is required")
 			return
 		}
 
 		var emailText pgtype.Text
 		if req.Email != nil && *req.Email != "" {
 			if _, err := mail.ParseAddress(*req.Email); err != nil {
-				writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-					"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Invalid email format"},
-				})
+				writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Invalid email format")
 				return
 			}
 			emailText = pgtype.Text{String: *req.Email, Valid: true}
@@ -262,13 +258,11 @@ func CreateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		if err != nil {
 			var pgErr *pgconn.PgError
 			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-				writeJSON(w, http.StatusConflict, map[string]any{
-					"error": map[string]string{"code": "DUPLICATE_EMAIL", "message": "A family member with this email already exists"},
-				})
+				writeError(w, http.StatusConflict, "DUPLICATE_EMAIL", "A family member with this email already exists")
 				return
 			}
 			a.Logger.Error("create user", "error", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to create user"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create user")
 			return
 		}
 
@@ -297,7 +291,7 @@ func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 
 		var userID pgtype.UUID
 		if err := userID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid user ID"})
+			writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid user ID")
 			return
 		}
 
@@ -310,9 +304,7 @@ func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		existing, err := a.Queries.GetUser(r.Context(), userID)
 		if err != nil {
 			a.Logger.Error("get user for update", "error", err)
-			writeJSON(w, http.StatusNotFound, map[string]any{
-				"error": map[string]string{"code": "NOT_FOUND", "message": "User not found"},
-			})
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "User not found")
 			return
 		}
 
@@ -320,9 +312,7 @@ func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		if req.Name != nil {
 			trimmed := strings.TrimSpace(*req.Name)
 			if trimmed == "" {
-				writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-					"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Name must not be empty"},
-				})
+				writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Name must not be empty")
 				return
 			}
 			name = trimmed
@@ -334,9 +324,7 @@ func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 				email = pgtype.Text{}
 			} else {
 				if _, err := mail.ParseAddress(*req.Email); err != nil {
-					writeJSON(w, http.StatusUnprocessableEntity, map[string]any{
-						"error": map[string]string{"code": "VALIDATION_ERROR", "message": "Invalid email format"},
-					})
+					writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Invalid email format")
 					return
 				}
 				email = pgtype.Text{String: *req.Email, Valid: true}
@@ -351,13 +339,11 @@ func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		if err != nil {
 			var pgErr *pgconn.PgError
 			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-				writeJSON(w, http.StatusConflict, map[string]any{
-					"error": map[string]string{"code": "DUPLICATE_EMAIL", "message": "A family member with this email already exists"},
-				})
+				writeError(w, http.StatusConflict, "DUPLICATE_EMAIL", "A family member with this email already exists")
 				return
 			}
 			a.Logger.Error("update user", "error", err)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to update user"})
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update user")
 			return
 		}
 


### PR DESCRIPTION
## Summary

- Route admin handlers through the existing `writeError` helper so all error responses produce the canonical `{"error":{"code","message"}}` envelope mandated by `.claude/rules/api.md`.
- Replaces hand-rolled `writeJSON(w, status, map[string]any{"error": map[string]string{...}})` boilerplate (5 files, 17 sites) with single-line calls.
- Cleans up a few legacy `{"error":"<string>"}` 4xx/5xx responses in the same handlers so they match the canonical shape too. JS clients already read `e.error?.message || fallback`, so the worst case is a more specific server message instead of the generic frontend fallback.

Net diff: **+33 / −69** across `internal/admin/{apikeys,categories,members,oauth,users}.go`. No behavior change for the structured-envelope sites (byte-for-byte identical output). No new helpers — uses the existing `writeError` (PR #754 pattern).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (admin/api/middleware/service all green)
- [ ] Manual smoke: create/list/revoke an API key from the UI; create a household member; trigger validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)