### PR TITLE
chore(pgconv): add TextOr helper, collapse if-Valid boilerplate

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -269,14 +269,8 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 			if string(conn.Status) == "disconnected" {
 				continue
 			}
-			name := "Unknown"
-			if conn.InstitutionName.Valid {
-				name = conn.InstitutionName.String
-			}
-			errMsg := ""
-			if conn.ErrorMessage.Valid {
-				errMsg = conn.ErrorMessage.String
-			}
+			name := pgconv.TextOr(conn.InstitutionName, "Unknown")
+			errMsg := pgconv.TextOr(conn.ErrorMessage, "")
 			lastSync := "Never"
 			isStale := ConnectionStaleness(
 				a.Config.SyncIntervalMinutes,

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -78,27 +78,12 @@ func UsersListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) 
 				eu.ConnectionCount = int64(len(connSet))
 				for _, acct := range accounts {
 					bal, hasBal := pgconv.NumericToFloat(acct.BalanceCurrent)
-					subtype := ""
-					if acct.Subtype.Valid {
-						// Clean up subtype for display (e.g. "credit_card" -> "Credit Card")
-						subtype = strings.ReplaceAll(acct.Subtype.String, "_", " ")
-					}
-					mask := ""
-					if acct.Mask.Valid {
-						mask = acct.Mask.String
-					}
-					institution := ""
-					if acct.InstitutionName.Valid {
-						institution = acct.InstitutionName.String
-					}
-					currency := "USD"
-					if acct.IsoCurrencyCode.Valid {
-						currency = acct.IsoCurrencyCode.String
-					}
-					displayName := acct.Name
-					if acct.DisplayName.Valid {
-						displayName = acct.DisplayName.String
-					}
+					// Clean up subtype for display (e.g. "credit_card" -> "Credit Card")
+					subtype := strings.ReplaceAll(pgconv.TextOr(acct.Subtype, ""), "_", " ")
+					mask := pgconv.TextOr(acct.Mask, "")
+					institution := pgconv.TextOr(acct.InstitutionName, "")
+					currency := pgconv.TextOr(acct.IsoCurrencyCode, "USD")
+					displayName := pgconv.TextOr(acct.DisplayName, acct.Name)
 
 					isLiability := IsLiabilityAccount(acct.Type)
 					displayBal := bal

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -51,6 +51,16 @@ func TextPtr(t pgtype.Text) *string {
 	return &t.String
 }
 
+// TextOr returns the underlying string value of a pgtype.Text, or fallback
+// when the text is NULL. Use this to collapse `if t.Valid { x = t.String }`
+// boilerplate at display/serialization sites.
+func TextOr(t pgtype.Text, fallback string) string {
+	if !t.Valid {
+		return fallback
+	}
+	return t.String
+}
+
 // Text wraps a string as a non-NULL pgtype.Text. Empty strings are preserved
 // as valid (non-NULL) empty values — use TextFromPtr when an empty/missing
 // input should map to NULL.

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -162,6 +162,27 @@ func TestTextPtr_Invalid(t *testing.T) {
 	}
 }
 
+func TestTextOr_Valid(t *testing.T) {
+	got := TextOr(pgtype.Text{String: "hello", Valid: true}, "fallback")
+	if got != "hello" {
+		t.Errorf("TextOr(valid) = %q, want %q", got, "hello")
+	}
+}
+
+func TestTextOr_EmptyValid(t *testing.T) {
+	got := TextOr(pgtype.Text{String: "", Valid: true}, "fallback")
+	if got != "" {
+		t.Errorf("TextOr(empty valid) = %q, want empty — fallback only kicks in for NULL", got)
+	}
+}
+
+func TestTextOr_Invalid(t *testing.T) {
+	got := TextOr(pgtype.Text{Valid: false}, "fallback")
+	if got != "fallback" {
+		t.Errorf("TextOr(invalid) = %q, want %q", got, "fallback")
+	}
+}
+
 func TestText(t *testing.T) {
 	got := Text("hello")
 	if !got.Valid || got.String != "hello" {

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -83,12 +83,8 @@ func (s *Service) GetAccountDetail(ctx context.Context, id string) (*AdminAccoun
 			conn, err := s.Queries.GetBankConnection(ctx, connID)
 			if err == nil {
 				detail.Provider = string(conn.Provider)
-				if conn.InstitutionName.Valid {
-					detail.InstitutionName = conn.InstitutionName.String
-				}
-				if conn.UserName.Valid {
-					detail.UserName = conn.UserName.String
-				}
+				detail.InstitutionName = pgconv.TextOr(conn.InstitutionName, "")
+				detail.UserName = pgconv.TextOr(conn.UserName, "")
 			}
 		}
 	}

--- a/internal/service/mcp_config.go
+++ b/internal/service/mcp_config.go
@@ -33,27 +33,19 @@ func (s *Service) GetMCPConfig(ctx context.Context) (*MCPConfig, error) {
 	for _, row := range rows {
 		switch row.Key {
 		case "mcp_mode":
-			if row.Value.Valid {
-				cfg.Mode = row.Value.String
-			}
+			cfg.Mode = pgconv.TextOr(row.Value, cfg.Mode)
 		case "mcp_disabled_tools":
-			if row.Value.Valid && row.Value.String != "" {
-				if err := json.Unmarshal([]byte(row.Value.String), &cfg.DisabledTools); err != nil {
+			if raw := pgconv.TextOr(row.Value, ""); raw != "" {
+				if err := json.Unmarshal([]byte(raw), &cfg.DisabledTools); err != nil {
 					cfg.DisabledTools = []string{}
 				}
 			}
 		case "mcp_instructions":
-			if row.Value.Valid {
-				cfg.Instructions = row.Value.String
-			}
+			cfg.Instructions = pgconv.TextOr(row.Value, "")
 		case "mcp_review_guidelines":
-			if row.Value.Valid {
-				cfg.ReviewGuidelines = row.Value.String
-			}
+			cfg.ReviewGuidelines = pgconv.TextOr(row.Value, "")
 		case "mcp_report_format":
-			if row.Value.Valid {
-				cfg.ReportFormat = row.Value.String
-			}
+			cfg.ReportFormat = pgconv.TextOr(row.Value, "")
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds `pgconv.TextOr(t pgtype.Text, fallback string) string` — the missing companion to `TextPtr`/`Text`/`TextFromPtr`. Returns the underlying string value or `fallback` when the text is NULL.

Applied at five sites where the same `if t.Valid { x = t.String } else { x = default }` pattern was inlined:

- [internal/admin/users.go](internal/admin/users.go#L80) — account enrichment loop (5 nullable text fields collapsed from 21 lines to 5)
- [internal/admin/dashboard.go](internal/admin/dashboard.go#L272) — connection health row (institution name + error message)
- [internal/service/accounts.go](internal/service/accounts.go#L86) — `GetAccountDetail` (institution + user name)
- [internal/service/mcp_config.go](internal/service/mcp_config.go#L33) — MCP config loader (4 fields)
- [internal/pgconv/pgconv_test.go](internal/pgconv/pgconv_test.go) — three new test cases (valid, empty-valid, invalid-with-fallback)

Net diff: **+47 / −49**. No behavior change at any site:
- The `users.go` defaults (`""`, `""`, `""`, `"USD"`, `acct.Name`) match the prior fallbacks exactly.
- The `mcp_config.go` `mcp_mode` case previously left `cfg.Mode` untouched on NULL, which kept the constructor default `"read_write"` — passing `cfg.Mode` as the fallback preserves that.
- All other sites previously zero-valued the field on NULL; passing `""` matches.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `make test-integration` (service package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)