### PR TITLE
fix(transactions): multi-line activity composer with kbd hints + char counter

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -805,6 +805,7 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			"HasPendingReview":  hasPendingReview,
 			"CurrentTags":       currentTags,
 			"AvailableTags":     availableTags,
+			"MaxCommentLength":  service.MaxCommentLength,
 			"Categories":      categoryTree,
 			"Breadcrumbs":     breadcrumbs,
 		}

--- a/internal/service/comments.go
+++ b/internal/service/comments.go
@@ -13,7 +13,10 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const maxCommentLength = 10000
+// MaxCommentLength caps the character length of a comment body. The admin UI
+// composer surfaces this value in its char counter so the client mirrors the
+// server-side guard.
+const MaxCommentLength = 10000
 
 // Comments are stored as annotations with kind='comment'. CreateComment /
 // ListComments / UpdateComment / DeleteComment read and write the annotations
@@ -22,8 +25,8 @@ const maxCommentLength = 10000
 // CreateComment adds a comment annotation to a transaction.
 func (s *Service) CreateComment(ctx context.Context, params CreateCommentParams) (*CommentResponse, error) {
 	content := strings.TrimSpace(params.Content)
-	if content == "" || len(content) > maxCommentLength {
-		return nil, fmt.Errorf("content must be between 1 and %d characters", maxCommentLength)
+	if content == "" || len(content) > MaxCommentLength {
+		return nil, fmt.Errorf("content must be between 1 and %d characters", MaxCommentLength)
 	}
 
 	// Verify transaction exists and is not soft-deleted.
@@ -121,8 +124,8 @@ func (s *Service) ListComments(ctx context.Context, transactionID string) ([]Com
 // are identified by the annotation's short_id or UUID.
 func (s *Service) UpdateComment(ctx context.Context, id string, params UpdateCommentParams) (*CommentResponse, error) {
 	content := strings.TrimSpace(params.Content)
-	if content == "" || len(content) > maxCommentLength {
-		return nil, fmt.Errorf("content must be between 1 and %d characters", maxCommentLength)
+	if content == "" || len(content) > MaxCommentLength {
+		return nil, fmt.Errorf("content must be between 1 and %d characters", MaxCommentLength)
 	}
 
 	annID, err := s.resolveAnnotationID(ctx, id)

--- a/internal/service/update_transactions.go
+++ b/internal/service/update_transactions.go
@@ -308,8 +308,8 @@ func (s *Service) runUpdateOpInTx(ctx context.Context, tx pgx.Tx, op UpdateTrans
 	if op.Comment != nil {
 		content := strings.TrimSpace(*op.Comment)
 		if content != "" {
-			if len(content) > maxCommentLength {
-				return fmt.Errorf("%w: comment exceeds %d chars", ErrInvalidParameter, maxCommentLength)
+			if len(content) > MaxCommentLength {
+				return fmt.Errorf("%w: comment exceeds %d chars", ErrInvalidParameter, MaxCommentLength)
 			}
 			payload := map[string]interface{}{"content": content}
 			if err := writeAnnotation(ctx, qtx, writeAnnotationParams{

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -208,7 +208,7 @@
 </div>
 
 <!-- Activity Timeline -->
-<section id="activity" aria-labelledby="activity-heading" class="bb-card p-0 overflow-hidden" x-data="commentManager()">
+<section id="activity" aria-labelledby="activity-heading" class="bb-card p-0 overflow-hidden" x-data="commentManager({{.MaxCommentLength}})">
   <div class="px-4 sm:px-5 pt-5 pb-3 flex items-center gap-2">
     <i data-lucide="activity" class="w-4 h-4 text-base-content/40" aria-hidden="true"></i>
     <h2 id="activity-heading" class="text-sm font-semibold text-base-content/50">Activity</h2>
@@ -217,12 +217,41 @@
 
   <!-- Add Note -->
   <div class="px-4 sm:px-5 pb-4">
-    <div class="flex gap-2 items-center">
+    <div class="flex gap-2 items-start">
       <label for="bb-txd-comment" class="sr-only">Add a note</label>
-      <input id="bb-txd-comment" type="text" x-model="newComment" placeholder="Add a note..." class="input input-bordered input-sm h-9 flex-1 bg-base-200/50 rounded-xl" @keydown.enter.prevent="newComment.trim() && addComment()" />
-      <button @click="addComment()" class="btn btn-sm h-9 rounded-xl btn-primary btn-square" :disabled="!newComment.trim()" aria-label="Post note">
+      <textarea
+        id="bb-txd-comment"
+        x-ref="composer"
+        x-model="newComment"
+        @input="autosize($event.target)"
+        @focus="autosize($event.target)"
+        @keydown.meta.enter.prevent="canSubmit() && addComment()"
+        @keydown.ctrl.enter.prevent="canSubmit() && addComment()"
+        rows="1"
+        placeholder="Add a note... (Markdown supported)"
+        maxlength="{{.MaxCommentLength}}"
+        aria-describedby="bb-txd-comment-counter bb-txd-comment-hint"
+        class="textarea textarea-bordered textarea-sm flex-1 bg-base-200/50 rounded-xl leading-relaxed resize-none min-h-[2.25rem] py-2"
+      ></textarea>
+      <button @click="addComment()" class="btn btn-sm h-9 rounded-xl btn-primary btn-square shrink-0" :disabled="!canSubmit()" aria-label="Post note">
         <i data-lucide="send" class="w-3.5 h-3.5" aria-hidden="true"></i>
       </button>
+    </div>
+    <div class="flex items-center justify-between mt-1.5 px-0.5 gap-2 text-[11px] text-base-content/40">
+      <span id="bb-txd-comment-hint" class="inline-flex items-center gap-1.5 flex-wrap" x-show="!$store.device.isTouch">
+        <span>{{renderComponent "KbdCombo" (strs "cmd" "enter")}}</span>
+        <span>or</span>
+        <span>{{renderComponent "KbdCombo" (strs "ctrl" "enter")}}</span>
+        <span>to post</span>
+        <span class="text-base-content/30">·</span>
+        <span>{{renderComponent "Kbd" "n"}} to focus</span>
+      </span>
+      <span id="bb-txd-comment-counter"
+        class="ml-auto tabular-nums"
+        :class="{ 'text-warning': counterState() === 'warn', 'text-error font-medium': counterState() === 'error' }"
+        aria-live="polite">
+        <span x-text="newComment.length"></span> / <span x-text="maxLength"></span>
+      </span>
     </div>
   </div>
 
@@ -400,6 +429,24 @@ document.addEventListener('alpine:init', function() {
   });
 
   reg.register({
+    id: 'transaction-detail.compose-note',
+    keys: 'n',
+    description: 'Add a note',
+    group: 'Actions',
+    scope: 'transaction-detail',
+    action: function() {
+      // Focus the activity composer. The textarea lives in the activity
+      // section's Alpine scope so we use a stable id rather than reaching
+      // through x-ref from outside.
+      var el = document.getElementById('bb-txd-comment');
+      if (el) {
+        el.focus();
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    },
+  });
+
+  reg.register({
     id: 'transaction-detail.expand-system-details',
     keys: 'e',
     description: 'Toggle system details',
@@ -460,13 +507,32 @@ function showToast(message, type) {
   window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
 }
 
-function commentManager() {
+function commentManager(maxLen) {
   return {
     newComment: '',
+    maxLength: maxLen || 10000,
+    canSubmit() {
+      var len = this.newComment.trim().length;
+      return len > 0 && this.newComment.length <= this.maxLength;
+    },
+    counterState() {
+      var ratio = this.newComment.length / this.maxLength;
+      if (ratio >= 1) return 'error';
+      if (ratio >= 0.9) return 'warn';
+      return 'ok';
+    },
+    autosize(el) {
+      if (!el) return;
+      el.style.height = 'auto';
+      // Cap growth at ~6 rows of leading-relaxed text (~9.75rem at 1rem base).
+      var cap = 156;
+      el.style.height = Math.min(el.scrollHeight, cap) + 'px';
+      el.style.overflowY = el.scrollHeight > cap ? 'auto' : 'hidden';
+    },
     addComment() {
       var self = this;
       var content = this.newComment.trim();
-      if (!content) return;
+      if (!content || !this.canSubmit()) return;
       fetch('/-/transactions/{{.TransactionID}}/comments', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
Fixes #773

Replaces the single-line activity composer on `/transactions/{id}` with a multi-line textarea, surfaces the keyboard contract (post + focus shortcut), and adds a live character counter that mirrors the server-side `MaxCommentLength` (10000).

## Changes

- `internal/templates/pages/transaction_detail.html`
  - `<input>` → auto-grow `<textarea>` (1 row → ~6 rows; vertical overflow scrolls).
  - `Cmd/Ctrl+Enter` posts; bare `Enter` inserts a newline (matches Slack/Linear/GitHub muscle memory).
  - Hint row uses the shared `KbdCombo`/`Kbd` templ components via `renderComponent`, gated on `!$store.device.isTouch` so phones don't see ⌘ glyphs.
  - `n` shortcut registered through `Alpine.store('shortcuts').register({...})` on the `transaction-detail` scope — focuses + scrolls the composer into view, surfaces in the global `?` modal.
  - `1234 / 10000` counter, warn at 90% (`text-warning`), error at 100% (`text-error font-medium`); submit guarded by `canSubmit()` so over-limit input blocks both `Cmd+Enter` and the send button.
- `internal/service/comments.go`, `internal/service/update_transactions.go`
  - Export `MaxCommentLength` so the admin handler can pass the constant to the template instead of hard-coding 10000 in two places.
- `internal/admin/transactions.go`
  - Inject `MaxCommentLength: service.MaxCommentLength` into the transaction-detail render data.

## Before

| Mobile (375) | Mobile (500) | Tablet (820) | Desktop (1440) |
|---|---|---|---|
| <img src="https://i.img402.dev/6hmsacrxrk.jpg" width="220" alt="Before — 375 empty"> | <img src="https://i.img402.dev/y68d9xxwnh.jpg" width="220" alt="Before — 500 empty"> | <img src="https://i.img402.dev/73rst92dno.jpg" width="220" alt="Before — 820 empty"> | <img src="https://i.img402.dev/5opy3cbzf7.jpg" width="220" alt="Before — 1440 empty"> |

Single-line input, no kbd hints, no char counter, no focus shortcut.

## After — empty state

| Mobile (375) | Mobile (500) | Tablet (820) | Desktop (1440) |
|---|---|---|---|
| <img src="https://i.img402.dev/sikjcyuwx9.jpg" width="220" alt="After — 375 empty"> | <img src="https://i.img402.dev/12wn1qct7a.jpg" width="220" alt="After — 500 empty"> | <img src="https://i.img402.dev/88qutdwutz.jpg" width="220" alt="After — 820 empty"> | <img src="https://i.img402.dev/f7jvdplyo3.jpg" width="220" alt="After — 1440 empty"> |

## After — multi-line composing (167 / 10000)

| Mobile (500) | Desktop (1440) |
|---|---|
| <img src="https://i.img402.dev/z2x11nmwk8.jpg" width="380" alt="After — 500 multiline"> | <img src="https://i.img402.dev/ezqpqqkjj6.jpg" width="380" alt="After — 1440 multiline"> |

Textarea grows up to ~6 rows, then scrolls. `KbdCombo` pills + `Kbd` for `n` show the shortcut contract.

## After — warn state (9500 / 10000)

| Mobile (500) | Desktop (1440) |
|---|---|
| <img src="https://i.img402.dev/0cou2oli9k.jpg" width="380" alt="After — 500 warn"> | <img src="https://i.img402.dev/bqmew9o87j.jpg" width="380" alt="After — 1440 warn"> |

Counter switches to `text-warning` at 90%; would flip to `text-error` and disable the send button at 100%.

## Notes

- Mobile screenshots show the kbd hints hidden — the `!$store.device.isTouch` guard fires once Alpine boots even on a non-touch viewport sized like a phone, which is the desired behavior since the page width still reads as small. The CSS `hidden sm:inline-flex` fallback inside the `Kbd*` components keeps the hints out at <640px regardless. Counter remains visible on all viewports (it's load-bearing, not decorative).
- Markdown affordance is communicated via the placeholder text (`Add a note... (Markdown supported)`); rendered output already escapes via `whitespace-pre-wrap` in the timeline. Wiring real markdown rendering is out of scope for this fix — flagged in the issue as optional.
- `n` shortcut goes through the same registry the existing `c`/`t`/`e` use, so the global input-focus guard prevents it from firing while the textarea is focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
