### PR TITLE
chore: use strconv for integer-to-string in non-format contexts

### DIFF
--- a/internal/admin/backups.go
+++ b/internal/admin/backups.go
@@ -234,7 +234,7 @@ func BackupScheduleHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc 
 		// Save retention.
 		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 			Key:   "backup_retention_days",
-			Value: pgtype.Text{String: fmt.Sprintf("%d", retentionDays), Valid: true},
+			Value: pgtype.Text{String: strconv.Itoa(retentionDays), Valid: true},
 		}); err != nil {
 			a.Logger.Error("save backup retention", "error", err)
 			SetFlash(ctx, sm, "error", "Failed to save retention setting.")

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -96,7 +96,7 @@ func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 
 		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 			Key:   "sync_interval_minutes",
-			Value: pgtype.Text{String: fmt.Sprintf("%d", syncInterval), Valid: true},
+			Value: pgtype.Text{String: strconv.Itoa(syncInterval), Valid: true},
 		}); err != nil {
 			a.Logger.Error("save sync interval", "error", err)
 			SetFlash(ctx, sm, "error", "Failed to save sync interval.")
@@ -139,7 +139,7 @@ func SettingsRetentionPostHandler(a *app.App, sm *scs.SessionManager) http.Handl
 
 		if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 			Key:   "sync_log_retention_days",
-			Value: pgtype.Text{String: fmt.Sprintf("%d", retentionDays), Valid: true},
+			Value: pgtype.Text{String: strconv.Itoa(retentionDays), Valid: true},
 		}); err != nil {
 			a.Logger.Error("save sync log retention", "error", err)
 			SetFlash(ctx, sm, "error", "Failed to save retention setting.")

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -640,7 +641,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				if n > 99 {
 					return "99+"
 				}
-				return fmt.Sprintf("%d", n)
+				return strconv.FormatInt(n, 10)
 			},
 			"deref": func(s *string) string {
 				if s == nil {
@@ -798,7 +799,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					switch v := args[1].(type) {
 					case pgtype.Timestamptz:
 						if v.Valid {
-							base += "?v=" + fmt.Sprintf("%d", v.Time.Unix())
+							base += "?v=" + strconv.FormatInt(v.Time.Unix(), 10)
 						}
 					case string:
 						if v != "" {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"breadbox/internal/service"
@@ -764,7 +765,7 @@ func (s *MCPServer) handleBatchCreateRules(ctx context.Context, _ *mcpsdk.CallTo
 	for i, r := range input.Rules {
 		if r.Name == "" || (len(r.Actions) == 0 && r.CategorySlug == "") {
 			errors = append(errors, map[string]string{
-				"index": fmt.Sprintf("%d", i),
+				"index": strconv.Itoa(i),
 				"error": "name and either actions or category_slug are required",
 			})
 			continue
@@ -774,7 +775,7 @@ func (s *MCPServer) handleBatchCreateRules(ctx context.Context, _ *mcpsdk.CallTo
 		conditions, err := parseConditions(r.Conditions)
 		if err != nil {
 			errors = append(errors, map[string]string{
-				"index": fmt.Sprintf("%d", i),
+				"index": strconv.Itoa(i),
 				"name":  r.Name,
 				"error": err.Error(),
 			})
@@ -794,7 +795,7 @@ func (s *MCPServer) handleBatchCreateRules(ctx context.Context, _ *mcpsdk.CallTo
 		})
 		if err != nil {
 			errors = append(errors, map[string]string{
-				"index": fmt.Sprintf("%d", i),
+				"index": strconv.Itoa(i),
 				"name":  r.Name,
 				"error": err.Error(),
 			})

--- a/internal/templates/components/helpers.go
+++ b/internal/templates/components/helpers.go
@@ -9,6 +9,7 @@ package components
 import (
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -177,7 +178,7 @@ func commaAmount(f float64) string {
 // 1234567 → "1,234,567". Used by FormatBalance and templates that need
 // a plain integer count formatted with commas.
 func CommaInt(n int64) string {
-	s := fmt.Sprintf("%d", n)
+	s := strconv.FormatInt(n, 10)
 	if len(s) <= 3 {
 		return s
 	}


### PR DESCRIPTION
## Summary

Replace `fmt.Sprintf(\"%d\", n)` with `strconv.Itoa` / `strconv.FormatInt` in nine call sites across admin handlers, the MCP batch-rule helper, the admin template funcMap, and the shared `components.CommaInt` helper.

`fmt.Sprintf(\"%d\", ...)` is the standard idiom-smell flagged by tools like `gocritic` (`sprintfQuotedString`/`numericInt`): when the format string is just `%d` and the value is `int`/`int64`, `strconv.Itoa` / `strconv.FormatInt` are clearer and skip the format parser. Same output, less indirection.

Touched call sites:

- [internal/admin/backups.go:237](internal/admin/backups.go:237) — backup_retention_days config write
- [internal/admin/settings.go:99](internal/admin/settings.go:99) — sync_interval_minutes config write
- [internal/admin/settings.go:142](internal/admin/settings.go:142) — sync_log_retention_days config write
- [internal/admin/templates.go:644](internal/admin/templates.go:644) — `badgeCount` funcMap
- [internal/admin/templates.go:802](internal/admin/templates.go:802) — `?v=<unix>` cache-bust suffix on `staticAsset`
- [internal/mcp/tools.go:768](internal/mcp/tools.go:768), [:778](internal/mcp/tools.go:778), [:798](internal/mcp/tools.go:798) — `batch_create_rules` per-item error envelope
- [internal/templates/components/helpers.go:181](internal/templates/components/helpers.go:181) — `CommaInt` thousands-separator formatter

No behavior change. `go build`, `go vet`, and the unit suites for `internal/admin`, `internal/mcp`, and `internal/templates/...` all pass.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/admin/... ./internal/mcp/... ./internal/templates/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)