### PR TITLE
fix(transactions): cache-bust activity timeline avatars

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -952,12 +952,13 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 				continue
 			}
 			entry := service.ActivityEntry{
-				Type:      "comment",
-				Timestamp: a.CreatedAt,
-				ActorName: a.ActorName,
-				ActorType: a.ActorType,
-				Detail:    content,
-				CommentID: a.ShortID,
+				Type:               "comment",
+				Timestamp:          a.CreatedAt,
+				ActorName:          a.ActorName,
+				ActorType:          a.ActorType,
+				ActorAvatarVersion: a.ActorAvatarVersion,
+				Detail:             content,
+				CommentID:          a.ShortID,
 			}
 			if a.ActorID != nil && *a.ActorID != "" {
 				id := *a.ActorID
@@ -1025,16 +1026,17 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 			note, _ := a.Payload["note"].(string)
 			td := tagDisplayFn(slug)
 			entry := service.ActivityEntry{
-				Type:           "tag",
-				Timestamp:      a.CreatedAt,
-				ActorName:      a.ActorName,
-				ActorType:      a.ActorType,
-				Summary:        "Added tag",
-				Detail:         note,
-				TagSlug:        slug,
-				TagDisplayName: td.DisplayName,
-				TagColor:       td.Color,
-				TagAction:      "added",
+				Type:               "tag",
+				Timestamp:          a.CreatedAt,
+				ActorName:          a.ActorName,
+				ActorType:          a.ActorType,
+				ActorAvatarVersion: a.ActorAvatarVersion,
+				Summary:            "Added tag",
+				Detail:             note,
+				TagSlug:            slug,
+				TagDisplayName:     td.DisplayName,
+				TagColor:           td.Color,
+				TagAction:          "added",
 			}
 			if a.ActorID != nil && *a.ActorID != "" {
 				id := *a.ActorID
@@ -1054,16 +1056,17 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 			note, _ := a.Payload["note"].(string)
 			td := tagDisplayFn(slug)
 			entry := service.ActivityEntry{
-				Type:           "tag",
-				Timestamp:      a.CreatedAt,
-				ActorName:      a.ActorName,
-				ActorType:      a.ActorType,
-				Summary:        "Removed tag",
-				Detail:         note,
-				TagSlug:        slug,
-				TagDisplayName: td.DisplayName,
-				TagColor:       td.Color,
-				TagAction:      "removed",
+				Type:               "tag",
+				Timestamp:          a.CreatedAt,
+				ActorName:          a.ActorName,
+				ActorType:          a.ActorType,
+				ActorAvatarVersion: a.ActorAvatarVersion,
+				Summary:            "Removed tag",
+				Detail:             note,
+				TagSlug:            slug,
+				TagDisplayName:     td.DisplayName,
+				TagColor:           td.Color,
+				TagAction:          "removed",
 			}
 			if a.ActorID != nil && *a.ActorID != "" {
 				id := *a.ActorID
@@ -1083,12 +1086,13 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 			displaySlug := categoryDisplay(slug)
 			summary := "Category set to " + displaySlug
 			entry := service.ActivityEntry{
-				Type:         "category",
-				Timestamp:    a.CreatedAt,
-				ActorName:    a.ActorName,
-				ActorType:    a.ActorType,
-				Summary:      summary,
-				CategoryName: displaySlug,
+				Type:               "category",
+				Timestamp:          a.CreatedAt,
+				ActorName:          a.ActorName,
+				ActorType:          a.ActorType,
+				ActorAvatarVersion: a.ActorAvatarVersion,
+				Summary:            summary,
+				CategoryName:       displaySlug,
 			}
 			if a.ActorID != nil && *a.ActorID != "" {
 				id := *a.ActorID

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -551,3 +551,90 @@ func TestBuildActivityTimeline_LegacyPrefixCommentSuppressed(t *testing.T) {
 		t.Fatalf("expected legacy [Review: ...] comment to be suppressed, got %d entries", len(entries))
 	}
 }
+
+// ActorAvatarVersion must flow from the joined-row Annotation through into
+// the ActivityEntry for actor-rendered rows (comment, tag_added, tag_removed,
+// category_set). The template uses it to cache-bust the avatar URL so that an
+// avatar upload invalidates the timeline image immediately rather than living
+// in the browser cache for the avatar handler's 24h max-age window. System and
+// agent rows must surface an empty version — no user avatar to fingerprint.
+func TestBuildActivityTimeline_PlumbsAvatarVersion(t *testing.T) {
+	userID := "user-1"
+	annotations := []service.Annotation{
+		{
+			ID:                 "ann-comment",
+			Kind:               "comment",
+			ActorName:          "Alice",
+			ActorType:          "user",
+			ActorID:            &userID,
+			ActorAvatarVersion: "1700000000",
+			Payload:            map[string]interface{}{"content": "Looks right"},
+			CreatedAt:          "2026-04-05T09:00:00Z",
+		},
+		{
+			ID:                 "ann-tag",
+			Kind:               "tag_added",
+			ActorName:          "Alice",
+			ActorType:          "user",
+			ActorID:            &userID,
+			ActorAvatarVersion: "1700000000",
+			Payload:            map[string]interface{}{"slug": "vacation"},
+			CreatedAt:          "2026-04-05T09:01:00Z",
+		},
+		{
+			ID:                 "ann-tag-removed",
+			Kind:               "tag_removed",
+			ActorName:          "Alice",
+			ActorType:          "user",
+			ActorID:            &userID,
+			ActorAvatarVersion: "1700000000",
+			Payload:            map[string]interface{}{"slug": "vacation"},
+			CreatedAt:          "2026-04-05T09:02:00Z",
+		},
+		{
+			ID:                 "ann-cat",
+			Kind:               "category_set",
+			ActorName:          "Alice",
+			ActorType:          "user",
+			ActorID:            &userID,
+			ActorAvatarVersion: "1700000000",
+			Payload:            map[string]interface{}{"category_slug": "groceries"},
+			CreatedAt:          "2026-04-05T09:03:00Z",
+		},
+		{
+			// rule_applied is system-authored — no avatar version.
+			ID:        "ann-rule",
+			Kind:      "rule_applied",
+			ActorName: "",
+			ActorType: "system",
+			Payload: map[string]interface{}{
+				"rule_id":      "rule-1",
+				"rule_name":    "Auto-categorize",
+				"applied_by":   "sync",
+				"action_field": "category",
+				"action_value": "groceries",
+			},
+			CreatedAt: "2026-04-05T09:04:00Z",
+		},
+	}
+
+	entries := buildActivityTimeline(annotations, nil, nil)
+
+	if len(entries) != 5 {
+		t.Fatalf("expected 5 entries, got %d", len(entries))
+	}
+
+	// Find each entry by Type+Summary fingerprint and assert.
+	for _, e := range entries {
+		switch {
+		case e.Type == "comment", e.Type == "tag", e.Type == "category":
+			if e.ActorAvatarVersion != "1700000000" {
+				t.Errorf("user-actor %s entry: ActorAvatarVersion = %q, want %q", e.Type, e.ActorAvatarVersion, "1700000000")
+			}
+		case e.Type == "rule":
+			if e.ActorAvatarVersion != "" {
+				t.Errorf("system rule entry: ActorAvatarVersion = %q, want empty", e.ActorAvatarVersion)
+			}
+		}
+	}
+}

--- a/internal/db/queries/annotations.sql
+++ b/internal/db/queries/annotations.sql
@@ -11,6 +11,33 @@ SELECT * FROM annotations
 WHERE transaction_id = $1
 ORDER BY created_at ASC;
 
+-- name: ListAnnotationsWithActorByTransaction :many
+-- Carries the actor user's updated_at as a unix-timestamp avatar version so
+-- the activity timeline can cache-bust avatar URLs (`?v=<ts>`) and pick up
+-- new uploads immediately rather than serving stale bytes within the avatar
+-- handler's 24h max-age window. annotations.actor_id can hold either a
+-- users.id or an auth_accounts.id depending on the call site; resolve both
+-- by joining auth_accounts and falling back to a direct users join.
+SELECT
+    a.id, a.short_id, a.transaction_id, a.kind, a.actor_type,
+    a.actor_id, a.actor_name, a.session_id, a.payload, a.tag_id,
+    a.rule_id, a.created_at,
+    COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at
+FROM annotations a
+LEFT JOIN auth_accounts aa
+    ON a.actor_type = 'user'
+   AND a.actor_id IS NOT NULL
+   AND a.actor_id::uuid = aa.id
+LEFT JOIN users u_via_account
+    ON aa.user_id = u_via_account.id
+LEFT JOIN users u_direct
+    ON a.actor_type = 'user'
+   AND a.actor_id IS NOT NULL
+   AND aa.id IS NULL
+   AND a.actor_id::uuid = u_direct.id
+WHERE a.transaction_id = $1
+ORDER BY a.created_at ASC;
+
 -- name: CountAnnotationsByTransactionAndKind :one
 SELECT COUNT(*) FROM annotations
 WHERE transaction_id = $1 AND kind = $2;

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
@@ -27,6 +28,13 @@ type Annotation struct {
 	TagID         *string                `json:"tag_id,omitempty"`
 	RuleID        *string                `json:"rule_id,omitempty"`
 	CreatedAt     string                 `json:"created_at"`
+
+	// ActorAvatarVersion is the unix timestamp of the user's most recent
+	// users.updated_at, used as a cache-busting `?v=<ts>` query string on
+	// avatar URLs in the activity timeline. Empty for non-user actors and
+	// for user actors whose row has been deleted. Mirrors the pattern in
+	// users.html — see admin/templates.go avatarURL helper.
+	ActorAvatarVersion string `json:"-"`
 }
 
 // writeAnnotationParams is the shared input for writing an annotation row via
@@ -88,14 +96,18 @@ func (s *Service) ListAnnotations(ctx context.Context, transactionID string) ([]
 		return nil, ErrNotFound
 	}
 
-	rows, err := s.Queries.ListAnnotationsByTransaction(ctx, txnID)
+	// Joined variant carries the actor user's updated_at so the timeline
+	// can cache-bust avatar URLs (`?v=<unix>`), matching the pattern used
+	// by users.html. Without it the browser cached the avatar bytes for up
+	// to 24h after a user uploaded a new picture.
+	rows, err := s.Queries.ListAnnotationsWithActorByTransaction(ctx, txnID)
 	if err != nil {
 		return nil, fmt.Errorf("list annotations: %w", err)
 	}
 
 	result := make([]Annotation, len(rows))
 	for i, r := range rows {
-		result[i] = annotationFromRow(r)
+		result[i] = annotationFromActorRow(r)
 	}
 	return result, nil
 }
@@ -131,6 +143,47 @@ func annotationFromRow(a db.Annotation) Annotation {
 		if err := json.Unmarshal(a.Payload, &payload); err == nil {
 			ann.Payload = payload
 		}
+	}
+
+	return ann
+}
+
+// annotationFromActorRow mirrors annotationFromRow but additionally surfaces
+// the joined user's updated_at as a unix-timestamp avatar version string.
+func annotationFromActorRow(a db.ListAnnotationsWithActorByTransactionRow) Annotation {
+	ann := Annotation{
+		ID:            formatUUID(a.ID),
+		ShortID:       a.ShortID,
+		TransactionID: formatUUID(a.TransactionID),
+		Kind:          a.Kind,
+		ActorType:     a.ActorType,
+		ActorID:       textPtr(a.ActorID),
+		ActorName:     a.ActorName,
+		CreatedAt:     pgconv.TimestampStr(a.CreatedAt),
+	}
+
+	if a.SessionID.Valid {
+		s := formatUUID(a.SessionID)
+		ann.SessionID = &s
+	}
+	if a.TagID.Valid {
+		s := formatUUID(a.TagID)
+		ann.TagID = &s
+	}
+	if a.RuleID.Valid {
+		s := formatUUID(a.RuleID)
+		ann.RuleID = &s
+	}
+
+	if len(a.Payload) > 0 && string(a.Payload) != "{}" {
+		var payload map[string]interface{}
+		if err := json.Unmarshal(a.Payload, &payload); err == nil {
+			ann.Payload = payload
+		}
+	}
+
+	if a.ActorUpdatedAt.Valid {
+		ann.ActorAvatarVersion = strconv.FormatInt(a.ActorUpdatedAt.Time.Unix(), 10)
 	}
 
 	return ann

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -396,6 +396,14 @@ type ActivityEntry struct {
 	ActorType string  `json:"actor_type"`         // "user", "agent", "system"
 	ActorID   *string `json:"actor_id,omitempty"` // user UUID when available (for avatar rendering)
 
+	// ActorAvatarVersion is a unix-timestamp string from the actor user's
+	// users.updated_at, used as the `?v=<ts>` cache buster on the rendered
+	// avatar URL. Mirrors the pattern in users.html so that avatar uploads
+	// invalidate the timeline image immediately rather than living in the
+	// browser cache for the avatar handler's 24h max-age window. Empty for
+	// non-user actors and for user actors whose row has been deleted.
+	ActorAvatarVersion string `json:"-"`
+
 	Summary string `json:"summary"`          // Short: "Approved as Food & Drink"
 	Detail  string `json:"detail,omitempty"` // Longer text (review note or comment body)
 

--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -292,7 +292,7 @@
         <i data-lucide="bot" class="w-4 h-4 text-primary" aria-hidden="true"></i>
       </div>
       {{else if and (eq .ActorType "user") .ActorID}}
-      <img src="{{avatarURL (deref .ActorID)}}" alt="{{.ActorName}} avatar" class="w-8 h-8 rounded-full object-cover shrink-0 mt-0.5" title="{{.ActorName}}">
+      <img src="{{avatarURL (deref .ActorID) .ActorAvatarVersion}}" alt="{{.ActorName}} avatar" class="w-8 h-8 rounded-full object-cover shrink-0 mt-0.5" title="{{.ActorName}}">
       {{else if eq .Type "rule"}}
       <div class="w-8 h-8 rounded-full bg-info/10 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
         <i data-lucide="zap" class="w-4 h-4 text-info" aria-hidden="true"></i>


### PR DESCRIPTION
Fixes #775

Adds a `?v=<unix-ts>` cache buster to user-actor avatar URLs in the activity timeline so an avatar upload invalidates the cached image immediately, instead of waiting for the avatar handler's 24-hour `max-age` window to expire. Mirrors the pattern already used by `users.html:92` (`{{avatarURL .ID .UpdatedAt}}`).

## Changes

- New sqlc query `ListAnnotationsWithActorByTransaction` carries the actor user's `users.updated_at` as a unix-timestamp avatar version. `annotations.actor_id` can hold either a `users.id` or an `auth_accounts.id` depending on call site (admin sessions stash the auth-account UUID via `ActorFromSession`), so the JOIN resolves both — `auth_accounts.user_id` first, falling back to a direct `users` lookup.
- `service.Annotation` and `service.ActivityEntry` gain `ActorAvatarVersion` (excluded from JSON via `json:"-"` — server-rendered only).
- `service.ListAnnotations` switches to the joined query and populates the version.
- `buildActivityTimeline` plumbs the version through user-actor entries (`comment`, `tag_added`, `tag_removed`, `category_set`). Rule and review rows don't render an avatar, so they ignore it.
- `transaction_detail.html:295` passes `.ActorAvatarVersion` as the second arg to `avatarURL`.
- New unit test `TestBuildActivityTimeline_PlumbsAvatarVersion` covers user-actor plumbing and the empty-version case for system actors.

## Validation

URL diff confirmed end-to-end against a logged-in admin session on `localhost:8082`:

```
# BEFORE (template reverted, server live)
$ curl -s -b cookies "http://localhost:8082/transactions/ra7ENqgG" | grep -oE '/avatars/[^"]*' | sort -u
/avatars/4fc736c2-7791-40b4-a49e-c1efda2a644f
/avatars/e7e622e6-c0bc-48f8-a500-5610e2a69d8a   # navbar (already cache-busted via users.html)

# AFTER (template restored)
$ curl -s -b cookies "http://localhost:8082/transactions/ra7ENqgG" | grep -oE '/avatars/[^"]*' | sort -u
/avatars/4fc736c2-7791-40b4-a49e-c1efda2a644f?v=1776304222
/avatars/e7e622e6-c0bc-48f8-a500-5610e2a69d8a   # navbar unchanged (no regression)
```

`go build ./...`, `go vet ./...`, `go test ./...` all pass.

## Visual

The visual diff is intentionally near-zero — the avatar bytes are identical because no upload has happened. The fix is in the URL fingerprint, not the rendered pixels. The screenshots below confirm no regression in the timeline layout.

### Before

| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/kjvuzfykfv.png" width="280" alt="before mobile"> | <img src="https://i.img402.dev/ue7kbwnitt.png" width="280" alt="before tablet"> | <img src="https://i.img402.dev/eeobny70o1.png" width="280" alt="before desktop"> |

### After

| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/91iy5b4yx3.png" width="280" alt="after mobile"> | <img src="https://i.img402.dev/lqaep9sj3f.png" width="280" alt="after tablet"> | <img src="https://i.img402.dev/bv0r7qd79q.png" width="280" alt="after desktop"> |

## Notes for reviewer

- The `actor_id` column stores `auth_accounts.id` for admin sessions (via `ActorFromSession`) but the avatar handler at `/avatars/{id}` is keyed on `users.id`. That's a separate, pre-existing bug — when the admin uploads an avatar, the timeline never resolves it. This PR's JOIN fixes the cache-bust regardless of which UUID flavor `actor_id` holds, so the moment the actor-id mismatch is resolved (a follow-up issue should track that), avatar uploads will already invalidate timeline images correctly.
- Acceptance criterion's "side-by-side stale-vs-fresh after upload" capture is not applicable in isolation — the rendered bytes only change after an upload, which is gated by the actor-id bug above. The URL diff above demonstrates that the cache-buster is in place.
