### PR TITLE
chore(admin): reuse FormatDurationMs in syncDuration funcMap

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -432,14 +432,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				return float64(a)
 			},
 			"syncDuration": func(start, end time.Time) string {
-				d := end.Sub(start)
-				if d < time.Second {
-					return fmt.Sprintf("%dms", d.Milliseconds())
-				}
-				if d < time.Minute {
-					return fmt.Sprintf("%.1fs", d.Seconds())
-				}
-				return fmt.Sprintf("%.0fm", d.Minutes())
+				return service.FormatDurationMs(end.Sub(start).Milliseconds())
 			},
 			"formatDurationMs": func(ms int32) string { return service.FormatDurationMs(int64(ms)) },
 			"relativeTime": func(t interface{}) string {


### PR DESCRIPTION
## Summary

The `syncDuration` template funcMap helper hand-rolled its own ms / sec / minute formatting:

```go
"syncDuration": func(start, end time.Time) string {
    d := end.Sub(start)
    if d < time.Second {
        return fmt.Sprintf(\"%dms\", d.Milliseconds())
    }
    if d < time.Minute {
        return fmt.Sprintf(\"%.1fs\", d.Seconds())
    }
    return fmt.Sprintf(\"%.0fm\", d.Minutes())
},
```

This duplicates [`service.FormatDurationMs`](internal/service/convert.go:62), which already powers the `formatDurationMs` helper in the same funcMap (see [internal/admin/templates.go:444](internal/admin/templates.go:444)) and is used by the completed-sync branch on the same template line in [internal/templates/pages/connection_detail.html:361](internal/templates/pages/connection_detail.html:361):

```html
{{if .DurationMs.Valid}}{{formatDurationMs .DurationMs.Int32}}{{else if and .StartedAt.Valid .CompletedAt.Valid}}{{syncDuration .StartedAt.Time .CompletedAt.Time}}{{end}}
```

Delegating `syncDuration` to `FormatDurationMs` removes the duplicated logic and unifies the two branches' output format — the in-progress fallback now also shows the \"Xm Ys\" breakdown (previously rounded to a bare \"Xm\") and the duration display is consistent whether the sync row has a recorded `duration_ms` or only `started_at`/`completed_at`. `FormatDurationMs` is already covered by [`TestFormatDurationMs`](internal/service/convert_test.go:168).

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/admin/... ./internal/service/...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)