### PR TITLE
fix(transactions): render comment annotations as chat bubbles

### DIFF
--- a/internal/templates/pages/transaction_detail.html
+++ b/internal/templates/pages/transaction_detail.html
@@ -259,6 +259,43 @@
         </div>
       </div>
     </a>
+    {{else if eq .Type "comment"}}
+    <div class="flex items-start gap-3 py-3 border-b border-base-300/60 dark:border-base-200 last:border-b-0 group">
+      <!-- Avatar -->
+      {{if eq .ActorType "agent"}}
+      <div class="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
+        <i data-lucide="bot" class="w-4 h-4 text-primary" aria-hidden="true"></i>
+      </div>
+      {{else if and (eq .ActorType "user") .ActorID}}
+      <img src="{{avatarURL (deref .ActorID)}}" alt="{{.ActorName}} avatar" class="w-8 h-8 rounded-full object-cover shrink-0 mt-0.5" title="{{.ActorName}}">
+      {{else}}
+      <div class="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center shrink-0 mt-0.5" aria-hidden="true">
+        <span class="text-xs font-semibold text-primary leading-none">{{firstChar .ActorName}}</span>
+      </div>
+      {{end}}
+
+      <!-- Bubble -->
+      <div class="flex-1 min-w-0 flex flex-col items-start">
+        <div class="rounded-2xl bg-base-200/60 px-3 py-2 max-w-[85%] sm:max-w-[75%] inline-block">
+          <div class="flex items-baseline gap-1.5 flex-wrap mb-0.5">
+            {{if .ActorName}}<span class="text-xs font-semibold text-base-content/70">{{.ActorName}}</span>{{end}}
+            {{if .Timestamp}}
+            <time datetime="{{.Timestamp}}" class="text-[11px] text-base-content/40" title="{{formatDateTime .Timestamp}}">{{clockTime .Timestamp}}</time>
+            {{end}}
+          </div>
+          {{if .Detail}}
+          <p class="text-sm whitespace-pre-wrap leading-relaxed break-words">{{.Detail}}</p>
+          {{end}}
+        </div>
+      </div>
+
+      <!-- Delete button -->
+      {{if .CommentID}}
+      <button class="btn btn-ghost btn-xs rounded-lg sm:opacity-0 sm:group-hover:opacity-100 transition-opacity text-error/50 hover:text-error" @click="deleteComment('{{.CommentID}}')" aria-label="Delete comment by {{.ActorName}} from {{relativeTime .Timestamp}}" title="Delete">
+        <i data-lucide="trash-2" class="w-3.5 h-3.5" aria-hidden="true"></i>
+      </button>
+      {{end}}
+    </div>
     {{else}}
     <div class="flex items-start gap-3 py-3 border-b border-base-300/60 dark:border-base-200 last:border-b-0 group">
       <!-- Icon -->


### PR DESCRIPTION
Fixes #774

Render comment-kind annotations as chat bubbles in the transaction activity timeline so human/agent dialogue is visually distinct from audit-log rows (rule applications, tag adds/removes, category sets).

## Before

| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/e7tbwuizss.png" width="280"> | <img src="https://i.img402.dev/fc9vvf3f7m.png" width="280"> | <img src="https://i.img402.dev/d6k5vjo4jt.png" width="280"> |

Comments and audit rows share identical chrome — `asdf asdf` and `Apple greens are potatoes` are visually indistinguishable from `Removed tag Suspicious` / `Added tag Decent`.

## After

| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/nwpjpuddft.png" width="280"> | <img src="https://i.img402.dev/sbqu2ka4i0.png" width="280"> | <img src="https://i.img402.dev/8369h76253.png" width="280"> |

Comments now render in a rounded `bg-base-200/60` bubble with author + timestamp inside the micro-header. Audit rows are unchanged.

## Notes

- **Scoped change**: implemented bubble + inline header. Deferred from the proposal:
  - Same-author 5-min stacking (avatar collapse)
  - Right-anchored "current viewer" tint
  These require plumbing `IsCurrentUser` and `StackPrev` through `service.ActivityEntry` plus a session lookup. Worth doing in a follow-up — the structural data plumbing is non-trivial and the bubble alone delivers the primary scannability win the issue calls out.
- Delete button (`@click="deleteComment(...)"`) preserved with same `aria-label` and hover-reveal behaviour.
- `whitespace-pre-wrap break-words` keeps long comments wrapping inside the bubble at 375px.
- `buildActivityTimeline` dedup paths (rule-sourced tag_added skip, tag-with-note suppression at `transactions.go:951`, legacy `[Review:` prefix filter) are unaffected — comment-bubble rendering happens after them in the template.
- No service / Go-layer changes were needed for this scope; existing `ActivityEntry` fields drive the new branch.
