### PR TITLE
chore(service): replace textPtrVal with pgconv.TextOr in account_links

### DIFF
--- a/internal/service/account_links.go
+++ b/internal/service/account_links.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -161,10 +162,10 @@ func (s *Service) GetAccountLink(ctx context.Context, id string) (*AccountLinkRe
 		ShortID:                 row.ShortID,
 		PrimaryAccountID:        formatUUID(row.PrimaryAccountID),
 		PrimaryAccountName:      row.PrimaryAccountDisplayName,
-		PrimaryUserName:         textPtrVal(row.PrimaryUserName),
+		PrimaryUserName:         pgconv.TextOr(row.PrimaryUserName, ""),
 		DependentAccountID:      formatUUID(row.DependentAccountID),
 		DependentAccountName:    row.DependentAccountDisplayName,
-		DependentUserName:       textPtrVal(row.DependentUserName),
+		DependentUserName:       pgconv.TextOr(row.DependentUserName, ""),
 		MatchStrategy:           row.MatchStrategy,
 		MatchToleranceDays:      int(row.MatchToleranceDays),
 		Enabled:                 row.Enabled,
@@ -192,10 +193,10 @@ func (s *Service) ListAccountLinks(ctx context.Context) ([]AccountLinkResponse, 
 			ShortID:                 row.ShortID,
 			PrimaryAccountID:        formatUUID(row.PrimaryAccountID),
 			PrimaryAccountName:      row.PrimaryAccountDisplayName,
-			PrimaryUserName:         textPtrVal(row.PrimaryUserName),
+			PrimaryUserName:         pgconv.TextOr(row.PrimaryUserName, ""),
 			DependentAccountID:      formatUUID(row.DependentAccountID),
 			DependentAccountName:    row.DependentAccountDisplayName,
-			DependentUserName:       textPtrVal(row.DependentUserName),
+			DependentUserName:       pgconv.TextOr(row.DependentUserName, ""),
 			MatchStrategy:           row.MatchStrategy,
 			MatchToleranceDays:      int(row.MatchToleranceDays),
 			Enabled:                 row.Enabled,
@@ -500,10 +501,3 @@ func (s *Service) RunMatchReconciliation(ctx context.Context, linkID string) (*M
 	}, nil
 }
 
-// textPtrVal returns the string value of a pgtype.Text, or empty string if null.
-func textPtrVal(t pgtype.Text) string {
-	if !t.Valid {
-		return ""
-	}
-	return t.String
-}


### PR DESCRIPTION
## Summary

- `internal/service/account_links.go` carried a local `textPtrVal(pgtype.Text) string` helper that returns `""` when the text is NULL — exactly what `pgconv.TextOr(t, "")` already does.
- Drop the wrapper and call `pgconv.TextOr` at the four sites in `GetAccountLink` / `ListAccountLinks`. This matches existing usage in [accounts.go:86](https://github.com/canalesb93/breadbox/blob/main/internal/service/accounts.go#L86), [mcp_config.go:36](https://github.com/canalesb93/breadbox/blob/main/internal/service/mcp_config.go#L36), and the admin layer.
- No behavior change. Net -6 lines.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/service/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)