### PR TITLE
fix(logs): add fade affordance to sync-status pill strip on mobile

### DIFF
--- a/internal/templates/components/pages/logs.templ
+++ b/internal/templates/components/pages/logs.templ
@@ -229,38 +229,41 @@ templ triggerOption(value, label, current string) {
 templ logsSyncStatusTabs(p LogsProps) {
 	<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-5">
 		<!-- Status pill tabs -->
-		<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 overflow-x-auto">
-			<a
-				href={ statusTabHref(p.StatusQueryAll) }
-				class={ statusPillClass(p.FilterStatus == "") }
-			>
-				All
-				<span class="text-[0.6rem] tabular-nums opacity-60">{ statsTotalSync(p.Stats) }</span>
-			</a>
-			<a
-				href={ statusTabHref(p.StatusQuerySuccess) }
-				class={ statusPillClass(p.FilterStatus == "success") }
-			>
-				<span class="w-1.5 h-1.5 rounded-full bg-success shrink-0"></span>
-				Success
-				<span class="text-[0.6rem] tabular-nums opacity-60">{ strconv.FormatInt(p.SuccessCount, 10) }</span>
-			</a>
-			<a
-				href={ statusTabHref(p.StatusQueryError) }
-				class={ statusPillClass(p.FilterStatus == "error") }
-			>
-				<span class="w-1.5 h-1.5 rounded-full bg-error shrink-0"></span>
-				Errors
-				<span class="text-[0.6rem] tabular-nums opacity-60">{ strconv.FormatInt(p.ErrorCount, 10) }</span>
-			</a>
-			<a
-				href={ statusTabHref(p.StatusQueryInProgress) }
-				class={ statusPillClass(p.FilterStatus == "in_progress") }
-			>
-				<span class="w-1.5 h-1.5 rounded-full bg-warning shrink-0"></span>
-				In Progress
-				<span class="text-[0.6rem] tabular-nums opacity-60">{ strconv.FormatInt(p.InProgressCount, 10) }</span>
-			</a>
+		<div class="relative min-w-0">
+			<div class="flex items-center gap-0.5 bg-base-200/60 rounded-lg p-0.5 overflow-x-auto">
+				<a
+					href={ statusTabHref(p.StatusQueryAll) }
+					class={ statusPillClass(p.FilterStatus == "") }
+				>
+					All
+					<span class="text-[0.6rem] tabular-nums opacity-60">{ statsTotalSync(p.Stats) }</span>
+				</a>
+				<a
+					href={ statusTabHref(p.StatusQuerySuccess) }
+					class={ statusPillClass(p.FilterStatus == "success") }
+				>
+					<span class="w-1.5 h-1.5 rounded-full bg-success shrink-0"></span>
+					Success
+					<span class="text-[0.6rem] tabular-nums opacity-60">{ strconv.FormatInt(p.SuccessCount, 10) }</span>
+				</a>
+				<a
+					href={ statusTabHref(p.StatusQueryError) }
+					class={ statusPillClass(p.FilterStatus == "error") }
+				>
+					<span class="w-1.5 h-1.5 rounded-full bg-error shrink-0"></span>
+					Errors
+					<span class="text-[0.6rem] tabular-nums opacity-60">{ strconv.FormatInt(p.ErrorCount, 10) }</span>
+				</a>
+				<a
+					href={ statusTabHref(p.StatusQueryInProgress) }
+					class={ statusPillClass(p.FilterStatus == "in_progress") }
+				>
+					<span class="w-1.5 h-1.5 rounded-full bg-warning shrink-0"></span>
+					In Progress
+					<span class="text-[0.6rem] tabular-nums opacity-60">{ strconv.FormatInt(p.InProgressCount, 10) }</span>
+				</a>
+			</div>
+			<div aria-hidden="true" class="pointer-events-none absolute inset-y-0 right-0 w-8 rounded-r-lg bg-gradient-to-l from-base-100 to-transparent sm:hidden"></div>
 		</div>
 		if hasAnySyncFilter(p) {
 			<a href="/logs?tab=syncs" class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-base-content/50 hover:text-base-content/80">


### PR DESCRIPTION
Fixes #786

Adds a right-edge fade affordance to the Sync Logs status pill strip on mobile so users see that "In Progress" continues past the viewport edge. The fade is only rendered below `sm` (640px) — at 820 px and 1440 px the strip already fits comfortably.

The fade is a `pointer-events-none` overlay positioned absolutely against a new `relative` wrapper around the existing `overflow-x-auto` container. No JS, no markup churn on the pills themselves, no regression on the desktop layout.

## Before

| Mobile 375 | Mobile 390 | Tablet 820 | Desktop 1440 |
|---|---|---|---|
| <img src="https://i.img402.dev/wkz4lz25pv.png" width="200" alt="375 before — clipped"> | <img src="https://i.img402.dev/l8s21vr60l.png" width="200" alt="390 before"> | <img src="https://i.img402.dev/iss2z5ciu5.png" width="200" alt="820 before"> | <img src="https://i.img402.dev/mx5mgjfbs6.png" width="200" alt="1440 before"> |

## After

| Mobile 375 | Mobile 390 | Tablet 820 | Desktop 1440 |
|---|---|---|---|
| <img src="https://i.img402.dev/ey1b2q3if8.png" width="200" alt="375 after — faded"> | <img src="https://i.img402.dev/88s06oy8v4.png" width="200" alt="390 after"> | <img src="https://i.img402.dev/dskoyxtf53.png" width="200" alt="820 after"> | <img src="https://i.img402.dev/vgnkkxk4hp.png" width="200" alt="1440 after"> |

## Notes

- `go build ./...` and `go vet ./...` clean.
- CSS regenerated via `make css` (artifact, not committed).
