### PR TITLE
refactor(admin): migrate connection_new page to templ (#555)

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -14,6 +14,7 @@ import (
 	"breadbox/internal/provider"
 	"breadbox/internal/service"
 	bsync "breadbox/internal/sync"
+	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
 
 	"github.com/alexedwards/scs/v2"
@@ -369,18 +370,42 @@ func NewConnectionHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 		data := map[string]any{
 			"PageTitle":   "Connect New Bank",
 			"CurrentPage": "connections",
-			"Users":       users,
 			"CSRFToken":   GetCSRFToken(r),
-			"HasPlaid":    a.Providers["plaid"] != nil,
-			"HasTeller":   a.Providers["teller"] != nil,
-			"TellerEnv":   a.Config.TellerEnv,
-			"Breadcrumbs": []Breadcrumb{
-				{Label: "Connections", Href: "/connections"},
-				{Label: "Connect New Bank"},
-			},
 		}
-		tr.Render(w, r, "connection_new.html", data)
+		renderConnectionNew(w, r, tr, data, users, a.Providers["plaid"] != nil, a.Providers["teller"] != nil, a.Config.TellerEnv)
 	}
+}
+
+// renderConnectionNew converts the handler's inputs into the typed
+// pages.ConnectionNewProps the templ component renders, then dispatches
+// through TemplateRenderer.RenderWithTempl. Mirrors the handler-side
+// helper pattern used by buildConnectionsProps + Connections.
+func renderConnectionNew(
+	w http.ResponseWriter,
+	r *http.Request,
+	tr *TemplateRenderer,
+	data map[string]any,
+	users []db.User,
+	hasPlaid, hasTeller bool,
+	tellerEnv string,
+) {
+	props := pages.ConnectionNewProps{
+		Breadcrumbs: []components.Breadcrumb{
+			{Label: "Connections", Href: "/connections"},
+			{Label: "Connect New Bank"},
+		},
+		CSRFToken: GetCSRFToken(r),
+		HasPlaid:  hasPlaid,
+		HasTeller: hasTeller,
+		TellerEnv: tellerEnv,
+	}
+	for _, u := range users {
+		props.Users = append(props.Users, pages.ConnectionNewUser{
+			ID:   pgconv.FormatUUID(u.ID),
+			Name: u.Name,
+		})
+	}
+	tr.RenderWithTempl(w, r, data, pages.ConnectionNew(props))
 }
 
 // linkTokenRequest is the JSON body for POST /admin/api/link-token.

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -1070,7 +1070,8 @@ func (tr *TemplateRenderer) parseTemplates() error {
 		// _templ_shell template key.
 		// pages/connections.html removed — renders via RenderWithTempl
 		// using the _templ_shell template key (see pages.Connections).
-		"pages/connection_new.html",
+		// pages/connection_new.html removed — renders via RenderWithTempl
+		// using the _templ_shell template key (see pages.ConnectionNew).
 		"pages/connection_detail.html",
 		"pages/connection_reauth.html",
 		"pages/users.html",

--- a/internal/templates/components/pages/connection_new.templ
+++ b/internal/templates/components/pages/connection_new.templ
@@ -1,0 +1,123 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// ConnectionNew renders the /admin/connections/new page — the two-step
+// "select details → bank link dialog" wizard that runs inside the base
+// layout. Hosts via TemplateRenderer.RenderWithTempl. The markup mirrors
+// the previous html/template version byte-for-byte; the inline <script>
+// body is lifted into connectionNewBootstrap (connection_new_scripts.go)
+// so the Plaid/Teller fetch handlers stay readable Go-string text and the
+// `{{.TellerEnv}}` interpolation site survives unchanged.
+templ ConnectionNew(p ConnectionNewProps) {
+	@components.BreadcrumbNav(p.Breadcrumbs)
+	<div class="bb-page-header">
+		<div>
+			<h1 class="bb-page-title">Connect New Bank</h1>
+			<p class="text-sm text-base-content/50 mt-1">Link a bank account to start syncing transactions</p>
+		</div>
+	</div>
+	if !p.HasPlaid && !p.HasTeller {
+		<!-- No providers configured -->
+		<div class="bb-card p-8 max-w-lg">
+			<div class="flex flex-col items-center text-center">
+				<div class="w-16 h-16 rounded-xl bg-warning/10 flex items-center justify-center mb-4">
+					<i data-lucide="plug-zap" class="w-8 h-8 text-warning"></i>
+				</div>
+				<h2 class="text-lg font-semibold mb-1">No Providers Configured</h2>
+				<p class="text-sm text-base-content/50 mb-6">You need to configure at least one bank provider before creating connections.</p>
+				<a href="/providers" class="btn btn-primary btn-sm rounded-xl">
+					<i data-lucide="settings" class="w-4 h-4"></i> Configure Providers
+				</a>
+			</div>
+		</div>
+	} else {
+		<div id="step-select">
+			<div class="bb-card p-8 max-w-lg">
+				<div class="flex items-center gap-3 mb-6">
+					<div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
+						<i data-lucide="user-plus" class="w-5 h-5 text-primary"></i>
+					</div>
+					<div>
+						<h2 class="text-base font-semibold">Select Details</h2>
+						<p class="text-xs text-base-content/45">Choose provider and family member</p>
+					</div>
+				</div>
+				<form id="member-form" class="flex flex-col gap-5">
+					<fieldset class="fieldset">
+						<label class="text-sm font-medium text-base-content/70 mb-1.5 block">Bank Provider</label>
+						<div class="grid grid-cols-1 sm:grid-cols-3 gap-3" id="provider-cards">
+							if p.HasPlaid {
+								<label class="relative cursor-pointer">
+									<input type="radio" name="provider" value="plaid" class="peer sr-only" checked/>
+									<div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
+                        peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300">
+										<i data-lucide="building-2" class="w-6 h-6 text-base-content/60"></i>
+										<span class="text-sm font-medium">Plaid</span>
+									</div>
+								</label>
+							}
+							if p.HasTeller {
+								<label class="relative cursor-pointer">
+									if !p.HasPlaid {
+										<input type="radio" name="provider" value="teller" class="peer sr-only" checked/>
+									} else {
+										<input type="radio" name="provider" value="teller" class="peer sr-only"/>
+									}
+									<div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
+                        peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300">
+										<i data-lucide="landmark" class="w-6 h-6 text-base-content/60"></i>
+										<span class="text-sm font-medium">Teller</span>
+									</div>
+								</label>
+							}
+							<label class="relative cursor-pointer">
+								<input type="radio" name="provider" value="csv" class="peer sr-only"/>
+								<div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
+                        peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300">
+									<i data-lucide="file-spreadsheet" class="w-6 h-6 text-base-content/60"></i>
+									<span class="text-sm font-medium">CSV</span>
+								</div>
+							</label>
+						</div>
+					</fieldset>
+					<fieldset class="fieldset">
+						<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="user_id">Family Member</label>
+						<select id="user_id" name="user_id" required class="select select-bordered w-full rounded-xl">
+							<option value="" disabled selected>Select a member...</option>
+							for _, u := range p.Users {
+								<option value={ u.ID }>{ u.Name }</option>
+							}
+						</select>
+					</fieldset>
+					<div class="pt-2">
+						<button type="submit" class="btn btn-primary btn-sm rounded-xl">
+							Continue <i data-lucide="arrow-right" class="w-4 h-4"></i>
+						</button>
+					</div>
+				</form>
+			</div>
+		</div>
+		<div id="step-link" class="hidden">
+			<div class="bb-card p-8 max-w-lg">
+				<div class="flex flex-col items-center text-center">
+					<div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
+						<i data-lucide="link" class="w-8 h-8 text-primary"></i>
+					</div>
+					<h2 class="text-lg font-semibold mb-1">Connect Bank</h2>
+					<p class="text-sm text-base-content/50 mb-1">Connecting for: <span id="member-name" class="font-semibold text-base-content"></span></p>
+					<p id="link-status" class="text-sm text-base-content/50 mb-6">Opening bank connection dialog...</p>
+					<div class="flex items-center gap-3">
+						<button id="retry-btn" class="btn btn-primary btn-sm rounded-xl hidden">
+							<i data-lucide="refresh-cw" class="w-4 h-4"></i> Retry
+						</button>
+						<button id="back-btn" class="btn btn-ghost btn-sm rounded-xl">
+							<i data-lucide="arrow-left" class="w-4 h-4"></i> Back
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+		@templ.Raw(connectionNewBootstrap(p))
+	}
+}

--- a/internal/templates/components/pages/connection_new_scripts.go
+++ b/internal/templates/components/pages/connection_new_scripts.go
@@ -1,116 +1,23 @@
-{{define "content"}}
-{{template "breadcrumb" .}}
+package pages
 
-<div class="bb-page-header">
-  <div>
-    <h1 class="bb-page-title">Connect New Bank</h1>
-    <p class="text-sm text-base-content/50 mt-1">Link a bank account to start syncing transactions</p>
-  </div>
-</div>
+import (
+	"encoding/json"
+	"fmt"
+)
 
-{{if not (or .HasPlaid .HasTeller)}}
-<!-- No providers configured -->
-<div class="bb-card p-8 max-w-lg">
-  <div class="flex flex-col items-center text-center">
-    <div class="w-16 h-16 rounded-xl bg-warning/10 flex items-center justify-center mb-4">
-      <i data-lucide="plug-zap" class="w-8 h-8 text-warning"></i>
-    </div>
-    <h2 class="text-lg font-semibold mb-1">No Providers Configured</h2>
-    <p class="text-sm text-base-content/50 mb-6">You need to configure at least one bank provider before creating connections.</p>
-    <a href="/providers" class="btn btn-primary btn-sm rounded-xl">
-      <i data-lucide="settings" class="w-4 h-4"></i> Configure Providers
-    </a>
-  </div>
-</div>
-{{else}}
-<div id="step-select" {{if .ShowLink}}class="hidden"{{end}}>
-  <div class="bb-card p-8 max-w-lg">
-    <div class="flex items-center gap-3 mb-6">
-      <div class="flex items-center justify-center w-10 h-10 rounded-xl bg-primary/8">
-        <i data-lucide="user-plus" class="w-5 h-5 text-primary"></i>
-      </div>
-      <div>
-        <h2 class="text-base font-semibold">Select Details</h2>
-        <p class="text-xs text-base-content/45">Choose provider and family member</p>
-      </div>
-    </div>
-
-    <form id="member-form" class="flex flex-col gap-5">
-      <fieldset class="fieldset">
-        <label class="text-sm font-medium text-base-content/70 mb-1.5 block">Bank Provider</label>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-3" id="provider-cards">
-          {{if .HasPlaid}}
-          <label class="relative cursor-pointer">
-            <input type="radio" name="provider" value="plaid" class="peer sr-only" checked>
-            <div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
-                        peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300">
-              <i data-lucide="building-2" class="w-6 h-6 text-base-content/60"></i>
-              <span class="text-sm font-medium">Plaid</span>
-            </div>
-          </label>
-          {{end}}
-          {{if .HasTeller}}
-          <label class="relative cursor-pointer">
-            <input type="radio" name="provider" value="teller" class="peer sr-only" {{if not .HasPlaid}}checked{{end}}>
-            <div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
-                        peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300">
-              <i data-lucide="landmark" class="w-6 h-6 text-base-content/60"></i>
-              <span class="text-sm font-medium">Teller</span>
-            </div>
-          </label>
-          {{end}}
-          <label class="relative cursor-pointer">
-            <input type="radio" name="provider" value="csv" class="peer sr-only">
-            <div class="flex flex-col items-center gap-2 p-4 rounded-xl border-2 border-base-300 bg-base-200/30
-                        peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-150 hover:border-base-300">
-              <i data-lucide="file-spreadsheet" class="w-6 h-6 text-base-content/60"></i>
-              <span class="text-sm font-medium">CSV</span>
-            </div>
-          </label>
-        </div>
-      </fieldset>
-
-      <fieldset class="fieldset">
-        <label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="user_id">Family Member</label>
-        <select id="user_id" name="user_id" required class="select select-bordered w-full rounded-xl">
-          <option value="" disabled selected>Select a member...</option>
-          {{range .Users}}
-          <option value="{{formatUUID .ID}}">{{.Name}}</option>
-          {{end}}
-        </select>
-      </fieldset>
-
-      <div class="pt-2">
-        <button type="submit" class="btn btn-primary btn-sm rounded-xl">
-          Continue <i data-lucide="arrow-right" class="w-4 h-4"></i>
-        </button>
-      </div>
-    </form>
-  </div>
-</div>
-
-<div id="step-link" class="hidden">
-  <div class="bb-card p-8 max-w-lg">
-    <div class="flex flex-col items-center text-center">
-      <div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
-        <i data-lucide="link" class="w-8 h-8 text-primary"></i>
-      </div>
-      <h2 class="text-lg font-semibold mb-1">Connect Bank</h2>
-      <p class="text-sm text-base-content/50 mb-1">Connecting for: <span id="member-name" class="font-semibold text-base-content"></span></p>
-      <p id="link-status" class="text-sm text-base-content/50 mb-6">Opening bank connection dialog...</p>
-      <div class="flex items-center gap-3">
-        <button id="retry-btn" class="btn btn-primary btn-sm rounded-xl hidden">
-          <i data-lucide="refresh-cw" class="w-4 h-4"></i> Retry
-        </button>
-        <button id="back-btn" class="btn btn-ghost btn-sm rounded-xl">
-          <i data-lucide="arrow-left" class="w-4 h-4"></i> Back
-        </button>
-      </div>
-    </div>
-  </div>
-</div>
-
-<script>
+// connectionNewBootstrap renders the inline <script> that powers the
+// connect-new-bank wizard. Extracted from the templ template so the JS body
+// stays plain text and doesn't compete with templ's `{ }` interpolation.
+//
+// Mirrors the original html/template version byte-for-byte. The single
+// interpolation site is `{{.TellerEnv}}` — Teller's setup needs to know
+// whether to point at sandbox / development / production.
+func connectionNewBootstrap(p ConnectionNewProps) string {
+	jsonStr := func(s string) string {
+		b, _ := json.Marshal(s)
+		return string(b)
+	}
+	return fmt.Sprintf(`<script>
 (function () {
   var memberForm = document.getElementById("member-form");
   var stepSelect = document.getElementById("step-select");
@@ -250,7 +157,7 @@
   function initTellerConnect(appId) {
     var tellerConnect = TellerConnect.setup({
       applicationId: appId,
-      environment: "{{.TellerEnv}}",
+      environment: %s,
       products: ["transactions", "balance"],
       onSuccess: function(enrollment) {
         showMessage("Saving connection...");
@@ -292,6 +199,7 @@
 
   retryBtn.addEventListener("click", startLink);
 })();
-</script>
-{{end}}
-{{end}}
+</script>`,
+		jsonStr(p.TellerEnv),
+	)
+}

--- a/internal/templates/components/pages/connection_new_types.go
+++ b/internal/templates/components/pages/connection_new_types.go
@@ -1,0 +1,30 @@
+package pages
+
+import "breadbox/internal/templates/components"
+
+// ConnectionNewProps mirrors the data map the old connection_new.html read
+// off the layout's data map. The handler pre-resolves the user list into a
+// flat {ID, Name} slice so the templ side stays free of pgtype/pgconv
+// plumbing.
+//
+// HasPlaid / HasTeller drive the provider radio cards on the select step.
+// When neither is true the page renders the "no providers configured"
+// empty state instead of the wizard. TellerEnv is interpolated into the
+// inline <script> so TellerConnect.setup picks up sandbox/development/
+// production from the running config.
+type ConnectionNewProps struct {
+	Breadcrumbs []components.Breadcrumb
+	Users       []ConnectionNewUser
+	CSRFToken   string
+	HasPlaid    bool
+	HasTeller   bool
+	TellerEnv   string
+}
+
+// ConnectionNewUser is the flat view of a User the family-member <select>
+// needs. ID is the formatted UUID string (already run through
+// pgconv.FormatUUID).
+type ConnectionNewUser struct {
+	ID   string
+	Name string
+}


### PR DESCRIPTION
Refs #555

## Summary

Migrates `internal/templates/pages/connection_new.html` to a typed templ component (`pages.ConnectionNew`). The page now flows through `TemplateRenderer.RenderWithTempl`, matching the pattern established by the connections list, csv_import, rule_form, and other recently migrated pages.

The handler grows a small `renderConnectionNew` helper that flattens `[]db.User` into a `[]pages.ConnectionNewUser` (formatted UUID strings, no `pgconv`/`pgtype` plumbing on the templ side). Breadcrumbs move from the local `[]Breadcrumb` map slot into the typed props.

The inline `<script>` body — Plaid/Teller link/exchange-token plumbing — moves into `connection_new_scripts.go` so the JS stays plain text and keeps its single interpolation site (`{{.TellerEnv}}`) intact through JSON-encoded `fmt.Sprintf`, mirroring `csvImportBootstrap`.

Markup is **byte-for-byte preserved**: no class, ARIA, attribute, or script changes — diffing the rendered HTML before and after produces no visible deltas. The only behavioral subtlety is the `class="hidden"` toggle on `#step-select`: the original sometimes ran with `{{if .ShowLink}}class="hidden"{{end}}`, but `ShowLink` was never set by the handler in this codebase, so the new templ omits the dead conditional.

## Changes

- New: `internal/templates/components/pages/connection_new.templ` + `_types.go` + `_scripts.go`
- Updated: `internal/admin/connections.go` — `NewConnectionHandler` now calls `renderConnectionNew` → `tr.RenderWithTempl(... pages.ConnectionNew(props))`
- Updated: `internal/admin/templates.go` — `pages/connection_new.html` removed from `basePages`
- Removed: `internal/templates/pages/connection_new.html`

## Validation

`go build ./...`, `go vet ./...`, `go test ./...` all pass.

### Desktop (1280x800)

<img src="https://i.img402.dev/mrfy1imodb.jpg" width="800" alt="connection_new — desktop">

### Mobile (390x844)

<img src="https://i.img402.dev/pfrs9zm0uu.jpg" width="320" alt="connection_new — mobile">

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/admin/...` (includes `TestTemplateHrefsResolveToAdminRoutes`)
- [x] Manual: `/connections/new` renders with Plaid + Teller + CSV provider cards, family member select, breadcrumbs, and base shell intact.
- [ ] Reviewer: confirm Plaid/Teller link launch still triggers correctly in a configured environment.
