### PR TITLE
fix(transactions): multi-line activity composer, mobile-clean kbd hint

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -781,6 +781,7 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			CurrentTags:      currentTags,
 			AvailableTags:    availableTags,
 			Categories:       categoryTree,
+			MaxCommentLength: service.MaxCommentLength,
 		}
 		renderTransactionDetail(tr, w, r, data, props)
 	}

--- a/internal/service/comments.go
+++ b/internal/service/comments.go
@@ -13,7 +13,10 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const maxCommentLength = 10000
+// MaxCommentLength caps the character length of a comment body. The admin
+// composer surfaces this in its char counter so the client mirrors the
+// server-side guard.
+const MaxCommentLength = 10000
 
 // Comments are stored as annotations with kind='comment'. CreateComment /
 // ListComments / UpdateComment / DeleteComment read and write the annotations
@@ -22,8 +25,8 @@ const maxCommentLength = 10000
 // CreateComment adds a comment annotation to a transaction.
 func (s *Service) CreateComment(ctx context.Context, params CreateCommentParams) (*CommentResponse, error) {
 	content := strings.TrimSpace(params.Content)
-	if content == "" || len(content) > maxCommentLength {
-		return nil, fmt.Errorf("content must be between 1 and %d characters", maxCommentLength)
+	if content == "" || len(content) > MaxCommentLength {
+		return nil, fmt.Errorf("content must be between 1 and %d characters", MaxCommentLength)
 	}
 
 	// Verify transaction exists and is not soft-deleted.
@@ -121,8 +124,8 @@ func (s *Service) ListComments(ctx context.Context, transactionID string) ([]Com
 // are identified by the annotation's short_id or UUID.
 func (s *Service) UpdateComment(ctx context.Context, id string, params UpdateCommentParams) (*CommentResponse, error) {
 	content := strings.TrimSpace(params.Content)
-	if content == "" || len(content) > maxCommentLength {
-		return nil, fmt.Errorf("content must be between 1 and %d characters", maxCommentLength)
+	if content == "" || len(content) > MaxCommentLength {
+		return nil, fmt.Errorf("content must be between 1 and %d characters", MaxCommentLength)
 	}
 
 	annID, err := s.resolveAnnotationID(ctx, id)

--- a/internal/service/update_transactions.go
+++ b/internal/service/update_transactions.go
@@ -308,8 +308,8 @@ func (s *Service) runUpdateOpInTx(ctx context.Context, tx pgx.Tx, op UpdateTrans
 	if op.Comment != nil {
 		content := strings.TrimSpace(*op.Comment)
 		if content != "" {
-			if len(content) > maxCommentLength {
-				return fmt.Errorf("%w: comment exceeds %d chars", ErrInvalidParameter, maxCommentLength)
+			if len(content) > MaxCommentLength {
+				return fmt.Errorf("%w: comment exceeds %d chars", ErrInvalidParameter, MaxCommentLength)
 			}
 			payload := map[string]interface{}{"content": content}
 			if err := writeAnnotation(ctx, qtx, writeAnnotationParams{

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -253,7 +253,7 @@ templ txdMain(p TransactionDetailProps) {
 
 templ txdActivity(p TransactionDetailProps) {
 	<!-- Activity Timeline -->
-	<section id="activity" aria-labelledby="activity-heading" class="bb-card p-0 overflow-hidden" x-data="commentManager()">
+	<section id="activity" aria-labelledby="activity-heading" class="bb-card p-0 overflow-hidden" x-data={ fmt.Sprintf("commentManager(%d)", p.MaxCommentLength) }>
 		<div class="px-4 sm:px-5 pt-5 pb-3 flex items-center gap-2">
 			<i data-lucide="activity" class="w-4 h-4 text-base-content/40" aria-hidden="true"></i>
 			<h2 id="activity-heading" class="text-sm font-semibold text-base-content/50">Activity</h2>
@@ -267,12 +267,41 @@ templ txdActivity(p TransactionDetailProps) {
 		</div>
 		<!-- Add Note -->
 		<div class="px-4 sm:px-5 pb-4">
-			<div class="flex gap-2 items-center">
+			<div class="flex gap-2 items-start">
 				<label for="bb-txd-comment" class="sr-only">Add a note</label>
-				<input id="bb-txd-comment" type="text" x-model="newComment" placeholder="Add a note..." class="input input-bordered input-sm h-9 flex-1 bg-base-200/50 rounded-xl" @keydown.enter.prevent="newComment.trim() && addComment()"/>
-				<button @click="addComment()" class="btn btn-sm h-9 rounded-xl btn-primary btn-square" :disabled="!newComment.trim()" aria-label="Post note">
+				<textarea
+					id="bb-txd-comment"
+					x-ref="composer"
+					x-model="newComment"
+					@input="autosize($event.target)"
+					@keydown.meta.enter.prevent="canSubmit() && addComment()"
+					@keydown.ctrl.enter.prevent="canSubmit() && addComment()"
+					rows="1"
+					placeholder="Add a note..."
+					maxlength={ fmt.Sprintf("%d", p.MaxCommentLength) }
+					aria-describedby="bb-txd-comment-counter bb-txd-comment-hint"
+					class="flex-1 block w-full text-sm bg-base-200/50 border border-base-content/10 focus:border-primary focus:outline-none focus:ring-0 rounded-xl resize-none leading-6 px-3 py-1.5 h-9 min-h-9 max-h-36 overflow-y-hidden whitespace-pre-wrap break-words"
+				></textarea>
+				<button @click="addComment()" class="btn btn-sm h-9 rounded-xl btn-primary btn-square shrink-0" :disabled="!canSubmit()" aria-label="Post note">
 					<i data-lucide="send" class="w-3.5 h-3.5" aria-hidden="true"></i>
 				</button>
+			</div>
+			<div class="mt-1.5 px-0.5 text-[11px] text-base-content/40 flex items-center gap-2">
+				<span id="bb-txd-comment-hint" class="hidden sm:inline-flex items-center gap-1.5 flex-wrap" x-show="!$store.device.isTouch">
+					@components.KbdCombo("cmd", "enter")
+					<span>to post</span>
+					<span class="text-base-content/30" aria-hidden="true">·</span>
+					@components.Kbd("n")
+					<span>to focus</span>
+				</span>
+				<span
+					id="bb-txd-comment-counter"
+					class="ml-auto tabular-nums"
+					:class="{ 'text-warning': counterState() === 'warn', 'text-error font-medium': counterState() === 'error', 'invisible': newComment.length === 0 }"
+					aria-live="polite"
+				>
+					<span x-text="newComment.length"></span> / <span x-text="maxLength"></span>
+				</span>
 			</div>
 		</div>
 		if len(p.ActivityDays) > 0 {
@@ -751,6 +780,20 @@ document.addEventListener('alpine:init', function() {
   });
 
   reg.register({
+    id: 'transaction-detail.compose-note',
+    keys: 'n',
+    description: 'Add a note',
+    group: 'Actions',
+    scope: 'transaction-detail',
+    action: function() {
+      var el = document.getElementById('bb-txd-comment');
+      if (!el) return;
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      el.focus();
+    },
+  });
+
+  reg.register({
     id: 'transaction-detail.expand-system-details',
     keys: 'e',
     description: 'Toggle system details',
@@ -811,13 +854,36 @@ function showToast(message, type) {
   window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
 }
 
-function commentManager() {
+function commentManager(maxLen) {
   return {
     newComment: '',
+    maxLength: maxLen || 10000,
+    canSubmit() {
+      var trimmed = this.newComment.trim().length;
+      return trimmed > 0 && this.newComment.length <= this.maxLength;
+    },
+    counterState() {
+      if (this.newComment.length === 0) return 'ok';
+      var ratio = this.newComment.length / this.maxLength;
+      if (ratio >= 1) return 'error';
+      if (ratio >= 0.9) return 'warn';
+      return 'ok';
+    },
+    autosize(el) {
+      // Reset to natural height so scrollHeight reflects current content,
+      // not the previously-set explicit height. Cap at max-h-36 (9rem ≈ 144px)
+      // so the composer never balloons past ~6 rows; overflow scrolls inside.
+      if (!el) return;
+      el.style.height = 'auto';
+      var max = 144;
+      var next = Math.min(el.scrollHeight, max);
+      el.style.height = next + 'px';
+      el.style.overflowY = el.scrollHeight > max ? 'auto' : 'hidden';
+    },
     addComment() {
       var self = this;
       var content = this.newComment.trim();
-      if (!content) return;
+      if (!content || !this.canSubmit()) return;
       fetch('/-/transactions/%[2]s/comments', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},

--- a/internal/templates/components/pages/transaction_detail_types.go
+++ b/internal/templates/components/pages/transaction_detail_types.go
@@ -49,4 +49,8 @@ type TransactionDetailProps struct {
 
 	// Two-level category tree powering the inline category picker.
 	Categories []service.CategoryResponse
+
+	// MaxCommentLength is the server-side cap (service.MaxCommentLength)
+	// surfaced to the composer so the char counter mirrors it.
+	MaxCommentLength int
 }


### PR DESCRIPTION
Fixes #773

Replaces the single-line activity composer on `/transactions/{id}` with an auto-grow textarea, surfaces the keyboard contract, and adds a live character counter that mirrors `service.MaxCommentLength`.

Re-do of #779 — closed with two regressions called out by review:

1. The textarea rendered multi-line by default. **Now** it starts at the same `h-9` single-line height as the original input and grows only as content is added, capped at ~6 rows.
2. The `Kbd` glyphs were hidden on mobile but the surrounding label strings ("to post", "to focus", separators) leaked through. **Now** the entire hint span is gated by both `hidden sm:inline-flex` (CSS-first, no FOUC) and `x-show="!$store.device.isTouch"` (touch-capable wide viewports), so the labels track visibility with the glyphs.

## Changes

- `internal/templates/pages/transaction_detail.html`
  - `<input>` → `<textarea>` with explicit Tailwind sizing (`h-9 min-h-9 max-h-36 leading-6 py-1.5`) so the empty state matches the original input visually.
  - `Cmd/Ctrl+Enter` posts; bare `Enter` inserts a newline (matches Slack/Linear/GitHub).
  - Hint row uses shared `KbdCombo`/`Kbd` templ components via `renderComponent`. Whole row hides on mobile + touch.
  - `n` shortcut registered through `Alpine.store('shortcuts').register({...})` on the `transaction-detail` scope; appears in the global `?` modal.
  - `1234 / 10000` counter, `text-warning` at 90%, `text-error font-medium` at 100%; submit guarded by `canSubmit()` so over-limit input blocks both `Cmd+Enter` and the send button. Counter is `invisible` while empty so the chrome row stays clean.
  - `autosize()` resets height to `auto` then sets to `min(scrollHeight, 144)`; toggles `overflow-y` so content past 6 rows scrolls inside the box.
- `internal/service/comments.go`, `internal/service/update_transactions.go`
  - Export `MaxCommentLength` (was `maxCommentLength`) so the admin handler can pass the constant to the template instead of hard-coding 10000.
- `internal/admin/transactions.go`
  - Inject `MaxCommentLength: service.MaxCommentLength` into the transaction-detail render data.

## Before

| Mobile (375) | Mobile (500) | Tablet (820) | Desktop (1440) |
|---|---|---|---|
| <img src="https://i.img402.dev/qxepyfs2mp.jpg" width="220" alt="Before — 375 empty"> | <img src="https://i.img402.dev/9fp8ug3w03.jpg" width="220" alt="Before — 500 empty"> | <img src="https://i.img402.dev/kos65coga2.jpg" width="220" alt="Before — 820 empty"> | <img src="https://i.img402.dev/srf9ctlmew.jpg" width="220" alt="Before — 1440 empty"> |

Single-line input, no kbd hints, no counter, no `n` shortcut.

## After — empty state

| Mobile (375) | Mobile (500) | Tablet (820) | Desktop (1440) |
|---|---|---|---|
| <img src="https://i.img402.dev/hwg6b0f1xv.jpg" width="220" alt="After — 375 empty"> | <img src="https://i.img402.dev/1s750evfx6.jpg" width="220" alt="After — 500 empty"> | <img src="https://i.img402.dev/77ar7wwaiu.jpg" width="220" alt="After — 820 empty"> | <img src="https://i.img402.dev/v3hiuy49b3.jpg" width="220" alt="After — 1440 empty"> |

Composer renders single-line. Counter is invisible while empty. Hint row absent on mobile, present on desktop.

## After — multi-line composing (248 / 10000)

| Mobile (500) | Desktop (1440) |
|---|---|
| <img src="https://i.img402.dev/6bzuauazli.jpg" width="380" alt="After — 500 multiline"> | <img src="https://i.img402.dev/u52bzvvu7k.jpg" width="380" alt="After — 1440 multiline"> |

Textarea wraps long paragraphs and grows up to 6 rows, then scrolls.

## After — warn state (9500 / 10000)

| Mobile (500) | Desktop (1440) |
|---|---|
| <img src="https://i.img402.dev/7f9553xtbr.jpg" width="380" alt="After — 500 warn"> | <img src="https://i.img402.dev/drkhxr9ss9.jpg" width="380" alt="After — 1440 warn"> |

Counter switches to `text-warning` past 90%; flips to `text-error` and disables the send button at 100%.

## Notes

- Hint label visibility now tracks the kbd glyph visibility — the user-facing fix from #779 review feedback.
- Empty composer renders at the same height as the previous input (`h-9` / 2.25rem). Auto-grow only kicks in once the user starts typing.
- The `n` shortcut goes through the same registry as `c`/`t`/`e`, so the global input-focus guard prevents it from firing while the textarea is focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
