### PR TITLE
chore(pgconv): collapse 4 more if-Valid sites onto TextOr

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -478,9 +478,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 						m = *v
 					}
 				case pgtype.Text:
-					if v.Valid {
-						m = v.String
-					}
+					m = pgconv.TextOr(v, "")
 				}
 				if m != "" {
 					return name + " ••" + m

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -11,6 +11,7 @@ import (
 
 	"breadbox/internal/appconfig"
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	bsync "breadbox/internal/sync"
 
 	"github.com/jackc/pgx/v5"
@@ -99,10 +100,7 @@ func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow
 		duration = &d
 	}
 
-	instName := ""
-	if institutionName.Valid {
-		instName = institutionName.String
-	}
+	instName := pgconv.TextOr(institutionName, "")
 
 	// Get account count.
 	accountCount, _ := s.Queries.CountAffectedAccountsBySyncLog(ctx, uid)
@@ -209,10 +207,7 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 			durationMsPtr = &ms
 		}
 
-		instName := ""
-		if institutionName.Valid {
-			instName = institutionName.String
-		}
+		instName := pgconv.TextOr(institutionName, "")
 
 		row := SyncLogRow{
 			ID:              formatUUID(id),
@@ -416,9 +411,7 @@ func (s *Service) GetSyncHealthSummary(ctx context.Context) (*SyncHealthSummary,
 		summary.LastSyncTime = &t
 	}
 
-	if lastStatus.Valid {
-		summary.LastSyncStatus = lastStatus.String
-	}
+	summary.LastSyncStatus = pgconv.TextOr(lastStatus, "")
 
 	// Determine overall health: healthy, degraded, or unhealthy.
 	// - unhealthy: success rate < 50% with 2+ syncs, or all recent syncs failed

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -200,10 +200,7 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 	}
 
 	// Track cursors for pagination.
-	previousCursor := ""
-	if conn.SyncCursor.Valid {
-		previousCursor = conn.SyncCursor.String
-	}
+	previousCursor := pgconv.TextOr(conn.SyncCursor, "")
 	cursor := previousCursor
 
 	// Load rule resolver (rules + category mappings) for this provider.


### PR DESCRIPTION
## Summary

Continuation of #778. Four more sites in the sync path that still inlined the `if t.Valid { x = t.String }` pattern, now collapsed onto `pgconv.TextOr`:

- [internal/sync/engine.go](internal/sync/engine.go#L203) — `runSync` previousCursor from `conn.SyncCursor`
- [internal/service/sync.go](internal/service/sync.go#L100) — `GetSyncLog` instName from `institutionName`
- [internal/service/sync.go](internal/service/sync.go#L207) — `ListSyncLogsPaginated` instName from `institutionName`
- [internal/service/sync.go](internal/service/sync.go#L411) — `GetSyncHealthSummary` lastStatus
- [internal/admin/templates.go](internal/admin/templates.go#L481) — `accountWithMask` funcMap, `pgtype.Text` branch in the type switch

Net diff: **+6 / −18**. No behavior change — every site already zero-valued the field on NULL, and passing `""` matches.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/service ./internal/sync ./internal/admin ./internal/pgconv\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)