### PR TITLE
fix(access): show full OAuth client IDs and add copy buttons

### DIFF
--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -142,6 +142,7 @@ func buildAccessClientRow(c service.OAuthClientResponse) pages.AccessClientRow {
 	return pages.AccessClientRow{
 		ID:             c.ID,
 		Name:           c.Name,
+		ClientID:       c.ClientID,
 		ClientIDPrefix: c.ClientIDPrefix,
 		Scope:          c.Scope,
 		CreatedAtShort: formatDateShortFromRFC3339(c.CreatedAt),

--- a/internal/templates/components/pages/access.templ
+++ b/internal/templates/components/pages/access.templ
@@ -99,8 +99,17 @@ templ accessActiveClientRow(c AccessClientRow, isAdmin bool, csrfToken string) {
 					<span class="badge badge-soft badge-primary badge-xs shrink-0">Full Access</span>
 				}
 			</div>
-			<div class="flex items-center gap-2 mt-0.5 flex-wrap">
-				<code class="font-mono text-[0.65rem] text-base-content/40">{ c.ClientIDPrefix }...</code>
+			<div class="flex items-center gap-x-1 gap-y-0.5 mt-0.5 flex-wrap" x-data="{ copied: false }">
+				<code class="font-mono text-[0.65rem] text-base-content/40 select-all">{ c.ClientID }</code>
+				<button
+					type="button"
+					class="btn btn-ghost btn-xs btn-circle text-base-content/40 hover:text-base-content"
+					:aria-label="copied ? 'Copied' : 'Copy client ID'"
+					@click={ "navigator.clipboard.writeText('" + c.ClientID + "'); copied = true; setTimeout(() => copied = false, 1500)" }
+				>
+					<i data-lucide="copy" class="w-3 h-3" x-show="!copied"></i>
+					<i data-lucide="check" class="w-3 h-3 text-success" x-show="copied" x-cloak></i>
+				</button>
 				<span class="text-xs text-base-content/35">Created { c.CreatedAtShort }</span>
 			</div>
 		</div>
@@ -141,7 +150,7 @@ templ accessRevokedClientRow(c AccessClientRow) {
 				<span class="badge badge-soft badge-error badge-xs shrink-0">Revoked</span>
 			</div>
 			<div class="flex items-center gap-2 mt-0.5 flex-wrap">
-				<code class="font-mono text-[0.65rem] text-base-content/30">{ c.ClientIDPrefix }...</code>
+				<code class="font-mono text-[0.65rem] text-base-content/30 select-all">{ c.ClientID }</code>
 				<span class="text-xs text-base-content/30">Created { c.CreatedAtShort }</span>
 			</div>
 		</div>
@@ -230,8 +239,17 @@ templ accessActiveKeyRow(k AccessKeyRow, isAdmin bool, csrfToken string) {
 					<span class="badge badge-soft badge-primary badge-xs shrink-0">Full Access</span>
 				}
 			</div>
-			<div class="flex items-center gap-x-2 gap-y-0.5 mt-0.5 flex-wrap">
-				<code class="font-mono text-[0.65rem] text-base-content/40">{ k.KeyPrefix }...</code>
+			<div class="flex items-center gap-x-1 gap-y-0.5 mt-0.5 flex-wrap" x-data="{ copied: false }">
+				<code class="font-mono text-[0.65rem] text-base-content/40 select-all">{ k.KeyPrefix }</code>
+				<button
+					type="button"
+					class="btn btn-ghost btn-xs btn-circle text-base-content/40 hover:text-base-content"
+					:aria-label="copied ? 'Copied' : 'Copy key prefix'"
+					@click={ "navigator.clipboard.writeText('" + k.KeyPrefix + "'); copied = true; setTimeout(() => copied = false, 1500)" }
+				>
+					<i data-lucide="copy" class="w-3 h-3" x-show="!copied"></i>
+					<i data-lucide="check" class="w-3 h-3 text-success" x-show="copied" x-cloak></i>
+				</button>
 				<span class="text-xs text-base-content/35">Created { k.CreatedAtShort }</span>
 				if k.LastUsedRelative != "" {
 					<span class="text-xs text-base-content/35">Last used { k.LastUsedRelative }</span>
@@ -275,7 +293,7 @@ templ accessRevokedKeyRow(k AccessKeyRow) {
 				<span class="badge badge-soft badge-error badge-xs shrink-0">Revoked</span>
 			</div>
 			<div class="flex items-center gap-2 mt-0.5 flex-wrap">
-				<code class="font-mono text-[0.65rem] text-base-content/30">{ k.KeyPrefix }...</code>
+				<code class="font-mono text-[0.65rem] text-base-content/30 select-all">{ k.KeyPrefix }</code>
 				<span class="text-xs text-base-content/30">Created { k.CreatedAtShort }</span>
 			</div>
 		</div>

--- a/internal/templates/components/pages/access_types.go
+++ b/internal/templates/components/pages/access_types.go
@@ -32,6 +32,7 @@ type AccessKeyRow struct {
 type AccessClientRow struct {
 	ID             string
 	Name           string
+	ClientID       string
 	ClientIDPrefix string
 	Scope          string
 	CreatedAtShort string


### PR DESCRIPTION
Fixes #783

Replaces the truncated `<code>bb_oc_xxxxxxx...</code>` prefix on `/access` with the full OAuth client ID and a copy-to-clipboard button. API key rows get the same copy affordance for the visible prefix.

OAuth client IDs are non-secret and live in `OAuthClientResponse.ClientID` already; no handler change required. API key plaintext is SHA-256 hashed at creation and cannot be recovered after the one-shot "created" page — the prefix is the only thing the row can offer, and copying it makes that explicit instead of misleading users with an ellipsis they can't expand.

The button is an Alpine `x-data="{ copied: false }"` cluster that swaps `copy` → `check` (`text-success`) for 1.5s and updates `aria-label` so the state is announced. Revoked rows get the full ID / prefix as plain selectable text (no button — the credential is dead).

## Before
<table>
  <tr><th>Mobile (375)</th><th>Tablet (820)</th><th>Desktop (1440)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/hfurzp5a1r.png" width="280" alt="before mobile"></td>
    <td><img src="https://i.img402.dev/7t3xr4uhdb.png" width="280" alt="before tablet"></td>
    <td><img src="https://i.img402.dev/1corj7tr46.png" width="280" alt="before desktop"></td>
  </tr>
</table>

## After
<table>
  <tr><th>Mobile (375)</th><th>Tablet (820)</th><th>Desktop (1440)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/u8me89p0mv.png" width="280" alt="after mobile"></td>
    <td><img src="https://i.img402.dev/mokmy56rai.png" width="280" alt="after tablet"></td>
    <td><img src="https://i.img402.dev/0zqirsfc9q.png" width="280" alt="after desktop"></td>
  </tr>
</table>

## Notes
- Issue's "Proposed fix" suggested `data-id="{{.ID}}"` (the row UUID); used `{{.ClientID}}` instead because the user-visible request is to copy the **client identifier**, not the internal row UUID. `OAuthClientResponse` already exposes `ClientID` so no service change.
- API keys: the issue title says "full ... API key IDs". After creation only the **prefix** survives (hash is one-way). The PR copies what's recoverable and leaves the existing one-shot reveal flow intact — restoring the full key would require disabling at-rest hashing, which is out of scope and a security regression.
- Skipped the optional `/oauth-clients/{id}` detail page — the issue marks it follow-up. Filing a separate issue is preferable to bundling.
- The follow-up detail page (#783 paragraph 2 "Optional") is intentionally not included.
