### PR TITLE
chore(templ): use strconv for integer-to-string in templ files

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -1,6 +1,9 @@
 package components
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+)
 
 // NavProps carries everything the sidebar needs. The bridge in
 // internal/admin/templates.go assembles this from the layout data map.
@@ -180,5 +183,5 @@ func badgeCount(n int64) string {
 	if n > 99 {
 		return "99+"
 	}
-	return fmt.Sprintf("%d", n)
+	return strconv.FormatInt(n, 10)
 }

--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"fmt"
+	"strconv"
 
 	"breadbox/internal/service"
 )
@@ -273,7 +274,7 @@ templ categoryRow(c service.CategoryResponse) {
 				</span>
 				if len(c.Children) > 0 {
 					<span class="text-[0.65rem] font-medium px-1.5 py-0.5 rounded-full bg-base-200/60 text-base-content/40 shrink-0">
-						{ fmt.Sprintf("%d", len(c.Children)) }
+						{ strconv.Itoa(len(c.Children)) }
 					</span>
 				}
 				if c.IsSystem {

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"fmt"
+	"strconv"
 
 	"breadbox/internal/templates/components"
 )
@@ -267,7 +268,7 @@ templ connectionsCard(c ConnectionsRow) {
 					<a href={ templ.SafeURL("/connections/" + c.ID) } class="text-right no-underline text-inherit" tabindex="-1" aria-hidden="true">
 						<div class="text-base sm:text-lg font-semibold tabular-nums tracking-tight">{ components.FormatAmount(c.TotalBalance) }</div>
 						<div class="text-xs text-base-content/40">
-							{ fmt.Sprintf("%d", c.AccountCount) }
+							{ strconv.FormatInt(c.AccountCount, 10) }
 							<span class="hidden sm:inline">{ connectionsAccountSuffix(c.AccountCount, false) }</span>
 							<span class="sm:hidden">{ connectionsAccountSuffix(c.AccountCount, true) }</span>
 						</div>
@@ -275,7 +276,7 @@ templ connectionsCard(c ConnectionsRow) {
 				} else {
 					<a href={ templ.SafeURL("/connections/" + c.ID) } class="text-right no-underline text-inherit" tabindex="-1" aria-hidden="true">
 						<div class="text-xs text-base-content/40">
-							{ fmt.Sprintf("%d", c.AccountCount) }
+							{ strconv.FormatInt(c.AccountCount, 10) }
 							<span class="hidden sm:inline">{ connectionsAccountSuffix(c.AccountCount, false) }</span>
 							<span class="sm:hidden">{ connectionsAccountSuffix(c.AccountCount, true) }</span>
 						</div>

--- a/internal/templates/components/pages/dashboard.templ
+++ b/internal/templates/components/pages/dashboard.templ
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"fmt"
+	"strconv"
 
 	"breadbox/internal/templates/components"
 )
@@ -37,7 +38,7 @@ templ dashOverviewStats(p DashboardProps) {
 		if p.ErrorCount > 0 {
 			<a href="/connections" class={ "bb-card bb-card--interactive p-4 no-underline group block", templ.KV("col-span-2 lg:col-span-3", p.ReviewsEnabled) }>
 				<div class="text-[0.65rem] uppercase tracking-wider text-warning">Connection Errors</div>
-				<div class="text-2xl font-bold tabular-nums tracking-tight mt-1 text-error/80">{ fmt.Sprintf("%d", p.ErrorCount) }</div>
+				<div class="text-2xl font-bold tabular-nums tracking-tight mt-1 text-error/80">{ strconv.Itoa(p.ErrorCount) }</div>
 				<div class="text-[0.65rem] text-base-content/40 mt-1 group-hover:text-primary/70 transition-colors">Fix &rarr;</div>
 			</a>
 		}

--- a/internal/templates/components/pages/logs.templ
+++ b/internal/templates/components/pages/logs.templ
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"fmt"
+	"strconv"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
@@ -123,7 +124,7 @@ templ logsSyncStats(p LogsProps) {
 					</div>
 					<div>
 						<div class={ "text-2xl font-semibold tabular-nums leading-none", errorTextClass(p.Stats.ErrorCount > 0) }>
-							{ fmt.Sprintf("%d", p.Stats.ErrorCount) }
+							{ strconv.FormatInt(p.Stats.ErrorCount, 10) }
 						</div>
 						<div class="text-xs text-base-content/40 mt-0.5">Errors</div>
 					</div>
@@ -242,7 +243,7 @@ templ logsSyncStatusTabs(p LogsProps) {
 			>
 				<span class="w-1.5 h-1.5 rounded-full bg-success shrink-0"></span>
 				Success
-				<span class="text-[0.6rem] tabular-nums opacity-60">{ fmt.Sprintf("%d", p.SuccessCount) }</span>
+				<span class="text-[0.6rem] tabular-nums opacity-60">{ strconv.FormatInt(p.SuccessCount, 10) }</span>
 			</a>
 			<a
 				href={ statusTabHref(p.StatusQueryError) }
@@ -250,7 +251,7 @@ templ logsSyncStatusTabs(p LogsProps) {
 			>
 				<span class="w-1.5 h-1.5 rounded-full bg-error shrink-0"></span>
 				Errors
-				<span class="text-[0.6rem] tabular-nums opacity-60">{ fmt.Sprintf("%d", p.ErrorCount) }</span>
+				<span class="text-[0.6rem] tabular-nums opacity-60">{ strconv.FormatInt(p.ErrorCount, 10) }</span>
 			</a>
 			<a
 				href={ statusTabHref(p.StatusQueryInProgress) }
@@ -258,7 +259,7 @@ templ logsSyncStatusTabs(p LogsProps) {
 			>
 				<span class="w-1.5 h-1.5 rounded-full bg-warning shrink-0"></span>
 				In Progress
-				<span class="text-[0.6rem] tabular-nums opacity-60">{ fmt.Sprintf("%d", p.InProgressCount) }</span>
+				<span class="text-[0.6rem] tabular-nums opacity-60">{ strconv.FormatInt(p.InProgressCount, 10) }</span>
 			</a>
 		</div>
 		if hasAnySyncFilter(p) {
@@ -376,7 +377,7 @@ templ logsWebhookStats(p LogsProps) {
 						<i data-lucide="webhook" class="w-4 h-4 text-base-content/40"></i>
 					</div>
 					<div>
-						<div class="text-2xl font-semibold tabular-nums leading-none">{ fmt.Sprintf("%d", p.WHStats.TotalEvents) }</div>
+						<div class="text-2xl font-semibold tabular-nums leading-none">{ strconv.FormatInt(p.WHStats.TotalEvents, 10) }</div>
 						<div class="text-xs text-base-content/40 mt-0.5">Total events</div>
 					</div>
 				</div>
@@ -388,7 +389,7 @@ templ logsWebhookStats(p LogsProps) {
 						<i data-lucide="check-circle-2" class="w-4 h-4 text-success"></i>
 					</div>
 					<div>
-						<div class="text-2xl font-semibold tabular-nums leading-none text-success">{ fmt.Sprintf("%d", p.WHStats.ProcessedCount) }</div>
+						<div class="text-2xl font-semibold tabular-nums leading-none text-success">{ strconv.FormatInt(p.WHStats.ProcessedCount, 10) }</div>
 						<div class="text-xs text-base-content/40 mt-0.5">Processed</div>
 					</div>
 				</div>
@@ -401,7 +402,7 @@ templ logsWebhookStats(p LogsProps) {
 					</div>
 					<div>
 						<div class={ "text-2xl font-semibold tabular-nums leading-none", warningTextClass(p.WHStats.ReceivedCount > 0) }>
-							{ fmt.Sprintf("%d", p.WHStats.ReceivedCount) }
+							{ strconv.FormatInt(p.WHStats.ReceivedCount, 10) }
 						</div>
 						<div class="text-xs text-base-content/40 mt-0.5">In-flight</div>
 					</div>
@@ -415,7 +416,7 @@ templ logsWebhookStats(p LogsProps) {
 					</div>
 					<div>
 						<div class={ "text-2xl font-semibold tabular-nums leading-none", errorTextClass(p.WHStats.ErrorCount > 0) }>
-							{ fmt.Sprintf("%d", p.WHStats.ErrorCount) }
+							{ strconv.FormatInt(p.WHStats.ErrorCount, 10) }
 						</div>
 						<div class="text-xs text-base-content/40 mt-0.5">Errors</div>
 					</div>
@@ -626,9 +627,9 @@ templ logsPaginator(page, totalPages int, total int64, showingStart, showingEnd 
 				if n == 0 {
 					<span class="bb-paginator__ellipsis">&hellip;</span>
 				} else if n == page {
-					<span class="bb-paginator__btn bb-paginator__btn--active">{ fmt.Sprintf("%d", n) }</span>
+					<span class="bb-paginator__btn bb-paginator__btn--active">{ strconv.Itoa(n) }</span>
 				} else {
-					<a href={ templ.SafeURL(fmt.Sprintf("%s%d", base, n)) } class="bb-paginator__btn">{ fmt.Sprintf("%d", n) }</a>
+					<a href={ templ.SafeURL(fmt.Sprintf("%s%d", base, n)) } class="bb-paginator__btn">{ strconv.Itoa(n) }</a>
 				}
 			}
 			if page < totalPages {
@@ -781,35 +782,35 @@ func statsTotalSync(s *service.SyncLogStats) string {
 	if s == nil {
 		return "0"
 	}
-	return fmt.Sprintf("%d", s.TotalSyncs)
+	return strconv.FormatInt(s.TotalSyncs, 10)
 }
 
 func webhookStatsTotal(s *service.WebhookEventStats) string {
 	if s == nil {
 		return "0"
 	}
-	return fmt.Sprintf("%d", s.TotalEvents)
+	return strconv.FormatInt(s.TotalEvents, 10)
 }
 
 func webhookStatsProcessed(s *service.WebhookEventStats) string {
 	if s == nil {
 		return "0"
 	}
-	return fmt.Sprintf("%d", s.ProcessedCount)
+	return strconv.FormatInt(s.ProcessedCount, 10)
 }
 
 func webhookStatsReceived(s *service.WebhookEventStats) string {
 	if s == nil {
 		return "0"
 	}
-	return fmt.Sprintf("%d", s.ReceivedCount)
+	return strconv.FormatInt(s.ReceivedCount, 10)
 }
 
 func webhookStatsErrors(s *service.WebhookEventStats) string {
 	if s == nil {
 		return "0"
 	}
-	return fmt.Sprintf("%d", s.ErrorCount)
+	return strconv.FormatInt(s.ErrorCount, 10)
 }
 
 // hasAnySyncFilter mirrors the `{{if or .FilterConnID .FilterTrigger

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"fmt"
+	"strconv"
 
 	"breadbox/internal/templates/components"
 )
@@ -128,17 +129,17 @@ templ settingsSyncCard(p SettingsProps) {
 
 templ syncIntervalOption(value, current int, label string) {
 	if value == current {
-		<option value={ fmt.Sprintf("%d", value) } selected>{ label }</option>
+		<option value={ strconv.Itoa(value) } selected>{ label }</option>
 	} else {
-		<option value={ fmt.Sprintf("%d", value) }>{ label }</option>
+		<option value={ strconv.Itoa(value) }>{ label }</option>
 	}
 }
 
 templ retentionOption(value, current int, label string) {
 	if value == current {
-		<option value={ fmt.Sprintf("%d", value) } selected>{ label }</option>
+		<option value={ strconv.Itoa(value) } selected>{ label }</option>
 	} else {
-		<option value={ fmt.Sprintf("%d", value) }>{ label }</option>
+		<option value={ strconv.Itoa(value) }>{ label }</option>
 	}
 }
 

--- a/internal/templates/components/pages/tags.templ
+++ b/internal/templates/components/pages/tags.templ
@@ -2,6 +2,7 @@ package pages
 
 import (
 	"fmt"
+	"strconv"
 
 	"breadbox/internal/templates/components"
 )
@@ -106,7 +107,7 @@ templ tagListRow(t TagRow) {
 					class="inline-flex items-baseline gap-1 text-xs text-base-content/70 hover:text-base-content"
 					title="View transactions"
 				>
-					<span class="font-medium">{ fmt.Sprintf("%d", t.TransactionCount) }</span>
+					<span class="font-medium">{ strconv.FormatInt(t.TransactionCount, 10) }</span>
 					<span class="text-base-content/40 hidden sm:inline">{ tagCountLabel(t.TransactionCount) }</span>
 				</a>
 			} else {
@@ -133,7 +134,7 @@ templ tagListRow(t TagRow) {
 							class="text-error"
 							data-id={ t.ID }
 							data-slug={ t.Slug }
-							data-count={ fmt.Sprintf("%d", t.TransactionCount) }
+							data-count={ strconv.FormatInt(t.TransactionCount, 10) }
 							aria-label={ fmt.Sprintf("Delete tag %s", t.Slug) }
 							@click="window.dispatchEvent(new CustomEvent('bb-delete-tag', {detail: {id: $el.dataset.id, slug: $el.dataset.slug, count: parseInt($el.dataset.count) || 0}}))"
 						>

--- a/internal/templates/components/tx_results.templ
+++ b/internal/templates/components/tx_results.templ
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"breadbox/internal/service"
@@ -43,7 +44,7 @@ templ TxResults(p TxResultsProps) {
 					<div class="flex items-center justify-between px-2 pt-4 pb-2">
 						<div class="flex items-center gap-3">
 							<h3 class="text-xs font-semibold text-base-content/50 tracking-wide">{ g.Label }</h3>
-							<span class="text-xs text-base-content/30 tabular-nums" data-txn-count={ fmt.Sprintf("%d", len(g.Transactions)) }>
+							<span class="text-xs text-base-content/30 tabular-nums" data-txn-count={ strconv.Itoa(len(g.Transactions)) }>
 								{ fmt.Sprintf("%d txn%s", len(g.Transactions), pluralS(len(g.Transactions))) }
 							</span>
 						</div>
@@ -90,7 +91,7 @@ templ TxResults(p TxResultsProps) {
 		<div class="bb-paginator" id="bb-tx-paginator">
 			<div class="bb-paginator__info">
 				<span class="text-xs text-base-content/50 tabular-nums hidden sm:inline">
-					Showing { fmt.Sprintf("%d&ndash;%d", p.ShowingStart, p.ShowingEnd) } of { fmt.Sprintf("%d", p.Total) }
+					Showing { fmt.Sprintf("%d&ndash;%d", p.ShowingStart, p.ShowingEnd) } of { strconv.Itoa(p.Total) }
 				</span>
 				<div class="bb-paginator__per-page">
 					<label class="text-xs text-base-content/40 whitespace-nowrap">Per page</label>
@@ -119,9 +120,9 @@ templ TxResults(p TxResultsProps) {
 					if n == 0 {
 						<span class="bb-paginator__ellipsis">&hellip;</span>
 					} else if n == p.Page {
-						<span class="bb-paginator__btn bb-paginator__btn--active">{ fmt.Sprintf("%d", n) }</span>
+						<span class="bb-paginator__btn bb-paginator__btn--active">{ strconv.Itoa(n) }</span>
 					} else {
-						<a href={ paginatorURL(p.PaginationBase, n) } class="bb-paginator__btn">{ fmt.Sprintf("%d", n) }</a>
+						<a href={ paginatorURL(p.PaginationBase, n) } class="bb-paginator__btn">{ strconv.Itoa(n) }</a>
 					}
 				}
 				<!-- Next -->
@@ -164,9 +165,9 @@ templ dayTotalBadge(class, attr string, value float64, income bool) {
 
 templ perPageOption(size, current int) {
 	if size == current {
-		<option value={ fmt.Sprintf("%d", size) } selected>{ fmt.Sprintf("%d", size) }</option>
+		<option value={ strconv.Itoa(size) } selected>{ strconv.Itoa(size) }</option>
 	} else {
-		<option value={ fmt.Sprintf("%d", size) }>{ fmt.Sprintf("%d", size) }</option>
+		<option value={ strconv.Itoa(size) }>{ strconv.Itoa(size) }</option>
 	}
 }
 

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"breadbox/internal/service"
@@ -105,7 +106,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 						>
 							<span class="text-base-content/20 mr-0.5">&middot;</span>
 							<i data-lucide="tag" class="w-3 h-3"></i>
-							<span class="text-[0.65rem] tabular-nums font-medium" data-tx-tag-count>{ fmt.Sprintf("%d", len(tx.Tags)) }</span>
+							<span class="text-[0.65rem] tabular-nums font-medium" data-tx-tag-count>{ strconv.Itoa(len(tx.Tags)) }</span>
 						</span>
 					}
 					<!-- Compact category label (below xl). Separator stays inside the
@@ -163,9 +164,11 @@ templ TxRow(tx service.AdminTransactionRow) {
 					></i>
 					<span class="sr-only">(pending)</span>
 				}
-				<span class={ "bb-tx-amount tabular-nums",
+				<span
+					class={ "bb-tx-amount tabular-nums",
 					templ.KV("bb-tx-amount--income", tx.Amount < 0),
-					templ.KV("bb-tx-amount--pending", tx.Pending) }>
+					templ.KV("bb-tx-amount--pending", tx.Pending) }
+				>
 					{ formatAmount(tx.Amount) }
 				</span>
 			</div>


### PR DESCRIPTION
## Summary

Replace `fmt.Sprintf(\"%d\", n)` with `strconv.Itoa` (int) / `strconv.FormatInt` (int64) in 33 call sites across 9 `.templ` files. Same idiom and rationale as [#780](https://github.com/canalesb93/breadbox/pull/780), applied to the rendering layer that pass left untouched.

`fmt.Sprintf(\"%d\", x)` with a single integer arg routes through the format parser for no benefit — `strconv.Itoa` / `strconv.FormatInt` are clearer and skip the indirection.

Files touched:

- [nav.templ](internal/templates/components/nav.templ) — `badgeCount(int64)` helper
- [tx_row.templ](internal/templates/components/tx_row.templ) — mobile tag-count pill
- [tx_results.templ](internal/templates/components/tx_results.templ) — paginator buttons, txn-count attr, page-size options, total
- [pages/categories.templ](internal/templates/components/pages/categories.templ) — children-count badge
- [pages/connections.templ](internal/templates/components/pages/connections.templ) — account-count next to total balance
- [pages/dashboard.templ](internal/templates/components/pages/dashboard.templ) — connection-error tile count
- [pages/logs.templ](internal/templates/components/pages/logs.templ) — sync/webhook stat tiles, paginator buttons, the five `*Stats*` helpers
- [pages/settings.templ](internal/templates/components/pages/settings.templ) — sync-interval / retention `<option>` values
- [pages/tags.templ](internal/templates/components/pages/tags.templ) — tag transaction-count and `data-count` attribute

Mixed-format `Sprintf` calls (e.g. `\"%d&ndash;%d\"`, `\"%s%d\"` paginator URLs) are left untouched — they have multiple verbs and `Sprintf` is still the right tool there.

## Test plan

- [x] `templ generate` produces a clean diff (only the 9 source files change; generated `_templ.go` is gitignored)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit tests, including templates and admin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)