### PR TITLE
fix(admin): align activity timeline avatars with user identity

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -126,8 +126,15 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, _ *TemplateRender
 }
 
 // ActorFromSession builds a service.Actor from the session.
+//
+// Prefers the linked users.id over the auth_accounts.id so that actor_id on
+// annotations matches the avatar handler's lookup key (/avatars/{users.id}).
+// Falls back to auth_accounts.id only for unlinked initial admin accounts.
 func ActorFromSession(sm *scs.SessionManager, r *http.Request) service.Actor {
-	id := sm.GetString(r.Context(), sessionKeyAccountID)
+	id := sm.GetString(r.Context(), sessionKeyUserID)
+	if id == "" {
+		id = sm.GetString(r.Context(), sessionKeyAccountID)
+	}
 	name := sm.GetString(r.Context(), sessionKeyAccountUsername)
 	if name == "" {
 		name = "admin"

--- a/internal/db/migrations/20260425131133_backfill_annotation_actor_user_id.sql
+++ b/internal/db/migrations/20260425131133_backfill_annotation_actor_user_id.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- Backfill annotations.actor_id for actor_type='user' rows where the recorded
+-- ID is an auth_accounts.id rather than the linked users.id. Before #788 the
+-- admin session built service.Actor from auth_accounts.id, so the avatar
+-- handler at GET /avatars/{id} (which keys on users.id) missed for every
+-- timeline entry written by an admin and fell through to the generated
+-- pattern. ActorFromSession now prefers users.id; this migration repairs
+-- existing rows so older timeline entries also resolve uploaded avatars.
+UPDATE annotations a
+SET actor_id = aa.user_id::text
+FROM auth_accounts aa
+WHERE a.actor_type = 'user'
+  AND a.actor_id IS NOT NULL
+  AND a.actor_id ~ '^[0-9a-fA-F-]{36}$'
+  AND a.actor_id::uuid = aa.id
+  AND aa.user_id IS NOT NULL;
+
+-- +goose Down
+-- One-way data repair. The original auth_accounts.id values are not preserved
+-- per row, so reversal would require re-deriving them from session history,
+-- which we do not retain. No-op on rollback.
+SELECT 1;

--- a/internal/db/queries/annotations.sql
+++ b/internal/db/queries/annotations.sql
@@ -18,6 +18,13 @@ ORDER BY created_at ASC;
 -- handler's 24h max-age window. annotations.actor_id can hold either a
 -- users.id or an auth_accounts.id depending on the call site; resolve both
 -- by joining auth_accounts and falling back to a direct users join.
+--
+-- Compare in text space (aa.id::text = a.actor_id) rather than casting
+-- a.actor_id::uuid, because actor_id can also hold a non-UUID short_id for
+-- system-actor rows (e.g. rule_applied writes the rule's short_id) and
+-- PostgreSQL does not guarantee short-circuit evaluation of conjunctions in
+-- JOIN conditions — a regex guard alone is not enough to prevent SQLSTATE
+-- 22P02 on the ::uuid cast.
 SELECT
     a.id, a.short_id, a.transaction_id, a.kind, a.actor_type,
     a.actor_id, a.actor_name, a.session_id, a.payload, a.tag_id,
@@ -26,15 +33,13 @@ SELECT
 FROM annotations a
 LEFT JOIN auth_accounts aa
     ON a.actor_type = 'user'
-   AND a.actor_id IS NOT NULL
-   AND a.actor_id::uuid = aa.id
+   AND aa.id::text = a.actor_id
 LEFT JOIN users u_via_account
     ON aa.user_id = u_via_account.id
 LEFT JOIN users u_direct
     ON a.actor_type = 'user'
-   AND a.actor_id IS NOT NULL
    AND aa.id IS NULL
-   AND a.actor_id::uuid = u_direct.id
+   AND u_direct.id::text = a.actor_id
 WHERE a.transaction_id = $1
 ORDER BY a.created_at ASC;
 


### PR DESCRIPTION
Fixes [#788](https://github.com/canalesb93/breadbox/issues/788) — activity-timeline rows showed the auto-generated pattern avatar instead of the admin's uploaded gradient.

## Root cause

`actor_id` on annotations was being written as `auth_accounts.id`, but the avatar handler at `/avatars/{id}` keys lookups on `users.id`. The IDs differ on linked admin accounts, so the timeline silently fell through to `serveGeneratedAvatar` while the sidebar (which already uses `users.id`) rendered the real picture. Same admin, two avatars.

While fixing the actor side I also hit a pre-existing bug in `ListAnnotationsWithActorByTransaction` (added in #781): the JOIN cast `actor_id::uuid` blew up on `rule_applied` annotations that store the rule's 8-char `short_id` in `actor_id` (`SQLSTATE 22P02`). The activity timeline silently rendered "0 events" for any transaction whose history included a rule application.

## Fix

1. `ActorFromSession` prefers `sessionKeyUserID` over `sessionKeyAccountID`, falling back only for unlinked initial admin accounts. New annotations attach to the user identity.
2. `ListAnnotationsWithActorByTransaction` compares in text space (`aa.id::text = a.actor_id`) rather than casting `actor_id::uuid`. Postgres does not guarantee short-circuit evaluation in JOIN conditions, so the previous regex guard alone wasn't enough.
3. One-shot backfill migration rewrites existing `annotations.actor_id` rows from `auth_accounts.id` to the linked `users.id`.

## Validation

| | Before | After |
|---|---|---|
| Desktop (1440×900) | <img src="https://i.img402.dev/e0ccmp3l58.png" width="380" alt="before — desktop"> | <img src="https://i.img402.dev/9mqtqrc0xu.png" width="380" alt="after — desktop"> |
| Tablet (820×1180) | <img src="https://i.img402.dev/f2j7c7el0f.png" width="380" alt="before — tablet"> | <img src="https://i.img402.dev/gsswnwmxif.png" width="380" alt="after — tablet"> |
| Mobile (500×844) | <img src="https://i.img402.dev/ootq8kcdut.png" width="280" alt="before — mobile"> | <img src="https://i.img402.dev/u409ousafr.png" width="280" alt="after — mobile"> |

Notice the sidebar avatar (gradient) matches the timeline avatar in the After column — they were diverging before.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./internal/admin/... ./internal/service/...` pass.
- [x] Manual: log in as admin, open `/transactions/e950fza1`, confirm activity rows render gradient avatar, sidebar matches.
- [x] Manual: confirmed timeline now lists 12 events (was rendering "0 events" with `SQLSTATE 22P02` in logs).
- [ ] CI on this PR.
