### PR TITLE
chore(templ): consolidate pageRange into components helper

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -720,49 +720,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return strings.ReplaceAll(subtype, "_", " ")
 			},
-			"pageRange": func(current, total int) []int {
-				// Returns page numbers to display: always include first, last,
-				// current, and neighbors. Use 0 as ellipsis sentinel.
-				if total <= 7 {
-					pages := make([]int, total)
-					for i := range pages {
-						pages[i] = i + 1
-					}
-					return pages
-				}
-				seen := map[int]bool{}
-				add := func(p int) {
-					if p >= 1 && p <= total {
-						seen[p] = true
-					}
-				}
-				add(1)
-				add(total)
-				for d := -1; d <= 1; d++ {
-					add(current + d)
-				}
-				sorted := make([]int, 0, len(seen))
-				for p := range seen {
-					sorted = append(sorted, p)
-				}
-				// Sort
-				for i := 0; i < len(sorted); i++ {
-					for j := i + 1; j < len(sorted); j++ {
-						if sorted[j] < sorted[i] {
-							sorted[i], sorted[j] = sorted[j], sorted[i]
-						}
-					}
-				}
-				// Insert 0 for gaps
-				result := make([]int, 0, len(sorted)*2)
-				for i, p := range sorted {
-					if i > 0 && p > sorted[i-1]+1 {
-						result = append(result, 0) // ellipsis
-					}
-					result = append(result, p)
-				}
-				return result
-			},
+			"pageRange": components.PageRange,
 			"avatarURL": func(args ...any) string {
 				if len(args) == 0 {
 					return "/avatars/unknown"

--- a/internal/templates/components/helpers.go
+++ b/internal/templates/components/helpers.go
@@ -9,6 +9,7 @@ package components
 import (
 	"fmt"
 	"math"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -246,3 +247,42 @@ func TitleCase(s string) string { return titleCase(s) }
 
 // PluralS returns "" for n == 1, else "s". See pluralS.
 func PluralS[T pluralInt](n T) string { return pluralS(n) }
+
+// PageRange returns the page numbers to display in a paginator. For totals
+// up to 7 it returns every page. Beyond that, it returns first, last,
+// current, and current's neighbors, inserting 0 as an ellipsis sentinel
+// wherever a gap would appear. Used by the admin funcMap and any templ
+// component that renders pagination, so all paginators stay aligned.
+func PageRange(current, total int) []int {
+	if total <= 7 {
+		out := make([]int, total)
+		for i := range out {
+			out[i] = i + 1
+		}
+		return out
+	}
+	seen := map[int]bool{}
+	add := func(p int) {
+		if p >= 1 && p <= total {
+			seen[p] = true
+		}
+	}
+	add(1)
+	add(total)
+	for d := -1; d <= 1; d++ {
+		add(current + d)
+	}
+	sorted := make([]int, 0, len(seen))
+	for p := range seen {
+		sorted = append(sorted, p)
+	}
+	slices.Sort(sorted)
+	result := make([]int, 0, len(sorted)*2)
+	for i, p := range sorted {
+		if i > 0 && p > sorted[i-1]+1 {
+			result = append(result, 0) // ellipsis
+		}
+		result = append(result, p)
+	}
+	return result
+}

--- a/internal/templates/components/helpers_test.go
+++ b/internal/templates/components/helpers_test.go
@@ -333,6 +333,36 @@ func TestAmount2f(t *testing.T) {
 	}
 }
 
+func TestPageRange(t *testing.T) {
+	tests := []struct {
+		name             string
+		current, total   int
+		want             []int
+	}{
+		{"zero pages", 1, 0, []int{}},
+		{"single page", 1, 1, []int{1}},
+		{"all pages shown when ≤ 7", 3, 7, []int{1, 2, 3, 4, 5, 6, 7}},
+		{"first page on long total inserts ellipsis", 1, 20, []int{1, 2, 0, 20}},
+		{"last page on long total inserts ellipsis", 20, 20, []int{1, 0, 19, 20}},
+		{"middle page shows both ellipses", 10, 20, []int{1, 0, 9, 10, 11, 0, 20}},
+		{"current near start collapses leading ellipsis", 3, 20, []int{1, 2, 3, 4, 0, 20}},
+		{"current near end collapses trailing ellipsis", 18, 20, []int{1, 0, 17, 18, 19, 20}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PageRange(tc.current, tc.total)
+			if len(got) != len(tc.want) {
+				t.Fatalf("PageRange(%d, %d) = %v, want %v", tc.current, tc.total, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("PageRange(%d, %d)[%d] = %d, want %d (full: %v)", tc.current, tc.total, i, got[i], tc.want[i], got)
+				}
+			}
+		})
+	}
+}
+
 func TestKbdGlyph(t *testing.T) {
 	// Covers modifier names (case-insensitive), arrows, special keys, and
 	// the single-letter uppercase fallback. Must stay in lock-step with the

--- a/internal/templates/components/pages/logs.templ
+++ b/internal/templates/components/pages/logs.templ
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"breadbox/internal/service"
+	"breadbox/internal/templates/components"
 )
 
 // Logs renders the combined sync-logs + webhook-events page body.
@@ -91,7 +92,6 @@ templ Logs(p LogsProps) {
 // ====================================================================
 // Sync logs tab
 // ====================================================================
-
 templ logsSyncStats(p LogsProps) {
 	if p.Stats != nil {
 		<div class="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-6 bb-stagger">
@@ -366,7 +366,6 @@ templ logsSyncEmpty(p LogsProps) {
 // ====================================================================
 // Webhook events tab
 // ====================================================================
-
 templ logsWebhookStats(p LogsProps) {
 	if p.WHStats != nil {
 		<div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6 bb-stagger">
@@ -607,7 +606,6 @@ templ logsWebhookEmpty(p LogsProps) {
 // ====================================================================
 // Shared paginator (mirrors the bb-paginator markup in source HTML)
 // ====================================================================
-
 templ logsPaginator(page, totalPages int, total int64, showingStart, showingEnd int, base string) {
 	<div class="bb-paginator">
 		<span class="text-xs text-base-content/50 tabular-nums hidden sm:inline">
@@ -624,7 +622,7 @@ templ logsPaginator(page, totalPages int, total int64, showingStart, showingEnd 
 					<i data-lucide="chevron-left" class="w-3.5 h-3.5"></i>
 				</a>
 			}
-			for _, n := range pageRange(page, totalPages) {
+			for _, n := range components.PageRange(page, totalPages) {
 				if n == 0 {
 					<span class="bb-paginator__ellipsis">&hellip;</span>
 				} else if n == page {
@@ -842,48 +840,4 @@ func webhookClearProviderHref(status string) string {
 		href += "&wh_status=" + status
 	}
 	return href
-}
-
-// pageRange mirrors the admin funcMap helper of the same name. Returns
-// page numbers to display with 0 as an ellipsis sentinel. Local copy so
-// the pages package doesn't have to back-import internal/admin.
-func pageRange(current, total int) []int {
-	if total <= 7 {
-		out := make([]int, total)
-		for i := range out {
-			out[i] = i + 1
-		}
-		return out
-	}
-	seen := map[int]bool{}
-	add := func(p int) {
-		if p >= 1 && p <= total {
-			seen[p] = true
-		}
-	}
-	add(1)
-	add(total)
-	for d := -1; d <= 1; d++ {
-		add(current + d)
-	}
-	sorted := make([]int, 0, len(seen))
-	for p := range seen {
-		sorted = append(sorted, p)
-	}
-	// Sort.
-	for i := 0; i < len(sorted); i++ {
-		for j := i + 1; j < len(sorted); j++ {
-			if sorted[j] < sorted[i] {
-				sorted[i], sorted[j] = sorted[j], sorted[i]
-			}
-		}
-	}
-	result := make([]int, 0, len(sorted)*2)
-	for i, p := range sorted {
-		if i > 0 && p > sorted[i-1]+1 {
-			result = append(result, 0) // ellipsis
-		}
-		result = append(result, p)
-	}
-	return result
 }

--- a/internal/templates/components/tx_results.templ
+++ b/internal/templates/components/tx_results.templ
@@ -2,7 +2,6 @@ package components
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"breadbox/internal/service"
@@ -116,7 +115,7 @@ templ TxResults(p TxResultsProps) {
 					</a>
 				}
 				<!-- Page numbers -->
-				for _, n := range pageRange(p.Page, p.TotalPages) {
+				for _, n := range PageRange(p.Page, p.TotalPages) {
 					if n == 0 {
 						<span class="bb-paginator__ellipsis">&hellip;</span>
 					} else if n == p.Page {
@@ -195,40 +194,4 @@ func txMetaScriptHTML(txns []service.AdminTransactionRow) string {
 
 func paginatorURL(base string, page int) templ.SafeURL {
 	return templ.SafeURL(fmt.Sprintf("%s%d", base, page))
-}
-
-// pageRange mirrors the admin funcMap helper of the same name. Returns
-// page numbers to display with 0 as an ellipsis sentinel.
-func pageRange(current, total int) []int {
-	if total <= 7 {
-		pages := make([]int, total)
-		for i := range pages {
-			pages[i] = i + 1
-		}
-		return pages
-	}
-	seen := map[int]bool{}
-	add := func(p int) {
-		if p >= 1 && p <= total {
-			seen[p] = true
-		}
-	}
-	add(1)
-	add(total)
-	for d := -1; d <= 1; d++ {
-		add(current + d)
-	}
-	sorted := make([]int, 0, len(seen))
-	for p := range seen {
-		sorted = append(sorted, p)
-	}
-	sort.Ints(sorted)
-	result := make([]int, 0, len(sorted)*2)
-	for i, p := range sorted {
-		if i > 0 && p > sorted[i-1]+1 {
-			result = append(result, 0) // ellipsis
-		}
-		result = append(result, p)
-	}
-	return result
 }


### PR DESCRIPTION
## Summary

Three near-identical copies of `pageRange` were sprinkled across the admin templates layer:

- `internal/admin/templates.go` — hand-rolled bubble sort.
- `internal/templates/components/tx_results.templ` — `sort.Ints`.
- `internal/templates/components/pages/logs.templ` — hand-rolled bubble sort, with a comment explaining it was duplicated to avoid a back-import.

This PR promotes the function to `components.PageRange`, switches it to `slices.Sort`, and has all three call sites delegate. Net 55 lines removed.

The behavior is unchanged — same first/last/current/neighbors set with `0` as the ellipsis sentinel — and the new helper has unit-test coverage in `helpers_test.go`.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `go test ./...` — all unit tests pass, including the new `TestPageRange` table.
- [x] `templ generate` produced no churn beyond the two intentional `.templ` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)