### PR TITLE
fix(tags): add lifecycle toggle and delete to /tags/{id}/edit

### DIFF
--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -133,6 +133,7 @@ func UpdateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Description *string `json:"description"`
 			Color       *string `json:"color"`
 			Icon        *string `json:"icon"`
+			Lifecycle   *string `json:"lifecycle"`
 		}
 		if !decodeJSON(w, r, &req) {
 			return
@@ -142,6 +143,7 @@ func UpdateTagAdminHandler(svc *service.Service) http.HandlerFunc {
 			Description: req.Description,
 			Color:       req.Color,
 			Icon:        req.Icon,
+			Lifecycle:   req.Lifecycle,
 		})
 		if err != nil {
 			handleTagError(w, err)

--- a/internal/db/queries/tags.sql
+++ b/internal/db/queries/tags.sql
@@ -21,6 +21,7 @@ SET display_name = $2,
     description = $3,
     color = $4,
     icon = $5,
+    lifecycle = $6,
     updated_at = NOW()
 WHERE id = $1
 RETURNING *;

--- a/internal/service/tags.go
+++ b/internal/service/tags.go
@@ -25,6 +25,7 @@ type TagResponse struct {
 	Description string  `json:"description"`
 	Color       *string `json:"color,omitempty"`
 	Icon        *string `json:"icon,omitempty"`
+	Lifecycle   string  `json:"lifecycle"`
 	CreatedAt   string  `json:"created_at"`
 	UpdatedAt   string  `json:"updated_at"`
 }
@@ -44,6 +45,7 @@ type UpdateTagParams struct {
 	Description *string
 	Color       *string
 	Icon        *string
+	Lifecycle   *string
 }
 
 // tagSlugRegex enforces the tag slug format: lowercase alphanumerics with
@@ -188,6 +190,15 @@ func (s *Service) UpdateTag(ctx context.Context, id string, params UpdateTagPara
 		icon = pgtype.Text{String: *params.Icon, Valid: *params.Icon != ""}
 	}
 
+	lifecycle := existing.Lifecycle
+	if params.Lifecycle != nil {
+		v := strings.TrimSpace(*params.Lifecycle)
+		if v != "persistent" && v != "ephemeral" {
+			return nil, fmt.Errorf("%w: lifecycle must be 'persistent' or 'ephemeral'", ErrInvalidParameter)
+		}
+		lifecycle = v
+	}
+
 	existingUID, _ := parseUUID(existing.ID)
 	tag, err := s.Queries.UpdateTag(ctx, db.UpdateTagParams{
 		ID:          existingUID,
@@ -195,6 +206,7 @@ func (s *Service) UpdateTag(ctx context.Context, id string, params UpdateTagPara
 		Description: description,
 		Color:       color,
 		Icon:        icon,
+		Lifecycle:   lifecycle,
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -270,6 +282,7 @@ func tagFromRow(t db.Tag) TagResponse {
 		Description: t.Description,
 		Color:       textPtr(t.Color),
 		Icon:        textPtr(t.Icon),
+		Lifecycle:   t.Lifecycle,
 		CreatedAt:   pgconv.TimestampStr(t.CreatedAt),
 		UpdatedAt:   pgconv.TimestampStr(t.UpdatedAt),
 	}

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -117,6 +117,28 @@ templ TagForm(p TagFormProps) {
 							placeholder="Short explanation of when to use this tag"
 						/>
 					</div>
+					if p.IsEdit {
+						<!-- Lifecycle -->
+						<div>
+							<label class="block text-xs font-medium text-base-content/50 mb-1.5">Lifecycle</label>
+							<div class="flex flex-col sm:flex-row gap-2">
+								<label class="flex-1 flex items-start gap-2.5 p-3 rounded-xl border border-base-300/60 cursor-pointer hover:bg-base-200/40 transition-colors" :class="lifecycle === 'persistent' ? 'bg-base-200/40 border-base-content/20' : ''">
+									<input type="radio" name="lifecycle" value="persistent" class="radio radio-xs mt-0.5" x-model="lifecycle"/>
+									<span class="flex-1 min-w-0">
+										<span class="block text-sm font-medium">Persistent</span>
+										<span class="block text-xs text-base-content/50 mt-0.5">Stays on transactions until removed.</span>
+									</span>
+								</label>
+								<label class="flex-1 flex items-start gap-2.5 p-3 rounded-xl border border-base-300/60 cursor-pointer hover:bg-base-200/40 transition-colors" :class="lifecycle === 'ephemeral' ? 'bg-base-200/40 border-base-content/20' : ''">
+									<input type="radio" name="lifecycle" value="ephemeral" class="radio radio-xs mt-0.5" x-model="lifecycle"/>
+									<span class="flex-1 min-w-0">
+										<span class="block text-sm font-medium">Ephemeral</span>
+										<span class="block text-xs text-base-content/50 mt-0.5">Auto-clears once the work is done (e.g. needs-review).</span>
+									</span>
+								</label>
+							</div>
+						</div>
+					}
 					<!-- Icon + color -->
 					<div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
 						<div>
@@ -182,6 +204,35 @@ templ TagForm(p TagFormProps) {
 				</button>
 			</div>
 		</form>
+		if p.IsEdit {
+			<div class="bb-card mt-6 border-error/30">
+				<div class="p-5 sm:p-6">
+					<div class="bb-icon-header">
+						<div class="bb-icon-header__tile bg-error/10 text-error">
+							<i data-lucide="alert-triangle" class="w-5 h-5"></i>
+						</div>
+						<div class="bb-icon-header__text">
+							<h2 class="text-sm font-semibold">Danger zone</h2>
+							<p class="text-xs text-base-content/45">Deleting a tag removes it from all transactions. Activity annotations are preserved.</p>
+						</div>
+					</div>
+					<div class="mt-4">
+						<button
+							type="button"
+							class="btn btn-sm btn-error btn-outline rounded-xl gap-1.5"
+							@click="deleteTag()"
+							:disabled="deleting"
+						>
+							<span x-show="!deleting" class="inline-flex items-center gap-1.5">
+								<i data-lucide="trash-2" class="w-3.5 h-3.5"></i>
+								<span>Delete tag</span>
+							</span>
+							<span x-show="deleting" class="loading loading-spinner loading-xs"></span>
+						</button>
+					</div>
+				</div>
+			</div>
+		}
 	</div>
 	@templ.Raw(tagFormBootstrap(p))
 }

--- a/internal/templates/components/pages/tag_form_types.go
+++ b/internal/templates/components/pages/tag_form_types.go
@@ -64,6 +64,14 @@ func tagColorOr(t *service.TagResponse) string {
 	return *t.Color
 }
 
+// tagLifecycleOr returns the tag's lifecycle or the default ('persistent').
+func tagLifecycleOr(t *service.TagResponse) string {
+	if t == nil || t.Lifecycle == "" {
+		return "persistent"
+	}
+	return t.Lifecycle
+}
+
 // tagFormBootstrap renders the Alpine component bootstrap. Extracting it
 // as a Go function keeps the templ template clean and lets us interpolate
 // Go values via jsStringLit rather than inside a <script> block.
@@ -77,7 +85,8 @@ function tagForm() {
     displayName: %s,
     description: %s,
     color: %s,
-    icon: %s
+    icon: %s,
+    lifecycle: %s
   };
   return {
     isEdit: isEdit,
@@ -87,7 +96,9 @@ function tagForm() {
     description: initial.description,
     color: initial.color,
     icon: initial.icon,
+    lifecycle: initial.lifecycle,
     submitting: false,
+    deleting: false,
     error: '',
     presetColors: ['#6366f1','#8b5cf6','#ec4899','#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#06b6d4','#3b82f6','#64748b','#78716c'],
 
@@ -111,7 +122,8 @@ function tagForm() {
           display_name: displayName,
           description: this.description || '',
           color: this.color || null,
-          icon: this.icon || null
+          icon: this.icon || null,
+          lifecycle: this.lifecycle || 'persistent'
         };
       } else {
         url = '/-/tags';
@@ -149,6 +161,42 @@ function tagForm() {
           self.restorePageState();
           self.error = 'Network error. Please try again.';
         });
+    },
+
+    deleteTag: function() {
+      if (!this.isEdit || !this.tagId) return;
+      var self = this;
+      var label = (this.displayName || this.slug || 'this tag');
+      var confirmFn = window.bbConfirm
+        ? window.bbConfirm({title: 'Delete tag?', message: 'Delete tag "' + label + '"? This removes it from all transactions. Activity annotations are preserved.', confirmLabel: 'Delete', variant: 'danger'})
+        : Promise.resolve(window.confirm('Delete tag "' + label + '"?'));
+      Promise.resolve(confirmFn).then(function(ok) {
+        if (!ok) return;
+        self.deleting = true;
+        fetch('/-/tags/' + self.tagId, { method: 'DELETE' })
+          .then(function(res) {
+            if (res.ok) {
+              window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Tag deleted', type:'success'}}));
+              setTimeout(function() { window.location.href = '/tags'; }, 300);
+              return;
+            }
+            return res.json().then(function(data) {
+              self.deleting = false;
+              self.restorePageState();
+              var msg = (data && data.error && data.error.message) ? data.error.message : 'Delete failed.';
+              window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: msg, type:'error'}}));
+            }).catch(function() {
+              self.deleting = false;
+              self.restorePageState();
+              window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Delete failed.', type:'error'}}));
+            });
+          })
+          .catch(function() {
+            self.deleting = false;
+            self.restorePageState();
+            window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Network error.', type:'error'}}));
+          });
+      });
     }
   };
 }
@@ -160,5 +208,6 @@ function tagForm() {
 		jsStringLit(tagDescriptionOr(p.Tag)),
 		jsStringLit(tagColorOr(p.Tag)),
 		jsStringLit(tagIconOr(p.Tag)),
+		jsStringLit(tagLifecycleOr(p.Tag)),
 	)
 }


### PR DESCRIPTION
Fixes #724

The tag edit form at `/tags/{id}/edit` was a dead-end — no way to toggle lifecycle and no delete affordance, so users had to bounce back to `/tags` and find a trash icon to delete. This adds a lifecycle radio (Persistent vs Ephemeral, plumbed through the service layer) and a "Danger zone" Delete tag button that reuses the existing `DELETE /-/tags/{id}` handler and routes back to `/tags` on success.

## Scope

The triage proposed a separate `/tags/{id}` detail page with a transactions preview and a new templ component. This PR keeps the change scoped to the existing edit form — that's the surface users actually land on, and the two missing controls (lifecycle, delete) are what makes it feel like a dead-end. A full detail page with transaction list can be a follow-up.

Plumbing in `internal/service/tags.go` exposes `lifecycle` on `TagResponse` and `UpdateTagParams`; the column already exists in the DB (added in `20260415075421_tags_and_annotations.sql`). The admin `PUT /-/tags/{id}` handler now accepts `lifecycle` in the JSON body.

## Before
| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/gyzb4pavst.png" width="280" alt="Edit tag mobile — before"> | <img src="https://i.img402.dev/q9qfitxixg.png" width="500" alt="Edit tag tablet — before"> | <img src="https://i.img402.dev/ks7whogl15.png" width="800" alt="Edit tag desktop — before"> |

## After
| Mobile | Tablet | Desktop |
|---|---|---|
| <img src="https://i.img402.dev/toqayt8sn3.png" width="280" alt="Edit tag mobile — after"> | <img src="https://i.img402.dev/xv5q4l40z4.png" width="500" alt="Edit tag tablet — after"> | <img src="https://i.img402.dev/zw23ww92ec.png" width="800" alt="Edit tag desktop — after"> |

## Notes

- Build, vet, unit tests pass locally.
- Deviation from the proposed fix: skipped the new `/tags/{id}` detail route and the inline transactions preview to keep this PR polish-sized; users still get the two affordances they were missing (lifecycle + delete) on the surface they already land on.
