### PR TITLE
chore(admin): consolidate transaction filter parsing into helper

### DIFF
--- a/internal/admin/csv_export.go
+++ b/internal/admin/csv_export.go
@@ -17,28 +17,9 @@ func ExportTransactionsCSVHandler(a *app.App, svc *service.Service) http.Handler
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		q := r.URL.Query()
-		params := service.AdminTransactionListParams{
-			Page:         1,
-			PageSize:     -1, // Export all matching rows (no pagination).
-			StartDate:    parseDateParam(r, "start_date"),
-			EndDate:      parseInclusiveDateParam(r, "end_date"),
-			AccountID:    optStrQuery(q, "account_id"),
-			UserID:       optStrQuery(q, "user_id"),
-			ConnectionID: optStrQuery(q, "connection_id"),
-			CategorySlug: optStrQuery(q, "category"),
-			MinAmount:    optFloatQuery(q, "min_amount"),
-			MaxAmount:    optFloatQuery(q, "max_amount"),
-			Search:       optStrQuery(q, "search"),
-		}
-
-		if v := q.Get("pending"); v != "" {
-			b := v == "true"
-			params.Pending = &b
-		}
-		if q.Get("sort") == "asc" {
-			params.SortOrder = "asc"
-		}
+		params := parseAdminTxFilters(r)
+		params.Page = 1
+		params.PageSize = -1 // Export all matching rows (no pagination).
 
 		result, err := svc.ListTransactionsAdmin(ctx, params)
 		if err != nil {

--- a/internal/admin/helpers_test.go
+++ b/internal/admin/helpers_test.go
@@ -141,6 +141,117 @@ func TestSplitCSV(t *testing.T) {
 	}
 }
 
+func TestParseAdminTxFilters(t *testing.T) {
+	r := httptest.NewRequest("GET",
+		"/?start_date=2026-04-01&end_date=2026-04-30"+
+			"&account_id=acc1&user_id=u1&connection_id=c1&category=food"+
+			"&min_amount=10.5&max_amount=99&search=coffee"+
+			"&pending=true&search_mode=words&search_field=name"+
+			"&sort=asc&tags=a,b&any_tag=c,d", nil)
+
+	p := parseAdminTxFilters(r)
+
+	if p.StartDate == nil || !p.StartDate.Equal(time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("StartDate = %v, want 2026-04-01", p.StartDate)
+	}
+	if p.EndDate == nil || !p.EndDate.Equal(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("EndDate = %v, want 2026-05-01 (inclusive +1d)", p.EndDate)
+	}
+	if p.AccountID == nil || *p.AccountID != "acc1" {
+		t.Errorf("AccountID = %v, want acc1", p.AccountID)
+	}
+	if p.UserID == nil || *p.UserID != "u1" {
+		t.Errorf("UserID = %v, want u1", p.UserID)
+	}
+	if p.ConnectionID == nil || *p.ConnectionID != "c1" {
+		t.Errorf("ConnectionID = %v, want c1", p.ConnectionID)
+	}
+	if p.CategorySlug == nil || *p.CategorySlug != "food" {
+		t.Errorf("CategorySlug = %v, want food", p.CategorySlug)
+	}
+	if p.MinAmount == nil || *p.MinAmount != 10.5 {
+		t.Errorf("MinAmount = %v, want 10.5", p.MinAmount)
+	}
+	if p.MaxAmount == nil || *p.MaxAmount != 99 {
+		t.Errorf("MaxAmount = %v, want 99", p.MaxAmount)
+	}
+	if p.Search == nil || *p.Search != "coffee" {
+		t.Errorf("Search = %v, want coffee", p.Search)
+	}
+	if p.Pending == nil || *p.Pending != true {
+		t.Errorf("Pending = %v, want true", p.Pending)
+	}
+	if p.SearchMode == nil || *p.SearchMode != "words" {
+		t.Errorf("SearchMode = %v, want words", p.SearchMode)
+	}
+	if p.SearchField == nil || *p.SearchField != "name" {
+		t.Errorf("SearchField = %v, want name", p.SearchField)
+	}
+	if p.SortOrder != "asc" {
+		t.Errorf("SortOrder = %q, want asc", p.SortOrder)
+	}
+	if got, want := p.Tags, []string{"a", "b"}; !equalStrings(got, want) {
+		t.Errorf("Tags = %v, want %v", got, want)
+	}
+	if got, want := p.AnyTag, []string{"c", "d"}; !equalStrings(got, want) {
+		t.Errorf("AnyTag = %v, want %v", got, want)
+	}
+	if p.Page != 0 || p.PageSize != 0 {
+		t.Errorf("Page/PageSize = %d/%d, want 0/0 (caller-controlled)", p.Page, p.PageSize)
+	}
+}
+
+func TestParseAdminTxFiltersEmpty(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	p := parseAdminTxFilters(r)
+
+	if p.StartDate != nil || p.EndDate != nil ||
+		p.AccountID != nil || p.UserID != nil || p.ConnectionID != nil ||
+		p.CategorySlug != nil || p.MinAmount != nil || p.MaxAmount != nil ||
+		p.Search != nil || p.Pending != nil ||
+		p.SearchMode != nil || p.SearchField != nil {
+		t.Errorf("expected all-nil filter pointers on empty request, got %+v", p)
+	}
+	if p.SortOrder != "" {
+		t.Errorf("SortOrder = %q, want empty (defaults to desc downstream)", p.SortOrder)
+	}
+	if len(p.Tags) != 0 || len(p.AnyTag) != 0 {
+		t.Errorf("Tags/AnyTag should be empty, got %v/%v", p.Tags, p.AnyTag)
+	}
+}
+
+func TestParseAdminTxFiltersIgnoresInvalid(t *testing.T) {
+	// Invalid search_mode and search_field should be silently dropped, not
+	// passed through to the service layer. Matches admin "silent failure"
+	// semantics for stale URLs.
+	r := httptest.NewRequest("GET", "/?search_mode=bogus&search_field=bogus&min_amount=abc&start_date=not-a-date", nil)
+	p := parseAdminTxFilters(r)
+	if p.SearchMode != nil {
+		t.Errorf("SearchMode should be nil for invalid value, got %v", *p.SearchMode)
+	}
+	if p.SearchField != nil {
+		t.Errorf("SearchField should be nil for invalid value, got %v", *p.SearchField)
+	}
+	if p.MinAmount != nil {
+		t.Errorf("MinAmount should be nil for non-numeric, got %v", *p.MinAmount)
+	}
+	if p.StartDate != nil {
+		t.Errorf("StartDate should be nil for malformed date, got %v", *p.StartDate)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestIsLiabilityAccount(t *testing.T) {
 	tests := []struct {
 		accountType string

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -95,47 +95,54 @@ func smartDateLabel(dateStr, today, yesterday string) string {
 	return t.Format("Mon, Jan 2, 2006")
 }
 
+// parseAdminTxFilters reads the standard transaction-list filter query params
+// from r and returns an AdminTransactionListParams populated with everything
+// except Page/PageSize. Callers control pagination semantics — list/search use
+// the user's per_page choice; per-account or single-shot views set their own.
+func parseAdminTxFilters(r *http.Request) service.AdminTransactionListParams {
+	q := r.URL.Query()
+	params := service.AdminTransactionListParams{
+		StartDate:    parseDateParam(r, "start_date"),
+		EndDate:      parseInclusiveDateParam(r, "end_date"),
+		AccountID:    optStrQuery(q, "account_id"),
+		UserID:       optStrQuery(q, "user_id"),
+		ConnectionID: optStrQuery(q, "connection_id"),
+		CategorySlug: optStrQuery(q, "category"),
+		MinAmount:    optFloatQuery(q, "min_amount"),
+		MaxAmount:    optFloatQuery(q, "max_amount"),
+		Search:       optStrQuery(q, "search"),
+	}
+	if v := q.Get("pending"); v != "" {
+		b := v == "true"
+		params.Pending = &b
+	}
+	if v := q.Get("search_mode"); v != "" && service.ValidateSearchMode(v) {
+		params.SearchMode = &v
+	}
+	if v := q.Get("search_field"); v != "" && service.ValidateSearchField(v) {
+		params.SearchField = &v
+	}
+	if q.Get("sort") == "asc" {
+		params.SortOrder = "asc"
+	}
+	// Tag filters. ?tags=needs-review,foo (AND) and ?any_tag=a,b (OR).
+	if v := q.Get("tags"); v != "" {
+		params.Tags = splitCSV(v)
+	}
+	if v := q.Get("any_tag"); v != "" {
+		params.AnyTag = splitCSV(v)
+	}
+	return params
+}
+
 // TransactionListHandler serves GET /admin/transactions.
 func TransactionListHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		q := r.URL.Query()
-		params := service.AdminTransactionListParams{
-			Page:         parsePage(r),
-			PageSize:     parsePerPage(r, 50, 25, 50, 100),
-			StartDate:    parseDateParam(r, "start_date"),
-			EndDate:      parseInclusiveDateParam(r, "end_date"),
-			AccountID:    optStrQuery(q, "account_id"),
-			UserID:       optStrQuery(q, "user_id"),
-			ConnectionID: optStrQuery(q, "connection_id"),
-			CategorySlug: optStrQuery(q, "category"),
-			MinAmount:    optFloatQuery(q, "min_amount"),
-			MaxAmount:    optFloatQuery(q, "max_amount"),
-			Search:       optStrQuery(q, "search"),
-		}
-
-		if v := q.Get("pending"); v != "" {
-			b := v == "true"
-			params.Pending = &b
-		}
-		if v := q.Get("search_mode"); v != "" && service.ValidateSearchMode(v) {
-			params.SearchMode = &v
-		}
-		if v := q.Get("search_field"); v != "" && service.ValidateSearchField(v) {
-			params.SearchField = &v
-		}
-		if q.Get("sort") == "asc" {
-			params.SortOrder = "asc"
-		}
-
-		// Tag filters. ?tags=needs-review,foo (AND) and ?any_tag=a,b (OR).
-		if v := q.Get("tags"); v != "" {
-			params.Tags = splitCSV(v)
-		}
-		if v := q.Get("any_tag"); v != "" {
-			params.AnyTag = splitCSV(v)
-		}
+		params := parseAdminTxFilters(r)
+		params.Page = parsePage(r)
+		params.PageSize = parsePerPage(r, 50, 25, 50, 100)
 
 		// Scope to viewer's own data. Editors and admins see all.
 		if !IsEditor(sm, r) {
@@ -348,41 +355,9 @@ func TransactionSearchHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		q := r.URL.Query()
-		params := service.AdminTransactionListParams{
-			Page:         parsePage(r),
-			PageSize:     parsePerPage(r, 50, 25, 50, 100),
-			StartDate:    parseDateParam(r, "start_date"),
-			EndDate:      parseInclusiveDateParam(r, "end_date"),
-			AccountID:    optStrQuery(q, "account_id"),
-			UserID:       optStrQuery(q, "user_id"),
-			ConnectionID: optStrQuery(q, "connection_id"),
-			CategorySlug: optStrQuery(q, "category"),
-			MinAmount:    optFloatQuery(q, "min_amount"),
-			MaxAmount:    optFloatQuery(q, "max_amount"),
-			Search:       optStrQuery(q, "search"),
-		}
-
-		if v := q.Get("pending"); v != "" {
-			b := v == "true"
-			params.Pending = &b
-		}
-		if v := q.Get("search_mode"); v != "" && service.ValidateSearchMode(v) {
-			params.SearchMode = &v
-		}
-		if v := q.Get("search_field"); v != "" && service.ValidateSearchField(v) {
-			params.SearchField = &v
-		}
-		if q.Get("sort") == "asc" {
-			params.SortOrder = "asc"
-		}
-
-		if v := q.Get("tags"); v != "" {
-			params.Tags = splitCSV(v)
-		}
-		if v := q.Get("any_tag"); v != "" {
-			params.AnyTag = splitCSV(v)
-		}
+		params := parseAdminTxFilters(r)
+		params.Page = parsePage(r)
+		params.PageSize = parsePerPage(r, 50, 25, 50, 100)
 
 		// Scope to viewer's own data. Editors and admins see all.
 		if !IsEditor(sm, r) {


### PR DESCRIPTION
## Summary

- Extract `parseAdminTxFilters(*http.Request)` in `internal/admin/transactions.go` and use it from `TransactionListHandler`, `TransactionSearchHandler`, and `ExportTransactionsCSVHandler`. Previously these three sites copy-pasted the same ~30-line block parsing `start_date`/`end_date`/account/user/connection/category/min_amount/max_amount/search/pending/search_mode/search_field/sort/tags/any_tag.
- Callers keep control of `Page`/`PageSize` (list/search use `parsePerPage`; export sets `-1`; helper leaves them zero).
- Side benefit: `csv_export` now also reads `tags`, `any_tag`, `search_mode`, and `search_field`. `buildExportURL` was already passing those filters through, so the exported CSV now matches the on-screen filtered list instead of silently dropping them.
- Adds unit tests for the helper covering populated, empty, and invalid-value (silent-failure) requests.

No behavior change for the list/search handlers — same params parsed identically.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/admin/ -run "TestParseAdminTxFilters"` — all three new tests pass
- [x] `go test ./...` — entire unit suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)