### PR TITLE
fix(templ): repair undefined pageRange in rules page

### DIFF
--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -1,6 +1,10 @@
 package pages
 
-import "fmt"
+import (
+	"fmt"
+
+	"breadbox/internal/templates/components"
+)
 
 // Rules renders the rules list page. Hosts inside the base layout via
 // TemplateRenderer.RenderWithTempl — the handler builds typed props in
@@ -275,7 +279,7 @@ templ rulesPaginator(p RulesProps) {
 					<i data-lucide="chevron-left" class="w-3.5 h-3.5"></i>
 				</a>
 			}
-			for _, n := range pageRange(p.Page, p.TotalPages) {
+			for _, n := range components.PageRange(p.Page, p.TotalPages) {
 				if n == 0 {
 					<span class="bb-paginator__ellipsis">…</span>
 				} else if n == p.Page {


### PR DESCRIPTION
## Summary

PR #824 consolidated `pageRange` into `components.PageRange` but missed `internal/templates/components/pages/rules.templ`, which still calls the unqualified name. After CI regenerated `rules_templ.go` on main, `go vet` errors with `undefined: pageRange` — main is currently red and every dependent PR is blocked.

This PR fixes the call site to `components.PageRange` and adds the missing `breadbox/internal/templates/components` import.

## Test plan

- [x] `templ generate`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/templates/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)