### PR TITLE
chore(service): consolidate sync-log duration calculation onto helper

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -656,19 +656,12 @@ func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRen
 				errorSyncs++
 			}
 
-			// Calculate duration (prefer stored duration_ms, fall back to timestamps).
-			var durSec float64
-			var hasDur bool
-			if log.DurationMs.Valid {
-				durSec = float64(log.DurationMs.Int32) / 1000.0
-				hasDur = true
-			} else if log.StartedAt.Valid && log.CompletedAt.Valid {
-				durSec = log.CompletedAt.Time.Sub(log.StartedAt.Time).Seconds()
-				hasDur = true
-			}
-			if hasDur && durSec >= 0 && durSec < 600 { // sanity check: under 10 min
-				avgDurationSec += durSec
-				durationCount++
+			if ms, ok := service.SyncLogDurationMs(log.DurationMs, log.StartedAt, log.CompletedAt); ok {
+				durSec := float64(ms) / 1000.0
+				if durSec >= 0 && durSec < 600 { // sanity check: under 10 min
+					avgDurationSec += durSec
+					durationCount++
+				}
 			}
 
 			// Populate day map.
@@ -1206,18 +1199,9 @@ func SyncConnectionStatusHandler(a *app.App) http.HandlerFunc {
 		if log.CompletedAt.Valid {
 			resp["completed_at"] = log.CompletedAt.Time.Format(time.RFC3339)
 		}
-		var durationMs int32
-		var hasDuration bool
-		if log.DurationMs.Valid {
-			durationMs = log.DurationMs.Int32
-			hasDuration = true
-		} else if log.StartedAt.Valid && log.CompletedAt.Valid {
-			durationMs = int32(log.CompletedAt.Time.Sub(log.StartedAt.Time).Milliseconds())
-			hasDuration = true
-		}
-		if hasDuration {
-			resp["duration_ms"] = durationMs
-			resp["duration_label"] = service.FormatDurationMs(int64(durationMs))
+		if ms, ok := service.SyncLogDurationMs(log.DurationMs, log.StartedAt, log.CompletedAt); ok {
+			resp["duration_ms"] = ms
+			resp["duration_label"] = service.FormatDurationMs(int64(ms))
 		}
 		if log.ErrorMessage.Valid {
 			resp["error_message"] = log.ErrorMessage.String

--- a/internal/service/connections.go
+++ b/internal/service/connections.go
@@ -117,12 +117,7 @@ func (s *Service) GetConnectionStatus(ctx context.Context, id string) (*Connecti
 			StartedAt:     timestampStr(syncLog.StartedAt),
 			CompletedAt:   timestampStr(syncLog.CompletedAt),
 		}
-		if syncLog.DurationMs.Valid {
-			slResp.DurationMs = &syncLog.DurationMs.Int32
-			d := FormatDurationMs(int64(syncLog.DurationMs.Int32))
-			slResp.Duration = &d
-		} else if syncLog.StartedAt.Valid && syncLog.CompletedAt.Valid {
-			ms := int32(syncLog.CompletedAt.Time.Sub(syncLog.StartedAt.Time).Milliseconds())
+		if ms, ok := SyncLogDurationMs(syncLog.DurationMs, syncLog.StartedAt, syncLog.CompletedAt); ok {
 			slResp.DurationMs = &ms
 			d := FormatDurationMs(int64(ms))
 			slResp.Duration = &d

--- a/internal/service/convert.go
+++ b/internal/service/convert.go
@@ -57,6 +57,23 @@ func connStatusPtr(s db.ConnectionStatus) *string {
 	return &str
 }
 
+// SyncLogDurationMs returns the duration of a sync log in milliseconds, preferring
+// the persisted duration_ms column and falling back to (completed_at - started_at)
+// when duration_ms is NULL. Returns (0, false) when neither source is available.
+//
+// Use this anywhere a handler or service needs the duration of a sync log row —
+// it consolidates the if-DurationMs.Valid / else-if-both-timestamps pattern that
+// otherwise gets duplicated at every display/serialization site.
+func SyncLogDurationMs(durationMs pgtype.Int4, startedAt, completedAt pgtype.Timestamptz) (int32, bool) {
+	if durationMs.Valid {
+		return durationMs.Int32, true
+	}
+	if startedAt.Valid && completedAt.Valid {
+		return int32(completedAt.Time.Sub(startedAt.Time).Milliseconds()), true
+	}
+	return 0, false
+}
+
 // FormatDurationMs converts milliseconds to a human-readable duration string.
 // Examples: 42ms, 1.2s, 2m 15s
 func FormatDurationMs(ms int64) string {

--- a/internal/service/convert_test.go
+++ b/internal/service/convert_test.go
@@ -194,6 +194,80 @@ func TestFormatDurationMs(t *testing.T) {
 	}
 }
 
+func TestSyncLogDurationMs(t *testing.T) {
+	start := time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC)
+	end := start.Add(2500 * time.Millisecond)
+
+	tests := []struct {
+		name      string
+		duration  pgtype.Int4
+		started   pgtype.Timestamptz
+		completed pgtype.Timestamptz
+		wantMs    int32
+		wantOK    bool
+	}{
+		{
+			name:     "stored duration_ms wins",
+			duration: pgtype.Int4{Int32: 1234, Valid: true},
+			// timestamps would compute a different value — stored value must win.
+			started:   pgtype.Timestamptz{Time: start, Valid: true},
+			completed: pgtype.Timestamptz{Time: end, Valid: true},
+			wantMs:    1234,
+			wantOK:    true,
+		},
+		{
+			name:      "fallback to timestamps when duration null",
+			duration:  pgtype.Int4{Valid: false},
+			started:   pgtype.Timestamptz{Time: start, Valid: true},
+			completed: pgtype.Timestamptz{Time: end, Valid: true},
+			wantMs:    2500,
+			wantOK:    true,
+		},
+		{
+			name:      "duration null and started null returns false",
+			duration:  pgtype.Int4{Valid: false},
+			started:   pgtype.Timestamptz{Valid: false},
+			completed: pgtype.Timestamptz{Time: end, Valid: true},
+			wantMs:    0,
+			wantOK:    false,
+		},
+		{
+			name:      "duration null and completed null returns false",
+			duration:  pgtype.Int4{Valid: false},
+			started:   pgtype.Timestamptz{Time: start, Valid: true},
+			completed: pgtype.Timestamptz{Valid: false},
+			wantMs:    0,
+			wantOK:    false,
+		},
+		{
+			name:      "all null returns false",
+			duration:  pgtype.Int4{Valid: false},
+			started:   pgtype.Timestamptz{Valid: false},
+			completed: pgtype.Timestamptz{Valid: false},
+			wantMs:    0,
+			wantOK:    false,
+		},
+		{
+			name:     "zero duration is still valid",
+			duration: pgtype.Int4{Int32: 0, Valid: true},
+			wantMs:   0,
+			wantOK:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms, ok := SyncLogDurationMs(tt.duration, tt.started, tt.completed)
+			if ok != tt.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if ms != tt.wantMs {
+				t.Errorf("ms = %d, want %d", ms, tt.wantMs)
+			}
+		})
+	}
+}
+
 func ptrFloat(f float64) *float64 {
 	return &f
 }


### PR DESCRIPTION
## Summary

The pattern *prefer `duration_ms`, fall back to `completed_at - started_at`* showed up at three display/serialization sites for sync logs:

- `internal/admin/connections.go` — connection-detail heatmap (avg duration)
- `internal/admin/connections.go` — `SyncConnectionStatusHandler` API response
- `internal/service/connections.go` — `GetConnectionStatus` last-sync-log response

Each was carrying the same conditional inline, with its own intermediate `var hasDuration bool` plumbing. Extract it into `service.SyncLogDurationMs(durationMs, startedAt, completedAt) (int32, bool)` and let callers decide what to do with the millisecond value.

Stylistic match for the recent `pgconv.TextOr` / `TextIfNotEmpty` consolidations (#778, #812, #820) — same idea applied to the sync-log duration shape.

## Notes

- `formatSyncDuration` in `connection_detail` rendering is intentionally preserved — it deliberately produces a coarser format (`"2m"` vs `FormatDurationMs("2m 5s")`) for historical rows that pre-date `duration_ms`. Touching that would be a UX behavior change, not a refactor, so it's left out of this PR.
- New unit test covers stored-wins, timestamp fallback, both-null, and zero-duration cases.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (unit) — green, including new `TestSyncLogDurationMs` table cases
- [ ] CI runs the integration tier; behavior is identical at all three call sites (the helper preserves the existing precedence and arithmetic exactly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)