### PR TITLE
mcp(annotations): generic kinds filter + action field on list_annotations; deprecate list_transaction_comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- **MCP tool `list_annotations`** now accepts an optional `kinds` filter (`comment`, `rule_applied`, `tag_added`, `tag_removed`, `category_set`). Empty preserves the existing full-timeline behavior. Pass `kinds=['comment']` to get the comment-only view; pass `kinds=['comment','tag_added','tag_removed','category_set']` to skip rule-application churn. (#776)
+- **MCP tool `list_annotations`** now accepts an optional `kinds` filter using generic, agent-friendly names: `comment`, `rule`, `tag`, `category`. Each response row carries the generic `kind` plus an `action` field (`added` / `removed` for `tag`, `set` for `category`, `applied` for `rule`) so agents can branch on the specific event without parsing the kind string. Empty preserves the existing full-timeline behavior. Pass `kinds=['comment']` for the comment-only view (replaces `list_transaction_comments`); pass `kinds=['tag']` for both add+remove tag events; pass `kinds=['comment','tag','category']` to skip rule-application churn. The DB-level kinds (`tag_added`, `tag_removed`, `rule_applied`, `category_set`) are no longer accepted at the MCP boundary — use the generic names. The admin UI and other internal code paths still see the raw DB kinds (no behavior change). (#776)
 
 ## [0.1.0] - 2026-04-XX
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   - New `provider_raw JSONB` column stores the unmodified provider payload for each transaction
 - **Rule DSL field renames.** Rules condition trees now use `provider_name`, `provider_merchant_name`, `provider_category_primary`, `provider_category_detailed` instead of the unqualified versions.
 
+### Deprecated
+
+- **MCP tool `list_transaction_comments`** is deprecated in favor of `list_annotations` with `kinds=['comment']`. The new `kinds` filter on `list_annotations` returns the same comment data using the canonical annotation shape. The legacy tool still works for now but will be removed in a future release. (#776)
+
+### Added
+
+- **MCP tool `list_annotations`** now accepts an optional `kinds` filter (`comment`, `rule_applied`, `tag_added`, `tag_removed`, `category_set`). Empty preserves the existing full-timeline behavior. Pass `kinds=['comment']` to get the comment-only view; pass `kinds=['comment','tag_added','tag_removed','category_set']` to skip rule-application churn. (#776)
+
 ## [0.1.0] - 2026-04-XX
 
 ### Added

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -195,6 +195,13 @@ Use this to close a review entry: `set category + remove needs-review (with note
 
 Return the activity timeline for a transaction. Each row is one of: `comment`, `tag_added`, `tag_removed`, `rule_applied`, `category_set`.
 
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `transaction_id` | string | UUID or short ID. Required. |
+| `kinds` | array | Optional kind filter. Any of: `comment`, `rule_applied`, `tag_added`, `tag_removed`, `category_set`. Empty (default) returns all kinds. |
+
+The `kinds` filter is the canonical replacement for the deprecated `list_transaction_comments` tool — pass `kinds=['comment']` for the comment-only view. Pass `kinds=['comment','tag_added','tag_removed','category_set']` to skip rule-application churn.
+
 ### create_tag / update_tag / delete_tag (Write)
 
 Admin-only tag CRUD. Agents typically don't need these — `add_transaction_tag` auto-creates tags on demand. Use these to set display name, color, or cascade-delete a tag.
@@ -353,9 +360,9 @@ Add a comment to a transaction.
 | `transaction_id` | string | Transaction ID |
 | `body` | string | Comment text |
 
-### list_transaction_comments (Read)
+### list_transaction_comments (Read) — Deprecated
 
-List comments on a transaction.
+Deprecated: prefer `list_annotations` with `kinds=['comment']`. Returns the same comment data with renamed fields (`author_*` instead of `actor_*`, `content` lifted out of `payload`). Will be removed in a future release.
 
 ### submit_report (Write)
 

--- a/docs/mcp-tools-reference.md
+++ b/docs/mcp-tools-reference.md
@@ -193,14 +193,21 @@ Use this to close a review entry: `set category + remove needs-review (with note
 
 ### list_annotations (Read)
 
-Return the activity timeline for a transaction. Each row is one of: `comment`, `tag_added`, `tag_removed`, `rule_applied`, `category_set`.
+Return the activity timeline for a transaction. Each row carries a generic `kind` plus an `action` for the specific event:
+
+| `kind` | `action` values | Notes |
+|--------|-----------------|-------|
+| `comment` | _(omitted)_ | Free-form comment. `payload.content` carries the body. |
+| `rule` | `applied` | A transaction rule fired. `payload.rule_name`, `rule_id` populated. |
+| `tag` | `added` / `removed` | Tag attached to or detached from the transaction. `tag_id` and `payload.slug` populated. |
+| `category` | `set` | Category was set (manual override or via rule). |
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `transaction_id` | string | UUID or short ID. Required. |
-| `kinds` | array | Optional kind filter. Any of: `comment`, `rule_applied`, `tag_added`, `tag_removed`, `category_set`. Empty (default) returns all kinds. |
+| `kinds` | array | Optional kind filter. Any of: `comment`, `rule`, `tag`, `category`. Empty (default) returns all kinds. |
 
-The `kinds` filter is the canonical replacement for the deprecated `list_transaction_comments` tool — pass `kinds=['comment']` for the comment-only view. Pass `kinds=['comment','tag_added','tag_removed','category_set']` to skip rule-application churn.
+The `kinds` filter is the canonical replacement for the deprecated `list_transaction_comments` tool — pass `kinds=['comment']` for the comment-only view. Pass `kinds=['comment','tag','category']` to skip rule-application churn. Branch on `action` when the add-vs-remove distinction matters (e.g. building a tag-history view).
 
 ### create_tag / update_tag / delete_tag (Write)
 

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -663,7 +663,7 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 		// Annotations are the canonical activity-timeline source. Review
 		// lifecycle events flow through tag_added / tag_removed annotations
 		// for the needs-review tag.
-		annotations, err := svc.ListAnnotations(ctx, idStr)
+		annotations, err := svc.ListAnnotations(ctx, idStr, service.ListAnnotationsParams{})
 		if err != nil && !errors.Is(err, service.ErrNotFound) {
 			a.Logger.Error("list transaction annotations", "error", err)
 		}

--- a/internal/mcp/response_shapes_integration_test.go
+++ b/internal/mcp/response_shapes_integration_test.go
@@ -249,9 +249,10 @@ func TestListAccountsResponseShape(t *testing.T) {
 	requireAbsent(t, "list_accounts[0]", acct, "provider")
 }
 
-// TestListAnnotationsResponseShape pins annotation event shape: `kind` (not
-// `type`), actor split across actor_type/actor_name/actor_id (not a single
-// `actor` string).
+// TestListAnnotationsResponseShape pins annotation event shape: generic `kind`
+// (comment | rule | tag | category) paired with an `action` field for the
+// specific event, actor split across actor_type/actor_name/actor_id (not a
+// single `actor` string), and the raw DB-only kind values must NOT leak.
 func TestListAnnotationsResponseShape(t *testing.T) {
 	f := seedFixtures(t)
 	res, _, err := f.svc.handleListAnnotations(f.ctx, nil, listAnnotationsInput{
@@ -259,26 +260,42 @@ func TestListAnnotationsResponseShape(t *testing.T) {
 	})
 	out := decodeToolResult[[]any](t, "list_annotations", res, err)
 	if len(out) == 0 {
-		t.Fatal("expected at least one annotation (tag_added from seeding)")
+		t.Fatal("expected at least one annotation (tag from seeding)")
 	}
 	ann := asObject(t, "list_annotations[0]", out[0])
 	requireKeys(t, "list_annotations[0]", ann,
-		"id", "transaction_id", "kind",
+		"id", "transaction_id", "kind", "action",
 		"actor_type", "actor_name", "created_at",
 	)
 	requireAbsent(t, "list_annotations[0]", ann, "actor", "type", "event_type")
+
+	kind, _ := ann["kind"].(string)
+	switch kind {
+	case "comment", "rule", "tag", "category":
+		// expected generic kind
+	default:
+		t.Errorf("list_annotations[0]: kind=%q is not one of the generic MCP kinds", kind)
+	}
+	if kind == "tag" {
+		if action, _ := ann["action"].(string); action != "added" && action != "removed" {
+			t.Errorf("list_annotations[0]: tag row must carry action=added|removed, got %q", action)
+		}
+	}
 }
 
-// TestListAnnotationsKindsFilter pins behavioral parity with the deprecated
-// list_transaction_comments tool. Both tools must return the same comment-row
-// IDs when list_annotations is filtered to kinds=['comment']. Also verifies
-// the kinds filter actually scopes the response and that an invalid kind is
-// rejected at the boundary.
+// TestListAnnotationsKindsFilter exercises the generic-kind filter and pins
+// behavioral parity with the deprecated list_transaction_comments tool. Both
+// tools must return the same comment-row IDs when list_annotations is filtered
+// to kinds=['comment']. Also verifies kinds=['tag'] returns both add+remove
+// events, that raw DB kinds (tag_added, tag_removed, rule_applied, category_set)
+// are NOT accepted at the MCP boundary, and that unknown kinds are rejected.
 func TestListAnnotationsKindsFilter(t *testing.T) {
 	f := seedFixtures(t)
 
 	// Seed at least one comment so list_transaction_comments has something to
-	// return — the base fixture only seeds a tag_added annotation.
+	// return — the base fixture only seeds a tag-added annotation. Also remove
+	// the seeded tag to produce a tag-removed event so the kinds=['tag'] check
+	// has both sides to find.
 	addRes, _, err := f.svc.handleAddTransactionComment(f.ctx, nil, addTransactionCommentInput{
 		WriteSessionContext: WriteSessionContext{SessionID: "sess", Reason: "kinds-parity"},
 		TransactionID:       f.txnID,
@@ -286,13 +303,21 @@ func TestListAnnotationsKindsFilter(t *testing.T) {
 	})
 	_ = decodeToolResult[map[string]any](t, "add_transaction_comment", addRes, err)
 
-	// Unfiltered: full timeline includes the tag_added + the comment.
+	rmRes, _, err := f.svc.handleRemoveTransactionTag(f.ctx, nil, removeTransactionTagInput{
+		WriteSessionContext: WriteSessionContext{SessionID: "sess", Reason: "kinds-tag-pair"},
+		TransactionID:       f.txnID,
+		TagSlug:             "needs-review",
+		Note:                "kinds-filter test",
+	})
+	_ = decodeToolResult[map[string]any](t, "remove_transaction_tag", rmRes, err)
+
+	// Unfiltered: full timeline includes the tag add + tag remove + comment.
 	allRes, _, err := f.svc.handleListAnnotations(f.ctx, nil, listAnnotationsInput{
 		TransactionID: f.txnID,
 	})
 	all := decodeToolResult[[]any](t, "list_annotations", allRes, err)
-	if len(all) < 2 {
-		t.Fatalf("expected at least 2 annotations (tag_added + comment), got %d", len(all))
+	if len(all) < 3 {
+		t.Fatalf("expected at least 3 annotations (tag added + tag removed + comment), got %d", len(all))
 	}
 
 	// Filtered to kind=comment.
@@ -307,12 +332,43 @@ func TestListAnnotationsKindsFilter(t *testing.T) {
 	commentIDs := map[string]struct{}{}
 	for i, raw := range comments {
 		ann := asObject(t, "list_annotations[comment]", raw)
-		kind, _ := ann["kind"].(string)
-		if kind != "comment" {
+		if kind, _ := ann["kind"].(string); kind != "comment" {
 			t.Errorf("list_annotations[%d]: kinds=['comment'] yielded kind=%q", i, kind)
+		}
+		if action, ok := ann["action"]; ok && action != "" {
+			t.Errorf("list_annotations[%d]: comment row should not carry action, got %v", i, action)
 		}
 		id, _ := ann["id"].(string)
 		commentIDs[id] = struct{}{}
+	}
+
+	// kinds=['tag'] expands to both tag_added and tag_removed at the DB layer;
+	// the response should carry generic kind=tag plus action=added|removed.
+	tagRes, _, err := f.svc.handleListAnnotations(f.ctx, nil, listAnnotationsInput{
+		TransactionID: f.txnID,
+		Kinds:         []string{"tag"},
+	})
+	tags := decodeToolResult[[]any](t, "list_annotations", tagRes, err)
+	if len(tags) < 2 {
+		t.Fatalf("kinds=['tag'] expected to expand to add+remove (>=2 rows), got %d", len(tags))
+	}
+	sawAdded, sawRemoved := false, false
+	for i, raw := range tags {
+		ann := asObject(t, "list_annotations[tag]", raw)
+		if kind, _ := ann["kind"].(string); kind != "tag" {
+			t.Errorf("list_annotations[%d]: kinds=['tag'] yielded kind=%q", i, kind)
+		}
+		switch ann["action"] {
+		case "added":
+			sawAdded = true
+		case "removed":
+			sawRemoved = true
+		default:
+			t.Errorf("list_annotations[%d]: tag row carries unexpected action %v", i, ann["action"])
+		}
+	}
+	if !sawAdded || !sawRemoved {
+		t.Errorf("kinds=['tag'] should surface both actions; sawAdded=%v sawRemoved=%v", sawAdded, sawRemoved)
 	}
 
 	// Parity with the deprecated list_transaction_comments tool: same set
@@ -332,7 +388,19 @@ func TestListAnnotationsKindsFilter(t *testing.T) {
 		}
 	}
 
-	// Invalid kind is rejected at the boundary instead of silently returning
+	// Raw DB kinds are NOT accepted at the MCP boundary — agents must use the
+	// generic names.
+	for _, rawKind := range []string{"tag_added", "tag_removed", "rule_applied", "category_set"} {
+		res, _, _ := f.svc.handleListAnnotations(f.ctx, nil, listAnnotationsInput{
+			TransactionID: f.txnID,
+			Kinds:         []string{rawKind},
+		})
+		if res == nil || !res.IsError {
+			t.Errorf("expected error envelope for raw DB kind %q (must use generic name)", rawKind)
+		}
+	}
+
+	// Unknown kind is rejected at the boundary instead of silently returning
 	// an empty slice.
 	badRes, _, _ := f.svc.handleListAnnotations(f.ctx, nil, listAnnotationsInput{
 		TransactionID: f.txnID,

--- a/internal/mcp/response_shapes_integration_test.go
+++ b/internal/mcp/response_shapes_integration_test.go
@@ -269,6 +269,80 @@ func TestListAnnotationsResponseShape(t *testing.T) {
 	requireAbsent(t, "list_annotations[0]", ann, "actor", "type", "event_type")
 }
 
+// TestListAnnotationsKindsFilter pins behavioral parity with the deprecated
+// list_transaction_comments tool. Both tools must return the same comment-row
+// IDs when list_annotations is filtered to kinds=['comment']. Also verifies
+// the kinds filter actually scopes the response and that an invalid kind is
+// rejected at the boundary.
+func TestListAnnotationsKindsFilter(t *testing.T) {
+	f := seedFixtures(t)
+
+	// Seed at least one comment so list_transaction_comments has something to
+	// return — the base fixture only seeds a tag_added annotation.
+	addRes, _, err := f.svc.handleAddTransactionComment(f.ctx, nil, addTransactionCommentInput{
+		WriteSessionContext: WriteSessionContext{SessionID: "sess", Reason: "kinds-parity"},
+		TransactionID:       f.txnID,
+		Content:             "Kinds-filter parity check",
+	})
+	_ = decodeToolResult[map[string]any](t, "add_transaction_comment", addRes, err)
+
+	// Unfiltered: full timeline includes the tag_added + the comment.
+	allRes, _, err := f.svc.handleListAnnotations(f.ctx, nil, listAnnotationsInput{
+		TransactionID: f.txnID,
+	})
+	all := decodeToolResult[[]any](t, "list_annotations", allRes, err)
+	if len(all) < 2 {
+		t.Fatalf("expected at least 2 annotations (tag_added + comment), got %d", len(all))
+	}
+
+	// Filtered to kind=comment.
+	commentRes, _, err := f.svc.handleListAnnotations(f.ctx, nil, listAnnotationsInput{
+		TransactionID: f.txnID,
+		Kinds:         []string{"comment"},
+	})
+	comments := decodeToolResult[[]any](t, "list_annotations", commentRes, err)
+	if len(comments) == 0 {
+		t.Fatal("kinds=['comment'] returned 0 rows; expected at least the seeded comment")
+	}
+	commentIDs := map[string]struct{}{}
+	for i, raw := range comments {
+		ann := asObject(t, "list_annotations[comment]", raw)
+		kind, _ := ann["kind"].(string)
+		if kind != "comment" {
+			t.Errorf("list_annotations[%d]: kinds=['comment'] yielded kind=%q", i, kind)
+		}
+		id, _ := ann["id"].(string)
+		commentIDs[id] = struct{}{}
+	}
+
+	// Parity with the deprecated list_transaction_comments tool: same set
+	// of annotation IDs.
+	legacyRes, _, err := f.svc.handleListTransactionComments(f.ctx, nil, listTransactionCommentsInput{
+		TransactionID: f.txnID,
+	})
+	legacy := decodeToolResult[[]any](t, "list_transaction_comments", legacyRes, err)
+	if len(legacy) != len(comments) {
+		t.Fatalf("parity: list_transaction_comments returned %d rows, list_annotations(kinds=['comment']) returned %d", len(legacy), len(comments))
+	}
+	for i, raw := range legacy {
+		c := asObject(t, "list_transaction_comments[parity]", raw)
+		id, _ := c["id"].(string)
+		if _, ok := commentIDs[id]; !ok {
+			t.Errorf("list_transaction_comments[%d] id=%q missing from list_annotations(kinds=['comment'])", i, id)
+		}
+	}
+
+	// Invalid kind is rejected at the boundary instead of silently returning
+	// an empty slice.
+	badRes, _, _ := f.svc.handleListAnnotations(f.ctx, nil, listAnnotationsInput{
+		TransactionID: f.txnID,
+		Kinds:         []string{"bogus_kind"},
+	})
+	if badRes == nil || !badRes.IsError {
+		t.Fatalf("expected error envelope for invalid kind, got %+v", badRes)
+	}
+}
+
 // TestListTransactionMatchesResponseShape pins matched_on (not matched_fields),
 // match_confidence (not confidence), account_link_id (not link_id), plus
 // the denormalized txn fields agents rely on.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -83,7 +83,7 @@ ACCOUNT LINKING:
 
 REPORTS & COMMUNICATION:
 - Tools: submit_report, add_transaction_comment, list_annotations
-- list_annotations is the canonical read path for the per-transaction activity timeline (comments + tag events + rule applications + category sets). Use it to see prior context before acting. Pass kinds=['comment'] for the comment-only view; pass kinds=['comment','tag_added','tag_removed','category_set'] to skip rule churn.
+- list_annotations is the canonical read path for the per-transaction activity timeline. Each row has a generic kind (comment | rule | tag | category) plus an action (added | removed | set | applied) for the specific event. Filter via kinds=['comment'] for the comment-only view, kinds=['tag'] for both add+remove tag events, kinds=['comment','tag','category'] to skip rule churn.
 - list_transaction_comments is deprecated — keep agents on list_annotations(kinds=['comment']).
 - Before submitting reports, read breadbox://report-format for report structure and formatting guidelines.
 
@@ -405,7 +405,7 @@ func (s *MCPServer) buildToolRegistry() {
 			"List all tags registered in the system. Each tag has a slug (stable identifier) and a display_name. Tags attached to transactions can be queried via the tags / any_tag filters on query_transactions.",
 			s.handleListTags, svc),
 		makeToolDefLogged("list_annotations", ToolRead,
-			"List the activity timeline for a transaction. Each annotation is a single event: comment, tag_added, tag_removed, rule_applied, or category_set. Ordered by created_at ASC. Payload carries kind-specific fields (content for comments, slug for tags, rule_name for rule applications). Pass kinds=['comment'] for the comment-only view (replaces the deprecated list_transaction_comments). Empty kinds returns the full timeline.",
+			"List the activity timeline for a transaction, ordered by created_at ASC. Each row carries a generic `kind` (comment | rule | tag | category) plus an `action` (added | removed | set | applied) for the specific event — branch on `action` when the distinction matters (e.g. tag added vs removed). Payload carries kind-specific fields (content for comments, slug for tag events, rule_name for rule applications). Pass kinds=['comment'] for the comment-only view (replaces the deprecated list_transaction_comments); pass kinds=['tag'] for all tag events. Empty kinds returns the full timeline.",
 			s.handleListAnnotations, svc),
 		makeToolDefLogged("add_transaction_tag", ToolWrite,
 			"Attach a tag to a transaction. Tags are an open-ended labeling system — auto-creates a persistent tag if the slug doesn't exist yet. Use note to attach a short rationale that is stored on the tag_added annotation. Idempotent: returns already_present=true if the tag was already attached.",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -82,8 +82,9 @@ ACCOUNT LINKING:
 - reconcile_account_link: re-run matching. confirm_match / reject_match: correct errors.
 
 REPORTS & COMMUNICATION:
-- Tools: submit_report, add_transaction_comment, list_transaction_comments, list_annotations
-- list_annotations returns the full activity timeline for a transaction (comments + tag events + rule applications + category sets). Use it to see prior context before acting.
+- Tools: submit_report, add_transaction_comment, list_annotations
+- list_annotations is the canonical read path for the per-transaction activity timeline (comments + tag events + rule applications + category sets). Use it to see prior context before acting. Pass kinds=['comment'] for the comment-only view; pass kinds=['comment','tag_added','tag_removed','category_set'] to skip rule churn.
+- list_transaction_comments is deprecated — keep agents on list_annotations(kinds=['comment']).
 - Before submitting reports, read breadbox://report-format for report structure and formatting guidelines.
 
 USER ROLES:
@@ -334,7 +335,7 @@ func (s *MCPServer) buildToolRegistry() {
 			"Add a free-standing comment to a transaction — narrative that's independent of any specific review decision (flagging unusual charges, noting shared expenses, cross-references, context that outlives a single review cycle). Supports markdown. IMPORTANT: when the comment is the rationale for a tag change or category set, pass it as part of an update_transactions operation (inline `comment`, or `note` on a tags_to_add/tags_to_remove entry) instead — those paths write a single linked annotation so the activity log doesn't double up.",
 			s.handleAddTransactionComment, svc),
 		makeToolDefLogged("list_transaction_comments", ToolRead,
-			"List all comments on a transaction, ordered chronologically. Check comments before making changes to understand prior context and decisions by other agents or family members.",
+			"Deprecated: prefer list_annotations with kinds=['comment']. Returns the same comment data with renamed fields (author_* instead of actor_*, content lifted out of payload). Will be removed in a future release.",
 			s.handleListTransactionComments, svc),
 		makeToolDefLogged("transaction_summary", ToolRead,
 			"Get aggregated transaction totals grouped by category and/or time period. Replaces the need to paginate through thousands of individual transactions for spending analysis. Amounts follow the convention: positive = money out (debit), negative = money in (credit). Only includes non-deleted, non-pending transactions by default.",
@@ -404,7 +405,7 @@ func (s *MCPServer) buildToolRegistry() {
 			"List all tags registered in the system. Each tag has a slug (stable identifier) and a display_name. Tags attached to transactions can be queried via the tags / any_tag filters on query_transactions.",
 			s.handleListTags, svc),
 		makeToolDefLogged("list_annotations", ToolRead,
-			"List the activity timeline for a transaction. Each annotation is a single event: comment, tag_added, tag_removed, rule_applied, or category_set. Ordered by created_at ASC. Payload carries kind-specific fields (content for comments, slug for tags, rule_name for rule applications).",
+			"List the activity timeline for a transaction. Each annotation is a single event: comment, tag_added, tag_removed, rule_applied, or category_set. Ordered by created_at ASC. Payload carries kind-specific fields (content for comments, slug for tags, rule_name for rule applications). Pass kinds=['comment'] for the comment-only view (replaces the deprecated list_transaction_comments). Empty kinds returns the full timeline.",
 			s.handleListAnnotations, svc),
 		makeToolDefLogged("add_transaction_tag", ToolWrite,
 			"Attach a tag to a transaction. Tags are an open-ended labeling system — auto-creates a persistent tag if the slug doesn't exist yet. Use note to attach a short rationale that is stored on the tag_added annotation. Idempotent: returns already_present=true if the tag was already attached.",

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -19,21 +19,21 @@ type listTagsInput struct {
 type listAnnotationsInput struct {
 	ReadSessionContext
 	TransactionID string   `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
-	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule_applied, tag_added, tag_removed, category_set. Empty = all kinds. Pass ['comment'] to get the comment-only timeline that list_transaction_comments used to provide."`
+	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule, tag, category. Empty = all kinds. Pass ['comment'] for the comment-only timeline (replaces list_transaction_comments). Pass ['tag'] to see both add+remove events; the response carries an 'action' field (added|removed|set|applied) for the specific event."`
 }
 
 type addTransactionTagInput struct {
 	WriteSessionContext
 	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
 	TagSlug       string `json:"tag_slug" jsonschema:"required,Tag slug to add (e.g. 'needs-review'). Auto-created as persistent if not registered."`
-	Note          string `json:"note,omitempty" jsonschema:"Optional note attached to the tag_added annotation."`
+	Note          string `json:"note,omitempty" jsonschema:"Optional note recorded on the resulting tag annotation (action=added)."`
 }
 
 type removeTransactionTagInput struct {
 	WriteSessionContext
 	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
 	TagSlug       string `json:"tag_slug" jsonschema:"required,Tag slug to remove"`
-	Note          string `json:"note,omitempty" jsonschema:"Optional rationale recorded on the tag_removed annotation."`
+	Note          string `json:"note,omitempty" jsonschema:"Optional rationale recorded on the resulting tag annotation (action=removed)."`
 }
 
 type createTagInput struct {
@@ -75,13 +75,12 @@ func (s *MCPServer) handleListAnnotations(_ context.Context, _ *mcpsdk.CallToolR
 	if input.TransactionID == "" {
 		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
 	}
-	for _, k := range input.Kinds {
-		if !validAnnotationKind(k) {
-			return errorResult(fmt.Errorf("invalid kind %q: expected one of comment, rule_applied, tag_added, tag_removed, category_set", k)), nil, nil
-		}
+	dbKinds, err := mapAnnotationKinds(input.Kinds)
+	if err != nil {
+		return errorResult(err), nil, nil
 	}
 	annotations, err := s.svc.ListAnnotations(ctx, input.TransactionID, service.ListAnnotationsParams{
-		Kinds: input.Kinds,
+		Kinds: dbKinds,
 	})
 	if err != nil {
 		if errors.Is(err, service.ErrNotFound) {
@@ -89,17 +88,110 @@ func (s *MCPServer) handleListAnnotations(_ context.Context, _ *mcpsdk.CallToolR
 		}
 		return errorResult(err), nil, nil
 	}
-	return jsonResult(annotations)
+	return jsonResult(toMCPAnnotations(annotations))
 }
 
-// validAnnotationKind enforces the annotations.kind CHECK constraint at the
-// MCP boundary so agents get a clear error instead of a silent empty result.
-func validAnnotationKind(k string) bool {
-	switch k {
-	case "comment", "rule_applied", "tag_added", "tag_removed", "category_set":
-		return true
+// mcpAnnotationKinds enumerates the generic kinds exposed at the MCP boundary.
+// The DB CHECK constraint stores finer-grained values (tag_added vs tag_removed,
+// rule_applied, category_set) — agents see one normalized name plus an `action`
+// field on each row.
+var mcpAnnotationKinds = map[string][]string{
+	"comment":  {"comment"},
+	"rule":     {"rule_applied"},
+	"tag":      {"tag_added", "tag_removed"},
+	"category": {"category_set"},
+}
+
+// mapAnnotationKinds translates the agent-facing generic kinds into the raw DB
+// kinds the service layer filters by. Returns nil for an empty input (no
+// filter). Rejects unknown kinds at the boundary so agents get a clear error
+// instead of a silent empty slice.
+func mapAnnotationKinds(kinds []string) ([]string, error) {
+	if len(kinds) == 0 {
+		return nil, nil
 	}
-	return false
+	out := make([]string, 0, len(kinds))
+	seen := make(map[string]bool, len(kinds))
+	for _, k := range kinds {
+		raw, ok := mcpAnnotationKinds[k]
+		if !ok {
+			return nil, fmt.Errorf("invalid kind %q: expected one of comment, rule, tag, category", k)
+		}
+		for _, r := range raw {
+			if seen[r] {
+				continue
+			}
+			seen[r] = true
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+// mcpAnnotation is the agent-facing annotation shape. `kind` is the generic
+// name (comment | rule | tag | category); `action` carries the specific event
+// (added | removed | set | applied) so agents can branch without parsing the
+// kind string. Comment rows omit `action` since there is only one event.
+type mcpAnnotation struct {
+	ID            string                 `json:"id"`
+	ShortID       string                 `json:"short_id"`
+	TransactionID string                 `json:"transaction_id"`
+	Kind          string                 `json:"kind"`
+	Action        string                 `json:"action,omitempty"`
+	ActorType     string                 `json:"actor_type"`
+	ActorID       *string                `json:"actor_id,omitempty"`
+	ActorName     string                 `json:"actor_name"`
+	SessionID     *string                `json:"session_id,omitempty"`
+	Payload       map[string]interface{} `json:"payload,omitempty"`
+	TagID         *string                `json:"tag_id,omitempty"`
+	RuleID        *string                `json:"rule_id,omitempty"`
+	CreatedAt     string                 `json:"created_at"`
+}
+
+// dbKindToMCP translates a stored DB kind into the (kind, action) pair surfaced
+// to MCP clients. Unknown kinds round-trip unchanged so future kinds don't
+// silently disappear from the timeline.
+func dbKindToMCP(dbKind string) (kind, action string) {
+	switch dbKind {
+	case "comment":
+		return "comment", ""
+	case "rule_applied":
+		return "rule", "applied"
+	case "tag_added":
+		return "tag", "added"
+	case "tag_removed":
+		return "tag", "removed"
+	case "category_set":
+		return "category", "set"
+	}
+	return dbKind, ""
+}
+
+func toMCPAnnotation(a service.Annotation) mcpAnnotation {
+	kind, action := dbKindToMCP(a.Kind)
+	return mcpAnnotation{
+		ID:            a.ID,
+		ShortID:       a.ShortID,
+		TransactionID: a.TransactionID,
+		Kind:          kind,
+		Action:        action,
+		ActorType:     a.ActorType,
+		ActorID:       a.ActorID,
+		ActorName:     a.ActorName,
+		SessionID:     a.SessionID,
+		Payload:       a.Payload,
+		TagID:         a.TagID,
+		RuleID:        a.RuleID,
+		CreatedAt:     a.CreatedAt,
+	}
+}
+
+func toMCPAnnotations(in []service.Annotation) []mcpAnnotation {
+	out := make([]mcpAnnotation, len(in))
+	for i, a := range in {
+		out[i] = toMCPAnnotation(a)
+	}
+	return out
 }
 
 func (s *MCPServer) handleAddTransactionTag(ctx context.Context, _ *mcpsdk.CallToolRequest, input addTransactionTagInput) (*mcpsdk.CallToolResult, any, error) {

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -18,7 +18,8 @@ type listTagsInput struct {
 
 type listAnnotationsInput struct {
 	ReadSessionContext
-	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
+	TransactionID string   `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
+	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule_applied, tag_added, tag_removed, category_set. Empty = all kinds. Pass ['comment'] to get the comment-only timeline that list_transaction_comments used to provide."`
 }
 
 type addTransactionTagInput struct {
@@ -74,7 +75,14 @@ func (s *MCPServer) handleListAnnotations(_ context.Context, _ *mcpsdk.CallToolR
 	if input.TransactionID == "" {
 		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
 	}
-	annotations, err := s.svc.ListAnnotations(ctx, input.TransactionID)
+	for _, k := range input.Kinds {
+		if !validAnnotationKind(k) {
+			return errorResult(fmt.Errorf("invalid kind %q: expected one of comment, rule_applied, tag_added, tag_removed, category_set", k)), nil, nil
+		}
+	}
+	annotations, err := s.svc.ListAnnotations(ctx, input.TransactionID, service.ListAnnotationsParams{
+		Kinds: input.Kinds,
+	})
 	if err != nil {
 		if errors.Is(err, service.ErrNotFound) {
 			return errorResult(fmt.Errorf("transaction not found")), nil, nil
@@ -82,6 +90,16 @@ func (s *MCPServer) handleListAnnotations(_ context.Context, _ *mcpsdk.CallToolR
 		return errorResult(err), nil, nil
 	}
 	return jsonResult(annotations)
+}
+
+// validAnnotationKind enforces the annotations.kind CHECK constraint at the
+// MCP boundary so agents get a clear error instead of a silent empty result.
+func validAnnotationKind(k string) bool {
+	switch k {
+	case "comment", "rule_applied", "tag_added", "tag_removed", "category_set":
+		return true
+	}
+	return false
 }
 
 func (s *MCPServer) handleAddTransactionTag(ctx context.Context, _ *mcpsdk.CallToolRequest, input addTransactionTagInput) (*mcpsdk.CallToolResult, any, error) {

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -88,9 +88,20 @@ func writeAnnotation(ctx context.Context, q *db.Queries, params writeAnnotationP
 	return nil
 }
 
-// ListAnnotations returns all annotations for a transaction, ordered by
-// created_at ASC. Drives the transaction detail activity timeline.
-func (s *Service) ListAnnotations(ctx context.Context, transactionID string) ([]Annotation, error) {
+// ListAnnotationsParams carries optional filters for ListAnnotations. Empty
+// fields preserve current behavior (return everything).
+type ListAnnotationsParams struct {
+	// Kinds limits results to specific annotation kinds (any of:
+	// comment | rule_applied | tag_added | tag_removed | category_set).
+	// Empty = no filter.
+	Kinds []string
+}
+
+// ListAnnotations returns annotations for a transaction, ordered by created_at
+// ASC. Drives the transaction detail activity timeline. Pass an empty
+// ListAnnotationsParams for the full timeline; use Kinds to scope the result
+// (e.g. comments only).
+func (s *Service) ListAnnotations(ctx context.Context, transactionID string, params ListAnnotationsParams) ([]Annotation, error) {
 	txnID, err := s.resolveTransactionID(ctx, transactionID)
 	if err != nil {
 		return nil, ErrNotFound
@@ -105,11 +116,28 @@ func (s *Service) ListAnnotations(ctx context.Context, transactionID string) ([]
 		return nil, fmt.Errorf("list annotations: %w", err)
 	}
 
-	result := make([]Annotation, len(rows))
-	for i, r := range rows {
-		result[i] = annotationFromActorRow(r)
+	keep := annotationKindFilter(params.Kinds)
+	result := make([]Annotation, 0, len(rows))
+	for _, r := range rows {
+		if keep != nil && !keep[r.Kind] {
+			continue
+		}
+		result = append(result, annotationFromActorRow(r))
 	}
 	return result, nil
+}
+
+// annotationKindFilter builds an O(1) lookup set from a kinds slice. Returns
+// nil when no filter is supplied so callers can short-circuit.
+func annotationKindFilter(kinds []string) map[string]bool {
+	if len(kinds) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(kinds))
+	for _, k := range kinds {
+		set[k] = true
+	}
+	return set
 }
 
 // annotationFromRow converts a db.Annotation into its service-layer response.


### PR DESCRIPTION
Fixes #776

Adds an optional `kinds` filter to `list_annotations` and deprecates the redundant `list_transaction_comments` tool, which was a strict subset of `list_annotations` with renamed fields. Agents should use `list_annotations(kinds=['comment'])` for the comment-only timeline going forward.

The MCP boundary exposes **generic, agent-friendly kinds** — `comment`, `rule`, `tag`, `category` — instead of leaking the four DB-level kinds (`tag_added`, `tag_removed`, `rule_applied`, `category_set`). Each response row pairs a generic `kind` with a separate `action` field (`added` | `removed` | `set` | `applied`) so agents can branch on the specific event without parsing kind strings.

## Why

`list_transaction_comments` and `list_annotations` already shared their query path — the legacy tool just post-filtered for `kind=='comment'` and renamed `actor_*` to `author_*`. Two read tools for the same data costs an agent-context slot at every tool-listing call, gives agents two near-identical names to choose between, and forks the maintenance path (e.g. #703's `CommentID` regression rode only one of the two).

On top of that, the original DB enum (`tag_added` / `tag_removed` / `category_set` / `rule_applied`) made the agent guess "do I want both tag_added AND tag_removed?" every time. Generic kinds + a separate `action` field is what an agent actually wants — one filter for "all tag events", with branching info still available when needed.

The recommended path from the issue (path 1) keeps backwards compatibility: the deprecated tool still works and points at the canonical replacement; removal is left for a future release with a `BREAKING` note in CHANGELOG.

## What changed

- `internal/service/annotations.go` — `Service.ListAnnotations` now takes a `ListAnnotationsParams` struct. Empty params preserve current behavior. Filtering happens in Go after the existing query (per-transaction N is small, no SQL change needed). Service layer continues to filter by **raw DB kinds** so the admin UI (which reads `service.Annotation.Kind` directly and renders kind-specific timeline rows) stays unchanged.
- `internal/mcp/tools_tags.go` — generic `kinds` filter at the MCP boundary, mapping to DB kinds via `mcpAnnotationKinds`. Response normalized to a new `mcpAnnotation` shape with `kind` + `action`. Invalid or raw DB kinds are rejected at the boundary instead of returning a silent empty slice.
- `internal/mcp/server.go` — `list_annotations` description rewritten around the generic kinds + `action` field; `list_transaction_comments` description marked deprecated and points at the replacement; server-instructions block reflects the same.
- `internal/admin/transactions.go` — admin activity timeline call site passes empty params (no behavior change; admin UI still sees the raw DB kinds).
- `internal/mcp/response_shapes_integration_test.go` —
  - `TestListAnnotationsResponseShape` now pins the generic kind enum + the presence of `action`, and asserts raw DB kind values do **not** leak.
  - `TestListAnnotationsKindsFilter` exercises kinds=['tag'] expansion to add+remove, asserts response shape (`kind: 'tag', action: 'added'|'removed'`), enforces parity with `list_transaction_comments` by ID set, and rejects raw DB kinds (`tag_added`, `tag_removed`, etc.) at the boundary alongside arbitrary unknown kinds.
- `docs/mcp-tools-reference.md` — documents the generic kinds, the `action` matrix per kind, and marks the legacy tool deprecated.
- `CHANGELOG.md` — adds `Deprecated` and `Added` entries under `[Unreleased]`.

## Token-budget note

Tool count is unchanged in this PR (deprecated tool is preserved for one release). The `list_annotations` description grew modestly to document the generic-kind matrix; `list_transaction_comments` shrank to a deprecation pointer. The token win materializes when the legacy tool is removed in a future release — at that point one full `Tool` entry (name + description + JSON schema) drops out of every `tools/list` response. The generic-kinds reshaping is a usability win for agents, not a token win.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit)
- [x] `go test -tags integration -count=1 -p 1 ./internal/mcp/ ./internal/service/` — passes, including `TestListAnnotationsKindsFilter` (kinds=['tag'] → both actions, raw DB kinds rejected, parity vs `list_transaction_comments`) and the existing `TestListAnnotationsResponseShape` / `TestListTransactionCommentsResponseShape` shape pins.

## Notes

- No DB migration; existing query path reused. DB CHECK constraint values (`tag_added` etc.) remain authoritative; only the MCP-facing surface uses the generic names.
- Admin activity timeline at `/transactions/{id}` is unaffected — same call shape into the same query, just an additional zero-value params arg, and the templ renderer still sees raw kinds.
- Followed the issue's recommended path 1 (deprecate, don't remove). Path 2 (immediate removal) was rejected for backwards-compat across externally-deployed agent prompts — same reasoning the issue calls out.
