### PR TITLE
fix(transactions): full-width composer with animated Comment CTA

### DIFF
--- a/input.css
+++ b/input.css
@@ -2268,20 +2268,6 @@
     }
   }
 
-  /* When a KbdCombo lives inside a DaisyUI button (e.g. the transaction
-     comment CTA), DaisyUI's button reset wipes the combo's bg. Re-style
-     it relative to the button's own foreground via currentColor so it
-     reads as a key cap on any btn variant in either theme. */
-  .btn .bb-kbd-combo {
-    background: color-mix(in srgb, currentColor 18%, transparent);
-    color: currentColor;
-    border-color: color-mix(in srgb, currentColor 35%, transparent);
-    box-shadow: none;
-  }
-  .btn .bb-kbd-combo__key + .bb-kbd-combo__key {
-    border-left-color: color-mix(in srgb, currentColor 35%, transparent);
-  }
-
   /* ── Triage mode: compact review rows ── */
   .bb-triage-row {
     @apply relative;

--- a/input.css
+++ b/input.css
@@ -2268,6 +2268,20 @@
     }
   }
 
+  /* When a KbdCombo lives inside a DaisyUI button (e.g. the transaction
+     comment CTA), DaisyUI's button reset wipes the combo's bg. Re-style
+     it relative to the button's own foreground via currentColor so it
+     reads as a key cap on any btn variant in either theme. */
+  .btn .bb-kbd-combo {
+    background: color-mix(in srgb, currentColor 18%, transparent);
+    color: currentColor;
+    border-color: color-mix(in srgb, currentColor 35%, transparent);
+    box-shadow: none;
+  }
+  .btn .bb-kbd-combo__key + .bb-kbd-combo__key {
+    border-left-color: color-mix(in srgb, currentColor 35%, transparent);
+  }
+
   /* ── Triage mode: compact review rows ── */
   .bb-triage-row {
     @apply relative;

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -304,7 +304,7 @@ templ txdActivity(p TransactionDetailProps) {
 					style="display:none"
 				>
 					<span class="text-xs font-medium">Comment</span>
-					@components.KbdCombo("cmd", "enter")
+					<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5" x-show="!$store.device.isTouch">⌘↵</span>
 				</button>
 			</div>
 		</div>

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -292,16 +292,8 @@ templ txdActivity(p TransactionDetailProps) {
 				</span>
 				<button
 					@click="addComment()"
-					class="btn btn-sm btn-primary rounded-xl gap-1.5 origin-right"
-					x-show="newComment.trim().length > 0"
-					x-transition:enter="transition ease-out duration-150"
-					x-transition:enter-start="opacity-0 scale-95 translate-y-1"
-					x-transition:enter-end="opacity-100 scale-100 translate-y-0"
-					x-transition:leave="transition ease-in duration-100"
-					x-transition:leave-start="opacity-100 scale-100 translate-y-0"
-					x-transition:leave-end="opacity-0 scale-95 translate-y-1"
+					class="btn btn-sm btn-primary rounded-xl gap-1.5 transition-all duration-200"
 					:disabled="!canSubmit()"
-					style="display:none"
 				>
 					<span class="text-xs font-medium">Comment</span>
 					<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5" x-show="!$store.device.isTouch">⌘↵</span>

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -278,17 +278,10 @@ templ txdActivity(p TransactionDetailProps) {
 				rows="1"
 				placeholder="Add a note..."
 				maxlength={ fmt.Sprintf("%d", p.MaxCommentLength) }
-				aria-describedby="bb-txd-comment-counter bb-txd-comment-hint"
+				aria-describedby="bb-txd-comment-counter"
 				class="block w-full text-sm bg-base-200/50 border border-base-content/10 focus:border-primary focus:outline-none focus:ring-0 rounded-xl resize-none leading-6 px-3 py-1.5 h-9 min-h-9 max-h-36 overflow-y-hidden whitespace-pre-wrap break-words"
 			></textarea>
 			<div class="mt-1.5 px-0.5 text-[11px] text-base-content/40 flex items-center gap-2 min-h-[1.75rem]">
-				<span id="bb-txd-comment-hint" class="hidden sm:inline-flex items-center gap-1.5 flex-wrap" x-show="!$store.device.isTouch && newComment.length === 0">
-					@components.KbdCombo("cmd", "enter")
-					<span>to post</span>
-					<span class="text-base-content/30" aria-hidden="true">·</span>
-					@components.Kbd("n")
-					<span>to focus</span>
-				</span>
 				<span
 					id="bb-txd-comment-counter"
 					class="ml-auto tabular-nums"

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -267,27 +267,22 @@ templ txdActivity(p TransactionDetailProps) {
 		</div>
 		<!-- Add Note -->
 		<div class="px-4 sm:px-5 pb-4">
-			<div class="flex gap-2 items-start">
-				<label for="bb-txd-comment" class="sr-only">Add a note</label>
-				<textarea
-					id="bb-txd-comment"
-					x-ref="composer"
-					x-model="newComment"
-					@input="autosize($event.target)"
-					@keydown.meta.enter.prevent="canSubmit() && addComment()"
-					@keydown.ctrl.enter.prevent="canSubmit() && addComment()"
-					rows="1"
-					placeholder="Add a note..."
-					maxlength={ fmt.Sprintf("%d", p.MaxCommentLength) }
-					aria-describedby="bb-txd-comment-counter bb-txd-comment-hint"
-					class="flex-1 block w-full text-sm bg-base-200/50 border border-base-content/10 focus:border-primary focus:outline-none focus:ring-0 rounded-xl resize-none leading-6 px-3 py-1.5 h-9 min-h-9 max-h-36 overflow-y-hidden whitespace-pre-wrap break-words"
-				></textarea>
-				<button @click="addComment()" class="btn btn-sm h-9 rounded-xl btn-primary btn-square shrink-0" :disabled="!canSubmit()" aria-label="Post note">
-					<i data-lucide="send" class="w-3.5 h-3.5" aria-hidden="true"></i>
-				</button>
-			</div>
-			<div class="mt-1.5 px-0.5 text-[11px] text-base-content/40 flex items-center gap-2">
-				<span id="bb-txd-comment-hint" class="hidden sm:inline-flex items-center gap-1.5 flex-wrap" x-show="!$store.device.isTouch">
+			<label for="bb-txd-comment" class="sr-only">Add a note</label>
+			<textarea
+				id="bb-txd-comment"
+				x-ref="composer"
+				x-model="newComment"
+				@input="autosize($event.target)"
+				@keydown.meta.enter.prevent="canSubmit() && addComment()"
+				@keydown.ctrl.enter.prevent="canSubmit() && addComment()"
+				rows="1"
+				placeholder="Add a note..."
+				maxlength={ fmt.Sprintf("%d", p.MaxCommentLength) }
+				aria-describedby="bb-txd-comment-counter bb-txd-comment-hint"
+				class="block w-full text-sm bg-base-200/50 border border-base-content/10 focus:border-primary focus:outline-none focus:ring-0 rounded-xl resize-none leading-6 px-3 py-1.5 h-9 min-h-9 max-h-36 overflow-y-hidden whitespace-pre-wrap break-words"
+			></textarea>
+			<div class="mt-1.5 px-0.5 text-[11px] text-base-content/40 flex items-center gap-2 min-h-[1.75rem]">
+				<span id="bb-txd-comment-hint" class="hidden sm:inline-flex items-center gap-1.5 flex-wrap" x-show="!$store.device.isTouch && newComment.length === 0">
 					@components.KbdCombo("cmd", "enter")
 					<span>to post</span>
 					<span class="text-base-content/30" aria-hidden="true">·</span>
@@ -302,6 +297,22 @@ templ txdActivity(p TransactionDetailProps) {
 				>
 					<span x-text="newComment.length"></span> / <span x-text="maxLength"></span>
 				</span>
+				<button
+					@click="addComment()"
+					class="btn btn-sm btn-primary rounded-xl gap-1.5 origin-right"
+					x-show="newComment.trim().length > 0"
+					x-transition:enter="transition ease-out duration-150"
+					x-transition:enter-start="opacity-0 scale-95 translate-y-1"
+					x-transition:enter-end="opacity-100 scale-100 translate-y-0"
+					x-transition:leave="transition ease-in duration-100"
+					x-transition:leave-start="opacity-100 scale-100 translate-y-0"
+					x-transition:leave-end="opacity-0 scale-95 translate-y-1"
+					:disabled="!canSubmit()"
+					style="display:none"
+				>
+					<span class="text-xs font-medium">Comment</span>
+					@components.KbdCombo("cmd", "enter")
+				</button>
 			</div>
 		</div>
 		if len(p.ActivityDays) > 0 {


### PR DESCRIPTION
## Summary

- Composer textarea is now full-width on its own row; the cramped square send icon is gone.
- "Comment ⌘↵" CTA is always visible: disabled when the field is empty, enabled (primary) once there is text. `transition-all duration-200` smooths the disabled→enabled change so the affordance still has motion without the show/hide pop-in.
- Surfaces the existing Cmd/Ctrl+Enter shortcut on the button itself; plain Enter still inserts a newline so multi-line composing works.
- Drops the "⌘↵ to post · N to focus" hint row below the field — redundant now that the CTA carries the shortcut.
- The kbd hint inside the CTA matches the prompt builder's **Copy Prompt** button (a single span with `border-current/30`, `opacity-60`, `text-[10px]`, no fill) so the shortcut chip reads consistently across CTAs and stays legible on a primary button.

## Validation

| Empty (disabled) | Typing (enabled) |
| --- | --- |
| <img src="https://i.img402.dev/s7d7gnmpf3.jpg" width="420" alt="composer empty — disabled CTA"> | <img src="https://i.img402.dev/ry851il90s.jpg" width="420" alt="composer with text — enabled CTA"> |

## Test plan

- [x] `go build ./...`
- [x] Manually exercised on transaction detail (`/transactions/<id>`) at 1280×800: empty state shows the button disabled; typing animates it to the enabled primary state; clearing the textarea animates it back to disabled.
- [x] Cmd+Enter posts the comment; Enter alone keeps inserting newlines.
- [x] kbd hint inside the CTA matches the existing Copy-Prompt pill style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)