### PR TITLE
fix(shortcuts): distinguish page-scoped from global; contain modal overscroll

### DIFF
--- a/input.css
+++ b/input.css
@@ -1559,6 +1559,9 @@
     width: min(95vw, 640px);
     max-height: min(80vh, 560px);
     overflow-y: auto;
+    /* Keep trackpad rubber-band contained so the page behind doesn't bleed
+       through at the top/bottom of the dialog scroll on macOS. */
+    overscroll-behavior: contain;
     box-shadow: 0 16px 70px oklch(0 0 0 / 0.15), 0 0 0 1px oklch(0 0 0 / 0.04);
     animation: bb-shortcuts-dialog-in 0.2s cubic-bezier(0.16, 1, 0.3, 1);
   }
@@ -1606,11 +1609,89 @@
     @apply px-6 py-5;
   }
 
+  /* A "section" wraps either the page-scoped or global block. The page
+     section is tinted with a subtle accent so users can tell at-a-glance
+     which shortcuts only work here vs. everywhere. The global section is
+     plain (no card chrome) when shown alongside a page section. */
+  .bb-shortcuts-section {
+    @apply mb-5;
+  }
+
+  .bb-shortcuts-section:last-child {
+    @apply mb-0;
+  }
+
+  .bb-shortcuts-section--page {
+    @apply rounded-lg px-4 py-4 mb-5;
+    background: oklch(from var(--color-info) l c h / 0.07);
+    border: 1px solid oklch(from var(--color-info) l c h / 0.2);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .bb-shortcuts-section--page {
+      background: oklch(from var(--color-info) l c h / 0.10);
+      border-color: oklch(from var(--color-info) l c h / 0.3);
+    }
+  }
+
+  /* Accent rail down the left edge so it's instantly readable as "scoped". */
+  .bb-shortcuts-section--page {
+    position: relative;
+  }
+
+  .bb-shortcuts-section--page::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0.75rem;
+    bottom: 0.75rem;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--color-info);
+    opacity: 0.55;
+  }
+
+  .bb-shortcuts-section--global {
+    @apply pt-1;
+  }
+
+  .bb-shortcuts-section-head {
+    @apply flex items-baseline gap-2 mb-3;
+  }
+
+  .bb-shortcuts-section-eyebrow {
+    @apply text-[0.6rem] font-semibold uppercase tracking-[0.08em];
+    color: var(--color-info);
+  }
+
+  .bb-shortcuts-section--global .bb-shortcuts-section-eyebrow {
+    @apply text-base-content/45;
+  }
+
+  .bb-shortcuts-section-title {
+    @apply text-[0.7rem] font-medium text-base-content/55;
+  }
+
+  .bb-shortcuts-section-title::before {
+    content: '·';
+    @apply mr-1.5 text-base-content/30;
+  }
+
   .bb-shortcuts-group {
     @apply mb-5;
   }
 
   .bb-shortcuts-group:last-child {
+    @apply mb-0;
+  }
+
+  /* Inside a page section we don't need much extra vertical rhythm — the
+     card chrome already separates groups from the global block. */
+  .bb-shortcuts-section--page .bb-shortcuts-group {
+    @apply mb-3;
+  }
+
+  .bb-shortcuts-section--page .bb-shortcuts-group:last-child {
     @apply mb-0;
   }
 

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -354,27 +354,28 @@
        below for the current bindings. -->
   <div x-data="shortcutsHelp()" x-show="open" x-cloak
        @open-shortcuts.window="openHelp()"
-       @keydown.window.escape="if (open) { open = false; $event.stopPropagation(); }">
-    <div class="bb-shortcuts-backdrop" @click="open = false"></div>
+       @keydown.window.escape="if (open) { closeHelp(); $event.stopPropagation(); }">
+    <div class="bb-shortcuts-backdrop" @click="closeHelp()"></div>
     <div class="bb-shortcuts-dialog">
       <div class="bb-shortcuts-header">
         <span class="bb-shortcuts-title">Keyboard Shortcuts</span>
-        <button class="bb-shortcuts-close" @click="open = false">
+        <button class="bb-shortcuts-close" @click="closeHelp()">
           <i data-lucide="x"></i>
         </button>
       </div>
       <div class="bb-shortcuts-body">
-        <!-- Page section: shortcuts scoped to the current page (populated by
-             pages that call $store.shortcuts.register with a page scope + set
-             $store.shortcuts.currentScope). Rendered ABOVE Global so the
-             page-specific actions are the first thing users see. Hidden
-             entirely when the current scope is 'global' or no page-scoped
-             shortcuts are registered. -->
+        <!-- Page section: shortcuts scoped to the current page. Rendered ABOVE
+             Global so the page-specific actions are the first thing users see.
+             Wrapped in a tinted card with an accent rail so it visually
+             separates from the (always-on) Global section below. Hidden when
+             the current scope is 'global' or no page-scoped shortcuts are
+             registered. -->
         <template x-if="sections.page.length > 0">
-          <div>
-            <div class="bb-shortcuts-group" style="padding-top:0.25rem;">
-              <div class="bb-shortcuts-group-label" style="opacity:0.65;" x-text="sections.pageLabel"></div>
-            </div>
+          <section class="bb-shortcuts-section bb-shortcuts-section--page">
+            <header class="bb-shortcuts-section-head">
+              <span class="bb-shortcuts-section-eyebrow">On this page</span>
+              <span class="bb-shortcuts-section-title" x-text="sections.pageLabel"></span>
+            </header>
             <template x-for="group in sections.page" :key="'page-' + group.label">
               <div class="bb-shortcuts-group">
                 <div class="bb-shortcuts-group-label" x-text="group.label"></div>
@@ -386,19 +387,31 @@
                 </template>
               </div>
             </template>
-          </div>
+          </section>
         </template>
-        <!-- Global section: shortcuts available on every page. -->
-        <template x-for="group in sections.global" :key="'global-' + group.label">
-          <div class="bb-shortcuts-group">
-            <div class="bb-shortcuts-group-label" x-text="group.label"></div>
-            <template x-for="item in group.items" :key="item.id">
-              <div class="bb-shortcuts-row">
-                <span class="bb-shortcuts-label" x-text="item.description"></span>
-                <span class="bb-shortcuts-keys" x-html="renderTokens(item.tokens)"></span>
+        <!-- Global section: shortcuts available on every page. The header is
+             only shown when there's a page section above it — when only global
+             shortcuts exist, the header is redundant. -->
+        <template x-if="sections.global.length > 0">
+          <section class="bb-shortcuts-section bb-shortcuts-section--global">
+            <template x-if="sections.page.length > 0">
+              <header class="bb-shortcuts-section-head">
+                <span class="bb-shortcuts-section-eyebrow">Global</span>
+                <span class="bb-shortcuts-section-title">Available everywhere</span>
+              </header>
+            </template>
+            <template x-for="group in sections.global" :key="'global-' + group.label">
+              <div class="bb-shortcuts-group">
+                <div class="bb-shortcuts-group-label" x-text="group.label"></div>
+                <template x-for="item in group.items" :key="item.id">
+                  <div class="bb-shortcuts-row">
+                    <span class="bb-shortcuts-label" x-text="item.description"></span>
+                    <span class="bb-shortcuts-keys" x-html="renderTokens(item.tokens)"></span>
+                  </div>
+                </template>
               </div>
             </template>
-          </div>
+          </section>
         </template>
         <template x-if="sections.global.length === 0 && sections.page.length === 0">
           <div class="bb-shortcuts-group">
@@ -1883,12 +1896,21 @@
           // dynamic scope changes) surface immediately.
           this.sections = buildSections();
           this.open = true;
+          // Freeze the body so trackpad rubber-band on the page behind doesn't
+          // bleed through the dialog (visible at the top/bottom of the dialog
+          // scroll on macOS).
+          if (window.bbLockScroll) window.bbLockScroll();
           setTimeout(function() {
             var dialog = document.querySelector('.bb-shortcuts-dialog');
             if (dialog && typeof lucide !== 'undefined') {
               lucide.createIcons({ nodes: [dialog] });
             }
           }, 50);
+        },
+        closeHelp: function() {
+          if (!this.open) return;
+          this.open = false;
+          if (window.bbUnlockScroll) window.bbUnlockScroll();
         }
       };
     }


### PR DESCRIPTION
## Summary

Two polish fixes on the keyboard-shortcuts help modal (the dialog you get from pressing `?`).

### 1. Page-scoped vs global shortcuts are now visually distinct

Before, the modal rendered page-scoped and global shortcuts as a single flat list of group-labeled rows. The only differentiation was a tiny "This page" caption at the top, which was easy to miss — once you scrolled past it, "Actions" / "Navigation" / "Selection" headers (page-scoped) blended right into the global "Actions" / "Go to" / "New" / "Selection" headers below.

Now the two scopes live in distinct sections:

- **Page section** is wrapped in an info-tinted card with a left accent rail and an eyebrow header reading `ON THIS PAGE · <Page name>` (e.g. *Transactions*, *Rules*, *Reports*).
- **Global section** sits below it with its own `GLOBAL · Available everywhere` header — but only when there is also a page section, since the header is redundant when global is the only thing showing.

When the current scope is `global` (or a scope with no page-scoped shortcuts, like `dashboard`/`settings`), the modal renders exactly as before — just the global groups, no extra headers.

### 2. Modal no longer "sees through" on overscroll

On macOS the trackpad rubber-band would expose whatever was behind the dialog at the top or bottom of its scroll because overscroll propagated to the document and `position: fixed` paint shifts with the body bounce.

- `overscroll-behavior: contain` on `.bb-shortcuts-dialog` so trackpad rubber-band stays in the dialog scroll.
- `bbLockScroll()` / `bbUnlockScroll()` wired into `openHelp` / new `closeHelp`, so the body can't rubber-band underneath while the modal is open. Matches the existing pattern in the global category picker.

## Files

- `internal/templates/layout/base.html` — modal markup (page/global sections), close handler unification, scroll-lock wiring.
- `input.css` — `.bb-shortcuts-section`, page-tint card with accent rail, `overscroll-behavior: contain` on the dialog.

## Test plan

- [x] Open `?` on `/transactions`: `ON THIS PAGE · Transactions` card with Actions/Navigation/Selection groups; `GLOBAL · Available everywhere` block below with the standard global shortcuts.
- [x] Open `?` on `/` (dashboard, no page-scoped shortcuts): just the global groups, no section headers — unchanged from before.
- [x] Trackpad-scroll past top and bottom of the dialog content: rubber-band contained, no bleed-through.
- [x] Body scroll-lock engages on open (`document.body.style.position === 'fixed'`) and clears on close.
- [x] `go build ./...` clean.
- [ ] Eyeball test on `/rules`, `/reports`, `/categories`, transaction detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)