### PR TITLE
chore(timefmt): consolidate duplicate relativeTime helpers

### DIFF
--- a/internal/admin/dashboard.go
+++ b/internal/admin/dashboard.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"encoding/json"
-	"fmt"
 	"math"
 	"net/http"
 	"sort"
@@ -13,6 +12,7 @@ import (
 	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 )
 
 // DashboardHandler serves GET /admin/ — the dashboard home page.
@@ -424,29 +424,10 @@ func DashboardHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) ht
 	}
 }
 
-// relativeTime converts a time to a human-readable relative string.
+// relativeTime is a thin alias for timefmt.Relative kept so admin call sites
+// (and the funcMap registration in templates.go) can refer to a short, local
+// name. Concentrating the implementation in internal/timefmt prevents drift
+// between admin and service copies.
 func relativeTime(t time.Time) string {
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		mins := int(d.Minutes())
-		if mins == 1 {
-			return "1 minute ago"
-		}
-		return fmt.Sprintf("%d minutes ago", mins)
-	case d < 24*time.Hour:
-		hours := int(d.Hours())
-		if hours == 1 {
-			return "1 hour ago"
-		}
-		return fmt.Sprintf("%d hours ago", hours)
-	default:
-		days := int(d.Hours() / 24)
-		if days == 1 {
-			return "1 day ago"
-		}
-		return fmt.Sprintf("%d days ago", days)
-	}
+	return timefmt.Relative(t)
 }

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -13,6 +13,7 @@ import (
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 	bsync "breadbox/internal/sync"
+	"breadbox/internal/timefmt"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -407,7 +408,7 @@ func (s *Service) GetSyncHealthSummary(ctx context.Context) (*SyncHealthSummary,
 	}
 
 	if lastSyncTime.Valid {
-		t := relativeTimeStr(lastSyncTime.Time)
+		t := timefmt.Relative(lastSyncTime.Time)
 		summary.LastSyncTime = &t
 	}
 
@@ -431,33 +432,6 @@ func (s *Service) GetSyncHealthSummary(ctx context.Context) (*SyncHealthSummary,
 	}
 
 	return summary, nil
-}
-
-// relativeTimeStr converts a time to a human-readable relative string.
-func relativeTimeStr(t time.Time) string {
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		mins := int(d.Minutes())
-		if mins == 1 {
-			return "1 minute ago"
-		}
-		return fmt.Sprintf("%d minutes ago", mins)
-	case d < 24*time.Hour:
-		hours := int(d.Hours())
-		if hours == 1 {
-			return "1 hour ago"
-		}
-		return fmt.Sprintf("%d hours ago", hours)
-	default:
-		days := int(d.Hours() / 24)
-		if days == 1 {
-			return "1 day ago"
-		}
-		return fmt.Sprintf("%d days ago", days)
-	}
 }
 
 // ListSyncLogAccounts returns the per-account breakdown for a specific sync log.
@@ -630,7 +604,7 @@ func (s *Service) GetProviderHealthSummaries(ctx context.Context) (map[string]*P
 		}
 		summary.LastSyncStatus = status
 		if syncTime.Valid {
-			t := relativeTimeStr(syncTime.Time)
+			t := timefmt.Relative(syncTime.Time)
 			summary.LastSyncTime = &t
 		}
 		if errMessage.Valid && errMessage.String != "" {

--- a/internal/service/sync_health_test.go
+++ b/internal/service/sync_health_test.go
@@ -2,32 +2,7 @@ package service
 
 import (
 	"testing"
-	"time"
 )
-
-func TestRelativeTimeStr(t *testing.T) {
-	tests := []struct {
-		name string
-		t    time.Time
-		want string
-	}{
-		{"just now", time.Now().Add(-10 * time.Second), "just now"},
-		{"1 minute ago", time.Now().Add(-90 * time.Second), "1 minute ago"},
-		{"5 minutes ago", time.Now().Add(-5 * time.Minute), "5 minutes ago"},
-		{"1 hour ago", time.Now().Add(-90 * time.Minute), "1 hour ago"},
-		{"3 hours ago", time.Now().Add(-3 * time.Hour), "3 hours ago"},
-		{"1 day ago", time.Now().Add(-36 * time.Hour), "1 day ago"},
-		{"5 days ago", time.Now().Add(-5 * 24 * time.Hour), "5 days ago"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := relativeTimeStr(tt.t)
-			if got != tt.want {
-				t.Errorf("relativeTimeStr() = %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestSyncHealthSummaryOverallHealth(t *testing.T) {
 	// Test the health determination logic by constructing summaries

--- a/internal/timefmt/timefmt.go
+++ b/internal/timefmt/timefmt.go
@@ -1,0 +1,39 @@
+// Package timefmt provides shared human-readable time formatters used across
+// the admin UI and service layer. Centralising these prevents the formatters
+// drifting between callers (admin used to ship its own copy, service its own).
+package timefmt
+
+import (
+	"fmt"
+	"time"
+)
+
+// Relative renders t as a human-readable "X ago" string relative to now.
+// Output buckets: "just now" (<1m), "N minute(s) ago" (<1h),
+// "N hour(s) ago" (<1d), "N day(s) ago" (>=1d). Uses time.Since(t), so
+// future times collapse to the "just now" bucket.
+func Relative(t time.Time) string {
+	d := time.Since(t)
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		mins := int(d.Minutes())
+		if mins == 1 {
+			return "1 minute ago"
+		}
+		return fmt.Sprintf("%d minutes ago", mins)
+	case d < 24*time.Hour:
+		hours := int(d.Hours())
+		if hours == 1 {
+			return "1 hour ago"
+		}
+		return fmt.Sprintf("%d hours ago", hours)
+	default:
+		days := int(d.Hours() / 24)
+		if days == 1 {
+			return "1 day ago"
+		}
+		return fmt.Sprintf("%d days ago", days)
+	}
+}

--- a/internal/timefmt/timefmt_test.go
+++ b/internal/timefmt/timefmt_test.go
@@ -1,0 +1,35 @@
+package timefmt
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRelative(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{"just now (zero)", now, "just now"},
+		{"just now (30s)", now.Add(-30 * time.Second), "just now"},
+		{"1 minute", now.Add(-1 * time.Minute), "1 minute ago"},
+		{"5 minutes", now.Add(-5 * time.Minute), "5 minutes ago"},
+		{"59 minutes", now.Add(-59 * time.Minute), "59 minutes ago"},
+		{"1 hour", now.Add(-1 * time.Hour), "1 hour ago"},
+		{"3 hours", now.Add(-3 * time.Hour), "3 hours ago"},
+		{"23 hours", now.Add(-23 * time.Hour), "23 hours ago"},
+		{"1 day", now.Add(-24 * time.Hour), "1 day ago"},
+		{"5 days", now.Add(-5 * 24 * time.Hour), "5 days ago"},
+		{"future collapses to just now", now.Add(1 * time.Hour), "just now"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Relative(tc.in); got != tc.want {
+				t.Errorf("Relative(%s) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`internal/admin/dashboard.go:relativeTime` and `internal/service/sync.go:relativeTimeStr` were byte-for-byte identical "X minutes ago" formatters — same buckets, same wording, same fallthrough. Two copies of the same logic across two layers is a drift hazard (one fix, one miss).

This PR extracts the implementation into a new tiny `internal/timefmt` package with full unit-test coverage:

- **New** `internal/timefmt/timefmt.go` — single `Relative(t time.Time) string` definition.
- **New** `internal/timefmt/timefmt_test.go` — covers all buckets (just-now, minutes, hours, days), singular/plural wording, and the future-time edge case.
- **`internal/admin/dashboard.go`** — `relativeTime` collapses to a 1-line alias for `timefmt.Relative`. The local name is kept so the funcMap registration in `templates.go` and the ~14 admin call sites stay unchanged.
- **`internal/service/sync.go`** — drops the local `relativeTimeStr` definition and updates the two call sites to call `timefmt.Relative` directly.
- **`internal/service/sync_health_test.go`** — removes the duplicate `TestRelativeTimeStr` (the new `timefmt_test.go` covers the same cases plus more).

Net: -79 / +83 (the bulk of the additions are the new tests).

This follows the same pattern as recent consolidations (#824 pageRange, #826 transaction-filter parsing, #831 sync-log duration).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages pass, including new `internal/timefmt` tests
- [ ] Integration tests via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)