### PR TITLE
fix(dashboard): replace full-row connection-errors card with compact alert banner

### DIFF
--- a/internal/templates/components/pages/dashboard.templ
+++ b/internal/templates/components/pages/dashboard.templ
@@ -2,7 +2,7 @@ package pages
 
 import (
 	"fmt"
-	"strconv"
+	"strings"
 
 	"breadbox/internal/templates/components"
 )
@@ -35,13 +35,27 @@ templ dashOverviewStats(p DashboardProps) {
 				<div class="text-[0.65rem] text-base-content/40 mt-1 group-hover:text-primary/70 transition-colors">Approve &rarr;</div>
 			</a>
 		}
-		if p.ErrorCount > 0 {
-			<a href="/connections" class={ "bb-card bb-card--interactive p-4 no-underline group block", templ.KV("col-span-2 lg:col-span-3", p.ReviewsEnabled) }>
-				<div class="text-[0.65rem] uppercase tracking-wider text-warning">Connection Errors</div>
-				<div class="text-2xl font-bold tabular-nums tracking-tight mt-1 text-error/80">{ strconv.Itoa(p.ErrorCount) }</div>
-				<div class="text-[0.65rem] text-base-content/40 mt-1 group-hover:text-primary/70 transition-colors">Fix &rarr;</div>
-			</a>
-		}
+	</div>
+}
+
+// dashConnectionErrorsBanner is a compact alert that surfaces failing
+// connections at the top of the dashboard. Replaces the old full-width
+// "Connection Errors" stat card, which left a sea of empty space on
+// desktop when the second row spanned all three columns just to show a
+// single number.
+templ dashConnectionErrorsBanner(p DashboardProps) {
+	<div role="alert" class="alert alert-warning rounded-xl mb-6 items-center">
+		<i data-lucide="alert-triangle" class="w-5 h-5 shrink-0"></i>
+		<div class="flex-1 min-w-0">
+			<h3 class="font-semibold text-sm">{ connectionErrorTitle(p.ErrorCount) }</h3>
+			if names := errorConnectionNames(p.ConnectionHealth); names != "" {
+				<p class="text-xs opacity-80 truncate">{ names }</p>
+			}
+		</div>
+		<a href="/connections" class="btn btn-sm btn-warning rounded-xl shrink-0">
+			<i data-lucide="wrench" class="w-3.5 h-3.5"></i>
+			Fix
+		</a>
 	</div>
 }
 
@@ -56,6 +70,9 @@ templ Dashboard(p DashboardProps) {
 	<div x-data x-init="$store.shortcuts.setScope('dashboard')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	if p.ShowUpdateBanner {
 		@dashUpdateBanner(p)
+	}
+	if p.ErrorCount > 0 {
+		@dashConnectionErrorsBanner(p)
 	}
 	if len(p.Accounts) == 0 {
 		<div class="bb-card mb-6 p-8 text-center">
@@ -243,4 +260,28 @@ templ dashScripts() {
 
 func dashDismissUpdateScript(version string) string {
 	return fmt.Sprintf(`fetch('/-/update/dismiss', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({version: %q}) }).then(() => $el.closest('.alert').remove())`, version)
+}
+
+func connectionErrorTitle(n int) string {
+	if n == 1 {
+		return "1 connection needs attention"
+	}
+	return fmt.Sprintf("%d connections need attention", n)
+}
+
+func errorConnectionNames(rows []ConnectionHealthRow) string {
+	const limit = 3
+	var names []string
+	for _, r := range rows {
+		if r.Status == "error" || r.Status == "pending_reauth" {
+			names = append(names, r.Name)
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	if len(names) <= limit {
+		return strings.Join(names, ", ")
+	}
+	return fmt.Sprintf("%s and %d more", strings.Join(names[:limit], ", "), len(names)-limit)
 }


### PR DESCRIPTION
## Summary

The dashboard's "Connection Errors" stat card spanned the full desktop row (`lg:col-span-3` whenever pending reviews were enabled), so a single number ended up pinned to the left of a 1024px+ wide card with the rest of the row empty.

Swap it for a compact alert banner that sits above the stat grid:

- Renders only when `ErrorCount > 0`, mirroring the existing update-banner pattern (`alert alert-warning` with rounded-xl).
- Surfaces the actual failing institutions inline (`Chase, CapitalOne`), truncating to "first 3 + N more" so the banner stays a single row.
- Keeps the "Fix" action as a `btn btn-warning` linking to `/connections`.
- Pluralizes the headline ("1 connection needs attention" / "N connections need attention").

The stat grid (Net Worth / Transactions / Pending Reviews) is now left alone — three cards on one row, no orphaned half-row underneath.

## Visuals

<table>
  <tr><th>Before — full-row card pinned left, mostly empty</th><th>After — compact alert banner above stats</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/ieplbl8dyz.png" width="420" alt="dashboard before"></td>
    <td><img src="https://i.img402.dev/0ycsnu36yl.png" width="420" alt="dashboard after"></td>
  </tr>
</table>

Banner copy variants (singular, multi, truncated):

<img src="https://i.img402.dev/96ff3gqcuk.png" width="800" alt="banner variants">

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/templates/... ./internal/admin/...` passes
- [x] `templ fmt` + `templ generate` clean
- [x] Live dashboard validated in browser (no-error state still renders the stat grid correctly; banner injected via JS to confirm visual fits)
- [ ] Reviewer can trigger an `error`-status connection in their dev DB to see the banner end-to-end
