### PR TITLE
chore(timefmt): collapse two more relativeTime duplicates onto shared helper

### DIFF
--- a/internal/templates/components/pages/rule_detail_types.go
+++ b/internal/templates/components/pages/rule_detail_types.go
@@ -7,6 +7,7 @@ import (
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
+	"breadbox/internal/timefmt"
 )
 
 // RuleDetailProps mirrors the data the old rule_detail.html read off the
@@ -159,32 +160,10 @@ func ruleStatsUnique(s *service.RuleStats) int64 {
 }
 
 // ruleRelativeTime renders a time.Time as "just now / N minutes ago / ..."
-// — mirrors admin.relativeTime so the LastActiveTime stat reads identically
-// to the original page.
+// for the LastActiveTime stat. Thin alias over timefmt.Relative so the templ
+// caller can stay package-local without importing timefmt.
 func ruleRelativeTime(t time.Time) string {
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		mins := int(d.Minutes())
-		if mins == 1 {
-			return "1 minute ago"
-		}
-		return fmt.Sprintf("%d minutes ago", mins)
-	case d < 24*time.Hour:
-		hours := int(d.Hours())
-		if hours == 1 {
-			return "1 hour ago"
-		}
-		return fmt.Sprintf("%d hours ago", hours)
-	default:
-		days := int(d.Hours() / 24)
-		if days == 1 {
-			return "1 day ago"
-		}
-		return fmt.Sprintf("%d days ago", days)
-	}
+	return timefmt.Relative(t)
 }
 
 // ruleApplyModalCountSentence renders the body sentence in the apply

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -8,6 +8,7 @@ import (
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
+	"breadbox/internal/timefmt"
 )
 
 // TransactionDetail renders the /admin/transactions/{id} detail page —
@@ -654,6 +655,7 @@ func clockTimeStr(s string) string {
 // relativeTimeStr renders an RFC3339 timestamp as a short relative
 // phrase ("just now", "5 minutes ago", "2 days ago"). Used in delete
 // button aria-labels so screen readers get a stable description.
+// Falls back to the raw input string when the timestamp can't be parsed.
 func relativeTimeStr(s string) string {
 	if s == "" {
 		return ""
@@ -665,29 +667,7 @@ func relativeTimeStr(s string) string {
 			return s
 		}
 	}
-	d := time.Since(t)
-	switch {
-	case d < time.Minute:
-		return "just now"
-	case d < time.Hour:
-		m := int(d.Minutes())
-		if m == 1 {
-			return "1 minute ago"
-		}
-		return fmt.Sprintf("%d minutes ago", m)
-	case d < 24*time.Hour:
-		h := int(d.Hours())
-		if h == 1 {
-			return "1 hour ago"
-		}
-		return fmt.Sprintf("%d hours ago", h)
-	default:
-		days := int(d.Hours() / 24)
-		if days == 1 {
-			return "1 day ago"
-		}
-		return fmt.Sprintf("%d days ago", days)
-	}
+	return timefmt.Relative(t)
 }
 
 // avatarURLStr mirrors the admin "avatarURL" funcMap for the (user_id,


### PR DESCRIPTION
## Summary

Two more copies of the \"just now / N minutes ago / N hours ago / N days ago\" bucket ladder were still kicking around outside [internal/timefmt](internal/timefmt/timefmt.go):

- [`ruleRelativeTime`](internal/templates/components/pages/rule_detail_types.go) — used for the `LastActiveTime` stat tile on the rule detail page.
- [`relativeTimeStr`](internal/templates/components/pages/transaction_detail.templ) — used in delete-comment aria-labels on the transaction activity timeline.

Both delegated nothing — each had its own switch with the same bucket boundaries the recent [#835](https://github.com/canalesb93/breadbox/pull/835) consolidation moved into [`timefmt.Relative`](internal/timefmt/timefmt.go). This PR replaces both bodies with a call to the shared helper so the bucket logic lives in one place.

The wrappers remain (call sites use different signatures: `time.Time` vs RFC3339 string with parse-fallback), but they're now thin one-liners. Net diff: +7 / -48.

Continues the consolidation pattern from [#835](https://github.com/canalesb93/breadbox/pull/835), [#831](https://github.com/canalesb93/breadbox/pull/831), and [#822](https://github.com/canalesb93/breadbox/pull/822).

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` green (timefmt + components + admin packages exercised)
- [ ] No UI surface change — output identical to before for every input bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)