### PR TITLE
Phase 2 of #827: extract Alpine factory from providers

### DIFF
--- a/internal/templates/components/pages/providers.templ
+++ b/internal/templates/components/pages/providers.templ
@@ -11,7 +11,17 @@ import (
 // base layout via TemplateRenderer.RenderWithTempl — the handler
 // builds typed props in admin/providers.go and the bridge drops the
 // rendered HTML into base.html's TemplContent slot.
+//
+// The Alpine factory `providerCard` lives in
+// static/js/admin/components/providers.js per the "Alpine page components"
+// convention (docs/design-system.md → section 14). Each card identifies
+// itself via `data-provider="<name>"` on the x-data root, read inside
+// testConnection() — not via a factory argument.
 templ Providers(p ProvidersProps) {
+	<!-- Component factory. Loaded synchronously (no defer) so the
+	     Alpine.data() registration runs before Alpine — itself deferred
+	     from <head> — fires alpine:init. -->
+	<script src="/static/js/admin/components/providers.js"></script>
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Providers</h1>
@@ -23,45 +33,14 @@ templ Providers(p ProvidersProps) {
 		@providersTellerCard(p, p.ProviderHealth["teller"])
 		@providersCSVCard(p.ProviderHealth["csv"])
 	</div>
-	<script>
-		function providerCard(name) {
-			return {
-				showConfig: false,
-				saving: false,
-				testing: false,
-				testResult: '',
-				testSuccess: false,
-
-				testConnection() {
-					this.testing = true;
-					this.testResult = '';
-					fetch('/-/test-provider/' + name, { method: 'POST' })
-						.then(res => res.json())
-						.then(data => {
-							this.testing = false;
-							this.testSuccess = data.success;
-							this.testResult = data.message || data.error || 'Unknown result';
-							setTimeout(() => { this.testResult = ''; }, 8000);
-						})
-						.catch(() => {
-							this.testing = false;
-							this.testSuccess = false;
-							this.testResult = 'Network error';
-							setTimeout(() => { this.testResult = ''; }, 8000);
-						});
-				}
-			};
-		}
-	</script>
 }
 
 // ====================================================================
 // Plaid card
 // ====================================================================
-
 templ providersPlaidCard(p ProvidersProps, h *service.ProviderHealthSummary) {
 	<!-- ─── Plaid ─── -->
-	<div class="bb-card p-0 overflow-hidden" x-data="providerCard('plaid')">
+	<div class="bb-card p-0 overflow-hidden" x-data="providerCard" data-provider="plaid">
 		<div class="px-4 sm:px-5 py-4 border-b border-base-300 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 min-w-0">
 			<div class="flex items-center gap-3 min-w-0">
 				<div class="w-10 h-10 rounded-xl bg-info/8 flex items-center justify-center flex-shrink-0">
@@ -200,10 +179,9 @@ templ plaidEnvOption(value, current, label string) {
 // ====================================================================
 // Teller card
 // ====================================================================
-
 templ providersTellerCard(p ProvidersProps, h *service.ProviderHealthSummary) {
 	<!-- ─── Teller ─── -->
-	<div class="bb-card p-0 overflow-hidden" x-data="providerCard('teller')">
+	<div class="bb-card p-0 overflow-hidden" x-data="providerCard" data-provider="teller">
 		<div class="px-4 sm:px-5 py-4 border-b border-base-300 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-3 min-w-0">
 			<div class="flex items-center gap-3 min-w-0">
 				<div class="w-10 h-10 rounded-xl bg-success/8 flex items-center justify-center flex-shrink-0">
@@ -360,7 +338,6 @@ templ providersTellerCard(p ProvidersProps, h *service.ProviderHealthSummary) {
 // ====================================================================
 // CSV Import card
 // ====================================================================
-
 templ providersCSVCard(h *service.ProviderHealthSummary) {
 	<!-- ─── CSV Import ─── -->
 	<div class="bb-card p-0 overflow-hidden">

--- a/static/js/admin/components/providers.js
+++ b/static/js/admin/components/providers.js
@@ -1,0 +1,40 @@
+// Provider card Alpine component for /providers.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+// Each card (Plaid, Teller) instantiates its own copy via x-data="providerCard"
+// and supplies the provider name as a `data-provider` attribute on the root,
+// read inside testConnection() via this.$el.dataset.provider. Keeping the
+// factory argument-free matches the convention; the per-instance variation
+// flows through the DOM, not through factory args.
+document.addEventListener('alpine:init', function () {
+  Alpine.data('providerCard', function () {
+    return {
+      showConfig: false,
+      saving: false,
+      testing: false,
+      testResult: '',
+      testSuccess: false,
+
+      testConnection: function () {
+        var self = this;
+        var name = this.$el.dataset.provider;
+        this.testing = true;
+        this.testResult = '';
+        fetch('/-/test-provider/' + name, { method: 'POST' })
+          .then(function (res) { return res.json(); })
+          .then(function (data) {
+            self.testing = false;
+            self.testSuccess = data.success;
+            self.testResult = data.message || data.error || 'Unknown result';
+            setTimeout(function () { self.testResult = ''; }, 8000);
+          })
+          .catch(function () {
+            self.testing = false;
+            self.testSuccess = false;
+            self.testResult = 'Network error';
+            setTimeout(function () { self.testResult = ''; }, 8000);
+          });
+      }
+    };
+  });
+});


### PR DESCRIPTION
Phase 2 of #827 — extract `providers`'s Alpine factory to follow the page-component convention codified in #828 / PR #836.

## Source today

- Factory body location: `internal/templates/components/pages/providers.templ:26-55` (inline `<script>` block, ~27 content lines)
- Existing data hand-off: `x-data="providerCard('plaid')"` / `x-data="providerCard('teller')"` (Go-style string-literal arg — not the lint-banned Go-expression form, but still an arg per existing convention)

## What changed

- New file `static/js/admin/components/providers.js` containing the `providerCard` Alpine factory, registered on `alpine:init`. Factory takes **no arguments**: each card supplies its own provider name via `data-provider="<name>"` on the x-data root, read inside `testConnection()` as `this.$el.dataset.provider`.
- `providers.templ`:
  - Synchronous `<script src="/static/js/admin/components/providers.js"></script>` at the top of the component (no `defer` — see #836 for rationale).
  - Inline `<script>...</script>` block deleted.
  - `x-data="providerCard('plaid')"` → `x-data="providerCard" data-provider="plaid"`; same for the Teller card.
- No `_scripts.go` to delete (this was a Source-B inline-only extraction).
- Lint allowlist in `scripts_lint_test.go` unchanged: `providers.templ` was never in `existingAntiPatternAllowlist` (only `category_form`, `report_detail`, `user_form`).
- Inline-script ceiling unchanged: post-extraction max stays at **147** (`connections.templ:454-620`), well below the current 180 ceiling. No need to lower.

## Validation

- `templ generate` clean.
- `go build ./... && go vet ./... && go test ./...` all green locally.
- Browser-validated at `/providers` via headless Chrome + CDP (Chrome DevTools MCP singleton was held by another instance, so I drove the browser directly):
  - Both Plaid and Teller cards mount with `x-data="providerCard"` and the correct `data-provider` value (`plaid` / `teller`).
  - Each Alpine instance initializes with `showConfig: false, testing: false, saving: false`.
  - Clicking the "Configuration" toggle flips `showConfig` from `false` → `true` (verified via `card._x_dataStack[0].showConfig`).
  - With `fetch` hijacked to capture URL + return a mock JSON response, calling `inst.testConnection()` from the Plaid card hits `POST /-/test-provider/plaid` and from the Teller card hits `POST /-/test-provider/teller` — i.e. `data-provider` is read correctly. The result message + success flag also threads through to `testResult` / `testSuccess`, matching the original behavior.
  - Console silent except for an unrelated, pre-existing `<meta name="apple-mobile-web-app-capable">` deprecation warning.

<img src="https://i.img402.dev/hepi4ypybb.jpg" width="800" alt="providers page after extraction — Plaid, Teller, CSV cards rendering with Alpine instances mounted">

## Test plan

- [x] `templ generate` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (incl. `TestNoLargeInlineScripts`)
- [x] `/providers` renders all three cards with sync-status badges, stat rows, and configuration toggles
- [x] Alpine `providerCard` factory registers and instantiates per-card without errors
- [x] `data-provider` attribute correctly drives `testConnection()`'s URL for both Plaid and Teller
- [x] `showConfig` toggle works (click "Configuration" → expanded panel)
- [x] Console silent (no errors, no Alpine warnings)

## Convention reference

- Full spec: `docs/design-system.md` → "Alpine page components"
- Reference port: `static/js/admin/components/prompt_builder.js` (Phase 1 — PR #836)

Refs #827.
