### PR TITLE
Phase 2 of #827: extract Alpine factory from rules

### DIFF
--- a/internal/admin/rules_render_test.go
+++ b/internal/admin/rules_render_test.go
@@ -31,8 +31,11 @@ func TestRulesTemplateRenders(t *testing.T) {
 
 	html := buf.String()
 
-	if !strings.Contains(html, "rulesPage()") {
+	if !strings.Contains(html, `x-data="rulesPage"`) {
 		t.Error("rules Alpine component not initialized")
+	}
+	if !strings.Contains(html, `src="/static/js/admin/components/rules.js"`) {
+		t.Error("rules.js script tag not rendered")
 	}
 	if !strings.Contains(html, "No rules yet") {
 		t.Error("empty-state message not rendered")

--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -11,11 +11,15 @@ import (
 // admin/rules.go and the bridge drops the rendered HTML into base.html's
 // TemplContent slot.
 //
-// Direct port of the old html/template version. The static `<script>`
-// blocks (rulesPage Alpine factory + bbRuleNav keyboard nav) are inlined
-// verbatim with @templ.Raw so the JS bodies don't compete with templ's
-// `{ }` interpolation.
+// Direct port of the old html/template version. The Alpine factory
+// (`rulesPage`), keyboard-navigation module (`bbRuleNav`), and URL helpers
+// live in static/js/admin/components/rules.js — see #827 / docs/design-system.md
+// → "Alpine page components".
 templ Rules(p RulesProps) {
+	<!-- Synchronous (NOT deferred) — Alpine's bundle in <head> is already
+	     deferred and dispatches alpine:init at parse-end, so a deferred
+	     component script would register its listener too late. -->
+	<script src="/static/js/admin/components/rules.js"></script>
 	<!-- Set the shortcut-registry scope so base.html's global dispatcher
 	     routes j/k/Enter/n/Space/d to this page's handlers. Reset on
 	     teardown so other pages don't inherit. -->
@@ -31,7 +35,7 @@ templ Rules(p RulesProps) {
 			</a>
 		</div>
 	</div>
-	<div x-data="rulesPage()">
+	<div x-data="rulesPage">
 		<!-- Rules count + sort -->
 		<div class="flex items-center justify-between flex-wrap gap-3 mb-4 px-1">
 			<div class="text-sm text-base-content/40">
@@ -65,7 +69,6 @@ templ Rules(p RulesProps) {
 		if p.TotalPages > 1 {
 			@rulesPaginator(p)
 		}
-		@templ.Raw(rulesScripts)
 	</div>
 }
 

--- a/static/js/admin/components/rules.js
+++ b/static/js/admin/components/rules.js
@@ -1,55 +1,43 @@
-package pages
+// Rules list Alpine component for /rules.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+// The page exposes:
+//   - `rulesPage()` Alpine factory (inline-toggle and delete actions on each row)
+//   - `bbSetRulesPerPage` / `bbSetRulesSort` URL-rewriter helpers, kept on
+//     `window` because they're invoked from `onchange="..."` handlers in the
+//     templ markup (`<select onchange="bbSetRulesPerPage(this.value)">`).
+//   - `bbRuleNav` keyboard-navigation module — also kept on `window` so the
+//     shortcut handlers (registered below) can reach it without closure
+//     gymnastics, and so it remains debuggable from the devtools console.
+//
+// All shortcut bindings flow through the global Alpine `shortcuts` store, per
+// .claude/rules/ui.md → "Keyboard shortcuts".
 
-// rulesScripts is the static JS body for the rules list page. Lifted
-// verbatim from the old rules.html so the Alpine factory + keyboard
-// navigation bbRuleNav module continue to work without churn. Inlined
-// via @templ.Raw because templ's `{ }` interpolation would otherwise
-// fight the JS object literals.
-const rulesScripts = `<script>
-function bbSetRulesPerPage(val) {
-  const u = new URL(window.location.href);
+// URL-rewriter helpers. Invoked from the templ markup via inline
+// `onchange="bbSetRulesPerPage(this.value)"`, so they must live on `window`.
+window.bbSetRulesPerPage = function (val) {
+  var u = new URL(window.location.href);
   u.searchParams.set('per_page', val);
   u.searchParams.delete('page');
   window.location.href = u.toString();
-}
-function bbSetRulesSort(val) {
-  const u = new URL(window.location.href);
+};
+
+window.bbSetRulesSort = function (val) {
+  var u = new URL(window.location.href);
   if (val) u.searchParams.set('sort_by', val);
   else u.searchParams.delete('sort_by');
   u.searchParams.delete('page');
   window.location.href = u.toString();
-}
-function rulesPage() {
-  return {
-    async toggleRule(id) {
-      try {
-        const resp = await fetch('/-/rules/' + id + '/toggle', { method: 'POST' });
-        if (resp.ok) location.reload();
-      } catch (e) {
-        // ignore
-      }
-    },
-    async deleteRule(id, el) {
-      const ok = await bbConfirm({title:'Delete this rule?',message:'This rule will be permanently deleted. This cannot be undone.',confirmLabel:'Delete',variant:'danger'});
-      if (!ok) return;
-      try {
-        const resp = await fetch('/-/rules/' + id, { method: 'DELETE' });
-        if (resp.ok) location.reload();
-      } catch (e) {
-        // ignore
-      }
-    }
-  };
-}
+};
 
 // Keyboard navigation for the rules list. Reads the DOM for visible rows
 // (no filter exists today, but offsetParent !== null stays future-proof)
 // instead of mirroring rule data into a store. The base.html dispatcher
 // already guards against input focus, overlays, and touch devices.
-var bbRuleNav = {
+window.bbRuleNav = {
   focusedIdx: -1,
   FOCUSED_CLASS: 'bb-tx-row--focused', // reuse the tx-list focus styling
-  visibleRows: function() {
+  visibleRows: function () {
     var all = document.querySelectorAll('[data-rule-row]');
     var out = [];
     for (var i = 0; i < all.length; i++) {
@@ -57,11 +45,11 @@ var bbRuleNav = {
     }
     return out;
   },
-  clearFocus: function() {
+  clearFocus: function () {
     var rows = document.querySelectorAll('[data-rule-row].' + this.FOCUSED_CLASS);
     for (var i = 0; i < rows.length; i++) rows[i].classList.remove(this.FOCUSED_CLASS);
   },
-  setFocus: function(idx) {
+  setFocus: function (idx) {
     var rows = this.visibleRows();
     if (!rows.length) { this.focusedIdx = -1; return; }
     if (idx < 0) idx = 0;
@@ -71,24 +59,59 @@ var bbRuleNav = {
     this.focusedIdx = idx;
     rows[idx].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   },
-  next: function() {
+  next: function () {
     var rows = this.visibleRows();
     if (!rows.length) return;
     this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx + 1);
   },
-  prev: function() {
+  prev: function () {
     var rows = this.visibleRows();
     if (!rows.length) return;
     this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx - 1);
   },
-  currentRow: function() {
+  currentRow: function () {
     var rows = this.visibleRows();
     if (this.focusedIdx < 0 || this.focusedIdx >= rows.length) return null;
     return rows[this.focusedIdx];
   },
 };
 
-document.addEventListener('alpine:init', function() {
+document.addEventListener('alpine:init', function () {
+  Alpine.data('rulesPage', function () {
+    return {
+      init: function () {
+        // No initial state to parse — all filtering / sorting is server-driven
+        // via the URL helpers above. This stub keeps the convention uniform
+        // (every factory has an init()).
+      },
+
+      toggleRule: async function (id) {
+        try {
+          var resp = await fetch('/-/rules/' + id + '/toggle', { method: 'POST' });
+          if (resp.ok) location.reload();
+        } catch (e) {
+          // ignore
+        }
+      },
+
+      deleteRule: async function (id, el) {
+        var ok = await bbConfirm({
+          title: 'Delete this rule?',
+          message: 'This rule will be permanently deleted. This cannot be undone.',
+          confirmLabel: 'Delete',
+          variant: 'danger',
+        });
+        if (!ok) return;
+        try {
+          var resp = await fetch('/-/rules/' + id, { method: 'DELETE' });
+          if (resp.ok) location.reload();
+        } catch (e) {
+          // ignore
+        }
+      },
+    };
+  });
+
   var reg = Alpine.store('shortcuts');
   if (!reg) return;
 
@@ -98,7 +121,7 @@ document.addEventListener('alpine:init', function() {
     description: 'Move down',
     group: 'Navigation',
     scope: 'rules',
-    action: function() { bbRuleNav.next(); },
+    action: function () { window.bbRuleNav.next(); },
   });
 
   reg.register({
@@ -107,7 +130,7 @@ document.addEventListener('alpine:init', function() {
     description: 'Move up',
     group: 'Navigation',
     scope: 'rules',
-    action: function() { bbRuleNav.prev(); },
+    action: function () { window.bbRuleNav.prev(); },
   });
 
   reg.register({
@@ -116,8 +139,8 @@ document.addEventListener('alpine:init', function() {
     description: 'Edit rule',
     group: 'Actions',
     scope: 'rules',
-    action: function() {
-      var row = bbRuleNav.currentRow();
+    action: function () {
+      var row = window.bbRuleNav.currentRow();
       if (!row) return;
       // Prefer the dedicated edit URL; fall back to the detail page (same
       // destination as clicking the row).
@@ -132,10 +155,10 @@ document.addEventListener('alpine:init', function() {
     description: 'New rule',
     group: 'Actions',
     scope: 'rules',
-    // This shadows the global ` + "`n+_`" + ` chord while on /rules — see the
-    // hasChordStartingWith guard in base.html. Users can still use ` + "`g r`" + `
-    // etc. to navigate; ` + "`n+r`" + ` chord lives everywhere else.
-    action: function() {
+    // This shadows the global `n+_` chord while on /rules — see the
+    // hasChordStartingWith guard in base.html. Users can still use `g r`
+    // etc. to navigate; `n+r` chord lives everywhere else.
+    action: function () {
       var btn = document.querySelector('[data-new-rule]');
       if (btn) btn.click();
     },
@@ -150,9 +173,9 @@ document.addEventListener('alpine:init', function() {
     // Only fire when a row is focused, otherwise let the browser scroll.
     // The dispatcher 'when' predicate gates the match itself; if Space
     // has no focused row, no shortcut matches and default scroll runs.
-    when: function() { return bbRuleNav.focusedIdx >= 0; },
-    action: function() {
-      var row = bbRuleNav.currentRow();
+    when: function () { return window.bbRuleNav.focusedIdx >= 0; },
+    action: function () {
+      var row = window.bbRuleNav.currentRow();
       if (!row) return;
       var btn = row.querySelector('[data-toggle-enabled]');
       if (btn) btn.click();
@@ -169,12 +192,11 @@ document.addEventListener('alpine:init', function() {
     // button — data-delete-action is absent there, so 'd' is a no-op on
     // system rules. The existing deleteRule flow shows bbConfirm() before
     // issuing the DELETE, so the confirm dialog still fires.
-    action: function() {
-      var row = bbRuleNav.currentRow();
+    action: function () {
+      var row = window.bbRuleNav.currentRow();
       if (!row) return;
       var btn = row.querySelector('[data-delete-action]');
       if (btn) btn.click();
     },
   });
 });
-</script>`


### PR DESCRIPTION
Phase 2 of #827 — extract `rules`'s Alpine factory to follow the page-component convention codified in #828.

## Source today

- **Factory body location:** `internal/templates/components/pages/rules_scripts.go` (raw Go string, ~180 LOC, rendered into `rules.templ` via `@templ.Raw(rulesScripts)`).
- **Existing data hand-off:** none — the script has no template-derived inputs. The page surfaced three pieces of behavior:
  1. `rulesPage()` Alpine factory with `toggleRule(id)` and `deleteRule(id, el)` async methods invoked from row dropdowns.
  2. Two free `bbSetRulesPerPage` / `bbSetRulesSort` URL-rewriter helpers, called from inline `onchange="bbSetRulesPerPage(this.value)"` / `onchange="bbSetRulesSort(this.value)"` in the paginator and sort `<select>`s.
  3. A `bbRuleNav` keyboard-navigation module (visible-row tracking, focus management) wired to six `Alpine.store('shortcuts').register(...)` calls under the `rules` scope (`j`/`k`/`Enter`/`n`/`Space`/`d`).

## Changes

- New file `static/js/admin/components/rules.js` containing all four pieces. Functional behavior is byte-equivalent to the deleted `rules_scripts.go`. Two intentional shape decisions:
  - `bbSetRulesPerPage`, `bbSetRulesSort`, and `bbRuleNav` stay as `window.*` exports (instead of folding them into the `rulesPage` factory). The two URL helpers are invoked from inline `onchange="..."` handlers in the templ markup, which resolve identifiers against `window`; folding them into Alpine would mean rewriting the `<select>`s to `@change="..."` and pulling them through the factory — out-of-scope churn for this PR. `bbRuleNav` is a singleton state holder consumed by the shortcut-store callbacks, and keeping it on `window` matches the original module's debug-from-console contract.
  - The `rulesPage` Alpine factory still gets a no-op `init()` so every page-component file in this codebase shares the same shape (per the convention in `docs/design-system.md`).
- `rules.templ`:
  - Loads the script via `<script src="/static/js/admin/components/rules.js"></script>` at the **top of the templ component** (synchronous, no `defer` — the rule from PR #836 ensures the `alpine:init` listener registers before Alpine fires the event).
  - `x-data="rulesPage()"` becomes the string-literal `x-data="rulesPage"` (the convention; the lint regex doesn't catch the `()` form, but the docs ask for the no-parens form so factories stay argument-free).
  - `@templ.Raw(rulesScripts)` line dropped.
- `rules_scripts.go` deleted.
- `internal/admin/rules_render_test.go` updated to assert the new wiring (`x-data="rulesPage"` + the `<script src=".../rules.js">` tag) instead of the old `rulesPage()` substring.

## Lint ceiling

Re-measured inline-script max across `internal/templates/components/pages/*.templ`: `connections.templ:454-620` still leads at **147 content lines**. This PR's extraction was a Go-string sidecar (`@templ.Raw(rulesScripts)`), not an inline `<script>` block, so it didn't count toward the lint anyway. Ceiling stays at **180** — no change.

## Allowlist

`rules.templ` is not in `existingAntiPatternAllowlist` in `scripts_lint_test.go` — nothing to remove.

## Validation

- `templ generate` — clean.
- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test ./...` — all green, including `internal/templates/components/pages` lint test and the updated `TestRulesTemplateRenders`.
- Browser-validated at `http://localhost:8091/rules` (logged in as `admin@example.com`), driven via puppeteer-core (the chrome-devtools MCP singleton was held in another worktree):
  - `<script src="/static/js/admin/components/rules.js">` is present in the rendered HTML.
  - `typeof window.bbSetRulesPerPage === 'function'`, `typeof window.bbSetRulesSort === 'function'`, `typeof window.bbRuleNav === 'object'`.
  - The `<div x-data="rulesPage">` root element exists.
  - 4 rule rows render (real seeded data; sort `<select>` driven by `bbSetRulesSort` is visible).
  - Pressing `j` puts `bb-tx-row--focused` on the first row and bumps `bbRuleNav.focusedIdx` to `0` — the keyboard-shortcut path through the `Alpine.store('shortcuts')` registration is intact.
  - Console silent except for the unrelated `apple-mobile-web-app-capable` deprecation warning that fires on every admin page (not introduced by this PR).

<img src="https://i.img402.dev/1t1lufo7cv.jpg" width="800" alt="/rules page after Alpine extraction">

## Test plan

- [x] `templ generate` clean
- [x] `go build ./...` / `go vet ./...` / `go test ./...` clean
- [x] `<script src="/static/js/admin/components/rules.js">` present
- [x] `bbSetRulesPerPage` / `bbSetRulesSort` / `bbRuleNav` defined on `window`
- [x] `rulesPage` factory mounted (`x-data="rulesPage"`)
- [x] Sort `<select onchange="bbSetRulesSort(...)">` calls into the new module
- [x] `j` keyboard shortcut focuses the first row via `bbRuleNav`
- [x] No new console errors
- [x] Screenshot captured at 1280x800

Refs #827.
