### PR TITLE
Phase 2 of #827: extract Alpine factory from dashboard

### DIFF
--- a/internal/templates/components/pages/dashboard.templ
+++ b/internal/templates/components/pages/dashboard.templ
@@ -47,7 +47,18 @@ templ dashOverviewStats(p DashboardProps) {
 
 // Dashboard renders the admin home page: agent reports and recent transactions.
 // Hosted inside base.html via TemplateRenderer.RenderWithTempl.
+//
+// The dashboard's Alpine factory (`agentReports`) lives in
+// static/js/admin/components/dashboard.js per the Alpine page-components
+// convention (docs/design-system.md). The <script src> below is loaded
+// synchronously — NOT `defer`ed — because Alpine itself ships as
+// <script defer> in <head>, so its alpine:init event fires before any
+// deferred page script could register the factory.
 templ Dashboard(p DashboardProps) {
+	<!-- Component factory for agentReports. Loaded synchronously (no defer)
+	     so the Alpine.data() registration runs before Alpine — itself
+	     deferred from <head> — fires alpine:init. -->
+	<script src="/static/js/admin/components/dashboard.js"></script>
 	<!--
 		Set the shortcut-registry scope so the ? help modal reflects "This page"
 		accurately (dashboard has no custom shortcuts — navigation lives via the
@@ -74,7 +85,6 @@ templ Dashboard(p DashboardProps) {
 		@dashAgentReportsCard(p)
 		@dashRecentTransactionsCard(p)
 	</div>
-	@dashScripts()
 }
 
 templ dashUpdateBanner(p DashboardProps) {
@@ -119,7 +129,7 @@ templ dashUpdateBanner(p DashboardProps) {
 }
 
 templ dashAgentReportsCard(p DashboardProps) {
-	<div class="bb-card flex flex-col h-full" x-data="{ ...agentReports() }">
+	<div class="bb-card flex flex-col h-full" x-data="agentReports">
 		<div class="px-5 py-4 flex flex-wrap items-center justify-between gap-x-3 gap-y-2 border-b border-base-200/60 shrink-0">
 			<div class="flex items-center gap-2 min-w-0">
 				<i data-lucide="bot" class="w-4 h-4 text-primary/70 shrink-0"></i>
@@ -214,29 +224,6 @@ templ dashRecentTransactionsCard(p DashboardProps) {
 			</div>
 		}
 	</div>
-}
-
-templ dashScripts() {
-	<!-- Agent Reports: dismiss logic -->
-	<script>
-		function agentReports() {
-			return {
-				dismissed: {},
-				markRead(id) {
-					this.dismissed[id] = true;
-					fetch('/-/reports/' + id + '/read', { method: 'POST' });
-				},
-				markAllRead() {
-					var self = this;
-					document.querySelectorAll('[id^="report-"]').forEach(function(el) {
-						var id = el.id.replace('report-', '');
-						self.dismissed[id] = true;
-					});
-					fetch('/-/reports/read-all', { method: 'POST' });
-				}
-			};
-		}
-	</script>
 }
 
 // ── Helpers ──────────────────────────────────────────────────

--- a/static/js/admin/components/dashboard.js
+++ b/static/js/admin/components/dashboard.js
@@ -1,0 +1,32 @@
+// Agent Reports Alpine component for /dashboard.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+// Powers the dashAgentReportsCard list — tracks which reports are dismissed
+// (mark-as-read) so they fade out without a page reload, and posts the read
+// state back to the server.
+document.addEventListener('alpine:init', function () {
+  Alpine.data('agentReports', function () {
+    return {
+      dismissed: {},
+
+      init: function () {
+        // No initial state to parse — dismissed map starts empty and fills
+        // as the user marks reports as read.
+      },
+
+      markRead: function (id) {
+        this.dismissed[id] = true;
+        fetch('/-/reports/' + id + '/read', { method: 'POST' });
+      },
+
+      markAllRead: function () {
+        var self = this;
+        document.querySelectorAll('[id^="report-"]').forEach(function (el) {
+          var id = el.id.replace('report-', '');
+          self.dismissed[id] = true;
+        });
+        fetch('/-/reports/read-all', { method: 'POST' });
+      },
+    };
+  });
+});


### PR DESCRIPTION
Phase 2 of #827 — extract `dashboard`'s Alpine factory to follow the page-component convention codified in #828.

## Source today
- Factory body location: `internal/templates/components/pages/dashboard.templ:236-256` (17 content lines, was inside `templ dashScripts()`)
- Existing data hand-off: none — the factory's `dismissed` map starts empty and only fills in response to user clicks. No props plumbed in.

## What changed
- **New:** `static/js/admin/components/dashboard.js` — registers the `agentReports` factory via `Alpine.data('agentReports', () => ({ init() { ... }, ... }))`. Factory takes no arguments.
- **Templ wiring:**
  - Added `<script src="/static/js/admin/components/dashboard.js"></script>` (synchronous, NOT `defer`ed) at the top of the `Dashboard` templ component.
  - Replaced `x-data="{ ...agentReports() }"` with the canonical `x-data="agentReports"` on `dashAgentReportsCard`. The spread shorthand was unnecessary once the factory registers via `Alpine.data()`.
  - Removed the now-orphaned `templ dashScripts()` block and its `@dashScripts()` invocation.
- **Untouched on purpose** (different Alpine patterns):
  - Line 56 `<div x-data x-init="$store.shortcuts.setScope('dashboard')" ...>` — scope wiring, no factory.
  - The inline-literal `x-data="{ pulling: false, pulled: false, error: '' }"` on the update banner — small ad-hoc state, fine as-is.
- No `_scripts.go` sidecar to delete — dashboard never had one.
- No `existingAntiPatternAllowlist` entry to remove (`dashboard.templ` was not on it).
- **Lint ceiling unchanged.** Removing dashboard's 17-line block doesn't move the high-water mark — the new max is still 147 in `connections.templ:454-620`, so the ceiling stays at 180 (147 + 33).

## Validation

Local browser validation against `/dashboard` on a freshly built `breadbox serve`:

- **Alpine factory check** — `Alpine.$data(document.querySelector('[x-data="agentReports"]'))` returns an object with `markRead`, `markAllRead`, and `dismissed` defined; the page title is "Home — Breadbox". No console errors.
- **`markRead(id)` test** — clicking the per-report check button toggles `dismissed[id] = true` reactively (verified through `Alpine.$data`), and the row fades out. Network call to `/-/reports/<id>/read` fires.
- **`markAllRead()` test** — populates `dismissed` with all 4 visible report IDs and fires `/-/reports/read-all`.
- The `pulling/pulled/error` inline-state alert (update banner, line 81) wasn't visible on this dev DB (no update available), so it wasn't exercised — but it's an inline literal `x-data`, untouched, with no possible cross-impact.

<img src="https://i.img402.dev/0fp607tw8f.jpg" width="800" alt="dashboard — after Phase 2 extraction">

## Test plan
- [x] `templ generate` clean
- [x] `go build ./...` clean (after one `make sqlc` refresh — epic branch was a sqlc generation behind main; regenerated db files were not committed)
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (including `TestNoLargeInlineScripts` — both `AntiPattern_xDataFactoryArgs` and `LineCount` subtests pass)
- [x] Browser-validated at `/dashboard`: stats cards render, Net Worth display correct, Agent Reports list renders with unread badge, `markRead`/`markAllRead` both functional, console silent, Recent Transactions on the right unaffected
- [x] Screenshot 1280×800 JPEG q=85 viewport-only

Refs #827.
