### PR TITLE
chore(admin): drop unused funcMap helpers; unify sync-duration fallback

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -895,12 +895,9 @@ func buildConnectionDetailProps(in connectionDetailInput) pages.ConnectionDetail
 		if sl.StartedAt.Valid {
 			row.StartedAtRelative = relativeTime(sl.StartedAt.Time)
 		}
-		if sl.DurationMs.Valid {
+		if ms, ok := service.SyncLogDurationMs(sl.DurationMs, sl.StartedAt, sl.CompletedAt); ok {
 			row.HasDuration = true
-			row.DurationLabel = service.FormatDurationMs(int64(sl.DurationMs.Int32))
-		} else if sl.StartedAt.Valid && sl.CompletedAt.Valid {
-			row.HasDuration = true
-			row.DurationLabel = formatSyncDuration(sl.StartedAt.Time, sl.CompletedAt.Time)
+			row.DurationLabel = service.FormatDurationMs(int64(ms))
 		}
 		if string(sl.Status) == "error" && sl.ErrorMessage.Valid {
 			row.ErrorMessageFriendly = bsync.FriendlyError(sl.ErrorMessage.String)
@@ -935,19 +932,6 @@ func formatNumericAbsCurrency(n pgtype.Numeric) string {
 		f = -f
 	}
 	return service.FormatCurrency(f)
-}
-
-// formatSyncDuration mirrors the funcMap "syncDuration" helper used for
-// historical sync rows that pre-date the duration_ms column.
-func formatSyncDuration(start, end time.Time) string {
-	d := end.Sub(start)
-	if d < time.Second {
-		return fmt.Sprintf("%dms", d.Milliseconds())
-	}
-	if d < time.Minute {
-		return fmt.Sprintf("%.1fs", d.Seconds())
-	}
-	return fmt.Sprintf("%.0fm", d.Minutes())
 }
 
 // ConnectionReauthHandler serves GET /admin/connections/{id}/reauth.

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -284,33 +284,6 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return fmt.Sprintf("%v", v)
 				}
 			},
-			"subf": func(a, b float64) float64 { return a - b },
-			"mulf": func(a, b float64) float64 { return a * b },
-			"divf": func(a, b float64) float64 {
-				if b == 0 {
-					return 0
-				}
-				return a / b
-			},
-			"minf": func(a, b float64) float64 {
-				if a < b {
-					return a
-				}
-				return b
-			},
-			"absf": func(a float64) float64 {
-				if a < 0 {
-					return -a
-				}
-				return a
-			},
-			"itof": func(a int) float64 {
-				return float64(a)
-			},
-			"syncDuration": func(start, end time.Time) string {
-				return service.FormatDurationMs(end.Sub(start).Milliseconds())
-			},
-			"formatDurationMs": func(ms int32) string { return service.FormatDurationMs(int64(ms)) },
 			"relativeTime": func(t interface{}) string {
 				switch v := t.(type) {
 				case time.Time:
@@ -336,9 +309,6 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				default:
 					return ""
 				}
-			},
-			"formatUUID": func(u pgtype.UUID) string {
-				return pgconv.FormatUUID(u)
 			},
 			"formatIntervalMinutes": components.FormatIntervalMinutes,
 			"accountLabel": func(name string, mask interface{}) string {


### PR DESCRIPTION
## Summary

- Remove nine funcMap helpers in \`internal/admin/templates.go\` that no longer have any template referencing them after the connection_detail and other pages migrated to templ: \`subf\`, \`mulf\`, \`divf\`, \`minf\`, \`absf\`, \`itof\`, \`syncDuration\`, \`formatDurationMs\`, \`formatUUID\`. Verified with \`grep -rln\` against \`internal/templates/\` — zero matches each.
- Collapse the sync-log duration fallback in \`buildConnectionDetailProps\` (connections.go) onto \`service.SyncLogDurationMs\` + \`service.FormatDurationMs\`, dropping the local \`formatSyncDuration\` helper. The legacy fallback rendered minutes as \`%.0fm\` (e.g. \`2m\` for 90s) while the primary path renders \`1m 30s\`, so the same column read inconsistently for rows pre-dating the \`duration_ms\` column. Unifying behind one helper makes both paths render identically and removes ~48 LOC of dead code.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/admin/... ./internal/service/... ./internal/templates/...\`
- [ ] Manual: visit \`/admin/connections/{id}\` for a connection with sync logs — duration column still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)