### PR TITLE
Phase 2 of #827: extract Alpine factory from categories

### DIFF
--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -15,7 +15,15 @@ import (
 // This is a purely configuration-focused page: no period selector, no
 // spending totals, no per-category amounts. Users manage the two-level
 // taxonomy here; spending analytics live on the Insights page.
+//
+// The categoriesPage Alpine factory + j/k/Enter/Space/e/n keyboard
+// shortcuts live in static/js/admin/components/categories.js. Loaded
+// synchronously at the top of the component (no `defer`) so
+// Alpine.data('categoriesPage', ...) is registered before Alpine —
+// itself <script defer> in <head> — fires alpine:init. See
+// docs/design-system.md → "Alpine page components".
 templ Categories(p CategoriesProps) {
+	<script src="/static/js/admin/components/categories.js"></script>
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Categories</h1>
@@ -28,24 +36,13 @@ templ Categories(p CategoriesProps) {
 	</div>
 	<!--
 		Set the shortcut-registry scope so base.html's global dispatcher routes
-		j/k/n (registered in bbCategoryNavScript) to this page's handlers, and
-		so the ? help modal surfaces them under "This page". Reset to 'global'
-		on Alpine teardown so other pages don't inherit the scope.
+		j/k/Enter/Space/e/n (registered inside categories.js) to this page's
+		handlers, and so the ? help modal surfaces them under "This page".
+		Reset to 'global' on Alpine teardown so other pages don't inherit the
+		scope.
 	-->
 	<div x-data x-init="$store.shortcuts.setScope('categories')" x-destroy="$store.shortcuts.setScope('global')"></div>
-	<div
-		x-data="{
-			filter: '',
-			expanded: {},
-			toggle(id) { this.expanded[id] = !this.expanded[id]; },
-			isOpen(id) { return !!this.expanded[id] || !!this.filter; },
-			matches(el) {
-				if (!this.filter) return true;
-				return (el.dataset.search || '').includes(this.filter.toLowerCase());
-			}
-		}"
-		class="space-y-4"
-	>
+	<div x-data="categoriesPage" class="space-y-4">
 		<div class="relative">
 			<i data-lucide="search" class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/30 pointer-events-none"></i>
 			<input
@@ -73,179 +70,6 @@ templ Categories(p CategoriesProps) {
 	@deleteCategoryModal()
 	<script>
 		document.addEventListener('DOMContentLoaded', function() { lucide.createIcons(); });
-	</script>
-	@categoriesKeyboardScript()
-}
-
-// categoriesKeyboardScript wires j/k/Enter/Space/e/n into the shared
-// $store.shortcuts registry at scope 'categories'. Enter (and Space) act on
-// the j/k-tracked row — primary rows expand/collapse; subcategory rows jump
-// to the filtered transactions list. `e` opens the edit page for the
-// focused category; `n` clicks the Add Category link. The inline @keydown
-// bindings on primary rows were removed so the dispatcher is the single
-// source of truth — otherwise a Tab-focused row would fire both the Alpine
-// handler and the page-scope shortcut and expansion would double-toggle.
-templ categoriesKeyboardScript() {
-	<script>
-		// Keyboard navigation for the categories tree. Reads the DOM for visible
-		// rows (two levels: primary row + subcategory rows inside each expanded
-		// x-collapse). offsetParent !== null respects both the filter (x-show
-		// on parent/child wrappers) and the collapsed state (x-collapse toggles
-		// display) — collapsed children simply won't appear in visibleRows().
-		var bbCategoryNav = {
-			focusedIdx: -1,
-			FOCUSED_CLASS: 'bb-tx-row--focused', // reuse the tx-list focus styling
-			visibleRows: function() {
-				var all = document.querySelectorAll('[data-category-row]');
-				var out = [];
-				for (var i = 0; i < all.length; i++) {
-					if (all[i].offsetParent !== null) out.push(all[i]);
-				}
-				return out;
-			},
-			clearFocus: function() {
-				var rows = document.querySelectorAll('[data-category-row].' + this.FOCUSED_CLASS);
-				for (var i = 0; i < rows.length; i++) rows[i].classList.remove(this.FOCUSED_CLASS);
-			},
-			setFocus: function(idx) {
-				var rows = this.visibleRows();
-				if (!rows.length) { this.focusedIdx = -1; return; }
-				if (idx < 0) idx = 0;
-				if (idx >= rows.length) idx = rows.length - 1;
-				this.clearFocus();
-				rows[idx].classList.add(this.FOCUSED_CLASS);
-				this.focusedIdx = idx;
-				rows[idx].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-			},
-			next: function() {
-				var rows = this.visibleRows();
-				if (!rows.length) return;
-				this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx + 1);
-			},
-			prev: function() {
-				var rows = this.visibleRows();
-				if (!rows.length) return;
-				this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx - 1);
-			},
-			// Returns the row a keyboard action should target — the j/k-tracked
-			// row when one is set, otherwise any row the user has Tab-focused.
-			// Keeps Enter/Space/e working for users who reach the tree via Tab
-			// instead of j/k.
-			currentRow: function() {
-				var rows = this.visibleRows();
-				if (this.focusedIdx >= 0 && this.focusedIdx < rows.length) return rows[this.focusedIdx];
-				var active = document.activeElement;
-				if (active && active.hasAttribute && active.hasAttribute('data-category-row')) return active;
-				return null;
-			},
-			// Activate the focused row: expand/collapse a primary via click
-			// (reuses the parent Alpine x-data's `toggle(id)`); jump to the
-			// filtered transactions list for a subcategory.
-			activateRow: function() {
-				var row = this.currentRow();
-				if (!row) return;
-				var level = row.getAttribute('data-category-level');
-				if (level === 'primary') {
-					row.click();
-					return;
-				}
-				if (level === 'sub') {
-					var slug = row.getAttribute('data-category-slug');
-					if (slug) window.location.href = '/transactions?category=' + encodeURIComponent(slug);
-				}
-			},
-			editRow: function() {
-				var row = this.currentRow();
-				if (!row) return;
-				var id = row.getAttribute('data-category-id');
-				if (id) window.location.href = '/categories/' + encodeURIComponent(id) + '/edit';
-			},
-		};
-
-		document.addEventListener('alpine:init', function() {
-			var reg = Alpine.store('shortcuts');
-			if (!reg) return;
-
-			reg.register({
-				id: 'categories.next',
-				keys: 'j',
-				description: 'Move down',
-				group: 'Navigation',
-				scope: 'categories',
-				action: function() { bbCategoryNav.next(); },
-			});
-
-			reg.register({
-				id: 'categories.prev',
-				keys: 'k',
-				description: 'Move up',
-				group: 'Navigation',
-				scope: 'categories',
-				action: function() { bbCategoryNav.prev(); },
-			});
-
-			reg.register({
-				id: 'categories.activate',
-				keys: 'Enter',
-				description: 'Expand primary / open subcategory',
-				group: 'Actions',
-				scope: 'categories',
-				action: function() { bbCategoryNav.activateRow(); },
-			});
-
-			reg.register({
-				id: 'categories.activate.space',
-				keys: ' ', // Space — e.key is a literal space
-				description: 'Expand / open (Space)',
-				group: 'Actions',
-				scope: 'categories',
-				visible: false, // Enter is the canonical binding shown in help
-				action: function() { bbCategoryNav.activateRow(); },
-			});
-
-			reg.register({
-				id: 'categories.edit',
-				keys: 'e',
-				description: 'Edit focused category',
-				group: 'Actions',
-				scope: 'categories',
-				action: function() { bbCategoryNav.editRow(); },
-			});
-
-			reg.register({
-				id: 'categories.new',
-				keys: 'n',
-				description: 'New category',
-				group: 'Actions',
-				scope: 'categories',
-				// Shadows the global `n+_` chord while on /categories via the
-				// page-scope-wins guard in base.html's hasChordStartingWith
-				// (added in M4.2). Clicks the Add Category link so middle-click
-				// / cmd-click semantics aren't silently bypassed.
-				action: function() {
-					var btn = document.querySelector('[data-new-category]');
-					if (btn) btn.click();
-				},
-			});
-		});
-
-		// When the user clicks a row (to expand/collapse a primary or select
-		// a sub), sync the j/k ring to that row so subsequent keyboard nav
-		// picks up from there — matches the tx-list convention.
-		document.addEventListener('click', function(e) {
-			var row = e.target && e.target.closest && e.target.closest('[data-category-row]');
-			if (!row) return;
-			// Ignore clicks on action buttons/links inside the row; those
-			// stop propagation already, but belt-and-suspenders in case a
-			// future affordance forgets.
-			if (e.target.closest('a, button')) return;
-			var rows = bbCategoryNav.visibleRows();
-			var idx = rows.indexOf(row);
-			if (idx < 0) return;
-			bbCategoryNav.clearFocus();
-			row.classList.add(bbCategoryNav.FOCUSED_CLASS);
-			bbCategoryNav.focusedIdx = idx;
-		});
 	</script>
 }
 

--- a/static/js/admin/components/categories.js
+++ b/static/js/admin/components/categories.js
@@ -1,0 +1,220 @@
+// Categories page Alpine component for /categories.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+//
+// Owns the per-instance filter / expansion state and the j/k focus ring
+// for the category tree. The shared base.html shortcuts dispatcher routes
+// j/k/Enter/Space/e/n to the registered handlers when the page scope is
+// 'categories' (set by the sibling x-init scope-setter div in templ).
+//
+// Keyboard registrations and the document-level click listener live at
+// module scope under one alpine:init — they're global by design and
+// shouldn't re-register every time the component mounts.
+(function () {
+  var FOCUSED_CLASS = 'bb-tx-row--focused'; // reuse the tx-list focus styling
+
+  // Reads the DOM for visible category rows (two levels: primary row +
+  // subcategory rows inside each expanded x-collapse). offsetParent !== null
+  // respects both the filter (x-show on parent/child wrappers) and the
+  // collapsed state (x-collapse toggles display) — collapsed children
+  // simply won't appear here.
+  function visibleRows() {
+    var all = document.querySelectorAll('[data-category-row]');
+    var out = [];
+    for (var i = 0; i < all.length; i++) {
+      if (all[i].offsetParent !== null) out.push(all[i]);
+    }
+    return out;
+  }
+
+  function clearFocus() {
+    var rows = document.querySelectorAll('[data-category-row].' + FOCUSED_CLASS);
+    for (var i = 0; i < rows.length; i++) rows[i].classList.remove(FOCUSED_CLASS);
+  }
+
+  // Module-level pointer to the live page-component instance, updated in
+  // init(). Lets the keyboard shortcuts and click listener — both registered
+  // once at alpine:init — call methods on the current Alpine instance.
+  var instance = null;
+
+  document.addEventListener('alpine:init', function () {
+    Alpine.data('categoriesPage', function () {
+      return {
+        // --- Filter + expansion state (used by inline x-show / x-collapse) ---
+        filter: '',
+        expanded: {},
+
+        // --- Keyboard navigation state ---
+        focusedIdx: -1,
+
+        init: function () {
+          instance = this;
+        },
+
+        destroy: function () {
+          if (instance === this) instance = null;
+        },
+
+        // --- Filter + expansion methods (called from inline x-* expressions) ---
+        toggle: function (id) {
+          this.expanded[id] = !this.expanded[id];
+        },
+
+        isOpen: function (id) {
+          return !!this.expanded[id] || !!this.filter;
+        },
+
+        matches: function (el) {
+          if (!this.filter) return true;
+          return (el.dataset.search || '').includes(this.filter.toLowerCase());
+        },
+
+        // --- Keyboard navigation methods ---
+        setFocus: function (idx) {
+          var rows = visibleRows();
+          if (!rows.length) { this.focusedIdx = -1; return; }
+          if (idx < 0) idx = 0;
+          if (idx >= rows.length) idx = rows.length - 1;
+          clearFocus();
+          rows[idx].classList.add(FOCUSED_CLASS);
+          this.focusedIdx = idx;
+          rows[idx].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        },
+
+        next: function () {
+          var rows = visibleRows();
+          if (!rows.length) return;
+          this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx + 1);
+        },
+
+        prev: function () {
+          var rows = visibleRows();
+          if (!rows.length) return;
+          this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx - 1);
+        },
+
+        // Returns the row a keyboard action should target — the j/k-tracked
+        // row when one is set, otherwise any row the user has Tab-focused.
+        // Keeps Enter/Space/e working for users who reach the tree via Tab
+        // instead of j/k.
+        currentRow: function () {
+          var rows = visibleRows();
+          if (this.focusedIdx >= 0 && this.focusedIdx < rows.length) return rows[this.focusedIdx];
+          var active = document.activeElement;
+          if (active && active.hasAttribute && active.hasAttribute('data-category-row')) return active;
+          return null;
+        },
+
+        // Activate the focused row: expand/collapse a primary via click
+        // (which fires the @click="toggle('<id>')" handler on the row);
+        // jump to the filtered transactions list for a subcategory.
+        activateRow: function () {
+          var row = this.currentRow();
+          if (!row) return;
+          var level = row.getAttribute('data-category-level');
+          if (level === 'primary') {
+            row.click();
+            return;
+          }
+          if (level === 'sub') {
+            var slug = row.getAttribute('data-category-slug');
+            if (slug) window.location.href = '/transactions?category=' + encodeURIComponent(slug);
+          }
+        },
+
+        editRow: function () {
+          var row = this.currentRow();
+          if (!row) return;
+          var id = row.getAttribute('data-category-id');
+          if (id) window.location.href = '/categories/' + encodeURIComponent(id) + '/edit';
+        },
+      };
+    });
+
+    // Page-scope keyboard shortcuts — registered once, dispatched by
+    // base.html's global handler when the active scope is 'categories'.
+    // The handlers delegate to whichever categoriesPage instance is live.
+    var reg = Alpine.store('shortcuts');
+    if (!reg) return;
+
+    reg.register({
+      id: 'categories.next',
+      keys: 'j',
+      description: 'Move down',
+      group: 'Navigation',
+      scope: 'categories',
+      action: function () { if (instance) instance.next(); },
+    });
+
+    reg.register({
+      id: 'categories.prev',
+      keys: 'k',
+      description: 'Move up',
+      group: 'Navigation',
+      scope: 'categories',
+      action: function () { if (instance) instance.prev(); },
+    });
+
+    reg.register({
+      id: 'categories.activate',
+      keys: 'Enter',
+      description: 'Expand primary / open subcategory',
+      group: 'Actions',
+      scope: 'categories',
+      action: function () { if (instance) instance.activateRow(); },
+    });
+
+    reg.register({
+      id: 'categories.activate.space',
+      keys: ' ', // Space — e.key is a literal space
+      description: 'Expand / open (Space)',
+      group: 'Actions',
+      scope: 'categories',
+      visible: false, // Enter is the canonical binding shown in help
+      action: function () { if (instance) instance.activateRow(); },
+    });
+
+    reg.register({
+      id: 'categories.edit',
+      keys: 'e',
+      description: 'Edit focused category',
+      group: 'Actions',
+      scope: 'categories',
+      action: function () { if (instance) instance.editRow(); },
+    });
+
+    reg.register({
+      id: 'categories.new',
+      keys: 'n',
+      description: 'New category',
+      group: 'Actions',
+      scope: 'categories',
+      // Shadows the global `n+_` chord while on /categories via the
+      // page-scope-wins guard in base.html's hasChordStartingWith
+      // (added in M4.2). Clicks the Add Category link so middle-click
+      // / cmd-click semantics aren't silently bypassed.
+      action: function () {
+        var btn = document.querySelector('[data-new-category]');
+        if (btn) btn.click();
+      },
+    });
+  });
+
+  // When the user clicks a row (to expand/collapse a primary or select
+  // a sub), sync the j/k ring to that row so subsequent keyboard nav
+  // picks up from there — matches the tx-list convention.
+  document.addEventListener('click', function (e) {
+    var row = e.target && e.target.closest && e.target.closest('[data-category-row]');
+    if (!row) return;
+    // Ignore clicks on action buttons/links inside the row; those
+    // stop propagation already, but belt-and-suspenders in case a
+    // future affordance forgets.
+    if (e.target.closest('a, button')) return;
+    var rows = visibleRows();
+    var idx = rows.indexOf(row);
+    if (idx < 0) return;
+    clearFocus();
+    row.classList.add(FOCUSED_CLASS);
+    if (instance) instance.focusedIdx = idx;
+  });
+})();


### PR DESCRIPTION
Phase 2 of #827 — extract `categories`'s Alpine factory to follow the page-component convention codified in #828 / PR #836.

## Source today

- **Block 1 (extracted):** `internal/templates/components/pages/categories.templ:89-249` — the keyboard navigation factory plus filter/expansion state, ~129 content lines split between `bbCategoryNav` (a global object), an `alpine:init` listener registering 6 page-scope shortcuts, and a document-level click listener.
- **Block 2 (kept inline, 1 line):** the trailing `lucide.createIcons()` `DOMContentLoaded` handler. Per `docs/design-system.md` ("A trivial inline `<script>` for one `lucide.createIcons()` call — fine to leave as-is"), this stays inline.
- **Existing data hand-off:** none — no `x-data` factory args, no JSON payload from props.

## What changed

- New file `static/js/admin/components/categories.js` with the `categoriesPage` Alpine factory:
  - Owns the per-instance state (`filter`, `expanded`, `focusedIdx`) and methods (`toggle`, `isOpen`, `matches`, `setFocus`, `next`, `prev`, `currentRow`, `activateRow`, `editRow`).
  - The factory takes **no arguments** per convention; all state lives inside the closure.
  - Keyboard-shortcut registration (j / k / Enter / Space / e / n) and the document-level row-click sync listener live at module scope under one `alpine:init` — they're global by design and shouldn't re-register on every component mount. A module-level `instance` pointer (set in `init()`, cleared in `destroy()`) lets the global handlers call methods on the live Alpine instance.
- `internal/templates/components/pages/categories.templ`:
  - Synchronous `<script src="/static/js/admin/components/categories.js"></script>` at the top of the component (no `defer` — see #836 for rationale).
  - The previous inline `x-data="{ filter: '', expanded: {}, toggle(id) { ... }, isOpen(id) { ... }, matches(el) { ... } }"` is now `x-data="categoriesPage"`.
  - The `categoriesKeyboardScript()` template (the 129-line inline block) is deleted.
  - The trivia `lucide.createIcons()` one-liner stays inline.
  - The sibling scope-setter `<div x-data x-init="$store.shortcuts.setScope('categories')" x-destroy="$store.shortcuts.setScope('global')">` is unchanged.
- No `_scripts.go` to delete — this was a Source-B inline-only extraction.
- Lint allowlist in `scripts_lint_test.go`: unchanged. `categories.templ` was never in `existingAntiPatternAllowlist`. (The remaining `category_form.templ:88` entry is a separate file / page that migrates later in its own PR.)
- Inline-script ceiling unchanged: post-extraction max stays at **147** (`connections.templ:454-620`), well below the current 180 ceiling. No need to lower.

## Validation

- `templ generate` clean.
- `go build ./... && go vet ./... && go test ./...` all green locally (incl. `TestNoLargeInlineScripts`).
- Browser-validated at `/categories` via headless Chrome + raw CDP (Chrome DevTools MCP singleton was held by another instance, so I drove the browser directly):
  - Root element mounts with `x-data="categoriesPage"`; `_x_dataStack[0]` exposes every method/state field the inline factory had (`filter`, `expanded`, `focusedIdx`, `toggle`, `isOpen`, `matches`, `next`, `prev`, `activateRow`, `editRow`).
  - Calling `data.toggle(id)` flips `data.isOpen(id)` from `false` → `true` (verified on the first primary row).
  - Setting `data.filter = 'food'` drops visible-row count from 123 → 116 (matches working).
  - `Alpine.store('shortcuts').items` registers all 6 categories-scoped IDs: `categories.next`, `categories.prev`, `categories.activate`, `categories.activate.space`, `categories.edit`, `categories.new`. Active scope reads `'categories'`, set by the sibling `x-init` div.
  - `<script src="/static/js/admin/components/categories.js">` is present in the rendered HTML.
  - Console silent except for two unrelated, pre-existing warnings: the `apple-mobile-web-app-capable` deprecation notice and a missing-icon lookup for `data-lucide="dice"` (used elsewhere on the page; not introduced by this PR).

<img src="https://i.img402.dev/4qnas7tbiq.jpg" width="800" alt="categories page after extraction — list renders with 17 top-level categories, filter input, kebab actions, and Alpine instance mounted">

## Test plan

- [x] `templ generate` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (incl. `TestNoLargeInlineScripts`)
- [x] `/categories` renders the full tree (17 top-level categories, kebab actions, filter input, sticky sidebar)
- [x] Alpine `categoriesPage` factory registers and instantiates without errors
- [x] Filter state (`filter`), expansion state (`expanded`), and j/k focus index (`focusedIdx`) all readable on `_x_dataStack[0]`
- [x] `toggle(id)` / `isOpen(id)` / `matches($el)` reachable from inline x-* expressions
- [x] All 6 page-scope shortcuts registered (`categories.next`, `categories.prev`, `categories.activate`, `categories.activate.space`, `categories.edit`, `categories.new`)
- [x] Active shortcut scope is `'categories'` while on the page
- [x] Console silent (no errors, no Alpine warnings introduced)

## Convention reference

- Full spec: `docs/design-system.md` → "Alpine page components"
- Reference port: `static/js/admin/components/prompt_builder.js` (Phase 1 — PR #836)

Refs #827.
