### PR TITLE
Phase 2 of #827: extract Alpine factory from tags

### DIFF
--- a/internal/templates/components/pages/tags.templ
+++ b/internal/templates/components/pages/tags.templ
@@ -12,6 +12,10 @@ import (
 // no per-tag analytics beyond a usage count linking to the filtered
 // transactions view.
 templ Tags(p TagsProps) {
+	<!-- Component factory. Loaded synchronously (no defer) so the
+	     Alpine.data() registration runs before Alpine — itself deferred from
+	     <head> — fires alpine:init. -->
+	<script src="/static/js/admin/components/tags.js"></script>
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Tags</h1>
@@ -22,7 +26,7 @@ templ Tags(p TagsProps) {
 			Add Tag
 		</a>
 	</div>
-	<div x-data="{filter: ''}" class="space-y-4">
+	<div x-data="tags" class="space-y-4">
 		<div class="relative">
 			<i data-lucide="search" class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-base-content/30 pointer-events-none"></i>
 			<input
@@ -47,29 +51,6 @@ templ Tags(p TagsProps) {
 			@tagsEmpty()
 		}
 	</div>
-	<script>
-		window.addEventListener('bb-delete-tag', function(e) {
-			var detail = e.detail;
-			var msg = 'Delete tag "' + detail.slug + '"?';
-			if (detail.count > 0) {
-				msg += '\n\nThis will remove the tag from ' + detail.count + ' transaction' + (detail.count === 1 ? '' : 's') + '. Activity annotations are preserved.';
-			}
-			bbConfirm({title: 'Delete tag?', message: msg, confirmLabel: 'Delete', variant: 'danger'}).then(function(ok) {
-				if (!ok) return;
-				fetch('/-/tags/' + detail.id, {method: 'DELETE'})
-					.then(function(r) {
-						if (r.ok) {
-							window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: 'Tag deleted', type:'success'}}));
-							setTimeout(function() { location.reload(); }, 400);
-						} else {
-							r.json().then(function(d) {
-								window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Delete failed', type:'error'}}));
-							});
-						}
-					});
-			});
-		});
-	</script>
 }
 
 // tagListRow renders one tag as a horizontal row: chip preview (natural
@@ -136,7 +117,7 @@ templ tagListRow(t TagRow) {
 							data-slug={ t.Slug }
 							data-count={ strconv.FormatInt(t.TransactionCount, 10) }
 							aria-label={ fmt.Sprintf("Delete tag %s", t.Slug) }
-							@click="window.dispatchEvent(new CustomEvent('bb-delete-tag', {detail: {id: $el.dataset.id, slug: $el.dataset.slug, count: parseInt($el.dataset.count) || 0}}))"
+							@click="deleteTag($el.dataset.id, $el.dataset.slug, $el.dataset.count)"
 						>
 							<i data-lucide="trash-2" class="w-3.5 h-3.5"></i> Delete
 						</button>

--- a/static/js/admin/components/tags.js
+++ b/static/js/admin/components/tags.js
@@ -1,0 +1,42 @@
+// Tags page Alpine component for /tags.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+// Owns the search filter state and the per-row delete flow (confirm → DELETE
+// fetch → toast + reload). The factory takes no arguments — row metadata
+// (id, slug, transaction count) flows in through the deleteTag() call site
+// via dataset attributes on the kebab Delete button.
+document.addEventListener('alpine:init', function () {
+  Alpine.data('tags', function () {
+    return {
+      filter: '',
+
+      init: function () {
+        // No initial parsing required — filter starts empty and tag rows
+        // render server-side. Method-based delete flow replaces the previous
+        // window 'bb-delete-tag' custom event listener.
+      },
+
+      deleteTag: function (id, slug, count) {
+        var n = parseInt(count, 10) || 0;
+        var msg = 'Delete tag "' + slug + '"?';
+        if (n > 0) {
+          msg += '\n\nThis will remove the tag from ' + n + ' transaction' + (n === 1 ? '' : 's') + '. Activity annotations are preserved.';
+        }
+        bbConfirm({title: 'Delete tag?', message: msg, confirmLabel: 'Delete', variant: 'danger'}).then(function (ok) {
+          if (!ok) return;
+          fetch('/-/tags/' + id, {method: 'DELETE'})
+            .then(function (r) {
+              if (r.ok) {
+                window.dispatchEvent(new CustomEvent('bb-toast', {detail: {message: 'Tag deleted', type: 'success'}}));
+                setTimeout(function () { location.reload(); }, 400);
+              } else {
+                r.json().then(function (d) {
+                  window.dispatchEvent(new CustomEvent('bb-toast', {detail: {message: (d.error && d.error.message) || 'Delete failed', type: 'error'}}));
+                });
+              }
+            });
+        });
+      }
+    };
+  });
+});


### PR DESCRIPTION
Phase 2 of #827 — extract `tags`'s Alpine factory to follow the page-component convention codified in #828 / PR #836.

## Source today

- Factory body location: `internal/templates/components/pages/tags.templ:50-72` (inline `<script>` block, ~21 content lines)
- Existing data hand-off: none — the factory has no Go-passed initial state. The wrapper `<div x-data="{filter: ''}">` held a single inline-literal field; row metadata (id, slug, count) is supplied per-button via `data-*` attributes already.

## What changed

- **New:** `static/js/admin/components/tags.js` — registers the `tags` Alpine factory via `Alpine.data('tags', () => ({ init() { ... }, deleteTag(...) { ... } }))`. The factory takes **no arguments** and owns both the search `filter` state and the per-row delete flow (confirm → DELETE fetch → toast + reload).
- **Templ wiring** (`internal/templates/components/pages/tags.templ`):
  - Synchronous `<script src="/static/js/admin/components/tags.js"></script>` (NOT `defer`ed) at the **top of the templ component** (see #836 for rationale).
  - `<div x-data="{filter: ''}">` → `<div x-data="tags">`. Same `filter` state, now owned by the factory.
  - Removed the inline `<script>...</script>` block (the `bb-delete-tag` global custom-event listener).
  - Delete kebab button: `@click="window.dispatchEvent(new CustomEvent('bb-delete-tag', ...))"` → `@click="deleteTag($el.dataset.id, $el.dataset.slug, $el.dataset.count)"`. Cleaner — no global event indirection, just a method call up the Alpine scope chain.
- No `_scripts.go` sidecar to delete — `tags` was Source B (inline-only) per the tracker.
- No `existingAntiPatternAllowlist` entry to remove — `tags.templ` was not on it.
- **Lint ceiling unchanged.** Removing this 21-line block doesn't move the high-water mark — max stays at **147** (`connections.templ:454-620`), so the ceiling stays at 180 (147 + 33).

## Validation

Local browser validation against `/tags` on a freshly built `breadbox serve` (port 8094, this branch's worktree):

- **Alpine factory check** — `Alpine.$data(document.querySelector('[x-data="tags"]'))` returns `{ filter: '', deleteTag: function, init: function }`. Page title `Tags — Breadbox`. The `tags.js` `<script src>` is loaded. 5 delete buttons render.
- **Filter test** — setting `data.filter = 'apples'` reduces visible rows from 5 → 1 reactively (Alpine `x-show` on each `data-search` row). Resetting to `''` restores all 5 rows.
- **`deleteTag()` test** — calling `data.deleteTag('test-id', 'apples', '1')` invokes `window.bbConfirm()` with `{ title: 'Delete tag?', message: 'Delete tag "apples"?\n\nThis will remove the tag from 1 transaction. Activity annotations are preserved.', variant: 'danger', confirmLabel: 'Delete' }`. Cancellation in confirm → no DELETE request fired (correct early-return path). The singular/plural "transaction"/"transactions" message branching is preserved.
- Console silent (no errors, no warnings).

<img src="https://i.img402.dev/3dha68xsi3.jpg" width="800" alt="tags page after extraction — list renders, kebab actions, no console errors">

## Test plan

- [x] `templ generate` clean
- [x] `go build ./...` clean (after one `make sqlc` refresh — epic branch was a sqlc generation behind main; regenerated db files were not committed)
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (including `TestNoLargeInlineScripts` — both `AntiPattern_xDataFactoryArgs` and `LineCount` subtests pass)
- [x] Browser-validated at `/tags`: list renders with 5 tags, search filter reactively narrows results, kebab dropdown opens, `deleteTag()` triggers `bbConfirm` with the right message including singular/plural handling, console silent.
