### PR TITLE
feat(annotations): summary, action, dedup at the service layer

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -913,194 +913,50 @@ func tagDisplayLookup(tags []service.TagResponse) func(string) tagDisplay {
 	}
 }
 
-// buildActivityTimeline produces a sorted activity list from annotations.
-// Review lifecycle events surface as tag_added/tag_removed on the
-// needs-review tag. Comment annotations originally authored as review notes
-// (identified by payload.review_id) render inline on their resolution event.
+// buildActivityTimeline produces a sorted activity list from annotations
+// and is the admin-handler bridge between the service-layer
+// service.Annotation shape (which carries derived fields like Summary, Action,
+// Origin) and the UI-layer service.ActivityEntry shape (which carries
+// presentation extras like TagColor and ReviewStatus).
+//
+// Dedup and summary derivation live in service.EnrichAnnotations; this
+// function delegates to it via the supplied lookups, then maps each
+// enriched annotation to its ActivityEntry.
 //
 // categoryDisplay maps a category slug to a human-readable name
-// ("Food & Drink › Groceries"). Pass a no-op (returning slug unchanged) in
-// tests that don't need humanization.
+// ("Food & Drink › Groceries"). Pass nil to use raw slugs.
 //
 // tagDisplayFn maps a tag slug to its display name + color for rendering a
-// tag chip on tag_added / tag_removed rows. Pass nil in tests that don't
-// exercise tag presentation.
+// tag chip on tag_added / tag_removed rows. Pass nil to use raw slugs.
 func buildActivityTimeline(annotations []service.Annotation, categoryDisplay func(string) string, tagDisplayFn func(string) tagDisplay) []service.ActivityEntry {
-	if categoryDisplay == nil {
-		categoryDisplay = func(s string) string { return s }
+	if len(annotations) == 0 {
+		return nil
 	}
-	if tagDisplayFn == nil {
-		tagDisplayFn = func(slug string) tagDisplay { return tagDisplay{DisplayName: slug} }
-	}
-	var entries []service.ActivityEntry
-
-	// Annotations.
-	for _, a := range annotations {
-		switch a.Kind {
-		case "comment":
-			content, _ := a.Payload["content"].(string)
-			// Filter legacy [Review: ...] prefix duplicates from pre-consolidation imports.
-			if strings.HasPrefix(content, "[Review: ") {
-				continue
-			}
-			// Dedup: suppress a comment that exactly duplicates a same-actor
-			// tag_added.note written within ±2s. update_transactions (MCP
-			// and REST) can write a tag-with-note AND a standalone comment
-			// in one call; the resulting rows land within a few ms of each
-			// other and render as twin adjacent events. The tag row already
-			// inlines the note via .Detail — the comment is redundant.
-			if isDuplicateOfAdjacentTagNote(annotations, a, content) {
-				continue
-			}
-			entry := service.ActivityEntry{
-				Type:               "comment",
-				Timestamp:          a.CreatedAt,
-				ActorName:          a.ActorName,
-				ActorType:          a.ActorType,
-				ActorAvatarVersion: a.ActorAvatarVersion,
-				Detail:             content,
-				CommentID:          a.ShortID,
-			}
-			if a.ActorID != nil && *a.ActorID != "" {
-				id := *a.ActorID
-				entry.ActorID = &id
-			}
-			entries = append(entries, entry)
-
-		case "rule_applied":
-			ruleName, _ := a.Payload["rule_name"].(string)
-			field, _ := a.Payload["action_field"].(string)
-			value, _ := a.Payload["action_value"].(string)
-			appliedBy, _ := a.Payload["applied_by"].(string)
-			// Older rows (and any future bug) can land here with rule_name
-			// empty and rule_id empty — render a generic subject instead of
-			// `Rule "" set category to food_and_drink_groceries`. The
-			// template already skips the /rules/<id> link when RuleID is
-			// empty, so the fallback text renders as plain copy.
-			subject := `Rule "` + ruleName + `"`
-			if ruleName == "" {
-				subject = "A rule"
-			}
-			// Humanize the action value for category actions so we render
-			// "Food & Drink › Groceries" rather than the raw slug.
-			displayValue := value
-			if field == "category" {
-				displayValue = categoryDisplay(value)
-			}
-			summary := subject + " applied"
-			switch field {
-			case "category":
-				summary = subject + " set category to " + displayValue
-			case "tag":
-				summary = subject + " added tag " + value
-			case "comment":
-				summary = subject + " added a comment"
-			}
-			how := "during sync"
-			if appliedBy == "retroactive" {
-				how = "retroactively"
-			}
-			entries = append(entries, service.ActivityEntry{
-				Type:      "rule",
-				Timestamp: a.CreatedAt,
-				// Rules aren't actors — keep the actor slot empty so the
-				// template's actor-meta span is skipped. Origin carries the
-				// "during sync" / "retroactively" qualifier as a subordinate
-				// meta pill next to the timestamp.
-				ActorName: "",
-				ActorType: "system",
-				Summary:   summary,
-				RuleName:  ruleName,
-				RuleID:    derefOr(a.RuleID, ""),
-				Origin:    how,
-			})
-
-		case "tag_added":
-			source, _ := a.Payload["source"].(string)
-			if source == "rule" {
-				// Represented separately via the rule_applied annotation
-				// written alongside tag_added during sync. Skip to avoid
-				// double-rendering. Mirrors the category_set dedup below.
-				continue
-			}
-			slug, _ := a.Payload["slug"].(string)
-			note, _ := a.Payload["note"].(string)
+	// Map the admin's tagDisplay (name + color) to the service-layer tag
+	// display closure (name only). Color stays here in the UI mapping pass.
+	var tagNameLookup func(string) string
+	if tagDisplayFn != nil {
+		tagNameLookup = func(slug string) string {
 			td := tagDisplayFn(slug)
-			entry := service.ActivityEntry{
-				Type:               "tag",
-				Timestamp:          a.CreatedAt,
-				ActorName:          a.ActorName,
-				ActorType:          a.ActorType,
-				ActorAvatarVersion: a.ActorAvatarVersion,
-				Summary:            "Added tag",
-				Detail:             note,
-				TagSlug:            slug,
-				TagDisplayName:     td.DisplayName,
-				TagColor:           td.Color,
-				TagAction:          "added",
+			if td.DisplayName != "" {
+				return td.DisplayName
 			}
-			if a.ActorID != nil && *a.ActorID != "" {
-				id := *a.ActorID
-				entry.ActorID = &id
-			}
-			entries = append(entries, entry)
-
-		case "tag_removed":
-			source, _ := a.Payload["source"].(string)
-			if source == "rule" {
-				// Future-proof: if a rule ever emits a rule-sourced tag_removed
-				// alongside a rule_applied annotation, dedup the same way as
-				// tag_added / category_set so the timeline stays symmetric.
-				continue
-			}
-			slug, _ := a.Payload["slug"].(string)
-			note, _ := a.Payload["note"].(string)
-			td := tagDisplayFn(slug)
-			entry := service.ActivityEntry{
-				Type:               "tag",
-				Timestamp:          a.CreatedAt,
-				ActorName:          a.ActorName,
-				ActorType:          a.ActorType,
-				ActorAvatarVersion: a.ActorAvatarVersion,
-				Summary:            "Removed tag",
-				Detail:             note,
-				TagSlug:            slug,
-				TagDisplayName:     td.DisplayName,
-				TagColor:           td.Color,
-				TagAction:          "removed",
-			}
-			if a.ActorID != nil && *a.ActorID != "" {
-				id := *a.ActorID
-				entry.ActorID = &id
-			}
-			entries = append(entries, entry)
-
-		case "category_set":
-			slug, _ := a.Payload["category_slug"].(string)
-			source, _ := a.Payload["source"].(string)
-			if source == "rule" {
-				// Represented separately via the rule_applied annotation
-				// written alongside category_set during sync. Skip to avoid
-				// double-rendering.
-				continue
-			}
-			displaySlug := categoryDisplay(slug)
-			summary := "Category set to " + displaySlug
-			entry := service.ActivityEntry{
-				Type:               "category",
-				Timestamp:          a.CreatedAt,
-				ActorName:          a.ActorName,
-				ActorType:          a.ActorType,
-				ActorAvatarVersion: a.ActorAvatarVersion,
-				Summary:            summary,
-				CategoryName:       displaySlug,
-			}
-			if a.ActorID != nil && *a.ActorID != "" {
-				id := *a.ActorID
-				entry.ActorID = &id
-			}
-			entries = append(entries, entry)
+			return slug
 		}
+	}
+
+	enriched := service.EnrichAnnotations(annotations, service.EnrichOptions{
+		TagDisplay:      tagNameLookup,
+		CategoryDisplay: categoryDisplay,
+	})
+
+	entries := make([]service.ActivityEntry, 0, len(enriched))
+	for _, a := range enriched {
+		entry, ok := activityEntryFromAnnotation(a, tagDisplayFn)
+		if !ok {
+			continue
+		}
+		entries = append(entries, entry)
 	}
 
 	// Sort by timestamp descending (newest first).
@@ -1109,6 +965,104 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 	})
 
 	return entries
+}
+
+// activityEntryFromAnnotation maps a single enriched service.Annotation to
+// the UI's ActivityEntry shape. Returns (zero, false) for unknown kinds so
+// the caller can drop them. Tag rows pull color from tagDisplayFn since
+// color is a presentation concern that lives in the admin layer.
+func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string) tagDisplay) (service.ActivityEntry, bool) {
+	switch a.Kind {
+	case "comment":
+		entry := service.ActivityEntry{
+			Type:               "comment",
+			Timestamp:          a.CreatedAt,
+			ActorName:          a.ActorName,
+			ActorType:          a.ActorType,
+			ActorAvatarVersion: a.ActorAvatarVersion,
+			Detail:             a.Content,
+			CommentID:          a.ShortID,
+		}
+		if a.ActorID != nil && *a.ActorID != "" {
+			id := *a.ActorID
+			entry.ActorID = &id
+		}
+		return entry, true
+
+	case "rule_applied":
+		// Subject carries the bare rule name in enrichment; the UI prefers
+		// the full pre-formatted Summary phrase but with the trailing
+		// "during sync" / "retroactively" stripped off (Origin renders
+		// it separately as a meta pill on the timeline row).
+		summary := a.Summary
+		if a.Origin != "" {
+			summary = strings.TrimSuffix(summary, " "+a.Origin)
+		}
+		return service.ActivityEntry{
+			Type:      "rule",
+			Timestamp: a.CreatedAt,
+			ActorName: "",
+			ActorType: "system",
+			Summary:   summary,
+			RuleName:  a.RuleName,
+			RuleID:    derefOr(a.RuleID, ""),
+			Origin:    a.Origin,
+		}, true
+
+	case "tag_added", "tag_removed":
+		// Look up color separately — service-layer enrichment doesn't
+		// carry presentation metadata.
+		var color *string
+		display := a.Subject
+		if tagDisplayFn != nil {
+			td := tagDisplayFn(a.TagSlug)
+			color = td.Color
+			if td.DisplayName != "" {
+				display = td.DisplayName
+			}
+		}
+		summary := "Added tag"
+		action := "added"
+		if a.Kind == "tag_removed" {
+			summary = "Removed tag"
+			action = "removed"
+		}
+		entry := service.ActivityEntry{
+			Type:               "tag",
+			Timestamp:          a.CreatedAt,
+			ActorName:          a.ActorName,
+			ActorType:          a.ActorType,
+			ActorAvatarVersion: a.ActorAvatarVersion,
+			Summary:            summary,
+			Detail:             a.Note,
+			TagSlug:            a.TagSlug,
+			TagDisplayName:     display,
+			TagColor:           color,
+			TagAction:          action,
+		}
+		if a.ActorID != nil && *a.ActorID != "" {
+			id := *a.ActorID
+			entry.ActorID = &id
+		}
+		return entry, true
+
+	case "category_set":
+		entry := service.ActivityEntry{
+			Type:               "category",
+			Timestamp:          a.CreatedAt,
+			ActorName:          a.ActorName,
+			ActorType:          a.ActorType,
+			ActorAvatarVersion: a.ActorAvatarVersion,
+			Summary:            "Category set to " + a.Subject,
+			CategoryName:       a.Subject,
+		}
+		if a.ActorID != nil && *a.ActorID != "" {
+			id := *a.ActorID
+			entry.ActorID = &id
+		}
+		return entry, true
+	}
+	return service.ActivityEntry{}, false
 }
 
 // ActivityDayGroup holds activity entries grouped by calendar day (in the

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -129,15 +129,32 @@ func mapAnnotationKinds(kinds []string) ([]string, error) {
 }
 
 // mcpAnnotation is the agent-facing annotation shape. `kind` is the generic
-// name (comment | rule | tag | category); `action` carries the specific event
-// (added | removed | set | applied) so agents can branch without parsing the
-// kind string. Comment rows omit `action` since there is only one event.
+// name (comment | rule | tag | category); `action` carries the specific
+// event verb (added | removed | set | applied | commented) so agents can
+// branch without parsing the kind string.
+//
+// `summary` is a human-readable one-liner ("Alice added the food tag") so
+// agents can read activity directly without composing sentences from
+// payload keys; the underlying `payload` is preserved for raw access.
+// `subject` is the canonical object of the event (tag display name,
+// category display name, rule name, or comment body preview), and the
+// top-level resource refs (`tag_slug`, `category_slug`, `rule_name`) make
+// cross-linking cheap.
 type mcpAnnotation struct {
 	ID            string                 `json:"id"`
 	ShortID       string                 `json:"short_id"`
 	TransactionID string                 `json:"transaction_id"`
 	Kind          string                 `json:"kind"`
 	Action        string                 `json:"action,omitempty"`
+	Summary       string                 `json:"summary,omitempty"`
+	Subject       string                 `json:"subject,omitempty"`
+	Origin        string                 `json:"origin,omitempty"`
+	Source        string                 `json:"source,omitempty"`
+	Content       string                 `json:"content,omitempty"`
+	Note          string                 `json:"note,omitempty"`
+	TagSlug       string                 `json:"tag_slug,omitempty"`
+	CategorySlug  string                 `json:"category_slug,omitempty"`
+	RuleName      string                 `json:"rule_name,omitempty"`
 	ActorType     string                 `json:"actor_type"`
 	ActorID       *string                `json:"actor_id,omitempty"`
 	ActorName     string                 `json:"actor_name"`
@@ -168,13 +185,30 @@ func dbKindToMCP(dbKind string) (kind, action string) {
 }
 
 func toMCPAnnotation(a service.Annotation) mcpAnnotation {
-	kind, action := dbKindToMCP(a.Kind)
+	kind, fallbackAction := dbKindToMCP(a.Kind)
+	// Action prefers the enriched value populated by
+	// service.EnrichAnnotations (which leaves it empty for kind=comment
+	// by design); fall back to the legacy kind→action mapping for raw
+	// rows returned via ListAnnotations(Raw=true).
+	action := a.Action
+	if action == "" && a.Kind != "comment" {
+		action = fallbackAction
+	}
 	return mcpAnnotation{
 		ID:            a.ID,
 		ShortID:       a.ShortID,
 		TransactionID: a.TransactionID,
 		Kind:          kind,
 		Action:        action,
+		Summary:       a.Summary,
+		Subject:       a.Subject,
+		Origin:        a.Origin,
+		Source:        a.Source,
+		Content:       a.Content,
+		Note:          a.Note,
+		TagSlug:       a.TagSlug,
+		CategorySlug:  a.CategorySlug,
+		RuleName:      a.RuleName,
 		ActorType:     a.ActorType,
 		ActorID:       a.ActorID,
 		ActorName:     a.ActorName,

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -15,6 +15,11 @@ import (
 // Annotation is the canonical timeline event for a transaction — the single
 // source of truth for comments, rule applications, tag changes, and category
 // sets.
+//
+// The derived fields (Action through RuleName, plus Summary) are populated by
+// ListAnnotations after enrichment and are empty on rows fetched via the raw
+// row converters. They give MCP agents and the admin UI a uniform, ready-to-
+// render view without forcing every consumer to fish keys out of Payload.
 type Annotation struct {
 	ID            string                 `json:"id"`
 	ShortID       string                 `json:"short_id"`
@@ -28,6 +33,51 @@ type Annotation struct {
 	TagID         *string                `json:"tag_id,omitempty"`
 	RuleID        *string                `json:"rule_id,omitempty"`
 	CreatedAt     string                 `json:"created_at"`
+
+	// ---- Derived fields (populated by ListAnnotations enrichment) ----
+
+	// Action is the normalized verb for the event:
+	//   added | removed | set | applied | commented
+	// It strips the verb out of Kind ("tag_added" → "added") so consumers
+	// can branch on a single-word action without parsing the kind string.
+	Action string `json:"action,omitempty"`
+
+	// Summary is a one-line human-readable rendering of the event:
+	//   "Alice added the Food tag"
+	//   "Rule \"Auto-tag new transactions\" added tag needs-review during sync"
+	//   "Bob set category to Groceries"
+	// Designed so MCP agents can read activity without composing sentences
+	// themselves and the admin UI can render rows with a single Summary draw.
+	Summary string `json:"summary,omitempty"`
+
+	// Subject is the canonical object of the event — the tag display-name,
+	// the category display-name, the rule name, or the comment body. Empty
+	// when the kind has no object (rare).
+	Subject string `json:"subject,omitempty"`
+
+	// Origin describes how a rule-applied row reached the transaction:
+	// "during sync" or "retroactively". Empty for non-rule events.
+	Origin string `json:"origin,omitempty"`
+
+	// Source surfaces the payload's source qualifier ("rule" when the row
+	// was written as part of a rule application). Most rule-source rows are
+	// elided by enrichment in favor of the parent rule_applied annotation,
+	// but Source remains populated where they survive.
+	Source string `json:"source,omitempty"`
+
+	// Content is the comment body for kind=comment, surfaced from payload
+	// so comment readers don't need to peek at the untyped map.
+	Content string `json:"content,omitempty"`
+
+	// Note is the optional rationale recorded alongside a tag add/remove,
+	// surfaced from payload.
+	Note string `json:"note,omitempty"`
+
+	// Top-level resource references surfaced from payload so consumers can
+	// cross-link without parsing the untyped map.
+	TagSlug      string `json:"tag_slug,omitempty"`
+	CategorySlug string `json:"category_slug,omitempty"`
+	RuleName     string `json:"rule_name,omitempty"`
 
 	// ActorAvatarVersion is the unix timestamp of the user's most recent
 	// users.updated_at, used as a cache-busting `?v=<ts>` query string on
@@ -95,12 +145,24 @@ type ListAnnotationsParams struct {
 	// comment | rule_applied | tag_added | tag_removed | category_set).
 	// Empty = no filter.
 	Kinds []string
+
+	// Raw, when true, skips enrichment and dedup. The returned rows have
+	// their structural fields populated but no Summary/Action/etc., and
+	// rule-source duplicates and same-actor adjacent comment-vs-tag-note
+	// duplicates are kept. Useful for audit/debugging callers that need
+	// the unmodified DB view. Defaults to false (enriched + deduped).
+	Raw bool
 }
 
 // ListAnnotations returns annotations for a transaction, ordered by created_at
-// ASC. Drives the transaction detail activity timeline. Pass an empty
-// ListAnnotationsParams for the full timeline; use Kinds to scope the result
-// (e.g. comments only).
+// ASC. Drives the transaction detail activity timeline and the MCP
+// list_annotations tool. By default the rows are enriched (Summary, Action,
+// Subject, top-level resource refs) and deduplicated (rule-source tag/category
+// rows are folded into the parent rule_applied row, and same-actor adjacent
+// comment-vs-tag-note pairs are collapsed). Pass Raw=true to bypass enrichment.
+//
+// Pass an empty ListAnnotationsParams for the full timeline; use Kinds to
+// scope the result (e.g. comments only).
 func (s *Service) ListAnnotations(ctx context.Context, transactionID string, params ListAnnotationsParams) ([]Annotation, error) {
 	txnID, err := s.resolveTransactionID(ctx, transactionID)
 	if err != nil {
@@ -116,15 +178,39 @@ func (s *Service) ListAnnotations(ctx context.Context, transactionID string, par
 		return nil, fmt.Errorf("list annotations: %w", err)
 	}
 
-	keep := annotationKindFilter(params.Kinds)
-	result := make([]Annotation, 0, len(rows))
+	all := make([]Annotation, 0, len(rows))
 	for _, r := range rows {
-		if keep != nil && !keep[r.Kind] {
-			continue
-		}
-		result = append(result, annotationFromActorRow(r))
+		all = append(all, annotationFromActorRow(r))
 	}
-	return result, nil
+
+	if params.Raw {
+		return filterAnnotationKinds(all, params.Kinds), nil
+	}
+
+	enriched, err := s.enrichAnnotations(ctx, all)
+	if err != nil {
+		return nil, fmt.Errorf("enrich annotations: %w", err)
+	}
+	return filterAnnotationKinds(enriched, params.Kinds), nil
+}
+
+// filterAnnotationKinds returns the subset of `in` whose Kind matches one of
+// the listed kinds. An empty kinds slice is treated as a no-op (returns the
+// input unchanged). Filtering happens after enrichment so dedup decisions
+// see the full set, not a kind-filtered slice that would miss the parent
+// rule_applied row needed to elide its rule-source duplicates.
+func filterAnnotationKinds(in []Annotation, kinds []string) []Annotation {
+	keep := annotationKindFilter(kinds)
+	if keep == nil {
+		return in
+	}
+	out := make([]Annotation, 0, len(in))
+	for _, a := range in {
+		if keep[a.Kind] {
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // annotationKindFilter builds an O(1) lookup set from a kinds slice. Returns

--- a/internal/service/annotations_enrich.go
+++ b/internal/service/annotations_enrich.go
@@ -1,0 +1,390 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// enrichAnnotations is the *Service method that owns building tag/category
+// display lookups (one DB query each, both bounded and small) and delegating
+// to the pure EnrichAnnotations helper. Splitting the method this way keeps
+// the algorithm testable without a database.
+func (s *Service) enrichAnnotations(ctx context.Context, in []Annotation) ([]Annotation, error) {
+	if len(in) == 0 {
+		return in, nil
+	}
+
+	tags, err := s.ListTags(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list tags for enrichment: %w", err)
+	}
+	tagDisplay := buildTagDisplayLookup(tags)
+
+	tree, err := s.ListCategoryTree(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list categories for enrichment: %w", err)
+	}
+	categoryDisplay := buildCategoryDisplayLookup(tree)
+
+	return EnrichAnnotations(in, EnrichOptions{
+		TagDisplay:      tagDisplay,
+		CategoryDisplay: categoryDisplay,
+	}), nil
+}
+
+// EnrichOptions carries the display lookups EnrichAnnotations needs to
+// humanize slugs into readable names. Both lookups are optional — empty
+// closures fall back to using the raw slug as the display name.
+type EnrichOptions struct {
+	// TagDisplay maps a tag slug to its registered display name. Returns
+	// the slug unchanged when the tag is no longer registered.
+	TagDisplay func(slug string) string
+
+	// CategoryDisplay maps a category slug to its "Parent › Child" display
+	// name. Returns the slug unchanged when the category isn't found.
+	CategoryDisplay func(slug string) string
+}
+
+// EnrichAnnotations is a pure transformation that:
+//
+//  1. Drops rule-source duplicates: tag_added / tag_removed / category_set
+//     rows whose payload.source == "rule" are emitted alongside a parent
+//     rule_applied row by sync; the rule_applied row carries the same
+//     information and is the canonical audit record. We keep rule_applied
+//     and elide its rule-source children.
+//
+//  2. Drops adjacent same-actor comment-vs-tag-note duplicates: the MCP
+//     update_transactions tool can write a tag-with-note AND a standalone
+//     comment in one call; the resulting rows land within milliseconds. We
+//     keep the tag row (its payload.note carries the rationale) and drop
+//     the redundant comment.
+//
+//  3. Computes Action, Summary, Subject, Origin, Source, Note, Content,
+//     and the top-level resource refs (TagSlug, CategorySlug, RuleName)
+//     from each row's kind and payload. Empty/missing values are tolerated:
+//     a row with an unknown kind round-trips with an empty Summary so
+//     unrecognized event types don't disappear.
+//
+// The function does not mutate its input. Order is preserved.
+func EnrichAnnotations(in []Annotation, opts EnrichOptions) []Annotation {
+	if len(in) == 0 {
+		return in
+	}
+
+	tagDisplay := opts.TagDisplay
+	if tagDisplay == nil {
+		tagDisplay = identityDisplay
+	}
+	categoryDisplay := opts.CategoryDisplay
+	if categoryDisplay == nil {
+		categoryDisplay = identityDisplay
+	}
+
+	out := make([]Annotation, 0, len(in))
+	for i := range in {
+		src := in[i]
+		// 1. Drop rule-source structural rows in favor of the parent
+		//    rule_applied row.
+		if isRuleSourceDuplicate(src) {
+			continue
+		}
+		// 2. Drop the standalone comment that mirrors an adjacent
+		//    tag_added.note from the same actor.
+		if src.Kind == "comment" && isCommentDuplicateOfTagNote(in, src) {
+			continue
+		}
+		out = append(out, enrichOne(src, tagDisplay, categoryDisplay))
+	}
+	return out
+}
+
+// identityDisplay is the fallback display closure when no lookup is supplied:
+// the raw slug round-trips unchanged.
+func identityDisplay(s string) string { return s }
+
+// isRuleSourceDuplicate reports whether an annotation row was written as a
+// side-effect of a rule application and therefore duplicates a parent
+// rule_applied row. Only tag_added / tag_removed / category_set rows can
+// carry source="rule" today; comment and rule_applied are never deduped here.
+func isRuleSourceDuplicate(a Annotation) bool {
+	switch a.Kind {
+	case "tag_added", "tag_removed", "category_set":
+		source, _ := a.Payload["source"].(string)
+		return source == "rule"
+	}
+	return false
+}
+
+// isCommentDuplicateOfTagNote reports whether `c` is the standalone-comment
+// half of an MCP update_transactions call that wrote a tag-with-note plus a
+// comment with identical content within ±2 seconds, by the same actor. The
+// tag row already inlines the note via payload.note; the comment is
+// redundant noise on the timeline.
+func isCommentDuplicateOfTagNote(all []Annotation, c Annotation) bool {
+	content, _ := c.Payload["content"].(string)
+	if content == "" {
+		return false
+	}
+	// Filter the legacy [Review: ...] prefix from pre-consolidation imports
+	// inline so we don't have to dedup an artifact that's pure import noise.
+	if strings.HasPrefix(content, "[Review: ") {
+		return true
+	}
+	cT, err := time.Parse(time.RFC3339Nano, c.CreatedAt)
+	if err != nil {
+		return false
+	}
+	const window = 2 * time.Second
+	for _, a := range all {
+		if a.Kind != "tag_added" {
+			continue
+		}
+		note, _ := a.Payload["note"].(string)
+		if note != content {
+			continue
+		}
+		if !sameActor(a, c) {
+			continue
+		}
+		aT, err := time.Parse(time.RFC3339Nano, a.CreatedAt)
+		if err != nil {
+			continue
+		}
+		diff := cT.Sub(aT)
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff <= window {
+			return true
+		}
+	}
+	return false
+}
+
+// sameActor compares two annotations' actor identity. Prefers a non-empty
+// ActorID match (system actors don't have IDs); falls back to ActorName when
+// both rows lack an ID. This mirrors the original admin-handler heuristic.
+func sameActor(a, b Annotation) bool {
+	aID := derefString(a.ActorID)
+	bID := derefString(b.ActorID)
+	if aID != "" && bID != "" {
+		return aID == bID
+	}
+	if aID == "" && bID == "" {
+		return a.ActorName == b.ActorName
+	}
+	return false
+}
+
+func derefString(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// enrichOne builds the derived fields for a single annotation. Unknown
+// kinds round-trip with an empty Summary so future kinds aren't dropped.
+func enrichOne(a Annotation, tagDisplay, categoryDisplay func(string) string) Annotation {
+	switch a.Kind {
+	case "comment":
+		// Comments don't carry an Action — kind="comment" is already the
+		// discriminator (there is only one comment verb). Pre-existing MCP
+		// integration tests pin this contract; set Action only for kinds
+		// where it adds information.
+		content, _ := a.Payload["content"].(string)
+		a.Content = content
+		a.Subject = content
+		a.Summary = formatCommentSummary(a.ActorName, content)
+
+	case "tag_added", "tag_removed":
+		slug, _ := a.Payload["slug"].(string)
+		note, _ := a.Payload["note"].(string)
+		source, _ := a.Payload["source"].(string)
+		display := tagDisplay(slug)
+		if display == "" {
+			display = slug
+		}
+		if a.Kind == "tag_added" {
+			a.Action = "added"
+		} else {
+			a.Action = "removed"
+		}
+		a.TagSlug = slug
+		a.Subject = display
+		a.Note = note
+		a.Source = source
+		a.Summary = formatTagSummary(a.ActorName, a.Action, display, note)
+
+	case "category_set":
+		slug, _ := a.Payload["category_slug"].(string)
+		source, _ := a.Payload["source"].(string)
+		display := categoryDisplay(slug)
+		if display == "" {
+			display = slug
+		}
+		a.Action = "set"
+		a.CategorySlug = slug
+		a.Subject = display
+		a.Source = source
+		a.Summary = formatCategorySummary(a.ActorName, display)
+
+	case "rule_applied":
+		ruleName, _ := a.Payload["rule_name"].(string)
+		field, _ := a.Payload["action_field"].(string)
+		value, _ := a.Payload["action_value"].(string)
+		appliedBy, _ := a.Payload["applied_by"].(string)
+		a.Action = "applied"
+		a.RuleName = ruleName
+		a.Origin = formatRuleOrigin(appliedBy)
+		// Surface the targeted resource ref so callers can cross-link
+		// without parsing payload.
+		switch field {
+		case "tag":
+			a.TagSlug = value
+			a.Subject = ruleName
+		case "category":
+			a.CategorySlug = value
+			a.Subject = ruleName
+		default:
+			a.Subject = ruleName
+		}
+		a.Summary = formatRuleSummary(ruleName, field, value, categoryDisplay, a.Origin)
+	}
+
+	return a
+}
+
+// formatCommentSummary builds a one-line preview of a comment for the
+// timeline summary slot. Long bodies are truncated to a single visual line
+// (with an ellipsis) while the full content stays on Annotation.Content.
+func formatCommentSummary(actor, content string) string {
+	preview := strings.TrimSpace(content)
+	if i := strings.IndexAny(preview, "\r\n"); i >= 0 {
+		preview = preview[:i] + "…"
+	}
+	const max = 120
+	if len(preview) > max {
+		preview = preview[:max] + "…"
+	}
+	switch {
+	case actor == "" && preview == "":
+		return "Comment"
+	case actor == "":
+		return "commented: " + preview
+	case preview == "":
+		return actor + " commented"
+	}
+	return actor + " commented: " + preview
+}
+
+func formatTagSummary(actor, action, display, note string) string {
+	if display == "" {
+		display = "tag"
+	}
+	prefix := actor + " " + action + " the " + display + " tag"
+	if actor == "" {
+		// Capitalize action verb so the sentence still scans without an
+		// actor prefix. ("Added the food tag", "Removed the food tag".)
+		prefix = strings.ToUpper(action[:1]) + action[1:] + " the " + display + " tag"
+	}
+	if note == "" {
+		return prefix
+	}
+	return prefix + " — " + note
+}
+
+func formatCategorySummary(actor, display string) string {
+	if actor == "" {
+		return "Set category to " + display
+	}
+	return actor + " set category to " + display
+}
+
+// formatRuleSummary mirrors the admin-side "Rule \"X\" set category to Y"
+// phrasing but appends the origin ("during sync" / "retroactively") so the
+// rendered string is self-contained for MCP consumers that don't read Origin
+// separately.
+func formatRuleSummary(ruleName, field, value string, categoryDisplay func(string) string, origin string) string {
+	subject := `Rule "` + ruleName + `"`
+	if ruleName == "" {
+		subject = "A rule"
+	}
+	displayValue := value
+	if field == "category" {
+		displayValue = categoryDisplay(value)
+		if displayValue == "" {
+			displayValue = value
+		}
+	}
+	var verb string
+	switch field {
+	case "category":
+		verb = "set category to " + displayValue
+	case "tag":
+		verb = "added tag " + value
+	case "comment":
+		verb = "added a comment"
+	default:
+		verb = "applied"
+	}
+	if origin == "" {
+		return subject + " " + verb
+	}
+	return subject + " " + verb + " " + origin
+}
+
+// formatRuleOrigin maps the payload's applied_by field to the standardized
+// origin phrase. "sync" (the default) yields "during sync"; "retroactive"
+// yields "retroactively"; anything else falls back to empty so callers don't
+// render a misleading qualifier.
+func formatRuleOrigin(appliedBy string) string {
+	switch appliedBy {
+	case "", "sync":
+		return "during sync"
+	case "retroactive":
+		return "retroactively"
+	}
+	return ""
+}
+
+// buildTagDisplayLookup converts a registered-tag list into a slug → display
+// name closure. Slugs without a registered tag fall back to the slug itself.
+func buildTagDisplayLookup(tags []TagResponse) func(string) string {
+	by := make(map[string]string, len(tags))
+	for _, t := range tags {
+		by[t.Slug] = t.DisplayName
+	}
+	return func(slug string) string {
+		if slug == "" {
+			return ""
+		}
+		if name, ok := by[slug]; ok && name != "" {
+			return name
+		}
+		return slug
+	}
+}
+
+// buildCategoryDisplayLookup converts a category tree into a slug → "Parent ›
+// Child" closure. Falls back to the slug when the category isn't found.
+func buildCategoryDisplayLookup(tree []CategoryResponse) func(string) string {
+	names := make(map[string]string, 64)
+	for _, parent := range tree {
+		names[parent.Slug] = parent.DisplayName
+		for _, child := range parent.Children {
+			names[child.Slug] = parent.DisplayName + " › " + child.DisplayName
+		}
+	}
+	return func(slug string) string {
+		if slug == "" {
+			return ""
+		}
+		if name, ok := names[slug]; ok {
+			return name
+		}
+		return slug
+	}
+}

--- a/internal/service/annotations_enrich_test.go
+++ b/internal/service/annotations_enrich_test.go
@@ -1,0 +1,419 @@
+package service
+
+import (
+	"testing"
+)
+
+// EnrichAnnotations is the canonical home of the dedup + summary logic that
+// powers the admin activity timeline and the MCP list_annotations tool. The
+// tests below cover its three responsibilities:
+//
+//  1. Drop rule-source structural rows (tag_added/tag_removed/category_set
+//     written alongside a rule_applied) so consumers don't see the same event
+//     twice.
+//  2. Drop the standalone-comment half of an MCP update_transactions call
+//     that wrote a tag-with-note plus an identical comment within ±2s.
+//  3. Compute Action/Summary/Subject/Origin/Source/Note/Content/TagSlug/
+//     CategorySlug/RuleName from the kind+payload.
+//
+// They are pure unit tests (no DB) — the helper takes EnrichOptions closures
+// directly so we don't need s.ListTags / s.ListCategoryTree.
+
+func tagDisplayFromMap(by map[string]string) func(string) string {
+	return func(slug string) string {
+		if name, ok := by[slug]; ok {
+			return name
+		}
+		return slug
+	}
+}
+
+func TestEnrichAnnotations_TagAddedHumanizesAndComposesSummary(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "a1",
+		Kind:      "tag_added",
+		ActorName: "Alice",
+		Payload: map[string]interface{}{
+			"slug": "food",
+		},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{
+		TagDisplay: tagDisplayFromMap(map[string]string{"food": "Food"}),
+	})
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	got := out[0]
+	if got.Action != "added" {
+		t.Errorf("Action = %q, want added", got.Action)
+	}
+	if got.TagSlug != "food" {
+		t.Errorf("TagSlug = %q, want food", got.TagSlug)
+	}
+	if got.Subject != "Food" {
+		t.Errorf("Subject = %q, want Food", got.Subject)
+	}
+	if got.Summary != "Alice added the Food tag" {
+		t.Errorf("Summary = %q, want %q", got.Summary, "Alice added the Food tag")
+	}
+}
+
+func TestEnrichAnnotations_TagRemovedWithNoteAppendsRationale(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "a1",
+		Kind:      "tag_removed",
+		ActorName: "Bob",
+		Payload: map[string]interface{}{
+			"slug": "needs-review",
+			"note": "wrong category",
+		},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{
+		TagDisplay: tagDisplayFromMap(map[string]string{"needs-review": "Needs Review"}),
+	})
+	got := out[0]
+	if got.Action != "removed" {
+		t.Errorf("Action = %q, want removed", got.Action)
+	}
+	if got.Note != "wrong category" {
+		t.Errorf("Note = %q, want \"wrong category\"", got.Note)
+	}
+	want := "Bob removed the Needs Review tag — wrong category"
+	if got.Summary != want {
+		t.Errorf("Summary = %q, want %q", got.Summary, want)
+	}
+}
+
+// Rule-source tag_added/tag_removed/category_set rows are deduped — the
+// parent rule_applied row carries the same information.
+func TestEnrichAnnotations_DropsRuleSourcedTagAdded(t *testing.T) {
+	ruleID := "rule-1"
+	rows := []Annotation{
+		{
+			ID:        "a-tag",
+			Kind:      "tag_added",
+			ActorName: "Auto-tag",
+			ActorType: "system",
+			ActorID:   &ruleID,
+			Payload: map[string]interface{}{
+				"slug":   "needs-review",
+				"source": "rule",
+			},
+			CreatedAt: "2026-04-04T12:00:00Z",
+		},
+		{
+			ID:        "a-rule",
+			Kind:      "rule_applied",
+			ActorName: "Auto-tag",
+			ActorType: "system",
+			ActorID:   &ruleID,
+			RuleID:    &ruleID,
+			Payload: map[string]interface{}{
+				"rule_name":    "Auto-tag",
+				"action_field": "tag",
+				"action_value": "needs-review",
+				"applied_by":   "sync",
+			},
+			CreatedAt: "2026-04-04T12:00:00Z",
+		},
+	}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1 (rule_applied only)", len(out))
+	}
+	if out[0].Kind != "rule_applied" {
+		t.Errorf("survivor kind = %q, want rule_applied", out[0].Kind)
+	}
+	if out[0].Action != "applied" {
+		t.Errorf("Action = %q, want applied", out[0].Action)
+	}
+	if out[0].Origin != "during sync" {
+		t.Errorf("Origin = %q, want \"during sync\"", out[0].Origin)
+	}
+	if out[0].TagSlug != "needs-review" {
+		t.Errorf("TagSlug = %q, want needs-review", out[0].TagSlug)
+	}
+	wantSummary := `Rule "Auto-tag" added tag needs-review during sync`
+	if out[0].Summary != wantSummary {
+		t.Errorf("Summary = %q, want %q", out[0].Summary, wantSummary)
+	}
+}
+
+// User-authored tag additions (no source=rule) survive enrichment.
+func TestEnrichAnnotations_KeepsUserAuthoredTagAdded(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "a1",
+		Kind:      "tag_added",
+		ActorName: "Alice",
+		Payload: map[string]interface{}{
+			"slug": "vacation",
+		},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 1 || out[0].Kind != "tag_added" {
+		t.Fatalf("expected user tag_added to survive, got %v", out)
+	}
+}
+
+func TestEnrichAnnotations_RuleAppliedRetroactiveOrigin(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "a1",
+		Kind:      "rule_applied",
+		ActorName: "",
+		ActorType: "system",
+		Payload: map[string]interface{}{
+			"rule_name":    "Walgreens",
+			"action_field": "category",
+			"action_value": "shopping",
+			"applied_by":   "retroactive",
+		},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{
+		CategoryDisplay: tagDisplayFromMap(map[string]string{"shopping": "Shopping"}),
+	})
+	got := out[0]
+	if got.Origin != "retroactively" {
+		t.Errorf("Origin = %q, want retroactively", got.Origin)
+	}
+	if got.CategorySlug != "shopping" {
+		t.Errorf("CategorySlug = %q, want shopping", got.CategorySlug)
+	}
+	want := `Rule "Walgreens" set category to Shopping retroactively`
+	if got.Summary != want {
+		t.Errorf("Summary = %q, want %q", got.Summary, want)
+	}
+}
+
+// Empty rule_name on a rule_applied row produces the "A rule" fallback
+// rather than `Rule ""` (mirrors the admin-handler invariant from #704).
+func TestEnrichAnnotations_RuleAppliedEmptyNameFallsBack(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "a1",
+		Kind:      "rule_applied",
+		ActorType: "system",
+		Payload: map[string]interface{}{
+			"rule_name":    "",
+			"action_field": "category",
+			"action_value": "food_and_drink_groceries",
+			"applied_by":   "retroactive",
+		},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{
+		CategoryDisplay: tagDisplayFromMap(map[string]string{"food_and_drink_groceries": "Food & Drink › Groceries"}),
+	})
+	want := "A rule set category to Food & Drink › Groceries retroactively"
+	if out[0].Summary != want {
+		t.Errorf("Summary = %q, want %q", out[0].Summary, want)
+	}
+}
+
+// Comment with content identical to an adjacent tag_added.note from the
+// same actor within ±2s is deduped (it's the standalone-comment half of
+// an MCP update_transactions call). The tag row already inlines the note.
+func TestEnrichAnnotations_DropsCommentDuplicatingAdjacentTagNote(t *testing.T) {
+	actor := "user-1"
+	note := "Please review this one again"
+	rows := []Annotation{
+		{
+			ID:        "a-tag",
+			Kind:      "tag_added",
+			ActorID:   &actor,
+			ActorName: "alice",
+			Payload: map[string]interface{}{
+				"slug": "needs-review",
+				"note": note,
+			},
+			CreatedAt: "2026-04-16T03:39:34.502794Z",
+		},
+		{
+			ID:        "a-comment",
+			Kind:      "comment",
+			ActorID:   &actor,
+			ActorName: "alice",
+			Payload: map[string]interface{}{
+				"content": note,
+			},
+			CreatedAt: "2026-04-16T03:39:34.513524Z",
+		},
+	}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1 (duplicate comment dropped)", len(out))
+	}
+	if out[0].Kind != "tag_added" {
+		t.Errorf("survivor kind = %q, want tag_added", out[0].Kind)
+	}
+}
+
+// A comment outside the ±2s window of a matching tag_added.note is NOT
+// deduped — users can legitimately repeat the same text minutes later.
+func TestEnrichAnnotations_KeepsDistantComment(t *testing.T) {
+	actor := "user-1"
+	note := "duplicate text"
+	rows := []Annotation{
+		{
+			ID:        "a-tag",
+			Kind:      "tag_added",
+			ActorID:   &actor,
+			ActorName: "alice",
+			Payload: map[string]interface{}{
+				"slug": "needs-review",
+				"note": note,
+			},
+			CreatedAt: "2026-04-16T03:39:34Z",
+		},
+		{
+			ID:        "a-comment",
+			Kind:      "comment",
+			ActorID:   &actor,
+			ActorName: "alice",
+			Payload: map[string]interface{}{
+				"content": note,
+			},
+			CreatedAt: "2026-04-16T03:40:34Z", // 60s later
+		},
+	}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2 (distant timestamps preserved)", len(out))
+	}
+}
+
+// Legacy [Review: ...] prefixed comments are import noise from the
+// pre-consolidation reviews table and get suppressed by enrichment.
+func TestEnrichAnnotations_DropsLegacyReviewPrefixedComment(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "legacy",
+		Kind:      "comment",
+		ActorName: "Legacy",
+		ActorType: "system",
+		Payload: map[string]interface{}{
+			"content": "[Review: Some note migrated before consolidation]",
+		},
+		CreatedAt: "2026-03-01T00:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 0 {
+		t.Errorf("len = %d, want 0 (legacy prefix should be suppressed)", len(out))
+	}
+}
+
+func TestEnrichAnnotations_CommentSummaryIncludesPreview(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "c1",
+		Kind:      "comment",
+		ActorName: "Alice",
+		Payload: map[string]interface{}{
+			"content": "split with Bob",
+		},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	got := out[0]
+	// Comments deliberately do NOT carry an Action — kind="comment" is
+	// the discriminator, and the existing MCP integration test pins
+	// this contract.
+	if got.Action != "" {
+		t.Errorf("Action = %q, want empty (comment kind)", got.Action)
+	}
+	if got.Content != "split with Bob" {
+		t.Errorf("Content = %q, want \"split with Bob\"", got.Content)
+	}
+	want := "Alice commented: split with Bob"
+	if got.Summary != want {
+		t.Errorf("Summary = %q, want %q", got.Summary, want)
+	}
+}
+
+func TestEnrichAnnotations_CommentSummaryTruncatesLongBodies(t *testing.T) {
+	body := ""
+	for i := 0; i < 200; i++ {
+		body += "x"
+	}
+	rows := []Annotation{{
+		ID:        "c1",
+		Kind:      "comment",
+		ActorName: "Alice",
+		Payload:   map[string]interface{}{"content": body},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	got := out[0]
+	// Content carries the full body; Summary truncates with an ellipsis
+	// at the 120-char preview budget. Rune count gives us a UTF-8-safe
+	// upper bound — "…" is one rune but 3 bytes.
+	if got.Content != body {
+		t.Errorf("Content should be unmodified, got %d chars", len(got.Content))
+	}
+	runeCount := len([]rune(got.Summary))
+	maxRunes := len([]rune("Alice commented: ")) + 120 + 1 // 120 preview + 1 ellipsis
+	if runeCount > maxRunes {
+		t.Errorf("Summary should be truncated, got %d runes (max %d): %q", runeCount, maxRunes, got.Summary)
+	}
+	tail := []rune(got.Summary)
+	if len(tail) == 0 || tail[len(tail)-1] != '…' {
+		t.Errorf("Summary should end with ellipsis, got %q", got.Summary)
+	}
+}
+
+// Multi-line comment bodies preview only the first line in Summary so the
+// timeline row stays single-line. Full body is on Content.
+func TestEnrichAnnotations_CommentSummaryStopsAtFirstNewline(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "c1",
+		Kind:      "comment",
+		ActorName: "Alice",
+		Payload:   map[string]interface{}{"content": "first line\nsecond line\nthird"},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	want := "Alice commented: first line…"
+	if out[0].Summary != want {
+		t.Errorf("Summary = %q, want %q", out[0].Summary, want)
+	}
+}
+
+// Unknown kinds round-trip with their structural fields intact and an
+// empty Action/Summary so future event types aren't silently dropped.
+func TestEnrichAnnotations_UnknownKindRoundTrips(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "a1",
+		Kind:      "future_event",
+		ActorName: "Alice",
+		Payload:   map[string]interface{}{"foo": "bar"},
+		CreatedAt: "2026-04-04T12:00:00Z",
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	got := out[0]
+	if got.Kind != "future_event" {
+		t.Errorf("Kind = %q, want future_event", got.Kind)
+	}
+	if got.Action != "" || got.Summary != "" {
+		t.Errorf("expected empty derived fields for unknown kind, got Action=%q Summary=%q", got.Action, got.Summary)
+	}
+}
+
+func TestEnrichAnnotations_PreservesOrder(t *testing.T) {
+	rows := []Annotation{
+		{ID: "a", Kind: "comment", ActorName: "alice", Payload: map[string]interface{}{"content": "1"}, CreatedAt: "2026-04-01T00:00:00Z"},
+		{ID: "b", Kind: "comment", ActorName: "bob", Payload: map[string]interface{}{"content": "2"}, CreatedAt: "2026-04-02T00:00:00Z"},
+		{ID: "c", Kind: "comment", ActorName: "cathy", Payload: map[string]interface{}{"content": "3"}, CreatedAt: "2026-04-03T00:00:00Z"},
+	}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 3 {
+		t.Fatalf("len = %d, want 3", len(out))
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		if out[i].ID != want {
+			t.Errorf("out[%d].ID = %q, want %q", i, out[i].ID, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Moves activity-timeline summary derivation and dedup rules out of the admin handler into the service layer so MCP agents (`list_annotations`) and the admin UI render from the same source of truth. Each annotation now carries pre-computed `summary`, `action`, `subject`, `origin`, and top-level resource refs — agents can read activity directly without fishing keys out of the untyped `payload`.

The previous split made `internal/admin/transactions.go` the canonical home of dedup ("rule-source tag_added vs rule_applied" and "comment vs adjacent tag-note within ±2s") plus sentence formatting. MCP `list_annotations` bypassed all of it and emitted both halves of every rule-source pair as separate rows. With activity logs being a primary read surface for both humans and agents, the divergence was a real readability gap.

## Changes

- **`service.Annotation`** gains derived fields populated by `ListAnnotations`:
  - `Action` — `added` | `removed` | `set` | `applied` (empty for comments, by contract — `kind="comment"` is the discriminator)
  - `Summary` — one-liner: `"Alice added the Food tag"`, `"Rule \"X\" set category to Groceries during sync"`
  - `Subject` — display name of the object (tag, category, rule, or comment preview)
  - `Origin` — `"during sync"` / `"retroactively"` for rule events
  - `Source`, `Note`, `Content` — surfaced from payload
  - Top-level `TagSlug`, `CategorySlug`, `RuleName` so cross-linking is cheap
- **`service.EnrichAnnotations`** — pure helper that owns dedup + summary derivation. Pairs with `(*Service).enrichAnnotations` which wires up the tag-name and category-tree lookups. Order preserved.
- **`ListAnnotationsParams.Raw`** — opt-out for callers that need the unmodified DB view (audit/debugging). Defaults to enriched + deduped.
- **MCP `mcpAnnotation`** shape extended with the new fields. Existing `kind`/`action` contract preserved (comments still carry no `action`).
- **`internal/admin/transactions.go`** `buildActivityTimeline` becomes a thin mapper from enriched annotations to UI `ActivityEntry`. Tag color remains a presentation concern that lives in the admin layer via the existing `tagDisplayLookup`.

## Why this matters for agents

Before, an agent reading a tag-add event had to:

```python
slug = annotation["payload"]["slug"]
note = annotation["payload"].get("note", "")
display = lookup_tag(slug)  # extra round-trip
sentence = f"{annotation['actor_name']} added the {display} tag"
if note:
    sentence += f" — {note}"
```

After:

```python
sentence = annotation["summary"]   # done
slug    = annotation["tag_slug"]   # for any cross-linking
```

Same for rule-applied events — the agent gets `"Rule \"X\" set category to Groceries during sync"` ready-to-render.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` (all green)
- [x] Pure unit tests for `EnrichAnnotations` cover dedup edges, rule-origin formatting, summary truncation, multi-line preview, unknown-kind round-tripping, and order preservation
- [x] Existing admin `buildActivityTimeline` tests still pass (the function still accepts the same signature; dedup just delegates to service)
- [ ] Reviewer: sanity-check the new MCP fields surface on a live `list_annotations` call

Sits on top of #845 (GitHub-style activity timeline) in the stack.
