### PR TITLE
fix(transactions): chat-bubble comments + actor avatars on system events

### DIFF
--- a/input.css
+++ b/input.css
@@ -611,6 +611,27 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
   }
 
+  /* ── Comment bubble ──
+   *
+   * Chat-style bubble used by the transaction-detail activity timeline for
+   * comment rows. The flat top-left corner visually points at the avatar on
+   * the rail without needing a CSS tail/notch. Future plan: hoist into a
+   * shared .bb-bubble once review cards adopt the same shape. */
+  .bb-comment-bubble {
+    display: inline-block;
+    max-width: 100%;
+    padding: 0.5rem 0.875rem;
+    font-size: 0.875rem;
+    line-height: 1.55;
+    color: color-mix(in srgb, var(--color-base-content) 88%, transparent);
+    background: color-mix(in srgb, var(--color-base-200) 75%, transparent);
+    border: 1px solid color-mix(in srgb, var(--color-base-300) 60%, transparent);
+    border-radius: 1rem;
+    border-top-left-radius: 0.375rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
   /* ── Info grid (detail pages) ── */
   .bb-info-grid {
     @apply grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm;

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -368,10 +368,18 @@ templ txdSystemSentence(e service.ActivityEntry) {
 	}
 }
 
-// txdActorInline renders the bold actor-name span used inside a system-event
-// sentence. Avatar isn't shown inline (it'd compete with the event icon);
-// the actor's identity reads from the bold name.
+// txdActorInline renders an actor reference inside a system-event sentence:
+// a tiny (16px) avatar followed by the bold name. Users get their photo;
+// agents get a bot tile; system/anonymous actors fall back to the bold name
+// alone since there is no actor identity to surface visually.
 templ txdActorInline(e service.ActivityEntry) {
+	if e.ActorType == "user" && e.ActorID != nil && *e.ActorID != "" {
+		<img src={ avatarURLStr(*e.ActorID, e.ActorAvatarVersion) } alt="" class="inline-block w-4 h-4 rounded-full object-cover align-text-bottom mr-1" aria-hidden="true"/>
+	} else if e.ActorType == "agent" {
+		<span class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary/10 align-text-bottom mr-1" aria-hidden="true">
+			<i data-lucide="bot" class="w-2.5 h-2.5 text-primary"></i>
+		</span>
+	}
 	<strong class="font-semibold text-base-content">{ e.ActorName }</strong>
 }
 
@@ -413,33 +421,34 @@ templ txdSystemIcon(e service.ActivityEntry) {
 	}
 }
 
-// txdTimelineComment renders a comment as a bordered card with a header bar
-// (author + verb + timestamp + delete) and a body. Avatar sits on the rail.
+// txdTimelineComment renders a comment as a chat-bubble: small author/time
+// meta-line above a rounded message blob. The bubble's top-left corner is
+// flattened so it visually points at the avatar on the rail. App-wide
+// bubble consolidation will hoist this style into a shared bb-bubble class
+// when the matching pattern lands on transactions and reviews.
 templ txdTimelineComment(e service.ActivityEntry) {
-	<li class="relative flex items-start gap-3 py-2 group">
+	<li class="relative flex items-start gap-3 py-2.5 group">
 		<div class="relative z-10 shrink-0 w-6 h-6 mt-0.5 flex items-center justify-center">
 			@txdCommentAvatar(e)
 		</div>
 		<div class="flex-1 min-w-0">
-			<article class="rounded-lg border border-base-200 bg-base-100 overflow-hidden">
-				<header class="px-3 py-2 bg-base-200/40 border-b border-base-200 flex items-baseline gap-1.5 flex-wrap">
-					if e.ActorName != "" {
-						<strong class="text-xs font-semibold text-base-content">{ e.ActorName }</strong>
-					}
-					<span class="text-xs text-base-content/50">commented</span>
-					if e.Timestamp != "" {
-						<time datetime={ e.Timestamp } class="text-[11px] text-base-content/40 tabular-nums" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
-					}
-					if e.CommentID != "" {
-						<button class="ml-auto rounded-md p-1 -m-1 text-base-content/30 hover:text-error hover:bg-error/5 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 transition" @click={ "deleteComment('" + e.CommentID + "')" } aria-label={ "Delete comment by " + e.ActorName } title="Delete comment">
-							<i data-lucide="trash-2" class="w-3.5 h-3.5" aria-hidden="true"></i>
-						</button>
-					}
-				</header>
-				if e.Detail != "" {
-					<div class="px-3 py-2.5 text-sm text-base-content/85 whitespace-pre-wrap leading-relaxed break-words">{ e.Detail }</div>
+			<div class="flex items-baseline gap-1.5 px-1 mb-1 flex-wrap">
+				if e.ActorName != "" {
+					<strong class="text-xs font-semibold text-base-content">{ e.ActorName }</strong>
 				}
-			</article>
+				<span class="text-xs text-base-content/50">commented</span>
+				if e.Timestamp != "" {
+					<time datetime={ e.Timestamp } class="text-[11px] text-base-content/40 tabular-nums" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
+				}
+				if e.CommentID != "" {
+					<button class="ml-auto rounded-md p-1 -m-1 text-base-content/30 hover:text-error hover:bg-error/5 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 transition" @click={ "deleteComment('" + e.CommentID + "')" } aria-label={ "Delete comment by " + e.ActorName } title="Delete comment">
+						<i data-lucide="trash-2" class="w-3.5 h-3.5" aria-hidden="true"></i>
+					</button>
+				}
+			</div>
+			if e.Detail != "" {
+				<div class="bb-comment-bubble">{ e.Detail }</div>
+			}
 		</div>
 	</li>
 }
@@ -489,12 +498,12 @@ templ txdTimelineEmptyComposer(p TransactionDetailProps) {
 	</div>
 }
 
-// txdComposerCard is the textarea + submit card. Visually mirrors a comment
-// bubble (header bar swapped for the focused-state hint). Carries the
-// "Toggle Needs Review" affordance from #846 — when on, posting also tags
-// the transaction needs-review.
+// txdComposerCard is the textarea + submit card. Mirrors the chat-bubble
+// shape of comment rows (rounded-2xl, flat top-left corner pointing at the
+// composer icon on the rail). Carries the "Toggle Needs Review" affordance
+// from #846 — when on, posting also tags the transaction needs-review.
 templ txdComposerCard(p TransactionDetailProps) {
-	<div class="rounded-lg border border-base-200 bg-base-100 overflow-hidden focus-within:border-primary/40 focus-within:ring-2 focus-within:ring-primary/10 transition">
+	<div class="rounded-2xl rounded-tl-md border border-base-200 bg-base-100 overflow-hidden focus-within:border-primary/40 focus-within:ring-2 focus-within:ring-primary/10 transition">
 		<label for="bb-txd-comment" class="sr-only">Add a comment</label>
 		<textarea
 			id="bb-txd-comment"


### PR DESCRIPTION
## Summary

Two refinements on top of the GitHub-style activity timeline (#845) based on review feedback:

- **Comments** render as a chat-bubble again instead of a bordered card with a separate header bar. The author/time meta-line floats above the bubble; the body sits in a rounded blob with a flat top-left corner pointing at the avatar on the rail. A new `.bb-comment-bubble` class in `input.css` owns the shape so future review/transaction bubble surfaces can adopt the same style as a single source of truth.

- **System events** (tag added/removed, category set) gain a tiny (16px) inline avatar to the left of the actor name. User actors get their photo, agents get a small bot tile, and rule/system rows continue to carry no actor avatar (the kind icon on the rail signals identity). This makes a long timeline easier to scan when several different household members have been editing the same transaction.

The composer card adopts the matching `rounded-2xl rounded-tl-md` shape so the focused state visually echoes the comment bubbles above it.

## Why

PR #845 leaned hard into GitHub's bordered-comment pattern; the chat-bubble is friendlier and matches the direction we want for app-wide bubble consolidation (transactions, reviews, etc.). Avatars on system rows give the timeline an at-a-glance "who did this" without the reader having to parse the verb first.

## Screenshots

<table>
  <tr><th>Comments — chat-bubble shape</th></tr>
  <tr><td><img src="https://i.img402.dev/21pnkm7qup.jpg" width="800" alt="Activity timeline — chat-bubble comments"></td></tr>
  <tr><th>System events — inline actor avatars</th></tr>
  <tr><td><img src="https://i.img402.dev/pa10e5pyf6.jpg" width="800" alt="Activity timeline — system events with avatars"></td></tr>
</table>

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...`
- [x] Validated visually in Chrome at 1280×900 against a mixed-kind timeline (12 events: comments, tag adds/removes with notes, rule fire)
- [ ] Reviewer: check rail alignment of the inline 16px avatars next to the bold actor names
- [ ] Future: hoist `.bb-comment-bubble` into a shared `.bb-bubble` once the matching pattern lands on transactions and reviews

Sits on top of #851 (annotation summary/dedup) in the stack.
