### PR TITLE
Phase 2 of #827: extract Alpine factory from reports

### DIFF
--- a/internal/templates/components/pages/reports.templ
+++ b/internal/templates/components/pages/reports.templ
@@ -9,6 +9,7 @@ import "fmt"
 // internal/templates/pages/reports.html byte-for-byte (responsive classes,
 // Alpine directives, ARIA, the inline reportsPage() Alpine component).
 templ Reports(p ReportsProps) {
+	<script src="/static/js/admin/components/reports.js"></script>
 	<!--
 		Set the shortcut-registry scope so base.html's global dispatcher routes
 		r (registered below) to a reload, and so the ? help modal surfaces it
@@ -47,7 +48,7 @@ templ Reports(p ReportsProps) {
 	</div>
 	<!-- Reports Inbox -->
 	if len(p.Reports) > 0 {
-		<div class="bb-card" x-data="reportsPage()">
+		<div class="bb-card" x-data="reportsPage">
 			<div class="divide-y divide-base-200/60 bb-stagger">
 				for _, r := range p.Reports {
 					@reportsRow(r)
@@ -62,9 +63,6 @@ templ Reports(p ReportsProps) {
 			<p class="text-base font-medium text-base-content/70 mb-1">{ reportsEmptyTitle(p.FilterStatus) }</p>
 			<p class="text-sm text-base-content/40 max-w-md mx-auto">{ reportsEmptyMessage(p.FilterStatus) }</p>
 		</div>
-	}
-	if len(p.Reports) > 0 {
-		@reportsScripts()
 	}
 }
 
@@ -125,20 +123,3 @@ templ reportsRow(r ReportsItem) {
 	</a>
 }
 
-// reportsScripts emits the inline Alpine factory for the reports inbox.
-// Lifted byte-for-byte from the original pages/reports.html so the
-// regression audit passes — only the wrapping {{if}} guard moves up to
-// the parent component.
-templ reportsScripts() {
-	<script>
-		function reportsPage() {
-		  return {
-		    dismissed: {},
-		    markRead(id) {
-		      this.dismissed[id] = true;
-		      fetch('/-/reports/' + id + '/read', { method: 'POST' });
-		    }
-		  };
-		}
-	</script>
-}

--- a/static/js/admin/components/reports.js
+++ b/static/js/admin/components/reports.js
@@ -1,0 +1,18 @@
+// Reports inbox Alpine component for /reports.
+//
+// Convention reference: docs/design-system.md -> "Alpine page components".
+// No server-side data hand-off needed — dismissed state is purely client-side.
+document.addEventListener('alpine:init', function () {
+  Alpine.data('reportsPage', function () {
+    return {
+      dismissed: {},
+
+      init: function () {},
+
+      markRead: function (id) {
+        this.dismissed[id] = true;
+        fetch('/-/reports/' + id + '/read', { method: 'POST' });
+      }
+    };
+  });
+});


### PR DESCRIPTION
Phase 2 of #827 — extract `reports`'s Alpine factory to follow the page-component convention codified in #828.

## Source today
- Factory body location: `internal/templates/components/pages/reports.templ:132-144` (the `reportsScripts` templ component)
- Existing data hand-off: none (dismissed state is purely client-side; no server props needed)

## Tasks
- [x] Move factory body → `static/js/admin/components/reports.js`. Wrapped in `Alpine.data('reportsPage', () => ({ init() {}, dismissed: {}, markRead() {...} }))` inside `alpine:init`. Factory takes no args.
- [x] Replace data hand-off: no server data needed — `dismissed` is purely client-side ephemeral state.
- [x] Templ wiring: `<script src="/static/js/admin/components/reports.js"></script>` (synchronous, NO `defer`) at the **top of the templ component**, then `x-data="reportsPage"` (string-literal) on the root element. Drop the `@reportsScripts()` call and the `reportsScripts` templ component.
- [x] No `_scripts.go` to delete (this page used an inline templ component instead).
- [x] `reports` was NOT in `existingAntiPatternAllowlist` — no entry to remove.
- [x] Re-measured inline-script max: max is still 147 lines (connections.templ). Ceiling stays at 180. Removing reports' 5-line script doesn't create a new low watermark.
- [x] `templ generate`, `go build/vet/test ./...` all green.
- [x] Browser-validated via Chrome DevTools MCP at `/reports`. Alpine factory registered correctly: `x-data="reportsPage"` (string literal), `dismissed` and `markRead` present, console silent.

## Screenshot

<img src="https://i.img402.dev/ow73vusykl.jpg" width="800" alt="reports — after">

🤖 Generated with [Claude Code](https://claude.com/claude-code)