### PR TITLE
Phase 2 of #827: extract Alpine factory from settings

### DIFF
--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -12,6 +12,7 @@ import (
 // typed props and the bridge drops the rendered HTML into base.html's
 // TemplContent slot.
 templ Settings(p SettingsProps) {
+	<script src="/static/js/admin/components/settings.js"></script>
 	<!--
 		Set the shortcut-registry scope so the ? help modal reflects "This page"
 		accurately. Settings intentionally has no custom shortcuts — it's a
@@ -31,13 +32,6 @@ templ Settings(p SettingsProps) {
 		@settingsSystemCard(p)
 		@settingsHelpCard(p)
 	</div>
-	<script>
-		(function() {
-			if (!location.hash) return;
-			var el = document.querySelector(location.hash);
-			if (el) setTimeout(function() { el.scrollIntoView({ behavior: 'smooth', block: 'start' }); }, 100);
-		})();
-	</script>
 }
 
 templ settingsSyncCard(p SettingsProps) {

--- a/static/js/admin/components/settings.js
+++ b/static/js/admin/components/settings.js
@@ -1,0 +1,30 @@
+// Settings page scripts for /settings.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+// This page does not use a named Alpine.data() factory — the root <div>
+// uses an empty x-data plus x-init/x-destroy to set the keyboard-shortcut
+// scope. One piece of behavior lives here:
+//
+//   1. If the URL contains a hash (#sync, #retention, #security, #help),
+//      scroll the matching collapsible card into view after a short delay
+//      so the Alpine x-show transition has time to expand it.
+//
+// The <script src> loads synchronously at the top of the templ component
+// (so any future alpine:init listeners register before Alpine fires the
+// event). That means this script runs BEFORE the rest of the body is
+// parsed, so the hash-scroll function has to wait for DOMContentLoaded to
+// query the target element.
+function bbSettingsScrollToHash() {
+  if (!location.hash) return;
+  var el = document.querySelector(location.hash);
+  if (el) {
+    setTimeout(function () {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 100);
+  }
+}
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', bbSettingsScrollToHash);
+} else {
+  bbSettingsScrollToHash();
+}


### PR DESCRIPTION
Phase 2 of #827 — extract `settings`'s inline hash-scroll IIFE to follow the page-component convention codified in #828.

## Source today
- Factory body location: `internal/templates/components/pages/settings.templ:34-40` (inline `<script>` block, ~5 lines)
- Existing data hand-off: none (no Alpine factory, no x-data wiring)

## Tasks
- [x] Move IIFE body → `static/js/admin/components/settings.js`. Wrapped in `DOMContentLoaded` guard (`bbSettingsScrollToHash` + `readyState` check) to handle the timing shift from script being hoisted to the top of the component.
- [x] Templ wiring: `<script src="/static/js/admin/components/settings.js"></script>` (synchronous, NO `defer`) at the **top of the templ component**. Deleted inline `<script>…</script>` block.
- [x] No `_scripts.go` orphan — this page never had one.
- [x] `settings.templ` is not in `existingAntiPatternAllowlist` — no entry to delete.
- [x] Re-measured inline-script max: still 147 lines in `connections.templ`. Ceiling stays at 180 (already `147 + 33`). No change needed.
- [x] `templ generate`, `go build/vet/test ./...` clean.
- [x] Browser-validated via Chrome DevTools MCP at `/settings#sync`. Sync card expanded on hash load, console silent.

## Screenshot

`/settings#sync` — Sync card expanded by hash-scroll after extraction:

<img src="https://i.img402.dev/l13xvkchnk.jpg" width="800" alt="settings — /settings#sync after extraction">