### PR TITLE
chore(admin): consolidate pagination URL builders onto shared helpers

### DIFF
--- a/internal/admin/helpers.go
+++ b/internal/admin/helpers.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -72,6 +73,33 @@ func parseInclusiveDateParam(r *http.Request, key string) *time.Time {
 	}
 	next := t.AddDate(0, 0, 1)
 	return &next
+}
+
+// pickValues returns a url.Values copy of the requested keys from
+// r.URL.Query(). Empty values are skipped, so the result encodes only the
+// filters actually in effect.
+func pickValues(r *http.Request, keys []string) url.Values {
+	src := r.URL.Query()
+	out := make(url.Values, len(keys))
+	for _, k := range keys {
+		if v := src.Get(k); v != "" {
+			out.Set(k, v)
+		}
+	}
+	return out
+}
+
+// paginationBase builds a "<path>?<filters>&<pageParam>=" prefix (or
+// "<path>?<pageParam>=" when no filters are present) so callers can append the
+// page number directly. The pageParam key is dropped from params if present —
+// the caller is appending a fresh value.
+func paginationBase(path string, params url.Values, pageParam string) string {
+	params.Del(pageParam)
+	encoded := params.Encode()
+	if encoded == "" {
+		return path + "?" + pageParam + "="
+	}
+	return path + "?" + encoded + "&" + pageParam + "="
 }
 
 // splitCSV splits a comma-separated string into trimmed non-empty entries.

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -97,14 +97,11 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 			if int64(showingEnd) > result.Total {
 				showingEnd = int(result.Total)
 			}
-			pBase := paginationBase("/logs", map[string]string{
-				"tab":           "syncs",
-				"connection_id": filterConnID,
-				"status":        filterStatus,
-				"trigger":       filterTrigger,
-				"date_from":     filterDateFrom,
-				"date_to":       filterDateTo,
-			}, "page")
+			pVals := pickValues(r, []string{
+				"connection_id", "status", "trigger", "date_from", "date_to",
+			})
+			pVals.Set("tab", "syncs")
+			pBase := paginationBase("/logs", pVals, "page")
 
 			// Connection filter options.
 			connOpts := make([]pages.LogsConnectionOption, 0, len(connections))
@@ -207,11 +204,9 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 			if int64(whShowingEnd) > result.Total {
 				whShowingEnd = int(result.Total)
 			}
-			whPBase := paginationBase("/logs", map[string]string{
-				"tab":         "webhooks",
-				"wh_provider": whFilterProvider,
-				"wh_status":   whFilterStatus,
-			}, "wh_page")
+			whVals := pickValues(r, []string{"wh_provider", "wh_status"})
+			whVals.Set("tab", "webhooks")
+			whPBase := paginationBase("/logs", whVals, "wh_page")
 
 			// Project webhook events into the templ view-model with
 			// pre-rendered relative + full timestamps.

--- a/internal/admin/rules.go
+++ b/internal/admin/rules.go
@@ -3,9 +3,7 @@ package admin
 import (
 	"errors"
 	"net/http"
-	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"breadbox/internal/service"
@@ -90,19 +88,9 @@ func renderRules(w http.ResponseWriter, r *http.Request, sm *scs.SessionManager,
 
 // buildRulesPaginationBase returns the pagination base URL for the rules page.
 func buildRulesPaginationBase(r *http.Request) string {
-	params := []string{"search", "category_slug", "enabled", "per_page", "sort_by"}
-	q := r.URL.Query()
-	var qs []string
-	for _, key := range params {
-		if v := q.Get(key); v != "" {
-			qs = append(qs, key+"="+url.QueryEscape(v))
-		}
-	}
-	base := "/rules?page="
-	if len(qs) > 0 {
-		base = "/rules?" + strings.Join(qs, "&") + "&page="
-	}
-	return base
+	return paginationBase("/rules", pickValues(r, []string{
+		"search", "category_slug", "enabled", "per_page", "sort_by",
+	}), "page")
 }
 
 // RuleFormPageHandler serves GET /admin/rules/new and /admin/rules/{id}/edit.

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"net/http"
-	"net/url"
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
@@ -126,20 +125,3 @@ func stringOrEmpty(s *string) string {
 	return *s
 }
 
-// paginationBase builds a URL query string prefix for pagination links.
-// It preserves all current filter params and ends with "&page=" (or "?page=")
-// so the template can append the page number directly.
-func paginationBase(path string, params map[string]string, pageParam string) string {
-	q := url.Values{}
-	for k, v := range params {
-		if v != "" {
-			q.Set(k, v)
-		}
-	}
-	q.Del(pageParam) // remove page param so we can append it fresh
-	encoded := q.Encode()
-	if encoded == "" {
-		return path + "?" + pageParam + "="
-	}
-	return path + "?" + encoded + "&" + pageParam + "="
-}

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"math"
 	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -1246,67 +1245,36 @@ func DeleteTransactionCommentHandler(a *app.App, sm *scs.SessionManager, svc *se
 	}
 }
 
+// txFilterParams lists the filter keys preserved across pagination and CSV
+// export links on the main transactions list. per_page is appended for
+// pagination but omitted from the export URL.
+var txFilterParams = []string{
+	"start_date", "end_date", "account_id", "user_id",
+	"connection_id", "category", "min_amount", "max_amount",
+	"pending", "search", "search_mode", "search_field", "sort",
+	"tags", "any_tag",
+}
+
 // buildPaginationBase returns the query string for pagination links (all params except page).
 func buildPaginationBase(r *http.Request) string {
-	paginationParams := []string{
-		"start_date", "end_date", "account_id", "user_id",
-		"connection_id", "category", "min_amount", "max_amount",
-		"pending", "search", "search_mode", "search_field", "sort", "per_page",
-		"tags", "any_tag",
-	}
-	q := r.URL.Query()
-	qs := make([]string, 0, len(paginationParams))
-	for _, key := range paginationParams {
-		if v := q.Get(key); v != "" {
-			qs = append(qs, key+"="+url.QueryEscape(v))
-		}
-	}
-	base := "/transactions?page="
-	if len(qs) > 0 {
-		base = "/transactions?" + strings.Join(qs, "&") + "&page="
-	}
-	return base
+	keys := append(append([]string{}, txFilterParams...), "per_page")
+	return paginationBase("/transactions", pickValues(r, keys), "page")
 }
 
 // buildExportURL returns the full CSV export URL with the current filter params.
 func buildExportURL(r *http.Request) string {
-	exportParams := []string{
-		"start_date", "end_date", "account_id", "user_id",
-		"connection_id", "category", "min_amount", "max_amount",
-		"pending", "search", "search_mode", "search_field", "sort",
-		"tags", "any_tag",
+	encoded := pickValues(r, txFilterParams).Encode()
+	if encoded == "" {
+		return "/-/transactions/export-csv"
 	}
-	q := r.URL.Query()
-	qs := make([]string, 0, len(exportParams))
-	for _, key := range exportParams {
-		if v := q.Get(key); v != "" {
-			qs = append(qs, key+"="+url.QueryEscape(v))
-		}
-	}
-	exportURL := "/-/transactions/export-csv"
-	if len(qs) > 0 {
-		exportURL += "?" + strings.Join(qs, "&")
-	}
-	return exportURL
+	return "/-/transactions/export-csv?" + encoded
 }
 
 // buildAccountPaginationBase returns the query string prefix for account detail pagination links.
 func buildAccountPaginationBase(r *http.Request, accountID string) string {
-	paginationParams := []string{
+	return paginationBase("/accounts/"+accountID, pickValues(r, []string{
 		"start_date", "end_date", "category", "pending", "search",
-	}
-	q := r.URL.Query()
-	qs := make([]string, 0, len(paginationParams))
-	for _, key := range paginationParams {
-		if v := q.Get(key); v != "" {
-			qs = append(qs, key+"="+url.QueryEscape(v))
-		}
-	}
-	base := "/accounts/" + accountID + "?page="
-	if len(qs) > 0 {
-		base = "/accounts/" + accountID + "?" + strings.Join(qs, "&") + "&page="
-	}
-	return base
+	}), "page")
 }
 
 // BulkUpdateTransactionsAdminHandler serves POST /-/transactions/batch-update.


### PR DESCRIPTION
## Summary

Five admin URL builders independently hand-rolled the same "extract these query params, URL-encode, suffix `&page=`" loop. Two lived in `synclogs.go` (signature `paginationBase(path, map, pageParam)`), three in `transactions.go` / `rules.go` (signature with a `[]string` of keys). Naming collision aside, the duplication was four-ish copies of the same five lines.

This PR unifies all of them onto two helpers in `internal/admin/helpers.go`:

- `pickValues(r, keys) url.Values` — extracts the named keys from `r.URL.Query()`, skipping empties.
- `paginationBase(path, params, pageParam) string` — builds `"<path>?<encoded>&<pageParam>="` (or `"<path>?<pageParam>="` when nothing is set).

The CSV-export builder reuses `pickValues(...).Encode()` directly since it doesn't need a trailing `&page=`.

Net **39 fewer LOC across 5 files**; a single source of truth for the encode-and-suffix pattern.

Same family as #835/#838 (timefmt), #831 (sync-log duration), #812 (pgconv), #826 (admin filter parsing).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/admin/...` — existing `TestBuildPaginationBase_URLEncodesValues` and `TestBuildExportURL_URLEncodesValues` still pass; they cover ampersand/equals/plus/space encoding through the new helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)