### PR TITLE
chore(templates): consolidate per-page pluralS helpers onto components.PluralS

### DIFF
--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -258,7 +258,7 @@ templ connDetailDayBar(ds DaySyncRow) {
 		<div class="text-[0.5rem] text-base-content/25 tabular-nums leading-none select-none">{ ds.ShortLabel }</div>
 		<!-- Tooltip -->
 		<div class="absolute -top-9 left-1/2 -translate-x-1/2 bg-base-content text-base-100 text-[0.6rem] px-2 py-1 rounded-lg whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10 tabular-nums shadow-sm">
-			{ fmt.Sprintf("%s: %d sync%s", ds.Label, ds.Total, connDetailPluralSyncs(ds.Total)) }
+			{ fmt.Sprintf("%s: %d sync%s", ds.Label, ds.Total, components.PluralS(ds.Total)) }
 			if ds.Error > 0 {
 				{ fmt.Sprintf(" (%d err)", ds.Error) }
 			}

--- a/internal/templates/components/pages/connection_detail_scripts.go
+++ b/internal/templates/components/pages/connection_detail_scripts.go
@@ -97,15 +97,6 @@ func connDetailBarStyle(mine, other, total int) string {
 	return "height: 52px; min-height: 4px;"
 }
 
-// connDetailPluralSyncs returns "" or "s" based on count for the sync
-// timeline tooltip — mirrors `{{if ne .Total 1}}s{{end}}`.
-func connDetailPluralSyncs(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
-}
-
 // connDetailAccentBar returns the colored accent-bar class for an account
 // card (left edge). Mirrors the source map of account types to bg colors.
 func connDetailAccentBar(t string) string {

--- a/internal/templates/components/pages/logs.templ
+++ b/internal/templates/components/pages/logs.templ
@@ -50,7 +50,7 @@ templ Logs(p LogsProps) {
 			if len(p.Logs) > 0 {
 				<!-- Results count -->
 				<div class="text-xs text-base-content/40 mb-3 px-1">
-					{ fmt.Sprintf("%d sync log%s", p.Total, pluralS64(p.Total)) }
+					{ fmt.Sprintf("%d sync log%s", p.Total, components.PluralS(p.Total)) }
 				</div>
 				<!-- Timeline view -->
 				<div class="space-y-1 bb-stagger">
@@ -72,7 +72,7 @@ templ Logs(p LogsProps) {
 			if len(p.WHEvents) > 0 {
 				<!-- Results count -->
 				<div class="text-xs text-base-content/40 mb-3 px-1">
-					{ fmt.Sprintf("%d webhook event%s", p.WHTotal, pluralS64(p.WHTotal)) }
+					{ fmt.Sprintf("%d webhook event%s", p.WHTotal, components.PluralS(p.WHTotal)) }
 				</div>
 				<!-- Event list -->
 				<div class="space-y-1 bb-stagger">
@@ -308,7 +308,7 @@ templ logsSyncRow(l LogsSyncRow) {
 						}
 						if l.AccountsAffected > 0 {
 							<span class="text-base-content/25">&middot;</span>
-							<span>{ fmt.Sprintf("%d account%s", l.AccountsAffected, pluralS64(l.AccountsAffected)) }</span>
+							<span>{ fmt.Sprintf("%d account%s", l.AccountsAffected, components.PluralS(l.AccountsAffected)) }</span>
 						}
 					</div>
 					if l.Status == "error" && l.FriendlyErrorMessage != nil && *l.FriendlyErrorMessage != "" {
@@ -652,15 +652,6 @@ templ logsPaginator(page, totalPages int, total int64, showingStart, showingEnd 
 // ====================================================================
 // Helpers
 // ====================================================================
-
-// pluralS64 returns "s" when n != 1, mirroring the {{if ne .X 1}}s{{end}}
-// pattern used in the source HTML.
-func pluralS64(n int64) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
-}
 
 func successRateBg(rate float64) string {
 	switch {

--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -38,7 +38,7 @@ templ Rules(p RulesProps) {
 				if p.TotalPages > 1 {
 					@templ.Raw(fmt.Sprintf("Showing %d&ndash;%d of ", p.ShowingStart, p.ShowingEnd))
 				}
-				{ fmt.Sprintf("%d rule%s found", p.Total, pluralS64(p.Total)) }
+				{ fmt.Sprintf("%d rule%s found", p.Total, components.PluralS(p.Total)) }
 			</div>
 			if len(p.Rules) > 0 {
 				<label class="flex items-center gap-2 text-xs text-base-content/40 whitespace-nowrap">
@@ -143,7 +143,7 @@ templ rulesRow(r RulesRow) {
 					<span class="text-base-content/30 shrink-0">&middot;</span>
 					<span class="inline-flex items-center gap-1 shrink-0 tabular-nums" title={ r.ActionsSummary }>
 						<i data-lucide="zap" class="w-3 h-3"></i>
-						{ fmt.Sprintf("%d action%s", r.ActionsCount, pluralS(r.ActionsCount)) }
+						{ fmt.Sprintf("%d action%s", r.ActionsCount, components.PluralS(r.ActionsCount)) }
 					</span>
 					<span class="text-base-content/30 shrink-0">&middot;</span>
 					<span class="tabular-nums shrink-0">{ fmt.Sprintf("%d hits", r.HitCount) }</span>
@@ -308,15 +308,6 @@ templ rulesPerPageOption(value, current int) {
 	} else {
 		<option value={ fmt.Sprintf("%d", value) }>{ fmt.Sprintf("%d", value) }</option>
 	}
-}
-
-// pluralS mirrors `{{if ne .X 1}}s{{end}}` for int counts. logs.templ
-// already defines pluralS64 for int64; this is the int sibling.
-func pluralS(n int) string {
-	if n == 1 {
-		return ""
-	}
-	return "s"
 }
 
 func rulesAvatarStyle(color *string) string {


### PR DESCRIPTION
## Summary

Three files in the `pages` package each carried their own copy of the same trivial `"" / "s"` plural helper:

- `rules.templ` → `pluralS(int)`
- `logs.templ` → `pluralS64(int64)`
- `connection_detail_scripts.go` → `connDetailPluralSyncs(int)`

`internal/templates/components/helpers.go` already exposes a generic `PluralS[T pluralInt]` (used internally by the parent components package's templ files), so the page-level callsites can lean on it directly. Removes 33 lines of duplicated boilerplate; the rendered HTML is byte-identical.

Same shape as the recent `timefmt` consolidations (#835, #838, #831 / sync-log duration helper).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all unit tests pass
- [x] `templ generate` regenerates `_templ.go` artifacts cleanly; the generated files now reference `components.PluralS` directly (verified via `grep`)

No UI screenshots: the helpers produce identical output, so this is a pure no-op refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)