### PR TITLE
Phase 2 of #827: extract Alpine factories from connections

### DIFF
--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -9,15 +9,24 @@ import (
 
 // Connections renders the bank-connections list page (and the Account
 // Links secondary tab). Hosts inside the base layout via
-// TemplateRenderer.RenderWithTempl. Mirrors the previous
-// internal/templates/pages/connections.html byte-for-byte (responsive
-// classes, Alpine directives, ARIA, scripts).
+// TemplateRenderer.RenderWithTempl.
+//
+// The Alpine factories (`syncAllBtn`, `syncBtn`), keyboard-navigation
+// module (`bbConnNav`), and shortcut registrations live in
+// static/js/admin/components/connections.js — see #827 / docs/design-system.md
+// → "Alpine page components".
 templ Connections(p ConnectionsProps) {
+	<!-- Component factories for syncAllBtn / syncBtn and the j/k/Enter/s
+	     keyboard-shortcut registrations. Loaded synchronously (NOT defer)
+	     because Alpine itself is deferred from <head> and dispatches
+	     alpine:init at parse-end — a deferred page script would register
+	     its listener after the event already fired. -->
+	<script src="/static/js/admin/components/connections.js"></script>
 	<!--
 		Set the shortcut-registry scope so base.html's global dispatcher routes
-		j/k/s/e/Enter (registered below) to this page's handlers, and so the
-		? help modal surfaces them under "This page". Reset to 'global' on
-		Alpine teardown so other pages don't inherit the scope.
+		j/k/s/Enter (registered in connections.js) to this page's handlers, and
+		so the ? help modal surfaces them under "This page". Reset to 'global'
+		on Alpine teardown so other pages don't inherit the scope.
 	-->
 	<div x-data x-init="$store.shortcuts.setScope('connections')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	<div
@@ -35,7 +44,7 @@ templ Connections(p ConnectionsProps) {
 			<div class="flex items-center gap-2 flex-wrap">
 				<div x-show="tab === 'connections'" x-cloak class="flex items-center gap-2">
 					if len(p.Connections) > 0 {
-						<div x-data="syncAllBtn()">
+						<div x-data="syncAllBtn">
 							<button
 								class="btn btn-outline btn-sm rounded-xl gap-2"
 								:disabled="state !== 'idle'"
@@ -140,7 +149,6 @@ templ Connections(p ConnectionsProps) {
 					</div>
 				</div>
 			}
-			@connectionsScripts()
 		</div>
 		<!-- /connections tab -->
 		<!-- ==================== ACCOUNT LINKS TAB ==================== -->
@@ -247,7 +255,7 @@ templ connectionsCard(c ConnectionsRow) {
 			<div class="flex items-center gap-2 sm:gap-3 shrink-0">
 				<!-- Sync Now button (non-CSV active connections only) -->
 				if c.Provider != "csv" && c.Status == "active" {
-					<div x-data={ fmt.Sprintf("syncBtn(%q)", c.ID) }>
+					<div x-data="syncBtn" data-conn-id={ c.ID }>
 						<button
 							type="button"
 							data-sync-btn
@@ -444,180 +452,6 @@ templ connectionsLinkRow(l ConnectionsLinkRow, csrfToken string) {
 			</div>
 		</div>
 	</div>
-}
-
-// connectionsScripts ships the per-page Alpine factories (syncAllBtn,
-// syncBtn) and the j/k/Enter/s keyboard-shortcut registrations. Preserved
-// byte-for-byte from the original pages/connections.html so the regression
-// audit passes.
-templ connectionsScripts() {
-	<script>
-		function syncAllBtn() {
-		  return {
-		    state: 'idle',
-		    triggerSyncAll() {
-		      if (this.state !== 'idle') return;
-		      this.state = 'syncing';
-		      var self = this;
-		      fetch('/-/connections/sync-all', { method: 'POST' })
-		        .then(function(res) {
-		          if (res.ok) {
-		            self.state = 'done';
-		            self.$nextTick(function() { lucide.createIcons(); });
-		            window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Sync triggered for all connections.', type: 'success' } }));
-		            setTimeout(function() { self.state = 'idle'; self.$nextTick(function() { lucide.createIcons(); }); }, 8000);
-		          } else {
-		            return res.json().then(function(data) {
-		              window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: data.error || 'Failed to trigger sync.', type: 'error' } }));
-		              self.state = 'idle';
-		              self.$nextTick(function() { lucide.createIcons(); });
-		            });
-		          }
-		        })
-		        .catch(function() {
-		          window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Network error. Please try again.', type: 'error' } }));
-		          self.state = 'idle';
-		          self.$nextTick(function() { lucide.createIcons(); });
-		        });
-		    }
-		  };
-		}
-
-		function syncBtn(connId) {
-		  return {
-		    state: 'idle',
-		    triggerSync() {
-		      if (this.state !== 'idle') return;
-		      this.state = 'syncing';
-		      var self = this;
-		      fetch('/-/connections/' + connId + '/sync', { method: 'POST' })
-		        .then(function(res) {
-		          if (res.ok) {
-		            self.state = 'done';
-		            self.$nextTick(function() { lucide.createIcons(); });
-		            window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Sync triggered for this connection.', type: 'success' } }));
-		            setTimeout(function() { self.state = 'idle'; self.$nextTick(function() { lucide.createIcons(); }); }, 5000);
-		          } else {
-		            return res.json().then(function(data) {
-		              window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: data.error || 'Failed to trigger sync.', type: 'error' } }));
-		              self.state = 'idle';
-		              self.$nextTick(function() { lucide.createIcons(); });
-		            });
-		          }
-		        })
-		        .catch(function() {
-		          window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Network error. Please try again.', type: 'error' } }));
-		          self.state = 'idle';
-		          self.$nextTick(function() { lucide.createIcons(); });
-		        });
-		    }
-		  };
-		}
-
-		// Keyboard navigation for the connections list. Reads the DOM for visible
-		// rows (respecting the family-member filter via data-filter-user + Alpine's
-		// x-show display:none) instead of mirroring connection data into a store.
-		// The base.html dispatcher already guards against input focus, overlays,
-		// and touch devices, so these handlers just do the thing.
-		var bbConnNav = {
-		  focusedIdx: -1,
-		  FOCUSED_CLASS: 'bb-tx-row--focused', // reuse the tx-list focus styling
-		  visibleRows: function() {
-		    var all = document.querySelectorAll('[data-connection-row]');
-		    var out = [];
-		    for (var i = 0; i < all.length; i++) {
-		      // offsetParent is null when x-show has display:none'd the row
-		      if (all[i].offsetParent !== null) out.push(all[i]);
-		    }
-		    return out;
-		  },
-		  clearFocus: function() {
-		    var rows = document.querySelectorAll('[data-connection-row].' + this.FOCUSED_CLASS);
-		    for (var i = 0; i < rows.length; i++) rows[i].classList.remove(this.FOCUSED_CLASS);
-		  },
-		  setFocus: function(idx) {
-		    var rows = this.visibleRows();
-		    if (!rows.length) { this.focusedIdx = -1; return; }
-		    if (idx < 0) idx = 0;
-		    if (idx >= rows.length) idx = rows.length - 1;
-		    this.clearFocus();
-		    rows[idx].classList.add(this.FOCUSED_CLASS);
-		    this.focusedIdx = idx;
-		    rows[idx].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-		  },
-		  next: function() {
-		    var rows = this.visibleRows();
-		    if (!rows.length) return;
-		    this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx + 1);
-		  },
-		  prev: function() {
-		    var rows = this.visibleRows();
-		    if (!rows.length) return;
-		    this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx - 1);
-		  },
-		  currentRow: function() {
-		    var rows = this.visibleRows();
-		    if (this.focusedIdx < 0 || this.focusedIdx >= rows.length) return null;
-		    return rows[this.focusedIdx];
-		  },
-		};
-
-		document.addEventListener('alpine:init', function() {
-		  var reg = Alpine.store('shortcuts');
-		  if (!reg) return;
-
-		  reg.register({
-		    id: 'connections.next',
-		    keys: 'j',
-		    description: 'Move down',
-		    group: 'Navigation',
-		    scope: 'connections',
-		    action: function() { bbConnNav.next(); },
-		  });
-
-		  reg.register({
-		    id: 'connections.prev',
-		    keys: 'k',
-		    description: 'Move up',
-		    group: 'Navigation',
-		    scope: 'connections',
-		    action: function() { bbConnNav.prev(); },
-		  });
-
-		  reg.register({
-		    id: 'connections.open',
-		    keys: 'Enter',
-		    description: 'Open connection',
-		    group: 'Actions',
-		    scope: 'connections',
-		    action: function() {
-		      var row = bbConnNav.currentRow();
-		      if (!row) return;
-		      var url = row.getAttribute('data-open-url');
-		      if (url) window.location.href = url;
-		    },
-		  });
-
-		  reg.register({
-		    id: 'connections.sync',
-		    keys: 's',
-		    description: 'Sync connection',
-		    group: 'Actions',
-		    scope: 'connections',
-		    action: function() {
-		      var row = bbConnNav.currentRow();
-		      if (!row) return;
-		      // Reuse the existing syncBtn Alpine component's click handler so CSRF,
-		      // toast, and UI-state logic (disabled, spinner, 5s cooldown) stay in
-		      // one place. Inactive and CSV connections don't render the button —
-		      // no-op in that case.
-		      var btn = row.querySelector('[data-sync-btn]');
-		      if (btn) btn.click();
-		    },
-		  });
-
-		});
-	</script>
 }
 
 templ connectionsCreateLinkModal(p ConnectionsProps) {

--- a/internal/templates/components/pages/scripts_lint_test.go
+++ b/internal/templates/components/pages/scripts_lint_test.go
@@ -19,9 +19,9 @@ import (
 // static/js/admin/components/<page>.js, the maximum drops; lower this value
 // in the same PR so the lint ratchets down. See #828 / #827.
 //
-// 2026-04-25 audit (post-prompt_builder extraction): max = 147 in
-// connections.templ:454-620. Ceiling = 147 + 33 = 180.
-const inlineScriptCeiling = 180
+// 2026-04-25 audit (post-connections extraction): max = 60 in
+// account_detail.templ:633-697. Ceiling = 60 + 30 = 90.
+const inlineScriptCeiling = 90
 
 // xDataFactoryAntiPattern catches the regression that #827 / #828 are
 // undoing: an x-data attribute rendered from a Go expression that calls a

--- a/static/js/admin/components/connections.js
+++ b/static/js/admin/components/connections.js
@@ -1,0 +1,202 @@
+// Connections list Alpine factories for /connections.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+// Two factories ship from this module:
+//
+//   - `syncAllBtn` — page-level "Sync All" button. Tracks state and disables
+//     itself for 8s after a successful POST so accidental re-clicks don't
+//     fan out duplicate jobs.
+//   - `syncBtn` — per-row sync button. Reads its connection ID from
+//     `data-conn-id` on the x-data root (set by the templ via
+//     `<div x-data="syncBtn" data-conn-id={ c.ID }>`) so the factory body
+//     keeps the no-arg shape the convention requires.
+//
+// `bbConnNav` is the keyboard-navigation module backing j/k/Enter/s.
+// Stashed on `window` so the shortcut handlers below can reach it without
+// closure gymnastics, and so it stays debuggable from the devtools console.
+//
+// All shortcut bindings flow through the global Alpine `shortcuts` store,
+// per .claude/rules/ui.md → "Keyboard shortcuts".
+
+// Keyboard navigation for the connections list. Reads the DOM for visible
+// rows (respecting the family-member filter via data-filter-user + Alpine's
+// x-show display:none) instead of mirroring connection data into a store.
+// The base.html dispatcher already guards against input focus, overlays,
+// and touch devices, so these handlers just do the thing.
+window.bbConnNav = {
+  focusedIdx: -1,
+  FOCUSED_CLASS: 'bb-tx-row--focused', // reuse the tx-list focus styling
+  visibleRows: function () {
+    var all = document.querySelectorAll('[data-connection-row]');
+    var out = [];
+    for (var i = 0; i < all.length; i++) {
+      // offsetParent is null when x-show has display:none'd the row
+      if (all[i].offsetParent !== null) out.push(all[i]);
+    }
+    return out;
+  },
+  clearFocus: function () {
+    var rows = document.querySelectorAll('[data-connection-row].' + this.FOCUSED_CLASS);
+    for (var i = 0; i < rows.length; i++) rows[i].classList.remove(this.FOCUSED_CLASS);
+  },
+  setFocus: function (idx) {
+    var rows = this.visibleRows();
+    if (!rows.length) { this.focusedIdx = -1; return; }
+    if (idx < 0) idx = 0;
+    if (idx >= rows.length) idx = rows.length - 1;
+    this.clearFocus();
+    rows[idx].classList.add(this.FOCUSED_CLASS);
+    this.focusedIdx = idx;
+    rows[idx].scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  },
+  next: function () {
+    var rows = this.visibleRows();
+    if (!rows.length) return;
+    this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx + 1);
+  },
+  prev: function () {
+    var rows = this.visibleRows();
+    if (!rows.length) return;
+    this.setFocus(this.focusedIdx < 0 ? 0 : this.focusedIdx - 1);
+  },
+  currentRow: function () {
+    var rows = this.visibleRows();
+    if (this.focusedIdx < 0 || this.focusedIdx >= rows.length) return null;
+    return rows[this.focusedIdx];
+  },
+};
+
+document.addEventListener('alpine:init', function () {
+  // Page-level "Sync All" button. Triggers a sync across every connection
+  // owned by the current user. Disables itself for 8s after a successful
+  // POST so accidental re-clicks don't fan out duplicate jobs.
+  Alpine.data('syncAllBtn', function () {
+    return {
+      state: 'idle',
+
+      init: function () {
+        // No initial state to parse — the factory is purely behavior.
+      },
+
+      triggerSyncAll: function () {
+        if (this.state !== 'idle') return;
+        this.state = 'syncing';
+        var self = this;
+        fetch('/-/connections/sync-all', { method: 'POST' })
+          .then(function (res) {
+            if (res.ok) {
+              self.state = 'done';
+              self.$nextTick(function () { lucide.createIcons(); });
+              window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Sync triggered for all connections.', type: 'success' } }));
+              setTimeout(function () { self.state = 'idle'; self.$nextTick(function () { lucide.createIcons(); }); }, 8000);
+            } else {
+              return res.json().then(function (data) {
+                window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: data.error || 'Failed to trigger sync.', type: 'error' } }));
+                self.state = 'idle';
+                self.$nextTick(function () { lucide.createIcons(); });
+              });
+            }
+          })
+          .catch(function () {
+            window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Network error. Please try again.', type: 'error' } }));
+            self.state = 'idle';
+            self.$nextTick(function () { lucide.createIcons(); });
+          });
+      },
+    };
+  });
+
+  // Per-row sync button. The wrapping element passes the connection ID via
+  // `data-conn-id`; the factory reads it once in init() so the body keeps
+  // the no-arg shape the convention requires.
+  Alpine.data('syncBtn', function () {
+    return {
+      state: 'idle',
+      connId: '',
+
+      init: function () {
+        this.connId = this.$el.dataset.connId || '';
+      },
+
+      triggerSync: function () {
+        if (this.state !== 'idle') return;
+        if (!this.connId) return;
+        this.state = 'syncing';
+        var self = this;
+        fetch('/-/connections/' + this.connId + '/sync', { method: 'POST' })
+          .then(function (res) {
+            if (res.ok) {
+              self.state = 'done';
+              self.$nextTick(function () { lucide.createIcons(); });
+              window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Sync triggered for this connection.', type: 'success' } }));
+              setTimeout(function () { self.state = 'idle'; self.$nextTick(function () { lucide.createIcons(); }); }, 5000);
+            } else {
+              return res.json().then(function (data) {
+                window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: data.error || 'Failed to trigger sync.', type: 'error' } }));
+                self.state = 'idle';
+                self.$nextTick(function () { lucide.createIcons(); });
+              });
+            }
+          })
+          .catch(function () {
+            window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Network error. Please try again.', type: 'error' } }));
+            self.state = 'idle';
+            self.$nextTick(function () { lucide.createIcons(); });
+          });
+      },
+    };
+  });
+
+  var reg = Alpine.store('shortcuts');
+  if (!reg) return;
+
+  reg.register({
+    id: 'connections.next',
+    keys: 'j',
+    description: 'Move down',
+    group: 'Navigation',
+    scope: 'connections',
+    action: function () { window.bbConnNav.next(); },
+  });
+
+  reg.register({
+    id: 'connections.prev',
+    keys: 'k',
+    description: 'Move up',
+    group: 'Navigation',
+    scope: 'connections',
+    action: function () { window.bbConnNav.prev(); },
+  });
+
+  reg.register({
+    id: 'connections.open',
+    keys: 'Enter',
+    description: 'Open connection',
+    group: 'Actions',
+    scope: 'connections',
+    action: function () {
+      var row = window.bbConnNav.currentRow();
+      if (!row) return;
+      var url = row.getAttribute('data-open-url');
+      if (url) window.location.href = url;
+    },
+  });
+
+  reg.register({
+    id: 'connections.sync',
+    keys: 's',
+    description: 'Sync connection',
+    group: 'Actions',
+    scope: 'connections',
+    action: function () {
+      var row = window.bbConnNav.currentRow();
+      if (!row) return;
+      // Reuse the existing syncBtn Alpine component's click handler so CSRF,
+      // toast, and UI-state logic (disabled, spinner, 5s cooldown) stay in
+      // one place. Inactive and CSV connections don't render the button —
+      // no-op in that case.
+      var btn = row.querySelector('[data-sync-btn]');
+      if (btn) btn.click();
+    },
+  });
+});


### PR DESCRIPTION
Phase 2 of #827 — extract `connections`'s Alpine factories to follow the page-component convention codified in #828.

**This PR removes the 147-line inline `<script>` block that was the lint ceiling's high-water mark.** After this lands, the ceiling drops from **180 to 90** — half the previous limit.

## Source today (pre-PR)
- Inline `<script>` block at `internal/templates/components/pages/connections.templ:454-620` (147 content lines), wrapped in a `connectionsScripts` templ function and rendered via `@connectionsScripts()`.
- `connections_scripts.go` is **Go-only helper code** (not JS) — kept as-is. The misnomer in the tracker referred to the inline templ block, not this file.

## What this PR does
- Moves both factories — `syncAllBtn` (page-level Sync All button, `state` machine + 8s cooldown) and `syncBtn` (per-row sync button, 5s cooldown) — into `static/js/admin/components/connections.js`, registered together inside one `alpine:init` listener.
- Moves the `bbConnNav` keyboard-navigation module (`visibleRows` / `next` / `prev` / `currentRow`) into the same module. Stashed on `window` so the shortcut handlers (registered in the same `alpine:init` block) can reach it without closure gymnastics, and so it stays debuggable from the devtools console.
- Both factories take **no arguments**. The per-row `syncBtn` reads its connection ID from `data-conn-id` on the x-data root in `init()` — this is the canonical no-arg shape the convention requires.
- Templ wiring:
  - Added synchronous `<script src="/static/js/admin/components/connections.js"></script>` at the top of the `Connections` templ component (NOT `defer` — Alpine itself is deferred from `<head>` and dispatches `alpine:init` at parse-end).
  - `<div x-data="syncAllBtn">` (string-literal, no factory call).
  - `<div x-data="syncBtn" data-conn-id={ c.ID }>` for per-row buttons.
  - Removed the `@connectionsScripts()` invocation and deleted the entire `connectionsScripts` templ function.
- Lowered `inlineScriptCeiling` in `scripts_lint_test.go` from **180 → 90**. The new maximum is `account_detail.templ:633-697` at 60 lines, so the ceiling = 60 + 30 = 90.
- Verified `connections.templ` is **NOT** in `existingAntiPatternAllowlist` (it never was — the connections factories used the `factory(args)` syntax inside `x-data` Go-template expressions, which the lint regex doesn't match because they go through `fmt.Sprintf`).

## Validation
- `templ generate`, `go build ./...`, `go vet ./...`, and `go test ./...` all green.
- `TestNoLargeInlineScripts` passes against the new ceiling of 90.
- Browser-validated at `/connections`:
  - Connections list renders (CapitalOne + Chase, with all account rows).
  - Status badges render correctly (Active / Stale / etc).
  - Per-row Sync Now button click → spinner → "done" check → toast.
  - Sync All button click → "Triggered!" with disabled state for 8s, console silent.
  - Click into a connection → navigates to `connection_detail` page (different page, untouched here).
  - Console silent except pre-existing form-label issues unrelated to this change.

<img src="https://i.img402.dev/n1bdqn5zt1.jpg" width="800" alt="connections list — after extraction">

## Convention reference
- Full spec: `docs/design-system.md` → "Alpine page components".
- Reference port: `static/js/admin/components/prompt_builder.js` (Phase 1).
- Rule: `.claude/rules/ui.md` → "JavaScript and Alpine".