### PR TITLE
Phase 2 of #827: extract Alpine factory from transaction_detail

### DIFF
--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -1,8 +1,8 @@
 package pages
 
 import (
-	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -11,17 +11,35 @@ import (
 )
 
 // TransactionDetail renders the /admin/transactions/{id} detail page —
-// hero header, account context banner, details + category sidebar,
-// activity timeline, and the inline JS that powers category edits, tag
-// management, and comment posting. Hosts inside base.html via
-// TemplateRenderer.RenderWithTempl.
+// hero header, account context banner, details + category sidebar, and
+// activity timeline. Hosts inside base.html via TemplateRenderer.RenderWithTempl.
+//
+// The Alpine factories (txdCategoryEditor, txdTagManager, txdCommentManager)
+// live in static/js/admin/components/transaction_detail.js. Initial state
+// is handed over via three @templ.JSONScript tags emitted at the top of
+// the component plus per-factory `data-*` scalar attributes. The factory
+// <script> is loaded synchronously (not deferred) so Alpine.data() is
+// registered before Alpine — itself <script defer> in <head> — fires
+// alpine:init.
 templ TransactionDetail(p TransactionDetailProps) {
+	<!-- JSONScript payloads must precede the synchronous <script src> below
+	     because the page-component file seeds window.__bbCategories /
+	     window.__bbAllTags from these tags at module load — both globals
+	     are read by the inline categoryPicker (tx_row.templ) and the global
+	     tag picker (base.html) at first render. -->
+	@templ.JSONScript("transaction-detail-data", p.Categories)
+	@templ.JSONScript("transaction-detail-available-tags", p.AvailableTags)
+	@templ.JSONScript("transaction-detail-current-tags", p.CurrentTags)
+	<!-- Component factory. Loaded synchronously (no defer) so the
+	     Alpine.data() registrations run before Alpine — itself deferred from
+	     <head> — fires alpine:init. -->
+	<script src="/static/js/admin/components/transaction_detail.js"></script>
 	@components.CategoryPickerStyles()
 	<!--
 		Set the shortcut-registry scope so base.html's global dispatcher routes
-		c / t / e (registered below) to this page's handlers, and so the
-		? help modal surfaces them under "This page". Reset to 'global' on
-		Alpine teardown so other pages don't inherit the scope.
+		c / t / e (registered in the page factory) to this page's handlers,
+		and so the ? help modal surfaces them under "This page". Reset to
+		'global' on Alpine teardown so other pages don't inherit the scope.
 	-->
 	<div x-data x-init="$store.shortcuts.setScope('transaction-detail')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	@components.BreadcrumbNav(p.Breadcrumbs)
@@ -32,7 +50,6 @@ templ TransactionDetail(p TransactionDetailProps) {
 	@txdMain(p)
 	@txdActivity(p)
 	@components.CategoryPickerScript()
-	@txdScripts(p)
 }
 
 templ txdHero(p TransactionDetailProps) {
@@ -189,7 +206,12 @@ templ txdMain(p TransactionDetailProps) {
 			</div>
 		</div>
 		<!-- Category + Tags Card -->
-		<div class="bb-card p-5 space-y-5" x-data="txCategoryEditor()">
+		<div
+			class="bb-card p-5 space-y-5"
+			x-data="txdCategoryEditor"
+			data-tx-id={ p.TransactionID }
+			data-category-override={ txdCategoryOverrideAttr(p) }
+		>
 			<div>
 				<h2 class="text-sm font-semibold text-base-content/50 mb-3">Category</h2>
 				<div class="bb-cat-picker" data-picker-source="txd-cat" x-data={ txdCategoryPickerInit(p) } @category-change="setCategoryFromPicker($event.detail)">
@@ -212,7 +234,7 @@ templ txdMain(p TransactionDetailProps) {
 				</div>
 			</div>
 			<!-- Tags -->
-			<div x-data="tagManager()">
+			<div x-data="txdTagManager" data-tx-id={ p.TransactionID }>
 				<div class="flex items-center justify-between mb-3">
 					<h2 class="text-sm font-semibold text-base-content/50">Tags</h2>
 				</div>
@@ -253,7 +275,14 @@ templ txdMain(p TransactionDetailProps) {
 
 templ txdActivity(p TransactionDetailProps) {
 	<!-- Activity Timeline -->
-	<section id="activity" aria-labelledby="activity-heading" class="bb-card p-0 overflow-hidden" x-data={ fmt.Sprintf("commentManager(%d)", p.MaxCommentLength) }>
+	<section
+		id="activity"
+		aria-labelledby="activity-heading"
+		class="bb-card p-0 overflow-hidden"
+		x-data="txdCommentManager"
+		data-tx-id={ p.TransactionID }
+		data-max-comment-length={ strconv.Itoa(p.MaxCommentLength) }
+	>
 		<div class="px-4 sm:px-5 pt-5 pb-3 flex items-center gap-2">
 			<i data-lucide="activity" class="w-4 h-4 text-base-content/40" aria-hidden="true"></i>
 			<h2 id="activity-heading" class="text-sm font-semibold text-base-content/50">Activity</h2>
@@ -514,14 +543,6 @@ templ txdInlineTagChip(e service.ActivityEntry) {
 	</span>
 }
 
-// txdScripts emits the inline <script> block: shortcut registry, the
-// txCategoryEditor / commentManager / tagManager Alpine components, and
-// the global tag-cache seed. The two {{toJSON .X}} interpolations from
-// the original template are realized here via json.Marshal.
-templ txdScripts(p TransactionDetailProps) {
-	@templ.Raw("<script>" + txdScriptBody(p) + "</script>")
-}
-
 // ---- helpers ----
 
 // txdHeroTileBg returns the rounded-tile background color class for the
@@ -709,296 +730,26 @@ func avatarURLStr(id, version string) string {
 }
 
 // txdCategoryPickerInit emits the x-data initializer for the inline
-// category picker. Mirrors the original interpolation of {{toJSON
-// .Categories}} and {{.Transaction.Category.ID}} so the markup is
-// byte-identical to the html/template output.
+// category picker. Categories flow into the shared `categoryPicker`
+// factory through `window.__bbCategories` (seeded by
+// transaction_detail.js from the @templ.JSONScript payload), matching
+// the convention used by tx_row.templ.
 func txdCategoryPickerInit(p TransactionDetailProps) string {
-	cats, _ := json.Marshal(p.Categories)
 	initial := ""
 	if p.Transaction != nil && p.Transaction.Category != nil && p.Transaction.Category.ID != nil {
 		initial = *p.Transaction.Category.ID
 	}
 	return fmt.Sprintf(
-		"categoryPicker({categories: %s, mode: 'assign', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', initial: '%s', sourceId: 'txd-cat'})",
-		string(cats), initial,
+		"categoryPicker({categories: window.__bbCategories, mode: 'assign', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', initial: '%s', sourceId: 'txd-cat'})",
+		initial,
 	)
 }
 
-// txdScriptBody assembles the inline JS block that powers the page:
-// shortcut registry registration (c / t / e), the txCategoryEditor /
-// commentManager / tagManager Alpine factories, and the
-// window.__bbAllTags seed. Lifted verbatim from the original
-// transaction_detail.html with the four template substitutions
-// ({{.TransactionID}}, {{.Transaction.CategoryOverride}}, two {{toJSON
-// ...}}) realized via Sprintf + json.Marshal.
-func txdScriptBody(p TransactionDetailProps) string {
-	availableTagsJSON, _ := json.Marshal(p.AvailableTags)
-	currentTagsJSON, _ := json.Marshal(p.CurrentTags)
-	overrideJS := "false"
+// txdCategoryOverrideAttr returns "true" / "false" for the data-category-override
+// attribute consumed by the txdCategoryEditor Alpine factory's init().
+func txdCategoryOverrideAttr(p TransactionDetailProps) string {
 	if p.Transaction != nil && p.Transaction.CategoryOverride {
-		overrideJS = "true"
+		return "true"
 	}
-
-	return fmt.Sprintf(`
-// Populate global tag cache so the picker works without a re-fetch.
-window.__bbAllTags = %[1]s || [];
-
-// Register transaction-detail scoped keyboard shortcuts in the global registry
-// (base.html). The dispatcher guards against touch, input focus, and open
-// overlays, so these handlers only need to care about "what does this key do".
-// Shortcuts surface automatically in the ? help modal (M0.3) under "This page".
-document.addEventListener('alpine:init', function() {
-  var reg = Alpine.store('shortcuts');
-  if (!reg) return;
-
-  reg.register({
-    id: 'transaction-detail.categorize',
-    keys: 'c',
-    description: 'Categorize transaction',
-    group: 'Actions',
-    scope: 'transaction-detail',
-    action: function() {
-      // Reuse the inline picker trigger — same contract as the click handler,
-      // so the categoryPicker's sourceId + listener wiring stays in one place.
-      var btn = document.querySelector('.bb-cat-picker[data-picker-source="txd-cat"] button');
-      if (btn) btn.click();
-    },
-  });
-
-  reg.register({
-    id: 'transaction-detail.tag',
-    keys: 't',
-    description: 'Edit tags',
-    group: 'Actions',
-    scope: 'transaction-detail',
-    action: function() {
-      // Click the "Add tag / Edit tags" chip so the tagManager component
-      // opens the picker with its current tag state (appliedCounts, etc.).
-      var btn = document.querySelector('.bb-tag-add');
-      if (btn) btn.click();
-    },
-  });
-
-  reg.register({
-    id: 'transaction-detail.compose-note',
-    keys: 'n',
-    description: 'Add a note',
-    group: 'Actions',
-    scope: 'transaction-detail',
-    action: function() {
-      var el = document.getElementById('bb-txd-comment');
-      if (!el) return;
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      el.focus();
-    },
-  });
-
-  reg.register({
-    id: 'transaction-detail.expand-system-details',
-    keys: 'e',
-    description: 'Toggle system details',
-    group: 'Actions',
-    scope: 'transaction-detail',
-    action: function() {
-      var btn = document.getElementById('bb-txd-system-details-toggle');
-      if (btn) btn.click();
-    },
-  });
-});
-
-function txCategoryEditor() {
-  return {
-    saving: false,
-    isOverride: %[3]s,
-    setCategoryFromPicker(detail) {
-      if (!detail.id) {
-        this.resetCategory();
-        return;
-      }
-      this.saving = true;
-      fetch('/-/transactions/%[2]s/category', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({category_id: detail.id})
-      })
-      .then(r => {
-        this.saving = false;
-        if (r.ok) {
-          this.isOverride = true;
-          showToast('Category updated.', 'success');
-        } else {
-          r.json().then(d => showToast(d.error?.message || 'Failed to update category.'));
-        }
-      })
-      .catch(() => { this.saving = false; showToast('Network error.'); });
-    },
-    resetCategory() {
-      this.saving = true;
-      fetch('/-/transactions/%[2]s/category', { method: 'DELETE' })
-      .then(r => {
-        this.saving = false;
-        if (r.ok || r.status === 204) {
-          this.isOverride = false;
-          showToast('Category reset to auto-detected.', 'success');
-          location.reload();
-        } else {
-          showToast('Failed to reset category.');
-        }
-      })
-      .catch(() => { this.saving = false; showToast('Network error.'); });
-    }
-  };
-}
-
-function showToast(message, type) {
-  window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
-}
-
-function commentManager(maxLen) {
-  return {
-    newComment: '',
-    maxLength: maxLen || 10000,
-    canSubmit() {
-      var trimmed = this.newComment.trim().length;
-      return trimmed > 0 && this.newComment.length <= this.maxLength;
-    },
-    counterState() {
-      if (this.newComment.length === 0) return 'ok';
-      var ratio = this.newComment.length / this.maxLength;
-      if (ratio >= 1) return 'error';
-      if (ratio >= 0.9) return 'warn';
-      return 'ok';
-    },
-    autosize(el) {
-      // Reset to natural height so scrollHeight reflects current content,
-      // not the previously-set explicit height. Cap at max-h-36 (9rem ≈ 144px)
-      // so the composer never balloons past ~6 rows; overflow scrolls inside.
-      if (!el) return;
-      el.style.height = 'auto';
-      var max = 144;
-      var next = Math.min(el.scrollHeight, max);
-      el.style.height = next + 'px';
-      el.style.overflowY = el.scrollHeight > max ? 'auto' : 'hidden';
-    },
-    addComment() {
-      var self = this;
-      var content = this.newComment.trim();
-      if (!content || !this.canSubmit()) return;
-      fetch('/-/transactions/%[2]s/comments', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({content: content})
-      })
-      .then(function(res) {
-        if (res.ok) {
-          self.newComment = '';
-          showToast('Comment added.', 'success');
-          location.reload();
-        } else {
-          return res.json().then(function(data) {
-            showToast(data.error || 'Failed to add comment.');
-          });
-        }
-      })
-      .catch(function() { showToast('Network error.'); });
-    },
-    deleteComment(id) {
-      bbConfirm({title:'Delete comment?',message:'This comment will be permanently removed.',confirmLabel:'Delete',variant:'danger'}).then(function(ok){
-        if(!ok) return;
-        fetch('/-/transactions/%[2]s/comments/' + id, {
-          method: 'DELETE'
-        })
-        .then(function(res) {
-          if (res.ok || res.status === 204) {
-            showToast('Comment deleted.', 'success');
-            location.reload();
-          } else {
-            return res.json().then(function(data) {
-              showToast(data.error || 'Failed to delete comment.');
-            });
-          }
-        })
-        .catch(function() { showToast('Network error.'); });
-      });
-    }
-  };
-}
-
-function tagManager() {
-  // Go marshals nil slices as `+"`null`"+`, so guard with `+"`|| []`"+` to keep the Alpine
-  // scope usable when the transaction has no tags / no registered tags.
-  return {
-    tags: (%[4]s || []).map(function(t) { return {
-      slug: t.slug,
-      displayName: t.display_name,
-      color: t.color,
-      icon: t.icon,
-    }; }),
-    availableTags: %[1]s || [],
-
-    openTagPicker() {
-      // Picker uses the same contract as the bulk bar: the tx's current tags
-      // render as "present" so the user can add and remove in one commit.
-      var counts = {};
-      this.tags.forEach(function(t) { counts[t.slug] = 1; });
-      window.dispatchEvent(new CustomEvent('open-tag-picker', {
-        detail: {
-          sourceId: 'txd-tag',
-          transactionIds: ['%[2]s'],
-          txCount: 1,
-          appliedCounts: counts,
-          availableTags: this.availableTags,
-        }
-      }));
-    },
-
-    applyTagDiff(adds, removes) {
-      adds = adds || []; removes = removes || [];
-      if (adds.length + removes.length === 0) return;
-      var op = {};
-      if (adds.length) op.tags_to_add = adds.map(function(s) { return {slug: s, note: ''}; });
-      if (removes.length) op.tags_to_remove = removes.map(function(s) { return {slug: s, note: ''}; });
-      fetch('/-/transactions/batch-update', {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({
-          operations: [Object.assign({transaction_id: '%[2]s'}, op)],
-          on_error: 'continue',
-        }),
-      })
-      .then(function(r) { return r.json().then(function(d) { return {ok: r.ok || r.status === 422, body: d}; }); })
-      .then(function(res) {
-        if (res.ok && res.body && res.body.succeeded > 0) {
-          showToast('Tags updated.', 'success');
-          location.reload();
-        } else {
-          var msg = (res.body && res.body.error && res.body.error.message) || 'Failed to update tags.';
-          showToast(msg);
-        }
-      })
-      .catch(function() { showToast('Network error.'); });
-    },
-
-    removeTag(tag, note) {
-      // Inline × on a tag chip — direct DELETE. Note is optional.
-      var url = '/-/transactions/%[2]s/tags/' + encodeURIComponent(tag.slug);
-      fetch(url, {
-        method: 'DELETE',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({note: note || ''}),
-      })
-      .then(function(res) { return res.json().then(function(d) { return {ok: res.ok, body: d}; }); })
-      .then(function(r) {
-        if (r.ok) {
-          showToast('Tag removed.', 'success');
-          location.reload();
-        } else {
-          showToast(r.body.error || 'Failed to remove tag.');
-        }
-      })
-      .catch(function() { showToast('Network error.'); });
-    },
-  };
-}
-`, string(availableTagsJSON), p.TransactionID, overrideJS, string(currentTagsJSON))
+	return "false"
 }

--- a/static/js/admin/components/transaction_detail.js
+++ b/static/js/admin/components/transaction_detail.js
@@ -1,0 +1,368 @@
+// Transaction detail Alpine components for /admin/transactions/{id}.
+//
+// Convention reference: docs/design-system.md -> "Alpine page components".
+//
+// The page renders three sibling Alpine factories (no parent root): the
+// category editor sidebar, the tag manager, and the activity-timeline
+// comment composer. Each factory takes no arguments; their initial state
+// flows in via @templ.JSONScript and `data-*` attributes wired up in
+// transaction_detail.templ.
+//
+// Three JSONScript payloads:
+//   #transaction-detail-data            -> p.Categories (the two-level tree)
+//   #transaction-detail-available-tags  -> p.AvailableTags
+//   #transaction-detail-current-tags    -> p.CurrentTags
+//
+// Scalars flow via data-* attributes on each factory's root (see templ):
+//   data-tx-id              -> p.TransactionID (all three factories)
+//   data-category-override  -> p.Transaction.CategoryOverride ("true"/"false")
+//   data-max-comment-length -> p.MaxCommentLength
+//
+// Back-compat note: the inline `categoryPicker` factory in tx_row.templ
+// reads `window.__bbCategories` as a global. The page's category sidebar
+// uses the same shared factory, so we seed `window.__bbCategories` from
+// the JSONScript payload at module top-level (mirrors rule_detail.js).
+// `window.__bbAllTags` is also seeded so the global tag picker (base.html)
+// can open without a re-fetch.
+//
+// `showToast` is exposed on `window` to match the contract used by
+// tx-row's inline x-init watcher and the rule_detail page.
+
+// --- Module-level globals consumed by tx_row + base.html ---
+
+function showToast(message, type) {
+  window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
+}
+
+window.showToast = showToast;
+
+// Seed window.__bbCategories and window.__bbAllTags as early as possible
+// so any inline component (tx_row's categoryPicker, base.html's tag
+// picker) that reads them on first render finds the populated values.
+(function seedGlobals() {
+  var catsEl = document.getElementById('transaction-detail-data');
+  if (catsEl) {
+    try {
+      window.__bbCategories = JSON.parse(catsEl.textContent);
+    } catch (e) {
+      console.error('transactionDetail: failed to parse #transaction-detail-data', e);
+    }
+  }
+  var tagsEl = document.getElementById('transaction-detail-available-tags');
+  if (tagsEl) {
+    try {
+      window.__bbAllTags = JSON.parse(tagsEl.textContent) || [];
+    } catch (e) {
+      console.error('transactionDetail: failed to parse #transaction-detail-available-tags', e);
+      window.__bbAllTags = [];
+    }
+  }
+})();
+
+document.addEventListener('alpine:init', function () {
+  // Register transaction-detail scoped keyboard shortcuts in the global
+  // registry (base.html). The dispatcher guards against touch, input
+  // focus, and open overlays, so these handlers only need to care about
+  // "what does this key do". Shortcuts surface automatically in the ?
+  // help modal under "This page".
+  var reg = Alpine.store('shortcuts');
+  if (reg) {
+    reg.register({
+      id: 'transaction-detail.categorize',
+      keys: 'c',
+      description: 'Categorize transaction',
+      group: 'Actions',
+      scope: 'transaction-detail',
+      action: function () {
+        // Reuse the inline picker trigger - same contract as the click
+        // handler, so the categoryPicker's sourceId + listener wiring stays
+        // in one place.
+        var btn = document.querySelector('.bb-cat-picker[data-picker-source="txd-cat"] button');
+        if (btn) btn.click();
+      },
+    });
+
+    reg.register({
+      id: 'transaction-detail.tag',
+      keys: 't',
+      description: 'Edit tags',
+      group: 'Actions',
+      scope: 'transaction-detail',
+      action: function () {
+        // Click the "Add tag / Edit tags" chip so the tagManager component
+        // opens the picker with its current tag state (appliedCounts, etc.).
+        var btn = document.querySelector('.bb-tag-add');
+        if (btn) btn.click();
+      },
+    });
+
+    reg.register({
+      id: 'transaction-detail.compose-note',
+      keys: 'n',
+      description: 'Add a note',
+      group: 'Actions',
+      scope: 'transaction-detail',
+      action: function () {
+        var el = document.getElementById('bb-txd-comment');
+        if (!el) return;
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        el.focus();
+      },
+    });
+
+    reg.register({
+      id: 'transaction-detail.expand-system-details',
+      keys: 'e',
+      description: 'Toggle system details',
+      group: 'Actions',
+      scope: 'transaction-detail',
+      action: function () {
+        var btn = document.getElementById('bb-txd-system-details-toggle');
+        if (btn) btn.click();
+      },
+    });
+  }
+
+  // Category editor sidebar. Reads transaction id + override flag from
+  // data-* attributes on its root.
+  Alpine.data('txdCategoryEditor', function () {
+    return {
+      saving: false,
+      isOverride: false,
+      txId: '',
+
+      init: function () {
+        var ds = this.$el.dataset;
+        this.txId = ds.txId || '';
+        this.isOverride = ds.categoryOverride === 'true';
+      },
+
+      setCategoryFromPicker: function (detail) {
+        if (!detail.id) {
+          this.resetCategory();
+          return;
+        }
+        var self = this;
+        this.saving = true;
+        fetch('/-/transactions/' + this.txId + '/category', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ category_id: detail.id }),
+        })
+          .then(function (r) {
+            self.saving = false;
+            if (r.ok) {
+              self.isOverride = true;
+              showToast('Category updated.', 'success');
+            } else {
+              r.json().then(function (d) { showToast(d.error?.message || 'Failed to update category.'); });
+            }
+          })
+          .catch(function () { self.saving = false; showToast('Network error.'); });
+      },
+
+      resetCategory: function () {
+        var self = this;
+        this.saving = true;
+        fetch('/-/transactions/' + this.txId + '/category', { method: 'DELETE' })
+          .then(function (r) {
+            self.saving = false;
+            if (r.ok || r.status === 204) {
+              self.isOverride = false;
+              showToast('Category reset to auto-detected.', 'success');
+              location.reload();
+            } else {
+              showToast('Failed to reset category.');
+            }
+          })
+          .catch(function () { self.saving = false; showToast('Network error.'); });
+      },
+    };
+  });
+
+  // Tag manager (chip strip + Add/Edit picker). Reads transaction id from
+  // a data-* attribute and the current/available tag lists from JSONScript.
+  Alpine.data('txdTagManager', function () {
+    return {
+      tags: [],
+      availableTags: [],
+      txId: '',
+
+      init: function () {
+        this.txId = this.$el.dataset.txId || '';
+
+        var currentEl = document.getElementById('transaction-detail-current-tags');
+        var current = [];
+        if (currentEl) {
+          try {
+            current = JSON.parse(currentEl.textContent) || [];
+          } catch (e) {
+            console.error('txdTagManager: failed to parse #transaction-detail-current-tags', e);
+          }
+        }
+        this.tags = current.map(function (t) {
+          return {
+            slug: t.slug,
+            displayName: t.display_name,
+            color: t.color,
+            icon: t.icon,
+          };
+        });
+
+        // Re-use the global seeded by the page-level seedGlobals() block.
+        this.availableTags = window.__bbAllTags || [];
+      },
+
+      openTagPicker: function () {
+        // Picker uses the same contract as the bulk bar: the tx's current
+        // tags render as "present" so the user can add and remove in one
+        // commit.
+        var counts = {};
+        this.tags.forEach(function (t) { counts[t.slug] = 1; });
+        window.dispatchEvent(new CustomEvent('open-tag-picker', {
+          detail: {
+            sourceId: 'txd-tag',
+            transactionIds: [this.txId],
+            txCount: 1,
+            appliedCounts: counts,
+            availableTags: this.availableTags,
+          },
+        }));
+      },
+
+      applyTagDiff: function (adds, removes) {
+        adds = adds || [];
+        removes = removes || [];
+        if (adds.length + removes.length === 0) return;
+        var op = {};
+        if (adds.length) op.tags_to_add = adds.map(function (s) { return { slug: s, note: '' }; });
+        if (removes.length) op.tags_to_remove = removes.map(function (s) { return { slug: s, note: '' }; });
+        fetch('/-/transactions/batch-update', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            operations: [Object.assign({ transaction_id: this.txId }, op)],
+            on_error: 'continue',
+          }),
+        })
+          .then(function (r) { return r.json().then(function (d) { return { ok: r.ok || r.status === 422, body: d }; }); })
+          .then(function (res) {
+            if (res.ok && res.body && res.body.succeeded > 0) {
+              showToast('Tags updated.', 'success');
+              location.reload();
+            } else {
+              var msg = (res.body && res.body.error && res.body.error.message) || 'Failed to update tags.';
+              showToast(msg);
+            }
+          })
+          .catch(function () { showToast('Network error.'); });
+      },
+
+      removeTag: function (tag, note) {
+        // Inline x on a tag chip - direct DELETE. Note is optional.
+        var url = '/-/transactions/' + this.txId + '/tags/' + encodeURIComponent(tag.slug);
+        fetch(url, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ note: note || '' }),
+        })
+          .then(function (res) { return res.json().then(function (d) { return { ok: res.ok, body: d }; }); })
+          .then(function (r) {
+            if (r.ok) {
+              showToast('Tag removed.', 'success');
+              location.reload();
+            } else {
+              showToast(r.body.error || 'Failed to remove tag.');
+            }
+          })
+          .catch(function () { showToast('Network error.'); });
+      },
+    };
+  });
+
+  // Activity-timeline comment composer. Reads txId + maxLength from data-*.
+  Alpine.data('txdCommentManager', function () {
+    return {
+      newComment: '',
+      maxLength: 10000,
+      txId: '',
+
+      init: function () {
+        var ds = this.$el.dataset;
+        this.txId = ds.txId || '';
+        var parsed = parseInt(ds.maxCommentLength, 10);
+        if (!isNaN(parsed) && parsed > 0) this.maxLength = parsed;
+      },
+
+      canSubmit: function () {
+        var trimmed = this.newComment.trim().length;
+        return trimmed > 0 && this.newComment.length <= this.maxLength;
+      },
+
+      counterState: function () {
+        if (this.newComment.length === 0) return 'ok';
+        var ratio = this.newComment.length / this.maxLength;
+        if (ratio >= 1) return 'error';
+        if (ratio >= 0.9) return 'warn';
+        return 'ok';
+      },
+
+      autosize: function (el) {
+        // Reset to natural height so scrollHeight reflects current content,
+        // not the previously-set explicit height. Cap at max-h-36 (9rem
+        // ~ 144px) so the composer never balloons past ~6 rows; overflow
+        // scrolls inside.
+        if (!el) return;
+        el.style.height = 'auto';
+        var max = 144;
+        var next = Math.min(el.scrollHeight, max);
+        el.style.height = next + 'px';
+        el.style.overflowY = el.scrollHeight > max ? 'auto' : 'hidden';
+      },
+
+      addComment: function () {
+        var self = this;
+        var content = this.newComment.trim();
+        if (!content || !this.canSubmit()) return;
+        fetch('/-/transactions/' + this.txId + '/comments', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ content: content }),
+        })
+          .then(function (res) {
+            if (res.ok) {
+              self.newComment = '';
+              showToast('Comment added.', 'success');
+              location.reload();
+            } else {
+              return res.json().then(function (data) {
+                showToast(data.error || 'Failed to add comment.');
+              });
+            }
+          })
+          .catch(function () { showToast('Network error.'); });
+      },
+
+      deleteComment: function (id) {
+        var self = this;
+        bbConfirm({ title: 'Delete comment?', message: 'This comment will be permanently removed.', confirmLabel: 'Delete', variant: 'danger' }).then(function (ok) {
+          if (!ok) return;
+          fetch('/-/transactions/' + self.txId + '/comments/' + id, {
+            method: 'DELETE',
+          })
+            .then(function (res) {
+              if (res.ok || res.status === 204) {
+                showToast('Comment deleted.', 'success');
+                location.reload();
+              } else {
+                return res.json().then(function (data) {
+                  showToast(data.error || 'Failed to delete comment.');
+                });
+              }
+            })
+            .catch(function () { showToast('Network error.'); });
+        });
+      },
+    };
+  });
+});


### PR DESCRIPTION
Phase 2 of #827 — extract `transaction_detail`'s Alpine factory to follow the page-component convention codified in #828. **Second Source-C extraction** (Go function returning script HTML, with prop interpolation).

## Source today
- Factory body: `internal/templates/components/pages/transaction_detail.templ` — a `func txdScriptBody(p TransactionDetailProps) string` block (lines 727+ on `main`) that built ~280 lines of JS via `fmt.Sprintf` with four prop substitutions, rendered through `@templ.Raw("<script>" + txdScriptBody(p) + "</script>")`.
- Existing data hand-off: four interpolations directly in the JS string (`p.AvailableTags` JSON, `p.CurrentTags` JSON, `p.TransactionID`, `p.Transaction.CategoryOverride`).

## Done
- Body moved → `static/js/admin/components/transaction_detail.js`. Three sibling factories registered as `Alpine.data('txdCategoryEditor', …)`, `Alpine.data('txdTagManager', …)`, `Alpine.data('txdCommentManager', …)`. Each takes **no arguments**.
- Data hand-off split:
  - **`@templ.JSONScript`** (complex):
    - `transaction-detail-data` ← `p.Categories` (also seeds `window.__bbCategories` for the shared `categoryPicker` factory in `tx_row.templ`)
    - `transaction-detail-available-tags` ← `p.AvailableTags` (also seeds `window.__bbAllTags` for the global tag picker in `base.html`)
    - `transaction-detail-current-tags` ← `p.CurrentTags`
  - **`data-*` attributes** (scalars on each factory's root):
    - `data-tx-id` ← `p.TransactionID`
    - `data-category-override` ← `"true"`/`"false"` from `p.Transaction.CategoryOverride`
    - `data-max-comment-length` ← `p.MaxCommentLength`
- Templ wiring: `<script src="/static/js/admin/components/transaction_detail.js"></script>` (synchronous, **NO** `defer`) at the top of the component. Three `@templ.JSONScript` tags **precede** the script — see ordering note below.
- Removed the entire `txdScriptBody` Go function (~280 LOC) and the `txdScripts` templ wrapper. `encoding/json` import dropped; `strconv` added.
- Lint allowlist: `transaction_detail.templ` was not present, no edits needed. Inline-script max remains 147 (in `connections.templ`); ceiling stays at 180.
- `templ generate`, `go build/vet/test ./...` all clean.

## Why this is a `JSONScript + data-attr` showcase

The original Source-C function interpolated four things into JS: two JSON arrays, one scalar string, and one boolean. This PR routes each through the right channel:

| Source value | New channel | Why |
|---|---|---|
| `p.Categories` (slice) | `@templ.JSONScript` | Complex tree, also needs to be visible as `window.__bbCategories` global for the shared `categoryPicker` factory in `tx_row.templ`. |
| `p.AvailableTags` (slice) | `@templ.JSONScript` | Complex array, also needs `window.__bbAllTags` for `base.html`'s tag picker. |
| `p.CurrentTags` (slice) | `@templ.JSONScript` | Complex array, only consumed inside `txdTagManager.init()`. |
| `p.TransactionID` (string) | `data-tx-id` | Scalar UUID, used by all three factories' fetch URLs. |
| `p.Transaction.CategoryOverride` (bool) | `data-category-override` | Scalar boolean, parsed in `txdCategoryEditor.init()`. |
| `p.MaxCommentLength` (int) | `data-max-comment-length` | Scalar integer, parsed in `txdCommentManager.init()`. |

The JS source is now 100% static — no `fmt.Sprintf` in Go.

## Ordering subtlety

The categoryPicker x-data (`tx_row`-pattern, shared factory) reads `window.__bbCategories` at Alpine.start, and `base.html`'s global tag picker reads `window.__bbAllTags`. Both globals are seeded by an IIFE at the top of `transaction_detail.js`. For that IIFE to see the JSONScript tags in the DOM, **JSONScript tags must precede the synchronous `<script src>`** in the templ — the file is ordered accordingly and the rationale is documented inline.

## Validation

Validated in Chrome DevTools MCP at `/transactions/2f9bad9c-…`:

- Hero, account banner, details, category sidebar, tags, activity timeline render.
- Category picker opens and shows the resolved label "Food & Drink › Groceries" (this confirms `window.__bbCategories` is populated before Alpine init).
- Tag picker opens with the two existing tags rendered as "present" (Needs Review + Needs Enrichment).
- Comment composer accepts input, button enables on text, submit succeeds (event count went from 3 → 4 after the round-trip + reload).
- Console silent (only pre-existing lucide "dice" warning + form-id warning).

<img src="https://i.img402.dev/0414jq7ai8.jpg" width="800" alt="transaction_detail — Alpine factory extracted to transaction_detail.js, category picker resolved, comment posted">

## Tasks
- [x] Move factory body → `static/js/admin/components/transaction_detail.js`.
- [x] Replace data hand-off via `@templ.JSONScript` (complex) + `data-*` attrs (scalars).
- [x] Templ wiring: synchronous `<script src>` (no defer), JSONScript tags precede it, string-literal `x-data` on each factory's root.
- [x] Delete `txdScriptBody` and `txdScripts` from the templ.
- [x] Re-measure inline-script max: still 147 (`connections.templ`); ceiling unchanged.
- [x] `templ generate`, `go build/vet/test ./...` clean.
- [x] Browser validate at `/transactions/{id}` — screenshot in PR body.
- [ ] Tick `transaction_detail` in #827 (after PR opens).
