### PR TITLE
Phase 2 of #827: extract Alpine factory from account_detail

### DIFF
--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -1,7 +1,6 @@
 package pages
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"strings"
@@ -13,10 +12,26 @@ import (
 // AccountDetail renders the /admin/accounts/{id} detail page — header
 // with type badge + status, balance + spending summary cards, the
 // collapsible Account Settings block, the filterable transaction list
-// (with shared TxRow rows + paginator), and the inline JS that bridges
-// display-name / excluded toggles + window.__bbCategories. Hosts inside
-// base.html via TemplateRenderer.RenderWithTempl.
+// (with shared TxRow rows + paginator), plus a sibling page-component
+// JS module that seeds window.__bbCategories and exposes the
+// updateDisplayName / toggleExcluded handlers consumed by the inline
+// onchange bindings in acctSettings. Hosts inside base.html via
+// TemplateRenderer.RenderWithTempl.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+// The page-component <script src> is loaded synchronously (not deferred)
+// so window.__bbCategories is populated before tx_row's inline
+// categoryPicker x-init runs and before Alpine — itself <script defer>
+// in <head> — fires alpine:init. The @templ.JSONScript tag must precede
+// the <script src> below so the IIFE in account_detail.js finds the
+// payload at parse time.
 templ AccountDetail(p AccountDetailProps) {
+	@templ.JSONScript("account-detail-data", p.Categories)
+	<!-- Page-component factory + inline-onchange handlers. Loaded
+	     synchronously (no defer) so window.__bbCategories is seeded
+	     before tx_row.templ's inline categoryPicker x-init runs and
+	     before Alpine fires alpine:init. -->
+	<script src="/static/js/admin/components/account_detail.js"></script>
 	@components.CategoryPickerStyles()
 	@components.BreadcrumbNav(p.Breadcrumbs)
 	@acctHeader(p)
@@ -32,7 +47,6 @@ templ AccountDetail(p AccountDetailProps) {
 		@acctEmptyState(p)
 	}
 	@components.CategoryPickerScript()
-	@acctScripts(p)
 }
 
 templ acctHeader(p AccountDetailProps) {
@@ -384,10 +398,6 @@ templ acctEmptyState(p AccountDetailProps) {
 	</div>
 }
 
-templ acctScripts(p AccountDetailProps) {
-	@templ.Raw(acctScriptsHTML(p))
-}
-
 // --- helpers ---
 
 // acctTypeIcon mirrors the {{if eq .Account.Type ...}} chain at the top
@@ -600,99 +610,4 @@ func htmlAttrEscape(s string) string {
 		`>`, "&gt;",
 	)
 	return r.Replace(s)
-}
-
-// acctScriptsHTML renders the two trailing <script> blocks verbatim
-// from the original page: window.__bbCategories seed + bulk-store
-// stub, and the showToast / quickSetCategory / updateDisplayName /
-// toggleExcluded handlers. Categories JSON is marshalled here; the
-// rest is a static literal.
-func acctScriptsHTML(p AccountDetailProps) string {
-	cats, err := json.Marshal(p.Categories)
-	if err != nil {
-		cats = []byte("[]")
-	}
-	return `<script>
-window.__bbCategories = ` + string(cats) + `;
-
-// Minimal bulk store for tx-row partial compatibility
-document.addEventListener('alpine:init', function() {
-  if (!Alpine.store('bulk')) {
-    Alpine.store('bulk', {
-      selecting: false,
-      sel: [],
-      isIn: function() { return false; },
-      toggle: function() {},
-      toggleMode: function() {},
-      clear: function() {}
-    });
-  }
-});
-</script>
-
-<script>
-function showToast(message, type) {
-  window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
-}
-
-function quickSetCategory(txId, categoryId) {
-  if (!categoryId) {
-    fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
-    .then(function(r) {
-      if (r.ok || r.status === 204) showToast('Category reset', 'success');
-    });
-    return;
-  }
-  fetch('/-/transactions/' + txId + '/category', {
-    method: 'POST',
-    headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({category_id: categoryId})
-  })
-  .then(function(r) {
-    if (r.ok) showToast('Category updated', 'success');
-    else r.json().then(function(d) { showToast(d.error?.message || 'Failed', 'error'); });
-  });
-}
-
-function updateDisplayName(accountId, val) {
-  var body = val === "" ? {display_name: null} : {display_name: val};
-  fetch("/-/accounts/" + accountId + "/display-name", {
-    method: "POST",
-    headers: {"Content-Type": "application/json"},
-    body: JSON.stringify(body)
-  })
-  .then(function(res) {
-    if (res.ok) {
-      showToast("Display name updated.", "success");
-    } else {
-      return res.json().then(function(data) {
-        showToast(data.error || "Failed to update display name.");
-      });
-    }
-  })
-  .catch(function() {
-    showToast("Network error. Please try again.");
-  });
-}
-
-function toggleExcluded(accountId, checked) {
-  fetch("/-/accounts/" + accountId + "/excluded", {
-    method: "POST",
-    headers: {"Content-Type": "application/json"},
-    body: JSON.stringify({excluded: checked})
-  })
-  .then(function(res) {
-    if (res.ok) {
-      showToast(checked ? "Account excluded." : "Account included.", "success");
-    } else {
-      return res.json().then(function(data) {
-        showToast(data.error || "Failed to update excluded state.");
-      });
-    }
-  })
-  .catch(function() {
-    showToast("Network error. Please try again.");
-  });
-}
-</script>`
 }

--- a/internal/templates/components/pages/scripts_lint_test.go
+++ b/internal/templates/components/pages/scripts_lint_test.go
@@ -19,9 +19,9 @@ import (
 // static/js/admin/components/<page>.js, the maximum drops; lower this value
 // in the same PR so the lint ratchets down. See #828 / #827.
 //
-// 2026-04-25 audit (post-connections extraction): max = 60 in
-// account_detail.templ:633-697. Ceiling = 60 + 30 = 90.
-const inlineScriptCeiling = 90
+// 2026-04-25 audit (post-account_detail extraction): max = 1 in
+// categories.templ:71-73. Ceiling = 1 + 30 = 31.
+const inlineScriptCeiling = 31
 
 // xDataFactoryAntiPattern catches the regression that #827 / #828 are
 // undoing: an x-data attribute rendered from a Go expression that calls a

--- a/static/js/admin/components/account_detail.js
+++ b/static/js/admin/components/account_detail.js
@@ -1,0 +1,139 @@
+// Account detail Alpine bridge for /accounts/{id}.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+//
+// This page renders no top-level Alpine factory of its own — the page is
+// mostly server-rendered + a few inline Alpine x-data sub-blocks (filter
+// panel, account-settings disclosure, transaction rows). The role of this
+// module is twofold:
+//
+//   1. Seed `window.__bbCategories` from the @templ.JSONScript payload so
+//      the inline `categoryPicker(...)` factory used by tx_row.templ and
+//      the filter row's category picker finds a populated category tree
+//      on first render. This mirrors the seeding pattern in
+//      transaction_detail.js / rule_detail.js.
+//
+//   2. Expose `showToast`, `quickSetCategory`, `updateDisplayName`, and
+//      `toggleExcluded` on `window` so:
+//        - the inline `onchange="updateDisplayName(...)"` and
+//          `onchange="toggleExcluded(...)"` bindings emitted by
+//          acctDisplayNameInputHTML / acctExcludedCheckboxHTML can find them.
+//        - tx_row's inline `x-init` watcher and Alpine pickers can call
+//          `quickSetCategory` and `showToast`.
+//
+// A no-op `Alpine.store('bulk', ...)` is registered so tx_row's
+// `$store.bulk.toggle()` and `.processing` references don't error on this
+// page (we never enter selection mode here).
+
+// --- Module-level globals consumed by tx_row + acct settings inputs ---
+
+function showToast(message, type) {
+  window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
+}
+
+// Inline category picker on tx-row fires this on change. Same contract as
+// /transactions and /rules/{id} — keep in sync if that endpoint evolves.
+function quickSetCategory(txId, categoryId) {
+  if (!categoryId) {
+    fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
+      .then(function (r) {
+        if (r.ok || r.status === 204) showToast('Category reset', 'success');
+      });
+    return;
+  }
+  fetch('/-/transactions/' + txId + '/category', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ category_id: categoryId }),
+  })
+    .then(function (r) {
+      if (r.ok) showToast('Category updated', 'success');
+      else r.json().then(function (d) { showToast(d.error?.message || 'Failed', 'error'); });
+    });
+}
+
+// Account-settings: the Display Name input fires onchange; PATCH the
+// account and toast on result. Empty string clears the override (sends
+// null) so the institution-supplied name takes over.
+function updateDisplayName(accountId, val) {
+  var body = val === '' ? { display_name: null } : { display_name: val };
+  fetch('/-/accounts/' + accountId + '/display-name', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+    .then(function (res) {
+      if (res.ok) {
+        showToast('Display name updated.', 'success');
+      } else {
+        return res.json().then(function (data) {
+          showToast(data.error || 'Failed to update display name.');
+        });
+      }
+    })
+    .catch(function () {
+      showToast('Network error. Please try again.');
+    });
+}
+
+// Account-settings: the Excluded checkbox fires onchange; POST the new
+// state and toast on result.
+function toggleExcluded(accountId, checked) {
+  fetch('/-/accounts/' + accountId + '/excluded', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ excluded: checked }),
+  })
+    .then(function (res) {
+      if (res.ok) {
+        showToast(checked ? 'Account excluded.' : 'Account included.', 'success');
+      } else {
+        return res.json().then(function (data) {
+          showToast(data.error || 'Failed to update excluded state.');
+        });
+      }
+    })
+    .catch(function () {
+      showToast('Network error. Please try again.');
+    });
+}
+
+window.showToast = showToast;
+window.quickSetCategory = quickSetCategory;
+window.updateDisplayName = updateDisplayName;
+window.toggleExcluded = toggleExcluded;
+
+// Seed window.__bbCategories as early as possible so inline x-data
+// initializers (the filter row's categoryPicker, plus tx_row's inline
+// categoryPicker on first render) find the populated value. Mirrors the
+// IIFE-at-top pattern from transaction_detail.js / rule_detail.js.
+//
+// The JSONScript tag must be emitted *above* this <script src> in the
+// templ component so the element exists when this IIFE runs.
+(function seedGlobals() {
+  var dataEl = document.getElementById('account-detail-data');
+  if (!dataEl) return;
+  try {
+    window.__bbCategories = JSON.parse(dataEl.textContent);
+  } catch (e) {
+    console.error('accountDetail: failed to parse #account-detail-data', e);
+    window.__bbCategories = null;
+  }
+})();
+
+document.addEventListener('alpine:init', function () {
+  // Minimal no-op bulk store. tx_row references $store.bulk.toggle() and
+  // .processing on render; we never enter selection mode on this page,
+  // so the stubbed handlers are sufficient.
+  if (!Alpine.store('bulk')) {
+    Alpine.store('bulk', {
+      selecting: false,
+      processing: false,
+      sel: [],
+      isIn: function () { return false; },
+      toggle: function () {},
+      toggleMode: function () {},
+      clear: function () {},
+    });
+  }
+});


### PR DESCRIPTION
Phase 2 of #827 — extract `account_detail`'s Alpine factory to follow the page-component convention codified in #828.

## Source today
- Factory body location: `internal/templates/components/pages/account_detail.templ:610-697` (`acctScriptsHTML(p)` Go function returning two `<script>` blocks via `@templ.Raw`)
- Existing data hand-off: Categories tree string-concatenated into the script body as `window.__bbCategories = <JSON>;`, plus `onchange="updateDisplayName(...)"` / `onchange="toggleExcluded(...)"` attribute bindings on the Account Settings inputs

## What landed

- Moved the script body into `static/js/admin/components/account_detail.js` and replaced the Go-string render with a synchronous `<script src="…">` at the top of `templ AccountDetail`.
- Categories now flow via `@templ.JSONScript("account-detail-data", p.Categories)` emitted **above** the `<script src>` so the IIFE at the top of `account_detail.js` finds the payload at parse time.
- Deleted the `acctScriptsHTML` Go function and the now-unused `encoding/json` import.

## Why no top-level factory + the `window.__bbCategories` shim

`account_detail` doesn't have its own page-level Alpine factory — the page is mostly server-rendered with inline `x-data` sub-blocks (filter panel, settings disclosure, tx rows). The module's role is the seed-and-shim pair that the inline pieces depend on:

1. **`window.__bbCategories` IIFE seed** at the top of the JS file, parsed from `#account-detail-data`. The shared `categoryPicker(...)` factory used by tx_row and the filter row reads this global on first render. Mirrors the seeding pattern in `transaction_detail.js` (#863) / `rule_detail.js` (#843).
2. **Globals on `window`**: `showToast`, `quickSetCategory`, `updateDisplayName`, `toggleExcluded`. The first two preserve the tx_row `x-init` watcher contract; the latter two are called by the inline `onchange="…"` bindings emitted by `acctDisplayNameInputHTML` / `acctExcludedCheckboxHTML` (kept as pure-HTML helpers — no JS to migrate there).
3. A **no-op `Alpine.store('bulk', …)`** is registered so `tx_row`'s `$store.bulk.toggle()` references don't blow up — selection mode never opens on this page.

The `categoryPicker(...)` invocations themselves are **not** touched by this PR. They migrate as part of a separate "extract shared categoryPicker" follow-up after this lands.

## Lint ceiling

The `acctScriptsHTML` Go function emitted a literal `<script>…</script>` whose 60-line body was the previous high-water mark (`account_detail.templ:633-697`). With it gone, the new max across `pages/*.templ` is 1 line (`categories.templ:71-73`, the `lucide.createIcons()` one-liner). Ceiling lowered to **31** (1 + 30 buffer) in `scripts_lint_test.go`.

## Validation

- `go build ./... && go vet ./... && go test ./...` — all clean.
- Browser-validated at `/accounts/{id}` (account `Essential Savings`):
  - Account header, balance + spending cards, breadcrumbs render.
  - Account Settings disclosure expands; Display Name and Excluded inputs persist (verified the `bb-toast` event fires "Display name updated." with `type=success` after triggering `change`).
  - Filter panel with category picker, transactions list with 50 rows + pagination, all category-pickers initialize with `categories: 17` (proves `window.__bbCategories` was populated by the IIFE).
  - Console silent (no errors related to extraction).

<img src="https://i.img402.dev/gdqbahzz86.jpg" width="800" alt="account_detail — after extraction">

## Tasks
- [x] Move factory body → `static/js/admin/components/account_detail.js` with no factory args
- [x] Replace data hand-off: complex state via `@templ.JSONScript("account-detail-data", p.Categories)` parsed in IIFE
- [x] Templ wiring: synchronous `<script src>` at top, JSONScript precedes it, `@acctScripts(p)` removed
- [x] Delete the entire `acctScriptsHTML` function and unused `encoding/json` import
- [x] Verify `account_detail.templ` not in `existingAntiPatternAllowlist` (confirmed — only `category_form.templ:88` and `user_form.templ:172` remain)
- [x] Re-measure inline-script max; lower lint ceiling from 90 → 31
- [x] `templ generate`, `go build/vet/test ./...` clean
- [x] Browser-validate via Chrome DevTools MCP, screenshot embedded above
- [ ] Tick `account_detail` in #827 (after merge)
