### PR TITLE
Phase 2 of #827: extract shared categoryPicker factory (allowlist -1, FINAL)

### DIFF
--- a/internal/templates/components/category_picker.templ
+++ b/internal/templates/components/category_picker.templ
@@ -1,174 +1,21 @@
 package components
 
-// CategoryPickerScript and CategoryPickerStyles are the two static blocks
-// the old html/template partials exposed (`category-picker-script` and
-// `category-picker-styles`). Both render byte-identical markup to the
-// original partial — the content is static, so we embed the raw strings
-// verbatim and skip per-request parsing.
+// CategoryPickerScript emits a synchronous <script src> tag that loads the
+// shared `categoryPicker` Alpine factory from
+// static/js/admin/components/category_picker.js. Pages embed this near the
+// top of their templ component (or just before the picker markup) so the
+// factory registers before Alpine — itself <script defer> in <head> —
+// fires alpine:init.
+//
+// CategoryPickerStyles continues to render the small set of legacy inline
+// styles that haven't migrated to the global CSS file yet.
 templ CategoryPickerScript() {
-	@templ.Raw(categoryPickerScriptHTML)
+	<script src="/static/js/admin/components/category_picker.js"></script>
 }
 
 templ CategoryPickerStyles() {
 	@templ.Raw(categoryPickerStylesHTML)
 }
-
-const categoryPickerScriptHTML = `<script>
-function categoryPicker(config) {
-  return {
-    open: false,
-    search: '',
-    selectedId: config.initial || '',
-    selectedLabel: '',
-    categories: config.categories || [],
-    mode: config.mode || 'assign', // 'assign' (UUIDs) or 'filter' (slugs)
-    name: config.name || '',
-    placeholder: config.placeholder || 'Select category...',
-    allowEmpty: config.allowEmpty !== false,
-    emptyLabel: config.emptyLabel || 'All categories',
-    highlightIndex: -1,
-    _bbSourceId: config.sourceId || '',
-
-    get flatList() {
-      let items = [];
-      if (this.allowEmpty) {
-        items.push({ id: '', slug: '', label: this.emptyLabel, isParent: false, indent: false, icon: null, color: null, hidden: false });
-      }
-      for (const cat of this.categories) {
-        // Skip the DB "uncategorized" category when allowEmpty provides its own empty option
-        if (this.allowEmpty && cat.slug === 'uncategorized') continue;
-        items.push({ id: cat.id, slug: cat.slug, label: cat.display_name, isParent: true, indent: false, icon: cat.icon, color: cat.color, hidden: cat.hidden || false });
-        if (cat.children) {
-          for (const child of cat.children) {
-            // Children inherit the parent color when they don't define their own,
-            // so colored dots render consistently regardless of category depth.
-            items.push({ id: child.id, slug: child.slug, label: child.display_name, isParent: false, indent: true, icon: child.icon || cat.icon, color: child.color || cat.color, hidden: child.hidden || false, parentLabel: cat.display_name });
-          }
-        }
-      }
-      return items;
-    },
-
-    get filteredList() {
-      if (!this.search) return this.flatList.filter(i => !i.hidden || i.id === '');
-      const q = this.search.toLowerCase();
-      return this.flatList.filter(i => {
-        if (i.hidden && i.id !== '') return false;
-        if (i.id === '' && !this.allowEmpty) return false;
-        return i.label.toLowerCase().includes(q) || (i.parentLabel && i.parentLabel.toLowerCase().includes(q)) || (i.slug && i.slug.toLowerCase().includes(q));
-      });
-    },
-
-    get value() {
-      return this.mode === 'filter' ? this.selectedSlug : this.selectedId;
-    },
-
-    get selectedSlug() {
-      const item = this.flatList.find(i => (this.mode === 'filter' ? i.slug === this.selectedId : i.id === this.selectedId));
-      return item ? item.slug : '';
-    },
-
-    get displayLabel() {
-      if (!this.selectedId) return this.allowEmpty ? this.emptyLabel : this.placeholder;
-      const item = this.flatList.find(i => (this.mode === 'filter' ? i.slug === this.selectedId : i.id === this.selectedId));
-      if (!item) return this.placeholder;
-      return item.indent ? (item.parentLabel + ' \u203a ' + item.label) : item.label;
-    },
-
-    get displayColor() {
-      if (!this.selectedId) return null;
-      const item = this.flatList.find(i => (this.mode === 'filter' ? i.slug === this.selectedId : i.id === this.selectedId));
-      return item ? item.color : null;
-    },
-
-    get displayIcon() {
-      if (!this.selectedId) return null;
-      const item = this.flatList.find(i => (this.mode === 'filter' ? i.slug === this.selectedId : i.id === this.selectedId));
-      return item ? item.icon : null;
-    },
-
-    itemValue(item) {
-      return this.mode === 'filter' ? item.slug : item.id;
-    },
-
-    select(item) {
-      this.selectedId = this.itemValue(item);
-      this.open = false;
-      this.search = '';
-      this.highlightIndex = -1;
-      this.$dispatch('category-change', { id: item.id, slug: item.slug, label: item.label });
-      this.$nextTick(() => {
-        if (typeof lucide !== 'undefined') lucide.createIcons({ nameAttr: 'data-lucide' });
-      });
-    },
-
-    handleKeydown(e) {
-      const list = this.filteredList;
-      if (e.key === 'ArrowDown') {
-        e.preventDefault();
-        this.highlightIndex = Math.min(this.highlightIndex + 1, list.length - 1);
-        this.scrollToHighlighted();
-      } else if (e.key === 'ArrowUp') {
-        e.preventDefault();
-        this.highlightIndex = Math.max(this.highlightIndex - 1, 0);
-        this.scrollToHighlighted();
-      } else if (e.key === 'Enter' && this.highlightIndex >= 0 && list[this.highlightIndex]) {
-        e.preventDefault();
-        this.select(list[this.highlightIndex]);
-      } else if (e.key === 'Escape') {
-        this.open = false;
-        this.search = '';
-        this.highlightIndex = -1;
-      }
-    },
-
-    scrollToHighlighted() {
-      this.$nextTick(() => {
-        const el = this.$refs.listbox?.querySelector('[data-highlighted="true"]');
-        if (el) el.scrollIntoView({ block: 'nearest' });
-      });
-    },
-
-    get hasResults() {
-      return this.filteredList.length > 0;
-    },
-
-    openPicker() {
-      this.open = false;
-      this.$dispatch('open-category-picker', {
-        mode: this.mode,
-        allowEmpty: this.allowEmpty,
-        emptyLabel: this.emptyLabel,
-        categories: this.categories,
-        sourceId: this._bbSourceId
-      });
-    },
-
-    init() {
-      // Ensure sourceId is set (prefer config value, fall back to DOM attribute)
-      if (!this._bbSourceId) {
-        this._bbSourceId = this.$el.closest('[data-picker-source]')?.dataset.pickerSource || ('picker-' + Math.random().toString(36).slice(2, 8));
-      }
-
-      // Listen for category-picked responses
-      var self = this;
-      window.addEventListener('category-picked', function(e) {
-        if (e.detail.sourceId === self._bbSourceId) {
-          self.selectedId = self.mode === 'filter' ? e.detail.slug : e.detail.id;
-          self.$dispatch('category-change', { id: e.detail.id, slug: e.detail.slug, label: e.detail.label });
-          self.$nextTick(function() {
-            if (typeof lucide !== 'undefined') lucide.createIcons({ nameAttr: 'data-lucide' });
-          });
-        }
-      });
-
-      this.$nextTick(() => {
-        if (typeof lucide !== 'undefined') lucide.createIcons({ nameAttr: 'data-lucide' });
-      });
-    }
-  };
-}
-</script>`
 
 const categoryPickerStylesHTML = `<style>
   /* Legacy inline picker styles removed — using global overlay via base.html */

--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -32,6 +32,7 @@ templ AccountDetail(p AccountDetailProps) {
 	     before tx_row.templ's inline categoryPicker x-init runs and
 	     before Alpine fires alpine:init. -->
 	<script src="/static/js/admin/components/account_detail.js"></script>
+	@components.CategoryPickerScript()
 	@components.CategoryPickerStyles()
 	@components.BreadcrumbNav(p.Breadcrumbs)
 	@acctHeader(p)
@@ -46,7 +47,6 @@ templ AccountDetail(p AccountDetailProps) {
 	} else {
 		@acctEmptyState(p)
 	}
-	@components.CategoryPickerScript()
 }
 
 templ acctHeader(p AccountDetailProps) {
@@ -112,7 +112,8 @@ templ acctSummaryCards(p AccountDetailProps) {
 					}
 					{ fmtBalancePtr(p.Account.BalanceCurrent) }
 				} else {
-					<span class="text-base-content/20">@templ.Raw("&mdash;")</span>
+					<span class="text-base-content/20">@templ.Raw("&mdash;")
+</span>
 				}
 			</div>
 			if p.HasCreditUtil {
@@ -272,7 +273,12 @@ templ acctFilterPanel(p AccountDetailProps) {
 				<div
 					class="bb-cat-picker"
 					data-picker-source="acct-filter-cat"
-					x-data={ acctCategoryPickerInit(p.FilterCategory) }
+					x-data="categoryPicker"
+					data-mode="filter"
+					data-source-id="acct-filter-cat"
+					data-allow-empty="true"
+					data-empty-label="All categories"
+					data-initial={ p.FilterCategory }
 					@category-change="$refs.catInput.value = selectedSlug"
 				>
 					<input type="hidden" name="category" x-ref="catInput" value={ p.FilterCategory }/>
@@ -360,7 +366,8 @@ templ acctPagination(p AccountDetailProps) {
 			<!-- Page numbers -->
 			for _, n := range acctPageRange(p.Page, p.TotalPages) {
 				if n == 0 {
-					<span class="bb-paginator__ellipsis">@templ.Raw("&hellip;")</span>
+					<span class="bb-paginator__ellipsis">@templ.Raw("&hellip;")
+</span>
 				} else if n == p.Page {
 					<span class="bb-paginator__btn bb-paginator__btn--active">{ fmt.Sprintf("%d", n) }</span>
 				} else {
@@ -443,16 +450,6 @@ func acctFiltersOpenInit(p AccountDetailProps) string {
 		return "{ filtersOpen: true }"
 	}
 	return "{ filtersOpen: false }"
-}
-
-// acctCategoryPickerInit builds the categoryPicker() x-data invocation
-// for the filter row. Slug values are server-generated and safe to
-// interpolate without escaping.
-func acctCategoryPickerInit(initial string) string {
-	return fmt.Sprintf(
-		"categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: %q, allowEmpty: true, emptyLabel: 'All categories', sourceId: 'acct-filter-cat'})",
-		initial,
-	)
 }
 
 // acctUtilBarColor returns the credit-utilization bar color class

--- a/internal/templates/components/pages/category_form.templ
+++ b/internal/templates/components/pages/category_form.templ
@@ -10,7 +10,17 @@ import (
 // base layout via TemplateRenderer.RenderWithTempl. The markup mirrors
 // the previous html/template version byte-for-byte so behavior (live
 // preview, icon picker, parent picker, Alpine submit flow) is preserved.
+//
+// The parent picker uses the shared `categoryPicker` Alpine factory from
+// static/js/admin/components/category_picker.js, fed by the JSONScript
+// payload below. CategoryPickerScript emits a synchronous <script src>
+// tag at the top so the factory registers before Alpine — itself
+// deferred from <head> — fires alpine:init.
 templ CategoryForm(p CategoryFormProps) {
+	if !p.IsEdit {
+		@templ.JSONScript("category-form-picker-data", p.Categories)
+	}
+	@components.CategoryPickerScript()
 	@components.BreadcrumbNav(p.Breadcrumbs)
 	@components.CategoryPickerStyles()
 	<div class="bb-page-header">
@@ -85,7 +95,13 @@ templ CategoryForm(p CategoryFormProps) {
 							<div
 								class="bb-cat-picker"
 								data-picker-source="cat-form-parent"
-								x-data={ "categoryPicker({categories: " + categoriesJSON(p.Categories) + ", mode: 'assign', placeholder: 'None (top-level)', allowEmpty: true, emptyLabel: 'None (top-level)', sourceId: 'cat-form-parent'})" }
+								x-data="categoryPicker"
+								data-mode="assign"
+								data-source-id="cat-form-parent"
+								data-placeholder="None (top-level)"
+								data-allow-empty="true"
+								data-empty-label="None (top-level)"
+								data-categories-source="category-form-picker-data"
 								@category-change="parentId = $event.detail.id"
 							>
 								<button type="button" class="select select-bordered w-full text-left flex items-center gap-2 rounded-xl bg-base-200/50" @click="openPicker()">
@@ -216,6 +232,5 @@ templ CategoryForm(p CategoryFormProps) {
 			</div>
 		</form>
 	</div>
-	@components.CategoryPickerScript()
 	@templ.Raw(categoryFormBootstrap(p))
 }

--- a/internal/templates/components/pages/category_form_types.go
+++ b/internal/templates/components/pages/category_form_types.go
@@ -19,17 +19,6 @@ type CategoryFormProps struct {
 	Breadcrumbs []components.Breadcrumb
 }
 
-// categoriesJSON marshals the parent-picker dataset. The helper exists so
-// the templ template can emit the JSON directly into an x-data attribute
-// without having to reach for encoding/json in markup.
-func categoriesJSON(cs []service.CategoryResponse) string {
-	b, err := json.Marshal(cs)
-	if err != nil {
-		return "[]"
-	}
-	return string(b)
-}
-
 // categoryColorOr returns the current color value or a sensible default
 // for the form's live preview. Keeps the preview header on-brand when a
 // category has no color set.

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -29,6 +29,7 @@ templ RuleDetail(p RuleDetailProps) {
 	     defer) so the Alpine.data() registration runs before Alpine — itself
 	     deferred from <head> — fires alpine:init. -->
 	<script src="/static/js/admin/components/rule_detail.js"></script>
+	@components.CategoryPickerScript()
 	@components.BreadcrumbNav(p.Breadcrumbs)
 	@templ.JSONScript("rule-detail-data", p.Categories)
 	<div
@@ -57,7 +58,6 @@ templ RuleDetail(p RuleDetailProps) {
 			@ruleDetailSyncActivity(p)
 		}
 	</div>
-	@components.CategoryPickerScript()
 }
 
 // ruleDetailHeader renders the page-title row with status badges and the

--- a/internal/templates/components/pages/scripts_lint_test.go
+++ b/internal/templates/components/pages/scripts_lint_test.go
@@ -42,11 +42,12 @@ var xDataFactoryAntiPattern = regexp.MustCompile(`x-data=\{\s*"[A-Za-z_$][A-Za-z
 // This allowlist must shrink monotonically: every Phase 2 PR that ports a
 // page deletes its entry here. If you find yourself adding to this list,
 // stop — the new Alpine factory belongs in static/js/admin/components/.
-var existingAntiPatternAllowlist = map[string]struct{}{
-	// `categoryPicker(...)` factory shared across category_form, transactions,
-	// account_detail, transaction_detail. See #827's Phase 2 queue.
-	"category_form.templ:88": {},
-}
+//
+// As of #827's Phase 2 closure, the allowlist is empty: every page-level
+// Alpine factory has been ported to static/js/admin/components/, and the
+// shared categoryPicker factory was extracted in the final PR. Keep the
+// map declaration so the stale-entry check below still compiles.
+var existingAntiPatternAllowlist = map[string]struct{}{}
 
 // TestNoLargeInlineScripts walks every *.templ file under
 // internal/templates/components/pages and enforces two rules:

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -34,6 +34,7 @@ templ TransactionDetail(p TransactionDetailProps) {
 	     Alpine.data() registrations run before Alpine — itself deferred from
 	     <head> — fires alpine:init. -->
 	<script src="/static/js/admin/components/transaction_detail.js"></script>
+	@components.CategoryPickerScript()
 	@components.CategoryPickerStyles()
 	<!--
 		Set the shortcut-registry scope so base.html's global dispatcher routes
@@ -49,7 +50,6 @@ templ TransactionDetail(p TransactionDetailProps) {
 	}
 	@txdMain(p)
 	@txdActivity(p)
-	@components.CategoryPickerScript()
 }
 
 templ txdHero(p TransactionDetailProps) {
@@ -214,7 +214,18 @@ templ txdMain(p TransactionDetailProps) {
 		>
 			<div>
 				<h2 class="text-sm font-semibold text-base-content/50 mb-3">Category</h2>
-				<div class="bb-cat-picker" data-picker-source="txd-cat" x-data={ txdCategoryPickerInit(p) } @category-change="setCategoryFromPicker($event.detail)">
+				<div
+					class="bb-cat-picker"
+					data-picker-source="txd-cat"
+					x-data="categoryPicker"
+					data-mode="assign"
+					data-source-id="txd-cat"
+					data-placeholder="Uncategorized"
+					data-allow-empty="true"
+					data-empty-label="Uncategorized"
+					data-initial={ txdCategoryInitial(p) }
+					@category-change="setCategoryFromPicker($event.detail)"
+				>
 					<button type="button" class="w-full flex items-center gap-3 p-3 rounded-xl bg-base-200/50 hover:bg-base-200 transition-colors" @click="openPicker()">
 						<template x-if="displayColor"><span class="w-3 h-3 rounded-full shrink-0" :style="'background-color:' + displayColor"></span></template>
 						<span x-text="displayLabel" class="text-sm font-medium flex-1 text-left"></span>
@@ -729,20 +740,17 @@ func avatarURLStr(id, version string) string {
 	return url
 }
 
-// txdCategoryPickerInit emits the x-data initializer for the inline
-// category picker. Categories flow into the shared `categoryPicker`
-// factory through `window.__bbCategories` (seeded by
-// transaction_detail.js from the @templ.JSONScript payload), matching
-// the convention used by tx_row.templ.
-func txdCategoryPickerInit(p TransactionDetailProps) string {
-	initial := ""
+// txdCategoryInitial returns the current category UUID for the picker's
+// data-initial attribute, or an empty string when the transaction has no
+// category. The shared `categoryPicker` factory reads this via the
+// `data-initial` attribute on its root and uses window.__bbCategories
+// (seeded by transaction_detail.js from the @templ.JSONScript payload)
+// for the option list.
+func txdCategoryInitial(p TransactionDetailProps) string {
 	if p.Transaction != nil && p.Transaction.Category != nil && p.Transaction.Category.ID != nil {
-		initial = *p.Transaction.Category.ID
+		return *p.Transaction.Category.ID
 	}
-	return fmt.Sprintf(
-		"categoryPicker({categories: window.__bbCategories, mode: 'assign', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', initial: '%s', sourceId: 'txd-cat'})",
-		initial,
-	)
+	return ""
 }
 
 // txdCategoryOverrideAttr returns "true" / "false" for the data-category-override

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -28,6 +28,7 @@ templ Transactions(p TransactionsProps) {
 		x-init="$store.shortcuts.setScope('transactions')"
 		x-destroy="$store.shortcuts.setScope('global')"
 	></div>
+	@components.CategoryPickerScript()
 	@components.CategoryPickerStyles()
 	@txPageHeader(p)
 	@txFilters(p)
@@ -37,7 +38,6 @@ templ Transactions(p TransactionsProps) {
 		@txEmptyState(p)
 	}
 	<!-- Floating bulk action bar is created via JS in <body> to avoid parent transform breaking position:fixed -->
-	@components.CategoryPickerScript()
 	@txPageScripts(p)
 	if p.IsReviewQueue() {
 		@txReviewQueueShortcuts()
@@ -240,7 +240,12 @@ templ txFilters(p TransactionsProps) {
 					<div
 						class="bb-cat-picker"
 						data-picker-source="tx-filter-cat"
-						x-data={ txCategoryPickerInit(p.FilterCategory) }
+						x-data="categoryPicker"
+						data-mode="filter"
+						data-source-id="tx-filter-cat"
+						data-allow-empty="true"
+						data-empty-label="All categories"
+						data-initial={ p.FilterCategory }
 						@category-change="$refs.catInput.value = selectedSlug"
 					>
 						<input type="hidden" name="category" x-ref="catInput" value={ p.FilterCategory }/>
@@ -399,19 +404,31 @@ templ txResultsShell(p TransactionsProps) {
 			     also guards on `$store.device.isTouch` to cover touch-capable
 			     large viewports. -->
 			<div class="hidden sm:flex items-center gap-2 text-xs text-base-content/30">
-				<span class="flex items-center gap-1">@components.Kbd("j")
-@components.Kbd("k")
-navigate</span>
-				<span class="flex items-center gap-1">@components.Kbd("Enter")
-open</span>
-				<span class="flex items-center gap-1">@components.Kbd("c")
-category</span>
-				<span class="flex items-center gap-1">@components.Kbd("t")
-tag</span>
-				<span class="flex items-center gap-1">@components.Kbd("e")
-expand</span>
-				<span class="flex items-center gap-1">@components.Kbd("x")
-select</span>
+				<span class="flex items-center gap-1">
+					@components.Kbd("j")
+					@components.Kbd("k")
+					navigate
+				</span>
+				<span class="flex items-center gap-1">
+					@components.Kbd("Enter")
+					open
+				</span>
+				<span class="flex items-center gap-1">
+					@components.Kbd("c")
+					category
+				</span>
+				<span class="flex items-center gap-1">
+					@components.Kbd("t")
+					tag
+				</span>
+				<span class="flex items-center gap-1">
+					@components.Kbd("e")
+					expand
+				</span>
+				<span class="flex items-center gap-1">
+					@components.Kbd("x")
+					select
+				</span>
 			</div>
 		</div>
 		<div id="bb-tx-results">
@@ -476,16 +493,6 @@ func filtersOpenWatch() string {
     if (qs && adv && qs.value.trim()) adv.value = qs.value.trim();
   }
 })`
-}
-
-// txCategoryPickerInit renders the inline categoryPicker() init string for
-// the Category filter dropdown. Slugs are server-generated and never contain
-// quotes; we strip any stray ones defensively anyway.
-func txCategoryPickerInit(filterCategory string) string {
-	return fmt.Sprintf(
-		"categoryPicker({categories: window.__bbCategories, mode: 'filter', initial: '%s', allowEmpty: true, emptyLabel: 'All categories', sourceId: 'tx-filter-cat'})",
-		strings.ReplaceAll(filterCategory, "'", ""),
-	)
 }
 
 // txSearchModeInit renders the x-data initializer for the search-mode

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -131,7 +131,13 @@ templ TxRow(tx service.AdminTransactionRow) {
 				<div
 					class="bb-cat-picker"
 					data-picker-source={ "tx-cat-" + tx.ID }
-					x-data={ txCategoryPickerInit(tx.ID, tx.CategoryID) }
+					x-data="categoryPicker"
+					data-mode="assign"
+					data-source-id={ "tx-cat-" + tx.ID }
+					data-placeholder="Uncategorized"
+					data-allow-empty="true"
+					data-empty-label="Uncategorized"
+					data-initial={ txCategoryInitial(tx.CategoryID) }
 					x-init={ fmt.Sprintf("$watch('selectedId', (v, old) => { if (old !== undefined && v !== old && !($store.bulk && $store.bulk.processing)) { quickSetCategory('%s', v) } })", tx.ID) }
 				>
 					<button type="button" class="btn btn-ghost btn-xs gap-1.5 rounded-lg" @click="openPicker()">
@@ -249,16 +255,15 @@ func txAvatarColorStyle(color *string) string {
 	return "--avatar-color: oklch(0.65 0 0)"
 }
 
-// txCategoryPickerInit builds the x-data payload for the inline picker. Short
-// IDs are base62 and category IDs are UUIDs, so single-quote interpolation is
-// safe — anything else is rejected upstream at parseID.
-func txCategoryPickerInit(txID string, categoryID *string) string {
-	initial := ""
+// txCategoryInitial returns the category UUID for the picker's data-initial
+// attribute, or empty string when the row is uncategorized. The shared
+// `categoryPicker` factory reads this via `data-initial` and pulls the
+// option list from window.__bbCategories (seeded by the host page's
+// component module — transactions.templ inline bootstrap, account_detail.js,
+// transaction_detail.js, rule_detail.js).
+func txCategoryInitial(categoryID *string) string {
 	if categoryID != nil {
-		initial = *categoryID
+		return *categoryID
 	}
-	return fmt.Sprintf(
-		"categoryPicker({categories: window.__bbCategories, mode: 'assign', initial: '%s', placeholder: 'Uncategorized', allowEmpty: true, emptyLabel: 'Uncategorized', sourceId: 'tx-cat-%s'})",
-		initial, txID,
-	)
+	return ""
 }

--- a/static/js/admin/components/category_picker.js
+++ b/static/js/admin/components/category_picker.js
@@ -1,0 +1,246 @@
+// Shared Alpine factory for the inline category picker.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+//
+// Drop-in replacement for the legacy `function categoryPicker(config) { ... }`
+// factory previously embedded inline in internal/templates/components/category_picker.templ.
+// Used across:
+//
+//   - /categories (parent picker on the create form)        — mode: 'assign'
+//   - /transactions (filter bar)                            — mode: 'filter'
+//   - /transactions/{id} (assign sidebar)                   — mode: 'assign'
+//   - tx-row inline picker (per-row quick set)              — mode: 'assign'
+//   - /accounts/{id} (filter bar)                           — mode: 'filter'
+//
+// The factory takes NO arguments — all configuration flows via `data-*` attrs
+// on the root element. Categories come from one of:
+//
+//   - `data-categories-source` → ID of a <script type="application/json"> tag
+//     emitted by `@templ.JSONScript("...", p.Categories)`. Useful when the
+//     page already has the tree as a server-side prop (e.g. category_form).
+//   - Fallback: `window.__bbCategories` — seeded by the host page's component
+//     module (transactions.templ inline bootstrap, account_detail.js,
+//     transaction_detail.js, rule_detail.js).
+//
+// Recognized data-* attributes (all optional):
+//
+//   data-mode              'assign' | 'filter'           default 'assign'
+//   data-source-id         picker overlay routing key    default '' (auto)
+//   data-initial           initial selected id/slug      default ''
+//   data-placeholder       button label when nothing set default 'Select category...'
+//   data-allow-empty       'true' | 'false'              default 'true'
+//   data-empty-label       label for the empty option    default 'All categories'
+//   data-categories-source JSONScript element id         default '' (use global)
+//
+// Outbound events (unchanged from the previous factory):
+//
+//   category-change   { id, slug, label }   — fired on selection.
+//   open-category-picker — opens the global overlay; payload carries
+//     mode, allowEmpty, emptyLabel, categories, sourceId so the overlay can
+//     filter and route the resulting category-picked event back here.
+//
+// Inbound: window 'category-picked' { sourceId, id, slug, label } — when
+// the global picker overlay (base.html) commits a selection that matches
+// this picker's sourceId, we update selectedId and re-emit category-change.
+
+document.addEventListener('alpine:init', function () {
+  Alpine.data('categoryPicker', function () {
+    return {
+      open: false,
+      search: '',
+      selectedId: '',
+      selectedLabel: '',
+      categories: [],
+      mode: 'assign',
+      name: '',
+      placeholder: 'Select category...',
+      allowEmpty: true,
+      emptyLabel: 'All categories',
+      highlightIndex: -1,
+      _bbSourceId: '',
+
+      get flatList() {
+        var items = [];
+        if (this.allowEmpty) {
+          items.push({ id: '', slug: '', label: this.emptyLabel, isParent: false, indent: false, icon: null, color: null, hidden: false });
+        }
+        for (var i = 0; i < this.categories.length; i++) {
+          var cat = this.categories[i];
+          // Skip the DB "uncategorized" category when allowEmpty provides its own empty option
+          if (this.allowEmpty && cat.slug === 'uncategorized') continue;
+          items.push({ id: cat.id, slug: cat.slug, label: cat.display_name, isParent: true, indent: false, icon: cat.icon, color: cat.color, hidden: cat.hidden || false });
+          if (cat.children) {
+            for (var j = 0; j < cat.children.length; j++) {
+              var child = cat.children[j];
+              // Children inherit the parent color when they don't define their own,
+              // so colored dots render consistently regardless of category depth.
+              items.push({ id: child.id, slug: child.slug, label: child.display_name, isParent: false, indent: true, icon: child.icon || cat.icon, color: child.color || cat.color, hidden: child.hidden || false, parentLabel: cat.display_name });
+            }
+          }
+        }
+        return items;
+      },
+
+      get filteredList() {
+        var self = this;
+        if (!this.search) return this.flatList.filter(function (i) { return !i.hidden || i.id === ''; });
+        var q = this.search.toLowerCase();
+        return this.flatList.filter(function (i) {
+          if (i.hidden && i.id !== '') return false;
+          if (i.id === '' && !self.allowEmpty) return false;
+          return i.label.toLowerCase().indexOf(q) !== -1
+            || (i.parentLabel && i.parentLabel.toLowerCase().indexOf(q) !== -1)
+            || (i.slug && i.slug.toLowerCase().indexOf(q) !== -1);
+        });
+      },
+
+      get value() {
+        return this.mode === 'filter' ? this.selectedSlug : this.selectedId;
+      },
+
+      get selectedSlug() {
+        var self = this;
+        var item = this.flatList.find(function (i) {
+          return self.mode === 'filter' ? i.slug === self.selectedId : i.id === self.selectedId;
+        });
+        return item ? item.slug : '';
+      },
+
+      get displayLabel() {
+        var self = this;
+        if (!this.selectedId) return this.allowEmpty ? this.emptyLabel : this.placeholder;
+        var item = this.flatList.find(function (i) {
+          return self.mode === 'filter' ? i.slug === self.selectedId : i.id === self.selectedId;
+        });
+        if (!item) return this.placeholder;
+        return item.indent ? (item.parentLabel + ' › ' + item.label) : item.label;
+      },
+
+      get displayColor() {
+        var self = this;
+        if (!this.selectedId) return null;
+        var item = this.flatList.find(function (i) {
+          return self.mode === 'filter' ? i.slug === self.selectedId : i.id === self.selectedId;
+        });
+        return item ? item.color : null;
+      },
+
+      get displayIcon() {
+        var self = this;
+        if (!this.selectedId) return null;
+        var item = this.flatList.find(function (i) {
+          return self.mode === 'filter' ? i.slug === self.selectedId : i.id === self.selectedId;
+        });
+        return item ? item.icon : null;
+      },
+
+      itemValue: function (item) {
+        return this.mode === 'filter' ? item.slug : item.id;
+      },
+
+      select: function (item) {
+        this.selectedId = this.itemValue(item);
+        this.open = false;
+        this.search = '';
+        this.highlightIndex = -1;
+        this.$dispatch('category-change', { id: item.id, slug: item.slug, label: item.label });
+        this.$nextTick(function () {
+          if (typeof lucide !== 'undefined') lucide.createIcons({ nameAttr: 'data-lucide' });
+        });
+      },
+
+      handleKeydown: function (e) {
+        var list = this.filteredList;
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          this.highlightIndex = Math.min(this.highlightIndex + 1, list.length - 1);
+          this.scrollToHighlighted();
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          this.highlightIndex = Math.max(this.highlightIndex - 1, 0);
+          this.scrollToHighlighted();
+        } else if (e.key === 'Enter' && this.highlightIndex >= 0 && list[this.highlightIndex]) {
+          e.preventDefault();
+          this.select(list[this.highlightIndex]);
+        } else if (e.key === 'Escape') {
+          this.open = false;
+          this.search = '';
+          this.highlightIndex = -1;
+        }
+      },
+
+      scrollToHighlighted: function () {
+        var self = this;
+        this.$nextTick(function () {
+          var el = self.$refs.listbox && self.$refs.listbox.querySelector('[data-highlighted="true"]');
+          if (el) el.scrollIntoView({ block: 'nearest' });
+        });
+      },
+
+      get hasResults() {
+        return this.filteredList.length > 0;
+      },
+
+      openPicker: function () {
+        this.open = false;
+        this.$dispatch('open-category-picker', {
+          mode: this.mode,
+          allowEmpty: this.allowEmpty,
+          emptyLabel: this.emptyLabel,
+          categories: this.categories,
+          sourceId: this._bbSourceId,
+        });
+      },
+
+      init: function () {
+        var ds = this.$el.dataset || {};
+        this.mode = ds.mode || 'assign';
+        this.placeholder = ds.placeholder || 'Select category...';
+        this.allowEmpty = ds.allowEmpty !== 'false';
+        this.emptyLabel = ds.emptyLabel || 'All categories';
+        this.selectedId = ds.initial || '';
+        this._bbSourceId = ds.sourceId || '';
+
+        // Categories: prefer an explicit JSONScript element when configured,
+        // fall back to the page-seeded window.__bbCategories global.
+        if (ds.categoriesSource) {
+          var srcEl = document.getElementById(ds.categoriesSource);
+          if (srcEl) {
+            try {
+              this.categories = JSON.parse(srcEl.textContent) || [];
+            } catch (e) {
+              console.error('categoryPicker: failed to parse #' + ds.categoriesSource, e);
+              this.categories = [];
+            }
+          } else {
+            this.categories = [];
+          }
+        } else {
+          this.categories = window.__bbCategories || [];
+        }
+
+        // Ensure sourceId is set (prefer explicit value, fall back to data-picker-source on a parent).
+        if (!this._bbSourceId) {
+          var src = this.$el.closest('[data-picker-source]');
+          this._bbSourceId = (src && src.dataset.pickerSource) || ('picker-' + Math.random().toString(36).slice(2, 8));
+        }
+
+        // Listen for category-picked responses from the global overlay (base.html).
+        var self = this;
+        window.addEventListener('category-picked', function (e) {
+          if (e.detail.sourceId === self._bbSourceId) {
+            self.selectedId = self.mode === 'filter' ? e.detail.slug : e.detail.id;
+            self.$dispatch('category-change', { id: e.detail.id, slug: e.detail.slug, label: e.detail.label });
+            self.$nextTick(function () {
+              if (typeof lucide !== 'undefined') lucide.createIcons({ nameAttr: 'data-lucide' });
+            });
+          }
+        });
+
+        this.$nextTick(function () {
+          if (typeof lucide !== 'undefined') lucide.createIcons({ nameAttr: 'data-lucide' });
+        });
+      },
+    };
+  });
+});


### PR DESCRIPTION
## Summary

- Extract the shared `categoryPicker` Alpine factory from the inline `<script>` in `internal/templates/components/category_picker.templ` to a no-arg factory in `static/js/admin/components/category_picker.js`. All five invocation sites (category_form, transactions, transaction_detail, tx_row, account_detail) now use `x-data=\"categoryPicker\"` plus `data-*` attributes per the docs/design-system convention.
- **Removes the last entry** (`category_form.templ:88`) from `existingAntiPatternAllowlist` in `scripts_lint_test.go`. **The allowlist is now empty** — Phase 2 of #827 has retired every page-level Alpine factory regression.
- `CategoryPickerScript()` now emits `<script src=\"/static/js/admin/components/category_picker.js\"></script>` synchronously, replacing a 185-line inline factory; all five host pages keep their existing `@components.CategoryPickerScript()` call (just moved to the top of the templ component) and pick up the new module unchanged.

## Allowlist status

```go
// internal/templates/components/pages/scripts_lint_test.go
var existingAntiPatternAllowlist = map[string]struct{}{}
```

After this PR: **empty**. Every prior anti-pattern hit (`report_detail.templ:18`, `user_form.templ:172`, `category_form.templ:88`) has been removed in its respective Phase 2 extraction PR.

## Implementation notes

- The new factory takes no arguments and reads its configuration from `data-*` attributes on the root element: `data-mode` (`assign` | `filter`), `data-source-id`, `data-initial`, `data-placeholder`, `data-allow-empty`, `data-empty-label`, and the optional `data-categories-source` pointing at a sibling `@templ.JSONScript` element.
- When `data-categories-source` is absent, the factory falls back to `window.__bbCategories` — already seeded by the host page's component module (transactions.templ inline bootstrap, account_detail.js, transaction_detail.js, rule_detail.js). This keeps `tx_row`'s per-row picker working without page-level plumbing changes.
- `category_form` is the only site that uses an explicit JSONScript (`@templ.JSONScript(\"category-form-picker-data\", p.Categories)`) because the form ships its own categories prop and never needed the global.
- Replaced four Go helpers that interpolated `categoryPicker(...)` calls into `x-data` (`txCategoryPickerInit` × 2, `txdCategoryPickerInit`, `acctCategoryPickerInit`) with two thin `data-initial` extractors (`txCategoryInitial`, `txdCategoryInitial`) that just return the current category UUID.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — all green.
- [x] Lint test (`TestNoLargeInlineScripts`) passes; allowlist is empty.
- [x] Inline-script ceiling unchanged at 31 (no new inline blocks).
- [x] `/categories/new`: parent picker opens, displays the full category hierarchy, selecting \"Income\" updates the button label.
- [x] `/transactions`: top-of-page filter picker opens with \"All categories\" empty option.
- [x] `/transactions/{id}`: assign sidebar picker shows current category (\"Food & Drink › Groceries\"), opens with \"Uncategorized\" empty option.
- [x] tx_row inline picker (xl+ breakpoint): factory dispatches `open-category-picker` with the correct mode/sourceId/categories — verified via `evaluate_script` since the local CSS doesn't include the Tailwind `xl:` breakpoint utilities.
- [x] `/accounts/{id}`: filter picker dataset shows mode='filter', sourceId='acct-filter-cat', allowEmpty='true', emptyLabel='All categories'.
- [x] Console silent across all four pages (one unrelated lucide warning about a missing `dice` icon — pre-existing in main).

## Screenshots

<table>
  <tr><th><code>/categories/new</code> — parent picker open</th><th><code>/transactions</code> — filter picker open</th></tr>
  <tr>
    <td><img src=\"https://i.img402.dev/tbqvuqjso5.jpg\" width=\"400\" alt=\"category form parent picker\"></td>
    <td><img src=\"https://i.img402.dev/4jrcz52ywe.jpg\" width=\"400\" alt=\"transactions filter picker\"></td>
  </tr>
  <tr><th><code>/transactions/{id}</code> — sidebar (closed)</th><th><code>/transactions/{id}</code> — picker open</th></tr>
  <tr>
    <td><img src=\"https://i.img402.dev/5gmazx65sg.jpg\" width=\"400\" alt=\"transaction detail sidebar\"></td>
    <td><img src=\"https://i.img402.dev/pgupx1hir2.jpg\" width=\"400\" alt=\"transaction detail picker open\"></td>
  </tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)