### PR TITLE
chore(pgconv): collapse pgtype.{Date,Timestamptz} literals onto helpers

### DIFF
--- a/internal/admin/helpers_test.go
+++ b/internal/admin/helpers_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"breadbox/internal/pgconv"
+
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -278,7 +280,7 @@ func TestConnectionStaleness(t *testing.T) {
 	now := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
 
 	syncedAt := func(d time.Duration) pgtype.Timestamptz {
-		return pgtype.Timestamptz{Time: now.Add(-d), Valid: true}
+		return pgconv.Timestamptz(now.Add(-d))
 	}
 	neverSynced := pgtype.Timestamptz{Valid: false}
 	override := func(minutes int32) pgtype.Int4 {

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -87,6 +87,20 @@ func TextIfNotEmpty(s string) pgtype.Text {
 	return pgtype.Text{String: s, Valid: true}
 }
 
+// Date wraps a time.Time as a non-NULL pgtype.Date. Use this to collapse
+// `pgtype.Date{Time: t, Valid: true}` boilerplate at insert and query-arg
+// sites where the value is always present.
+func Date(t time.Time) pgtype.Date {
+	return pgtype.Date{Time: t, Valid: true}
+}
+
+// Timestamptz wraps a time.Time as a non-NULL pgtype.Timestamptz. Use this
+// to collapse `pgtype.Timestamptz{Time: t, Valid: true}` boilerplate at
+// insert and query-arg sites where the value is always present.
+func Timestamptz(t time.Time) pgtype.Timestamptz {
+	return pgtype.Timestamptz{Time: t, Valid: true}
+}
+
 // TimestampStr renders a pgtype.Timestamptz as an RFC3339 UTC string. Returns
 // an empty string when the timestamp is NULL. Use for NOT NULL columns where
 // an empty response field is acceptable for the rare invalid case.

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -234,6 +234,28 @@ func TestTextIfNotEmpty_Empty(t *testing.T) {
 	}
 }
 
+func TestDate(t *testing.T) {
+	when := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+	got := Date(when)
+	if !got.Valid {
+		t.Errorf("Date(%v).Valid = false, want true", when)
+	}
+	if !got.Time.Equal(when) {
+		t.Errorf("Date(%v).Time = %v, want %v", when, got.Time, when)
+	}
+}
+
+func TestTimestamptz(t *testing.T) {
+	when := time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC)
+	got := Timestamptz(when)
+	if !got.Valid {
+		t.Errorf("Timestamptz(%v).Valid = false, want true", when)
+	}
+	if !got.Time.Equal(when) {
+		t.Errorf("Timestamptz(%v).Time = %v, want %v", when, got.Time, when)
+	}
+}
+
 func TestTimestampStr_Valid(t *testing.T) {
 	ts := pgtype.Timestamptz{
 		Time:  time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC),

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -560,13 +560,13 @@ func (s *Service) BulkRecategorizeByFilter(ctx context.Context, params BulkRecat
 
 	if params.StartDate != nil {
 		query += fmt.Sprintf(" AND t.date >= $%d", argN)
-		args = append(args, pgtype.Date{Time: *params.StartDate, Valid: true})
+		args = append(args, pgconv.Date(*params.StartDate))
 		argN++
 	}
 
 	if params.EndDate != nil {
 		query += fmt.Sprintf(" AND t.date < $%d", argN)
-		args = append(args, pgtype.Date{Time: *params.EndDate, Valid: true})
+		args = append(args, pgconv.Date(*params.EndDate))
 		argN++
 	}
 

--- a/internal/service/category_integration_test.go
+++ b/internal/service/category_integration_test.go
@@ -54,7 +54,7 @@ func mustCreateTransactionWithCategory(t *testing.T, q *db.Queries, acctID, catI
 		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
-		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
+		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,
 		CategoryID:            catID,
 	})

--- a/internal/service/convert_test.go
+++ b/internal/service/convert_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"breadbox/internal/pgconv"
+
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -210,16 +212,16 @@ func TestSyncLogDurationMs(t *testing.T) {
 			name:     "stored duration_ms wins",
 			duration: pgtype.Int4{Int32: 1234, Valid: true},
 			// timestamps would compute a different value — stored value must win.
-			started:   pgtype.Timestamptz{Time: start, Valid: true},
-			completed: pgtype.Timestamptz{Time: end, Valid: true},
+			started:   pgconv.Timestamptz(start),
+			completed: pgconv.Timestamptz(end),
 			wantMs:    1234,
 			wantOK:    true,
 		},
 		{
 			name:      "fallback to timestamps when duration null",
 			duration:  pgtype.Int4{Valid: false},
-			started:   pgtype.Timestamptz{Time: start, Valid: true},
-			completed: pgtype.Timestamptz{Time: end, Valid: true},
+			started:   pgconv.Timestamptz(start),
+			completed: pgconv.Timestamptz(end),
 			wantMs:    2500,
 			wantOK:    true,
 		},
@@ -227,14 +229,14 @@ func TestSyncLogDurationMs(t *testing.T) {
 			name:      "duration null and started null returns false",
 			duration:  pgtype.Int4{Valid: false},
 			started:   pgtype.Timestamptz{Valid: false},
-			completed: pgtype.Timestamptz{Time: end, Valid: true},
+			completed: pgconv.Timestamptz(end),
 			wantMs:    0,
 			wantOK:    false,
 		},
 		{
 			name:      "duration null and completed null returns false",
 			duration:  pgtype.Int4{Valid: false},
-			started:   pgtype.Timestamptz{Time: start, Valid: true},
+			started:   pgconv.Timestamptz(start),
 			completed: pgtype.Timestamptz{Valid: false},
 			wantMs:    0,
 			wantOK:    false,

--- a/internal/service/csv_import.go
+++ b/internal/service/csv_import.go
@@ -119,7 +119,7 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 		ConnectionID: connID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusInProgress,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create sync log: %w", err)
@@ -236,7 +236,7 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 			ProviderTransactionID:   externalTxnID,
 			Amount:                  amountNumeric,
 			IsoCurrencyCode:         pgconv.Text("USD"),
-			Date:                    pgtype.Date{Time: dateVal, Valid: true},
+			Date:                    pgconv.Date(dateVal),
 			ProviderName:            desc,
 			ProviderMerchantName:    pgconv.TextIfNotEmpty(merchant),
 			ProviderCategoryPrimary: pgconv.TextIfNotEmpty(category),
@@ -271,7 +271,7 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 	err = s.Queries.UpdateSyncLog(ctx, db.UpdateSyncLogParams{
 		ID:            syncLog.ID,
 		Status:        syncStatus,
-		CompletedAt:   pgtype.Timestamptz{Time: completedAt, Valid: true},
+		CompletedAt:   pgconv.Timestamptz(completedAt),
 		AddedCount:    int32(result.NewCount),
 		ModifiedCount: int32(result.UpdatedCount),
 		RemovedCount:  0,

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -730,7 +730,7 @@ func TestImportCategoriesTSV_MergeInto(t *testing.T) {
 		ProviderTransactionID: "txn_merge_1",
 		Amount:                pgtype.Numeric{Int: big.NewInt(550), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
-		Date:                  pgtype.Date{Time: testutil.MustParseDate("2025-01-15"), Valid: true},
+		Date:                  pgconv.Date(testutil.MustParseDate("2025-01-15")),
 		ProviderName:          "Starbucks",
 		CategoryID:            sourceCat.ID,
 	})

--- a/internal/service/mcp_synclog_csv_integration_test.go
+++ b/internal/service/mcp_synclog_csv_integration_test.go
@@ -200,7 +200,7 @@ func TestListSyncLogsPaginated_WithData(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 	if err != nil {
 		t.Fatalf("CreateSyncLog: %v", err)
@@ -241,14 +241,14 @@ func TestListSyncLogsPaginated_FilterByConnection(t *testing.T) {
 			ConnectionID: conn1.ID,
 			Trigger:      db.SyncTriggerManual,
 			Status:       db.SyncStatusSuccess,
-			StartedAt:    pgtype.Timestamptz{Time: now.Add(time.Duration(i) * time.Minute), Valid: true},
+			StartedAt:    pgconv.Timestamptz(now.Add(time.Duration(i) * time.Minute)),
 		})
 	}
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn2.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusError,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 
 	conn1ID := pgconv.FormatUUID(conn1.ID)
@@ -277,13 +277,13 @@ func TestListSyncLogsPaginated_FilterByStatus(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusError,
-		StartedAt:    pgtype.Timestamptz{Time: now.Add(time.Minute), Valid: true},
+		StartedAt:    pgconv.Timestamptz(now.Add(time.Minute)),
 	})
 
 	status := "error"
@@ -316,7 +316,7 @@ func TestListSyncLogsPaginated_Pagination(t *testing.T) {
 			ConnectionID: conn.ID,
 			Trigger:      db.SyncTriggerManual,
 			Status:       db.SyncStatusSuccess,
-			StartedAt:    pgtype.Timestamptz{Time: now.Add(time.Duration(i) * time.Minute), Valid: true},
+			StartedAt:    pgconv.Timestamptz(now.Add(time.Duration(i) * time.Minute)),
 		})
 	}
 
@@ -378,13 +378,13 @@ func TestCountSyncLogsFiltered_Basic(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusError,
-		StartedAt:    pgtype.Timestamptz{Time: now.Add(time.Minute), Valid: true},
+		StartedAt:    pgconv.Timestamptz(now.Add(time.Minute)),
 	})
 
 	// Count all
@@ -423,12 +423,12 @@ func TestSyncLogStats_WithData(t *testing.T) {
 			ConnectionID: conn.ID,
 			Trigger:      db.SyncTriggerManual,
 			Status:       db.SyncStatusInProgress,
-			StartedAt:    pgtype.Timestamptz{Time: now.Add(time.Duration(i) * time.Minute), Valid: true},
+			StartedAt:    pgconv.Timestamptz(now.Add(time.Duration(i) * time.Minute)),
 		})
 		queries.UpdateSyncLog(ctx, db.UpdateSyncLogParams{
 			ID:            log.ID,
 			Status:        db.SyncStatusSuccess,
-			CompletedAt:   pgtype.Timestamptz{Time: now.Add(time.Duration(i)*time.Minute + 5*time.Second), Valid: true},
+			CompletedAt:   pgconv.Timestamptz(now.Add(time.Duration(i)*time.Minute + 5*time.Second)),
 			AddedCount:    int32(i + 1),
 			ModifiedCount: 0,
 			RemovedCount:  0,
@@ -438,12 +438,12 @@ func TestSyncLogStats_WithData(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusInProgress,
-		StartedAt:    pgtype.Timestamptz{Time: now.Add(5 * time.Minute), Valid: true},
+		StartedAt:    pgconv.Timestamptz(now.Add(5 * time.Minute)),
 	})
 	queries.UpdateSyncLog(ctx, db.UpdateSyncLogParams{
 		ID:            errLog.ID,
 		Status:        db.SyncStatusError,
-		CompletedAt:   pgtype.Timestamptz{Time: now.Add(5*time.Minute + 2*time.Second), Valid: true},
+		CompletedAt:   pgconv.Timestamptz(now.Add(5*time.Minute + 2*time.Second)),
 		ErrorMessage:  pgtype.Text{String: "provider error", Valid: true},
 	})
 
@@ -485,13 +485,13 @@ func TestSyncLogStats_FilterByConnection(t *testing.T) {
 		ConnectionID: conn1.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn2.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 
 	conn1ID := pgconv.FormatUUID(conn1.ID)
@@ -521,19 +521,19 @@ func TestListSyncLogsPaginated_FilterByTrigger(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now.Add(time.Minute), Valid: true},
+		StartedAt:    pgconv.Timestamptz(now.Add(time.Minute)),
 	})
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusError,
-		StartedAt:    pgtype.Timestamptz{Time: now.Add(2 * time.Minute), Valid: true},
+		StartedAt:    pgconv.Timestamptz(now.Add(2 * time.Minute)),
 	})
 
 	// Filter by manual trigger.
@@ -580,13 +580,13 @@ func TestCountSyncLogsFiltered_ByTrigger(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerWebhook,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now.Add(time.Minute), Valid: true},
+		StartedAt:    pgconv.Timestamptz(now.Add(time.Minute)),
 	})
 
 	trigger := "webhook"
@@ -619,19 +619,19 @@ func TestListSyncLogsPaginated_FilterByDateRange(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: day1, Valid: true},
+		StartedAt:    pgconv.Timestamptz(day1),
 	})
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: day2, Valid: true},
+		StartedAt:    pgconv.Timestamptz(day2),
 	})
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusError,
-		StartedAt:    pgtype.Timestamptz{Time: day3, Valid: true},
+		StartedAt:    pgconv.Timestamptz(day3),
 	})
 
 	// Filter: from March 10 onward — should return day2 and day3.
@@ -692,21 +692,21 @@ func TestListSyncLogsPaginated_CombinedFilters(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: day1, Valid: true},
+		StartedAt:    pgconv.Timestamptz(day1),
 	})
 	// Cron success on day1.
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: day1.Add(time.Hour), Valid: true},
+		StartedAt:    pgconv.Timestamptz(day1.Add(time.Hour)),
 	})
 	// Manual error on day2.
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusError,
-		StartedAt:    pgtype.Timestamptz{Time: day2, Valid: true},
+		StartedAt:    pgconv.Timestamptz(day2),
 	})
 
 	// Filter: manual + success + day1 range — should return 1.
@@ -753,13 +753,13 @@ func TestSyncLogStats_FilterByTriggerAndDate(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: day1, Valid: true},
+		StartedAt:    pgconv.Timestamptz(day1),
 	})
 	queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: day2, Valid: true},
+		StartedAt:    pgconv.Timestamptz(day2),
 	})
 
 	// Stats for manual trigger only.
@@ -803,7 +803,7 @@ func TestGetConnectionStatus_WithSyncLog(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now),
 	})
 
 	connID := pgconv.FormatUUID(conn.ID)
@@ -1372,8 +1372,8 @@ func TestCountSyncLogs(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: now.Add(-time.Minute), Valid: true},
-		CompletedAt:  pgtype.Timestamptz{Time: now, Valid: true},
+		StartedAt:    pgconv.Timestamptz(now.Add(-time.Minute)),
+		CompletedAt:  pgconv.Timestamptz(now),
 	})
 	if err != nil {
 		t.Fatalf("CreateSyncLog failed: %v", err)
@@ -1401,8 +1401,8 @@ func TestCleanupSyncLogs_DeletesOldLogs(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: oldTime, Valid: true},
-		CompletedAt:  pgtype.Timestamptz{Time: oldTime.Add(time.Second), Valid: true},
+		StartedAt:    pgconv.Timestamptz(oldTime),
+		CompletedAt:  pgconv.Timestamptz(oldTime.Add(time.Second)),
 	})
 	if err != nil {
 		t.Fatalf("CreateSyncLog (old) failed: %v", err)
@@ -1414,8 +1414,8 @@ func TestCleanupSyncLogs_DeletesOldLogs(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerManual,
 		Status:       db.SyncStatusSuccess,
-		StartedAt:    pgtype.Timestamptz{Time: recentTime, Valid: true},
-		CompletedAt:  pgtype.Timestamptz{Time: recentTime.Add(time.Second), Valid: true},
+		StartedAt:    pgconv.Timestamptz(recentTime),
+		CompletedAt:  pgconv.Timestamptz(recentTime.Add(time.Second)),
 	})
 	if err != nil {
 		t.Fatalf("CreateSyncLog (recent) failed: %v", err)
@@ -1453,7 +1453,7 @@ func TestCleanupSyncLogs_SkipsInProgress(t *testing.T) {
 		ConnectionID: conn.ID,
 		Trigger:      db.SyncTriggerCron,
 		Status:       db.SyncStatusInProgress,
-		StartedAt:    pgtype.Timestamptz{Time: oldTime, Valid: true},
+		StartedAt:    pgconv.Timestamptz(oldTime),
 	})
 	if err != nil {
 		t.Fatalf("CreateSyncLog (in_progress) failed: %v", err)

--- a/internal/service/members.go
+++ b/internal/service/members.go
@@ -173,7 +173,7 @@ func (s *Service) generateSetupToken(ctx context.Context, accountID pgtype.UUID)
 	err := s.Queries.SetAuthAccountSetupToken(ctx, db.SetAuthAccountSetupTokenParams{
 		ID:                  accountID,
 		SetupToken:          pgconv.Text(token),
-		SetupTokenExpiresAt: pgtype.Timestamptz{Time: expiresAt, Valid: true},
+		SetupTokenExpiresAt: pgconv.Timestamptz(expiresAt),
 	})
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("store setup token: %w", err)

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
@@ -180,7 +181,7 @@ func (s *Service) CreateAuthorizationCode(ctx context.Context, clientID string, 
 	}
 
 	codeHash := hashToken(code)
-	expiresAt := pgtype.Timestamptz{Time: time.Now().Add(authCodeTTL), Valid: true}
+	expiresAt := pgconv.Timestamptz(time.Now().Add(authCodeTTL))
 
 	err = s.Queries.CreateOAuthAuthorizationCode(ctx, db.CreateOAuthAuthorizationCodeParams{
 		CodeHash:            codeHash,
@@ -318,7 +319,7 @@ func (s *Service) issueTokenPair(ctx context.Context, clientID string, adminID p
 	}
 
 	accessTokenHash := hashToken(accessTokenStr)
-	accessExpiresAt := pgtype.Timestamptz{Time: time.Now().Add(accessTokenTTL), Valid: true}
+	accessExpiresAt := pgconv.Timestamptz(time.Now().Add(accessTokenTTL))
 
 	accessToken, err := s.Queries.CreateOAuthAccessToken(ctx, db.CreateOAuthAccessTokenParams{
 		TokenHash: accessTokenHash,
@@ -338,7 +339,7 @@ func (s *Service) issueTokenPair(ctx context.Context, clientID string, adminID p
 	}
 
 	refreshTokenHash := hashToken(refreshTokenStr)
-	refreshExpiresAt := pgtype.Timestamptz{Time: time.Now().Add(refreshTokenTTL), Valid: true}
+	refreshExpiresAt := pgconv.Timestamptz(time.Now().Add(refreshTokenTTL))
 
 	_, err = s.Queries.CreateOAuthRefreshToken(ctx, db.CreateOAuthRefreshTokenParams{
 		TokenHash:     refreshTokenHash,

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -698,7 +698,7 @@ func (s *Service) CreateTransactionRule(ctx context.Context, params CreateTransa
 		if err != nil {
 			return nil, fmt.Errorf("%w: invalid expires_in %q: %v", ErrInvalidParameter, params.ExpiresIn, err)
 		}
-		expiresAt = pgtype.Timestamptz{Time: time.Now().Add(dur), Valid: true}
+		expiresAt = pgconv.Timestamptz(time.Now().Add(dur))
 	}
 
 	createdByType := params.Actor.Type
@@ -932,7 +932,7 @@ func (s *Service) ListTransactionRules(ctx context.Context, params TransactionRu
 		} else {
 			whereSQL += " AND " + cursorClause
 		}
-		args = append(args, pgtype.Timestamptz{Time: cursorTime, Valid: true}, cursorUUID)
+		args = append(args, pgconv.Timestamptz(cursorTime), cursorUUID)
 		argN += 2
 	}
 
@@ -1063,11 +1063,11 @@ func (s *Service) UpdateTransactionRule(ctx context.Context, id string, params U
 			if err != nil {
 				return nil, fmt.Errorf("%w: invalid expires_at format, use RFC3339", ErrInvalidParameter)
 			}
-			expiresAt = pgtype.Timestamptz{Time: t, Valid: true}
+			expiresAt = pgconv.Timestamptz(t)
 		}
 	} else if existing.ExpiresAt != nil {
 		t, _ := time.Parse(time.RFC3339, *existing.ExpiresAt)
-		expiresAt = pgtype.Timestamptz{Time: t, Valid: true}
+		expiresAt = pgconv.Timestamptz(t)
 	}
 
 	var conditionsArg any
@@ -2339,7 +2339,7 @@ func (s *Service) ListRuleApplications(ctx context.Context, ruleID string, limit
 			return nil, false, ErrInvalidCursor
 		}
 		query += fmt.Sprintf(" AND (ann.created_at, ann.id) < ($%d, $%d)", argN, argN+1)
-		args = append(args, pgtype.Timestamptz{Time: cursorTime, Valid: true}, cursorUUID)
+		args = append(args, pgconv.Timestamptz(cursorTime), cursorUUID)
 		argN += 2
 	}
 

--- a/internal/service/transaction_query_integration_test.go
+++ b/internal/service/transaction_query_integration_test.go
@@ -1036,7 +1036,7 @@ func upsertTxnWithCategory(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
-		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
+		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,
 		CategoryID:            categoryID,
 	})
@@ -1053,7 +1053,7 @@ func upsertTxnPending(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID, na
 		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
-		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
+		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,
 		Pending:               true,
 	})
@@ -1194,7 +1194,7 @@ func upsertTxnWithAmount(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID,
 		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
-		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
+		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,
 	})
 	if err != nil {
@@ -1215,7 +1215,7 @@ func upsertTxnWithMerchant(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
-		Date:                  pgtype.Date{Time: testutil.MustParseDate(date), Valid: true},
+		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,
 		ProviderMerchantName:  pgtype.Text{String: merchant, Valid: true},
 	})

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -161,14 +161,14 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 	if params.StartDate != nil {
 		buf.WriteString(" AND t.date >= $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.StartDate, Valid: true})
+		args = append(args, pgconv.Date(*params.StartDate))
 		argN++
 	}
 
 	if params.EndDate != nil {
 		buf.WriteString(" AND t.date < $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.EndDate, Valid: true})
+		args = append(args, pgconv.Date(*params.EndDate))
 		argN++
 	}
 
@@ -271,7 +271,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		buf.WriteString(", $")
 		buf.WriteString(strconv.Itoa(argN + 1))
 		buf.WriteByte(')')
-		args = append(args, pgtype.Date{Time: cursorDate, Valid: true}, cursorUUID)
+		args = append(args, pgconv.Date(cursorDate), cursorUUID)
 		argN += 2
 	}
 
@@ -556,14 +556,14 @@ func (s *Service) CountTransactionsFiltered(ctx context.Context, params Transact
 	if params.StartDate != nil {
 		buf.WriteString(" AND t.date >= $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.StartDate, Valid: true})
+		args = append(args, pgconv.Date(*params.StartDate))
 		argN++
 	}
 
 	if params.EndDate != nil {
 		buf.WriteString(" AND t.date < $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.EndDate, Valid: true})
+		args = append(args, pgconv.Date(*params.EndDate))
 		argN++
 	}
 
@@ -736,14 +736,14 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 	if params.StartDate != nil {
 		buf.WriteString(" AND t.date >= $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.StartDate, Valid: true})
+		args = append(args, pgconv.Date(*params.StartDate))
 		argN++
 	}
 
 	if params.EndDate != nil {
 		buf.WriteString(" AND t.date < $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.EndDate, Valid: true})
+		args = append(args, pgconv.Date(*params.EndDate))
 		argN++
 	}
 

--- a/internal/service/transactions_bench_test.go
+++ b/internal/service/transactions_bench_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"breadbox/internal/pgconv"
+
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -70,14 +72,14 @@ func benchBuildListTransactionsQuery(params benchListParams) (string, []any) {
 	if params.StartDate != nil {
 		buf.WriteString(" AND t.date >= $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.StartDate, Valid: true})
+		args = append(args, pgconv.Date(*params.StartDate))
 		argN++
 	}
 
 	if params.EndDate != nil {
 		buf.WriteString(" AND t.date < $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.EndDate, Valid: true})
+		args = append(args, pgconv.Date(*params.EndDate))
 		argN++
 	}
 
@@ -142,7 +144,7 @@ func benchBuildListTransactionsQuery(params benchListParams) (string, []any) {
 		buf.WriteString(", $")
 		buf.WriteString(strconv.Itoa(argN + 1))
 		buf.WriteByte(')')
-		args = append(args, pgtype.Date{Time: *params.CursorDate, Valid: true}, *params.CursorID)
+		args = append(args, pgconv.Date(*params.CursorDate), *params.CursorID)
 		argN += 2
 	}
 
@@ -212,14 +214,14 @@ func benchBuildCountTransactionsQuery(params benchCountParams) (string, []any) {
 	if params.StartDate != nil {
 		buf.WriteString(" AND t.date >= $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.StartDate, Valid: true})
+		args = append(args, pgconv.Date(*params.StartDate))
 		argN++
 	}
 
 	if params.EndDate != nil {
 		buf.WriteString(" AND t.date < $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.EndDate, Valid: true})
+		args = append(args, pgconv.Date(*params.EndDate))
 		argN++
 	}
 
@@ -344,14 +346,14 @@ func benchBuildAdminListQuery(params benchAdminListParams) (string, []any) {
 	if params.StartDate != nil {
 		buf.WriteString(" AND t.date >= $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.StartDate, Valid: true})
+		args = append(args, pgconv.Date(*params.StartDate))
 		argN++
 	}
 
 	if params.EndDate != nil {
 		buf.WriteString(" AND t.date < $")
 		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, pgtype.Date{Time: *params.EndDate, Valid: true})
+		args = append(args, pgconv.Date(*params.EndDate))
 		argN++
 	}
 

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -90,7 +90,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 		ConnectionID: connectionID,
 		Trigger:      trigger,
 		Status:       db.SyncStatusInProgress,
-		StartedAt:    pgtype.Timestamptz{Time: time.Now(), Valid: true},
+		StartedAt:    pgconv.Timestamptz(time.Now()),
 	})
 	if err != nil {
 		return fmt.Errorf("create sync log: %w", err)
@@ -101,7 +101,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 
 	// Update sync_log with final status.
 	completedAt := time.Now()
-	now := pgtype.Timestamptz{Time: completedAt, Valid: true}
+	now := pgconv.Timestamptz(completedAt)
 	status := db.SyncStatusSuccess
 	var errMsg pgtype.Text
 	if syncErr != nil {
@@ -552,7 +552,7 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 		ProviderPendingTransactionID: optionalText(txn.PendingExternalID),
 		Amount:                       decimalToNumeric(txn.Amount),
 		IsoCurrencyCode:              pgconv.TextIfNotEmpty(txn.ISOCurrencyCode),
-		Date:                         pgtype.Date{Time: txn.Date, Valid: true},
+		Date:                         pgconv.Date(txn.Date),
 		AuthorizedDate:               optionalDate(txn.AuthorizedDate),
 		Datetime:                     optionalTimestamptz(txn.Datetime),
 		AuthorizedDatetime:           optionalTimestamptz(txn.AuthorizedDatetime),
@@ -1220,14 +1220,14 @@ func optionalTimestamptz(t *time.Time) pgtype.Timestamptz {
 	if t == nil {
 		return pgtype.Timestamptz{}
 	}
-	return pgtype.Timestamptz{Time: *t, Valid: true}
+	return pgconv.Timestamptz(*t)
 }
 
 func optionalDate(t *time.Time) pgtype.Date {
 	if t == nil {
 		return pgtype.Date{}
 	}
-	return pgtype.Date{Time: *t, Valid: true}
+	return pgconv.Date(*t)
 }
 
 func decimalToNumeric(d decimal.Decimal) pgtype.Numeric {

--- a/internal/sync/engine_test.go
+++ b/internal/sync/engine_test.go
@@ -5,8 +5,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
-
-	"github.com/jackc/pgx/v5/pgtype"
+	"breadbox/internal/pgconv"
 )
 
 func TestClassifyUpsertResult(t *testing.T) {
@@ -73,8 +72,8 @@ func TestClassifyUpsertResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			txn := db.Transaction{
-				CreatedAt: pgtype.Timestamptz{Time: tt.createdAt, Valid: true},
-				UpdatedAt: pgtype.Timestamptz{Time: tt.updatedAt, Valid: true},
+				CreatedAt: pgconv.Timestamptz(tt.createdAt),
+				UpdatedAt: pgconv.Timestamptz(tt.updatedAt),
 			}
 
 			gotNew, gotChanged := classifyUpsertResult(txn, tt.upsertStart)

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -183,7 +184,7 @@ func MustCreateTransaction(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 		ProviderTransactionID: extID,
 		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
-		Date:                  pgtype.Date{Time: MustParseDate(date), Valid: true},
+		Date:                  pgconv.Date(MustParseDate(date)),
 		ProviderName:          name,
 	})
 	if err != nil {

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -122,7 +122,7 @@ func NewHandler(providers map[string]provider.Provider, engine *sync.Engine, que
 			var expTime pgtype.Timestamptz
 			if event.ConsentExpirationTime != nil {
 				if t, err := time.Parse(time.RFC3339, *event.ConsentExpirationTime); err == nil {
-					expTime = pgtype.Timestamptz{Time: t, Valid: true}
+					expTime = pgconv.Timestamptz(t)
 				}
 			}
 			processErr = queries.UpdateConnectionConsentExpiration(r.Context(), db.UpdateConnectionConsentExpirationParams{


### PR DESCRIPTION
## Summary

Add `pgconv.Date(t)` and `pgconv.Timestamptz(t)` to wrap the `pgtype.X{Time: t, Valid: true}` boilerplate that was repeated ~85 times across the codebase. Lines up with the existing `pgconv.Text(s)` helper for `pgtype.Text{String: s, Valid: true}` — the time-typed siblings just hadn't been factored out yet.

Pure readability/maintainability pass. No behavior change.

```go
// before
pgtype.Date{Time: txn.Date, Valid: true}
pgtype.Timestamptz{Time: time.Now().Add(authCodeTTL), Valid: true}

// after
pgconv.Date(txn.Date)
pgconv.Timestamptz(time.Now().Add(authCodeTTL))
```

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` (and with `-tags integration`)
- [x] `go test ./...`
- [x] `make test-integration`
- [x] New unit tests in `internal/pgconv/pgconv_test.go` for `Date` and `Timestamptz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)