### PR TITLE
feat(transactions): activity-log v1 — timeline, annotations service, follow-up polish

### DIFF
--- a/internal/admin/tags.go
+++ b/internal/admin/tags.go
@@ -1,7 +1,6 @@
 package admin
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
@@ -174,7 +173,6 @@ func AddTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *serv
 
 		var body struct {
 			Slug string `json:"slug"`
-			Note string `json:"note,omitempty"`
 		}
 		if !decodeJSON(w, r, &body) {
 			return
@@ -184,7 +182,7 @@ func AddTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *serv
 			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "slug is required")
 			return
 		}
-		added, alreadyPresent, err := svc.AddTransactionTag(r.Context(), txnID, body.Slug, actor, body.Note)
+		added, alreadyPresent, err := svc.AddTransactionTag(r.Context(), txnID, body.Slug, actor)
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrNotFound):
@@ -207,24 +205,13 @@ func AddTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *serv
 }
 
 // RemoveTransactionTagAdminHandler handles DELETE /-/transactions/{id}/tags/{slug}.
-// Query/body: optional note recorded on the tag_removed annotation. Accepts
-// either form-encoded or JSON.
 func RemoveTransactionTagAdminHandler(a *app.App, sm *scs.SessionManager, svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		txnID := chi.URLParam(r, "id")
 		slug := chi.URLParam(r, "slug")
 		actor := ActorFromSession(sm, r)
 
-		note := strings.TrimSpace(r.URL.Query().Get("note"))
-		if note == "" {
-			var body struct {
-				Note string `json:"note"`
-			}
-			_ = json.NewDecoder(r.Body).Decode(&body)
-			note = strings.TrimSpace(body.Note)
-		}
-
-		removed, alreadyAbsent, err := svc.RemoveTransactionTag(r.Context(), txnID, slug, actor, note)
+		removed, alreadyAbsent, err := svc.RemoveTransactionTag(r.Context(), txnID, slug, actor)
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrNotFound):

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -684,7 +684,7 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			timelineTags = nil
 		}
 
-		activity := buildActivityTimeline(annotations, categoryDisplayLookup(categoryTree), tagDisplayLookup(timelineTags))
+		activity := buildActivityTimeline(annotations, categoryDetailLookup(categoryTree), tagDisplayLookup(timelineTags))
 		activityDays := groupActivityByDay(activity)
 
 		// Load tags currently attached + the registered-tag list (for the inline
@@ -813,75 +813,48 @@ func renderTransactionDetail(tr *TemplateRenderer, w http.ResponseWriter, r *htt
 	tr.RenderWithTempl(w, r, data, pages.TransactionDetail(props))
 }
 
-// categoryDisplayLookup returns a slug→"Parent › Child" formatter for the
-// given category tree. Falls back to the raw slug when a match can't be
-// found (e.g. the category was deleted after the annotation was written).
-func categoryDisplayLookup(tree []service.CategoryResponse) func(string) string {
-	names := make(map[string]string, 64)
-	for _, parent := range tree {
-		names[parent.Slug] = parent.DisplayName
-		for _, child := range parent.Children {
-			names[child.Slug] = parent.DisplayName + " › " + child.DisplayName
-		}
-	}
-	return func(slug string) string {
-		if slug == "" {
-			return ""
-		}
-		if name, ok := names[slug]; ok {
-			return name
-		}
-		return slug
-	}
+// categoryDisplay carries the presentation metadata needed to render a
+// category_set timeline row: a "Parent › Child" name plus the registered
+// color + icon used elsewhere in the app for that category.
+type categoryDisplay struct {
+	DisplayName string
+	Color       *string
+	Icon        *string
 }
 
-// isDuplicateOfAdjacentTagNote reports whether a comment annotation exactly
-// duplicates a tag_added.note from the same actor within ±2 seconds — the
-// signature of a single update_transactions call that wrote both a tag with
-// a note and a standalone comment. Timestamps outside RFC3339-parseable
-// range are treated as non-matching (fail open, never over-dedup).
-func isDuplicateOfAdjacentTagNote(all []service.Annotation, c service.Annotation, content string) bool {
-	if content == "" {
-		return false
-	}
-	cT, err := time.Parse(time.RFC3339Nano, c.CreatedAt)
-	if err != nil {
-		return false
-	}
-	const window = 2 * time.Second
-	for _, a := range all {
-		if a.Kind != "tag_added" {
-			continue
-		}
-		note, _ := a.Payload["note"].(string)
-		if note != content {
-			continue
-		}
-		// Match only if both rows share the same actor id (when available);
-		// fall back to actor name for system/agent rows without an id.
-		sameActor := false
-		switch {
-		case a.ActorID != nil && c.ActorID != nil && *a.ActorID != "" && *a.ActorID == *c.ActorID:
-			sameActor = true
-		case (a.ActorID == nil || *a.ActorID == "") && (c.ActorID == nil || *c.ActorID == "") && a.ActorName == c.ActorName:
-			sameActor = true
-		}
-		if !sameActor {
-			continue
-		}
-		aT, err := time.Parse(time.RFC3339Nano, a.CreatedAt)
-		if err != nil {
-			continue
-		}
-		diff := cT.Sub(aT)
-		if diff < 0 {
-			diff = -diff
-		}
-		if diff <= window {
-			return true
+// categoryDetailLookup returns a slug → presentation lookup built from the
+// category tree. Falls back to the raw slug with nil color/icon when a match
+// can't be found (e.g. the category was deleted after the annotation was
+// written).
+func categoryDetailLookup(tree []service.CategoryResponse) func(string) categoryDisplay {
+	by := make(map[string]categoryDisplay, 64)
+	for _, parent := range tree {
+		by[parent.Slug] = categoryDisplay{DisplayName: parent.DisplayName, Color: parent.Color, Icon: parent.Icon}
+		for _, child := range parent.Children {
+			color := child.Color
+			if color == nil {
+				color = parent.Color
+			}
+			icon := child.Icon
+			if icon == nil {
+				icon = parent.Icon
+			}
+			by[child.Slug] = categoryDisplay{
+				DisplayName: parent.DisplayName + " › " + child.DisplayName,
+				Color:       color,
+				Icon:        icon,
+			}
 		}
 	}
-	return false
+	return func(slug string) categoryDisplay {
+		if slug == "" {
+			return categoryDisplay{}
+		}
+		if d, ok := by[slug]; ok {
+			return d
+		}
+		return categoryDisplay{DisplayName: slug}
+	}
 }
 
 // tagDisplay carries presentation metadata for rendering a tag chip on a
@@ -923,12 +896,12 @@ func tagDisplayLookup(tags []service.TagResponse) func(string) tagDisplay {
 // function delegates to it via the supplied lookups, then maps each
 // enriched annotation to its ActivityEntry.
 //
-// categoryDisplay maps a category slug to a human-readable name
-// ("Food & Drink › Groceries"). Pass nil to use raw slugs.
+// categoryDetail maps a category slug to a display name + color + icon for
+// rendering category_set rows. Pass nil to use raw slugs and skip color/icon.
 //
 // tagDisplayFn maps a tag slug to its display name + color for rendering a
 // tag chip on tag_added / tag_removed rows. Pass nil to use raw slugs.
-func buildActivityTimeline(annotations []service.Annotation, categoryDisplay func(string) string, tagDisplayFn func(string) tagDisplay) []service.ActivityEntry {
+func buildActivityTimeline(annotations []service.Annotation, categoryDetail func(string) categoryDisplay, tagDisplayFn func(string) tagDisplay) []service.ActivityEntry {
 	if len(annotations) == 0 {
 		return nil
 	}
@@ -944,24 +917,38 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 			return slug
 		}
 	}
+	// Same translation for the category lookup: enrichment only needs the
+	// display name; color + icon stay on the admin side.
+	var categoryNameLookup func(string) string
+	if categoryDetail != nil {
+		categoryNameLookup = func(slug string) string {
+			d := categoryDetail(slug)
+			if d.DisplayName != "" {
+				return d.DisplayName
+			}
+			return slug
+		}
+	}
 
 	enriched := service.EnrichAnnotations(annotations, service.EnrichOptions{
 		TagDisplay:      tagNameLookup,
-		CategoryDisplay: categoryDisplay,
+		CategoryDisplay: categoryNameLookup,
 	})
 
 	entries := make([]service.ActivityEntry, 0, len(enriched))
 	for _, a := range enriched {
-		entry, ok := activityEntryFromAnnotation(a, tagDisplayFn)
+		entry, ok := activityEntryFromAnnotation(a, tagDisplayFn, categoryDetail)
 		if !ok {
 			continue
 		}
 		entries = append(entries, entry)
 	}
 
-	// Sort by timestamp descending (newest first).
+	// Sort by timestamp ascending (oldest first → newest last). The composer
+	// sits at the bottom of the timeline so new bubbles appear right where
+	// the user typed them.
 	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Timestamp > entries[j].Timestamp
+		return entries[i].Timestamp < entries[j].Timestamp
 	})
 
 	return entries
@@ -970,8 +957,9 @@ func buildActivityTimeline(annotations []service.Annotation, categoryDisplay fun
 // activityEntryFromAnnotation maps a single enriched service.Annotation to
 // the UI's ActivityEntry shape. Returns (zero, false) for unknown kinds so
 // the caller can drop them. Tag rows pull color from tagDisplayFn since
-// color is a presentation concern that lives in the admin layer.
-func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string) tagDisplay) (service.ActivityEntry, bool) {
+// color is a presentation concern that lives in the admin layer; same for
+// the category color+icon on category_set rows.
+func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string) tagDisplay, categoryDetail func(string) categoryDisplay) (service.ActivityEntry, bool) {
 	switch a.Kind {
 	case "comment":
 		entry := service.ActivityEntry{
@@ -1047,14 +1035,26 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 		return entry, true
 
 	case "category_set":
+		display := a.Subject
+		var color, icon *string
+		if categoryDetail != nil {
+			d := categoryDetail(a.CategorySlug)
+			if d.DisplayName != "" {
+				display = d.DisplayName
+			}
+			color = d.Color
+			icon = d.Icon
+		}
 		entry := service.ActivityEntry{
 			Type:               "category",
 			Timestamp:          a.CreatedAt,
 			ActorName:          a.ActorName,
 			ActorType:          a.ActorType,
 			ActorAvatarVersion: a.ActorAvatarVersion,
-			Summary:            "Category set to " + a.Subject,
-			CategoryName:       a.Subject,
+			Summary:            "Category set to " + display,
+			CategoryName:       display,
+			CategoryColor:      color,
+			CategoryIcon:       icon,
 		}
 		if a.ActorID != nil && *a.ActorID != "" {
 			id := *a.ActorID
@@ -1276,11 +1276,9 @@ func BulkUpdateTransactionsAdminHandler(a *app.App, sm *scs.SessionManager, svc 
 				CategorySlug  *string `json:"category_slug,omitempty"`
 				TagsToAdd     []struct {
 					Slug string `json:"slug"`
-					Note string `json:"note,omitempty"`
 				} `json:"tags_to_add,omitempty"`
 				TagsToRemove []struct {
 					Slug string `json:"slug"`
-					Note string `json:"note,omitempty"`
 				} `json:"tags_to_remove,omitempty"`
 				Comment *string `json:"comment,omitempty"`
 			} `json:"operations"`
@@ -1306,10 +1304,10 @@ func BulkUpdateTransactionsAdminHandler(a *app.App, sm *scs.SessionManager, svc 
 				Comment:       op.Comment,
 			}
 			for _, t := range op.TagsToAdd {
-				ops[i].TagsToAdd = append(ops[i].TagsToAdd, service.UpdateTransactionsTagOp{Slug: t.Slug, Note: t.Note})
+				ops[i].TagsToAdd = append(ops[i].TagsToAdd, service.UpdateTransactionsTagOp{Slug: t.Slug})
 			}
 			for _, t := range op.TagsToRemove {
-				ops[i].TagsToRemove = append(ops[i].TagsToRemove, service.UpdateTransactionsTagOp{Slug: t.Slug, Note: t.Note})
+				ops[i].TagsToRemove = append(ops[i].TagsToRemove, service.UpdateTransactionsTagOp{Slug: t.Slug})
 			}
 		}
 

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -203,14 +203,14 @@ func TestBuildActivityTimeline_RuleAppliedEmptyNameFallsBack(t *testing.T) {
 		CreatedAt: "2026-04-04T12:00:00Z",
 	}}
 
-	categoryDisplay := func(slug string) string {
+	catLookup := func(slug string) categoryDisplay {
 		if slug == "food_and_drink_groceries" {
-			return "Food & Drink › Groceries"
+			return categoryDisplay{DisplayName: "Food & Drink › Groceries"}
 		}
-		return slug
+		return categoryDisplay{DisplayName: slug}
 	}
 
-	entries := buildActivityTimeline(annotations, categoryDisplay, nil)
+	entries := buildActivityTimeline(annotations, catLookup, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))
@@ -253,14 +253,14 @@ func TestBuildActivityTimeline_RuleAppliedNamedStillQuoted(t *testing.T) {
 		CreatedAt: "2026-04-04T12:00:00Z",
 	}}
 
-	categoryDisplay := func(slug string) string {
+	catLookup := func(slug string) categoryDisplay {
 		if slug == "shopping" {
-			return "Shopping"
+			return categoryDisplay{DisplayName: "Shopping"}
 		}
-		return slug
+		return categoryDisplay{DisplayName: slug}
 	}
 
-	entries := buildActivityTimeline(annotations, categoryDisplay, nil)
+	entries := buildActivityTimeline(annotations, catLookup, nil)
 
 	if len(entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(entries))

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -26,14 +26,13 @@ func ListTagsHandler(svc *service.Service) http.HandlerFunc {
 
 // AddTransactionTagHandler attaches a tag to a transaction. Auto-creates the
 // tag if the slug is not yet registered. Mirrors the admin-side handler.
-// POST /api/v1/transactions/{id}/tags — body: {"slug":"...", "note":"..."}.
+// POST /api/v1/transactions/{id}/tags — body: {"slug":"..."}.
 func AddTransactionTagHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		txnID := chi.URLParam(r, "id")
 
 		var body struct {
 			Slug string `json:"slug"`
-			Note string `json:"note,omitempty"`
 		}
 		if !decodeJSON(w, r, &body) {
 			return
@@ -45,7 +44,7 @@ func AddTransactionTagHandler(svc *service.Service) http.HandlerFunc {
 		}
 
 		actor := service.ActorFromContext(r.Context())
-		added, alreadyPresent, err := svc.AddTransactionTag(r.Context(), txnID, body.Slug, actor, body.Note)
+		added, alreadyPresent, err := svc.AddTransactionTag(r.Context(), txnID, body.Slug, actor)
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrNotFound):
@@ -67,26 +66,14 @@ func AddTransactionTagHandler(svc *service.Service) http.HandlerFunc {
 }
 
 // RemoveTransactionTagHandler removes a tag from a transaction.
-// DELETE /api/v1/transactions/{id}/tags/{slug} — optional ?note=... or JSON
-// body {"note":"..."} recorded on the tag_removed annotation.
+// DELETE /api/v1/transactions/{id}/tags/{slug}.
 func RemoveTransactionTagHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		txnID := chi.URLParam(r, "id")
 		slug := chi.URLParam(r, "slug")
 
-		note := strings.TrimSpace(r.URL.Query().Get("note"))
-		if note == "" && r.ContentLength > 0 {
-			var body struct {
-				Note string `json:"note"`
-			}
-			if !decodeJSON(w, r, &body) {
-				return
-			}
-			note = strings.TrimSpace(body.Note)
-		}
-
 		actor := service.ActorFromContext(r.Context())
-		removed, alreadyAbsent, err := svc.RemoveTransactionTag(r.Context(), txnID, slug, actor, note)
+		removed, alreadyAbsent, err := svc.RemoveTransactionTag(r.Context(), txnID, slug, actor)
 		if err != nil {
 			switch {
 			case errors.Is(err, service.ErrNotFound):

--- a/internal/api/tags_integration_test.go
+++ b/internal/api/tags_integration_test.go
@@ -73,7 +73,6 @@ func TestAPI_AddTransactionTag_Success(t *testing.T) {
 
 	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/tags", map[string]string{
 		"slug": "needs-review",
-		"note": "flagged by bot",
 	})
 	assertStatus(t, resp, http.StatusOK)
 

--- a/internal/mcp/response_shapes_integration_test.go
+++ b/internal/mcp/response_shapes_integration_test.go
@@ -104,7 +104,7 @@ func seedFixtures(t *testing.T) *fixtures {
 	// Use the service-layer helper so a tag_added annotation is written —
 	// list_annotations relies on that to have at least one entry to assert.
 	if _, _, err := svc.AddTransactionTag(ctx, formatUUIDTest(t, txn.ID), "needs-review",
-		service.Actor{Type: "system", Name: "test"}, "seeded"); err != nil {
+		service.Actor{Type: "system", Name: "test"}); err != nil {
 		t.Fatalf("AddTransactionTag: %v", err)
 	}
 
@@ -307,7 +307,6 @@ func TestListAnnotationsKindsFilter(t *testing.T) {
 		WriteSessionContext: WriteSessionContext{SessionID: "sess", Reason: "kinds-tag-pair"},
 		TransactionID:       f.txnID,
 		TagSlug:             "needs-review",
-		Note:                "kinds-filter test",
 	})
 	_ = decodeToolResult[map[string]any](t, "remove_transaction_tag", rmRes, err)
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -58,7 +58,7 @@ REVIEW WORKFLOW (tag-based):
 - The "review queue" is just transactions tagged "needs-review". Fresh installs have a seeded rule that auto-tags new transactions on sync.
 - find-work: query_transactions(tags=["needs-review"])
 - do-work: update_transactions(operations: [...]) — atomic compound op per transaction. Each operation can set_category + add/remove tags + attach a comment in a single write. Max 50 operations per call.
-- signal-done: the update_transactions operation's tags_to_remove entry is how you close a review. Including a note is strongly recommended — it lands on the audit trail.
+- signal-done: the update_transactions operation's tags_to_remove entry is how you close a review. Pair it with the 'comment' field on the same operation to record the rationale — the comment is the canonical audit artifact (tag adds/removes no longer carry per-action notes).
 - If you can't confidently categorize a transaction, leave the tag on it. The tag IS the queue.
 - Tag tools: list_tags, add_transaction_tag (single), remove_transaction_tag (single), list_annotations (activity timeline), plus update_transactions for compound ops.
 - Before processing reviews or creating rules, read breadbox://review-guidelines for detailed guidelines.
@@ -97,19 +97,19 @@ USER ROLES:
 // User-editable via the MCP Settings page.
 const DefaultReviewGuidelines = `REVIEW PRINCIPLES — follow these strictly:
 
-1. THE REVIEW QUEUE IS A TAG. Transactions tagged "needs-review" are the queue. Find them with query_transactions(tags=["needs-review"]). Close them with update_transactions operations that remove the needs-review tag. Including a note explaining the decision is strongly recommended — it lands on the audit trail.
+1. THE REVIEW QUEUE IS A TAG. Transactions tagged "needs-review" are the queue. Find them with query_transactions(tags=["needs-review"]). Close them with update_transactions operations that remove the needs-review tag. Pair every removal with a 'comment' on the same operation explaining the decision — the comment is the audit trail (tag changes no longer carry their own per-action notes).
 
 2. EVERY REVIEW MUST BE INDIVIDUALLY ASSESSED. You must look at each transaction before closing it. Even when processing in batches via update_transactions (max 50 operations per call), you must have examined each transaction's name, amount, and context to determine the correct category. There is no auto-close mechanism — quality depends on your judgment.
 
 3. RULES ARE FORWARD-LOOKING. Transaction rules apply automatically to NEW transactions during sync. Do NOT use apply_rules or apply_retroactively=true during routine reviews. These are reserved for explicit one-off bulk work (initial setup only). During routine work, create rules and let them match future syncs naturally.
 
-4. PRIOR ANNOTATIONS ARE HUMAN CORRECTIONS. When a transaction has a history (list_annotations shows prior comments, rule applications, or category sets authored by humans), read that context first. A human's explicit decision overrides your prior categorization. Acknowledge the correction in the note you pass on the update_transactions tags_to_remove entry — that note lands on the audit trail.
+4. PRIOR ANNOTATIONS ARE HUMAN CORRECTIONS. When a transaction has a history (list_annotations shows prior comments, rule applications, or category sets authored by humans), read that context first. A human's explicit decision overrides your prior categorization. Acknowledge the correction in the 'comment' field on the update_transactions operation that closes the review — that comment lands on the audit trail.
 
-5. LEAVE THE TAG ON RATHER THAN GUESS. If you cannot confidently determine the correct category, do NOT remove the needs-review tag. Leaving it attached keeps the transaction in the queue for a future pass. Never remove the tag with a placeholder note just to "clear" the queue.
+5. LEAVE THE TAG ON RATHER THAN GUESS. If you cannot confidently determine the correct category, do NOT remove the needs-review tag. Leaving it attached keeps the transaction in the queue for a future pass. Never remove the tag with a placeholder comment just to "clear" the queue.
 
-6. EXPLAIN NON-OBVIOUS DECISIONS VIA THE TAG REMOVAL NOTE. The note you pass on tags_to_remove[{slug: "needs-review", note: "..."}] is the primary audit artifact for the review decision. You can also attach an optional 'comment' in the same update_transactions operation for longer narrative, but don't double-write the same explanation.
+6. EXPLAIN NON-OBVIOUS DECISIONS VIA THE COMMENT FIELD. The 'comment' you pass on the update_transactions operation is the primary audit artifact for the review decision — keep all rationale there, not in tag metadata. Tag adds/removes carry no per-action notes.
 
-7. NEVER BULK-CLOSE WITHOUT EXAMINATION. Do not batch 50 update_transactions operations with a default category and a generic "approved" note. Each item in the batch must have been individually assessed with the correct category assigned and a specific rationale.
+7. NEVER BULK-CLOSE WITHOUT EXAMINATION. Do not batch 50 update_transactions operations with a default category and a generic "approved" comment. Each item in the batch must have been individually assessed with the correct category assigned and a specific rationale.
 
 8. ALWAYS USE CATEGORY_SLUG. When setting categories, use category_slug (e.g., "food_and_drink_groceries") not category_id. Slugs are human-readable, stable, and consistent across sessions.
 
@@ -332,7 +332,7 @@ func (s *MCPServer) buildToolRegistry() {
 			"Remove a manual category override from a transaction and re-resolve its category from the automatic mapping rules. Use this to undo a categorize_transaction action.",
 			s.handleResetTransactionCategory, svc),
 		makeToolDefLogged("add_transaction_comment", ToolWrite,
-			"Add a free-standing comment to a transaction — narrative that's independent of any specific review decision (flagging unusual charges, noting shared expenses, cross-references, context that outlives a single review cycle). Supports markdown. IMPORTANT: when the comment is the rationale for a tag change or category set, pass it as part of an update_transactions operation (inline `comment`, or `note` on a tags_to_add/tags_to_remove entry) instead — those paths write a single linked annotation so the activity log doesn't double up.",
+			"Add a free-standing comment to a transaction — narrative that's independent of any specific review decision (flagging unusual charges, noting shared expenses, cross-references, context that outlives a single review cycle). Supports markdown. IMPORTANT: when the comment is the rationale for a tag change or category set, pass it inline on the same update_transactions operation as the change (use the `comment` field) so the activity log links the rationale to the action atomically.",
 			s.handleAddTransactionComment, svc),
 		makeToolDefLogged("list_transaction_comments", ToolRead,
 			"Deprecated: prefer list_annotations with kinds=['comment']. Returns the same comment data with renamed fields (author_* instead of actor_*, content lifted out of payload). Will be removed in a future release.",
@@ -408,13 +408,13 @@ func (s *MCPServer) buildToolRegistry() {
 			"List the activity timeline for a transaction, ordered by created_at ASC. Each row carries a generic `kind` (comment | rule | tag | category) plus an `action` (added | removed | set | applied) for the specific event — branch on `action` when the distinction matters (e.g. tag added vs removed). Payload carries kind-specific fields (content for comments, slug for tag events, rule_name for rule applications). Pass kinds=['comment'] for the comment-only view (replaces the deprecated list_transaction_comments); pass kinds=['tag'] for all tag events. Empty kinds returns the full timeline.",
 			s.handleListAnnotations, svc),
 		makeToolDefLogged("add_transaction_tag", ToolWrite,
-			"Attach a tag to a transaction. Tags are an open-ended labeling system — auto-creates a persistent tag if the slug doesn't exist yet. Use note to attach a short rationale that is stored on the tag_added annotation. Idempotent: returns already_present=true if the tag was already attached.",
+			"Attach a tag to a transaction. Tags are an open-ended labeling system — auto-creates a persistent tag if the slug doesn't exist yet. Idempotent: returns already_present=true if the tag was already attached. To record decision context for a tag change, leave a comment on the same transaction (add_transaction_comment, or the `comment` field on update_transactions).",
 			s.handleAddTransactionTag, svc),
 		makeToolDefLogged("remove_transaction_tag", ToolWrite,
-			"Remove a tag from a transaction. A note is recommended (it's recorded on the tag_removed annotation for auditability) but not required. Idempotent: returns already_absent=true if the tag wasn't attached.",
+			"Remove a tag from a transaction. Idempotent: returns already_absent=true if the tag wasn't attached. To record why the tag was removed (e.g. closing a needs-review item), pair this with a comment on the same transaction — see update_transactions for the atomic compound op.",
 			s.handleRemoveTransactionTag, svc),
 		makeToolDefLogged("update_transactions", ToolWrite,
-			"Compound write for up to 50 transactions at once. Each operation can: set a category (category_slug), add tags (tags_to_add), remove tags (tags_to_remove), and attach a comment — all atomically per transaction, with annotations written for every change. The preferred tool for closing review work (set category + remove needs-review + explain) in one call. Example operation: {\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\",\"note\":\"clearly groceries\"}],\"comment\":\"Costco run\"}. on_error: 'continue' (default — each op in its own DB tx, partial failures OK) or 'abort' (one DB tx, rolls back on first error). Notes on tag removal are optional but recommended for workflow tags like needs-review.",
+			"Compound write for up to 50 transactions at once. Each operation can: set a category (category_slug), add tags (tags_to_add), remove tags (tags_to_remove), and attach a comment — all atomically per transaction, with annotations written for every change. The preferred tool for closing review work (set category + remove needs-review + explain) in one call. Use the `comment` field to capture decision rationale; tag adds/removes carry no per-action note — keep all narrative in the comment. Example operation: {\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\"}],\"comment\":\"Clearly groceries — Costco run.\"}. on_error: 'continue' (default — each op in its own DB tx, partial failures OK) or 'abort' (one DB tx, rolls back on first error).",
 			s.handleUpdateTransactions, svc),
 		makeToolDefLogged("create_tag", ToolWrite,
 			"Register a new tag in the system. Admin-only write — agents can auto-create tags implicitly via add_transaction_tag (pass a new slug), so use create_tag only when users need to set display_name/color/icon up front. Slug regex: ^[a-z0-9][a-z0-9\\-:]*[a-z0-9]$.",

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -26,14 +26,12 @@ type addTransactionTagInput struct {
 	WriteSessionContext
 	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
 	TagSlug       string `json:"tag_slug" jsonschema:"required,Tag slug to add (e.g. 'needs-review'). Auto-created as persistent if not registered."`
-	Note          string `json:"note,omitempty" jsonschema:"Optional note recorded on the resulting tag annotation (action=added)."`
 }
 
 type removeTransactionTagInput struct {
 	WriteSessionContext
 	TransactionID string `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
 	TagSlug       string `json:"tag_slug" jsonschema:"required,Tag slug to remove"`
-	Note          string `json:"note,omitempty" jsonschema:"Optional rationale recorded on the resulting tag annotation (action=removed)."`
 }
 
 type createTagInput struct {
@@ -236,7 +234,7 @@ func (s *MCPServer) handleAddTransactionTag(ctx context.Context, _ *mcpsdk.CallT
 		return errorResult(fmt.Errorf("transaction_id and tag_slug are required")), nil, nil
 	}
 	actor := service.ActorFromContext(ctx)
-	added, alreadyPresent, err := s.svc.AddTransactionTag(context.Background(), input.TransactionID, input.TagSlug, actor, input.Note)
+	added, alreadyPresent, err := s.svc.AddTransactionTag(context.Background(), input.TransactionID, input.TagSlug, actor)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}
@@ -256,7 +254,7 @@ func (s *MCPServer) handleRemoveTransactionTag(ctx context.Context, _ *mcpsdk.Ca
 		return errorResult(fmt.Errorf("transaction_id and tag_slug are required")), nil, nil
 	}
 	actor := service.ActorFromContext(ctx)
-	removed, alreadyAbsent, err := s.svc.RemoveTransactionTag(context.Background(), input.TransactionID, input.TagSlug, actor, input.Note)
+	removed, alreadyAbsent, err := s.svc.RemoveTransactionTag(context.Background(), input.TransactionID, input.TagSlug, actor)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}

--- a/internal/mcp/tools_update_transactions.go
+++ b/internal/mcp/tools_update_transactions.go
@@ -12,24 +12,23 @@ import (
 // updateTransactionsInput is the top-level input for the update_transactions tool.
 type updateTransactionsInput struct {
 	WriteSessionContext
-	Operations []transactionOperationInput `json:"operations" jsonschema:"required,Array of per-transaction operations. Max 50. Each item can set a category AND add/remove tags AND attach a comment in a single atomic op. Example: [{\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\",\"note\":\"clearly groceries\"}]}]"`
+	Operations []transactionOperationInput `json:"operations" jsonschema:"required,Array of per-transaction operations. Max 50. Each item can set a category AND add/remove tags AND attach a comment in a single atomic op. Use the 'comment' field to record decision rationale; tag adds/removes carry no per-action note. Example: [{\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\"}],\"comment\":\"clearly groceries\"}]"`
 	OnError    string                      `json:"on_error,omitempty" jsonschema:"\"continue\" (default — each op runs in its own DB tx, partial failures don't undo successful items) or \"abort\" (whole batch is one DB tx, rolls back on first error)."`
 }
 
 // transactionOperationInput describes a single compound operation applied to
 // one transaction.
 type transactionOperationInput struct {
-	TransactionID string           `json:"transaction_id" jsonschema:"required,UUID or short ID."`
-	CategorySlug  *string          `json:"category_slug,omitempty" jsonschema:"Category slug to set (e.g. 'food_and_drink_groceries'). Sets category_override=true. Omit to leave the category unchanged."`
-	TagsToAdd     []tagOpEntryInput `json:"tags_to_add,omitempty" jsonschema:"List of tags to add. Each item: {slug, note?}. Auto-creates persistent tags if the slug is unknown."`
-	TagsToRemove  []tagOpEntryInput `json:"tags_to_remove,omitempty" jsonschema:"List of tags to remove. Each item: {slug, note?}. note is recommended for auditability."`
-	Comment       *string          `json:"comment,omitempty" jsonschema:"Optional free-form comment written as an annotation attributed to you. Max 10000 chars. Prefer including narrative inline here instead of a separate add_transaction_comment call."`
+	TransactionID string            `json:"transaction_id" jsonschema:"required,UUID or short ID."`
+	CategorySlug  *string           `json:"category_slug,omitempty" jsonschema:"Category slug to set (e.g. 'food_and_drink_groceries'). Sets category_override=true. Omit to leave the category unchanged."`
+	TagsToAdd     []tagOpEntryInput `json:"tags_to_add,omitempty" jsonschema:"List of tags to add. Each item: {slug}. Auto-creates persistent tags if the slug is unknown."`
+	TagsToRemove  []tagOpEntryInput `json:"tags_to_remove,omitempty" jsonschema:"List of tags to remove. Each item: {slug}."`
+	Comment       *string           `json:"comment,omitempty" jsonschema:"Free-form comment written as an annotation attributed to you. Max 10000 chars. This is the canonical place to record decision context (e.g. why a tag was added or a category set) — prefer the comment over a per-tag note."`
 }
 
 // tagOpEntryInput is a single tag add/remove entry.
 type tagOpEntryInput struct {
 	Slug string `json:"slug" jsonschema:"required,Tag slug (lowercase alphanumerics with hyphens/colons)."`
-	Note string `json:"note,omitempty" jsonschema:"Short rationale. Recommended for auditability."`
 }
 
 // handleUpdateTransactions runs the compound batch.
@@ -54,16 +53,10 @@ func (s *MCPServer) handleUpdateTransactions(ctx context.Context, _ *mcpsdk.Call
 			Comment:       op.Comment,
 		}
 		for _, t := range op.TagsToAdd {
-			ops[i].TagsToAdd = append(ops[i].TagsToAdd, service.UpdateTransactionsTagOp{
-				Slug: t.Slug,
-				Note: t.Note,
-			})
+			ops[i].TagsToAdd = append(ops[i].TagsToAdd, service.UpdateTransactionsTagOp{Slug: t.Slug})
 		}
 		for _, t := range op.TagsToRemove {
-			ops[i].TagsToRemove = append(ops[i].TagsToRemove, service.UpdateTransactionsTagOp{
-				Slug: t.Slug,
-				Note: t.Note,
-			})
+			ops[i].TagsToRemove = append(ops[i].TagsToRemove, service.UpdateTransactionsTagOp{Slug: t.Slug})
 		}
 	}
 

--- a/internal/service/tags_integration_test.go
+++ b/internal/service/tags_integration_test.go
@@ -51,7 +51,7 @@ func TestAddTransactionTag_AutoCreatesTag(t *testing.T) {
 		t.Fatalf("precondition: expected vacation-2026 tag not to exist")
 	}
 
-	added, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "vacation-2026", service.Actor{Type: "user", ID: "u1", Name: "Alice"}, "")
+	added, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "vacation-2026", service.Actor{Type: "user", ID: "u1", Name: "Alice"})
 	if err != nil {
 		t.Fatalf("AddTransactionTag: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestAddTransactionTag_WritesAnnotation(t *testing.T) {
 	acctID := seedTxnFixture(t, queries)
 	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn2", "Coffee", 500, "2026-03-01")
 
-	_, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "agent", ID: "agent-1", Name: "ReviewBot"}, "")
+	_, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "agent", ID: "agent-1", Name: "ReviewBot"})
 	if err != nil {
 		t.Fatalf("AddTransactionTag: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestAddTransactionTag_WritesAnnotation(t *testing.T) {
 	}
 
 	// Idempotent second add: no new annotation.
-	_, alreadyPresent, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "agent", ID: "agent-1", Name: "ReviewBot"}, "")
+	_, alreadyPresent, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "agent", ID: "agent-1", Name: "ReviewBot"})
 	if err != nil {
 		t.Fatalf("second AddTransactionTag: %v", err)
 	}
@@ -109,11 +109,11 @@ func TestRemoveTransactionTag_NoNote(t *testing.T) {
 
 	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
 
-	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", Name: "A"}, ""); err != nil {
+	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", Name: "A"}); err != nil {
 		t.Fatalf("AddTransactionTag: %v", err)
 	}
 
-	removed, _, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", Name: "A"}, "")
+	removed, _, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", Name: "A"})
 	if err != nil {
 		t.Fatalf("RemoveTransactionTag without note should succeed: %v", err)
 	}
@@ -137,10 +137,10 @@ func TestRemoveTransactionTag_EmptyNoteSucceeds(t *testing.T) {
 
 	testutil.MustCreateTag(t, queries, "watchlist", "Watch")
 
-	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "watchlist", service.Actor{Type: "user", Name: "A"}, ""); err != nil {
+	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "watchlist", service.Actor{Type: "user", Name: "A"}); err != nil {
 		t.Fatalf("AddTransactionTag: %v", err)
 	}
-	removed, _, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "watchlist", service.Actor{Type: "user", Name: "A"}, "")
+	removed, _, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "watchlist", service.Actor{Type: "user", Name: "A"})
 	if err != nil {
 		t.Fatalf("RemoveTransactionTag: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestRemoveTransactionTag_AlreadyAbsent_NoError(t *testing.T) {
 
 	testutil.MustCreateTag(t, queries, "unused", "Unused")
 
-	removed, alreadyAbsent, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "unused", service.Actor{Type: "user", Name: "A"}, "")
+	removed, alreadyAbsent, err := svc.RemoveTransactionTag(ctx, txn.ShortID, "unused", service.Actor{Type: "user", Name: "A"})
 	if err != nil {
 		t.Fatalf("RemoveTransactionTag: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestRemoveTransactionTag_AlreadyAbsent_NoError(t *testing.T) {
 	}
 
 	// Also: slug that doesn't even exist at all returns alreadyAbsent.
-	removed, alreadyAbsent, err = svc.RemoveTransactionTag(ctx, txn.ShortID, "nonexistent", service.Actor{Type: "user", Name: "A"}, "")
+	removed, alreadyAbsent, err = svc.RemoveTransactionTag(ctx, txn.ShortID, "nonexistent", service.Actor{Type: "user", Name: "A"})
 	if err != nil {
 		t.Fatalf("RemoveTransactionTag nonexistent: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestListTransactionTags(t *testing.T) {
 	acctID := seedTxnFixture(t, queries)
 	txn := testutil.MustCreateTransaction(t, queries, acctID, "txn6", "Coffee", 500, "2026-03-01")
 
-	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", ID: "u1", Name: "Alice"}, ""); err != nil {
+	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", ID: "u1", Name: "Alice"}); err != nil {
 		t.Fatalf("AddTransactionTag: %v", err)
 	}
 

--- a/internal/service/transaction_tags.go
+++ b/internal/service/transaction_tags.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
@@ -33,7 +32,7 @@ type TransactionTagResponse struct {
 //   - added:          true when a new (transaction, tag) pair was created.
 //   - alreadyPresent: true when the pair already existed (no-op, no annotation
 //     written).
-func (s *Service) AddTransactionTag(ctx context.Context, txnID, slug string, actor Actor, note string) (added bool, alreadyPresent bool, _ error) {
+func (s *Service) AddTransactionTag(ctx context.Context, txnID, slug string, actor Actor) (added bool, alreadyPresent bool, _ error) {
 	txnUUID, err := s.resolveTransactionID(ctx, txnID)
 	if err != nil {
 		return false, false, ErrNotFound
@@ -88,9 +87,6 @@ func (s *Service) AddTransactionTag(ctx context.Context, txnID, slug string, act
 
 	// Write annotation for the audit trail.
 	payload := map[string]interface{}{"slug": slug}
-	if note != "" {
-		payload["note"] = note
-	}
 	actorType := actor.Type
 	if actorType == "rule" {
 		// Annotations carry a constrained actor_type set; map "rule" onto
@@ -119,7 +115,7 @@ func (s *Service) AddTransactionTag(ctx context.Context, txnID, slug string, act
 // RemoveTransactionTag removes a tag from a transaction. Returns:
 //   - removed:      true when the (transaction, tag) pair was deleted.
 //   - alreadyAbsent: true when the pair wasn't present (no-op, no error).
-func (s *Service) RemoveTransactionTag(ctx context.Context, txnID, slug string, actor Actor, note string) (removed bool, alreadyAbsent bool, _ error) {
+func (s *Service) RemoveTransactionTag(ctx context.Context, txnID, slug string, actor Actor) (removed bool, alreadyAbsent bool, _ error) {
 	txnUUID, err := s.resolveTransactionID(ctx, txnID)
 	if err != nil {
 		return false, false, ErrNotFound
@@ -138,8 +134,6 @@ func (s *Service) RemoveTransactionTag(ctx context.Context, txnID, slug string, 
 		}
 		return false, false, fmt.Errorf("get tag by slug: %w", err)
 	}
-
-	trimmedNote := strings.TrimSpace(note)
 
 	tx, err := s.Pool.Begin(ctx)
 	if err != nil {
@@ -164,9 +158,6 @@ func (s *Service) RemoveTransactionTag(ctx context.Context, txnID, slug string, 
 	}
 
 	payload := map[string]interface{}{"slug": slug}
-	if trimmedNote != "" {
-		payload["note"] = trimmedNote
-	}
 	actorType := actor.Type
 	if actorType == "rule" {
 		actorType = "system"

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -410,7 +410,14 @@ type ActivityEntry struct {
 	// Type-specific
 	ReviewStatus string `json:"review_status,omitempty"` // approved, rejected, skipped, pending
 	CategoryName string `json:"category_name,omitempty"` // display name
-	RuleName     string `json:"rule_name,omitempty"`
+	// CategoryColor and CategoryIcon drive the icon-tile rendering on
+	// category_set timeline rows so each event reads at a glance with the
+	// same color cue used elsewhere in the app. Empty/nil when the category
+	// is no longer registered (deleted categories fall back to a neutral
+	// folder icon).
+	CategoryColor *string `json:"category_color,omitempty"`
+	CategoryIcon  *string `json:"category_icon,omitempty"`
+	RuleName      string  `json:"rule_name,omitempty"`
 	RuleID       string `json:"rule_id,omitempty"`
 	CommentID    string `json:"comment_id,omitempty"`
 	TagSlug      string `json:"tag_slug,omitempty"` // for tag_added / tag_removed entries

--- a/internal/service/update_transactions.go
+++ b/internal/service/update_transactions.go
@@ -27,7 +27,6 @@ type UpdateTransactionsOp struct {
 // UpdateTransactionsTagOp is a single tag add/remove entry.
 type UpdateTransactionsTagOp struct {
 	Slug string
-	Note string
 }
 
 // UpdateTransactionsResult is the per-op outcome returned by UpdateTransactions.
@@ -242,9 +241,6 @@ func (s *Service) runUpdateOpInTx(ctx context.Context, tx pgx.Tx, op UpdateTrans
 			continue
 		}
 		payload := map[string]interface{}{"slug": slug}
-		if t.Note != "" {
-			payload["note"] = t.Note
-		}
 		if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
 			TransactionID: txnUID,
 			Kind:          "tag_added",
@@ -275,7 +271,6 @@ func (s *Service) runUpdateOpInTx(ctx context.Context, tx pgx.Tx, op UpdateTrans
 			}
 			return fmt.Errorf("get tag %q: %w", slug, err)
 		}
-		trimmedNote := strings.TrimSpace(t.Note)
 		rows, err := qtx.RemoveTransactionTag(ctx, db.RemoveTransactionTagParams{
 			TransactionID: txnUID,
 			TagID:         tag.ID,
@@ -288,9 +283,6 @@ func (s *Service) runUpdateOpInTx(ctx context.Context, tx pgx.Tx, op UpdateTrans
 			continue
 		}
 		payload := map[string]interface{}{"slug": slug}
-		if trimmedNote != "" {
-			payload["note"] = trimmedNote
-		}
 		if err := writeAnnotation(ctx, qtx, writeAnnotationParams{
 			TransactionID: txnUID,
 			Kind:          "tag_removed",

--- a/internal/service/update_transactions_integration_test.go
+++ b/internal/service/update_transactions_integration_test.go
@@ -27,19 +27,20 @@ func TestUpdateTransactions_CompoundOp(t *testing.T) {
 	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
 
 	// Pre-attach needs-review to mimic the seeded auto-rule.
-	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", ID: "u1", Name: "Tester"}, ""); err != nil {
+	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", ID: "u1", Name: "Tester"}); err != nil {
 		t.Fatalf("seed AddTransactionTag: %v", err)
 	}
 
-	// Compound op: set category, add a new tag, remove needs-review with a note,
-	// and attach a comment.
+	// Compound op: set category, add a new tag, remove needs-review, and
+	// attach a comment carrying the rationale (notes on tag actions are
+	// deprecated — the comment is the audit artifact).
 	results, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
 		Operations: []service.UpdateTransactionsOp{{
 			TransactionID: txn.ShortID,
 			CategorySlug:  strPtr("food_and_drink_groceries"),
 			TagsToAdd:     []service.UpdateTransactionsTagOp{{Slug: "subscription:monthly"}},
-			TagsToRemove:  []service.UpdateTransactionsTagOp{{Slug: "needs-review", Note: "clearly groceries"}},
-			Comment:       strPtr("Costco run"),
+			TagsToRemove:  []service.UpdateTransactionsTagOp{{Slug: "needs-review"}},
+			Comment:       strPtr("Clearly groceries — Costco run."),
 		}},
 		Actor: service.Actor{Type: "user", ID: "u1", Name: "Tester"},
 	})
@@ -175,23 +176,23 @@ func TestUpdateTransactions_AbortMode_RollsBack(t *testing.T) {
 	}
 }
 
-// TestUpdateTransactions_TagRemovalWithoutNote verifies that tag removal
-// without a note succeeds — note is optional.
-func TestUpdateTransactions_TagRemovalWithoutNote(t *testing.T) {
+// TestUpdateTransactions_TagRemoval verifies that tag removal via the
+// compound op writes a tag_removed annotation and detaches the tag.
+func TestUpdateTransactions_TagRemoval(t *testing.T) {
 	svc, queries, _ := newService(t)
 	ctx := context.Background()
 	acctID := seedTxnFixture(t, queries)
 	txn := testutil.MustCreateTransaction(t, queries, acctID, "tx_c", "Subscription", 999, "2026-04-03")
 
 	testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
-	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", ID: "u1", Name: "Tester"}, ""); err != nil {
+	if _, _, err := svc.AddTransactionTag(ctx, txn.ShortID, "needs-review", service.Actor{Type: "user", ID: "u1", Name: "Tester"}); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
 	results, err := svc.UpdateTransactions(ctx, service.UpdateTransactionsParams{
 		Operations: []service.UpdateTransactionsOp{{
 			TransactionID: txn.ShortID,
-			TagsToRemove:  []service.UpdateTransactionsTagOp{{Slug: "needs-review", Note: ""}},
+			TagsToRemove:  []service.UpdateTransactionsTagOp{{Slug: "needs-review"}},
 		}},
 		Actor: service.Actor{Type: "user", ID: "u1", Name: "Tester"},
 	})

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -824,9 +824,10 @@ func (e *Engine) applyTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.U
 }
 
 // removeTagFromRule deletes a (transaction, tag) row and writes the matching
-// tag_removed annotation. No-op if the tag slug doesn't exist. The rule's
-// name is used as the removal note so the activity timeline carries a source
-// attribution.
+// tag_removed annotation. No-op if the tag slug doesn't exist. Source
+// attribution flows through the parent rule_applied annotation; the
+// rule-source tag_removed row is deduped from the rendered timeline by
+// service.EnrichAnnotations.
 func (e *Engine) removeTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, slug string, ruleID pgtype.UUID, ruleShortID, ruleName string) error {
 	var tagID pgtype.UUID
 	err := tx.QueryRow(ctx, `SELECT id FROM tags WHERE slug = $1`, slug).Scan(&tagID)
@@ -852,7 +853,6 @@ func (e *Engine) removeTagFromRule(ctx context.Context, tx pgx.Tx, txnID pgtype.
 		"source":    "rule",
 		"rule_id":   ruleShortID,
 		"rule_name": ruleName,
-		"note":      fmt.Sprintf("Removed by rule: %s", ruleName),
 	}
 	if err := writeSyncAnnotation(ctx, tx, writeSyncAnnotationParams{
 		TransactionID: txnID,

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -264,8 +264,14 @@ templ txdActivity(p TransactionDetailProps) {
 		</header>
 		if len(p.ActivityDays) > 0 {
 			<ol class="bb-timeline relative pl-4 sm:pl-5 pr-4 sm:pr-5 pb-2" role="list" aria-label="Transaction activity timeline">
-				<!-- Continuous left rail. Spans the full timeline excluding top/bottom padding. -->
-				<span class="absolute left-[27px] sm:left-[31px] top-2 bottom-12 w-px bg-base-200" aria-hidden="true"></span>
+				<!--
+					Continuous left rail. Top/bottom anchored so it threads
+					through every 24px tile (events + day separators) and the
+					composer. left-[28px]/[32px] = container padding (16/20px)
+					+ tile half-width (12px) — keeps the rail centered under
+					every circle on the timeline.
+				-->
+				<span class="absolute left-[28px] sm:left-[32px] top-2 bottom-12 w-px bg-base-200" aria-hidden="true"></span>
 				for di, day := range p.ActivityDays {
 					@txdTimelineDay(day.Label, di == 0)
 					for _, event := range day.Events {
@@ -285,25 +291,31 @@ templ txdActivity(p TransactionDetailProps) {
 }
 
 // txdTimelineDay renders a horizontal day separator with a small dot anchored
-// on the rail. The first day's separator gets a tighter top margin so the
-// timeline doesn't open with a large gap.
+// on the rail. The dot sits in a 24px tile so its center aligns with the
+// rail (and with every other 24px tile on the timeline). The first day's
+// separator gets a tighter top margin so the timeline doesn't open with a
+// large gap.
 templ txdTimelineDay(label string, first bool) {
 	<li class={ "relative flex items-center gap-3 select-none", templ.KV("pt-1 pb-3", first), templ.KV("pt-5 pb-3", !first) } role="separator" aria-label={ label }>
-		<span class="relative z-10 w-3 h-3 rounded-full bg-base-300 ring-4 ring-base-100" aria-hidden="true"></span>
-		<h3 class="text-[11px] font-semibold uppercase tracking-wider text-base-content/40">{ label }</h3>
+		<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center" aria-hidden="true">
+			<span class="w-3 h-3 rounded-full bg-base-300 ring-4 ring-base-100"></span>
+		</div>
+		<h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/40">{ label }</h3>
 		<span class="flex-1 h-px bg-base-200" aria-hidden="true"></span>
 	</li>
 }
 
 // txdTimelineSystem renders a compact one-liner row for tag / category /
 // rule / review events. Icon tile sits on the rail; sentence flows to the
-// right of the rail.
+// right of the rail. Both the 24px icon tile and the first text line share
+// a 24px line-box so their centers align horizontally — no per-element
+// margin tweaks needed.
 templ txdTimelineSystem(e service.ActivityEntry) {
 	<li class="relative flex items-start gap-3 py-2 group">
-		<div class="relative z-10 shrink-0 w-6 h-6 mt-0.5">
+		<div class="relative z-10 shrink-0 w-6 h-6 rounded-full bg-base-100">
 			@txdSystemIcon(e)
 		</div>
-		<div class="flex-1 min-w-0 pt-0.5 text-sm leading-snug text-base-content/75 break-words">
+		<div class="flex-1 min-w-0 text-xs leading-6 text-base-content/75 break-words">
 			@txdSystemSentence(e)
 			<span class="text-base-content/40 ml-1">
 				if e.Origin != "" {
@@ -311,7 +323,9 @@ templ txdTimelineSystem(e service.ActivityEntry) {
 				}
 				if e.Timestamp != "" {
 					<span aria-hidden="true">&middot;</span>
-					<time datetime={ e.Timestamp } class="tabular-nums" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
+					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
+						<time datetime={ e.Timestamp } class="tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
+					</span>
 				}
 			</span>
 		</div>
@@ -395,9 +409,7 @@ templ txdSystemIcon(e service.ActivityEntry) {
 			}
 		</span>
 	} else if e.Type == "category" {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-warning/15 ring-4 ring-base-100" aria-hidden="true">
-			<i data-lucide="folder" class="w-3 h-3 text-warning"></i>
-		</span>
+		@txdCategoryIcon(e)
 	} else if e.Type == "rule" {
 		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-info/15 ring-4 ring-base-100" aria-hidden="true">
 			<i data-lucide="zap" class="w-3 h-3 text-info"></i>
@@ -421,6 +433,33 @@ templ txdSystemIcon(e service.ActivityEntry) {
 	}
 }
 
+// txdCategoryIcon renders the category-set icon tile using the category's
+// own color + icon when known. Falls back to the neutral folder treatment
+// when the category was deleted (or never carried color/icon metadata).
+templ txdCategoryIcon(e service.ActivityEntry) {
+	if e.CategoryColor != nil && *e.CategoryColor != "" {
+		<span
+			class="flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-100"
+			style={ "background-color: " + *e.CategoryColor + "26" }
+			aria-hidden="true"
+		>
+			if e.CategoryIcon != nil && *e.CategoryIcon != "" {
+				<i data-lucide={ *e.CategoryIcon } class="w-3 h-3" style={ "color: " + *e.CategoryColor }></i>
+			} else {
+				<i data-lucide="folder" class="w-3 h-3" style={ "color: " + *e.CategoryColor }></i>
+			}
+		</span>
+	} else if e.CategoryIcon != nil && *e.CategoryIcon != "" {
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
+			<i data-lucide={ *e.CategoryIcon } class="w-3 h-3 text-base-content/60"></i>
+		</span>
+	} else {
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
+			<i data-lucide="folder" class="w-3 h-3 text-base-content/50"></i>
+		</span>
+	}
+}
+
 // txdTimelineComment renders a comment as a chat-bubble: small author/time
 // meta-line above a rounded message blob. The bubble's top-left corner is
 // flattened so it visually points at the avatar on the rail. App-wide
@@ -428,17 +467,25 @@ templ txdSystemIcon(e service.ActivityEntry) {
 // when the matching pattern lands on transactions and reviews.
 templ txdTimelineComment(e service.ActivityEntry) {
 	<li class="relative flex items-start gap-3 py-2.5 group">
-		<div class="relative z-10 shrink-0 w-6 h-6 mt-0.5 flex items-center justify-center">
+		<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100">
 			@txdCommentAvatar(e)
 		</div>
 		<div class="flex-1 min-w-0">
-			<div class="flex items-baseline gap-1.5 px-1 mb-1 flex-wrap">
+			<!--
+				Meta line shares a 24px line-box with the avatar so the actor
+				baseline sits dead-center on the rail circle. Keeping every
+				label at text-xs / leading-6 also matches the system-event
+				rows above for a uniform actor + timestamp treatment.
+			-->
+			<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6">
 				if e.ActorName != "" {
-					<strong class="text-xs font-semibold text-base-content">{ e.ActorName }</strong>
+					<strong class="font-semibold text-base-content">{ e.ActorName }</strong>
 				}
-				<span class="text-xs text-base-content/50">commented</span>
+				<span class="text-base-content/55">commented</span>
 				if e.Timestamp != "" {
-					<time datetime={ e.Timestamp } class="text-[11px] text-base-content/40 tabular-nums" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
+					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
+						<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
+					</span>
 				}
 				if e.CommentID != "" {
 					<button class="ml-auto rounded-md p-1 -m-1 text-base-content/30 hover:text-error hover:bg-error/5 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 transition" @click={ "deleteComment('" + e.CommentID + "')" } aria-label={ "Delete comment by " + e.ActorName } title="Delete comment">
@@ -447,7 +494,7 @@ templ txdTimelineComment(e service.ActivityEntry) {
 				}
 			</div>
 			if e.Detail != "" {
-				<div class="bb-comment-bubble">{ e.Detail }</div>
+				<div class="bb-comment-bubble mt-1">{ e.Detail }</div>
 			}
 		</div>
 	</li>
@@ -475,7 +522,7 @@ templ txdCommentAvatar(e service.ActivityEntry) {
 // Alpine component.
 templ txdTimelineComposer(p TransactionDetailProps) {
 	<li class="relative flex items-start gap-3 pt-3 pb-1">
-		<div class="relative z-10 shrink-0 w-6 h-6 mt-0.5 flex items-center justify-center" aria-hidden="true">
+		<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100" aria-hidden="true">
 			<span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 ring-4 ring-base-100">
 				<i data-lucide="message-square" class="w-3 h-3 text-primary"></i>
 			</span>


### PR DESCRIPTION
## Summary
End-to-end activity-log work for transaction details, plus a follow-up pass:

- **`feat(transactions): GitHub-style activity timeline`** — replaces the old separate-comments rendering with a unified timeline (events + chat-bubble comments + composer).
- **`feat(annotations): summary, action, dedup at the service layer`** — service-layer enrichment owns `Summary`/`Action`/`Subject`/`Origin`, dedups rule-source rows and the `update_transactions` comment-vs-tag-note pair.
- **`fix(transactions): restore chat-bubble comments + actor avatars on system events`** — bubble styling, avatars on actor-driven system rows.
- **`fix(transactions): activity-log follow-ups — drop tag/category notes, polish timeline`** — see below.

### Follow-ups (latest commit)
- **Notes deprecated at creation**: `note` is gone from REST (`/api/v1/transactions/{id}/tags`), MCP (`add_transaction_tag`, `remove_transaction_tag`, `update_transactions.tags_to_*`), the admin batch endpoint, and the service layer (`AddTransactionTag`, `RemoveTransactionTag`, `UpdateTransactionsTagOp`). Tool descriptions and `DefaultInstructions` / `DefaultReviewGuidelines` rephrase guidance to direct agents at the `comment` field instead. Sync engine no longer auto-writes a "Removed by rule: …" note on rule-driven `tag_removed` rows. Legacy `note` payloads still surface via `Annotation.Note` and the historic dedup so existing timelines render unchanged.
- **Timeline order flipped**: chronological (oldest first → newest last → composer at bottom), so new bubbles appear right where the user typed them.
- **Rail alignment**: rail nudged to `left-[28px] sm:left-[32px]` and the day-separator dot wrapped in a 24px tile. `leading-6` on row text + dropped `mt-0.5` / `pt-0.5` so icon centers align with the first text-line center.
- **Category-set rows** use the registered category color + icon for the icon tile (new `CategoryColor` / `CategoryIcon` on `ActivityEntry`).
- **Standardized meta labels** (actor, "commented", origin, timestamp) at `text-xs leading-6` across system + comment rows.
- **Opaque `bg-base-100` underlay** on system-event icon tiles, comment avatars, and the composer icon so the rail no longer bleeds through alpha-tinted fills.
- **DaisyUI tooltips** on relative timestamps showing the full local date+time (native `title=` kept as a11y fallback).
- Removed the dead admin `isDuplicateOfAdjacentTagNote` helper.

## Test plan
- [x] \`go build ./...\` and \`go vet ./...\` clean.
- [x] \`go test ./internal/service/ ./internal/admin/\` (unit) green.
- [x] \`make test-integration\` green across all packages.
- [x] Verified locally on \`localhost:8091\`: rail centered through every circle, no bleed-through behind avatars/icon tiles, timestamps show full local time on hover, category rows pick up the right color/icon, composer at the bottom.
- [ ] Reviewer: confirm MCP agents prompt correctly when migrating from \`note\` → \`comment\` in their workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)