### PR TITLE
chore(templates): consolidate duplicate statusBadge/errorMessage helpers

### DIFF
--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -361,16 +361,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				return name
 			},
 			"statusBadge": func(status string) template.HTML {
-				switch status {
-				case "active":
-					return `<span class="badge badge-soft badge-success badge-sm">Active</span>`
-				case "pending_reauth":
-					return `<span class="badge badge-soft badge-warning badge-sm">Reauth Needed</span>`
-				case "error":
-					return `<span class="badge badge-soft badge-error badge-sm">Error</span>`
-				default:
-					return `<span class="badge badge-ghost badge-sm">Disconnected</span>`
-				}
+				return template.HTML(components.StatusBadge(status))
 			},
 			"syncBadge": func(status string) template.HTML {
 				switch status {
@@ -384,20 +375,7 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return template.HTML(`<span class="badge badge-ghost badge-sm">` + template.HTMLEscapeString(status) + `</span>`)
 				}
 			},
-			"errorMessage": func(code string) string {
-				messages := map[string]string{
-					"ITEM_LOGIN_REQUIRED":      "Your bank login has changed. Please re-authenticate.",
-					"INSUFFICIENT_CREDENTIALS": "Additional credentials are needed. Please re-authenticate.",
-					"INVALID_CREDENTIALS":      "Your bank credentials are incorrect. Please re-authenticate.",
-					"MFA_NOT_SUPPORTED":        "This connection requires MFA which is not supported. Please reconnect.",
-					"NO_ACCOUNTS":              "No accounts found for this connection.",
-					"enrollment.disconnected":  "This bank connection has been disconnected.",
-				}
-				if msg, ok := messages[code]; ok {
-					return msg
-				}
-				return code
-			},
+			"errorMessage": components.ErrorMessage,
 			"syncFriendlyError": func(rawErr string) string {
 				return bsync.FriendlyError(rawErr)
 			},

--- a/internal/templates/components/helpers.go
+++ b/internal/templates/components/helpers.go
@@ -248,6 +248,43 @@ func TitleCase(s string) string { return titleCase(s) }
 // PluralS returns "" for n == 1, else "s". See pluralS.
 func PluralS[T pluralInt](n T) string { return pluralS(n) }
 
+// StatusBadge renders the inline HTML for a connection-status badge. Same
+// markup as the admin funcMap "statusBadge" entry — reused by templ pages
+// (via @templ.Raw) and the funcMap helper so all three sites stay aligned.
+func StatusBadge(status string) string {
+	switch status {
+	case "active":
+		return `<span class="badge badge-soft badge-success badge-sm">Active</span>`
+	case "pending_reauth":
+		return `<span class="badge badge-soft badge-warning badge-sm">Reauth Needed</span>`
+	case "error":
+		return `<span class="badge badge-soft badge-error badge-sm">Error</span>`
+	default:
+		return `<span class="badge badge-ghost badge-sm">Disconnected</span>`
+	}
+}
+
+// ErrorMessage maps Plaid/Teller connection error codes to human-friendly
+// strings. Mirrors the admin funcMap "errorMessage" entry. Unknown codes
+// pass through unchanged.
+func ErrorMessage(code string) string {
+	switch code {
+	case "ITEM_LOGIN_REQUIRED":
+		return "Your bank login has changed. Please re-authenticate."
+	case "INSUFFICIENT_CREDENTIALS":
+		return "Additional credentials are needed. Please re-authenticate."
+	case "INVALID_CREDENTIALS":
+		return "Your bank credentials are incorrect. Please re-authenticate."
+	case "MFA_NOT_SUPPORTED":
+		return "This connection requires MFA which is not supported. Please reconnect."
+	case "NO_ACCOUNTS":
+		return "No accounts found for this connection."
+	case "enrollment.disconnected":
+		return "This bank connection has been disconnected."
+	}
+	return code
+}
+
 // PageRange returns the page numbers to display in a paginator. For totals
 // up to 7 it returns every page. Beyond that, it returns first, last,
 // current, and current's neighbors, inserting 0 as an ellipsis sentinel

--- a/internal/templates/components/helpers_test.go
+++ b/internal/templates/components/helpers_test.go
@@ -397,3 +397,47 @@ func TestKbdGlyph(t *testing.T) {
 		}
 	}
 }
+
+func TestStatusBadge(t *testing.T) {
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"active", `<span class="badge badge-soft badge-success badge-sm">Active</span>`},
+		{"pending_reauth", `<span class="badge badge-soft badge-warning badge-sm">Reauth Needed</span>`},
+		{"error", `<span class="badge badge-soft badge-error badge-sm">Error</span>`},
+		{"disconnected", `<span class="badge badge-ghost badge-sm">Disconnected</span>`},
+		{"", `<span class="badge badge-ghost badge-sm">Disconnected</span>`},
+		{"unknown", `<span class="badge badge-ghost badge-sm">Disconnected</span>`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.status, func(t *testing.T) {
+			if got := StatusBadge(tc.status); got != tc.want {
+				t.Errorf("StatusBadge(%q) = %q, want %q", tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestErrorMessage(t *testing.T) {
+	tests := []struct {
+		code string
+		want string
+	}{
+		{"ITEM_LOGIN_REQUIRED", "Your bank login has changed. Please re-authenticate."},
+		{"INSUFFICIENT_CREDENTIALS", "Additional credentials are needed. Please re-authenticate."},
+		{"INVALID_CREDENTIALS", "Your bank credentials are incorrect. Please re-authenticate."},
+		{"MFA_NOT_SUPPORTED", "This connection requires MFA which is not supported. Please reconnect."},
+		{"NO_ACCOUNTS", "No accounts found for this connection."},
+		{"enrollment.disconnected", "This bank connection has been disconnected."},
+		{"UNKNOWN_CODE", "UNKNOWN_CODE"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.code, func(t *testing.T) {
+			if got := ErrorMessage(tc.code); got != tc.want {
+				t.Errorf("ErrorMessage(%q) = %q, want %q", tc.code, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -25,7 +25,7 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 				<div class="flex-1 min-w-0">
 					<p class="font-semibold text-sm">This connection needs re-authentication</p>
 					if p.HasErrorCode {
-						<p class="text-xs text-base-content/50 mt-0.5">{ connDetailErrorMessage(p.ErrorCode) }</p>
+						<p class="text-xs text-base-content/50 mt-0.5">{ components.ErrorMessage(p.ErrorCode) }</p>
 					} else if p.HasErrorMessage {
 						<p class="text-xs text-base-content/50 mt-0.5 truncate">{ p.ErrorMessage }</p>
 					}
@@ -76,7 +76,7 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 								}
 							</span>
 						} else {
-							@templ.Raw(connDetailStatusBadge(p.Status))
+							@templ.Raw(components.StatusBadge(p.Status))
 						}
 						if p.Paused {
 							<span class="badge badge-ghost badge-sm">Paused</span>

--- a/internal/templates/components/pages/connection_detail_scripts.go
+++ b/internal/templates/components/pages/connection_detail_scripts.go
@@ -5,26 +5,6 @@ import (
 	"strings"
 )
 
-// connDetailErrorMessage maps Plaid/Teller error codes to human-readable
-// messages. Mirrors the funcMap "errorMessage" helper in admin/templates.go.
-func connDetailErrorMessage(code string) string {
-	switch code {
-	case "ITEM_LOGIN_REQUIRED":
-		return "Your bank login has changed. Please re-authenticate."
-	case "INSUFFICIENT_CREDENTIALS":
-		return "Additional credentials are needed. Please re-authenticate."
-	case "INVALID_CREDENTIALS":
-		return "Your bank credentials are incorrect. Please re-authenticate."
-	case "MFA_NOT_SUPPORTED":
-		return "This connection requires MFA which is not supported. Please reconnect."
-	case "NO_ACCOUNTS":
-		return "No accounts found for this connection."
-	case "enrollment.disconnected":
-		return "This bank connection has been disconnected."
-	}
-	return code
-}
-
 // connDetailHeaderTileBg returns the icon-tile background class by provider.
 func connDetailHeaderTileBg(provider string) string {
 	switch provider {
@@ -34,22 +14,6 @@ func connDetailHeaderTileBg(provider string) string {
 		return "bg-success/10"
 	default:
 		return "bg-warning/10"
-	}
-}
-
-// connDetailStatusBadge returns the inline HTML for the status badge.
-// Mirrors the funcMap "statusBadge" helper in admin/templates.go. Returned
-// as a string for use with @templ.Raw to preserve the literal markup.
-func connDetailStatusBadge(status string) string {
-	switch status {
-	case "active":
-		return `<span class="badge badge-soft badge-success badge-sm">Active</span>`
-	case "pending_reauth":
-		return `<span class="badge badge-soft badge-warning badge-sm">Reauth Needed</span>`
-	case "error":
-		return `<span class="badge badge-soft badge-error badge-sm">Error</span>`
-	default:
-		return `<span class="badge badge-ghost badge-sm">Disconnected</span>`
 	}
 }
 

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -225,7 +225,7 @@ templ connectionsCard(c ConnectionsRow) {
 								}
 							</span>
 						} else {
-							@templ.Raw(connectionsStatusBadge(c.Status))
+							@templ.Raw(components.StatusBadge(c.Status))
 						}
 						if c.Paused {
 							<span class="badge badge-ghost badge-xs">Paused</span>
@@ -289,7 +289,7 @@ templ connectionsCard(c ConnectionsRow) {
 			<div class="mx-4 sm:mx-6 mb-4 flex items-center justify-between gap-2 text-xs text-warning bg-warning/10 rounded-lg px-3 py-2">
 				<div class="flex items-center gap-2 min-w-0">
 					<i data-lucide="alert-triangle" class="w-3.5 h-3.5 shrink-0"></i>
-					<span class="truncate">{ connectionsErrorMessage(c.ErrorCode) }</span>
+					<span class="truncate">{ components.ErrorMessage(c.ErrorCode) }</span>
 				</div>
 				if c.Provider != "csv" && (c.ErrorCode == "ITEM_LOGIN_REQUIRED" || c.ErrorCode == "INSUFFICIENT_CREDENTIALS" || c.ErrorCode == "INVALID_CREDENTIALS" || c.Status == "pending_reauth") {
 					<a href={ templ.SafeURL("/connections/" + c.ID + "/reauth") } class="btn btn-warning btn-xs rounded-lg shrink-0" @click.stop>Re-authenticate</a>

--- a/internal/templates/components/pages/connections_scripts.go
+++ b/internal/templates/components/pages/connections_scripts.go
@@ -38,43 +38,6 @@ func connectionsHumanize(s string) string {
 	return strings.ReplaceAll(s, "_", " ")
 }
 
-// connectionsErrorMessage maps Plaid/Teller error codes to human-readable
-// messages. Mirrors the funcMap "errorMessage" helper in admin/templates.go.
-func connectionsErrorMessage(code string) string {
-	switch code {
-	case "ITEM_LOGIN_REQUIRED":
-		return "Your bank login has changed. Please re-authenticate."
-	case "INSUFFICIENT_CREDENTIALS":
-		return "Additional credentials are needed. Please re-authenticate."
-	case "INVALID_CREDENTIALS":
-		return "Your bank credentials are incorrect. Please re-authenticate."
-	case "MFA_NOT_SUPPORTED":
-		return "This connection requires MFA which is not supported. Please reconnect."
-	case "NO_ACCOUNTS":
-		return "No accounts found for this connection."
-	case "enrollment.disconnected":
-		return "This bank connection has been disconnected."
-	}
-	return code
-}
-
-// connectionsStatusBadge returns the inline HTML for the connection status
-// badge. Mirrors the funcMap "statusBadge" helper in admin/templates.go.
-// Returned as a string for use with @templ.Raw to preserve the literal
-// markup byte-for-byte.
-func connectionsStatusBadge(status string) string {
-	switch status {
-	case "active":
-		return `<span class="badge badge-soft badge-success badge-sm">Active</span>`
-	case "pending_reauth":
-		return `<span class="badge badge-soft badge-warning badge-sm">Reauth Needed</span>`
-	case "error":
-		return `<span class="badge badge-soft badge-error badge-sm">Error</span>`
-	default:
-		return `<span class="badge badge-ghost badge-sm">Disconnected</span>`
-	}
-}
-
 // connectionsLinkActionURL builds a templ.SafeURL for the account-link form
 // actions (reconcile, delete). The path-construction lives in Go rather
 // than as a string literal in the .templ file so the routes-drift test


### PR DESCRIPTION
## Summary

The connection status-badge HTML and Plaid/Teller error-code → friendly-message mapping were each copy-pasted three times: once in the admin funcMap and once each in the `connections` and `connection_detail` templ script helpers. Comments in each clone explicitly noted the duplication (\"Mirrors the funcMap...\").

Moves both to [`internal/templates/components/helpers.go`](internal/templates/components/helpers.go) — the canonical home for shared funcMap mirrors (alongside `FormatAmount`, `FormatBalance`, `RelativeDate`, `PageRange`) — and deletes the three call-site duplicates.

- New: `components.StatusBadge(status string) string` and `components.ErrorMessage(code string) string`.
- Funcmap [`statusBadge`/`errorMessage`](internal/admin/templates.go) now delegate.
- Templ pages call the shared helpers directly via `@templ.Raw(components.StatusBadge(...))` and `{ components.ErrorMessage(...) }`.
- 14 new unit tests exercise every branch (all status values + all 6 error codes + unknown/empty fallthrough).

Same pattern as [#835](https://github.com/canalesb93/breadbox/pull/835) (relativeTime), [#831](https://github.com/canalesb93/breadbox/pull/831) (sync-log duration), [#812](https://github.com/canalesb93/breadbox/pull/812) (pgconv).

Net: **+87 / −101** across 7 files, no behavior change (helpers produce byte-identical HTML).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — new `TestStatusBadge` and `TestErrorMessage` pass; full unit suite green
- [ ] CI integration tests pass
- [ ] CI templ-check passes (verifies regenerated `*_templ.go` matches sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)