### PR TITLE
chore(pgconv): add TextPtrIfNotEmpty, collapse duplicate `*string`→pgtype.Text patterns

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -1257,14 +1257,9 @@ func UpdateAccountDisplayNameHandler(a *app.App, sm *scs.SessionManager) http.Ha
 			return
 		}
 
-		var displayName pgtype.Text
-		if req.DisplayName != nil {
-			displayName = pgconv.TextIfNotEmpty(*req.DisplayName)
-		}
-
 		account, err := a.Queries.UpdateAccountDisplayName(r.Context(), db.UpdateAccountDisplayNameParams{
 			ID:          accountID,
-			DisplayName: displayName,
+			DisplayName: pgconv.TextPtrIfNotEmpty(req.DisplayName),
 		})
 		if err != nil {
 			a.Logger.Error("update account display name", "error", err)

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -88,6 +88,17 @@ func TextIfNotEmpty(s string) pgtype.Text {
 	return pgtype.Text{String: s, Valid: true}
 }
 
+// TextPtrIfNotEmpty wraps *string as pgtype.Text, treating both nil and the
+// empty string as NULL. Pointer counterpart to TextIfNotEmpty — use when an
+// optional input that was either omitted (nil) or explicitly cleared ("")
+// should map to NULL.
+func TextPtrIfNotEmpty(s *string) pgtype.Text {
+	if s == nil || *s == "" {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: *s, Valid: true}
+}
+
 // Date wraps a time.Time as a non-NULL pgtype.Date. Use this to collapse
 // `pgtype.Date{Time: t, Valid: true}` boilerplate at insert and query-arg
 // sites where the value is always present.

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -234,6 +234,29 @@ func TestTextIfNotEmpty_Empty(t *testing.T) {
 	}
 }
 
+func TestTextPtrIfNotEmpty_Nil(t *testing.T) {
+	got := TextPtrIfNotEmpty(nil)
+	if got.Valid {
+		t.Errorf("TextPtrIfNotEmpty(nil) = %+v, want invalid (NULL)", got)
+	}
+}
+
+func TestTextPtrIfNotEmpty_EmptyPointer(t *testing.T) {
+	s := ""
+	got := TextPtrIfNotEmpty(&s)
+	if got.Valid {
+		t.Errorf("TextPtrIfNotEmpty(&\"\") = %+v, want invalid (NULL)", got)
+	}
+}
+
+func TestTextPtrIfNotEmpty_NonEmpty(t *testing.T) {
+	s := "hello"
+	got := TextPtrIfNotEmpty(&s)
+	if !got.Valid || got.String != "hello" {
+		t.Errorf("TextPtrIfNotEmpty(&hello) = %+v, want {hello true}", got)
+	}
+}
+
 func TestDate(t *testing.T) {
 	when := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
 	got := Date(when)

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -599,7 +599,7 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 	params := db.UpsertTransactionParams{
 		AccountID:                    accountID,
 		ProviderTransactionID:        txn.ExternalID,
-		ProviderPendingTransactionID: optionalText(txn.PendingExternalID),
+		ProviderPendingTransactionID: pgconv.TextPtrIfNotEmpty(txn.PendingExternalID),
 		Amount:                       decimalToNumeric(txn.Amount),
 		IsoCurrencyCode:              pgconv.TextIfNotEmpty(txn.ISOCurrencyCode),
 		Date:                         pgconv.Date(txn.Date),
@@ -607,10 +607,10 @@ func (e *Engine) upsertTransaction(ctx context.Context, q *db.Queries, txn *prov
 		Datetime:                     optionalTimestamptz(txn.Datetime),
 		AuthorizedDatetime:           optionalTimestamptz(txn.AuthorizedDatetime),
 		ProviderName:                 txn.Name,
-		ProviderMerchantName:         optionalText(txn.MerchantName),
-		ProviderCategoryPrimary:      optionalText(txn.CategoryPrimary),
-		ProviderCategoryDetailed:     optionalText(txn.CategoryDetailed),
-		ProviderCategoryConfidence:   optionalText(txn.CategoryConfidence),
+		ProviderMerchantName:         pgconv.TextPtrIfNotEmpty(txn.MerchantName),
+		ProviderCategoryPrimary:      pgconv.TextPtrIfNotEmpty(txn.CategoryPrimary),
+		ProviderCategoryDetailed:     pgconv.TextPtrIfNotEmpty(txn.CategoryDetailed),
+		ProviderCategoryConfidence:   pgconv.TextPtrIfNotEmpty(txn.CategoryConfidence),
 		ProviderPaymentChannel:       pgconv.TextIfNotEmpty(txn.PaymentChannel),
 		Pending:                      txn.Pending,
 		ProviderRaw:                  txn.Raw,
@@ -1266,13 +1266,6 @@ func classifyUpsertResult(txn db.Transaction, upsertStart time.Time) (isNew bool
 }
 
 // --- helpers ---
-
-func optionalText(s *string) pgtype.Text {
-	if s == nil || *s == "" {
-		return pgtype.Text{}
-	}
-	return pgtype.Text{String: *s, Valid: true}
-}
 
 func optionalTimestamptz(t *time.Time) pgtype.Timestamptz {
 	if t == nil {

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -101,13 +101,11 @@ func NewHandler(providers map[string]provider.Provider, engine *sync.Engine, que
 			if event.NeedsReauth {
 				status = db.ConnectionStatusPendingReauth
 			}
-			errCode := pgconv.TextFromPtr(event.ErrorCode)
-			errMsg := pgconv.TextFromPtr(event.ErrorMessage)
 			processErr = queries.UpdateBankConnectionStatus(r.Context(), db.UpdateBankConnectionStatusParams{
 				ID:           conn.ID,
 				Status:       status,
-				ErrorCode:    errCode,
-				ErrorMessage: errMsg,
+				ErrorCode:    pgconv.TextFromPtr(event.ErrorCode),
+				ErrorMessage: pgconv.TextFromPtr(event.ErrorMessage),
 			})
 			if processErr != nil {
 				logger.Error("failed to update connection status", "error", processErr)
@@ -158,14 +156,13 @@ func logWebhookEvent(ctx context.Context, queries *db.Queries, logger *slog.Logg
 	if payloadHash != nil {
 		hash = *payloadHash
 	}
-	errText := pgconv.TextFromPtr(errMsg)
 	evt, err := queries.CreateWebhookEvent(ctx, db.CreateWebhookEventParams{
 		Provider:       providerType,
 		EventType:      eventType,
 		ConnectionID:   connectionID,
 		RawPayloadHash: hash,
 		Status:         status,
-		ErrorMessage:   errText,
+		ErrorMessage:   pgconv.TextFromPtr(errMsg),
 	})
 	if err != nil {
 		// Don't fail the webhook handler if event logging fails.
@@ -180,11 +177,10 @@ func updateWebhookEventStatus(ctx context.Context, queries *db.Queries, logger *
 	if !eventID.Valid {
 		return // Event logging failed earlier, skip update.
 	}
-	errText := pgconv.TextFromPtr(errMsg)
 	if err := queries.UpdateWebhookEventStatus(ctx, db.UpdateWebhookEventStatusParams{
 		ID:           eventID,
 		Status:       status,
-		ErrorMessage: errText,
+		ErrorMessage: pgconv.TextFromPtr(errMsg),
 	}); err != nil {
 		logger.Warn("failed to update webhook event status", "event_id", fmt.Sprintf("%x", eventID.Bytes), "error", err)
 	}


### PR DESCRIPTION
## Summary

Continues the pgconv consolidation thread (#812, #806, etc.) — adds one more helper and replaces hand-rolled boilerplate at insert sites.

- New: `pgconv.TextPtrIfNotEmpty(s *string) pgtype.Text` — pointer counterpart to `TextIfNotEmpty`, treats both `nil` and `""` as NULL.
- Replaces 11 sites across `internal/sync/engine.go`, `internal/webhook/handler.go`, `internal/admin/connections.go`, and `internal/service/categories.go`.
- Drops the now-redundant local `optionalText` helper in sync/engine and the unused `derefStr` in service/categories (its last caller switched to `pgconv.TextOr`).

No behavior change — same NULL-handling semantics, just less surface area to read.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit)
- [x] `go test -tags integration -p 1 ./internal/pgconv/... ./internal/sync/... ./internal/webhook/... ./internal/service/...` (integration tests covering all touched packages — sync upserts, categories CRUD)
- [x] New unit tests cover `TextPtrIfNotEmpty` (nil, empty pointer, populated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)