### PR TITLE
chore(timefmt): consolidate RFC3339 string formatters

### DIFF
--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -8,6 +8,7 @@ import (
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -132,7 +133,7 @@ func buildAccessKeyRow(k service.APIKeyResponse) pages.AccessKeyRow {
 		KeyPrefix:        k.KeyPrefix,
 		Scope:            k.Scope,
 		CreatedAtShort:   formatDateShortFromRFC3339(k.CreatedAt),
-		LastUsedRelative: relativeTimeFromRFC3339Ptr(k.LastUsedAt),
+		LastUsedRelative: timefmt.RelativeFromRFC3339Ptr(k.LastUsedAt),
 	}
 }
 

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -3,12 +3,12 @@ package admin
 import (
 	"net/http"
 	"net/url"
-	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 )
@@ -123,7 +123,7 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 					InstitutionName:      l.InstitutionName,
 					Trigger:              l.Trigger,
 					Status:               l.Status,
-					StartedAtRelative:    relativeTimeFromRFC3339Ptr(l.StartedAt),
+					StartedAtRelative:    timefmt.RelativeFromRFC3339Ptr(l.StartedAt),
 					Duration:             l.Duration,
 					AccountsAffected:     l.AccountsAffected,
 					FriendlyErrorMessage: l.FriendlyErrorMessage,
@@ -221,8 +221,8 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 					InstitutionName:   e.InstitutionName,
 					PayloadHash:       e.PayloadHash,
 					ErrorMessage:      e.ErrorMessage,
-					CreatedAtRelative: relativeTimeFromRFC3339Ptr(e.CreatedAt),
-					CreatedAtFull:     formatDateTimeFromRFC3339Ptr(e.CreatedAt),
+					CreatedAtRelative: timefmt.RelativeFromRFC3339Ptr(e.CreatedAt),
+					CreatedAtFull:     timefmt.LocalDateTimeFromRFC3339Ptr(e.CreatedAt),
 				})
 			}
 
@@ -272,30 +272,3 @@ func encodeSyncStatusQuery(status, connID, trigger, dateFrom, dateTo string) str
 	return v.Encode()
 }
 
-// relativeTimeFromRFC3339Ptr parses a *string RFC3339 timestamp and
-// returns a humanised "X minutes ago" string. Mirrors the *string
-// branch of the `relativeTime` funcMap helper.
-func relativeTimeFromRFC3339Ptr(s *string) string {
-	if s == nil || *s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, *s)
-	if err != nil {
-		return *s
-	}
-	return relativeTime(t)
-}
-
-// formatDateTimeFromRFC3339Ptr parses a *string RFC3339 timestamp into
-// the local "Jan 2, 2006 3:04 PM" rendering used by the `formatDateTime`
-// funcMap helper.
-func formatDateTimeFromRFC3339Ptr(s *string) string {
-	if s == nil || *s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, *s)
-	if err != nil {
-		return *s
-	}
-	return t.Local().Format("Jan 2, 2006 3:04 PM")
-}

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -46,7 +46,7 @@ func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.Sess
 			Purpose:       detail.Purpose,
 			AgentName:     detail.AgentName,
 			APIKeyName:    detail.APIKeyName,
-			CreatedAt:     relativeTimeFromRFC3339(detail.CreatedAt),
+			CreatedAt:     timefmt.RelativeFromRFC3339(detail.CreatedAt),
 			ToolCallCount: detail.ToolCallCount,
 			ErrorCount:    detail.ErrorCount,
 			WriteCount:    detail.WriteCount,
@@ -64,8 +64,8 @@ func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.Sess
 				Sequence:       c.Sequence,
 				OffsetLabel:    c.OffsetLabel,
 				CreatedAt:      c.CreatedAt,
-				CreatedAtAbs:   formatDateTimeFromRFC3339(c.CreatedAt),
-				CreatedAtRel:   relativeTimeFromRFC3339(c.CreatedAt),
+				CreatedAtAbs:   timefmt.LocalDateTimeFromRFC3339(c.CreatedAt),
+				CreatedAtRel:   timefmt.RelativeFromRFC3339(c.CreatedAt),
 			}
 			if c.DurationMs != nil {
 				tc.DurationMs = *c.DurationMs
@@ -81,33 +81,6 @@ func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.Sess
 		}
 	}
 	return out
-}
-
-// relativeTimeFromRFC3339 mirrors the funcMap "relativeTime" branch
-// for an RFC3339 string. Returns the input unchanged when parsing
-// fails (matches the funcMap fallback).
-func relativeTimeFromRFC3339(s string) string {
-	if s == "" {
-		return ""
-	}
-	parsed, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return s
-	}
-	return relativeTime(parsed)
-}
-
-// formatDateTimeFromRFC3339 mirrors the funcMap "formatDateTime"
-// branch for an RFC3339 string ("Jan 2, 2006 3:04 PM" in local time).
-func formatDateTimeFromRFC3339(s string) string {
-	if s == "" {
-		return ""
-	}
-	parsed, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return s
-	}
-	return parsed.Local().Format("Jan 2, 2006 3:04 PM")
 }
 
 // prettyJSONIndent mirrors the funcMap "prettyJSON" branch for raw

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -7,6 +7,7 @@ import (
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -82,7 +83,7 @@ func buildSyncLogDetailProps(log *service.SyncLogRow, accounts []service.SyncLog
 			UnchangedCount:    log.UnchangedCount,
 			ErrorMessage:      stringOrEmpty(log.ErrorMessage),
 			WarningMessage:    stringOrEmpty(log.WarningMessage),
-			StartedAtRelative: relativeTimeFromRFC3339Ptr(log.StartedAt),
+			StartedAtRelative: timefmt.RelativeFromRFC3339Ptr(log.StartedAt),
 			Duration:          stringOrEmpty(log.Duration),
 			AccountsAffected:  log.AccountsAffected,
 			TotalRuleHits:     log.TotalRuleHits,

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
@@ -179,11 +178,11 @@ templ txdMain(p TransactionDetailProps) {
 						</div>
 						<div>
 							<p class="text-base-content/30 mb-0.5">Created</p>
-							<p class="text-base-content/50">{ formatDateTimeStr(p.Transaction.CreatedAt) }</p>
+							<p class="text-base-content/50">{ timefmt.LocalDateTimeFromRFC3339(p.Transaction.CreatedAt) }</p>
 						</div>
 						<div>
 							<p class="text-base-content/30 mb-0.5">Updated</p>
-							<p class="text-base-content/50">{ formatDateTimeStr(p.Transaction.UpdatedAt) }</p>
+							<p class="text-base-content/50">{ timefmt.LocalDateTimeFromRFC3339(p.Transaction.UpdatedAt) }</p>
 						</div>
 					</div>
 				</div>
@@ -323,8 +322,8 @@ templ txdTimelineSystem(e service.ActivityEntry) {
 				}
 				if e.Timestamp != "" {
 					<span aria-hidden="true">&middot;</span>
-					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
-						<time datetime={ e.Timestamp } class="tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
+					<span class="tooltip tooltip-top" data-tip={ timefmt.LocalDateTimeFromRFC3339(e.Timestamp) }>
+						<time datetime={ e.Timestamp } class="tabular-nums cursor-default" title={ timefmt.LocalDateTimeFromRFC3339(e.Timestamp) }>{ timefmt.RelativeFromRFC3339(e.Timestamp) }</time>
 					</span>
 				}
 			</span>
@@ -483,8 +482,8 @@ templ txdTimelineComment(e service.ActivityEntry) {
 				}
 				<span class="text-base-content/55">commented</span>
 				if e.Timestamp != "" {
-					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
-						<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
+					<span class="tooltip tooltip-top" data-tip={ timefmt.LocalDateTimeFromRFC3339(e.Timestamp) }>
+						<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default" title={ timefmt.LocalDateTimeFromRFC3339(e.Timestamp) }>{ timefmt.RelativeFromRFC3339(e.Timestamp) }</time>
 					</span>
 				}
 				if e.CommentID != "" {
@@ -720,56 +719,6 @@ func accountTypeLabel(acctType, subtype string) string {
 		return "Investment"
 	}
 	return acctType
-}
-
-// formatDateTimeStr parses an RFC3339 timestamp and renders it in the
-// admin standard "Jan 2, 2006 3:04 PM" local format. Unparseable input
-// is returned unchanged.
-func formatDateTimeStr(s string) string {
-	if s == "" {
-		return ""
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.Local().Format("Jan 2, 2006 3:04 PM")
-	}
-	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.Local().Format("Jan 2, 2006 3:04 PM")
-	}
-	return s
-}
-
-// clockTimeStr renders the local clock portion of an RFC3339 timestamp
-// ("3:04 PM"). Used by activity-timeline rows where the day separator
-// already carries the date.
-func clockTimeStr(s string) string {
-	if s == "" {
-		return ""
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.Local().Format("3:04 PM")
-	}
-	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.Local().Format("3:04 PM")
-	}
-	return s
-}
-
-// relativeTimeStr renders an RFC3339 timestamp as a short relative
-// phrase ("just now", "5 minutes ago", "2 days ago"). Used in delete
-// button aria-labels so screen readers get a stable description.
-// Falls back to the raw input string when the timestamp can't be parsed.
-func relativeTimeStr(s string) string {
-	if s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		t, err = time.Parse(time.RFC3339Nano, s)
-		if err != nil {
-			return s
-		}
-	}
-	return timefmt.Relative(t)
 }
 
 // avatarURLStr mirrors the admin "avatarURL" funcMap for the (user_id,

--- a/internal/timefmt/timefmt.go
+++ b/internal/timefmt/timefmt.go
@@ -8,6 +8,17 @@ import (
 	"time"
 )
 
+// Layouts shared by the local-time formatters. Kept as constants so handlers
+// and templ helpers can render with the same wall-clock format.
+const (
+	// LocalDateTimeLayout is the admin "Jan 2, 2006 3:04 PM" format used in
+	// detail pages, audit timelines, and tooltips that show absolute time.
+	LocalDateTimeLayout = "Jan 2, 2006 3:04 PM"
+	// LocalClockLayout is the "3:04 PM" clock-only form paired with a
+	// same-day day separator on activity timelines.
+	LocalClockLayout = "3:04 PM"
+)
+
 // Relative renders t as a human-readable "X ago" string relative to now.
 // Output buckets: "just now" (<1m), "N minute(s) ago" (<1h),
 // "N hour(s) ago" (<1d), "N day(s) ago" (>=1d). Uses time.Since(t), so
@@ -36,4 +47,99 @@ func Relative(t time.Time) string {
 		}
 		return fmt.Sprintf("%d days ago", days)
 	}
+}
+
+// parseRFC3339 accepts either RFC3339 or RFC3339Nano. Returns ok=false when
+// the input is empty or unparseable so callers can decide whether to fall
+// back to the raw string.
+func parseRFC3339(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// RelativeFromRFC3339 renders an RFC3339 (or RFC3339Nano) timestamp via
+// Relative. Returns "" for empty input and the raw string when parsing fails,
+// matching the pre-existing admin/templ helpers.
+func RelativeFromRFC3339(s string) string {
+	if s == "" {
+		return ""
+	}
+	t, ok := parseRFC3339(s)
+	if !ok {
+		return s
+	}
+	return Relative(t)
+}
+
+// RelativeFromRFC3339Ptr is the *string overload of RelativeFromRFC3339.
+// Returns "" when s is nil or points to the empty string.
+func RelativeFromRFC3339Ptr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return RelativeFromRFC3339(*s)
+}
+
+// LocalDateTime renders t in the admin "Jan 2, 2006 3:04 PM" local-time format.
+func LocalDateTime(t time.Time) string {
+	return t.Local().Format(LocalDateTimeLayout)
+}
+
+// LocalDateTimeFromRFC3339 parses an RFC3339 timestamp and renders it via
+// LocalDateTime. Returns "" for empty input and the raw string when parsing
+// fails.
+func LocalDateTimeFromRFC3339(s string) string {
+	if s == "" {
+		return ""
+	}
+	t, ok := parseRFC3339(s)
+	if !ok {
+		return s
+	}
+	return LocalDateTime(t)
+}
+
+// LocalDateTimeFromRFC3339Ptr is the *string overload of
+// LocalDateTimeFromRFC3339. Returns "" when s is nil.
+func LocalDateTimeFromRFC3339Ptr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return LocalDateTimeFromRFC3339(*s)
+}
+
+// LocalClock renders t as "3:04 PM" in the local timezone. Used on activity
+// timelines where the day separator already carries the date.
+func LocalClock(t time.Time) string {
+	return t.Local().Format(LocalClockLayout)
+}
+
+// LocalClockFromRFC3339 parses an RFC3339 timestamp and renders it via
+// LocalClock. Returns "" for empty input and the raw string when parsing fails.
+func LocalClockFromRFC3339(s string) string {
+	if s == "" {
+		return ""
+	}
+	t, ok := parseRFC3339(s)
+	if !ok {
+		return s
+	}
+	return LocalClock(t)
+}
+
+// LocalClockFromRFC3339Ptr is the *string overload of LocalClockFromRFC3339.
+// Returns "" when s is nil.
+func LocalClockFromRFC3339Ptr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return LocalClockFromRFC3339(*s)
 }

--- a/internal/timefmt/timefmt_test.go
+++ b/internal/timefmt/timefmt_test.go
@@ -1,6 +1,7 @@
 package timefmt
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -32,4 +33,87 @@ func TestRelative(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRelativeFromRFC3339(t *testing.T) {
+	now := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"unparseable falls through", "not-a-timestamp", "not-a-timestamp"},
+		{"5 minutes", now, "5 minutes ago"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RelativeFromRFC3339(tc.in); got != tc.want {
+				t.Errorf("RelativeFromRFC3339(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("nil ptr → empty", func(t *testing.T) {
+		if got := RelativeFromRFC3339Ptr(nil); got != "" {
+			t.Errorf("RelativeFromRFC3339Ptr(nil) = %q, want \"\"", got)
+		}
+	})
+	t.Run("non-nil ptr delegates", func(t *testing.T) {
+		s := now
+		if got := RelativeFromRFC3339Ptr(&s); got != "5 minutes ago" {
+			t.Errorf("RelativeFromRFC3339Ptr(&now) = %q, want %q", got, "5 minutes ago")
+		}
+	})
+}
+
+func TestLocalDateTimeFromRFC3339(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		if got := LocalDateTimeFromRFC3339(""); got != "" {
+			t.Errorf("LocalDateTimeFromRFC3339(\"\") = %q, want \"\"", got)
+		}
+	})
+	t.Run("unparseable falls through", func(t *testing.T) {
+		if got := LocalDateTimeFromRFC3339("nope"); got != "nope" {
+			t.Errorf("LocalDateTimeFromRFC3339(\"nope\") = %q, want \"nope\"", got)
+		}
+	})
+	t.Run("RFC3339 parses", func(t *testing.T) {
+		// Don't pin a timezone: just confirm the layout is the admin format
+		// (contains comma-year and AM/PM marker).
+		got := LocalDateTimeFromRFC3339("2026-04-01T15:04:05Z")
+		if !strings.Contains(got, "2026") || (!strings.Contains(got, "AM") && !strings.Contains(got, "PM")) {
+			t.Errorf("LocalDateTimeFromRFC3339 = %q, want admin Jan 2, 2006 3:04 PM format", got)
+		}
+	})
+	t.Run("RFC3339Nano parses", func(t *testing.T) {
+		got := LocalDateTimeFromRFC3339("2026-04-01T15:04:05.123456789Z")
+		if !strings.Contains(got, "2026") {
+			t.Errorf("LocalDateTimeFromRFC3339 (nano) = %q, want admin format", got)
+		}
+	})
+	t.Run("nil ptr", func(t *testing.T) {
+		if got := LocalDateTimeFromRFC3339Ptr(nil); got != "" {
+			t.Errorf("LocalDateTimeFromRFC3339Ptr(nil) = %q, want \"\"", got)
+		}
+	})
+}
+
+func TestLocalClockFromRFC3339(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		if got := LocalClockFromRFC3339(""); got != "" {
+			t.Errorf("LocalClockFromRFC3339(\"\") = %q, want \"\"", got)
+		}
+	})
+	t.Run("unparseable falls through", func(t *testing.T) {
+		if got := LocalClockFromRFC3339("nope"); got != "nope" {
+			t.Errorf("LocalClockFromRFC3339(\"nope\") = %q, want \"nope\"", got)
+		}
+	})
+	t.Run("RFC3339 parses to short clock", func(t *testing.T) {
+		got := LocalClockFromRFC3339("2026-04-01T15:04:05Z")
+		if !strings.Contains(got, ":") || (!strings.Contains(got, "AM") && !strings.Contains(got, "PM")) {
+			t.Errorf("LocalClockFromRFC3339 = %q, want H:MM AM/PM", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

The same "parse RFC3339 → format relative / local datetime" logic existed three times — in `internal/admin/sessions.go`, `internal/admin/logs.go`, and the `transaction_detail.templ` — each with slightly different fallback behavior (only `transaction_detail` accepted `RFC3339Nano`). Continues the recent consolidation pattern (#831, #835, #838) of pushing repeated time formatting onto `internal/timefmt`.

This PR adds string-based formatters to `internal/timefmt`:

- `RelativeFromRFC3339(s string) string` / `RelativeFromRFC3339Ptr(*string) string`
- `LocalDateTimeFromRFC3339(s string) string` / `LocalDateTimeFromRFC3339Ptr(*string) string`
- `LocalClockFromRFC3339(s string) string` / `LocalClockFromRFC3339Ptr(*string) string`

All accept both `RFC3339` and `RFC3339Nano`, return `""` for empty input, and fall back to the raw string when parsing fails — matching the union of the three previous variants.

Call sites updated:

- [internal/admin/sessions.go](internal/admin/sessions.go) — drop local `relativeTimeFromRFC3339` / `formatDateTimeFromRFC3339`
- [internal/admin/logs.go](internal/admin/logs.go) — drop local `relativeTimeFromRFC3339Ptr` / `formatDateTimeFromRFC3339Ptr`
- [internal/admin/apikeys.go](internal/admin/apikeys.go), [internal/admin/synclogs.go](internal/admin/synclogs.go) — switch to the shared helpers
- [internal/templates/components/pages/transaction_detail.templ](internal/templates/components/pages/transaction_detail.templ) — drop local `formatDateTimeStr` / `relativeTimeStr` helpers; also drops the unused `clockTimeStr`

Net: +208 / −121 with the shared helpers + tests; the call-site files all shrink.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` — unit tests pass; new test cases cover the empty / unparseable / RFC3339 / RFC3339Nano / nil-ptr branches in `internal/timefmt`
- [ ] CI integration tests (`-tags integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)