### PR TITLE
chore(nav): swap rules sidebar icon to lightning bolt

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -78,7 +78,7 @@ templ Nav(p NavProps) {
 		}
 		if p.IsAdmin {
 			<a href="/rules" class={ "bb-sidebar-link", navActive(p.CurrentPage, "rules") }>
-				<i data-lucide="list-filter"></i> Rules
+				<i data-lucide="zap"></i> Rules
 			</a>
 			<a href="/categories" class={ "bb-sidebar-link", navActive(p.CurrentPage, "categories") }>
 				<i data-lucide="folder"></i> Categories


### PR DESCRIPTION
## Summary
- Replace the `list-filter` Lucide icon next to **Rules** in the admin sidebar with `zap` (lightning bolt) to better convey the auto-fire nature of rules.

## Test plan
- [x] `go build ./...`
- [ ] Verify icon renders in sidebar after merge