### PR TITLE
Phase 3 of #827: drop allowlist scaffolding, tighten lint, doc cleanup

### DIFF
--- a/.claude/rules/ui.md
+++ b/.claude/rules/ui.md
@@ -99,8 +99,8 @@ The full convention — file layout, factory shape, data-passing patterns, and a
 
 Hard rules enforced by `internal/templates/components/pages/scripts_lint_test.go` (runs as part of `go test ./...`):
 
-- **No `x-data={ "factory(...)"`** — the Go-expression form that interpolates props into the factory call is the regression #827 / #828 are removing. Use `x-data="factory"` plus `@templ.JSONScript` or `data-*`. A small allowlist tracks pre-existing offenders; do not add to it.
-- **No literal `<script>...</script>` block in `internal/templates/components/pages/*.templ` exceeds 180 content lines.** The ceiling ratchets down as Phase 2 of #827 progresses; lower it (never raise it) when an extraction creates a new low watermark.
+- **No `x-data={ "factory(...)"`** — the Go-expression form that interpolates props into the factory call. Use `x-data="factory"` plus `@templ.JSONScript` or `data-*`.
+- **No literal `<script>...</script>` block in `internal/templates/components/pages/*.templ` exceeds 5 content lines.** Anything larger belongs in `static/js/admin/components/<page>.js`. Never raise the ceiling.
 
 When a new admin page needs Alpine, do **not** add a `<page>_scripts.go` sidecar or a multi-line inline `<script>` block — write the factory in `static/js/admin/components/<page>.js` and follow the convention.
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -799,7 +799,7 @@ Run `templ fmt .` before committing — it normalizes whitespace and attribute o
 
 Page-level Alpine factories — the things rendered as `x-data="..."` at the root of an admin page — live in `static/js/admin/components/<pageSlug>.js` and load via a synchronous `<script src="...">` placed at the top of the templ component. This keeps JS out of templ files and out of `_scripts.go` Go-string sidecars, so editors give you syntax highlighting, the formatter works, and refactors are mechanical.
 
-Tracker for the migration: #827 (foundation: #828; reference port: `prompt_builder`).
+History: the migration from inline factories to static modules was tracked in #827 (foundation: #828; reference port: `prompt_builder`).
 
 ### File layout
 
@@ -873,24 +873,24 @@ Don't mix: pick the one that fits the data shape. `data-*` for primitives, JSON 
 
 - **`x-data={ "myPage(" + p.JSON + ")" }`** — Go-expression `x-data` calling a factory with interpolated args. The lint rejects this. Move the data into a `data-*` attribute or `@templ.JSONScript`.
 - **`@templ.Raw("<script>" + factoryBody + "</script>")`** — embedding a multi-line factory as a Go string. No syntax highlighting, no editor IntelliSense, fragile escaping. Move the body into `static/js/admin/components/`.
-- **A new `<page>_scripts.go` next to `<page>.templ`** — the whole sidecar pattern is what #827 deletes. New code uses `static/js/admin/components/`.
-- **A trivial inline `<script>` for one `lucide.createIcons()` call** — fine to leave as-is; the lint allows up to 180 content lines today and will tighten as Phase 2 progresses. The cutoff for "extract" vs "inline" is roughly: more than ~10 lines of factory logic, or anything that would benefit from being a JS file (closures, helpers, conditional flows).
+- **A new `<page>_scripts.go` next to `<page>.templ`** — the sidecar pattern was removed by #827. New code uses `static/js/admin/components/`.
+- **A trivial one-liner inline `<script>` for `lucide.createIcons()`** — fine to leave as-is; the lint caps inline blocks at 5 content lines. Anything larger belongs in a JS file.
 
 ### Sharing logic across pages
 
-For now, each page has its own factory file. If two pages need the same factory, prefer copying first and consolidating later — premature shared modules are hard to undo. When a third page wants the same logic, factor it out (still as a plain JS file; no bundler).
+Most pages have their own factory file. For factories that genuinely need to be shared (the canonical example is `categoryPicker`, used by category form, transactions filter bar, and per-row category assignment), put the module in `static/js/admin/components/<name>.js` and have each consumer load the script and pass differing state via `data-*` attributes. Prefer copying first and consolidating only when a third page wants the same logic — premature shared modules are hard to undo.
 
-For shared CDN scripts (e.g. `marked`, `dompurify`) that need to load exactly once across multiple pages, the templ-idiomatic pattern is `templ.OnceHandle`. Phase 2 introduces this when a page first needs it; until then, each page pulls in its own `<script src="...">` — duplicate loads are harmless on the admin tier.
+For shared CDN scripts (e.g. `marked`, `dompurify`) that need to load exactly once across multiple pages, the templ-idiomatic pattern is `templ.OnceHandle`. Use it when a page first needs it; until then, each page pulls in its own `<script src="...">` — duplicate loads are harmless on the admin tier.
 
 ### Lint
 
 `internal/templates/components/pages/scripts_lint_test.go` runs as part of `go test ./...` and enforces two rules:
 
-1. **No `x-data={ "factory("` Go-expression form.** Hard fail. Existing pre-Phase-1 occurrences are listed in `existingAntiPatternAllowlist` and removed by their respective Phase 2 PRs.
-2. **No literal `<script>...</script>` block in `internal/templates/components/pages/*.templ` exceeds the line ceiling.** Currently 180 content lines (147 measured max + 33 buffer). Lower this in any PR that creates a new low watermark; never raise it.
+1. **No `x-data={ "factory("` Go-expression form.** Hard fail.
+2. **No literal `<script>...</script>` block in `internal/templates/components/pages/*.templ` exceeds 5 content lines.** Anything larger belongs in `static/js/admin/components/<page>.js`. Never raise the ceiling.
 
-Failure messages include `path:line[-end]` so the next agent can extract the offender directly.
+Failure messages include `path:line[-end]` so the offender can be extracted directly.
 
 ### Reference implementation
 
-`static/js/admin/components/prompt_builder.js` + `internal/templates/components/pages/prompt_builder.templ` (the `/agent-wizard/{type}` page). Copy this shape for any new Alpine page component, and follow `#827`'s per-page PR template when porting an existing page.
+`static/js/admin/components/prompt_builder.js` + `internal/templates/components/pages/prompt_builder.templ` (the `/agent-wizard/{type}` page). Copy this shape for any new Alpine page component.

--- a/internal/templates/components/pages/scripts_lint_test.go
+++ b/internal/templates/components/pages/scripts_lint_test.go
@@ -2,7 +2,6 @@ package pages
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -12,44 +11,22 @@ import (
 
 // inlineScriptCeiling is the maximum number of content lines allowed in a
 // literal inline <script>...</script> block inside a *.templ file in this
-// package. The ceiling is a high-water mark — set to "current measured max +
-// ~30" so existing code passes comfortably and new regressions fail loudly.
-//
-// As Phase 2 of #827 proceeds and pages get extracted to
-// static/js/admin/components/<page>.js, the maximum drops; lower this value
-// in the same PR so the lint ratchets down. See #828 / #827.
-//
-// 2026-04-25 audit (post reviews + transactions extraction — final Phase 2):
-// max = 1 in categories.templ:71-73. Ceiling = 1 + 30 = 31. Phase 2 of #827
-// is complete after this PR — every page-level Alpine factory now lives in
-// static/js/admin/components/.
-const inlineScriptCeiling = 31
+// package. Page-level Alpine factories live in static/js/admin/components/
+// per docs/design-system.md → "Alpine page components"; literal inline
+// scripts in templ files are reserved for trivial DOM glue (e.g. a one-shot
+// lucide.createIcons()).
+const inlineScriptCeiling = 5
 
-// xDataFactoryAntiPattern catches the regression that #827 / #828 are
-// undoing: an x-data attribute rendered from a Go expression that calls a
-// factory with interpolated arguments — e.g.
+// xDataFactoryAntiPattern catches the regression that #827 / #828 removed:
+// an x-data attribute rendered from a Go expression that calls a factory
+// with interpolated arguments — e.g.
 //
 //	x-data={ "promptBuilder(" + p.BlocksJSON + ")" }
 //
-// The string-literal form `x-data="factoryName"` is allowed (it's the new
-// convention). The factory must take no arguments; data flows through
-// @templ.JSONScript or data-* attributes instead.
+// The string-literal form `x-data="factoryName"` is the convention. The
+// factory takes no arguments; data flows through @templ.JSONScript or
+// data-* attributes instead.
 var xDataFactoryAntiPattern = regexp.MustCompile(`x-data=\{\s*"[A-Za-z_$][A-Za-z0-9_$]*\(`)
-
-// existingAntiPatternAllowlist tracks anti-pattern hits that were already in
-// the codebase when the lint shipped (Phase 1 of #827). Each entry is
-// `<basename>:<lineNumber>` and is paired with a comment naming the page
-// that will remove it in its Phase 2 extraction PR.
-//
-// This allowlist must shrink monotonically: every Phase 2 PR that ports a
-// page deletes its entry here. If you find yourself adding to this list,
-// stop — the new Alpine factory belongs in static/js/admin/components/.
-//
-// As of #827's Phase 2 closure, the allowlist is empty: every page-level
-// Alpine factory has been ported to static/js/admin/components/, and the
-// shared categoryPicker factory was extracted in the final PR. Keep the
-// map declaration so the stale-entry check below still compiles.
-var existingAntiPatternAllowlist = map[string]struct{}{}
 
 // TestNoLargeInlineScripts walks every *.templ file under
 // internal/templates/components/pages and enforces two rules:
@@ -60,15 +37,13 @@ var existingAntiPatternAllowlist = map[string]struct{}{}
 //
 // Excluded from the line-count rule: <script src="...">, <script
 // type="application/json">, and any line rendered through Go expressions
-// such as `@templ.Raw("<script>" + body + "</script>")`. Those are tracked
-// in #827's per-page extraction queue rather than enforced here.
+// such as `@templ.Raw("<script>" + body + "</script>")`.
 func TestNoLargeInlineScripts(t *testing.T) {
 	t.Run("AntiPattern_xDataFactoryArgs", func(t *testing.T) {
 		entries, err := filepath.Glob("*.templ")
 		if err != nil {
 			t.Fatalf("glob *.templ: %v", err)
 		}
-		seen := map[string]struct{}{}
 		for _, path := range entries {
 			f, err := os.Open(path)
 			if err != nil {
@@ -83,18 +58,12 @@ func TestNoLargeInlineScripts(t *testing.T) {
 				if !xDataFactoryAntiPattern.MatchString(line) {
 					continue
 				}
-				key := fmt.Sprintf("%s:%d", path, lineNo)
-				seen[key] = struct{}{}
-				if _, exempt := existingAntiPatternAllowlist[key]; exempt {
-					continue
-				}
 				t.Errorf(
 					"%s:%d: x-data factory-with-arguments anti-pattern detected:\n  %s\n"+
 						"Use string-literal x-data=\"factoryName\" + @templ.JSONScript(...) "+
 						"or data-* attributes instead. See docs/design-system.md → "+
-						"\"Alpine page components\". If this is brand-new code, do not "+
-						"add it to the allowlist — port the factory to "+
-						"static/js/admin/components/ instead.",
+						"\"Alpine page components\". Port the factory to "+
+						"static/js/admin/components/ instead of inlining it.",
 					path, lineNo, strings.TrimSpace(line),
 				)
 			}
@@ -102,19 +71,6 @@ func TestNoLargeInlineScripts(t *testing.T) {
 				t.Errorf("scan %s: %v", path, err)
 			}
 			f.Close()
-		}
-		// The allowlist must shrink monotonically: every Phase 2 PR removes
-		// its entry. Stale entries (line moved, file removed, or page already
-		// migrated) need cleanup so the lint stays trustworthy.
-		for k := range existingAntiPatternAllowlist {
-			if _, ok := seen[k]; !ok {
-				t.Errorf(
-					"existingAntiPatternAllowlist has stale entry %q "+
-						"(no matching x-data factory-args occurrence found). "+
-						"Delete the entry — the lint is now clean for that page.",
-					k,
-				)
-			}
 		}
 	})
 


### PR DESCRIPTION
Final cleanup PR for #827 — Phase 2 is done, this rips out the transitional scaffolding so the lint and docs reflect the finished state.

## What changes

### Lint (`internal/templates/components/pages/scripts_lint_test.go`)
- **Drop `existingAntiPatternAllowlist`** and the stale-entry cross-check — the map has been empty since the categoryPicker extraction (#866), so the machinery is dead weight.
- **Lower `inlineScriptCeiling` from 31 → 5.** Current measured max is 1 line (`categories.templ:71-73`'s `lucide.createIcons()` one-liner). Five leaves room for similar trivial DOM glue while rejecting anything factory-sized.
- Removed `fmt` import (no longer needed once `seen` map is gone).

### Docs
- **`docs/design-system.md` §14**: drop "in progress" qualifiers, "Phase 2 ratchets" language, and `existingAntiPatternAllowlist` references; rewrite the "Sharing logic across pages" section to document the `categoryPicker` shared-factory pattern as the canonical example; reflect the new ceiling (5).
- **`.claude/rules/ui.md`**: same update to the "JavaScript and Alpine" section.

## Validation

```
$ go build ./...           # clean
$ go vet ./...             # clean
$ go test ./...            # all green, including TestNoLargeInlineScripts
```

Targets `epic/827-alpine-extraction` (final epic→main PR will follow).
