### PR TITLE
fix(providers): provider name read in init() not testConnection()

### DIFF
--- a/static/js/admin/components/providers.js
+++ b/static/js/admin/components/providers.js
@@ -2,25 +2,30 @@
 //
 // Convention reference: docs/design-system.md → "Alpine page components".
 // Each card (Plaid, Teller) instantiates its own copy via x-data="providerCard"
-// and supplies the provider name as a `data-provider` attribute on the root,
-// read inside testConnection() via this.$el.dataset.provider. Keeping the
-// factory argument-free matches the convention; the per-instance variation
-// flows through the DOM, not through factory args.
+// and supplies the provider name as a `data-provider` attribute on the root.
+// We read the attribute once in init() — `this.$el` only points at the
+// x-data root inside init(); inside event-bound methods (e.g.
+// testConnection() called from @click) Alpine binds `this.$el` to the
+// element with the directive (the button), which has no data-provider.
 document.addEventListener('alpine:init', function () {
   Alpine.data('providerCard', function () {
     return {
+      provider: '',
       showConfig: false,
       saving: false,
       testing: false,
       testResult: '',
       testSuccess: false,
 
+      init: function () {
+        this.provider = this.$el.dataset.provider || '';
+      },
+
       testConnection: function () {
         var self = this;
-        var name = this.$el.dataset.provider;
         this.testing = true;
         this.testResult = '';
-        fetch('/-/test-provider/' + name, { method: 'POST' })
+        fetch('/-/test-provider/' + this.provider, { method: 'POST' })
           .then(function (res) { return res.json(); })
           .then(function (data) {
             self.testing = false;


### PR DESCRIPTION
Bug fix on top of #878 (the #827 epic). Found while smoke-testing the merged epic.

## What was broken

Clicking **Test Connection** on `/providers` POSTed to `/-/test-provider/undefined` and returned 400.

## Root cause

`providers.js` (extracted in #839) was reading the provider name lazily inside `testConnection()`:

```js
testConnection: function () {
  var name = this.$el.dataset.provider;   // ← undefined
  // ...
}
```

Inside an event-bound method called from `@click="testConnection()"`, Alpine binds `this.$el` to the **element with the directive** (the button), not to the `x-data` root. The button has no `data-provider`, so `dataset.provider` is undefined.

(Verified in DevTools: invoked the same method via `@click` and `this.$el.tagName` was `BUTTON` with `className="btn btn-sm btn-ghost rounded-xl"`.)

## Fix

Read the attr once in `init()` (where `this.$el` IS the x-data root) and store it on the component. `testConnection()` references the stable property.

```js
init: function () {
  this.provider = this.$el.dataset.provider || '';
},

testConnection: function () {
  fetch('/-/test-provider/' + this.provider, { method: 'POST' })
  // ...
}
```

This matches every other extracted factory's pattern — they all read `data-*` attrs in `init()` and store on the component. Audited the rest of `static/js/admin/components/*.js`; `providers.js` was the only factory reading `dataset` outside `init()`.

## Validation

- Smoke-tested in Chrome DevTools MCP: `POST /-/test-provider/plaid [200]` ✓
- Also confirmed `/connections/new` → "Continue" flow opens Plaid Link sandbox dialog correctly ✓
- `go build`, `go vet`, `go test ./...` all green

Targets `epic/827-alpine-extraction` so it ships with #878.
