### PR TITLE
chore(admin): collapse time-coercion type switches onto coerceTime helper

### DIFF
--- a/internal/admin/helpers_test.go
+++ b/internal/admin/helpers_test.go
@@ -376,3 +376,70 @@ func TestConnectionStaleness(t *testing.T) {
 		})
 	}
 }
+
+func TestCoerceTime(t *testing.T) {
+	ref := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+	rfc3339 := ref.Format(time.RFC3339)
+	rfc3339Nano := ref.Format(time.RFC3339Nano)
+	emptyStr := ""
+	junkStr := "not-a-timestamp"
+	rfcStr := rfc3339
+	tests := []struct {
+		name    string
+		in      any
+		wantOK  bool
+		wantRaw string
+		wantEq  bool // expect returned time == ref
+	}{
+		{"time.Time", ref, true, "", true},
+		{"*time.Time non-nil", &ref, true, "", true},
+		{"*time.Time nil", (*time.Time)(nil), false, "", false},
+		{"string RFC3339", rfc3339, true, "", true},
+		{"string RFC3339Nano", rfc3339Nano, true, "", true},
+		{"string empty", "", false, "", false},
+		{"string junk echoes raw", "not-a-timestamp", false, "not-a-timestamp", false},
+		{"*string non-nil RFC3339", &rfcStr, true, "", true},
+		{"*string nil", (*string)(nil), false, "", false},
+		{"*string empty", &emptyStr, false, "", false},
+		{"*string junk echoes raw", &junkStr, false, "not-a-timestamp", false},
+		{"pgtype.Timestamptz valid", pgtype.Timestamptz{Time: ref, Valid: true}, true, "", true},
+		{"pgtype.Timestamptz invalid", pgtype.Timestamptz{}, false, "", false},
+		{"unsupported type", 42, false, "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, raw, ok := coerceTime(tc.in)
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if raw != tc.wantRaw {
+				t.Errorf("raw = %q, want %q", raw, tc.wantRaw)
+			}
+			if tc.wantEq && !got.Equal(ref) {
+				t.Errorf("time = %v, want %v", got, ref)
+			}
+		})
+	}
+}
+
+func TestFormatCoercedTime(t *testing.T) {
+	ref := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+	stamp := func(tm time.Time) string { return tm.UTC().Format("2006-01-02") }
+	tests := []struct {
+		name string
+		in   any
+		want string
+	}{
+		{"valid time", ref, "2024-05-01"},
+		{"empty input", "", ""},
+		{"nil pointer", (*string)(nil), ""},
+		{"junk string echoes raw", "not-a-timestamp", "not-a-timestamp"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatCoercedTime(tc.in, stamp); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -276,26 +276,14 @@ func encodeSyncStatusQuery(status, connID, trigger, dateFrom, dateTo string) str
 // returns a humanised "X minutes ago" string. Mirrors the *string
 // branch of the `relativeTime` funcMap helper.
 func relativeTimeFromRFC3339Ptr(s *string) string {
-	if s == nil || *s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, *s)
-	if err != nil {
-		return *s
-	}
-	return relativeTime(t)
+	return formatCoercedTime(s, relativeTime)
 }
 
 // formatDateTimeFromRFC3339Ptr parses a *string RFC3339 timestamp into
 // the local "Jan 2, 2006 3:04 PM" rendering used by the `formatDateTime`
 // funcMap helper.
 func formatDateTimeFromRFC3339Ptr(s *string) string {
-	if s == nil || *s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, *s)
-	if err != nil {
-		return *s
-	}
-	return t.Local().Format("Jan 2, 2006 3:04 PM")
+	return formatCoercedTime(s, func(tm time.Time) string {
+		return tm.Local().Format("Jan 2, 2006 3:04 PM")
+	})
 }

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -87,27 +87,15 @@ func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.Sess
 // for an RFC3339 string. Returns the input unchanged when parsing
 // fails (matches the funcMap fallback).
 func relativeTimeFromRFC3339(s string) string {
-	if s == "" {
-		return ""
-	}
-	parsed, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return s
-	}
-	return relativeTime(parsed)
+	return formatCoercedTime(s, relativeTime)
 }
 
 // formatDateTimeFromRFC3339 mirrors the funcMap "formatDateTime"
 // branch for an RFC3339 string ("Jan 2, 2006 3:04 PM" in local time).
 func formatDateTimeFromRFC3339(s string) string {
-	if s == "" {
-		return ""
-	}
-	parsed, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return s
-	}
-	return parsed.Local().Format("Jan 2, 2006 3:04 PM")
+	return formatCoercedTime(s, func(tm time.Time) string {
+		return tm.Local().Format("Jan 2, 2006 3:04 PM")
+	})
 }
 
 // prettyJSONIndent mirrors the funcMap "prettyJSON" branch for raw

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -109,6 +109,71 @@ var componentRegistry = map[string]componentAdapter{
 	},
 }
 
+// coerceTime extracts a time.Time from common template input shapes:
+// time.Time, *time.Time, string, *string, and pgtype.Timestamptz.
+// Returns (t, "", true) when a usable time is available. For unparseable
+// strings returns (zero, raw, false) so callers can echo them back
+// unchanged — matching the historical funcMap fallback. Empty/nil
+// inputs and invalid pgtype.Timestamptz return (zero, "", false).
+//
+// Strings are parsed as RFC3339 first, then RFC3339Nano so timestamps
+// carrying sub-second precision (e.g. some annotation feeds) round-trip
+// correctly through every formatter, not just clockTime.
+func coerceTime(v any) (time.Time, string, bool) {
+	parse := func(s string) (time.Time, bool) {
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			return t, true
+		}
+		if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+			return t, true
+		}
+		return time.Time{}, false
+	}
+	switch x := v.(type) {
+	case time.Time:
+		return x, "", true
+	case *time.Time:
+		if x == nil {
+			return time.Time{}, "", false
+		}
+		return *x, "", true
+	case string:
+		if x == "" {
+			return time.Time{}, "", false
+		}
+		if t, ok := parse(x); ok {
+			return t, "", true
+		}
+		return time.Time{}, x, false
+	case *string:
+		if x == nil || *x == "" {
+			return time.Time{}, "", false
+		}
+		if t, ok := parse(*x); ok {
+			return t, "", true
+		}
+		return time.Time{}, *x, false
+	case pgtype.Timestamptz:
+		if x.Valid {
+			return x.Time, "", true
+		}
+		return time.Time{}, "", false
+	}
+	return time.Time{}, "", false
+}
+
+// formatCoercedTime resolves v through coerceTime and applies format on
+// success; on parse failure it returns the raw string fallback (or "" for
+// empty/nil inputs). Centralises the "parse-or-echo" branch that every
+// time-rendering funcMap helper used to copy.
+func formatCoercedTime(v any, format func(time.Time) string) string {
+	t, raw, ok := coerceTime(v)
+	if ok {
+		return format(t)
+	}
+	return raw
+}
+
 // assertAdminTxRow extracts a service.AdminTransactionRow from data,
 // accepting both value and pointer forms.
 func assertAdminTxRow(data any) (service.AdminTransactionRow, error) {
@@ -284,31 +349,13 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 					return fmt.Sprintf("%v", v)
 				}
 			},
-			"relativeTime": func(t interface{}) string {
-				switch v := t.(type) {
-				case time.Time:
-					return relativeTime(v)
-				case pgtype.Timestamptz:
-					if v.Valid {
-						return relativeTime(v.Time)
-					}
+			"relativeTime": func(t any) string {
+				// Invalid pgtype.Timestamptz renders as "Never" — special-cased
+				// because every other unparseable input echoes the raw value.
+				if pt, ok := t.(pgtype.Timestamptz); ok && !pt.Valid {
 					return "Never"
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return relativeTime(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return relativeTime(parsed)
-					}
-					return *v
-				default:
-					return ""
 				}
+				return formatCoercedTime(t, relativeTime)
 			},
 			"formatIntervalMinutes": components.FormatIntervalMinutes,
 			"accountLabel": func(name string, mask interface{}) string {
@@ -659,99 +706,24 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return acctType
 			},
-			"formatDateTime": func(t interface{}) string {
-				format := func(tm time.Time) string {
+			"formatDateTime": func(t any) string {
+				return formatCoercedTime(t, func(tm time.Time) string {
 					return tm.Local().Format("Jan 2, 2006 3:04 PM")
-				}
-				switch v := t.(type) {
-				case time.Time:
-					return format(v)
-				case *time.Time:
-					if v == nil {
-						return ""
-					}
-					return format(*v)
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return format(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return format(parsed)
-					}
-					return *v
-				default:
-					return ""
-				}
+				})
 			},
 			// clockTime renders the local clock portion of a timestamp
 			// ("2:03 AM"). Paired with a same-day day separator on the
 			// activity timeline it disambiguates 10 events that would all
 			// otherwise read "8 days ago" (#707).
-			"clockTime": func(t interface{}) string {
-				format := func(tm time.Time) string {
+			"clockTime": func(t any) string {
+				return formatCoercedTime(t, func(tm time.Time) string {
 					return tm.Local().Format("3:04 PM")
-				}
-				switch v := t.(type) {
-				case time.Time:
-					return format(v)
-				case *time.Time:
-					if v == nil {
-						return ""
-					}
-					return format(*v)
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return format(parsed)
-					}
-					if parsed, err := time.Parse(time.RFC3339Nano, v); err == nil {
-						return format(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return format(parsed)
-					}
-					return *v
-				default:
-					return ""
-				}
+				})
 			},
-			"formatDateShort": func(t interface{}) string {
-				format := func(tm time.Time) string {
+			"formatDateShort": func(t any) string {
+				return formatCoercedTime(t, func(tm time.Time) string {
 					return tm.Local().Format("Jan 2, 3:04 PM")
-				}
-				switch v := t.(type) {
-				case time.Time:
-					return format(v)
-				case *time.Time:
-					if v == nil {
-						return ""
-					}
-					return format(*v)
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return format(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return format(parsed)
-					}
-					return *v
-				default:
-					return ""
-				}
+				})
 			},
 			"formatDate":   components.FormatDate,
 			"relativeDate": components.RelativeDate,


### PR DESCRIPTION
## Summary

The four funcMap formatters (`relativeTime`, `formatDateTime`, `clockTime`, `formatDateShort`) and the four sidecar helpers in `sessions.go` / `logs.go` each carried a near-identical type switch that coerced `time.Time | *time.Time | string | *string | pgtype.Timestamptz` into a `time.Time` before formatting. Centralise that on a single `coerceTime` (plus a one-line `formatCoercedTime` wrapper) so each formatter becomes a thin format-function wrapper.

- Net **-52 LOC** in production code (templates.go / sessions.go / logs.go), with new unit tests for the helper.
- `relativeTime` keeps its `"Never"` special case for invalid `pgtype.Timestamptz`; every other branch delegates cleanly.
- Side-benefit: `relativeTime`, `formatDateTime`, and `formatDateShort` now also fall through to `time.RFC3339Nano` on parse, matching `clockTime`. Strictly more permissive — never less. (Strings that already parsed as RFC3339 still parse there first.)

Pure refactor of duplication that's been growing across recent template work (#835, #838, #871). No template-visible behaviour change.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass, including new `TestCoerceTime` (14 cases) and `TestFormatCoercedTime` (4 cases) covering every coercion branch (time.Time, *time.Time, RFC3339, RFC3339Nano, empty/nil/junk, valid/invalid Timestamptz, unsupported types)
- [ ] CI green