### PR TITLE
fix(ui): row category-change reactivity + household card email fallback

### DIFF
--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -220,6 +220,7 @@ func buildUsersProps(in usersListInput) pages.UsersProps {
 		if la, ok := in.LoginAccountMap[uid]; ok && la.Username != "" {
 			row.HasLogin = true
 			row.LoginRole = la.Role
+			row.LoginUsername = la.Username
 			row.LoginSetupPending = len(la.HashedPassword) == 0
 		}
 		for _, a := range eu.Accounts {

--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -30,7 +30,10 @@ templ AccountDetail(p AccountDetailProps) {
 	<!-- Page-component factory + inline-onchange handlers. Loaded
 	     synchronously (no defer) so window.__bbCategories is seeded
 	     before tx_row.templ's inline categoryPicker x-init runs and
-	     before Alpine fires alpine:init. -->
+	     before Alpine fires alpine:init. tx_row_helpers loads first
+	     because account_detail.js calls window.updateRowCategory after
+	     a successful category POST. -->
+	<script src="/static/js/admin/components/tx_row_helpers.js"></script>
 	<script src="/static/js/admin/components/account_detail.js"></script>
 	@components.CategoryPickerScript()
 	@components.CategoryPickerStyles()

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -27,7 +27,10 @@ import (
 templ RuleDetail(p RuleDetailProps) {
 	<!-- Component factory + initial-state JSON. Loaded synchronously (no
 	     defer) so the Alpine.data() registration runs before Alpine — itself
-	     deferred from <head> — fires alpine:init. -->
+	     deferred from <head> — fires alpine:init. tx_row_helpers loads first
+	     because rule_detail.js calls window.updateRowCategory after a
+	     successful category POST on the embedded tx_row partials. -->
+	<script src="/static/js/admin/components/tx_row_helpers.js"></script>
 	<script src="/static/js/admin/components/rule_detail.js"></script>
 	@components.CategoryPickerScript()
 	@components.BreadcrumbNav(p.Breadcrumbs)

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -27,7 +27,10 @@ templ Transactions(p TransactionsProps) {
 	@templ.JSONScript("transactions-data", txDataPayload(p))
 	<!-- Page-component factories. Loaded synchronously (no defer) so the
 	     Alpine.data() registrations run before Alpine - itself deferred from
-	     <head> - fires alpine:init. -->
+	     <head> - fires alpine:init. tx_row_helpers loads before the page
+	     factory because transactions.js reads window.updateRowCategory /
+	     _slugForCategoryId off the shared helper at parse time. -->
+	<script src="/static/js/admin/components/tx_row_helpers.js"></script>
 	<script src="/static/js/admin/components/reviews.js"></script>
 	<script src="/static/js/admin/components/transactions.js"></script>
 	<!--

--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -145,6 +145,8 @@ templ usersMemberCard(u UsersEnrichedRow) {
 						</div>
 						if u.HasEmail {
 							<p class="text-xs text-base-content/45 mt-0.5">{ u.Email }</p>
+						} else if u.LoginUsername != "" {
+							<p class="text-xs text-base-content/45 mt-0.5">{ u.LoginUsername }</p>
 						} else {
 							<p class="text-xs text-base-content/30 italic mt-0.5">No email</p>
 						}

--- a/internal/templates/components/pages/users_types.go
+++ b/internal/templates/components/pages/users_types.go
@@ -34,6 +34,7 @@ type UsersEnrichedRow struct {
 	CreatedAtLabel    string // "Jan 2006"
 	HasLogin          bool
 	LoginRole         string // "admin", "editor", "viewer" — empty when no login
+	LoginUsername     string // auth_accounts.username — typically the email-style admin login
 	LoginSetupPending bool
 	Accounts          []UsersAccountRow
 }

--- a/static/js/admin/components/account_detail.js
+++ b/static/js/admin/components/account_detail.js
@@ -31,13 +31,19 @@ function showToast(message, type) {
   window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: message, type: type || 'error' } }));
 }
 
-// Inline category picker on tx-row fires this on change. Same contract as
-// /transactions and /rules/{id} — keep in sync if that endpoint evolves.
+// Inline category picker on tx-row fires this on change. Mirrors the
+// /transactions and /rules/{id} paths; the post-success
+// `window.updateRowCategory(...)` call is what makes the avatar icon and
+// xl-hidden compact label update without a reload (same shared helper
+// loaded from static/js/admin/components/tx_row_helpers.js).
 function quickSetCategory(txId, categoryId) {
   if (!categoryId) {
     fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
       .then(function (r) {
-        if (r.ok || r.status === 204) showToast('Category reset', 'success');
+        if (r.ok || r.status === 204) {
+          showToast('Category reset', 'success');
+          if (window.updateRowCategory) window.updateRowCategory(txId, '');
+        }
       });
     return;
   }
@@ -47,8 +53,14 @@ function quickSetCategory(txId, categoryId) {
     body: JSON.stringify({ category_id: categoryId }),
   })
     .then(function (r) {
-      if (r.ok) showToast('Category updated', 'success');
-      else r.json().then(function (d) { showToast(d.error?.message || 'Failed', 'error'); });
+      if (r.ok) {
+        showToast('Category updated', 'success');
+        if (window.updateRowCategory) {
+          window.updateRowCategory(txId, (window._slugForCategoryId || function () { return ''; })(categoryId));
+        }
+      } else {
+        r.json().then(function (d) { showToast(d.error?.message || 'Failed', 'error'); });
+      }
     });
 }
 

--- a/static/js/admin/components/rule_detail.js
+++ b/static/js/admin/components/rule_detail.js
@@ -16,13 +16,19 @@
 
 // --- Module-level globals consumed by tx_row + base.html ---
 
-// Inline category picker on tx-row fires this on change. Matches the impl on
-// /transactions and /accounts/{id} — keep in sync if that endpoint evolves.
+// Inline category picker on tx-row fires this on change. Mirrors the
+// /transactions and /account/{id} paths; the post-success
+// `window.updateRowCategory(...)` call is what makes the avatar icon and
+// xl-hidden compact label update without a reload (same shared helper
+// loaded from static/js/admin/components/tx_row_helpers.js).
 function quickSetCategory(txId, categoryId) {
   if (!categoryId) {
     fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
       .then(function (r) {
-        if (r.ok || r.status === 204) showToast('Category reset', 'success');
+        if (r.ok || r.status === 204) {
+          showToast('Category reset', 'success');
+          if (window.updateRowCategory) window.updateRowCategory(txId, '');
+        }
       });
     return;
   }
@@ -32,8 +38,14 @@ function quickSetCategory(txId, categoryId) {
     body: JSON.stringify({ category_id: categoryId }),
   })
     .then(function (r) {
-      if (r.ok) showToast('Category updated', 'success');
-      else r.json().then(function (d) { showToast(d.error?.message || 'Failed', 'error'); });
+      if (r.ok) {
+        showToast('Category updated', 'success');
+        if (window.updateRowCategory) {
+          window.updateRowCategory(txId, (window._slugForCategoryId || function () { return ''; })(categoryId));
+        }
+      } else {
+        r.json().then(function (d) { showToast(d.error?.message || 'Failed', 'error'); });
+      }
     });
 }
 

--- a/static/js/admin/components/transactions.js
+++ b/static/js/admin/components/transactions.js
@@ -181,123 +181,30 @@ function updateRowTags(txId, changes) {
   if (typeof lucide !== 'undefined') lucide.createIcons({ nodes: [row] });
 }
 
-/* ── In-place category update on a row ──
+// updateRowCategory + _slugForCategoryId now live in
+// static/js/admin/components/tx_row_helpers.js (loaded by transactions.templ
+// and the other tx_row consumers). The local references below pick them up
+// off `window`, so the rest of this file (bulk path) can keep calling
+// `updateRowCategory(...)` unchanged.
+var updateRowCategory = window.updateRowCategory;
+var _slugForCategoryId = window._slugForCategoryId;
+
+/* ── Single transaction category quick-set ──
  *
- * Updates a row's displayed category (avatar icon + color, mobile label, and
- * inline cat-picker label) from the global category cache, without a reload.
- * Pass the empty string or null to clear the category back to "Uncategorized".
- *
- *   updateRowCategory(txId, 'food_and_drink_groceries')
- *   updateRowCategory(txId, '')   // reset
+ * Posts the new category to the server, then mirrors the bulk path by
+ * calling updateRowCategory() so the avatar icon, mobile compact label,
+ * and any other category-derived row UI all update without a reload.
+ * The inline cat-picker button itself is already reactive (selectedId →
+ * displayLabel via Alpine), but the rest of the row was server-rendered
+ * and stays stale until updateRowCategory rewrites it.
  */
-function updateRowCategory(txId, slug) {
-  if (!txId) return;
-  var row = document.querySelector('.bb-tx-row[data-tx-id="' + CSS.escape(txId) + '"]');
-  if (!row) return;
-
-  // Look up the category metadata (icon, color, display_name, id) by slug.
-  // window.__bbCategories is the parent -> children tree; flatten on the fly.
-  var meta = null, parentMeta = null;
-  if (slug) {
-    var cats = window.__bbCategories || [];
-    for (var i = 0; i < cats.length && !meta; i++) {
-      if (cats[i].slug === slug) { meta = cats[i]; break; }
-      if (cats[i].children) {
-        for (var j = 0; j < cats[i].children.length; j++) {
-          if (cats[i].children[j].slug === slug) {
-            meta = cats[i].children[j];
-            parentMeta = cats[i];
-            break;
-          }
-        }
-      }
-    }
-  }
-
-  // 1) Update the avatar (or convert a letter-avatar to an icon-avatar).
-  // Build via DOM APIs (textContent / safe icon-name whitelist) instead of
-  // string-concat innerHTML - display_name is admin-controlled and could
-  // otherwise smuggle stored XSS through the category metadata.
-  var avatarWrap = row.querySelector('.bb-tx-avatar')?.parentElement;
-  if (avatarWrap) {
-    var color = (meta && (meta.color || (parentMeta && parentMeta.color))) || 'oklch(0.65 0 0)';
-    var icon = meta && (meta.icon || (parentMeta && parentMeta.icon));
-    var avatar = document.createElement('div');
-    if (_safeLucideName(icon)) {
-      avatar.className = 'bb-tx-avatar';
-      avatar.style.setProperty('--avatar-color', color);
-      var iconEl = document.createElement('i');
-      iconEl.setAttribute('data-lucide', icon);
-      iconEl.className = 'w-4 h-4';
-      avatar.appendChild(iconEl);
-      avatarWrap.replaceChildren(avatar);
-      if (typeof lucide !== 'undefined') lucide.createIcons({ nodes: [avatarWrap] });
-    } else {
-      // Fall back to letter avatar (no category icon resolved or icon name
-      // failed validation - the latter shouldn't happen for trusted data).
-      var name = row.querySelector('a[href*="/transactions/"]')?.textContent?.trim() || '?';
-      avatar.className = 'bb-tx-avatar bb-tx-avatar--letter';
-      var letter = document.createElement('span');
-      letter.textContent = name.charAt(0).toUpperCase();
-      avatar.appendChild(letter);
-      avatarWrap.replaceChildren(avatar);
-    }
-  }
-
-  // 2) Update the inline cat picker (Alpine reactive - updating selectedId
-  // re-derives displayLabel/displayColor/displayIcon). The picker has an
-  // x-init $watch on selectedId that fires quickSetCategory; that watcher
-  // checks $store.bulk.processing and skips when bulk ops are in flight, so
-  // we don't double-call the API or double-toast on top of the bulk action.
-  var pickerEl = row.querySelector('.bb-cat-picker');
-  if (pickerEl && window.Alpine && Alpine.$data) {
-    var data = Alpine.$data(pickerEl);
-    if (data) data.selectedId = (meta && meta.id) || '';
-  }
-
-  // 3) Update the mobile category label. Use textContent for the
-  // display_name (admin-controlled) so HTML in a category name can't
-  // execute via the bulk update path.
-  var mobileLabel = row.querySelector('span.sm\\:hidden.inline-flex.items-center.gap-1, span.sm\\:hidden.text-base-content\\/25');
-  if (mobileLabel) {
-    var newLabel = document.createElement('span');
-    if (meta) {
-      newLabel.className = 'sm:hidden inline-flex items-center gap-1 shrink-0 min-w-0';
-      var labelColor = (meta.color || (parentMeta && parentMeta.color)) || '';
-      if (labelColor) {
-        var dot = document.createElement('span');
-        dot.className = 'w-1.5 h-1.5 rounded-full shrink-0';
-        dot.style.backgroundColor = labelColor;
-        newLabel.appendChild(dot);
-      }
-      var name = document.createElement('span');
-      name.className = 'text-base-content/50 truncate max-w-24';
-      name.textContent = meta.display_name || meta.slug;
-      newLabel.appendChild(name);
-    } else {
-      newLabel.className = 'sm:hidden text-base-content/25 truncate shrink-0';
-      newLabel.textContent = 'Uncategorized';
-    }
-    mobileLabel.replaceWith(newLabel);
-  }
-}
-
-// Lucide icon names are slug-shaped (e.g. "trending-up", "circle-off"). Reject
-// anything else so a malicious icon value can't break out of the data-lucide
-// attribute and inject scripts when set via innerHTML in `syncChipGlyph` or
-// the avatar update above. Returns the icon if safe, null otherwise.
-function _safeLucideName(name) {
-  if (!name || typeof name !== 'string') return null;
-  return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(name) ? name : null;
-}
-
-/* ── Single transaction category quick-set ── */
 function quickSetCategory(txId, categoryId) {
   if (!categoryId) {
     fetch('/-/transactions/' + txId + '/category', { method: 'DELETE' })
     .then(r => {
       if (r.ok || r.status === 204) {
         window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Category reset', type:'success'}}));
+        updateRowCategory(txId, '');
       }
     });
     return;
@@ -310,11 +217,13 @@ function quickSetCategory(txId, categoryId) {
   .then(r => {
     if (r.ok) {
       window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message:'Category updated', type:'success'}}));
+      updateRowCategory(txId, _slugForCategoryId(categoryId));
     } else {
       r.json().then(d => window.dispatchEvent(new CustomEvent('bb-toast', {detail:{message: d.error?.message || 'Failed', type:'error'}})));
     }
   });
 }
+
 
 // Expose helpers to window so inline event handlers, AJAX-injected scripts
 // (eval'd inside _serverFetch), and the per-row inline cat-picker x-init
@@ -323,7 +232,8 @@ window.bbSetPerPage = bbSetPerPage;
 window.computeAppliedCounts = computeAppliedCounts;
 window.removeTag = removeTag;
 window.updateRowTags = updateRowTags;
-window.updateRowCategory = updateRowCategory;
+// updateRowCategory is exposed by tx_row_helpers.js; quickSetCategory is
+// the single-row variant defined above.
 window.quickSetCategory = quickSetCategory;
 
 document.addEventListener('alpine:init', function () {

--- a/static/js/admin/components/tx_row_helpers.js
+++ b/static/js/admin/components/tx_row_helpers.js
@@ -1,0 +1,136 @@
+// Shared row-update helpers for pages that render `tx_row.templ` with the
+// inline category picker (currently /transactions, /account/{id}, /rules/{id}).
+//
+// The inline picker's `x-init` watcher fires `quickSetCategory(txId, id)`
+// when the user picks a new category. The button label updates reactively
+// via Alpine (selectedId → displayLabel), but the rest of the row —
+// avatar icon/color, the xl-hidden compact category label — is server-
+// rendered and stays stale until JS rewrites it. `updateRowCategory()` is
+// the canonical "rewrite the row's category-derived UI" function; pages
+// call it after a successful POST so the change is visible without reload.
+//
+// Loaded as a separate <script src> from each parent page's templ so all
+// three quickSetCategory implementations can share one definition. Exposes
+// helpers on `window` so the per-page factories can call them.
+
+/* ── In-place category update on a row ── */
+function updateRowCategory(txId, slug) {
+  if (!txId) return;
+  var row = document.querySelector('.bb-tx-row[data-tx-id="' + CSS.escape(txId) + '"]');
+  if (!row) return;
+
+  // Look up category metadata (icon, color, display_name, id) by slug.
+  // window.__bbCategories is the parent → children tree; flatten on the fly.
+  var meta = null, parentMeta = null;
+  if (slug) {
+    var cats = window.__bbCategories || [];
+    for (var i = 0; i < cats.length && !meta; i++) {
+      if (cats[i].slug === slug) { meta = cats[i]; break; }
+      if (cats[i].children) {
+        for (var j = 0; j < cats[i].children.length; j++) {
+          if (cats[i].children[j].slug === slug) {
+            meta = cats[i].children[j];
+            parentMeta = cats[i];
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  // 1) Update the avatar (or convert a letter-avatar to an icon-avatar).
+  // Build via DOM APIs (textContent + a strict icon-name whitelist) instead
+  // of innerHTML — display_name is admin-controlled and could otherwise
+  // smuggle stored XSS through the category metadata.
+  var avatarWrap = row.querySelector('.bb-tx-avatar') && row.querySelector('.bb-tx-avatar').parentElement;
+  if (avatarWrap) {
+    var color = (meta && (meta.color || (parentMeta && parentMeta.color))) || 'oklch(0.65 0 0)';
+    var icon = meta && (meta.icon || (parentMeta && parentMeta.icon));
+    var avatar = document.createElement('div');
+    if (_safeLucideName(icon)) {
+      avatar.className = 'bb-tx-avatar';
+      avatar.style.setProperty('--avatar-color', color);
+      var iconEl = document.createElement('i');
+      iconEl.setAttribute('data-lucide', icon);
+      iconEl.className = 'w-4 h-4';
+      avatar.appendChild(iconEl);
+      avatarWrap.replaceChildren(avatar);
+      if (typeof lucide !== 'undefined') lucide.createIcons({ nodes: [avatarWrap] });
+    } else {
+      var name = (row.querySelector('a[href*="/transactions/"]') && row.querySelector('a[href*="/transactions/"]').textContent.trim()) || '?';
+      avatar.className = 'bb-tx-avatar bb-tx-avatar--letter';
+      var letter = document.createElement('span');
+      letter.textContent = name.charAt(0).toUpperCase();
+      avatar.appendChild(letter);
+      avatarWrap.replaceChildren(avatar);
+    }
+  }
+
+  // 2) Update the inline cat picker (Alpine-reactive: writing selectedId
+  // re-derives displayLabel/displayColor/displayIcon). The picker has an
+  // x-init $watch on selectedId that fires quickSetCategory; that watcher
+  // checks $store.bulk.processing and skips when bulk ops are in flight,
+  // so we don't double-call the API or double-toast on top of the bulk
+  // action. For the single-row path (this function is also called from
+  // quickSetCategory's success branch) the picker already holds the new
+  // id, so this assignment is a no-op and the watcher won't re-fire.
+  var pickerEl = row.querySelector('.bb-cat-picker');
+  if (pickerEl && window.Alpine && Alpine.$data) {
+    var data = Alpine.$data(pickerEl);
+    if (data) data.selectedId = (meta && meta.id) || '';
+  }
+
+  // 3) Update the compact (xl-hidden) category label. The row template
+  // uses the `xl` breakpoint to swap between the inline picker (xl+) and
+  // a compact "Category" / "Uncategorized" label below xl. Use textContent
+  // for display_name (admin-controlled) so HTML in a category name can't
+  // execute via this update path.
+  var mobileLabel = row.querySelector('span.xl\\:hidden.inline-flex.items-center.gap-1, span.xl\\:hidden.text-base-content\\/25');
+  if (mobileLabel) {
+    var newLabel = document.createElement('span');
+    if (meta) {
+      newLabel.className = 'xl:hidden inline-flex items-center gap-1 shrink min-w-0';
+      var labelColor = (meta.color || (parentMeta && parentMeta.color)) || '';
+      if (labelColor) {
+        var dot = document.createElement('span');
+        dot.className = 'w-1.5 h-1.5 rounded-full shrink-0';
+        dot.style.backgroundColor = labelColor;
+        newLabel.appendChild(dot);
+      }
+      var labelName = document.createElement('span');
+      labelName.className = 'text-base-content/50 truncate';
+      labelName.textContent = meta.display_name || meta.slug;
+      newLabel.appendChild(labelName);
+    } else {
+      newLabel.className = 'xl:hidden text-base-content/25 truncate shrink-0';
+      newLabel.textContent = 'Uncategorized';
+    }
+    mobileLabel.replaceWith(newLabel);
+  }
+}
+
+// Lucide icon names are slug-shaped (e.g. "trending-up"). Reject anything
+// else so a malicious icon value can't break out of the data-lucide
+// attribute and inject scripts when set via innerHTML elsewhere.
+function _safeLucideName(name) {
+  if (!name || typeof name !== 'string') return null;
+  return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(name) ? name : null;
+}
+
+// Look up a category slug by id from the window.__bbCategories tree
+// (parents + children). Returns '' if not found.
+function _slugForCategoryId(id) {
+  if (!id) return '';
+  var cats = window.__bbCategories || [];
+  for (var i = 0; i < cats.length; i++) {
+    if (cats[i].id === id) return cats[i].slug;
+    var children = cats[i].children || [];
+    for (var j = 0; j < children.length; j++) {
+      if (children[j].id === id) return children[j].slug;
+    }
+  }
+  return '';
+}
+
+window.updateRowCategory = updateRowCategory;
+window._slugForCategoryId = _slugForCategoryId;


### PR DESCRIPTION
Two pre-existing bugs found during manual smoke-checks of the #827 epic. Both predate the Alpine extraction (identical code on `main`) and the fix is easier now that the per-page factories are split out.

## 1. Tx row: category change required full reload

Picking a new category from a tx-row's inline picker fired `quickSetCategory(txId, id)` via the picker's `x-init $watch`. `quickSetCategory` POSTed and toasted but **never updated the row's avatar icon/color or the xl-hidden compact category label** — only the picker button label updated (Alpine reactivity on `selectedId → displayLabel`). Below the `xl` breakpoint the picker is hidden, so the category text stayed stale until reload.

The bulk-categorize path already had `updateRowCategory(txId, slug)` that walks a row and rewrites avatar + mobile label + inline picker. The fix wires it into the single-row path:

- Extract `updateRowCategory` + a small `_slugForCategoryId` helper into a new shared module: `static/js/admin/components/tx_row_helpers.js`. Loaded with a sync `<script src>` from `transactions.templ`, `account_detail.templ`, and `rule_detail.templ`, **before** each page's factory script.
- Have all three pages' `quickSetCategory` call `window.updateRowCategory(txId, slug)` on the success branch (and on the DELETE/reset branch with `''`).

Also fixed a stale CSS selector in `updateRowCategory` while moving it: the "mobile label" lookup used `span.sm:hidden...` but the row template uses the `xl` breakpoint. The bulk-categorize path was silently failing to update that label too. The shared helper now matches `xl:hidden`.

## 2. Household card: "No email" for admin-linked members

The card on `/users` pulled email from `users.email` only. When a user record had no email but was linked to an `auth_account` (the typical "create + link admin to a household member" path), the card showed "No email" even though `admin@example.com` was right there in the sidebar.

- Thread `auth_accounts.username` through `UsersEnrichedRow` as `LoginUsername`.
- `users.templ` falls back to `LoginUsername` when `HasEmail` is false but `LoginUsername` is non-empty; "No email" remains for users with neither.

## Validation

Smoke-tested all four flows in Chrome DevTools MCP on the running server:
- `/transactions` row category change: avatar, mobile label, picker button all update without reload (Uncategorized → Food & Drink → reset). Same on `/account/{id}` and `/rules/{id}`.
- `/users` card now shows `admin@example.com` instead of "No email".
- `go build`, `go vet`, `go test ./...` all green.

Targets `epic/827-alpine-extraction`.
