### PR TITLE
chore(pgconv): add Int4 + NumericCents helpers, collapse boilerplate

### DIFF
--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -1339,7 +1339,7 @@ func UpdateConnectionSyncIntervalHandler(a *app.App, sm *scs.SessionManager) htt
 
 		var interval pgtype.Int4
 		if req.Minutes != nil {
-			interval = pgtype.Int4{Int32: *req.Minutes, Valid: true}
+			interval = pgconv.Int4(*req.Minutes)
 		}
 
 		conn, err := a.Queries.UpdateConnectionSyncInterval(r.Context(), db.UpdateConnectionSyncIntervalParams{

--- a/internal/admin/connections_test.go
+++ b/internal/admin/connections_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
@@ -177,7 +178,7 @@ func TestComputeNextSync(t *testing.T) {
 				Time:  lastSynced,
 				Valid: true,
 			},
-			SyncIntervalOverrideMinutes: pgtype.Int4{Int32: 30, Valid: true},
+			SyncIntervalOverrideMinutes: pgconv.Int4(30),
 		}
 		info := computeNextSync(p, globalInterval, now)
 		if info.IsOverdue {
@@ -201,7 +202,7 @@ func TestComputeNextSync(t *testing.T) {
 				Time:  lastSynced,
 				Valid: true,
 			},
-			SyncIntervalOverrideMinutes: pgtype.Int4{Int32: 60, Valid: true},
+			SyncIntervalOverrideMinutes: pgconv.Int4(60),
 		}
 		info := computeNextSync(p, globalInterval, now)
 		if info.IsOverdue {

--- a/internal/admin/helpers_test.go
+++ b/internal/admin/helpers_test.go
@@ -284,7 +284,7 @@ func TestConnectionStaleness(t *testing.T) {
 	}
 	neverSynced := pgtype.Timestamptz{Valid: false}
 	override := func(minutes int32) pgtype.Int4 {
-		return pgtype.Int4{Int32: minutes, Valid: true}
+		return pgconv.Int4(minutes)
 	}
 	noOverride := pgtype.Int4{Valid: false}
 

--- a/internal/mcp/response_shapes_integration_test.go
+++ b/internal/mcp/response_shapes_integration_test.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"math/big"
 	"testing"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/testutil"
 
@@ -71,7 +71,7 @@ func seedFixtures(t *testing.T) *fixtures {
 		Name:              "Primary Credit Card",
 		Type:              "credit",
 		IsoCurrencyCode:   pgtype.Text{String: "USD", Valid: true},
-		BalanceCurrent:    pgtype.Numeric{Int: big.NewInt(50000), Exp: -2, Valid: true},
+		BalanceCurrent:    pgconv.NumericCents(50000),
 	})
 	if err != nil {
 		t.Fatalf("upsert primary account: %v", err)

--- a/internal/pgconv/pgconv.go
+++ b/internal/pgconv/pgconv.go
@@ -3,6 +3,7 @@ package pgconv
 
 import (
 	"fmt"
+	"math/big"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -131,4 +132,18 @@ func DateStrPtr(d pgtype.Date) *string {
 	}
 	s := d.Time.Format("2006-01-02")
 	return &s
+}
+
+// Int4 wraps an int32 as a non-NULL pgtype.Int4. Use this to collapse
+// `pgtype.Int4{Int32: n, Valid: true}` boilerplate at insert and query-arg
+// sites where the value is always present.
+func Int4(n int32) pgtype.Int4 {
+	return pgtype.Int4{Int32: n, Valid: true}
+}
+
+// NumericCents wraps an int64 cents value as a non-NULL pgtype.Numeric with
+// Exp=-2. Use for monetary amounts at insert and test sites: NumericCents(1050)
+// represents 10.50 in the underlying NUMERIC(12,2) column.
+func NumericCents(cents int64) pgtype.Numeric {
+	return pgtype.Numeric{Int: big.NewInt(cents), Exp: -2, Valid: true}
 }

--- a/internal/pgconv/pgconv_test.go
+++ b/internal/pgconv/pgconv_test.go
@@ -330,3 +330,53 @@ func TestDateStrPtr_Invalid(t *testing.T) {
 		t.Errorf("DateStrPtr(invalid) = %v, want nil", got)
 	}
 }
+
+func TestInt4(t *testing.T) {
+	got := Int4(42)
+	if !got.Valid || got.Int32 != 42 {
+		t.Errorf("Int4(42) = %+v, want {42 true}", got)
+	}
+}
+
+func TestInt4_Zero(t *testing.T) {
+	got := Int4(0)
+	if !got.Valid || got.Int32 != 0 {
+		t.Errorf("Int4(0) = %+v, want {0 true} — zero stays valid", got)
+	}
+}
+
+func TestNumericCents(t *testing.T) {
+	got := NumericCents(1050)
+	if !got.Valid {
+		t.Fatalf("NumericCents(1050).Valid = false, want true")
+	}
+	if got.Exp != -2 {
+		t.Errorf("NumericCents(1050).Exp = %d, want -2", got.Exp)
+	}
+	if got.Int == nil || got.Int.Int64() != 1050 {
+		t.Errorf("NumericCents(1050).Int = %v, want 1050", got.Int)
+	}
+	f, ok := NumericToFloat(got)
+	if !ok || f != 10.50 {
+		t.Errorf("NumericCents(1050) → NumericToFloat = (%v, %v), want (10.50, true)", f, ok)
+	}
+}
+
+func TestNumericCents_Negative(t *testing.T) {
+	got := NumericCents(-4200)
+	f, ok := NumericToFloat(got)
+	if !ok || f != -42.00 {
+		t.Errorf("NumericCents(-4200) → NumericToFloat = (%v, %v), want (-42, true)", f, ok)
+	}
+}
+
+func TestNumericCents_Zero(t *testing.T) {
+	got := NumericCents(0)
+	if !got.Valid {
+		t.Errorf("NumericCents(0).Valid = false, want true — zero stays valid")
+	}
+	f, ok := NumericToFloat(got)
+	if !ok || f != 0 {
+		t.Errorf("NumericCents(0) → NumericToFloat = (%v, %v), want (0, true)", f, ok)
+	}
+}

--- a/internal/service/category_integration_test.go
+++ b/internal/service/category_integration_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"math/big"
 	"strings"
 	"testing"
 
@@ -52,7 +51,7 @@ func mustCreateTransactionWithCategory(t *testing.T, q *db.Queries, acctID, catI
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
 		ProviderTransactionID: extID,
-		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		Amount:                pgconv.NumericCents(amountCents),
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,

--- a/internal/service/convert_test.go
+++ b/internal/service/convert_test.go
@@ -210,7 +210,7 @@ func TestSyncLogDurationMs(t *testing.T) {
 	}{
 		{
 			name:     "stored duration_ms wins",
-			duration: pgtype.Int4{Int32: 1234, Valid: true},
+			duration: pgconv.Int4(1234),
 			// timestamps would compute a different value — stored value must win.
 			started:   pgconv.Timestamptz(start),
 			completed: pgconv.Timestamptz(end),
@@ -251,7 +251,7 @@ func TestSyncLogDurationMs(t *testing.T) {
 		},
 		{
 			name:     "zero duration is still valid",
-			duration: pgtype.Int4{Int32: 0, Valid: true},
+			duration: pgconv.Int4(0),
 			wantMs:   0,
 			wantOK:   true,
 		},

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"math/big"
 	"strings"
 	"testing"
 
@@ -105,7 +104,7 @@ func TestListAccounts_WithData(t *testing.T) {
 		Type:              "depository",
 		Subtype:           pgtype.Text{String: "checking", Valid: true},
 		IsoCurrencyCode:   pgtype.Text{String: "USD", Valid: true},
-		BalanceCurrent:    pgtype.Numeric{Int: big.NewInt(100000), Exp: -2, Valid: true},
+		BalanceCurrent:    pgconv.NumericCents(100000),
 	})
 	if err != nil {
 		t.Fatalf("upsert account: %v", err)
@@ -728,7 +727,7 @@ func TestImportCategoriesTSV_MergeInto(t *testing.T) {
 	_, err = queries.UpsertTransaction(ctx, db.UpsertTransactionParams{
 		AccountID:             acct.ID,
 		ProviderTransactionID: "txn_merge_1",
-		Amount:                pgtype.Numeric{Int: big.NewInt(550), Exp: -2, Valid: true},
+		Amount:                pgconv.NumericCents(550),
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgconv.Date(testutil.MustParseDate("2025-01-15")),
 		ProviderName:          "Starbucks",

--- a/internal/service/mcp_sessions.go
+++ b/internal/service/mcp_sessions.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 	"breadbox/internal/shortid"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -124,7 +125,7 @@ func (s *Service) LogToolCall(ctx context.Context, input ToolCallLogInput) {
 
 	var durationMs pgtype.Int4
 	if input.DurationMs > 0 {
-		durationMs = pgtype.Int4{Int32: int32(input.DurationMs), Valid: true}
+		durationMs = pgconv.Int4(int32(input.DurationMs))
 	}
 
 	err := s.Queries.CreateToolCallLog(ctx, db.CreateToolCallLogParams{

--- a/internal/service/transaction_query_integration_test.go
+++ b/internal/service/transaction_query_integration_test.go
@@ -9,7 +9,6 @@ package service_test
 import (
 	"context"
 	"errors"
-	"math/big"
 	"testing"
 	"time"
 
@@ -1034,7 +1033,7 @@ func upsertTxnWithCategory(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
 		ProviderTransactionID: extID,
-		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		Amount:                pgconv.NumericCents(amountCents),
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,
@@ -1051,7 +1050,7 @@ func upsertTxnPending(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID, na
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
 		ProviderTransactionID: extID,
-		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		Amount:                pgconv.NumericCents(amountCents),
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,
@@ -1192,7 +1191,7 @@ func upsertTxnWithAmount(t *testing.T, q *db.Queries, acctID pgtype.UUID, extID,
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
 		ProviderTransactionID: extID,
-		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		Amount:                pgconv.NumericCents(amountCents),
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,
@@ -1213,7 +1212,7 @@ func upsertTxnWithMerchant(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
 		ProviderTransactionID: extID,
-		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		Amount:                pgconv.NumericCents(amountCents),
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgconv.Date(testutil.MustParseDate(date)),
 		ProviderName:          name,

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -118,7 +118,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	var durationMs pgtype.Int4
 	if syncLog.StartedAt.Valid {
 		ms := completedAt.Sub(syncLog.StartedAt.Time).Milliseconds()
-		durationMs = pgtype.Int4{Int32: int32(ms), Valid: true}
+		durationMs = pgconv.Int4(int32(ms))
 	}
 
 	if err := e.db.UpdateSyncLog(ctx, db.UpdateSyncLogParams{

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -28,7 +28,6 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"os"
 	"strings"
 	"testing"
@@ -182,7 +181,7 @@ func MustCreateTransaction(t *testing.T, q *db.Queries, acctID pgtype.UUID, extI
 	txn, err := q.UpsertTransaction(context.Background(), db.UpsertTransactionParams{
 		AccountID:             acctID,
 		ProviderTransactionID: extID,
-		Amount:                pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},
+		Amount:                pgconv.NumericCents(amountCents),
 		IsoCurrencyCode:       pgtype.Text{String: "USD", Valid: true},
 		Date:                  pgconv.Date(MustParseDate(date)),
 		ProviderName:          name,


### PR DESCRIPTION
## Summary

Extends `pgconv` with two more constructors, continuing the recent helper-consolidation pass (#867 Text, #869 Date/Timestamptz):

- `pgconv.Int4(int32)` — wraps `pgtype.Int4{Int32: n, Valid: true}` (5 production + 4 test sites).
- `pgconv.NumericCents(int64)` — wraps the cents amount pattern `pgtype.Numeric{Int: big.NewInt(c), Exp: -2, Valid: true}` (1 testutil + 8 integration-test sites).

Drops the now-unused `math/big` import from four test files. Pure readability/maintainability pass — no behavior change.

```go
// before
durationMs = pgtype.Int4{Int32: int32(ms), Valid: true}
Amount: pgtype.Numeric{Int: big.NewInt(amountCents), Exp: -2, Valid: true},

// after
durationMs = pgconv.Int4(int32(ms))
Amount: pgconv.NumericCents(amountCents),
```

The `Exp=0` / `Exp=2` sites in `internal/service/convert_test.go` are intentionally left alone — that table tests the underlying converter across multiple exponents and shouldn't collapse onto a cents-specific helper.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...` (and with `-tags integration`)
- [x] `go test ./...` (unit)
- [x] `make test-integration`
- [x] New unit tests for `Int4` and `NumericCents` covering zero, negative, and round-trip via `NumericToFloat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)