### PR TITLE
chore(timefmt): consolidate RFC3339 date renderers onto shared helpers

### DIFF
--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -3,11 +3,11 @@ package admin
 import (
 	"net/http"
 	"strings"
-	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -131,7 +131,7 @@ func buildAccessKeyRow(k service.APIKeyResponse) pages.AccessKeyRow {
 		Name:             k.Name,
 		KeyPrefix:        k.KeyPrefix,
 		Scope:            k.Scope,
-		CreatedAtShort:   formatDateShortFromRFC3339(k.CreatedAt),
+		CreatedAtShort:   timefmt.FormatRFC3339Local(k.CreatedAt, timefmt.LayoutDateShortLocal),
 		LastUsedRelative: relativeTimeFromRFC3339Ptr(k.LastUsedAt),
 	}
 }
@@ -144,23 +144,8 @@ func buildAccessClientRow(c service.OAuthClientResponse) pages.AccessClientRow {
 		Name:           c.Name,
 		ClientIDPrefix: c.ClientIDPrefix,
 		Scope:          c.Scope,
-		CreatedAtShort: formatDateShortFromRFC3339(c.CreatedAt),
+		CreatedAtShort: timefmt.FormatRFC3339Local(c.CreatedAt, timefmt.LayoutDateShortLocal),
 	}
-}
-
-// formatDateShortFromRFC3339 mirrors the `formatDateShort` funcMap helper
-// for a string-typed timestamp: parses RFC3339 and renders as
-// "Jan 2, 3:04 PM" in the local timezone. Returns the input verbatim on
-// parse failure (matching the helper's fall-through).
-func formatDateShortFromRFC3339(s string) string {
-	if s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return s
-	}
-	return t.Local().Format("Jan 2, 3:04 PM")
 }
 
 // APIKeyNewPageHandler serves GET /admin/api-keys/new.

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -9,6 +9,7 @@ import (
 	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 )
@@ -222,7 +223,7 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 					PayloadHash:       e.PayloadHash,
 					ErrorMessage:      e.ErrorMessage,
 					CreatedAtRelative: relativeTimeFromRFC3339Ptr(e.CreatedAt),
-					CreatedAtFull:     formatDateTimeFromRFC3339Ptr(e.CreatedAt),
+					CreatedAtFull:     timefmt.FormatRFC3339LocalPtr(e.CreatedAt, timefmt.LayoutDateTimeLocal),
 				})
 			}
 
@@ -286,16 +287,3 @@ func relativeTimeFromRFC3339Ptr(s *string) string {
 	return relativeTime(t)
 }
 
-// formatDateTimeFromRFC3339Ptr parses a *string RFC3339 timestamp into
-// the local "Jan 2, 2006 3:04 PM" rendering used by the `formatDateTime`
-// funcMap helper.
-func formatDateTimeFromRFC3339Ptr(s *string) string {
-	if s == nil || *s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, *s)
-	if err != nil {
-		return *s
-	}
-	return t.Local().Format("Jan 2, 2006 3:04 PM")
-}

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -8,6 +8,7 @@ import (
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -64,7 +65,7 @@ func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.Sess
 				Sequence:       c.Sequence,
 				OffsetLabel:    c.OffsetLabel,
 				CreatedAt:      c.CreatedAt,
-				CreatedAtAbs:   formatDateTimeFromRFC3339(c.CreatedAt),
+				CreatedAtAbs:   timefmt.FormatRFC3339Local(c.CreatedAt, timefmt.LayoutDateTimeLocal),
 				CreatedAtRel:   relativeTimeFromRFC3339(c.CreatedAt),
 			}
 			if c.DurationMs != nil {
@@ -95,19 +96,6 @@ func relativeTimeFromRFC3339(s string) string {
 		return s
 	}
 	return relativeTime(parsed)
-}
-
-// formatDateTimeFromRFC3339 mirrors the funcMap "formatDateTime"
-// branch for an RFC3339 string ("Jan 2, 2006 3:04 PM" in local time).
-func formatDateTimeFromRFC3339(s string) string {
-	if s == "" {
-		return ""
-	}
-	parsed, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return s
-	}
-	return parsed.Local().Format("Jan 2, 2006 3:04 PM")
 }
 
 // prettyJSONIndent mirrors the funcMap "prettyJSON" branch for raw

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -22,6 +22,7 @@ import (
 	"breadbox/internal/templates"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 	"breadbox/internal/version"
 
 	"github.com/a-h/templ"
@@ -167,6 +168,31 @@ func renderTemplComponent(name string, data any) template.HTML {
 		return template.HTML(fmt.Sprintf("<!-- renderComponent(%q) render error: %s -->", name, template.HTMLEscapeString(err.Error())))
 	}
 	return template.HTML(buf.String())
+}
+
+// formatTimeAny renders v as a local-time string using layout. Accepts
+// time.Time, *time.Time, RFC3339 string, or *string — the four shapes the
+// admin funcMap date helpers have to cope with — and returns "" for nil
+// pointers, the input verbatim for strings that fail to parse, and "" for
+// any other type. Shared by the formatDateTime / clockTime / formatDateShort
+// funcMap entries so the four-case switch lives in exactly one place.
+func formatTimeAny(v any, layout string) string {
+	format := func(tm time.Time) string { return tm.Local().Format(layout) }
+	switch val := v.(type) {
+	case time.Time:
+		return format(val)
+	case *time.Time:
+		if val == nil {
+			return ""
+		}
+		return format(*val)
+	case string:
+		return timefmt.FormatRFC3339Local(val, layout)
+	case *string:
+		return timefmt.FormatRFC3339LocalPtr(val, layout)
+	default:
+		return ""
+	}
 }
 
 // buildNavProps assembles a NavProps from the already-injected layout data
@@ -659,100 +685,16 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return acctType
 			},
-			"formatDateTime": func(t interface{}) string {
-				format := func(tm time.Time) string {
-					return tm.Local().Format("Jan 2, 2006 3:04 PM")
-				}
-				switch v := t.(type) {
-				case time.Time:
-					return format(v)
-				case *time.Time:
-					if v == nil {
-						return ""
-					}
-					return format(*v)
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return format(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return format(parsed)
-					}
-					return *v
-				default:
-					return ""
-				}
-			},
-			// clockTime renders the local clock portion of a timestamp
-			// ("2:03 AM"). Paired with a same-day day separator on the
-			// activity timeline it disambiguates 10 events that would all
-			// otherwise read "8 days ago" (#707).
-			"clockTime": func(t interface{}) string {
-				format := func(tm time.Time) string {
-					return tm.Local().Format("3:04 PM")
-				}
-				switch v := t.(type) {
-				case time.Time:
-					return format(v)
-				case *time.Time:
-					if v == nil {
-						return ""
-					}
-					return format(*v)
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return format(parsed)
-					}
-					if parsed, err := time.Parse(time.RFC3339Nano, v); err == nil {
-						return format(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return format(parsed)
-					}
-					return *v
-				default:
-					return ""
-				}
-			},
-			"formatDateShort": func(t interface{}) string {
-				format := func(tm time.Time) string {
-					return tm.Local().Format("Jan 2, 3:04 PM")
-				}
-				switch v := t.(type) {
-				case time.Time:
-					return format(v)
-				case *time.Time:
-					if v == nil {
-						return ""
-					}
-					return format(*v)
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return format(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return format(parsed)
-					}
-					return *v
-				default:
-					return ""
-				}
-			},
+			// formatDateTime renders a timestamp as "Jan 2, 2006 3:04 PM" in
+			// the local timezone. clockTime renders only the time portion —
+			// paired with a same-day day separator on the activity timeline
+			// it disambiguates events that would all otherwise read "8 days
+			// ago" (#707). formatDateShort drops the year for tight cells.
+			// All three accept time.Time, *time.Time, RFC3339 string, or
+			// *string and share a single switch via formatTimeAny.
+			"formatDateTime":  func(t any) string { return formatTimeAny(t, timefmt.LayoutDateTimeLocal) },
+			"clockTime":       func(t any) string { return formatTimeAny(t, timefmt.LayoutClockLocal) },
+			"formatDateShort": func(t any) string { return formatTimeAny(t, timefmt.LayoutDateShortLocal) },
 			"formatDate":   components.FormatDate,
 			"relativeDate": components.RelativeDate,
 			"formatNumeric": func(n pgtype.Numeric) string {

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
@@ -722,36 +721,18 @@ func accountTypeLabel(acctType, subtype string) string {
 	return acctType
 }
 
-// formatDateTimeStr parses an RFC3339 timestamp and renders it in the
-// admin standard "Jan 2, 2006 3:04 PM" local format. Unparseable input
-// is returned unchanged.
+// formatDateTimeStr renders an RFC3339 timestamp in the admin standard
+// "Jan 2, 2006 3:04 PM" local format. Thin alias over timefmt so the
+// templ caller can stay package-local.
 func formatDateTimeStr(s string) string {
-	if s == "" {
-		return ""
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.Local().Format("Jan 2, 2006 3:04 PM")
-	}
-	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.Local().Format("Jan 2, 2006 3:04 PM")
-	}
-	return s
+	return timefmt.FormatRFC3339Local(s, timefmt.LayoutDateTimeLocal)
 }
 
 // clockTimeStr renders the local clock portion of an RFC3339 timestamp
 // ("3:04 PM"). Used by activity-timeline rows where the day separator
 // already carries the date.
 func clockTimeStr(s string) string {
-	if s == "" {
-		return ""
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.Local().Format("3:04 PM")
-	}
-	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.Local().Format("3:04 PM")
-	}
-	return s
+	return timefmt.FormatRFC3339Local(s, timefmt.LayoutClockLocal)
 }
 
 // relativeTimeStr renders an RFC3339 timestamp as a short relative
@@ -759,15 +740,9 @@ func clockTimeStr(s string) string {
 // button aria-labels so screen readers get a stable description.
 // Falls back to the raw input string when the timestamp can't be parsed.
 func relativeTimeStr(s string) string {
-	if s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		t, err = time.Parse(time.RFC3339Nano, s)
-		if err != nil {
-			return s
-		}
+	t, ok := timefmt.ParseRFC3339(s)
+	if !ok {
+		return s
 	}
 	return timefmt.Relative(t)
 }

--- a/internal/timefmt/timefmt.go
+++ b/internal/timefmt/timefmt.go
@@ -8,6 +8,62 @@ import (
 	"time"
 )
 
+// Layout strings shared by admin and templ helpers. Use these instead of
+// inlining the format string at each call site so date rendering stays
+// aligned across pages.
+const (
+	// LayoutDateTimeLocal renders "Jan 2, 2006 3:04 PM" — the admin standard
+	// for full timestamps (audit logs, metadata blocks, tooltips).
+	LayoutDateTimeLocal = "Jan 2, 2006 3:04 PM"
+	// LayoutDateShortLocal renders "Jan 2, 3:04 PM" — used in tight cells
+	// (API key tables, log lists) where the year is implied.
+	LayoutDateShortLocal = "Jan 2, 3:04 PM"
+	// LayoutClockLocal renders "3:04 PM" — used on activity-timeline rows
+	// where a same-day separator already carries the date.
+	LayoutClockLocal = "3:04 PM"
+)
+
+// ParseRFC3339 parses s as RFC3339 and falls back to RFC3339Nano. Returns
+// (zero, false) when s is empty or unparseable. Use when you need the parsed
+// time.Time directly; prefer FormatRFC3339Local for the common format-and-
+// render path.
+func ParseRFC3339(s string) (time.Time, bool) {
+	if s == "" {
+		return time.Time{}, false
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, true
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, true
+	}
+	return time.Time{}, false
+}
+
+// FormatRFC3339Local parses s as RFC3339 (or RFC3339Nano) and renders the
+// result in the local timezone using layout. Returns "" when s is empty,
+// and the input verbatim when s fails to parse — matching the
+// fall-through behavior the admin funcMap helpers have always used.
+func FormatRFC3339Local(s, layout string) string {
+	if s == "" {
+		return ""
+	}
+	t, ok := ParseRFC3339(s)
+	if !ok {
+		return s
+	}
+	return t.Local().Format(layout)
+}
+
+// FormatRFC3339LocalPtr is the *string variant of FormatRFC3339Local.
+// Returns "" for nil or empty input.
+func FormatRFC3339LocalPtr(s *string, layout string) string {
+	if s == nil {
+		return ""
+	}
+	return FormatRFC3339Local(*s, layout)
+}
+
 // Relative renders t as a human-readable "X ago" string relative to now.
 // Output buckets: "just now" (<1m), "N minute(s) ago" (<1h),
 // "N hour(s) ago" (<1d), "N day(s) ago" (>=1d). Uses time.Since(t), so

--- a/internal/timefmt/timefmt_test.go
+++ b/internal/timefmt/timefmt_test.go
@@ -33,3 +33,79 @@ func TestRelative(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRFC3339(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		ok   bool
+	}{
+		{"empty", "", false},
+		{"rfc3339", "2026-01-15T14:30:00Z", true},
+		{"rfc3339 with offset", "2026-01-15T14:30:00-05:00", true},
+		{"rfc3339nano", "2026-01-15T14:30:00.123456789Z", true},
+		{"garbage", "not a date", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ok := ParseRFC3339(tc.in)
+			if ok != tc.ok {
+				t.Errorf("ParseRFC3339(%q) ok = %v, want %v", tc.in, ok, tc.ok)
+			}
+		})
+	}
+}
+
+func TestFormatRFC3339Local(t *testing.T) {
+	// Pin the local zone so the test is deterministic regardless of where it runs.
+	loc, err := time.LoadLocation("UTC")
+	if err != nil {
+		t.Fatalf("load UTC: %v", err)
+	}
+	prev := time.Local
+	time.Local = loc
+	defer func() { time.Local = prev }()
+
+	cases := []struct {
+		name   string
+		in     string
+		layout string
+		want   string
+	}{
+		{"empty returns empty", "", LayoutDateTimeLocal, ""},
+		{"rfc3339 datetime", "2026-01-15T14:30:00Z", LayoutDateTimeLocal, "Jan 15, 2026 2:30 PM"},
+		{"rfc3339 clock", "2026-01-15T14:30:00Z", LayoutClockLocal, "2:30 PM"},
+		{"rfc3339 short", "2026-01-15T14:30:00Z", LayoutDateShortLocal, "Jan 15, 2:30 PM"},
+		{"rfc3339nano", "2026-01-15T14:30:00.123Z", LayoutClockLocal, "2:30 PM"},
+		{"unparseable returns input", "not a date", LayoutDateTimeLocal, "not a date"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FormatRFC3339Local(tc.in, tc.layout); got != tc.want {
+				t.Errorf("FormatRFC3339Local(%q, %q) = %q, want %q", tc.in, tc.layout, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatRFC3339LocalPtr(t *testing.T) {
+	loc, err := time.LoadLocation("UTC")
+	if err != nil {
+		t.Fatalf("load UTC: %v", err)
+	}
+	prev := time.Local
+	time.Local = loc
+	defer func() { time.Local = prev }()
+
+	if got := FormatRFC3339LocalPtr(nil, LayoutDateTimeLocal); got != "" {
+		t.Errorf("FormatRFC3339LocalPtr(nil) = %q, want empty", got)
+	}
+	s := "2026-01-15T14:30:00Z"
+	if got := FormatRFC3339LocalPtr(&s, LayoutDateTimeLocal); got != "Jan 15, 2026 2:30 PM" {
+		t.Errorf("FormatRFC3339LocalPtr(&s) = %q, want Jan 15, 2026 2:30 PM", got)
+	}
+	empty := ""
+	if got := FormatRFC3339LocalPtr(&empty, LayoutDateTimeLocal); got != "" {
+		t.Errorf("FormatRFC3339LocalPtr(&\"\") = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

Three admin funcMap helpers (\`formatDateTime\`, \`clockTime\`, \`formatDateShort\`) and four per-page mirrors (\`sessions.go\`, \`apikeys.go\`, \`logs.go\`, \`transaction_detail.templ\`) all repeated the same RFC3339 parse-and-format dance with slightly different layouts. This PR moves the primitives into \`internal/timefmt\` and rewrites every caller as a one-liner.

- New shared helpers in \`timefmt\`:
  - Layout constants: \`LayoutDateTimeLocal\` (\`Jan 2, 2006 3:04 PM\`), \`LayoutDateShortLocal\` (\`Jan 2, 3:04 PM\`), \`LayoutClockLocal\` (\`3:04 PM\`).
  - \`ParseRFC3339(s)\` — tries RFC3339, falls back to RFC3339Nano.
  - \`FormatRFC3339Local(s, layout)\` and \`FormatRFC3339LocalPtr(s, layout)\` — collapse the empty-input + parse-failure fall-throughs every call site re-implemented.
- Admin funcMap: the three ~30-line switch blocks collapse to one-liners over a private \`formatTimeAny\` helper that only owns the four-case input switch.
- \`apikeys.go\`, \`logs.go\`, \`sessions.go\`: drop \`formatDateShortFromRFC3339\`, \`formatDateTimeFromRFC3339Ptr\`, \`formatDateTimeFromRFC3339\` — call \`timefmt\` directly instead.
- \`transaction_detail.templ\`: \`formatDateTimeStr\`, \`clockTimeStr\`, \`relativeTimeStr\` become thin templ-callable wrappers over the shared helpers.

Net: 183 insertions / 173 deletions, but the inserts are mostly tests and doc comments — actual logic shrinks substantially.

### Behavior note

\`formatDateTime\`, \`formatDateShort\`, and the \`*string\` branch of \`clockTime\` previously only tried \`time.RFC3339\`. They now also fall back to \`RFC3339Nano\`, matching what the \`string\` branch of \`clockTime\` already did. Strict superset — no existing input changes its output.

## Test plan

- [x] \`go test ./internal/timefmt/...\` — new tests cover \`ParseRFC3339\`, \`FormatRFC3339Local\` for every layout, and the \`*string\` variant (with \`time.Local\` pinned to UTC for determinism).
- [x] \`go build ./... && go vet ./... && go test ./...\` all green.
- [x] Loaded \`/access\`, \`/agents\`, and \`/logs\` against a running server — all 200 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)