### PR TITLE
chore(timefmt): consolidate RFC3339 formatters + collapse 3 funcMap entries

### DIFF
--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -3,11 +3,11 @@ package admin
 import (
 	"net/http"
 	"strings"
-	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -131,8 +131,8 @@ func buildAccessKeyRow(k service.APIKeyResponse) pages.AccessKeyRow {
 		Name:             k.Name,
 		KeyPrefix:        k.KeyPrefix,
 		Scope:            k.Scope,
-		CreatedAtShort:   formatDateShortFromRFC3339(k.CreatedAt),
-		LastUsedRelative: relativeTimeFromRFC3339Ptr(k.LastUsedAt),
+		CreatedAtShort:   timefmt.FormatRFC3339(k.CreatedAt, timefmt.LayoutDateShort),
+		LastUsedRelative: timefmt.RelativeRFC3339Ptr(k.LastUsedAt),
 	}
 }
 
@@ -144,23 +144,8 @@ func buildAccessClientRow(c service.OAuthClientResponse) pages.AccessClientRow {
 		Name:           c.Name,
 		ClientIDPrefix: c.ClientIDPrefix,
 		Scope:          c.Scope,
-		CreatedAtShort: formatDateShortFromRFC3339(c.CreatedAt),
+		CreatedAtShort: timefmt.FormatRFC3339(c.CreatedAt, timefmt.LayoutDateShort),
 	}
-}
-
-// formatDateShortFromRFC3339 mirrors the `formatDateShort` funcMap helper
-// for a string-typed timestamp: parses RFC3339 and renders as
-// "Jan 2, 3:04 PM" in the local timezone. Returns the input verbatim on
-// parse failure (matching the helper's fall-through).
-func formatDateShortFromRFC3339(s string) string {
-	if s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return s
-	}
-	return t.Local().Format("Jan 2, 3:04 PM")
 }
 
 // APIKeyNewPageHandler serves GET /admin/api-keys/new.

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -3,12 +3,12 @@ package admin
 import (
 	"net/http"
 	"net/url"
-	"time"
 
 	"breadbox/internal/app"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 )
@@ -123,7 +123,7 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 					InstitutionName:      l.InstitutionName,
 					Trigger:              l.Trigger,
 					Status:               l.Status,
-					StartedAtRelative:    relativeTimeFromRFC3339Ptr(l.StartedAt),
+					StartedAtRelative:    timefmt.RelativeRFC3339Ptr(l.StartedAt),
 					Duration:             l.Duration,
 					AccountsAffected:     l.AccountsAffected,
 					FriendlyErrorMessage: l.FriendlyErrorMessage,
@@ -221,8 +221,8 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 					InstitutionName:   e.InstitutionName,
 					PayloadHash:       e.PayloadHash,
 					ErrorMessage:      e.ErrorMessage,
-					CreatedAtRelative: relativeTimeFromRFC3339Ptr(e.CreatedAt),
-					CreatedAtFull:     formatDateTimeFromRFC3339Ptr(e.CreatedAt),
+					CreatedAtRelative: timefmt.RelativeRFC3339Ptr(e.CreatedAt),
+					CreatedAtFull:     timefmt.FormatRFC3339Ptr(e.CreatedAt, timefmt.LayoutDateTime),
 				})
 			}
 
@@ -272,30 +272,3 @@ func encodeSyncStatusQuery(status, connID, trigger, dateFrom, dateTo string) str
 	return v.Encode()
 }
 
-// relativeTimeFromRFC3339Ptr parses a *string RFC3339 timestamp and
-// returns a humanised "X minutes ago" string. Mirrors the *string
-// branch of the `relativeTime` funcMap helper.
-func relativeTimeFromRFC3339Ptr(s *string) string {
-	if s == nil || *s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, *s)
-	if err != nil {
-		return *s
-	}
-	return relativeTime(t)
-}
-
-// formatDateTimeFromRFC3339Ptr parses a *string RFC3339 timestamp into
-// the local "Jan 2, 2006 3:04 PM" rendering used by the `formatDateTime`
-// funcMap helper.
-func formatDateTimeFromRFC3339Ptr(s *string) string {
-	if s == nil || *s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, *s)
-	if err != nil {
-		return *s
-	}
-	return t.Local().Format("Jan 2, 2006 3:04 PM")
-}

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -46,7 +46,7 @@ func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.Sess
 			Purpose:       detail.Purpose,
 			AgentName:     detail.AgentName,
 			APIKeyName:    detail.APIKeyName,
-			CreatedAt:     relativeTimeFromRFC3339(detail.CreatedAt),
+			CreatedAt:     timefmt.RelativeRFC3339(detail.CreatedAt),
 			ToolCallCount: detail.ToolCallCount,
 			ErrorCount:    detail.ErrorCount,
 			WriteCount:    detail.WriteCount,
@@ -64,8 +64,8 @@ func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.Sess
 				Sequence:       c.Sequence,
 				OffsetLabel:    c.OffsetLabel,
 				CreatedAt:      c.CreatedAt,
-				CreatedAtAbs:   formatDateTimeFromRFC3339(c.CreatedAt),
-				CreatedAtRel:   relativeTimeFromRFC3339(c.CreatedAt),
+				CreatedAtAbs:   timefmt.FormatRFC3339(c.CreatedAt, timefmt.LayoutDateTime),
+				CreatedAtRel:   timefmt.RelativeRFC3339(c.CreatedAt),
 			}
 			if c.DurationMs != nil {
 				tc.DurationMs = *c.DurationMs
@@ -81,33 +81,6 @@ func buildSessionDetailProps(detail service.MCPSessionDetailResponse) pages.Sess
 		}
 	}
 	return out
-}
-
-// relativeTimeFromRFC3339 mirrors the funcMap "relativeTime" branch
-// for an RFC3339 string. Returns the input unchanged when parsing
-// fails (matches the funcMap fallback).
-func relativeTimeFromRFC3339(s string) string {
-	if s == "" {
-		return ""
-	}
-	parsed, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return s
-	}
-	return relativeTime(parsed)
-}
-
-// formatDateTimeFromRFC3339 mirrors the funcMap "formatDateTime"
-// branch for an RFC3339 string ("Jan 2, 2006 3:04 PM" in local time).
-func formatDateTimeFromRFC3339(s string) string {
-	if s == "" {
-		return ""
-	}
-	parsed, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return s
-	}
-	return parsed.Local().Format("Jan 2, 2006 3:04 PM")
 }
 
 // prettyJSONIndent mirrors the funcMap "prettyJSON" branch for raw

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -7,6 +7,7 @@ import (
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
@@ -82,7 +83,7 @@ func buildSyncLogDetailProps(log *service.SyncLogRow, accounts []service.SyncLog
 			UnchangedCount:    log.UnchangedCount,
 			ErrorMessage:      stringOrEmpty(log.ErrorMessage),
 			WarningMessage:    stringOrEmpty(log.WarningMessage),
-			StartedAtRelative: relativeTimeFromRFC3339Ptr(log.StartedAt),
+			StartedAtRelative: timefmt.RelativeRFC3339Ptr(log.StartedAt),
 			Duration:          stringOrEmpty(log.Duration),
 			AccountsAffected:  log.AccountsAffected,
 			TotalRuleHits:     log.TotalRuleHits,

--- a/internal/admin/templates.go
+++ b/internal/admin/templates.go
@@ -22,6 +22,7 @@ import (
 	"breadbox/internal/templates"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
+	"breadbox/internal/timefmt"
 	"breadbox/internal/version"
 
 	"github.com/a-h/templ"
@@ -107,6 +108,33 @@ var componentRegistry = map[string]componentAdapter{
 		}
 		return components.KbdCombo(keys...), nil
 	},
+}
+
+// formatTimeAny returns a funcMap-shaped helper that renders a time-ish
+// value via layout in the local timezone. Accepted shapes: time.Time,
+// *time.Time, RFC3339/RFC3339Nano string, *string. Nil pointers and the
+// empty string render as ""; an unparseable string passes through
+// verbatim so callers don't show "0001-01-01..." on bad data. Centralises
+// what used to be three near-identical funcMap entries (#871).
+func formatTimeAny(layout string) func(any) string {
+	format := func(t time.Time) string { return t.Local().Format(layout) }
+	return func(v any) string {
+		switch v := v.(type) {
+		case time.Time:
+			return format(v)
+		case *time.Time:
+			if v == nil {
+				return ""
+			}
+			return format(*v)
+		case string:
+			return timefmt.FormatRFC3339(v, layout)
+		case *string:
+			return timefmt.FormatRFC3339Ptr(v, layout)
+		default:
+			return ""
+		}
+	}
 }
 
 // assertAdminTxRow extracts a service.AdminTransactionRow from data,
@@ -659,100 +687,13 @@ func NewTemplateRenderer(sm *scs.SessionManager) (*TemplateRenderer, error) {
 				}
 				return acctType
 			},
-			"formatDateTime": func(t interface{}) string {
-				format := func(tm time.Time) string {
-					return tm.Local().Format("Jan 2, 2006 3:04 PM")
-				}
-				switch v := t.(type) {
-				case time.Time:
-					return format(v)
-				case *time.Time:
-					if v == nil {
-						return ""
-					}
-					return format(*v)
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return format(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return format(parsed)
-					}
-					return *v
-				default:
-					return ""
-				}
-			},
+			"formatDateTime": formatTimeAny(timefmt.LayoutDateTime),
 			// clockTime renders the local clock portion of a timestamp
 			// ("2:03 AM"). Paired with a same-day day separator on the
 			// activity timeline it disambiguates 10 events that would all
 			// otherwise read "8 days ago" (#707).
-			"clockTime": func(t interface{}) string {
-				format := func(tm time.Time) string {
-					return tm.Local().Format("3:04 PM")
-				}
-				switch v := t.(type) {
-				case time.Time:
-					return format(v)
-				case *time.Time:
-					if v == nil {
-						return ""
-					}
-					return format(*v)
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return format(parsed)
-					}
-					if parsed, err := time.Parse(time.RFC3339Nano, v); err == nil {
-						return format(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return format(parsed)
-					}
-					return *v
-				default:
-					return ""
-				}
-			},
-			"formatDateShort": func(t interface{}) string {
-				format := func(tm time.Time) string {
-					return tm.Local().Format("Jan 2, 3:04 PM")
-				}
-				switch v := t.(type) {
-				case time.Time:
-					return format(v)
-				case *time.Time:
-					if v == nil {
-						return ""
-					}
-					return format(*v)
-				case string:
-					if parsed, err := time.Parse(time.RFC3339, v); err == nil {
-						return format(parsed)
-					}
-					return v
-				case *string:
-					if v == nil {
-						return ""
-					}
-					if parsed, err := time.Parse(time.RFC3339, *v); err == nil {
-						return format(parsed)
-					}
-					return *v
-				default:
-					return ""
-				}
-			},
+			"clockTime":       formatTimeAny(timefmt.LayoutClock),
+			"formatDateShort": formatTimeAny(timefmt.LayoutDateShort),
 			"formatDate":   components.FormatDate,
 			"relativeDate": components.RelativeDate,
 			"formatNumeric": func(n pgtype.Numeric) string {

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
@@ -722,54 +721,26 @@ func accountTypeLabel(acctType, subtype string) string {
 	return acctType
 }
 
-// formatDateTimeStr parses an RFC3339 timestamp and renders it in the
-// admin standard "Jan 2, 2006 3:04 PM" local format. Unparseable input
-// is returned unchanged.
+// formatDateTimeStr renders an RFC3339 timestamp in the admin standard
+// "Jan 2, 2006 3:04 PM" local format. Unparseable input is returned
+// unchanged. Thin wrapper around timefmt.FormatRFC3339 so call sites
+// inside the templ stay short.
 func formatDateTimeStr(s string) string {
-	if s == "" {
-		return ""
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.Local().Format("Jan 2, 2006 3:04 PM")
-	}
-	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.Local().Format("Jan 2, 2006 3:04 PM")
-	}
-	return s
+	return timefmt.FormatRFC3339(s, timefmt.LayoutDateTime)
 }
 
 // clockTimeStr renders the local clock portion of an RFC3339 timestamp
 // ("3:04 PM"). Used by activity-timeline rows where the day separator
 // already carries the date.
 func clockTimeStr(s string) string {
-	if s == "" {
-		return ""
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.Local().Format("3:04 PM")
-	}
-	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.Local().Format("3:04 PM")
-	}
-	return s
+	return timefmt.FormatRFC3339(s, timefmt.LayoutClock)
 }
 
 // relativeTimeStr renders an RFC3339 timestamp as a short relative
 // phrase ("just now", "5 minutes ago", "2 days ago"). Used in delete
 // button aria-labels so screen readers get a stable description.
-// Falls back to the raw input string when the timestamp can't be parsed.
 func relativeTimeStr(s string) string {
-	if s == "" {
-		return ""
-	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		t, err = time.Parse(time.RFC3339Nano, s)
-		if err != nil {
-			return s
-		}
-	}
-	return timefmt.Relative(t)
+	return timefmt.RelativeRFC3339(s)
 }
 
 // avatarURLStr mirrors the admin "avatarURL" funcMap for the (user_id,

--- a/internal/timefmt/timefmt.go
+++ b/internal/timefmt/timefmt.go
@@ -8,6 +8,73 @@ import (
 	"time"
 )
 
+// Layout strings used by the admin UI to render absolute timestamps. Kept
+// here so admin handlers, templ pages, and the funcMap entries all share
+// one canonical format per shape.
+const (
+	// LayoutDateTime is the "Jan 2, 2006 3:04 PM" rendering used wherever
+	// both the date and clock are shown together.
+	LayoutDateTime = "Jan 2, 2006 3:04 PM"
+
+	// LayoutClock is the clock-only "3:04 PM" rendering used on activity
+	// rows where a day separator already carries the date.
+	LayoutClock = "3:04 PM"
+
+	// LayoutDateShort is the compact "Jan 2, 3:04 PM" rendering used on
+	// dense list views (api keys, sessions).
+	LayoutDateShort = "Jan 2, 3:04 PM"
+)
+
+// FormatRFC3339 parses an RFC3339 (or RFC3339Nano) timestamp string and
+// renders it via layout in the local timezone. Empty input yields ""; an
+// unparseable string is returned unchanged so callers don't display
+// "0001-01-01..." on bad data.
+func FormatRFC3339(s, layout string) string {
+	if s == "" {
+		return ""
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Local().Format(layout)
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t.Local().Format(layout)
+	}
+	return s
+}
+
+// FormatRFC3339Ptr is FormatRFC3339 for nullable *string inputs. nil and
+// empty both render as "".
+func FormatRFC3339Ptr(s *string, layout string) string {
+	if s == nil {
+		return ""
+	}
+	return FormatRFC3339(*s, layout)
+}
+
+// RelativeRFC3339 parses an RFC3339 (or RFC3339Nano) timestamp string and
+// returns Relative(t). Empty input yields ""; an unparseable string is
+// returned unchanged.
+func RelativeRFC3339(s string) string {
+	if s == "" {
+		return ""
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return Relative(t)
+	}
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return Relative(t)
+	}
+	return s
+}
+
+// RelativeRFC3339Ptr is RelativeRFC3339 for nullable *string inputs.
+func RelativeRFC3339Ptr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return RelativeRFC3339(*s)
+}
+
 // Relative renders t as a human-readable "X ago" string relative to now.
 // Output buckets: "just now" (<1m), "N minute(s) ago" (<1h),
 // "N hour(s) ago" (<1d), "N day(s) ago" (>=1d). Uses time.Since(t), so

--- a/internal/timefmt/timefmt_test.go
+++ b/internal/timefmt/timefmt_test.go
@@ -33,3 +33,65 @@ func TestRelative(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatRFC3339(t *testing.T) {
+	// Pin the inputs to UTC so the assertions are stable regardless of
+	// the runner's local zone (formatter renders in local time).
+	utc := time.FixedZone("UTC", 0)
+	ts := time.Date(2026, 4, 26, 14, 5, 0, 0, utc)
+	rfc := ts.Format(time.RFC3339)
+	rfcNano := ts.Format(time.RFC3339Nano)
+
+	want := ts.Local().Format(LayoutDateTime)
+	if got := FormatRFC3339(rfc, LayoutDateTime); got != want {
+		t.Errorf("FormatRFC3339(rfc) = %q, want %q", got, want)
+	}
+	if got := FormatRFC3339(rfcNano, LayoutDateTime); got != want {
+		t.Errorf("FormatRFC3339(nano) = %q, want %q", got, want)
+	}
+	if got := FormatRFC3339("", LayoutDateTime); got != "" {
+		t.Errorf("FormatRFC3339(empty) = %q, want \"\"", got)
+	}
+	if got := FormatRFC3339("not a date", LayoutDateTime); got != "not a date" {
+		t.Errorf("FormatRFC3339(garbage) = %q, want input passthrough", got)
+	}
+}
+
+func TestFormatRFC3339Ptr(t *testing.T) {
+	utc := time.FixedZone("UTC", 0)
+	ts := time.Date(2026, 4, 26, 14, 5, 0, 0, utc)
+	rfc := ts.Format(time.RFC3339)
+	want := ts.Local().Format(LayoutClock)
+
+	if got := FormatRFC3339Ptr(&rfc, LayoutClock); got != want {
+		t.Errorf("FormatRFC3339Ptr(&rfc) = %q, want %q", got, want)
+	}
+	if got := FormatRFC3339Ptr(nil, LayoutClock); got != "" {
+		t.Errorf("FormatRFC3339Ptr(nil) = %q, want \"\"", got)
+	}
+}
+
+func TestRelativeRFC3339(t *testing.T) {
+	now := time.Now()
+	rfc := now.Add(-3 * time.Minute).Format(time.RFC3339)
+	if got := RelativeRFC3339(rfc); got != "3 minutes ago" {
+		t.Errorf("RelativeRFC3339 = %q, want %q", got, "3 minutes ago")
+	}
+	if got := RelativeRFC3339(""); got != "" {
+		t.Errorf("RelativeRFC3339(empty) = %q, want \"\"", got)
+	}
+	if got := RelativeRFC3339("garbage"); got != "garbage" {
+		t.Errorf("RelativeRFC3339(garbage) = %q, want passthrough", got)
+	}
+}
+
+func TestRelativeRFC3339Ptr(t *testing.T) {
+	now := time.Now()
+	rfc := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	if got := RelativeRFC3339Ptr(&rfc); got != "1 hour ago" {
+		t.Errorf("RelativeRFC3339Ptr = %q, want %q", got, "1 hour ago")
+	}
+	if got := RelativeRFC3339Ptr(nil); got != "" {
+		t.Errorf("RelativeRFC3339Ptr(nil) = %q, want \"\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

Consolidates eight near-duplicate timestamp-formatting helpers across `internal/admin/` and the templ pages onto a small set of shared helpers in `internal/timefmt`.

**Before** — five admin handler files each shipped their own copy of the same RFC3339 boilerplate:
- `formatDateTimeFromRFC3339` (sessions)
- `formatDateShortFromRFC3339` (apikeys)
- `formatDateTimeFromRFC3339Ptr` (logs)
- `relativeTimeFromRFC3339` (sessions)
- `relativeTimeFromRFC3339Ptr` (logs)

…and three nearly identical funcMap entries in `internal/admin/templates.go` (`formatDateTime`, `clockTime`, `formatDateShort`) each repeated the same 25-line `interface{}` type-switch with only the layout string differing.

**After** — `internal/timefmt` exposes:

```go
const (
    LayoutDateTime  = "Jan 2, 2006 3:04 PM"
    LayoutClock     = "3:04 PM"
    LayoutDateShort = "Jan 2, 3:04 PM"
)

func FormatRFC3339(s, layout string) string
func FormatRFC3339Ptr(s *string, layout string) string
func RelativeRFC3339(s string) string
func RelativeRFC3339Ptr(s *string) string
```

The funcMap trio collapses behind a single `formatTimeAny(layout)` factory that returns the funcMap-shaped closure. The templ-side `formatDateTimeStr`/`clockTimeStr`/`relativeTimeStr` thin-wrap the new helpers so the bodies shrink to one line each.

Net -27 lines, with new unit tests covering the four exported helpers.

## Behaviour

Identical for every existing call site. The only delta is that the funcMap path now also accepts `RFC3339Nano` strings in two more spots (`formatDateTime` / `formatDateShort`), matching what `clockTime` already did — a strict superset of the prior behaviour.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (incl. new `internal/timefmt` tests)
- [x] `templ generate` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)