### PR TITLE
fix(categories): write category_set annotation on manual picker

### DIFF
--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -198,7 +198,7 @@ func handleCategoryError(w http.ResponseWriter, err error) {
 }
 
 // SetTransactionCategoryAdminHandler handles POST /admin/api/transactions/{id}/category.
-func SetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
+func SetTransactionCategoryAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		var req struct {
@@ -211,7 +211,8 @@ func SetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "category_id is required")
 			return
 		}
-		if err := svc.SetTransactionCategory(r.Context(), id, req.CategoryID); err != nil {
+		actor := ActorFromSession(sm, r)
+		if err := svc.SetTransactionCategory(r.Context(), id, req.CategoryID, actor); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
 				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
@@ -228,10 +229,11 @@ func SetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
 }
 
 // ResetTransactionCategoryAdminHandler handles DELETE /admin/api/transactions/{id}/category.
-func ResetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
+func ResetTransactionCategoryAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		if err := svc.ResetTransactionCategory(r.Context(), id); err != nil {
+		actor := ActorFromSession(sm, r)
+		if err := svc.ResetTransactionCategory(r.Context(), id, actor); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
 				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
@@ -245,7 +247,7 @@ func ResetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerFunc
 
 // BatchSetTransactionCategoryAdminHandler handles POST /admin/api/transactions/batch-categorize.
 // Accepts {items: [{transaction_id, category_id}]} and sets category overrides on all.
-func BatchSetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerFunc {
+func BatchSetTransactionCategoryAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			Items []struct {
@@ -265,6 +267,7 @@ func BatchSetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerF
 			return
 		}
 
+		actor := ActorFromSession(sm, r)
 		succeeded := 0
 		failed := 0
 		for _, item := range req.Items {
@@ -272,7 +275,7 @@ func BatchSetTransactionCategoryAdminHandler(svc *service.Service) http.HandlerF
 				failed++
 				continue
 			}
-			if err := svc.SetTransactionCategory(r.Context(), item.TransactionID, item.CategoryID); err != nil {
+			if err := svc.SetTransactionCategory(r.Context(), item.TransactionID, item.CategoryID, actor); err != nil {
 				failed++
 				continue
 			}

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -240,11 +240,11 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			r.Use(RequireEditor(sm))
 
 			// Transaction category override
-			r.Post("/transactions/{id}/category", SetTransactionCategoryAdminHandler(svc))
-			r.Delete("/transactions/{id}/category", ResetTransactionCategoryAdminHandler(svc))
+			r.Post("/transactions/{id}/category", SetTransactionCategoryAdminHandler(svc, sm))
+			r.Delete("/transactions/{id}/category", ResetTransactionCategoryAdminHandler(svc, sm))
 
 			// Transaction bulk categorize
-			r.Post("/transactions/batch-categorize", BatchSetTransactionCategoryAdminHandler(svc))
+			r.Post("/transactions/batch-categorize", BatchSetTransactionCategoryAdminHandler(svc, sm))
 
 			// Batch compound update (bulk actions on transactions list).
 			r.Post("/transactions/batch-update", BulkUpdateTransactionsAdminHandler(a, sm, svc))

--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -399,7 +399,8 @@ func SetTransactionCategoryHandler(svc *service.Service) http.HandlerFunc {
 			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "category_id is required")
 			return
 		}
-		if err := svc.SetTransactionCategory(r.Context(), id, input.CategoryID); err != nil {
+		actor := service.ActorFromContext(r.Context())
+		if err := svc.SetTransactionCategory(r.Context(), id, input.CategoryID, actor); err != nil {
 			if errors.Is(err, service.ErrNotFound) {
 				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
 				return
@@ -420,7 +421,8 @@ func SetTransactionCategoryHandler(svc *service.Service) http.HandlerFunc {
 func ResetTransactionCategoryHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
-		if err := svc.ResetTransactionCategory(r.Context(), id); err != nil {
+		actor := service.ActorFromContext(r.Context())
+		if err := svc.ResetTransactionCategory(r.Context(), id, actor); err != nil {
 			writeServiceError(w, err, "Transaction not found", "Failed to reset transaction category")
 			return
 		}
@@ -438,7 +440,8 @@ func BatchCategorizeHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 
-		result, err := svc.BatchSetTransactionCategory(r.Context(), input.Items)
+		actor := service.ActorFromContext(r.Context())
+		result, err := svc.BatchSetTransactionCategory(r.Context(), input.Items, actor)
 		if err != nil {
 			if errors.Is(err, service.ErrInvalidParameter) {
 				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -341,6 +341,7 @@ func (s *MCPServer) handleCategorizeTransaction(ctx context.Context, _ *mcpsdk.C
 	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
+	actor := service.ActorFromContext(ctx)
 	ctx = context.Background()
 	if input.TransactionID == "" {
 		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
@@ -359,7 +360,7 @@ func (s *MCPServer) handleCategorizeTransaction(ctx context.Context, _ *mcpsdk.C
 		categoryID = cat.ID
 	}
 
-	if err := s.svc.SetTransactionCategory(ctx, input.TransactionID, categoryID); err != nil {
+	if err := s.svc.SetTransactionCategory(ctx, input.TransactionID, categoryID, actor); err != nil {
 		return errorResult(err), nil, nil
 	}
 	return &mcpsdk.CallToolResult{
@@ -373,11 +374,12 @@ func (s *MCPServer) handleResetTransactionCategory(ctx context.Context, _ *mcpsd
 	if err := s.checkWritePermission(ctx); err != nil {
 		return errorResult(err), nil, nil
 	}
+	actor := service.ActorFromContext(ctx)
 	ctx = context.Background()
 	if input.TransactionID == "" {
 		return errorResult(fmt.Errorf("transaction_id is required")), nil, nil
 	}
-	if err := s.svc.ResetTransactionCategory(ctx, input.TransactionID); err != nil {
+	if err := s.svc.ResetTransactionCategory(ctx, input.TransactionID, actor); err != nil {
 		return errorResult(err), nil, nil
 	}
 	return &mcpsdk.CallToolResult{
@@ -850,6 +852,7 @@ func (s *MCPServer) handleBatchCategorize(ctx context.Context, _ *mcpsdk.CallToo
 		return errorResult(fmt.Errorf("items array is required and must not be empty")), nil, nil
 	}
 
+	actor := service.ActorFromContext(ctx)
 	items := make([]service.BatchCategorizeItem, len(input.Items))
 	for i, item := range input.Items {
 		items[i] = service.BatchCategorizeItem{
@@ -858,7 +861,7 @@ func (s *MCPServer) handleBatchCategorize(ctx context.Context, _ *mcpsdk.CallToo
 		}
 	}
 
-	result, err := s.svc.BatchSetTransactionCategory(ctx, items)
+	result, err := s.svc.BatchSetTransactionCategory(ctx, items, actor)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -401,8 +401,12 @@ func (s *Service) MergeCategories(ctx context.Context, sourceID, targetID string
 	return nil
 }
 
-// SetTransactionCategory sets a manual category override on a transaction.
-func (s *Service) SetTransactionCategory(ctx context.Context, txnID, categoryID string) error {
+// SetTransactionCategory sets a manual category override on a transaction and
+// records a `category_set` annotation attributed to the supplied actor. The
+// UPDATE and the annotation write run in a single DB transaction so a failed
+// annotation rolls back the category change — keeping the activity timeline in
+// sync with the persisted state.
+func (s *Service) SetTransactionCategory(ctx context.Context, txnID, categoryID string, actor Actor) error {
 	txnUID, err := s.resolveTransactionID(ctx, txnID)
 	if err != nil {
 		return ErrNotFound
@@ -412,7 +416,21 @@ func (s *Service) SetTransactionCategory(ctx context.Context, txnID, categoryID 
 		return ErrCategoryNotFound
 	}
 
-	rowsAffected, err := s.Queries.SetTransactionCategoryOverride(ctx, db.SetTransactionCategoryOverrideParams{
+	// Resolve the slug for the annotation payload. resolveCategoryID accepts
+	// UUID/short_id, so we still need a row lookup to get the canonical slug.
+	cat, err := s.Queries.GetCategoryByID(ctx, catUID)
+	if err != nil {
+		return ErrCategoryNotFound
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin set_transaction_category: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	rowsAffected, err := qtx.SetTransactionCategoryOverride(ctx, db.SetTransactionCategoryOverrideParams{
 		ID:         txnUID,
 		CategoryID: catUID,
 	})
@@ -427,19 +445,38 @@ func (s *Service) SetTransactionCategory(ctx context.Context, txnID, categoryID 
 	if rowsAffected == 0 {
 		return ErrNotFound
 	}
+
+	if err := writeCategorySetAnnotation(ctx, qtx, txnUID, actor, cat.Slug, false); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit set_transaction_category: %w", err)
+	}
 	return nil
 }
 
-// ResetTransactionCategory clears the manual override and sets the category to uncategorized.
-// Transaction rules will re-categorize it on the next sync if a matching rule exists.
-func (s *Service) ResetTransactionCategory(ctx context.Context, txnID string) error {
+// ResetTransactionCategory clears the manual override and sets the category to
+// uncategorized. Transaction rules will re-categorize it on the next sync if a
+// matching rule exists. Records a `category_set` annotation with
+// `action: "reset"` attributed to the supplied actor in the same DB transaction
+// as the writes.
+func (s *Service) ResetTransactionCategory(ctx context.Context, txnID string, actor Actor) error {
 	txnUID, err := s.resolveTransactionID(ctx, txnID)
 	if err != nil {
 		return ErrNotFound
 	}
 
-	// Clear the override flag
-	rowsAffected, err := s.Queries.ClearTransactionCategoryOverride(ctx, txnUID)
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin reset_transaction_category: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	// Clear the override flag — bail out early on a missing transaction so the
+	// uncategorized lookup below isn't reached for nonexistent rows.
+	rowsAffected, err := qtx.ClearTransactionCategoryOverride(ctx, txnUID)
 	if err != nil {
 		return fmt.Errorf("clear override: %w", err)
 	}
@@ -447,17 +484,56 @@ func (s *Service) ResetTransactionCategory(ctx context.Context, txnID string) er
 		return ErrNotFound
 	}
 
-	// Set to uncategorized — rules will re-categorize on next sync.
-	uncategorized, err := s.Queries.GetCategoryBySlug(ctx, "uncategorized")
+	uncategorized, err := qtx.GetCategoryBySlug(ctx, "uncategorized")
 	if err != nil {
 		return fmt.Errorf("get uncategorized: %w", err)
 	}
-	_, err = s.Pool.Exec(ctx, "UPDATE transactions SET category_id = $1 WHERE id = $2", uncategorized.ID, txnUID)
-	return err
+
+	// Set to uncategorized — rules will re-categorize on next sync.
+	if _, err := tx.Exec(ctx, "UPDATE transactions SET category_id = $1 WHERE id = $2", uncategorized.ID, txnUID); err != nil {
+		return fmt.Errorf("reset category: %w", err)
+	}
+
+	if err := writeCategorySetAnnotation(ctx, qtx, txnUID, actor, "uncategorized", true); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit reset_transaction_category: %w", err)
+	}
+	return nil
+}
+
+// writeCategorySetAnnotation writes a manual `category_set` annotation. Manual
+// writes carry `source: "manual"` and never include rule_id/rule_name — those
+// are reserved for rule-driven writes (see internal/ruleapply/annotations.go).
+// When isReset is true, the payload also records `action: "reset"` so the
+// timeline can distinguish reset events from forward category changes.
+func writeCategorySetAnnotation(ctx context.Context, q *db.Queries, txnUID pgtype.UUID, actor Actor, slug string, isReset bool) error {
+	if actor.Type == "" {
+		actor = SystemActor()
+	}
+	payload := map[string]interface{}{
+		"category_slug": slug,
+		"source":        "manual",
+	}
+	if isReset {
+		payload["action"] = "reset"
+	}
+	return writeAnnotation(ctx, q, writeAnnotationParams{
+		TransactionID: txnUID,
+		Kind:          "category_set",
+		ActorType:     normalizeAnnotationActorType(actor.Type),
+		ActorID:       actor.ID,
+		ActorName:     actor.Name,
+		Payload:       payload,
+	})
 }
 
 // BatchSetTransactionCategory sets category overrides on multiple transactions at once.
-func (s *Service) BatchSetTransactionCategory(ctx context.Context, items []BatchCategorizeItem) (*BatchCategorizeResult, error) {
+// Each successful row gets its own actor-attributed `category_set` annotation
+// via SetTransactionCategory.
+func (s *Service) BatchSetTransactionCategory(ctx context.Context, items []BatchCategorizeItem, actor Actor) (*BatchCategorizeResult, error) {
 	if len(items) == 0 {
 		return nil, fmt.Errorf("%w: items array is empty", ErrInvalidParameter)
 	}
@@ -490,7 +566,7 @@ func (s *Service) BatchSetTransactionCategory(ctx context.Context, items []Batch
 			continue
 		}
 
-		if err := s.SetTransactionCategory(ctx, item.TransactionID, categoryID); err != nil {
+		if err := s.SetTransactionCategory(ctx, item.TransactionID, categoryID, actor); err != nil {
 			result.Failed = append(result.Failed, BatchCategorizeError{
 				TransactionID: item.TransactionID,
 				Error:         err.Error(),

--- a/internal/service/category_integration_test.go
+++ b/internal/service/category_integration_test.go
@@ -629,7 +629,7 @@ func TestSetTransactionCategory_Success(t *testing.T) {
 	acctID := seedTxnFixture(t, q)
 	txn := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "txn_manual", "Manual Txn", 500, "2025-02-01")
 
-	err := svc.SetTransactionCategory(ctx, pgconv.FormatUUID(txn.ID), target.ID)
+	err := svc.SetTransactionCategory(ctx, pgconv.FormatUUID(txn.ID), target.ID, service.SystemActor())
 	if err != nil {
 		t.Fatalf("SetTransactionCategory: %v", err)
 	}
@@ -655,7 +655,7 @@ func TestSetTransactionCategory_Success(t *testing.T) {
 func TestSetTransactionCategory_InvalidTransaction(t *testing.T) {
 	svc, _, _ := newService(t)
 	cat := mustCreateCategoryViaService(t, svc, "cat_for_invalid", "Cat", nil)
-	err := svc.SetTransactionCategory(context.Background(), "00000000-0000-0000-0000-000000000000", cat.ID)
+	err := svc.SetTransactionCategory(context.Background(), "00000000-0000-0000-0000-000000000000", cat.ID, service.SystemActor())
 	if err == nil {
 		t.Error("expected error for nonexistent transaction")
 	}
@@ -669,7 +669,7 @@ func TestSetTransactionCategory_InvalidCategory(t *testing.T) {
 	acctID := seedTxnFixture(t, q)
 	txn := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "txn_badcat", "Bad Cat", 100, "2025-02-01")
 
-	err := svc.SetTransactionCategory(ctx, pgconv.FormatUUID(txn.ID), "00000000-0000-0000-0000-000000000000")
+	err := svc.SetTransactionCategory(ctx, pgconv.FormatUUID(txn.ID), "00000000-0000-0000-0000-000000000000", service.SystemActor())
 	if !errors.Is(err, service.ErrCategoryNotFound) {
 		t.Errorf("expected ErrCategoryNotFound, got: %v", err)
 	}
@@ -680,7 +680,7 @@ func TestSetTransactionCategory_InvalidCategory(t *testing.T) {
 
 func TestResetTransactionCategory_NotFound(t *testing.T) {
 	svc, _, _ := newService(t)
-	err := svc.ResetTransactionCategory(context.Background(), "00000000-0000-0000-0000-000000000000")
+	err := svc.ResetTransactionCategory(context.Background(), "00000000-0000-0000-0000-000000000000", service.SystemActor())
 	if err == nil {
 		t.Error("expected error for nonexistent transaction")
 	}
@@ -700,7 +700,7 @@ func TestBatchSetTransactionCategory_SetsOverrideFlag(t *testing.T) {
 
 	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
 		{TransactionID: pgconv.FormatUUID(txn1.ID), CategorySlug: "batch_groceries"},
-	})
+	}, service.SystemActor())
 	if err != nil {
 		t.Fatalf("BatchSetTransactionCategory: %v", err)
 	}
@@ -732,7 +732,7 @@ func TestBatchSetTransactionCategory_PartialFailure(t *testing.T) {
 	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
 		{TransactionID: pgconv.FormatUUID(txn.ID), CategorySlug: "batch_good"},
 		{TransactionID: pgconv.FormatUUID(txn.ID), CategorySlug: "nonexistent_slug"},
-	})
+	}, service.SystemActor())
 	if err != nil {
 		t.Fatalf("BatchSetTransactionCategory: %v", err)
 	}
@@ -746,7 +746,7 @@ func TestBatchSetTransactionCategory_PartialFailure(t *testing.T) {
 
 func TestBatchSetTransactionCategory_EmptyItems(t *testing.T) {
 	svc, _, _ := newService(t)
-	_, err := svc.BatchSetTransactionCategory(context.Background(), []service.BatchCategorizeItem{})
+	_, err := svc.BatchSetTransactionCategory(context.Background(), []service.BatchCategorizeItem{}, service.SystemActor())
 	if err == nil {
 		t.Error("expected error for empty items")
 	}
@@ -758,7 +758,7 @@ func TestBatchSetTransactionCategory_TooManyItems(t *testing.T) {
 	for i := range items {
 		items[i] = service.BatchCategorizeItem{TransactionID: "x", CategorySlug: "y"}
 	}
-	_, err := svc.BatchSetTransactionCategory(context.Background(), items)
+	_, err := svc.BatchSetTransactionCategory(context.Background(), items, service.SystemActor())
 	if err == nil {
 		t.Error("expected error for >500 items")
 	}
@@ -880,4 +880,136 @@ func parseUUIDForTest(s string) (pgtype.UUID, error) {
 		return pgtype.UUID{}, err
 	}
 	return u, nil
+}
+
+// --- category_set annotation regression coverage ---
+
+// TestSetTransactionCategoryWritesAnnotation verifies the manual category
+// picker (admin POST, REST PATCH, MCP categorize_transaction) emits a
+// `category_set` annotation attributed to the supplied actor with the manual
+// source qualifier. Closes the activity-timeline gap on the transaction
+// detail page.
+func TestSetTransactionCategoryWritesAnnotation(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	target := mustCreateCategoryViaService(t, svc, "annot_groceries", "Groceries", nil)
+
+	acctID := seedTxnFixture(t, q)
+	txn := mustCreateTransactionWithCategory(t, q, acctID, uncat.ID, "txn_annot_set", "Annot Set", 500, "2025-02-01")
+
+	actor := service.Actor{Type: "user", ID: "user-1", Name: "Alice"}
+	if err := svc.SetTransactionCategory(ctx, pgconv.FormatUUID(txn.ID), target.ID, actor); err != nil {
+		t.Fatalf("SetTransactionCategory: %v", err)
+	}
+
+	// Use Raw=true so enrichment dedup doesn't fold our row away.
+	annots, err := svc.ListAnnotations(ctx, pgconv.FormatUUID(txn.ID), service.ListAnnotationsParams{Raw: true})
+	if err != nil {
+		t.Fatalf("ListAnnotations: %v", err)
+	}
+
+	var got *service.Annotation
+	for i, a := range annots {
+		if a.Kind == "category_set" {
+			got = &annots[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("expected a category_set annotation, got %d annotations: %+v", len(annots), annots)
+	}
+
+	if got.ActorType != "user" {
+		t.Errorf("ActorType = %q, want user", got.ActorType)
+	}
+	if got.ActorName != "Alice" {
+		t.Errorf("ActorName = %q, want Alice", got.ActorName)
+	}
+	if got.ActorID == nil || *got.ActorID != "user-1" {
+		t.Errorf("ActorID = %v, want user-1", got.ActorID)
+	}
+	if slug, _ := got.Payload["category_slug"].(string); slug != "annot_groceries" {
+		t.Errorf("payload.category_slug = %q, want annot_groceries", slug)
+	}
+	if src, _ := got.Payload["source"].(string); src != "manual" {
+		t.Errorf("payload.source = %q, want manual", src)
+	}
+	if _, hasAction := got.Payload["action"]; hasAction {
+		t.Errorf("payload should not include action on a non-reset write, got: %+v", got.Payload)
+	}
+	if _, hasRule := got.Payload["rule_id"]; hasRule {
+		t.Errorf("payload must not include rule_id for a manual write, got: %+v", got.Payload)
+	}
+	if _, hasRule := got.Payload["rule_name"]; hasRule {
+		t.Errorf("payload must not include rule_name for a manual write, got: %+v", got.Payload)
+	}
+	if got.RuleID != nil {
+		t.Errorf("RuleID = %v, want nil for manual write", got.RuleID)
+	}
+}
+
+// TestResetTransactionCategoryWritesAnnotation verifies the reset path emits
+// a `category_set` annotation with action=reset so the timeline can render the
+// reset event distinctly from a forward category change.
+func TestResetTransactionCategoryWritesAnnotation(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+
+	uncat := mustSeedUncategorized(t, q)
+	source := mustCreateCategoryViaService(t, svc, "annot_source", "Source", nil)
+	srcUID, _ := parseUUIDForTest(source.ID)
+
+	acctID := seedTxnFixture(t, q)
+	txn := mustCreateTransactionWithCategory(t, q, acctID, srcUID, "txn_annot_reset", "Annot Reset", 500, "2025-02-01")
+	_ = uncat // referenced by reset path via slug lookup
+
+	actor := service.Actor{Type: "user", ID: "user-2", Name: "Bob"}
+	if err := svc.ResetTransactionCategory(ctx, pgconv.FormatUUID(txn.ID), actor); err != nil {
+		t.Fatalf("ResetTransactionCategory: %v", err)
+	}
+
+	annots, err := svc.ListAnnotations(ctx, pgconv.FormatUUID(txn.ID), service.ListAnnotationsParams{Raw: true})
+	if err != nil {
+		t.Fatalf("ListAnnotations: %v", err)
+	}
+
+	var got *service.Annotation
+	for i, a := range annots {
+		if a.Kind == "category_set" {
+			got = &annots[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("expected a category_set annotation after reset, got %d annotations: %+v", len(annots), annots)
+	}
+
+	if got.ActorType != "user" || got.ActorName != "Bob" {
+		t.Errorf("actor mismatch: type=%q name=%q, want user/Bob", got.ActorType, got.ActorName)
+	}
+	if slug, _ := got.Payload["category_slug"].(string); slug != "uncategorized" {
+		t.Errorf("payload.category_slug = %q, want uncategorized", slug)
+	}
+	if src, _ := got.Payload["source"].(string); src != "manual" {
+		t.Errorf("payload.source = %q, want manual", src)
+	}
+	if action, _ := got.Payload["action"].(string); action != "reset" {
+		t.Errorf("payload.action = %q, want reset", action)
+	}
+
+	// Verify decoded payload after the JSON round trip in writeAnnotation.
+	if !strings.Contains(string(mustMarshalJSON(t, got.Payload)), `"action":"reset"`) {
+		t.Errorf("serialized payload should include action=reset, got: %s", string(mustMarshalJSON(t, got.Payload)))
+	}
+}
+
+func mustMarshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
 }

--- a/internal/service/integration_test.go
+++ b/internal/service/integration_test.go
@@ -934,7 +934,7 @@ func TestBatchSetTransactionCategory_Success(t *testing.T) {
 	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
 		{TransactionID: pgconv.FormatUUID(txn1.ID), CategorySlug: "food_and_drink"},
 		{TransactionID: pgconv.FormatUUID(txn2.ID), CategorySlug: "transportation"},
-	})
+	}, service.SystemActor())
 	if err != nil {
 		t.Fatalf("BatchSetTransactionCategory: %v", err)
 	}
@@ -993,7 +993,7 @@ func TestBatchSetTransactionCategory_InvalidTxnID(t *testing.T) {
 	result, err := svc.BatchSetTransactionCategory(ctx, []service.BatchCategorizeItem{
 		{TransactionID: pgconv.FormatUUID(txn1.ID), CategorySlug: "food_and_drink"},
 		{TransactionID: "00000000-0000-0000-0000-000000000099", CategorySlug: "food_and_drink"},
-	})
+	}, service.SystemActor())
 	if err != nil {
 		t.Fatalf("BatchSetTransactionCategory: %v", err)
 	}
@@ -1017,7 +1017,7 @@ func TestBatchSetTransactionCategory_MaxLimitExceeded(t *testing.T) {
 		}
 	}
 
-	_, err := svc.BatchSetTransactionCategory(ctx, items)
+	_, err := svc.BatchSetTransactionCategory(ctx, items, service.SystemActor())
 	if err == nil {
 		t.Fatal("expected error for > 500 items, got nil")
 	}

--- a/internal/service/short_id_integration_test.go
+++ b/internal/service/short_id_integration_test.go
@@ -379,7 +379,7 @@ func TestShortID_SetTransactionCategory_WithShortIDs(t *testing.T) {
 	}
 
 	// Categorize using short_ids for both transaction and category.
-	err = svc.SetTransactionCategory(ctx, dbTxn.ShortID, catShortID)
+	err = svc.SetTransactionCategory(ctx, dbTxn.ShortID, catShortID, service.SystemActor())
 	if err != nil {
 		t.Fatalf("SetTransactionCategory with short_ids: %v", err)
 	}


### PR DESCRIPTION
## Why
The transaction detail category picker — admin (`POST /admin/api/transactions/{id}/category`), REST (`PATCH /api/v1/transactions/{id}/category`), and MCP (`categorize_transaction`) — persisted the change but wrote no `category_set` annotation. Manual category changes were missing from the activity timeline entirely. Same gap on reset.

## What
- `SetTransactionCategory` and `ResetTransactionCategory` (and the batch helper) now accept an `Actor` and write a `category_set` annotation atomically with the category UPDATE.
- Manual writes use payload `{ category_slug, source: "manual" }`; reset adds `action: "reset"`.
- All four call sites (admin, REST, MCP, batch) thread the actor in.

## Test plan
- [x] `go test ./...`
- [x] `make test-integration`
- [x] New integration test `TestSetTransactionCategoryWritesAnnotation` verifies the annotation lands with the expected actor/payload.
- [x] Reset path also writes an annotation with `action: "reset"`.

Part of the **activity-log-v2** stack.
