### PR TITLE
fix(admin): share now anchor between day-grouping and relative timestamps

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -683,8 +683,14 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			timelineTags = nil
 		}
 
+		// Capture a single now anchor so the day-bucket labels
+		// ("Today" / "Yesterday" / weekday) and the per-row relative
+		// timestamps ("5 minutes ago" / "yesterday") agree across
+		// midnight and timezone boundaries. Threaded into the templ via
+		// props.Now → relativeTimeStrAt.
+		now := time.Now()
 		activity := buildActivityTimeline(annotations, categoryDetailLookup(categoryTree), tagDisplayLookup(timelineTags))
-		activityDays := groupActivityByDay(activity)
+		activityDays := groupActivityByDay(activity, now)
 
 		// Load tags currently attached + the registered-tag list (for the inline
 		// add-tag suggestion datalist). Also derive HasPendingReview from the
@@ -795,6 +801,7 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 			Account:          account,
 			Activity:         activity,
 			ActivityDays:     componentActivityDays,
+			Now:              now,
 			HasPendingReview: hasPendingReview,
 			CurrentTags:      currentTags,
 			AvailableTags:    availableTags,
@@ -1076,13 +1083,14 @@ type ActivityDayGroup struct {
 // groupActivityByDay groups a sorted-desc activity list into per-day buckets.
 // Timestamp is an RFC3339 string on ActivityEntry; entries with unparseable
 // timestamps are skipped (they're dropped rather than mis-bucketed). Each
-// returned group preserves the relative ordering of the input slice.
-func groupActivityByDay(entries []service.ActivityEntry) []ActivityDayGroup {
+// returned group preserves the relative ordering of the input slice. The
+// now anchor is passed in (rather than read via time.Now()) so the bucket
+// labels share the same reference clock as the per-row relative timestamps.
+func groupActivityByDay(entries []service.ActivityEntry, now time.Time) []ActivityDayGroup {
 	if len(entries) == 0 {
 		return nil
 	}
 
-	now := time.Now()
 	today := now.Format("2006-01-02")
 	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
 
@@ -1100,7 +1108,7 @@ func groupActivityByDay(entries []service.ActivityEntry) []ActivityDayGroup {
 		if !ok {
 			groups = append(groups, ActivityDayGroup{
 				Date:  date,
-				Label: activityDayLabel(date, today, yesterday),
+				Label: activityDayLabel(date, today, yesterday, now),
 			})
 			idx = len(groups) - 1
 			groupIdx[date] = idx
@@ -1114,7 +1122,9 @@ func groupActivityByDay(entries []service.ActivityEntry) []ActivityDayGroup {
 // activityDayLabel returns "Today", "Yesterday", or "Thursday, April 16" /
 // "Thursday, April 16, 2025" for older dates. The long-form weekday/month
 // mirrors GitHub's timeline convention and reads well at mobile widths.
-func activityDayLabel(dateStr, today, yesterday string) string {
+// now provides the reference year for the same-year shortening so the
+// label cannot disagree with the day-grouping anchor across New Year.
+func activityDayLabel(dateStr, today, yesterday string, now time.Time) string {
 	if dateStr == today {
 		return "Today"
 	}
@@ -1125,7 +1135,7 @@ func activityDayLabel(dateStr, today, yesterday string) string {
 	if err != nil {
 		return dateStr
 	}
-	if t.Year() == time.Now().Year() {
+	if t.Year() == now.Year() {
 		return t.Format("Monday, January 2")
 	}
 	return t.Format("Monday, January 2, 2006")

--- a/internal/admin/transactions_test.go
+++ b/internal/admin/transactions_test.go
@@ -4,8 +4,10 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"breadbox/internal/service"
+	"breadbox/internal/timefmt"
 )
 
 func TestBuildPaginationBase_URLEncodesValues(t *testing.T) {
@@ -292,7 +294,7 @@ func TestGroupActivityByDay_BucketsByLocalDate(t *testing.T) {
 		{Type: "comment", Timestamp: "2026-04-14T15:00:00Z", Summary: "c"},
 	}
 
-	groups := groupActivityByDay(entries)
+	groups := groupActivityByDay(entries, time.Now())
 
 	if len(groups) != 2 {
 		t.Fatalf("expected 2 day groups, got %d", len(groups))
@@ -319,10 +321,11 @@ func TestGroupActivityByDay_BucketsByLocalDate(t *testing.T) {
 }
 
 func TestGroupActivityByDay_EmptyInput(t *testing.T) {
-	if groups := groupActivityByDay(nil); groups != nil {
+	now := time.Now()
+	if groups := groupActivityByDay(nil, now); groups != nil {
 		t.Errorf("expected nil for nil input, got %v", groups)
 	}
-	if groups := groupActivityByDay([]service.ActivityEntry{}); groups != nil {
+	if groups := groupActivityByDay([]service.ActivityEntry{}, now); groups != nil {
 		t.Errorf("expected nil for empty input, got %v", groups)
 	}
 }
@@ -332,12 +335,60 @@ func TestGroupActivityByDay_DropsUnparseableTimestamps(t *testing.T) {
 		{Type: "comment", Timestamp: "2026-04-16T09:00:00Z", Summary: "ok"},
 		{Type: "comment", Timestamp: "not-a-date", Summary: "bad"},
 	}
-	groups := groupActivityByDay(entries)
+	groups := groupActivityByDay(entries, time.Now())
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 day group, got %d", len(groups))
 	}
 	if len(groups[0].Events) != 1 || groups[0].Events[0].Summary != "ok" {
 		t.Errorf("expected only the parseable entry to survive, got %+v", groups[0].Events)
+	}
+}
+
+// At a midnight boundary the day-bucket label and the per-row relative-time
+// helper must agree because they share the same now anchor. Before this fix
+// each path captured its own time.Now(), so a row at 23:55 could end up
+// grouped under "Today" with a "yesterday" timestamp (or vice-versa). The
+// fix threads a single now through groupActivityByDay + timefmt.RelativeAt.
+func TestGroupActivityByDay_SharesNowAnchorWithRelative(t *testing.T) {
+	loc := time.Local
+	// Anchor: 2026-04-27 00:10:00 local. The 23:55 row sits in "yesterday"
+	// (2026-04-26) and the 00:05 row in "today" (2026-04-27).
+	now := time.Date(2026, 4, 27, 0, 10, 0, 0, loc)
+	yesterdayLate := time.Date(2026, 4, 26, 23, 55, 0, 0, loc)
+	todayEarly := time.Date(2026, 4, 27, 0, 5, 0, 0, loc)
+
+	entries := []service.ActivityEntry{
+		{Type: "comment", Timestamp: todayEarly.Format(time.RFC3339), Summary: "today-early"},
+		{Type: "comment", Timestamp: yesterdayLate.Format(time.RFC3339), Summary: "yesterday-late"},
+	}
+
+	groups := groupActivityByDay(entries, now)
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 day groups, got %d", len(groups))
+	}
+
+	// First group is the today-early row (input order preserved).
+	today := groups[0]
+	yesterday := groups[1]
+
+	if today.Label != "Today" {
+		t.Errorf("today bucket label = %q, want %q", today.Label, "Today")
+	}
+	if yesterday.Label != "Yesterday" {
+		t.Errorf("yesterday bucket label = %q, want %q", yesterday.Label, "Yesterday")
+	}
+
+	// Per-row relative time, anchored against the same now, must put the
+	// 23:55 row at "15 minutes ago" (a < 1h bucket — i.e. clearly NOT
+	// "1 day ago", which is what an unanchored Relative() drift could
+	// produce if its time.Now() crossed midnight independently).
+	yesterdayRel := timefmt.RelativeAt(yesterdayLate, now)
+	if yesterdayRel != "15 minutes ago" {
+		t.Errorf("yesterday-late relative = %q, want %q", yesterdayRel, "15 minutes ago")
+	}
+	todayRel := timefmt.RelativeAt(todayEarly, now)
+	if todayRel != "5 minutes ago" {
+		t.Errorf("today-early relative = %q, want %q", todayRel, "5 minutes ago")
 	}
 }
 

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
@@ -317,9 +318,9 @@ templ txdActivity(p TransactionDetailProps) {
 					@txdTimelineDay(day.Label, di == 0)
 					for _, event := range day.Events {
 						if event.Type == "comment" {
-							@txdTimelineComment(event)
+							@txdTimelineComment(event, p.Now)
 						} else {
-							@txdTimelineSystem(event)
+							@txdTimelineSystem(event, p.Now)
 						}
 					}
 				}
@@ -351,7 +352,7 @@ templ txdTimelineDay(label string, first bool) {
 // right of the rail. Both the 24px icon tile and the first text line share
 // a 24px line-box so their centers align horizontally — no per-element
 // margin tweaks needed.
-templ txdTimelineSystem(e service.ActivityEntry) {
+templ txdTimelineSystem(e service.ActivityEntry, now time.Time) {
 	<li class="relative flex items-start gap-3 py-2 group">
 		<div class="relative z-10 shrink-0 w-6 h-6 rounded-full bg-base-100">
 			@txdSystemIcon(e)
@@ -365,7 +366,7 @@ templ txdTimelineSystem(e service.ActivityEntry) {
 				if e.Timestamp != "" {
 					<span aria-hidden="true">&middot;</span>
 					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
-						<time datetime={ e.Timestamp } class="tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
+						<time datetime={ e.Timestamp } class="tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
 					</span>
 				}
 			</span>
@@ -506,7 +507,7 @@ templ txdCategoryIcon(e service.ActivityEntry) {
 // flattened so it visually points at the avatar on the rail. App-wide
 // bubble consolidation will hoist this style into a shared bb-bubble class
 // when the matching pattern lands on transactions and reviews.
-templ txdTimelineComment(e service.ActivityEntry) {
+templ txdTimelineComment(e service.ActivityEntry, now time.Time) {
 	<li class="relative flex items-start gap-3 py-2.5 group">
 		<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100">
 			@txdCommentAvatar(e)
@@ -525,7 +526,7 @@ templ txdTimelineComment(e service.ActivityEntry) {
 				<span class="text-base-content/55">commented</span>
 				if e.Timestamp != "" {
 					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
-						<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStr(e.Timestamp) }</time>
+						<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
 					</span>
 				}
 				if e.CommentID != "" {
@@ -775,6 +776,16 @@ func clockTimeStr(s string) string {
 // button aria-labels so screen readers get a stable description.
 func relativeTimeStr(s string) string {
 	return timefmt.RelativeRFC3339(s)
+}
+
+// relativeTimeStrAt is relativeTimeStr with an explicit now anchor so the
+// activity-timeline rows render against the same clock that the day-bucket
+// labels were computed with. Without a shared anchor a row at 23:55 can
+// land under "Today" while its relative timestamp says "yesterday" (or
+// vice-versa) — see internal/admin/transactions.go buildActivityTimeline
+// for where now is captured.
+func relativeTimeStrAt(s string, now time.Time) string {
+	return timefmt.RelativeRFC3339At(s, now)
 }
 
 // avatarURLStr mirrors the admin "avatarURL" funcMap for the (user_id,

--- a/internal/templates/components/pages/transaction_detail_types.go
+++ b/internal/templates/components/pages/transaction_detail_types.go
@@ -1,6 +1,8 @@
 package pages
 
 import (
+	"time"
+
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components"
 )
@@ -39,6 +41,14 @@ type TransactionDetailProps struct {
 	// Activity timeline.
 	Activity     []service.ActivityEntry
 	ActivityDays []ActivityDayGroup
+
+	// Now is the single time anchor captured by the handler at the top
+	// of buildActivityTimeline. The per-row relative-time helpers
+	// (relativeTimeStrAt) read this so they share the exact same clock
+	// reference as the day-bucket labels in ActivityDays — preventing
+	// the "Today" / "yesterday" mismatch that occurs when each path
+	// calls time.Now() independently across midnight.
+	Now time.Time
 
 	// Has the transaction got a needs-review tag attached?
 	HasPendingReview bool

--- a/internal/timefmt/timefmt.go
+++ b/internal/timefmt/timefmt.go
@@ -55,14 +55,22 @@ func FormatRFC3339Ptr(s *string, layout string) string {
 // returns Relative(t). Empty input yields ""; an unparseable string is
 // returned unchanged.
 func RelativeRFC3339(s string) string {
+	return RelativeRFC3339At(s, time.Now())
+}
+
+// RelativeRFC3339At is RelativeRFC3339 with an explicit now anchor. Pages
+// that mix relative-time rendering with day-bucket labels share a single
+// now via this entry point so the two paths can never disagree across
+// midnight or timezone boundaries.
+func RelativeRFC3339At(s string, now time.Time) string {
 	if s == "" {
 		return ""
 	}
 	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return Relative(t)
+		return RelativeAt(t, now)
 	}
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return Relative(t)
+		return RelativeAt(t, now)
 	}
 	return s
 }
@@ -75,12 +83,29 @@ func RelativeRFC3339Ptr(s *string) string {
 	return RelativeRFC3339(*s)
 }
 
+// RelativeRFC3339PtrAt is RelativeRFC3339Ptr with an explicit now anchor.
+func RelativeRFC3339PtrAt(s *string, now time.Time) string {
+	if s == nil {
+		return ""
+	}
+	return RelativeRFC3339At(*s, now)
+}
+
 // Relative renders t as a human-readable "X ago" string relative to now.
 // Output buckets: "just now" (<1m), "N minute(s) ago" (<1h),
-// "N hour(s) ago" (<1d), "N day(s) ago" (>=1d). Uses time.Since(t), so
-// future times collapse to the "just now" bucket.
+// "N hour(s) ago" (<1d), "N day(s) ago" (>=1d). Future times collapse
+// to the "just now" bucket. Delegates to RelativeAt with time.Now().
 func Relative(t time.Time) string {
-	d := time.Since(t)
+	return RelativeAt(t, time.Now())
+}
+
+// RelativeAt is Relative with an explicit now anchor. The page-level
+// timeline assembler captures one now at the top and threads it through
+// both the day-grouping and the per-row relative-time helpers via this
+// function so labels ("Today" / "Yesterday") and timestamps
+// ("yesterday" / "5 minutes ago") always agree.
+func RelativeAt(t, now time.Time) string {
+	d := now.Sub(t)
 	switch {
 	case d < time.Minute:
 		return "just now"

--- a/internal/timefmt/timefmt_test.go
+++ b/internal/timefmt/timefmt_test.go
@@ -34,6 +34,47 @@ func TestRelative(t *testing.T) {
 	}
 }
 
+// TestRelativeAt locks the rendering to a fixed anchor so the bucket
+// boundaries are deterministic — Relative()'s table uses time.Now() and
+// thus drifts. RelativeAt is the entry point page-level callers use to
+// share their now anchor with day-grouping logic; verifying it here means
+// the shared anchor produces the strings tests downstream assert on.
+func TestRelativeAt(t *testing.T) {
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{"just now (zero)", now, "just now"},
+		{"just now (30s)", now.Add(-30 * time.Second), "just now"},
+		{"1 minute", now.Add(-1 * time.Minute), "1 minute ago"},
+		{"15 minutes (midnight boundary)", now.Add(-15 * time.Minute), "15 minutes ago"},
+		{"59 minutes", now.Add(-59 * time.Minute), "59 minutes ago"},
+		{"1 hour", now.Add(-1 * time.Hour), "1 hour ago"},
+		{"23 hours", now.Add(-23 * time.Hour), "23 hours ago"},
+		{"1 day", now.Add(-24 * time.Hour), "1 day ago"},
+		{"5 days", now.Add(-5 * 24 * time.Hour), "5 days ago"},
+		{"future collapses to just now", now.Add(1 * time.Hour), "just now"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RelativeAt(tc.in, now); got != tc.want {
+				t.Errorf("RelativeAt(%s) = %q, want %q", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// Relative must delegate to RelativeAt with time.Now() — sanity check that
+// the two entry points stay consistent at a coarse level.
+func TestRelativeDelegatesToRelativeAt(t *testing.T) {
+	in := time.Now().Add(-3 * time.Minute)
+	if got, want := Relative(in), "3 minutes ago"; got != want {
+		t.Errorf("Relative = %q, want %q", got, want)
+	}
+}
+
 func TestFormatRFC3339(t *testing.T) {
 	// Pin the inputs to UTC so the assertions are stable regardless of
 	// the runner's local zone (formatter renders in local time).


### PR DESCRIPTION
## Why
On the transaction detail timeline, day-group labels ("Today" / "Yesterday") and per-row relative timestamps ("2h ago" / "yesterday") each captured `time.Now()` independently. They can disagree across midnight or across timezones — e.g. a row at 23:55 ending up grouped under "Today" but rendered as "yesterday".

## What
- New `timefmt.RelativeAt(t, now)` (and matching `RelativeRFC3339At` / `RelativeRFC3339PtrAt`) takes an explicit anchor; `Relative(t)` delegates with `time.Now()`.
- `buildActivityTimeline` captures `now` once and threads it through `activityDayLabel`, `groupActivityByDay`, and the templ via `TransactionDetailProps.Now` → `relativeTimeStrAt`.
- Templ inner functions `txdTimelineSystem` / `txdTimelineComment` now accept `now time.Time` so the row-level renderer reads from the page-level anchor.

## Test plan
- [x] New unit test `TestGroupActivityByDay_SharesNowAnchorWithRelative` covers the 23:55 / 00:05 day-boundary case — bucket label and relative time agree.
- [x] New `TestRelativeAt` table-driven test pinned to a fixed anchor.
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green.

## UI
The fix is purely a correctness-on-edge-cases change. At non-edge times (more than a few minutes from a calendar boundary) there is nothing visually different from `main`, so no screenshot.

Part of the **activity-log-v2** stack.
