### PR TITLE
polish(ui): hover underline on activity-timeline timestamps

### DIFF
--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -366,7 +366,7 @@ templ txdTimelineSystem(e service.ActivityEntry, now time.Time) {
 				if e.Timestamp != "" {
 					<span aria-hidden="true">&middot;</span>
 					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
-						<time datetime={ e.Timestamp } class="tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
+						<time datetime={ e.Timestamp } class="tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
 					</span>
 				}
 			</span>
@@ -526,7 +526,7 @@ templ txdTimelineComment(e service.ActivityEntry, now time.Time) {
 				<span class="text-base-content/55">commented</span>
 				if e.Timestamp != "" {
 					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
-						<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
+						<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
 					</span>
 				}
 				if e.CommentID != "" {


### PR DESCRIPTION
## Why
Activity-timeline timestamps are wrapped in a daisyUI tooltip that reveals the absolute time on hover, but the trigger had no visual affordance — they read as static text and the tooltip felt undiscoverable.

## What
Subtle `hover:underline underline-offset-2 decoration-base-content/30` on every `<time>` in the timeline (system rows + comment rows). `cursor-default` preserved — they're not links.

## Screenshots

**Desktop — default state**
<img src="https://i.img402.dev/85c78bz9dc.jpg" width="800" alt="timeline timestamps default">

**Desktop — hovered**
<img src="https://i.img402.dev/783k3gewj6.jpg" width="800" alt="timeline timestamp on hover">

**Mobile**
<img src="https://i.img402.dev/gjbhzzz4pd.jpg" width="400" alt="mobile timeline">

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`.
- [x] Visual validation in Chrome DevTools at 1280x800 and 390x844.

Part of the **activity-log-v2** stack.
