### PR TITLE
feat(comments): soft-delete tombstones in the activity timeline

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -973,6 +973,15 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 			ActorAvatarVersion: a.ActorAvatarVersion,
 			Detail:             a.Content,
 			CommentID:          a.ShortID,
+			IsDeleted:          a.IsDeleted,
+		}
+		// Tombstoned comments don't echo their original body and don't
+		// expose a CommentID — there's nothing left to delete a second
+		// time, and the trash button on the row would be misleading.
+		if a.IsDeleted {
+			entry.Detail = ""
+			entry.CommentID = ""
+			entry.Summary = a.Summary
 		}
 		if a.ActorID != nil && *a.ActorID != "" {
 			id := *a.ActorID

--- a/internal/db/migrations/20260426223322_annotations_soft_delete.sql
+++ b/internal/db/migrations/20260426223322_annotations_soft_delete.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- Soft-delete tombstones for comment annotations. Hard-deleting wiped any
+-- record that a comment ever existed; the activity timeline lost its audit
+-- trail. With deleted_at set, ListAnnotations keeps the row and the UI
+-- renders a muted single-line "<Actor> deleted a comment" tombstone.
+ALTER TABLE annotations ADD COLUMN deleted_at TIMESTAMPTZ NULL;
+CREATE INDEX IF NOT EXISTS annotations_deleted_at_idx ON annotations (deleted_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS annotations_deleted_at_idx;
+ALTER TABLE annotations DROP COLUMN IF EXISTS deleted_at;

--- a/internal/db/queries/annotations.sql
+++ b/internal/db/queries/annotations.sql
@@ -25,10 +25,14 @@ ORDER BY created_at ASC;
 -- PostgreSQL does not guarantee short-circuit evaluation of conjunctions in
 -- JOIN conditions — a regex guard alone is not enough to prevent SQLSTATE
 -- 22P02 on the ::uuid cast.
+--
+-- deleted_at is surfaced so the service layer can flag tombstoned comments
+-- without filtering them out — the activity timeline still shows
+-- "<Actor> deleted a comment" rows for audit value.
 SELECT
     a.id, a.short_id, a.transaction_id, a.kind, a.actor_type,
     a.actor_id, a.actor_name, a.session_id, a.payload, a.tag_id,
-    a.rule_id, a.created_at,
+    a.rule_id, a.created_at, a.deleted_at,
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at
 FROM annotations a
 LEFT JOIN auth_accounts aa
@@ -61,3 +65,14 @@ RETURNING *;
 
 -- name: DeleteAnnotation :exec
 DELETE FROM annotations WHERE id = $1;
+
+-- name: SoftDeleteAnnotation :exec
+-- Flags an annotation as deleted (sets deleted_at = NOW()) without removing
+-- the row. Used by DeleteComment so the activity timeline preserves the
+-- tombstone — actor + timestamp survive, only the comment payload is
+-- semantically retired. Idempotent: re-soft-deleting an already-tombstoned
+-- row is a no-op since the WHERE clause filters out non-tombstoned rows.
+UPDATE annotations
+SET deleted_at = NOW()
+WHERE id = $1
+  AND deleted_at IS NULL;

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -34,6 +34,12 @@ type Annotation struct {
 	RuleID        *string                `json:"rule_id,omitempty"`
 	CreatedAt     string                 `json:"created_at"`
 
+	// IsDeleted flags a soft-deleted (tombstoned) annotation. Today only
+	// comments can be soft-deleted via DeleteComment; the row stays on the
+	// timeline with actor + timestamp intact while the UI renders a muted
+	// "<Actor> deleted a comment" line in place of the comment bubble.
+	IsDeleted bool `json:"is_deleted,omitempty"`
+
 	// ---- Derived fields (populated by ListAnnotations enrichment) ----
 
 	// Action is the normalized verb for the event:
@@ -259,6 +265,10 @@ func annotationFromRow(a db.Annotation) Annotation {
 		}
 	}
 
+	if a.DeletedAt.Valid {
+		ann.IsDeleted = true
+	}
+
 	return ann
 }
 
@@ -298,6 +308,10 @@ func annotationFromActorRow(a db.ListAnnotationsWithActorByTransactionRow) Annot
 
 	if a.ActorUpdatedAt.Valid {
 		ann.ActorAvatarVersion = strconv.FormatInt(a.ActorUpdatedAt.Time.Unix(), 10)
+	}
+
+	if a.DeletedAt.Valid {
+		ann.IsDeleted = true
 	}
 
 	return ann

--- a/internal/service/annotations_enrich.go
+++ b/internal/service/annotations_enrich.go
@@ -91,8 +91,10 @@ func EnrichAnnotations(in []Annotation, opts EnrichOptions) []Annotation {
 			continue
 		}
 		// 2. Drop the standalone comment that mirrors an adjacent
-		//    tag_added.note from the same actor.
-		if src.Kind == "comment" && isCommentDuplicateOfTagNote(in, src) {
+		//    tag_added.note from the same actor — but tombstones never
+		//    fold: a deleted comment is a distinct event with audit value
+		//    of its own and must always survive enrichment.
+		if src.Kind == "comment" && !src.IsDeleted && isCommentDuplicateOfTagNote(in, src) {
 			continue
 		}
 		out = append(out, enrichOne(src, tagDisplay, categoryDisplay))
@@ -197,7 +199,13 @@ func enrichOne(a Annotation, tagDisplay, categoryDisplay func(string) string) An
 		content, _ := a.Payload["content"].(string)
 		a.Content = content
 		a.Subject = content
-		a.Summary = formatCommentSummary(a.ActorName, content)
+		if a.IsDeleted {
+			// Tombstones don't echo the original body — the comment is
+			// retired; only actor + verb remain on the timeline.
+			a.Summary = formatDeletedCommentSummary(a.ActorName)
+		} else {
+			a.Summary = formatCommentSummary(a.ActorName, content)
+		}
 
 	case "tag_added", "tag_removed":
 		slug, _ := a.Payload["slug"].(string)
@@ -255,6 +263,17 @@ func enrichOne(a Annotation, tagDisplay, categoryDisplay func(string) string) An
 	}
 
 	return a
+}
+
+// formatDeletedCommentSummary renders the tombstone sentence shown in place
+// of a deleted comment's bubble. Mirrors the system-row sentence shape so
+// the timeline reads the same when a comment is gone — only actor + verb
+// remain.
+func formatDeletedCommentSummary(actor string) string {
+	if actor == "" {
+		return "Comment deleted"
+	}
+	return actor + " deleted a comment"
 }
 
 // formatCommentSummary builds a one-line preview of a comment for the

--- a/internal/service/annotations_enrich_test.go
+++ b/internal/service/annotations_enrich_test.go
@@ -250,6 +250,70 @@ func TestEnrichAnnotations_DropsCommentDuplicatingAdjacentTagNote(t *testing.T) 
 	}
 }
 
+// Tombstoned comments must NEVER be folded into an adjacent tag-with-note
+// even when the timestamps and actor match — a deletion is a distinct audit
+// event and the timeline must surface it independently.
+func TestEnrichAnnotations_TombstoneNeverFoldsIntoTagNote(t *testing.T) {
+	actor := "user-1"
+	note := "Please review this one again"
+	rows := []Annotation{
+		{
+			ID:        "a-tag",
+			Kind:      "tag_added",
+			ActorID:   &actor,
+			ActorName: "alice",
+			Payload: map[string]interface{}{
+				"slug": "needs-review",
+				"note": note,
+			},
+			CreatedAt: "2026-04-16T03:39:34.502794Z",
+		},
+		{
+			ID:        "a-comment",
+			Kind:      "comment",
+			ActorID:   &actor,
+			ActorName: "alice",
+			Payload: map[string]interface{}{
+				"content": note,
+			},
+			CreatedAt: "2026-04-16T03:39:34.513524Z",
+			IsDeleted: true,
+		},
+	}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2 (tombstone must survive enrichment)", len(out))
+	}
+	// Tombstone Summary is the muted "<Actor> deleted a comment" sentence,
+	// not the original body.
+	gotComment := out[1]
+	if gotComment.Kind != "comment" || !gotComment.IsDeleted {
+		t.Fatalf("expected tombstoned comment to survive; got kind=%q deleted=%v", gotComment.Kind, gotComment.IsDeleted)
+	}
+	if gotComment.Summary != "alice deleted a comment" {
+		t.Errorf("Summary = %q, want %q", gotComment.Summary, "alice deleted a comment")
+	}
+}
+
+// A bare tombstone (no actor name) renders the system-shape "Comment deleted"
+// sentence so the timeline still narrates the event.
+func TestEnrichAnnotations_TombstoneSummaryFallsBackWithoutActor(t *testing.T) {
+	rows := []Annotation{{
+		ID:        "ghost",
+		Kind:      "comment",
+		Payload:   map[string]interface{}{"content": "old body"},
+		CreatedAt: "2026-04-16T03:39:34Z",
+		IsDeleted: true,
+	}}
+	out := EnrichAnnotations(rows, EnrichOptions{})
+	if len(out) != 1 {
+		t.Fatalf("len = %d, want 1", len(out))
+	}
+	if out[0].Summary != "Comment deleted" {
+		t.Errorf("Summary = %q, want %q", out[0].Summary, "Comment deleted")
+	}
+}
+
 // A comment outside the ±2s window of a matching tag_added.note is NOT
 // deduped — users can legitimately repeat the same text minutes later.
 func TestEnrichAnnotations_KeepsDistantComment(t *testing.T) {

--- a/internal/service/comments.go
+++ b/internal/service/comments.go
@@ -114,6 +114,13 @@ func (s *Service) ListComments(ctx context.Context, transactionID string) ([]Com
 		if r.Kind != "comment" {
 			continue
 		}
+		// Tombstoned comments are kept on the activity timeline (rendered as
+		// "<Actor> deleted a comment") but elided from the REST/MCP comment
+		// list — external callers expect the same semantics as the prior
+		// hard-delete behavior.
+		if r.DeletedAt.Valid {
+			continue
+		}
 		content, reviewID := contentFromAnnotationPayload(r.Payload)
 		result = append(result, commentFromAnnotation(r, content, reviewID))
 	}
@@ -142,6 +149,13 @@ func (s *Service) UpdateComment(ctx context.Context, id string, params UpdateCom
 	}
 
 	if existing.Kind != "comment" {
+		return nil, ErrNotFound
+	}
+
+	// A tombstoned comment is no longer editable — its content is retired
+	// even though the row survives for audit. Treat as not-found so the
+	// API surface matches the prior hard-delete semantics.
+	if existing.DeletedAt.Valid {
 		return nil, ErrNotFound
 	}
 
@@ -177,7 +191,18 @@ func (s *Service) UpdateComment(ctx context.Context, id string, params UpdateCom
 	return &resp, nil
 }
 
-// DeleteComment hard-deletes a comment annotation.
+// DeleteComment soft-deletes a comment annotation: the row stays put with a
+// deleted_at timestamp so the activity timeline can render a tombstone
+// ("<Actor> deleted a comment · <relative-time>") instead of silently dropping
+// every record that the comment ever existed. Hard-delete erased the audit
+// trail; soft-delete preserves actor + timestamp so the timeline keeps its
+// audit value.
+//
+// Idempotent against a row that's already tombstoned: SoftDeleteAnnotation's
+// WHERE clause filters out non-tombstoned rows so a re-delete is a no-op
+// rather than an error. We still verify the annotation exists, is a comment,
+// and the actor is authorized — those checks short-circuit on the first
+// soft-delete and stay correct on retries.
 func (s *Service) DeleteComment(ctx context.Context, id string, actor Actor) error {
 	annID, err := s.resolveAnnotationID(ctx, id)
 	if err != nil {
@@ -200,8 +225,8 @@ func (s *Service) DeleteComment(ctx context.Context, id string, actor Actor) err
 		return ErrForbidden
 	}
 
-	if err := s.Queries.DeleteAnnotation(ctx, annID); err != nil {
-		return fmt.Errorf("delete comment annotation: %w", err)
+	if err := s.Queries.SoftDeleteAnnotation(ctx, annID); err != nil {
+		return fmt.Errorf("soft-delete comment annotation: %w", err)
 	}
 
 	return nil

--- a/internal/service/comments_soft_delete_integration_test.go
+++ b/internal/service/comments_soft_delete_integration_test.go
@@ -1,0 +1,136 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+)
+
+// TestDeleteComment_SoftDeleteTombstone is the canonical integration test for
+// the soft-delete behavior introduced by PR 4 of activity-log-v2. The contract
+// is: DeleteComment marks the row deleted_at = NOW() instead of removing it,
+// so the activity timeline (ListAnnotations) keeps the audit trail with
+// IsDeleted=true and a "<Actor> deleted a comment" Summary, while the
+// REST/MCP comments listing (ListComments) hides the row to preserve the
+// prior external API semantics.
+func TestDeleteComment_SoftDeleteTombstone(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := seedTransaction(t, queries, acctID, "ext_soft_delete_1", "Coffee", 100, "2024-06-01")
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	actor := service.Actor{Type: "agent", ID: "key-soft-1", Name: "TombstoneBot"}
+	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "About to be tombstoned",
+		Actor:         actor,
+	})
+	if err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+
+	if err := svc.DeleteComment(ctx, comment.ID, actor); err != nil {
+		t.Fatalf("DeleteComment failed: %v", err)
+	}
+
+	// ListComments hides the row — REST/MCP callers see the same external
+	// shape as the prior hard-delete behavior.
+	comments, err := svc.ListComments(ctx, txnID)
+	if err != nil {
+		t.Fatalf("ListComments after delete: %v", err)
+	}
+	if len(comments) != 0 {
+		t.Errorf("ListComments after soft-delete: got %d comments, want 0", len(comments))
+	}
+
+	// ListAnnotations keeps the row, marks it deleted, and the enriched
+	// Summary uses the tombstone phrasing rather than the original body.
+	anns, err := svc.ListAnnotations(ctx, txnID, service.ListAnnotationsParams{Kinds: []string{"comment"}})
+	if err != nil {
+		t.Fatalf("ListAnnotations: %v", err)
+	}
+	if len(anns) != 1 {
+		t.Fatalf("expected 1 annotation row preserved, got %d", len(anns))
+	}
+	got := anns[0]
+	if !got.IsDeleted {
+		t.Errorf("annotation IsDeleted = false, want true")
+	}
+	if got.ActorName != "TombstoneBot" {
+		t.Errorf("ActorName = %q, want %q (actor must survive on tombstone)", got.ActorName, "TombstoneBot")
+	}
+	wantSummary := "TombstoneBot deleted a comment"
+	if got.Summary != wantSummary {
+		t.Errorf("Summary = %q, want %q", got.Summary, wantSummary)
+	}
+	if strings.Contains(got.Summary, "About to be tombstoned") {
+		t.Errorf("tombstone Summary should not echo the original body; got %q", got.Summary)
+	}
+}
+
+// TestDeleteComment_Idempotent re-deleting a tombstoned comment must not
+// error. The underlying SoftDeleteAnnotation query filters non-tombstoned
+// rows, so the second call is a no-op and still returns nil.
+func TestDeleteComment_Idempotent(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := seedTransaction(t, queries, acctID, "ext_soft_delete_idem", "Coffee", 100, "2024-06-01")
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	actor := service.Actor{Type: "agent", ID: "key-soft-2", Name: "IdemBot"}
+	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "delete me twice",
+		Actor:         actor,
+	})
+	if err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+
+	if err := svc.DeleteComment(ctx, comment.ID, actor); err != nil {
+		t.Fatalf("first DeleteComment failed: %v", err)
+	}
+	if err := svc.DeleteComment(ctx, comment.ID, actor); err != nil {
+		t.Fatalf("second DeleteComment must be idempotent, got: %v", err)
+	}
+}
+
+// TestUpdateComment_TombstonedNotFound editing a tombstoned comment must
+// fail — the content is retired and external API surfaces shouldn't allow
+// a soft-deleted body to come back through an Update path.
+func TestUpdateComment_TombstonedNotFound(t *testing.T) {
+	svc, queries, _ := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := seedTransaction(t, queries, acctID, "ext_soft_delete_upd", "Coffee", 100, "2024-06-01")
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	actor := service.Actor{Type: "agent", ID: "key-soft-3", Name: "EditBot"}
+	comment, err := svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "first",
+		Actor:         actor,
+	})
+	if err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+
+	if err := svc.DeleteComment(ctx, comment.ID, actor); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	_, err = svc.UpdateComment(ctx, comment.ID, service.UpdateCommentParams{
+		Content: "resurrect",
+		Actor:   actor,
+	})
+	if err != service.ErrNotFound {
+		t.Errorf("UpdateComment on tombstone: got %v, want ErrNotFound", err)
+	}
+}

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -436,6 +436,12 @@ type ActivityEntry struct {
 	// with this phrase; Origin keeps the actor slot empty for system rows
 	// and lets the template render origin as a subordinate meta pill.
 	Origin string `json:"origin,omitempty"`
+
+	// IsDeleted flags a tombstoned comment. The activity timeline keeps the
+	// row to preserve audit value — actor + timestamp survive — but renders
+	// it as a muted single-line "<Actor> deleted a comment" sentence
+	// instead of the chat bubble.
+	IsDeleted bool `json:"is_deleted,omitempty"`
 }
 
 type Condition struct {

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -507,7 +507,22 @@ templ txdCategoryIcon(e service.ActivityEntry) {
 // flattened so it visually points at the avatar on the rail. App-wide
 // bubble consolidation will hoist this style into a shared bb-bubble class
 // when the matching pattern lands on transactions and reviews.
+//
+// Tombstoned comments (IsDeleted=true) skip the bubble entirely and route to
+// txdTimelineDeletedComment, which mirrors the system-row layout so a
+// deleted comment reads as a single muted line preserving actor + timestamp.
 templ txdTimelineComment(e service.ActivityEntry, now time.Time) {
+	if e.IsDeleted {
+		@txdTimelineDeletedComment(e, now)
+	} else {
+		@txdTimelineCommentBubble(e, now)
+	}
+}
+
+// txdTimelineCommentBubble renders the chat-bubble variant — the historical
+// shape pulled out so the entry-point templ above can branch cleanly on
+// IsDeleted without duplicating either path.
+templ txdTimelineCommentBubble(e service.ActivityEntry, now time.Time) {
 	<li class="relative flex items-start gap-3 py-2.5 group">
 		<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100">
 			@txdCommentAvatar(e)
@@ -537,6 +552,37 @@ templ txdTimelineComment(e service.ActivityEntry, now time.Time) {
 			</div>
 			if e.Detail != "" {
 				<div class="bb-comment-bubble mt-1">{ e.Detail }</div>
+			}
+		</div>
+	</li>
+}
+
+// txdTimelineDeletedComment renders a tombstoned comment as a muted
+// single-line system-style row using the same rail/icon scaffolding as
+// txdTimelineSystem. The comment body is gone — only "<Actor> deleted a
+// comment · <relative-time>" remains, preserving audit value (we still
+// know who removed what and when) without re-displaying retired content.
+templ txdTimelineDeletedComment(e service.ActivityEntry, now time.Time) {
+	<li class="relative flex items-start gap-3 py-2 group">
+		<div class="relative z-10 shrink-0 w-6 h-6 rounded-full bg-base-100">
+			<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
+				<i data-lucide="trash-2" class="w-3 h-3 text-base-content/40"></i>
+			</span>
+		</div>
+		<div class="flex-1 min-w-0 text-xs leading-6 text-base-content/55 italic break-words">
+			if e.ActorName != "" {
+				<span class="font-medium text-base-content/70 not-italic">{ e.ActorName }</span>
+				<span>deleted a comment</span>
+			} else {
+				<span>Comment deleted</span>
+			}
+			if e.Timestamp != "" {
+				<span class="text-base-content/40 ml-1 not-italic">
+					<span aria-hidden="true">&middot;</span>
+					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
+						<time datetime={ e.Timestamp } class="tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
+					</span>
+				</span>
 			}
 		</div>
 	</li>


### PR DESCRIPTION
## Why
Hard-deleting a comment erased its annotation row, so the activity timeline lost any record that a comment was ever there. The audit value of the timeline depends on tombstones surviving deletes — actor + timestamp must remain even though the body is retired.

## What
- Additive migration: `annotations.deleted_at TIMESTAMPTZ NULL` + `annotations_deleted_at_idx`.
- `DeleteComment` switches from `DELETE FROM` to a new `SoftDeleteAnnotation` (`UPDATE … SET deleted_at = NOW() WHERE deleted_at IS NULL`). Idempotent — re-deleting a tombstoned comment is a no-op, not an error.
- `service.Annotation.IsDeleted` flagged from the row; `EnrichAnnotations` skips dedup folding for tombstoned comments (rule: "tombstones never fold") so a deleted comment can never be silently absorbed into an adjacent tag-with-note.
- Tombstones get a dedicated `Summary` (`"<Actor> deleted a comment"`) instead of echoing the original body.
- `service.ActivityEntry.IsDeleted` propagated from the admin-layer mapper.
- Templ: `txdTimelineComment` branches on `IsDeleted` and routes to a new `txdTimelineDeletedComment` row that mirrors the system-row layout — single muted line, trash icon on the rail, `<Actor> deleted a comment · <relative-time>`. The chat bubble path is unchanged for live comments (extracted into `txdTimelineCommentBubble`).
- `ListComments` (REST/MCP) hides tombstones to preserve the prior external API semantics; only the activity timeline sees them.
- `UpdateComment` rejects edits on tombstoned rows (`ErrNotFound`).
- Inline JS still does `location.reload()` post-delete; **PR 5 will replace that with an optimistic in-place tombstone swap**.

## Screenshots
<img src="https://i.img402.dev/t6p1e7bnui.jpg" width="800" alt="activity timeline with deleted-comment tombstone — desktop">

<img src="https://i.img402.dev/r605wb8d0l.jpg" width="400" alt="activity timeline with deleted-comment tombstone — mobile">

## Test plan
- [x] New integration coverage in `internal/service/comments_soft_delete_integration_test.go`: soft-delete keeps the annotation row with `IsDeleted=true`, hides it from `ListComments`, and renders the tombstone Summary; second `DeleteComment` is idempotent; `UpdateComment` on a tombstone returns `ErrNotFound`.
- [x] New unit tests in `annotations_enrich_test.go` pin the "tombstones never fold" rule and the actor-less Summary fallback.
- [x] `make test-integration` passes (full suite, including pre-existing `TestDeleteComment_Success` which still expects 0 visible comments after delete since `ListComments` filters tombstones).
- [x] `go build ./...`, `go vet ./...`, `go test ./...`.

Part of the **activity-log-v2** stack (PR 4 of 8). Parent: #891.
