### PR TITLE
feat(transaction-detail): optimistic in-place activity-timeline updates

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -235,6 +235,10 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		r.Post("/transactions/{id}/comments", CreateTransactionCommentHandler(a, sm, svc))
 		r.Delete("/transactions/{id}/comments/{comment_id}", DeleteTransactionCommentHandler(a, sm, svc))
 
+		// Activity-timeline partial render — powers the optimistic-update
+		// flow on the detail page. Accessible to all roles (read-only).
+		r.Get("/transactions/{id}/timeline/rows", TimelineRowsHandler(a, sm, svc))
+
 		// Editor+ API routes (categorization, tagging, access management).
 		r.Group(func(r chi.Router) {
 			r.Use(RequireEditor(sm))

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -975,12 +975,16 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 			CommentID:          a.ShortID,
 			IsDeleted:          a.IsDeleted,
 		}
-		// Tombstoned comments don't echo their original body and don't
-		// expose a CommentID — there's nothing left to delete a second
-		// time, and the trash button on the row would be misleading.
+		// Tombstoned comments don't echo their original body. The
+		// CommentID short_id stays populated so the optimistic-update
+		// path on the detail page can match the tombstone back to the
+		// bubble it replaces (`?comment_ids=<id>` on the timeline-rows
+		// endpoint). The bubble template gates the trash button on
+		// CommentID being non-empty AND the row not being IsDeleted, so
+		// keeping the ID here doesn't accidentally re-surface the
+		// delete affordance on a tombstone.
 		if a.IsDeleted {
 			entry.Detail = ""
-			entry.CommentID = ""
 			entry.Summary = a.Summary
 		}
 		if a.ActorID != nil && *a.ActorID != "" {
@@ -1212,6 +1216,139 @@ func DeleteTransactionCommentHandler(a *app.App, sm *scs.SessionManager, svc *se
 		}
 
 		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// TimelineRowsHandler serves GET /-/transactions/{id}/timeline/rows?since=<RFC3339>[&comment_ids=<id1,id2>].
+//
+// Powers the optimistic-update flow on the transaction detail page: each
+// Alpine action (set category, add tag, comment, etc.) POSTs the mutation
+// and then GETs this endpoint to fetch the rendered HTML for the row(s)
+// that were just written. Reuses the same buildActivityTimeline +
+// pages.TimelineRows helpers as the page handler so server-rendered row
+// markup is the single source of truth (Strategy A — see
+// static/js/admin/components/transaction_detail.js header).
+//
+// Behavior:
+//   - `since` is a RFC3339 timestamp; only entries with Timestamp > since
+//     are returned. Empty/missing `since` returns no entries (the JS uses
+//     this as a sentinel for "no prior cursor — first load only").
+//   - `comment_ids` is a comma-separated list of comment short_ids. Comment
+//     entries matching any of those IDs are included in the response even
+//     when their Timestamp is older than `since`. This handles the
+//     soft-delete case: PR 4's tombstone flips `is_deleted` on an existing
+//     annotation rather than inserting a new one, so the deleted comment's
+//     CreatedAt stays in the past — the JS passes the deleted ID here and
+//     gets the freshly-rendered tombstone row back.
+//   - Returns text/html with the rendered <li> rows, plus an optional day
+//     separator <li> when the new entries fall on a different calendar day
+//     from the most recent prior entry (or when there were no prior entries).
+//   - Empty body when no new entries exist (e.g. the mutation was a no-op).
+func TimelineRowsHandler(a *app.App, sm *scs.SessionManager, svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		txnID := chi.URLParam(r, "id")
+		sinceRaw := strings.TrimSpace(r.URL.Query().Get("since"))
+		commentIDsRaw := strings.TrimSpace(r.URL.Query().Get("comment_ids"))
+		commentIDs := map[string]bool{}
+		if commentIDsRaw != "" {
+			for _, id := range strings.Split(commentIDsRaw, ",") {
+				if id = strings.TrimSpace(id); id != "" {
+					commentIDs[id] = true
+				}
+			}
+		}
+
+		// Build the timeline the same way TransactionDetailHandler does so
+		// the row markup is byte-equivalent to the main page render.
+		annotations, err := svc.ListAnnotations(ctx, txnID, service.ListAnnotationsParams{})
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				return
+			}
+			a.Logger.Error("timeline rows: list annotations", "error", err)
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to load activity")
+			return
+		}
+		categoryTree, err := svc.ListCategoryTree(ctx)
+		if err != nil {
+			a.Logger.Error("timeline rows: list categories", "error", err)
+		}
+		timelineTags, err := svc.ListTags(ctx)
+		if err != nil {
+			a.Logger.Error("timeline rows: list tags", "error", err)
+			timelineTags = nil
+		}
+
+		now := time.Now()
+		entries := buildActivityTimeline(annotations, categoryDetailLookup(categoryTree), tagDisplayLookup(timelineTags))
+
+		// Compute the prior-most-recent timestamp as the boundary between
+		// "already on the page" and "newly inserted". An empty `since` means
+		// the JS hasn't tracked a cursor yet — return nothing rather than the
+		// full timeline (the page already has every entry on first paint).
+		var prior, since time.Time
+		var haveSince, havePrior bool
+		if sinceRaw != "" {
+			if parsed, perr := time.Parse(time.RFC3339, sinceRaw); perr == nil {
+				since = parsed
+				haveSince = true
+			}
+		}
+
+		var newEntries []service.ActivityEntry
+		for _, e := range entries {
+			ts, perr := time.Parse(time.RFC3339, e.Timestamp)
+			if perr != nil {
+				continue
+			}
+			// Always include comment entries whose ID matches one of the
+			// explicit comment_ids — this is the soft-delete tombstone path
+			// where the row's CreatedAt is older than `since` but its
+			// IsDeleted state just flipped.
+			if e.Type == "comment" && commentIDs[e.CommentID] {
+				newEntries = append(newEntries, e)
+				continue
+			}
+			if haveSince {
+				if ts.After(since) {
+					newEntries = append(newEntries, e)
+				} else if !havePrior || ts.After(prior) {
+					prior = ts
+					havePrior = true
+				}
+			}
+		}
+
+		// Decide whether we need a day separator before the new rows. The
+		// separator is needed when the first new entry's calendar day is
+		// different from the most recent prior entry's calendar day (or
+		// when there were no prior entries — the activity-empty case).
+		var dayLabel string
+		if len(newEntries) > 0 {
+			firstNewTs, _ := time.Parse(time.RFC3339, newEntries[0].Timestamp)
+			firstNewDay := firstNewTs.Local().Format("2006-01-02")
+			if !havePrior || prior.Local().Format("2006-01-02") != firstNewDay {
+				today := now.Format("2006-01-02")
+				yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
+				dayLabel = activityDayLabel(firstNewDay, today, yesterday, now)
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if len(newEntries) == 0 {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		comp := pages.TimelineRows(pages.TimelineRowsProps{
+			Entries:           newEntries,
+			Now:               now,
+			DaySeparatorLabel: dayLabel,
+		})
+		if err := comp.Render(ctx, w); err != nil {
+			a.Logger.Error("timeline rows: render", "error", err)
+		}
 	}
 }
 

--- a/internal/admin/transactions_timeline_rows_integration_test.go
+++ b/internal/admin/transactions_timeline_rows_integration_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package admin
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// TestTimelineRowsHandler_RendersNewRows verifies that GET
+// /-/transactions/{id}/timeline/rows?since=<ts> returns rendered <li> rows
+// for activity entries created after the given timestamp.
+func TestTimelineRowsHandler_RendersNewRows(t *testing.T) {
+	pool, q := testutil.ServicePool(t)
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, q, "Alice")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-1")
+	acct := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-1", "Checking")
+	txn := testutil.MustCreateTransaction(t, q, acct.ID, "ext-txn-1", "Coffee", 500, "2026-04-01")
+
+	// Capture a "before" timestamp, then write a comment annotation. The
+	// render endpoint should return the comment row when asked for
+	// "everything since <before>".
+	// `before` rounds to seconds when serialized as RFC3339, and the
+	// annotation's CreatedAt rounds the same way. To guarantee
+	// CreatedAt > before once both have second-resolution, anchor
+	// `before` two seconds in the past.
+	before := time.Now().Add(-2 * time.Second)
+
+	actor := service.Actor{Type: "user", ID: pgconv.FormatUUID(user.ID), Name: "Alice"}
+	if _, err := svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: pgconv.FormatUUID(txn.ID),
+		Content:       "First note",
+		Actor:         actor,
+	}); err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+
+	r := chi.NewRouter()
+	a := &app.App{DB: pool, Queries: q, Logger: slog.Default()}
+	r.Get("/-/transactions/{id}/timeline/rows", TimelineRowsHandler(a, &scs.SessionManager{}, svc))
+
+	url := "/-/transactions/" + pgconv.FormatUUID(txn.ID) + "/timeline/rows?since=" + before.Format(time.RFC3339)
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "<li") {
+		t.Fatalf("expected <li> markup in body, got: %s", body)
+	}
+	// The comment bubble template renders the actor name + "commented".
+	if !strings.Contains(body, "commented") {
+		t.Errorf("expected 'commented' meta-line in body, got: %s", body)
+	}
+	if !strings.Contains(body, "First note") {
+		t.Errorf("expected comment body 'First note' in markup, got: %s", body)
+	}
+}
+
+// TestTimelineRowsHandler_EmptyWhenNoNewRows verifies that the render
+// endpoint returns an empty 200 body when there are no entries newer than
+// the given since cursor.
+func TestTimelineRowsHandler_EmptyWhenNoNewRows(t *testing.T) {
+	pool, q := testutil.ServicePool(t)
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, q, "Bob")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-2")
+	acct := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-2", "Checking")
+	txn := testutil.MustCreateTransaction(t, q, acct.ID, "ext-txn-2", "Lunch", 1200, "2026-04-02")
+
+	actor := service.Actor{Type: "user", ID: pgconv.FormatUUID(user.ID), Name: "Bob"}
+	if _, err := svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: pgconv.FormatUUID(txn.ID),
+		Content:       "Old note",
+		Actor:         actor,
+	}); err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+
+	// Use a since timestamp well in the future — nothing should match.
+	since := time.Now().Add(1 * time.Hour).Format(time.RFC3339)
+
+	r := chi.NewRouter()
+	a := &app.App{DB: pool, Queries: q, Logger: slog.Default()}
+	r.Get("/-/transactions/{id}/timeline/rows", TimelineRowsHandler(a, &scs.SessionManager{}, svc))
+
+	url := "/-/transactions/" + pgconv.FormatUUID(txn.ID) + "/timeline/rows?since=" + since
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.TrimSpace(w.Body.String()) != "" {
+		t.Fatalf("expected empty body when nothing newer than since, got: %s", w.Body.String())
+	}
+}
+
+// TestTimelineRowsHandler_NoSinceCursor verifies that calling the endpoint
+// without a `since` cursor returns an empty 200 (the JS uses the absence
+// of a cursor as a sentinel for "first load — page already has every row").
+func TestTimelineRowsHandler_NoSinceCursor(t *testing.T) {
+	pool, q := testutil.ServicePool(t)
+	svc := newTestSvc(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, q, "Charlie")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-3")
+	acct := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-3", "Checking")
+	txn := testutil.MustCreateTransaction(t, q, acct.ID, "ext-txn-3", "Coffee", 350, "2026-04-03")
+
+	actor := service.Actor{Type: "user", ID: pgconv.FormatUUID(user.ID), Name: "Charlie"}
+	if _, err := svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: pgconv.FormatUUID(txn.ID),
+		Content:       "A note",
+		Actor:         actor,
+	}); err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+
+	r := chi.NewRouter()
+	a := &app.App{DB: pool, Queries: q, Logger: slog.Default()}
+	r.Get("/-/transactions/{id}/timeline/rows", TimelineRowsHandler(a, &scs.SessionManager{}, svc))
+
+	req := httptest.NewRequest(http.MethodGet, "/-/transactions/"+pgconv.FormatUUID(txn.ID)+"/timeline/rows", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if strings.TrimSpace(w.Body.String()) != "" {
+		t.Fatalf("expected empty body when no since cursor passed, got: %s", w.Body.String())
+	}
+}

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -295,6 +295,8 @@ templ txdActivity(p TransactionDetailProps) {
 		data-tx-id={ p.TransactionID }
 		data-max-comment-length={ strconv.Itoa(p.MaxCommentLength) }
 		data-has-pending-review={ strconv.FormatBool(p.HasPendingReview) }
+		data-last-activity-ts={ txdLastActivityTimestamp(p.Activity) }
+		data-today={ p.Now.Format("2006-01-02") }
 		@bb-toggle-pin-review.window="if (!hasPendingReview) pinReview = !pinReview"
 	>
 		<header class="px-4 sm:px-5 pt-5 pb-4 flex items-center gap-2">
@@ -523,7 +525,7 @@ templ txdTimelineComment(e service.ActivityEntry, now time.Time) {
 // shape pulled out so the entry-point templ above can branch cleanly on
 // IsDeleted without duplicating either path.
 templ txdTimelineCommentBubble(e service.ActivityEntry, now time.Time) {
-	<li class="relative flex items-start gap-3 py-2.5 group">
+	<li class="relative flex items-start gap-3 py-2.5 group" data-comment-id={ e.CommentID }>
 		<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100">
 			@txdCommentAvatar(e)
 		</div>
@@ -563,7 +565,7 @@ templ txdTimelineCommentBubble(e service.ActivityEntry, now time.Time) {
 // comment · <relative-time>" remains, preserving audit value (we still
 // know who removed what and when) without re-displaying retired content.
 templ txdTimelineDeletedComment(e service.ActivityEntry, now time.Time) {
-	<li class="relative flex items-start gap-3 py-2 group">
+	<li class="relative flex items-start gap-3 py-2 group" data-comment-id={ e.CommentID }>
 		<div class="relative z-10 shrink-0 w-6 h-6 rounded-full bg-base-100">
 			<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
 				<i data-lucide="trash-2" class="w-3 h-3 text-base-content/40"></i>
@@ -868,4 +870,49 @@ func txdCategoryOverrideAttr(p TransactionDetailProps) string {
 		return "true"
 	}
 	return "false"
+}
+
+// txdLastActivityTimestamp returns the RFC3339 timestamp of the latest
+// activity entry, or empty string when the timeline has no entries. Used
+// as a `data-last-activity-ts` cursor on the activity section so the JS
+// optimistic-update path can ask the render endpoint for "everything newer
+// than this timestamp" after a mutation.
+func txdLastActivityTimestamp(entries []service.ActivityEntry) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	return entries[len(entries)-1].Timestamp
+}
+
+// TimelineRowsProps drives the partial-render endpoint used by the
+// optimistic-update flow. The handler builds the activity entries the
+// same way the main page does, slices off the new ones, and passes them
+// through here. DaySeparatorLabel is non-empty when the new rows live in
+// a different calendar day from whatever was already on the page — the
+// JS then knows to insert this fragment as a fresh day group.
+//
+// The component renders ONLY the new <li> rows (and an optional
+// separator) — never the surrounding <ol> or composer. The JS unwraps
+// the fragment and inserts each <li> right before the composer.
+type TimelineRowsProps struct {
+	Entries           []service.ActivityEntry
+	Now               time.Time
+	DaySeparatorLabel string
+}
+
+// TimelineRows renders activity rows for the partial-render endpoint
+// (GET /-/transactions/{id}/timeline/rows). Reuses txdTimelineDay /
+// txdTimelineSystem / txdTimelineComment so the row markup matches the
+// main page exactly — no client-side templating, no risk of drift.
+templ TimelineRows(p TimelineRowsProps) {
+	if p.DaySeparatorLabel != "" {
+		@txdTimelineDay(p.DaySeparatorLabel, false)
+	}
+	for _, e := range p.Entries {
+		if e.Type == "comment" {
+			@txdTimelineComment(e, p.Now)
+		} else {
+			@txdTimelineSystem(e, p.Now)
+		}
+	}
 }

--- a/static/js/admin/components/transaction_detail.js
+++ b/static/js/admin/components/transaction_detail.js
@@ -27,6 +27,35 @@
 //
 // `showToast` is exposed on `window` to match the contract used by
 // tx-row's inline x-init watcher and the rule_detail page.
+//
+// ---- Optimistic in-place activity-timeline updates (Strategy A) ----
+//
+// Mutating actions (set category, add/remove tag, add/delete comment,
+// pin/unpin needs-review) used to call location.reload() — or, in the
+// category-set case, do nothing visible — to surface the resulting
+// timeline row. We now keep the user on the page:
+//
+//   1. POST/PATCH/DELETE the mutation as before.
+//   2. On 2xx, GET /-/transactions/{id}/timeline/rows?since=<lastTs>.
+//      The server reuses the same templ helpers as the main page (see
+//      pages.TimelineRows in transaction_detail.templ) so row markup is
+//      a single source of truth — no client-side row templating, no
+//      drift risk from a duplicated JS renderer.
+//   3. Insert the returned <li> rows just before the composer at the
+//      bottom of the timeline <ol>. Update the cached "last activity
+//      timestamp" cursor so subsequent fetches only get fresh rows.
+//   4. Update local chip state (category chip, tag chips, pin state) so
+//      the sidebar reflects the change without a reload.
+//
+// Failure path: every catch / non-2xx branch calls restorePageState()
+// (clears the SPA progress bar + content fade left over from any link
+// click) and surfaces a toast. Chip-state rollback happens at the call
+// site so the user sees the prior state restored.
+//
+// Day-grouping: the render endpoint inserts a `<li class="...">Today</li>`
+// separator ahead of the new rows when the new rows fall on a different
+// calendar day than the most recent existing row (see TimelineRowsHandler
+// in internal/admin/transactions.go).
 
 // --- Module-level globals consumed by tx_row + base.html ---
 
@@ -35,6 +64,149 @@ function showToast(message, type) {
 }
 
 window.showToast = showToast;
+
+// restorePageState clears the global SPA progress bar + content fade that
+// auto-starts on internal link clicks. Per .claude/rules/ui.md every
+// async error path must invoke this so the page doesn't stay blurred /
+// non-interactive after a failed fetch. Defined at module scope so all
+// three factories can share a single implementation.
+function restorePageState() {
+  if (window.bbProgress && typeof window.bbProgress.finish === 'function') {
+    window.bbProgress.finish();
+  }
+  var main = document.querySelector('main');
+  if (main) {
+    main.style.opacity = '';
+    main.style.filter = '';
+    main.style.pointerEvents = '';
+  }
+}
+
+// timelineRoot returns the activity <section> element (root of the
+// txdCommentManager factory). Used by the cross-factory helpers below
+// because the comment manager owns the cursor + insertion point but
+// every factory needs to trigger a refresh after its mutation.
+function timelineRoot() {
+  return document.getElementById('activity');
+}
+
+// timelineList returns the <ol class="bb-timeline"> inside the activity
+// section (or null when the timeline started empty — only the
+// txdTimelineEmptyComposer was rendered).
+function timelineList() {
+  var root = timelineRoot();
+  if (!root) return null;
+  return root.querySelector('ol.bb-timeline');
+}
+
+// composerLi finds the <li> wrapping txdComposerCard at the bottom of
+// the timeline. New rows must insert *before* this so the composer
+// stays at the bottom.
+function composerLi() {
+  var ol = timelineList();
+  if (!ol) return null;
+  // The composer is the last child <li>. Use lastElementChild instead
+  // of a class selector because the composer's <li> doesn't carry a
+  // distinguishing class today.
+  return ol.lastElementChild;
+}
+
+// fetchTimelineRows fetches and inserts the rendered <li> rows for any
+// activity entries newer than the cached cursor. The optional
+// `replaceCommentIDs` array forces the endpoint to also return rows for
+// those comment short_ids regardless of cursor age — used by the
+// soft-delete path where the tombstone replaces an existing bubble (its
+// CreatedAt is older than `since`, but `is_deleted` just flipped).
+// Returns a promise that resolves to the number of rows inserted (0 = no
+// new rows, treat as silent success).
+function fetchTimelineRows(txId, replaceCommentIDs) {
+  var root = timelineRoot();
+  if (!root) return Promise.resolve(0);
+  var since = root.dataset.lastActivityTs || '';
+  var params = [];
+  if (since) params.push('since=' + encodeURIComponent(since));
+  if (replaceCommentIDs && replaceCommentIDs.length) {
+    params.push('comment_ids=' + encodeURIComponent(replaceCommentIDs.join(',')));
+  }
+  var url = '/-/transactions/' + encodeURIComponent(txId) + '/timeline/rows';
+  if (params.length) url += '?' + params.join('&');
+  return fetch(url, { headers: { Accept: 'text/html' } })
+    .then(function (res) {
+      if (!res.ok) throw new Error('render-failed');
+      return res.text();
+    })
+    .then(function (html) {
+      if (!html.trim()) return 0;
+      // Parse the fragment. The server returns one or more <li> elements
+      // (plus an optional day separator <li>) — no surrounding wrapper.
+      var tpl = document.createElement('template');
+      tpl.innerHTML = html.trim();
+      var nodes = Array.prototype.slice.call(tpl.content.children);
+      if (nodes.length === 0) return 0;
+
+      // Insertion point: the timeline may already exist (timelineList())
+      // or the page may have rendered txdTimelineEmptyComposer (no <ol>
+      // yet). For the empty case we don't try to materialize the rail —
+      // a single fresh row reading without it is acceptable; the next
+      // page load will render the proper rail. The 99%-case is the
+      // non-empty timeline.
+      var ol = timelineList();
+      var composer = composerLi();
+      if (!ol) {
+        // Empty-state fallback: full reload so the timeline gets its
+        // proper <ol> rail. Rare path; acceptable.
+        window.location.reload();
+        return 0;
+      }
+
+      // Insert each node. For replacement rows (tombstones — the
+      // returned <li> has data-comment-id matching one of the requested
+      // replaceCommentIDs), find the matching bubble <li> and swap it
+      // in place. For genuinely new rows, insert just before the
+      // composer (so the composer stays at the bottom).
+      var inserted = 0;
+      var replaceSet = {};
+      if (replaceCommentIDs && replaceCommentIDs.length) {
+        replaceCommentIDs.forEach(function (id) { replaceSet[id] = true; });
+      }
+      nodes.forEach(function (n) {
+        var commentID = (n.dataset && n.dataset.commentId) || '';
+        if (commentID && replaceSet[commentID]) {
+          var existing = ol.querySelector('li[data-comment-id="' + commentID + '"]');
+          if (existing) {
+            existing.parentNode.replaceChild(n, existing);
+            inserted++;
+            return;
+          }
+        }
+        if (composer) {
+          ol.insertBefore(n, composer);
+        } else {
+          ol.appendChild(n);
+        }
+        inserted++;
+      });
+
+      // Update the cursor so the next fetch only sees newer rows. Every
+      // returned <li> has a <time datetime="..."> child for the activity
+      // entry's timestamp; the last one is the newest. Skip rows that
+      // were replacements (older timestamps would regress the cursor).
+      var lastTime = null;
+      for (var i = nodes.length - 1; i >= 0; i--) {
+        var nodeID = (nodes[i].dataset && nodes[i].dataset.commentId) || '';
+        if (nodeID && replaceSet[nodeID]) continue;
+        var t = nodes[i].querySelector('time[datetime]');
+        if (t) { lastTime = t.getAttribute('datetime'); break; }
+      }
+      if (lastTime) root.dataset.lastActivityTs = lastTime;
+
+      // Re-bootstrap Lucide icons inside the freshly-inserted rows.
+      if (window.lucide && typeof window.lucide.createIcons === 'function') {
+        window.lucide.createIcons();
+      }
+      return inserted;
+    });
+}
 
 // Seed window.__bbCategories and window.__bbAllTags as early as possible
 // so any inline component (tx_row's categoryPicker, base.html's tag
@@ -143,39 +315,58 @@ document.addEventListener('alpine:init', function () {
           return;
         }
         var self = this;
+        var prevOverride = this.isOverride;
         this.saving = true;
+        // Optimistic chip-state update: flip override badge immediately
+        // so the sidebar reads as "manual" while the request flies.
+        this.isOverride = true;
         fetch('/-/transactions/' + this.txId + '/category', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ category_id: detail.id }),
         })
           .then(function (r) {
-            self.saving = false;
-            if (r.ok) {
-              self.isOverride = true;
-              showToast('Category updated.', 'success');
-            } else {
-              r.json().then(function (d) { showToast(d.error?.message || 'Failed to update category.'); });
+            if (!r.ok && r.status !== 204) {
+              return r.json().then(function (d) {
+                throw new Error((d && d.error && d.error.message) || 'Failed to update category.');
+              });
             }
+            return fetchTimelineRows(self.txId);
           })
-          .catch(function () { self.saving = false; showToast('Network error.'); });
+          .then(function () {
+            self.saving = false;
+            showToast('Category updated.', 'success');
+          })
+          .catch(function (e) {
+            self.saving = false;
+            self.isOverride = prevOverride;
+            restorePageState();
+            showToast((e && e.message) || 'Network error.');
+          });
       },
 
       resetCategory: function () {
         var self = this;
+        var prevOverride = this.isOverride;
         this.saving = true;
+        this.isOverride = false;
         fetch('/-/transactions/' + this.txId + '/category', { method: 'DELETE' })
           .then(function (r) {
-            self.saving = false;
-            if (r.ok || r.status === 204) {
-              self.isOverride = false;
-              showToast('Category reset to auto-detected.', 'success');
-              location.reload();
-            } else {
-              showToast('Failed to reset category.');
+            if (!r.ok && r.status !== 204) {
+              throw new Error('Failed to reset category.');
             }
+            return fetchTimelineRows(self.txId);
           })
-          .catch(function () { self.saving = false; showToast('Network error.'); });
+          .then(function () {
+            self.saving = false;
+            showToast('Category reset to auto-detected.', 'success');
+          })
+          .catch(function (e) {
+            self.saving = false;
+            self.isOverride = prevOverride;
+            restorePageState();
+            showToast((e && e.message) || 'Network error.');
+          });
       },
     };
   });
@@ -230,10 +421,42 @@ document.addEventListener('alpine:init', function () {
         }));
       },
 
+      // tagFromAvailable looks up the {displayName, color, icon} for a
+      // slug from the seeded availableTags list. Falls back to a chip
+      // displaying the slug verbatim when the tag isn't in the registry
+      // (rare; e.g. created concurrently elsewhere).
+      tagFromAvailable: function (slug) {
+        for (var i = 0; i < this.availableTags.length; i++) {
+          var t = this.availableTags[i];
+          if (t.slug === slug) {
+            return {
+              slug: t.slug,
+              displayName: t.display_name || t.slug,
+              color: t.color,
+              icon: t.icon,
+            };
+          }
+        }
+        return { slug: slug, displayName: slug, color: null, icon: null };
+      },
+
       applyTagDiff: function (adds, removes) {
         adds = adds || [];
         removes = removes || [];
         if (adds.length + removes.length === 0) return;
+        var self = this;
+        var prevTags = this.tags.slice();
+        // Optimistic chip-state update: add new chips, drop removed ones.
+        var tagsCopy = prevTags.slice();
+        removes.forEach(function (slug) {
+          tagsCopy = tagsCopy.filter(function (t) { return t.slug !== slug; });
+        });
+        adds.forEach(function (slug) {
+          if (!tagsCopy.some(function (t) { return t.slug === slug; })) {
+            tagsCopy.push(self.tagFromAvailable(slug));
+          }
+        });
+        this.tags = tagsCopy;
         var op = {};
         if (adds.length) op.tags_to_add = adds.map(function (s) { return { slug: s, note: '' }; });
         if (removes.length) op.tags_to_remove = removes.map(function (s) { return { slug: s, note: '' }; });
@@ -247,18 +470,24 @@ document.addEventListener('alpine:init', function () {
         })
           .then(function (r) { return r.json().then(function (d) { return { ok: r.ok || r.status === 422, body: d }; }); })
           .then(function (res) {
-            if (res.ok && res.body && res.body.succeeded > 0) {
-              showToast('Tags updated.', 'success');
-              location.reload();
-            } else {
+            if (!(res.ok && res.body && res.body.succeeded > 0)) {
               var msg = (res.body && res.body.error && res.body.error.message) || 'Failed to update tags.';
-              showToast(msg);
+              throw new Error(msg);
             }
+            return fetchTimelineRows(self.txId);
           })
-          .catch(function () { showToast('Network error.'); });
+          .then(function () { showToast('Tags updated.', 'success'); })
+          .catch(function (e) {
+            self.tags = prevTags;
+            restorePageState();
+            showToast((e && e.message) || 'Network error.');
+          });
       },
 
       removeTag: function (tag, note) {
+        var self = this;
+        var prevTags = this.tags.slice();
+        this.tags = prevTags.filter(function (t) { return t.slug !== tag.slug; });
         // Inline x on a tag chip - direct DELETE. Note is optional.
         var url = '/-/transactions/' + this.txId + '/tags/' + encodeURIComponent(tag.slug);
         fetch(url, {
@@ -268,14 +497,17 @@ document.addEventListener('alpine:init', function () {
         })
           .then(function (res) { return res.json().then(function (d) { return { ok: res.ok, body: d }; }); })
           .then(function (r) {
-            if (r.ok) {
-              showToast('Tag removed.', 'success');
-              location.reload();
-            } else {
-              showToast(r.body.error || 'Failed to remove tag.');
+            if (!r.ok) {
+              throw new Error((r.body && (r.body.error?.message || r.body.error)) || 'Failed to remove tag.');
             }
+            return fetchTimelineRows(self.txId);
           })
-          .catch(function () { showToast('Network error.'); });
+          .then(function () { showToast('Tag removed.', 'success'); })
+          .catch(function (e) {
+            self.tags = prevTags;
+            restorePageState();
+            showToast((e && e.message) || 'Network error.');
+          });
       },
     };
   });
@@ -292,6 +524,7 @@ document.addEventListener('alpine:init', function () {
       txId: '',
       hasPendingReview: false,
       pinReview: false,
+      submitting: false,
 
       init: function () {
         var ds = this.$el.dataset;
@@ -303,7 +536,7 @@ document.addEventListener('alpine:init', function () {
 
       canSubmit: function () {
         var trimmed = this.newComment.trim().length;
-        return trimmed > 0 && this.newComment.length <= this.maxLength;
+        return !this.submitting && trimmed > 0 && this.newComment.length <= this.maxLength;
       },
 
       counterState: function () {
@@ -332,6 +565,8 @@ document.addEventListener('alpine:init', function () {
         var content = this.newComment.trim();
         if (!content || !this.canSubmit()) return;
         var shouldPin = this.pinReview && !this.hasPendingReview;
+        var prevPinReview = this.pinReview;
+        this.submitting = true;
         fetch('/-/transactions/' + this.txId + '/comments', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -340,36 +575,59 @@ document.addEventListener('alpine:init', function () {
           .then(function (res) {
             if (!res.ok) {
               return res.json().then(function (data) {
-                showToast(data.error || 'Failed to add comment.');
+                throw new Error((data && data.error) || 'Failed to add comment.');
               });
             }
-            if (!shouldPin) {
-              self.newComment = '';
-              showToast('Comment added.', 'success');
-              location.reload();
-              return;
-            }
+            // Optionally chain the pin tag write.
+            if (!shouldPin) return null;
             return fetch('/-/transactions/' + self.txId + '/tags', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ slug: 'needs-review', note: '' }),
-            })
-              .then(function (tagRes) {
-                self.newComment = '';
-                if (tagRes.ok) {
-                  showToast('Comment added; tagged needs-review.', 'success');
-                } else {
-                  showToast('Comment added (tag failed).', 'warning');
-                }
-                location.reload();
-              })
-              .catch(function () {
-                self.newComment = '';
-                showToast('Comment added (tag failed).', 'warning');
-                location.reload();
-              });
+            }).then(function (tagRes) {
+              if (!tagRes.ok) throw new Error('Tag write failed');
+              return null;
+            });
           })
-          .catch(function () { showToast('Network error.'); });
+          .then(function () {
+            return fetchTimelineRows(self.txId);
+          })
+          .then(function () {
+            self.newComment = '';
+            self.submitting = false;
+            if (shouldPin) {
+              // Update local state so subsequent posts don't try to pin again
+              // and the composer's "Toggle Needs Review" checkbox hides.
+              self.hasPendingReview = true;
+              self.pinReview = false;
+              showToast('Comment added; tagged needs-review.', 'success');
+            } else {
+              showToast('Comment added.', 'success');
+            }
+            // Reset textarea height after successful clear.
+            var ta = document.getElementById('bb-txd-comment');
+            if (ta) self.autosize(ta);
+          })
+          .catch(function (e) {
+            self.submitting = false;
+            self.pinReview = prevPinReview;
+            restorePageState();
+            // Comment write may have succeeded even if the pin tag write
+            // failed; surface a "warning" tone in that path.
+            var msg = (e && e.message) || 'Network error.';
+            if (msg === 'Tag write failed') {
+              showToast('Comment added (tag failed).', 'warning');
+              // Refresh timeline so the comment row still appears even when
+              // the secondary tag write was the one that failed.
+              fetchTimelineRows(self.txId).then(function () {
+                self.newComment = '';
+                var ta = document.getElementById('bb-txd-comment');
+                if (ta) self.autosize(ta);
+              }).catch(function () {});
+            } else {
+              showToast(msg);
+            }
+          });
       },
 
       deleteComment: function (id) {
@@ -380,16 +638,24 @@ document.addEventListener('alpine:init', function () {
             method: 'DELETE',
           })
             .then(function (res) {
-              if (res.ok || res.status === 204) {
-                showToast('Comment deleted.', 'success');
-                location.reload();
-              } else {
+              if (!res.ok && res.status !== 204) {
                 return res.json().then(function (data) {
-                  showToast(data.error || 'Failed to delete comment.');
+                  throw new Error((data && data.error) || 'Failed to delete comment.');
                 });
               }
+              // Pass the deleted comment's short_id as a replacement
+              // ID. The render endpoint will return the tombstone row
+              // for that annotation (PR 4 soft-delete keeps the
+              // annotation in place but flips is_deleted=true), and
+              // fetchTimelineRows swaps it in over the original bubble
+              // by matching data-comment-id.
+              return fetchTimelineRows(self.txId, [id]);
             })
-            .catch(function () { showToast('Network error.'); });
+            .then(function () { showToast('Comment deleted.', 'success'); })
+            .catch(function (e) {
+              restorePageState();
+              showToast((e && e.message) || 'Network error.');
+            });
         });
       },
     };


### PR DESCRIPTION
## Why
The transaction-detail page used `location.reload()` after every comment, tag, and needs-review change — and **didn't reload at all** after a manual category set, so the change was invisible until the user manually refreshed. Either way, the activity timeline never reflected the action without a full page round-trip.

## What
**Architecture**: server-rendered row fragments (Strategy A). Each mutating endpoint persists, then the JS GETs `/-/transactions/{id}/timeline/rows?since=…` to fetch row HTML rendered by the same templ helpers as the main page (single source of truth for row markup; no client-side row templating). Soft-deletes pass `?comment_ids=<short_id>` so the tombstone returns even though its `created_at` is older than the cursor — and the JS swaps it in place over the matching bubble via `data-comment-id`.

**Action types covered (all six)**:
- Category set / reset
- Tag add / remove
- Comment add
- Comment delete (replaces the bubble with the PR 4 tombstone in place)
- Needs-review pin (chained from the comment composer's `Toggle Needs Review` checkbox)

**Render endpoint**: `GET /-/transactions/{id}/timeline/rows?since=<RFC3339>[&comment_ids=<id1,id2>]`. Reuses `buildActivityTimeline` + the existing `txdTimelineSystem` / `txdTimelineComment` / `txdTimelineDeletedComment` templ helpers. New `pages.TimelineRows` templ wraps them, plus an optional day-separator `<li>` when the new rows fall on a calendar day after the last existing row. Cursor lives on the activity section as `data-last-activity-ts`, refreshed after every successful render.

**Error path**: `restorePageState()` clears the SPA progress bar / opacity / filter / pointer-events; chip state (override badge, tag chips, pin checkbox) rolls back; toast surfaces the failure. The composer textarea content stays so the user can retry.

## Screenshots
<img src="https://i.img402.dev/98v7n09k98.jpg" width="800" alt="Before — pre-action timeline">
<img src="https://i.img402.dev/thqtkui3vw.jpg" width="800" alt="After category set — chip flipped to Home › Furniture, new system row, no reload">
<img src="https://i.img402.dev/do4tokahmr.jpg" width="800" alt="After comment add — bubble appended at the bottom">
<img src="https://i.img402.dev/7dd67qqvky.jpg" width="800" alt="After comment delete — bubble swapped to tombstone in place">
<img src="https://i.img402.dev/j1zmjz3usr.jpg" width="400" alt="Mobile (390x844) — timeline post-actions">

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` green at branch tip.
- [x] `make test-integration` green (full suite, including 3 new tests for `/timeline/rows`).
- [x] `internal/templates/components/pages/scripts_lint_test.go` still green (no Go-expression `x-data`, no inline `<script>` block over 5 lines).
- [x] Manual: each of six action types verified in browser. DevTools network log confirms every action is a `POST/PATCH/DELETE` followed by a single `GET .../timeline/rows`, no full-page navigations.

Part of the **activity-log-v2** stack.
