### PR TITLE
chore(admin): consolidate URL UUID parsing into shared helpers

### DIFF
--- a/internal/admin/avatars.go
+++ b/internal/admin/avatars.go
@@ -105,7 +105,7 @@ func resolveUUID(idStr string) (pgtype.UUID, error) {
 // UploadUserAvatarHandler serves POST /-/users/{id}/avatar.
 func UploadUserAvatarHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		userID, ok := parseUserID(w, r)
+		userID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid user ID")
 		if !ok {
 			return
 		}
@@ -116,7 +116,7 @@ func UploadUserAvatarHandler(a *app.App) http.HandlerFunc {
 // DeleteUserAvatarHandler serves DELETE /-/users/{id}/avatar.
 func DeleteUserAvatarHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		userID, ok := parseUserID(w, r)
+		userID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid user ID")
 		if !ok {
 			return
 		}
@@ -132,7 +132,7 @@ func DeleteUserAvatarHandler(a *app.App) http.HandlerFunc {
 // RegenerateUserAvatarHandler serves POST /-/users/{id}/avatar/regenerate.
 func RegenerateUserAvatarHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		userID, ok := parseUserID(w, r)
+		userID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid user ID")
 		if !ok {
 			return
 		}
@@ -210,15 +210,6 @@ func RegenerateMyAvatarHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 }
 
 // --- Helpers ---
-
-func parseUserID(w http.ResponseWriter, r *http.Request) (pgtype.UUID, bool) {
-	var userID pgtype.UUID
-	if err := userID.Scan(chi.URLParam(r, "id")); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid user ID"})
-		return pgtype.UUID{}, false
-	}
-	return userID, true
-}
 
 func requireSessionUser(w http.ResponseWriter, sm *scs.SessionManager, r *http.Request) (pgtype.UUID, bool) {
 	uid := SessionUserID(sm, r)

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -568,13 +568,11 @@ func ExchangeTokenHandler(a *app.App) http.HandlerFunc {
 func ConnectionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		idStr := chi.URLParam(r, "id")
-
-		var connID pgtype.UUID
-		if err := connID.Scan(idStr); err != nil {
-			tr.RenderNotFound(w, r)
+		connID, ok := parseURLUUIDOrNotFound(w, r, tr, "id")
+		if !ok {
 			return
 		}
+		idStr := chi.URLParam(r, "id")
 
 		conn, err := a.Queries.GetBankConnection(ctx, connID)
 		if err != nil {
@@ -938,13 +936,11 @@ func formatNumericAbsCurrency(n pgtype.Numeric) string {
 func ConnectionReauthHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		idStr := chi.URLParam(r, "id")
-
-		var connID pgtype.UUID
-		if err := connID.Scan(idStr); err != nil {
-			tr.RenderNotFound(w, r)
+		connID, ok := parseURLUUIDOrNotFound(w, r, tr, "id")
+		if !ok {
 			return
 		}
+		idStr := chi.URLParam(r, "id")
 
 		conn, err := a.Queries.GetBankConnection(ctx, connID)
 		if err != nil {
@@ -986,12 +982,9 @@ func renderConnectionReauth(w http.ResponseWriter, r *http.Request, tr *Template
 // ConnectionReauthAPIHandler serves POST /admin/api/connections/{id}/reauth.
 func ConnectionReauthAPIHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		idStr := chi.URLParam(r, "id")
 		ctx := r.Context()
-
-		var connID pgtype.UUID
-		if err := connID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid connection ID"})
+		connID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
+		if !ok {
 			return
 		}
 
@@ -1032,11 +1025,8 @@ func ConnectionReauthAPIHandler(a *app.App) http.HandlerFunc {
 // ConnectionReauthCompleteHandler serves POST /admin/api/connections/{id}/reauth-complete.
 func ConnectionReauthCompleteHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		idStr := chi.URLParam(r, "id")
-
-		var connID pgtype.UUID
-		if err := connID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid connection ID"})
+		connID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
+		if !ok {
 			return
 		}
 
@@ -1060,19 +1050,16 @@ func ConnectionReauthCompleteHandler(a *app.App) http.HandlerFunc {
 // DeleteConnectionHandler serves DELETE /admin/api/connections/{id}.
 func DeleteConnectionHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		idStr := chi.URLParam(r, "id")
 		ctx := r.Context()
-
-		var connID pgtype.UUID
-		if err := connID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid connection ID"})
+		connID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
+		if !ok {
 			return
 		}
 
 		// Load connection and call provider to revoke access.
 		conn, err := a.Queries.GetBankConnection(ctx, connID)
 		if err == nil {
-			if prov, ok := a.Providers[string(conn.Provider)]; ok {
+			if prov, provOK := a.Providers[string(conn.Provider)]; provOK {
 				provConn := provider.Connection{
 					ProviderName:         string(conn.Provider),
 					ExternalID:           conn.ExternalID.String,
@@ -1103,7 +1090,7 @@ func DeleteConnectionHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 			return
 		}
 		if deleted > 0 {
-			a.Logger.Info("soft-deleted transactions for connection", "connection_id", idStr, "count", deleted)
+			a.Logger.Info("soft-deleted transactions for connection", "connection_id", pgconv.FormatUUID(connID), "count", deleted)
 		}
 
 		err = txQueries.DeleteBankConnection(ctx, connID)
@@ -1126,13 +1113,11 @@ func DeleteConnectionHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 // SyncConnectionHandler serves POST /admin/api/connections/{id}/sync.
 func SyncConnectionHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		idStr := chi.URLParam(r, "id")
-
-		var connID pgtype.UUID
-		if err := connID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid connection ID"})
+		connID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
+		if !ok {
 			return
 		}
+		idStr := chi.URLParam(r, "id")
 
 		if a.SyncEngine == nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Sync engine not initialized"})
@@ -1155,13 +1140,11 @@ func SyncConnectionHandler(a *app.App) http.HandlerFunc {
 // connection — used by the detail page to poll progress without full reloads.
 func SyncConnectionStatusHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		idStr := chi.URLParam(r, "id")
-
-		var connID pgtype.UUID
-		if err := connID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid connection ID"})
+		connID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
+		if !ok {
 			return
 		}
+		idStr := chi.URLParam(r, "id")
 
 		logs, err := a.Queries.GetSyncLogsByConnection(r.Context(), db.GetSyncLogsByConnectionParams{
 			ConnectionID: connID,
@@ -1233,11 +1216,8 @@ func SyncAllConnectionsHandler(a *app.App) http.HandlerFunc {
 // UpdateAccountExcludedHandler serves POST /admin/api/accounts/{id}/excluded.
 func UpdateAccountExcludedHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		idStr := chi.URLParam(r, "id")
-
-		var accountID pgtype.UUID
-		if err := accountID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid account ID"})
+		accountID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid account ID")
+		if !ok {
 			return
 		}
 
@@ -1265,11 +1245,8 @@ func UpdateAccountExcludedHandler(a *app.App, sm *scs.SessionManager) http.Handl
 // UpdateAccountDisplayNameHandler serves POST /admin/api/accounts/{id}/display-name.
 func UpdateAccountDisplayNameHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		idStr := chi.URLParam(r, "id")
-
-		var accountID pgtype.UUID
-		if err := accountID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid account ID"})
+		accountID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid account ID")
+		if !ok {
 			return
 		}
 
@@ -1302,11 +1279,8 @@ func UpdateAccountDisplayNameHandler(a *app.App, sm *scs.SessionManager) http.Ha
 // UpdateConnectionPausedHandler serves POST /admin/api/connections/{id}/paused.
 func UpdateConnectionPausedHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		idStr := chi.URLParam(r, "id")
-
-		var connID pgtype.UUID
-		if err := connID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid connection ID"})
+		connID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
+		if !ok {
 			return
 		}
 
@@ -1334,11 +1308,8 @@ func UpdateConnectionPausedHandler(a *app.App, sm *scs.SessionManager) http.Hand
 // UpdateConnectionSyncIntervalHandler serves POST /admin/api/connections/{id}/sync-interval.
 func UpdateConnectionSyncIntervalHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		idStr := chi.URLParam(r, "id")
-
-		var connID pgtype.UUID
-		if err := connID.Scan(idStr); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid connection ID"})
+		connID, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
+		if !ok {
 			return
 		}
 

--- a/internal/admin/helpers.go
+++ b/internal/admin/helpers.go
@@ -7,8 +7,34 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// parseURLUUIDOrNotFound extracts the named chi URL param and decodes it as a
+// UUID. On parse failure it renders the styled 404 page via tr and returns
+// ok=false. Used by HTML detail/edit handlers.
+func parseURLUUIDOrNotFound(w http.ResponseWriter, r *http.Request, tr *TemplateRenderer, key string) (pgtype.UUID, bool) {
+	var id pgtype.UUID
+	if err := id.Scan(chi.URLParam(r, key)); err != nil {
+		tr.RenderNotFound(w, r)
+		return pgtype.UUID{}, false
+	}
+	return id, true
+}
+
+// parseURLUUIDOrInvalid extracts the named chi URL param and decodes it as a
+// UUID. On parse failure it writes a 400 response with the legacy
+// {"error": label} envelope and returns ok=false. Used by admin JSON handlers
+// that pre-date the canonical error envelope.
+func parseURLUUIDOrInvalid(w http.ResponseWriter, r *http.Request, key, label string) (pgtype.UUID, bool) {
+	var id pgtype.UUID
+	if err := id.Scan(chi.URLParam(r, key)); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": label})
+		return pgtype.UUID{}, false
+	}
+	return id, true
+}
 
 // parsePage returns the 1-indexed page from ?page=, flooring at 1 when the
 // param is missing, non-numeric, or less than 1.

--- a/internal/admin/helpers_test.go
+++ b/internal/admin/helpers_test.go
@@ -1,14 +1,27 @@
 package admin
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"breadbox/internal/pgconv"
 
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// withChiParam wraps r with a chi.RouteContext that has key=value, so
+// chi.URLParam(r, key) returns value when the request bypasses the router.
+func withChiParam(r *http.Request, key, value string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, value)
+	return r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+}
 
 func TestParsePage(t *testing.T) {
 	tests := []struct {
@@ -375,4 +388,82 @@ func TestConnectionStaleness(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseURLUUIDOrInvalid(t *testing.T) {
+	t.Run("valid UUID returns ok", func(t *testing.T) {
+		r := withChiParam(httptest.NewRequest("GET", "/", nil), "id", "11111111-1111-1111-1111-111111111111")
+		w := httptest.NewRecorder()
+		got, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid ID")
+		if !ok {
+			t.Fatalf("ok = false, want true; body=%s", w.Body.String())
+		}
+		if !got.Valid {
+			t.Error("returned UUID is not valid")
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want default 200 (helper should not write on success)", w.Code)
+		}
+	})
+
+	t.Run("invalid UUID writes 400 with label", func(t *testing.T) {
+		r := withChiParam(httptest.NewRequest("GET", "/", nil), "id", "not-a-uuid")
+		w := httptest.NewRecorder()
+		_, ok := parseURLUUIDOrInvalid(w, r, "id", "Invalid connection ID")
+		if ok {
+			t.Fatal("ok = true, want false")
+		}
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+		var body map[string]string
+		if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body["error"] != "Invalid connection ID" {
+			t.Errorf("error = %q, want %q", body["error"], "Invalid connection ID")
+		}
+	})
+}
+
+func TestParseURLUUIDOrNotFound(t *testing.T) {
+	sm := scs.New()
+	tr, err := NewTemplateRenderer(sm)
+	if err != nil {
+		t.Fatalf("NewTemplateRenderer: %v", err)
+	}
+
+	// Wrap the request in scs's session middleware so RenderNotFound's
+	// IsViewer call doesn't panic on a missing session context.
+	loadSession := func(r *http.Request) *http.Request {
+		ctx, err := sm.Load(r.Context(), "")
+		if err != nil {
+			t.Fatalf("session load: %v", err)
+		}
+		return r.WithContext(ctx)
+	}
+
+	t.Run("valid UUID returns ok", func(t *testing.T) {
+		r := loadSession(withChiParam(httptest.NewRequest("GET", "/", nil), "id", "22222222-2222-2222-2222-222222222222"))
+		w := httptest.NewRecorder()
+		got, ok := parseURLUUIDOrNotFound(w, r, tr, "id")
+		if !ok {
+			t.Fatalf("ok = false, want true; body=%s", w.Body.String())
+		}
+		if !got.Valid {
+			t.Error("returned UUID is not valid")
+		}
+	})
+
+	t.Run("invalid UUID renders 404", func(t *testing.T) {
+		r := loadSession(withChiParam(httptest.NewRequest("GET", "/", nil), "id", "garbage"))
+		w := httptest.NewRecorder()
+		_, ok := parseURLUUIDOrNotFound(w, r, tr, "id")
+		if ok {
+			t.Fatal("ok = true, want false")
+		}
+		if w.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+		}
+	})
 }

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -419,13 +419,10 @@ func TransactionSearchHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 func AccountDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		idStr := chi.URLParam(r, "id")
-
-		var accountID pgtype.UUID
-		if err := accountID.Scan(idStr); err != nil {
-			tr.RenderNotFound(w, r)
+		if _, ok := parseURLUUIDOrNotFound(w, r, tr, "id"); !ok {
 			return
 		}
+		idStr := chi.URLParam(r, "id")
 
 		detail, err := svc.GetAccountDetail(ctx, idStr)
 		if err != nil {

--- a/internal/admin/users.go
+++ b/internal/admin/users.go
@@ -278,13 +278,11 @@ func NewUserHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) ht
 func EditUserHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		idStr := chi.URLParam(r, "id")
-
-		var userID pgtype.UUID
-		if err := userID.Scan(idStr); err != nil {
-			tr.RenderNotFound(w, r)
+		userID, ok := parseURLUUIDOrNotFound(w, r, tr, "id")
+		if !ok {
 			return
 		}
+		idStr := chi.URLParam(r, "id")
 
 		user, err := a.Queries.GetUser(ctx, userID)
 		if err != nil {
@@ -444,13 +442,11 @@ func UpdateUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 func CreateLoginPageHandler(a *app.App, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		idStr := chi.URLParam(r, "id")
-
-		var userID pgtype.UUID
-		if err := userID.Scan(idStr); err != nil {
-			tr.RenderNotFound(w, r)
+		userID, ok := parseURLUUIDOrNotFound(w, r, tr, "id")
+		if !ok {
 			return
 		}
+		idStr := chi.URLParam(r, "id")
 
 		user, err := a.Queries.GetUser(ctx, userID)
 		if err != nil {


### PR DESCRIPTION
## Summary

Two near-identical patterns were duplicated **17 times** across admin handlers:

```go
// HTML detail handlers (5x)
idStr := chi.URLParam(r, "id")
var connID pgtype.UUID
if err := connID.Scan(idStr); err != nil {
    tr.RenderNotFound(w, r)
    return
}

// JSON mutation handlers (12x — connections.go and avatars.go)
idStr := chi.URLParam(r, "id")
var connID pgtype.UUID
if err := connID.Scan(idStr); err != nil {
    writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid X ID"})
    return
}
```

Adds two helpers in `internal/admin/helpers.go`:

- `parseURLUUIDOrNotFound(w, r, tr, key)` — for HTML detail/edit handlers
- `parseURLUUIDOrInvalid(w, r, key, label)` — for JSON mutation handlers (preserves the legacy `{"error": "..."}` envelope used by these endpoints)

Collapses all 17 call sites onto them. The local `parseUserID` in `avatars.go` is removed in favor of the shared helper.

**Behavior preserved exactly** — same status codes, same body shapes, same error messages. This is a pure refactor; no API contracts change.

## Stats

- 4 handler files: -64 lines
- helpers.go: +26 lines (two helpers + doc comments)
- helpers_test.go: +91 lines (focused unit tests for both helpers)
- 17 call sites consolidated

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit, including new helper tests)
- [x] `go test -tags integration ./internal/admin/...`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)