### PR TITLE
feat(sync): sync_started + sync_updated annotations on the activity timeline

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -1077,8 +1077,38 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 			entry.ActorID = &id
 		}
 		return entry, true
+
+	case "sync_started", "sync_updated":
+		// Sync events: actor is the provider (Plaid / Teller / CSV import).
+		// Summary is the canonical sentence built by EnrichAnnotations; the
+		// templ row renders it as-is via the fallback branch in
+		// txdSystemSentence — same path used by rule rows that pre-format the
+		// sentence in the service layer.
+		entry := service.ActivityEntry{
+			Type:               syncEntryType(a.Kind),
+			Timestamp:          a.CreatedAt,
+			ActorName:          a.ActorName,
+			ActorType:          a.ActorType,
+			ActorAvatarVersion: a.ActorAvatarVersion,
+			Summary:            a.Summary,
+		}
+		if a.ActorID != nil && *a.ActorID != "" {
+			id := *a.ActorID
+			entry.ActorID = &id
+		}
+		return entry, true
 	}
 	return service.ActivityEntry{}, false
+}
+
+// syncEntryType maps the raw DB kind to the ActivityEntry type. Both sync_*
+// kinds collapse to a single "sync" type in the UI — the icon is identical
+// (refresh-cw) and the Summary already differentiates the verb.
+func syncEntryType(dbKind string) string {
+	if dbKind == "sync_started" || dbKind == "sync_updated" {
+		return "sync"
+	}
+	return dbKind
 }
 
 // ActivityDayGroup holds activity entries grouped by calendar day (in the

--- a/internal/db/migrations/20260426231203_annotations_sync_kinds.sql
+++ b/internal/db/migrations/20260426231203_annotations_sync_kinds.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- Extend the annotations.kind CHECK constraint to recognise sync events on the
+-- activity timeline:
+--   - sync_started: written when a transaction is first imported (initial sync).
+--   - sync_updated: written when a subsequent sync flipped pending status.
+--
+-- Drop + add must run in a single SQL transaction so the table is never without
+-- a constraint. Goose wraps each migration in a transaction by default, which
+-- gives us the atomicity we need; we just drop and re-add inline.
+ALTER TABLE annotations DROP CONSTRAINT IF EXISTS annotations_kind_check;
+ALTER TABLE annotations ADD CONSTRAINT annotations_kind_check
+  CHECK (kind IN (
+    'comment',
+    'rule_applied',
+    'tag_added',
+    'tag_removed',
+    'category_set',
+    'sync_started',
+    'sync_updated'
+  ));
+
+-- +goose Down
+ALTER TABLE annotations DROP CONSTRAINT IF EXISTS annotations_kind_check;
+ALTER TABLE annotations ADD CONSTRAINT annotations_kind_check
+  CHECK (kind IN (
+    'comment',
+    'rule_applied',
+    'tag_added',
+    'tag_removed',
+    'category_set'
+  ));

--- a/internal/db/queries/bank_connections.sql
+++ b/internal/db/queries/bank_connections.sql
@@ -84,7 +84,7 @@ SELECT COUNT(*) FROM bank_connections WHERE status IN ('error', 'pending_reauth'
 SELECT * FROM bank_connections WHERE status = 'active';
 
 -- name: GetBankConnectionForSync :one
-SELECT id, provider, external_id, encrypted_credentials, sync_cursor, user_id FROM bank_connections WHERE id = $1 AND status != 'disconnected';
+SELECT id, short_id, provider, external_id, encrypted_credentials, sync_cursor, user_id FROM bank_connections WHERE id = $1 AND status != 'disconnected';
 
 -- name: ListConnectionsForAPI :many
 SELECT bc.id, bc.short_id, bc.user_id, bc.provider, bc.institution_id, bc.institution_name,

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -19,7 +19,7 @@ type listTagsInput struct {
 type listAnnotationsInput struct {
 	ReadSessionContext
 	TransactionID string   `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
-	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule, tag, category. Empty = all kinds. Pass ['comment'] for the comment-only timeline (replaces list_transaction_comments). Pass ['tag'] to see both add+remove events; the response carries an 'action' field (added|removed|set|applied) for the specific event."`
+	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule, tag, category, sync. Empty = all kinds. Pass ['comment'] for the comment-only timeline (replaces list_transaction_comments). Pass ['tag'] to see both add+remove events; the response carries an 'action' field (added|removed|set|applied|started|updated) for the specific event. Pass ['sync'] to see initial-import + pending-flip rows."`
 }
 
 type addTransactionTagInput struct {
@@ -98,6 +98,7 @@ var mcpAnnotationKinds = map[string][]string{
 	"rule":     {"rule_applied"},
 	"tag":      {"tag_added", "tag_removed"},
 	"category": {"category_set"},
+	"sync":     {"sync_started", "sync_updated"},
 }
 
 // mapAnnotationKinds translates the agent-facing generic kinds into the raw DB
@@ -113,7 +114,7 @@ func mapAnnotationKinds(kinds []string) ([]string, error) {
 	for _, k := range kinds {
 		raw, ok := mcpAnnotationKinds[k]
 		if !ok {
-			return nil, fmt.Errorf("invalid kind %q: expected one of comment, rule, tag, category", k)
+			return nil, fmt.Errorf("invalid kind %q: expected one of comment, rule, tag, category, sync", k)
 		}
 		for _, r := range raw {
 			if seen[r] {
@@ -178,6 +179,10 @@ func dbKindToMCP(dbKind string) (kind, action string) {
 		return "tag", "removed"
 	case "category_set":
 		return "category", "set"
+	case "sync_started":
+		return "sync", "started"
+	case "sync_updated":
+		return "sync", "updated"
 	}
 	return dbKind, ""
 }

--- a/internal/ruleapply/annotations.go
+++ b/internal/ruleapply/annotations.go
@@ -120,9 +120,12 @@ func writeAnnotation(ctx context.Context, tx pgx.Tx, r annotationRow) error {
 		actorID = pgconv.Text(r.ActorID)
 	}
 
+	// created_at = clock_timestamp() so multiple rule-driven rows written inside
+	// the same sync tx preserve their write order on the timeline (the column
+	// default NOW() returns the transaction-start time, tying every row).
 	if _, err := tx.Exec(ctx,
-		`INSERT INTO annotations (transaction_id, kind, actor_type, actor_id, actor_name, session_id, payload, tag_id, rule_id)
-		VALUES ($1, $2, $3, $4, $5, NULL, $6::jsonb, $7, $8)`,
+		`INSERT INTO annotations (transaction_id, kind, actor_type, actor_id, actor_name, session_id, payload, tag_id, rule_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, NULL, $6::jsonb, $7, $8, clock_timestamp())`,
 		r.TransactionID, r.Kind, r.ActorType, actorID, r.ActorName, payloadJSON,
 		r.TagID, r.RuleID,
 	); err != nil {

--- a/internal/service/annotations_enrich.go
+++ b/internal/service/annotations_enrich.go
@@ -260,6 +260,17 @@ func enrichOne(a Annotation, tagDisplay, categoryDisplay func(string) string) An
 			a.Subject = ruleName
 		}
 		a.Summary = formatRuleSummary(ruleName, field, value, categoryDisplay, a.Origin)
+
+	case "sync_started":
+		a.Action = "started"
+		a.Subject = a.ActorName
+		a.Summary = formatSyncStartedSummary(a.ActorName)
+
+	case "sync_updated":
+		a.Action = "updated"
+		a.Subject = a.ActorName
+		from, to := readStatusChange(a.Payload)
+		a.Summary = formatSyncUpdatedSummary(a.ActorName, from, to)
 	}
 
 	return a
@@ -353,6 +364,44 @@ func formatRuleSummary(ruleName, field, value string, categoryDisplay func(strin
 		return subject + " " + verb
 	}
 	return subject + " " + verb + " " + origin
+}
+
+// formatSyncStartedSummary renders the timeline sentence for a sync_started
+// row. ActorName is the provider display name ("Plaid", "Teller", "CSV
+// import"); fall back to a generic phrase when it's unexpectedly empty so the
+// timeline is never just blank.
+func formatSyncStartedSummary(provider string) string {
+	if provider == "" {
+		return "Initial sync imported this transaction"
+	}
+	return "Initial sync from " + provider + " imported this transaction"
+}
+
+// formatSyncUpdatedSummary renders the timeline sentence for a sync_updated
+// row. The pending flip is the only field-level change we surface today, so
+// the sentence always carries the from→to label when the payload provides one.
+func formatSyncUpdatedSummary(provider, from, to string) string {
+	prefix := "Synced"
+	if provider != "" {
+		prefix = "Synced from " + provider
+	}
+	if from == "" || to == "" {
+		return prefix
+	}
+	return prefix + " · " + from + " → " + to
+}
+
+// readStatusChange pulls the from/to labels out of a sync_updated payload's
+// status_change object. Returns ("", "") when the payload is missing the
+// keys so callers can render a defensive fallback summary.
+func readStatusChange(payload map[string]interface{}) (string, string) {
+	sc, ok := payload["status_change"].(map[string]interface{})
+	if !ok {
+		return "", ""
+	}
+	from, _ := sc["from"].(string)
+	to, _ := sc["to"].(string)
+	return from, to
 }
 
 // formatRuleOrigin maps the payload's applied_by field to the standardized

--- a/internal/sync/annotations.go
+++ b/internal/sync/annotations.go
@@ -1,0 +1,124 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"breadbox/internal/pgconv"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// providerDisplayName returns the human-friendly name for a provider type.
+// Used as ActorName on sync_started / sync_updated annotations so the activity
+// timeline reads "Plaid imported this transaction" rather than the raw enum.
+func providerDisplayName(provider string) string {
+	switch provider {
+	case "plaid":
+		return "Plaid"
+	case "teller":
+		return "Teller"
+	case "csv":
+		return "CSV import"
+	}
+	return provider
+}
+
+// writeSyncStartedAnnotation records that a transaction was first imported
+// during the initial sync of a connection. One row is written per newly
+// inserted transaction, attributed to the system actor named after the
+// provider. The connection and sync_log short ids in the payload let the UI
+// link back to the originating sync run.
+func writeSyncStartedAnnotation(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, providerType, connShortID, syncLogShortID string) error {
+	payload := map[string]any{
+		"provider":      providerType,
+		"connection_id": connShortID,
+		"sync_log_id":   syncLogShortID,
+	}
+	return insertSyncAnnotation(ctx, tx, syncAnnotationRow{
+		TransactionID: txnID,
+		Kind:          "sync_started",
+		ActorType:     "system",
+		ActorID:       connShortID,
+		ActorName:     providerDisplayName(providerType),
+		Payload:       payload,
+	})
+}
+
+// writeSyncUpdatedAnnotation records that a subsequent sync touched a
+// transaction whose `pending` flag flipped. Only emitted on a pending status
+// change — silent for plain field touches and rule-driven category changes
+// (those have their own annotation kinds).
+func writeSyncUpdatedAnnotation(ctx context.Context, tx pgx.Tx, txnID pgtype.UUID, providerType, connShortID, syncLogShortID string, fromPending, toPending bool) error {
+	payload := map[string]any{
+		"provider":      providerType,
+		"connection_id": connShortID,
+		"sync_log_id":   syncLogShortID,
+		"status_change": map[string]any{
+			"from": pendingLabel(fromPending),
+			"to":   pendingLabel(toPending),
+		},
+	}
+	return insertSyncAnnotation(ctx, tx, syncAnnotationRow{
+		TransactionID: txnID,
+		Kind:          "sync_updated",
+		ActorType:     "system",
+		ActorID:       connShortID,
+		ActorName:     providerDisplayName(providerType),
+		Payload:       payload,
+	})
+}
+
+// pendingLabel maps the boolean pending flag to the timeline-friendly label
+// used in the sync_updated payload's status_change object.
+func pendingLabel(pending bool) string {
+	if pending {
+		return "pending"
+	}
+	return "posted"
+}
+
+// syncAnnotationRow is the column set required to insert a sync-attributed
+// annotation. Mirrors the shape used by ruleapply.writeAnnotation but lives
+// inside the sync package so we don't pull a rule-flavoured helper into a
+// non-rule code path.
+type syncAnnotationRow struct {
+	TransactionID pgtype.UUID
+	Kind          string
+	ActorType     string
+	ActorID       string
+	ActorName     string
+	Payload       map[string]any
+}
+
+func insertSyncAnnotation(ctx context.Context, tx pgx.Tx, r syncAnnotationRow) error {
+	var payloadJSON []byte
+	if r.Payload == nil {
+		payloadJSON = []byte(`{}`)
+	} else {
+		b, err := json.Marshal(r.Payload)
+		if err != nil {
+			return fmt.Errorf("marshal sync annotation payload: %w", err)
+		}
+		payloadJSON = b
+	}
+
+	actorID := pgtype.Text{}
+	if r.ActorID != "" {
+		actorID = pgconv.Text(r.ActorID)
+	}
+
+	// created_at = clock_timestamp() so sync_started writes preserve their
+	// pre-rule ordering on the timeline; see the matching note in engine.go's
+	// writeSyncAnnotation.
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO annotations (transaction_id, kind, actor_type, actor_id, actor_name, session_id, payload, created_at)
+		VALUES ($1, $2, $3, $4, $5, NULL, $6::jsonb, clock_timestamp())`,
+		r.TransactionID, r.Kind, r.ActorType, actorID, r.ActorName, payloadJSON,
+	); err != nil {
+		return fmt.Errorf("insert %s annotation: %w", r.Kind, err)
+	}
+	return nil
+}

--- a/internal/sync/engine.go
+++ b/internal/sync/engine.go
@@ -97,7 +97,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 	}
 
 	// Run the sync and capture results.
-	added, modified, removed, unchanged, perAccount, ruleHits, warningMsg, syncErr := e.runSync(ctx, connectionID, logger)
+	added, modified, removed, unchanged, perAccount, ruleHits, warningMsg, syncErr := e.runSync(ctx, connectionID, syncLog.ShortID, logger)
 
 	// Update sync_log with final status.
 	completedAt := time.Now()
@@ -157,7 +157,7 @@ func (e *Engine) Sync(ctx context.Context, connectionID pgtype.UUID, trigger db.
 }
 
 // runSync performs the actual sync loop for a connection. Returns counts, per-account breakdown, rule hit counts JSON, warning message, and any error.
-func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *slog.Logger) (added, modified, removed, unchanged int, perAccount map[string]*accountSyncCounts, ruleHits []byte, warning string, err error) {
+func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, syncLogShortID string, logger *slog.Logger) (added, modified, removed, unchanged int, perAccount map[string]*accountSyncCounts, ruleHits []byte, warning string, err error) {
 	// Initialize per-account tracking map.
 	perAccount = make(map[string]*accountSyncCounts)
 
@@ -330,6 +330,8 @@ func (e *Engine) runSync(ctx context.Context, connectionID pgtype.UUID, logger *
 			upsertStart:      upsertStart,
 			perAccount:       perAccount,
 			logger:           logger,
+			connShortID:      conn.ShortID,
+			syncLogShortID:   syncLogShortID,
 		}
 
 		for i := range pendingAdded {
@@ -447,6 +449,8 @@ type processTransactionOpts struct {
 	upsertStart      time.Time
 	perAccount       map[string]*accountSyncCounts
 	logger           *slog.Logger
+	connShortID      string // bank connection short_id, used for sync_started/sync_updated actor_id + payload
+	syncLogShortID   string // sync_logs short_id of the current run, recorded in sync annotation payloads
 }
 
 // processTransactionResult captures the outcome of processing a single transaction.
@@ -486,6 +490,13 @@ func (e *Engine) processTransaction(ctx context.Context, txn *provider.Transacti
 		return result
 	}
 
+	// Capture the prior `pending` value before the upsert so we can detect a
+	// flip on subsequent syncs and emit a `sync_updated` annotation. A missing
+	// row (NoRows) is treated as "no prior state" — the upsert will INSERT and
+	// classifyUpsertResult will mark isNew, in which case we emit
+	// `sync_started` instead.
+	priorPending, hadPrior := e.lookupPriorPending(ctx, opts.tx, txn.ExternalID)
+
 	dbTxn, err := e.upsertTransaction(ctx, opts.txQueries, txn, opts.accountIDCache)
 	if err != nil {
 		opts.logger.Error("upsert "+label+" transaction", "external_id", txn.ExternalID, "error", err)
@@ -494,6 +505,27 @@ func (e *Engine) processTransaction(ctx context.Context, txn *provider.Transacti
 	}
 
 	isNew, isChanged := classifyUpsertResult(dbTxn, opts.upsertStart)
+
+	// Emit sync annotations (initial import + pending flip) before rules run
+	// so the activity timeline reads "imported" → "rule applied" in chronological
+	// order rather than the reverse.
+	switch {
+	case providerAdded && isNew:
+		// Brand-new transaction landed during this sync. One row per insert.
+		// Classified by the upsert path (created_at ~= updated_at) — re-runs of
+		// a partially-completed initial sync hit this branch only on rows that
+		// were actually inserted on this pass, not previously-imported rows.
+		if err := writeSyncStartedAnnotation(ctx, opts.tx, dbTxn.ID, opts.providerName, opts.connShortID, opts.syncLogShortID); err != nil {
+			opts.logger.Error("write sync_started annotation", "transaction_id", dbTxn.ID, "error", err)
+		}
+	case hadPrior && priorPending != dbTxn.Pending:
+		// Pending flipped (true→false or false→true). Other field touches are
+		// intentionally silent — rule firings get their own kind, and plain
+		// field updates don't carry timeline value worth a row each.
+		if err := writeSyncUpdatedAnnotation(ctx, opts.tx, dbTxn.ID, opts.providerName, opts.connShortID, opts.syncLogShortID, priorPending, dbTxn.Pending); err != nil {
+			opts.logger.Error("write sync_updated annotation", "transaction_id", dbTxn.ID, "error", err)
+		}
+	}
 
 	// For provider-added transactions, a newly inserted row counts as "added".
 	// For provider-modified transactions, isNew is not expected — all changes
@@ -536,6 +568,24 @@ func (e *Engine) processTransaction(ctx context.Context, txn *provider.Transacti
 	}
 
 	return result
+}
+
+// lookupPriorPending returns the existing transaction's `pending` flag inside
+// the active sync transaction. The boolean second return is false when there
+// is no prior row (or the lookup fails) — callers treat that as "no prior
+// state available" and skip sync_updated emission.
+func (e *Engine) lookupPriorPending(ctx context.Context, tx pgx.Tx, externalID string) (bool, bool) {
+	var pending bool
+	err := tx.QueryRow(ctx,
+		`SELECT pending FROM transactions WHERE provider_transaction_id = $1`,
+		externalID).Scan(&pending)
+	if err != nil {
+		// pgx.ErrNoRows is the expected "no prior row" path; any other error
+		// also degrades gracefully — sync_started will be emitted on insert
+		// or the sync_updated row simply won't be written for this txn.
+		return false, false
+	}
+	return pending, true
 }
 
 // upsertTransaction upserts a single transaction without rule evaluation.
@@ -924,9 +974,17 @@ func writeSyncAnnotation(ctx context.Context, tx pgx.Tx, params writeSyncAnnotat
 		actorID = pgconv.Text(params.ActorID)
 	}
 
+	// created_at = clock_timestamp() (real wall-clock) instead of relying on the
+	// column default (NOW(), which returns the transaction-start time). Within
+	// the sync tx we write multiple annotations per transaction — sync_started
+	// before applyRulesToTransaction, then a rule_applied / category_set /
+	// tag_added cluster — and the timeline orders them by created_at ASC. With
+	// NOW() every row tied at the same instant and the displayed order fell
+	// back to arbitrary tie-breaking, surfacing rule rows ahead of the
+	// sync_started row that logically precedes them.
 	_, err := tx.Exec(ctx,
-		`INSERT INTO annotations (transaction_id, kind, actor_type, actor_id, actor_name, session_id, payload, tag_id, rule_id)
-		VALUES ($1, $2, $3, $4, $5, NULL, $6::jsonb, $7, $8)`,
+		`INSERT INTO annotations (transaction_id, kind, actor_type, actor_id, actor_name, session_id, payload, tag_id, rule_id, created_at)
+		VALUES ($1, $2, $3, $4, $5, NULL, $6::jsonb, $7, $8, clock_timestamp())`,
 		params.TransactionID, params.Kind, params.ActorType, actorID, params.ActorName, payloadJSON,
 		params.TagID, params.RuleID)
 	return err

--- a/internal/sync/sync_annotations_integration_test.go
+++ b/internal/sync/sync_annotations_integration_test.go
@@ -1,0 +1,311 @@
+//go:build integration
+
+package sync_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/provider"
+	"breadbox/internal/testutil"
+
+	"github.com/shopspring/decimal"
+)
+
+// TestSync_SyncStartedAnnotation_OnInitialImport asserts that a fresh
+// transaction lands a `sync_started` annotation attributed to the provider
+// with payload {provider, connection_id, sync_log_id}.
+func TestSync_SyncStartedAnnotation_OnInitialImport(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategories(t, queries)
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added: []provider.Transaction{
+				{
+					ExternalID:        "txn_started",
+					AccountExternalID: "ext_acct_1",
+					Amount:            decimal.NewFromFloat(42.50),
+					Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+					Name:              "Starbucks",
+					ISOCurrencyCode:   "USD",
+				},
+			},
+			Cursor: "cursor_1",
+		},
+	}
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerInitial); err != nil {
+		t.Fatalf("Sync() error: %v", err)
+	}
+
+	var actorType, actorName, payloadJSON string
+	err := pool.QueryRow(ctx, `
+		SELECT a.actor_type, a.actor_name, a.payload::text
+		FROM annotations a
+		JOIN transactions t ON a.transaction_id = t.id
+		WHERE t.provider_transaction_id = 'txn_started'
+		  AND a.kind = 'sync_started'`).Scan(&actorType, &actorName, &payloadJSON)
+	if err != nil {
+		t.Fatalf("query sync_started annotation: %v", err)
+	}
+	if actorType != "system" {
+		t.Errorf("actor_type = %q, want system", actorType)
+	}
+	if actorName != "Plaid" {
+		t.Errorf("actor_name = %q, want Plaid", actorName)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload["provider"] != "plaid" {
+		t.Errorf("payload.provider = %v, want plaid", payload["provider"])
+	}
+	if payload["connection_id"] != conn.ShortID {
+		t.Errorf("payload.connection_id = %v, want %s", payload["connection_id"], conn.ShortID)
+	}
+	if _, ok := payload["sync_log_id"].(string); !ok {
+		t.Errorf("payload.sync_log_id missing or not a string: %v", payload["sync_log_id"])
+	}
+}
+
+// TestSync_SyncUpdatedAnnotation_OnPendingFlip asserts that flipping pending
+// from true → false in a subsequent sync writes a `sync_updated` annotation
+// carrying the status_change object.
+func TestSync_SyncUpdatedAnnotation_OnPendingFlip(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategories(t, queries)
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added: []provider.Transaction{
+				{
+					ExternalID:        "txn_flip",
+					AccountExternalID: "ext_acct_1",
+					Amount:            decimal.NewFromFloat(42.50),
+					Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+					Name:              "Starbucks",
+					ISOCurrencyCode:   "USD",
+					Pending:           true,
+				},
+			},
+			Cursor: "cursor_1",
+		},
+	}
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerInitial); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	// Second sync: same transaction surfaces as Modified with pending=false.
+	mock.syncResult = provider.SyncResult{
+		Modified: []provider.Transaction{
+			{
+				ExternalID:        "txn_flip",
+				AccountExternalID: "ext_acct_1",
+				Amount:            decimal.NewFromFloat(42.50),
+				Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+				Name:              "Starbucks",
+				ISOCurrencyCode:   "USD",
+				Pending:           false,
+			},
+		},
+		Cursor: "cursor_2",
+	}
+
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	var payloadJSON string
+	err := pool.QueryRow(ctx, `
+		SELECT a.payload::text
+		FROM annotations a
+		JOIN transactions t ON a.transaction_id = t.id
+		WHERE t.provider_transaction_id = 'txn_flip'
+		  AND a.kind = 'sync_updated'`).Scan(&payloadJSON)
+	if err != nil {
+		t.Fatalf("query sync_updated annotation: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	sc, ok := payload["status_change"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload.status_change missing or wrong type: %v", payload["status_change"])
+	}
+	if sc["from"] != "pending" {
+		t.Errorf("status_change.from = %v, want pending", sc["from"])
+	}
+	if sc["to"] != "posted" {
+		t.Errorf("status_change.to = %v, want posted", sc["to"])
+	}
+}
+
+// TestSync_SyncUpdatedAnnotation_NoOp asserts that a subsequent sync touching
+// no user-visible fields writes no `sync_updated` row.
+func TestSync_SyncUpdatedAnnotation_NoOp(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	seedCategories(t, queries)
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	txn := provider.Transaction{
+		ExternalID:        "txn_noop",
+		AccountExternalID: "ext_acct_1",
+		Amount:            decimal.NewFromFloat(42.50),
+		Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+		Name:              "Starbucks",
+		ISOCurrencyCode:   "USD",
+		Pending:           false,
+	}
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added:  []provider.Transaction{txn},
+			Cursor: "cursor_1",
+		},
+	}
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerInitial); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	// Re-send the SAME row as Modified — nothing has changed.
+	mock.syncResult = provider.SyncResult{
+		Modified: []provider.Transaction{txn},
+		Cursor:   "cursor_2",
+	}
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	var count int
+	err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM annotations a
+		JOIN transactions t ON a.transaction_id = t.id
+		WHERE t.provider_transaction_id = 'txn_noop'
+		  AND a.kind = 'sync_updated'`).Scan(&count)
+	if err != nil {
+		t.Fatalf("count sync_updated: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 sync_updated rows for no-op sync, got %d", count)
+	}
+}
+
+// TestSync_SyncUpdatedAnnotation_RuleOnlyChange asserts that a subsequent
+// sync that fires a rule (only the category changes) does NOT write a
+// `sync_updated` row but DOES write the rule_applied + category_set rows.
+func TestSync_SyncUpdatedAnnotation_RuleOnlyChange(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	ctx := context.Background()
+
+	_, food := seedCategoriesWithFood(t, queries)
+	_ = food
+
+	user := testutil.MustCreateUser(t, queries, "Alice")
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "item_1")
+	testutil.MustCreateAccount(t, queries, conn.ID, "ext_acct_1", "Checking")
+
+	txn := provider.Transaction{
+		ExternalID:        "txn_rule_only",
+		AccountExternalID: "ext_acct_1",
+		Amount:            decimal.NewFromFloat(42.50),
+		Date:              time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC),
+		Name:              "Starbucks",
+		ISOCurrencyCode:   "USD",
+		Pending:           false,
+	}
+	mock := &mockProvider{
+		syncResult: provider.SyncResult{
+			Added:  []provider.Transaction{txn},
+			Cursor: "cursor_1",
+		},
+	}
+	providers := map[string]provider.Provider{"plaid": mock}
+	engine := newEngine(t, pool, queries, providers)
+
+	// Initial sync — no rule yet, so the txn lands uncategorized.
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerInitial); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+
+	// Add a rule that fires on_change AND on_create matching this txn name.
+	// We'll use trigger 'always' so it fires on the second sync too.
+	testutil.MustCreateTransactionRule(
+		t, queries, "Starbucks → Food",
+		[]byte(`{"field": "provider_name","op":"contains","value":"Starbucks"}`),
+		[]byte(`[{"type":"set_category","category_slug":"food_and_drink"}]`),
+		"always",
+	)
+
+	// Second sync — provider returns the same row (Modified), but the upsert
+	// classifies it as "unchanged" (no field-level change). Even so, our sync
+	// engine currently only fires rules on isNew||isChanged paths, so we need
+	// to bump a field. Bump merchant_name so the upsert flags isChanged but
+	// pending stays put — this is exactly the "rule fires, no pending flip"
+	// scenario the spec calls out.
+	merchant := "Starbucks Corp"
+	txn.MerchantName = &merchant
+	mock.syncResult = provider.SyncResult{
+		Modified: []provider.Transaction{txn},
+		Cursor:   "cursor_2",
+	}
+	if err := engine.Sync(ctx, conn.ID, db.SyncTriggerManual); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	// rule_applied row should exist.
+	var ruleAppliedCount int
+	err := pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM annotations a
+		JOIN transactions t ON a.transaction_id = t.id
+		WHERE t.provider_transaction_id = 'txn_rule_only'
+		  AND a.kind = 'rule_applied'`).Scan(&ruleAppliedCount)
+	if err != nil {
+		t.Fatalf("count rule_applied: %v", err)
+	}
+	if ruleAppliedCount < 1 {
+		t.Errorf("expected at least 1 rule_applied row, got %d", ruleAppliedCount)
+	}
+
+	// sync_updated row should NOT exist (pending didn't flip).
+	var syncUpdatedCount int
+	err = pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM annotations a
+		JOIN transactions t ON a.transaction_id = t.id
+		WHERE t.provider_transaction_id = 'txn_rule_only'
+		  AND a.kind = 'sync_updated'`).Scan(&syncUpdatedCount)
+	if err != nil {
+		t.Fatalf("count sync_updated: %v", err)
+	}
+	if syncUpdatedCount != 0 {
+		t.Errorf("expected 0 sync_updated rows when only category changed, got %d", syncUpdatedCount)
+	}
+}

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -388,6 +388,8 @@ templ txdSystemSentence(e service.ActivityEntry) {
 		} else {
 			<span class="font-medium text-base-content break-words">{ e.Summary }</span>
 		}
+	} else if e.Type == "sync" {
+		<span class="font-medium text-base-content break-words">{ e.Summary }</span>
 	} else if e.Type == "tag" {
 		if e.ActorName != "" {
 			@txdActorInline(e)
@@ -457,6 +459,10 @@ templ txdSystemIcon(e service.ActivityEntry) {
 	} else if e.Type == "rule" {
 		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-info/15 ring-4 ring-base-100" aria-hidden="true">
 			<i data-lucide="zap" class="w-3 h-3 text-info"></i>
+		</span>
+	} else if e.Type == "sync" {
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
+			<i data-lucide="refresh-cw" class="w-3 h-3 text-base-content/60"></i>
 		</span>
 	} else if e.Type == "review" {
 		<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-100", txdReviewBg(e.ReviewStatus) } aria-hidden="true">


### PR DESCRIPTION
## Why
The activity timeline had no events for sync itself — even though sync is the canonical reason a transaction lands, and its `pending → posted` flip is exactly the change a household member cares about ("did this clear yet?"). Rule firings already have their own annotations; sync didn't.

## What
Two new annotation kinds emitted from inside the connection-sync DB tx:

- **`sync_started`** — written once when a transaction is first imported. Payload: `{ provider, connection_id, sync_log_id }`. Actor: system, named after the provider ("Plaid", "Teller", "CSV import").
- **`sync_updated`** — written when a subsequent sync flips `pending`. Payload includes `{ status_change: { from, to } }`. Other field changes stay out of the timeline.

Migration: additive — extends the `annotations.kind` CHECK constraint to recognise the two new kinds. MCP: new `sync` kind alias maps to both raw kinds; `dbKindToMCP` surfaces `(sync, started)` and `(sync, updated)` action labels.

UI: `txdSystemSentence` renders the enrichment-built Summary; `txdSystemIcon` uses Lucide `refresh-cw` neutral tile.

## Volume note
Typical sync writes ~1 annotation per *new* transaction (`sync_started`). Subsequent syncs write a `sync_updated` row only on a pending-flip — the bulk case (no flip, no rule fire) is silent. Reviewed against the >10/txn ceiling: clean (0–1 per txn).

## Screenshots
> The screenshots below were rendered against fixture annotations INSERTed against the dev DB (the worktree has no live sync provider). The migration, sync-engine wiring, MCP wiring, enrichment, admin/templ branches, and the four integration tests are all real changes; the rendering surface is exercised end-to-end against actual rows of the new kinds.

<img src="https://i.img402.dev/2ve252ng2e.jpg" width="800" alt="Activity timeline with sync_started and sync_updated rows">

<details>
<summary>Mobile</summary>
<img src="https://i.img402.dev/211u7tc1dp.jpg" width="400" alt="Mobile view of activity timeline with sync rows">
</details>

## Test plan
- [x] Integration: new txn → `sync_started` lands with provider actor + payload (`TestSync_SyncStartedAnnotation_OnInitialImport`).
- [x] Integration: pending flip → `sync_updated` with `status_change` payload (`TestSync_SyncUpdatedAnnotation_OnPendingFlip`).
- [x] Integration: no-op sync → no `sync_updated` row (`TestSync_SyncUpdatedAnnotation_NoOp`).
- [x] Integration: rule-only sync → no `sync_updated` row, but `rule_applied` still lands (`TestSync_SyncUpdatedAnnotation_RuleOnlyChange`).
- [x] `make test-integration` green.
- [x] MCP: `list_annotations(kinds=["sync"])` returns both raw kinds.

Part of the **activity-log-v2** stack.
