### PR TITLE
polish(transaction-detail): empty-state above the composer

### DIFF
--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -629,14 +629,18 @@ templ txdTimelineComposer(p TransactionDetailProps) {
 	</li>
 }
 
-// txdTimelineEmptyComposer is shown when there are no events. Composer
-// renders without a rail so the empty state isn't visually noisy.
+// txdTimelineEmptyComposer is shown when there are no events. The empty-state
+// message occupies the timeline slot (where future rows will appear) so the
+// composer stays as the lone interactive control at the bottom — mirroring
+// the populated layout where the timeline lives above the composer.
 templ txdTimelineEmptyComposer(p TransactionDetailProps) {
 	<div class="px-4 sm:px-5 pb-5">
-		@txdComposerCard(p)
-		<div class="mt-5 pt-4 border-t border-base-200 text-center">
+		<div class="pt-2 pb-5 text-center">
 			<i data-lucide="clock" class="w-5 h-5 text-base-content/20 mx-auto" aria-hidden="true"></i>
 			<p class="text-xs text-base-content/40 mt-1.5">No activity yet. Comments, tag changes, and rule hits appear here.</p>
+		</div>
+		<div class="pt-4 border-t border-base-200">
+			@txdComposerCard(p)
 		</div>
 	</div>
 }


### PR DESCRIPTION
## Why
On a transaction with zero activity rows, the empty-state ("No activity yet…") rendered **below** the composer — backwards from the populated layout, where the timeline lives above the composer. After PR 6 (sync_started annotations) lands, this state will be rare in practice, but it's still worth fixing the layout for the rare-but-correct case.

## What
The empty-state message now occupies the timeline slot (where future rows will appear), with the composer kept as the only interactive control at the bottom. Mirrors the populated layout (rows-above-composer).

## Screenshots
<img src="https://i.img402.dev/c353ou3m3v.jpg" width="800" alt="empty state — desktop">
<img src="https://i.img402.dev/grj3d6n856.jpg" width="400" alt="empty state — mobile">

## Test plan
- [x] `go build / vet / test` green.
- [x] Visual validation at 1280x800 and 390x844 (forced empty branch via local templ tweak; reverted before submit).

Final PR in the **activity-log-v2** stack.
