### PR TITLE
chore(service): collapse RFC3339 boilerplate onto pgconv.TimestampStr

### DIFF
--- a/internal/service/account_links.go
+++ b/internal/service/account_links.go
@@ -171,8 +171,8 @@ func (s *Service) GetAccountLink(ctx context.Context, id string) (*AccountLinkRe
 		Enabled:                 row.Enabled,
 		MatchCount:              matchCount,
 		UnmatchedDependentCount: unmatchedCount,
-		CreatedAt:               row.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:               row.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:               pgconv.TimestampStr(row.CreatedAt),
+		UpdatedAt:               pgconv.TimestampStr(row.UpdatedAt),
 	}, nil
 }
 
@@ -202,8 +202,8 @@ func (s *Service) ListAccountLinks(ctx context.Context) ([]AccountLinkResponse, 
 			Enabled:                 row.Enabled,
 			MatchCount:              matchCount,
 			UnmatchedDependentCount: unmatchedCount,
-			CreatedAt:               row.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-			UpdatedAt:               row.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			CreatedAt:               pgconv.TimestampStr(row.CreatedAt),
+			UpdatedAt:               pgconv.TimestampStr(row.UpdatedAt),
 		})
 	}
 	return result, nil
@@ -346,7 +346,7 @@ func (s *Service) ListTransactionMatches(ctx context.Context, linkID string) ([]
 			DependentTransactionID: formatUUID(row.DependentTransactionID),
 			MatchConfidence:        row.MatchConfidence,
 			MatchedOn:              row.MatchedOn,
-			CreatedAt:              row.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			CreatedAt:              pgconv.TimestampStr(row.CreatedAt),
 			PrimaryTxnName:         row.PrimaryTxnName,
 			PrimaryTxnMerchant:     textPtr(row.PrimaryTxnMerchant),
 			DependentTxnName:       row.DependentTxnName,
@@ -457,7 +457,7 @@ func (s *Service) ManualMatch(ctx context.Context, linkID, primaryTxnID, depende
 		DependentTransactionID: formatUUID(match.DependentTransactionID),
 		MatchConfidence:        match.MatchConfidence,
 		MatchedOn:              match.MatchedOn,
-		CreatedAt:              match.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:              pgconv.TimestampStr(match.CreatedAt),
 	}, nil
 }
 

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -109,8 +109,8 @@ func accountFromAllRow(r db.ListAccountsRow) AccountResponse {
 		BalanceLimit:      numericFloat(r.BalanceLimit),
 		IsoCurrencyCode:   textPtr(r.IsoCurrencyCode),
 		LastBalanceUpdate: timestampStr(r.LastBalanceUpdate),
-		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:         pgconv.TimestampStr(r.CreatedAt),
+		UpdatedAt:         pgconv.TimestampStr(r.UpdatedAt),
 		ConnectionStatus:  nullConnStatusPtr(r.ConnectionStatus),
 		IsDependentLinked: r.IsDependentLinked,
 	}
@@ -133,8 +133,8 @@ func accountFromUserRow(r db.ListAccountsByUserRow) AccountResponse {
 		BalanceLimit:      numericFloat(r.BalanceLimit),
 		IsoCurrencyCode:   textPtr(r.IsoCurrencyCode),
 		LastBalanceUpdate: timestampStr(r.LastBalanceUpdate),
-		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:         pgconv.TimestampStr(r.CreatedAt),
+		UpdatedAt:         pgconv.TimestampStr(r.UpdatedAt),
 		ConnectionStatus:  connStatusPtr(r.ConnectionStatus),
 		IsDependentLinked: r.IsDependentLinked,
 	}
@@ -157,8 +157,8 @@ func accountFromGetRow(r db.GetAccountRow) AccountResponse {
 		BalanceLimit:      numericFloat(r.BalanceLimit),
 		IsoCurrencyCode:   textPtr(r.IsoCurrencyCode),
 		LastBalanceUpdate: timestampStr(r.LastBalanceUpdate),
-		CreatedAt:         r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:         r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:         pgconv.TimestampStr(r.CreatedAt),
+		UpdatedAt:         pgconv.TimestampStr(r.UpdatedAt),
 		ConnectionStatus:  nullConnStatusPtr(r.ConnectionStatus),
 		IsDependentLinked: r.IsDependentLinked,
 	}

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -129,6 +130,6 @@ func apiKeyFromRow(r db.ApiKey) APIKeyResponse {
 		Scope:      r.Scope,
 		LastUsedAt: timestampStr(r.LastUsedAt),
 		RevokedAt:  timestampStr(r.RevokedAt),
-		CreatedAt:  r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:  pgconv.TimestampStr(r.CreatedAt),
 	}
 }

--- a/internal/service/connections.go
+++ b/internal/service/connections.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"breadbox/internal/pgconv"
+
 	"github.com/jackc/pgx/v5"
 )
 
@@ -32,8 +34,8 @@ func (s *Service) ListConnections(ctx context.Context, userID *string) ([]Connec
 				ErrorCode:       textPtr(r.ErrorCode),
 				ErrorMessage:    textPtr(r.ErrorMessage),
 				LastSyncedAt:    timestampStr(r.LastSyncedAt),
-				CreatedAt:       r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-				UpdatedAt:       r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+				CreatedAt:       pgconv.TimestampStr(r.CreatedAt),
+				UpdatedAt:       pgconv.TimestampStr(r.UpdatedAt),
 			}
 		}
 		return result, nil
@@ -57,8 +59,8 @@ func (s *Service) ListConnections(ctx context.Context, userID *string) ([]Connec
 			ErrorCode:       textPtr(r.ErrorCode),
 			ErrorMessage:    textPtr(r.ErrorMessage),
 			LastSyncedAt:    timestampStr(r.LastSyncedAt),
-			CreatedAt:       r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-			UpdatedAt:       r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			CreatedAt:       pgconv.TimestampStr(r.CreatedAt),
+			UpdatedAt:       pgconv.TimestampStr(r.UpdatedAt),
 		}
 	}
 	return result, nil
@@ -91,8 +93,8 @@ func (s *Service) GetConnectionStatus(ctx context.Context, id string) (*Connecti
 			ErrorCode:       textPtr(conn.ErrorCode),
 			ErrorMessage:    textPtr(conn.ErrorMessage),
 			LastSyncedAt:    timestampStr(conn.LastSyncedAt),
-			CreatedAt:       conn.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-			UpdatedAt:       conn.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			CreatedAt:       pgconv.TimestampStr(conn.CreatedAt),
+			UpdatedAt:       pgconv.TimestampStr(conn.UpdatedAt),
 		},
 	}
 

--- a/internal/service/mcp_sessions.go
+++ b/internal/service/mcp_sessions.go
@@ -175,7 +175,7 @@ func (s *Service) ListMCPSessions(ctx context.Context, page, pageSize int) ([]MC
 			ShortID:       r.ShortID,
 			Purpose:       r.Purpose,
 			APIKeyName:    r.ApiKeyName,
-			CreatedAt:     r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			CreatedAt:     pgconv.TimestampStr(r.CreatedAt),
 			ToolCallCount: r.ToolCallCount,
 			LastCallAt:    timestampStr(r.LastCallAt),
 			AgentName:     r.AgentName,
@@ -292,7 +292,7 @@ func mcpSessionFromRow(r db.McpSession) MCPSessionResponse {
 		ShortID:    r.ShortID,
 		Purpose:    r.Purpose,
 		APIKeyName: r.ApiKeyName,
-		CreatedAt:  r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:  pgconv.TimestampStr(r.CreatedAt),
 	}
 }
 
@@ -304,7 +304,7 @@ func toolCallFromRow(r db.McpToolCall) ToolCallLogResponse {
 		Reason:         r.Reason,
 		IsError:        r.IsError,
 		ActorName:      r.ActorName,
-		CreatedAt:      r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:      pgconv.TimestampStr(r.CreatedAt),
 	}
 	if len(r.RequestJson) > 0 {
 		raw := json.RawMessage(r.RequestJson)

--- a/internal/service/members.go
+++ b/internal/service/members.go
@@ -82,7 +82,7 @@ func (s *Service) CreateLoginAccount(ctx context.Context, params CreateLoginAcco
 		return nil, fmt.Errorf("get user: %w", err)
 	}
 
-	expiresStr := expiresAt.UTC().Format("2006-01-02T15:04:05Z07:00")
+	expiresStr := expiresAt.UTC().Format(time.RFC3339)
 	return &LoginAccountResponse{
 		ID:                  formatUUID(account.ID),
 		UserID:              formatUUID(account.UserID),
@@ -93,8 +93,8 @@ func (s *Service) CreateLoginAccount(ctx context.Context, params CreateLoginAcco
 		HasPassword:         account.HashedPassword != nil,
 		SetupToken:          token,
 		SetupTokenExpiresAt: &expiresStr,
-		CreatedAt:           account.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:           account.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:           pgconv.TimestampStr(account.CreatedAt),
+		UpdatedAt:           pgconv.TimestampStr(account.UpdatedAt),
 	}, nil
 }
 
@@ -115,13 +115,13 @@ func (s *Service) ListLoginAccounts(ctx context.Context) ([]LoginAccountResponse
 			Username:    r.Username,
 			Role:        r.Role,
 			HasPassword: r.HashedPassword != nil,
-			CreatedAt:   r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-			UpdatedAt:   r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+			CreatedAt:   pgconv.TimestampStr(r.CreatedAt),
+			UpdatedAt:   pgconv.TimestampStr(r.UpdatedAt),
 		}
 		if r.SetupToken.Valid {
 			resp.SetupToken = r.SetupToken.String
 			if r.SetupTokenExpiresAt.Valid {
-				s := r.SetupTokenExpiresAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00")
+				s := pgconv.TimestampStr(r.SetupTokenExpiresAt)
 				resp.SetupTokenExpiresAt = &s
 			}
 		}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -400,6 +400,6 @@ func oauthClientFromRow(r db.OauthClient) OAuthClientResponse {
 		ClientIDPrefix: r.ClientIDPrefix,
 		Scope:          r.Scope,
 		RevokedAt:      timestampStr(r.RevokedAt),
-		CreatedAt:      r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:      pgconv.TimestampStr(r.CreatedAt),
 	}
 }

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -41,7 +41,7 @@ func agentReportFromRow(r db.AgentReport) AgentReportResponse {
 		Tags:          tags,
 		Author:        textPtr(r.Author),
 		ReadAt:        timestampStr(r.ReadAt),
-		CreatedAt:     r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt:     pgconv.TimestampStr(r.CreatedAt),
 	}
 }
 

--- a/internal/service/users.go
+++ b/internal/service/users.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
 )
 
 func (s *Service) ListUsers(ctx context.Context) ([]UserResponse, error) {
@@ -25,7 +26,7 @@ func userFromRow(r db.User) UserResponse {
 		ShortID:   r.ShortID,
 		Name:      r.Name,
 		Email:     textPtr(r.Email),
-		CreatedAt: r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt: r.UpdatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00"),
+		CreatedAt: pgconv.TimestampStr(r.CreatedAt),
+		UpdatedAt: pgconv.TimestampStr(r.UpdatedAt),
 	}
 }


### PR DESCRIPTION
## Summary

The literal `"2006-01-02T15:04:05Z07:00"` is identical to `time.RFC3339`, and [`pgconv.TimestampStr`](internal/pgconv/pgconv.go:108) already does exactly `ts.Time.UTC().Format(time.RFC3339)` with a NULL-safe fallback.

This collapses **32 inline occurrences across 9 service files** onto the existing helper, matching the pgconv consolidation pattern established in #867, #869, and #882.

- 8 files: replace `r.CreatedAt.Time.UTC().Format("2006-01-02T15:04:05Z07:00")` → `pgconv.TimestampStr(r.CreatedAt)`
- 1 file ([members.go:85](internal/service/members.go:85)): the only non-pgtype site (a `time.Time` from a setup-token expiry) switches the literal to the `time.RFC3339` constant.
- 3 files (apikeys, connections, users) gained the `breadbox/internal/pgconv` import.

## Behavior change

Invalid (NULL) timestamps now render as `""` instead of `"0001-01-01T00:00:00Z"`. All affected columns are `NOT NULL`, so this is purely defense-in-depth — no observed callers rely on the zero-time string.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all unit tests pass
- [x] `go test -tags=integration ./internal/service/... -p 1` — passes
- [x] No remaining `Format("2006-01-02T15:04:05Z07:00")` in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)