### PR TITLE
chore(admin): collapse SetFlash + Redirect early-returns onto FlashRedirect helper

### DIFF
--- a/internal/admin/account_links.go
+++ b/internal/admin/account_links.go
@@ -92,8 +92,7 @@ func CreateAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManager)
 		dependentID := r.FormValue("dependent_account_id")
 
 		if primaryID == "" || dependentID == "" {
-			SetFlash(r.Context(), sm, "error", "Both accounts must be selected.")
-			http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Both accounts must be selected.", "/connections?tab=links")
 			return
 		}
 
@@ -102,8 +101,7 @@ func CreateAccountLinkAdminHandler(svc *service.Service, sm *scs.SessionManager)
 			DependentAccountID: dependentID,
 		})
 		if err != nil {
-			SetFlash(r.Context(), sm, "error", "Failed to create link: "+err.Error())
-			http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to create link: "+err.Error(), "/connections?tab=links")
 			return
 		}
 

--- a/internal/admin/apikeys.go
+++ b/internal/admin/apikeys.go
@@ -175,8 +175,7 @@ func APIKeyCreatePageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
-			SetFlash(r.Context(), sm, "error", "Name is required")
-			http.Redirect(w, r, "/api-keys/new", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Name is required", "/api-keys/new")
 			return
 		}
 		scope := r.FormValue("scope")
@@ -185,8 +184,7 @@ func APIKeyCreatePageHandler(svc *service.Service, sm *scs.SessionManager, tr *T
 		}
 		result, err := svc.CreateAPIKey(r.Context(), name, scope)
 		if err != nil {
-			SetFlash(r.Context(), sm, "error", "Failed to create API key")
-			http.Redirect(w, r, "/api-keys/new", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to create API key", "/api-keys/new")
 			return
 		}
 		// Store the plaintext key in the session so the "created" page can display it once.

--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -218,8 +218,7 @@ func SetupAccountHandler(sm *scs.SessionManager, queries *db.Queries, _ *Templat
 
 		// If password is already set, redirect to login.
 		if account.HashedPassword != nil {
-			SetFlash(r.Context(), sm, "info", "Your account is already set up. Please sign in.")
-			http.Redirect(w, r, "/login", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "info", "Your account is already set up. Please sign in.", "/login")
 			return
 		}
 

--- a/internal/admin/backups.go
+++ b/internal/admin/backups.go
@@ -97,16 +97,14 @@ func CreateBackupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		ctx := r.Context()
 
 		if a.BackupService == nil {
-			SetFlash(ctx, sm, "error", "Backup service is not available.")
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Backup service is not available.", "/backups")
 			return
 		}
 
 		filename, err := a.BackupService.CreateBackup(ctx, "manual")
 		if err != nil {
 			a.Logger.Error("create backup", "error", err)
-			SetFlash(ctx, sm, "error", "Failed to create backup: "+err.Error())
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to create backup: "+err.Error(), "/backups")
 			return
 		}
 
@@ -142,16 +140,14 @@ func DeleteBackupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		ctx := r.Context()
 
 		if a.BackupService == nil {
-			SetFlash(ctx, sm, "error", "Backup service not available.")
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Backup service not available.", "/backups")
 			return
 		}
 
 		filename := chi.URLParam(r, "filename")
 		if err := a.BackupService.DeleteBackup(filename); err != nil {
 			a.Logger.Error("delete backup", "error", err, "filename", filename)
-			SetFlash(ctx, sm, "error", "Failed to delete backup.")
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to delete backup.", "/backups")
 			return
 		}
 
@@ -166,8 +162,7 @@ func RestoreBackupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		ctx := r.Context()
 
 		if a.BackupService == nil {
-			SetFlash(ctx, sm, "error", "Backup service not available.")
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Backup service not available.", "/backups")
 			return
 		}
 
@@ -180,22 +175,19 @@ func RestoreBackupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		case "upload":
 			file, header, err := r.FormFile("backup_file")
 			if err != nil {
-				SetFlash(ctx, sm, "error", "No backup file provided.")
-				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "No backup file provided.", "/backups")
 				return
 			}
 			defer file.Close()
 
 			if !strings.HasSuffix(header.Filename, ".sql.gz") {
-				SetFlash(ctx, sm, "error", "Invalid file type. Only .sql.gz files are supported.")
-				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Invalid file type. Only .sql.gz files are supported.", "/backups")
 				return
 			}
 
 			if err := a.BackupService.RestoreFromReader(ctx, file); err != nil {
 				a.Logger.Error("restore from upload", "error", err)
-				SetFlash(ctx, sm, "error", "Restore failed: "+err.Error())
-				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Restore failed: "+err.Error(), "/backups")
 				return
 			}
 
@@ -204,15 +196,13 @@ func RestoreBackupHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 		case "existing":
 			filename := r.FormValue("backup_filename")
 			if filename == "" {
-				SetFlash(ctx, sm, "error", "No backup file selected.")
-				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "No backup file selected.", "/backups")
 				return
 			}
 
 			if err := a.BackupService.RestoreBackup(ctx, filename); err != nil {
 				a.Logger.Error("restore from existing", "error", err, "filename", filename)
-				SetFlash(ctx, sm, "error", "Restore failed: "+err.Error())
-				http.Redirect(w, r, "/backups", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Restore failed: "+err.Error(), "/backups")
 				return
 			}
 
@@ -243,16 +233,14 @@ func BackupScheduleHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc 
 			"weekly":    true,
 		}
 		if !validSchedules[schedule] {
-			SetFlash(ctx, sm, "error", "Invalid backup schedule.")
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid backup schedule.", "/backups")
 			return
 		}
 
 		// Validate retention.
 		retentionDays, err := strconv.Atoi(retentionStr)
 		if err != nil || retentionDays < 1 || retentionDays > 365 {
-			SetFlash(ctx, sm, "error", "Invalid retention period. Must be 1-365 days.")
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid retention period. Must be 1-365 days.", "/backups")
 			return
 		}
 
@@ -262,8 +250,7 @@ func BackupScheduleHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc 
 			Value: pgconv.Text(schedule),
 		}); err != nil {
 			a.Logger.Error("save backup schedule", "error", err)
-			SetFlash(ctx, sm, "error", "Failed to save backup schedule.")
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to save backup schedule.", "/backups")
 			return
 		}
 
@@ -273,8 +260,7 @@ func BackupScheduleHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc 
 			Value: pgconv.Text(strconv.Itoa(retentionDays)),
 		}); err != nil {
 			a.Logger.Error("save backup retention", "error", err)
-			SetFlash(ctx, sm, "error", "Failed to save retention setting.")
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to save retention setting.", "/backups")
 			return
 		}
 
@@ -293,16 +279,14 @@ func RestoreExistingBackupHandler(a *app.App, sm *scs.SessionManager) http.Handl
 		ctx := r.Context()
 
 		if a.BackupService == nil {
-			SetFlash(ctx, sm, "error", "Backup service not available.")
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Backup service not available.", "/backups")
 			return
 		}
 
 		filename := chi.URLParam(r, "filename")
 		if err := a.BackupService.RestoreBackup(ctx, filename); err != nil {
 			a.Logger.Error("restore backup", "error", err, "filename", filename)
-			SetFlash(ctx, sm, "error", "Restore failed: "+err.Error())
-			http.Redirect(w, r, "/backups", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Restore failed: "+err.Error(), "/backups")
 			return
 		}
 

--- a/internal/admin/flash.go
+++ b/internal/admin/flash.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/alexedwards/scs/v2"
 )
@@ -16,6 +17,19 @@ const (
 func SetFlash(ctx context.Context, sm *scs.SessionManager, msgType, message string) {
 	sm.Put(ctx, flashTypeKey, msgType)
 	sm.Put(ctx, flashMessageKey, message)
+}
+
+// FlashRedirect sets a flash message and writes a 303 See Other redirect.
+// It collapses the SetFlash + http.Redirect early-return idiom in admin POST
+// handlers; the caller still issues `return` after invoking it.
+//
+//	if err := svc.Foo(r.Context()); err != nil {
+//	    FlashRedirect(w, r, sm, "error", "Failed: "+err.Error(), "/foo")
+//	    return
+//	}
+func FlashRedirect(w http.ResponseWriter, r *http.Request, sm *scs.SessionManager, msgType, message, target string) {
+	SetFlash(r.Context(), sm, msgType, message)
+	http.Redirect(w, r, target, http.StatusSeeOther)
 }
 
 // GetFlash retrieves and clears the flash message from the session.

--- a/internal/admin/getting_started.go
+++ b/internal/admin/getting_started.go
@@ -117,8 +117,7 @@ func DismissGettingStartedHandler(a *app.App, sm *scs.SessionManager) http.Handl
 			Value: pgconv.Text("true"),
 		}); err != nil {
 			a.Logger.Error("dismiss getting started: set app config", "error", err)
-			SetFlash(r.Context(), sm, "error", "Failed to dismiss guide. Please try again.")
-			http.Redirect(w, r, "/getting-started", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to dismiss guide. Please try again.", "/getting-started")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Getting Started guide dismissed. You can re-open it from Settings.")
@@ -135,8 +134,7 @@ func ReopenGettingStartedHandler(a *app.App, sm *scs.SessionManager) http.Handle
 			Value: pgconv.Text("false"),
 		}); err != nil {
 			a.Logger.Error("reopen getting started: set app config", "error", err)
-			SetFlash(r.Context(), sm, "error", "Failed to re-open guide. Please try again.")
-			http.Redirect(w, r, "/settings", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to re-open guide. Please try again.", "/settings")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Getting Started guide re-opened.")

--- a/internal/admin/mcp.go
+++ b/internal/admin/mcp.go
@@ -33,8 +33,7 @@ func MCPSaveModeHandler(svc *service.Service, sm *scs.SessionManager) http.Handl
 	return func(w http.ResponseWriter, r *http.Request) {
 		mode := r.FormValue("mode")
 		if err := svc.SaveMCPMode(r.Context(), mode); err != nil {
-			SetFlash(r.Context(), sm, "error", "Invalid mode: must be read_only or read_write")
-			http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid mode: must be read_only or read_write", "/agents?tab=settings")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "MCP mode updated.")
@@ -46,8 +45,7 @@ func MCPSaveModeHandler(svc *service.Service, sm *scs.SessionManager) http.Handl
 func MCPSaveToolsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
-			SetFlash(r.Context(), sm, "error", "Invalid form data")
-			http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid form data", "/agents?tab=settings")
 			return
 		}
 
@@ -65,8 +63,7 @@ func MCPSaveToolsHandler(svc *service.Service, mcpServer *breadboxmcp.MCPServer,
 		}
 
 		if err := svc.SaveMCPDisabledTools(r.Context(), disabled); err != nil {
-			SetFlash(r.Context(), sm, "error", "Failed to save tool settings")
-			http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to save tool settings", "/agents?tab=settings")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Tool settings updated.")
@@ -80,8 +77,7 @@ func MCPSaveInstructionsHandler(svc *service.Service, sm *scs.SessionManager) ht
 		instructions := strings.TrimSpace(r.FormValue("instructions"))
 
 		if err := svc.SaveMCPInstructions(r.Context(), instructions); err != nil {
-			SetFlash(r.Context(), sm, "error", err.Error())
-			http.Redirect(w, r, "/agents?tab=settings", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", err.Error(), "/agents?tab=settings")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Instructions saved.")
@@ -94,8 +90,7 @@ func MCPSaveReviewGuidelinesHandler(svc *service.Service, sm *scs.SessionManager
 	return func(w http.ResponseWriter, r *http.Request) {
 		guidelines := strings.TrimSpace(r.FormValue("review_guidelines"))
 		if err := svc.SaveMCPReviewGuidelines(r.Context(), guidelines); err != nil {
-			SetFlash(r.Context(), sm, "error", err.Error())
-			http.Redirect(w, r, "/agents?tab=settings#review-guidelines", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", err.Error(), "/agents?tab=settings#review-guidelines")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Review guidelines saved.")
@@ -108,8 +103,7 @@ func MCPSaveReportFormatHandler(svc *service.Service, sm *scs.SessionManager) ht
 	return func(w http.ResponseWriter, r *http.Request) {
 		format := strings.TrimSpace(r.FormValue("report_format"))
 		if err := svc.SaveMCPReportFormat(r.Context(), format); err != nil {
-			SetFlash(r.Context(), sm, "error", err.Error())
-			http.Redirect(w, r, "/agents?tab=settings#report-format", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", err.Error(), "/agents?tab=settings#report-format")
 			return
 		}
 		SetFlash(r.Context(), sm, "success", "Report format saved.")

--- a/internal/admin/member_password.go
+++ b/internal/admin/member_password.go
@@ -18,15 +18,13 @@ func changePasswordForAccount(a *app.App, sm *scs.SessionManager, w http.Respons
 
 	var accountID pgtype.UUID
 	if err := accountID.Scan(accountIDStr); err != nil {
-		SetFlash(ctx, sm, "error", "Invalid session.")
-		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		FlashRedirect(w, r, sm, "error", "Invalid session.", redirectPath)
 		return
 	}
 
 	account, err := a.Queries.GetAuthAccountByID(ctx, accountID)
 	if err != nil {
-		SetFlash(ctx, sm, "error", "Account not found.")
-		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		FlashRedirect(w, r, sm, "error", "Account not found.", redirectPath)
 		return
 	}
 
@@ -35,32 +33,27 @@ func changePasswordForAccount(a *app.App, sm *scs.SessionManager, w http.Respons
 	confirmPassword := r.FormValue("confirm_password")
 
 	if account.HashedPassword == nil {
-		SetFlash(ctx, sm, "error", "No password set. Please contact your administrator.")
-		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		FlashRedirect(w, r, sm, "error", "No password set. Please contact your administrator.", redirectPath)
 		return
 	}
 	if err := bcrypt.CompareHashAndPassword(account.HashedPassword, []byte(currentPassword)); err != nil {
-		SetFlash(ctx, sm, "error", "Current password is incorrect.")
-		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		FlashRedirect(w, r, sm, "error", "Current password is incorrect.", redirectPath)
 		return
 	}
 
 	if len(newPassword) < 8 {
-		SetFlash(ctx, sm, "error", "New password must be at least 8 characters.")
-		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		FlashRedirect(w, r, sm, "error", "New password must be at least 8 characters.", redirectPath)
 		return
 	}
 
 	if newPassword != confirmPassword {
-		SetFlash(ctx, sm, "error", "New passwords do not match.")
-		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		FlashRedirect(w, r, sm, "error", "New passwords do not match.", redirectPath)
 		return
 	}
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), 12)
 	if err != nil {
-		SetFlash(ctx, sm, "error", "Failed to hash password.")
-		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		FlashRedirect(w, r, sm, "error", "Failed to hash password.", redirectPath)
 		return
 	}
 
@@ -69,8 +62,7 @@ func changePasswordForAccount(a *app.App, sm *scs.SessionManager, w http.Respons
 		HashedPassword: hashedPassword,
 	}); err != nil {
 		a.Logger.Error("update account password", "error", err)
-		SetFlash(ctx, sm, "error", "Failed to update password.")
-		http.Redirect(w, r, redirectPath, http.StatusSeeOther)
+		FlashRedirect(w, r, sm, "error", "Failed to update password.", redirectPath)
 		return
 	}
 

--- a/internal/admin/members.go
+++ b/internal/admin/members.go
@@ -223,16 +223,14 @@ func LinkAdminToUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc
 
 		// Guard: must be an unlinked account.
 		if SessionUserID(sm, r) != "" {
-			SetFlash(ctx, sm, "error", "Your account is already linked to a household member.")
-			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Your account is already linked to a household member.", "/my-account")
 			return
 		}
 
 		accountIDStr := SessionAccountID(sm, r)
 		accountID, err := parseUUID(accountIDStr)
 		if err != nil {
-			SetFlash(ctx, sm, "error", "Invalid session.")
-			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid session.", "/my-account")
 			return
 		}
 
@@ -243,14 +241,12 @@ func LinkAdminToUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc
 		case "create":
 			name := strings.TrimSpace(r.FormValue("name"))
 			if name == "" {
-				SetFlash(ctx, sm, "error", "Name is required.")
-				http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Name is required.", "/my-account")
 				return
 			}
 			user, err := a.Queries.CreateUser(ctx, db.CreateUserParams{Name: name})
 			if err != nil {
-				SetFlash(ctx, sm, "error", "Failed to create household member.")
-				http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Failed to create household member.", "/my-account")
 				return
 			}
 			userID = user.ID
@@ -258,32 +254,27 @@ func LinkAdminToUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc
 		case "existing":
 			uid := r.FormValue("user_id")
 			if uid == "" {
-				SetFlash(ctx, sm, "error", "Please select a household member.")
-				http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Please select a household member.", "/my-account")
 				return
 			}
 			parsed, err := parseUUID(uid)
 			if err != nil {
-				SetFlash(ctx, sm, "error", "Invalid user selected.")
-				http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Invalid user selected.", "/my-account")
 				return
 			}
 			// Verify user exists and isn't already linked.
 			if _, err := a.Queries.GetUser(ctx, parsed); err != nil {
-				SetFlash(ctx, sm, "error", "Household member not found.")
-				http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Household member not found.", "/my-account")
 				return
 			}
 			if _, err := a.Queries.GetAuthAccountByUserID(ctx, parsed); err == nil {
-				SetFlash(ctx, sm, "error", "That household member already has a login account.")
-				http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "That household member already has a login account.", "/my-account")
 				return
 			}
 			userID = parsed
 
 		default:
-			SetFlash(ctx, sm, "error", "Invalid request.")
-			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid request.", "/my-account")
 			return
 		}
 
@@ -292,8 +283,7 @@ func LinkAdminToUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc
 			ID:     accountID,
 			UserID: userID,
 		}); err != nil {
-			SetFlash(ctx, sm, "error", "Failed to link account.")
-			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to link account.", "/my-account")
 			return
 		}
 
@@ -308,12 +298,9 @@ func LinkAdminToUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc
 // MyAccountChangePasswordHandler serves POST /my-account/password -- member changes their own password.
 func MyAccountChangePasswordHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-
 		accountIDStr := SessionAccountID(sm, r)
 		if accountIDStr == "" {
-			SetFlash(ctx, sm, "error", "Invalid session.")
-			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid session.", "/my-account")
 			return
 		}
 
@@ -328,16 +315,14 @@ func MyAccountWipeDataHandler(a *app.App, sm *scs.SessionManager) http.HandlerFu
 
 		userIDStr := SessionUserID(sm, r)
 		if userIDStr == "" {
-			SetFlash(ctx, sm, "error", "Invalid session.")
-			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid session.", "/my-account")
 			return
 		}
 
 		txnCount, err := a.Service.WipeUserData(ctx, userIDStr)
 		if err != nil {
 			a.Logger.Error("member wipe own data", "error", err, "user_id", userIDStr)
-			SetFlash(ctx, sm, "error", "Failed to wipe data.")
-			http.Redirect(w, r, "/my-account", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to wipe data.", "/my-account")
 			return
 		}
 

--- a/internal/admin/oauth.go
+++ b/internal/admin/oauth.go
@@ -386,8 +386,7 @@ func OAuthClientCreatePageHandler(svc *service.Service, sm *scs.SessionManager, 
 	return func(w http.ResponseWriter, r *http.Request) {
 		name := strings.TrimSpace(r.FormValue("name"))
 		if name == "" {
-			SetFlash(r.Context(), sm, "error", "Name is required")
-			http.Redirect(w, r, "/oauth-clients/new", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Name is required", "/oauth-clients/new")
 			return
 		}
 		scope := r.FormValue("scope")
@@ -396,8 +395,7 @@ func OAuthClientCreatePageHandler(svc *service.Service, sm *scs.SessionManager, 
 		}
 		result, err := svc.CreateOAuthClient(r.Context(), name, scope)
 		if err != nil {
-			SetFlash(r.Context(), sm, "error", "Failed to create OAuth client")
-			http.Redirect(w, r, "/oauth-clients/new", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to create OAuth client", "/oauth-clients/new")
 			return
 		}
 		sm.Put(r.Context(), "created_oauth_client_id", result.ClientID)

--- a/internal/admin/providers.go
+++ b/internal/admin/providers.go
@@ -87,8 +87,7 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 		ctx := r.Context()
 
 		if os.Getenv("PLAID_CLIENT_ID") != "" {
-			SetFlash(ctx, sm, "error", "Plaid is configured via environment variables and cannot be changed here.")
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Plaid is configured via environment variables and cannot be changed here.", "/providers")
 			return
 		}
 
@@ -114,26 +113,22 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 			a.Config.PlaidEnv = "sandbox"
 			a.Config.WebhookURL = ""
 			_ = a.ReinitProvider("plaid")
-			SetFlash(ctx, sm, "success", "Plaid configuration cleared.")
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "success", "Plaid configuration cleared.", "/providers")
 			return
 		}
 
 		if plaidSecret == "" {
-			SetFlash(ctx, sm, "error", "Plaid secret is required.")
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Plaid secret is required.", "/providers")
 			return
 		}
 
 		if webhookURL != "" && !strings.HasPrefix(webhookURL, "https://") {
-			SetFlash(ctx, sm, "error", "Webhook URL must use HTTPS.")
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Webhook URL must use HTTPS.", "/providers")
 			return
 		}
 
 		if err := plaidprovider.ValidateCredentials(ctx, plaidClientID, plaidSecret, plaidEnv); err != nil {
-			SetFlash(ctx, sm, "error", "Invalid Plaid credentials: "+err.Error())
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid Plaid credentials: "+err.Error(), "/providers")
 			return
 		}
 
@@ -146,8 +141,7 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 		for _, entry := range entries {
 			if err := a.Queries.SetAppConfig(ctx, entry); err != nil {
 				a.Logger.Error("save plaid config", "error", err, "key", entry.Key)
-				SetFlash(ctx, sm, "error", "Failed to save Plaid credentials.")
-				http.Redirect(w, r, "/providers", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Failed to save Plaid credentials.", "/providers")
 				return
 			}
 		}
@@ -163,8 +157,7 @@ func ProvidersSavePlaidHandler(a *app.App, sm *scs.SessionManager) http.HandlerF
 
 		if err := a.ReinitProvider("plaid"); err != nil {
 			a.Logger.Error("reinit plaid provider", "error", err)
-			SetFlash(ctx, sm, "error", "Plaid credentials saved but provider failed to initialize: "+err.Error())
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Plaid credentials saved but provider failed to initialize: "+err.Error(), "/providers")
 			return
 		}
 
@@ -179,15 +172,13 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 		ctx := r.Context()
 
 		if os.Getenv("TELLER_APP_ID") != "" {
-			SetFlash(ctx, sm, "error", "Teller is configured via environment variables and cannot be changed here.")
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Teller is configured via environment variables and cannot be changed here.", "/providers")
 			return
 		}
 
 		// Parse multipart form (10MB max for cert/key files).
 		if err := r.ParseMultipartForm(10 << 20); err != nil {
-			SetFlash(ctx, sm, "error", "Failed to parse form data.")
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to parse form data.", "/providers")
 			return
 		}
 
@@ -208,8 +199,7 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 			a.Config.TellerCertPEM = nil
 			a.Config.TellerKeyPEM = nil
 			_ = a.ReinitProvider("teller")
-			SetFlash(ctx, sm, "success", "Teller configuration cleared.")
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "success", "Teller configuration cleared.", "/providers")
 			return
 		}
 
@@ -231,8 +221,7 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 		for _, entry := range configEntries {
 			if err := a.Queries.SetAppConfig(ctx, entry); err != nil {
 				a.Logger.Error("save teller config", "error", err, "key", entry.Key)
-				SetFlash(ctx, sm, "error", "Failed to save Teller configuration.")
-				http.Redirect(w, r, "/providers", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", "Failed to save Teller configuration.", "/providers")
 				return
 			}
 		}
@@ -249,36 +238,31 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 		if a.Config.TellerCertPath == "" {
 			certPEM, keyPEM, err := readTellerCertFiles(r)
 			if err != nil {
-				SetFlash(ctx, sm, "error", err.Error())
-				http.Redirect(w, r, "/providers", http.StatusSeeOther)
+				FlashRedirect(w, r, sm, "error", err.Error(), "/providers")
 				return
 			}
 
 			if certPEM != nil && keyPEM != nil {
 				// Validate the key pair.
 				if err := tellerprovider.ValidateCredentialsPEM(certPEM, keyPEM); err != nil {
-					SetFlash(ctx, sm, "error", "Invalid certificate/key: "+err.Error())
-					http.Redirect(w, r, "/providers", http.StatusSeeOther)
+					FlashRedirect(w, r, sm, "error", "Invalid certificate/key: "+err.Error(), "/providers")
 					return
 				}
 
 				if len(a.Config.EncryptionKey) == 0 {
-					SetFlash(ctx, sm, "error", "Encryption key is required to store certificates. Set ENCRYPTION_KEY environment variable.")
-					http.Redirect(w, r, "/providers", http.StatusSeeOther)
+					FlashRedirect(w, r, sm, "error", "Encryption key is required to store certificates. Set ENCRYPTION_KEY environment variable.", "/providers")
 					return
 				}
 
 				// Encrypt and store.
 				encCert, err := crypto.Encrypt(certPEM, a.Config.EncryptionKey)
 				if err != nil {
-					SetFlash(ctx, sm, "error", "Failed to encrypt certificate.")
-					http.Redirect(w, r, "/providers", http.StatusSeeOther)
+					FlashRedirect(w, r, sm, "error", "Failed to encrypt certificate.", "/providers")
 					return
 				}
 				encKey, err := crypto.Encrypt(keyPEM, a.Config.EncryptionKey)
 				if err != nil {
-					SetFlash(ctx, sm, "error", "Failed to encrypt private key.")
-					http.Redirect(w, r, "/providers", http.StatusSeeOther)
+					FlashRedirect(w, r, sm, "error", "Failed to encrypt private key.", "/providers")
 					return
 				}
 
@@ -288,15 +272,13 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 				if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 					Key: "teller_cert_pem", Value: pgconv.Text(certB64),
 				}); err != nil {
-					SetFlash(ctx, sm, "error", "Failed to save certificate.")
-					http.Redirect(w, r, "/providers", http.StatusSeeOther)
+					FlashRedirect(w, r, sm, "error", "Failed to save certificate.", "/providers")
 					return
 				}
 				if err := a.Queries.SetAppConfig(ctx, db.SetAppConfigParams{
 					Key: "teller_key_pem", Value: pgconv.Text(keyB64),
 				}); err != nil {
-					SetFlash(ctx, sm, "error", "Failed to save private key.")
-					http.Redirect(w, r, "/providers", http.StatusSeeOther)
+					FlashRedirect(w, r, sm, "error", "Failed to save private key.", "/providers")
 					return
 				}
 
@@ -307,8 +289,7 @@ func ProvidersSaveTellerHandler(a *app.App, sm *scs.SessionManager) http.Handler
 
 		if err := a.ReinitProvider("teller"); err != nil {
 			a.Logger.Error("reinit teller provider", "error", err)
-			SetFlash(ctx, sm, "error", "Teller settings saved but provider failed to initialize: "+err.Error())
-			http.Redirect(w, r, "/providers", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Teller settings saved but provider failed to initialize: "+err.Error(), "/providers")
 			return
 		}
 

--- a/internal/admin/settings.go
+++ b/internal/admin/settings.go
@@ -89,8 +89,7 @@ func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 
 		syncInterval, err := strconv.Atoi(syncIntervalStr)
 		if err != nil || !isValidSyncInterval(syncInterval) {
-			SetFlash(ctx, sm, "error", "Invalid sync interval.")
-			http.Redirect(w, r, "/settings", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid sync interval.", "/settings")
 			return
 		}
 
@@ -99,8 +98,7 @@ func SettingsSyncPostHandler(a *app.App, sm *scs.SessionManager) http.HandlerFun
 			Value: pgconv.Text(strconv.Itoa(syncInterval)),
 		}); err != nil {
 			a.Logger.Error("save sync interval", "error", err)
-			SetFlash(ctx, sm, "error", "Failed to save sync interval.")
-			http.Redirect(w, r, "/settings", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to save sync interval.", "/settings")
 			return
 		}
 		a.Config.SyncIntervalMinutes = syncInterval
@@ -132,8 +130,7 @@ func SettingsRetentionPostHandler(a *app.App, sm *scs.SessionManager) http.Handl
 		retentionStr := r.FormValue("sync_log_retention_days")
 		retentionDays, err := strconv.Atoi(retentionStr)
 		if err != nil || retentionDays < 0 || retentionDays > 3650 {
-			SetFlash(ctx, sm, "error", "Invalid retention period. Must be 0-3650 days.")
-			http.Redirect(w, r, "/settings", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Invalid retention period. Must be 0-3650 days.", "/settings")
 			return
 		}
 
@@ -142,8 +139,7 @@ func SettingsRetentionPostHandler(a *app.App, sm *scs.SessionManager) http.Handl
 			Value: pgconv.Text(strconv.Itoa(retentionDays)),
 		}); err != nil {
 			a.Logger.Error("save sync log retention", "error", err)
-			SetFlash(ctx, sm, "error", "Failed to save retention setting.")
-			http.Redirect(w, r, "/settings", http.StatusSeeOther)
+			FlashRedirect(w, r, sm, "error", "Failed to save retention setting.", "/settings")
 			return
 		}
 


### PR DESCRIPTION
## Summary

- Add `FlashRedirect(w, r, sm, msgType, message, target)` helper in [internal/admin/flash.go](internal/admin/flash.go) that wraps the very common `SetFlash + http.Redirect(303) + return` early-return idiom in admin POST handlers.
- Mechanically rewrite **75 sites** across 11 handler files to use the helper. Each site collapses from 3 lines to 2 (the caller still issues `return`).
- Net **-63 LOC**. No behavior change — same flash payload, same `http.StatusSeeOther` redirect, same target URL.

Continues the consolidation work in the spirit of recent chores (#877 sync-status badges, #882 pgconv helpers, #884 timefmt).

## Before / After

```go
// Before (3 lines, ×75)
SetFlash(r.Context(), sm, "error", "Failed: "+err.Error())
http.Redirect(w, r, "/connections?tab=links", http.StatusSeeOther)
return

// After (2 lines)
FlashRedirect(w, r, sm, "error", "Failed: "+err.Error(), "/connections?tab=links")
return
```

The non-early-return cases (e.g. `if/else` setting a flash with a single trailing redirect, or referer-fallback redirects) are intentionally left alone — the helper is only for the early-return path where the message and target are co-located.

## Files touched

| File | Sites |
|---|---|
| internal/admin/providers.go | 19 |
| internal/admin/backups.go | 16 |
| internal/admin/members.go | 13 |
| internal/admin/member_password.go | 8 |
| internal/admin/mcp.go | 6 |
| internal/admin/settings.go | 4 |
| internal/admin/account_links.go | 2 |
| internal/admin/apikeys.go | 2 |
| internal/admin/getting_started.go | 2 |
| internal/admin/oauth.go | 2 |
| internal/admin/auth.go | 1 |

Plus the helper definition in [internal/admin/flash.go](internal/admin/flash.go).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all unit tests pass (no behavior change; existing admin tests still green)
- [ ] CI green

No UI changes — pure Go internal refactor, no screenshot needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)