### PR TITLE
polish(transaction-detail): mobile responsiveness pass over the activity timeline

### DIFF
--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -55,13 +55,13 @@ templ TransactionDetail(p TransactionDetailProps) {
 
 templ txdHero(p TransactionDetailProps) {
 	<!-- Hero: Transaction name + amount -->
-	<div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
-		<div class="flex items-center gap-4">
+	<div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4 mb-4 sm:mb-6">
+		<div class="flex items-center gap-3 sm:gap-4 min-w-0">
 			<div class={ "w-12 h-12 rounded-xl flex items-center justify-center shrink-0", txdHeroTileBg(p.Transaction.Amount) }>
 				<i data-lucide={ txdHeroIcon(p.Transaction.Amount) } class={ "w-6 h-6", txdHeroIconColor(p.Transaction.Amount) }></i>
 			</div>
-			<div>
-				<h1 class="bb-page-title">{ p.Transaction.ProviderName }</h1>
+			<div class="min-w-0">
+				<h1 class="bb-page-title break-words">{ p.Transaction.ProviderName }</h1>
 				<div class="flex items-center gap-2 mt-0.5 flex-wrap">
 					<span class="text-xs text-base-content/40">{ components.FormatDate(p.Transaction.Date) }</span>
 					if p.Transaction.ProviderMerchantName != nil && *p.Transaction.ProviderMerchantName != "" {
@@ -96,7 +96,7 @@ templ txdHero(p TransactionDetailProps) {
 
 templ txdAccountBanner(p TransactionDetailProps) {
 	<!-- Account Context Banner -->
-	<div class="bb-card p-0 mb-6 overflow-hidden">
+	<div class="bb-card p-0 mb-4 sm:mb-6 overflow-hidden">
 		<div class="flex items-center gap-4 px-5 py-3.5">
 			<div class="w-9 h-9 rounded-lg bg-base-200/70 flex items-center justify-center shrink-0">
 				<i data-lucide="building-2" class="w-5 h-5 text-base-content/40"></i>
@@ -137,7 +137,7 @@ templ txdAccountBanner(p TransactionDetailProps) {
 
 templ txdMain(p TransactionDetailProps) {
 	<!-- Main content: Details + Category sidebar -->
-	<div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+	<div class="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6 mb-4 sm:mb-6">
 		<!-- Transaction Details -->
 		<div class="bb-card p-5 lg:col-span-2">
 			<h2 class="text-sm font-semibold text-base-content/50 mb-5">Details</h2>
@@ -679,7 +679,10 @@ templ txdComposerCard(p TransactionDetailProps) {
 			if !p.HasPendingReview {
 				<label class="ml-auto btn btn-sm btn-ghost rounded-md gap-2 cursor-pointer transition-all duration-200" :title="pinReview ? 'Posting will also tag this transaction needs-review (Shift+R)' : 'Also tag needs-review when posting (Shift+R)'">
 					<input type="checkbox" class="checkbox checkbox-xs checkbox-primary" x-model="pinReview"/>
-					<span class="text-xs font-medium">Toggle Needs Review</span>
+					<span class="text-xs font-medium">
+						<span class="sm:hidden">Needs review</span>
+						<span class="hidden sm:inline">Toggle Needs Review</span>
+					</span>
 				</label>
 			}
 			<button

--- a/static/js/admin/components/transaction_detail.js
+++ b/static/js/admin/components/transaction_detail.js
@@ -165,6 +165,7 @@ function fetchTimelineRows(txId, replaceCommentIDs) {
       // in place. For genuinely new rows, insert just before the
       // composer (so the composer stays at the bottom).
       var inserted = 0;
+      var lastAppended = null;
       var replaceSet = {};
       if (replaceCommentIDs && replaceCommentIDs.length) {
         replaceCommentIDs.forEach(function (id) { replaceSet[id] = true; });
@@ -185,7 +186,23 @@ function fetchTimelineRows(txId, replaceCommentIDs) {
           ol.appendChild(n);
         }
         inserted++;
+        lastAppended = n;
       });
+
+      // Mobile auto-scroll: on small viewports the composer (and any
+      // freshly-appended row above it) often lands below the fold. After a
+      // user posts a comment / sets a category / adds a tag the new row
+      // would otherwise be invisible until they scroll manually. Bring the
+      // last appended row into view so the optimistic update is visible.
+      // Skipped for replacement rows (tombstones) — the bubble being swapped
+      // is already on screen if the user just clicked its trash button.
+      if (lastAppended) {
+        // rAF so the layout settles before measuring; smooth scroll so the
+        // motion doubles as a "your action landed" signal.
+        window.requestAnimationFrame(function () {
+          lastAppended.scrollIntoView({ behavior: 'smooth', block: 'end' });
+        });
+      }
 
       // Update the cursor so the next fetch only sees newer rows. Every
       // returned <li> has a <time datetime="..."> child for the activity


### PR DESCRIPTION
## Why
The activity-log v2 stack (PRs 1–8) shipped desktop-first. A mobile pass on `/transactions/{id}` (390x844) found a few rough edges that this PR tightens up:

- Hero title with long merchant names (e.g. "American Express Platinum Card") needed `min-w-0` + `break-words` so it could shrink/wrap inside the inline icon row instead of pushing the layout.
- Card-to-card vertical gap (`mb-6`) was generous for narrow viewports — tightened to `mb-4 sm:mb-6`.
- Composer "Toggle Needs Review" label is verbose enough to crowd the submit button on iPhone-13-mini width — switched to a shorter "Needs review" mobile label, full label restored at `sm:`.
- Optimistic comment-add on mobile silently inserted the new row below the fold — the user typed "Comment" and visually nothing happened until they manually scrolled. Added a `scrollIntoView({block: 'end'})` on the freshly-inserted `<li>` so every optimistic append (comment / category set / tag add) lands on screen.

## What
Tailwind-only fixes in `internal/templates/components/pages/transaction_detail.templ` (no Go changes), plus a small JS tweak in `static/js/admin/components/transaction_detail.js`. Rail position, opaque-tile sizing, and `leading-6` invariants from `docs/activity-timeline.md` preserved.

- `txdHero` — outer flex now `gap-3 sm:gap-4 mb-4 sm:mb-6`; inner row gets `min-w-0` and the title wrapper gets `min-w-0 break-words` so long merchant names wrap cleanly inside the icon+text row.
- `txdAccountBanner` — `mb-4 sm:mb-6` (was `mb-6`).
- `txdMain` — outer grid `gap-4 sm:gap-6 mb-4 sm:mb-6` to tighten card spacing on narrow viewports.
- `txdComposerCard` — Toggle Needs Review label now renders as "Needs review" below `sm` (saves ~8 chars next to the Comment button) and the full "Toggle Needs Review" at `sm:` and up.
- `transaction_detail.js` `fetchTimelineRows` — track the last appended (non-replacement) `<li>` and `scrollIntoView({behavior: 'smooth', block: 'end'})` it via `requestAnimationFrame` so the optimistic append is always visible. Tombstone-replacement rows are skipped since the bubble being swapped is already in view.

## Screenshots

**Before — populated (mobile)**
<img src="https://i.img402.dev/1lnvqkutkk.jpg" width="400" alt="populated timeline before — mobile">

**After — populated (mobile)**
<img src="https://i.img402.dev/0p0jk7x0yx.jpg" width="400" alt="populated timeline after — mobile">

**Before — composer with toggle (mobile)**
<img src="https://i.img402.dev/ux96q09zo2.jpg" width="400" alt="composer before — mobile">

**After — composer with toggle (mobile)**
<img src="https://i.img402.dev/c38ewrjyb7.jpg" width="400" alt="composer after — mobile">

**Desktop unchanged (regression check, 1280x800)**
<img src="https://i.img402.dev/mkm704hngg.jpg" width="800" alt="desktop after — unchanged">

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (incl. `scripts_lint_test.go`) all green.
- [x] Visual at 390x844 — hero, account banner, details card, category sidebar, activity rail, tombstone rows, sync-row sentence ("Synced from Teller · pending → posted"), composer with and without Toggle Needs Review.
- [x] Visual at 1280x800 — desktop layout unchanged.
- [x] Optimistic comment-add inserts a row that is auto-scrolled into view (verified by triggering a comment add via the existing API path; the new `<li>` was inserted and the auto-scroll branch fired without console errors).

Part of the **activity-log-v2** stack. Parent: #897.
