### PR TITLE
polish(activity): landmark icon for sync events

### DIFF
--- a/docs/activity-timeline.md
+++ b/docs/activity-timeline.md
@@ -65,7 +65,7 @@ Today's `Type` values:
 | `review`   | (legacy, retained for fallback)  | `txdTimelineSystem`     |
 
 `syncEntryType` collapses both DB-level `sync_*` kinds onto a single `sync`
-type because they share an icon (`refresh-cw`) and the differentiated verb
+type because they share an icon (`landmark`) and the differentiated verb
 already lives on the `Summary` string.
 
 `IsDeleted` is preserved on the comment entry — it gates the tombstone branch
@@ -485,7 +485,7 @@ ring colour):
 ```
 
 Pick a Lucide name that already appears in the codebase when possible —
-`refresh-cw` for sync, `zap` for rules, etc. New icons are fine but check
+`landmark` for sync, `zap` for rules, etc. New icons are fine but check
 `docs/design-system.md` -> "Icons" first.
 
 For the sentence, decide whether your kind should:

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -1103,7 +1103,7 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 
 // syncEntryType maps the raw DB kind to the ActivityEntry type. Both sync_*
 // kinds collapse to a single "sync" type in the UI — the icon is identical
-// (refresh-cw) and the Summary already differentiates the verb.
+// (landmark) and the Summary already differentiates the verb.
 func syncEntryType(dbKind string) string {
 	if dbKind == "sync_started" || dbKind == "sync_updated" {
 		return "sync"

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -462,7 +462,7 @@ templ txdSystemIcon(e service.ActivityEntry) {
 		</span>
 	} else if e.Type == "sync" {
 		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
-			<i data-lucide="refresh-cw" class="w-3 h-3 text-base-content/60"></i>
+			<i data-lucide="landmark" class="w-3 h-3 text-base-content/60"></i>
 		</span>
 	} else if e.Type == "review" {
 		<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-100", txdReviewBg(e.ReviewStatus) } aria-hidden="true">


### PR DESCRIPTION
## Why
PR 6 introduced `sync_started` / `sync_updated` rows with the `refresh-cw` icon. `landmark` reads more clearly as "the bank synced this transaction" — same iconography family the rest of the admin uses for connection/account contexts.

## What
One-line swap in `txdSystemIcon` (`internal/templates/components/pages/transaction_detail.templ`). Inline-comment + `docs/activity-timeline.md` updated to match.

## Screenshots
<img src="https://i.img402.dev/ddegvhtzdb.jpg" width="400" alt="sync row mobile">
<img src="https://i.img402.dev/erdpwwjfct.jpg" width="800" alt="sync row desktop">

## Test plan
- [x] `go build ./...` / `go vet ./...` / `go test ./...` green.
- [x] Visual at 390x844 and 1280x800 (sync row reads as the new landmark glyph).

Part of the **activity-log-v2** stack.
