### PR TITLE
fix(activity): keep composer needs-review toggle in sync with timeline tag changes

### DIFF
--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -676,18 +676,30 @@ templ txdComposerCard(p TransactionDetailProps) {
 					<span x-text="newComment.length"></span>/<span x-text="maxLength"></span>
 				</span>
 			</span>
-			if !p.HasPendingReview {
-				<label class="ml-auto btn btn-sm btn-ghost rounded-md gap-2 cursor-pointer transition-all duration-200" :title="pinReview ? 'Posting will also tag this transaction needs-review (Shift+R)' : 'Also tag needs-review when posting (Shift+R)'">
-					<input type="checkbox" class="checkbox checkbox-xs checkbox-primary" x-model="pinReview"/>
-					<span class="text-xs font-medium">
-						<span class="sm:hidden">Needs review</span>
-						<span class="hidden sm:inline">Toggle Needs Review</span>
-					</span>
-				</label>
-			}
+			<!--
+				Toggle visibility is bound to `hasPendingReview` (initialized
+				from data-has-pending-review) so the timeline-driven
+				bb-needs-review-changed event can hide/show the affordance
+				without a page reload — see static/js/admin/components/transaction_detail.js.
+				`x-cloak` keeps the label hidden during initial Alpine boot
+				when the txn already has the tag.
+			-->
+			<label
+				class="ml-auto btn btn-sm btn-ghost rounded-md gap-2 cursor-pointer transition-all duration-200"
+				:title="pinReview ? 'Posting will also tag this transaction needs-review (Shift+R)' : 'Also tag needs-review when posting (Shift+R)'"
+				x-show="!hasPendingReview"
+				x-cloak
+			>
+				<input type="checkbox" class="checkbox checkbox-xs checkbox-primary" x-model="pinReview"/>
+				<span class="text-xs font-medium">
+					<span class="sm:hidden">Needs review</span>
+					<span class="hidden sm:inline">Toggle Needs Review</span>
+				</span>
+			</label>
 			<button
 				@click="addComment()"
-				class={ "btn btn-sm btn-primary rounded-md gap-1.5", templ.KV("ml-auto", p.HasPendingReview) }
+				class="btn btn-sm btn-primary rounded-md gap-1.5"
+				:class="{ 'ml-auto': hasPendingReview }"
 				:disabled="!canSubmit()"
 			>
 				<i data-lucide="message-square" class="w-3.5 h-3.5" x-show="!pinReview" aria-hidden="true"></i>

--- a/static/js/admin/components/transaction_detail.js
+++ b/static/js/admin/components/transaction_detail.js
@@ -56,6 +56,24 @@
 // separator ahead of the new rows when the new rows fall on a different
 // calendar day than the most recent existing row (see TimelineRowsHandler
 // in internal/admin/transactions.go).
+//
+// ---- Cross-factory needs-review sync (Option B: $dispatch event) ----
+//
+// The composer's "Toggle Needs Review" affordance is bound to
+// `pinReview` and gated by `hasPendingReview` inside txdCommentManager,
+// while the timeline's tag chips (add via picker, remove via inline ✕)
+// live in txdTagManager. They are sibling Alpine factories with no
+// shared store, so a successful timeline-driven mutation of the
+// `needs-review` slug used to leave the composer's toggle stuck on its
+// old state — e.g. removing the chip from the timeline kept the
+// composer reading "Needs review tagged" until a full reload.
+//
+// Fix: when a timeline-driven add/remove of the `needs-review` slug
+// confirms server-side, dispatch a `bb-needs-review-changed` window
+// event with `{ isOn: bool }`. txdCommentManager's init() listens and
+// flips `hasPendingReview` (and clears `pinReview` when the tag is
+// already present) so the composer re-renders against the new truth.
+// Slug-scoped — other tag mutations don't touch the composer.
 
 // --- Module-level globals consumed by tx_row + base.html ---
 
@@ -223,6 +241,15 @@ function fetchTimelineRows(txId, replaceCommentIDs) {
       }
       return inserted;
     });
+}
+
+// notifyNeedsReviewChanged dispatches the cross-factory sync event when a
+// successful timeline-driven add/remove of the `needs-review` slug lands.
+// txdCommentManager listens and updates its bound state so the composer's
+// "Toggle Needs Review" affordance reflects the new truth without a reload.
+// Caller is responsible for slug-scoping; this just fires the event.
+function notifyNeedsReviewChanged(isOn) {
+  window.dispatchEvent(new CustomEvent('bb-needs-review-changed', { detail: { isOn: !!isOn } }));
 }
 
 // Seed window.__bbCategories and window.__bbAllTags as early as possible
@@ -493,7 +520,14 @@ document.addEventListener('alpine:init', function () {
             }
             return fetchTimelineRows(self.txId);
           })
-          .then(function () { showToast('Tags updated.', 'success'); })
+          .then(function () {
+            // Slug-scoped: only dispatch when the diff touched needs-review.
+            // The composer toggle's hasPendingReview/pinReview state only
+            // cares about that one slug.
+            if (adds.indexOf('needs-review') !== -1) notifyNeedsReviewChanged(true);
+            else if (removes.indexOf('needs-review') !== -1) notifyNeedsReviewChanged(false);
+            showToast('Tags updated.', 'success');
+          })
           .catch(function (e) {
             self.tags = prevTags;
             restorePageState();
@@ -519,7 +553,11 @@ document.addEventListener('alpine:init', function () {
             }
             return fetchTimelineRows(self.txId);
           })
-          .then(function () { showToast('Tag removed.', 'success'); })
+          .then(function () {
+            // Slug-scoped sync to the composer toggle (see header comment).
+            if (tag.slug === 'needs-review') notifyNeedsReviewChanged(false);
+            showToast('Tag removed.', 'success');
+          })
           .catch(function (e) {
             self.tags = prevTags;
             restorePageState();
@@ -549,6 +587,20 @@ document.addEventListener('alpine:init', function () {
         var parsed = parseInt(ds.maxCommentLength, 10);
         if (!isNaN(parsed) && parsed > 0) this.maxLength = parsed;
         this.hasPendingReview = ds.hasPendingReview === 'true';
+
+        // Cross-factory sync (Option B). When the timeline tag manager
+        // adds or removes the needs-review slug, mirror the change on the
+        // composer's bound state so the "Toggle Needs Review" affordance
+        // hides/shows correctly without a page reload. Idempotent — bail
+        // when the state already matches so the composer's own toggle
+        // path doesn't fight itself.
+        var self = this;
+        window.addEventListener('bb-needs-review-changed', function (e) {
+          var next = !!(e && e.detail && e.detail.isOn);
+          if (self.hasPendingReview === next) return;
+          self.hasPendingReview = next;
+          if (next) self.pinReview = false;
+        });
       },
 
       canSubmit: function () {


### PR DESCRIPTION
## Why
Removing the `needs-review` tag chip from the timeline left the composer's "Toggle Needs Review" affordance stuck in its old state — the user could see the tag was gone but the composer still hid the toggle (or vice-versa). The composer (`txdCommentManager`) and the timeline tag area (`txdTagManager`) are independent Alpine factories with no shared state, so a timeline-initiated mutation never reached the composer.

## What
Option B (`$dispatch` event). Picked because the factories are already independent — adding a one-line dispatch on each side is structurally lighter than introducing an `Alpine.store`.

- New module helper `notifyNeedsReviewChanged(isOn)` fires a `bb-needs-review-changed` window event after a successful timeline-driven add/remove of the `needs-review` slug. Slug-scoped — other tag mutations don't touch the composer.
- `txdCommentManager.init()` registers an idempotent listener that updates `hasPendingReview` and clears `pinReview` when the tag is being added (so the composer doesn't try to re-pin).
- The composer's "Toggle Needs Review" label is now `x-show="!hasPendingReview"` instead of a Go-side `if !p.HasPendingReview` so the show/hide is reactive without a page reload. Initial state still flows from `data-has-pending-review`; `x-cloak` keeps it hidden during Alpine boot.

## Test plan
- [x] Open a transaction tagged `needs-review` → composer toggle hidden.
- [x] Click the timeline tag chip's ✕ → tag removed → composer toggle now visible (no reload).
- [x] Re-add `needs-review` via the timeline tag picker → composer toggle hides again.
- [x] Mobile viewport (390x844) — same flow works.
- [x] Other tags (not `needs-review`) don't touch composer state (slug-scoped).
- [x] `go build ./...`, `go vet ./...`, `go test ./...` green.
- [x] `templ generate` clean; `templ fmt` clean; `scripts_lint_test.go` passes.

## Screenshots
**Before — toggle hidden, `needs-review` chip present**
<img src="https://i.img402.dev/tuchfmlvlw.jpg" width="800" alt="before timeline remove">

**After — timeline ✕ removed the chip, composer toggle now visible (no reload)**
<img src="https://i.img402.dev/3fbmn018ep.jpg" width="800" alt="after timeline remove">

**Mobile (390x844)**
<img src="https://i.img402.dev/3u9yeli1b2.jpg" width="400" alt="mobile flow">

Part of the **activity-log-v2** stack.
