### PR TITLE
chore: remove dead helpers (BalanceTotals, annotationFromRow)

### DIFF
--- a/internal/admin/helpers.go
+++ b/internal/admin/helpers.go
@@ -142,13 +142,6 @@ func splitCSV(s string) []string {
 	return out
 }
 
-// BalanceTotals holds aggregated asset/liability/net-worth values.
-type BalanceTotals struct {
-	TotalAssets      float64
-	TotalLiabilities float64
-	NetWorth         float64
-}
-
 // IsLiabilityAccount returns true for account types that represent liabilities (credit, loan).
 func IsLiabilityAccount(accountType string) bool {
 	return accountType == "credit" || accountType == "loan"

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -232,48 +232,9 @@ func annotationKindFilter(kinds []string) map[string]bool {
 	return set
 }
 
-// annotationFromRow converts a db.Annotation into its service-layer response.
-func annotationFromRow(a db.Annotation) Annotation {
-	ann := Annotation{
-		ID:            formatUUID(a.ID),
-		ShortID:       a.ShortID,
-		TransactionID: formatUUID(a.TransactionID),
-		Kind:          a.Kind,
-		ActorType:     a.ActorType,
-		ActorID:       textPtr(a.ActorID),
-		ActorName:     a.ActorName,
-		CreatedAt:     pgconv.TimestampStr(a.CreatedAt),
-	}
-
-	if a.SessionID.Valid {
-		s := formatUUID(a.SessionID)
-		ann.SessionID = &s
-	}
-	if a.TagID.Valid {
-		s := formatUUID(a.TagID)
-		ann.TagID = &s
-	}
-	if a.RuleID.Valid {
-		s := formatUUID(a.RuleID)
-		ann.RuleID = &s
-	}
-
-	if len(a.Payload) > 0 && string(a.Payload) != "{}" {
-		var payload map[string]interface{}
-		if err := json.Unmarshal(a.Payload, &payload); err == nil {
-			ann.Payload = payload
-		}
-	}
-
-	if a.DeletedAt.Valid {
-		ann.IsDeleted = true
-	}
-
-	return ann
-}
-
-// annotationFromActorRow mirrors annotationFromRow but additionally surfaces
-// the joined user's updated_at as a unix-timestamp avatar version string.
+// annotationFromActorRow converts a joined annotation+actor row into its
+// service-layer response, surfacing the actor's updated_at as a unix-timestamp
+// avatar version string.
 func annotationFromActorRow(a db.ListAnnotationsWithActorByTransactionRow) Annotation {
 	ann := Annotation{
 		ID:            formatUUID(a.ID),


### PR DESCRIPTION
## Summary

Two unused leftovers from earlier refactors:

- `BalanceTotals` in [internal/admin/helpers.go](internal/admin/helpers.go) was added in #364 alongside `IsLiabilityAccount` / `ConnectionStaleness`, but nothing in the codebase references the struct.
- `annotationFromRow` in [internal/service/annotations.go](internal/service/annotations.go) was superseded by `annotationFromActorRow` in #781 (avatar version surfacing); the older variant has had no callers since.

Net -46 lines, no behavior change. Confirmed via grep and the `deadcode` tool.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` passes
- [x] `make test-integration` passes (annotation flows exercised in service + mcp packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)