### PR TITLE
feat(tag-chip): show slug tooltip when display name differs

### DIFF
--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -55,7 +55,12 @@ templ TagForm(p TagFormProps) {
 				<!-- Live preview chip -->
 				<div class="flex items-center gap-3 p-3 bg-base-200/40 rounded-xl mb-5">
 					<span class="text-[11px] uppercase tracking-wider text-base-content/40 font-medium shrink-0">Preview</span>
-					<span class="bb-tag" :style="'--tag-color:' + (color || '#6366f1')">
+					<span
+						class="bb-tag"
+						:class="displayName && slug && displayName !== slug ? 'tooltip tooltip-top' : ''"
+						:data-tip="displayName && slug && displayName !== slug ? slug : null"
+						:style="'--tag-color:' + (color || '#6366f1')"
+					>
 						<template x-if="icon">
 							<i :data-lucide="icon"></i>
 						</template>

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -252,7 +252,12 @@ templ txdMain(p TransactionDetailProps) {
 				</div>
 				<div class="flex flex-wrap gap-1.5 min-h-[1.5rem] items-center">
 					<template x-for="t in tags" :key="t.slug">
-						<span class="bb-tag" :style="t.color ? ('--tag-color:' + t.color) : ''">
+						<span
+							class="bb-tag"
+							:class="t.displayName && t.displayName !== t.slug ? 'tooltip tooltip-top' : ''"
+							:data-tip="t.displayName && t.displayName !== t.slug ? t.slug : null"
+							:style="t.color ? ('--tag-color:' + t.color) : ''"
+						>
 							<template x-if="t.icon"><i :data-lucide="t.icon"></i></template>
 							<a :href="'/transactions?tags=' + t.slug" class="hover:underline" x-text="t.displayName || t.slug"></a>
 							<button
@@ -701,9 +706,14 @@ templ txdComposerCard(p TransactionDetailProps) {
 // strike-through. The chip is byte-equivalent to the original markup.
 templ txdInlineTagChip(e service.ActivityEntry) {
 	<span
-		class={ "bb-tag bb-tag-sm ml-1 align-middle", templ.KV("line-through opacity-70", e.TagAction == "removed") }
+		class={ "bb-tag bb-tag-sm ml-1 align-middle",
+			templ.KV("line-through opacity-70", e.TagAction == "removed"),
+			templ.KV("tooltip tooltip-top", txdTagChipShowTooltip(e)) }
 		if e.TagColor != nil && *e.TagColor != "" {
 			style={ "--tag-color: " + *e.TagColor }
+		}
+		if txdTagChipShowTooltip(e) {
+			data-tip={ e.TagSlug }
 		}
 		title={ e.TagSlug }
 	>
@@ -715,6 +725,12 @@ templ txdInlineTagChip(e service.ActivityEntry) {
 			}
 		</span>
 	</span>
+}
+
+// txdTagChipShowTooltip mirrors components.tagChipShowTooltip — only show
+// the slug-tooltip when the chip's visible label is the display name.
+func txdTagChipShowTooltip(e service.ActivityEntry) bool {
+	return e.TagDisplayName != "" && e.TagDisplayName != e.TagSlug
 }
 
 // ---- helpers ----

--- a/internal/templates/components/pages/transactions.templ
+++ b/internal/templates/components/pages/transactions.templ
@@ -340,7 +340,11 @@ templ txFilters(p TransactionsProps) {
 						<button
 							type="button"
 							class="bb-tag bb-tag-interactive"
-							:class="!isSelected(t.slug) && 'bb-tag-ghost'"
+							:class="{
+								'bb-tag-ghost': !isSelected(t.slug),
+								'tooltip tooltip-top': t.display_name && t.display_name !== t.slug,
+							}"
+							:data-tip="t.display_name && t.display_name !== t.slug ? t.slug : null"
 							:style="t.color ? ('--tag-color:' + t.color) : ''"
 							@click="toggle(t.slug)"
 						>

--- a/internal/templates/components/tag_chip.templ
+++ b/internal/templates/components/tag_chip.templ
@@ -33,9 +33,12 @@ templ TagChipSm(tag TagChipData) {
 
 templ tagChipBody(class string, tag TagChipData) {
 	<span
-		class={ class }
+		class={ class, templ.KV("tooltip tooltip-top", tagChipShowTooltip(tag)) }
 		if tag.Color != nil {
 			style={ "--tag-color: " + deref(tag.Color) }
+		}
+		if tagChipShowTooltip(tag) {
+			data-tip={ tag.Slug }
 		}
 		title={ tag.Slug }
 	>
@@ -44,4 +47,12 @@ templ tagChipBody(class string, tag TagChipData) {
 		}
 		<span class="truncate">{ tag.DisplayName }</span>
 	</span>
+}
+
+// tagChipShowTooltip returns true when the chip's visible label is the
+// display name (so the tooltip reveals what slug it maps to). Tags
+// without a display name already render the slug as their label, so
+// surfacing it in a tooltip would be redundant noise.
+func tagChipShowTooltip(tag TagChipData) bool {
+	return tag.DisplayName != "" && tag.DisplayName != tag.Slug
 }

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -551,7 +551,9 @@
                   'bb-tagpicker-chip--mixed':          chip.state === 'mixed',
                   'bb-tagpicker-chip--pending-add':    chip.state === 'pending-add',
                   'bb-tagpicker-chip--pending-remove': chip.state === 'pending-remove',
+                  'tooltip tooltip-top':               chip.display_name && chip.display_name !== chip.slug,
                 }"
+                :data-tip="chip.display_name && chip.display_name !== chip.slug ? chip.slug : null"
                 :style="chip.color ? ('--tag-color:' + chip.color) : ''"
                 @click="cycleChip(chip)"
                 x-effect="syncChipGlyph($el, chip.state, chip.icon)"


### PR DESCRIPTION
## Summary

Tag chips render the **display name** as the visible label, which means the **slug** — the stable identifier used in rules, filters, search, and the URL `?tags=` param — is hidden from the user. This adds a DaisyUI tooltip that surfaces the slug on hover, but only when the chip is actually showing a display name. When the chip already falls back to rendering the slug (no display name set), the tooltip would just repeat what's already visible, so it's suppressed.

Predicate (applied at every call site): `display_name != "" && display_name != slug`.

## Call sites covered

| Where | File |
| --- | --- |
| Canonical `components.TagChip` / `TagChipSm` (transaction rows, `/tags`) | `internal/templates/components/tag_chip.templ` |
| Transaction-detail Tags section (Alpine `txdTagManager`) | `internal/templates/components/pages/transaction_detail.templ` |
| Transaction-detail activity timeline inline chip (`txdInlineTagChip`) | same |
| Transactions filter sidebar selector chips | `internal/templates/components/pages/transactions.templ` |
| Shared tag picker dialog | `internal/templates/layout/base.html` |
| `/tags/new` + `/tags/edit` live preview chip | `internal/templates/components/pages/tag_form.templ` |

## Validation

Verified in a real browser at `localhost:8083` against the dev DB (one tag: `needs-review` → `Needs Review`). DOM check on the transactions list:

```js
[...document.querySelectorAll('.bb-tag')].slice(0, 5).map(c => ({
  cls: c.className, dataTip: c.getAttribute('data-tip'),
  text: c.innerText.trim()
}))
```

```json
[
  {"cls": "bb-tag bb-tag-interactive tooltip tooltip-top", "dataTip": "needs-review", "text": "Needs Review"},
  {"cls": "bb-tag bb-tag-sm tooltip tooltip-top",          "dataTip": "needs-review", "text": "Needs Review"},
  {"cls": "bb-tag bb-tag-sm tooltip tooltip-top",          "dataTip": "needs-review", "text": "Needs Review"}
]
```

DOM check on `/transactions/{id}` Tags section (Alpine path):

```json
{"cls": "bb-tag tooltip tooltip-top", "dataTip": "needs-review", "text": "Needs Review"}
```

Both the `tooltip tooltip-top` class and `data-tip="needs-review"` attribute are correctly present on every chip whose visible label is the display name. Tooltip renders correctly on hover (visually verified locally — see screenshot in the comment thread).

## Test plan

- [x] `go build ./...`, `go vet ./...`, `templ generate`, `go test ./internal/templates/...` all green
- [x] Filter chip in `/transactions` sidebar shows `needs-review` tooltip on hover
- [x] Inline chips in transaction rows show tooltip on hover
- [x] Tags section chip on `/transactions/{id}` shows tooltip on hover
- [ ] Verify tag-picker dialog chips show tooltip on hover
- [ ] Verify `/tags/new` live preview shows tooltip when both slug and display_name are filled and differ
