### PR TITLE
feat(activity): show profile name for actor display

### DIFF
--- a/internal/db/queries/annotations.sql
+++ b/internal/db/queries/annotations.sql
@@ -19,6 +19,12 @@ ORDER BY created_at ASC;
 -- users.id or an auth_accounts.id depending on the call site; resolve both
 -- by joining auth_accounts and falling back to a direct users join.
 --
+-- Also surfaces the joined users.name so the service layer can prefer the
+-- user's profile name over the value frozen into annotations.actor_name at
+-- write time (which is whatever Actor.Name carried — typically the
+-- auth_accounts.username/email login). Falls back to the stored actor_name
+-- when the join misses or the profile name is blank.
+--
 -- Compare in text space (aa.id::text = a.actor_id) rather than casting
 -- a.actor_id::uuid, because actor_id can also hold a non-UUID short_id for
 -- system-actor rows (e.g. rule_applied writes the rule's short_id) and
@@ -33,7 +39,13 @@ SELECT
     a.id, a.short_id, a.transaction_id, a.kind, a.actor_type,
     a.actor_id, a.actor_name, a.session_id, a.payload, a.tag_id,
     a.rule_id, a.created_at, a.deleted_at,
-    COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at
+    COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
+    -- Empty-string-coalesced join of the actor's profile name. The service
+    -- layer prefers this over annotations.actor_name (which is whatever
+    -- Actor.Name carried at write time — typically the auth_accounts
+    -- username/email login) and falls back to actor_name when this is "".
+    -- Non-user actors (system, agent) miss both joins and resolve to "".
+    COALESCE(u_via_account.name, u_direct.name, '')::text AS actor_user_name
 FROM annotations a
 LEFT JOIN auth_accounts aa
     ON a.actor_type = 'user'

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -235,7 +235,22 @@ func annotationKindFilter(kinds []string) map[string]bool {
 // annotationFromActorRow converts a joined annotation+actor row into its
 // service-layer response, surfacing the actor's updated_at as a unix-timestamp
 // avatar version string.
+//
+// For user-attributed rows we prefer the live users.name carried by the join
+// (a.ActorUserName) over the annotations.actor_name that was frozen in at
+// write time. Actor.Name from a logged-in admin session is the
+// auth_accounts.username (typically an email), so without this preference
+// the timeline rendered "admin@example.com added the Food tag" even when
+// the linked household member had a real profile name. Falls back to the
+// stored actor_name when the join missed (rare, e.g. the user was
+// hard-deleted) or the profile name is blank. Non-user actors (system,
+// agent) always fall through to the stored actor_name.
 func annotationFromActorRow(a db.ListAnnotationsWithActorByTransactionRow) Annotation {
+	displayName := a.ActorName
+	if a.ActorType == "user" && a.ActorUserName != "" {
+		displayName = a.ActorUserName
+	}
+
 	ann := Annotation{
 		ID:            formatUUID(a.ID),
 		ShortID:       a.ShortID,
@@ -243,7 +258,7 @@ func annotationFromActorRow(a db.ListAnnotationsWithActorByTransactionRow) Annot
 		Kind:          a.Kind,
 		ActorType:     a.ActorType,
 		ActorID:       textPtr(a.ActorID),
-		ActorName:     a.ActorName,
+		ActorName:     displayName,
 		CreatedAt:     pgconv.TimestampStr(a.CreatedAt),
 	}
 

--- a/internal/service/annotations_actor_name_integration_test.go
+++ b/internal/service/annotations_actor_name_integration_test.go
@@ -1,0 +1,128 @@
+//go:build integration
+
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// TestListAnnotations_PrefersProfileName verifies that user-attributed
+// timeline rows render the joined users.name (a real profile name) instead
+// of the email/username carried by Actor.Name at write time. ActorFromSession
+// builds Actor.Name from auth_accounts.username — typically an email like
+// "admin@example.com" — but the timeline reads better with "Alice Example"
+// when the linked household member has a profile name set.
+//
+// Covers three branches of annotationFromActorRow:
+//
+//  1. actor_id == users.id, users.name set → ActorName resolves to users.name.
+//  2. actor_id == auth_accounts.id (legacy initial-admin sessions),
+//     users.name set → still resolves via the auth_accounts → users join.
+//  3. actor_id references a hard-deleted user → no join match, falls back
+//     to the value frozen into annotations.actor_name at write time.
+//
+// Non-user actors (agent, system) are exercised by every other comment-
+// related integration test in this package — they bypass the join entirely.
+func TestListAnnotations_PrefersProfileName(t *testing.T) {
+	svc, queries, pool := newService(t)
+	ctx := context.Background()
+	acctID := seedTxnFixture(t, queries)
+	txn := seedTransaction(t, queries, acctID, "ext_actor_name_1", "Coffee", 100, "2024-06-01")
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	// --- Case 1: actor_id == users.id, users.name set ---
+	alice := testutil.MustCreateUser(t, queries, "Alice Example")
+	aliceActor := service.Actor{
+		Type: "user",
+		ID:   pgconv.FormatUUID(alice.ID),
+		Name: "alice@example.com", // simulates ActorFromSession (auth username)
+	}
+	if _, err := svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "users.id branch",
+		Actor:         aliceActor,
+	}); err != nil {
+		t.Fatalf("create comment (users.id branch): %v", err)
+	}
+
+	// --- Case 2: actor_id == auth_accounts.id, joined user has a name ---
+	bob := testutil.MustCreateUser(t, queries, "Bob Example")
+	bobAccount, err := queries.CreateAuthAccount(ctx, db.CreateAuthAccountParams{
+		UserID:         bob.ID,
+		Username:       "bob@example.com",
+		HashedPassword: []byte("not-real"),
+		Role:           "editor",
+	})
+	if err != nil {
+		t.Fatalf("create auth account: %v", err)
+	}
+	bobActor := service.Actor{
+		Type: "user",
+		ID:   pgconv.FormatUUID(bobAccount.ID), // legacy: account id, not user id
+		Name: "bob@example.com",
+	}
+	if _, err := svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "auth_accounts.id branch",
+		Actor:         bobActor,
+	}); err != nil {
+		t.Fatalf("create comment (auth_accounts.id branch): %v", err)
+	}
+
+	// --- Case 3: actor_id points at a user we then hard-delete ---
+	charlie := testutil.MustCreateUser(t, queries, "Charlie Example")
+	charlieActor := service.Actor{
+		Type: "user",
+		ID:   pgconv.FormatUUID(charlie.ID),
+		Name: "charlie@example.com",
+	}
+	if _, err := svc.CreateComment(ctx, service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "fallback branch",
+		Actor:         charlieActor,
+	}); err != nil {
+		t.Fatalf("create comment (fallback branch): %v", err)
+	}
+	// Drop Charlie. annotations.actor_id is plain TEXT — no FK — so the row
+	// survives, but the join now misses on both sides, exercising the
+	// fallback-to-stored-actor_name path. Raw SQL because there is no
+	// production DeleteUser query (users are soft-handled elsewhere).
+	if _, err := pool.Exec(ctx, "DELETE FROM users WHERE id = $1", charlie.ID); err != nil {
+		t.Fatalf("delete charlie: %v", err)
+	}
+
+	anns, err := svc.ListAnnotations(ctx, txnID, service.ListAnnotationsParams{
+		Kinds: []string{"comment"},
+	})
+	if err != nil {
+		t.Fatalf("ListAnnotations: %v", err)
+	}
+	if len(anns) != 3 {
+		t.Fatalf("expected 3 comments, got %d", len(anns))
+	}
+
+	// Comments are ordered by created_at ASC; insertion order matches.
+	want := []struct {
+		content string
+		name    string
+	}{
+		{"users.id branch", "Alice Example"},
+		{"auth_accounts.id branch", "Bob Example"},
+		{"fallback branch", "charlie@example.com"},
+	}
+	for i, w := range want {
+		if anns[i].Content != w.content {
+			t.Fatalf("annotation[%d] content = %q, want %q", i, anns[i].Content, w.content)
+		}
+		if anns[i].ActorName != w.name {
+			t.Errorf("annotation[%d] (%s) ActorName = %q, want %q",
+				i, w.content, anns[i].ActorName, w.name)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Activity-timeline rows attributed to a logged-in user rendered as the user's auth-account username — `admin@example.com added the Food tag`. `ActorFromSession` builds `Actor.Name` from `auth_accounts.username`, which is typically an email; the household member's `users.name` reads more naturally when set.

## What

- `ListAnnotationsWithActorByTransaction` now selects the actor's `users.name` alongside the existing email/username column, via the same auth_accounts → users join already in place for the avatar version.
- `annotationFromActorRow` prefers the joined profile name for `ActorType == "user"` rows; falls back to the `annotations.actor_name` frozen in at write time when the join misses (hard-deleted user) or the profile name is blank. Non-user actors (`system`, `agent`) are untouched.
- Surfaces uniformly through admin timeline, REST `list_annotations`, and MCP `list_annotations` — no per-consumer override needed.

## Schema note

The `users` table only has a single `name` column (no `first_name`/`last_name`/`display_name`). Used `users.name` directly. `COALESCE(..., '')::text` is the well-trodden pattern for telling sqlc the result is non-NULL when both LEFT-JOIN sides may miss.

## Test plan
- [x] `go build / vet / test` green.
- [x] `make test-integration` green; new `TestListAnnotations_PrefersProfileName` covers the three branches:
  - `actor_id == users.id`, profile name set → ActorName resolves to `users.name`.
  - `actor_id == auth_accounts.id` (legacy initial-admin sessions), profile name set → still resolves through the auth_accounts → users join.
  - Hard-deleted user → falls back to the value frozen into `annotations.actor_name` at write time.
- [x] Visual at 1280x800 and 390x844 against `/transactions/PsbN5oBU` (Sephora — has 9 events including comments, tag toggles, category set).

## Screenshots

### Before — auth-username rendering
<img src="https://i.img402.dev/6rack9wexf.jpg" width="800" alt="before — admin@example.com">

### After — profile name
<img src="https://i.img402.dev/7bnozvznh5.jpg" width="800" alt="after — Ricardo Canales">

### Mobile (390x844)
<img src="https://i.img402.dev/5t8rwyo05k.jpg" width="320" alt="mobile — Ricardo Canales">

Follow-up to the activity-log v2 stack.
