### PR TITLE
polish(activity): chip-render rule-driven tags/categories and scope link to rule name

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -1002,16 +1002,54 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 		if a.Origin != "" {
 			summary = strings.TrimSuffix(summary, " "+a.Origin)
 		}
-		return service.ActivityEntry{
-			Type:      "rule",
-			Timestamp: a.CreatedAt,
-			ActorName: "",
-			ActorType: "system",
-			Summary:   summary,
-			RuleName:  a.RuleName,
-			RuleID:    derefOr(a.RuleID, ""),
-			Origin:    a.Origin,
-		}, true
+		field, _ := a.Payload["action_field"].(string)
+		entry := service.ActivityEntry{
+			Type:        "rule",
+			Timestamp:   a.CreatedAt,
+			ActorName:   "",
+			ActorType:   "system",
+			Summary:     summary,
+			RuleName:    a.RuleName,
+			RuleID:      derefOr(a.RuleID, ""),
+			RuleShortID: a.RuleShortID,
+			ActionField: field,
+			Origin:      a.Origin,
+		}
+		// Hydrate the chip-rendering fields so the templ can render the
+		// rule-driven row with a tag chip or category chip in place of the
+		// plain-text resource that the Summary string carries. The chip
+		// helpers reuse the same fields populated for user-driven
+		// tag_added / category_set rows; keeping the data path unified
+		// means the templ doesn't have to branch by Type to find the
+		// presentation metadata.
+		switch field {
+		case "tag":
+			if tagDisplayFn != nil {
+				td := tagDisplayFn(a.TagSlug)
+				entry.TagSlug = a.TagSlug
+				entry.TagDisplayName = td.DisplayName
+				if entry.TagDisplayName == "" {
+					entry.TagDisplayName = a.TagSlug
+				}
+				entry.TagColor = td.Color
+			} else {
+				entry.TagSlug = a.TagSlug
+				entry.TagDisplayName = a.TagSlug
+			}
+		case "category":
+			if categoryDetail != nil {
+				d := categoryDetail(a.CategorySlug)
+				entry.CategoryName = d.DisplayName
+				if entry.CategoryName == "" {
+					entry.CategoryName = a.CategorySlug
+				}
+				entry.CategoryColor = d.Color
+				entry.CategoryIcon = d.Icon
+			} else {
+				entry.CategoryName = a.CategorySlug
+			}
+		}
+		return entry, true
 
 	case "tag_added", "tag_removed":
 		// Look up color separately — service-layer enrichment doesn't

--- a/internal/service/annotations.go
+++ b/internal/service/annotations.go
@@ -84,6 +84,12 @@ type Annotation struct {
 	TagSlug      string `json:"tag_slug,omitempty"`
 	CategorySlug string `json:"category_slug,omitempty"`
 	RuleName     string `json:"rule_name,omitempty"`
+	// RuleShortID is the rule's 8-char short_id, surfaced from
+	// payload.rule_id so admin UI consumers can link to /rules/<short_id>
+	// without resolving the FK separately. The DB row's rule_id column is
+	// the UUID and stays exposed via Annotation.RuleID; this field is the
+	// human-friendly handle the timeline link uses.
+	RuleShortID string `json:"rule_short_id,omitempty"`
 
 	// ActorAvatarVersion is the unix timestamp of the user's most recent
 	// users.updated_at, used as a cache-busting `?v=<ts>` query string on

--- a/internal/service/annotations_enrich.go
+++ b/internal/service/annotations_enrich.go
@@ -241,11 +241,13 @@ func enrichOne(a Annotation, tagDisplay, categoryDisplay func(string) string) An
 
 	case "rule_applied":
 		ruleName, _ := a.Payload["rule_name"].(string)
+		ruleShortID, _ := a.Payload["rule_id"].(string)
 		field, _ := a.Payload["action_field"].(string)
 		value, _ := a.Payload["action_value"].(string)
 		appliedBy, _ := a.Payload["applied_by"].(string)
 		a.Action = "applied"
 		a.RuleName = ruleName
+		a.RuleShortID = ruleShortID
 		a.Origin = formatRuleOrigin(appliedBy)
 		// Surface the targeted resource ref so callers can cross-link
 		// without parsing payload.

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -419,6 +419,19 @@ type ActivityEntry struct {
 	CategoryIcon  *string `json:"category_icon,omitempty"`
 	RuleName      string  `json:"rule_name,omitempty"`
 	RuleID       string `json:"rule_id,omitempty"`
+	// RuleShortID is the rule's 8-char short_id used to build the
+	// /rules/<short_id> link target on rule_applied timeline rows. The
+	// rule detail route accepts either UUID or short_id, but the
+	// activity timeline prefers short_id so the rendered href matches
+	// the canonical handle agents and humans use everywhere else.
+	RuleShortID string `json:"rule_short_id,omitempty"`
+	// ActionField identifies what a rule_applied row targeted ("tag",
+	// "category", or "comment"). Drives the chip-vs-text branch in the
+	// templ — when ActionField=="tag" the row renders the tag chip
+	// already populated in TagSlug/TagDisplayName/TagColor; when
+	// "category" it renders the category chip from CategoryName +
+	// CategoryColor + CategoryIcon.
+	ActionField string `json:"action_field,omitempty"`
 	CommentID    string `json:"comment_id,omitempty"`
 	TagSlug      string `json:"tag_slug,omitempty"` // for tag_added / tag_removed entries
 

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -377,17 +377,15 @@ templ txdTimelineSystem(e service.ActivityEntry, now time.Time) {
 }
 
 // txdSystemSentence assembles the actor-verb-object phrase shown next to a
-// system-event icon. For rule rows the prebuilt Summary is rendered as-is
-// (optionally linked to /rules/<id>); for actor-driven rows we compose:
+// system-event icon. Rule rows render as: rule-name link + verb + chip,
+// matching the bolding pattern of user-driven rows so a rule firing reads
+// the same as a person doing the equivalent action. For actor-driven rows
+// we compose:
 //   <strong>Alice</strong> added the <chip>food</chip>
-//   <strong>Alice</strong> set category to <em>Groceries</em>
+//   <strong>Alice</strong> set category to <chip>Groceries</chip>
 templ txdSystemSentence(e service.ActivityEntry) {
 	if e.Type == "rule" {
-		if e.RuleID != "" {
-			<a href={ templ.SafeURL("/rules/" + e.RuleID) } class="font-medium text-base-content hover:text-primary transition-colors break-words">{ e.Summary }</a>
-		} else {
-			<span class="font-medium text-base-content break-words">{ e.Summary }</span>
-		}
+		@txdRuleSentence(e)
 	} else if e.Type == "sync" {
 		<span class="font-medium text-base-content break-words">{ e.Summary }</span>
 	} else if e.Type == "tag" {
@@ -412,11 +410,11 @@ templ txdSystemSentence(e service.ActivityEntry) {
 	} else if e.Type == "category" {
 		if e.ActorName != "" {
 			@txdActorInline(e)
-			<span>set category to </span>
+			<span>set the category to </span>
 		} else {
-			<span class="font-medium text-base-content">Set category to </span>
+			<span class="font-medium text-base-content">Set the category to </span>
 		}
-		<span class="font-medium text-base-content">{ e.CategoryName }</span>
+		@txdInlineCategoryChip(e)
 	} else {
 		<!-- Review (legacy) and any unknown kind: fall back to Summary -->
 		if e.Summary != "" {
@@ -709,6 +707,85 @@ templ txdComposerCard(p TransactionDetailProps) {
 			</button>
 		</div>
 	</div>
+}
+
+// txdRuleSentence renders the rule_applied row body in the actor-verb-object
+// shape used by user-driven rows: bold rule name (linked to the rule detail
+// page on the *name only* — not the whole row, so the chip stays clickable
+// without accidentally navigating away) → plain verb → resource chip. Falls
+// back to the prebuilt Summary string when the action_field is anything we
+// don't have chip metadata for, preserving forward compatibility with future
+// rule action types.
+templ txdRuleSentence(e service.ActivityEntry) {
+	@txdRuleActor(e)
+	if e.ActionField == "tag" {
+		<span>added the </span>
+		@txdInlineTagChip(e)
+		<span class="ml-1">tag</span>
+	} else if e.ActionField == "category" {
+		<span>set the category to </span>
+		@txdInlineCategoryChip(e)
+	} else {
+		<!-- Unknown / future action_field: fall through to the bare
+		     verb so we never render a stale "set category to <slug>"
+		     when only Summary carries the right phrasing. -->
+		<span class="text-base-content/55">{ txdRuleVerbFallback(e) }</span>
+	}
+}
+
+// txdRuleActor renders the rule's name as either a link to /rules/<short_id>
+// (when the short_id is known) or plain bold text. Only the name itself is
+// the anchor so the chip rendered later in the row stays an independent
+// click target — avoiding the "click the tag, end up on the rule page"
+// regression the previous whole-row link caused.
+templ txdRuleActor(e service.ActivityEntry) {
+	<span>Rule </span>
+	if e.RuleShortID != "" {
+		<a
+			href={ templ.SafeURL("/rules/" + e.RuleShortID) }
+			class="font-semibold text-base-content hover:underline underline-offset-2 decoration-base-content/40 break-words"
+		>{ e.RuleName }</a>
+	} else if e.RuleID != "" {
+		<a
+			href={ templ.SafeURL("/rules/" + e.RuleID) }
+			class="font-semibold text-base-content hover:underline underline-offset-2 decoration-base-content/40 break-words"
+		>{ e.RuleName }</a>
+	} else {
+		<strong class="font-semibold text-base-content">{ e.RuleName }</strong>
+	}
+}
+
+// txdRuleVerbFallback returns the trailing verb-and-object text for rule
+// rows whose action_field doesn't have a chip rendering. Strips the rule
+// name + opening quote off the prebuilt Summary so we don't render the
+// rule name twice when this branch fires.
+func txdRuleVerbFallback(e service.ActivityEntry) string {
+	s := e.Summary
+	prefix := "Rule \"" + e.RuleName + "\" "
+	if strings.HasPrefix(s, prefix) {
+		return s[len(prefix):]
+	}
+	return s
+}
+
+// txdInlineCategoryChip renders a pill matching the canonical bb-tag chip
+// styling (the same look used for tags) but populated from a category's
+// color + icon + display name. Reuses the --tag-color CSS variable so a
+// single CSS class drives both tag and category chips.
+templ txdInlineCategoryChip(e service.ActivityEntry) {
+	<span
+		class="bb-tag bb-tag-sm align-middle"
+		if e.CategoryColor != nil && *e.CategoryColor != "" {
+			style={ "--tag-color: " + *e.CategoryColor }
+		}
+	>
+		if e.CategoryIcon != nil && *e.CategoryIcon != "" {
+			<i data-lucide={ *e.CategoryIcon }></i>
+		} else {
+			<i data-lucide="folder"></i>
+		}
+		<span class="truncate">{ e.CategoryName }</span>
+	</span>
 }
 
 // txdInlineTagChip renders the inline tag pill that follows the summary

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -753,6 +753,7 @@ templ txdRuleActor(e service.ActivityEntry) {
 	} else {
 		<strong class="font-semibold text-base-content">{ e.RuleName }</strong>
 	}
+	{ " " }
 }
 
 // txdRuleVerbFallback returns the trailing verb-and-object text for rule


### PR DESCRIPTION
## Why
Two related touch-ups on rule-driven activity rows:

1. Rule rows rendered the tag/category as plain text — user-driven equivalents render them as styled chips. The mismatch made rule-driven rows look secondary even when the underlying event was the same.
2. The whole rule row was a link to `/rules/{id}` — clicking the tag chip accidentally navigated. Scope the link to just the rule name with a proper hover affordance, and target the rule's short_id so the URL matches the canonical handle the rest of the app uses.

## What
- New structured fields on `service.ActivityEntry`: `RuleShortID`, `ActionField`. The rule-applied row now hydrates `TagDisplayName`/`TagColor` (or `CategoryName`/`CategoryColor`/`CategoryIcon`) the same way a user-driven `tag_added` / `category_set` row does, so the templ composes the row from data instead of the prebuilt summary string.
- `service.Annotation.RuleShortID` carries the rule's short_id from the `rule_applied` payload (`payload.rule_id`, which the ruleapply package already writes as a short_id).
- New `txdRuleSentence` / `txdRuleActor` / `txdInlineCategoryChip` helpers compose the rule_applied row as: bold rule-name link (only the name, hover-underline) → plain verb → existing tag chip or new category chip → time. No new chip components — `txdInlineCategoryChip` reuses the canonical `bb-tag` styling driven by `--tag-color`.
- User-driven `category_set` rows also pick up the new chip rendering for parity ("Alice set the category to [chip]").

## Test plan
- [x] `go build`, `go vet`, `go test ./...` green.
- [x] `make test-integration` green; `EnrichAnnotations` rule-source dedup contract unchanged (rule-driven `tag_added`/`category_set` rows still fold into the parent `rule_applied` row, so the only system row to repaint is `rule_applied` itself — verified against a real `Auto-tag new transactions for review` firing on `xmxvYqXD`).
- [x] Visual at 1280x800 and 390x844; rule-name hover state captured.
- [x] Tombstone, sync-row, comment-bubble, and empty-state rendering unchanged (only `txdSystemSentence`'s `rule` and `category` branches were touched).

## Screenshots

**Before — whole-row link, plain-text tag**

<img src="https://i.img402.dev/87wy56x9u5.jpg" width="800" alt="rule row before — whole row is a link, tag rendered as plain text">

**After — chip + scoped link to rule name only**

<img src="https://i.img402.dev/3zj2zne7f0.jpg" width="800" alt="rule row after — only rule name is a link, tag renders as a chip">

**Hover on rule name** (underline-only affordance)

<img src="https://i.img402.dev/axkzakr0ma.jpg" width="800" alt="rule name hover">

**Mobile — 390x844**

<img src="https://i.img402.dev/23b489618s.jpg" width="400" alt="mobile rendering">

Follow-up to the activity-log v2 stack.
