### PR TITLE
chore: drop duplicate parseUUID wrappers

### DIFF
--- a/internal/admin/members.go
+++ b/internal/admin/members.go
@@ -228,7 +228,7 @@ func LinkAdminToUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc
 		}
 
 		accountIDStr := SessionAccountID(sm, r)
-		accountID, err := parseUUID(accountIDStr)
+		accountID, err := pgconv.ParseUUID(accountIDStr)
 		if err != nil {
 			FlashRedirect(w, r, sm, "error", "Invalid session.", "/my-account")
 			return
@@ -257,7 +257,7 @@ func LinkAdminToUserHandler(a *app.App, sm *scs.SessionManager) http.HandlerFunc
 				FlashRedirect(w, r, sm, "error", "Please select a household member.", "/my-account")
 				return
 			}
-			parsed, err := parseUUID(uid)
+			parsed, err := pgconv.ParseUUID(uid)
 			if err != nil {
 				FlashRedirect(w, r, sm, "error", "Invalid user selected.", "/my-account")
 				return

--- a/internal/admin/oauth.go
+++ b/internal/admin/oauth.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // OAuthMetadataHandler returns the OAuth 2.0 Authorization Server Metadata (RFC 8414).
@@ -209,7 +208,7 @@ func OAuthAuthorizeSubmitHandler(svc *service.Service, sm *scs.SessionManager) h
 		}
 
 		// Parse admin UUID.
-		adminUUID, err := parseUUID(adminID)
+		adminUUID, err := pgconv.ParseUUID(adminID)
 		if err != nil {
 			oauthError(w, http.StatusInternalServerError, "server_error", "Invalid session")
 			return
@@ -530,6 +529,3 @@ func isForwardedHTTPS(r *http.Request) bool {
 	return r.Header.Get("X-Forwarded-Proto") == "https"
 }
 
-func parseUUID(s string) (pgtype.UUID, error) {
-	return pgconv.ParseUUID(s)
-}

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -9,7 +9,6 @@ import (
 	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func (s *Service) ListAccounts(ctx context.Context, userID *string) ([]AccountResponse, error) {
@@ -78,7 +77,7 @@ func (s *Service) GetAccountDetail(ctx context.Context, id string) (*AdminAccoun
 
 	if acct.ConnectionID != nil {
 		detail.ConnectionID = *acct.ConnectionID
-		connID, err := parseUUID(*acct.ConnectionID)
+		connID, err := pgconv.ParseUUID(*acct.ConnectionID)
 		if err == nil {
 			conn, err := s.Queries.GetBankConnection(ctx, connID)
 			if err == nil {
@@ -164,6 +163,3 @@ func accountFromGetRow(r db.GetAccountRow) AccountResponse {
 	}
 }
 
-func parseUUID(s string) (pgtype.UUID, error) {
-	return pgconv.ParseUUID(s)
-}

--- a/internal/service/apikeys.go
+++ b/internal/service/apikeys.go
@@ -79,7 +79,7 @@ func (s *Service) ListAPIKeys(ctx context.Context) ([]APIKeyResponse, error) {
 }
 
 func (s *Service) RevokeAPIKey(ctx context.Context, id string) error {
-	uid, err := parseUUID(id)
+	uid, err := pgconv.ParseUUID(id)
 	if err != nil {
 		return ErrNotFound
 	}

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -596,7 +596,7 @@ func (s *Service) BulkRecategorizeByFilter(ctx context.Context, params BulkRecat
 	if err != nil {
 		return nil, fmt.Errorf("%w: target category %q not found", ErrCategoryNotFound, params.TargetCategorySlug)
 	}
-	targetUID, err := parseUUID(targetCat.ID)
+	targetUID, err := pgconv.ParseUUID(targetCat.ID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid target category ID: %w", err)
 	}

--- a/internal/service/csv_import.go
+++ b/internal/service/csv_import.go
@@ -46,7 +46,7 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 		params.AccountName = "CSV Import"
 	}
 
-	userID, err := parseUUID(params.UserID)
+	userID, err := pgconv.ParseUUID(params.UserID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid user ID: %w", err)
 	}
@@ -56,7 +56,7 @@ func (s *Service) ImportCSV(ctx context.Context, params CSVImportParams) (*CSVIm
 
 	if params.ConnectionID != "" {
 		// Re-import: load existing connection and get first account.
-		connID, err = parseUUID(params.ConnectionID)
+		connID, err = pgconv.ParseUUID(params.ConnectionID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid connection ID: %w", err)
 		}

--- a/internal/service/mcp_sessions.go
+++ b/internal/service/mcp_sessions.go
@@ -98,7 +98,7 @@ func (s *Service) GetMCPSession(ctx context.Context, idOrShort string) (MCPSessi
 		}
 		return mcpSessionFromRow(row), nil
 	}
-	uid, err := parseUUID(idOrShort)
+	uid, err := pgconv.ParseUUID(idOrShort)
 	if err != nil {
 		return MCPSessionResponse{}, fmt.Errorf("%w: invalid session ID", ErrInvalidParameter)
 	}
@@ -118,7 +118,7 @@ func (s *Service) LogToolCall(ctx context.Context, input ToolCallLogInput) {
 			if err == nil {
 				sessionID = row.ID
 			}
-		} else if uid, err := parseUUID(input.SessionID); err == nil {
+		} else if uid, err := pgconv.ParseUUID(input.SessionID); err == nil {
 			sessionID = uid
 		}
 	}
@@ -196,7 +196,7 @@ func (s *Service) GetMCPSessionDetail(ctx context.Context, idOrShort string) (MC
 		return MCPSessionDetailResponse{}, err
 	}
 
-	uid, _ := parseUUID(session.ID)
+	uid, _ := pgconv.ParseUUID(session.ID)
 	rows, err := s.Queries.ListToolCallsBySession(ctx, uid)
 	if err != nil {
 		return MCPSessionDetailResponse{}, fmt.Errorf("list tool calls: %w", err)
@@ -279,7 +279,7 @@ func (s *Service) ResolveSessionUUID(ctx context.Context, idOrShort string) (pgt
 		}
 		return row.ID, nil
 	}
-	uid, err := parseUUID(idOrShort)
+	uid, err := pgconv.ParseUUID(idOrShort)
 	if err != nil {
 		return pgtype.UUID{}, fmt.Errorf("%w: invalid session_id", ErrInvalidParameter)
 	}

--- a/internal/service/oauth.go
+++ b/internal/service/oauth.go
@@ -123,7 +123,7 @@ func (s *Service) ListOAuthClients(ctx context.Context) ([]OAuthClientResponse, 
 
 // RevokeOAuthClient revokes an OAuth client and all its access tokens.
 func (s *Service) RevokeOAuthClient(ctx context.Context, id string) error {
-	uid, err := parseUUID(id)
+	uid, err := pgconv.ParseUUID(id)
 	if err != nil {
 		return ErrNotFound
 	}

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -137,7 +137,7 @@ func (s *Service) CountUnreadAgentReports(ctx context.Context) (int64, error) {
 
 // GetAgentReport returns a single report by ID.
 func (s *Service) GetAgentReport(ctx context.Context, reportID string) (AgentReportResponse, error) {
-	uid, err := parseUUID(reportID)
+	uid, err := pgconv.ParseUUID(reportID)
 	if err != nil {
 		return AgentReportResponse{}, fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
 	}
@@ -150,7 +150,7 @@ func (s *Service) GetAgentReport(ctx context.Context, reportID string) (AgentRep
 
 // MarkAgentReportRead marks a single report as read.
 func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) error {
-	uid, err := parseUUID(reportID)
+	uid, err := pgconv.ParseUUID(reportID)
 	if err != nil {
 		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
 	}
@@ -159,7 +159,7 @@ func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) erro
 
 // MarkAgentReportUnread clears read_at on a single report, returning it to the unread queue.
 func (s *Service) MarkAgentReportUnread(ctx context.Context, reportID string) error {
-	uid, err := parseUUID(reportID)
+	uid, err := pgconv.ParseUUID(reportID)
 	if err != nil {
 		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
 	}

--- a/internal/service/resolve.go
+++ b/internal/service/resolve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"breadbox/internal/pgconv"
 	"breadbox/internal/shortid"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -24,7 +25,7 @@ func (s *Service) resolveID(ctx context.Context, idOrShort string, lookup shortI
 		}
 		return uid, nil
 	}
-	uid, err := parseUUID(idOrShort)
+	uid, err := pgconv.ParseUUID(idOrShort)
 	if err != nil {
 		return pgtype.UUID{}, fmt.Errorf("invalid id: %w", err)
 	}

--- a/internal/service/resolve_test.go
+++ b/internal/service/resolve_test.go
@@ -6,15 +6,17 @@ import (
 	"fmt"
 	"testing"
 
+	"breadbox/internal/pgconv"
+
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-// validUUID is a well-formed UUID for testing parseUUID passthrough.
+// validUUID is a well-formed UUID for testing UUID passthrough.
 const validUUID = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11"
 
 // mockLookupOK returns a fixed UUID, simulating a successful short ID query.
 func mockLookupOK(_ context.Context, _ string) (pgtype.UUID, error) {
-	uid, _ := parseUUID(validUUID)
+	uid, _ := pgconv.ParseUUID(validUUID)
 	return uid, nil
 }
 

--- a/internal/service/rules.go
+++ b/internal/service/rules.go
@@ -922,7 +922,7 @@ func (s *Service) ListTransactionRules(ctx context.Context, params TransactionRu
 		if err != nil {
 			return nil, ErrInvalidCursor
 		}
-		cursorUUID, err := parseUUID(cursorIDStr)
+		cursorUUID, err := pgconv.ParseUUID(cursorIDStr)
 		if err != nil {
 			return nil, ErrInvalidCursor
 		}
@@ -1084,7 +1084,7 @@ func (s *Service) UpdateTransactionRule(ctx context.Context, id string, params U
 		return nil, fmt.Errorf("marshal actions: %w", err)
 	}
 
-	ruleID, _ := parseUUID(id) // already validated by GetTransactionRule above
+	ruleID, _ := pgconv.ParseUUID(id) // already validated by GetTransactionRule above
 
 	query := `UPDATE transaction_rules
 		SET name = $2, conditions = $3, actions = $4, trigger = $5, priority = $6, enabled = $7, expires_at = $8, updated_at = NOW()
@@ -1264,7 +1264,7 @@ func (s *Service) ApplyRuleRetroactively(ctx context.Context, ruleID string) (in
 		return 0, fmt.Errorf("%w: rule has no applicable actions", ErrInvalidParameter)
 	}
 
-	ruleUUID, _ := parseUUID(ruleID)
+	ruleUUID, _ := pgconv.ParseUUID(ruleID)
 	ruleShortID, ruleName := s.ruleIdentityForAudit(ctx, ruleUUID)
 
 	var totalMatched int64
@@ -1447,7 +1447,7 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 		if err != nil {
 			continue
 		}
-		uuid, _ := parseUUID(r.ID)
+		uuid, _ := pgconv.ParseUUID(r.ID)
 		compiled = append(compiled, compiledRule{
 			id:       r.ID,
 			uuid:     uuid,
@@ -1665,7 +1665,7 @@ func (s *Service) ApplyAllRulesRetroactively(ctx context.Context) (map[string]in
 
 	// Update hit counts for all matched rules.
 	for ruleID, count := range hitCounts {
-		id, err := parseUUID(ruleID)
+		id, err := pgconv.ParseUUID(ruleID)
 		if err != nil {
 			continue
 		}
@@ -1832,7 +1832,7 @@ func (s *Service) previewRuleInternal(ctx context.Context, excludeRuleID *pgtype
 // BatchIncrementHitCounts updates hit counts for rules that matched.
 func (s *Service) BatchIncrementHitCounts(ctx context.Context, hits map[string]int) error {
 	for ruleID, count := range hits {
-		id, err := parseUUID(ruleID)
+		id, err := pgconv.ParseUUID(ruleID)
 		if err != nil {
 			continue
 		}
@@ -2107,7 +2107,7 @@ func (s *Service) categorySlugToUUID(ctx context.Context, slug string) (pgtype.U
 	if err != nil {
 		return pgtype.UUID{}, fmt.Errorf("%w: category slug %q not found", ErrInvalidParameter, slug)
 	}
-	return parseUUID(cat.ID)
+	return pgconv.ParseUUID(cat.ID)
 }
 
 // parseDuration parses a duration string like "30d", "24h", "1w".
@@ -2334,7 +2334,7 @@ func (s *Service) ListRuleApplications(ctx context.Context, ruleID string, limit
 		if err != nil {
 			return nil, false, ErrInvalidCursor
 		}
-		cursorUUID, err := parseUUID(cursorIDStr)
+		cursorUUID, err := pgconv.ParseUUID(cursorIDStr)
 		if err != nil {
 			return nil, false, ErrInvalidCursor
 		}

--- a/internal/service/sync.go
+++ b/internal/service/sync.go
@@ -54,7 +54,7 @@ func (s *Service) TriggerSync(ctx context.Context, connectionID *string) error {
 
 // GetSyncLog returns a single sync log with connection info.
 func (s *Service) GetSyncLog(ctx context.Context, syncLogID string) (*SyncLogRow, error) {
-	uid, err := parseUUID(syncLogID)
+	uid, err := pgconv.ParseUUID(syncLogID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid sync log id: %w", err)
 	}
@@ -242,7 +242,7 @@ func (s *Service) ListSyncLogsPaginated(ctx context.Context, params SyncLogListP
 	if len(logs) > 0 {
 		syncLogIDs := make([]pgtype.UUID, 0, len(logs))
 		for _, l := range logs {
-			uid, err := parseUUID(l.ID)
+			uid, err := pgconv.ParseUUID(l.ID)
 			if err == nil {
 				syncLogIDs = append(syncLogIDs, uid)
 			}
@@ -436,7 +436,7 @@ func (s *Service) GetSyncHealthSummary(ctx context.Context) (*SyncHealthSummary,
 
 // ListSyncLogAccounts returns the per-account breakdown for a specific sync log.
 func (s *Service) ListSyncLogAccounts(ctx context.Context, syncLogID string) ([]SyncLogAccountRow, error) {
-	uid, err := parseUUID(syncLogID)
+	uid, err := pgconv.ParseUUID(syncLogID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid sync log id: %w", err)
 	}
@@ -490,7 +490,7 @@ func (s *Service) parseRuleHits(ctx context.Context, ruleHitsJSON []byte) ([]Rul
 	}
 	ruleInfoMap := make(map[string]ruleInfo, len(hitMap))
 	for ruleID := range hitMap {
-		uid, err := parseUUID(ruleID)
+		uid, err := pgconv.ParseUUID(ruleID)
 		if err != nil {
 			continue
 		}
@@ -626,7 +626,7 @@ func (s *Service) buildSyncLogWhereClause(params SyncLogListParams) (string, []a
 	argN := 1
 
 	if params.ConnectionID != nil {
-		uid, err := parseUUID(*params.ConnectionID)
+		uid, err := pgconv.ParseUUID(*params.ConnectionID)
 		if err != nil {
 			return "", nil, 0, fmt.Errorf("invalid connection id: %w", err)
 		}

--- a/internal/service/tags.go
+++ b/internal/service/tags.go
@@ -109,7 +109,7 @@ func (s *Service) GetTag(ctx context.Context, idOrSlug string) (*TagResponse, er
 	}
 
 	// Try UUID
-	if uid, err := parseUUID(idOrSlug); err == nil {
+	if uid, err := pgconv.ParseUUID(idOrSlug); err == nil {
 		tag, err := s.Queries.GetTagByID(ctx, uid)
 		if err == nil {
 			resp := tagFromRow(tag)
@@ -186,7 +186,7 @@ func (s *Service) UpdateTag(ctx context.Context, id string, params UpdateTagPara
 		lifecycle = v
 	}
 
-	existingUID, _ := parseUUID(existing.ID)
+	existingUID, _ := pgconv.ParseUUID(existing.ID)
 	tag, err := s.Queries.UpdateTag(ctx, db.UpdateTagParams{
 		ID:          existingUID,
 		DisplayName: displayName,
@@ -212,7 +212,7 @@ func (s *Service) DeleteTag(ctx context.Context, id string) error {
 	if err != nil {
 		return err
 	}
-	uid, err := parseUUID(existing.ID)
+	uid, err := pgconv.ParseUUID(existing.ID)
 	if err != nil {
 		return ErrNotFound
 	}

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -262,7 +262,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		if err != nil {
 			return nil, err
 		}
-		cursorUUID, err := parseUUID(cursorID)
+		cursorUUID, err := pgconv.ParseUUID(cursorID)
 		if err != nil {
 			return nil, ErrInvalidCursor
 		}
@@ -465,7 +465,7 @@ func (s *Service) attachTagsToTransactions(ctx context.Context, txns []Transacti
 	ids := make([]pgtype.UUID, 0, len(txns))
 	idx := make(map[string]int, len(txns))
 	for i, t := range txns {
-		uid, err := parseUUID(t.ID)
+		uid, err := pgconv.ParseUUID(t.ID)
 		if err != nil {
 			continue
 		}
@@ -697,7 +697,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 	needAccountJoin = true
 
 	if params.UserID != nil {
-		uid, err := parseUUID(*params.UserID)
+		uid, err := pgconv.ParseUUID(*params.UserID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid user id: %w", err)
 		}
@@ -711,7 +711,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 	}
 
 	if params.ConnectionID != nil {
-		cid, err := parseUUID(*params.ConnectionID)
+		cid, err := pgconv.ParseUUID(*params.ConnectionID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid connection id: %w", err)
 		}
@@ -723,7 +723,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 	}
 
 	if params.AccountID != nil {
-		aid, err := parseUUID(*params.AccountID)
+		aid, err := pgconv.ParseUUID(*params.AccountID)
 		if err != nil {
 			return nil, fmt.Errorf("invalid account id: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Remove two identical private `parseUUID` wrappers (in `internal/admin/oauth.go` and `internal/service/accounts.go`) that just delegated to `pgconv.ParseUUID`.
- Replace the ~38 call sites with direct `pgconv.ParseUUID(...)` calls.
- Drop the now-unused `pgx/v5/pgtype` import from both files; add `breadbox/internal/pgconv` to `internal/service/resolve.go` and its test.

No behavior change — purely a deduplication / single-source-of-truth cleanup, in the same vein as `e7aca39` (RFC3339 boilerplate) and `c706704` (FlashRedirect helper).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit)
- [x] `make test-integration` for `internal/service`, `internal/admin`, `internal/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)