### PR TITLE
chore: consolidate *string deref helpers into internal/strutil

### DIFF
--- a/internal/admin/account_links.go
+++ b/internal/admin/account_links.go
@@ -6,6 +6,7 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
+	"breadbox/internal/strutil"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
 
@@ -56,10 +57,10 @@ func renderAccountLinkDetail(tr *TemplateRenderer, w http.ResponseWriter, r *htt
 			Amount:                 m.Amount,
 			PrimaryTransactionID:   m.PrimaryTransactionID,
 			PrimaryTxnName:         m.PrimaryTxnName,
-			PrimaryTxnMerchant:     derefString(m.PrimaryTxnMerchant),
+			PrimaryTxnMerchant:     strutil.Deref(m.PrimaryTxnMerchant),
 			DependentTransactionID: m.DependentTransactionID,
 			DependentTxnName:       m.DependentTxnName,
-			DependentTxnMerchant:   derefString(m.DependentTxnMerchant),
+			DependentTxnMerchant:   strutil.Deref(m.DependentTxnMerchant),
 			MatchConfidence:        m.MatchConfidence,
 			MatchedOn:              m.MatchedOn,
 		}
@@ -76,13 +77,6 @@ func renderAccountLinkDetail(tr *TemplateRenderer, w http.ResponseWriter, r *htt
 		Matches:                 rows,
 	}
 	tr.RenderWithTempl(w, r, data, pages.AccountLinkDetail(props))
-}
-
-func derefString(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
 }
 
 // CreateAccountLinkAdminHandler handles POST /-/account-links.

--- a/internal/admin/csv_export.go
+++ b/internal/admin/csv_export.go
@@ -9,6 +9,7 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
+	"breadbox/internal/strutil"
 )
 
 // ExportTransactionsCSVHandler serves GET /admin/-/transactions/export-csv.
@@ -71,13 +72,13 @@ func ExportTransactionsCSVHandler(a *app.App, svc *service.Service) http.Handler
 			row := []string{
 				tx.Date,
 				tx.Name,
-				derefStr(tx.MerchantName),
+				strutil.Deref(tx.MerchantName),
 				strconv.FormatFloat(tx.Amount, 'f', 2, 64),
-				derefStr(tx.IsoCurrencyCode),
+				strutil.Deref(tx.IsoCurrencyCode),
 				tx.AccountName,
 				tx.InstitutionName,
 				tx.UserName,
-				derefStr(tx.CategoryDisplayName),
+				strutil.Deref(tx.CategoryDisplayName),
 				strconv.FormatBool(tx.Pending),
 				tx.ID,
 			}
@@ -89,10 +90,3 @@ func ExportTransactionsCSVHandler(a *app.App, svc *service.Service) http.Handler
 	}
 }
 
-// derefStr safely dereferences a string pointer, returning empty string if nil.
-func derefStr(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -7,6 +7,7 @@ import (
 	"breadbox/internal/app"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
+	"breadbox/internal/strutil"
 	"breadbox/internal/templates/components/pages"
 	"breadbox/internal/timefmt"
 
@@ -56,9 +57,9 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 				a.Logger.Error("list bank connections for sync log filters", "error", err)
 			}
 
-			filterConnID := stringOrEmpty(params.ConnectionID)
-			filterStatus := stringOrEmpty(params.Status)
-			filterTrigger := stringOrEmpty(params.Trigger)
+			filterConnID := strutil.Deref(params.ConnectionID)
+			filterStatus := strutil.Deref(params.Status)
+			filterTrigger := strutil.Deref(params.Trigger)
 			filterDateFrom := r.URL.Query().Get("date_from")
 			filterDateTo := r.URL.Query().Get("date_to")
 

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -5,6 +5,7 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/service"
+	"breadbox/internal/strutil"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
 	"breadbox/internal/timefmt"
@@ -81,10 +82,10 @@ func buildSyncLogDetailProps(log *service.SyncLogRow, accounts []service.SyncLog
 			ModifiedCount:     log.ModifiedCount,
 			RemovedCount:      log.RemovedCount,
 			UnchangedCount:    log.UnchangedCount,
-			ErrorMessage:      stringOrEmpty(log.ErrorMessage),
-			WarningMessage:    stringOrEmpty(log.WarningMessage),
+			ErrorMessage:      strutil.Deref(log.ErrorMessage),
+			WarningMessage:    strutil.Deref(log.WarningMessage),
 			StartedAtRelative: timefmt.RelativeRFC3339Ptr(log.StartedAt),
-			Duration:          stringOrEmpty(log.Duration),
+			Duration:          strutil.Deref(log.Duration),
 			AccountsAffected:  log.AccountsAffected,
 			TotalRuleHits:     log.TotalRuleHits,
 		}
@@ -117,12 +118,5 @@ func buildSyncLogDetailProps(log *service.SyncLogRow, accounts []service.SyncLog
 		}
 	}
 	return out
-}
-
-func stringOrEmpty(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
 }
 

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -13,6 +13,7 @@ import (
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
+	"breadbox/internal/strutil"
 	"breadbox/internal/templates/components"
 	"breadbox/internal/templates/components/pages"
 
@@ -318,10 +319,10 @@ func renderTransactions(w http.ResponseWriter, r *http.Request, tr *TemplateRend
 		AllTags:           in.allTags,
 		FilterStartDate:   q.Get("start_date"),
 		FilterEndDate:     q.Get("end_date"),
-		FilterAccountID:   stringOrEmpty(in.params.AccountID),
-		FilterUserID:      stringOrEmpty(in.params.UserID),
-		FilterConnID:      stringOrEmpty(in.params.ConnectionID),
-		FilterCategory:    stringOrEmpty(in.params.CategorySlug),
+		FilterAccountID:   strutil.Deref(in.params.AccountID),
+		FilterUserID:      strutil.Deref(in.params.UserID),
+		FilterConnID:      strutil.Deref(in.params.ConnectionID),
+		FilterCategory:    strutil.Deref(in.params.CategorySlug),
 		FilterMinAmount:   q.Get("min_amount"),
 		FilterMaxAmount:   q.Get("max_amount"),
 		FilterPending:     q.Get("pending"),
@@ -1009,7 +1010,7 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 			ActorType: "system",
 			Summary:   summary,
 			RuleName:  a.RuleName,
-			RuleID:    derefOr(a.RuleID, ""),
+			RuleID:    strutil.DerefOr(a.RuleID, ""),
 			Origin:    a.Origin,
 		}, true
 
@@ -1179,14 +1180,6 @@ func activityDayLabel(dateStr, today, yesterday string, now time.Time) string {
 		return t.Format("Monday, January 2")
 	}
 	return t.Format("Monday, January 2, 2006")
-}
-
-// derefOr returns *p if non-nil, else def.
-func derefOr(p *string, def string) string {
-	if p == nil {
-		return def
-	}
-	return *p
 }
 
 // CreateTransactionCommentHandler serves POST /admin/api/transactions/{id}/comments.

--- a/internal/service/annotations_enrich.go
+++ b/internal/service/annotations_enrich.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"breadbox/internal/strutil"
 )
 
 // enrichAnnotations is the *Service method that owns building tag/category
@@ -169,8 +171,8 @@ func isCommentDuplicateOfTagNote(all []Annotation, c Annotation) bool {
 // ActorID match (system actors don't have IDs); falls back to ActorName when
 // both rows lack an ID. This mirrors the original admin-handler heuristic.
 func sameActor(a, b Annotation) bool {
-	aID := derefString(a.ActorID)
-	bID := derefString(b.ActorID)
+	aID := strutil.Deref(a.ActorID)
+	bID := strutil.Deref(b.ActorID)
 	if aID != "" && bID != "" {
 		return aID == bID
 	}
@@ -178,13 +180,6 @@ func sameActor(a, b Annotation) bool {
 		return a.ActorName == b.ActorName
 	}
 	return false
-}
-
-func derefString(p *string) string {
-	if p == nil {
-		return ""
-	}
-	return *p
 }
 
 // enrichOne builds the derived fields for a single annotation. Unknown

--- a/internal/strutil/strutil.go
+++ b/internal/strutil/strutil.go
@@ -1,0 +1,20 @@
+// Package strutil provides small, dependency-free helpers for string values.
+// Lives alongside sliceutil and pgconv as the home for primitive helpers
+// shared across admin, service, and provider layers.
+package strutil
+
+// Deref returns the dereferenced string, or "" when p is nil.
+func Deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+// DerefOr returns the dereferenced string, or def when p is nil.
+func DerefOr(p *string, def string) string {
+	if p == nil {
+		return def
+	}
+	return *p
+}

--- a/internal/strutil/strutil_test.go
+++ b/internal/strutil/strutil_test.go
@@ -1,0 +1,32 @@
+package strutil
+
+import "testing"
+
+func TestDeref(t *testing.T) {
+	if got := Deref(nil); got != "" {
+		t.Errorf("Deref(nil) = %q, want \"\"", got)
+	}
+	s := "hello"
+	if got := Deref(&s); got != "hello" {
+		t.Errorf("Deref(&\"hello\") = %q, want \"hello\"", got)
+	}
+	empty := ""
+	if got := Deref(&empty); got != "" {
+		t.Errorf("Deref(&\"\") = %q, want \"\"", got)
+	}
+}
+
+func TestDerefOr(t *testing.T) {
+	if got := DerefOr(nil, "fallback"); got != "fallback" {
+		t.Errorf("DerefOr(nil, \"fallback\") = %q, want \"fallback\"", got)
+	}
+	s := "hello"
+	if got := DerefOr(&s, "fallback"); got != "hello" {
+		t.Errorf("DerefOr(&\"hello\", \"fallback\") = %q, want \"hello\"", got)
+	}
+	// Empty pointed-to string overrides the default — the pointer is non-nil.
+	empty := ""
+	if got := DerefOr(&empty, "fallback"); got != "" {
+		t.Errorf("DerefOr(&\"\", \"fallback\") = %q, want \"\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

Six different files defined the same nil-safe pointer-dereference helper under five different names:

| File | Local name |
| ---- | ---------- |
| `internal/admin/synclogs.go` | `stringOrEmpty` |
| `internal/admin/csv_export.go` | `derefStr` |
| `internal/admin/account_links.go` | `derefString` |
| `internal/admin/transactions.go` | `derefOr` (default-aware variant) |
| `internal/service/annotations_enrich.go` | `derefString` |
| `internal/admin/logs.go` | (calls `stringOrEmpty` from synclogs.go) |

All five no-default versions had identical bodies; `derefOr` is the same shape with a fallback. New `internal/strutil` package exposes `Deref(p)` and `DerefOr(p, def)` so future callers have one obvious place to land.

`internal/templates/components/helpers.go` keeps its local `deref()` — that file is intentionally a templ-side mirror of the admin funcMap and short names are part of its ergonomics.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all unit tests pass)
- [x] New `internal/strutil/strutil_test.go` covers nil, non-nil, and empty-string cases for both helpers