### PR TITLE
fix(timeline): preserve shared now anchor and hover affordance in primitives

### DIFF
--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -1,5 +1,7 @@
 package components
 
+import "time"
+
 // Generic activity-timeline primitives extracted from the transaction-detail
 // page. They render the GitHub-style chrome — a continuous left rail, day
 // separators, 24px icon tiles that thread through the rail, comment bubbles,
@@ -59,10 +61,11 @@ type TimelineProps struct {
 // strong text, chips, links, and inline avatars without this primitive having
 // to know about any of them.
 type TimelineRowProps struct {
-	Icon      string // Lucide icon for the tile. Required when no children-icon override is rendered.
-	IconTone  string // "neutral" | "info" | "success" | "warning" | "error". "" → "neutral".
-	Timestamp string // RFC3339; rendered as a tooltip + relative-time pill. "" → omitted.
-	Origin    string // Optional italic suffix (e.g. "rule", "agent"). "" → omitted.
+	Icon      string    // Lucide icon for the tile. Required when no children-icon override is rendered.
+	IconTone  string    // "neutral" | "info" | "success" | "warning" | "error". "" → "neutral".
+	Timestamp string    // RFC3339; rendered as a tooltip + relative-time pill. "" → omitted.
+	Origin    string    // Optional italic suffix (e.g. "rule", "agent"). "" → omitted.
+	Now       time.Time // Request-level now anchor threaded through to the relative-time helper so day-bucket labels and per-row timestamps can never disagree across midnight. Zero → render-time time.Now() fallback.
 }
 
 // TimelineActor is reused inside comment rows.
@@ -151,7 +154,7 @@ templ TimelineSystemRow(p TimelineRowProps) {
 					if p.Timestamp != "" {
 						<span aria-hidden="true">&middot;</span>
 						<span class="tooltip tooltip-top" data-tip={ formatTimelineTimestamp(p.Timestamp) }>
-							<time datetime={ p.Timestamp } class="tabular-nums cursor-default" title={ formatTimelineTimestamp(p.Timestamp) }>{ relativeTimelineTimestamp(p.Timestamp) }</time>
+							<time datetime={ p.Timestamp } class="tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatTimelineTimestamp(p.Timestamp) }>{ relativeTimelineTimestamp(p.Timestamp, p.Now) }</time>
 						</span>
 					}
 				</span>
@@ -167,7 +170,7 @@ templ TimelineSystemRow(p TimelineRowProps) {
 // outer ring-4 ring-base-100) inside the `tile` slot. This keeps the row
 // chrome (rail anchor, sentence layout, timestamp suffix) reusable while
 // letting the caller drive the iconography.
-templ TimelineSystemRowCustomTile(timestamp, origin string, tile, body templ.Component) {
+templ TimelineSystemRowCustomTile(timestamp, origin string, now time.Time, tile, body templ.Component) {
 	<li class="relative flex items-start gap-3 py-2 group">
 		<div class="relative z-10 shrink-0 w-6 h-6 rounded-full bg-base-100">
 			@tile
@@ -182,7 +185,7 @@ templ TimelineSystemRowCustomTile(timestamp, origin string, tile, body templ.Com
 					if timestamp != "" {
 						<span aria-hidden="true">&middot;</span>
 						<span class="tooltip tooltip-top" data-tip={ formatTimelineTimestamp(timestamp) }>
-							<time datetime={ timestamp } class="tabular-nums cursor-default" title={ formatTimelineTimestamp(timestamp) }>{ relativeTimelineTimestamp(timestamp) }</time>
+							<time datetime={ timestamp } class="tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatTimelineTimestamp(timestamp) }>{ relativeTimelineTimestamp(timestamp, now) }</time>
 						</span>
 					}
 				</span>
@@ -195,7 +198,7 @@ templ TimelineSystemRowCustomTile(timestamp, origin string, tile, body templ.Com
 // a header-line ("<actor> commented · <time>") above the bubble body. The
 // bubble body is the children slot so callers can render plain text,
 // markdown, action buttons inside the meta line, etc.
-templ TimelineCommentRow(actor TimelineActor, timestamp string) {
+templ TimelineCommentRow(actor TimelineActor, timestamp string, now time.Time) {
 	<li class="relative flex items-start gap-3 py-2.5 group">
 		<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100">
 			@timelineCommentAvatar(actor)
@@ -212,7 +215,7 @@ templ TimelineCommentRow(actor TimelineActor, timestamp string) {
 				<span class="text-base-content/55">commented</span>
 				if timestamp != "" {
 					<span class="tooltip tooltip-top" data-tip={ formatTimelineTimestamp(timestamp) }>
-						<time datetime={ timestamp } class="text-base-content/40 tabular-nums cursor-default" title={ formatTimelineTimestamp(timestamp) }>{ relativeTimelineTimestamp(timestamp) }</time>
+						<time datetime={ timestamp } class="text-base-content/40 tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatTimelineTimestamp(timestamp) }>{ relativeTimelineTimestamp(timestamp, now) }</time>
 					</span>
 				}
 			</div>

--- a/internal/templates/components/timeline_helpers.go
+++ b/internal/templates/components/timeline_helpers.go
@@ -92,17 +92,19 @@ func formatTimelineTimestamp(s string) string {
 }
 
 // relativeTimelineTimestamp renders an RFC3339 timestamp as a short relative
-// phrase ("just now", "5 minutes ago", "2 days ago").
-func relativeTimelineTimestamp(s string) string {
+// phrase ("just now", "5 minutes ago", "2 days ago") relative to the supplied
+// now anchor. Pages that mix relative-time rendering with day-bucket labels
+// share a single now via this entry point so the two paths can never disagree
+// across midnight (the day-boundary bug PR #890 fixed for the txn-detail
+// timeline). Callers that don't need a shared anchor pass the zero
+// time.Time and fall back to time.Now() at render — equivalent to the pre-fix
+// behaviour so the primitives keep working without ceremony.
+func relativeTimelineTimestamp(s string, now time.Time) string {
 	if s == "" {
 		return ""
 	}
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		t, err = time.Parse(time.RFC3339Nano, s)
-		if err != nil {
-			return s
-		}
+	if now.IsZero() {
+		now = time.Now()
 	}
-	return timefmt.Relative(t)
+	return timefmt.RelativeRFC3339At(s, now)
 }

--- a/internal/templates/components/timeline_helpers_test.go
+++ b/internal/templates/components/timeline_helpers_test.go
@@ -1,0 +1,68 @@
+package components
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRelativeTimelineTimestamp_AnchorWiring covers the two contracts we
+// promise the row primitives:
+//
+//  1. A zero now anchor falls back to wall-clock time.Now() so non-day-
+//     grouped callers keep working without ceremony.
+//  2. An explicit now anchor is honoured end-to-end, so day-grouped
+//     callers can thread a single request-level now through the helper
+//     and the day-bucket label without the two paths disagreeing across
+//     midnight (the contract documented in docs/activity-timeline.md and
+//     fixed for transaction-detail in PR #890).
+func TestRelativeTimelineTimestamp_AnchorWiring(t *testing.T) {
+	// Picked deliberately in the middle of a day in UTC so the local
+	// timezone of the test runner can't shift it past a day boundary.
+	ts := "2026-04-15T12:00:00Z"
+
+	t.Run("zero anchor falls back to time.Now", func(t *testing.T) {
+		// "just now" buckets to <1 minute, so passing a timestamp
+		// effectively equal to wall-clock now exercises the
+		// time.Now() fallback path.
+		now := time.Now().UTC().Format(time.RFC3339)
+		if got := relativeTimelineTimestamp(now, time.Time{}); got != "just now" {
+			t.Fatalf("zero-anchor fallback: relativeTimelineTimestamp(now, zero) = %q, want %q", got, "just now")
+		}
+	})
+
+	t.Run("explicit anchor is honoured", func(t *testing.T) {
+		// Five hours after ts.
+		anchor, err := time.Parse(time.RFC3339, "2026-04-15T17:00:00Z")
+		if err != nil {
+			t.Fatalf("parse anchor: %v", err)
+		}
+		if got := relativeTimelineTimestamp(ts, anchor); got != "5 hours ago" {
+			t.Fatalf("explicit anchor: relativeTimelineTimestamp(ts, +5h) = %q, want %q", got, "5 hours ago")
+		}
+	})
+
+	t.Run("explicit anchor disagrees with wall clock", func(t *testing.T) {
+		// Anchor pinned 2 days after ts, even though wall-clock
+		// time.Now() is far in the future. The explicit anchor must
+		// win — that's the whole point of the parameter.
+		anchor, err := time.Parse(time.RFC3339, "2026-04-17T12:00:00Z")
+		if err != nil {
+			t.Fatalf("parse anchor: %v", err)
+		}
+		if got := relativeTimelineTimestamp(ts, anchor); got != "2 days ago" {
+			t.Fatalf("explicit anchor: relativeTimelineTimestamp(ts, +2d) = %q, want %q", got, "2 days ago")
+		}
+	})
+
+	t.Run("empty input yields empty", func(t *testing.T) {
+		if got := relativeTimelineTimestamp("", time.Time{}); got != "" {
+			t.Fatalf("empty input: got %q, want empty", got)
+		}
+	})
+
+	t.Run("unparseable input passes through", func(t *testing.T) {
+		if got := relativeTimelineTimestamp("not-a-timestamp", time.Now()); got != "not-a-timestamp" {
+			t.Fatalf("unparseable input: got %q, want passthrough", got)
+		}
+	})
+}


### PR DESCRIPTION
## Why
PR #908 introduced shared timeline primitives at `internal/templates/components/timeline.templ` + `timeline_helpers.go`. Two contracts from `docs/activity-timeline.md` slipped:

1. **Shared `now` anchor** — `relativeTimelineTimestamp` called `timefmt.Relative(t)`, which calls `time.Now()` at render time. The doc requires the request-level `now` to be threaded through both day-bucket labels and per-row relative timestamps so they can never disagree at midnight (the bug PR #890 fixed in `transaction_detail.templ`).
2. **Hover affordance** — every `<time>` in the timeline carries `tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30`. The new primitives dropped the three hover classes.

No live consumer adopted the primitives yet, so neither bug shipped. Fixing both before any page migrates onto them.

## What
- `relativeTimelineTimestamp(s, now time.Time)` — new `now` parameter; falls back to `time.Now()` when zero so non-day-grouped callers keep working without ceremony. Delegates to `timefmt.RelativeRFC3339At` instead of `timefmt.Relative`.
- `Now time.Time` added to `TimelineRowProps` (drives `TimelineSystemRow`).
- `TimelineSystemRowCustomTile(timestamp, origin string, now time.Time, tile, body templ.Component)` — new `now` positional after `origin`.
- `TimelineCommentRow(actor TimelineActor, timestamp string, now time.Time)` — new trailing `now` positional.
- Every `<time>` in `timeline.templ` now carries `hover:underline underline-offset-2 decoration-base-content/30`.

`TimelineCommentRowRaw` and `TimelineEmpty` render no `<time>` element, so they're untouched.

`transaction_detail.templ` is intentionally unchanged — it still uses its own `txd*` helpers (including `relativeTimeStrAt`) and isn't a consumer of these primitives yet.

## Test plan
- [x] `go build / vet / test` green.
- [x] New unit tests in `internal/templates/components/timeline_helpers_test.go` cover the zero-anchor wall-clock fallback, an explicit anchor on a fresh timestamp, an explicit anchor that disagrees with wall-clock (the day-boundary contract), empty input, and unparseable input passthrough.
- [x] `transaction_detail.templ` (still using its own `txd*` helpers) is unaffected — visual regression check on `/transactions/{id}` confirms the activity timeline renders identically.

## Screenshots
**Transaction detail still renders correctly (regression check)**
<img src="https://i.img402.dev/76t2k7wwmh.jpg" width="800" alt="transaction detail — desktop, unchanged">

<details>
<summary>Mobile (390x844)</summary>

<img src="https://i.img402.dev/z7ya9npmtj.jpg" width="320" alt="transaction detail — mobile">
</details>

Follow-up to PR #908. Unblocks future migration of `transaction_detail.templ` onto the shared primitives.
