### PR TITLE
fix(nav): smooth sidebar Documentation/GitHub arrow slide-in

### DIFF
--- a/input.css
+++ b/input.css
@@ -402,7 +402,11 @@
   .bb-sidebar-link .bb-nav-external-arrow,
   .bb-sidebar-link .bb-nav-external-arrow svg {
     @apply w-3.5 h-3.5 opacity-0 -translate-x-1;
-    transition: opacity 0.15s ease, transform 0.15s ease;
+    /* Tailwind v4 emits `-translate-x-1` as the CSS `translate` property,
+       not `transform` — transitioning `transform` here would no-op and
+       the arrow would snap into place, looking like a 4px jump while
+       opacity faded in. Transition `translate` so the slide is real. */
+    transition: opacity 0.15s ease, translate 0.15s ease;
   }
   .bb-sidebar-link.group:hover .bb-nav-external-arrow,
   .bb-sidebar-link.group:hover .bb-nav-external-arrow svg {


### PR DESCRIPTION
## Summary

The trailing external-link arrow on the **Documentation** and **GitHub** buttons in the sidebar footer was snapping into place on hover instead of sliding — the icon appeared to jump a few pixels while opacity faded in.

**Root cause:** Tailwind v4 compiles `-translate-x-1` / `translate-x-0` to the CSS `translate` property, not `transform`. The transition rule was listening for `transform` changes, which never fired, so only opacity animated and the position snapped.

**Fix (`input.css:405`):** transition `translate` instead of `transform`. Comment added so the v4 gotcha doesn't get reverted.

## Test plan

- [ ] Hover **Documentation** in the sidebar footer — arrow slides in smoothly from a few px to the left, no jump.
- [ ] Hover **GitHub** — same.
- [ ] Hover-out — arrow slides back out instead of snapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)