### PR TITLE
refactor(transaction-detail): migrate activity timeline onto shared primitives

### DIFF
--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -317,11 +317,7 @@ templ txdActivity(p TransactionDetailProps) {
 				for di, day := range p.ActivityDays {
 					@components.TimelineDay(day.Label, di == 0)
 					for _, event := range day.Events {
-						if event.Type == "comment" {
-							@txdTimelineComment(event, p.Now)
-						} else {
-							@txdTimelineSystem(event, p.Now)
-						}
+						@txdTimelineRow(event, p.Now)
 					}
 				}
 				@txdTimelineComposer(p)
@@ -338,31 +334,63 @@ templ txdActivity(p TransactionDetailProps) {
 	</div>
 }
 
-// txdTimelineSystem renders a compact one-liner row for tag / category /
-// rule / review events. Icon tile sits on the rail; sentence flows to the
-// right of the rail. Both the 24px icon tile and the first text line share
-// a 24px line-box so their centers align horizontally — no per-element
-// margin tweaks needed.
-templ txdTimelineSystem(e service.ActivityEntry, now time.Time) {
-	<li class="relative flex items-start gap-3 py-2 group">
-		<div class="relative z-10 shrink-0 w-6 h-6 rounded-full bg-base-100">
-			@txdSystemIcon(e)
-		</div>
-		<div class="flex-1 min-w-0 text-xs leading-6 text-base-content/75 break-words">
-			@txdSystemSentence(e)
-			<span class="text-base-content/40 ml-1">
-				if e.Origin != "" {
-					<span class="italic">&middot; { e.Origin }</span>
-				}
-				if e.Timestamp != "" {
-					<span aria-hidden="true">&middot;</span>
-					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
-						<time datetime={ e.Timestamp } class="tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
-					</span>
-				}
-			</span>
-		</div>
-	</li>
+// txdTimelineRow dispatches an activity entry to the right primitive call.
+// Comments split on IsDeleted to either a chat bubble (live) or a single-line
+// tombstone (deleted). System events (tag/category/rule/sync/review) use the
+// custom-tile primitive so the page-local txdSystemIcon palette continues to
+// drive the 24px tile while the primitive owns the rail anchor, leading-6
+// text container, and timestamp/origin suffix.
+templ txdTimelineRow(e service.ActivityEntry, now time.Time) {
+	if e.Type == "comment" {
+		if e.IsDeleted {
+			@components.TimelineSystemRowCustomTile(
+				e.Timestamp,
+				e.Origin,
+				now,
+				txdDeletedCommentTile(),
+				txdDeletedCommentBody(e),
+				templ.Attributes{"data-comment-id": e.CommentID},
+			)
+		} else {
+			@components.TimelineCommentRowRaw(txdCommentAvatar(e), templ.Attributes{"data-comment-id": e.CommentID}) {
+				@txdCommentBubbleBody(e, now)
+			}
+		}
+	} else {
+		@components.TimelineSystemRowCustomTile(
+			e.Timestamp,
+			e.Origin,
+			now,
+			txdSystemIcon(e),
+			txdSystemSentence(e),
+			nil,
+		)
+	}
+}
+
+// txdDeletedCommentTile renders the 24px trash icon tile used on the rail
+// for tombstoned comments. Mirrors the legacy txdTimelineDeletedComment tile
+// markup so the migration is byte-equivalent.
+templ txdDeletedCommentTile() {
+	<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
+		<i data-lucide="trash-2" class="w-3 h-3 text-base-content/40"></i>
+	</span>
+}
+
+// txdDeletedCommentBody renders the muted single-line tombstone body inside
+// the system-row primitive's leading-6 text container. Wraps the visible
+// text in an inner <span> whose color overrides the primitive's default
+// text-base-content/75 with the tombstone's text-base-content/55, plus the
+// italic + actor highlight pattern from the legacy template.
+templ txdDeletedCommentBody(e service.ActivityEntry) {
+	<span class="text-base-content/55 italic">
+		if e.ActorName != "" {
+			<span class="font-medium text-base-content/70 not-italic">{ e.ActorName } </span>
+			<span>deleted a comment</span>
+		} else {
+			<span>Comment deleted</span>
+		}
+	</span>
 }
 
 // txdSystemSentence assembles the actor-verb-object phrase shown next to a
@@ -497,90 +525,36 @@ templ txdCategoryIcon(e service.ActivityEntry) {
 	}
 }
 
-// txdTimelineComment renders a comment as a chat-bubble: small author/time
-// meta-line above a rounded message blob. The bubble's top-left corner is
-// flattened so it visually points at the avatar on the rail. App-wide
-// bubble consolidation will hoist this style into a shared bb-bubble class
-// when the matching pattern lands on transactions and reviews.
-//
-// Tombstoned comments (IsDeleted=true) skip the bubble entirely and route to
-// txdTimelineDeletedComment, which mirrors the system-row layout so a
-// deleted comment reads as a single muted line preserving actor + timestamp.
-templ txdTimelineComment(e service.ActivityEntry, now time.Time) {
-	if e.IsDeleted {
-		@txdTimelineDeletedComment(e, now)
-	} else {
-		@txdTimelineCommentBubble(e, now)
-	}
-}
-
-// txdTimelineCommentBubble renders the chat-bubble variant — the historical
-// shape pulled out so the entry-point templ above can branch cleanly on
-// IsDeleted without duplicating either path.
-templ txdTimelineCommentBubble(e service.ActivityEntry, now time.Time) {
-	<li class="relative flex items-start gap-3 py-2.5 group" data-comment-id={ e.CommentID }>
-		<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100">
-			@txdCommentAvatar(e)
-		</div>
-		<div class="flex-1 min-w-0">
-			<!--
-				Meta line shares a 24px line-box with the avatar so the actor
-				baseline sits dead-center on the rail circle. Keeping every
-				label at text-xs / leading-6 also matches the system-event
-				rows above for a uniform actor + timestamp treatment.
-			-->
-			<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6">
-				if e.ActorName != "" {
-					<strong class="font-semibold text-base-content">{ e.ActorName }</strong>
-				}
-				<span class="text-base-content/55">commented</span>
-				if e.Timestamp != "" {
-					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
-						<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
-					</span>
-				}
-				if e.CommentID != "" {
-					<button class="ml-auto rounded-md p-1 -m-1 text-base-content/30 hover:text-error hover:bg-error/5 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 transition" @click={ "deleteComment('" + e.CommentID + "')" } aria-label={ "Delete comment by " + e.ActorName } title="Delete comment">
-						<i data-lucide="trash-2" class="w-3.5 h-3.5" aria-hidden="true"></i>
-					</button>
-				}
-			</div>
-			if e.Detail != "" {
-				<div class="bb-comment-bubble mt-1">{ e.Detail }</div>
-			}
-		</div>
-	</li>
-}
-
-// txdTimelineDeletedComment renders a tombstoned comment as a muted
-// single-line system-style row using the same rail/icon scaffolding as
-// txdTimelineSystem. The comment body is gone — only "<Actor> deleted a
-// comment · <relative-time>" remains, preserving audit value (we still
-// know who removed what and when) without re-displaying retired content.
-templ txdTimelineDeletedComment(e service.ActivityEntry, now time.Time) {
-	<li class="relative flex items-start gap-3 py-2 group" data-comment-id={ e.CommentID }>
-		<div class="relative z-10 shrink-0 w-6 h-6 rounded-full bg-base-100">
-			<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
-				<i data-lucide="trash-2" class="w-3 h-3 text-base-content/40"></i>
+// txdCommentBubbleBody renders the body slot for a live comment row — the
+// meta line (actor / "commented" / timestamp / delete button) above the
+// rounded message bubble. Wrapped by components.TimelineCommentRowRaw which
+// owns the row's <li>, rail anchor, and avatar tile.
+templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
+	<!--
+		Meta line shares a 24px line-box with the avatar so the actor
+		baseline sits dead-center on the rail circle. Keeping every
+		label at text-xs / leading-6 also matches the system-event
+		rows above for a uniform actor + timestamp treatment.
+	-->
+	<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6">
+		if e.ActorName != "" {
+			<strong class="font-semibold text-base-content">{ e.ActorName }</strong>
+		}
+		<span class="text-base-content/55">commented</span>
+		if e.Timestamp != "" {
+			<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
+				<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
 			</span>
-		</div>
-		<div class="flex-1 min-w-0 text-xs leading-6 text-base-content/55 italic break-words">
-			if e.ActorName != "" {
-				<span class="font-medium text-base-content/70 not-italic">{ e.ActorName }</span>
-				<span>deleted a comment</span>
-			} else {
-				<span>Comment deleted</span>
-			}
-			if e.Timestamp != "" {
-				<span class="text-base-content/40 ml-1 not-italic">
-					<span aria-hidden="true">&middot;</span>
-					<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
-						<time datetime={ e.Timestamp } class="tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
-					</span>
-				</span>
-			}
-		</div>
-	</li>
+		}
+		if e.CommentID != "" {
+			<button class="ml-auto rounded-md p-1 -m-1 text-base-content/30 hover:text-error hover:bg-error/5 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 transition" @click={ "deleteComment('" + e.CommentID + "')" } aria-label={ "Delete comment by " + e.ActorName } title="Delete comment">
+				<i data-lucide="trash-2" class="w-3.5 h-3.5" aria-hidden="true"></i>
+			</button>
+		}
+	</div>
+	if e.Detail != "" {
+		<div class="bb-comment-bubble mt-1">{ e.Detail }</div>
+	}
 }
 
 // txdCommentAvatar renders the 24px avatar for a comment. User actors get
@@ -993,18 +967,14 @@ type TimelineRowsProps struct {
 }
 
 // TimelineRows renders activity rows for the partial-render endpoint
-// (GET /-/transactions/{id}/timeline/rows). Reuses components.TimelineDay /
-// txdTimelineSystem / txdTimelineComment so the row markup matches the
-// main page exactly — no client-side templating, no risk of drift.
+// (GET /-/transactions/{id}/timeline/rows). Reuses components.TimelineDay
+// + the same txdTimelineRow dispatch as the main page so the row markup
+// matches exactly — no client-side templating, no risk of drift.
 templ TimelineRows(p TimelineRowsProps) {
 	if p.DaySeparatorLabel != "" {
 		@components.TimelineDay(p.DaySeparatorLabel, false)
 	}
 	for _, e := range p.Entries {
-		if e.Type == "comment" {
-			@txdTimelineComment(e, p.Now)
-		} else {
-			@txdTimelineSystem(e, p.Now)
-		}
+		@txdTimelineRow(e, p.Now)
 	}
 }

--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -170,8 +170,12 @@ templ TimelineSystemRow(p TimelineRowProps) {
 // outer ring-4 ring-base-100) inside the `tile` slot. This keeps the row
 // chrome (rail anchor, sentence layout, timestamp suffix) reusable while
 // letting the caller drive the iconography.
-templ TimelineSystemRowCustomTile(timestamp, origin string, now time.Time, tile, body templ.Component) {
-	<li class="relative flex items-start gap-3 py-2 group">
+//
+// `attrs` is spread onto the outer <li> so callers can attach JS coordination
+// attributes (e.g. `data-comment-id` on a tombstone row that mirrors a comment
+// bubble's row marker). Pass `nil` when no extras are needed.
+templ TimelineSystemRowCustomTile(timestamp, origin string, now time.Time, tile, body templ.Component, attrs templ.Attributes) {
+	<li class="relative flex items-start gap-3 py-2 group" { attrs... }>
 		<div class="relative z-10 shrink-0 w-6 h-6 rounded-full bg-base-100">
 			@tile
 		</div>
@@ -229,8 +233,13 @@ templ TimelineCommentRow(actor TimelineActor, timestamp string, now time.Time) {
 // the meta line. The avatar slot fills the 24px tile on the rail; the body
 // slot fills the right-hand column. Use TimelineCommentRow when the default
 // "Name commented · timestamp" meta line is enough.
-templ TimelineCommentRowRaw(avatar templ.Component) {
-	<li class="relative flex items-start gap-3 py-2.5 group">
+//
+// `attrs` is spread onto the outer <li> so callers can attach JS coordination
+// attributes — e.g. the transaction-detail page sets `data-comment-id` on
+// every comment row so its optimistic-update flow can swap a bubble for a
+// tombstone in place. Pass `nil` when no extras are needed.
+templ TimelineCommentRowRaw(avatar templ.Component, attrs templ.Attributes) {
+	<li class="relative flex items-start gap-3 py-2.5 group" { attrs... }>
 		<div class="relative z-10 shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-base-100">
 			@avatar
 		</div>


### PR DESCRIPTION
## Why
PR #908 introduced shared timeline primitives at `internal/templates/components/timeline.templ` but didn't migrate the canonical consumer. PR #917 fixed two bugs in those primitives (now-anchor + hover affordance). With both in place, this PR migrates `transaction_detail.templ` onto the primitives — proves the surface is sufficient, eliminates the parallel `txd*` path, and lets future timeline pages copy this consumer as the reference.

## What
- Replaces `txdActivity`'s render loop with `Timeline` + `TimelineDay` + `TimelineSystemRowCustomTile` / `TimelineCommentRowRaw`.
- Deletes `txdTimelineDay`, `txdTimelineSystem`, `txdTimelineComment`, `txdTimelineCommentBubble`, `txdTimelineDeletedComment` (now handled by primitives).
- Keeps `txdSystemIcon`, `txdSystemSentence`, `txdRuleSentence`, `txdRuleActor`, `txdInlineTagChip`, `txdInlineCategoryChip`, `txdCommentAvatar` — page-local sentence/icon rendering (passed as slots to the primitives). Adds two small page-local helpers (`txdTimelineRow` dispatch, `txdCommentBubbleBody`, `txdDeletedCommentTile`, `txdDeletedCommentBody`) that bind the primitive slots to the existing data shape.
- `TimelineRows` (optimistic-update render endpoint) unchanged externally — its body now defers to the same `txdTimelineRow` dispatch as the page render. `data-comment-id` and day-separator emission preserved (the JS depends on both).
- Shared `props.Now` threaded through every primitive call so day-bucket labels and per-row relative timestamps stay anchored.

### Primitive extension — `templ.Attributes` spread
`TimelineSystemRowCustomTile` and `TimelineCommentRowRaw` now accept a `templ.Attributes` argument that is spread onto the outer `<li>`. This is the smallest extension that lets the page-local caller attach `data-comment-id` to every comment row (live bubble + tombstone) — the optimistic-update flow's swap-in-place behaviour depends on that marker. `nil` is accepted for callers that don't need extras (e.g. tag/category/rule system rows).

The alternative — wrapping the primitive in another page-local element — would either re-introduce the duplicated `<li>` markup the migration is trying to delete, or break the JS, which expects the `<li>` itself to be the row wrapper.

## Stack note
Stacked on top of PR #917 — depends on the `Now time.Time` prop on `TimelineRowProps` and the hover-affordance fixes. The PR diff vs. main shows both commits; #917 should land first, after which I'll rebase this onto main.

## Test plan
- [x] `go build / vet / test` green.
- [x] `make test-integration` — `transactions_timeline_rows_integration_test.go` HTML-structure assertions still pass (3/3 timeline tests). Unrelated `internal/service` deadlock failures observed pre-existed; not introduced by this PR.
- [x] Visual side-by-side (before / after on the same transaction `PsbN5oBU`): byte-equivalent rendering at desktop (1280x800) and mobile (390x844).
- [x] Optimistic flow: comment add — in-place insertion, no full reload (network panel: only `POST /-/transactions/{id}/comments` + `GET /-/transactions/{id}/timeline/rows?since=...`).

## Screenshots

### Desktop (1280x800)
<table>
  <tr><th>Before (#917 baseline)</th><th>After (this PR)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/4sulu7gkiv.jpg" width="400" alt="timeline desktop before"></td>
    <td><img src="https://i.img402.dev/35u2rqhjlq.jpg" width="400" alt="timeline desktop after"></td>
  </tr>
</table>

### Mobile (390x844)
<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/2tgzh7lc8n.jpg" width="320" alt="timeline mobile before"></td>
    <td><img src="https://i.img402.dev/8n6q1dp82z.jpg" width="320" alt="timeline mobile after"></td>
  </tr>
</table>

### Optimistic comment add (after — network panel confirms POST + render-rows GET, no full-page nav)
<img src="https://i.img402.dev/hr15k2o0h6.jpg" width="800" alt="optimistic comment add">

Empty-state not pictured: every transaction in the dev DB has at least one annotation (the initial-sync system row). The empty branch in `txdActivity` was unchanged structurally — it still renders `txdTimelineEmptyComposer`.

Follow-up to PR #908 / #917 / #918.
