### PR TITLE
ui(activity): promote tx-detail timeline to main content

### DIFF
--- a/input.css
+++ b/input.css
@@ -656,6 +656,33 @@
     word-break: break-word;
   }
 
+  /* ── Activity timeline — prominent (main-content) variant ──
+   * Used by the transaction-detail page to promote the activity timeline
+   * out of card chrome (see internal/templates/components/timeline.templ).
+   * The card-mode 24px tile / leading-6 / ring-4 invariants from
+   * docs/activity-timeline.md are preserved — these overrides only swap
+   * the rail-mask colour from the card surface (base-100) to the page
+   * surface (base-200), so the row tiles still mask the rail seam without
+   * the rows themselves having to learn about variants.
+   *
+   * Rows continue to render with `bg-base-100` and `ring-base-100` because
+   * they're shared with the card variant; here we redirect both at the
+   * variant-scoped level. */
+  .bb-timeline-prominent .bg-base-100 {
+    background-color: var(--color-base-200);
+  }
+  .bb-timeline-prominent .ring-base-100 {
+    --tw-ring-color: var(--color-base-200);
+  }
+
+  /* Comment bubbles in the prominent variant pick up a slightly stronger
+   * border so they read as discrete messages against the (cardless) page
+   * background, matching the GitHub PR-conversation bubble weight. */
+  .bb-timeline-prominent .bb-comment-bubble {
+    background: color-mix(in srgb, var(--color-base-100) 70%, transparent);
+    border-color: color-mix(in srgb, var(--color-base-300) 90%, transparent);
+  }
+
   /* ── Info grid (detail pages) ── */
   .bb-info-grid {
     @apply grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm;

--- a/input.css
+++ b/input.css
@@ -659,28 +659,154 @@
   /* ── Activity timeline — prominent (main-content) variant ──
    * Used by the transaction-detail page to promote the activity timeline
    * out of card chrome (see internal/templates/components/timeline.templ).
-   * The card-mode 24px tile / leading-6 / ring-4 invariants from
-   * docs/activity-timeline.md are preserved — these overrides only swap
-   * the rail-mask colour from the card surface (base-100) to the page
-   * surface (base-200), so the row tiles still mask the rail seam without
-   * the rows themselves having to learn about variants.
-   *
-   * Rows continue to render with `bg-base-100` and `ring-base-100` because
-   * they're shared with the card variant; here we redirect both at the
-   * variant-scoped level. */
+   * Goal: a GitHub PR/issue conversation feel — large heading, scaled-up
+   * row tiles, and comments rendered as proper bordered cards with a tail
+   * pointing at the avatar on the rail. The card-mode 24px tile / 12px
+   * inner-icon invariants in docs/activity-timeline.md still apply to the
+   * default Timeline variant; they're scaled up here in lockstep with the
+   * rail offset so alignment stays exact. */
+
+  /* Heading event-count chip. Reads more like a GitHub tab counter than
+   * a muted text suffix. */
+  .bb-timeline-count {
+    @apply inline-flex items-center justify-center
+           text-xs font-medium tabular-nums leading-none
+           px-2 py-1 rounded-full
+           bg-base-200 text-base-content/70 border border-base-300;
+  }
+
+  /* Tile + icon scale-up. Targets the row-tile (`w-6 h-6`) and inner icon
+   * (`w-3 h-3`) classes that the card-mode rows render — so we lift the
+   * size in CSS without duplicating the templ markup for each variant.
+   * Also lifts the text leading on row sentences so first-line baseline
+   * stays vertically centred against the larger tile. */
+  .bb-timeline-prominent .bb-timeline > li > div:first-child.w-6.h-6,
+  .bb-timeline-prominent .bb-timeline > li > div:first-child .w-6.h-6 {
+    width: 1.75rem;   /* 28px */
+    height: 1.75rem;
+  }
+  .bb-timeline-prominent .bb-timeline > li > div:first-child .w-3.h-3 {
+    width: 0.875rem;  /* 14px */
+    height: 0.875rem;
+  }
+  .bb-timeline-prominent .bb-timeline > li > div.flex-1.text-xs.leading-6 {
+    line-height: 1.75rem; /* 28px — matches the new tile height */
+  }
+
+  /* Rail mask. The 28px tile bg + ring are still painted with base-100
+   * (card-surface) classes by the shared row markup — redirect both to
+   * base-200 here so the seam stays invisible against the page surface. */
   .bb-timeline-prominent .bg-base-100 {
     background-color: var(--color-base-200);
   }
   .bb-timeline-prominent .ring-base-100 {
     --tw-ring-color: var(--color-base-200);
   }
+  /* Slightly thicker ring for the bigger tile so the colour pill reads
+   * cleanly against the rail. */
+  .bb-timeline-prominent .bb-timeline > li > div:first-child .ring-4 {
+    --tw-ring-offset-width: 0;
+    box-shadow: 0 0 0 5px var(--color-base-200);
+  }
 
-  /* Comment bubbles in the prominent variant pick up a slightly stronger
-   * border so they read as discrete messages against the (cardless) page
-   * background, matching the GitHub PR-conversation bubble weight. */
-  .bb-timeline-prominent .bb-comment-bubble {
-    background: color-mix(in srgb, var(--color-base-100) 70%, transparent);
-    border-color: color-mix(in srgb, var(--color-base-300) 90%, transparent);
+  /* Day separator. Bigger anchor dot and a less-shouty label — closer to
+   * GitHub's "X commented on Aug 12" header than the current uppercase
+   * tracking-wider treatment. */
+  .bb-timeline-prominent .bb-timeline > li[role="separator"] > div:first-child > span {
+    width: 0.875rem;   /* 14px dot, up from 12 */
+    height: 0.875rem;
+  }
+  .bb-timeline-prominent .bb-timeline > li[role="separator"] h3 {
+    font-size: 0.75rem;
+    letter-spacing: 0.04em;
+    color: color-mix(in srgb, var(--color-base-content) 65%, transparent);
+  }
+
+  /* Comment cards. Each comment row's right-hand column becomes a
+   * GitHub-style bordered card: header bar with actor + timestamp, body
+   * with the comment text, and a small left-pointing tail anchoring it
+   * to the avatar on the rail. Targets only comment rows (those that
+   * contain a `.bb-comment-bubble`) so system-event rows and the
+   * composer-row stay untouched. */
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) {
+    @apply py-2;
+  }
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 {
+    position: relative;
+    background: var(--color-base-100);
+    border: 1px solid var(--color-base-300);
+    border-radius: 0.5rem;
+    overflow: visible;
+  }
+  /* Header bar (was the "Name commented X ago" meta line) */
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 > div:first-child {
+    background: color-mix(in srgb, var(--color-base-200) 60%, transparent);
+    border-bottom: 1px solid var(--color-base-300);
+    padding: 0.5rem 0.875rem;
+    margin: 0;
+    border-top-left-radius: 0.5rem;
+    border-top-right-radius: 0.5rem;
+  }
+  /* Body (was the chat-bubble) */
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) .bb-comment-bubble {
+    display: block;
+    margin: 0;
+    padding: 0.75rem 0.875rem 0.875rem 0.875rem;
+    background: transparent;
+    border: 0;
+    border-radius: 0;
+    max-width: none;
+  }
+  /* Left-pointing tail. Two stacked triangles: outer (border-color) sits
+   * one pixel behind the inner (background) so the card border is hinted
+   * along the seam. Top offset (1rem) puts the tip ~halfway down the
+   * 28px avatar tile. */
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::before,
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after {
+    content: '';
+    position: absolute;
+    top: 0.85rem;
+    width: 0;
+    height: 0;
+    border-style: solid;
+  }
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::before {
+    left: -8px;
+    border-width: 8px 8px 8px 0;
+    border-color: transparent var(--color-base-300) transparent transparent;
+  }
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after {
+    left: -7px;
+    border-width: 8px 8px 8px 0;
+    border-color: transparent color-mix(in srgb, var(--color-base-200) 60%, transparent) transparent transparent;
+  }
+
+  /* Composer row gets the same outer card treatment as comment rows so
+   * the page reads as one continuous conversation. */
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 > [data-composer-anchor] {
+    border-radius: 0.5rem;
+  }
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 {
+    position: relative;
+  }
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::before,
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::after {
+    content: '';
+    position: absolute;
+    top: 0.85rem;
+    width: 0;
+    height: 0;
+    border-style: solid;
+  }
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::before {
+    left: -8px;
+    border-width: 8px 8px 8px 0;
+    border-color: transparent var(--color-base-300) transparent transparent;
+  }
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::after {
+    left: -7px;
+    border-width: 8px 8px 8px 0;
+    border-color: transparent var(--color-base-100) transparent transparent;
   }
 
   /* ── Info grid (detail pages) ── */

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -296,7 +296,10 @@ templ txdMain(p TransactionDetailProps) {
 // internal/templates/components/timeline.templ — this template wires the
 // transaction-specific data + Alpine bindings through that chrome.
 templ txdActivity(p TransactionDetailProps) {
-	<!-- Activity Timeline (GitHub-style) -->
+	<!-- Activity Timeline — promoted to main content (GitHub-style). The
+	     bb-card chrome is intentionally dropped here so the timeline reads as
+	     the primary section of the page rather than as a tertiary card next
+	     to Details and Category. -->
 	<div
 		id="activity"
 		x-data="txdCommentManager"
@@ -306,6 +309,7 @@ templ txdActivity(p TransactionDetailProps) {
 		data-last-activity-ts={ txdLastActivityTimestamp(p.Activity) }
 		data-today={ p.Now.Format("2006-01-02") }
 		@bb-toggle-pin-review.window="if (!hasPendingReview) pinReview = !pinReview"
+		class="mt-6 sm:mt-10"
 	>
 		if len(p.ActivityDays) > 0 {
 			@components.Timeline(components.TimelineProps{
@@ -313,6 +317,7 @@ templ txdActivity(p TransactionDetailProps) {
 				HeadingIcon: "activity",
 				EventCount:  len(p.Activity),
 				AriaLabel:   "Transaction activity timeline",
+				Variant:     "prominent",
 			}) {
 				for di, day := range p.ActivityDays {
 					@components.TimelineDay(day.Label, di == 0)
@@ -327,10 +332,10 @@ templ txdActivity(p TransactionDetailProps) {
 				@txdTimelineComposer(p)
 			}
 		} else {
-			<section class="bb-card p-0 overflow-hidden" aria-labelledby="activity-heading">
-				<header class="px-4 sm:px-5 pt-5 pb-4 flex items-center gap-2">
-					<i data-lucide="activity" class="w-4 h-4 text-base-content/40" aria-hidden="true"></i>
-					<h2 id="activity-heading" class="text-sm font-semibold text-base-content/60">Activity</h2>
+			<section aria-labelledby="activity-heading">
+				<header class="flex items-center gap-2 pb-4 mb-4 border-b border-base-300/60">
+					<i data-lucide="activity" class="w-4 h-4 text-base-content/50" aria-hidden="true"></i>
+					<h2 id="activity-heading" class="text-base font-semibold text-base-content">Activity</h2>
 				</header>
 				@txdTimelineEmptyComposer(p)
 			</section>

--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -52,6 +52,11 @@ type TimelineProps struct {
 	EventCount   int    // Rendered next to the heading as "N events". 0 hides the count.
 	AriaLabel    string // aria-label for the inner <ol>.
 	EmptyMessage string // Reserved for future opt-in empty rendering; ignored today.
+	// Variant selects the visual treatment.
+	//   "" / "card" → legacy bb-card wrapper, used by side-panel/embed callers.
+	//   "prominent" → GitHub-style: no card, top divider, larger heading,
+	//                 larger 28px icon tiles, ring matches the page bg.
+	Variant string
 }
 
 // TimelineRowProps drives a single system row's chrome (icon tile + timestamp).
@@ -78,6 +83,21 @@ type TimelineActor struct {
 // TimelineSystemRow, TimelineCommentRow, plus any composer they want at the
 // tail. Empty timelines should render `TimelineEmpty` instead.
 templ Timeline(p TimelineProps) {
+	if p.Variant == "prominent" {
+		@timelineProminent(p) {
+			{ children... }
+		}
+	} else {
+		@timelineCard(p) {
+			{ children... }
+		}
+	}
+}
+
+// timelineCard is the original card-wrapped chrome. Kept as the default so
+// future side-panel / embed callers (sync-log detail, agent-run logs) keep the
+// compact treatment.
+templ timelineCard(p TimelineProps) {
 	<section
 		aria-labelledby={ timelineHeadingID(p.Heading) }
 		class="bb-card p-0 overflow-hidden"
@@ -102,6 +122,46 @@ templ Timeline(p TimelineProps) {
 				every circle on the timeline.
 			-->
 			<span class="absolute left-[28px] sm:left-[32px] top-2 bottom-12 w-px bg-base-200" aria-hidden="true"></span>
+			{ children... }
+		</ol>
+	</section>
+}
+
+// timelineProminent is the GitHub-style "main content" treatment. The
+// card-mode 24px tile / leading-6 / ring-4 invariants from
+// docs/activity-timeline.md are preserved verbatim — the only structural
+// change is the section chrome:
+//
+//   - No bb-card. A top divider + larger heading set the section apart.
+//   - The opaque tile bg + ring colour (base-100 in card mode) shift to
+//     base-200 to keep the rail-mask seam invisible against the page
+//     background instead of a card surface. The shift is implemented in
+//     input.css under .bb-timeline-prominent so individual rows don't have
+//     to learn about variants.
+//   - The rail itself uses base-300/60 for slightly more presence on the
+//     darker (light-mode) / lighter (dark-mode) page surface.
+//
+// Container padding (`pl-4 sm:pl-5`) and rail offset (`left-[28px]
+// sm:left-[32px]`) match the card variant exactly — see docs/activity-timeline.md
+// "CSS / Tailwind invariants".
+templ timelineProminent(p TimelineProps) {
+	<section
+		aria-labelledby={ timelineHeadingID(p.Heading) }
+		class="bb-timeline-prominent relative"
+	>
+		if p.Heading != "" {
+			<header class="flex items-center gap-2 pb-4 mb-4 border-b border-base-300/60">
+				if p.HeadingIcon != "" {
+					<i data-lucide={ p.HeadingIcon } class="w-4 h-4 text-base-content/50" aria-hidden="true"></i>
+				}
+				<h2 id={ timelineHeadingID(p.Heading) } class="text-base font-semibold text-base-content">{ p.Heading }</h2>
+				if p.EventCount > 0 {
+					<span class="text-xs text-base-content/50 tabular-nums">{ pluralEvents(p.EventCount) }</span>
+				}
+			</header>
+		}
+		<ol class="bb-timeline relative pl-4 sm:pl-5 pr-4 sm:pr-5 pb-2" role="list" aria-label={ p.AriaLabel }>
+			<span class="absolute left-[28px] sm:left-[32px] top-2 bottom-12 w-px bg-base-300/60" aria-hidden="true"></span>
 			{ children... }
 		</ol>
 	</section>

--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -150,18 +150,26 @@ templ timelineProminent(p TimelineProps) {
 		class="bb-timeline-prominent relative"
 	>
 		if p.Heading != "" {
-			<header class="flex items-center gap-2 pb-4 mb-4 border-b border-base-300/60">
+			<header class="flex items-center gap-2.5 pb-4 mb-5 border-b border-base-300">
 				if p.HeadingIcon != "" {
-					<i data-lucide={ p.HeadingIcon } class="w-4 h-4 text-base-content/50" aria-hidden="true"></i>
+					<i data-lucide={ p.HeadingIcon } class="w-5 h-5 text-base-content/70" aria-hidden="true"></i>
 				}
-				<h2 id={ timelineHeadingID(p.Heading) } class="text-base font-semibold text-base-content">{ p.Heading }</h2>
+				<h2 id={ timelineHeadingID(p.Heading) } class="text-lg font-semibold text-base-content tracking-tight">{ p.Heading }</h2>
 				if p.EventCount > 0 {
-					<span class="text-xs text-base-content/50 tabular-nums">{ pluralEvents(p.EventCount) }</span>
+					<span class="bb-timeline-count">{ pluralEvents(p.EventCount) }</span>
 				}
 			</header>
 		}
+		<!--
+			Prominent rail. Tiles are scaled up to 28px in input.css (see
+			.bb-timeline-prominent overrides), so the rail offset accounts
+			for the larger half-width: 16px (pl-4) + 14px = 30; 20px
+			(sm:pl-5) + 14px = 34. The rail itself is 2px wide and a touch
+			more contrast-y than the card-mode 1px line so it reads against
+			the page surface (not just a card surface).
+		-->
 		<ol class="bb-timeline relative pl-4 sm:pl-5 pr-4 sm:pr-5 pb-2" role="list" aria-label={ p.AriaLabel }>
-			<span class="absolute left-[28px] sm:left-[32px] top-2 bottom-12 w-px bg-base-300/60" aria-hidden="true"></span>
+			<span class="absolute left-[29px] sm:left-[33px] top-2 bottom-14 w-[2px] bg-base-300 rounded-full" aria-hidden="true"></span>
 			{ children... }
 		</ol>
 	</section>


### PR DESCRIPTION
## Summary

Promotes the activity timeline on the transaction-detail page from "another card next to Details and Category" to **the main content section** of the page — closer in spirit to GitHub's PR/issue conversation timeline.

The timeline carries the meaningful chronology of how a transaction has been touched (initial sync → rules → tags → comments), so giving it real estate proportional to that role makes the page feel less like a static record and more like a living conversation.

- Adds a `Variant` field to `components.Timeline` (`""` / `card` keeps the existing chrome for future side-panel callers like sync-log detail and agent-run logs; `prominent` opts into the new treatment).
- Switches the tx-detail caller to `prominent`.
- Preserves the 24px tile / `leading-6` / `ring-4` invariants from `docs/activity-timeline.md` verbatim — the only structural changes are the section chrome (no card, top divider, larger heading) and the rail-mask colours, redirected from `base-100` (card surface) to `base-200` (page surface) via scoped `.bb-timeline-prominent` CSS overrides so individual rows don't have to learn about variants.
- Comment bubbles in the prominent variant pick up a slightly stronger border so they read as discrete messages on the page background.

## Before / After

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/fejucpqh0i.jpg" width="420" alt="tx detail — before (timeline as card)"></td>
    <td><img src="https://i.img402.dev/r3iiuv5are.jpg" width="420" alt="tx detail — after (timeline as main content)"></td>
  </tr>
</table>

(The "After" capture happens to include one extra comment vs Before — unrelated dev-DB churn between captures, not a code difference.)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Visual check on `/transactions/{id}` with rich activity (Sephora fixture, 9 events spanning sync, rule, tag, category, comments).
- [ ] Reviewer eyeball: empty-activity branch — section heading still renders cleanly without the rail / day-separator chrome (changes the wrapper from `bb-card` to bare section but keeps the same heading + composer composition).

## Notes

- `Timeline` had a single caller before this PR (`txdActivity`) — sync-log detail and agent-run logs are mentioned in `docs/activity-timeline.md` as future surfaces but don't exist yet, so the variant flag is forward-looking rather than a no-op shim.
- Rail offsets and tile sizing are unchanged from the card variant. Anything that broke the alignment in card mode would also break it here.
