### PR TITLE
fix(tag-chip): single-row icon+label, restore icon on activity rows

### DIFF
--- a/input.css
+++ b/input.css
@@ -467,6 +467,7 @@
     max-width: 100%;
   }
 
+
   .bb-tag > i, .bb-tag > svg {
     width: 0.75rem;
     height: 0.75rem;
@@ -2683,4 +2684,17 @@
   }
   .bb-report-body tbody tr:last-child td { @apply border-b-0; }
 
+}
+
+/* ─── Unlayered overrides ───
+ * Rules outside any @layer beat anything inside one, regardless of
+ * specificity. We need that here because DaisyUI 5's `.tooltip` rule lands
+ * in a deeper sub-layer (`daisyui.l1.l2.l3`) than our `@layer components`
+ * tag styles (`daisyui.l1.l2`), so a chained `.bb-tag.tooltip` selector
+ * inside @layer components still loses on cascade order. Pulling the
+ * override out of every layer is the smallest fix that pins icon + label
+ * to a single row whenever a chip carries both classes (see #904, where
+ * the slug-tooltip class made the chip render two-line). */
+.bb-tag.tooltip {
+  display: inline-flex;
 }

--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -866,6 +866,7 @@ func categoryDetailLookup(tree []service.CategoryResponse) func(string) category
 type tagDisplay struct {
 	DisplayName string
 	Color       *string
+	Icon        *string
 }
 
 // tagDisplayLookup returns a slug -> presentation lookup built from the
@@ -874,7 +875,7 @@ type tagDisplay struct {
 func tagDisplayLookup(tags []service.TagResponse) func(string) tagDisplay {
 	by := make(map[string]tagDisplay, len(tags))
 	for _, t := range tags {
-		by[t.Slug] = tagDisplay{DisplayName: t.DisplayName, Color: t.Color}
+		by[t.Slug] = tagDisplay{DisplayName: t.DisplayName, Color: t.Color, Icon: t.Icon}
 	}
 	return func(slug string) tagDisplay {
 		if slug == "" {
@@ -1032,6 +1033,7 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 					entry.TagDisplayName = a.TagSlug
 				}
 				entry.TagColor = td.Color
+				entry.TagIcon = td.Icon
 			} else {
 				entry.TagSlug = a.TagSlug
 				entry.TagDisplayName = a.TagSlug
@@ -1052,13 +1054,14 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 		return entry, true
 
 	case "tag_added", "tag_removed":
-		// Look up color separately — service-layer enrichment doesn't
-		// carry presentation metadata.
-		var color *string
+		// Look up presentation metadata separately — service-layer
+		// enrichment carries identifiers, not display attributes.
+		var color, icon *string
 		display := a.Subject
 		if tagDisplayFn != nil {
 			td := tagDisplayFn(a.TagSlug)
 			color = td.Color
+			icon = td.Icon
 			if td.DisplayName != "" {
 				display = td.DisplayName
 			}
@@ -1080,6 +1083,7 @@ func activityEntryFromAnnotation(a service.Annotation, tagDisplayFn func(string)
 			TagSlug:            a.TagSlug,
 			TagDisplayName:     display,
 			TagColor:           color,
+			TagIcon:            icon,
 			TagAction:          action,
 		}
 		if a.ActorID != nil && *a.ActorID != "" {

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -435,11 +435,12 @@ type ActivityEntry struct {
 	CommentID    string `json:"comment_id,omitempty"`
 	TagSlug      string `json:"tag_slug,omitempty"` // for tag_added / tag_removed entries
 
-	// TagDisplayName and TagColor drive the rendered tag-chip on
+	// TagDisplayName, TagColor and TagIcon drive the rendered tag-chip on
 	// tag_added / tag_removed timeline rows. Empty/nil when the tag no
 	// longer exists in the registry (deleted tags still show their slug).
 	TagDisplayName string  `json:"tag_display_name,omitempty"`
 	TagColor       *string `json:"tag_color,omitempty"`
+	TagIcon        *string `json:"tag_icon,omitempty"`
 	// TagAction distinguishes "added" vs "removed" so the template can
 	// render a plus / minus overlay on tag rows.
 	TagAction string `json:"tag_action,omitempty"` // "added" | "removed"

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -783,35 +783,20 @@ templ txdInlineCategoryChip(e service.ActivityEntry) {
 }
 
 // txdInlineTagChip renders the inline tag pill that follows the summary
-// for tag_added / tag_removed timeline rows. Removed tags render with
-// strike-through. The chip is byte-equivalent to the original markup.
+// for tag_added / tag_removed timeline rows. Delegates to the canonical
+// components.TagChipSm so icon, color, label, and slug-tooltip rendering
+// stay in lockstep with every other tag chip in the app. The wrapper
+// carries the removed-state strikethrough + opacity treatment so the
+// inner chip can stay shape-identical to non-strike chips.
 templ txdInlineTagChip(e service.ActivityEntry) {
-	<span
-		class={ "bb-tag bb-tag-sm ml-1 align-middle",
-			templ.KV("line-through opacity-70", e.TagAction == "removed"),
-			templ.KV("tooltip tooltip-top", txdTagChipShowTooltip(e)) }
-		if e.TagColor != nil && *e.TagColor != "" {
-			style={ "--tag-color: " + *e.TagColor }
-		}
-		if txdTagChipShowTooltip(e) {
-			data-tip={ e.TagSlug }
-		}
-		title={ e.TagSlug }
-	>
-		<span class="truncate">
-			if e.TagDisplayName != "" {
-				{ e.TagDisplayName }
-			} else {
-				{ e.TagSlug }
-			}
-		</span>
+	<span class={ "ml-1 align-middle inline-flex", templ.KV("line-through opacity-70", e.TagAction == "removed") }>
+		@components.TagChipSm(components.TagChipData{
+			Slug:        e.TagSlug,
+			DisplayName: e.TagDisplayName,
+			Color:       e.TagColor,
+			Icon:        e.TagIcon,
+		})
 	</span>
-}
-
-// txdTagChipShowTooltip mirrors components.tagChipShowTooltip — only show
-// the slug-tooltip when the chip's visible label is the display name.
-func txdTagChipShowTooltip(e service.ActivityEntry) bool {
-	return e.TagDisplayName != "" && e.TagDisplayName != e.TagSlug
 }
 
 // ---- helpers ----


### PR DESCRIPTION
## Summary

Two regressions on tag chips, fixed together because they share a render path:

1. **Icon dropped below the label whenever the slug-tooltip class was present** (regression from #904). DaisyUI 5's `.tooltip` rule lives in a deeper cascade sub-layer (`daisyui.l1.l2.l3`) than our `@layer components` chip styles, so its `display: inline-block` beat `.bb-tag`'s `inline-flex` regardless of selector specificity. The fix is one chained selector pulled out of every layer so it wins by cascade-order:

   ```css
   .bb-tag.tooltip { display: inline-flex; }
   ```

2. **Activity timeline tag chips never rendered the tag icon.** `txdInlineTagChip` was a hand-rolled span that diverged from the canonical `components.TagChipSm` and never read `Icon` from the registered tag. Same tag, same page — icon present in the Tags card and on transaction rows, missing in the activity log. Consolidated to delegate to `components.TagChipSm` so the chip flows through one component everywhere; the wrapper now only carries the `removed` strikethrough state. `Icon *string` is threaded through `tagDisplay` → `service.ActivityEntry.TagIcon` so both the `rule_applied(tag)` and `tag_added` / `tag_removed` enrichment branches populate it.

## Validation

Captured at `localhost:.../transactions/PsbN5oBU` — same transaction, same DB, before vs after the patch. Look at the **Tags** card (top right) and the highlighted activity rows.

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/eh0jt9db7w.jpg" width="420" alt="before — Needs Review chip wraps to two lines, activity rows have no icon"></td>
    <td><img src="https://i.img402.dev/vhwqe5wma2.jpg" width="420" alt="after — single-row chip with icon, activity rows render the icon"></td>
  </tr>
</table>

Computed-style check on the same six chips (DevTools eval):

```
BEFORE:                                     AFTER:
bb-tag tooltip tooltip-top      → block     → flex
bb-tag bb-tag-add               → flex      → flex      (untouched)
bb-tag bb-tag-sm tooltip ...    → inline-block, hasIcon=false → flex, hasIcon=true
bb-tag bb-tag-sm align-middle   → inline-flex (untouched)
bb-tag bb-tag-sm line-through ..→ inline-block, hasIcon=false → flex, hasIcon=true
bb-tag bb-tag-sm tooltip ...    → inline-block, hasIcon=false → flex, hasIcon=true
```

## Test plan
- [x] `templ generate`, `go build ./...`, `go vet ./...` clean
- [x] `go test ./internal/admin/... ./internal/service/... ./internal/templates/...` green (existing `TestBuildActivityTimeline_TagRowHasChipMetadata` still passes; new icon field flows through nil tagDisplayFn fallback unchanged)
- [x] Visual: Tags section chip with icon + slug-tooltip renders single row
- [x] Visual: Activity timeline `tag_added` / `tag_removed` / `rule_applied(tag)` rows render the tag icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)