### PR TITLE
fix(nav): drop slide on sidebar external-link arrow, fade only

### DIFF
--- a/input.css
+++ b/input.css
@@ -401,16 +401,12 @@
      colour but overrides the size + opacity rules. */
   .bb-sidebar-link .bb-nav-external-arrow,
   .bb-sidebar-link .bb-nav-external-arrow svg {
-    @apply w-3.5 h-3.5 opacity-0 -translate-x-1;
-    /* Tailwind v4 emits `-translate-x-1` as the CSS `translate` property,
-       not `transform` — transitioning `transform` here would no-op and
-       the arrow would snap into place, looking like a 4px jump while
-       opacity faded in. Transition `translate` so the slide is real. */
-    transition: opacity 0.15s ease, translate 0.15s ease;
+    @apply w-3.5 h-3.5 opacity-0;
+    transition: opacity 0.15s ease;
   }
   .bb-sidebar-link.group:hover .bb-nav-external-arrow,
   .bb-sidebar-link.group:hover .bb-nav-external-arrow svg {
-    @apply opacity-60 translate-x-0;
+    @apply opacity-60;
   }
 
   /* ── Sidebar notification badges ── */


### PR DESCRIPTION
## Summary

Follow-up to #919. Drops the slide-in on the **Documentation** / **GitHub** arrow entirely — the icon now just fades in on hover. The motion didn't add information, and removing it sidesteps the Tailwind v4 `translate`-vs-`transform` footgun the prior PR worked around.

## Test plan

- [ ] Hover **Documentation** in the sidebar footer — arrow fades in, no horizontal motion.
- [ ] Hover **GitHub** — same.
- [ ] Hover-out — arrow fades out cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)