### PR TITLE
Move docs/GitHub links into a Help nav section

### DIFF
--- a/input.css
+++ b/input.css
@@ -395,13 +395,13 @@
   }
 
   /* ── External-link arrow (Documentation / GitHub buttons) ── */
-  /* The trailing chevron-style glyph is hidden by default and slides
-     + fades in when the parent .group is hovered. Kept inside the
+  /* Always visible on mobile (no hover affordance there), hidden by
+     default and faded in on hover at lg+. Kept inside the
      bb-sidebar-link cascade so the arrow inherits the link's icon
      colour but overrides the size + opacity rules. */
   .bb-sidebar-link .bb-nav-external-arrow,
   .bb-sidebar-link .bb-nav-external-arrow svg {
-    @apply w-3.5 h-3.5 opacity-0;
+    @apply w-3.5 h-3.5 opacity-60 lg:opacity-0;
     transition: opacity 0.15s ease;
   }
   .bb-sidebar-link.group:hover .bb-nav-external-arrow,

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -101,6 +101,9 @@ templ Nav(p NavProps) {
 				<i data-lucide="settings"></i> Settings
 			</a>
 		}
+		<div class="bb-sidebar-section">Help</div>
+		@navExternalLink("https://docs.breadbox.sh", "book-open", "Documentation")
+		@navExternalLink("https://github.com/canalesb93/breadbox", "github", "GitHub")
 	</nav>
 	<!--
 		Footer entrypoint to /settings/account. Settings has its own
@@ -108,9 +111,6 @@ templ Nav(p NavProps) {
 		personal-scope.
 	-->
 	<div class="mt-auto pt-3 border-t border-base-300 px-2">
-		@navExternalLink("https://docs.breadbox.sh", "book-open", "Documentation")
-		@navExternalLink("https://github.com/canalesb93/breadbox", "github", "GitHub")
-		<div class="my-1.5 mx-2 border-t border-base-300/60"></div>
 		<a href="/settings/account" class={ "flex items-center gap-2.5 py-2.5 px-2.5 rounded-lg no-underline transition-colors hover:bg-base-200/70", navActive(p.CurrentPage, "account") } title="My Account">
 			if p.HasLinkedUser {
 				<img src={ navAvatar(p.SessionUserID, p.SessionAvatarVersion) } alt="" class="bb-sidebar-profile-avatar shrink-0"/>


### PR DESCRIPTION
Lift the external Documentation and GitHub links out of the footer block
above the account button into their own "Help" section at the bottom of
the main sidebar nav, alongside the other section headers (Setup,
Overview, Manage, System). The footer now contains only the account
entry.

https://claude.ai/code/session_01NmDUdqcRAuYa9dY2pSQ5qN