### PR TITLE
ui(nav): rename Activity page back to Logs

### DIFF
--- a/internal/admin/agents_page.go
+++ b/internal/admin/agents_page.go
@@ -14,7 +14,7 @@ import (
 // Historically this route was a 4-tab composite (guide / wizard / settings /
 // activity). The guide tab was removed, MCP settings moved into the unified
 // Settings shell at /settings/mcp, and the activity tab moved to
-// /activity?tab=sessions. What remains is a single page rendering the prompt
+// /logs?tab=sessions. What remains is a single page rendering the prompt
 // wizard cards via the AgentWizard templ component.
 func AgentsPageHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/logs.go
+++ b/internal/admin/logs.go
@@ -24,8 +24,8 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 		}
 
 		data := map[string]any{
-			"PageTitle":   "Activity",
-			"CurrentPage": "activity",
+			"PageTitle":   "Logs",
+			"CurrentPage": "logs",
 			"CSRFToken":   GetCSRFToken(r),
 			"Flash":       GetFlash(ctx, sm),
 		}
@@ -102,7 +102,7 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 				"connection_id", "status", "trigger", "date_from", "date_to",
 			})
 			pVals.Set("tab", "syncs")
-			pBase := paginationBase("/activity",pVals, "page")
+			pBase := paginationBase("/logs", pVals, "page")
 
 			// Connection filter options.
 			connOpts := make([]pages.LogsConnectionOption, 0, len(connections))
@@ -207,7 +207,7 @@ func LogsPageHandler(a *app.App, svc *service.Service, sm *scs.SessionManager, t
 			}
 			whVals := pickValues(r, []string{"wh_provider", "wh_status"})
 			whVals.Set("tab", "webhooks")
-			whPBase := paginationBase("/activity",whVals, "wh_page")
+			whPBase := paginationBase("/logs", whVals, "wh_page")
 
 			// Project webhook events into the templ view-model with
 			// pre-rendered relative + full timestamps.

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -161,19 +161,22 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		})
 
 		// Agent Prompts page (formerly /agents) — editors can view.
-		// Per-session detail lives under /activity/sessions/{id} since
-		// session data is hosted on the Activity page's Sessions tab;
+		// Per-session detail lives under /logs/sessions/{id} since
+		// session data is hosted on the Logs page's Sessions tab;
 		// it's registered here under the editor+ scope to preserve the
 		// previous /agents/sessions/{id} permission level.
 		r.Get("/agent-prompts", AgentsPageHandler(svc, sm, tr))
 		r.Get("/agent-prompts/builder/{type}", PromptBuilderHandler(sm, tr))
 		r.Get("/agent-prompts/builder/{type}/copy", PromptCopyHandler())
-		r.Get("/activity/sessions/{id}", SessionDetailHandler(svc, sm, tr))
+		r.Get("/logs/sessions/{id}", SessionDetailHandler(svc, sm, tr))
 
-		// Legacy /agents and /agent-wizard redirects.
+		// Legacy /agents, /agent-wizard, and /activity/sessions redirects.
 		r.Get("/agents", redirectGET("/agent-prompts"))
 		r.Get("/agents/sessions/{id}", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/activity/sessions/"+chi.URLParam(r, "id"), http.StatusMovedPermanently)
+			http.Redirect(w, r, "/logs/sessions/"+chi.URLParam(r, "id"), http.StatusMovedPermanently)
+		})
+		r.Get("/activity/sessions/{id}", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/logs/sessions/"+chi.URLParam(r, "id"), http.StatusMovedPermanently)
 		})
 		r.Get("/agent-wizard/{type}", func(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, "/agent-prompts/builder/"+chi.URLParam(r, "type"), http.StatusMovedPermanently)
@@ -220,24 +223,26 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			http.Redirect(w, r, "/settings/oauth-clients/"+chi.URLParam(r, "id")+"/revoke", http.StatusPermanentRedirect)
 		})
 
-		// Activity page (formerly /logs) — sync history, webhook events,
-		// agent sessions tabs. The per-sync-log detail page lives under
-		// /activity/sync-logs/{id}; the per-session detail page lives
-		// under /activity/sessions/{id} (since session data is on the
-		// activity page's Sessions tab).
-		r.Get("/activity", LogsPageHandler(a, svc, sm, tr))
-		r.Get("/activity/sync-logs/{id}", SyncLogDetailHandler(a, sm, tr, svc))
+		// Logs page — sync history, webhook events, agent sessions tabs.
+		// The per-sync-log detail page lives under /logs/sync-logs/{id};
+		// the per-session detail page lives under /logs/sessions/{id}
+		// (since session data is on the Logs page's Sessions tab).
+		r.Get("/logs", LogsPageHandler(a, svc, sm, tr))
+		r.Get("/logs/sync-logs/{id}", SyncLogDetailHandler(a, sm, tr, svc))
 
-		// Legacy /logs and /sync-logs redirects.
-		r.Get("/logs", redirectGET("/activity"))
+		// Legacy /activity, /sync-logs, and /webhook-events redirects.
+		r.Get("/activity", redirectGET("/logs"))
 		r.Get("/sync-logs", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/activity?tab=syncs", http.StatusMovedPermanently)
+			http.Redirect(w, r, "/logs?tab=syncs", http.StatusMovedPermanently)
 		})
 		r.Get("/sync-logs/{id}", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/activity/sync-logs/"+chi.URLParam(r, "id"), http.StatusMovedPermanently)
+			http.Redirect(w, r, "/logs/sync-logs/"+chi.URLParam(r, "id"), http.StatusMovedPermanently)
+		})
+		r.Get("/activity/sync-logs/{id}", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/logs/sync-logs/"+chi.URLParam(r, "id"), http.StatusMovedPermanently)
 		})
 		r.Get("/webhook-events", func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/activity?tab=webhooks", http.StatusMovedPermanently)
+			http.Redirect(w, r, "/logs?tab=webhooks", http.StatusMovedPermanently)
 		})
 
 		r.Get("/account-links", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/sessions.go
+++ b/internal/admin/sessions.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// SessionDetailHandler serves GET /admin/activity/sessions/{id}.
+// SessionDetailHandler serves GET /admin/logs/sessions/{id}.
 func SessionDetailHandler(svc *service.Service, sm *scs.SessionManager, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
@@ -23,7 +23,7 @@ func SessionDetailHandler(svc *service.Service, sm *scs.SessionManager, tr *Temp
 			return
 		}
 
-		data := BaseTemplateData(r, sm, "activity", "Session Detail")
+		data := BaseTemplateData(r, sm, "logs", "Session Detail")
 		props := buildSessionDetailProps(detail)
 		renderSessionDetail(w, r, tr, data, props)
 	}

--- a/internal/admin/synclogs.go
+++ b/internal/admin/synclogs.go
@@ -41,13 +41,13 @@ func SyncLogDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRender
 
 		data := map[string]any{
 			"PageTitle":   "Sync Log Detail",
-			"CurrentPage": "activity",
+			"CurrentPage": "logs",
 			"CSRFToken":   GetCSRFToken(r),
 			"Flash":       GetFlash(ctx, sm),
 		}
 
 		breadcrumbs := []components.Breadcrumb{
-			{Label: "Activity", Href: "/activity?tab=syncs"},
+			{Label: "Logs", Href: "/logs?tab=syncs"},
 			{Label: syncLog.InstitutionName},
 		}
 

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -92,8 +92,8 @@ templ Nav(p NavProps) {
 			</a>
 		}
 		if p.IsAdmin {
-			<a href="/activity" class={ "bb-sidebar-link", navActive(p.CurrentPage, "activity") }>
-				<i data-lucide="activity"></i> Activity
+			<a href="/logs" class={ "bb-sidebar-link", navActive(p.CurrentPage, "logs") }>
+				<i data-lucide="scroll-text"></i> Logs
 			</a>
 		}
 		if p.IsEditor {

--- a/internal/templates/components/pages/getting_started.templ
+++ b/internal/templates/components/pages/getting_started.templ
@@ -223,7 +223,7 @@ templ gsStep4(p GettingStartedProps) {
 				if p.HasSync {
 					<a href="/transactions" class="btn btn-ghost btn-sm rounded-xl">View Transactions</a>
 				} else if p.HasConnection {
-					<a href="/activity" class="btn btn-ghost btn-sm rounded-xl">View Activity</a>
+					<a href="/logs" class="btn btn-ghost btn-sm rounded-xl">View Logs</a>
 				} else {
 					<span class="btn btn-sm btn-disabled rounded-xl">View Logs</span>
 				}

--- a/internal/templates/components/pages/logs.templ
+++ b/internal/templates/components/pages/logs.templ
@@ -19,7 +19,7 @@ templ Logs(p LogsProps) {
 	>
 		<div class="bb-page-header">
 			<div>
-				<h1 class="bb-page-title">Activity</h1>
+				<h1 class="bb-page-title">Logs</h1>
 				<p class="text-sm text-base-content/50 mt-1">Sync history, webhooks, and agent sessions</p>
 			</div>
 		</div>
@@ -177,7 +177,7 @@ templ logsSyncFilterBar(p LogsProps) {
 			</button>
 			<form
 				method="GET"
-				action="/activity"
+				action="/logs"
 				x-show="filtersOpen"
 				x-cloak
 				x-collapse
@@ -221,7 +221,7 @@ templ logsSyncFilterBar(p LogsProps) {
 					</label>
 				</div>
 				<div class="bb-filter-actions">
-					<a href="/activity?tab=syncs" class="btn btn-sm btn-ghost rounded-xl">Reset</a>
+					<a href="/logs?tab=syncs" class="btn btn-sm btn-ghost rounded-xl">Reset</a>
 					<button type="submit" class="btn btn-sm btn-primary rounded-xl">
 						<i data-lucide="search" class="w-3.5 h-3.5"></i>
 						Apply Filters
@@ -280,7 +280,7 @@ templ logsSyncStatusTabs(p LogsProps) {
 			<div aria-hidden="true" class="pointer-events-none absolute inset-y-0 right-0 w-8 rounded-r-lg bg-gradient-to-l from-base-100 to-transparent sm:hidden"></div>
 		</div>
 		if hasAnySyncFilter(p) {
-			<a href="/activity?tab=syncs" class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-base-content/50 hover:text-base-content/80">
+			<a href="/logs?tab=syncs" class="btn btn-ghost btn-xs rounded-lg gap-1.5 text-base-content/50 hover:text-base-content/80">
 				<i data-lucide="x" class="w-3 h-3"></i>
 				Clear all filters
 			</a>
@@ -290,7 +290,7 @@ templ logsSyncStatusTabs(p LogsProps) {
 
 templ logsSyncRow(l LogsSyncRow) {
 	<div class={ "bb-card bb-card--interactive group transition-all duration-150", syncRowBorder(l.Status) }>
-		<a href={ templ.SafeURL("/activity/sync-logs/" + l.ID) } class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 py-3 px-4 no-underline">
+		<a href={ templ.SafeURL("/logs/sync-logs/" + l.ID) } class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 py-3 px-4 no-underline">
 			<!-- Top row: status icon + main content + (desktop) changes -->
 			<div class="flex items-center gap-3 sm:gap-4 flex-1 min-w-0">
 				<!-- Status indicator -->
@@ -375,7 +375,7 @@ templ logsSyncEmpty(p LogsProps) {
 				}
 			</p>
 			if hasAnySyncFilter(p) {
-				<a href="/activity?tab=syncs" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
+				<a href="/logs?tab=syncs" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
 			}
 		</div>
 	</div>
@@ -480,7 +480,7 @@ templ logsWebhookStatusTabs(p LogsProps) {
 			</a>
 		</div>
 		<!-- Provider filter dropdown -->
-		<form method="GET" action="/activity" class="flex items-center gap-2">
+		<form method="GET" action="/logs" class="flex items-center gap-2">
 			<input type="hidden" name="tab" value="webhooks"/>
 			if p.WHFilterStatus != "" {
 				<input type="hidden" name="wh_status" value={ p.WHFilterStatus }/>
@@ -615,7 +615,7 @@ templ logsWebhookEmpty(p LogsProps) {
 				}
 			</p>
 			if p.WHFilterProvider != "" || p.WHFilterStatus != "" {
-				<a href="/activity?tab=webhooks" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
+				<a href="/logs?tab=webhooks" class="btn btn-ghost btn-sm rounded-xl">Clear filters</a>
 			}
 		</div>
 	</div>
@@ -643,7 +643,7 @@ templ logsSessionsBody(p LogsProps) {
 }
 
 templ logsSessionRow(s LogsSessionRow) {
-	<a href={ templ.SafeURL("/activity/sessions/" + s.ShortID) } class="bb-card bb-card--interactive group flex items-start gap-3 py-3 px-4 no-underline">
+	<a href={ templ.SafeURL("/logs/sessions/" + s.ShortID) } class="bb-card bb-card--interactive group flex items-start gap-3 py-3 px-4 no-underline">
 		<div class="w-8 h-8 rounded-lg bg-base-200/60 flex items-center justify-center shrink-0 mt-0.5">
 			<i data-lucide="bot" class="w-3.5 h-3.5 text-base-content/40"></i>
 		</div>
@@ -701,7 +701,7 @@ templ logsSessionsEmpty() {
 templ logsSessionsPaginator(p LogsProps) {
 	<div class="bb-paginator mt-6">
 		if p.SessionsPage > 1 {
-			<a href={ templ.SafeURL(fmt.Sprintf("/activity?tab=sessions&s_page=%d", p.SessionsPage-1)) } class="btn btn-sm btn-ghost rounded-lg">
+			<a href={ templ.SafeURL(fmt.Sprintf("/logs?tab=sessions&s_page=%d", p.SessionsPage-1)) } class="btn btn-sm btn-ghost rounded-lg">
 				<i data-lucide="chevron-left" class="w-3.5 h-3.5"></i>
 				Previous
 			</a>
@@ -710,7 +710,7 @@ templ logsSessionsPaginator(p LogsProps) {
 			{ fmt.Sprintf("Page %d of %d", p.SessionsPage, p.SessionsTotalPages) }
 		</span>
 		if p.SessionsPage < p.SessionsTotalPages {
-			<a href={ templ.SafeURL(fmt.Sprintf("/activity?tab=sessions&s_page=%d", p.SessionsPage+1)) } class="btn btn-sm btn-ghost rounded-lg">
+			<a href={ templ.SafeURL(fmt.Sprintf("/logs?tab=sessions&s_page=%d", p.SessionsPage+1)) } class="btn btn-sm btn-ghost rounded-lg">
 				Next
 				<i data-lucide="chevron-right" class="w-3.5 h-3.5"></i>
 			</a>
@@ -859,13 +859,13 @@ func statusPillClass(active bool) string {
 	return base + " text-base-content/40 hover:text-base-content/60"
 }
 
-// statusTabHref renders /activity?tab=syncs&<query> as a SafeURL — query
+// statusTabHref renders /logs?tab=syncs&<query> as a SafeURL — query
 // is already url.Values-encoded by the handler.
 func statusTabHref(query string) templ.SafeURL {
 	if query == "" {
-		return templ.SafeURL("/activity?tab=syncs&")
+		return templ.SafeURL("/logs?tab=syncs&")
 	}
-	return templ.SafeURL("/activity?tab=syncs&" + query)
+	return templ.SafeURL("/logs?tab=syncs&" + query)
 }
 
 // statsTotalSync returns the formatted Stats.TotalSyncs count.
@@ -912,10 +912,10 @@ func hasAnySyncFilter(p LogsProps) bool {
 	return p.FilterConnID != "" || p.FilterTrigger != "" || p.FilterDateFrom != "" || p.FilterDateTo != "" || p.FilterStatus != ""
 }
 
-// webhookTabHref builds /activity?tab=webhooks[&wh_status=…][&wh_provider=…].
+// webhookTabHref builds /logs?tab=webhooks[&wh_status=…][&wh_provider=…].
 // The empty status case (the "All" tab) only appends the provider clause.
 func webhookTabHref(status, provider string) string {
-	href := "/activity?tab=webhooks"
+	href := "/logs?tab=webhooks"
 	if status != "" {
 		href += "&wh_status=" + status
 	}
@@ -928,7 +928,7 @@ func webhookTabHref(status, provider string) string {
 // webhookClearProviderHref builds the "x" link that clears just the
 // provider filter while preserving the status tab.
 func webhookClearProviderHref(status string) string {
-	href := "/activity?tab=webhooks"
+	href := "/logs?tab=webhooks"
 	if status != "" {
 		href += "&wh_status=" + status
 	}

--- a/internal/templates/components/pages/rule_detail.templ
+++ b/internal/templates/components/pages/rule_detail.templ
@@ -558,7 +558,7 @@ templ ruleDetailSyncRow(h map[string]any) {
 	{{ startedAt, _ := h["started_at"].(string) }}
 	{{ instPtr, _ := h["institution"].(*string) }}
 	{{ hits := syncHistoryHitCount(h) }}
-	<a href={ templ.SafeURL("/activity/sync-logs/" + syncID) } class="flex items-center justify-between p-3 bg-base-200/40 rounded-xl hover:bg-base-200/60 transition-colors">
+	<a href={ templ.SafeURL("/logs/sync-logs/" + syncID) } class="flex items-center justify-between p-3 bg-base-200/40 rounded-xl hover:bg-base-200/60 transition-colors">
 		<div class="flex items-center gap-3">
 			<div class={ "w-8", "h-8", "rounded-lg", "flex", "items-center", "justify-center", syncStatusBgClass(status) }>
 				if status == "success" {

--- a/internal/templates/components/pages/session_detail.templ
+++ b/internal/templates/components/pages/session_detail.templ
@@ -10,7 +10,7 @@ templ SessionDetail(p SessionDetailProps) {
 	<div class="bb-page-header">
 		<div>
 			<div class="flex items-center gap-2 text-sm text-base-content/50 mb-1">
-				<a href="/activity?tab=sessions" class="hover:text-base-content">Activity</a>
+				<a href="/logs?tab=sessions" class="hover:text-base-content">Logs</a>
 				<i data-lucide="chevron-right" class="w-3 h-3"></i>
 				<span>Session</span>
 			</div>

--- a/internal/templates/components/pages/settings_layout.templ
+++ b/internal/templates/components/pages/settings_layout.templ
@@ -15,7 +15,7 @@ type SettingsLayoutProps struct {
 // constant *values* are stable identifiers used by the rail's active-state
 // matcher; they intentionally do not need to track URL slug changes.
 //
-// /activity is intentionally outside the Settings shell — it lives as a
+// /logs is intentionally outside the Settings shell — it lives as a
 // top-level observability page in the main sidebar.
 const (
 	SettingsTabProfile   = "profile"

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -1497,7 +1497,7 @@
         // System
         { id: 'sys-access', shortcutId: 'global.go.k', group: 'System', title: 'API Keys', desc: 'API keys and OAuth clients', icon: 'shield-check', href: '/settings/api-keys', keywords: 'tokens authentication api keys oauth connector claude access' },
         { id: 'sys-providers', shortcutId: 'global.go.p', group: 'System', title: 'Providers', desc: 'Configure Plaid, Teller, CSV', icon: 'plug', href: '/settings/providers', keywords: 'plaid teller csv bank setup' },
-        { id: 'sys-logs', shortcutId: 'global.go.v', group: 'System', title: 'Activity', desc: 'Sync logs, webhook events, agent sessions', icon: 'scroll-text', href: '/activity', keywords: 'sync history errors status webhooks events sessions logs' },
+        { id: 'sys-logs', shortcutId: 'global.go.v', group: 'System', title: 'Logs', desc: 'Sync logs, webhook events, agent sessions', icon: 'scroll-text', href: '/logs', keywords: 'sync history errors status webhooks events sessions activity' },
         { id: 'sys-backups', shortcutId: 'global.go.b', group: 'System', title: 'Backups', desc: 'Database backup and restore', icon: 'hard-drive', href: '/settings/backups', keywords: 'backup restore database dump export' },
         { id: 'sys-settings', shortcutId: 'global.go.s', group: 'System', title: 'Settings', desc: 'Sync schedule, security, system', icon: 'settings', href: '/settings', keywords: 'schedule password encryption' },
         // Quick Actions
@@ -2070,8 +2070,8 @@
         r: { path: '/reviews',            label: 'Go to Reviews' },
         u: { path: '/rules',              label: 'Go to Rules' },
         a: { path: '/categories',         label: 'Go to Categories' },
-        v: { path: '/activity',           label: 'Go to Activity' },
-        l: { path: '/activity',           label: 'Go to Activity' },
+        v: { path: '/logs',               label: 'Go to Logs' },
+        l: { path: '/logs',               label: 'Go to Logs' },
         b: { path: '/settings/backups',   label: 'Go to Backups' },
         s: { path: '/settings',           label: 'Go to Settings' },
         p: { path: '/settings/providers', label: 'Go to Providers' },


### PR DESCRIPTION
Restores /logs as the primary route for sync history, webhook events,
and agent sessions. /activity, /activity/sync-logs/{id}, and
/activity/sessions/{id} keep working via 301 redirects so existing
bookmarks and inbound links don't break. Sidebar entry now uses the
scroll-text icon to match the global quick-search definition.

Browser validation skipped — Chrome DevTools MCP not available in
this session. Build, vet, and unit tests pass.

https://claude.ai/code/session_01SqbYRFxRJrnZNvXeCmvtbm