### PR TITLE
ui(activity): distinguish category from tag in annotation rows

### DIFF
--- a/input.css
+++ b/input.css
@@ -676,139 +676,12 @@
            bg-base-200 text-base-content/70 border border-base-300;
   }
 
-  /* Tile + icon scale-up. Targets the row-tile (`w-6 h-6`) and inner icon
-   * (`w-3 h-3`) classes that the card-mode rows render — so we lift the
-   * size in CSS without duplicating the templ markup for each variant.
-   * Also lifts the text leading on row sentences so first-line baseline
-   * stays vertically centred against the larger tile. */
-  .bb-timeline-prominent .bb-timeline > li > div:first-child.w-6.h-6,
-  .bb-timeline-prominent .bb-timeline > li > div:first-child .w-6.h-6 {
-    width: 1.75rem;   /* 28px */
-    height: 1.75rem;
-  }
-  .bb-timeline-prominent .bb-timeline > li > div:first-child .w-3.h-3 {
-    width: 0.875rem;  /* 14px */
-    height: 0.875rem;
-  }
-  .bb-timeline-prominent .bb-timeline > li > div.flex-1.text-xs.leading-6 {
-    line-height: 1.75rem; /* 28px — matches the new tile height */
-  }
-
-  /* Rail mask. The 28px tile bg + ring are still painted with base-100
-   * (card-surface) classes by the shared row markup — redirect both to
-   * base-200 here so the seam stays invisible against the page surface. */
-  .bb-timeline-prominent .bg-base-100 {
-    background-color: var(--color-base-200);
-  }
-  .bb-timeline-prominent .ring-base-100 {
-    --tw-ring-color: var(--color-base-200);
-  }
-  /* Slightly thicker ring for the bigger tile so the colour pill reads
-   * cleanly against the rail. */
-  .bb-timeline-prominent .bb-timeline > li > div:first-child .ring-4 {
-    --tw-ring-offset-width: 0;
-    box-shadow: 0 0 0 5px var(--color-base-200);
-  }
-
-  /* Day separator. Bigger anchor dot and a less-shouty label — closer to
-   * GitHub's "X commented on Aug 12" header than the current uppercase
-   * tracking-wider treatment. */
-  .bb-timeline-prominent .bb-timeline > li[role="separator"] > div:first-child > span {
-    width: 0.875rem;   /* 14px dot, up from 12 */
-    height: 0.875rem;
-  }
-  .bb-timeline-prominent .bb-timeline > li[role="separator"] h3 {
-    font-size: 0.75rem;
-    letter-spacing: 0.04em;
-    color: color-mix(in srgb, var(--color-base-content) 65%, transparent);
-  }
-
-  /* Comment cards. Each comment row's right-hand column becomes a
-   * GitHub-style bordered card: header bar with actor + timestamp, body
-   * with the comment text, and a small left-pointing tail anchoring it
-   * to the avatar on the rail. Targets only comment rows (those that
-   * contain a `.bb-comment-bubble`) so system-event rows and the
-   * composer-row stay untouched. */
-  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) {
-    @apply py-2;
-  }
-  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 {
-    position: relative;
-    background: var(--color-base-100);
-    border: 1px solid var(--color-base-300);
-    border-radius: 0.5rem;
-    overflow: visible;
-  }
-  /* Header bar (was the "Name commented X ago" meta line) */
-  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 > div:first-child {
-    background: color-mix(in srgb, var(--color-base-200) 60%, transparent);
-    border-bottom: 1px solid var(--color-base-300);
-    padding: 0.5rem 0.875rem;
-    margin: 0;
-    border-top-left-radius: 0.5rem;
-    border-top-right-radius: 0.5rem;
-  }
-  /* Body (was the chat-bubble) */
-  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) .bb-comment-bubble {
-    display: block;
-    margin: 0;
-    padding: 0.75rem 0.875rem 0.875rem 0.875rem;
-    background: transparent;
-    border: 0;
-    border-radius: 0;
-    max-width: none;
-  }
-  /* Left-pointing tail. Two stacked triangles: outer (border-color) sits
-   * one pixel behind the inner (background) so the card border is hinted
-   * along the seam. Top offset (1rem) puts the tip ~halfway down the
-   * 28px avatar tile. */
-  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::before,
-  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after {
-    content: '';
-    position: absolute;
-    top: 0.85rem;
-    width: 0;
-    height: 0;
-    border-style: solid;
-  }
-  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::before {
-    left: -8px;
-    border-width: 8px 8px 8px 0;
-    border-color: transparent var(--color-base-300) transparent transparent;
-  }
-  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after {
-    left: -7px;
-    border-width: 8px 8px 8px 0;
-    border-color: transparent color-mix(in srgb, var(--color-base-200) 60%, transparent) transparent transparent;
-  }
-
-  /* Composer row gets the same outer card treatment as comment rows so
-   * the page reads as one continuous conversation. */
-  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 > [data-composer-anchor] {
-    border-radius: 0.5rem;
-  }
-  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 {
-    position: relative;
-  }
-  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::before,
-  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::after {
-    content: '';
-    position: absolute;
-    top: 0.85rem;
-    width: 0;
-    height: 0;
-    border-style: solid;
-  }
-  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::before {
-    left: -8px;
-    border-width: 8px 8px 8px 0;
-    border-color: transparent var(--color-base-300) transparent transparent;
-  }
-  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::after {
-    left: -7px;
-    border-width: 8px 8px 8px 0;
-    border-color: transparent var(--color-base-100) transparent transparent;
-  }
+  /* Note: the size/colour/layout overrides for `.bb-timeline-prominent` are
+   * defined below the closing `}` of @layer components (search for
+   * "Activity timeline — prominent overrides"). They have to live outside
+   * the layer because they target Tailwind utility classes (w-6, h-6,
+   * leading-6, ring-4, py-2.5, …) — utilities live in @layer utilities
+   * and beat anything in @layer components regardless of specificity. */
 
   /* ── Info grid (detail pages) ── */
   .bb-info-grid {
@@ -2850,4 +2723,149 @@
  * the slug-tooltip class made the chip render two-line). */
 .bb-tag.tooltip {
   display: inline-flex;
+}
+
+/* ── Activity timeline — prominent overrides ──
+ * Has to live unlayered because every rule below targets Tailwind utility
+ * classes (w-6, h-6, leading-6, ring-4, py-2.5, …). Inside @layer components
+ * those overrides lose to the utilities regardless of specificity, leaving
+ * tiles at 24px and the rail offset (engineered for 28px tiles) two pixels
+ * to the right of every circle's centre. See input.css line ~660 for the
+ * placeholder comment in the @layer components block. */
+
+/* Tile + icon scale-up. Targets the row-tile (`w-6 h-6`) and inner icon
+ * (`w-3 h-3`) classes that the card-mode rows render — so we lift the
+ * size in CSS without duplicating the templ markup for each variant. */
+.bb-timeline-prominent .bb-timeline > li > div:first-child.w-6.h-6,
+.bb-timeline-prominent .bb-timeline > li > div:first-child .w-6.h-6 {
+  width: 1.75rem;   /* 28px */
+  height: 1.75rem;
+}
+.bb-timeline-prominent .bb-timeline > li > div:first-child .w-3.h-3 {
+  width: 0.875rem;  /* 14px */
+  height: 0.875rem;
+}
+/* Lift the text leading on row sentences so the first-line baseline stays
+ * vertically centred against the larger 28px tile next to it. */
+.bb-timeline-prominent .bb-timeline > li > div.flex-1.text-xs.leading-6 {
+  line-height: 1.75rem; /* 28px — matches the tile height */
+}
+
+/* Rail mask. The 28px tile bg + ring are still painted with base-100
+ * (card-surface) classes by the shared row markup — redirect both to
+ * base-200 here so the seam stays invisible against the page surface. */
+.bb-timeline-prominent .bg-base-100 {
+  background-color: var(--color-base-200);
+}
+.bb-timeline-prominent .ring-base-100 {
+  --tw-ring-color: var(--color-base-200);
+}
+/* Slightly thicker ring for the bigger tile so the colour pill reads
+ * cleanly against the rail. */
+.bb-timeline-prominent .bb-timeline > li > div:first-child .ring-4 {
+  --tw-ring-offset-width: 0;
+  box-shadow: 0 0 0 5px var(--color-base-200);
+}
+
+/* Day separator. Bigger anchor dot and a less-shouty label — closer to
+ * GitHub's "X commented on Aug 12" header than the default uppercase
+ * tracking-wider treatment. */
+.bb-timeline-prominent .bb-timeline > li[role="separator"] > div:first-child > span {
+  width: 0.875rem;   /* 14px dot, up from 12 */
+  height: 0.875rem;
+}
+.bb-timeline-prominent .bb-timeline > li[role="separator"] h3 {
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--color-base-content) 65%, transparent);
+}
+
+/* Comment cards. Each comment row's right-hand column becomes a
+ * GitHub-style bordered card: header bar with actor + timestamp, body
+ * with the comment text, and a small left-pointing tail anchoring it
+ * to the avatar on the rail. Targets only comment rows (those that
+ * contain a `.bb-comment-bubble`) so system-event rows and the
+ * composer-row stay untouched. */
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) {
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 {
+  position: relative;
+  background: var(--color-base-100);
+  border: 1px solid var(--color-base-300);
+  border-radius: 0.5rem;
+  overflow: visible;
+}
+/* Header bar (was the "Name commented X ago" meta line) */
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 > div:first-child {
+  background: color-mix(in srgb, var(--color-base-200) 60%, transparent);
+  border-bottom: 1px solid var(--color-base-300);
+  padding: 0.5rem 0.875rem;
+  margin: 0;
+  border-top-left-radius: 0.5rem;
+  border-top-right-radius: 0.5rem;
+}
+/* Body (was the chat-bubble) */
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) .bb-comment-bubble {
+  display: block;
+  margin: 0;
+  padding: 0.75rem 0.875rem 0.875rem 0.875rem;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  max-width: none;
+}
+/* Left-pointing tail. Two stacked triangles: outer (border-color) sits
+ * one pixel behind the inner (background) so the card border is hinted
+ * along the seam. The triangle is 16px tall; with `top: 6px` its vertical
+ * centre lands at y=14 inside the card, which is exactly the centre of
+ * the 28px avatar next to it (both flex items share the row's top edge
+ * via `items-start`, so card_top == avatar_top). */
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::before,
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::before {
+  left: -8px;
+  border-width: 8px 8px 8px 0;
+  border-color: transparent var(--color-base-300) transparent transparent;
+}
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after {
+  left: -7px;
+  border-width: 8px 8px 8px 0;
+  border-color: transparent color-mix(in srgb, var(--color-base-200) 60%, transparent) transparent transparent;
+}
+
+/* Composer row gets the same outer card treatment as comment rows so
+ * the page reads as one continuous conversation. */
+.bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 > [data-composer-anchor] {
+  border-radius: 0.5rem;
+}
+.bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 {
+  position: relative;
+}
+.bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::before,
+.bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  width: 0;
+  height: 0;
+  border-style: solid;
+}
+.bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::before {
+  left: -8px;
+  border-width: 8px 8px 8px 0;
+  border-color: transparent var(--color-base-300) transparent transparent;
+}
+.bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::after {
+  left: -7px;
+  border-width: 8px 8px 8px 0;
+  border-color: transparent var(--color-base-100) transparent transparent;
 }

--- a/input.css
+++ b/input.css
@@ -2790,6 +2790,15 @@
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
 }
+/* Initials-variant comment avatar uses bg-base-200 for contrast against the
+ * card-mode page surface. In prominent mode the rail mask is also base-200,
+ * so the neutral circle would otherwise blend right into its surroundings
+ * and the avatar reads as a floating letter. Bump it to base-300 so the
+ * circle still reads. Image avatars (no bg class) and agent avatars
+ * (bg-primary/10) aren't matched and stay as-is. */
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div:first-child .bg-base-200 {
+  background-color: var(--color-base-300);
+}
 .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 {
   position: relative;
   background: var(--color-base-100);

--- a/input.css
+++ b/input.css
@@ -2790,14 +2790,16 @@
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
 }
-/* Initials-variant comment avatar uses bg-base-200 for contrast against the
- * card-mode page surface. In prominent mode the rail mask is also base-200,
- * so the neutral circle would otherwise blend right into its surroundings
- * and the avatar reads as a floating letter. Bump it to base-300 so the
- * circle still reads. Image avatars (no bg class) and agent avatars
- * (bg-primary/10) aren't matched and stay as-is. */
-.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div:first-child .bg-base-200 {
-  background-color: var(--color-base-300);
+/* GitHub-style 1px outline on comment-row avatars. The rail mask is
+ * base-200, so without an outline a neutral avatar (image / agent /
+ * initials) reads as floating without a defined edge. base-300 is our
+ * "border" colour and works in both themes — subtle gray-on-white in
+ * light mode, subtle lift on near-black in dark mode. We use `border`
+ * (not box-shadow) so it works on `<img>` too — replaced elements
+ * ignore inset shadows. With box-sizing:border-box the outer 28px
+ * stays intact, so the rail still threads through the avatar centre. */
+.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div:first-child .ring-4 {
+  border: 1px solid var(--color-base-300);
 }
 .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 {
   position: relative;

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -741,23 +741,25 @@ func txdRuleVerbFallback(e service.ActivityEntry) string {
 	return s
 }
 
-// txdInlineCategoryChip renders a pill matching the canonical bb-tag chip
-// styling (the same look used for tags) but populated from a category's
-// color + icon + display name. Reuses the --tag-color CSS variable so a
-// single CSS class drives both tag and category chips.
+// txdInlineCategoryChip renders an inline category reference matching the
+// app's canonical category visual: a colored dot + (optional) icon + bold
+// name. Deliberately *not* shaped like a tag pill — categories and tags
+// look almost identical when both render as bb-tag chips, so the timeline
+// uses the dot+name pattern from the category picker / filters here to
+// keep the two readable at a glance.
 templ txdInlineCategoryChip(e service.ActivityEntry) {
-	<span
-		class="bb-tag bb-tag-sm align-middle"
+	<span class="inline-flex items-center gap-1 align-middle">
 		if e.CategoryColor != nil && *e.CategoryColor != "" {
-			style={ "--tag-color: " + *e.CategoryColor }
+			<span class="bb-cat-dot" style={ "background-color: " + *e.CategoryColor }></span>
 		}
-	>
 		if e.CategoryIcon != nil && *e.CategoryIcon != "" {
-			<i data-lucide={ *e.CategoryIcon }></i>
-		} else {
-			<i data-lucide="folder"></i>
+			if e.CategoryColor != nil && *e.CategoryColor != "" {
+				<i data-lucide={ *e.CategoryIcon } class="w-3.5 h-3.5 shrink-0" style={ "color: " + *e.CategoryColor }></i>
+			} else {
+				<i data-lucide={ *e.CategoryIcon } class="w-3.5 h-3.5 shrink-0 text-base-content/60"></i>
+			}
 		}
-		<span class="truncate">{ e.CategoryName }</span>
+		<strong class="font-semibold text-base-content break-words">{ e.CategoryName }</strong>
 	</span>
 }
 


### PR DESCRIPTION
Inline category references in the activity timeline rendered as
bb-tag pills, identical in shape to tag chips. Switch to the
canonical category visual used elsewhere in the app — colored dot +
icon + bold name — so a "set the category to X" row no longer reads
like "added the X tag" at a glance.

https://claude.ai/code/session_0116pqcLiRtWnQmzaMktxQqK