### PR TITLE
ui(transaction-detail): larger tag pills + lock-toggle for category override

### DIFF
--- a/input.css
+++ b/input.css
@@ -440,7 +440,8 @@
    * Color driven by --tag-color CSS variable so server- and client-rendered chips stay consistent.
    *
    * Variants:
-   *   .bb-tag         — default (forms, detail pages, filter panels)
+   *   .bb-tag         — default (forms, filter panels, dense detail rows)
+   *   .bb-tag-lg      — primary interactive surface (detail-page tag editor)
    *   .bb-tag-sm      — compact (transaction rows, dense lists)
    *   .bb-tag-ghost   — selector/filter state when unselected (muted)
    *   .bb-tag-remove  — inline × button, hidden until hover/focus on parent
@@ -483,6 +484,26 @@
   .bb-tag-sm > i, .bb-tag-sm > svg {
     width: 0.65rem;
     height: 0.65rem;
+  }
+
+  /* Larger pill for primary interactive contexts (e.g. the tag editor on the
+     transaction detail card). The default size suits dense lists and filter
+     bars; this variant gives a comfortable tap/click target where managing
+     tags is the section's main action. */
+  .bb-tag-lg {
+    padding: 0.3125rem 0.625rem;
+    font-size: 0.8125rem;
+    gap: 0.3125rem;
+  }
+
+  .bb-tag-lg > i, .bb-tag-lg > svg {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+
+  .bb-tag-lg .bb-tag-remove > i, .bb-tag-lg .bb-tag-remove > svg {
+    width: 0.875rem;
+    height: 0.875rem;
   }
 
   /* Below xl, transaction-row tag chips collapse into a single icon + count

--- a/internal/admin/categories.go
+++ b/internal/admin/categories.go
@@ -245,6 +245,31 @@ func ResetTransactionCategoryAdminHandler(svc *service.Service, sm *scs.SessionM
 	}
 }
 
+// SetCategoryOverrideAdminHandler handles PATCH /-/transactions/{id}/category-override.
+// Flips the override flag without changing the category — drives the lock
+// toggle on the transaction detail page.
+func SetCategoryOverrideAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		var req struct {
+			Override bool `json:"override"`
+		}
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		actor := ActorFromSession(sm, r)
+		if err := svc.SetCategoryOverrideFlag(r.Context(), id, req.Override, actor); err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update override")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
 // BatchSetTransactionCategoryAdminHandler handles POST /admin/api/transactions/batch-categorize.
 // Accepts {items: [{transaction_id, category_id}]} and sets category overrides on all.
 func BatchSetTransactionCategoryAdminHandler(svc *service.Service, sm *scs.SessionManager) http.HandlerFunc {

--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -327,6 +327,7 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 			// Transaction category override
 			r.Post("/transactions/{id}/category", SetTransactionCategoryAdminHandler(svc, sm))
 			r.Delete("/transactions/{id}/category", ResetTransactionCategoryAdminHandler(svc, sm))
+			r.Patch("/transactions/{id}/category-override", SetCategoryOverrideAdminHandler(svc, sm))
 
 			// Transaction bulk categorize
 			r.Post("/transactions/batch-categorize", BatchSetTransactionCategoryAdminHandler(svc, sm))

--- a/internal/db/queries/categories.sql
+++ b/internal/db/queries/categories.sql
@@ -59,6 +59,14 @@ UPDATE transactions
 SET category_override = FALSE, updated_at = NOW()
 WHERE id = $1;
 
+-- name: SetCategoryOverrideFlag :execrows
+-- Flips the override flag without changing the category. Used by the
+-- detail-page lock toggle, which only governs whether transaction rules
+-- may re-categorize the row.
+UPDATE transactions
+SET category_override = $2, updated_at = NOW()
+WHERE id = $1 AND deleted_at IS NULL;
+
 -- ReassignRulesCategory was removed in 20260415070000_rule_actions_v2 — rule
 -- category targets now live inside the actions JSONB. Reassignment is handled
 -- in the service layer via pool.Exec to keep sqlc happy with JSONB subqueries.

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -504,6 +504,28 @@ func (s *Service) ResetTransactionCategory(ctx context.Context, txnID string, ac
 	return nil
 }
 
+// SetCategoryOverrideFlag flips the category_override flag on a transaction
+// without touching the category itself. Used by the detail-page lock toggle:
+// locking shields the row from transaction rules; unlocking lets rules
+// re-categorize on the next sync.
+func (s *Service) SetCategoryOverrideFlag(ctx context.Context, txnID string, override bool, actor Actor) error {
+	txnUID, err := s.resolveTransactionID(ctx, txnID)
+	if err != nil {
+		return ErrNotFound
+	}
+	rowsAffected, err := s.Queries.SetCategoryOverrideFlag(ctx, db.SetCategoryOverrideFlagParams{
+		ID:               txnUID,
+		CategoryOverride: override,
+	})
+	if err != nil {
+		return fmt.Errorf("set category override flag: %w", err)
+	}
+	if rowsAffected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
 // writeCategorySetAnnotation writes a manual `category_set` annotation. Manual
 // writes carry `source: "manual"` and never include rule_id/rule_name — those
 // are reserved for rule-driven writes (see internal/ruleapply/annotations.go).

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -234,14 +234,18 @@ templ txdMain(p TransactionDetailProps) {
 					</button>
 				</div>
 				<div class="flex items-center gap-2 mt-3">
-					if p.Transaction.CategoryOverride {
-						<span class="badge badge-ghost badge-xs">Manual override</span>
-					}
-					<template x-if="isOverride">
-						<button class="btn btn-ghost btn-xs rounded-lg text-base-content/40 hover:text-base-content" @click="resetCategory()">
-							<i data-lucide="rotate-ccw" class="w-3.5 h-3.5"></i> Reset to auto
-						</button>
-					</template>
+					<button
+						type="button"
+						class="btn btn-xs rounded-full gap-1.5 px-2.5"
+						:class="isOverride ? 'btn-primary btn-soft' : 'btn-ghost text-base-content/55 hover:text-base-content'"
+						:aria-pressed="isOverride ? 'true' : 'false'"
+						:title="isOverride ? 'Locked — protected from automatic rules. Click to unlock.' : 'Auto — managed by transaction rules. Click to lock.'"
+						@click="toggleOverride()"
+						:disabled="saving"
+					>
+						<i :data-lucide="isOverride ? 'lock' : 'lock-open'" class="w-3.5 h-3.5"></i>
+						<span x-text="isOverride ? 'Locked' : 'Auto'"></span>
+					</button>
 					<span x-show="saving" class="loading loading-spinner loading-xs"></span>
 				</div>
 			</div>

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -250,10 +250,10 @@ templ txdMain(p TransactionDetailProps) {
 				<div class="flex items-center justify-between mb-3">
 					<h2 class="text-sm font-semibold text-base-content/50">Tags</h2>
 				</div>
-				<div class="flex flex-wrap gap-1.5 min-h-[1.5rem] items-center">
+				<div class="flex flex-wrap gap-2 min-h-[1.75rem] items-center">
 					<template x-for="t in tags" :key="t.slug">
 						<span
-							class="bb-tag"
+							class="bb-tag bb-tag-lg"
 							:class="t.displayName && t.displayName !== t.slug ? 'tooltip tooltip-top' : ''"
 							:data-tip="t.displayName && t.displayName !== t.slug ? t.slug : null"
 							:style="t.color ? ('--tag-color:' + t.color) : ''"
@@ -276,7 +276,7 @@ templ txdMain(p TransactionDetailProps) {
 					     can add, remove, or both from one session. -->
 					<button
 						type="button"
-						class="bb-tag bb-tag-add"
+						class="bb-tag bb-tag-lg bb-tag-add"
 						@click="openTagPicker()"
 						@tag-selection-commit.window="if ($event.detail.sourceId === 'txd-tag') { applyTagDiff($event.detail.adds, $event.detail.removes) }"
 						title="Edit tags"

--- a/static/js/admin/components/transaction_detail.js
+++ b/static/js/admin/components/transaction_detail.js
@@ -451,6 +451,42 @@ document.addEventListener('alpine:init', function () {
             showToast((e && e.message) || 'Network error.');
           });
       },
+
+      // Flips the override flag without changing the category. Locked rows are
+      // protected from transaction rules; unlocked rows can be re-categorized
+      // on the next sync if a matching rule fires.
+      toggleOverride: function () {
+        if (this.saving) return;
+        var self = this;
+        var prevOverride = this.isOverride;
+        var next = !prevOverride;
+        this.saving = true;
+        this.isOverride = next;
+        fetch('/-/transactions/' + this.txId + '/category-override', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ override: next }),
+        })
+          .then(function (r) {
+            if (!r.ok && r.status !== 204) {
+              return r.json().then(function (d) {
+                throw new Error((d && d.error && d.error.message) || 'Failed to update lock.');
+              });
+            }
+          })
+          .then(function () {
+            self.saving = false;
+            if (window.lucide && typeof window.lucide.createIcons === 'function') {
+              window.lucide.createIcons();
+            }
+            showToast(next ? 'Category locked.' : 'Category unlocked.', 'success');
+          })
+          .catch(function (e) {
+            self.saving = false;
+            self.isOverride = prevOverride;
+            showToast((e && e.message) || 'Network error.');
+          });
+      },
     };
   });
 


### PR DESCRIPTION
Two iterations on the transaction detail card so its primary interactive surfaces — managing tags and managing override state — read as interactive instead of as passive labels.

## Tag pills (`ed0c22d`)

The default `.bb-tag` size is tuned for filter bars and dense list rows where chips are info, not actions. On the detail card the chip strip is the section's main affordance — add, remove, edit — and the existing sizing felt too small to invite a click.

Added a `.bb-tag-lg` variant (font `0.8125rem`, padding `5px·10px`, icons `0.875rem`) and applied it to the chip strip + Add/Edit-tags button. Default `.bb-tag` size is unchanged everywhere else (transactions list, filter bars, picker, forms).

## Category override → lock toggle (`f6a7c7a`)

The "Manual override" badge + tiny "Reset to auto" ghost button were a split affordance, and "Reset to auto" conflated *clearing the override* with *clearing the category and re-running rules* (it called `DELETE /-/transactions/{id}/category`). There was no way to flip the override flag while keeping the category in place.

Replaced both with a single state-bearing pill:

- **Locked** (override = true): primary-soft pill with `lock` icon. Click unlocks; rules can re-categorize on next sync.
- **Auto** (override = false): ghost pill with `lock-open` icon. Click locks the current category against rules.

Tooltip on each state spells out the rule contract. The "Reset to auto" button is removed entirely — users wanting to clear the category can pick *Uncategorized* from the picker (which still triggers a recategorize).

Backend wiring:

- New sqlc query `SetCategoryOverrideFlag` — flips the column without touching `category_id`.
- New service method `Service.SetCategoryOverrideFlag` — no annotation written (intentional — the toggle is a soft setting, not an auditable mutation).
- New admin endpoint `PATCH /-/transactions/{id}/category-override` with `{ "override": bool }`.
- JS factory adds `toggleOverride()` with optimistic update + rollback on error.

## Visual evidence

Captured in headless Chromium 141 (Playwright) at `1280×800` @ 2× DPR against a freshly-seeded `breadbox_test` DB. Same transaction, both states.

**Locked + tags applied** — the side-by-side contrast:

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://i.img402.dev/j5c09rv8wc.jpg" width="420" alt="before — Manual override badge + Reset to auto ghost button, small tag pills"></td>
    <td><img src="https://i.img402.dev/52k3f9l0ei.jpg" width="420" alt="after — Locked toggle pill, larger tag pills"></td>
  </tr>
</table>

**Auto + no tags applied** — empty-state + unlocked toggle look:

<img src="https://i.img402.dev/xfbkjqrjlg.jpg" width="800" alt="after — Auto toggle and Add tag pill on an unlocked, untagged transaction">

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` — all green
- [x] Headless browser load of `/transactions/{id}` with seeded data — Alpine binds, Lucide icons render, lock toggle reads correct state, tags chip strip renders at the larger size
- [x] Toggle lock state directly in DB (`category_override = TRUE/FALSE`) — UI re-renders correctly across both branches
- [ ] Manual click-through on the lock toggle to confirm the PATCH round-trips and the chip flips state without a reload (covered by the JS optimistic-update path; not exercised in headless capture)

https://claude.ai/code/session_01SPjtynMvUVxXMQNS8ueatw