### PR TITLE
ui(activity): render annotation comments as markdown via shared scanner

### DIFF
--- a/input.css
+++ b/input.css
@@ -653,9 +653,55 @@
     border: 1px solid color-mix(in srgb, var(--color-base-300) 60%, transparent);
     border-radius: 1rem;
     border-top-left-radius: 0.375rem;
-    white-space: pre-wrap;
     word-break: break-word;
   }
+  /* Markdown element styling inside a comment bubble. Tuned to the
+     bubble's compact scale — paragraph margins are tighter than the
+     report body, headings are de-emphasized (comments shouldn't shout
+     section titles), and code blocks fit inside the bubble's inline-block
+     width without breaking the chat-row rhythm. Mirrors the shared
+     marked + DOMPurify pipeline used by .bb-report-body. */
+  .bb-comment-bubble > :first-child { @apply mt-0; }
+  .bb-comment-bubble p { @apply mb-2; }
+  .bb-comment-bubble h1,
+  .bb-comment-bubble h2,
+  .bb-comment-bubble h3,
+  .bb-comment-bubble h4 { @apply text-sm font-semibold text-base-content mt-3 mb-1; }
+  .bb-comment-bubble ul { @apply list-disc pl-5 my-1.5 space-y-0.5; }
+  .bb-comment-bubble ol { @apply list-decimal pl-5 my-1.5 space-y-0.5; }
+  .bb-comment-bubble li { @apply marker:text-base-content/50; }
+  .bb-comment-bubble strong { @apply font-semibold text-base-content; }
+  .bb-comment-bubble em { @apply italic; }
+  .bb-comment-bubble a {
+    @apply text-primary underline decoration-primary/30 hover:decoration-primary underline-offset-2;
+  }
+  .bb-comment-bubble a[href^="/transactions/"] {
+    @apply rounded bg-primary/5 px-1 py-px no-underline hover:bg-primary/10;
+  }
+  .bb-comment-bubble code:not(pre code) {
+    @apply bg-base-300/40 text-[0.85em] px-1 py-px rounded font-mono;
+  }
+  .bb-comment-bubble pre {
+    @apply bg-base-300/40 rounded-lg p-2 my-2 overflow-x-auto text-xs font-mono border border-base-300/60;
+  }
+  .bb-comment-bubble pre code { @apply bg-transparent p-0; }
+  .bb-comment-bubble blockquote {
+    @apply border-l-2 border-base-300 pl-2 my-2 text-base-content/60;
+  }
+  .bb-comment-bubble hr { @apply hidden; }
+  .bb-comment-bubble .bb-report-table-wrap {
+    @apply my-2 overflow-x-auto rounded-lg;
+  }
+  .bb-comment-bubble table {
+    @apply w-full text-xs border-collapse;
+  }
+  .bb-comment-bubble thead th {
+    @apply text-left font-semibold text-[0.65rem] uppercase tracking-wider text-base-content/50 px-2 py-1 border-b border-base-300 whitespace-nowrap;
+  }
+  .bb-comment-bubble tbody td {
+    @apply px-2 py-1 border-b border-base-200 whitespace-nowrap sm:whitespace-normal;
+  }
+  .bb-comment-bubble tbody tr:last-child td { @apply border-b-0; }
 
   /* ── Activity timeline — prominent (main-content) variant ──
    * Used by the transaction-detail page to promote the activity timeline

--- a/internal/templates/components/pages/report_detail.templ
+++ b/internal/templates/components/pages/report_detail.templ
@@ -14,12 +14,19 @@ import "breadbox/internal/templates/components"
 // (no defer) and at the top of the component so the factory is
 // registered before Alpine — itself <script defer> in <head> — fires
 // alpine:init.
+//
+// Markdown rendering is delegated to the shared static/js/admin/markdown.js
+// scanner (also used by transaction-detail comments). It scans every
+// `[data-markdown]` element on DOMContentLoaded and rewrites it via
+// marked + DOMPurify, so this template only needs to point the body div
+// at its raw markdown via `data-markdown="..."`.
 templ ReportDetail(p ReportDetailProps) {
-	<!-- CDN dependencies for the body markdown renderer, then the
+	<!-- CDN dependencies for the shared markdown renderer, then the
 	     report_detail Alpine factory. Loaded synchronously (no defer)
 	     so Alpine.data() registration runs before alpine:init. -->
 	<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
 	<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js" integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7" crossorigin="anonymous"></script>
+	<script src="/static/js/admin/markdown.js"></script>
 	<script src="/static/js/admin/components/report_detail.js"></script>
 	@components.BreadcrumbNav(p.Breadcrumbs)
 	<div x-data="reportDetail" data-report-id={ p.Report.ID } data-is-read={ boolLiteral(p.Report.IsRead) } class="max-w-4xl">

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -31,6 +31,16 @@ templ TransactionDetail(p TransactionDetailProps) {
 	@templ.JSONScript("transaction-detail-data", p.Categories)
 	@templ.JSONScript("transaction-detail-available-tags", p.AvailableTags)
 	@templ.JSONScript("transaction-detail-current-tags", p.CurrentTags)
+	<!-- Markdown rendering for activity-timeline comment bubbles. The
+	     shared static/js/admin/markdown.js scanner runs marked +
+	     DOMPurify (same versions / SRI as report_detail.templ) over
+	     every [data-markdown] element on DOMContentLoaded, and
+	     transaction_detail.js calls window.bbRenderMarkdown(node) on
+	     each freshly-inserted timeline row so optimistic comment
+	     additions render markdown without a full reload. -->
+	<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
+	<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js" integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7" crossorigin="anonymous"></script>
+	<script src="/static/js/admin/markdown.js"></script>
 	<!-- Component factory. Loaded synchronously (no defer) so the
 	     Alpine.data() registrations run before Alpine — itself deferred from
 	     <head> — fires alpine:init. -->
@@ -558,7 +568,18 @@ templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 		}
 	</div>
 	if e.Detail != "" {
-		<div class="bb-comment-bubble mt-1">{ e.Detail }</div>
+		<!--
+			Markdown rendering: the bubble div ships with the raw
+			markdown source in data-markdown and is rewritten by the
+			shared static/js/admin/markdown.js scanner (loaded at the
+			top of the page) on DOMContentLoaded. Optimistic inserts
+			from transaction_detail.js call window.bbRenderMarkdown(
+			newRow) so freshly-added comments render without a reload.
+			data-markdown-breaks="true" makes single newlines render as
+			<br>, matching the chat-style expectation users have when
+			typing in the composer.
+		-->
+		<div class="bb-comment-bubble mt-1" data-markdown={ e.Detail } data-markdown-breaks="true"></div>
 	}
 }
 
@@ -645,6 +666,10 @@ templ txdComposerCard(p TransactionDetailProps) {
 				>
 					<span x-text="newComment.length"></span>/<span x-text="maxLength"></span>
 				</span>
+			</span>
+			<span class="hidden sm:inline-flex items-center gap-1 text-[11px] text-base-content/40" title="Markdown is supported (bold, italic, lists, links, code).">
+				<i data-lucide="markdown" class="w-3.5 h-3.5" aria-hidden="true"></i>
+				<span>Markdown supported</span>
 			</span>
 			<!--
 				Toggle visibility is bound to `hasPendingReview` (initialized

--- a/static/js/admin/components/report_detail.js
+++ b/static/js/admin/components/report_detail.js
@@ -4,10 +4,12 @@
 // Initial scalar state (report ID + is-read flag) flows in via data-*
 // attributes on the x-data root and is read in init().
 //
-// The DOMContentLoaded listener at the bottom runs DOMPurify.sanitize(
-// marked.parse(body)) over each `.bb-report-body` element and rewrites
-// external links to open in a new tab. It depends on the marked and
-// dompurify CDN scripts loaded as siblings of this file in the templ.
+// Markdown rendering for the body lives in the shared
+// static/js/admin/markdown.js scanner (loaded as a sibling script in
+// report_detail.templ). It picks up the `.bb-report-body[data-markdown]`
+// element on DOMContentLoaded and runs marked + DOMPurify with the
+// shared link/table/last-child enhancements. This file is now purely
+// the Alpine factory for the toolbar (mark-read, copy-link, toast).
 document.addEventListener('alpine:init', function () {
   Alpine.data('reportDetail', function () {
     return {
@@ -56,27 +58,3 @@ document.addEventListener('alpine:init', function () {
   });
 });
 
-// External-link targeting only — styling lives in .bb-report-body (input.css).
-document.addEventListener('DOMContentLoaded', function () {
-  document.querySelectorAll('.bb-report-body').forEach(function (el) {
-    var md = el.getAttribute('data-markdown');
-    if (!md) return;
-    el.innerHTML = DOMPurify.sanitize(marked.parse(md));
-    el.querySelectorAll('a').forEach(function (a) {
-      var href = a.getAttribute('href') || '';
-      if (a.href && !a.href.startsWith(window.location.origin) && !href.startsWith('/')) {
-        a.setAttribute('target', '_blank');
-        a.setAttribute('rel', 'noopener');
-      }
-    });
-    el.querySelectorAll('table').forEach(function (t) {
-      if (t.parentNode && t.parentNode.classList && t.parentNode.classList.contains('bb-report-table-wrap')) return;
-      var wrap = document.createElement('div');
-      wrap.className = 'bb-report-table-wrap';
-      t.parentNode.insertBefore(wrap, t);
-      wrap.appendChild(t);
-    });
-    var lastChild = el.lastElementChild;
-    if (lastChild) lastChild.classList.add('!mb-0');
-  });
-});

--- a/static/js/admin/components/transaction_detail.js
+++ b/static/js/admin/components/transaction_detail.js
@@ -278,6 +278,15 @@ function fetchTimelineRows(txId, replaceCommentIDs, opts) {
       if (window.lucide && typeof window.lucide.createIcons === 'function') {
         window.lucide.createIcons();
       }
+      // Render markdown inside any freshly-inserted comment bubbles.
+      // The shared scanner is loaded as a sibling script in
+      // transaction_detail.templ; it auto-runs on DOMContentLoaded for
+      // server-rendered rows but optimistic inserts (and tombstone
+      // swaps) bypass that, so we re-scan each new node here. Idempotent
+      // — already-rendered bubbles carry data-markdown-rendered="1".
+      if (typeof window.bbRenderMarkdown === 'function') {
+        nodes.forEach(function (n) { window.bbRenderMarkdown(n); });
+      }
       return inserted;
     });
 }

--- a/static/js/admin/markdown.js
+++ b/static/js/admin/markdown.js
@@ -1,0 +1,86 @@
+// Shared markdown rendering for any element carrying `data-markdown="..."`.
+//
+// Used by:
+//   - /reports/{id}              -> .bb-report-body (full-page markdown)
+//   - /transactions/{id}         -> .bb-comment-bubble (annotation comments)
+//
+// Loaded as a sibling of marked + DOMPurify CDN scripts. Auto-runs on
+// DOMContentLoaded and exposes `window.bbRenderMarkdown(root)` so pages
+// that mutate the DOM after load (e.g. transaction_detail.js inserting
+// freshly-fetched timeline rows) can re-process newly-inserted nodes
+// without a full reload.
+//
+// Per-element opt-ins via data-* attributes:
+//   data-markdown-breaks="true"  -> marked `breaks: true` (single newlines
+//                                    become <br>) — friendlier for chat-style
+//                                    user comments.
+//
+// Behavior applied to every rendered block:
+//   - DOMPurify.sanitize() guards against XSS in untrusted input.
+//   - External links get target="_blank" + rel="noopener" so leaving the
+//     admin doesn't lose the user's spot.
+//   - <table> elements are wrapped in .bb-report-table-wrap for horizontal
+//     scrolling on narrow viewports.
+//   - The last block-level child gets `!mb-0` so the container's bottom
+//     padding stays even (no double gap from a trailing <p class="mb-3">).
+//
+// Idempotent: an element with `data-markdown-rendered="1"` is skipped on
+// subsequent passes, so calling `bbRenderMarkdown(document)` multiple
+// times after partial updates is safe.
+(function () {
+  function renderOne(el) {
+    if (!el || el.dataset.markdownRendered === '1') return;
+    var md = el.getAttribute('data-markdown');
+    if (md === null) return;
+    if (typeof marked === 'undefined' || typeof DOMPurify === 'undefined') return;
+
+    var opts = {};
+    if (el.dataset.markdownBreaks === 'true') opts.breaks = true;
+
+    var html;
+    try {
+      html = DOMPurify.sanitize(marked.parse(md, opts));
+    } catch (e) {
+      // Fall back to a pre-wrapped escaped block so the user still sees
+      // their content even if marked/DOMPurify barf on edge-case input.
+      html = '<pre style="white-space:pre-wrap">' +
+        md.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') +
+        '</pre>';
+    }
+    el.innerHTML = html;
+    el.dataset.markdownRendered = '1';
+
+    el.querySelectorAll('a').forEach(function (a) {
+      var href = a.getAttribute('href') || '';
+      if (a.href && !a.href.startsWith(window.location.origin) && !href.startsWith('/')) {
+        a.setAttribute('target', '_blank');
+        a.setAttribute('rel', 'noopener');
+      }
+    });
+
+    el.querySelectorAll('table').forEach(function (t) {
+      if (t.parentNode && t.parentNode.classList && t.parentNode.classList.contains('bb-report-table-wrap')) return;
+      var wrap = document.createElement('div');
+      wrap.className = 'bb-report-table-wrap';
+      t.parentNode.insertBefore(wrap, t);
+      wrap.appendChild(t);
+    });
+
+    var lastChild = el.lastElementChild;
+    if (lastChild) lastChild.classList.add('!mb-0');
+  }
+
+  function renderAll(root) {
+    var scope = root || document;
+    // Include the root itself when it carries data-markdown.
+    if (scope.nodeType === 1 && scope.hasAttribute && scope.hasAttribute('data-markdown')) {
+      renderOne(scope);
+    }
+    if (typeof scope.querySelectorAll !== 'function') return;
+    scope.querySelectorAll('[data-markdown]').forEach(renderOne);
+  }
+
+  window.bbRenderMarkdown = renderAll;
+
+  document.addEventListener('DOMContentLoaded', function () { renderAll(document); });
+})();


### PR DESCRIPTION
Extract the marked + DOMPurify pipeline used by /reports into a shared
static/js/admin/markdown.js scanner that processes any element carrying
data-markdown="...". Both /reports/{id} (.bb-report-body) and the
transaction-detail activity timeline (.bb-comment-bubble) now go through
the same renderer, so users can write **bold**, lists, code, blockquotes,
and links in transaction comments and see them styled like reports.

- markdown.js auto-runs on DOMContentLoaded and exposes
  window.bbRenderMarkdown(node) for optimistic-update paths;
  transaction_detail.js calls it after each freshly-inserted timeline row
  so newly-posted comments render without a reload. Idempotent via
  data-markdown-rendered="1".
- Comments opt into chat-style soft breaks via data-markdown-breaks="true"
  (single newlines -> <br>); reports keep the default behavior.
- bb-comment-bubble CSS gains markdown element rules tuned to the bubble's
  compact scale (tighter paragraph margins, smaller code blocks). Drops
  white-space: pre-wrap since markdown handles whitespace now.
- Composer footer shows a "Markdown supported" hint on >=sm screens.

https://claude.ai/code/session_0188vYxyjZ6TNQHRDVFvGXM3