### PR TITLE
fix(activity-timeline): composer surface, sync icon, mobile composer toolbar

### DIFF
--- a/input.css
+++ b/input.css
@@ -2774,12 +2774,30 @@
 
 /* Rail mask. The 28px tile bg + ring are still painted with base-100
  * (card-surface) classes by the shared row markup — redirect both to
- * base-200 here so the seam stays invisible against the page surface. */
-.bb-timeline-prominent .bg-base-100 {
+ * base-200 here so the seam stays invisible against the page surface.
+ * Selectors are scoped to the rail-mask wrapper (`> li > div:first-child`)
+ * and its descendants so the remap doesn't bleed into other elements
+ * inside the section that legitimately want a base-100 surface — e.g.
+ * the comment composer card, whose `bg-base-100` would otherwise blend
+ * into the base-200 page and erase the entire composer chrome. */
+.bb-timeline-prominent .bb-timeline > li > div:first-child.bg-base-100 {
   background-color: var(--color-base-200);
 }
-.bb-timeline-prominent .ring-base-100 {
+.bb-timeline-prominent .bb-timeline > li > div:first-child .ring-base-100,
+.bb-timeline-prominent .bb-timeline > li > div:first-child.ring-base-100 {
   --tw-ring-color: var(--color-base-200);
+}
+/* Inner tile pills painted `bg-base-200` (sync, deleted-comment trash,
+ * neutral review, unknown-kind fallback) match the base-200 page surface
+ * in prominent mode and disappear. Lift the fill to base-300 so the
+ * circle reads as a defined shape on the rail. Targets only direct
+ * children of the rail-mask wrapper so the inner lucide icon's color
+ * isn't touched. Comment rows are excluded — their initials/image/agent
+ * avatars rely on the GitHub-style 1px base-300 outline below (added in
+ * #927) instead of a fill bump, since the fill approach didn't help
+ * image avatars that already carry their own background. */
+.bb-timeline-prominent .bb-timeline > li:not(:has(.bb-comment-bubble)) > div:first-child > .bg-base-200 {
+  background-color: var(--color-base-300);
 }
 /* Slightly thicker ring for the bigger tile so the colour pill reads
  * cleanly against the rail. */
@@ -2875,9 +2893,15 @@
 }
 
 /* Composer row gets the same outer card treatment as comment rows so
- * the page reads as one continuous conversation. */
+ * the page reads as one continuous conversation. The composer card
+ * carries `border-base-200` from the templ markup (matches the lighter
+ * card-mode chrome); against a base-200 page surface that border is
+ * invisible from outside the card, so lift it to base-300 here to give
+ * the composer a defined edge — same treatment the comment cards above
+ * already use. */
 .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 > [data-composer-anchor] {
   border-radius: 0.5rem;
+  border-color: var(--color-base-300);
 }
 .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 {
   position: relative;

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -665,10 +665,11 @@ templ txdComposerCard(p TransactionDetailProps) {
 				x-cloak
 			>
 				<input type="checkbox" class="checkbox checkbox-xs checkbox-primary" x-model="pinReview"/>
-				<span class="text-xs font-medium">
-					<span class="sm:hidden">Add Needs Review</span>
-					<span class="hidden sm:inline">Add Needs Review</span>
-				</span>
+				<!-- Mobile drops the label entirely so the toolbar fits the
+				     390px composer width. The checkbox + :title tooltip carry
+				     the affordance; the desktop label restores the full text
+				     once horizontal room opens up at sm. -->
+				<span class="text-xs font-medium hidden sm:inline">Add Needs Review</span>
 			</label>
 			<button
 				@click="addComment()"
@@ -678,7 +679,12 @@ templ txdComposerCard(p TransactionDetailProps) {
 			>
 				<i data-lucide="message-square" class="w-3.5 h-3.5" x-show="!pinReview" aria-hidden="true"></i>
 				<i data-lucide="message-square-x" class="w-3.5 h-3.5" x-show="pinReview" x-cloak aria-hidden="true"></i>
-				<span class="text-xs font-medium" x-text="pinReview ? 'Comment and tag' : 'Comment'"></span>
+				<!-- Two spans share the same Alpine state so the wording can
+				     shrink on mobile ("Comment + tag") while the desktop copy
+				     stays explicit ("Comment and tag"). Splitting at sm keeps
+				     the toolbar within the composer width on a 390px viewport. -->
+				<span class="text-xs font-medium sm:hidden" x-text="pinReview ? 'Comment + tag' : 'Comment'"></span>
+				<span class="text-xs font-medium hidden sm:inline" x-text="pinReview ? 'Comment and tag' : 'Comment'"></span>
 				<span class="hidden sm:inline ml-0.5 text-[10px] opacity-70 border border-current/30 rounded px-1 leading-none py-0.5" x-show="!$store.device.isTouch">⌘↵</span>
 			</button>
 		</div>


### PR DESCRIPTION
## Summary

Three small visual regressions on the prominent (transaction-detail) variant of the activity timeline introduced in the GitHub-style promotion stack (#922 / #927):

1. **Comment composer card invisible** against the page surface in prominent mode.
2. **Sync icon tiles** (and other neutral system tiles) disappear on the rail.
3. **Composer toolbar overflows** at the 390px mobile breakpoint.

## Bugs

### 1. Composer card has no visible surface

The rail-mask remap

```css
.bb-timeline-prominent .bg-base-100 { background-color: var(--color-base-200); }
.bb-timeline-prominent .ring-base-100 { --tw-ring-color: var(--color-base-200); }
```

was authored to repaint only the per-row outer rail-mask wrapper so the seam stays invisible against the base-200 page surface. But `.bb-timeline-prominent .bg-base-100` is a plain descendant selector — it also matches the composer card:

```html
<div data-composer-anchor class="rounded-2xl rounded-tl-md border border-base-200 bg-base-100 ...">
```

so the entire composer surface gets repainted base-200 (= page bg) and merges with the page. Combined with the composer's existing `border-base-200` (also matching the page), there's no visible card from outside.

**Fix:** scope both remaps to the rail-mask wrapper (`> li > div:first-child` and its descendants) so they don't bleed into other elements that legitimately want a `bg-base-100` surface. Also lift the composer's outer `border-base-200` to base-300 in prominent mode — same treatment the comment cards above already use — so the composer reads as a defined card from the page side.

### 2. Sync (and other neutral) icon tiles invisible

`txdSystemIcon` paints sync, deleted-comment trash, neutral review, and the unknown-kind fallback with `bg-base-200`:

```html
<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
  <i data-lucide="landmark" ...></i>
</span>
```

In prominent mode every layer of that pill is base-200:
- the page surface IS base-200,
- `ring-base-100` is remapped to base-200,
- the `box-shadow: 0 0 0 5px var(--color-base-200)` halo is base-200,
- the inner fill itself is `bg-base-200`.

So the entire circle blends into the surrounding page and you see only the lucide glyph floating mid-rail. The `landmark` sync icon was the most obvious case.

**Fix:** lift the inner pill `bg-base-200` to `bg-base-300` for non-comment rows in prominent mode. The fix is scoped to direct children of the rail-mask wrapper (`> div:first-child > .bg-base-200`) so the inner lucide icon's color isn't touched. Comment rows are excluded — their initials/image/agent avatars rely on the GitHub-style 1px `base-300` outline added in #927 instead of a fill bump (the fill-bump approach was rejected then because it doesn't help image/agent avatars that already carry their own bg).

### 3. Composer toolbar overflows at 390px

The composer's bottom toolbar has

```html
<span class="text-xs font-medium">
  <span class="sm:hidden">Add Needs Review</span>           <!-- mobile -->
  <span class="hidden sm:inline">Add Needs Review</span>    <!-- desktop -->
</span>
...
<span class="text-xs font-medium" x-text="pinReview ? 'Comment and tag' : 'Comment'"></span>
```

The mobile and desktop spans render the same "Add Needs Review" label (copy-paste leftover from a refactor — the mobile branch was meant to be shorter), and the "Comment and tag" button uses the longest variant on every breakpoint. At a 390px viewport the composer's content width is roughly `390 - main(p-4) - timeline(pl-4) - rail-tile - composer-padding ≈ 300px`, which can't fit Counter (~50) + "Add Needs Review" btn (~150) + "Comment and tag" btn (~130).

**Fix:**
- Drop the "Add Needs Review" label entirely on mobile — the checkbox + `:title` tooltip carry the affordance once horizontal room runs out.
- Split the button `x-text` into two spans bound to the same Alpine state: `"Comment + tag"` on mobile, `"Comment and tag"` at sm+.

## Why no screenshots

I'm running in a remote Claude Code on the web session where the Chrome DevTools MCP plugin isn't loaded — `mcp__plugin_chrome-devtools-mcp_chrome-devtools__*` tools are listed as allowed in `.claude/settings.json` but ToolSearch can't surface them in this environment. As compensation, I:

- Booted the dev server against the test DB, seeded a transaction with comment + sync_started + sync_updated annotations, logged in via curl, and verified the rendered HTML through the new code path matches the templ source on both the system tiles (`bg-base-200 ring-base-100`) and the composer (`bg-base-100 border-base-200`).
- Inspected the compiled CSS in `static/css/styles.css` to confirm every new selector lands at the expected unlayered specificity:

```css
.bb-timeline-prominent .bb-timeline>li>div:first-child.bg-base-100 { background-color:var(--color-base-200) }
.bb-timeline-prominent .bb-timeline>li>div:first-child .ring-base-100 { --tw-ring-color:var(--color-base-200) }
.bb-timeline-prominent .bb-timeline>li:not(:has(.bb-comment-bubble))>div:first-child>.bg-base-200 { background-color:var(--color-base-300) }
.bb-timeline-prominent .bb-timeline>li:has([data-composer-anchor])>div.flex-1>[data-composer-anchor] { border-color:var(--color-base-300); border-radius:.5rem }
```

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.

## Test plan

- [ ] Open `/transactions/{id}` on a transaction with comment + sync annotations on a 1280×800 desktop viewport — composer card has a visible base-300 border and base-100 surface against the base-200 page; sync `landmark` tile reads as a base-300 circle on the rail.
- [ ] Same page at 390×844 mobile — toolbar fits inside the composer width (Counter, [☑] checkbox-only, "Comment + tag" button), no horizontal overflow.
- [ ] Toggle the "Needs Review" checkbox at desktop sm+ — label still says "Add Needs Review", button switches between "Comment" / "Comment and tag".
- [ ] Confirm the comment-row avatar treatment is unchanged (still using the 1px `base-300` outline from #927, not a fill bump).
- [ ] Both light and dark mode look right.

https://claude.ai/code/session_014pJGzTo3ah8SotB6MkdHVi

---
_Generated by [Claude Code](https://claude.ai/code/session_014pJGzTo3ah8SotB6MkdHVi)_