### PR TITLE
fix(activity-timeline): mobile-friendly annotation rows + composer

### DIFF
--- a/input.css
+++ b/input.css
@@ -2971,3 +2971,68 @@
   border-width: 8px 8px 8px 0;
   border-color: transparent var(--color-base-100) transparent transparent;
 }
+
+/* ── Activity timeline — inline chip fix ──
+ * Tag chips (`.bb-tag`) inside timeline sentence bodies carry a `truncate`
+ * class on their inner text span. That class truncates chip labels when the
+ * parent container is narrow (min-w-0 flex-1). In the prominent timeline the
+ * chip is the primary informational element; truncation defeats its purpose.
+ * Override: let the chip text fully wrap / display at natural width inside
+ * system-event sentence bodies (non-comment, non-composer rows). */
+.bb-timeline-prominent .bb-timeline
+  > li:not(:has(.bb-comment-bubble)):not(:has([data-composer-anchor]))
+  > div.flex-1 .bb-tag span.truncate {
+  overflow: visible;
+  text-overflow: unset;
+  white-space: normal;
+}
+
+/* ── Activity timeline — mobile responsive fixes ──
+ * Fixes for narrow (≤639px) viewports where system-event sentences with
+ * inline chips, long rule names, and tag badges could overflow or look
+ * cramped. */
+
+/* System-event sentence bodies: allow inline chips + timestamp suffix to
+ * wrap naturally on narrow screens. The leading-6 line-box is preserved
+ * for single-line sentences (short actor names, brief verbs); multi-line
+ * wrap picks up normal 1.5 leading so content stays readable. */
+@media (max-width: 639px) {
+  .bb-timeline-prominent .bb-timeline > li > div.flex-1.text-xs {
+    line-height: 1.5; /* relax from 1.75rem (28px) to 1.5 on mobile */
+  }
+
+  /* Timestamp/origin suffix: break onto its own line after the sentence
+   * body on very narrow viewports. The suffix `<span>` has ml-1 from the
+   * templ markup; on mobile we push it to a new pseudo-line so it doesn't
+   * tuck tightly against the last word of the sentence when the sentence
+   * has already wrapped. */
+  .bb-timeline-prominent .bb-timeline
+    > li:not(:has(.bb-comment-bubble)):not(:has([data-composer-anchor]))
+    > div.flex-1 > span:last-child {
+    display: block;
+    margin-left: 0;
+    margin-top: 0.125rem;
+  }
+
+  /* Composer card textarea: slightly smaller min-height on mobile so the
+   * keyboard doesn't immediately scroll the page when tapping to type. */
+  .bb-timeline-prominent .bb-timeline
+    > li:has([data-composer-anchor]) textarea {
+    min-height: 4rem;
+  }
+}
+
+/* Comment rows: on mobile the delete button should always be visible (not
+ * sm:opacity-0 hidden-until-hover). The templ markup hides it with
+ * sm:opacity-0 which means it's visible on mobile by default already —
+ * but ensure the tap target is large enough. */
+@media (max-width: 639px) {
+  .bb-timeline-prominent .bb-timeline
+    > li:has(.bb-comment-bubble) > div.flex-1 > div:first-child button {
+    min-width: 2rem;
+    min-height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -554,19 +554,24 @@ templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 		baseline sits dead-center on the rail circle. Keeping every
 		label at text-xs / leading-6 also matches the system-event
 		rows above for a uniform actor + timestamp treatment.
+
+		On mobile: min-w-0 + overflow-hidden keep the actor name from
+		pushing the delete button off-screen. The delete button uses
+		shrink-0 so it never collapses. At sm+ ml-auto pushes it to the
+		far right; on mobile it follows naturally after the timestamp.
 	-->
-	<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6">
+	<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6 min-w-0">
 		if e.ActorName != "" {
-			<strong class="font-semibold text-base-content">{ e.ActorName }</strong>
+			<strong class="font-semibold text-base-content truncate min-w-0 max-w-[10rem] sm:max-w-none">{ e.ActorName }</strong>
 		}
-		<span class="text-base-content/55">commented</span>
+		<span class="text-base-content/55 shrink-0">commented</span>
 		if e.Timestamp != "" {
-			<span class="tooltip tooltip-top" data-tip={ formatDateTimeStr(e.Timestamp) }>
+			<span class="tooltip tooltip-top shrink-0" data-tip={ formatDateTimeStr(e.Timestamp) }>
 				<time datetime={ e.Timestamp } class="text-base-content/40 tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ formatDateTimeStr(e.Timestamp) }>{ relativeTimeStrAt(e.Timestamp, now) }</time>
 			</span>
 		}
 		if e.CommentID != "" {
-			<button class="ml-auto rounded-md p-1 -m-1 text-base-content/30 hover:text-error hover:bg-error/5 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 transition" @click={ "deleteComment('" + e.CommentID + "')" } aria-label={ "Delete comment by " + e.ActorName } title="Delete comment">
+			<button class="shrink-0 sm:ml-auto rounded-md p-1 -m-1 text-base-content/30 hover:text-error hover:bg-error/5 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 transition" @click={ "deleteComment('" + e.CommentID + "')" } aria-label={ "Delete comment by " + e.ActorName } title="Delete comment">
 				<i data-lucide="trash-2" class="w-3.5 h-3.5" aria-hidden="true"></i>
 			</button>
 		}
@@ -661,57 +666,73 @@ templ txdComposerCard(p TransactionDetailProps) {
 			aria-describedby="bb-txd-comment-counter"
 			class="block w-full text-sm bg-transparent border-0 focus:outline-none focus:ring-0 resize-none leading-6 px-3 py-2.5 min-h-[5rem] max-h-48 whitespace-pre-wrap break-words"
 		></textarea>
-		<div class="px-3 py-2 bg-base-200/40 border-t border-base-200 flex items-center gap-2 min-h-[2.5rem]">
-			<span class="text-[11px] text-base-content/40 tabular-nums">
-				<span
-					id="bb-txd-comment-counter"
-					:class="{ 'text-warning': counterState() === 'warn', 'text-error font-medium': counterState() === 'error', 'invisible': newComment.length === 0 }"
-					aria-live="polite"
-				>
-					<span x-text="newComment.length"></span>/<span x-text="maxLength"></span>
+		<!--
+			Toolbar: two rows on mobile, one row on sm+.
+			Row 1 (mobile-only): char counter + Markdown hint on left,
+			  pin-review checkbox on right.
+			Row 2: Submit button full-width on mobile, auto-width on sm+.
+			On sm+ everything collapses back to a single flex row.
+		-->
+		<div class="px-3 py-2 bg-base-200/40 border-t border-base-200 min-h-[2.5rem]">
+			<!-- Top sub-row: meta + pin-review toggle -->
+			<div class="flex items-center gap-2">
+				<span class="text-[11px] text-base-content/40 tabular-nums">
+					<span
+						id="bb-txd-comment-counter"
+						:class="{ 'text-warning': counterState() === 'warn', 'text-error font-medium': counterState() === 'error', 'invisible': newComment.length === 0 }"
+						aria-live="polite"
+					>
+						<span x-text="newComment.length"></span>/<span x-text="maxLength"></span>
+					</span>
 				</span>
-			</span>
-			<span class="hidden sm:inline-flex items-center gap-1 text-[11px] text-base-content/40" title="Markdown is supported (bold, italic, lists, links, code).">
-				<i data-lucide="markdown" class="w-3.5 h-3.5" aria-hidden="true"></i>
-				<span>Markdown supported</span>
-			</span>
-			<!--
-				Toggle visibility is bound to `hasPendingReview` (initialized
-				from data-has-pending-review) so the timeline-driven
-				bb-needs-review-changed event can hide/show the affordance
-				without a page reload — see static/js/admin/components/transaction_detail.js.
-				`x-cloak` keeps the label hidden during initial Alpine boot
-				when the txn already has the tag.
-			-->
-			<label
-				class="ml-auto btn btn-sm btn-ghost rounded-md gap-2 cursor-pointer transition-all duration-200"
-				:title="pinReview ? 'Posting will also tag this transaction needs-review (Shift+R)' : 'Also tag needs-review when posting (Shift+R)'"
-				x-show="!hasPendingReview"
-				x-cloak
-			>
-				<input type="checkbox" class="checkbox checkbox-xs checkbox-primary" x-model="pinReview"/>
-				<!-- Mobile drops the label entirely so the toolbar fits the
-				     390px composer width. The checkbox + :title tooltip carry
-				     the affordance; the desktop label restores the full text
-				     once horizontal room opens up at sm. -->
-				<span class="text-xs font-medium hidden sm:inline">Add Needs Review</span>
-			</label>
-			<button
-				@click="addComment()"
-				class="btn btn-sm btn-primary rounded-md gap-1.5"
-				:class="{ 'ml-auto': hasPendingReview }"
-				:disabled="!canSubmit()"
-			>
-				<i data-lucide="message-square" class="w-3.5 h-3.5" x-show="!pinReview" aria-hidden="true"></i>
-				<i data-lucide="message-square-x" class="w-3.5 h-3.5" x-show="pinReview" x-cloak aria-hidden="true"></i>
-				<!-- Two spans share the same Alpine state so the wording can
-				     shrink on mobile ("Comment + tag") while the desktop copy
-				     stays explicit ("Comment and tag"). Splitting at sm keeps
-				     the toolbar within the composer width on a 390px viewport. -->
-				<span class="text-xs font-medium sm:hidden" x-text="pinReview ? 'Comment + tag' : 'Comment'"></span>
-				<span class="text-xs font-medium hidden sm:inline" x-text="pinReview ? 'Comment and tag' : 'Comment'"></span>
-				<span class="hidden sm:inline ml-0.5 text-[10px] opacity-70 border border-current/30 rounded px-1 leading-none py-0.5" x-show="!$store.device.isTouch">⌘↵</span>
-			</button>
+				<span class="hidden sm:inline-flex items-center gap-1 text-[11px] text-base-content/40" title="Markdown is supported (bold, italic, lists, links, code).">
+					<i data-lucide="markdown" class="w-3.5 h-3.5" aria-hidden="true"></i>
+					<span>Markdown supported</span>
+				</span>
+				<!--
+					Toggle visibility is bound to `hasPendingReview` (initialized
+					from data-has-pending-review) so the timeline-driven
+					bb-needs-review-changed event can hide/show the affordance
+					without a page reload — see static/js/admin/components/transaction_detail.js.
+					`x-cloak` keeps the label hidden during initial Alpine boot
+					when the txn already has the tag.
+				-->
+				<label
+					class="ml-auto btn btn-sm btn-ghost rounded-md gap-1.5 cursor-pointer transition-all duration-200 sm:gap-2"
+					:title="pinReview ? 'Posting will also tag this transaction needs-review (Shift+R)' : 'Also tag needs-review when posting (Shift+R)'"
+					x-show="!hasPendingReview"
+					x-cloak
+				>
+					<input type="checkbox" class="checkbox checkbox-xs checkbox-primary" x-model="pinReview"/>
+					<!-- Mobile: shorter label to fit 390px. Desktop: full text. -->
+					<span class="text-xs font-medium sm:hidden" x-text="pinReview ? 'Pin review' : 'Needs review?'"></span>
+					<span class="text-xs font-medium hidden sm:inline">Add Needs Review</span>
+				</label>
+				<!-- Submit button: inline with meta on sm+; appears below on mobile via the sibling div -->
+				<button
+					@click="addComment()"
+					class="hidden sm:inline-flex btn btn-sm btn-primary rounded-md gap-1.5"
+					:class="{ 'ml-auto': hasPendingReview }"
+					:disabled="!canSubmit()"
+				>
+					<i data-lucide="message-square" class="w-3.5 h-3.5" x-show="!pinReview" aria-hidden="true"></i>
+					<i data-lucide="message-square-x" class="w-3.5 h-3.5" x-show="pinReview" x-cloak aria-hidden="true"></i>
+					<span class="text-xs font-medium" x-text="pinReview ? 'Comment and tag' : 'Comment'"></span>
+					<span class="ml-0.5 text-[10px] opacity-70 border border-current/30 rounded px-1 leading-none py-0.5" x-show="!$store.device.isTouch">⌘↵</span>
+				</button>
+			</div>
+			<!-- Mobile-only submit row: full-width button below the meta line -->
+			<div class="flex sm:hidden mt-2">
+				<button
+					@click="addComment()"
+					class="btn btn-sm btn-primary rounded-md gap-1.5 w-full justify-center"
+					:disabled="!canSubmit()"
+				>
+					<i data-lucide="message-square" class="w-3.5 h-3.5" x-show="!pinReview" aria-hidden="true"></i>
+					<i data-lucide="message-square-x" class="w-3.5 h-3.5" x-show="pinReview" x-cloak aria-hidden="true"></i>
+					<span class="text-xs font-medium" x-text="pinReview ? 'Comment + tag' : 'Comment'"></span>
+				</button>
+			</div>
 		</div>
 	</div>
 }


### PR DESCRIPTION
## Summary

Fixes mobile rendering of the activity timeline on the transaction detail page. On narrow viewports (≤639 px / iPhone-class), system-event sentences with inline tag chips could truncate chip labels or overflow; the composer toolbar's single-row layout caused the char counter, pin-review toggle, and submit button to collide; and comment-row header elements (actor name, delete button) could be pushed off-screen. The changes add targeted CSS overrides in `input.css` and rework the `.templ` markup to use `min-w-0`, `shrink-0`, `truncate`, and a two-sub-row toolbar layout that collapses back to the existing single-row design at `sm+`.

## Changes
- `input.css`: override `truncate` on `.bb-tag span` inside system-event rows so chip labels fully display; relax `line-height` and break timestamp suffixes to their own line on mobile; shrink textarea `min-height` on mobile; ensure comment delete buttons have a 2rem minimum tap target
- `transaction_detail.templ`: add `min-w-0` to comment-bubble header flex container; cap actor name with `max-w-[10rem] sm:max-w-none truncate`; mark "commented" text and timestamp tooltip as `shrink-0`; change delete button from `ml-auto` to `shrink-0 sm:ml-auto` so it stays visible on narrow screens; refactor composer toolbar into two sub-rows (meta + pin-review toggle on top, submit button below) that reflow cleanly on mobile while preserving the sm+ single-row layout; shorten pin-review label on mobile, full text on sm+

## Test plan
- [ ] Validate at iPhone (390×844), Tablet (768×1024), Desktop (1440×900) before merging
- [ ] Confirm activity timeline contract preserved (dedup, soft-delete, optimistic updates) per docs/activity-timeline.md
- [ ] Check composer: char counter, Markdown hint, pin-review toggle, and submit button all visible and functional at 390 px
- [ ] Check comment rows: actor name truncates gracefully; delete button visible and tappable at 390 px

> Note: Screenshots not yet attached — this PR was opened from a partial agent run in the mobile-responsiveness sprint. A follow-up will attach before/after screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
