### PR TITLE
fix(transactions): tighter mobile rows with expand-to-reveal detail

### DIFF
--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -62,10 +62,14 @@ templ TxRow(tx service.AdminTransactionRow) {
 				<div class="flex items-center gap-2">
 					<a href={ templ.URL("/transactions/" + tx.ID) } @click.stop class="font-medium text-sm hover:text-primary transition-colors truncate">{ tx.Name }</a>
 				</div>
-				<div class="flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 min-w-0">
+				<!-- Meta line: hidden on mobile (<sm) — only visible sm+.
+				     On mobile the expand panel shows account/category/date.
+				     On sm+ we show account + compact category (below xl) or
+				     the inline category picker handles it (xl+). -->
+				<div class="hidden sm:flex items-center gap-1.5 mt-0.5 text-xs text-base-content/40 min-w-0">
 					if tx.UserName != "" {
-						<!-- Avatar renders at every breakpoint so owner identity survives
-						     on mobile without eating space with a truncated first word. -->
+						<!-- Avatar renders at sm+ breakpoints so owner identity survives
+						     on tablet/desktop without eating space on narrow phones. -->
 						if tx.EffectiveUserID != nil {
 							<img src={ avatarURL(deref(tx.EffectiveUserID)) } alt="" class="w-4 h-4 rounded-full object-cover shrink-0" title={ tx.UserName }/>
 						} else {
@@ -97,7 +101,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 							}
 						}
 					</span>
-					<!-- Compact tag indicator (below xl): tag icon + count pill. -->
+					<!-- Compact tag indicator (sm–xl): tag icon + count pill. -->
 					if len(tx.Tags) > 0 {
 						<span
 							class="xl:hidden inline-flex items-center gap-0.5 text-base-content/40 shrink-0"
@@ -109,7 +113,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 							<span class="text-[0.65rem] tabular-nums font-medium" data-tx-tag-count>{ strconv.Itoa(len(tx.Tags)) }</span>
 						</span>
 					}
-					<!-- Compact category label (below xl). Separator stays inside the
+					<!-- Compact category label (sm–xl). Separator stays inside the
 					     conditional so it never orphans when the meta line is empty. -->
 					if tx.CategoryDisplayName != nil {
 						<span class="xl:hidden text-base-content/20 shrink-0">&middot;</span>
@@ -122,6 +126,33 @@ templ TxRow(tx service.AdminTransactionRow) {
 					} else {
 						<span class="xl:hidden text-base-content/20 shrink-0">&middot;</span>
 						<span class="xl:hidden text-base-content/25 truncate shrink-0">Uncategorized</span>
+					}
+				</div>
+				<!-- Mobile-only sub-line (<sm): date + category dot.
+				     Keeps the row informative on iPhone without crowding the name. -->
+				<div class="flex sm:hidden items-center gap-1.5 mt-0.5 text-xs text-base-content/40 overflow-hidden">
+					<span class="tabular-nums text-base-content/35 shrink-0 whitespace-nowrap">{ formatDate(tx.Date) }</span>
+					if tx.CategoryDisplayName != nil {
+						<span class="text-base-content/20">&middot;</span>
+						<span class="inline-flex items-center gap-1 min-w-0">
+							if tx.CategoryColor != nil {
+								<span class="w-1.5 h-1.5 rounded-full shrink-0" style={ "background-color: " + deref(tx.CategoryColor) }></span>
+							}
+							<span class="text-base-content/50 truncate">{ deref(tx.CategoryDisplayName) }</span>
+						</span>
+					}
+					if len(tx.Tags) > 0 {
+						<span class="text-base-content/20">&middot;</span>
+						<span class="inline-flex items-center gap-0.5 text-base-content/40 shrink-0" title={ fmt.Sprintf("%d tag%s", len(tx.Tags), pluralS(len(tx.Tags))) }>
+							<i data-lucide="tag" class="w-3 h-3"></i>
+							<span class="text-[0.65rem] tabular-nums font-medium">{ strconv.Itoa(len(tx.Tags)) }</span>
+						</span>
+					}
+					if tx.AgentReviewed {
+						<span class="text-base-content/20">&middot;</span>
+						<span class="inline-flex items-center gap-0.5 text-primary/60 shrink-0" title="Categorized by AI agent">
+							<i data-lucide="bot" class="w-3 h-3"></i>
+						</span>
 					}
 				</div>
 			</div>
@@ -161,7 +192,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 			     against the amount and soften the glyph (bb-tx-amount pending
 			     modifier). The flex+justify-end layout keeps the right edge
 			     locked and the row height stable across pending and settled. -->
-			<div class="w-20 sm:w-24 shrink-0 pl-2 sm:pl-3 flex items-center justify-end gap-1">
+			<div class="w-20 sm:w-24 shrink-0 pl-0 sm:pl-3 flex items-center justify-end gap-1">
 				if tx.Pending {
 					<i
 						data-lucide="clock"
@@ -200,20 +231,26 @@ templ TxRow(tx service.AdminTransactionRow) {
 		     actual content. -->
 		<div
 			class="overflow-hidden transition-[max-height] duration-200 ease-out"
-			:class="expanded ? 'max-h-64' : 'max-h-0'"
+			:class="expanded ? 'max-h-80' : 'max-h-0'"
 			aria-hidden="!expanded"
 		>
 			<div class="transition-opacity duration-150" :class="expanded ? 'opacity-100' : 'opacity-0'">
 				<div class="border-t border-base-300/50 bg-base-200/20 px-4 py-3">
 					<div class="flex flex-col sm:flex-row sm:items-start gap-4">
 						<div class="flex flex-wrap gap-x-6 gap-y-2 text-xs">
+							<!-- Date: only shown in expand panel on mobile (<sm);
+							     on sm+ the date column in the row header already shows it. -->
+							<div class="sm:hidden">
+								<span class="text-base-content/30">Account</span>
+								<span class="text-base-content/60 ml-1.5">{ tx.AccountName }</span>
+							</div>
 							if tx.MerchantName != nil {
 								<div>
 									<span class="text-base-content/30">Merchant</span>
 									<span class="text-base-content/60 ml-1.5">{ titleCase(deref(tx.MerchantName)) }</span>
 								</div>
 							}
-							<div>
+							<div class="hidden sm:block">
 								<span class="text-base-content/30">Account</span>
 								<span class="text-base-content/60 ml-1.5">{ tx.AccountName } ({ tx.InstitutionName })</span>
 							</div>
@@ -225,6 +262,22 @@ templ TxRow(tx service.AdminTransactionRow) {
 									<span class="text-base-content/60 ml-1.5">&mdash;</span>
 								}
 							</div>
+							if len(tx.Tags) > 0 {
+								<div class="sm:hidden">
+									<span class="text-base-content/30">Tags</span>
+									<span class="ml-1.5 inline-flex flex-wrap gap-1">
+										for _, tag := range tx.Tags {
+											@TagChipSm(TagChipDataFromTx(tag))
+										}
+									</span>
+								</div>
+							}
+							if tx.CategoryDisplayName != nil {
+								<div class="sm:hidden">
+									<span class="text-base-content/30">Category</span>
+									<span class="text-base-content/60 ml-1.5">{ deref(tx.CategoryDisplayName) }</span>
+								</div>
+							}
 							<div>
 								<span class="text-base-content/30">ID</span>
 								<code class="font-mono text-[0.65rem] bg-base-200 px-1.5 py-0.5 rounded ml-1.5">{ tx.ID }</code>


### PR DESCRIPTION
On iPhone (< 640 px / `sm` breakpoint) the transaction list was showing the full meta line — account name, Needs Review badge, tag count, category — all crammed into 390 px. This PR hides that line on mobile and replaces it with a lightweight sub-line, deferring full detail to tap-to-expand.

## What changed

**`tx_row.templ`** (`TxRow` component)

| Part | Before | After |
|---|---|---|
| Meta line | `flex …` (always visible) | `hidden sm:flex …` (hidden <640 px) |
| Mobile sub-line | — | `flex sm:hidden …` — date (nowrap) + category dot + truncated name + tag count + AI badge |
| Expand panel | Account shown at all sizes | `sm:hidden` Account block (no institution) + `sm:hidden` Tags + `sm:hidden` Category added for mobile; desktop Account block gets `hidden sm:block` to avoid duplicate |
| Expand max-height | `max-h-64` | `max-h-80` (extra space for the 3 new mobile rows) |
| Amount column left-padding | `pl-2 sm:pl-3` | `pl-0 sm:pl-3` (reclaim 8 px on narrow screens) |

Tablet (≥ 640 px) and desktop are visually unchanged.

## Screenshots

<table>
  <tr><th>Viewport</th><th>Before</th><th>After</th></tr>
  <tr>
    <td><b>iPhone 390×844</b></td>
    <td><img src="https://i.img402.dev/7zhf8hh9vj.jpg" width="320" alt="before — iPhone"></td>
    <td><img src="https://i.img402.dev/v2aous0hdl.jpg" width="320" alt="after — iPhone"></td>
  </tr>
  <tr>
    <td><b>Tablet 768×1024</b></td>
    <td><img src="https://i.img402.dev/nbq9frbrhj.jpg" width="400" alt="before — tablet"></td>
    <td><img src="https://i.img402.dev/xz4th759bx.jpg" width="400" alt="after — tablet"></td>
  </tr>
  <tr>
    <td><b>Desktop 1440×900</b></td>
    <td><img src="https://i.img402.dev/oa4er9szcz.jpg" width="600" alt="before — desktop"></td>
    <td><img src="https://i.img402.dev/cqdykwfubk.jpg" width="600" alt="after — desktop"></td>
  </tr>
  <tr>
    <td><b>iPhone — expanded</b></td>
    <td colspan="2" align="center"><img src="https://i.img402.dev/6ogaj1zutm.jpg" width="320" alt="after — iPhone expanded"></td>
  </tr>
</table>

🤖 Generated with [Claude Code](https://claude.com/claude-code)