### PR TITLE
fix(categories,rules): mobile-friendly category and rule cards

### DIFF
--- a/internal/templates/components/pages/rules.templ
+++ b/internal/templates/components/pages/rules.templ
@@ -27,7 +27,7 @@ templ Rules(p RulesProps) {
 	<div class="bb-page-header">
 		<div>
 			<h1 class="bb-page-title">Rules</h1>
-			<p class="text-sm text-base-content/50 mt-1">Automatically categorize, tag, or comment on transactions during sync</p>
+			<p class="text-sm text-base-content/50 mt-1 hidden sm:block">Automatically categorize, tag, or comment on transactions during sync</p>
 		</div>
 		<div class="flex items-center gap-2">
 			<a href="/rules/new" class="btn btn-primary btn-sm rounded-xl" data-new-rule>
@@ -116,7 +116,7 @@ templ rulesRow(r RulesRow) {
 			<!-- Main info -->
 			<div class="flex-1 min-w-0">
 				<div class="flex items-center gap-2 flex-wrap">
-					<span class="font-semibold text-sm truncate">{ r.Name }</span>
+					<span class="font-semibold text-sm line-clamp-2 sm:truncate sm:line-clamp-none">{ r.Name }</span>
 					if r.IsSystem {
 						<span class="hidden sm:inline-flex badge badge-soft badge-info badge-xs gap-1" title="Built-in system rule">
 							<i data-lucide="shield" class="w-2.5 h-2.5"></i>


### PR DESCRIPTION
## Summary

Fixes two mobile layout regressions on the Categories and Rules pages. The `bb-page-header` CSS class was compiled without `align-items: flex-start`, causing CTA buttons (\"Add Category\", \"New Rule\") to stretch full-width on mobile instead of staying compact. Also hides the Rules subtitle on mobile to reduce vertical clutter, and allows long rule names to wrap to 2 lines on mobile instead of truncating mid-word.

## Screenshots — Categories

| Viewport | Before | After |
| --- | --- | --- |
| iPhone (390×844) | <img src="https://i.img402.dev/6v1e0dhg8y.jpg" width="320" alt="categories before iphone"> | <img src="https://i.img402.dev/ytnjxtm7y2.jpg" width="320" alt="categories after iphone"> |
| Tablet (768×1024) | — | <img src="https://i.img402.dev/ynfngswsby.jpg" width="400" alt="categories after tablet"> |
| Desktop (1440×900) | — | <img src="https://i.img402.dev/sz0aq8vfki.jpg" width="800" alt="categories after desktop"> |

## Screenshots — Rules (iPhone only)

| Before | After |
| --- | --- |
| <img src="https://i.img402.dev/hwas9lkwzt.jpg" width="320" alt="rules before iphone"> | <img src="https://i.img402.dev/id2b9rezrw.jpg" width="320" alt="rules after iphone"> |

## Changes
- Recompile `static/css/styles.css` to include `align-items: flex-start` on `.bb-page-header` (was compiled without it, causing full-width CTA buttons on mobile)
- `rules.templ`: add `hidden sm:block` to subtitle description to keep the header compact on mobile
- `rules.templ`: replace `truncate` with `line-clamp-2 sm:truncate sm:line-clamp-none` on rule name spans so long names wrap gracefully on mobile instead of cutting off mid-word

## Test plan
- [x] Validated at iPhone (390×844), tablet (768×1024), and desktop (1440×900) via Chrome DevTools MCP
- [x] `go build ./...` and `go test ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)