### PR TITLE
fix(account-detail): mobile-friendly account header and meta

### DIFF
--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -61,7 +61,7 @@ templ acctHeader(p AccountDetailProps) {
 			</div>
 			<div>
 				<h1 class="bb-page-title">{ acctDisplayLabel(p.Account) }</h1>
-				<div class="flex items-center gap-2 mt-0.5">
+				<div class="flex items-center flex-wrap gap-x-2 gap-y-1 mt-0.5">
 					{{ typeLabel := accountTypeLabel(p.Account.Type, "") }}
 					{{ subtype := "" }}
 					if p.Account.Subtype != nil {
@@ -115,8 +115,9 @@ templ acctSummaryCards(p AccountDetailProps) {
 					}
 					{ fmtBalancePtr(p.Account.BalanceCurrent) }
 				} else {
-					<span class="text-base-content/20">@templ.Raw("&mdash;")
-</span>
+					<span class="text-base-content/20">
+						@templ.Raw("&mdash;")
+					</span>
 				}
 			</div>
 			if p.HasCreditUtil {
@@ -247,7 +248,7 @@ templ acctTransactionsHeader(p AccountDetailProps) {
 					@click="filtersOpen = !filtersOpen"
 				>
 					<i data-lucide="sliders-horizontal" class="w-3.5 h-3.5"></i>
-					<span>Filters</span>
+					<span class="hidden sm:inline">Filters</span>
 					if acctHasFilters(p) {
 						<span class="badge badge-xs" :class="filtersOpen ? 'badge-primary-content' : 'badge-primary'">Active</span>
 					}
@@ -262,7 +263,7 @@ templ acctTransactionsHeader(p AccountDetailProps) {
 
 templ acctFilterPanel(p AccountDetailProps) {
 	<form method="GET" action={ templ.SafeURL("/accounts/" + p.AccountID) } x-show="filtersOpen" x-cloak x-collapse class="bb-card mb-4 p-4" x-data>
-		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-4">
+		<div class="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-5 gap-3 mb-4">
 			<label class="bb-filter-label">
 				Start Date
 				<input type="date" name="start_date" value={ p.FilterStartDate } class="input input-sm input-bordered w-full"/>
@@ -271,7 +272,7 @@ templ acctFilterPanel(p AccountDetailProps) {
 				End Date
 				<input type="date" name="end_date" value={ p.FilterEndDate } class="input input-sm input-bordered w-full"/>
 			</label>
-			<label class="bb-filter-label">
+			<label class="bb-filter-label col-span-2 sm:col-span-1">
 				Category
 				<div
 					class="bb-cat-picker"
@@ -291,7 +292,7 @@ templ acctFilterPanel(p AccountDetailProps) {
 					</button>
 				</div>
 			</label>
-			<label class="bb-filter-label">
+			<label class="bb-filter-label col-span-2 sm:col-span-1">
 				Status
 				<select name="pending" class="select select-sm select-bordered w-full">
 					<option value="">All</option>
@@ -307,7 +308,7 @@ templ acctFilterPanel(p AccountDetailProps) {
 					}
 				</select>
 			</label>
-			<label class="bb-filter-label">
+			<label class="bb-filter-label col-span-2 sm:col-span-1">
 				Search
 				<input type="text" name="search" value={ p.FilterSearch } placeholder="Name or merchant" class="input input-sm input-bordered w-full"/>
 			</label>
@@ -369,8 +370,9 @@ templ acctPagination(p AccountDetailProps) {
 			<!-- Page numbers -->
 			for _, n := range acctPageRange(p.Page, p.TotalPages) {
 				if n == 0 {
-					<span class="bb-paginator__ellipsis">@templ.Raw("&hellip;")
-</span>
+					<span class="bb-paginator__ellipsis">
+						@templ.Raw("&hellip;")
+					</span>
 				} else if n == p.Page {
 					<span class="bb-paginator__btn bb-paginator__btn--active">{ fmt.Sprintf("%d", n) }</span>
 				} else {


### PR DESCRIPTION
## Summary

The account detail page (`/accounts/:id`) had several mobile layout issues: the header badge row (type, mask, status badges) could overflow without wrapping on narrow screens; the Filters button showed the full "Filters" label at all sizes, crowding the toolbar on phones; and the filter panel was a single column on mobile, forcing date pickers and other fields into a tall stack.

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| iPhone (390×844) | <img src="https://i.img402.dev/8kypxfbx0p.jpg" width="320" alt="before — iphone"> | <img src="https://i.img402.dev/qjuwx90p2v.jpg" width="320" alt="after — iphone"> |
| Tablet (768×1024) | <img src="https://i.img402.dev/7wpul626ia.jpg" width="400" alt="before — tablet"> | <img src="https://i.img402.dev/4x0lt7qhe5.jpg" width="400" alt="after — tablet"> |
| Desktop (1440×900) | <img src="https://i.img402.dev/y782gff92o.jpg" width="600" alt="before — desktop"> | <img src="https://i.img402.dev/4rjaktb9gc.jpg" width="600" alt="after — desktop"> |

## Changes

- `acctHeader`: Added `flex-wrap gap-x-2 gap-y-1` to the badge subtitle row so type label, mask, Excluded/Linked/status badges wrap gracefully on narrow screens instead of overflowing
- `acctTransactionsHeader`: Wrapped the "Filters" label in `hidden sm:inline` — the button shows icon + active badge + chevron only on mobile, matching the existing CSV button pattern
- `acctFilterPanel`: Changed grid from `grid-cols-1` to `grid-cols-2` on mobile so Start Date and End Date sit side by side; added `col-span-2 sm:col-span-1` to Category, Status, and Search so they remain full-width on mobile but collapse to individual columns at `sm`+

## Test plan

- [x] Validated at iPhone 390×844, Tablet 768×1024, Desktop 1440×900 via Chrome DevTools MCP
- [x] Filter panel open/close verified on mobile (with active filter)
- [x] `go test ./...` passes — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)