### PR TITLE
fix(settings): mobile-friendly forms and cards

### DIFF
--- a/input.css
+++ b/input.css
@@ -254,8 +254,8 @@
   .bb-icon-tile--error   { @apply bg-error/10 text-error; }
 
   /* Action row at the bottom of a sectioned form card.
-     Holds Cancel + primary (Save/Create) buttons right-aligned. */
-  .bb-action-row { @apply p-4 sm:p-5 border-t border-base-300 bg-base-200/20 flex items-center justify-end gap-2; }
+     Left-aligned on mobile (full-width context), right-aligned on sm+. */
+  .bb-action-row { @apply p-4 sm:p-5 border-t border-base-300 bg-base-200/20 flex items-center justify-start sm:justify-end gap-2; }
 
   /* Form inputs/selects with subtle base-200 bg that clears on focus. */
   .bb-form-input { @apply input w-full rounded-xl bg-base-200/50 focus:bg-base-100 transition-colors; }

--- a/internal/templates/components/pages/agents_settings.templ
+++ b/internal/templates/components/pages/agents_settings.templ
@@ -86,7 +86,7 @@ templ agentsSettingsReviewGuidelinesCard(p AgentsSettingsProps) {
 			</div>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">Review Guidelines</h2>
-				<p class="text-xs text-base-content/40" x-show="!expanded">Served as <code class="text-xs">breadbox://review-guidelines</code> to agents during reviews</p>
+				<p class="text-xs text-base-content/40 truncate" x-show="!expanded">Served as <code class="text-xs">breadbox://review-guidelines</code> to agents during reviews</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Guidelines for reviewing transactions and creating rules — agents read this resource before processing reviews</p>
 			</div>
 			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
@@ -123,7 +123,7 @@ templ agentsSettingsReportFormatCard(p AgentsSettingsProps) {
 			</div>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">Report Format</h2>
-				<p class="text-xs text-base-content/40" x-show="!expanded">Served as <code class="text-xs">breadbox://report-format</code> to agents when submitting reports</p>
+				<p class="text-xs text-base-content/40 truncate" x-show="!expanded">Served as <code class="text-xs">breadbox://report-format</code> to agents when submitting reports</p>
 				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>Report structure templates and formatting guidelines — agents read this resource before submitting reports</p>
 			</div>
 			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>

--- a/internal/templates/components/pages/mcp_settings.templ
+++ b/internal/templates/components/pages/mcp_settings.templ
@@ -102,10 +102,12 @@ templ mcpSettingsEditableCard(c mcpSettingsCardSpec) {
 			</div>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">{ c.Title }</h2>
-				<p class="text-xs text-base-content/40" x-show="!expanded">@templ.Raw(c.SubtitleCol)
-</p>
-				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>@templ.Raw(c.SubtitleExp)
-</p>
+				<p class="text-xs text-base-content/40 truncate" x-show="!expanded">
+					@templ.Raw(c.SubtitleCol)
+				</p>
+				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>
+					@templ.Raw(c.SubtitleExp)
+				</p>
 			</div>
 			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>


### PR DESCRIPTION
## Summary

Improves mobile layout on the **Agents Settings** and **MCP Settings** sub-pages. Collapsed card subtitles now truncate instead of wrapping on narrow viewports, preventing the subtitle text from overflowing the card header row. The shared `.bb-action-row` utility class is updated to left-align buttons on mobile (`justify-start`) and right-align on `sm+` screens (`sm:justify-end`), matching expected thumb-reach conventions on small displays.

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| iPhone (390×844) | ![](https://i.img402.dev/yji99p9shk.jpg) | ![](https://i.img402.dev/efowuyck8j.jpg) |
| Tablet (768×1024) | ![](https://i.img402.dev/me3lshh4dk.jpg) | ![](https://i.img402.dev/o707sowwpg.jpg) |
| Desktop (1440×900) | ![](https://i.img402.dev/ni4b7zigcl.jpg) | ![](https://i.img402.dev/epua18e23a.jpg) |

## Changes
- `input.css`: `.bb-action-row` updated from `justify-end` to `justify-start sm:justify-end` so action buttons are left-aligned on mobile
- `agents_settings.templ`: added `truncate` to collapsed subtitle `<p>` in both the Review Guidelines and Report Format cards
- `mcp_settings.templ`: added `truncate` to collapsed subtitle `<p>` in the shared `mcpSettingsEditableCard` component; also cleaned up inline whitespace around `@templ.Raw()` calls

## Out of scope
- Other settings sub-pages (profile, providers, account) not yet validated — flagged for follow-up iteration.

## Test plan
- [x] Validated at iPhone (390×844), Tablet (768×1024), Desktop (1440×900) via Chrome DevTools MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)
