### PR TITLE
fix(layout): mobile-friendly sidebar / top nav with drawer

### DIFF
--- a/input.css
+++ b/input.css
@@ -267,16 +267,23 @@
   /* Danger-zone card tint — combine with .bb-card for destructive-action cards. */
   .bb-danger-card { @apply border-error/20 bg-error/[0.02]; }
 
-  /* ── Mobile Navbar (glassmorphism) ── */
+  /* ── Mobile Navbar — sticky so it anchors at the top while scrolling ── */
   .bb-mobile-navbar {
     @apply navbar px-2 bg-base-100;
+    position: sticky;
+    top: 0;
+    z-index: 30;
     border-bottom: 1px solid oklch(0 0 0 / 0.06);
+    /* Subtle backdrop blur for depth when content scrolls underneath */
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    background-color: oklch(var(--b1) / 0.92);
   }
 
   @media (prefers-color-scheme: dark) {
     .bb-mobile-navbar {
-      @apply bg-base-100;
       border-bottom-color: oklch(1 0 0 / 0.08);
+      background-color: oklch(var(--b1) / 0.88);
     }
   }
 
@@ -315,6 +322,7 @@
 
   .bb-sidebar-brand {
     @apply text-lg font-semibold px-3 py-1 mb-5 no-underline text-base-content flex items-center gap-2;
+    /* When used inside the brand+close flex row we override mb and px via !mb-0 !px-0 !py-0 */
   }
 
   .bb-sidebar-nav {

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -209,8 +209,11 @@
 
     <!-- Main content -->
     <div class="drawer-content bg-base-200">
-      <!-- Mobile navbar -->
-      <div class="bb-mobile-navbar lg:hidden">
+      <!-- Mobile navbar — sticky so it stays at top while scrolling -->
+      <div class="bb-mobile-navbar lg:hidden"
+           x-data="{ open: false }"
+           x-init="$watch('open', v => { var t = document.getElementById('bb-drawer-trigger'); if (t) t.setAttribute('aria-expanded', v ? 'true' : 'false'); });
+                   document.getElementById('bb-drawer').addEventListener('change', e => { open = e.target.checked; });">
         <div class="flex-none">
           <label for="bb-drawer"
                  id="bb-drawer-trigger"
@@ -219,20 +222,33 @@
                  tabindex="0"
                  aria-label="Open navigation menu"
                  aria-controls="bb-drawer-sidebar"
-                 aria-expanded="false">
+                 :aria-expanded="open.toString()">
             <i data-lucide="menu" class="w-5 h-5" aria-hidden="true"></i>
           </label>
         </div>
-        <div class="flex-1 min-w-0">
+        <div class="flex-1 min-w-0 flex items-center gap-2">
+          <i data-lucide="package" class="w-4 h-4 shrink-0 opacity-70" aria-hidden="true"></i>
           <a href="/" class="text-sm font-semibold truncate">Breadbox</a>
         </div>
-        <div class="flex-none">
+        <div class="flex-none flex items-center gap-1">
           <button class="btn btn-square btn-ghost"
                   x-data @click="$dispatch('open-cmdk')"
                   aria-label="Search"
                   title="Search">
             <i data-lucide="search" class="w-5 h-5" aria-hidden="true"></i>
           </button>
+          {{if .AdminUsername}}
+          <a href="/settings/account"
+             class="btn btn-square btn-ghost"
+             aria-label="My Account"
+             title="My Account">
+            {{if .SessionUserID}}
+            <img src="/avatars/{{.SessionUserID}}" alt="" class="w-7 h-7 rounded-full object-cover" />
+            {{else}}
+            <i data-lucide="user-circle" class="w-5 h-5" aria-hidden="true"></i>
+            {{end}}
+          </a>
+          {{end}}
         </div>
       </div>
       <!-- Page content -->
@@ -251,11 +267,19 @@
     <div class="drawer-side" id="bb-drawer-sidebar">
       <label for="bb-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
       <aside class="bb-sidebar" id="bb-sidebar" aria-label="Main navigation">
-        <!-- Brand -->
-        <a href="/" class="bb-sidebar-brand">
-          <i data-lucide="package" class="w-5 h-5"></i>
-          Breadbox
-        </a>
+        <!-- Brand + close button row -->
+        <div class="flex items-center justify-between mb-5">
+          <a href="/" class="bb-sidebar-brand !mb-0 !px-0 !py-0">
+            <i data-lucide="package" class="w-5 h-5"></i>
+            Breadbox
+          </a>
+          <!-- Close button — only visible on mobile/tablet (< lg) -->
+          <label for="bb-drawer"
+                 class="btn btn-sm btn-square btn-ghost lg:hidden shrink-0"
+                 aria-label="Close navigation menu">
+            <i data-lucide="x" class="w-4 h-4" aria-hidden="true"></i>
+          </label>
+        </div>
         <!-- Search trigger -->
         <div class="bb-sidebar-search" x-data @click="$dispatch('open-cmdk')" role="button" tabindex="0" @keydown.enter="$dispatch('open-cmdk')">
           <i data-lucide="search"></i>


### PR DESCRIPTION
Four small improvements to the admin UI on narrow viewports — no behaviour changes at desktop width.

## Changes

- **Sticky top bar**: `.bb-mobile-navbar` gets `position: sticky; top: 0; z-index: 30` plus a `backdrop-filter: blur(8px)` so content scrolls under a frosted header instead of the bar disappearing off-screen.
- **Package icon in mobile logo**: aligns the mobile navbar brand with the desktop sidebar brand.
- **User avatar in mobile top bar**: tapping the avatar goes straight to `/settings/account`; falls back to a `user-circle` icon when no linked user exists.
- **X close button in drawer header**: a `label[for="bb-drawer"]` in the sidebar header gives users a clear way to dismiss the drawer without tapping the overlay.
- **`aria-expanded` sync**: Alpine `$watch` keeps the hamburger trigger's `aria-expanded` attribute in sync with the drawer checkbox state.

## Screenshots

### iPhone (390 × 844)

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/jo9bqmj23f.png" width="320" alt="iPhone — before"></td>
    <td><img src="https://i.img402.dev/hy4iofoljh.png" width="320" alt="iPhone — after"></td>
  </tr>
</table>

### iPhone — drawer open

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/6r33qdreef.png" width="320" alt="iPhone drawer — before"></td>
    <td><img src="https://i.img402.dev/9poo7f45co.png" width="320" alt="iPhone drawer — after"></td>
  </tr>
</table>

### Tablet (768 × 1024)

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/xbnofwn9sd.png" width="400" alt="Tablet — before"></td>
    <td><img src="https://i.img402.dev/you975v7p4.png" width="400" alt="Tablet — after"></td>
  </tr>
</table>

### Desktop (1440 × 900)

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/6p6nbh1ide.png" width="600" alt="Desktop — before"></td>
    <td><img src="https://i.img402.dev/bh7f2sgbz4.png" width="600" alt="Desktop — after"></td>
  </tr>
</table>

## Test plan

- [ ] iPhone (390px): sticky navbar stays at top when scrolling; hamburger opens drawer; avatar links to `/settings/account`
- [ ] Drawer open: X button in sidebar header closes drawer; nav links work
- [ ] Tablet (768px): mobile navbar still shows (below `lg` breakpoint)
- [ ] Desktop (1024px+): mobile navbar hidden; sidebar always visible; no regression
- [ ] `aria-expanded` on hamburger reads `true` when drawer is open, `false` when closed
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)