### PR TITLE
fix(settings): mobile-friendly profile/providers/account sub-pages

### DIFF
--- a/input.css
+++ b/input.css
@@ -254,8 +254,8 @@
   .bb-icon-tile--error   { @apply bg-error/10 text-error; }
 
   /* Action row at the bottom of a sectioned form card.
-     Holds Cancel + primary (Save/Create) buttons right-aligned. */
-  .bb-action-row { @apply p-4 sm:p-5 border-t border-base-300 bg-base-200/20 flex items-center justify-end gap-2; }
+     Left-aligned on mobile (thumb-reach), right-aligned on sm+. */
+  .bb-action-row { @apply p-4 sm:p-5 border-t border-base-300 bg-base-200/20 flex items-center justify-start sm:justify-end gap-2; }
 
   /* Form inputs/selects with subtle base-200 bg that clears on focus. */
   .bb-form-input { @apply input w-full rounded-xl bg-base-200/50 focus:bg-base-100 transition-colors; }

--- a/internal/templates/components/pages/my_account.templ
+++ b/internal/templates/components/pages/my_account.templ
@@ -13,9 +13,9 @@ package pages
 templ MyAccount(p MyAccountProps) {
 	<div class="max-w-2xl">
 		<div class="bb-page-header">
-			<div>
+			<div class="min-w-0">
 				<h1 class="bb-page-title">Account</h1>
-				<p class="text-sm text-base-content/50 mt-1">
+				<p class="text-sm text-base-content/50 mt-1 truncate">
 					if p.AdminUsername != "" {
 						Signed in as <span class="text-base-content/70 font-medium">{ p.AdminUsername }</span>
 						if p.RoleDisplay != "" {
@@ -54,7 +54,7 @@ templ MyProfile(p MyAccountProps) {
 	<script src="/static/js/admin/components/user_form.js"></script>
 	<div class="max-w-2xl">
 		<div class="bb-page-header">
-			<div>
+			<div class="min-w-0">
 				<h1 class="bb-page-title">Profile</h1>
 				<p class="text-sm text-base-content/50 mt-1">Update your name, email, and avatar</p>
 			</div>
@@ -104,12 +104,12 @@ templ myAccountProfileCard(p MyAccountProps) {
 					</div>
 					<div class="bb-icon-header__text">
 						<h2 class="text-sm font-semibold truncate">Profile</h2>
-						<p class="text-xs text-base-content/45">
+						<p class="text-xs text-base-content/45 flex flex-wrap items-center gap-x-1.5 gap-y-1">
 							<button type="button" @click="$refs.fileInput.click()" class="link link-hover inline-flex items-center gap-1"><i data-lucide="upload" class="w-3 h-3"></i>Upload photo</button>
 							<span class="text-base-content/20">·</span>
 							<button type="button" @click="regenerate()" class="link link-hover inline-flex items-center gap-1"><i data-lucide="refresh-cw" class="w-3 h-3"></i>Regenerate</button>
 							<template x-if="hasCustomAvatar">
-								<span>
+								<span class="inline-flex items-center gap-1.5">
 									<span class="text-base-content/20">·</span>
 									<button type="button" @click="removeAvatar()" class="link link-hover text-error/70 hover:text-error">Remove</button>
 								</span>

--- a/internal/templates/components/pages/providers.templ
+++ b/internal/templates/components/pages/providers.templ
@@ -23,7 +23,7 @@ templ Providers(p ProvidersProps) {
 	     from <head> — fires alpine:init. -->
 	<script src="/static/js/admin/components/providers.js"></script>
 	<div class="bb-page-header">
-		<div>
+		<div class="min-w-0">
 			<h1 class="bb-page-title">Providers</h1>
 			<p class="text-sm text-base-content/50 mt-1">Configure bank data providers for syncing accounts and transactions</p>
 		</div>
@@ -66,9 +66,9 @@ templ providersPlaidCard(p ProvidersProps, h *service.ProviderHealthSummary) {
 				</button>
 				<div x-show="showConfig" x-collapse x-cloak class="mt-4 space-y-4">
 					if p.PlaidFromEnv {
-						<p class="text-sm text-base-content/50 mb-4 flex items-center gap-1.5">
-							<i data-lucide="lock" class="w-3.5 h-3.5"></i>
-							Configured via environment variables (read-only)
+						<p class="text-sm text-base-content/50 mb-4 flex flex-wrap items-center gap-1.5">
+							<i data-lucide="lock" class="w-3.5 h-3.5 shrink-0"></i>
+							<span>Configured via environment variables (read-only)</span>
 						</p>
 						<dl class="bb-info-grid">
 							<dt>
@@ -207,9 +207,9 @@ templ providersTellerCard(p ProvidersProps, h *service.ProviderHealthSummary) {
 				</button>
 				<div x-show="showConfig" x-collapse x-cloak class="mt-4 space-y-4">
 					if p.TellerFromEnv {
-						<p class="text-sm text-base-content/50 mb-4 flex items-center gap-1.5">
-							<i data-lucide="lock" class="w-3.5 h-3.5"></i>
-							Configured via environment variables (read-only)
+						<p class="text-sm text-base-content/50 mb-4 flex flex-wrap items-center gap-1.5">
+							<i data-lucide="lock" class="w-3.5 h-3.5 shrink-0"></i>
+							<span>Configured via environment variables (read-only)</span>
 						</p>
 						<dl class="bb-info-grid">
 							<dt>


### PR DESCRIPTION
Improves mobile layout on the **Account**, **Profile**, and **Providers** Settings sub-pages. The primary fix is `.bb-action-row` getting left-aligned buttons on mobile (thumb-reach convention), right-aligned on `sm+`. Secondary fixes: `min-w-0` guards on page-header text blocks so long subtitles truncate cleanly; avatar action buttons wrap gracefully; Providers read-only notice keeps its lock icon fixed while text wraps.

## Screenshots

All three viewports shown for the Account sub-page (most representative of all three pages).

| Viewport | Before | After |
| --- | --- | --- |
| iPhone (390×844) | <img src="https://i.img402.dev/hb3j1sncrt.jpg" width="260" alt="account — before — iphone"> | <img src="https://i.img402.dev/baubq4rr09.jpg" width="260" alt="account — after — iphone"> |
| Tablet (768×1024) | <img src="https://i.img402.dev/nt048b6kq9.jpg" width="380" alt="account — before — tablet"> | <img src="https://i.img402.dev/3gkhy5465f.jpg" width="380" alt="account — after — tablet"> |
| Desktop (1440×900) | <img src="https://i.img402.dev/llgqj4adgu.jpg" width="600" alt="account — before — desktop"> | <img src="https://i.img402.dev/or86hx4e5q.jpg" width="600" alt="account — after — desktop"> |

Key change visible on iPhone: "Update password" / "Save Changes" buttons are now **left-aligned** (thumb-reach) instead of pushed to the far right edge. Tablet and desktop keep buttons right-aligned (`sm:justify-end`) — no regression.

## Changes

- `input.css`: `.bb-action-row` updated from `justify-end` to `justify-start sm:justify-end`
- `my_account.templ`: `min-w-0` on page-header `<div>` in both `MyAccount` and `MyProfile`; `truncate` on Account subtitle; avatar action `<p>` uses `flex flex-wrap` so Upload/Regenerate/Remove wrap instead of overflow
- `providers.templ`: `min-w-0` on page-header `<div>`; `flex-wrap` + `shrink-0` on lock icon in env read-only notices (Plaid + Teller)

## Out of scope

- `agents_settings.templ` + `mcp_settings.templ` (PR #939)

## Test plan

- [x] Validated at iPhone (390×844), Tablet (768×1024), Desktop (1440×900) via Chrome DevTools MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)
