### PR TITLE
fix(reports): mobile-friendly header, filters, and summary cards

### DIFF
--- a/internal/templates/components/pages/report_detail.templ
+++ b/internal/templates/components/pages/report_detail.templ
@@ -70,7 +70,7 @@ templ ReportDetail(p ReportDetailProps) {
 				</div>
 			</div>
 			<!-- Action toolbar -->
-			<div class="flex items-center gap-1 px-3 sm:px-4 py-2 border-t border-base-200/60 bg-base-200/20 rounded-b-2xl">
+			<div class="flex flex-wrap items-center gap-1 px-3 sm:px-4 py-2 border-t border-base-200/60 bg-base-200/20 rounded-b-2xl">
 				<button type="button" @click="toggleRead()" class="btn btn-ghost btn-xs rounded-lg text-xs">
 					<i :data-lucide="isRead ? 'rotate-ccw' : 'check'" class="w-3.5 h-3.5"></i>
 					<span x-text="isRead ? 'Mark unread' : 'Mark read'"></span>

--- a/internal/templates/components/pages/reports.templ
+++ b/internal/templates/components/pages/reports.templ
@@ -24,16 +24,16 @@ templ Reports(p ReportsProps) {
 		<div class="flex items-center gap-2">
 			<a href="/settings/mcp#report-format" class="btn btn-ghost btn-sm rounded-xl text-xs no-underline" aria-label="Manage report format" title="Customize how agents write reports">
 				<i data-lucide="sliders-horizontal" class="w-3.5 h-3.5"></i>
-				<span class="hidden sm:inline">Manage format</span>
+				<span>Manage format</span>
 			</a>
 		</div>
 	</div>
 	<!-- Filter Tabs + Actions -->
-	<div class="flex items-center gap-1 border-b border-base-200/80 mb-6">
+	<div class="flex items-center gap-1 border-b border-base-200/80 mb-6 overflow-x-auto">
 		<a href="/reports" class={ reportsTabClass(p.FilterStatus == "") }>All</a>
 		<a href="/reports?status=unread" class={ reportsTabClass(p.FilterStatus == "unread") }>Unread</a>
 		<a href="/reports?status=read" class={ reportsTabClass(p.FilterStatus == "read") }>Read</a>
-		<div class="ml-auto flex items-center gap-2">
+		<div class="ml-auto flex items-center gap-2 shrink-0">
 			<span class="text-xs text-base-content/30 hidden sm:inline">{ reportsCountLabel(p.TotalCount) }</span>
 			<button
 				class="btn btn-ghost btn-sm rounded-xl text-xs cursor-pointer"


### PR DESCRIPTION
## Summary

The Agent Reports page had three small mobile-UX rough edges: the "Manage format" button in the page header showed only a bare icon on mobile (its label was `hidden sm:inline`), the filter tab bar had no overflow protection on very narrow screens, and the report detail action toolbar had no wrapping — causing the three action buttons to sit in a single rigid row that could overflow on small phones.

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| iPhone (390×844) | <img src="https://i.img402.dev/j51lq01nn9.jpg" width="280" alt="before iphone"> | <img src="https://i.img402.dev/dwtidcxygu.jpg" width="280" alt="after iphone"> |
| Tablet (768×1024) | <img src="https://i.img402.dev/vh1mxh2kq9.jpg" width="360" alt="before tablet"> | <img src="https://i.img402.dev/zkm3mfz7w9.jpg" width="360" alt="after tablet"> |
| Desktop (1440×900) | <img src="https://i.img402.dev/383n7hfzgb.jpg" width="800" alt="before desktop"> | <img src="https://i.img402.dev/jhwcnwh57g.jpg" width="800" alt="after desktop"> |

## Changes

- `reports.templ`: Remove `hidden sm:inline` from "Manage format" label — shows text on all viewports
- `reports.templ`: Add `overflow-x-auto` to filter tab row and `shrink-0` to the right-side actions group
- `report_detail.templ`: Change action toolbar from `flex` to `flex flex-wrap` so buttons can wrap on narrow screens

## Test plan

- [x] Validated at iPhone (390×844), tablet (768×1024), and desktop (1440×900) via Chrome DevTools MCP
- [x] `go build ./...` passes with no errors
- [x] Desktop layout unchanged — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
