### PR TITLE
fix(modals): mobile-friendly create-account-link and delete-category dialogs

### DIFF
--- a/internal/templates/components/pages/categories.templ
+++ b/internal/templates/components/pages/categories.templ
@@ -249,7 +249,7 @@ templ deleteCategoryModal() {
 		x-data="{deleteId: '', deleteName: '', submitting: false}"
 		@delete-category.window="deleteId = $event.detail.id; deleteName = $event.detail.name; document.getElementById('delete-modal').showModal()"
 	>
-		<div class="modal-box rounded-xl max-w-md">
+		<div class="modal-box w-full sm:max-w-md [padding-bottom:calc(1.5rem+env(safe-area-inset-bottom,0px))] sm:[padding-bottom:1.5rem]">
 			<div class="flex items-center gap-3 mb-4">
 				<div class="w-10 h-10 rounded-xl bg-error/10 flex items-center justify-center">
 					<i data-lucide="alert-triangle" class="w-5 h-5 text-error"></i>

--- a/internal/templates/components/pages/connections.templ
+++ b/internal/templates/components/pages/connections.templ
@@ -456,7 +456,7 @@ templ connectionsLinkRow(l ConnectionsLinkRow, csrfToken string) {
 
 templ connectionsCreateLinkModal(p ConnectionsProps) {
 	<dialog id="create-link-modal" class="modal modal-bottom sm:modal-middle">
-		<div class="modal-box rounded-xl max-w-lg">
+		<div class="modal-box w-full sm:max-w-lg [padding-bottom:calc(1.5rem+env(safe-area-inset-bottom,0px))] sm:[padding-bottom:1.5rem]">
 			<h3 class="font-bold text-lg">Create Account Link</h3>
 			<p class="text-sm text-base-content/50 mt-1">Link a dependent (authorized user) account to the primary cardholder's account.</p>
 			<form method="POST" action="/-/account-links" class="mt-4 space-y-4" x-data="{ loading: false }" @submit="loading = true">


### PR DESCRIPTION
## Summary

Fixes two modals that were clipped or poorly padded on mobile viewports. The Create Account Link modal (`connections.templ`) and the Delete Category confirmation modal (`categories.templ`) both get `w-full` so they fill the screen width on small devices and `env(safe-area-inset-bottom)` bottom padding so the content isn't obscured by iPhone home-indicator notches. On `sm:` and above the original `max-w-*` caps and standard padding are preserved unchanged.

## Screenshots — Create Account Link modal (iPhone)

| Before | After |
| --- | --- |
| ![](https://i.img402.dev/0p0gzzkr3z.jpg) | ![](https://i.img402.dev/5n4a7vehvy.jpg) |

## Screenshots — Delete Category modal (iPhone)

| Before | After |
| --- | --- |
| ![](https://i.img402.dev/v27zijf1ev.jpg) | ![](https://i.img402.dev/2zitdjrgkp.jpg) |

## Changes
- `connections.templ`: `connectionsCreateLinkModal` — replaced `rounded-xl max-w-lg` with `w-full sm:max-w-lg` + safe-area bottom padding
- `categories.templ`: `deleteCategoryModal` — replaced `rounded-xl max-w-md` with `w-full sm:max-w-md` + safe-area bottom padding

## Out of scope (follow-up)
- Other modals (edit-tag, edit-rule, csv-import, etc.) flagged for future iteration

## Test plan
- [x] Validated at iPhone (390×844) via Chrome DevTools MCP
- [x] Modals open/close cleanly; form submission works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
