### PR TITLE
fix(auth): mobile-friendly login page

### DIFF
--- a/input.css
+++ b/input.css
@@ -776,7 +776,11 @@
 
   /* ── Wizard / Auth pages (login, setup, error) ── */
   .bb-wizard-bg {
-    @apply bg-base-200 min-h-screen flex items-center justify-center p-4;
+    /* Mobile: top-aligned with generous top padding so content isn't dead-center
+       in a sea of dark background. sm+: vertically centered as before. */
+    @apply bg-base-200 min-h-screen flex items-start justify-center
+           px-4 pt-10 pb-8
+           sm:items-center sm:py-4;
   }
 
   .bb-wizard-orb {
@@ -788,7 +792,8 @@
   }
 
   .bb-wizard-brand {
-    @apply flex justify-center mb-8;
+    /* Tighten vertical gap on mobile; restore on sm+ */
+    @apply flex justify-center mb-5 sm:mb-8;
   }
 
   .bb-wizard-brand-icon {
@@ -797,7 +802,8 @@
   }
 
   .bb-wizard-card {
-    @apply bg-base-100 rounded-xl border border-base-300 p-6;
+    /* Tighter padding on mobile (p-5), comfortable on sm+ (p-6) */
+    @apply bg-base-100 rounded-xl border border-base-300 p-5 sm:p-6;
     animation: bb-wizard-enter 0.3s ease-out;
   }
 

--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -115,8 +115,9 @@ templ acctSummaryCards(p AccountDetailProps) {
 					}
 					{ fmtBalancePtr(p.Account.BalanceCurrent) }
 				} else {
-					<span class="text-base-content/20">@templ.Raw("&mdash;")
-</span>
+					<span class="text-base-content/20">
+						@templ.Raw("&mdash;")
+					</span>
 				}
 			</div>
 			if p.HasCreditUtil {
@@ -369,8 +370,9 @@ templ acctPagination(p AccountDetailProps) {
 			<!-- Page numbers -->
 			for _, n := range acctPageRange(p.Page, p.TotalPages) {
 				if n == 0 {
-					<span class="bb-paginator__ellipsis">@templ.Raw("&hellip;")
-</span>
+					<span class="bb-paginator__ellipsis">
+						@templ.Raw("&hellip;")
+					</span>
 				} else if n == p.Page {
 					<span class="bb-paginator__btn bb-paginator__btn--active">{ fmt.Sprintf("%d", n) }</span>
 				} else {

--- a/internal/templates/components/pages/agents_settings.templ
+++ b/internal/templates/components/pages/agents_settings.templ
@@ -253,7 +253,6 @@ templ agentsSettingsConnectionCard() {
 }
 
 // agentsSettingsToolsSummary mirrors the
-//
 //	"{{.ToolsEnabledCount}} of {{.ToolsTotalCount}} tools enabled
 //	{{if gt .ToolsDisabledCount 0}} · {{.ToolsDisabledCount}} disabled{{end}}"
 //
@@ -291,4 +290,3 @@ func claudeDesktopConfigJSON() string {
   }
 }`
 }
-

--- a/internal/templates/components/pages/login.templ
+++ b/internal/templates/components/pages/login.templ
@@ -9,7 +9,7 @@ templ Login(p LoginProps) {
 		FlashType: p.FlashType,
 		FlashMsg:  p.FlashMsg,
 	}) {
-		<div class="text-center mb-8">
+		<div class="text-center mb-6 sm:mb-8">
 			<h1 class="text-xl font-semibold tracking-tight">Welcome back</h1>
 			<p class="text-sm text-base-content/50 mt-1.5">Sign in to your Breadbox dashboard</p>
 		</div>
@@ -32,6 +32,8 @@ templ Login(p LoginProps) {
 					value={ p.Username }
 					required
 					autocomplete="email"
+					autocorrect="off"
+					autocapitalize="none"
 					placeholder="Enter your email"
 					class="input w-full h-12 rounded-xl text-base bg-base-200/50 border-base-300 focus:bg-base-100 focus:border-primary/40 transition-all duration-200"
 				/>

--- a/internal/templates/components/pages/mcp_settings.templ
+++ b/internal/templates/components/pages/mcp_settings.templ
@@ -102,10 +102,12 @@ templ mcpSettingsEditableCard(c mcpSettingsCardSpec) {
 			</div>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">{ c.Title }</h2>
-				<p class="text-xs text-base-content/40" x-show="!expanded">@templ.Raw(c.SubtitleCol)
-</p>
-				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>@templ.Raw(c.SubtitleExp)
-</p>
+				<p class="text-xs text-base-content/40" x-show="!expanded">
+					@templ.Raw(c.SubtitleCol)
+				</p>
+				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>
+					@templ.Raw(c.SubtitleExp)
+				</p>
 			</div>
 			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>

--- a/internal/templates/components/pages/prompt_builder.templ
+++ b/internal/templates/components/pages/prompt_builder.templ
@@ -260,7 +260,7 @@ templ PromptBuilder(p PromptBuilderProps) {
 								:class="copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'"
 							>
 								<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path></svg>
-								<span>Copy<span class="hidden sm:inline"> Prompt</span></span>
+								<span>Copy<span class="hidden sm:inline">Prompt</span></span>
 								<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
 							</span>
 							<span

--- a/internal/templates/components/pages/reports.templ
+++ b/internal/templates/components/pages/reports.templ
@@ -122,4 +122,3 @@ templ reportsRow(r ReportsItem) {
 		</div>
 	</a>
 }
-

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -320,7 +320,6 @@ func encryptionStatus(has bool) string {
 // did, but without the expand/collapse chrome — a tab page IS the
 // disclosure now.
 // ---------------------------------------------------------------------
-
 templ settingsSyncSchedule(p SettingsProps) {
 	<div class="bb-card p-5">
 		<div class="bb-icon-header">

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -1,8 +1,6 @@
 package pages
 
-import (
-	"breadbox/internal/templates/components"
-)
+import "breadbox/internal/templates/components"
 
 // TagForm renders the create/edit tag form. Hosts inside the base layout
 // via TemplateRenderer.RenderWithTempl. The markup mirrors the previous

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -62,9 +62,11 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 					></i>
 					<span class="sr-only">(pending)</span>
 				}
-				<span class={ "bb-tx-amount tabular-nums",
+				<span
+					class={ "bb-tx-amount tabular-nums",
 					templ.KV("bb-tx-amount--income", tx.Amount < 0),
-					templ.KV("bb-tx-amount--pending", tx.Pending) }>
+					templ.KV("bb-tx-amount--pending", tx.Pending) }
+				>
 					{ formatAmount(tx.Amount) }
 				</span>
 			</div>


### PR DESCRIPTION
Top-align the login card on mobile so the form sits close to the top of the screen — previously it dead-centered in the viewport, leaving ~200px of empty dark background above it on an iPhone, making the page feel unanchored.

## Screenshots

<table>
  <tr><th>Viewport</th><th>Before</th><th>After</th></tr>
  <tr>
    <td>iPhone (390×844)</td>
    <td><img src="https://i.img402.dev/6mgy2ck9s4.jpg" width="280" alt="iPhone — before"></td>
    <td><img src="https://i.img402.dev/xx4kg14ixm.jpg" width="280" alt="iPhone — after"></td>
  </tr>
  <tr>
    <td>Tablet (768×1024)</td>
    <td><img src="https://i.img402.dev/ukp3u6j39t.jpg" width="380" alt="Tablet — before"></td>
    <td><img src="https://i.img402.dev/amdn6mwoqa.jpg" width="380" alt="Tablet — after"></td>
  </tr>
  <tr>
    <td>Desktop (1440×900)</td>
    <td><img src="https://i.img402.dev/56zjfqjucc.jpg" width="600" alt="Desktop — before"></td>
    <td><img src="https://i.img402.dev/hk4ixw63j0.jpg" width="600" alt="Desktop — after"></td>
  </tr>
</table>

## Changes

- `input.css` — `bb-wizard-bg`: `items-start` + `pt-10 pb-8` on mobile; `sm:items-center sm:py-4` restores the centred layout on wider viewports
- `input.css` — `bb-wizard-brand`: `mb-5` on mobile → `sm:mb-8` (tighter gap below brand icon)
- `input.css` — `bb-wizard-card`: `p-5` on mobile → `sm:p-6` (less internal padding on small screens)
- `login.templ` — heading margin `mb-6 sm:mb-8`; email input gains `autocorrect="off" autocapitalize="none"` to suppress iOS corrections
- Several `.templ` files receive whitespace-only `templ fmt` normalisation

## Test plan

- [x] Validated at iPhone (390×844), tablet (768×1024), and desktop (1440×900) via Chrome DevTools MCP
- [x] Login form still functional (200 OK from `/login`)
- [x] Desktop/tablet layout unchanged — `sm:items-center` breakpoint fires at 640px

🤖 Generated with [Claude Code](https://claude.com/claude-code)
