### PR TITLE
fix(tags): mobile-friendly tag list and actions

### DIFF
--- a/internal/templates/components/pages/tags.templ
+++ b/internal/templates/components/pages/tags.templ
@@ -21,7 +21,7 @@ templ Tags(p TagsProps) {
 			<h1 class="bb-page-title">Tags</h1>
 			<p class="text-sm text-base-content/50 mt-1 hidden sm:block">Open-ended labels for coordinating work on transactions</p>
 		</div>
-		<a href="/tags/new" class="btn btn-sm btn-primary rounded-xl gap-2">
+		<a href="/tags/new" class="btn btn-sm btn-primary rounded-xl gap-2 self-start sm:self-auto">
 			<i data-lucide="plus" class="w-4 h-4"></i>
 			Add Tag
 		</a>
@@ -62,10 +62,10 @@ templ tagListRow(t TagRow) {
 	<div
 		data-search={ tagSearchIndex(t) }
 		x-show="!filter || ($el.dataset.search || '').includes(filter.toLowerCase())"
-		class="group flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3"
+		class="group flex items-center gap-2 sm:gap-4 px-3 sm:px-5 py-3"
 	>
 		<!-- Chip preview — natural width, capped so it can't monopolize the row -->
-		<div class="shrink-0 min-w-0 max-w-[10rem] sm:max-w-[14rem]">
+		<div class="shrink-0 min-w-0 max-w-[7rem] sm:max-w-[14rem]">
 			@components.TagChip(components.TagChipData{
 				Slug:        t.Slug,
 				DisplayName: t.DisplayName,
@@ -73,15 +73,28 @@ templ tagListRow(t TagRow) {
 				Icon:        t.Icon,
 			})
 		</div>
-		<!-- Slug + optional description -->
+		<!-- Slug + optional description + mobile count -->
 		<div class="flex-1 min-w-0">
-			<code class="font-mono text-xs text-base-content/60 bg-base-200/50 px-1.5 py-0.5 rounded">{ t.Slug }</code>
+			<code class="font-mono text-xs text-base-content/60 bg-base-200/50 px-1.5 py-0.5 rounded block truncate max-w-full">{ t.Slug }</code>
 			if t.Description != "" {
-				<p class="text-xs text-base-content/50 mt-1 line-clamp-1">{ t.Description }</p>
+				<p class="text-xs text-base-content/50 mt-0.5 truncate">{ t.Description }</p>
 			}
+			<!-- Transaction count on mobile only -->
+			<div class="sm:hidden mt-0.5">
+				if t.TransactionCount > 0 {
+					<a
+						href={ templ.SafeURL(fmt.Sprintf("/transactions?tags=%s", t.Slug)) }
+						class="inline-flex items-baseline gap-0.5 text-xs text-base-content/50 hover:text-base-content"
+						title="View transactions"
+					>
+						<span class="font-medium tabular-nums">{ strconv.FormatInt(t.TransactionCount, 10) }</span>
+						<span class="text-base-content/35">{ tagCountLabel(t.TransactionCount) }</span>
+					</a>
+				}
+			</div>
 		</div>
-		<!-- Transaction count (always visible; desktop gets the "txns" label) -->
-		<div class="shrink-0 text-right tabular-nums">
+		<!-- Transaction count on desktop only -->
+		<div class="hidden sm:block shrink-0 text-right tabular-nums">
 			if t.TransactionCount > 0 {
 				<a
 					href={ templ.SafeURL(fmt.Sprintf("/transactions?tags=%s", t.Slug)) }
@@ -89,7 +102,7 @@ templ tagListRow(t TagRow) {
 					title="View transactions"
 				>
 					<span class="font-medium">{ strconv.FormatInt(t.TransactionCount, 10) }</span>
-					<span class="text-base-content/40 hidden sm:inline">{ tagCountLabel(t.TransactionCount) }</span>
+					<span class="text-base-content/40">{ tagCountLabel(t.TransactionCount) }</span>
 				</a>
 			} else {
 				<span class="text-xs text-base-content/25">&mdash;</span>


### PR DESCRIPTION
## Summary

Tightens the tag list row layout for narrow viewports: reduces horizontal gaps and chip max-width on mobile, makes the slug `<code>` element block-level with truncation to prevent overflow, moves the transaction count into an inline element beneath the slug on small screens (hidden on `sm+`), and hides the existing desktop count column below `sm`. Also adds `self-start` to the "Add Tag" button header so it doesn't stretch vertically on mobile.

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| iPhone (390×844) | ![](https://i.img402.dev/53n181kgm7.jpg) | ![](https://i.img402.dev/1oqwseifcp.jpg) |
| Tablet (768×1024) | ![](https://i.img402.dev/fptlo1nr68.jpg) | ![](https://i.img402.dev/690se7zpu8.jpg) |
| Desktop (1440×900) | ![](https://i.img402.dev/98nv0kjriv.jpg) | ![](https://i.img402.dev/qv0eaku0c7.jpg) |

## Changes

- `self-start sm:self-auto` on "Add Tag" button — prevents vertical stretch in header flex row on mobile
- Row gap reduced from `gap-3` → `gap-2` on mobile; horizontal padding from `px-4` → `px-3`
- Tag chip max-width reduced from `max-w-[10rem]` → `max-w-[7rem]` on mobile
- Slug `<code>` made `block truncate max-w-full` to prevent long slugs from breaking the layout
- Description line-clamp replaced with `truncate` for single-line overflow control
- Transaction count moved below slug for mobile (`sm:hidden`); desktop count column is now `hidden sm:block`

## Test plan

- [x] Validated at iPhone (390×844), Tablet (768×1024), Desktop (1440×900) via Chrome DevTools MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)
