### PR TITLE
fix(api-keys): mobile-friendly key list and create flow

### DIFF
--- a/internal/admin/router.go
+++ b/internal/admin/router.go
@@ -127,23 +127,14 @@ func NewAdminRouter(a *app.App, sm *scs.SessionManager, tr *TemplateRenderer, sv
 		// API Keys + OAuth Clients page (Settings → API Keys tab).
 		// Editors can view and create.
 		r.Get("/settings/api-keys", AccessPageHandler(svc, sm, tr))
+		r.Get("/settings/api-keys/new", APIKeyNewPageHandler(sm, tr))
+		r.Post("/settings/api-keys/new", APIKeyCreatePageHandler(svc, sm, tr))
+		r.Get("/settings/api-keys/{id}/created", APIKeyCreatedPageHandler(sm, tr))
 
-		r.Route("/settings/api-keys", func(r chi.Router) {
-			r.Get("/new", APIKeyNewPageHandler(sm, tr))
-			r.Post("/new", APIKeyCreatePageHandler(svc, sm, tr))
-			r.Get("/{id}/created", APIKeyCreatedPageHandler(sm, tr))
-			// Revoke is admin-only — handled in the admin group below.
-		})
-
-		r.Route("/settings/oauth-clients", func(r chi.Router) {
-			r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-				http.Redirect(w, r, "/settings/api-keys", http.StatusMovedPermanently)
-			})
-			r.Get("/new", OAuthClientNewPageHandler(sm, tr))
-			r.Post("/new", OAuthClientCreatePageHandler(svc, sm, tr))
-			r.Get("/{id}/created", OAuthClientCreatedPageHandler(sm, tr))
-			// Revoke is admin-only — handled in the admin group below.
-		})
+		r.Get("/settings/oauth-clients", redirectGET("/settings/api-keys"))
+		r.Get("/settings/oauth-clients/new", OAuthClientNewPageHandler(sm, tr))
+		r.Post("/settings/oauth-clients/new", OAuthClientCreatePageHandler(svc, sm, tr))
+		r.Get("/settings/oauth-clients/{id}/created", OAuthClientCreatedPageHandler(sm, tr))
 
 		// Legacy /access, /api-keys, /oauth-clients redirects.
 		r.Get("/access", redirectGET("/settings/api-keys"))

--- a/internal/templates/components/pages/access.templ
+++ b/internal/templates/components/pages/access.templ
@@ -68,7 +68,7 @@ templ accessOAuthClientsSection(p AccessProps) {
 				</div>
 			}
 		} else {
-			<div class="bb-card p-12 text-center">
+			<div class="bb-card p-8 sm:p-12 text-center">
 				<div class="flex flex-col items-center">
 					<div class="w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center mb-4">
 						<i data-lucide="fingerprint" class="w-7 h-7 text-base-content/30"></i>
@@ -199,7 +199,7 @@ templ accessAPIKeysSection(p AccessProps) {
 				</div>
 			}
 		} else {
-			<div class="bb-card p-12 text-center">
+			<div class="bb-card p-8 sm:p-12 text-center">
 				<div class="flex flex-col items-center">
 					<div class="w-14 h-14 rounded-xl bg-base-200 flex items-center justify-center mb-4">
 						<i data-lucide="key" class="w-7 h-7 text-base-content/30"></i>

--- a/internal/templates/components/pages/account_detail.templ
+++ b/internal/templates/components/pages/account_detail.templ
@@ -115,8 +115,9 @@ templ acctSummaryCards(p AccountDetailProps) {
 					}
 					{ fmtBalancePtr(p.Account.BalanceCurrent) }
 				} else {
-					<span class="text-base-content/20">@templ.Raw("&mdash;")
-</span>
+					<span class="text-base-content/20">
+						@templ.Raw("&mdash;")
+					</span>
 				}
 			</div>
 			if p.HasCreditUtil {
@@ -369,8 +370,9 @@ templ acctPagination(p AccountDetailProps) {
 			<!-- Page numbers -->
 			for _, n := range acctPageRange(p.Page, p.TotalPages) {
 				if n == 0 {
-					<span class="bb-paginator__ellipsis">@templ.Raw("&hellip;")
-</span>
+					<span class="bb-paginator__ellipsis">
+						@templ.Raw("&hellip;")
+					</span>
 				} else if n == p.Page {
 					<span class="bb-paginator__btn bb-paginator__btn--active">{ fmt.Sprintf("%d", n) }</span>
 				} else {

--- a/internal/templates/components/pages/agents_settings.templ
+++ b/internal/templates/components/pages/agents_settings.templ
@@ -253,7 +253,6 @@ templ agentsSettingsConnectionCard() {
 }
 
 // agentsSettingsToolsSummary mirrors the
-//
 //	"{{.ToolsEnabledCount}} of {{.ToolsTotalCount}} tools enabled
 //	{{if gt .ToolsDisabledCount 0}} · {{.ToolsDisabledCount}} disabled{{end}}"
 //
@@ -291,4 +290,3 @@ func claudeDesktopConfigJSON() string {
   }
 }`
 }
-

--- a/internal/templates/components/pages/api_key_created.templ
+++ b/internal/templates/components/pages/api_key_created.templ
@@ -27,20 +27,22 @@ templ APIKeyCreated(p APIKeyCreatedProps) {
 		</div>
 		<div class="mb-5">
 			<label class="text-xs font-medium text-base-content/50 mb-1.5 block">API Key</label>
-			<div class="flex gap-2" x-data="{ copied: false }">
-				<input type="text" value={ p.PlaintextKey } readonly id="api-key-value" class="input input-sm font-mono flex-1 bg-base-200/50 border-base-300 rounded-xl text-xs"/>
-				<button class="btn btn-primary btn-sm rounded-xl shrink-0 gap-2" :class="copied && '!btn-success'" @click="navigator.clipboard.writeText(document.getElementById('api-key-value').value).then(function(){ $data.copied = true; setTimeout(function(){ $data.copied = false; }, 2000); })">
+			<div class="flex flex-col sm:flex-row gap-2" x-data="{ copied: false }">
+				<div class="relative flex-1 min-w-0">
+					<input type="text" value={ p.PlaintextKey } readonly id="api-key-value" class="input input-sm font-mono w-full bg-base-200/50 border-base-300 rounded-xl text-xs truncate"/>
+				</div>
+				<button class="btn btn-primary btn-sm rounded-xl shrink-0 gap-2 w-full sm:w-auto" :class="copied && '!btn-success'" @click="navigator.clipboard.writeText(document.getElementById('api-key-value').value).then(function(){ $data.copied = true; setTimeout(function(){ $data.copied = false; }, 2000); })">
 					<i data-lucide="clipboard" class="w-4 h-4" x-show="!copied"></i>
 					<i data-lucide="check" class="w-4 h-4" x-show="copied" x-cloak></i>
 					<span x-text="copied ? 'Copied!' : 'Copy'"></span>
 				</button>
 			</div>
 		</div>
-		<div class="flex items-center justify-between pt-4 border-t border-base-300">
-			<p class="text-xs text-base-content/40">
+		<div class="flex flex-wrap items-center justify-between gap-2 pt-4 border-t border-base-300">
+			<p class="text-xs text-base-content/40 min-w-0">
 				Use in the <code class="font-mono text-primary/70 bg-primary/5 px-1.5 py-0.5 rounded">X-API-Key</code> header for API requests.
 			</p>
-			<a href="/settings/api-keys" class="btn btn-ghost btn-sm rounded-xl">Done</a>
+			<a href="/settings/api-keys" class="btn btn-ghost btn-sm rounded-xl shrink-0">Done</a>
 		</div>
 	</div>
 }

--- a/internal/templates/components/pages/mcp_settings.templ
+++ b/internal/templates/components/pages/mcp_settings.templ
@@ -102,10 +102,12 @@ templ mcpSettingsEditableCard(c mcpSettingsCardSpec) {
 			</div>
 			<div class="min-w-0 flex-1">
 				<h2 class="font-semibold">{ c.Title }</h2>
-				<p class="text-xs text-base-content/40" x-show="!expanded">@templ.Raw(c.SubtitleCol)
-</p>
-				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>@templ.Raw(c.SubtitleExp)
-</p>
+				<p class="text-xs text-base-content/40" x-show="!expanded">
+					@templ.Raw(c.SubtitleCol)
+				</p>
+				<p class="text-xs text-base-content/40" x-show="expanded" x-cloak>
+					@templ.Raw(c.SubtitleExp)
+				</p>
 			</div>
 			<i data-lucide="chevron-down" class="w-4 h-4 text-base-content/30 transition-transform duration-200 flex-shrink-0" :class="expanded && 'rotate-180'"></i>
 		</div>

--- a/internal/templates/components/pages/prompt_builder.templ
+++ b/internal/templates/components/pages/prompt_builder.templ
@@ -260,7 +260,7 @@ templ PromptBuilder(p PromptBuilderProps) {
 								:class="copied ? 'opacity-0 scale-75' : 'opacity-100 scale-100'"
 							>
 								<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"></rect><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"></path></svg>
-								<span>Copy<span class="hidden sm:inline"> Prompt</span></span>
+								<span>Copy<span class="hidden sm:inline">Prompt</span></span>
 								<span class="hidden sm:inline ml-1 text-[10px] opacity-60 border border-current/30 rounded px-1 leading-none py-0.5">C</span>
 							</span>
 							<span

--- a/internal/templates/components/pages/reports.templ
+++ b/internal/templates/components/pages/reports.templ
@@ -122,4 +122,3 @@ templ reportsRow(r ReportsItem) {
 		</div>
 	</a>
 }
-

--- a/internal/templates/components/pages/settings.templ
+++ b/internal/templates/components/pages/settings.templ
@@ -320,7 +320,6 @@ func encryptionStatus(has bool) string {
 // did, but without the expand/collapse chrome — a tab page IS the
 // disclosure now.
 // ---------------------------------------------------------------------
-
 templ settingsSyncSchedule(p SettingsProps) {
 	<div class="bb-card p-5">
 		<div class="bb-icon-header">

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -1,8 +1,6 @@
 package pages
 
-import (
-	"breadbox/internal/templates/components"
-)
+import "breadbox/internal/templates/components"
 
 // TagForm renders the create/edit tag form. Hosts inside the base layout
 // via TemplateRenderer.RenderWithTempl. The markup mirrors the previous

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -62,9 +62,11 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 					></i>
 					<span class="sr-only">(pending)</span>
 				}
-				<span class={ "bb-tx-amount tabular-nums",
+				<span
+					class={ "bb-tx-amount tabular-nums",
 					templ.KV("bb-tx-amount--income", tx.Amount < 0),
-					templ.KV("bb-tx-amount--pending", tx.Pending) }>
+					templ.KV("bb-tx-amount--pending", tx.Pending) }
+				>
 					{ formatAmount(tx.Amount) }
 				</span>
 			</div>


### PR DESCRIPTION
Fix two independent bugs on `/settings/api-keys` and its sub-pages, plus a CSS bundle gap that broke the Settings sidebar layout on all settings pages.

## Summary

- **Router 404 bug (critical):** `/settings/api-keys` returned 404 for all users. chi v5 silently drops a bare `r.Get("/path")` when a sibling `r.Route("/path", …)` is also registered — the subrouter wins and the exact-match GET handler is swallowed. Fixed by flattening both the api-keys and oauth-clients route groups into individual `r.Get`/`r.Post` registrations, eliminating the conflict.
- **CSS bundle stale:** The `static/css/styles.css` bundle dated April 16 was missing the `lg:flex-row`, `lg:w-72`, and `lg:hidden` classes added by `SettingsLayout`. On desktop the settings rail rendered as a broken horizontal strip instead of a left-rail sidebar. Rebuilt with `tailwindcss-extra`.
- **Created-page mobile layout:** On iPhone, the API key input + Copy button were side-by-side and the button was cramped. Now stacked vertically (`flex-col sm:flex-row`) with a full-width Copy button on small screens. Footer row (`flex-wrap`) prevents the `X-API-Key` hint and Done button from overlapping.
- **Empty-state padding:** Reduced `p-12` → `p-8 sm:p-12` on the OAuth/API-keys empty states so they don't feel oversized on a 390px viewport.
- **templ fmt:** Whitespace-only reformatting pass on all `.templ` files in the tree.

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| iPhone (390×844) — created page | <img src="https://i.img402.dev/bc31hfu5e1.jpg" width="300" alt="before iphone"> | <img src="https://i.img402.dev/0whg1p3j7x.jpg" width="300" alt="after iphone"> |
| Tablet (768×1024) | <img src="https://i.img402.dev/o8fa84d7ka.jpg" width="400" alt="before tablet"> | <img src="https://i.img402.dev/h13krwf2x3.jpg" width="400" alt="after tablet"> |
| Desktop (1440×900) | <img src="https://i.img402.dev/hfsn9uas2q.jpg" width="600" alt="before desktop"> | <img src="https://i.img402.dev/fz1z28v8sr.jpg" width="600" alt="after desktop"> |

## Changes

- `internal/admin/router.go` — flatten api-keys and oauth-clients route groups to fix 404
- `internal/templates/components/pages/api_key_created.templ` — mobile-first copy-row layout
- `internal/templates/components/pages/access.templ` — reduced empty-state padding on mobile
- `static/css/styles.css` — rebuilt to include missing `lg:*` responsive classes (gitignored, rebuilt locally)
- All `.templ` files — `templ fmt` pass

## Test plan

- [x] Validated iPhone (390×844), tablet (768×1024), desktop (1440×900) via Chrome DevTools MCP
- [x] `/settings/api-keys` returns 200 (was 404 before fix)
- [x] `/settings/api-keys/new` and `/{id}/created` routes still work
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
