### PR TITLE
fix(connections): mobile-friendly connection detail page

### DIFF
--- a/internal/templates/components/pages/connection_detail.templ
+++ b/internal/templates/components/pages/connection_detail.templ
@@ -58,7 +58,7 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 			</div>
 		}
 		<!-- Header with actions -->
-		<div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
+		<div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-6">
 			<div class="flex items-center gap-4 min-w-0">
 				<div class={ "w-11 h-11 rounded-xl flex items-center justify-center shrink-0", connDetailHeaderTileBg(p.Provider) }>
 					switch p.Provider {
@@ -103,7 +103,7 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 					</div>
 				</div>
 			</div>
-			<div class="flex items-center gap-2 flex-wrap shrink-0">
+			<div class="flex items-center gap-2 flex-wrap sm:shrink-0">
 				if p.Status == "error" || p.Status == "pending_reauth" {
 					<a href={ templ.SafeURL("/connections/" + p.ConnID + "/reauth") } class="btn btn-sm btn-outline rounded-xl">Re-authenticate</a>
 				}
@@ -163,7 +163,7 @@ templ ConnectionDetail(p ConnectionDetailProps) {
 
 templ connDetailSyncHealth(p ConnectionDetailProps) {
 	<div class="bb-card p-0 mb-6 overflow-hidden">
-		<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 divide-x divide-base-300/40">
+		<div class="grid grid-cols-2 sm:grid-cols-5 [&>*:not(:last-child)]:border-r [&>*:not(:last-child)]:border-base-300/40 sm:[&>*]:border-r sm:[&>*:last-child]:border-r-0 [&>*:nth-child(n+3)]:border-t [&>*:nth-child(n+3)]:border-base-300/40 sm:[&>*:nth-child(n+3)]:border-t-0 [&>*:nth-child(2n)]:border-r-0 sm:[&>*:nth-child(2n)]:border-r [&>*:last-child:nth-child(odd)]:col-span-2 sm:[&>*:last-child:nth-child(odd)]:col-span-1">
 			<div class="p-4">
 				<div class="text-[0.65rem] font-medium text-base-content/40 uppercase tracking-wider mb-1.5">Success Rate</div>
 				<div class="flex items-baseline gap-1">
@@ -275,7 +275,7 @@ templ connDetailDayBar(ds DaySyncRow) {
 
 templ connDetailInfoGrid(p ConnectionDetailProps) {
 	<div class="bb-card p-0 mb-6 overflow-hidden">
-		<div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 divide-x divide-base-300/40">
+		<div class="grid grid-cols-2 sm:grid-cols-5 [&>*:not(:last-child)]:border-r [&>*:not(:last-child)]:border-base-300/40 sm:[&>*]:border-r sm:[&>*:last-child]:border-r-0 [&>*:nth-child(n+3)]:border-t [&>*:nth-child(n+3)]:border-base-300/40 sm:[&>*:nth-child(n+3)]:border-t-0 [&>*:nth-child(2n)]:border-r-0 sm:[&>*:nth-child(2n)]:border-r [&>*:last-child:nth-child(odd)]:col-span-2 sm:[&>*:last-child:nth-child(odd)]:col-span-1">
 			<div class="p-4">
 				<div class="text-[0.65rem] font-medium text-base-content/40 uppercase tracking-wider mb-1.5">Family Member</div>
 				<div class="text-sm font-semibold truncate">{ p.UserName }</div>
@@ -322,7 +322,7 @@ templ connDetailInfoGrid(p ConnectionDetailProps) {
 			</div>
 		</div>
 		if p.ConsecutiveFailures > 0 {
-			<div class="border-t border-base-300/40 grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 divide-x divide-base-300/40">
+			<div class="border-t border-base-300/40 grid grid-cols-2 sm:grid-cols-5 [&>*:not(:last-child)]:border-r [&>*:not(:last-child)]:border-base-300/40 sm:[&>*]:border-r sm:[&>*:last-child]:border-r-0">
 				<div class="p-4">
 					<div class="text-[0.65rem] font-medium text-base-content/40 uppercase tracking-wider mb-1.5">Consecutive Failures</div>
 					<div class="text-sm font-semibold text-warning">{ fmt.Sprintf("%d", p.ConsecutiveFailures) }</div>


### PR DESCRIPTION
Fix mobile layout on the per-connection detail page (`/connections/{id}`). The connections list page was shipped in #936; this PR covers the detail view only.

## Summary
- Sync Health stats card and Connection Info grid both used `grid-cols-2 sm:grid-cols-3 lg:grid-cols-5` with `divide-x` — at mobile the 5th item (Avg Duration / Sync Interval) landed on its own row as a lone orphan spanning half the card width. Switched to `grid-cols-2 sm:grid-cols-5` with explicit row-divider utilities and `col-span-2` on the last odd item so it spans full width cleanly.
- Removed `shrink-0` from the action-buttons row at mobile so buttons wrap naturally instead of overflowing.

## Screenshots

| Viewport | Before | After |
| --- | --- | --- |
| iPhone (390×844) | <img src="https://i.img402.dev/2qaeq5oq9u.jpg" width="320" alt="before iphone"> | <img src="https://i.img402.dev/y9hun4dz5l.jpg" width="320" alt="after iphone"> |
| Tablet (768×1024) | <img src="https://i.img402.dev/hgk1f68o0l.jpg" width="400" alt="before tablet"> | <img src="https://i.img402.dev/j4b48mbvhb.jpg" width="400" alt="after tablet"> |
| Desktop (1440×900) | <img src="https://i.img402.dev/u4hih8vzlg.jpg" width="600" alt="before desktop"> | <img src="https://i.img402.dev/xtjblczvve.jpg" width="600" alt="after desktop"> |

## Changes
- `connection_detail.templ`: sync-health grid → `grid-cols-2 sm:grid-cols-5` with row-dividers + `[&>*:last-child:nth-child(odd)]:col-span-2 sm:[&>*:last-child:nth-child(odd)]:col-span-1`
- `connection_detail.templ`: info-grid → same responsive grid pattern
- `connection_detail.templ`: consecutive-failures sub-row → same border utilities, no `divide-x`
- `connection_detail.templ`: action-buttons container: `shrink-0` → `sm:shrink-0` (only shrink on wide screens)

## Out of scope
- Connections list page (shipped in PR #936)

## Test plan
- [x] Validated at iPhone (390×844) / tablet (768×1024) / desktop (1440×900) via Chrome DevTools MCP
- [x] Build passes: `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
