### PR TITLE
fix(modals): mobile-friendly edit-tag, edit-rule, and csv-import dialogs

### DIFF
--- a/input.css
+++ b/input.css
@@ -254,8 +254,15 @@
   .bb-icon-tile--error   { @apply bg-error/10 text-error; }
 
   /* Action row at the bottom of a sectioned form card.
-     Holds Cancel + primary (Save/Create) buttons right-aligned. */
-  .bb-action-row { @apply p-4 sm:p-5 border-t border-base-300 bg-base-200/20 flex items-center justify-end gap-2; }
+     Stacks Cancel + primary buttons vertically on mobile (primary first via
+     flex-col-reverse) and aligns them right on sm+. Safe-area bottom padding
+     ensures home-indicator clearance on iOS. */
+  .bb-action-row {
+    @apply p-4 sm:p-5 border-t border-base-300 bg-base-200/20
+           flex flex-col-reverse sm:flex-row items-stretch sm:items-center sm:justify-end gap-2;
+    padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px));
+    @media (min-width: 640px) { padding-bottom: 1.25rem; }
+  }
 
   /* Form inputs/selects with subtle base-200 bg that clears on focus. */
   .bb-form-input { @apply input w-full rounded-xl bg-base-200/50 focus:bg-base-100 transition-colors; }

--- a/internal/templates/components/pages/csv_import.templ
+++ b/internal/templates/components/pages/csv_import.templ
@@ -109,8 +109,8 @@ templ CSVImport(p CSVImportProps) {
 					<i data-lucide="alert-circle" class="w-4 h-4 shrink-0 mt-0.5"></i>
 					<span id="upload-status"></span>
 				</div>
-				<div class="flex items-center gap-3 pt-2">
-					<button type="button" id="upload-btn" class="btn btn-primary btn-sm rounded-xl" onclick="uploadFile()">
+				<div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 pt-2">
+					<button type="button" id="upload-btn" class="btn btn-primary btn-sm rounded-xl w-full sm:w-auto" onclick="uploadFile()">
 						<i data-lucide="upload" class="w-4 h-4"></i> Upload &amp; Parse
 					</button>
 					<p id="upload-progress" class="text-sm text-base-content/60"></p>
@@ -199,14 +199,16 @@ templ CSVImport(p CSVImportProps) {
 						<input type="text" id="account-name" class="input input-bordered w-full rounded-xl" value="CSV Import" placeholder="e.g., Chase Checking CSV"/>
 					</fieldset>
 				}
-				<div class="flex items-center gap-3 pt-2">
-					<button type="button" class="btn btn-ghost btn-sm rounded-xl" onclick="window._csvWizard.setStep(1)">
-						<i data-lucide="arrow-left" class="w-4 h-4"></i> Back
-					</button>
-					<button type="button" class="btn btn-sm btn-outline rounded-xl" onclick="previewData()">
-						<i data-lucide="eye" class="w-4 h-4"></i> Preview
-					</button>
-					<button type="button" id="continue-btn" class="btn btn-primary btn-sm rounded-xl hidden" onclick="goToStep3()">
+				<div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 pt-2">
+					<div class="flex items-center gap-2">
+						<button type="button" class="btn btn-ghost btn-sm rounded-xl flex-1 sm:flex-none" onclick="window._csvWizard.setStep(1)">
+							<i data-lucide="arrow-left" class="w-4 h-4"></i> Back
+						</button>
+						<button type="button" class="btn btn-sm btn-outline rounded-xl flex-1 sm:flex-none" onclick="previewData()">
+							<i data-lucide="eye" class="w-4 h-4"></i> Preview
+						</button>
+					</div>
+					<button type="button" id="continue-btn" class="btn btn-primary btn-sm rounded-xl hidden w-full sm:w-auto" onclick="goToStep3()">
 						Continue <i data-lucide="arrow-right" class="w-4 h-4"></i>
 					</button>
 					<p id="preview-status" class="text-sm text-error"></p>
@@ -265,11 +267,11 @@ templ CSVImport(p CSVImportProps) {
 						<span id="summary-member" class="text-sm font-semibold"></span>
 					</div>
 				</div>
-				<div class="flex items-center gap-3">
-					<button type="button" class="btn btn-ghost btn-sm rounded-xl" onclick="goToStep(2)">
+				<div class="flex flex-col-reverse sm:flex-row items-stretch sm:items-center gap-3">
+					<button type="button" class="btn btn-ghost btn-sm rounded-xl w-full sm:w-auto" onclick="goToStep(2)">
 						<i data-lucide="arrow-left" class="w-4 h-4"></i> Back
 					</button>
-					<button type="button" id="import-btn" class="btn btn-primary btn-sm rounded-xl" onclick="doImport()">
+					<button type="button" id="import-btn" class="btn btn-primary btn-sm rounded-xl w-full sm:w-auto" onclick="doImport()">
 						<i data-lucide="download" class="w-4 h-4"></i> Import Transactions
 					</button>
 				</div>

--- a/internal/templates/components/pages/rule_form.templ
+++ b/internal/templates/components/pages/rule_form.templ
@@ -373,8 +373,8 @@ templ RuleForm(p RuleFormProps) {
 				</template>
 				<!-- Action row -->
 				<div class="bb-action-row">
-					<a href="/rules" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
-					<button type="submit" class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32" :disabled="submitting">
+					<a href="/rules" class="btn btn-sm btn-ghost rounded-xl w-full sm:w-auto">Cancel</a>
+					<button type="submit" class="btn btn-sm btn-primary rounded-xl gap-1.5 w-full sm:w-auto min-w-32" :disabled="submitting">
 						<span x-show="!submitting" class="inline-flex items-center gap-1.5">
 							<i data-lucide="save" class="w-3.5 h-3.5"></i>
 							<span x-text="isEdit ? 'Save Changes' : 'Create Rule'"></span>

--- a/internal/templates/components/pages/tag_form.templ
+++ b/internal/templates/components/pages/tag_form.templ
@@ -1,8 +1,6 @@
 package pages
 
-import (
-	"breadbox/internal/templates/components"
-)
+import "breadbox/internal/templates/components"
 
 // TagForm renders the create/edit tag form. Hosts inside the base layout
 // via TemplateRenderer.RenderWithTempl. The markup mirrors the previous
@@ -191,10 +189,10 @@ templ TagForm(p TagFormProps) {
 				</div>
 			</div>
 			<div class="bb-action-row">
-				<a href="/tags" class="btn btn-sm btn-ghost rounded-xl">Cancel</a>
+				<a href="/tags" class="btn btn-sm btn-ghost rounded-xl w-full sm:w-auto">Cancel</a>
 				<button
 					type="submit"
-					class="btn btn-sm btn-primary rounded-xl gap-1.5 min-w-32"
+					class="btn btn-sm btn-primary rounded-xl gap-1.5 w-full sm:w-auto min-w-32"
 					:disabled="submitting"
 				>
 					<span x-show="!submitting" class="inline-flex items-center gap-1.5">


### PR DESCRIPTION
Make the edit-tag, edit-rule, and csv-import forms usable on iPhone by stacking action buttons full-width on mobile and adding iOS safe-area bottom clearance.

## Changes

- **`input.css`**: `bb-action-row` now uses `flex-col-reverse sm:flex-row items-stretch sm:items-center sm:justify-end` so buttons stack vertically on mobile (primary first via `flex-col-reverse`) and align right on sm+. Added `padding-bottom: calc(1rem + env(safe-area-inset-bottom, 0px))` with `sm:` reset for home-indicator clearance.
- **`tag_form.templ`**: Cancel + Save Changes buttons get `w-full sm:w-auto` so they fill the row on mobile.
- **`rule_form.templ`**: Same treatment for Cancel + Save Changes.
- **`csv_import.templ`**: Step 1 Upload & Parse button, step 2 Back/Preview/Continue row, and step 3 Back/Import row all converted to `flex-col` / `w-full sm:w-auto` for mobile.

## Screenshots — Edit Tag (iPhone 390×844)

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/cp5wki99ek.png" width="320" alt="edit-tag before"></td>
    <td><img src="https://i.img402.dev/r59jkzyyef.png" width="320" alt="edit-tag after"></td>
  </tr>
</table>

## Screenshots — Edit Rule (iPhone 390×844)

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/5064id22se.png" width="320" alt="edit-rule before"></td>
    <td><img src="https://i.img402.dev/uh028bm51g.png" width="320" alt="edit-rule after"></td>
  </tr>
</table>

## Screenshots — CSV Import step 1 (iPhone 390×844)

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/es398hpzxv.png" width="320" alt="csv-import before"></td>
    <td><img src="https://i.img402.dev/d0wdrwf8o6.png" width="320" alt="csv-import after"></td>
  </tr>
</table>

## Out of scope

- Other form pages using `bb-action-row` (category_form, user_form, create_login, my_account) — they automatically benefit from the `bb-action-row` CSS change but were not independently tested in this PR.

## Test plan

- [x] Validated at iPhone (390×844) via Chrome DevTools MCP
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass
- [x] Edit-tag, edit-rule forms: primary button full-width on mobile, Cancel below
- [x] CSV import step 1: Upload & Parse button full-width on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)
