### PR TITLE
fix(oauth): mobile-friendly authorize, new-client, and created pages

### DIFF
--- a/internal/templates/components/pages/oauth_authorize.templ
+++ b/internal/templates/components/pages/oauth_authorize.templ
@@ -28,11 +28,11 @@ templ OAuthAuthorize(p OAuthAuthorizeProps) {
 		FlashType: p.FlashType,
 		FlashMsg:  p.FlashMsg,
 	}) {
-		<div class="flex flex-col items-center justify-center min-h-[60vh] px-4">
-			<div class="bb-card p-8 max-w-md w-full">
+		<div class="flex flex-col items-center justify-center min-h-[60vh] px-4 py-6">
+			<div class="bb-card p-6 sm:p-8 max-w-md w-full">
 				<div class="flex flex-col items-center text-center mb-6">
-					<div class="w-16 h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
-						<i data-lucide="shield-check" class="w-8 h-8 text-primary"></i>
+					<div class="w-14 h-14 sm:w-16 sm:h-16 rounded-xl bg-primary/10 flex items-center justify-center mb-4">
+						<i data-lucide="shield-check" class="w-7 h-7 sm:w-8 sm:h-8 text-primary"></i>
 					</div>
 					<h2 class="text-lg font-semibold mb-1">Authorize Access</h2>
 					<p class="text-sm text-base-content/50">
@@ -41,19 +41,19 @@ templ OAuthAuthorize(p OAuthAuthorizeProps) {
 				</div>
 				<div class="rounded-xl bg-base-200/50 p-4 mb-6">
 					<div class="text-xs font-medium text-base-content/50 mb-2">This will allow the application to:</div>
-					<ul class="space-y-2">
-						<li class="flex items-center gap-2 text-sm">
-							<i data-lucide="check" class="w-4 h-4 text-success shrink-0"></i>
-							Read your transactions, accounts, and categories
+					<ul class="space-y-2.5">
+						<li class="flex items-start gap-2 text-sm">
+							<i data-lucide="check" class="w-4 h-4 text-success shrink-0 mt-0.5"></i>
+							<span>Read your transactions, accounts, and categories</span>
 						</li>
 						if p.Scope != "read_only" {
-							<li class="flex items-center gap-2 text-sm">
-								<i data-lucide="check" class="w-4 h-4 text-success shrink-0"></i>
-								Categorize transactions and manage rules
+							<li class="flex items-start gap-2 text-sm">
+								<i data-lucide="check" class="w-4 h-4 text-success shrink-0 mt-0.5"></i>
+								<span>Categorize transactions and manage rules</span>
 							</li>
-							<li class="flex items-center gap-2 text-sm">
-								<i data-lucide="check" class="w-4 h-4 text-success shrink-0"></i>
-								Use MCP tools in read/write mode
+							<li class="flex items-start gap-2 text-sm">
+								<i data-lucide="check" class="w-4 h-4 text-success shrink-0 mt-0.5"></i>
+								<span>Use MCP tools in read/write mode</span>
 							</li>
 						}
 					</ul>
@@ -66,12 +66,12 @@ templ OAuthAuthorize(p OAuthAuthorizeProps) {
 					<input type="hidden" name="scope" value={ p.Scope }/>
 					<input type="hidden" name="code_challenge" value={ p.CodeChallenge }/>
 					<input type="hidden" name="code_challenge_method" value={ p.CodeChallengeMethod }/>
-					<div class="flex gap-3">
-						<button type="submit" name="action" value="approve" class="btn btn-primary flex-1 rounded-xl">
+					<div class="flex flex-col sm:flex-row gap-3">
+						<button type="submit" name="action" value="approve" class="btn btn-primary flex-1 rounded-xl order-1 sm:order-none">
 							<i data-lucide="check" class="w-4 h-4"></i>
 							Authorize
 						</button>
-						<button type="submit" name="action" value="deny" class="btn btn-ghost flex-1 rounded-xl">
+						<button type="submit" name="action" value="deny" class="btn btn-ghost flex-1 rounded-xl order-2 sm:order-none">
 							Deny
 						</button>
 					</div>

--- a/internal/templates/components/pages/oauth_client_created.templ
+++ b/internal/templates/components/pages/oauth_client_created.templ
@@ -26,56 +26,60 @@ templ OAuthClientCreated(p OAuthClientCreatedProps) {
 			<p class="text-sm text-base-content/50 mt-1">Copy your credentials now -- you won't see the secret again</p>
 		</div>
 	</div>
-	<div class="bb-card p-6 max-w-lg" x-data="oauthClientCreated" data-secret={ p.ClientSecret }>
-		<div class="flex items-center gap-3 mb-5">
-			<div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center">
-				<i data-lucide="check" class="w-5 h-5 text-success"></i>
-			</div>
-			<div>
-				<h2 class="text-sm font-semibold">{ p.ClientName }</h2>
-				<p class="text-xs text-base-content/45">Copy these credentials -- the secret won't be shown again.</p>
-			</div>
-		</div>
-		<div class="space-y-4 mb-5">
-			<div>
-				<label class="text-xs font-medium text-base-content/50 mb-1.5 block">Client ID</label>
-				<div class="flex gap-2">
-					<input type="text" value={ p.ClientID } readonly id="oauth-client-id" class="input input-sm font-mono flex-1 bg-base-200/50 border-base-300 rounded-xl text-xs"/>
-					<button class="btn btn-sm btn-ghost rounded-xl shrink-0 gap-1.5" :class="copiedId && '!text-success'" @click="copyClientId()">
-						<i data-lucide="clipboard" class="w-3.5 h-3.5" x-show="!copiedId"></i>
-						<i data-lucide="check" class="w-3.5 h-3.5" x-show="copiedId" x-cloak></i>
-						<span x-text="copiedId ? 'Copied!' : 'Copy'"></span>
-					</button>
+	<div class="bb-card max-w-lg" x-data="oauthClientCreated" data-secret={ p.ClientSecret }>
+		<div class="p-5 sm:p-6">
+			<div class="flex items-center gap-3 mb-5">
+				<div class="w-9 h-9 rounded-lg bg-success/10 flex items-center justify-center shrink-0">
+					<i data-lucide="check" class="w-5 h-5 text-success"></i>
+				</div>
+				<div class="min-w-0">
+					<h2 class="text-sm font-semibold truncate">{ p.ClientName }</h2>
+					<p class="text-xs text-base-content/45">Copy these credentials -- the secret won't be shown again.</p>
 				</div>
 			</div>
-			<div>
-				<label class="text-xs font-medium text-base-content/50 mb-1.5 block">Client Secret</label>
-				<div class="flex gap-2">
-					<input type="text" value={ p.ClientSecret } readonly id="oauth-client-secret" class="input input-sm font-mono flex-1 bg-base-200/50 border-base-300 rounded-xl text-xs"/>
-					<button class="btn btn-primary btn-sm rounded-xl shrink-0 gap-1.5" :class="copiedSecret && '!btn-success'" @click="copyClientSecret()">
-						<i data-lucide="clipboard" class="w-3.5 h-3.5" x-show="!copiedSecret"></i>
-						<i data-lucide="check" class="w-3.5 h-3.5" x-show="copiedSecret" x-cloak></i>
-						<span x-text="copiedSecret ? 'Copied!' : 'Copy'"></span>
-					</button>
+			<div class="space-y-4">
+				<div>
+					<label class="text-xs font-medium text-base-content/50 mb-1.5 block">Client ID</label>
+					<div class="flex gap-2">
+						<input type="text" value={ p.ClientID } readonly id="oauth-client-id" class="input input-sm font-mono min-w-0 flex-1 bg-base-200/50 border-base-300 rounded-xl text-xs"/>
+						<button class="btn btn-sm btn-ghost rounded-xl shrink-0 gap-1" :class="copiedId && '!text-success'" @click="copyClientId()">
+							<i data-lucide="clipboard" class="w-3.5 h-3.5" x-show="!copiedId"></i>
+							<i data-lucide="check" class="w-3.5 h-3.5" x-show="copiedId" x-cloak></i>
+							<span class="hidden sm:inline" x-text="copiedId ? 'Copied!' : 'Copy'"></span>
+						</button>
+					</div>
+				</div>
+				<div>
+					<label class="text-xs font-medium text-base-content/50 mb-1.5 block">Client Secret</label>
+					<div class="flex gap-2">
+						<input type="text" value={ p.ClientSecret } readonly id="oauth-client-secret" class="input input-sm font-mono min-w-0 flex-1 bg-base-200/50 border-base-300 rounded-xl text-xs"/>
+						<button class="btn btn-primary btn-sm rounded-xl shrink-0 gap-1" :class="copiedSecret && '!btn-success'" @click="copyClientSecret()">
+							<i data-lucide="clipboard" class="w-3.5 h-3.5" x-show="!copiedSecret"></i>
+							<i data-lucide="check" class="w-3.5 h-3.5" x-show="copiedSecret" x-cloak></i>
+							<span class="hidden sm:inline" x-text="copiedSecret ? 'Copied!' : 'Copy'"></span>
+						</button>
+					</div>
 				</div>
 			</div>
 		</div>
-		<div class="pt-4 border-t border-base-300 space-y-3">
-			<div class="flex items-center justify-between">
-				<p class="text-xs text-base-content/40">
-					Paste the Client ID and Secret into your connector's settings.
-				</p>
-				<a href="/access" class="btn btn-ghost btn-sm rounded-xl shrink-0">Done</a>
-			</div>
-			<div class="rounded-xl bg-base-200/50 p-3">
-				<div class="text-xs font-medium text-base-content/50 mb-1.5">MCP Server URL</div>
-				<div class="flex gap-2">
-					<input type="text" value={ p.MCPServerURL } readonly id="oauth-mcp-url" class="input input-sm font-mono flex-1 bg-base-100 border-base-300 rounded-xl text-xs text-primary/80"/>
-					<button class="btn btn-sm btn-ghost rounded-xl shrink-0 gap-1.5" :class="copiedUrl && '!text-success'" @click="copyMCPUrl()">
-						<i data-lucide="clipboard" class="w-3.5 h-3.5" x-show="!copiedUrl"></i>
-						<i data-lucide="check" class="w-3.5 h-3.5" x-show="copiedUrl" x-cloak></i>
-						<span x-text="copiedUrl ? 'Copied!' : 'Copy'"></span>
-					</button>
+		<div class="border-t border-base-300">
+			<div class="p-4 sm:p-5 bg-base-200/50 space-y-3">
+				<div class="rounded-xl bg-base-100 p-3">
+					<div class="text-xs font-medium text-base-content/50 mb-1.5">MCP Server URL</div>
+					<div class="flex gap-2">
+						<input type="text" value={ p.MCPServerURL } readonly id="oauth-mcp-url" class="input input-sm font-mono min-w-0 flex-1 bg-base-200/50 border-base-300 rounded-xl text-xs text-primary/80"/>
+						<button class="btn btn-sm btn-ghost rounded-xl shrink-0 gap-1" :class="copiedUrl && '!text-success'" @click="copyMCPUrl()">
+							<i data-lucide="clipboard" class="w-3.5 h-3.5" x-show="!copiedUrl"></i>
+							<i data-lucide="check" class="w-3.5 h-3.5" x-show="copiedUrl" x-cloak></i>
+							<span class="hidden sm:inline" x-text="copiedUrl ? 'Copied!' : 'Copy'"></span>
+						</button>
+					</div>
+				</div>
+				<div class="flex items-center justify-between gap-3">
+					<p class="text-xs text-base-content/40">
+						Paste these into your connector's settings.
+					</p>
+					<a href="/access" class="btn btn-ghost btn-sm rounded-xl shrink-0">Done</a>
 				</div>
 			</div>
 		</div>

--- a/internal/templates/components/pages/oauth_client_new.templ
+++ b/internal/templates/components/pages/oauth_client_new.templ
@@ -17,27 +17,29 @@ templ OAuthClientNew(p OAuthClientNewProps) {
 			<p class="text-sm text-base-content/50 mt-1">Generate credentials for an external connector (e.g., Claude)</p>
 		</div>
 	</div>
-	<div class="bb-card p-6 max-w-lg">
+	<div class="bb-card max-w-lg">
 		<form method="POST" action="/oauth-clients/new">
 			<input type="hidden" name="_csrf" value={ p.CSRFToken }/>
-			<fieldset class="fieldset mb-5">
-				<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="name">Name</label>
-				<input type="text" id="name" name="name" class="input input-bordered w-full rounded-xl" placeholder="e.g., Claude Connector, Scheduled Agent" required autofocus/>
-				<p class="text-xs text-base-content/40 mt-2">A descriptive name shown on the consent screen when authorizing.</p>
-			</fieldset>
-			<fieldset class="fieldset mb-6">
-				<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="scope">Scope</label>
-				<select id="scope" name="scope" class="select select-bordered w-full rounded-xl">
-					<option value="full_access">Full Access — read and write via MCP</option>
-					<option value="read_only">Read Only — query data only</option>
-				</select>
-				<p class="text-xs text-base-content/40 mt-2">Controls what the connected service can do. Full access allows transaction categorization, rule management, and write MCP tools.</p>
-			</fieldset>
-			<div class="flex gap-3 pt-2">
+			<div class="p-5 sm:p-6 space-y-5">
+				<fieldset class="fieldset">
+					<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="name">Name</label>
+					<input type="text" id="name" name="name" class="input input-bordered w-full rounded-xl" placeholder="e.g., Claude Connector, Scheduled Agent" required autofocus/>
+					<p class="text-xs text-base-content/40 mt-2">A descriptive name shown on the consent screen when authorizing.</p>
+				</fieldset>
+				<fieldset class="fieldset">
+					<label class="text-sm font-medium text-base-content/70 mb-1.5 block" for="scope">Scope</label>
+					<select id="scope" name="scope" class="select select-bordered w-full rounded-xl">
+						<option value="full_access">Full Access — read and write via MCP</option>
+						<option value="read_only">Read Only — query data only</option>
+					</select>
+					<p class="text-xs text-base-content/40 mt-2">Controls what the connected service can do. Full access allows transaction categorization, rule management, and write MCP tools.</p>
+				</fieldset>
+			</div>
+			<div class="bb-action-row">
+				<a href="/access" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
 				<button type="submit" class="btn btn-primary btn-sm rounded-xl">
 					<i data-lucide="plus" class="w-4 h-4"></i> Create OAuth Client
 				</button>
-				<a href="/access" class="btn btn-ghost btn-sm rounded-xl">Cancel</a>
 			</div>
 		</form>
 	</div>


### PR DESCRIPTION
Makes the three OAuth pages — Authorize, New Client, and Client Created — comfortable to use on narrow mobile screens by tightening padding/icon sizes at small viewports, stacking buttons vertically on mobile, adding `min-w-0` to prevent mono-font inputs from overflowing, hiding button labels on small screens, and reorganizing the Created page's footer into a tinted action area with a proper Done/Cancel row.

## Screenshots — Authorize (iPhone)

| Before | After |
| --- | --- |
| ![](https://i.img402.dev/xrgk8fv5rs.png) | ![](https://i.img402.dev/dgmsv0r8fz.png) |

## Screenshots — New Client (iPhone)

| Before | After |
| --- | --- |
| ![](https://i.img402.dev/u7q1lrfoil.png) | ![](https://i.img402.dev/fr2gyv5238.png) |

## Screenshots — Created (iPhone)

| Before | After |
| --- | --- |
| ![](https://i.img402.dev/8zlkuxgwl0.png) | ![](https://i.img402.dev/cui3lene2s.png) |

## Changes
- `oauth_authorize.templ`: responsive padding (`py-6`, `sm:p-8`), smaller icon at mobile (`sm:w-16`), list items use `items-start` + `mt-0.5` so icons don't misalign on wrapping text, Authorize/Deny buttons stack vertically on mobile (`flex-col sm:flex-row`) with Authorize on top (`order-1 sm:order-none`)
- `oauth_client_new.templ`: card content moved into a padded inner div (`p-5 sm:p-6`); action row converted to `bb-action-row` with Cancel before the primary button
- `oauth_client_created.templ`: added `shrink-0`/`min-w-0` to header row, `min-w-0 flex-1` on credential inputs, copy-button labels hidden on mobile (`hidden sm:inline`), footer restructured into a tinted section (`bg-base-200/50`) with the MCP URL field sitting inside a white card and the Done button in a flex row below it

## Test plan
- [x] Validated at iPhone (390×844) via Chrome DevTools MCP
- [x] OAuth flows still work (Allow/Deny, Save, Done)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
