### PR TITLE
feat(feed): aggressive grouping — sessions, bulk actions, sync-error dedup

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"net/http"
 	"sort"
 	"strings"
@@ -8,24 +9,34 @@ import (
 
 	"breadbox/internal/app"
 	"breadbox/internal/pgconv"
-	"breadbox/internal/ptrutil"
 	"breadbox/internal/service"
 	"breadbox/internal/templates/components/pages"
 )
 
-// FeedHandler serves GET /feed — the activity-style household feed page,
-// designed as a candidate replacement for the legacy stats dashboard. The
-// page renders a chronological, GitHub-style timeline of household events
-// (syncs, agent reports, transaction comments, rule applications, manual
-// recategorizations) with rich cards on the high-signal items and compact
-// rows on the low-signal ones.
+// feedWindowDays is the bounded lookback window for the home Feed page.
+// Events older than this drop off; the cap ensures the page never grows
+// unbounded and that the day buckets stay interpretable. Tuned with the
+// product owner — three days lines up with "what's happened this weekend".
+const feedWindowDays = 3
+
+// FeedHandler serves GET /feed — the activity-style household feed page.
+//
+// The aggregation pipeline is:
+//
+//  1. service.ListFeedEvents returns already-grouped sync / agent_session /
+//     bulk_action / comment events for the last `feedWindowDays`.
+//  2. Reports + connection alerts are pulled here (unrelated to grouping).
+//  3. We project FeedEvents onto the templ-side `pages.FeedItem` shape,
+//     resolve tag/category display names for bulk-action subjects, and
+//     bucket the merged stream by day for the rail's day separators.
 func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		now := time.Now()
+		window := time.Duration(feedWindowDays) * 24 * time.Hour
 
-		// Build display lookups so enriched annotation summaries render the
-		// human-friendly category and tag names instead of raw slugs.
+		// Display lookups so bulk-action subjects render with friendly tag
+		// and category display names instead of raw slugs.
 		categoryTree, err := svc.ListCategories(ctx)
 		if err != nil {
 			a.Logger.Error("feed: list categories", "error", err)
@@ -37,104 +48,61 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		}
 		tagDisplayFn := tagDisplayLookup(tags)
 
-		// 1. Pull cross-transaction annotations (the substrate for most feed
-		//    items: comments, rule applications, manual category sets, manual
-		//    tag actions).
-		feedRows, err := svc.ListFeedActivity(ctx, 250)
-		if err != nil {
-			a.Logger.Error("feed: list activity", "error", err)
-		}
-
-		// 2. Pull recent sync logs — one feed card per sync run keeps the
-		//    "X transactions arrived from Chase" event compact.
-		syncResult, err := svc.ListSyncLogsPaginated(ctx, service.SyncLogListParams{
-			Page:     1,
-			PageSize: 25,
+		// 1. Grouped events from the service.
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+			Window:        window,
+			BulkThreshold: 3,
+			SampleLimit:   5,
 		})
 		if err != nil {
-			a.Logger.Error("feed: list sync logs", "error", err)
+			a.Logger.Error("feed: list events", "error", err)
 		}
 
-		// 3. Recent agent reports — rich cards. We pull the wider list (read
-		//    + unread) so the feed shows the full activity stream rather than
-		//    only the unread queue.
-		recentReports, err := svc.ListAgentReports(ctx, 20)
+		// 2. Reports — windowed to match the feed bound.
+		reports, err := svc.ListAgentReports(ctx, 50)
 		if err != nil {
 			a.Logger.Error("feed: list agent reports", "error", err)
 		}
 
-		// 4. Connection alerts — pinned warning cards at the top for any
-		//    connection currently in error/pending_reauth state.
-		var connectionAlerts []pages.FeedAlert
-		bankConnections, err := a.Queries.ListBankConnections(ctx)
-		if err != nil {
-			a.Logger.Error("feed: list bank connections", "error", err)
-		}
-		for _, conn := range bankConnections {
-			status := string(conn.Status)
-			if status != "error" && status != "pending_reauth" {
+		// 3. Connection alerts — current state, not windowed.
+		alerts := buildFeedConnectionAlerts(ctx, a)
+
+		// 4. Project FeedEvents onto templ-side FeedItems.
+		items := make([]pages.FeedItem, 0, len(events)+len(reports))
+		var lastSyncAt time.Time
+		var lastSyncStatus, lastSyncInstitution string
+		var totalNewTransactionsToday, ruleHitsToday int
+		startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+
+		for _, ev := range events {
+			if ev.Timestamp.Before(now.Add(-window)) {
 				continue
 			}
-			alert := pages.FeedAlert{
-				ConnectionID:   pgconv.FormatUUID(conn.ID),
-				Institution:    pgconv.TextOr(conn.InstitutionName, "Unknown bank"),
-				Provider:       string(conn.Provider),
-				Status:         status,
-				ErrorMessage:   pgconv.TextOr(conn.ErrorMessage, ""),
-				LastSyncedAt:   "Never",
-				ConsecutiveFailures: int(conn.ConsecutiveFailures),
+			it := projectFeedEvent(ev, tagDisplayFn, categoryDetail)
+			if it == nil {
+				continue
 			}
-			if conn.LastSyncedAt.Valid {
-				alert.LastSyncedAt = relativeTime(conn.LastSyncedAt.Time)
-			}
-			connectionAlerts = append(connectionAlerts, alert)
-		}
+			items = append(items, *it)
 
-		// 5. Build feed items.
-		items := make([]pages.FeedItem, 0, 64)
-
-		// Sync items — emit one per sync run with non-zero changes OR errors.
-		// Successful no-op syncs are noisy; suppress them so the feed stays
-		// signal-rich.
-		if syncResult != nil {
-			for _, log := range syncResult.Logs {
-				hasChanges := log.AddedCount+log.ModifiedCount+log.RemovedCount > 0
-				isFailure := log.Status == "error"
-				if !hasChanges && !isFailure {
-					continue
+			// Hero-stat collection over the same loop.
+			switch ev.Type {
+			case "sync":
+				if ev.Sync != nil && ev.Sync.StartedAt.After(lastSyncAt) {
+					lastSyncAt = ev.Sync.StartedAt
+					lastSyncStatus = ev.Sync.Status
+					lastSyncInstitution = ev.Sync.InstitutionName
 				}
-				ts := time.Time{}
-				if log.StartedAt != nil {
-					if t, err := time.Parse(time.RFC3339, *log.StartedAt); err == nil {
-						ts = t
+				if ev.Sync != nil && ev.Timestamp.After(startOfDay) {
+					totalNewTransactionsToday += ev.Sync.AddedCount
+					for _, ro := range ev.Sync.RuleOutcomes {
+						ruleHitsToday += ro.Count
 					}
 				}
-				if ts.IsZero() {
-					continue
-				}
-				item := pages.FeedItem{
-					Type:         "sync",
-					Timestamp:    ts,
-					TimestampStr: ts.UTC().Format(time.RFC3339),
-					Sync: &pages.FeedSync{
-						SyncLogID:       log.ID,
-						InstitutionName: log.InstitutionName,
-						Provider:        log.Provider,
-						Trigger:         log.Trigger,
-						Status:          log.Status,
-						AddedCount:      int(log.AddedCount),
-						ModifiedCount:   int(log.ModifiedCount),
-						RemovedCount:    int(log.RemovedCount),
-						RuleHits:        int(log.TotalRuleHits),
-						ErrorMessage:    ptrutil.DerefOr(log.ErrorMessage, ""),
-					},
-				}
-				items = append(items, item)
 			}
 		}
 
-		// Agent report items.
-		for _, rep := range recentReports {
+		// 5. Append reports as their own feed items.
+		for _, rep := range reports {
 			if rep.CreatedAt == "" {
 				continue
 			}
@@ -142,7 +110,10 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			if err != nil {
 				continue
 			}
-			item := pages.FeedItem{
+			if ts.Before(now.Add(-window)) {
+				continue
+			}
+			items = append(items, pages.FeedItem{
 				Type:         "report",
 				Timestamp:    ts,
 				TimestampStr: ts.UTC().Format(time.RFC3339),
@@ -156,147 +127,44 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 					DisplayAuthor: reportDisplayAuthor(rep.CreatedByName, rep.Author),
 					IsUnread:      rep.ReadAt == nil,
 				},
-			}
-			items = append(items, item)
-		}
-
-		// Annotation-driven items. We group rule_applied rows by (rule_id, day)
-		// to collapse "Rule X auto-categorized 47 transactions" into a single
-		// card instead of 47 separate ones. Comments, manual category sets,
-		// and manual tag actions stay as individual rows.
-		ruleBatches := make(map[string]*pages.FeedRuleBatch)
-		for _, fr := range feedRows {
-			ann := fr.Annotation
-			if ann.CreatedAtTime.IsZero() {
-				continue
-			}
-			ts := ann.CreatedAtTime
-			tsStr := ts.UTC().Format(time.RFC3339)
-
-			switch ann.Kind {
-			case "rule_applied":
-				dayKey := ts.Local().Format("2006-01-02")
-				ruleKey := dayKey + "|" + safeStr(ann.RuleID) + "|" + ann.RuleName
-				batch, ok := ruleBatches[ruleKey]
-				if !ok {
-					batch = &pages.FeedRuleBatch{
-						RuleName:    ann.RuleName,
-						RuleShortID: ann.RuleShortID,
-						DayLabel:    ts.Local().Format("Jan 2"),
-						LatestTS:    ts,
-					}
-					ruleBatches[ruleKey] = batch
-				}
-				batch.Count++
-				field, _ := ann.Payload["action_field"].(string)
-				if field != "" {
-					if batch.ActionFields == nil {
-						batch.ActionFields = map[string]int{}
-					}
-					batch.ActionFields[field]++
-				}
-				if ts.After(batch.LatestTS) {
-					batch.LatestTS = ts
-				}
-				// Track up to 4 sample transactions for the expand affordance.
-				if len(batch.Samples) < 4 {
-					batch.Samples = append(batch.Samples, pages.FeedTransactionSample{
-						ShortID:      fr.TransactionShortID,
-						MerchantName: pickMerchant(fr),
-						Amount:       fr.Amount,
-						Currency:     fr.IsoCurrencyCode,
-					})
-				}
-
-			case "comment":
-				if ann.IsDeleted {
-					continue
-				}
-				items = append(items, pages.FeedItem{
-					Type:         "comment",
-					Timestamp:    ts,
-					TimestampStr: tsStr,
-					Comment: &pages.FeedComment{
-						ActorName:          ann.ActorName,
-						ActorType:          ann.ActorType,
-						ActorID:            safeStr(ann.ActorID),
-						ActorAvatarVersion: ann.ActorAvatarVersion,
-						Content:            ann.Content,
-						Transaction:        feedTransactionRef(fr),
-					},
-				})
-
-			case "tag_added", "tag_removed":
-				display := tagDisplayFn(ann.TagSlug)
-				name := display.DisplayName
-				if name == "" {
-					name = ann.TagSlug
-				}
-				items = append(items, pages.FeedItem{
-					Type:         "tag",
-					Timestamp:    ts,
-					TimestampStr: tsStr,
-					Tag: &pages.FeedTagChange{
-						ActorName:          ann.ActorName,
-						ActorType:          ann.ActorType,
-						ActorID:            safeStr(ann.ActorID),
-						ActorAvatarVersion: ann.ActorAvatarVersion,
-						Action:             strings.TrimPrefix(ann.Kind, "tag_"),
-						TagSlug:            ann.TagSlug,
-						TagName:            name,
-						TagColor:           ptrutil.DerefOr(display.Color, ""),
-						TagIcon:            ptrutil.DerefOr(display.Icon, ""),
-						Note:               ann.Note,
-						Transaction:        feedTransactionRef(fr),
-					},
-				})
-
-			case "category_set":
-				cd := categoryDetail(ann.CategorySlug)
-				name := cd.DisplayName
-				if name == "" {
-					name = ann.CategorySlug
-				}
-				items = append(items, pages.FeedItem{
-					Type:         "category",
-					Timestamp:    ts,
-					TimestampStr: tsStr,
-					Category: &pages.FeedCategoryChange{
-						ActorName:          ann.ActorName,
-						ActorType:          ann.ActorType,
-						ActorID:            safeStr(ann.ActorID),
-						ActorAvatarVersion: ann.ActorAvatarVersion,
-						CategorySlug:       ann.CategorySlug,
-						CategoryName:       name,
-						CategoryColor:      ptrutil.DerefOr(cd.Color, ""),
-						CategoryIcon:       ptrutil.DerefOr(cd.Icon, ""),
-						Transaction:        feedTransactionRef(fr),
-					},
-				})
-			}
-		}
-		for _, batch := range ruleBatches {
-			items = append(items, pages.FeedItem{
-				Type:         "rule_batch",
-				Timestamp:    batch.LatestTS,
-				TimestampStr: batch.LatestTS.UTC().Format(time.RFC3339),
-				RuleBatch:    batch,
 			})
 		}
 
-		// 6. Sort newest-first. Feed convention is reverse-chronological so
-		//    the most recent activity is always on top — the inverse of the
-		//    per-transaction timeline (chat-style; new at the bottom).
+		// 6. Sort + day-bucket.
 		sort.Slice(items, func(i, j int) bool {
 			return items[i].Timestamp.After(items[j].Timestamp)
 		})
-
-		// 7. Group into day buckets for the day-separator chrome.
 		days := groupFeedByDay(items, now)
 
-		// 8. At-a-glance hero stats — quick "today" snapshot derived from the
-		//    feed itself plus a couple of cheap counts.
-		hero := buildFeedHero(now, items, feedRows, recentReports, syncResult)
+		// 7. Hero band.
+		var commentsToday, eventsToday, unreadReports int
+		for _, it := range items {
+			if it.Timestamp.After(startOfDay) {
+				eventsToday++
+				if it.Type == "comment" {
+					commentsToday++
+				}
+			}
+		}
+		for _, r := range reports {
+			if r.ReadAt == nil {
+				unreadReports++
+			}
+		}
+		hero := pages.FeedHero{
+			Generated:            now.Format("Mon, Jan 2"),
+			EventsToday:          eventsToday,
+			NewTransactionsToday: totalNewTransactionsToday,
+			CommentsToday:        commentsToday,
+			RuleHitsToday:        ruleHitsToday,
+			UnreadReports:        unreadReports,
+			LastSyncAt:           lastSyncAt,
+			LastSyncStatus:       lastSyncStatus,
+			LastSyncInstitution:  lastSyncInstitution,
+		}
+		if !lastSyncAt.IsZero() {
+			hero.LastSyncRel = relativeTime(lastSyncAt)
+		}
 
 		data := map[string]any{
 			"PageTitle":   "Feed",
@@ -306,9 +174,10 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		body := pages.Feed(pages.FeedProps{
 			CSRFToken:        GetCSRFToken(r),
 			Hero:             hero,
-			ConnectionAlerts: connectionAlerts,
+			ConnectionAlerts: alerts,
 			Days:             days,
 			TotalItems:       len(items),
+			WindowDays:       feedWindowDays,
 			Now:              now,
 			Filter:           strings.TrimSpace(r.URL.Query().Get("filter")),
 		})
@@ -316,50 +185,227 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 	}
 }
 
-// pickMerchant prefers merchant_name when present, falling back to the
-// transaction name (which often carries the raw description from the
-// provider).
-func pickMerchant(fr service.FeedActivityRow) string {
-	if fr.MerchantName != "" {
-		return fr.MerchantName
+// buildFeedConnectionAlerts collects the pinned warning cards rendered above
+// the rail. Each alert maps one bank connection currently in error or
+// pending_reauth state to a `pages.FeedAlert`.
+func buildFeedConnectionAlerts(ctx context.Context, a *app.App) []pages.FeedAlert {
+	bankConnections, err := a.Queries.ListBankConnections(ctx)
+	if err != nil {
+		a.Logger.Error("feed: list bank connections", "error", err)
+		return nil
 	}
-	return fr.TransactionName
+	out := make([]pages.FeedAlert, 0)
+	for _, conn := range bankConnections {
+		status := string(conn.Status)
+		if status != "error" && status != "pending_reauth" {
+			continue
+		}
+		alert := pages.FeedAlert{
+			ConnectionID:        pgconv.FormatUUID(conn.ID),
+			Institution:         pgconv.TextOr(conn.InstitutionName, "Unknown bank"),
+			Provider:            string(conn.Provider),
+			Status:              status,
+			ErrorMessage:        pgconv.TextOr(conn.ErrorMessage, ""),
+			LastSyncedAt:        "Never",
+			ConsecutiveFailures: int(conn.ConsecutiveFailures),
+		}
+		if conn.LastSyncedAt.Valid {
+			alert.LastSyncedAt = relativeTime(conn.LastSyncedAt.Time)
+		}
+		out = append(out, alert)
+	}
+	return out
 }
 
-// feedTransactionRef builds the FeedTransactionRef projection that every
-// transaction-anchored card uses for the "$amount at Merchant" subtitle.
-func feedTransactionRef(fr service.FeedActivityRow) pages.FeedTransactionRef {
+// projectFeedEvent maps one service-layer FeedEvent onto its templ-side
+// FeedItem projection. Returns nil for events with unrecognised Type so the
+// caller can skip them. tagDisplayFn / categoryDetail resolve display
+// metadata for bulk-action subjects.
+func projectFeedEvent(ev service.FeedEvent, tagDisplayFn func(string) tagDisplay, categoryDetail func(string) categoryDisplay) *pages.FeedItem {
+	tsStr := ev.Timestamp.UTC().Format(time.RFC3339)
+	switch ev.Type {
+	case "sync":
+		if ev.Sync == nil {
+			return nil
+		}
+		return &pages.FeedItem{
+			Type:         "sync",
+			Timestamp:    ev.Timestamp,
+			TimestampStr: tsStr,
+			Sync:         projectFeedSync(ev.Sync),
+		}
+	case "comment":
+		if ev.Comment == nil {
+			return nil
+		}
+		return &pages.FeedItem{
+			Type:         "comment",
+			Timestamp:    ev.Timestamp,
+			TimestampStr: tsStr,
+			Comment: &pages.FeedComment{
+				ActorName:          ev.Comment.ActorName,
+				ActorType:          ev.Comment.ActorType,
+				ActorID:            ev.Comment.ActorID,
+				ActorAvatarVersion: ev.Comment.ActorAvatarVersion,
+				Content:            ev.Comment.Content,
+				Transaction:        projectSampleTx(ev.Comment.Transaction),
+			},
+		}
+	case "agent_session":
+		if ev.AgentSession == nil {
+			return nil
+		}
+		return &pages.FeedItem{
+			Type:         "agent_session",
+			Timestamp:    ev.Timestamp,
+			TimestampStr: tsStr,
+			AgentSession: projectFeedAgentSession(ev.AgentSession),
+		}
+	case "bulk_action":
+		if ev.BulkAction == nil {
+			return nil
+		}
+		return &pages.FeedItem{
+			Type:         "bulk_action",
+			Timestamp:    ev.Timestamp,
+			TimestampStr: tsStr,
+			BulkAction:   projectFeedBulkAction(ev.BulkAction, tagDisplayFn, categoryDetail),
+		}
+	}
+	return nil
+}
+
+func projectFeedSync(s *service.FeedSyncEvent) *pages.FeedSync {
+	out := &pages.FeedSync{
+		SyncLogID:       s.SyncLogID,
+		InstitutionName: s.InstitutionName,
+		Provider:        s.Provider,
+		Trigger:         s.Trigger,
+		Status:          s.Status,
+		ErrorMessage:    s.ErrorMessage,
+		AddedCount:      s.AddedCount,
+		ModifiedCount:   s.ModifiedCount,
+		RemovedCount:    s.RemovedCount,
+		StartedAt:       s.StartedAt,
+		RetryCount:      s.RetryCount,
+		FirstFailureAt:  s.FirstFailureAt,
+		AdditionalCount: s.AdditionalCount,
+	}
+	out.SampleTransactions = make([]pages.FeedTransactionRef, 0, len(s.SampleTransactions))
+	for _, tx := range s.SampleTransactions {
+		out.SampleTransactions = append(out.SampleTransactions, projectSampleTx(tx))
+	}
+	out.RuleOutcomes = make([]pages.FeedRuleOutcome, 0, len(s.RuleOutcomes))
+	for _, ro := range s.RuleOutcomes {
+		out.RuleOutcomes = append(out.RuleOutcomes, pages.FeedRuleOutcome{
+			RuleName:    ro.RuleName,
+			RuleShortID: ro.RuleShortID,
+			Count:       ro.Count,
+		})
+	}
+	return out
+}
+
+func projectFeedAgentSession(s *service.FeedAgentSessionEvent) *pages.FeedAgentSession {
+	out := &pages.FeedAgentSession{
+		SessionID:          s.SessionID,
+		SessionShortID:     s.SessionShortID,
+		APIKeyName:         s.APIKeyName,
+		Purpose:            s.Purpose,
+		ActorName:          s.ActorName,
+		ActorType:          s.ActorType,
+		ActorID:            s.ActorID,
+		ActorAvatarVersion: s.ActorAvatarVersion,
+		StartedAt:          s.StartedAt,
+		EndedAt:            s.EndedAt,
+		AnnotationCount:    s.AnnotationCount,
+		UniqueTransactions: s.UniqueTransactions,
+		Categorised:        s.KindCounts["category_set"],
+		Tagged:             s.KindCounts["tag_added"],
+		UntaggedRemoved:    s.KindCounts["tag_removed"],
+		Commented:          s.KindCounts["comment"],
+		RuleApplied:        s.KindCounts["rule_applied"],
+	}
+	out.SampleTransactions = make([]pages.FeedTransactionRef, 0, len(s.SampleTransactions))
+	for _, tx := range s.SampleTransactions {
+		out.SampleTransactions = append(out.SampleTransactions, projectSampleTx(tx))
+	}
+	return out
+}
+
+func projectFeedBulkAction(b *service.FeedBulkActionEvent, tagDisplayFn func(string) tagDisplay, categoryDetail func(string) categoryDisplay) *pages.FeedBulkAction {
+	out := &pages.FeedBulkAction{
+		ActorName:          b.ActorName,
+		ActorType:          b.ActorType,
+		ActorID:            b.ActorID,
+		ActorAvatarVersion: b.ActorAvatarVersion,
+		Kind:               b.Kind,
+		Count:              b.Count,
+		StartedAt:          b.StartedAt,
+		EndedAt:            b.EndedAt,
+	}
+	for _, sub := range b.Subjects {
+		display := pages.FeedBulkSubject{
+			Name:  sub.Name,
+			Slug:  sub.Slug,
+			Count: sub.Count,
+		}
+		switch b.Kind {
+		case "tag_added", "tag_removed":
+			td := tagDisplayFn(sub.Slug)
+			if td.DisplayName != "" {
+				display.Name = td.DisplayName
+			}
+			if td.Color != nil {
+				display.Color = *td.Color
+			}
+			if td.Icon != nil {
+				display.Icon = *td.Icon
+			}
+		case "category_set":
+			cd := categoryDetail(sub.Slug)
+			if cd.DisplayName != "" {
+				display.Name = cd.DisplayName
+			}
+			if cd.Color != nil {
+				display.Color = *cd.Color
+			}
+			if cd.Icon != nil {
+				display.Icon = *cd.Icon
+			}
+		}
+		if display.Name == "" {
+			display.Name = sub.Slug
+		}
+		out.Subjects = append(out.Subjects, display)
+	}
+	out.SampleTransactions = make([]pages.FeedTransactionRef, 0, len(b.SampleTransactions))
+	for _, tx := range b.SampleTransactions {
+		out.SampleTransactions = append(out.SampleTransactions, projectSampleTx(tx))
+	}
+	return out
+}
+
+func projectSampleTx(tx service.FeedSampleTx) pages.FeedTransactionRef {
 	return pages.FeedTransactionRef{
-		ShortID:      fr.TransactionShortID,
-		Name:         fr.TransactionName,
-		MerchantName: pickMerchant(fr),
-		Amount:       fr.Amount,
-		Currency:     fr.IsoCurrencyCode,
-		Date:         fr.TransactionDate,
-		AccountName:  fr.AccountName,
-		Institution:  fr.InstitutionName,
+		ShortID:      tx.ShortID,
+		Name:         tx.Name,
+		MerchantName: tx.MerchantName,
+		Amount:       tx.Amount,
+		Currency:     tx.Currency,
+		Date:         tx.Date,
+		AccountName:  tx.AccountName,
+		Institution:  tx.Institution,
 	}
-}
-
-// safeStr dereferences a *string with an empty-string fallback. Used for the
-// many *string-typed fields on Annotation that the feed projection wants to
-// pass through as plain strings.
-func safeStr(p *string) string {
-	if p == nil {
-		return ""
-	}
-	return *p
 }
 
 // excerpt returns the first `n` runes of `s`, trimmed at the nearest word
-// boundary if the cut would land mid-word. Trailing whitespace is stripped
-// and an ellipsis is appended when the original was longer.
+// boundary if the cut would land mid-word.
 func excerpt(s string, n int) string {
 	s = strings.TrimSpace(s)
 	if n <= 0 || len(s) <= n {
 		return s
 	}
-	// Cut on rune boundaries.
 	runes := []rune(s)
 	if len(runes) <= n {
 		return s
@@ -414,56 +460,4 @@ func friendlyDayLabel(t, now time.Time) string {
 		return t.Format("Jan 2")
 	}
 	return t.Format("Jan 2, 2006")
-}
-
-// buildFeedHero derives the at-a-glance numbers shown above the feed: events
-// today, sync status, unread-report count, and the count of pinned alerts.
-func buildFeedHero(now time.Time, items []pages.FeedItem, rows []service.FeedActivityRow, reports []service.AgentReportResponse, syncResult *service.SyncLogListResult) pages.FeedHero {
-	hero := pages.FeedHero{
-		Generated: now.Format("Mon, Jan 2"),
-	}
-	startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
-	for _, it := range items {
-		if it.Timestamp.After(startOfDay) {
-			hero.EventsToday++
-			switch it.Type {
-			case "sync":
-				if it.Sync != nil {
-					hero.NewTransactionsToday += it.Sync.AddedCount
-				}
-			case "comment":
-				hero.CommentsToday++
-			case "rule_batch":
-				if it.RuleBatch != nil {
-					hero.RuleHitsToday += it.RuleBatch.Count
-				}
-			}
-		}
-	}
-	for _, r := range reports {
-		if r.ReadAt == nil {
-			hero.UnreadReports++
-		}
-	}
-	if syncResult != nil {
-		for _, log := range syncResult.Logs {
-			if log.StartedAt == nil {
-				continue
-			}
-			t, err := time.Parse(time.RFC3339, *log.StartedAt)
-			if err != nil {
-				continue
-			}
-			if hero.LastSyncAt.IsZero() || t.After(hero.LastSyncAt) {
-				hero.LastSyncAt = t
-				hero.LastSyncStatus = log.Status
-				hero.LastSyncInstitution = log.InstitutionName
-			}
-		}
-	}
-	if !hero.LastSyncAt.IsZero() {
-		hero.LastSyncRel = relativeTime(hero.LastSyncAt)
-	}
-	_ = rows
-	return hero
 }

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -47,12 +47,23 @@ func (s *Service) ListFeedActivity(ctx context.Context, limit int) ([]FeedActivi
 SELECT
     a.id, a.short_id, a.transaction_id, a.kind, a.actor_type, a.actor_id, a.actor_name,
     a.payload, a.tag_id, a.rule_id, a.session_id, a.created_at,
+    COALESCE(u_via_account.name, u_direct.name, '')::text AS actor_user_name,
+    COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
     ac.name, bc.institution_name
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
 LEFT JOIN accounts ac ON t.account_id = ac.id
 LEFT JOIN bank_connections bc ON ac.connection_id = bc.id
+LEFT JOIN auth_accounts aa
+    ON a.actor_type = 'user'
+   AND aa.id::text = a.actor_id
+LEFT JOIN users u_via_account
+    ON aa.user_id = u_via_account.id
+LEFT JOIN users u_direct
+    ON a.actor_type = 'user'
+   AND aa.id IS NULL
+   AND u_direct.id::text = a.actor_id
 WHERE t.deleted_at IS NULL
 ORDER BY a.created_at DESC
 LIMIT $1
@@ -77,11 +88,6 @@ LIMIT $1
 	}
 
 	out = enrichFeedActivityRows(out)
-
-	if err := s.hydrateFeedAvatarVersions(ctx, out); err != nil {
-		s.Logger.Debug("hydrate feed avatar versions", "error", err)
-	}
-
 	return out, nil
 }
 
@@ -279,9 +285,6 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 		return nil, err
 	}
 	annotationRows = enrichFeedActivityRows(annotationRows)
-	if err := s.hydrateFeedAvatarVersions(ctx, annotationRows); err != nil {
-		s.Logger.Debug("hydrate feed avatar versions", "error", err)
-	}
 
 	syncEvents, err := s.fetchFeedSyncEvents(ctx, cutoff, params.SampleLimit)
 	if err != nil {
@@ -307,21 +310,38 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 }
 
 // fetchFeedAnnotations runs the windowed annotation query used by
-// `ListFeedEvents`. It excludes annotations that are byproducts of a sync
-// (per-transaction `sync_started` / `sync_updated` rows and rule
-// applications fired during sync — they're represented by the parent sync
-// card instead).
+// `ListFeedEvents`. Excludes annotations that are byproducts of a sync
+// (`sync_started` / `sync_updated` rows and rule applications fired
+// during sync — both are represented by the parent sync card).
+//
+// The user join mirrors `ListAnnotationsWithActorByTransaction`: it
+// resolves user.name through either an auth_accounts row whose user_id
+// links to users, or a direct users.id match against actor_id, and
+// surfaces both the live profile name (preferred over the frozen-at-
+// write-time `annotations.actor_name`) and the user's `updated_at` for
+// avatar cache-busting.
 func (s *Service) fetchFeedAnnotations(ctx context.Context, cutoff time.Time) ([]FeedActivityRow, error) {
 	const q = `
 SELECT
     a.id, a.short_id, a.transaction_id, a.kind, a.actor_type, a.actor_id, a.actor_name,
     a.payload, a.tag_id, a.rule_id, a.session_id, a.created_at,
+    COALESCE(u_via_account.name, u_direct.name, '')::text AS actor_user_name,
+    COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
     ac.name, bc.institution_name
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
 LEFT JOIN accounts ac ON t.account_id = ac.id
 LEFT JOIN bank_connections bc ON ac.connection_id = bc.id
+LEFT JOIN auth_accounts aa
+    ON a.actor_type = 'user'
+   AND aa.id::text = a.actor_id
+LEFT JOIN users u_via_account
+    ON aa.user_id = u_via_account.id
+LEFT JOIN users u_direct
+    ON a.actor_type = 'user'
+   AND aa.id IS NULL
+   AND u_direct.id::text = a.actor_id
 WHERE t.deleted_at IS NULL
   AND a.created_at >= $1
   AND a.kind NOT IN ('sync_started', 'sync_updated')
@@ -364,6 +384,8 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		shortID                             string
 		payload                             []byte
 		createdAt                           pgtype.Timestamptz
+		actorUserName                       string
+		actorUpdatedAt                      pgtype.Timestamptz
 		txShort, txName                     string
 		merchantName                        pgtype.Text
 		amount                              pgtype.Numeric
@@ -375,10 +397,20 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 	if err := s.Scan(
 		&id, &shortID, &txnID, &kind, &actorType, &actorIDOpt, &actorName,
 		&payload, &tagID, &ruleID, &sessionID, &createdAt,
+		&actorUserName, &actorUpdatedAt,
 		&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate,
 		&accountName, &institutionName,
 	); err != nil {
 		return FeedActivityRow{}, fmt.Errorf("scan feed activity row: %w", err)
+	}
+
+	// Prefer the live users.name over the actor_name frozen at write time
+	// (which is typically the auth_accounts.username/email login). Mirrors
+	// the same preference annotation_actor_row.go applies on the per-tx
+	// timeline so feed and timeline render the same display name.
+	displayName := actorName
+	if actorType == "user" && actorUserName != "" {
+		displayName = actorUserName
 	}
 
 	ann := Annotation{
@@ -387,9 +419,12 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		TransactionID: formatUUID(txnID),
 		Kind:          kind,
 		ActorType:     actorType,
-		ActorName:     actorName,
+		ActorName:     displayName,
 		CreatedAt:     pgconv.TimestampStr(createdAt),
 		CreatedAtTime: createdAt.Time.UTC(),
+	}
+	if actorUpdatedAt.Valid {
+		ann.ActorAvatarVersion = strconv.FormatInt(actorUpdatedAt.Time.Unix(), 10)
 	}
 	if actorIDOpt.Valid && actorIDOpt.String != "" {
 		s := actorIDOpt.String
@@ -460,51 +495,6 @@ func enrichFeedActivityRows(in []FeedActivityRow) []FeedActivityRow {
 	return out
 }
 
-// hydrateFeedAvatarVersions populates Annotation.ActorAvatarVersion on every
-// user-attributed row in `rows` using a single batch query against users.
-func (s *Service) hydrateFeedAvatarVersions(ctx context.Context, rows []FeedActivityRow) error {
-	ids := make([]string, 0, len(rows))
-	seen := make(map[string]bool)
-	for _, r := range rows {
-		if r.Annotation.ActorType != "user" || r.Annotation.ActorID == nil {
-			continue
-		}
-		id := *r.Annotation.ActorID
-		if id == "" || seen[id] {
-			continue
-		}
-		seen[id] = true
-		ids = append(ids, id)
-	}
-	if len(ids) == 0 {
-		return nil
-	}
-
-	const q = `SELECT id::text, EXTRACT(EPOCH FROM updated_at)::bigint FROM users WHERE id::text = ANY($1::text[])`
-	pgrows, err := s.Pool.Query(ctx, q, ids)
-	if err != nil {
-		return err
-	}
-	defer pgrows.Close()
-	versions := make(map[string]string, len(ids))
-	for pgrows.Next() {
-		var id string
-		var ts int64
-		if err := pgrows.Scan(&id, &ts); err != nil {
-			return err
-		}
-		versions[id] = strconv.FormatInt(ts, 10)
-	}
-	for i := range rows {
-		if rows[i].Annotation.ActorType != "user" || rows[i].Annotation.ActorID == nil {
-			continue
-		}
-		if v, ok := versions[*rows[i].Annotation.ActorID]; ok {
-			rows[i].Annotation.ActorAvatarVersion = v
-		}
-	}
-	return nil
-}
 
 // ── Sync events ───────────────────────────────────────────────────────────
 

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -16,6 +17,9 @@ import (
 // transaction context (merchant, amount, currency, account, institution) so
 // the home Feed page can render rich cards for events that happened on any
 // transaction without re-fetching transaction details per row.
+//
+// FeedActivityRow is the low-level read helper. The feed page itself reads
+// `FeedEvent`s from `ListFeedEvents`, which applies grouping on top.
 type FeedActivityRow struct {
 	Annotation Annotation
 
@@ -31,15 +35,9 @@ type FeedActivityRow struct {
 }
 
 // ListFeedActivity returns the most recent annotations across every
-// transaction, joined with merchant/amount/account context so the global
-// feed page can render rich rows without N+1 lookups. Annotations are
-// returned newest-first (DESC) — the feed surface shows newest at the top
-// (inverse of the per-transaction timeline, which puts newest at the
-// bottom near the composer).
-//
-// EnrichAnnotations is applied after the SQL fetch with descending order
-// reversed temporarily, since enrichment dedup logic assumes ASC ordering
-// (rule-source duplicates appear adjacent to their parent rule_applied row).
+// transaction, joined with merchant/amount/account context. Pre-existing
+// helper kept for any caller that wants the raw annotation feed; the home
+// Feed page itself goes through `ListFeedEvents`.
 func (s *Service) ListFeedActivity(ctx context.Context, limit int) ([]FeedActivityRow, error) {
 	if limit <= 0 || limit > 500 {
 		limit = 200
@@ -48,7 +46,7 @@ func (s *Service) ListFeedActivity(ctx context.Context, limit int) ([]FeedActivi
 	const q = `
 SELECT
     a.id, a.short_id, a.transaction_id, a.kind, a.actor_type, a.actor_id, a.actor_name,
-    a.payload, a.tag_id, a.rule_id, a.created_at,
+    a.payload, a.tag_id, a.rule_id, a.session_id, a.created_at,
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
     ac.name, bc.institution_name
 FROM annotations a
@@ -68,76 +66,9 @@ LIMIT $1
 
 	out := make([]FeedActivityRow, 0, limit)
 	for rows.Next() {
-		var (
-			id, txnID, tagID, ruleID                    pgtype.UUID
-			actorID, actorName, kind, actorType         string
-			actorIDOpt                                  pgtype.Text
-			shortID                                     string
-			payload                                     []byte
-			createdAt                                   pgtype.Timestamptz
-			txShort, txName                             string
-			merchantName                                pgtype.Text
-			amount                                      pgtype.Numeric
-			isoCcy                                      pgtype.Text
-			txDate                                      pgtype.Date
-			accountName, institutionName                pgtype.Text
-		)
-
-		if err := rows.Scan(
-			&id, &shortID, &txnID, &kind, &actorType, &actorIDOpt, &actorName,
-			&payload, &tagID, &ruleID, &createdAt,
-			&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate,
-			&accountName, &institutionName,
-		); err != nil {
-			return nil, fmt.Errorf("scan feed activity row: %w", err)
-		}
-
-		ann := Annotation{
-			ID:            formatUUID(id),
-			ShortID:       shortID,
-			TransactionID: formatUUID(txnID),
-			Kind:          kind,
-			ActorType:     actorType,
-			ActorName:     actorName,
-			CreatedAt:     pgconv.TimestampStr(createdAt),
-			CreatedAtTime: createdAt.Time.UTC(),
-		}
-		if actorIDOpt.Valid && actorIDOpt.String != "" {
-			s := actorIDOpt.String
-			ann.ActorID = &s
-		}
-		_ = actorID
-		if tagID.Valid {
-			s := formatUUID(tagID)
-			ann.TagID = &s
-		}
-		if ruleID.Valid {
-			s := formatUUID(ruleID)
-			ann.RuleID = &s
-		}
-		if len(payload) > 0 && string(payload) != "{}" {
-			var p map[string]interface{}
-			if err := json.Unmarshal(payload, &p); err == nil {
-				ann.Payload = p
-			}
-		}
-
-		row := FeedActivityRow{
-			Annotation:         ann,
-			TransactionShortID: txShort,
-			TransactionName:    txName,
-			MerchantName:       pgconv.TextOr(merchantName, ""),
-			IsoCurrencyCode:    pgconv.TextOr(isoCcy, "USD"),
-			AccountName:        pgconv.TextOr(accountName, ""),
-			InstitutionName:    pgconv.TextOr(institutionName, ""),
-		}
-		if amount.Valid {
-			if f, err := amount.Float64Value(); err == nil && f.Valid {
-				row.Amount = f.Float64
-			}
-		}
-		if txDate.Valid {
-			row.TransactionDate = txDate.Time.Format("2006-01-02")
+		row, err := scanFeedActivityRow(rows)
+		if err != nil {
+			return nil, err
 		}
 		out = append(out, row)
 	}
@@ -145,44 +76,392 @@ LIMIT $1
 		return nil, fmt.Errorf("iterate feed activity rows: %w", err)
 	}
 
-	// Enrichment expects ASC ordering for dedup heuristics; reverse, enrich,
-	// reverse back.
-	asc := make([]Annotation, len(out))
-	for i, r := range out {
-		asc[len(out)-1-i] = r.Annotation
+	out = enrichFeedActivityRows(out)
+
+	if err := s.hydrateFeedAvatarVersions(ctx, out); err != nil {
+		s.Logger.Debug("hydrate feed avatar versions", "error", err)
+	}
+
+	return out, nil
+}
+
+// FeedEvent is the unit the Feed page renders — one row on the rail,
+// possibly representing many underlying annotations that have been grouped
+// together. Exactly one of the typed payload pointers is set; the rest are
+// nil.
+type FeedEvent struct {
+	Type      string    // "sync" | "agent_session" | "bulk_action" | "comment"
+	Timestamp time.Time // sortable wall-clock anchor for newest-first ordering
+
+	Sync         *FeedSyncEvent
+	AgentSession *FeedAgentSessionEvent
+	BulkAction   *FeedBulkActionEvent
+	Comment      *FeedCommentEvent
+}
+
+// FeedSyncEvent represents one sync run. The card shows the headline
+// (`12 new transactions from Chase`), inline transaction samples (top
+// `SampleLimit` by absolute amount), and any rule outcomes that fired
+// during the sync (lifted from `sync_logs.rule_hits`).
+//
+// Failed syncs that repeat because of cron retries (same connection +
+// same error message) collapse into a single FeedSyncEvent with the
+// retry counters populated. The card displays "Has been failing for
+// 18h · 49 attempts" instead of 49 identical rows.
+type FeedSyncEvent struct {
+	SyncLogID       string
+	InstitutionName string
+	Provider        string
+	Trigger         string
+	Status          string
+	ErrorMessage    string
+
+	AddedCount    int
+	ModifiedCount int
+	RemovedCount  int
+
+	StartedAt   time.Time
+	CompletedAt time.Time
+
+	// RetryCount counts the additional same-error sync attempts that
+	// were folded into this card. 0 = single attempt; N = total attempts
+	// is RetryCount + 1. Only populated for failed syncs.
+	RetryCount      int
+	FirstFailureAt  time.Time
+
+	SampleTransactions []FeedSampleTx
+	AdditionalCount    int
+
+	RuleOutcomes []FeedRuleOutcome
+}
+
+// FeedAgentSessionEvent represents one MCP agent session whose annotations
+// are folded into a single card. An MCP review session that touches 50
+// transactions and writes 200 annotations is one row here, not 200.
+type FeedAgentSessionEvent struct {
+	SessionID      string
+	SessionShortID string
+	APIKeyName     string
+	Purpose        string
+
+	ActorName          string
+	ActorType          string
+	ActorID            string
+	ActorAvatarVersion string
+
+	StartedAt time.Time
+	EndedAt   time.Time
+
+	AnnotationCount    int
+	UniqueTransactions int
+
+	// KindCounts breaks the session's annotations down by kind so the card
+	// can render "categorised 23 · tagged 12 · commented 8" without the
+	// caller iterating annotations a second time.
+	KindCounts map[string]int
+
+	SampleTransactions []FeedSampleTx
+}
+
+// FeedBulkActionEvent represents ≥ N annotations from the same actor of
+// the same kind within a soft time-bucket — typically a human running a
+// bulk recategorisation or an agent making changes outside an MCP session.
+type FeedBulkActionEvent struct {
+	ActorName          string
+	ActorType          string
+	ActorID            string
+	ActorAvatarVersion string
+
+	Kind  string // "tag_added" | "tag_removed" | "category_set" | "rule_applied"
+	Count int
+
+	// Subjects is the deduped list of subject names (tag names, category
+	// names, rule names) that were applied. When all rows share one
+	// subject, the card renders "added the Groceries tag to 12
+	// transactions"; with several subjects it renders the count per
+	// subject ("Groceries: 8 · Transport: 4").
+	Subjects []FeedBulkSubject
+
+	StartedAt time.Time
+	EndedAt   time.Time
+
+	SampleTransactions []FeedSampleTx
+}
+
+// FeedBulkSubject is one (subject, count) pair inside a bulk-action card.
+type FeedBulkSubject struct {
+	Name  string
+	Slug  string
+	Color string
+	Icon  string
+	Count int
+}
+
+// FeedCommentEvent is one standalone comment — surfaced as its own row when
+// it isn't part of an MCP session and isn't part of a bulk-action group.
+type FeedCommentEvent struct {
+	ActorName          string
+	ActorType          string
+	ActorID            string
+	ActorAvatarVersion string
+	Content            string
+
+	Transaction FeedSampleTx
+}
+
+// FeedSampleTx is the small projection used inside every event card to
+// reference a transaction. Carries enough to render the merchant + amount
+// pair without an extra fetch per card.
+type FeedSampleTx struct {
+	ShortID      string
+	Name         string
+	MerchantName string
+	Amount       float64
+	Currency     string
+	Date         string
+	AccountName  string
+	Institution  string
+}
+
+// FeedRuleOutcome is one (rule, count) pair shown inline on a sync card.
+type FeedRuleOutcome struct {
+	RuleName    string
+	RuleShortID string
+	Count       int
+}
+
+// FeedEventsParams configures the window + grouping thresholds applied by
+// `ListFeedEvents`. Zero values resolve to sensible defaults: 3-day window,
+// soft-group threshold of 3, sample limit of 5.
+type FeedEventsParams struct {
+	Window        time.Duration
+	BulkThreshold int
+	SampleLimit   int
+}
+
+// ListFeedEvents returns grouped FeedEvents for the home Feed page,
+// already ordered newest-first.
+//
+// The grouping pipeline is:
+//
+//  1. Pull annotations from the window, dropping rule-applied rows that
+//     fired during sync (`payload.applied_by == "sync"`) and the
+//     per-transaction `sync_started` / `sync_updated` rows — both are
+//     already represented by their parent sync card.
+//  2. Hard-group annotations by `session_id`. Every session collapses
+//     into a single AgentSession event regardless of how many annotations
+//     it produced.
+//  3. Soft-bucket the remaining (un-sessioned) annotations by
+//     `(actor_id, kind, floor(time / 5min))`. Buckets with ≥ BulkThreshold
+//     events become BulkAction events; the rest of the un-sessioned
+//     annotations are dropped UNLESS they're standalone comments — those
+//     pass through as Comment events because every comment is high-signal.
+//  4. Sync logs from the window become Sync events with inline transaction
+//     samples and `RuleOutcomes` lifted from `sync_logs.rule_hits`.
+//
+// Reports + connection alerts are returned by separate handler-level
+// queries, not by this function.
+func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) ([]FeedEvent, error) {
+	if params.Window <= 0 {
+		params.Window = 3 * 24 * time.Hour
+	}
+	if params.BulkThreshold <= 0 {
+		params.BulkThreshold = 3
+	}
+	if params.SampleLimit <= 0 {
+		params.SampleLimit = 5
+	}
+
+	cutoff := time.Now().Add(-params.Window)
+
+	annotationRows, err := s.fetchFeedAnnotations(ctx, cutoff)
+	if err != nil {
+		return nil, err
+	}
+	annotationRows = enrichFeedActivityRows(annotationRows)
+	if err := s.hydrateFeedAvatarVersions(ctx, annotationRows); err != nil {
+		s.Logger.Debug("hydrate feed avatar versions", "error", err)
+	}
+
+	syncEvents, err := s.fetchFeedSyncEvents(ctx, cutoff, params.SampleLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	sessionMeta, err := s.fetchFeedSessionMeta(ctx, annotationRows)
+	if err != nil {
+		s.Logger.Debug("fetch feed session meta", "error", err)
+	}
+
+	groupedEvents := groupAnnotationsIntoEvents(annotationRows, sessionMeta, params)
+
+	out := make([]FeedEvent, 0, len(syncEvents)+len(groupedEvents))
+	out = append(out, syncEvents...)
+	out = append(out, groupedEvents...)
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Timestamp.After(out[j].Timestamp)
+	})
+
+	return out, nil
+}
+
+// fetchFeedAnnotations runs the windowed annotation query used by
+// `ListFeedEvents`. It excludes annotations that are byproducts of a sync
+// (per-transaction `sync_started` / `sync_updated` rows and rule
+// applications fired during sync — they're represented by the parent sync
+// card instead).
+func (s *Service) fetchFeedAnnotations(ctx context.Context, cutoff time.Time) ([]FeedActivityRow, error) {
+	const q = `
+SELECT
+    a.id, a.short_id, a.transaction_id, a.kind, a.actor_type, a.actor_id, a.actor_name,
+    a.payload, a.tag_id, a.rule_id, a.session_id, a.created_at,
+    t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
+    ac.name, bc.institution_name
+FROM annotations a
+JOIN transactions t ON a.transaction_id = t.id
+LEFT JOIN accounts ac ON t.account_id = ac.id
+LEFT JOIN bank_connections bc ON ac.connection_id = bc.id
+WHERE t.deleted_at IS NULL
+  AND a.created_at >= $1
+  AND a.kind NOT IN ('sync_started', 'sync_updated')
+  AND COALESCE(a.payload->>'applied_by', '') <> 'sync'
+ORDER BY a.created_at DESC
+`
+
+	rows, err := s.Pool.Query(ctx, q, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("list feed annotations: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]FeedActivityRow, 0, 256)
+	for rows.Next() {
+		row, err := scanFeedActivityRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate feed annotation rows: %w", err)
+	}
+	return out, nil
+}
+
+// scanFeedActivityRow is the shared row scanner used by
+// `fetchFeedAnnotations` and `ListFeedActivity`. The `Scanner` interface
+// keeps the shape independent of pgx-vs-rows specifics.
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
+	var (
+		id, txnID, tagID, ruleID, sessionID pgtype.UUID
+		actorName, kind, actorType          string
+		actorIDOpt                          pgtype.Text
+		shortID                             string
+		payload                             []byte
+		createdAt                           pgtype.Timestamptz
+		txShort, txName                     string
+		merchantName                        pgtype.Text
+		amount                              pgtype.Numeric
+		isoCcy                              pgtype.Text
+		txDate                              pgtype.Date
+		accountName, institutionName        pgtype.Text
+	)
+
+	if err := s.Scan(
+		&id, &shortID, &txnID, &kind, &actorType, &actorIDOpt, &actorName,
+		&payload, &tagID, &ruleID, &sessionID, &createdAt,
+		&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate,
+		&accountName, &institutionName,
+	); err != nil {
+		return FeedActivityRow{}, fmt.Errorf("scan feed activity row: %w", err)
+	}
+
+	ann := Annotation{
+		ID:            formatUUID(id),
+		ShortID:       shortID,
+		TransactionID: formatUUID(txnID),
+		Kind:          kind,
+		ActorType:     actorType,
+		ActorName:     actorName,
+		CreatedAt:     pgconv.TimestampStr(createdAt),
+		CreatedAtTime: createdAt.Time.UTC(),
+	}
+	if actorIDOpt.Valid && actorIDOpt.String != "" {
+		s := actorIDOpt.String
+		ann.ActorID = &s
+	}
+	if tagID.Valid {
+		s := formatUUID(tagID)
+		ann.TagID = &s
+	}
+	if ruleID.Valid {
+		s := formatUUID(ruleID)
+		ann.RuleID = &s
+	}
+	if sessionID.Valid {
+		s := formatUUID(sessionID)
+		ann.SessionID = &s
+	}
+	if len(payload) > 0 && string(payload) != "{}" {
+		var p map[string]interface{}
+		if err := json.Unmarshal(payload, &p); err == nil {
+			ann.Payload = p
+		}
+	}
+
+	row := FeedActivityRow{
+		Annotation:         ann,
+		TransactionShortID: txShort,
+		TransactionName:    txName,
+		MerchantName:       pgconv.TextOr(merchantName, ""),
+		IsoCurrencyCode:    pgconv.TextOr(isoCcy, "USD"),
+		AccountName:        pgconv.TextOr(accountName, ""),
+		InstitutionName:    pgconv.TextOr(institutionName, ""),
+	}
+	if amount.Valid {
+		if f, err := amount.Float64Value(); err == nil && f.Valid {
+			row.Amount = f.Float64
+		}
+	}
+	if txDate.Valid {
+		row.TransactionDate = txDate.Time.Format("2006-01-02")
+	}
+	return row, nil
+}
+
+// enrichFeedActivityRows runs `EnrichAnnotations` over a feed-activity slice
+// (ASC ordering required by the dedup heuristics) and returns the rows in
+// their original order.
+func enrichFeedActivityRows(in []FeedActivityRow) []FeedActivityRow {
+	if len(in) == 0 {
+		return in
+	}
+	asc := make([]Annotation, len(in))
+	for i, r := range in {
+		asc[len(in)-1-i] = r.Annotation
 	}
 	enriched := EnrichAnnotations(asc, EnrichOptions{})
-
-	// Map enriched annotations back by ID and rebuild DESC-ordered slice.
 	byID := make(map[string]Annotation, len(enriched))
 	for _, a := range enriched {
 		byID[a.ID] = a
 	}
-	desc := make([]FeedActivityRow, 0, len(enriched))
-	for _, r := range out {
+	out := make([]FeedActivityRow, 0, len(enriched))
+	for _, r := range in {
 		if a, ok := byID[r.Annotation.ID]; ok {
 			r.Annotation = a
-			desc = append(desc, r)
+			out = append(out, r)
 		}
 	}
-
-	// Best-effort actor avatar version for user actors. The dashboard
-	// already does the same trick via a join on users.updated_at; for the
-	// feed we issue a single follow-up batch lookup keyed by actor_id so
-	// we don't have to re-do the whole join.
-	if err := s.hydrateFeedAvatarVersions(ctx, desc); err != nil {
-		s.Logger.Debug("hydrate feed avatar versions", "error", err)
-	}
-
-	_ = strconv.Itoa // keep import used across small refactors
-	_ = time.Now
-	return desc, nil
+	return out
 }
 
 // hydrateFeedAvatarVersions populates Annotation.ActorAvatarVersion on every
 // user-attributed row in `rows` using a single batch query against users.
-// Best-effort: failures are returned to the caller for logging, but the feed
-// still renders without avatar cache-busting.
 func (s *Service) hydrateFeedAvatarVersions(ctx context.Context, rows []FeedActivityRow) error {
 	ids := make([]string, 0, len(rows))
 	seen := make(map[string]bool)
@@ -225,4 +504,645 @@ func (s *Service) hydrateFeedAvatarVersions(ctx context.Context, rows []FeedActi
 		}
 	}
 	return nil
+}
+
+// ── Sync events ───────────────────────────────────────────────────────────
+
+// fetchFeedSyncEvents returns one FeedEvent per sync run within the window
+// (failed runs always included; successful no-op runs filtered out).
+// Inline transaction samples are batched in a single follow-up query.
+func (s *Service) fetchFeedSyncEvents(ctx context.Context, cutoff time.Time, sampleLimit int) ([]FeedEvent, error) {
+	const q = `
+SELECT
+    sl.id, sl.connection_id,
+    bc.institution_name, bc.provider,
+    sl.trigger, sl.status,
+    sl.added_count, sl.modified_count, sl.removed_count,
+    sl.error_message, sl.started_at, sl.completed_at, sl.rule_hits
+FROM sync_logs sl
+JOIN bank_connections bc ON sl.connection_id = bc.id
+WHERE sl.started_at >= $1
+ORDER BY sl.started_at DESC
+`
+
+	rows, err := s.Pool.Query(ctx, q, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("list feed sync logs: %w", err)
+	}
+	defer rows.Close()
+
+	var raws []syncRowRaw
+	for rows.Next() {
+		var r syncRowRaw
+		if err := rows.Scan(
+			&r.id, &r.connectionID, &r.institutionName, &r.provider,
+			&r.trigger, &r.status,
+			&r.addedCount, &r.modifiedCount, &r.removedCount,
+			&r.errorMessage, &r.startedAt, &r.completedAt, &r.ruleHitsJSON,
+		); err != nil {
+			return nil, fmt.Errorf("scan feed sync row: %w", err)
+		}
+		raws = append(raws, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate feed sync rows: %w", err)
+	}
+
+	syncIDs := make([]string, 0, len(raws))
+	for _, r := range raws {
+		hasChanges := r.addedCount+r.modifiedCount+r.removedCount > 0
+		if hasChanges || r.status == "error" {
+			syncIDs = append(syncIDs, formatUUID(r.id))
+		}
+	}
+	samplesBySync, err := s.fetchSyncSampleTransactions(ctx, raws, sampleLimit)
+	if err != nil {
+		s.Logger.Debug("fetch sync sample transactions", "error", err)
+	}
+
+	// Dedup repeated same-error sync attempts per connection. The cron
+	// retry cadence (every 15 minutes for connections in error state)
+	// otherwise dumps 50+ identical cards into the rail and drowns out
+	// every signal event. Each (connection_id, error_message) cluster
+	// folds into the most recent attempt with `RetryCount` set.
+	type errKey struct {
+		connectionID string
+		errorMessage string
+	}
+	errClusters := make(map[errKey]*FeedSyncEvent)
+
+	out := make([]FeedEvent, 0, len(raws))
+	for _, r := range raws {
+		hasChanges := r.addedCount+r.modifiedCount+r.removedCount > 0
+		if !hasChanges && r.status != "error" {
+			continue
+		}
+		if !r.startedAt.Valid {
+			continue
+		}
+
+		ev := &FeedSyncEvent{
+			SyncLogID:       formatUUID(r.id),
+			InstitutionName: pgconv.TextOr(r.institutionName, ""),
+			Provider:        r.provider,
+			Trigger:         r.trigger,
+			Status:          r.status,
+			ErrorMessage:    pgconv.TextOr(r.errorMessage, ""),
+			AddedCount:      int(r.addedCount),
+			ModifiedCount:   int(r.modifiedCount),
+			RemovedCount:    int(r.removedCount),
+			StartedAt:       r.startedAt.Time.UTC(),
+			RuleOutcomes:    s.parseFeedRuleHits(ctx, r.ruleHitsJSON),
+		}
+		if r.completedAt.Valid {
+			ev.CompletedAt = r.completedAt.Time.UTC()
+		}
+		samples := samplesBySync[ev.SyncLogID]
+		if len(samples) > sampleLimit {
+			ev.AdditionalCount = len(samples) - sampleLimit
+			samples = samples[:sampleLimit]
+		} else if ev.AddedCount > len(samples) {
+			ev.AdditionalCount = ev.AddedCount - len(samples)
+		}
+		ev.SampleTransactions = samples
+
+		if r.status == "error" {
+			key := errKey{
+				connectionID: formatUUID(r.connectionID),
+				errorMessage: ev.ErrorMessage,
+			}
+			if existing, ok := errClusters[key]; ok {
+				existing.RetryCount++
+				if ev.StartedAt.Before(existing.FirstFailureAt) || existing.FirstFailureAt.IsZero() {
+					existing.FirstFailureAt = ev.StartedAt
+				}
+				continue
+			}
+			ev.FirstFailureAt = ev.StartedAt
+			errClusters[key] = ev
+		}
+
+		out = append(out, FeedEvent{
+			Type:      "sync",
+			Timestamp: ev.StartedAt,
+			Sync:      ev,
+		})
+	}
+	return out, nil
+}
+
+// syncRowRaw is the per-row scratch struct used by `fetchFeedSyncEvents`
+// to keep raw column values around long enough to drive the follow-up
+// sample-transaction fetch. Hoisted out of the function so the helper can
+// take a typed slice instead of a struct literal.
+type syncRowRaw struct {
+	id, connectionID                        pgtype.UUID
+	institutionName                         pgtype.Text
+	provider                                string
+	trigger, status                         string
+	addedCount, modifiedCount, removedCount int32
+	errorMessage                            pgtype.Text
+	startedAt, completedAt                  pgtype.Timestamptz
+	ruleHitsJSON                            []byte
+}
+
+// fetchSyncSampleTransactions issues one SQL query to fetch all transactions
+// added in the window and partitions them per-sync in Go using each
+// transaction's account → connection mapping plus the sync's started_at /
+// completed_at window.
+func (s *Service) fetchSyncSampleTransactions(ctx context.Context, raws []syncRowRaw, sampleLimit int) (map[string][]FeedSampleTx, error) {
+	if len(raws) == 0 {
+		return nil, nil
+	}
+
+	connIDs := make(map[string]bool, len(raws))
+	earliest := time.Now()
+	for _, r := range raws {
+		connIDs[formatUUID(r.connectionID)] = true
+		if r.startedAt.Valid && r.startedAt.Time.Before(earliest) {
+			earliest = r.startedAt.Time
+		}
+	}
+	connList := make([]string, 0, len(connIDs))
+	for id := range connIDs {
+		connList = append(connList, id)
+	}
+
+	const q = `
+SELECT t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
+       t.created_at, ac.name, bc.id::text, bc.institution_name
+FROM transactions t
+JOIN accounts ac ON ac.id = t.account_id
+JOIN bank_connections bc ON ac.connection_id = bc.id
+WHERE t.created_at >= $1
+  AND t.deleted_at IS NULL
+  AND bc.id::text = ANY($2::text[])
+ORDER BY t.created_at DESC
+`
+
+	rows, err := s.Pool.Query(ctx, q, earliest.Add(-1*time.Minute), connList)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type txRow struct {
+		FeedSampleTx
+		ConnectionID string
+		CreatedAt    time.Time
+	}
+	var fetched []txRow
+	for rows.Next() {
+		var (
+			shortID, provName string
+			merchantName      pgtype.Text
+			amount            pgtype.Numeric
+			isoCcy            pgtype.Text
+			txDate            pgtype.Date
+			createdAt         pgtype.Timestamptz
+			accountName       pgtype.Text
+			connID            string
+			institutionName   pgtype.Text
+		)
+		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &accountName, &connID, &institutionName); err != nil {
+			return nil, err
+		}
+		t := txRow{
+			FeedSampleTx: FeedSampleTx{
+				ShortID:      shortID,
+				Name:         provName,
+				MerchantName: pgconv.TextOr(merchantName, ""),
+				Currency:     pgconv.TextOr(isoCcy, "USD"),
+				AccountName:  pgconv.TextOr(accountName, ""),
+				Institution:  pgconv.TextOr(institutionName, ""),
+			},
+			ConnectionID: connID,
+			CreatedAt:    createdAt.Time.UTC(),
+		}
+		if amount.Valid {
+			if f, err := amount.Float64Value(); err == nil && f.Valid {
+				t.Amount = f.Float64
+			}
+		}
+		if txDate.Valid {
+			t.Date = txDate.Time.Format("2006-01-02")
+		}
+		fetched = append(fetched, t)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	samples := make(map[string][]FeedSampleTx, len(raws))
+	for _, r := range raws {
+		if !r.startedAt.Valid {
+			continue
+		}
+		connID := formatUUID(r.connectionID)
+		windowStart := r.startedAt.Time.Add(-30 * time.Second)
+		windowEnd := r.startedAt.Time.Add(2 * time.Hour)
+		if r.completedAt.Valid {
+			windowEnd = r.completedAt.Time.Add(30 * time.Second)
+		}
+
+		var picked []FeedSampleTx
+		for _, t := range fetched {
+			if t.ConnectionID != connID {
+				continue
+			}
+			if t.CreatedAt.Before(windowStart) || t.CreatedAt.After(windowEnd) {
+				continue
+			}
+			picked = append(picked, t.FeedSampleTx)
+		}
+		// Sort by absolute amount desc so the biggest transactions surface
+		// first — they're the highest-signal samples for "what came in".
+		sort.SliceStable(picked, func(i, j int) bool {
+			return absFloat(picked[i].Amount) > absFloat(picked[j].Amount)
+		})
+		if len(picked) > sampleLimit {
+			samples[formatUUID(r.id)] = append([]FeedSampleTx(nil), picked[:sampleLimit]...)
+		} else {
+			samples[formatUUID(r.id)] = picked
+		}
+	}
+	return samples, nil
+}
+
+// parseFeedRuleHits decodes the `sync_logs.rule_hits` JSONB column into the
+// feed's lightweight FeedRuleOutcome slice. The richer SyncLogRow path
+// resolves rule names against the live rules table; on the feed we accept
+// the frozen names captured at sync-time, which is good enough for the
+// "X auto-tagged" outcome line and avoids the extra round-trip.
+func (s *Service) parseFeedRuleHits(ctx context.Context, payload []byte) []FeedRuleOutcome {
+	if len(payload) == 0 || string(payload) == "{}" || string(payload) == "[]" {
+		return nil
+	}
+	type hit struct {
+		RuleID      string `json:"rule_id"`
+		RuleShortID string `json:"rule_short_id"`
+		RuleName    string `json:"rule_name"`
+		Count       int    `json:"count"`
+	}
+	var raw []hit
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return nil
+	}
+	out := make([]FeedRuleOutcome, 0, len(raw))
+	for _, h := range raw {
+		if h.Count <= 0 {
+			continue
+		}
+		out = append(out, FeedRuleOutcome{
+			RuleName:    h.RuleName,
+			RuleShortID: h.RuleShortID,
+			Count:       h.Count,
+		})
+	}
+	return out
+}
+
+// fetchFeedSessionMeta fetches mcp_sessions metadata for any session_ids
+// referenced by the supplied annotations. Returns a map keyed by session
+// UUID string.
+func (s *Service) fetchFeedSessionMeta(ctx context.Context, rows []FeedActivityRow) (map[string]feedSessionMeta, error) {
+	ids := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, r := range rows {
+		if r.Annotation.SessionID == nil {
+			continue
+		}
+		id := *r.Annotation.SessionID
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	const q = `
+SELECT id::text, short_id, api_key_name, purpose, created_at
+FROM mcp_sessions
+WHERE id::text = ANY($1::text[])
+`
+
+	pgrows, err := s.Pool.Query(ctx, q, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer pgrows.Close()
+	out := make(map[string]feedSessionMeta, len(ids))
+	for pgrows.Next() {
+		var id, shortID, keyName, purpose string
+		var createdAt pgtype.Timestamptz
+		if err := pgrows.Scan(&id, &shortID, &keyName, &purpose, &createdAt); err != nil {
+			return nil, err
+		}
+		out[id] = feedSessionMeta{
+			ID:         id,
+			ShortID:    shortID,
+			APIKeyName: keyName,
+			Purpose:    purpose,
+			CreatedAt:  createdAt.Time.UTC(),
+		}
+	}
+	return out, nil
+}
+
+type feedSessionMeta struct {
+	ID         string
+	ShortID    string
+	APIKeyName string
+	Purpose    string
+	CreatedAt  time.Time
+}
+
+// ── Grouping ──────────────────────────────────────────────────────────────
+
+// groupAnnotationsIntoEvents applies the two-stage grouping described on
+// `ListFeedEvents`: hard group by session_id, then soft-bucket the
+// remaining un-sessioned annotations.
+func groupAnnotationsIntoEvents(rows []FeedActivityRow, sessions map[string]feedSessionMeta, params FeedEventsParams) []FeedEvent {
+	bySession := make(map[string][]FeedActivityRow)
+	var unsessioned []FeedActivityRow
+	for _, r := range rows {
+		if r.Annotation.SessionID != nil && *r.Annotation.SessionID != "" {
+			id := *r.Annotation.SessionID
+			bySession[id] = append(bySession[id], r)
+		} else {
+			unsessioned = append(unsessioned, r)
+		}
+	}
+
+	out := make([]FeedEvent, 0, len(bySession)+len(unsessioned))
+
+	for sessionID, rows := range bySession {
+		ev := buildAgentSessionEvent(sessionID, rows, sessions[sessionID], params)
+		out = append(out, FeedEvent{
+			Type:         "agent_session",
+			Timestamp:    ev.EndedAt,
+			AgentSession: &ev,
+		})
+	}
+
+	out = append(out, groupUnsessionedAnnotations(unsessioned, params)...)
+	return out
+}
+
+// buildAgentSessionEvent collapses the annotations of one MCP session into
+// a single FeedAgentSessionEvent, summarising the kind breakdown and
+// picking up to SampleLimit unique transaction samples.
+func buildAgentSessionEvent(sessionID string, rows []FeedActivityRow, meta feedSessionMeta, params FeedEventsParams) FeedAgentSessionEvent {
+	ev := FeedAgentSessionEvent{
+		SessionID:      sessionID,
+		SessionShortID: meta.ShortID,
+		APIKeyName:     meta.APIKeyName,
+		Purpose:        meta.Purpose,
+		KindCounts:     make(map[string]int),
+	}
+	if !meta.CreatedAt.IsZero() {
+		ev.StartedAt = meta.CreatedAt
+	}
+
+	uniqueTx := make(map[string]FeedSampleTx)
+	for _, r := range rows {
+		ann := r.Annotation
+		if ev.ActorName == "" {
+			ev.ActorName = ann.ActorName
+			ev.ActorType = ann.ActorType
+			ev.ActorAvatarVersion = ann.ActorAvatarVersion
+			if ann.ActorID != nil {
+				ev.ActorID = *ann.ActorID
+			}
+		}
+		ev.AnnotationCount++
+		ev.KindCounts[ann.Kind]++
+		if ev.StartedAt.IsZero() || ann.CreatedAtTime.Before(ev.StartedAt) {
+			ev.StartedAt = ann.CreatedAtTime
+		}
+		if ann.CreatedAtTime.After(ev.EndedAt) {
+			ev.EndedAt = ann.CreatedAtTime
+		}
+		if _, ok := uniqueTx[r.TransactionShortID]; !ok {
+			uniqueTx[r.TransactionShortID] = sampleTxFromRow(r)
+		}
+	}
+	ev.UniqueTransactions = len(uniqueTx)
+
+	samples := make([]FeedSampleTx, 0, len(uniqueTx))
+	for _, t := range uniqueTx {
+		samples = append(samples, t)
+	}
+	sort.SliceStable(samples, func(i, j int) bool {
+		return absFloat(samples[i].Amount) > absFloat(samples[j].Amount)
+	})
+	if len(samples) > params.SampleLimit {
+		samples = samples[:params.SampleLimit]
+	}
+	ev.SampleTransactions = samples
+
+	if ev.ActorName == "" && meta.APIKeyName != "" {
+		ev.ActorName = meta.APIKeyName
+		ev.ActorType = "agent"
+	}
+	if ev.EndedAt.IsZero() {
+		ev.EndedAt = ev.StartedAt
+	}
+	return ev
+}
+
+// groupUnsessionedAnnotations buckets the remaining annotations by
+// (actor_id, kind, 5-min). Buckets at-or-above BulkThreshold collapse into
+// a FeedBulkActionEvent; smaller buckets pass through annotations
+// individually but only `comment` rows are kept (other singleton
+// recategorisations are too low-signal for the home feed).
+func groupUnsessionedAnnotations(rows []FeedActivityRow, params FeedEventsParams) []FeedEvent {
+	if len(rows) == 0 {
+		return nil
+	}
+	const bucketWindow = 5 * time.Minute
+
+	type bucketKey struct {
+		actorID string
+		kind    string
+		bucket  int64
+	}
+
+	buckets := make(map[bucketKey][]FeedActivityRow)
+	keyOrder := make([]bucketKey, 0)
+	for _, r := range rows {
+		actorID := ""
+		if r.Annotation.ActorID != nil {
+			actorID = *r.Annotation.ActorID
+		}
+		if actorID == "" {
+			actorID = r.Annotation.ActorType + ":" + r.Annotation.ActorName
+		}
+		k := bucketKey{
+			actorID: actorID,
+			kind:    r.Annotation.Kind,
+			bucket:  r.Annotation.CreatedAtTime.Unix() / int64(bucketWindow.Seconds()),
+		}
+		if _, ok := buckets[k]; !ok {
+			keyOrder = append(keyOrder, k)
+		}
+		buckets[k] = append(buckets[k], r)
+	}
+
+	out := make([]FeedEvent, 0, len(buckets))
+	for _, k := range keyOrder {
+		bucket := buckets[k]
+		if len(bucket) >= params.BulkThreshold {
+			ev := buildBulkActionEvent(bucket, params)
+			out = append(out, FeedEvent{
+				Type:       "bulk_action",
+				Timestamp:  ev.EndedAt,
+				BulkAction: &ev,
+			})
+			continue
+		}
+		// Below threshold — only standalone comments survive in v2.
+		for _, r := range bucket {
+			if r.Annotation.Kind != "comment" || r.Annotation.IsDeleted {
+				continue
+			}
+			ev := FeedCommentEvent{
+				ActorName:          r.Annotation.ActorName,
+				ActorType:          r.Annotation.ActorType,
+				ActorAvatarVersion: r.Annotation.ActorAvatarVersion,
+				Content:            r.Annotation.Content,
+				Transaction:        sampleTxFromRow(r),
+			}
+			if r.Annotation.ActorID != nil {
+				ev.ActorID = *r.Annotation.ActorID
+			}
+			out = append(out, FeedEvent{
+				Type:      "comment",
+				Timestamp: r.Annotation.CreatedAtTime,
+				Comment:   &ev,
+			})
+		}
+	}
+	return out
+}
+
+// buildBulkActionEvent collapses one (actor, kind, time-bucket) cluster of
+// annotations into a single FeedBulkActionEvent, summarising the subjects
+// (tag names, category names, rule names) the actor applied.
+func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedBulkActionEvent {
+	ev := FeedBulkActionEvent{
+		Count: len(rows),
+	}
+	subjectCounts := make(map[string]int)
+	subjectMeta := make(map[string]FeedBulkSubject)
+	uniqueTx := make(map[string]FeedSampleTx)
+
+	for _, r := range rows {
+		ann := r.Annotation
+		if ev.ActorName == "" {
+			ev.ActorName = ann.ActorName
+			ev.ActorType = ann.ActorType
+			ev.ActorAvatarVersion = ann.ActorAvatarVersion
+			ev.Kind = ann.Kind
+			if ann.ActorID != nil {
+				ev.ActorID = *ann.ActorID
+			}
+		}
+		if ev.StartedAt.IsZero() || ann.CreatedAtTime.Before(ev.StartedAt) {
+			ev.StartedAt = ann.CreatedAtTime
+		}
+		if ann.CreatedAtTime.After(ev.EndedAt) {
+			ev.EndedAt = ann.CreatedAtTime
+		}
+		key := bulkSubjectKey(ann)
+		if key != "" {
+			subjectCounts[key]++
+			if _, ok := subjectMeta[key]; !ok {
+				subjectMeta[key] = FeedBulkSubject{
+					Name: ann.Subject,
+					Slug: bulkSubjectSlug(ann),
+				}
+			}
+		}
+		if _, ok := uniqueTx[r.TransactionShortID]; !ok {
+			uniqueTx[r.TransactionShortID] = sampleTxFromRow(r)
+		}
+	}
+
+	subjects := make([]FeedBulkSubject, 0, len(subjectCounts))
+	for k, count := range subjectCounts {
+		s := subjectMeta[k]
+		s.Count = count
+		subjects = append(subjects, s)
+	}
+	sort.SliceStable(subjects, func(i, j int) bool {
+		return subjects[i].Count > subjects[j].Count
+	})
+	ev.Subjects = subjects
+
+	samples := make([]FeedSampleTx, 0, len(uniqueTx))
+	for _, t := range uniqueTx {
+		samples = append(samples, t)
+	}
+	sort.SliceStable(samples, func(i, j int) bool {
+		return absFloat(samples[i].Amount) > absFloat(samples[j].Amount)
+	})
+	if len(samples) > params.SampleLimit {
+		samples = samples[:params.SampleLimit]
+	}
+	ev.SampleTransactions = samples
+	return ev
+}
+
+func bulkSubjectKey(a Annotation) string {
+	switch a.Kind {
+	case "tag_added", "tag_removed":
+		return "tag:" + a.TagSlug
+	case "category_set":
+		return "category:" + a.CategorySlug
+	case "rule_applied":
+		return "rule:" + a.RuleShortID
+	}
+	return ""
+}
+
+func bulkSubjectSlug(a Annotation) string {
+	switch a.Kind {
+	case "tag_added", "tag_removed":
+		return a.TagSlug
+	case "category_set":
+		return a.CategorySlug
+	case "rule_applied":
+		return a.RuleShortID
+	}
+	return ""
+}
+
+// sampleTxFromRow projects a feed-activity row into the small FeedSampleTx
+// shape used by every event card.
+func sampleTxFromRow(r FeedActivityRow) FeedSampleTx {
+	merchant := r.MerchantName
+	if merchant == "" {
+		merchant = r.TransactionName
+	}
+	return FeedSampleTx{
+		ShortID:      r.TransactionShortID,
+		Name:         r.TransactionName,
+		MerchantName: merchant,
+		Amount:       r.Amount,
+		Currency:     r.IsoCurrencyCode,
+		Date:         r.TransactionDate,
+		AccountName:  r.AccountName,
+		Institution:  r.InstitutionName,
+	}
+}
+
+func absFloat(f float64) float64 {
+	if f < 0 {
+		return -f
+	}
+	return f
 }

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -9,22 +9,15 @@ import (
 )
 
 // Feed renders the home Feed — a chronological, GitHub-style activity stream
-// across the whole household. Designed as a candidate replacement for the
-// stats-heavy dashboard: replaces "what is my net worth" surfaces with
-// "what changed today" surfaces. The page composes:
+// across the whole household. Designed as the eventual replacement for the
+// stats-heavy dashboard.
 //
-//   - feedHero — the at-a-glance band: title, generated-at line, and the
-//     four KPIs (events today, new transactions, last sync, unread reports).
-//   - feedAlerts — pinned warning cards for connections in error state.
-//   - feedFilters — the scope-chip strip ("All", "From me", "From agents",
-//     "Syncs", "Reports").
-//   - feedTimeline — the actual rail: day separators + per-item cards mixed
-//     across a single left rail (reusing the timeline primitive's chrome).
-//
-// The feed convention is reverse-chronological — newest at the top — which
-// is the inverse of the per-transaction activity timeline (composer-anchored,
-// newest at the bottom). A global feed is consumed differently: people
-// glance at the top to see "what's new", then scroll back through history.
+// Items are aggressively grouped: every MCP agent session collapses into a
+// single AgentSession card, ≥3 same-actor same-kind annotations within a
+// 5-minute window collapse into a BulkAction card, and per-sync rule
+// outcomes fold into the parent sync card. Standalone comments survive
+// individually because every comment is high-signal. The window is bounded
+// to the last 3 days so the page never grows unbounded.
 templ Feed(p FeedProps) {
 	<div x-data x-init="$store.shortcuts.setScope('feed')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	@feedHero(p)
@@ -36,8 +29,7 @@ templ Feed(p FeedProps) {
 }
 
 // feedHero is the prominent header band: title + small generated-at line +
-// four highly-scannable KPI tiles. Anchors the page so the user sees a
-// "today" snapshot before they start reading the stream.
+// four highly-scannable KPI tiles.
 templ feedHero(p FeedProps) {
 	<header class="mb-6">
 		<div class="flex flex-wrap items-end justify-between gap-3 mb-4">
@@ -72,10 +64,6 @@ templ feedHero(p FeedProps) {
 	</header>
 }
 
-// feedHeroTile renders one KPI tile — neutral icon + label + big number +
-// optional sublabel. Used for the "events today", "new transactions", and
-// "unread reports" tiles; the sync tile renders separately so it can carry
-// a status dot.
 templ feedHeroTile(icon, label, value, sub string) {
 	<div class="bb-card p-4">
 		<div class="flex items-center gap-2">
@@ -89,9 +77,6 @@ templ feedHeroTile(icon, label, value, sub string) {
 	</div>
 }
 
-// feedHeroSyncTile is the special "Last sync" tile — pulses a coloured dot
-// based on the latest sync status. Designed so the user sees at a glance
-// whether everything is healthy without reading numbers.
 templ feedHeroSyncTile(p FeedProps) {
 	<a href="/logs?tab=syncs" class="bb-card bb-card--interactive p-4 no-underline group block">
 		<div class="flex items-center gap-2">
@@ -111,9 +96,6 @@ templ feedHeroSyncTile(p FeedProps) {
 	</a>
 }
 
-// feedAlerts renders the pinned-warning band. Each alert is a vivid warning
-// card with a Reconnect CTA — the goal is "you cannot scroll past this
-// without seeing it".
 templ feedAlerts(p FeedProps) {
 	<div class="space-y-2 mb-6">
 		for _, a := range p.ConnectionAlerts {
@@ -147,17 +129,13 @@ templ feedAlertCard(a FeedAlert) {
 	</div>
 }
 
-// feedFilters renders the scope-chip strip — a row of pill buttons that
-// re-issue the page with a ?filter= query param. Visual treatment matches
-// the bb-tag-chip family used elsewhere on the admin so it feels familiar.
 templ feedFilters(p FeedProps) {
 	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto" aria-label="Feed filters">
 		@feedFilterChip("All", "", "layers", p.Filter)
 		@feedFilterChip("Syncs", "syncs", "refresh-cw", p.Filter)
 		@feedFilterChip("Reports", "reports", "file-text", p.Filter)
 		@feedFilterChip("Comments", "comments", "message-circle", p.Filter)
-		@feedFilterChip("Rules", "rules", "zap", p.Filter)
-		@feedFilterChip("From agents", "agents", "bot", p.Filter)
+		@feedFilterChip("Sessions", "sessions", "bot", p.Filter)
 		@feedFilterChip("From me", "me", "user", p.Filter)
 	</nav>
 }
@@ -174,10 +152,6 @@ templ feedFilterChip(label, slug, icon, current string) {
 	</a>
 }
 
-// feedTimeline owns the rail itself — a single ordered list with day
-// separators and per-item rendering branching off Type. The rail uses the
-// "prominent" timeline variant so it feels like the page's main content
-// (vs. a sidebar widget like the per-transaction timeline).
 templ feedTimeline(p FeedProps) {
 	if len(p.Days) == 0 {
 		<div class="bb-card p-12 text-center">
@@ -202,13 +176,15 @@ templ feedTimeline(p FeedProps) {
 				}
 			}
 		}
+		if p.WindowDays > 0 {
+			<p class="text-xs text-base-content/40 text-center mt-6">
+				Showing the last { fmt.Sprintf("%d days", p.WindowDays) }.
+			</p>
+		}
 	}
 }
 
-// feedRow dispatches on item Type to the right card renderer. Each renderer
-// uses TimelineSystemRow for compact one-liners (tag/category/rule_batch)
-// and a custom <li> for rich cards (sync/report/comment) that need
-// multi-line layout.
+// feedRow dispatches on item Type to the right card renderer.
 templ feedRow(it FeedItem) {
 	switch it.Type {
 		case "sync":
@@ -223,26 +199,24 @@ templ feedRow(it FeedItem) {
 			if it.Comment != nil {
 				@feedCommentCard(it, it.Comment)
 			}
-		case "tag":
-			if it.Tag != nil {
-				@feedTagRow(it, it.Tag)
+		case "agent_session":
+			if it.AgentSession != nil {
+				@feedAgentSessionCard(it, it.AgentSession)
 			}
-		case "category":
-			if it.Category != nil {
-				@feedCategoryRow(it, it.Category)
-			}
-		case "rule_batch":
-			if it.RuleBatch != nil {
-				@feedRuleBatchCard(it, it.RuleBatch)
+		case "bulk_action":
+			if it.BulkAction != nil {
+				@feedBulkActionCard(it, it.BulkAction)
 			}
 	}
 }
 
 // ── Sync card ─────────────────────────────────────────────────────────────
 //
-// Rich card. Provider-coloured icon tile, headline ("12 new transactions
-// from Chase"), supporting line ("3 modified · 2 rules applied · 4s ago"),
-// CTA chevron to the sync-log detail page. Failures get an error variant.
+// Provider-tinted icon tile, headline ("12 new transactions from Chase"),
+// status counts (added · modified · removed · trigger), inline transaction
+// samples, and any rule outcomes that fired during the sync. The sample
+// strip is the centerpiece — the user wants to *see* what came in, not
+// count it.
 templ feedSyncCard(it FeedItem, s *FeedSync) {
 	<li class="relative flex items-start gap-3 py-3 group">
 		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200">
@@ -250,57 +224,78 @@ templ feedSyncCard(it FeedItem, s *FeedSync) {
 				<i data-lucide={ feedSyncIcon(s.Status) } class={ "w-3.5 h-3.5", feedSyncTileText(s.Status) }></i>
 			</span>
 		</div>
-		<a
-			href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) }
-			class="flex-1 min-w-0 bb-card bb-card--interactive p-3.5 sm:p-4 no-underline block group/card"
-		>
-			<div class="flex items-start gap-3">
-				<div class="flex-1 min-w-0">
-					<div class="flex items-baseline gap-2 flex-wrap">
-						<span class="font-semibold text-sm text-base-content">
-							{ feedSyncHeadline(s) }
-						</span>
-						<span class="text-xs text-base-content/50">{ feedProviderLabel(s.Provider) }</span>
-						<span class="text-xs text-base-content/35">&middot;</span>
-						<span class="text-xs text-base-content/55 tabular-nums">
-							{ relativeFromRFC3339(it.TimestampStr) }
-						</span>
+		<div class="flex-1 min-w-0 bb-card p-3.5 sm:p-4">
+			<div class="flex items-baseline gap-2 flex-wrap">
+				<a href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) } class="font-semibold text-sm text-base-content hover:text-primary transition-colors no-underline">
+					{ feedSyncHeadline(s) }
+				</a>
+				if lab := feedProviderLabel(s.Provider); lab != "" {
+					<span class="text-xs text-base-content/50">{ lab }</span>
+				}
+				<span class="text-xs text-base-content/35">&middot;</span>
+				<span class="text-xs text-base-content/55 tabular-nums">
+					{ relativeFromRFC3339(it.TimestampStr) }
+				</span>
+			</div>
+			<div class="text-xs text-base-content/55 mt-1.5 flex items-center gap-3 flex-wrap">
+				if s.AddedCount > 0 {
+					<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-success" aria-hidden="true"></span>{ fmt.Sprintf("%d added", s.AddedCount) }</span>
+				}
+				if s.ModifiedCount > 0 {
+					<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-info" aria-hidden="true"></span>{ fmt.Sprintf("%d modified", s.ModifiedCount) }</span>
+				}
+				if s.RemovedCount > 0 {
+					<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-base-content/30" aria-hidden="true"></span>{ fmt.Sprintf("%d removed", s.RemovedCount) }</span>
+				}
+				if s.Trigger != "" && s.Trigger != "cron" {
+					<span class="inline-flex items-center gap-1 text-base-content/50"><i data-lucide="hand" class="w-3 h-3"></i>{ feedTriggerLabel(s.Trigger) }</span>
+				}
+			</div>
+			if s.Status == "error" && s.ErrorMessage != "" {
+				<div class="mt-2.5 text-xs text-error/90 bg-error/8 rounded-lg px-2.5 py-1.5 border border-error/20">
+					<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
+					{ s.ErrorMessage }
+				</div>
+				if s.RetryCount > 0 {
+					<div class="mt-1.5 text-xs text-base-content/55 flex items-center gap-1.5">
+						<i data-lucide="refresh-cw" class="w-3 h-3"></i>
+						<span>{ feedSyncRetryLabel(s) }</span>
 					</div>
-					<div class="text-xs text-base-content/55 mt-1.5 flex items-center gap-3 flex-wrap">
-						if s.AddedCount > 0 {
-							<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-success" aria-hidden="true"></span>{ fmt.Sprintf("%d added", s.AddedCount) }</span>
+				}
+			}
+			if len(s.SampleTransactions) > 0 {
+				<div class="mt-3 pt-3 border-t border-base-200">
+					@feedTransactionSampleList(s.SampleTransactions, s.AdditionalCount)
+				</div>
+			}
+			if len(s.RuleOutcomes) > 0 {
+				<div class="mt-2 flex items-center gap-2 flex-wrap text-xs text-base-content/55">
+					<i data-lucide="zap" class="w-3 h-3 text-primary/70"></i>
+					for i, ro := range s.RuleOutcomes {
+						if i > 0 {
+							<span class="text-base-content/25">·</span>
 						}
-						if s.ModifiedCount > 0 {
-							<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-info" aria-hidden="true"></span>{ fmt.Sprintf("%d modified", s.ModifiedCount) }</span>
+						if ro.RuleShortID != "" {
+							<a href={ templ.SafeURL("/rules/" + ro.RuleShortID) } class="hover:text-primary transition-colors no-underline">
+								<span class="text-base-content/85">{ ro.RuleName }</span>
+								<span class="text-base-content/55">&nbsp;applied to&nbsp;</span>
+								<span class="font-medium tabular-nums">{ fmt.Sprintf("%d", ro.Count) }</span>
+							</a>
+						} else {
+							<span>
+								<span class="text-base-content/85">{ feedNonEmpty(ro.RuleName, "A rule") }</span>
+								<span class="text-base-content/55">&nbsp;applied to&nbsp;</span>
+								<span class="font-medium tabular-nums">{ fmt.Sprintf("%d", ro.Count) }</span>
+							</span>
 						}
-						if s.RemovedCount > 0 {
-							<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-base-content/30" aria-hidden="true"></span>{ fmt.Sprintf("%d removed", s.RemovedCount) }</span>
-						}
-						if s.RuleHits > 0 {
-							<span class="inline-flex items-center gap-1 text-primary/80"><i data-lucide="zap" class="w-3 h-3"></i>{ fmt.Sprintf("%d rule hit%s", s.RuleHits, pluralFeedS(s.RuleHits)) }</span>
-						}
-						if s.Trigger != "" && s.Trigger != "cron" {
-							<span class="inline-flex items-center gap-1 text-base-content/50"><i data-lucide="hand" class="w-3 h-3"></i>{ feedTriggerLabel(s.Trigger) }</span>
-						}
-					</div>
-					if s.Status == "error" && s.ErrorMessage != "" {
-						<div class="mt-2 text-xs text-error/90 bg-error/8 rounded-lg px-2.5 py-1.5 border border-error/20">
-							<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
-							{ s.ErrorMessage }
-						</div>
 					}
 				</div>
-				<i data-lucide="chevron-right" class="w-4 h-4 text-base-content/25 shrink-0 mt-0.5 group-hover/card:text-base-content/55 transition-colors"></i>
-			</div>
-		</a>
+			}
+		</div>
 	</li>
 }
 
 // ── Report card ───────────────────────────────────────────────────────────
-//
-// Big rich card. Priority-coloured icon tile, title, excerpt body, author
-// chip + tags. Designed to make agent reports feel like first-class items
-// in the feed, not buried sidebar widgets.
 templ feedReportCard(it FeedItem, r *FeedReport) {
 	<li class="relative flex items-start gap-3 py-3 group">
 		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200">
@@ -345,11 +340,7 @@ templ feedReportCard(it FeedItem, r *FeedReport) {
 	</li>
 }
 
-// ── Comment card ──────────────────────────────────────────────────────────
-//
-// Mid-weight card. Avatar tile, "<actor> commented on <transaction>", a
-// chat-style bubble carrying the comment body, and a small transaction-ref
-// strip with merchant + amount.
+// ── Standalone comment card ───────────────────────────────────────────────
 templ feedCommentCard(it FeedItem, c *FeedComment) {
 	<li class="relative flex items-start gap-3 py-3 group">
 		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200 flex items-center justify-center">
@@ -373,103 +364,90 @@ templ feedCommentCard(it FeedItem, c *FeedComment) {
 	</li>
 }
 
-// ── Tag row ───────────────────────────────────────────────────────────────
+// ── Agent session card ────────────────────────────────────────────────────
 //
-// Compact one-liner via TimelineSystemRow. Shows actor, action ("added"/
-// "removed"), tag chip with its own color, and the linked transaction.
-templ feedTagRow(it FeedItem, t *FeedTagChange) {
-	@components.TimelineSystemRow(components.TimelineRowProps{
-		Icon:      feedTagIcon(t.Action),
-		IconTone:  feedTagTone(t.Action),
-		Timestamp: it.TimestampStr,
-	}) {
-		<strong class="font-medium text-base-content">{ feedActorDisplay(t.ActorName, t.ActorType) }</strong>
-		<span class="text-base-content/55">
-			if t.Action == "added" {
-				added the
-			} else {
-				removed the
-			}
-		</span>
-		@feedTagChipInline(t.TagName, t.TagColor)
-		<span class="text-base-content/55">tag on</span>
-		<a href={ templ.SafeURL("/transactions/" + t.Transaction.ShortID) } class="font-medium text-base-content hover:text-primary transition-colors">
-			{ feedTransactionLabel(t.Transaction) }
-		</a>
-		if t.Note != "" {
-			<span class="block text-base-content/55 mt-0.5 italic">&ldquo;{ t.Note }&rdquo;</span>
-		}
-	}
-}
-
-// ── Category row ──────────────────────────────────────────────────────────
-templ feedCategoryRow(it FeedItem, c *FeedCategoryChange) {
-	@components.TimelineSystemRow(components.TimelineRowProps{
-		Icon:      "folder",
-		IconTone:  "info",
-		Timestamp: it.TimestampStr,
-	}) {
-		<strong class="font-medium text-base-content">{ feedActorDisplay(c.ActorName, c.ActorType) }</strong>
-		<span class="text-base-content/55">set category to</span>
-		@feedCategoryChipInline(c.CategoryName, c.CategoryColor, c.CategoryIcon)
-		<span class="text-base-content/55">on</span>
-		<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-medium text-base-content hover:text-primary transition-colors">
-			{ feedTransactionLabel(c.Transaction) }
-		</a>
-	}
-}
-
-// ── Rule batch card ───────────────────────────────────────────────────────
-//
-// Mid-weight card. Collapses N rule_applied rows for one rule on one day
-// into a single row with a count and an expandable sample list. Heavy users
-// of automation see "Rule X auto-categorized 47 transactions today" as a
-// single line instead of 47 rows.
-templ feedRuleBatchCard(it FeedItem, b *FeedRuleBatch) {
-	<li class="relative flex items-start gap-3 py-2.5 group" x-data="{ expanded: false }">
+// Collapses every annotation in one MCP session into a single row. Header
+// reads "<agent> ran a session — 47 transactions touched"; below, a
+// breakdown of the kinds of action taken plus inline transaction samples
+// and a link to the full session log.
+templ feedAgentSessionCard(it FeedItem, s *FeedAgentSession) {
+	<li class="relative flex items-start gap-3 py-3 group">
 		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200">
-			<span class="flex items-center justify-center w-7 h-7 rounded-full ring-4 ring-base-200 bg-primary/12">
-				<i data-lucide="zap" class="w-3.5 h-3.5 text-primary"></i>
-			</span>
+			@feedActorAvatar(s.ActorType, s.ActorID, s.ActorAvatarVersion, feedSessionActorName(s), "lg")
 		</div>
-		<div class="flex-1 min-w-0 text-sm leading-6">
-			<div class="flex items-baseline gap-1.5 flex-wrap">
-				<span class="text-base-content/55">Rule</span>
-				if b.RuleShortID != "" {
-					<a href={ templ.SafeURL("/rules/" + b.RuleShortID) } class="font-semibold text-base-content hover:text-primary transition-colors">{ b.RuleName }</a>
-				} else {
-					<strong class="font-semibold text-base-content">{ b.RuleName }</strong>
-				}
-				<span class="text-base-content/55">auto-applied to</span>
-				<strong class="font-semibold text-base-content">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</strong>
-				if af := feedRuleActionLabel(b.ActionFields); af != "" {
-					<span class="text-base-content/55">{ af }</span>
-				}
-				<span class="text-base-content/30 mx-1">·</span>
-				<span class="text-base-content/45 tabular-nums text-xs">{ relativeFromRFC3339(it.TimestampStr) }</span>
+		<div class="flex-1 min-w-0 bb-card p-3.5 sm:p-4">
+			<div class="flex items-baseline gap-2 flex-wrap text-sm">
+				<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
+				<span class="text-base-content/55">ran a session</span>
+				<span class="text-base-content/30">·</span>
+				<span class="font-medium text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
+				<span class="text-base-content/30">·</span>
+				<span class="text-xs text-base-content/45 tabular-nums">{ relativeFromRFC3339(it.TimestampStr) }</span>
 			</div>
-			if len(b.Samples) > 0 {
-				<button
-					type="button"
-					class="text-xs text-primary/70 hover:text-primary transition-colors mt-1 inline-flex items-center gap-1"
-					@click="expanded = !expanded"
-				>
-					<i data-lucide="chevron-right" class="w-3 h-3 transition-transform" :class="expanded ? 'rotate-90' : ''"></i>
-					<span x-text="expanded ? 'Hide examples' : 'Show examples'"></span>
-				</button>
-				<div x-show="expanded" x-cloak class="mt-2 space-y-1">
-					for _, s := range b.Samples {
-						<a
-							href={ templ.SafeURL("/transactions/" + s.ShortID) }
-							class="flex items-center justify-between gap-2 text-xs text-base-content/70 hover:text-base-content transition-colors px-2.5 py-1.5 rounded-lg bg-base-200/50 hover:bg-base-200 no-underline"
-						>
-							<span class="truncate">{ feedNonEmpty(s.MerchantName, "Unknown") }</span>
-							<span class="tabular-nums shrink-0">{ feedAmountWithSign(s.Amount, s.Currency) }</span>
-						</a>
+			if breakdown := feedSessionBreakdown(s); breakdown != "" {
+				<div class="text-xs text-base-content/55 mt-1.5 flex items-center gap-1.5 flex-wrap">
+					<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
+					<span>{ breakdown }</span>
+					if dur := feedSessionDuration(s); dur != "" {
+						<span class="text-base-content/30 mx-1">·</span>
+						<i data-lucide="clock" class="w-3 h-3"></i>
+						<span>{ dur }</span>
 					}
-					if b.Count > len(b.Samples) {
-						<div class="text-xs text-base-content/40 pl-2.5 mt-1">+ { fmt.Sprintf("%d more", b.Count-len(b.Samples)) }</div>
+				</div>
+			}
+			if len(s.SampleTransactions) > 0 {
+				<div class="mt-3 pt-3 border-t border-base-200">
+					@feedTransactionSampleList(s.SampleTransactions, max0(s.UniqueTransactions-len(s.SampleTransactions)))
+				</div>
+			}
+			if s.SessionShortID != "" {
+				<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-xs text-primary/70 hover:text-primary transition-colors mt-3 inline-flex items-center gap-1 no-underline">
+					Open session log
+					<i data-lucide="arrow-right" class="w-3 h-3"></i>
+				</a>
+			}
+		</div>
+	</li>
+}
+
+// ── Bulk action card ──────────────────────────────────────────────────────
+//
+// Collapses ≥3 same-actor same-kind annotations within a 5-minute bucket
+// into one row. "<actor> categorised 12 transactions as Groceries · 4 more
+// to other categories", with the same inline transaction-sample strip.
+templ feedBulkActionCard(it FeedItem, b *FeedBulkAction) {
+	<li class="relative flex items-start gap-3 py-3 group">
+		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200">
+			@feedActorAvatar(b.ActorType, b.ActorID, b.ActorAvatarVersion, b.ActorName, "lg")
+		</div>
+		<div class="flex-1 min-w-0 bb-card p-3.5 sm:p-4">
+			<div class="text-sm flex items-baseline gap-1.5 flex-wrap">
+				<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
+				<span class="text-base-content/65">{ feedBulkVerb(b.Kind) }</span>
+				<span class="font-semibold text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
+				if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
+					<span class="text-base-content/65">{ subjectLabel }</span>
+				}
+				<span class="text-base-content/30">·</span>
+				<span class="text-xs text-base-content/45 tabular-nums">{ relativeFromRFC3339(it.TimestampStr) }</span>
+			</div>
+			if len(b.Subjects) > 1 {
+				<div class="text-xs text-base-content/55 mt-1.5 flex items-center gap-1.5 flex-wrap">
+					for i, sub := range b.Subjects {
+						if i >= 4 {
+							<span class="text-base-content/40">+ { fmt.Sprintf("%d more", len(b.Subjects)-4) }</span>
+							break
+						}
+						<span class="inline-flex items-center gap-1 bg-base-200 px-1.5 py-0.5 rounded-md text-[0.7rem]">
+							<span class="font-medium text-base-content/85">{ sub.Name }</span>
+							<span class="text-base-content/55 tabular-nums">&times;{ fmt.Sprintf("%d", sub.Count) }</span>
+						</span>
 					}
+				</div>
+			}
+			if len(b.SampleTransactions) > 0 {
+				<div class="mt-3 pt-3 border-t border-base-200">
+					@feedTransactionSampleList(b.SampleTransactions, max0(b.Count-len(b.SampleTransactions)))
 				</div>
 			}
 		</div>
@@ -478,8 +456,43 @@ templ feedRuleBatchCard(it FeedItem, b *FeedRuleBatch) {
 
 // ── Shared subcomponents ──────────────────────────────────────────────────
 
-// feedTransactionRefStrip is the small horizontal strip rendered beneath a
-// comment bubble that anchors the comment to its source transaction.
+// feedTransactionSampleList renders an inline list of up to 5 transaction
+// samples. Mobile collapses to 3 visible (the rest hidden via `hidden
+// sm:grid` on the `.feed-sample-row[data-sample-index>=3]` rows), so the
+// card stays compact on a phone but rich on desktop.
+templ feedTransactionSampleList(samples []FeedTransactionRef, additional int) {
+	<ul class="space-y-1" role="list">
+		for i, tx := range samples {
+			<li class={ "flex items-center justify-between gap-2", templ.KV("hidden sm:flex", i >= 3) }>
+				<a
+					href={ templ.SafeURL("/transactions/" + tx.ShortID) }
+					class="flex items-center gap-2 min-w-0 flex-1 text-xs text-base-content/85 hover:text-base-content transition-colors no-underline"
+				>
+					<i data-lucide="receipt" class="w-3 h-3 text-base-content/35 shrink-0"></i>
+					<span class="font-medium truncate">{ feedNonEmpty(tx.MerchantName, tx.Name) }</span>
+					if tx.AccountName != "" {
+						<span class="text-base-content/35 hidden sm:inline">·</span>
+						<span class="text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>
+					}
+				</a>
+				<span class={ "text-xs tabular-nums font-medium shrink-0", feedAmountClass(tx.Amount) }>
+					{ feedAmountWithSign(tx.Amount, tx.Currency) }
+				</span>
+			</li>
+		}
+		if additional > 0 {
+			<li class="text-xs text-base-content/40 pl-5">
+				<span class="sm:hidden">{ fmt.Sprintf("+ %d more", additional+max0(len(samples)-3)) }</span>
+				<span class="hidden sm:inline">{ fmt.Sprintf("+ %d more", additional) }</span>
+			</li>
+		} else if len(samples) > 3 {
+			<li class="text-xs text-base-content/40 pl-5 sm:hidden">
+				{ fmt.Sprintf("+ %d more", len(samples)-3) }
+			</li>
+		}
+	</ul>
+}
+
 templ feedTransactionRefStrip(tx FeedTransactionRef) {
 	if tx.ShortID != "" {
 		<a
@@ -500,25 +513,6 @@ templ feedTransactionRefStrip(tx FeedTransactionRef) {
 			</div>
 		</a>
 	}
-}
-
-templ feedTagChipInline(name, color string) {
-	<span class={ "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-xs font-medium",
-		templ.KV("bg-base-200 text-base-content/75", color == "") } style={ feedTagStyle(color) }>
-		<i data-lucide="tag" class="w-2.5 h-2.5" aria-hidden="true"></i>
-		<span>{ name }</span>
-	</span>
-}
-
-templ feedCategoryChipInline(name, color, icon string) {
-	<span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md text-xs font-medium" style={ feedCategoryStyle(color) }>
-		if icon != "" {
-			<i data-lucide={ icon } class="w-2.5 h-2.5" aria-hidden="true"></i>
-		} else {
-			<i data-lucide="folder" class="w-2.5 h-2.5" aria-hidden="true"></i>
-		}
-		<span>{ name }</span>
-	</span>
 }
 
 templ feedActorAvatar(actorType, actorID, version, name, size string) {
@@ -563,6 +557,92 @@ func feedActorDisplay(name, actorType string) string {
 		return "Breadbox"
 	}
 	return "Someone"
+}
+
+func feedSessionActorName(s *FeedAgentSession) string {
+	if s.ActorName != "" {
+		return s.ActorName
+	}
+	if s.APIKeyName != "" {
+		return s.APIKeyName
+	}
+	return "An agent"
+}
+
+func feedSessionBreakdown(s *FeedAgentSession) string {
+	parts := []string{}
+	if s.Categorised > 0 {
+		parts = append(parts, fmt.Sprintf("%d categorised", s.Categorised))
+	}
+	if s.Tagged > 0 {
+		parts = append(parts, fmt.Sprintf("%d tagged", s.Tagged))
+	}
+	if s.UntaggedRemoved > 0 {
+		parts = append(parts, fmt.Sprintf("%d untagged", s.UntaggedRemoved))
+	}
+	if s.Commented > 0 {
+		parts = append(parts, fmt.Sprintf("%d commented", s.Commented))
+	}
+	if s.RuleApplied > 0 {
+		parts = append(parts, fmt.Sprintf("%d rules applied", s.RuleApplied))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func feedSessionDuration(s *FeedAgentSession) string {
+	if s.StartedAt.IsZero() || s.EndedAt.IsZero() {
+		return ""
+	}
+	d := s.EndedAt.Sub(s.StartedAt)
+	if d < 1 {
+		return ""
+	}
+	if d < 60 {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < 3600 {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	return fmt.Sprintf("%dh", int(d.Hours()))
+}
+
+func feedBulkVerb(kind string) string {
+	switch kind {
+	case "tag_added":
+		return "added a tag to"
+	case "tag_removed":
+		return "removed a tag from"
+	case "category_set":
+		return "categorised"
+	case "rule_applied":
+		return "ran a rule on"
+	}
+	return "updated"
+}
+
+// feedBulkSubjectLabel returns the trailing phrase for a bulk-action card —
+// "as Groceries", "with Needs Review", "with rule X". When subjects span
+// multiple values, the chip strip below the headline carries the breakdown
+// instead and this function returns "".
+func feedBulkSubjectLabel(b *FeedBulkAction) string {
+	if len(b.Subjects) != 1 {
+		return ""
+	}
+	name := b.Subjects[0].Name
+	if name == "" {
+		return ""
+	}
+	switch b.Kind {
+	case "tag_added":
+		return "with the " + name + " tag"
+	case "tag_removed":
+		return "with the " + name + " tag"
+	case "category_set":
+		return "as " + name
+	case "rule_applied":
+		return "with rule " + name
+	}
+	return ""
 }
 
 func feedTransactionLabel(tx FeedTransactionRef) string {
@@ -674,6 +754,20 @@ func feedReportIcon(priority string) string {
 	return "file-text"
 }
 
+// feedSyncRetryLabel renders the "+N attempts since X ago" line on a
+// failed sync card whose retry attempts have been folded into one row.
+func feedSyncRetryLabel(s *FeedSync) string {
+	total := s.RetryCount + 1
+	if s.FirstFailureAt.IsZero() {
+		return fmt.Sprintf("%d attempts so far", total)
+	}
+	since := timefmt.Relative(s.FirstFailureAt)
+	if since == "" {
+		return fmt.Sprintf("%d attempts so far", total)
+	}
+	return fmt.Sprintf("Failing since %s · %d attempts", since, total)
+}
+
 func feedSyncHeadline(s *FeedSync) string {
 	bank := s.InstitutionName
 	if bank == "" {
@@ -716,56 +810,6 @@ func feedTriggerLabel(t string) string {
 		return "first sync"
 	}
 	return t
-}
-
-func feedRuleActionLabel(fields map[string]int) string {
-	if len(fields) == 0 {
-		return ""
-	}
-	if len(fields) == 1 {
-		for k := range fields {
-			switch k {
-			case "tag":
-				return "(tagged)"
-			case "category":
-				return "(categorised)"
-			}
-			return "(" + k + ")"
-		}
-	}
-	parts := make([]string, 0, len(fields))
-	for k := range fields {
-		parts = append(parts, k)
-	}
-	return "(" + strings.Join(parts, " + ") + ")"
-}
-
-func feedTagIcon(action string) string {
-	if action == "removed" {
-		return "tag"
-	}
-	return "tag"
-}
-
-func feedTagTone(action string) string {
-	if action == "removed" {
-		return "error"
-	}
-	return "success"
-}
-
-func feedTagStyle(color string) string {
-	if color == "" {
-		return ""
-	}
-	return fmt.Sprintf("background-color: color-mix(in srgb, %s 18%%, transparent); color: %s;", color, color)
-}
-
-func feedCategoryStyle(color string) string {
-	if color == "" {
-		return "background-color: oklch(var(--b2)); color: var(--bc, #1f2937);"
-	}
-	return fmt.Sprintf("background-color: color-mix(in srgb, %s 18%%, transparent); color: %s;", color, color)
 }
 
 func feedHeroSubEvents(p FeedProps) string {
@@ -825,10 +869,13 @@ func pluralFeedS(n int) string {
 	return "s"
 }
 
-// relativeFromRFC3339 is the relative-time formatter the feed uses for
-// per-row timestamps. It mirrors the "relativeTimelineTimestamp" helper used
-// by the per-transaction timeline so feed rows feel visually identical to
-// activity rows on a transaction page.
+func max0(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
 func relativeFromRFC3339(s string) string {
 	if s == "" {
 		return ""

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -3,22 +3,27 @@ package pages
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"breadbox/internal/templates/components"
 	"breadbox/internal/timefmt"
 )
 
 // Feed renders the home Feed — a chronological, GitHub-style activity stream
-// across the whole household. Designed as the eventual replacement for the
-// stats-heavy dashboard.
-//
-// Items are aggressively grouped: every MCP agent session collapses into a
-// single AgentSession card, ≥3 same-actor same-kind annotations within a
-// 5-minute window collapse into a BulkAction card, and per-sync rule
-// outcomes fold into the parent sync card. Standalone comments survive
-// individually because every comment is high-signal. The window is bounded
-// to the last 3 days so the page never grows unbounded.
+// across the whole household. Every row threads through the shared timeline
+// primitives (TimelineSystemRow / TimelineSystemRowCustomTile /
+// TimelineCommentRow) so the visual language stays identical to the per-
+// transaction activity log on /transactions/{id}. The home feed is just a
+// global, grouped view of the same shape.
 templ Feed(p FeedProps) {
+	<!-- Comment bubbles use the shared markdown scanner so a comment posted
+	     from the per-transaction composer renders identically when it
+	     surfaces here. Same marked + DOMPurify versions / SRI as the
+	     per-transaction page. The scanner is idempotent — safe on every
+	     feed visit. -->
+	<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
+	<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js" integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7" crossorigin="anonymous"></script>
+	<script src="/static/js/admin/markdown.js"></script>
 	<div x-data x-init="$store.shortcuts.setScope('feed')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	@feedHero(p)
 	if len(p.ConnectionAlerts) > 0 {
@@ -28,8 +33,8 @@ templ Feed(p FeedProps) {
 	@feedTimeline(p)
 }
 
-// feedHero is the prominent header band: title + small generated-at line +
-// four highly-scannable KPI tiles.
+// ── Hero band ─────────────────────────────────────────────────────────────
+
 templ feedHero(p FeedProps) {
 	<header class="mb-6">
 		<div class="flex flex-wrap items-end justify-between gap-3 mb-4">
@@ -96,6 +101,8 @@ templ feedHeroSyncTile(p FeedProps) {
 	</a>
 }
 
+// ── Pinned alerts ─────────────────────────────────────────────────────────
+
 templ feedAlerts(p FeedProps) {
 	<div class="space-y-2 mb-6">
 		for _, a := range p.ConnectionAlerts {
@@ -129,6 +136,8 @@ templ feedAlertCard(a FeedAlert) {
 	</div>
 }
 
+// ── Filters ───────────────────────────────────────────────────────────────
+
 templ feedFilters(p FeedProps) {
 	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto" aria-label="Feed filters">
 		@feedFilterChip("All", "", "layers", p.Filter)
@@ -152,6 +161,8 @@ templ feedFilterChip(label, slug, icon, current string) {
 	</a>
 }
 
+// ── Timeline + dispatch ───────────────────────────────────────────────────
+
 templ feedTimeline(p FeedProps) {
 	if len(p.Days) == 0 {
 		<div class="bb-card p-12 text-center">
@@ -172,7 +183,7 @@ templ feedTimeline(p FeedProps) {
 			for _, day := range p.Days {
 				@components.TimelineDay(day.Label, day.First)
 				for _, item := range day.Items {
-					@feedRow(item)
+					@feedRow(item, p.Now)
 				}
 			}
 		}
@@ -184,352 +195,361 @@ templ feedTimeline(p FeedProps) {
 	}
 }
 
-// feedRow dispatches on item Type to the right card renderer.
-templ feedRow(it FeedItem) {
+// feedRow dispatches each FeedItem to the right primitive. Comments use
+// TimelineCommentRow (matching the per-transaction activity log shape);
+// every other event type uses TimelineSystemRowCustomTile so the rail
+// chrome, leading-6 body container, and tile geometry stay identical to
+// the existing timeline surfaces. We never reach for a bespoke <li>.
+templ feedRow(it FeedItem, now time.Time) {
 	switch it.Type {
 		case "sync":
 			if it.Sync != nil {
-				@feedSyncCard(it, it.Sync)
+				@components.TimelineSystemRowCustomTile(
+					"", "", now,
+					feedSyncTile(it.Sync.Status),
+					feedSyncBody(it, it.Sync, now),
+					nil,
+				)
 			}
 		case "report":
 			if it.Report != nil {
-				@feedReportCard(it, it.Report)
+				@components.TimelineSystemRowCustomTile(
+					"", "", now,
+					feedReportTile(it.Report.Priority),
+					feedReportBody(it, it.Report, now),
+					nil,
+				)
 			}
 		case "comment":
 			if it.Comment != nil {
-				@feedCommentCard(it, it.Comment)
+				@feedCommentRow(it, it.Comment, now)
 			}
 		case "agent_session":
 			if it.AgentSession != nil {
-				@feedAgentSessionCard(it, it.AgentSession)
+				@components.TimelineSystemRowCustomTile(
+					"", "", now,
+					feedActorTile(it.AgentSession.ActorType, it.AgentSession.ActorID, it.AgentSession.ActorAvatarVersion, feedSessionActorName(it.AgentSession)),
+					feedAgentSessionBody(it, it.AgentSession, now),
+					nil,
+				)
 			}
 		case "bulk_action":
 			if it.BulkAction != nil {
-				@feedBulkActionCard(it, it.BulkAction)
+				@components.TimelineSystemRowCustomTile(
+					"", "", now,
+					feedActorTile(it.BulkAction.ActorType, it.BulkAction.ActorID, it.BulkAction.ActorAvatarVersion, it.BulkAction.ActorName),
+					feedBulkActionBody(it, it.BulkAction, now),
+					nil,
+				)
 			}
 	}
 }
 
-// ── Sync card ─────────────────────────────────────────────────────────────
-//
-// Provider-tinted icon tile, headline ("12 new transactions from Chase"),
-// status counts (added · modified · removed · trigger), inline transaction
-// samples, and any rule outcomes that fired during the sync. The sample
-// strip is the centerpiece — the user wants to *see* what came in, not
-// count it.
-templ feedSyncCard(it FeedItem, s *FeedSync) {
-	<li class="relative flex items-start gap-3 py-3 group">
-		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200">
-			<span class={ "flex items-center justify-center w-7 h-7 rounded-full ring-4 ring-base-200", feedSyncTileBg(s.Status) }>
-				<i data-lucide={ feedSyncIcon(s.Status) } class={ "w-3.5 h-3.5", feedSyncTileText(s.Status) }></i>
-			</span>
-		</div>
-		<div class="flex-1 min-w-0 bb-card p-3.5 sm:p-4">
-			<div class="flex items-baseline gap-2 flex-wrap">
-				<a href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) } class="font-semibold text-sm text-base-content hover:text-primary transition-colors no-underline">
-					{ feedSyncHeadline(s) }
-				</a>
-				if lab := feedProviderLabel(s.Provider); lab != "" {
-					<span class="text-xs text-base-content/50">{ lab }</span>
-				}
-				<span class="text-xs text-base-content/35">&middot;</span>
-				<span class="text-xs text-base-content/55 tabular-nums">
-					{ relativeFromRFC3339(it.TimestampStr) }
-				</span>
-			</div>
-			<div class="text-xs text-base-content/55 mt-1.5 flex items-center gap-3 flex-wrap">
-				if s.AddedCount > 0 {
-					<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-success" aria-hidden="true"></span>{ fmt.Sprintf("%d added", s.AddedCount) }</span>
-				}
-				if s.ModifiedCount > 0 {
-					<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-info" aria-hidden="true"></span>{ fmt.Sprintf("%d modified", s.ModifiedCount) }</span>
-				}
-				if s.RemovedCount > 0 {
-					<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-base-content/30" aria-hidden="true"></span>{ fmt.Sprintf("%d removed", s.RemovedCount) }</span>
-				}
-				if s.Trigger != "" && s.Trigger != "cron" {
-					<span class="inline-flex items-center gap-1 text-base-content/50"><i data-lucide="hand" class="w-3 h-3"></i>{ feedTriggerLabel(s.Trigger) }</span>
-				}
-			</div>
-			if s.Status == "error" && s.ErrorMessage != "" {
-				<div class="mt-2.5 text-xs text-error/90 bg-error/8 rounded-lg px-2.5 py-1.5 border border-error/20">
-					<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
-					{ s.ErrorMessage }
-				</div>
-				if s.RetryCount > 0 {
-					<div class="mt-1.5 text-xs text-base-content/55 flex items-center gap-1.5">
-						<i data-lucide="refresh-cw" class="w-3 h-3"></i>
-						<span>{ feedSyncRetryLabel(s) }</span>
-					</div>
-				}
-			}
-			if len(s.SampleTransactions) > 0 {
-				<div class="mt-3 pt-3 border-t border-base-200">
-					@feedTransactionSampleList(s.SampleTransactions, s.AdditionalCount)
-				</div>
-			}
-			if len(s.RuleOutcomes) > 0 {
-				<div class="mt-2 flex items-center gap-2 flex-wrap text-xs text-base-content/55">
-					<i data-lucide="zap" class="w-3 h-3 text-primary/70"></i>
-					for i, ro := range s.RuleOutcomes {
-						if i > 0 {
-							<span class="text-base-content/25">·</span>
-						}
-						if ro.RuleShortID != "" {
-							<a href={ templ.SafeURL("/rules/" + ro.RuleShortID) } class="hover:text-primary transition-colors no-underline">
-								<span class="text-base-content/85">{ ro.RuleName }</span>
-								<span class="text-base-content/55">&nbsp;applied to&nbsp;</span>
-								<span class="font-medium tabular-nums">{ fmt.Sprintf("%d", ro.Count) }</span>
-							</a>
-						} else {
-							<span>
-								<span class="text-base-content/85">{ feedNonEmpty(ro.RuleName, "A rule") }</span>
-								<span class="text-base-content/55">&nbsp;applied to&nbsp;</span>
-								<span class="font-medium tabular-nums">{ fmt.Sprintf("%d", ro.Count) }</span>
-							</span>
-						}
-					}
-				</div>
-			}
-		</div>
-	</li>
+// ── Tile templates (24px on the rail) ─────────────────────────────────────
+
+// feedSyncTile is the icon tile for a sync row. Tinted by status.
+templ feedSyncTile(status string) {
+	<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-200", feedSyncTileBg(status) } aria-hidden="true">
+		<i data-lucide={ feedSyncIcon(status) } class={ "w-3 h-3", feedSyncTileText(status) }></i>
+	</span>
 }
 
-// ── Report card ───────────────────────────────────────────────────────────
-templ feedReportCard(it FeedItem, r *FeedReport) {
-	<li class="relative flex items-start gap-3 py-3 group">
-		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200">
-			<span class={ "flex items-center justify-center w-7 h-7 rounded-full ring-4 ring-base-200", feedReportTileBg(r.Priority) }>
-				<i data-lucide={ feedReportIcon(r.Priority) } class={ "w-3.5 h-3.5", feedReportTileText(r.Priority) }></i>
-			</span>
-		</div>
-		<a
-			href={ templ.SafeURL("/reports/" + r.ID) }
-			class="flex-1 min-w-0 bb-card bb-card--interactive p-4 no-underline block"
-		>
-			<div class="flex items-start gap-2 flex-wrap mb-1.5">
-				if r.IsUnread {
-					<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
-				}
-				if r.Priority == "critical" {
-					<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
-				} else if r.Priority == "warning" {
-					<span class="badge badge-warning badge-xs uppercase tracking-wide">Warning</span>
-				}
-				<span class="text-xs text-base-content/45 ml-auto tabular-nums">{ relativeFromRFC3339(it.TimestampStr) }</span>
-			</div>
-			<h3 class="text-base font-semibold text-base-content tracking-tight leading-snug">{ r.Title }</h3>
-			if r.BodyExcerpt != "" {
-				<p class="text-sm text-base-content/65 leading-relaxed mt-1.5 line-clamp-3">{ r.BodyExcerpt }</p>
-			}
-			<div class="flex items-center gap-2 flex-wrap mt-3 pt-3 border-t border-base-200">
-				<i data-lucide="bot" class="w-3.5 h-3.5 text-base-content/40"></i>
-				<span class="text-xs text-base-content/55">{ r.DisplayAuthor }</span>
-				if len(r.Tags) > 0 {
-					<span class="text-xs text-base-content/30 mx-1">·</span>
-					for _, t := range r.Tags {
-						<span class="inline-flex items-center px-1.5 py-0.5 rounded-md bg-base-200 text-[0.65rem] font-medium text-base-content/65">{ t }</span>
-					}
-				}
-				<span class="text-xs text-primary/70 ml-auto inline-flex items-center gap-1">
-					Read
-					<i data-lucide="arrow-right" class="w-3 h-3"></i>
-				</span>
-			</div>
+// feedReportTile is the icon tile for an agent-report row. Tinted by
+// priority (critical/warning/info → error/warning/primary palette).
+templ feedReportTile(priority string) {
+	<span class={ "flex items-center justify-center w-6 h-6 rounded-full ring-4 ring-base-200", feedReportTileBg(priority) } aria-hidden="true">
+		<i data-lucide={ feedReportIcon(priority) } class={ "w-3 h-3", feedReportTileText(priority) }></i>
+	</span>
+}
+
+// feedActorTile is the avatar tile used for actor-driven rows
+// (agent_session, bulk_action). Mirrors the per-tx timeline avatar tile so
+// the same person looks identical on both surfaces. We pass a single 24px
+// tile through the rail's ring-4 ring-base-200 scaffolding.
+templ feedActorTile(actorType, actorID, version, name string) {
+	if actorType == "user" && actorID != "" {
+		<img src={ feedAvatarURL(actorID, version) } alt={ name + " avatar" } class="w-6 h-6 rounded-full object-cover ring-4 ring-base-200" title={ name }/>
+	} else if actorType == "agent" {
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary/12 ring-4 ring-base-200" aria-hidden="true" title={ name }>
+			<i data-lucide="bot" class="w-3 h-3 text-primary"></i>
+		</span>
+	} else {
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-200" aria-hidden="true" title={ name }>
+			<span class="text-[10px] font-semibold text-base-content/60 leading-none">{ feedFirstChar(name) }</span>
+		</span>
+	}
+}
+
+// ── Row body templates ────────────────────────────────────────────────────
+//
+// Each body lives inside the primitive's `flex-1 min-w-0 text-xs leading-6`
+// container. Multi-line bodies render the headline first (with an inline
+// timestamp pill) and any supporting content below.
+
+templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
+	<div class="flex items-baseline gap-1.5 flex-wrap">
+		<a href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
+			{ feedSyncHeadline(s) }
 		</a>
-	</li>
-}
-
-// ── Standalone comment card ───────────────────────────────────────────────
-templ feedCommentCard(it FeedItem, c *FeedComment) {
-	<li class="relative flex items-start gap-3 py-3 group">
-		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200 flex items-center justify-center">
-			@feedActorAvatar(c.ActorType, c.ActorID, c.ActorAvatarVersion, c.ActorName, "lg")
-		</div>
-		<div class="flex-1 min-w-0">
-			<div class="flex items-baseline gap-1.5 flex-wrap text-xs leading-6 mb-1.5">
-				<strong class="font-semibold text-base-content">{ feedActorDisplay(c.ActorName, c.ActorType) }</strong>
-				<span class="text-base-content/55">commented on</span>
-				<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-medium text-base-content hover:text-primary transition-colors">
-					{ feedTransactionLabel(c.Transaction) }
-				</a>
-				<span class="text-base-content/30">·</span>
-				<span class="text-base-content/45 tabular-nums">{ relativeFromRFC3339(it.TimestampStr) }</span>
-			</div>
-			<div class="bb-card p-3.5 sm:p-4 leading-relaxed">
-				<p class="text-sm text-base-content/85 whitespace-pre-wrap break-words">{ c.Content }</p>
-				@feedTransactionRefStrip(c.Transaction)
-			</div>
-		</div>
-	</li>
-}
-
-// ── Agent session card ────────────────────────────────────────────────────
-//
-// Collapses every annotation in one MCP session into a single row. Header
-// reads "<agent> ran a session — 47 transactions touched"; below, a
-// breakdown of the kinds of action taken plus inline transaction samples
-// and a link to the full session log.
-templ feedAgentSessionCard(it FeedItem, s *FeedAgentSession) {
-	<li class="relative flex items-start gap-3 py-3 group">
-		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200">
-			@feedActorAvatar(s.ActorType, s.ActorID, s.ActorAvatarVersion, feedSessionActorName(s), "lg")
-		</div>
-		<div class="flex-1 min-w-0 bb-card p-3.5 sm:p-4">
-			<div class="flex items-baseline gap-2 flex-wrap text-sm">
-				<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
-				<span class="text-base-content/55">ran a session</span>
-				<span class="text-base-content/30">·</span>
-				<span class="font-medium text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
-				<span class="text-base-content/30">·</span>
-				<span class="text-xs text-base-content/45 tabular-nums">{ relativeFromRFC3339(it.TimestampStr) }</span>
-			</div>
-			if breakdown := feedSessionBreakdown(s); breakdown != "" {
-				<div class="text-xs text-base-content/55 mt-1.5 flex items-center gap-1.5 flex-wrap">
-					<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
-					<span>{ breakdown }</span>
-					if dur := feedSessionDuration(s); dur != "" {
-						<span class="text-base-content/30 mx-1">·</span>
-						<i data-lucide="clock" class="w-3 h-3"></i>
-						<span>{ dur }</span>
-					}
-				</div>
+		if lab := feedProviderLabel(s.Provider); lab != "" {
+			<span class="text-base-content/45">{ lab }</span>
+		}
+		@feedRowTimestamp(it.TimestampStr, now)
+	</div>
+	if s.AddedCount+s.ModifiedCount+s.RemovedCount > 0 {
+		<div class="text-base-content/55 mt-0.5 flex items-center gap-2 flex-wrap">
+			if s.AddedCount > 0 {
+				<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-success" aria-hidden="true"></span>{ fmt.Sprintf("%d added", s.AddedCount) }</span>
 			}
-			if len(s.SampleTransactions) > 0 {
-				<div class="mt-3 pt-3 border-t border-base-200">
-					@feedTransactionSampleList(s.SampleTransactions, max0(s.UniqueTransactions-len(s.SampleTransactions)))
-				</div>
+			if s.ModifiedCount > 0 {
+				<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-info" aria-hidden="true"></span>{ fmt.Sprintf("%d modified", s.ModifiedCount) }</span>
 			}
-			if s.SessionShortID != "" {
-				<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-xs text-primary/70 hover:text-primary transition-colors mt-3 inline-flex items-center gap-1 no-underline">
-					Open session log
-					<i data-lucide="arrow-right" class="w-3 h-3"></i>
-				</a>
+			if s.RemovedCount > 0 {
+				<span class="inline-flex items-center gap-1"><span class="w-1.5 h-1.5 rounded-full bg-base-content/30" aria-hidden="true"></span>{ fmt.Sprintf("%d removed", s.RemovedCount) }</span>
+			}
+			if s.Trigger != "" && s.Trigger != "cron" {
+				<span class="text-base-content/45">&middot; { feedTriggerLabel(s.Trigger) }</span>
 			}
 		</div>
-	</li>
-}
-
-// ── Bulk action card ──────────────────────────────────────────────────────
-//
-// Collapses ≥3 same-actor same-kind annotations within a 5-minute bucket
-// into one row. "<actor> categorised 12 transactions as Groceries · 4 more
-// to other categories", with the same inline transaction-sample strip.
-templ feedBulkActionCard(it FeedItem, b *FeedBulkAction) {
-	<li class="relative flex items-start gap-3 py-3 group">
-		<div class="relative z-10 shrink-0 w-7 h-7 rounded-full bg-base-200">
-			@feedActorAvatar(b.ActorType, b.ActorID, b.ActorAvatarVersion, b.ActorName, "lg")
+	}
+	if s.Status == "error" && s.ErrorMessage != "" {
+		<div class="mt-1.5 text-error/90 bg-error/8 rounded-lg px-2.5 py-1.5 border border-error/20">
+			<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
+			{ s.ErrorMessage }
 		</div>
-		<div class="flex-1 min-w-0 bb-card p-3.5 sm:p-4">
-			<div class="text-sm flex items-baseline gap-1.5 flex-wrap">
-				<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
-				<span class="text-base-content/65">{ feedBulkVerb(b.Kind) }</span>
-				<span class="font-semibold text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
-				if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
-					<span class="text-base-content/65">{ subjectLabel }</span>
+		if s.RetryCount > 0 {
+			<div class="mt-1 text-base-content/55 flex items-center gap-1.5">
+				<i data-lucide="refresh-cw" class="w-3 h-3"></i>
+				<span>{ feedSyncRetryLabel(s) }</span>
+			</div>
+		}
+	}
+	if len(s.SampleTransactions) > 0 {
+		<div class="mt-2">
+			@feedTxRefList(s.SampleTransactions, s.AdditionalCount)
+		</div>
+	}
+	if len(s.RuleOutcomes) > 0 {
+		<div class="mt-1.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+			<i data-lucide="zap" class="w-3 h-3 text-primary/70"></i>
+			for i, ro := range s.RuleOutcomes {
+				if i > 0 {
+					<span class="text-base-content/25">·</span>
 				}
-				<span class="text-base-content/30">·</span>
-				<span class="text-xs text-base-content/45 tabular-nums">{ relativeFromRFC3339(it.TimestampStr) }</span>
-			</div>
-			if len(b.Subjects) > 1 {
-				<div class="text-xs text-base-content/55 mt-1.5 flex items-center gap-1.5 flex-wrap">
-					for i, sub := range b.Subjects {
-						if i >= 4 {
-							<span class="text-base-content/40">+ { fmt.Sprintf("%d more", len(b.Subjects)-4) }</span>
-							break
-						}
-						<span class="inline-flex items-center gap-1 bg-base-200 px-1.5 py-0.5 rounded-md text-[0.7rem]">
-							<span class="font-medium text-base-content/85">{ sub.Name }</span>
-							<span class="text-base-content/55 tabular-nums">&times;{ fmt.Sprintf("%d", sub.Count) }</span>
-						</span>
-					}
-				</div>
-			}
-			if len(b.SampleTransactions) > 0 {
-				<div class="mt-3 pt-3 border-t border-base-200">
-					@feedTransactionSampleList(b.SampleTransactions, max0(b.Count-len(b.SampleTransactions)))
-				</div>
+				if ro.RuleShortID != "" {
+					<a href={ templ.SafeURL("/rules/" + ro.RuleShortID) } class="hover:text-primary transition-colors no-underline">
+						<span class="font-medium text-base-content/85">{ feedNonEmpty(ro.RuleName, "A rule") }</span>
+						<span>&nbsp;applied to&nbsp;</span>
+						<span class="font-medium tabular-nums text-base-content/85">{ fmt.Sprintf("%d", ro.Count) }</span>
+					</a>
+				} else {
+					<span>
+						<span class="font-medium text-base-content/85">{ feedNonEmpty(ro.RuleName, "A rule") }</span>
+						<span>&nbsp;applied to&nbsp;</span>
+						<span class="font-medium tabular-nums text-base-content/85">{ fmt.Sprintf("%d", ro.Count) }</span>
+					</span>
+				}
 			}
 		</div>
-	</li>
+	}
 }
 
-// ── Shared subcomponents ──────────────────────────────────────────────────
+templ feedReportBody(it FeedItem, r *FeedReport, now time.Time) {
+	<div class="flex items-baseline gap-1.5 flex-wrap">
+		<a href={ templ.SafeURL("/reports/" + r.ID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
+			{ r.Title }
+		</a>
+		if r.IsUnread {
+			<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
+		}
+		if r.Priority == "critical" {
+			<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
+		} else if r.Priority == "warning" {
+			<span class="badge badge-warning badge-xs uppercase tracking-wide">Warning</span>
+		}
+		@feedRowTimestamp(it.TimestampStr, now)
+	</div>
+	if r.BodyExcerpt != "" {
+		<p class="text-base-content/65 leading-relaxed mt-0.5 line-clamp-2">{ r.BodyExcerpt }</p>
+	}
+	<div class="mt-1 flex items-center gap-1.5 flex-wrap text-base-content/55">
+		<i data-lucide="bot" class="w-3 h-3"></i>
+		<span>{ r.DisplayAuthor }</span>
+		if len(r.Tags) > 0 {
+			<span class="text-base-content/30 mx-1">·</span>
+			for _, t := range r.Tags {
+				<span class="inline-flex items-center px-1.5 py-0.5 rounded-md bg-base-200 text-[0.65rem] font-medium text-base-content/65">{ t }</span>
+			}
+		}
+	</div>
+}
 
-// feedTransactionSampleList renders an inline list of up to 5 transaction
-// samples. Mobile collapses to 3 visible (the rest hidden via `hidden
-// sm:grid` on the `.feed-sample-row[data-sample-index>=3]` rows), so the
-// card stays compact on a phone but rich on desktop.
-templ feedTransactionSampleList(samples []FeedTransactionRef, additional int) {
-	<ul class="space-y-1" role="list">
-		for i, tx := range samples {
-			<li class={ "flex items-center justify-between gap-2", templ.KV("hidden sm:flex", i >= 3) }>
-				<a
-					href={ templ.SafeURL("/transactions/" + tx.ShortID) }
-					class="flex items-center gap-2 min-w-0 flex-1 text-xs text-base-content/85 hover:text-base-content transition-colors no-underline"
-				>
-					<i data-lucide="receipt" class="w-3 h-3 text-base-content/35 shrink-0"></i>
-					<span class="font-medium truncate">{ feedNonEmpty(tx.MerchantName, tx.Name) }</span>
-					if tx.AccountName != "" {
-						<span class="text-base-content/35 hidden sm:inline">·</span>
-						<span class="text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>
-					}
-				</a>
-				<span class={ "text-xs tabular-nums font-medium shrink-0", feedAmountClass(tx.Amount) }>
-					{ feedAmountWithSign(tx.Amount, tx.Currency) }
+templ feedAgentSessionBody(it FeedItem, s *FeedAgentSession, now time.Time) {
+	<div class="flex items-baseline gap-1.5 flex-wrap">
+		<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
+		<span class="text-base-content/55">ran a session</span>
+		<span class="text-base-content/30">·</span>
+		<span class="font-medium text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
+		@feedRowTimestamp(it.TimestampStr, now)
+	</div>
+	if breakdown := feedSessionBreakdown(s); breakdown != "" {
+		<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+			<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
+			<span>{ breakdown }</span>
+			if dur := feedSessionDuration(s); dur != "" {
+				<span class="text-base-content/30 mx-1">·</span>
+				<i data-lucide="clock" class="w-3 h-3"></i>
+				<span>{ dur }</span>
+			}
+		</div>
+	}
+	if len(s.SampleTransactions) > 0 {
+		<div class="mt-2">
+			@feedTxRefList(s.SampleTransactions, max0(s.UniqueTransactions-len(s.SampleTransactions)))
+		</div>
+	}
+	if s.SessionShortID != "" {
+		<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-primary/70 hover:text-primary transition-colors mt-1.5 inline-flex items-center gap-1 no-underline">
+			Open session log
+			<i data-lucide="arrow-right" class="w-3 h-3"></i>
+		</a>
+	}
+}
+
+templ feedBulkActionBody(it FeedItem, b *FeedBulkAction, now time.Time) {
+	<div class="flex items-baseline gap-1.5 flex-wrap">
+		<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
+		<span class="text-base-content/65">{ feedBulkVerb(b.Kind) }</span>
+		<span class="font-semibold text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
+		if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
+			<span class="text-base-content/65">{ subjectLabel }</span>
+		}
+		@feedRowTimestamp(it.TimestampStr, now)
+	</div>
+	if len(b.Subjects) > 1 {
+		<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+			for i, sub := range b.Subjects {
+				if i >= 4 {
+					<span class="text-base-content/40">+ { fmt.Sprintf("%d more", len(b.Subjects)-4) }</span>
+					break
+				}
+				<span class="inline-flex items-center gap-1 bg-base-200 px-1.5 py-0.5 rounded-md">
+					<span class="font-medium text-base-content/85">{ sub.Name }</span>
+					<span class="text-base-content/55 tabular-nums">&times;{ fmt.Sprintf("%d", sub.Count) }</span>
 				</span>
+			}
+		</div>
+	}
+	if len(b.SampleTransactions) > 0 {
+		<div class="mt-2">
+			@feedTxRefList(b.SampleTransactions, max0(b.Count-len(b.SampleTransactions)))
+		</div>
+	}
+}
+
+// feedRowTimestamp renders the inline relative-time pill used at the end of
+// every row's headline. We render our own (instead of letting
+// TimelineSystemRowCustomTile auto-append it) so the timestamp lands at
+// the end of the *first* line, not after the multi-line body content.
+templ feedRowTimestamp(timestamp string, now time.Time) {
+	if timestamp != "" {
+		<span class="text-base-content/30 mx-0.5">·</span>
+		<span class="tooltip tooltip-top" data-tip={ feedFormatTimestamp(timestamp) }>
+			<time datetime={ timestamp } class="text-base-content/40 tabular-nums cursor-default hover:underline underline-offset-2 decoration-base-content/30" title={ feedFormatTimestamp(timestamp) }>{ feedRelativeTimestamp(timestamp, now) }</time>
+		</span>
+	}
+}
+
+// ── Comment row ───────────────────────────────────────────────────────────
+//
+// Comments wrap the existing TimelineCommentRowRaw primitive so the meta
+// line and avatar tile match the per-transaction activity log byte-for-
+// byte. The bubble body uses the shared `.bb-comment-bubble` CSS class
+// (defined in input.css) and the same data-markdown attribute the per-tx
+// page consumes — so a comment posted from the per-tx composer renders
+// identically when it surfaces on the home feed.
+templ feedCommentRow(it FeedItem, c *FeedComment, now time.Time) {
+	@components.TimelineCommentRowRaw(feedCommentAvatar(c), nil) {
+		<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6 min-w-0">
+			<strong class="font-semibold text-base-content truncate min-w-0 max-w-[10rem] sm:max-w-none">{ feedActorDisplay(c.ActorName, c.ActorType) }</strong>
+			<span class="text-base-content/55 shrink-0">commented on</span>
+			<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-medium text-base-content hover:text-primary transition-colors no-underline truncate min-w-0">
+				{ feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name) }
+			</a>
+			@feedRowTimestamp(it.TimestampStr, now)
+		</div>
+		if c.Content != "" {
+			<div class="bb-comment-bubble mt-1" data-markdown={ c.Content } data-markdown-breaks="true"></div>
+		}
+	}
+}
+
+templ feedCommentAvatar(c *FeedComment) {
+	if c.ActorType == "user" && c.ActorID != "" {
+		<img src={ feedAvatarURL(c.ActorID, c.ActorAvatarVersion) } alt={ c.ActorName + " avatar" } class="w-6 h-6 rounded-full object-cover ring-4 ring-base-200" title={ c.ActorName }/>
+	} else if c.ActorType == "agent" {
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary/12 ring-4 ring-base-200" aria-hidden="true" title={ c.ActorName }>
+			<i data-lucide="bot" class="w-3 h-3 text-primary"></i>
+		</span>
+	} else {
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-200" aria-hidden="true" title={ c.ActorName }>
+			<span class="text-[10px] font-semibold text-base-content/60 leading-none">{ feedFirstChar(c.ActorName) }</span>
+		</span>
+	}
+}
+
+// ── Shared transaction-reference helpers ──────────────────────────────────
+//
+// `feedTxRefRow` is the canonical inline reference to a transaction —
+// receipt icon, merchant name, optional account name, signed amount.
+// Used inside sync, agent_session, and bulk_action bodies. Keeping a
+// single source of truth so the sample list looks identical wherever it
+// surfaces.
+
+// feedTxRefRow renders one transaction-reference line.
+templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
+	<a
+		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
+		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content transition-colors no-underline group/txref"
+	>
+		<span class="flex items-center gap-2 min-w-0 flex-1">
+			<i data-lucide="receipt" class="w-3 h-3 text-base-content/35 shrink-0"></i>
+			<span class={ "font-medium truncate", templ.KV("text-base-content/65", dimmed) }>{ feedNonEmpty(tx.MerchantName, tx.Name) }</span>
+			if tx.AccountName != "" {
+				<span class="text-base-content/35 hidden sm:inline">·</span>
+				<span class="text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>
+			}
+		</span>
+		<span class={ "tabular-nums font-medium shrink-0", feedAmountClass(tx.Amount) }>
+			{ feedAmountWithSign(tx.Amount, tx.Currency) }
+		</span>
+	</a>
+}
+
+// feedTxRefList wraps `feedTxRefRow` for the multi-sample case used by
+// sync / session / bulk-action bodies. Mobile collapses to 3 visible rows
+// via `hidden sm:flex` on samples ≥ index 3; desktop shows up to 5.
+templ feedTxRefList(samples []FeedTransactionRef, additional int) {
+	<ul class="space-y-0.5" role="list">
+		for i, tx := range samples {
+			<li class={ templ.KV("hidden sm:block", i >= 3) }>
+				@feedTxRefRow(tx, false)
 			</li>
 		}
 		if additional > 0 {
-			<li class="text-xs text-base-content/40 pl-5">
+			<li class="text-base-content/40 pl-5">
 				<span class="sm:hidden">{ fmt.Sprintf("+ %d more", additional+max0(len(samples)-3)) }</span>
 				<span class="hidden sm:inline">{ fmt.Sprintf("+ %d more", additional) }</span>
 			</li>
 		} else if len(samples) > 3 {
-			<li class="text-xs text-base-content/40 pl-5 sm:hidden">
+			<li class="text-base-content/40 pl-5 sm:hidden">
 				{ fmt.Sprintf("+ %d more", len(samples)-3) }
 			</li>
 		}
 	</ul>
 }
 
-templ feedTransactionRefStrip(tx FeedTransactionRef) {
-	if tx.ShortID != "" {
-		<a
-			href={ templ.SafeURL("/transactions/" + tx.ShortID) }
-			class="flex items-center justify-between gap-3 mt-3 pt-3 border-t border-base-200 text-xs no-underline group/strip"
-		>
-			<div class="flex items-center gap-2 min-w-0">
-				<i data-lucide="receipt" class="w-3.5 h-3.5 text-base-content/40 shrink-0"></i>
-				<span class="font-medium text-base-content truncate">{ feedNonEmpty(tx.MerchantName, tx.Name) }</span>
-				if tx.AccountName != "" {
-					<span class="text-base-content/35 hidden sm:inline">·</span>
-					<span class="text-base-content/50 truncate hidden sm:inline">{ tx.AccountName }</span>
-				}
-			</div>
-			<div class="flex items-center gap-2 shrink-0">
-				<span class={ "tabular-nums font-medium", feedAmountClass(tx.Amount) }>{ feedAmountWithSign(tx.Amount, tx.Currency) }</span>
-				<i data-lucide="arrow-right" class="w-3 h-3 text-base-content/30 group-hover/strip:text-primary/60 transition-colors"></i>
-			</div>
-		</a>
-	}
-}
-
-templ feedActorAvatar(actorType, actorID, version, name, size string) {
-	if actorType == "user" && actorID != "" {
-		<img src={ feedAvatarURL(actorID, version) } alt={ name + " avatar" } class={ feedAvatarSize(size), "rounded-full object-cover ring-4 ring-base-200" } title={ name }/>
-	} else if actorType == "agent" {
-		<span class={ feedAvatarSize(size), "rounded-full bg-primary/12 ring-4 ring-base-200 flex items-center justify-center" } title={ name }>
-			<i data-lucide="bot" class="w-3.5 h-3.5 text-primary"></i>
-		</span>
-	} else {
-		<span class={ feedAvatarSize(size), "rounded-full bg-base-300 ring-4 ring-base-200 flex items-center justify-center" } title={ name }>
-			<i data-lucide="settings" class="w-3.5 h-3.5 text-base-content/55"></i>
-		</span>
-	}
-}
-
-// ── Helper sub-renderers (string functions) ───────────────────────────────
+// ── String helpers ────────────────────────────────────────────────────────
 
 func feedAvatarURL(id, version string) string {
 	base := "/avatars/" + id
@@ -537,13 +557,6 @@ func feedAvatarURL(id, version string) string {
 		return base + "?v=" + version
 	}
 	return base
-}
-
-func feedAvatarSize(size string) string {
-	if size == "lg" {
-		return "w-7 h-7"
-	}
-	return "w-6 h-6"
 }
 
 func feedActorDisplay(name, actorType string) string {
@@ -620,10 +633,6 @@ func feedBulkVerb(kind string) string {
 	return "updated"
 }
 
-// feedBulkSubjectLabel returns the trailing phrase for a bulk-action card —
-// "as Groceries", "with Needs Review", "with rule X". When subjects span
-// multiple values, the chip strip below the headline carries the breakdown
-// instead and this function returns "".
 func feedBulkSubjectLabel(b *FeedBulkAction) string {
 	if len(b.Subjects) != 1 {
 		return ""
@@ -633,9 +642,7 @@ func feedBulkSubjectLabel(b *FeedBulkAction) string {
 		return ""
 	}
 	switch b.Kind {
-	case "tag_added":
-		return "with the " + name + " tag"
-	case "tag_removed":
+	case "tag_added", "tag_removed":
 		return "with the " + name + " tag"
 	case "category_set":
 		return "as " + name
@@ -645,25 +652,18 @@ func feedBulkSubjectLabel(b *FeedBulkAction) string {
 	return ""
 }
 
-func feedTransactionLabel(tx FeedTransactionRef) string {
-	merchant := tx.MerchantName
-	if merchant == "" {
-		merchant = tx.Name
-	}
-	if merchant == "" {
-		merchant = "a transaction"
-	}
-	if tx.Amount != 0 {
-		return fmt.Sprintf("%s · %s", merchant, feedAmountWithSign(tx.Amount, tx.Currency))
-	}
-	return merchant
-}
-
 func feedNonEmpty(a, fallback string) string {
 	if strings.TrimSpace(a) != "" {
 		return a
 	}
 	return fallback
+}
+
+func feedFirstChar(s string) string {
+	for _, r := range s {
+		return string(r)
+	}
+	return ""
 }
 
 func feedSyncDotClass(status string) string {
@@ -754,20 +754,6 @@ func feedReportIcon(priority string) string {
 	return "file-text"
 }
 
-// feedSyncRetryLabel renders the "+N attempts since X ago" line on a
-// failed sync card whose retry attempts have been folded into one row.
-func feedSyncRetryLabel(s *FeedSync) string {
-	total := s.RetryCount + 1
-	if s.FirstFailureAt.IsZero() {
-		return fmt.Sprintf("%d attempts so far", total)
-	}
-	since := timefmt.Relative(s.FirstFailureAt)
-	if since == "" {
-		return fmt.Sprintf("%d attempts so far", total)
-	}
-	return fmt.Sprintf("Failing since %s · %d attempts", since, total)
-}
-
 func feedSyncHeadline(s *FeedSync) string {
 	bank := s.InstitutionName
 	if bank == "" {
@@ -786,6 +772,18 @@ func feedSyncHeadline(s *FeedSync) string {
 		return fmt.Sprintf("%d transaction%s removed at %s", s.RemovedCount, pluralFeedS(s.RemovedCount), bank)
 	}
 	return "Synced " + bank
+}
+
+func feedSyncRetryLabel(s *FeedSync) string {
+	total := s.RetryCount + 1
+	if s.FirstFailureAt.IsZero() {
+		return fmt.Sprintf("%d attempts so far", total)
+	}
+	since := timefmt.Relative(s.FirstFailureAt)
+	if since == "" {
+		return fmt.Sprintf("%d attempts so far", total)
+	}
+	return fmt.Sprintf("Failing since %s · %d attempts", since, total)
 }
 
 func feedProviderLabel(p string) string {
@@ -876,9 +874,25 @@ func max0(n int) int {
 	return n
 }
 
-func relativeFromRFC3339(s string) string {
+// feedRelativeTimestamp / feedFormatTimestamp mirror the helpers used by
+// the per-tx timeline rows so a feed row's tooltip + relative-time pill
+// renders identical to the activity log.
+func feedRelativeTimestamp(s string, now time.Time) string {
 	if s == "" {
 		return ""
 	}
-	return timefmt.RelativeRFC3339(s)
+	if now.IsZero() {
+		now = time.Now()
+	}
+	return timefmt.RelativeRFC3339At(s, now)
+}
+
+func feedFormatTimestamp(s string) string {
+	if s == "" {
+		return ""
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t.Local().Format("Jan 2, 2006 3:04 PM")
+	}
+	return s
 }

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -2,49 +2,46 @@ package pages
 
 import "time"
 
-// FeedProps is the full view model for the new household Feed page — a
-// timeline-style replacement candidate for the legacy stats dashboard. The
-// page surfaces sync runs, agent reports, transaction comments, rule-driven
-// auto-categorisation batches, and per-transaction recategorisations as a
-// chronological stream of mixed-weight cards on a single GitHub-style rail.
+// FeedProps is the full view model for the home Feed page. The page
+// surfaces sync runs, agent reports, MCP agent sessions, bulk-action
+// bursts, and standalone comments as a chronological stream of mixed-
+// weight cards on a single GitHub-style rail.
+//
+// The grouped-events shape (sync / agent_session / bulk_action / comment)
+// is computed by `service.ListFeedEvents`; this view-model is a thin
+// projection that rebinds the service shapes onto display-side types so
+// the templ never has to import the service package.
 type FeedProps struct {
 	CSRFToken string
 
-	// Hero is the at-a-glance band rendered above the rail — today's
-	// snapshot (events, new transactions, last sync, unread reports) plus a
-	// one-line generated-at label.
+	// Hero is the at-a-glance band rendered above the rail.
 	Hero FeedHero
 
 	// ConnectionAlerts pin to the very top of the page (above the rail) so
-	// connections in error/pending_reauth state are impossible to miss when
-	// the rest of the feed is dominated by routine syncs.
+	// connections in error/pending_reauth state are impossible to miss.
 	ConnectionAlerts []FeedAlert
 
-	// Days is the day-bucketed feed body. Each FeedDay contains its rendered
-	// label ("Today", "Yesterday", "Mar 14") and the items that occurred in
-	// that bucket, ordered newest-first within the bucket.
+	// Days is the day-bucketed feed body. Each FeedDay contains its
+	// rendered label ("Today", "Yesterday", "Jan 2") and the items that
+	// occurred in that bucket, ordered newest-first within the bucket.
 	Days []FeedDay
 
-	// TotalItems is the count rendered next to the section heading; useful
-	// when the page is dense and the user wants a quick "how much is here"
-	// signal before scrolling.
+	// TotalItems is the count rendered next to the section heading.
 	TotalItems int
 
-	// Now is the request-level time anchor threaded through to the relative-
-	// time helpers so day-bucket labels and per-row timestamps share a single
-	// reference and never disagree across midnight.
+	// WindowDays is rendered as a footer note ("showing the last 3 days").
+	WindowDays int
+
+	// Now is the request-level time anchor used for relative-time helpers.
 	Now time.Time
 
-	// Filter is the active scope ("" = all, "agents", "household", "syncs",
-	// "reports") parsed from the ?filter= query param. The page renders the
-	// filter chips with the matching one highlighted; the actual filtering
-	// is applied at the handler layer for now.
+	// Filter is the active scope ("" = all, "syncs", "reports", "comments",
+	// "agents", "me") parsed from the ?filter= query param. Renders chip
+	// state only — actual filtering applies at the handler layer.
 	Filter string
 }
 
-// FeedHero powers the at-a-glance band above the feed rail. Numeric fields
-// are derived from today's items; string fields ("Generated") are formatted
-// in the handler to keep the templ side free of time arithmetic.
+// FeedHero powers the at-a-glance band above the feed rail.
 type FeedHero struct {
 	Generated            string
 	EventsToday          int
@@ -54,51 +51,47 @@ type FeedHero struct {
 	UnreadReports        int
 
 	LastSyncAt          time.Time
-	LastSyncRel         string // human-readable "5 minutes ago"
+	LastSyncRel         string
 	LastSyncStatus      string
 	LastSyncInstitution string
 }
 
-// FeedAlert is one pinned warning rendered above the feed rail. Each alert
-// corresponds to a connection currently in error or pending_reauth state.
+// FeedAlert is one pinned warning for a connection in error /
+// pending_reauth state.
 type FeedAlert struct {
 	ConnectionID        string
 	Institution         string
 	Provider            string
-	Status              string // "error" | "pending_reauth"
+	Status              string
 	ErrorMessage        string
-	LastSyncedAt        string // relative time string
+	LastSyncedAt        string
 	ConsecutiveFailures int
 }
 
-// FeedDay is one day-bucket of feed items. The day separator on the rail
-// renders the Label; the Items render below it newest-first.
+// FeedDay is one day-bucket of feed items.
 type FeedDay struct {
-	Key   string // YYYY-MM-DD — used for stable test snapshots and DOM ids.
-	Label string // "Today" / "Yesterday" / "Jan 2"
+	Key   string
+	Label string
 	Items []FeedItem
 	First bool
 }
 
-// FeedItem is a single rail row. Type drives the renderer branch; the union
-// pointers carry the per-type payload. Exactly one of the pointers is set
-// for any given Type; the rest are nil.
+// FeedItem is a single rail row. Type drives the renderer branch; the
+// union pointers carry the per-type payload. Exactly one is set per row.
 type FeedItem struct {
-	Type         string    // "sync" | "report" | "comment" | "tag" | "category" | "rule_batch"
-	Timestamp    time.Time // sortable wall-clock time
-	TimestampStr string    // RFC3339 for the templ row's relative-time helper
+	Type         string
+	Timestamp    time.Time
+	TimestampStr string
 
-	Sync     *FeedSync
-	Report   *FeedReport
-	Comment  *FeedComment
-	Tag      *FeedTagChange
-	Category *FeedCategoryChange
-	RuleBatch *FeedRuleBatch
+	Sync         *FeedSync
+	Report       *FeedReport
+	Comment      *FeedComment
+	AgentSession *FeedAgentSession
+	BulkAction   *FeedBulkAction
 }
 
-// FeedTransactionRef is the small card-within-a-card that every transaction-
-// anchored row uses to anchor the event to its source ("$87.42 at Whole
-// Foods · Chase Sapphire").
+// FeedTransactionRef is the small card-within-a-card that anchors any
+// transaction-anchored row to its source ("$87.42 at Whole Foods · Chase").
 type FeedTransactionRef struct {
 	ShortID      string
 	Name         string
@@ -110,19 +103,41 @@ type FeedTransactionRef struct {
 	Institution  string
 }
 
-// FeedSync is the sync-card payload — counts + status + provider/institution
-// labels for one sync_logs row.
+// FeedSync is the sync-card payload. Inline transaction samples and rule
+// outcomes are rendered directly inside the card so a sync card answers
+// "what came in, and what did Breadbox do with it" in one glance.
 type FeedSync struct {
 	SyncLogID       string
 	InstitutionName string
 	Provider        string
 	Trigger         string
 	Status          string
-	AddedCount      int
-	ModifiedCount   int
-	RemovedCount    int
-	RuleHits        int
 	ErrorMessage    string
+
+	AddedCount    int
+	ModifiedCount int
+	RemovedCount  int
+
+	StartedAt time.Time
+
+	// RetryCount + FirstFailureAt are populated only on error syncs that
+	// folded N earlier same-error retry attempts; the card renders them
+	// as "Failing for 18h · 49 attempts" so a flapping connection takes
+	// up one rail row instead of dozens.
+	RetryCount     int
+	FirstFailureAt time.Time
+
+	SampleTransactions []FeedTransactionRef
+	AdditionalCount    int
+
+	RuleOutcomes []FeedRuleOutcome
+}
+
+// FeedRuleOutcome is one (rule, count) line inside a sync card.
+type FeedRuleOutcome struct {
+	RuleName    string
+	RuleShortID string
+	Count       int
 }
 
 // FeedReport is the rich agent-report card payload.
@@ -131,14 +146,13 @@ type FeedReport struct {
 	ShortID       string
 	Title         string
 	BodyExcerpt   string
-	Priority      string // "info" | "warning" | "critical"
+	Priority      string
 	Tags          []string
 	DisplayAuthor string
 	IsUnread      bool
 }
 
-// FeedComment carries everything the comment-bubble row needs to render in
-// the global feed (actor + content + linked transaction).
+// FeedComment carries one standalone comment row.
 type FeedComment struct {
 	ActorName          string
 	ActorType          string
@@ -148,52 +162,61 @@ type FeedComment struct {
 	Transaction        FeedTransactionRef
 }
 
-// FeedTagChange carries one tag_added / tag_removed event.
-type FeedTagChange struct {
+// FeedAgentSession is the rich card that collapses every annotation in
+// one MCP session into a single row.
+type FeedAgentSession struct {
+	SessionID      string
+	SessionShortID string
+	APIKeyName     string
+	Purpose        string
+
 	ActorName          string
 	ActorType          string
 	ActorID            string
 	ActorAvatarVersion string
-	Action             string // "added" | "removed"
-	TagSlug            string
-	TagName            string
-	TagColor           string
-	TagIcon            string
-	Note               string
-	Transaction        FeedTransactionRef
+
+	StartedAt time.Time
+	EndedAt   time.Time
+
+	AnnotationCount    int
+	UniqueTransactions int
+
+	// Counts breaks the session's annotations down by category-of-action
+	// for the inline summary line ("23 categorised · 12 tagged · 8
+	// commented · 4 rules applied"). Order is fixed by the templ.
+	Categorised    int
+	Tagged         int
+	UntaggedRemoved int
+	Commented      int
+	RuleApplied    int
+
+	SampleTransactions []FeedTransactionRef
 }
 
-// FeedCategoryChange carries one manual category_set event.
-type FeedCategoryChange struct {
+// FeedBulkAction is the rich card that collapses ≥3 same-actor same-kind
+// annotations from a 5-minute bucket into a single row.
+type FeedBulkAction struct {
 	ActorName          string
 	ActorType          string
 	ActorID            string
 	ActorAvatarVersion string
-	CategorySlug       string
-	CategoryName       string
-	CategoryColor      string
-	CategoryIcon       string
-	Transaction        FeedTransactionRef
+
+	Kind  string
+	Count int
+
+	Subjects []FeedBulkSubject
+
+	StartedAt time.Time
+	EndedAt   time.Time
+
+	SampleTransactions []FeedTransactionRef
 }
 
-// FeedRuleBatch is the collapsed (rule, day)-grouped rule_applied card. The
-// per-transaction rows fold into one with a count, sample list, and the
-// breakdown of action fields ("tag" / "category" / etc).
-type FeedRuleBatch struct {
-	RuleName     string
-	RuleShortID  string
-	Count        int
-	ActionFields map[string]int // "tag" -> N, "category" -> M
-	Samples      []FeedTransactionSample
-	DayLabel     string
-	LatestTS     time.Time
-}
-
-// FeedTransactionSample is one expandable sample row inside a rule batch
-// card.
-type FeedTransactionSample struct {
-	ShortID      string
-	MerchantName string
-	Amount       float64
-	Currency     string
+// FeedBulkSubject is one (subject, count) chip inside a bulk-action card.
+type FeedBulkSubject struct {
+	Name  string
+	Slug  string
+	Color string
+	Icon  string
+	Count int
 }


### PR DESCRIPTION
## Summary

Iterates on `/feed` so the page shows **happenings**, not raw annotations. A 200-annotation MCP review session is now one card. Cron-retry storms collapse to one card with an attempt counter. Sync cards render inline transaction samples so you can *see* what came in.

Counter from the dev DB: **690 raw annotations + 50+ failed sync logs** in 3 days collapsed to **14 feed events**.

## Grouping pipeline (`service.ListFeedEvents`)

1. **Hard group by `session_id`** — every annotation in one MCP session collapses into a single **AgentSession** card with a kind-breakdown line ("23 categorised · 12 tagged · 8 commented") and inline transaction samples.
2. **Soft-bucket by `(actor, kind, 5-min)`** — ≥3 same-actor same-kind annotations within a 5-minute window become a **BulkAction** card. Below threshold, only standalone comments survive (every comment is high signal); standalone tag/category set events drop off the home feed (they're still visible on the per-transaction activity timeline).
3. **Sync-error dedup** — repeated cron-retry attempts with the same `(connection_id, error_message)` fold into a single sync card with `RetryCount` populated. The card renders "Failing since 18h · 49 attempts" instead of 49 identical rows.

## Sync cards: inline samples + rule outcomes

Sync cards now show the top 5 actually-new transactions (by absolute amount) inline, with mobile collapsing to 3 visible via `hidden sm:flex`. Rule outcomes from `sync_logs.rule_hits` render under the sample list — "Auto-tag rule applied to 47" — so the rule activity that previously got its own row folds into the parent sync card.

## What got removed

The standalone `tag` / `category` / `rule_batch` event types and their templ renderers. The home feed now renders five card types: **sync**, **report**, **comment** (standalone), **agent_session**, **bulk_action**. Granular tag/category events are still readable on the per-transaction timeline; they just don't dominate the home feed anymore.

## Window

Bounded to the **last 3 days** at the SQL layer (`a.created_at >= NOW() - INTERVAL '3 days'` and equivalent for syncs). Surfaced as a footer note under the rail. Doesn't change with current time the way "last 7 days" would, except for the day labels.

## Decisions

| Knob | Value | Why |
|------|-------|-----|
| Window | 3 days | Bounded so the page never grows unbounded; lines up with "what's happened this weekend". |
| BulkThreshold | 3 | Matches the v1 plan; tuneable. |
| SampleLimit | 5 | 5 desktop / 3 mobile fits comfortably without scrolling. |
| Soft-bucket | 5 min | Long enough to capture a "burst", short enough that a paused-then-resumed session doesn't merge. |

## Screenshots

### Desktop — top of feed (1280×900)

The two sync-error cards are the dedup at work: 49 identical Teller-DNS-error retries collapsed into one card, plus a separate 2-attempt cluster for a different error.

<img src="https://i.img402.dev/nm9vd19oku.jpg" width="900" alt="Feed v2 — desktop viewport">

### Desktop — full scroll

Shows every card type rendered against real data: sync error cluster with retry counts, sync success card with inline transaction samples (WATER SUPPLY COMPANY, MAGNA BANK), standalone comments, a bulk-action card ("admin@example.com updated 4 transactions"), and a 319-transaction sync card with the first 5 inline + "+ 314 more". Footer reads "Showing the last 3 days."

<img src="https://i.img402.dev/18g8oximoh.jpg" width="900" alt="Feed v2 — desktop full page">

### Mobile (390×844)

<img src="https://i.img402.dev/4vv2yffjrx.jpg" width="320" alt="Feed v2 — mobile viewport">

<details><summary>Mobile — full scroll</summary>

<img src="https://i.img402.dev/wqx2j5dk23.jpg" width="320" alt="Feed v2 — mobile full page">

</details>

## Test plan

- [ ] On the VM, visit `/feed` and confirm the rail renders with the grouped cards
- [ ] Confirm an MCP session that touches many transactions renders as one AgentSession card
- [ ] Confirm a sync card with N>0 added transactions shows the inline sample strip
- [ ] If a connection has been failing: confirm the sync error card carries "Failing since X · N attempts"
- [ ] Confirm `/` dashboard still renders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)