### PR TITLE
fix(auth): redirect /login to / when already authenticated

### DIFF
--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -69,6 +69,10 @@ var dummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing
 func LoginHandler(sm *scs.SessionManager, queries *db.Queries, _ *TemplateRenderer) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
+			if sm.GetString(r.Context(), sessionKeyAccountID) != "" {
+				http.Redirect(w, r, "/", http.StatusSeeOther)
+				return
+			}
 			renderLogin(w, r, sm, "", "")
 			return
 		}


### PR DESCRIPTION
## Summary
- `LoginHandler` GET branch now checks the session and 303-redirects to `/` when `sessionKeyAccountID` is set, so logged-in users hitting `/login` land on the dashboard instead of seeing the sign-in form again.

## Validation
Verified via curl against `make dev`:

\`\`\`
# Unauthenticated GET /login -> 200
status=200

# Sign in (POST /login)
status=303 location=/

# Re-visit /login with the session cookie
status=303 location=/
\`\`\`

No visual change — the GET handler short-circuits before rendering the login template — so no screenshot is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)