### PR TITLE
feat(feed): wire up filter chips on /feed page

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -34,6 +34,23 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		ctx := r.Context()
 		now := time.Now()
 		window := time.Duration(feedWindowDays) * 24 * time.Hour
+		filter := strings.TrimSpace(r.URL.Query().Get("filter"))
+
+		// Resolve the session actor for the "me" chip. Prefer the linked
+		// household user_id; fall back to the auth_account id for the
+		// initial admin (which writes annotations against its account id).
+		// If neither resolves we silently downgrade to "All" rather than
+		// erroring — see filterFeedEvents.
+		var sessionActorID string
+		if filter == "me" {
+			sessionActorID = SessionUserID(tr.sm, r)
+			if sessionActorID == "" {
+				sessionActorID = SessionAccountID(tr.sm, r)
+			}
+			if sessionActorID == "" {
+				filter = ""
+			}
+		}
 
 		// Display lookups so bulk-action subjects render with friendly tag
 		// and category display names instead of raw slugs.
@@ -53,19 +70,31 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			Window:        window,
 			BulkThreshold: 3,
 			SampleLimit:   5,
+			Filter:        filter,
+			ActorID:       sessionActorID,
 		})
 		if err != nil {
 			a.Logger.Error("feed: list events", "error", err)
 		}
 
-		// 2. Reports — windowed to match the feed bound.
-		reports, err := svc.ListAgentReports(ctx, 50)
-		if err != nil {
-			a.Logger.Error("feed: list agent reports", "error", err)
+		// 2. Reports — windowed to match the feed bound. Skipped under the
+		// syncs/comments/sessions/me chips, which scope the page to events
+		// the service layer produces.
+		var reports []service.AgentReportResponse
+		if filter == "" || filter == "reports" {
+			reports, err = svc.ListAgentReports(ctx, 50)
+			if err != nil {
+				a.Logger.Error("feed: list agent reports", "error", err)
+			}
 		}
 
-		// 3. Connection alerts — current state, not windowed.
-		alerts := buildFeedConnectionAlerts(ctx, a)
+		// 3. Connection alerts — current state, not windowed. Hidden under
+		// any active chip so the filtered view is exclusively the chip's
+		// scope; the alerts re-appear on the unfiltered "All" page.
+		var alerts []pages.FeedAlert
+		if filter == "" {
+			alerts = buildFeedConnectionAlerts(ctx, a)
+		}
 
 		// 4. Project FeedEvents onto templ-side FeedItems.
 		items := make([]pages.FeedItem, 0, len(events)+len(reports))
@@ -179,7 +208,7 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			TotalItems:       len(items),
 			WindowDays:       feedWindowDays,
 			Now:              now,
-			Filter:           strings.TrimSpace(r.URL.Query().Get("filter")),
+			Filter:           filter,
 		})
 		tr.RenderWithTempl(w, r, data, body)
 	}

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -243,6 +243,18 @@ type FeedEventsParams struct {
 	Window        time.Duration
 	BulkThreshold int
 	SampleLimit   int
+
+	// Filter scopes the resulting event slice to a single chip on the feed
+	// rail. Empty string means "no filter" — every grouped event is
+	// returned. See `filterFeedEvents` for the recognised values.
+	Filter string
+
+	// ActorID is consulted only when Filter == "me". The handler resolves
+	// the session's user_id (falling back to the auth_account id for the
+	// initial admin) before calling. Both forms are matched because
+	// `annotations.actor_id` historically stores either depending on
+	// whether the auth_account is linked to a household user.
+	ActorID string
 }
 
 // ListFeedEvents returns grouped FeedEvents for the home Feed page,
@@ -306,7 +318,77 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 		return out[i].Timestamp.After(out[j].Timestamp)
 	})
 
+	out = filterFeedEvents(out, params.Filter, params.ActorID)
 	return out, nil
+}
+
+// filterFeedEvents narrows a feed-event slice to the subset matching the
+// chip-filter string. Applied after grouping so the windowed pull stays
+// shared across filters and the slice is small enough that an in-memory
+// sweep beats re-running the SQL.
+//
+// Filter values:
+//   - ""           → no filter, returns input unchanged
+//   - "syncs"      → only sync events
+//   - "comments"   → only comment events
+//   - "sessions"   → only agent_session events
+//   - "reports"    → reports come from the handler, so ListFeedEvents
+//                    contributes nothing in this mode
+//   - "me"         → events authored by the supplied actorID; bulk-action
+//                    rows match on the bucket actor as well. If actorID is
+//                    empty (e.g. the initial admin without a linked user)
+//                    the filter is treated as "no filter" so the page
+//                    keeps rendering instead of going blank.
+func filterFeedEvents(events []FeedEvent, filter, actorID string) []FeedEvent {
+	switch filter {
+	case "":
+		return events
+	case "reports":
+		return nil
+	case "syncs":
+		return filterEventsByType(events, "sync")
+	case "comments":
+		return filterEventsByType(events, "comment")
+	case "sessions":
+		return filterEventsByType(events, "agent_session")
+	case "me":
+		if actorID == "" {
+			return events
+		}
+		return filterEventsByActor(events, actorID)
+	}
+	return events
+}
+
+func filterEventsByType(events []FeedEvent, t string) []FeedEvent {
+	out := make([]FeedEvent, 0, len(events))
+	for _, ev := range events {
+		if ev.Type == t {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func filterEventsByActor(events []FeedEvent, actorID string) []FeedEvent {
+	out := make([]FeedEvent, 0, len(events))
+	for _, ev := range events {
+		switch ev.Type {
+		case "comment":
+			if ev.Comment != nil && ev.Comment.ActorID == actorID {
+				out = append(out, ev)
+			}
+		case "agent_session":
+			if ev.AgentSession != nil && ev.AgentSession.ActorID == actorID {
+				out = append(out, ev)
+			}
+		case "bulk_action":
+			if ev.BulkAction != nil && ev.BulkAction.ActorID == actorID {
+				out = append(out, ev)
+			}
+		}
+	}
+	return out
 }
 
 // fetchFeedAnnotations runs the windowed annotation query used by

--- a/internal/service/feed_test.go
+++ b/internal/service/feed_test.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFilterFeedEvents covers the chip-driven post-filter applied by
+// `ListFeedEvents` over its grouped output. The pipeline that produces the
+// input slice is integration-tested elsewhere; this unit test pins the
+// filter switch independently of the DB so each chip's contract is easy
+// to read in isolation.
+func TestFilterFeedEvents(t *testing.T) {
+	now := time.Now()
+	mkSync := func() FeedEvent {
+		return FeedEvent{Type: "sync", Timestamp: now, Sync: &FeedSyncEvent{}}
+	}
+	mkComment := func(actorID string) FeedEvent {
+		return FeedEvent{
+			Type:      "comment",
+			Timestamp: now,
+			Comment:   &FeedCommentEvent{ActorID: actorID},
+		}
+	}
+	mkSession := func(actorID string) FeedEvent {
+		return FeedEvent{
+			Type:         "agent_session",
+			Timestamp:    now,
+			AgentSession: &FeedAgentSessionEvent{ActorID: actorID},
+		}
+	}
+	mkBulk := func(actorID string) FeedEvent {
+		return FeedEvent{
+			Type:       "bulk_action",
+			Timestamp:  now,
+			BulkAction: &FeedBulkActionEvent{ActorID: actorID},
+		}
+	}
+
+	events := []FeedEvent{
+		mkSync(),
+		mkComment("user-A"),
+		mkComment("user-B"),
+		mkSession("user-A"),
+		mkBulk("user-B"),
+	}
+
+	cases := []struct {
+		name    string
+		filter  string
+		actorID string
+		want    []string // expected ev.Type sequence
+	}{
+		{"empty filter passes all", "", "", []string{"sync", "comment", "comment", "agent_session", "bulk_action"}},
+		{"unknown filter passes all", "wat", "", []string{"sync", "comment", "comment", "agent_session", "bulk_action"}},
+		{"reports drops everything from service layer", "reports", "", nil},
+		{"syncs keeps only sync events", "syncs", "", []string{"sync"}},
+		{"comments keeps only comment events", "comments", "", []string{"comment", "comment"}},
+		{"sessions keeps only agent_session events", "sessions", "", []string{"agent_session"}},
+		{"me with empty actor downgrades to all", "me", "", []string{"sync", "comment", "comment", "agent_session", "bulk_action"}},
+		{"me filters to comments + sessions + bulk by actor", "me", "user-A", []string{"comment", "agent_session"}},
+		{"me with non-matching actor returns nothing", "me", "user-Z", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterFeedEvents(events, tc.filter, tc.actorID)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len(got)=%d want=%d (got types: %v)", len(got), len(tc.want), typesOf(got))
+			}
+			for i, ev := range got {
+				if ev.Type != tc.want[i] {
+					t.Errorf("event %d: got type=%q want=%q", i, ev.Type, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func typesOf(evs []FeedEvent) []string {
+	out := make([]string, len(evs))
+	for i, ev := range evs {
+		out[i] = ev.Type
+	}
+	return out
+}

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -30,7 +30,20 @@ templ Feed(p FeedProps) {
 		@feedAlerts(p)
 	}
 	@feedFilters(p)
+	if p.Filter != "" {
+		@feedActiveFilterBanner(p)
+	}
 	@feedTimeline(p)
+}
+
+// feedActiveFilterBanner makes the active chip explicit above the rail.
+// The chip strip alone is easy to miss when scanning a sparse rail.
+templ feedActiveFilterBanner(p FeedProps) {
+	<div class="flex items-center gap-2 text-xs text-base-content/60 mb-3 px-1">
+		<i data-lucide="filter" class="w-3 h-3"></i>
+		<span>Showing only: <span class="font-medium text-base-content/80">{ feedFilterLabel(p.Filter) }</span></span>
+		<a href="/feed" class="text-primary/80 hover:text-primary no-underline ml-1">Clear filter</a>
+	</div>
 }
 
 // ── Hero band ─────────────────────────────────────────────────────────────
@@ -836,6 +849,24 @@ func feedFilterHRef(slug string) string {
 		return "/feed"
 	}
 	return "/feed?filter=" + slug
+}
+
+// feedFilterLabel renders the chip-name string used in the active-filter
+// banner above the rail. Mirrors the labels in `feedFilters`.
+func feedFilterLabel(slug string) string {
+	switch slug {
+	case "syncs":
+		return "Syncs"
+	case "reports":
+		return "Reports"
+	case "comments":
+		return "Comments"
+	case "sessions":
+		return "Sessions"
+	case "me":
+		return "From me"
+	}
+	return slug
 }
 
 func feedAmountClass(amount float64) string {


### PR DESCRIPTION
Wire up the filter chips on `/feed` so they actually filter. Until now the chips re-issued the page with `?filter=…` but the handler only used the value to drive chip-active state — every filter rendered the unfiltered rail.

## Summary

- **Service** (`internal/service/feed.go`) — `FeedEventsParams` gains `Filter` + `ActorID`. `filterFeedEvents` runs after grouping so the windowed annotation/sync pull stays shared across chips and only the in-memory slice is sliced.
- **Handler** (`internal/admin/feed.go`) — parses `?filter=`, resolves the session's `user_id` (falling back to the auth-account id for the initial admin) for the `me` chip, and skips reports + connection alerts under chip scopes so the filtered view is exclusively the chip's class. `reports` mode skips the service-layer events and only renders agent reports.
- **UI** (`internal/templates/components/pages/feed.templ`) — adds an explicit `Showing only: <chip>` banner with a `Clear filter` link above the rail. The chip strip alone is easy to miss on a sparse rail.
- **Test** (`internal/service/feed_test.go`) — unit-level coverage for `filterFeedEvents` over a synthetic event slice (no DB).

## Filter contract

| `?filter=` | Service events | Reports | Connection alerts |
|-|-|-|-|
| (none) | all grouped events | included | shown |
| `syncs` | only sync events | hidden | hidden |
| `comments` | only comment events | hidden | hidden |
| `sessions` | only agent_session events | hidden | hidden |
| `reports` | none | included | hidden |
| `me` | events authored by session user_id | hidden | hidden |

`me` with no resolvable session actor (e.g. an unlinked initial admin in some edge cases) silently downgrades to "All" rather than rendering blank.

## Screenshots

<table>
  <tr><th>All (no filter)</th><th>Comments only</th><th>Syncs only</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/dm66hiqyhy.jpg" width="320" alt="feed all"></td>
    <td><img src="https://i.img402.dev/yp85tpcpui.jpg" width="320" alt="feed filter=comments"></td>
    <td><img src="https://i.img402.dev/bgj6yxznvb.jpg" width="320" alt="feed filter=syncs"></td>
  </tr>
</table>

## Test plan

- [x] `go build ./... && go vet ./... && go test ./internal/admin/... ./internal/service/... ./internal/templates/... -count=1`
- [x] Visual: each chip renders the right subset; banner appears with active filter; "Clear filter" link returns to `/feed`.
- [ ] Reviewer: confirm grouping/timeline shape unchanged on the unfiltered view.
