### PR TITLE
ui(feed): polish empty states with first-run / quiet / filtered variants

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -34,6 +34,23 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		ctx := r.Context()
 		now := time.Now()
 		window := time.Duration(feedWindowDays) * 24 * time.Hour
+		filter := strings.TrimSpace(r.URL.Query().Get("filter"))
+
+		// Resolve the session actor for the "me" chip. Prefer the linked
+		// household user_id; fall back to the auth_account id for the
+		// initial admin (which writes annotations against its account id).
+		// If neither resolves we silently downgrade to "All" rather than
+		// erroring — see filterFeedEvents.
+		var sessionActorID string
+		if filter == "me" {
+			sessionActorID = SessionUserID(tr.sm, r)
+			if sessionActorID == "" {
+				sessionActorID = SessionAccountID(tr.sm, r)
+			}
+			if sessionActorID == "" {
+				filter = ""
+			}
+		}
 
 		// Display lookups so bulk-action subjects render with friendly tag
 		// and category display names instead of raw slugs.
@@ -53,19 +70,31 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			Window:        window,
 			BulkThreshold: 3,
 			SampleLimit:   5,
+			Filter:        filter,
+			ActorID:       sessionActorID,
 		})
 		if err != nil {
 			a.Logger.Error("feed: list events", "error", err)
 		}
 
-		// 2. Reports — windowed to match the feed bound.
-		reports, err := svc.ListAgentReports(ctx, 50)
-		if err != nil {
-			a.Logger.Error("feed: list agent reports", "error", err)
+		// 2. Reports — windowed to match the feed bound. Skipped under the
+		// syncs/comments/sessions/me chips, which scope the page to events
+		// the service layer produces.
+		var reports []service.AgentReportResponse
+		if filter == "" || filter == "reports" {
+			reports, err = svc.ListAgentReports(ctx, 50)
+			if err != nil {
+				a.Logger.Error("feed: list agent reports", "error", err)
+			}
 		}
 
-		// 3. Connection alerts — current state, not windowed.
-		alerts := buildFeedConnectionAlerts(ctx, a)
+		// 3. Connection alerts — current state, not windowed. Hidden under
+		// any active chip so the filtered view is exclusively the chip's
+		// scope; the alerts re-appear on the unfiltered "All" page.
+		var alerts []pages.FeedAlert
+		if filter == "" {
+			alerts = buildFeedConnectionAlerts(ctx, a)
+		}
 
 		// 4. Project FeedEvents onto templ-side FeedItems.
 		items := make([]pages.FeedItem, 0, len(events)+len(reports))
@@ -179,7 +208,7 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			TotalItems:       len(items),
 			WindowDays:       feedWindowDays,
 			Now:              now,
-			Filter:           strings.TrimSpace(r.URL.Query().Get("filter")),
+			Filter:           filter,
 		})
 		tr.RenderWithTempl(w, r, data, body)
 	}

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -197,6 +197,13 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		if !lastSyncAt.IsZero() {
 			hero.LastSyncRel = relativeTime(lastSyncAt)
 		}
+		// Next-sync ETA — drives the "Next sync in ~6h" sub-line under the
+		// Last Sync hero tile so the page answers "why no new transactions
+		// yet?" inline. The scheduler is nil in test env (no cron); leave
+		// the field empty there and the templ hides the sub-line.
+		if a.Scheduler != nil {
+			hero.NextSyncRel = formatNextSync(a.Scheduler.NextRun())
+		}
 
 		data := map[string]any{
 			"PageTitle":   "Feed",

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -88,12 +88,15 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// 3. Connection alerts — current state, not windowed. Hidden under
-		// any active chip so the filtered view is exclusively the chip's
-		// scope; the alerts re-appear on the unfiltered "All" page.
-		var alerts []pages.FeedAlert
-		if filter == "" {
-			alerts = buildFeedConnectionAlerts(ctx, a)
+		// 3. Connection alerts + empty-state meta — current state, not
+		// windowed. Alerts hide under any active chip so the filtered view
+		// is exclusively the chip's scope; the alerts re-appear on the
+		// unfiltered "All" page. The meta (hasConnections + global last-
+		// sync-at) is always collected so the empty-state branch can pick
+		// the right copy regardless of filter.
+		alerts, hasConnections, globalLastSyncAt := buildFeedConnectionMeta(ctx, a)
+		if filter != "" {
+			alerts = nil
 		}
 
 		// 4. Project FeedEvents onto templ-side FeedItems.
@@ -209,22 +212,33 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			WindowDays:       feedWindowDays,
 			Now:              now,
 			Filter:           filter,
+			HasConnections:   hasConnections,
+			LastSyncAt:       globalLastSyncAt,
+			IsAdmin:          IsAdmin(tr.sm, r),
 		})
 		tr.RenderWithTempl(w, r, data, body)
 	}
 }
 
-// buildFeedConnectionAlerts collects the pinned warning cards rendered above
-// the rail. Each alert maps one bank connection currently in error or
-// pending_reauth state to a `pages.FeedAlert`.
-func buildFeedConnectionAlerts(ctx context.Context, a *app.App) []pages.FeedAlert {
+// buildFeedConnectionMeta does one ListBankConnections pass and projects out
+// three things the page needs: the pinned alert cards (for connections in
+// error/pending_reauth), whether *any* connection exists (drives the first-
+// run empty state), and the most recent successful sync time across the
+// household (drives the "quiet around here · last sync was {rel}" empty
+// state). Co-locating the projections means the empty-state branch can
+// pick the right copy without a second query.
+func buildFeedConnectionMeta(ctx context.Context, a *app.App) (alerts []pages.FeedAlert, hasConnections bool, globalLastSyncAt time.Time) {
 	bankConnections, err := a.Queries.ListBankConnections(ctx)
 	if err != nil {
 		a.Logger.Error("feed: list bank connections", "error", err)
-		return nil
+		return nil, false, time.Time{}
 	}
-	out := make([]pages.FeedAlert, 0)
+	alerts = make([]pages.FeedAlert, 0)
 	for _, conn := range bankConnections {
+		hasConnections = true
+		if conn.LastSyncedAt.Valid && conn.LastSyncedAt.Time.After(globalLastSyncAt) {
+			globalLastSyncAt = conn.LastSyncedAt.Time
+		}
 		status := string(conn.Status)
 		if status != "error" && status != "pending_reauth" {
 			continue
@@ -241,9 +255,9 @@ func buildFeedConnectionAlerts(ctx context.Context, a *app.App) []pages.FeedAler
 		if conn.LastSyncedAt.Valid {
 			alert.LastSyncedAt = relativeTime(conn.LastSyncedAt.Time)
 		}
-		out = append(out, alert)
+		alerts = append(alerts, alert)
 	}
-	return out
+	return alerts, hasConnections, globalLastSyncAt
 }
 
 // projectFeedEvent maps one service-layer FeedEvent onto its templ-side

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -243,6 +243,18 @@ type FeedEventsParams struct {
 	Window        time.Duration
 	BulkThreshold int
 	SampleLimit   int
+
+	// Filter scopes the resulting event slice to a single chip on the feed
+	// rail. Empty string means "no filter" — every grouped event is
+	// returned. See `filterFeedEvents` for the recognised values.
+	Filter string
+
+	// ActorID is consulted only when Filter == "me". The handler resolves
+	// the session's user_id (falling back to the auth_account id for the
+	// initial admin) before calling. Both forms are matched because
+	// `annotations.actor_id` historically stores either depending on
+	// whether the auth_account is linked to a household user.
+	ActorID string
 }
 
 // ListFeedEvents returns grouped FeedEvents for the home Feed page,
@@ -306,7 +318,77 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 		return out[i].Timestamp.After(out[j].Timestamp)
 	})
 
+	out = filterFeedEvents(out, params.Filter, params.ActorID)
 	return out, nil
+}
+
+// filterFeedEvents narrows a feed-event slice to the subset matching the
+// chip-filter string. Applied after grouping so the windowed pull stays
+// shared across filters and the slice is small enough that an in-memory
+// sweep beats re-running the SQL.
+//
+// Filter values:
+//   - ""           → no filter, returns input unchanged
+//   - "syncs"      → only sync events
+//   - "comments"   → only comment events
+//   - "sessions"   → only agent_session events
+//   - "reports"    → reports come from the handler, so ListFeedEvents
+//                    contributes nothing in this mode
+//   - "me"         → events authored by the supplied actorID; bulk-action
+//                    rows match on the bucket actor as well. If actorID is
+//                    empty (e.g. the initial admin without a linked user)
+//                    the filter is treated as "no filter" so the page
+//                    keeps rendering instead of going blank.
+func filterFeedEvents(events []FeedEvent, filter, actorID string) []FeedEvent {
+	switch filter {
+	case "":
+		return events
+	case "reports":
+		return nil
+	case "syncs":
+		return filterEventsByType(events, "sync")
+	case "comments":
+		return filterEventsByType(events, "comment")
+	case "sessions":
+		return filterEventsByType(events, "agent_session")
+	case "me":
+		if actorID == "" {
+			return events
+		}
+		return filterEventsByActor(events, actorID)
+	}
+	return events
+}
+
+func filterEventsByType(events []FeedEvent, t string) []FeedEvent {
+	out := make([]FeedEvent, 0, len(events))
+	for _, ev := range events {
+		if ev.Type == t {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func filterEventsByActor(events []FeedEvent, actorID string) []FeedEvent {
+	out := make([]FeedEvent, 0, len(events))
+	for _, ev := range events {
+		switch ev.Type {
+		case "comment":
+			if ev.Comment != nil && ev.Comment.ActorID == actorID {
+				out = append(out, ev)
+			}
+		case "agent_session":
+			if ev.AgentSession != nil && ev.AgentSession.ActorID == actorID {
+				out = append(out, ev)
+			}
+		case "bulk_action":
+			if ev.BulkAction != nil && ev.BulkAction.ActorID == actorID {
+				out = append(out, ev)
+			}
+		}
+	}
+	return out
 }
 
 // fetchFeedAnnotations runs the windowed annotation query used by

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -1,0 +1,513 @@
+//go:build integration
+
+// Integration tests that pin down `Service.ListFeedEvents` grouping behaviour.
+//
+// The feed page intentionally collapses noisy clusters of annotations into a
+// handful of high-signal cards. The cases below seed real annotations + sync
+// logs + mcp_sessions + transactions and assert each grouping rule the
+// previous iterations of /feed established. They serve as a regression net so
+// future iterations can't quietly drop the dedup, bulk-bucket, or
+// session-collapse logic.
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// feedSeed bundles the IDs needed across the per-subtest seeders. Every
+// subtest gets a fresh, truncated DB via newService → testutil.Pool, so
+// helpers populate this struct top-down.
+type feedSeed struct {
+	UserID  pgtype.UUID
+	ConnID  pgtype.UUID
+	AcctID  pgtype.UUID
+	TxnIDs  []pgtype.UUID
+}
+
+// seedFeedFixture creates one user/connection/account plus `txnCount`
+// transactions so tests have transaction IDs to attach annotations to.
+func seedFeedFixture(t *testing.T, queries *db.Queries, suffix string, txnCount int) feedSeed {
+	t.Helper()
+	user := testutil.MustCreateUser(t, queries, "Alice "+suffix)
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "feed_conn_"+suffix)
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "feed_acct_"+suffix, "Checking "+suffix)
+
+	out := feedSeed{UserID: user.ID, ConnID: conn.ID, AcctID: acct.ID}
+	for i := 0; i < txnCount; i++ {
+		txn := testutil.MustCreateTransaction(
+			t, queries, acct.ID,
+			fmt.Sprintf("feed_txn_%s_%d", suffix, i),
+			fmt.Sprintf("Merchant %s %d", suffix, i),
+			int64(1000+i*250),
+			"2026-04-15",
+		)
+		out.TxnIDs = append(out.TxnIDs, txn.ID)
+	}
+	return out
+}
+
+// insertAnnotation inserts an annotation and forces its `created_at` to the
+// supplied time. The sqlc-generated InsertAnnotation does not accept a
+// created_at parameter (the column defaults to NOW()), so we patch it after
+// the fact — mirrors what real history would look like once enough wall-time
+// has elapsed.
+func insertAnnotation(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	queries *db.Queries,
+	txnID pgtype.UUID,
+	kind, actorType, actorID, actorName string,
+	sessionID pgtype.UUID,
+	payload []byte,
+	createdAt time.Time,
+) pgtype.UUID {
+	t.Helper()
+	params := db.InsertAnnotationParams{
+		TransactionID: txnID,
+		Kind:          kind,
+		ActorType:     actorType,
+		ActorName:     actorName,
+		Payload:       payload,
+	}
+	if actorID != "" {
+		params.ActorID = pgtype.Text{String: actorID, Valid: true}
+	}
+	if sessionID.Valid {
+		params.SessionID = sessionID
+	}
+	ann, err := queries.InsertAnnotation(ctx, params)
+	if err != nil {
+		t.Fatalf("InsertAnnotation(%s): %v", kind, err)
+	}
+	if _, err := pool.Exec(ctx,
+		"UPDATE annotations SET created_at = $1 WHERE id = $2",
+		createdAt, ann.ID,
+	); err != nil {
+		t.Fatalf("backdate annotation: %v", err)
+	}
+	return ann.ID
+}
+
+// findEventByType returns the first FeedEvent of the requested type, or nil.
+func findEventByType(events []service.FeedEvent, eventType string) *service.FeedEvent {
+	for i := range events {
+		if events[i].Type == eventType {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+// countEventsByType counts events whose Type matches.
+func countEventsByType(events []service.FeedEvent, eventType string) int {
+	n := 0
+	for _, e := range events {
+		if e.Type == eventType {
+			n++
+		}
+	}
+	return n
+}
+
+func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
+	t.Run("SyncErrorDedup", func(t *testing.T) {
+		svc, queries, _ := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "syncerr", 0)
+
+		now := time.Now().UTC()
+		errMsg := pgtype.Text{String: "ITEM_LOGIN_REQUIRED", Valid: true}
+		// Five sync_logs, same connection + same error message, oldest →
+		// newest. The dedup key is (connection_id, error_message); these
+		// should collapse into one event with RetryCount == 4 and
+		// FirstFailureAt == oldest.
+		oldest := now.Add(-90 * time.Minute)
+		for i := 0; i < 5; i++ {
+			startedAt := now.Add(time.Duration(-90+i*15) * time.Minute)
+			if _, err := queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+				ConnectionID: seed.ConnID,
+				Trigger:      db.SyncTriggerCron,
+				Status:       db.SyncStatusError,
+				StartedAt:    pgconv.Timestamptz(startedAt),
+				CompletedAt:  pgconv.Timestamptz(startedAt.Add(2 * time.Second)),
+				ErrorMessage: errMsg,
+			}); err != nil {
+				t.Fatalf("CreateSyncLog %d: %v", i, err)
+			}
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "sync"); got != 1 {
+			t.Fatalf("expected 1 sync event after dedup, got %d", got)
+		}
+		ev := findEventByType(events, "sync").Sync
+		if ev.RetryCount != 4 {
+			t.Errorf("RetryCount = %d, want 4", ev.RetryCount)
+		}
+		if ev.Status != "error" {
+			t.Errorf("Status = %q, want %q", ev.Status, "error")
+		}
+		// FirstFailureAt is the oldest start. Compare at second precision —
+		// pgtype rounds to micro and time.Now() roundtrips through pg.
+		if !ev.FirstFailureAt.Truncate(time.Second).Equal(oldest.Truncate(time.Second)) {
+			t.Errorf("FirstFailureAt = %v, want %v", ev.FirstFailureAt, oldest)
+		}
+	})
+
+	t.Run("DifferentErrorsDoNotDedupe", func(t *testing.T) {
+		svc, queries, _ := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "differr", 0)
+
+		now := time.Now().UTC()
+		mkLog := func(offsetMin int, msg string) {
+			startedAt := now.Add(time.Duration(offsetMin) * time.Minute)
+			if _, err := queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+				ConnectionID: seed.ConnID,
+				Trigger:      db.SyncTriggerCron,
+				Status:       db.SyncStatusError,
+				StartedAt:    pgconv.Timestamptz(startedAt),
+				CompletedAt:  pgconv.Timestamptz(startedAt.Add(time.Second)),
+				ErrorMessage: pgtype.Text{String: msg, Valid: true},
+			}); err != nil {
+				t.Fatalf("CreateSyncLog: %v", err)
+			}
+		}
+		// Three with err A, two with err B.
+		for i := 0; i < 3; i++ {
+			mkLog(-90+i*5, "ITEM_LOGIN_REQUIRED")
+		}
+		for i := 0; i < 2; i++ {
+			mkLog(-30+i*5, "RATE_LIMIT_EXCEEDED")
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "sync"); got != 2 {
+			t.Fatalf("expected 2 sync events (one per distinct error), got %d", got)
+		}
+	})
+
+	t.Run("HardGroupBySessionID", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "session", 5)
+
+		// Create one MCP session + 12 annotations across 5 transactions
+		// (4 category_set, 4 tag_added, 4 comment), all with session_id.
+		session, err := queries.CreateMCPSession(ctx, db.CreateMCPSessionParams{
+			ApiKeyID:   "00000000-0000-0000-0000-000000000abc",
+			ApiKeyName: "review-bot",
+			Purpose:    "categorize",
+		})
+		if err != nil {
+			t.Fatalf("CreateMCPSession: %v", err)
+		}
+
+		// Need a tag for tag_added rows.
+		tag := testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
+
+		now := time.Now().UTC()
+		actorID := pgconv.FormatUUID(session.ID)
+		mk := func(kind string, txnIdx int, idx int) {
+			ts := now.Add(time.Duration(-30+idx) * time.Second)
+			params := db.InsertAnnotationParams{
+				TransactionID: seed.TxnIDs[txnIdx],
+				Kind:          kind,
+				ActorType:     "agent",
+				ActorID:       pgtype.Text{String: actorID, Valid: true},
+				ActorName:     "review-bot",
+				SessionID:     session.ID,
+				Payload:       []byte(`{}`),
+			}
+			if kind == "tag_added" {
+				params.TagID = tag.ID
+				params.Payload = []byte(`{"tag_slug":"needs-review"}`)
+			}
+			if kind == "category_set" {
+				params.Payload = []byte(`{"category_slug":"food_and_drink"}`)
+			}
+			ann, err := queries.InsertAnnotation(ctx, params)
+			if err != nil {
+				t.Fatalf("InsertAnnotation(%s): %v", kind, err)
+			}
+			if _, err := pool.Exec(ctx,
+				"UPDATE annotations SET created_at = $1 WHERE id = $2", ts, ann.ID,
+			); err != nil {
+				t.Fatalf("backdate: %v", err)
+			}
+		}
+		// 4 of each kind, distributed over 5 transactions.
+		for i := 0; i < 4; i++ {
+			mk("category_set", i%5, i)
+		}
+		for i := 0; i < 4; i++ {
+			mk("tag_added", (i+1)%5, 4+i)
+		}
+		for i := 0; i < 4; i++ {
+			mk("comment", (i+2)%5, 8+i)
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "agent_session"); got != 1 {
+			t.Fatalf("expected 1 agent_session event, got %d (events=%+v)", got, events)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 0 {
+			t.Errorf("expected 0 bulk_action events (sessioned annotations should not bucket), got %d", got)
+		}
+		if got := countEventsByType(events, "comment"); got != 0 {
+			t.Errorf("expected 0 comment events (sessioned comments should fold into the session), got %d", got)
+		}
+		ev := findEventByType(events, "agent_session").AgentSession
+		if ev.AnnotationCount != 12 {
+			t.Errorf("AnnotationCount = %d, want 12", ev.AnnotationCount)
+		}
+		if ev.UniqueTransactions != 5 {
+			t.Errorf("UniqueTransactions = %d, want 5", ev.UniqueTransactions)
+		}
+		for _, kind := range []string{"category_set", "tag_added", "comment"} {
+			if ev.KindCounts[kind] != 4 {
+				t.Errorf("KindCounts[%s] = %d, want 4", kind, ev.KindCounts[kind])
+			}
+		}
+	})
+
+	t.Run("SoftBucketBulkAction", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "bulk", 4)
+
+		now := time.Now().UTC()
+		actorID := "user-actor-bulk"
+		// 4 category_set annotations, same actor, 4 different transactions,
+		// all within ~30 seconds (well inside the 5-minute soft bucket and
+		// the 2-minute window the spec asks us to assert).
+		for i := 0; i < 4; i++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"category_set", "user", actorID, "Alice",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				now.Add(time.Duration(-30+i*10)*time.Second),
+			)
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event, got %d", got)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Kind != "category_set" {
+			t.Errorf("Kind = %q, want %q", ev.Kind, "category_set")
+		}
+		if ev.Count != 4 {
+			t.Errorf("Count = %d, want 4", ev.Count)
+		}
+	})
+
+	t.Run("BelowThresholdDropsStandaloneCategorySet", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "below", 2)
+
+		now := time.Now().UTC()
+		// Two category_set annotations from the same actor in the same
+		// minute. Default BulkThreshold is 3 → bucket count 2 falls through,
+		// and only `comment` rows survive sub-threshold, so these category
+		// rows should disappear from the feed.
+		for i := 0; i < 2; i++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"category_set", "user", "actor-below", "Alice",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				now.Add(time.Duration(-10+i*5)*time.Second),
+			)
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 0 {
+			t.Errorf("expected 0 bulk_action events (under threshold), got %d", got)
+		}
+		if got := countEventsByType(events, "comment"); got != 0 {
+			t.Errorf("expected 0 comment events, got %d", got)
+		}
+		// The whole feed should be empty for this fixture (no sync logs were
+		// seeded either).
+		if len(events) != 0 {
+			t.Errorf("expected 0 events total, got %d (%+v)", len(events), events)
+		}
+	})
+
+	t.Run("StandaloneCommentSurvives", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "comment", 1)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-comment", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"Looks like a duplicate"}`),
+			now.Add(-5*time.Minute),
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "comment"); got != 1 {
+			t.Fatalf("expected 1 comment event, got %d", got)
+		}
+	})
+
+	t.Run("SyncStartedAndUpdatedExcluded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "syncann", 1)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"sync_started", "system", "", "Plaid Sync",
+			pgtype.UUID{},
+			[]byte(`{}`),
+			now.Add(-30*time.Second),
+		)
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"sync_updated", "system", "", "Plaid Sync",
+			pgtype.UUID{},
+			[]byte(`{}`),
+			now.Add(-20*time.Second),
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected sync_started/sync_updated annotations to be excluded; got %d events: %+v", len(events), events)
+		}
+	})
+
+	t.Run("RuleAppliedDuringSyncExcluded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "rulesync", 1)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"rule_applied", "system", "", "Plaid Sync",
+			pgtype.UUID{},
+			[]byte(`{"applied_by":"sync"}`),
+			now.Add(-30*time.Second),
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected rule_applied(applied_by=sync) to be excluded; got %d events", len(events))
+		}
+	})
+
+	t.Run("RuleAppliedRetroactiveIncluded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "ruleretro", 5)
+
+		// Need a real rule so rule_applied annotations have an FK target.
+		rule := testutil.MustCreateTransactionRule(t, queries, "Coffee Rule", []byte(`[]`), []byte(`[]`), "on_create")
+		ruleShortID := rule.ShortID
+
+		now := time.Now().UTC()
+		actorID := "actor-retro"
+		// 5 rule_applied annotations, same actor, no `applied_by=sync`, all
+		// within ~30 seconds → should produce a single bulk_action event.
+		for i := 0; i < 5; i++ {
+			params := db.InsertAnnotationParams{
+				TransactionID: seed.TxnIDs[i],
+				Kind:          "rule_applied",
+				ActorType:     "user",
+				ActorID:       pgtype.Text{String: actorID, Valid: true},
+				ActorName:     "Alice",
+				RuleID:        rule.ID,
+				Payload:       []byte(fmt.Sprintf(`{"rule_short_id":%q}`, ruleShortID)),
+			}
+			ann, err := queries.InsertAnnotation(ctx, params)
+			if err != nil {
+				t.Fatalf("InsertAnnotation %d: %v", i, err)
+			}
+			if _, err := pool.Exec(ctx,
+				"UPDATE annotations SET created_at = $1 WHERE id = $2",
+				now.Add(time.Duration(-30+i*5)*time.Second), ann.ID,
+			); err != nil {
+				t.Fatalf("backdate: %v", err)
+			}
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event, got %d (%+v)", got, events)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Kind != "rule_applied" {
+			t.Errorf("Kind = %q, want %q", ev.Kind, "rule_applied")
+		}
+		if ev.Count != 5 {
+			t.Errorf("Count = %d, want 5", ev.Count)
+		}
+	})
+
+	t.Run("WindowIsBounded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "window", 1)
+
+		// Annotation aged 4 days ago, with a 3-day window: must be excluded.
+		old := time.Now().UTC().Add(-4 * 24 * time.Hour)
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-window", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"old"}`),
+			old,
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+			Window: 3 * 24 * time.Hour,
+		})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected 0 events with 3d window vs 4d-old annotation; got %d", len(events))
+		}
+	})
+}

--- a/internal/service/feed_test.go
+++ b/internal/service/feed_test.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFilterFeedEvents covers the chip-driven post-filter applied by
+// `ListFeedEvents` over its grouped output. The pipeline that produces the
+// input slice is integration-tested elsewhere; this unit test pins the
+// filter switch independently of the DB so each chip's contract is easy
+// to read in isolation.
+func TestFilterFeedEvents(t *testing.T) {
+	now := time.Now()
+	mkSync := func() FeedEvent {
+		return FeedEvent{Type: "sync", Timestamp: now, Sync: &FeedSyncEvent{}}
+	}
+	mkComment := func(actorID string) FeedEvent {
+		return FeedEvent{
+			Type:      "comment",
+			Timestamp: now,
+			Comment:   &FeedCommentEvent{ActorID: actorID},
+		}
+	}
+	mkSession := func(actorID string) FeedEvent {
+		return FeedEvent{
+			Type:         "agent_session",
+			Timestamp:    now,
+			AgentSession: &FeedAgentSessionEvent{ActorID: actorID},
+		}
+	}
+	mkBulk := func(actorID string) FeedEvent {
+		return FeedEvent{
+			Type:       "bulk_action",
+			Timestamp:  now,
+			BulkAction: &FeedBulkActionEvent{ActorID: actorID},
+		}
+	}
+
+	events := []FeedEvent{
+		mkSync(),
+		mkComment("user-A"),
+		mkComment("user-B"),
+		mkSession("user-A"),
+		mkBulk("user-B"),
+	}
+
+	cases := []struct {
+		name    string
+		filter  string
+		actorID string
+		want    []string // expected ev.Type sequence
+	}{
+		{"empty filter passes all", "", "", []string{"sync", "comment", "comment", "agent_session", "bulk_action"}},
+		{"unknown filter passes all", "wat", "", []string{"sync", "comment", "comment", "agent_session", "bulk_action"}},
+		{"reports drops everything from service layer", "reports", "", nil},
+		{"syncs keeps only sync events", "syncs", "", []string{"sync"}},
+		{"comments keeps only comment events", "comments", "", []string{"comment", "comment"}},
+		{"sessions keeps only agent_session events", "sessions", "", []string{"agent_session"}},
+		{"me with empty actor downgrades to all", "me", "", []string{"sync", "comment", "comment", "agent_session", "bulk_action"}},
+		{"me filters to comments + sessions + bulk by actor", "me", "user-A", []string{"comment", "agent_session"}},
+		{"me with non-matching actor returns nothing", "me", "user-Z", nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterFeedEvents(events, tc.filter, tc.actorID)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len(got)=%d want=%d (got types: %v)", len(got), len(tc.want), typesOf(got))
+			}
+			for i, ev := range got {
+				if ev.Type != tc.want[i] {
+					t.Errorf("event %d: got type=%q want=%q", i, ev.Type, tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func typesOf(evs []FeedEvent) []string {
+	out := make([]string, len(evs))
+	for i, ev := range evs {
+		out[i] = ev.Type
+	}
+	return out
+}

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -178,13 +178,7 @@ templ feedFilterChip(label, slug, icon, current string) {
 
 templ feedTimeline(p FeedProps) {
 	if len(p.Days) == 0 {
-		<div class="bb-card p-12 text-center">
-			<i data-lucide="rss" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
-			<h2 class="text-lg font-semibold mb-1">Nothing in your feed yet</h2>
-			<p class="text-sm text-base-content/50">
-				As bank syncs run, agents post reports, and household members tag transactions, they'll show up here.
-			</p>
-		</div>
+		@feedEmptyState(p)
 	} else {
 		@components.Timeline(components.TimelineProps{
 			Heading:     "Activity",
@@ -206,6 +200,134 @@ templ feedTimeline(p FeedProps) {
 			</p>
 		}
 	}
+}
+
+// ── Empty states ──────────────────────────────────────────────────────────
+//
+// The /feed page has four distinct empty cases, each with its own copy
+// and CTA. We dispatch off (HasConnections, Filter, LastSyncAt) so the
+// right card renders in each scenario.
+
+// feedEmptyState picks the right empty-state variant. Order matters:
+//   1. No connections at all → first-run onboarding card.
+//   2. Filter active → "No <chip-label>" card with a clear-filter link.
+//   3. Otherwise → "Quiet around here" with a Sync now / browse-history CTA.
+templ feedEmptyState(p FeedProps) {
+	if !p.HasConnections {
+		@feedEmptyFirstRun()
+	} else if p.Filter != "" {
+		@feedEmptyFiltered(p.Filter)
+	} else {
+		@feedEmptyNoRecent(p)
+	}
+}
+
+// feedEmptyFirstRun is shown when zero bank connections exist. The CTA is
+// the only path forward — connect a bank — so we render it as a primary
+// button rather than a quiet link.
+templ feedEmptyFirstRun() {
+	<div class="bb-card p-10 sm:p-12 text-center">
+		<i data-lucide="landmark" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+		<h2 class="text-lg font-semibold mb-1">Welcome to Breadbox</h2>
+		<p class="text-sm text-base-content/55 max-w-md mx-auto mb-5">
+			Connect your first bank to start filling your feed.
+		</p>
+		<a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">
+			<i data-lucide="plus" class="w-3.5 h-3.5"></i>
+			Connect a bank
+		</a>
+	</div>
+}
+
+// feedEmptyFiltered is shown when a chip filter is active but produced
+// zero rows. The CTA is "Clear filter" — the same affordance the active-
+// filter banner offers, repeated here so a user landing in an empty state
+// has a clear way out without scrolling back up.
+templ feedEmptyFiltered(filter string) {
+	<div class="bb-card p-10 sm:p-12 text-center">
+		<i data-lucide="filter" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+		<h2 class="text-lg font-semibold mb-1">{ feedEmptyFilteredHeadline(filter) }</h2>
+		<p class="text-sm text-base-content/55 mb-5">
+			Nothing in this slice today.
+		</p>
+		<a href="/feed" class="btn btn-sm btn-ghost rounded-xl border border-base-300">
+			<i data-lucide="x" class="w-3.5 h-3.5"></i>
+			Clear filter
+		</a>
+	</div>
+}
+
+// feedEmptyNoRecent is the "all caught up" card for households that have
+// connections but no events in the windowed feed. Admins get a "Sync now"
+// button (POST /-/connections/sync-all → reload); members see only the
+// browse-history link, since sync-all is admin-only.
+templ feedEmptyNoRecent(p FeedProps) {
+	if p.IsAdmin {
+		<script src="/static/js/admin/components/feed.js"></script>
+		<div class="bb-card p-10 sm:p-12 text-center" x-data="feedSyncNow">
+			<i data-lucide="moon" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+			<h2 class="text-lg font-semibold mb-1">Quiet around here</h2>
+			<p class="text-sm text-base-content/55 mb-5">
+				{ feedEmptyNoRecentSubline(p.LastSyncAt) }
+			</p>
+			<div class="flex items-center justify-center gap-2 flex-wrap">
+				<button
+					type="button"
+					class="btn btn-primary btn-sm rounded-xl"
+					x-bind:disabled="state !== 'idle'"
+					x-on:click="triggerSyncNow()"
+				>
+					<i data-lucide="refresh-cw" class="w-3.5 h-3.5" x-bind:class="state === 'syncing' ? 'animate-spin' : ''"></i>
+					<span x-text="state === 'syncing' ? 'Syncing…' : (state === 'done' ? 'Sync queued' : 'Sync now')"></span>
+				</button>
+				<a href="/transactions" class="btn btn-sm btn-ghost rounded-xl border border-base-300">
+					<i data-lucide="receipt" class="w-3.5 h-3.5"></i>
+					Browse transactions
+				</a>
+			</div>
+		</div>
+	} else {
+		<div class="bb-card p-10 sm:p-12 text-center">
+			<i data-lucide="moon" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+			<h2 class="text-lg font-semibold mb-1">Quiet around here</h2>
+			<p class="text-sm text-base-content/55 mb-5">
+				{ feedEmptyNoRecentSubline(p.LastSyncAt) }
+			</p>
+			<a href="/transactions" class="btn btn-sm btn-ghost rounded-xl border border-base-300">
+				<i data-lucide="receipt" class="w-3.5 h-3.5"></i>
+				Browse transactions
+			</a>
+		</div>
+	}
+}
+
+// feedEmptyFilteredHeadline maps a chip slug onto its empty-state
+// headline. Mirrors feedFilterLabel but pluralises for the headline copy.
+func feedEmptyFilteredHeadline(filter string) string {
+	switch filter {
+	case "syncs":
+		return "No syncs in the last 3 days"
+	case "reports":
+		return "No reports in the last 3 days"
+	case "comments":
+		return "No comments in the last 3 days"
+	case "sessions":
+		return "No agent sessions in the last 3 days"
+	case "me":
+		return "Nothing from you in the last 3 days"
+	}
+	return "No matches"
+}
+
+// feedEmptyNoRecentSubline composes the supporting copy for the "quiet
+// around here" empty state. Mentions the last successful sync time when
+// we have one — gives operators a quick read on whether sync is broken
+// or genuinely quiet.
+func feedEmptyNoRecentSubline(lastSync time.Time) string {
+	if lastSync.IsZero() {
+		return "No activity in the last 3 days. Try syncing to pull the latest from your banks."
+	}
+	return "No activity in the last 3 days. Last sync was " + timefmt.Relative(lastSync) + "."
 }
 
 // feedRow dispatches each FeedItem to the right primitive. Comments use

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -47,7 +47,6 @@ templ feedActiveFilterBanner(p FeedProps) {
 }
 
 // ── Hero band ─────────────────────────────────────────────────────────────
-
 templ feedHero(p FeedProps) {
 	<header class="mb-6">
 		<div class="flex flex-wrap items-end justify-between gap-3 mb-4">
@@ -107,6 +106,12 @@ templ feedHeroSyncTile(p FeedProps) {
 			<div class="text-[0.65rem] text-base-content/45 mt-1 truncate">
 				{ feedSyncSubLine(p.Hero.LastSyncStatus, p.Hero.LastSyncInstitution) }
 			</div>
+			if feedShowNextSync(p.Hero.LastSyncStatus, p.Hero.NextSyncRel) {
+				<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate flex items-center gap-1">
+					<i data-lucide="clock" class="w-3 h-3 shrink-0" aria-hidden="true"></i>
+					<span>Next sync { p.Hero.NextSyncRel }</span>
+				</div>
+			}
 		} else {
 			<div class="text-2xl font-bold tabular-nums tracking-tight mt-1.5 text-base-content/30">—</div>
 			<div class="text-[0.65rem] text-base-content/45 mt-1">No syncs yet</div>
@@ -115,7 +120,6 @@ templ feedHeroSyncTile(p FeedProps) {
 }
 
 // ── Pinned alerts ─────────────────────────────────────────────────────────
-
 templ feedAlerts(p FeedProps) {
 	<div class="space-y-2 mb-6">
 		for _, a := range p.ConnectionAlerts {
@@ -150,7 +154,6 @@ templ feedAlertCard(a FeedAlert) {
 }
 
 // ── Filters ───────────────────────────────────────────────────────────────
-
 templ feedFilters(p FeedProps) {
 	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto" aria-label="Feed filters">
 		@feedFilterChip("All", "", "layers", p.Filter)
@@ -175,7 +178,6 @@ templ feedFilterChip(label, slug, icon, current string) {
 }
 
 // ── Timeline + dispatch ───────────────────────────────────────────────────
-
 templ feedTimeline(p FeedProps) {
 	if len(p.Days) == 0 {
 		@feedEmptyState(p)
@@ -420,7 +422,6 @@ templ feedActorTile(actorType, actorID, version, name string) {
 // Each body lives inside the primitive's `flex-1 min-w-0 text-xs leading-6`
 // container. Multi-line bodies render the headline first (with an inline
 // timestamp pill) and any supporting content below.
-
 templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 	<div class="flex items-baseline gap-1.5 flex-wrap">
 		<a href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
@@ -827,6 +828,21 @@ func feedSyncSubLine(status, institution string) string {
 		return institution + " · syncing now"
 	}
 	return institution
+}
+
+// feedShowNextSync gates the "Next sync in ~6h" sub-line. We hide it when
+// the relative-time string is missing (e.g. test env with no scheduler) and
+// when the most recent sync errored — in the failing case the next cron
+// tick won't help until the user reauths, so showing an ETA there is just
+// noise.
+func feedShowNextSync(status, nextRel string) bool {
+	if nextRel == "" {
+		return false
+	}
+	if status == "error" {
+		return false
+	}
+	return true
 }
 
 func feedSyncTileBg(status string) string {

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -30,7 +30,20 @@ templ Feed(p FeedProps) {
 		@feedAlerts(p)
 	}
 	@feedFilters(p)
+	if p.Filter != "" {
+		@feedActiveFilterBanner(p)
+	}
 	@feedTimeline(p)
+}
+
+// feedActiveFilterBanner makes the active chip explicit above the rail.
+// The chip strip alone is easy to miss when scanning a sparse rail.
+templ feedActiveFilterBanner(p FeedProps) {
+	<div class="flex items-center gap-2 text-xs text-base-content/60 mb-3 px-1">
+		<i data-lucide="filter" class="w-3 h-3"></i>
+		<span>Showing only: <span class="font-medium text-base-content/80">{ feedFilterLabel(p.Filter) }</span></span>
+		<a href="/feed" class="text-primary/80 hover:text-primary no-underline ml-1">Clear filter</a>
+	</div>
 }
 
 // ── Hero band ─────────────────────────────────────────────────────────────
@@ -836,6 +849,24 @@ func feedFilterHRef(slug string) string {
 		return "/feed"
 	}
 	return "/feed?filter=" + slug
+}
+
+// feedFilterLabel renders the chip-name string used in the active-filter
+// banner above the rail. Mirrors the labels in `feedFilters`.
+func feedFilterLabel(slug string) string {
+	switch slug {
+	case "syncs":
+		return "Syncs"
+	case "reports":
+		return "Reports"
+	case "comments":
+		return "Comments"
+	case "sessions":
+		return "Sessions"
+	case "me":
+		return "From me"
+	}
+	return slug
 }
 
 func feedAmountClass(amount float64) string {

--- a/internal/templates/components/pages/feed_empty_test.go
+++ b/internal/templates/components/pages/feed_empty_test.go
@@ -1,0 +1,165 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedEmptyStateVariants asserts the right empty-state copy + CTA
+// renders for each of the four scenarios the dispatcher in feedTimeline
+// covers. Each variant is constructed with a minimal FeedProps and
+// rendered to a strings.Builder; we then probe for distinguishing text.
+//
+// This is a no-DB unit test — pure templ rendering — so it lives in the
+// pages package alongside the component it exercises and runs under
+// `go test ./...` without any integration build tag.
+func TestFeedEmptyStateVariants(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name        string
+		props       FeedProps
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "first_run_no_connections",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: false,
+			},
+			mustContain: []string{
+				"Welcome to Breadbox",
+				"Connect your first bank to start filling your feed.",
+				`href="/connections/new"`,
+				"btn-primary",
+			},
+			mustOmit: []string{
+				"Quiet around here",
+				"Clear filter",
+				"feedSyncNow",
+			},
+		},
+		{
+			name: "no_recent_admin_with_last_sync",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				LastSyncAt:     now.Add(-2 * time.Hour),
+				IsAdmin:        true,
+			},
+			mustContain: []string{
+				"Quiet around here",
+				"Last sync was",
+				"Sync now",
+				// The sync-all kickoff lives in static/js/admin/components/feed.js;
+				// the page wires it in via x-data="feedSyncNow" on the empty-state
+				// card and a <script src=…feed.js> tag immediately above. Asserting
+				// on `feedSyncNow` covers both ends without coupling the test to
+				// the inline URL string.
+				"feedSyncNow",
+				`/static/js/admin/components/feed.js`,
+				`href="/transactions"`,
+			},
+			mustOmit: []string{
+				"Welcome to Breadbox",
+				"Clear filter",
+			},
+		},
+		{
+			name: "no_recent_member_no_sync_button",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				LastSyncAt:     now.Add(-26 * time.Hour),
+				IsAdmin:        false,
+			},
+			mustContain: []string{
+				"Quiet around here",
+				`href="/transactions"`,
+			},
+			mustOmit: []string{
+				// non-admin members never see the sync trigger — neither the
+				// button copy nor the wiring to the sync-all kickoff factory.
+				"Sync now",
+				"feedSyncNow",
+			},
+		},
+		{
+			name: "no_recent_no_sync_yet",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				IsAdmin:        true,
+			},
+			mustContain: []string{
+				"Quiet around here",
+				"Try syncing to pull the latest",
+				"Sync now",
+			},
+			mustOmit: []string{
+				"Last sync was",
+			},
+		},
+		{
+			name: "filtered_no_match_comments",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Filter:         "comments",
+				LastSyncAt:     now.Add(-1 * time.Hour),
+			},
+			mustContain: []string{
+				"No comments in the last 3 days",
+				"Clear filter",
+				`href="/feed"`,
+			},
+			mustOmit: []string{
+				"Welcome to Breadbox",
+				"Quiet around here",
+				"Sync now",
+				"feedSyncNow",
+			},
+		},
+		{
+			name: "filtered_no_match_reports",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Filter:         "reports",
+			},
+			mustContain: []string{
+				"No reports in the last 3 days",
+				"Clear filter",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := Feed(tc.props).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes):\n%s", want, buf.Len(), html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_hero_test.go
+++ b/internal/templates/components/pages/feed_hero_test.go
@@ -1,0 +1,102 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedHeroNextSyncSubLine asserts the next-sync ETA sub-line under the
+// Last Sync hero tile is gated on (a) a non-empty NextSyncRel and (b) a
+// non-error LastSyncStatus. The tile renders the existing "Wells Fargo ·
+// healthy" line in either case — what we toggle is the second muted line
+// that points users at the upcoming cron fire.
+//
+// Pure templ render, no DB — runs under `go test ./...`.
+func TestFeedHeroNextSyncSubLine(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name        string
+		hero        FeedHero
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "healthy_with_next_sync_eta",
+			hero: FeedHero{
+				LastSyncAt:          now.Add(-38 * time.Minute),
+				LastSyncRel:         "38 minutes ago",
+				LastSyncStatus:      "success",
+				LastSyncInstitution: "Wells Fargo",
+				NextSyncRel:         "in ~6h",
+			},
+			mustContain: []string{
+				"Wells Fargo",
+				"healthy",
+				"Next sync in ~6h",
+				`data-lucide="clock"`,
+			},
+		},
+		{
+			name: "failing_hides_next_sync",
+			hero: FeedHero{
+				LastSyncAt:          now.Add(-2 * time.Hour),
+				LastSyncRel:         "2 hours ago",
+				LastSyncStatus:      "error",
+				LastSyncInstitution: "Wells Fargo",
+				NextSyncRel:         "in ~6h",
+			},
+			mustContain: []string{
+				"Wells Fargo",
+				"failing",
+			},
+			mustOmit: []string{
+				"Next sync",
+			},
+		},
+		{
+			name: "healthy_without_eta_hides_sub_line",
+			hero: FeedHero{
+				LastSyncAt:          now.Add(-1 * time.Hour),
+				LastSyncRel:         "1 hour ago",
+				LastSyncStatus:      "success",
+				LastSyncInstitution: "Wells Fargo",
+				NextSyncRel:         "",
+			},
+			mustContain: []string{
+				"healthy",
+			},
+			mustOmit: []string{
+				"Next sync",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			props := FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Hero:           tc.hero,
+			}
+			var buf strings.Builder
+			if err := Feed(props).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes)", want, buf.Len())
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -39,6 +39,24 @@ type FeedProps struct {
 	// "agents", "me") parsed from the ?filter= query param. Renders chip
 	// state only — actual filtering applies at the handler layer.
 	Filter string
+
+	// HasConnections is true when at least one bank connection exists,
+	// regardless of status. Drives the empty-state branch — first-run
+	// (no connections) gets a different copy + CTA than "quiet around
+	// here" (has connections, no events in window).
+	HasConnections bool
+
+	// LastSyncAt is the most recent successful sync timestamp across the
+	// household, mirrored from FeedHero so the empty-state copy can
+	// render "Last sync was {relative-time}" without re-deriving it.
+	// Zero value means "no sync yet".
+	LastSyncAt time.Time
+
+	// IsAdmin is true when the current session has the admin role. The
+	// "Sync now" empty-state CTA POSTs to /-/connections/sync-all which
+	// is admin-only; non-admin members see the link to /transactions
+	// instead.
+	IsAdmin bool
 }
 
 // FeedHero powers the at-a-glance band above the feed rail.

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -72,6 +72,12 @@ type FeedHero struct {
 	LastSyncRel         string
 	LastSyncStatus      string
 	LastSyncInstitution string
+
+	// NextSyncRel is a human-readable countdown to the next scheduled cron
+	// fire (e.g. "in ~6h", "in 12m"). Empty when the scheduler is unset
+	// (test env) or when the connection is failing — in the failing case
+	// we suppress it because the next tick won't help until reauth.
+	NextSyncRel string
 }
 
 // FeedAlert is one pinned warning for a connection in error /

--- a/static/js/admin/components/feed.js
+++ b/static/js/admin/components/feed.js
@@ -1,0 +1,39 @@
+// Feed page Alpine factories for /feed.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+//
+//   - `feedSyncNow` — backs the "Sync now" button on the empty-state card.
+//     Triggers a household-wide sync (POST /-/connections/sync-all) and
+//     reloads the page once the kickoff returns 2xx so the freshly written
+//     sync_logs surface in the feed timeline. Admin-only; the templ guards
+//     the button with `if p.IsAdmin`, so this factory is only ever bound
+//     under an admin session.
+
+document.addEventListener('alpine:init', function () {
+  Alpine.data('feedSyncNow', function () {
+    return {
+      state: 'idle',
+
+      triggerSyncNow: function () {
+        if (this.state !== 'idle') return;
+        this.state = 'syncing';
+        var self = this;
+        fetch('/-/connections/sync-all', { method: 'POST' })
+          .then(function (res) {
+            if (res.ok) {
+              self.state = 'done';
+              window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Sync triggered. Reloading…', type: 'success' } }));
+              setTimeout(function () { window.location.reload(); }, 1200);
+            } else {
+              self.state = 'idle';
+              window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Failed to trigger sync.', type: 'error' } }));
+            }
+          })
+          .catch(function () {
+            self.state = 'idle';
+            window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Network error. Please try again.', type: 'error' } }));
+          });
+      },
+    };
+  });
+});


### PR DESCRIPTION
Polishes /feed empty states so each scenario gets the right copy and CTA, instead of one card answering every empty case the same way.

## Summary

- **First-run** (no connections) — primary "Connect a bank" CTA pointing at `/connections/new`. The only path forward, so we lead with it.
- **Quiet around here** (has connections, no events in the 3-day window) — admins get a "Sync now" button (POST `/-/connections/sync-all`, then reload); members see only "Browse transactions" since `sync-all` is admin-only at the route layer. Subline mentions the last successful sync time when one exists ("Last sync was 2 hours ago").
- **Filtered no-match** (chip active, zero matches) — pluralised headline per chip ("No comments in the last 3 days") with a Clear-filter link that drops the `?filter=` param.

`feedTimeline` dispatches off `(HasConnections, Filter, LastSyncAt)` to pick the variant. Existing grouping/timeline-primitives shape and the parent stack's filter wiring are untouched.

## Changes

- `internal/templates/components/pages/feed_types.go` — `FeedProps` gains `HasConnections`, `LastSyncAt`, `IsAdmin`.
- `internal/admin/feed.go` — refactors `buildFeedConnectionAlerts` → `buildFeedConnectionMeta`, projecting alerts + connection-existence + global-last-sync from a single `ListBankConnections` pass.
- `internal/templates/components/pages/feed.templ` — splits the empty branch into `feedEmptyFirstRun` / `feedEmptyFiltered` / `feedEmptyNoRecent`.
- `static/js/admin/components/feed.js` — new Alpine factory `feedSyncNow` for the admin sync-all kickoff (per `docs/design-system.md` "Alpine page components", to satisfy the inline-script lint).
- `internal/templates/components/pages/feed_empty_test.go` — renders the templ for each variant and asserts the right copy / CTA / wiring.

## Screenshots

Filtered no-match (`/feed?filter=reports` — no agent reports in the dev DB):

<img src="https://i.img402.dev/9jcwl6ivad.jpg" width="800" alt="/feed?filter=reports empty state — desktop">

Mobile (390×844):

<img src="https://i.img402.dev/r1d2xg43h8.jpg" width="320" alt="/feed?filter=reports empty state — mobile">

The other variants have unit-test coverage (`go test ./internal/templates/components/pages/... -run TestFeedEmpty`) — five sub-cases assert headline / CTA / script wiring / IsAdmin gate.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/admin/... ./internal/service/... ./internal/templates/...`
- [x] Visit `/feed?filter=reports` — empty card with Clear-filter link
- [x] Visit `/feed?filter=comments` — same shape, headline pluralises ("No comments in the last 3 days")
- [x] Visit `/feed` (with comments + syncs in window) — timeline renders, no regression on filter wiring from #954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
