### PR TITLE
ci: run on stacked-PR base branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI/CD
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "stack/**"]
   merge_group:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary

The `pull_request` filter in `.github/workflows/ci.yml` only matched PRs whose base is `main`:

```yaml
on:
  pull_request:
    branches: [main]
```

This means any PR in a stack — where the base is the previous branch in the stack (e.g. `stack/feed-polish/01-filter-chips`) rather than `main` — gets **zero CI runs**. That directly violates the guardrail in `.claude/rules/stacked-prs.md`:

> Every PR must independently pass CI — non-negotiable. At every branch tip in the stack, `go build ./...`, `go vet ./...`, and `go test ./...` must all pass.

Without CI firing on stacked PRs, that requirement is unenforceable.

## Fix

Add `"stack/**"` to the `pull_request.branches` filter so PRs targeting stack branches trigger CI. One-line YAML diff; no other workflow files touched.

## Impact

- PRs #955 and #956 (the current open `stack/feed-polish` stack) currently have **zero CI runs** because of this filter.
- After this PR merges, those stacked PRs will need a no-op push (e.g. empty commit or rebase) or a manual workflow re-run to pick up CI on their existing tips.

## Test plan

- [ ] CI runs on this PR (base = `main`, so the existing rule already covers it — it should still trigger).
- [ ] After merge, push a no-op commit to a `stack/**` branch and confirm CI fires.