### PR TITLE
ui(feed): next-sync ETA sub-line under Last Sync hero tile

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -197,6 +197,13 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		if !lastSyncAt.IsZero() {
 			hero.LastSyncRel = relativeTime(lastSyncAt)
 		}
+		// Next-sync ETA — drives the "Next sync in ~6h" sub-line under the
+		// Last Sync hero tile so the page answers "why no new transactions
+		// yet?" inline. The scheduler is nil in test env (no cron); leave
+		// the field empty there and the templ hides the sub-line.
+		if a.Scheduler != nil {
+			hero.NextSyncRel = formatNextSync(a.Scheduler.NextRun())
+		}
 
 		data := map[string]any{
 			"PageTitle":   "Feed",

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -1,0 +1,513 @@
+//go:build integration
+
+// Integration tests that pin down `Service.ListFeedEvents` grouping behaviour.
+//
+// The feed page intentionally collapses noisy clusters of annotations into a
+// handful of high-signal cards. The cases below seed real annotations + sync
+// logs + mcp_sessions + transactions and assert each grouping rule the
+// previous iterations of /feed established. They serve as a regression net so
+// future iterations can't quietly drop the dedup, bulk-bucket, or
+// session-collapse logic.
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// feedSeed bundles the IDs needed across the per-subtest seeders. Every
+// subtest gets a fresh, truncated DB via newService → testutil.Pool, so
+// helpers populate this struct top-down.
+type feedSeed struct {
+	UserID  pgtype.UUID
+	ConnID  pgtype.UUID
+	AcctID  pgtype.UUID
+	TxnIDs  []pgtype.UUID
+}
+
+// seedFeedFixture creates one user/connection/account plus `txnCount`
+// transactions so tests have transaction IDs to attach annotations to.
+func seedFeedFixture(t *testing.T, queries *db.Queries, suffix string, txnCount int) feedSeed {
+	t.Helper()
+	user := testutil.MustCreateUser(t, queries, "Alice "+suffix)
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "feed_conn_"+suffix)
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "feed_acct_"+suffix, "Checking "+suffix)
+
+	out := feedSeed{UserID: user.ID, ConnID: conn.ID, AcctID: acct.ID}
+	for i := 0; i < txnCount; i++ {
+		txn := testutil.MustCreateTransaction(
+			t, queries, acct.ID,
+			fmt.Sprintf("feed_txn_%s_%d", suffix, i),
+			fmt.Sprintf("Merchant %s %d", suffix, i),
+			int64(1000+i*250),
+			"2026-04-15",
+		)
+		out.TxnIDs = append(out.TxnIDs, txn.ID)
+	}
+	return out
+}
+
+// insertAnnotation inserts an annotation and forces its `created_at` to the
+// supplied time. The sqlc-generated InsertAnnotation does not accept a
+// created_at parameter (the column defaults to NOW()), so we patch it after
+// the fact — mirrors what real history would look like once enough wall-time
+// has elapsed.
+func insertAnnotation(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	queries *db.Queries,
+	txnID pgtype.UUID,
+	kind, actorType, actorID, actorName string,
+	sessionID pgtype.UUID,
+	payload []byte,
+	createdAt time.Time,
+) pgtype.UUID {
+	t.Helper()
+	params := db.InsertAnnotationParams{
+		TransactionID: txnID,
+		Kind:          kind,
+		ActorType:     actorType,
+		ActorName:     actorName,
+		Payload:       payload,
+	}
+	if actorID != "" {
+		params.ActorID = pgtype.Text{String: actorID, Valid: true}
+	}
+	if sessionID.Valid {
+		params.SessionID = sessionID
+	}
+	ann, err := queries.InsertAnnotation(ctx, params)
+	if err != nil {
+		t.Fatalf("InsertAnnotation(%s): %v", kind, err)
+	}
+	if _, err := pool.Exec(ctx,
+		"UPDATE annotations SET created_at = $1 WHERE id = $2",
+		createdAt, ann.ID,
+	); err != nil {
+		t.Fatalf("backdate annotation: %v", err)
+	}
+	return ann.ID
+}
+
+// findEventByType returns the first FeedEvent of the requested type, or nil.
+func findEventByType(events []service.FeedEvent, eventType string) *service.FeedEvent {
+	for i := range events {
+		if events[i].Type == eventType {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+// countEventsByType counts events whose Type matches.
+func countEventsByType(events []service.FeedEvent, eventType string) int {
+	n := 0
+	for _, e := range events {
+		if e.Type == eventType {
+			n++
+		}
+	}
+	return n
+}
+
+func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
+	t.Run("SyncErrorDedup", func(t *testing.T) {
+		svc, queries, _ := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "syncerr", 0)
+
+		now := time.Now().UTC()
+		errMsg := pgtype.Text{String: "ITEM_LOGIN_REQUIRED", Valid: true}
+		// Five sync_logs, same connection + same error message, oldest →
+		// newest. The dedup key is (connection_id, error_message); these
+		// should collapse into one event with RetryCount == 4 and
+		// FirstFailureAt == oldest.
+		oldest := now.Add(-90 * time.Minute)
+		for i := 0; i < 5; i++ {
+			startedAt := now.Add(time.Duration(-90+i*15) * time.Minute)
+			if _, err := queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+				ConnectionID: seed.ConnID,
+				Trigger:      db.SyncTriggerCron,
+				Status:       db.SyncStatusError,
+				StartedAt:    pgconv.Timestamptz(startedAt),
+				CompletedAt:  pgconv.Timestamptz(startedAt.Add(2 * time.Second)),
+				ErrorMessage: errMsg,
+			}); err != nil {
+				t.Fatalf("CreateSyncLog %d: %v", i, err)
+			}
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "sync"); got != 1 {
+			t.Fatalf("expected 1 sync event after dedup, got %d", got)
+		}
+		ev := findEventByType(events, "sync").Sync
+		if ev.RetryCount != 4 {
+			t.Errorf("RetryCount = %d, want 4", ev.RetryCount)
+		}
+		if ev.Status != "error" {
+			t.Errorf("Status = %q, want %q", ev.Status, "error")
+		}
+		// FirstFailureAt is the oldest start. Compare at second precision —
+		// pgtype rounds to micro and time.Now() roundtrips through pg.
+		if !ev.FirstFailureAt.Truncate(time.Second).Equal(oldest.Truncate(time.Second)) {
+			t.Errorf("FirstFailureAt = %v, want %v", ev.FirstFailureAt, oldest)
+		}
+	})
+
+	t.Run("DifferentErrorsDoNotDedupe", func(t *testing.T) {
+		svc, queries, _ := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "differr", 0)
+
+		now := time.Now().UTC()
+		mkLog := func(offsetMin int, msg string) {
+			startedAt := now.Add(time.Duration(offsetMin) * time.Minute)
+			if _, err := queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+				ConnectionID: seed.ConnID,
+				Trigger:      db.SyncTriggerCron,
+				Status:       db.SyncStatusError,
+				StartedAt:    pgconv.Timestamptz(startedAt),
+				CompletedAt:  pgconv.Timestamptz(startedAt.Add(time.Second)),
+				ErrorMessage: pgtype.Text{String: msg, Valid: true},
+			}); err != nil {
+				t.Fatalf("CreateSyncLog: %v", err)
+			}
+		}
+		// Three with err A, two with err B.
+		for i := 0; i < 3; i++ {
+			mkLog(-90+i*5, "ITEM_LOGIN_REQUIRED")
+		}
+		for i := 0; i < 2; i++ {
+			mkLog(-30+i*5, "RATE_LIMIT_EXCEEDED")
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "sync"); got != 2 {
+			t.Fatalf("expected 2 sync events (one per distinct error), got %d", got)
+		}
+	})
+
+	t.Run("HardGroupBySessionID", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "session", 5)
+
+		// Create one MCP session + 12 annotations across 5 transactions
+		// (4 category_set, 4 tag_added, 4 comment), all with session_id.
+		session, err := queries.CreateMCPSession(ctx, db.CreateMCPSessionParams{
+			ApiKeyID:   "00000000-0000-0000-0000-000000000abc",
+			ApiKeyName: "review-bot",
+			Purpose:    "categorize",
+		})
+		if err != nil {
+			t.Fatalf("CreateMCPSession: %v", err)
+		}
+
+		// Need a tag for tag_added rows.
+		tag := testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
+
+		now := time.Now().UTC()
+		actorID := pgconv.FormatUUID(session.ID)
+		mk := func(kind string, txnIdx int, idx int) {
+			ts := now.Add(time.Duration(-30+idx) * time.Second)
+			params := db.InsertAnnotationParams{
+				TransactionID: seed.TxnIDs[txnIdx],
+				Kind:          kind,
+				ActorType:     "agent",
+				ActorID:       pgtype.Text{String: actorID, Valid: true},
+				ActorName:     "review-bot",
+				SessionID:     session.ID,
+				Payload:       []byte(`{}`),
+			}
+			if kind == "tag_added" {
+				params.TagID = tag.ID
+				params.Payload = []byte(`{"tag_slug":"needs-review"}`)
+			}
+			if kind == "category_set" {
+				params.Payload = []byte(`{"category_slug":"food_and_drink"}`)
+			}
+			ann, err := queries.InsertAnnotation(ctx, params)
+			if err != nil {
+				t.Fatalf("InsertAnnotation(%s): %v", kind, err)
+			}
+			if _, err := pool.Exec(ctx,
+				"UPDATE annotations SET created_at = $1 WHERE id = $2", ts, ann.ID,
+			); err != nil {
+				t.Fatalf("backdate: %v", err)
+			}
+		}
+		// 4 of each kind, distributed over 5 transactions.
+		for i := 0; i < 4; i++ {
+			mk("category_set", i%5, i)
+		}
+		for i := 0; i < 4; i++ {
+			mk("tag_added", (i+1)%5, 4+i)
+		}
+		for i := 0; i < 4; i++ {
+			mk("comment", (i+2)%5, 8+i)
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "agent_session"); got != 1 {
+			t.Fatalf("expected 1 agent_session event, got %d (events=%+v)", got, events)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 0 {
+			t.Errorf("expected 0 bulk_action events (sessioned annotations should not bucket), got %d", got)
+		}
+		if got := countEventsByType(events, "comment"); got != 0 {
+			t.Errorf("expected 0 comment events (sessioned comments should fold into the session), got %d", got)
+		}
+		ev := findEventByType(events, "agent_session").AgentSession
+		if ev.AnnotationCount != 12 {
+			t.Errorf("AnnotationCount = %d, want 12", ev.AnnotationCount)
+		}
+		if ev.UniqueTransactions != 5 {
+			t.Errorf("UniqueTransactions = %d, want 5", ev.UniqueTransactions)
+		}
+		for _, kind := range []string{"category_set", "tag_added", "comment"} {
+			if ev.KindCounts[kind] != 4 {
+				t.Errorf("KindCounts[%s] = %d, want 4", kind, ev.KindCounts[kind])
+			}
+		}
+	})
+
+	t.Run("SoftBucketBulkAction", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "bulk", 4)
+
+		now := time.Now().UTC()
+		actorID := "user-actor-bulk"
+		// 4 category_set annotations, same actor, 4 different transactions,
+		// all within ~30 seconds (well inside the 5-minute soft bucket and
+		// the 2-minute window the spec asks us to assert).
+		for i := 0; i < 4; i++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"category_set", "user", actorID, "Alice",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				now.Add(time.Duration(-30+i*10)*time.Second),
+			)
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event, got %d", got)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Kind != "category_set" {
+			t.Errorf("Kind = %q, want %q", ev.Kind, "category_set")
+		}
+		if ev.Count != 4 {
+			t.Errorf("Count = %d, want 4", ev.Count)
+		}
+	})
+
+	t.Run("BelowThresholdDropsStandaloneCategorySet", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "below", 2)
+
+		now := time.Now().UTC()
+		// Two category_set annotations from the same actor in the same
+		// minute. Default BulkThreshold is 3 → bucket count 2 falls through,
+		// and only `comment` rows survive sub-threshold, so these category
+		// rows should disappear from the feed.
+		for i := 0; i < 2; i++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"category_set", "user", "actor-below", "Alice",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				now.Add(time.Duration(-10+i*5)*time.Second),
+			)
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 0 {
+			t.Errorf("expected 0 bulk_action events (under threshold), got %d", got)
+		}
+		if got := countEventsByType(events, "comment"); got != 0 {
+			t.Errorf("expected 0 comment events, got %d", got)
+		}
+		// The whole feed should be empty for this fixture (no sync logs were
+		// seeded either).
+		if len(events) != 0 {
+			t.Errorf("expected 0 events total, got %d (%+v)", len(events), events)
+		}
+	})
+
+	t.Run("StandaloneCommentSurvives", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "comment", 1)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-comment", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"Looks like a duplicate"}`),
+			now.Add(-5*time.Minute),
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "comment"); got != 1 {
+			t.Fatalf("expected 1 comment event, got %d", got)
+		}
+	})
+
+	t.Run("SyncStartedAndUpdatedExcluded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "syncann", 1)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"sync_started", "system", "", "Plaid Sync",
+			pgtype.UUID{},
+			[]byte(`{}`),
+			now.Add(-30*time.Second),
+		)
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"sync_updated", "system", "", "Plaid Sync",
+			pgtype.UUID{},
+			[]byte(`{}`),
+			now.Add(-20*time.Second),
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected sync_started/sync_updated annotations to be excluded; got %d events: %+v", len(events), events)
+		}
+	})
+
+	t.Run("RuleAppliedDuringSyncExcluded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "rulesync", 1)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"rule_applied", "system", "", "Plaid Sync",
+			pgtype.UUID{},
+			[]byte(`{"applied_by":"sync"}`),
+			now.Add(-30*time.Second),
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected rule_applied(applied_by=sync) to be excluded; got %d events", len(events))
+		}
+	})
+
+	t.Run("RuleAppliedRetroactiveIncluded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "ruleretro", 5)
+
+		// Need a real rule so rule_applied annotations have an FK target.
+		rule := testutil.MustCreateTransactionRule(t, queries, "Coffee Rule", []byte(`[]`), []byte(`[]`), "on_create")
+		ruleShortID := rule.ShortID
+
+		now := time.Now().UTC()
+		actorID := "actor-retro"
+		// 5 rule_applied annotations, same actor, no `applied_by=sync`, all
+		// within ~30 seconds → should produce a single bulk_action event.
+		for i := 0; i < 5; i++ {
+			params := db.InsertAnnotationParams{
+				TransactionID: seed.TxnIDs[i],
+				Kind:          "rule_applied",
+				ActorType:     "user",
+				ActorID:       pgtype.Text{String: actorID, Valid: true},
+				ActorName:     "Alice",
+				RuleID:        rule.ID,
+				Payload:       []byte(fmt.Sprintf(`{"rule_short_id":%q}`, ruleShortID)),
+			}
+			ann, err := queries.InsertAnnotation(ctx, params)
+			if err != nil {
+				t.Fatalf("InsertAnnotation %d: %v", i, err)
+			}
+			if _, err := pool.Exec(ctx,
+				"UPDATE annotations SET created_at = $1 WHERE id = $2",
+				now.Add(time.Duration(-30+i*5)*time.Second), ann.ID,
+			); err != nil {
+				t.Fatalf("backdate: %v", err)
+			}
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event, got %d (%+v)", got, events)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Kind != "rule_applied" {
+			t.Errorf("Kind = %q, want %q", ev.Kind, "rule_applied")
+		}
+		if ev.Count != 5 {
+			t.Errorf("Count = %d, want 5", ev.Count)
+		}
+	})
+
+	t.Run("WindowIsBounded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "window", 1)
+
+		// Annotation aged 4 days ago, with a 3-day window: must be excluded.
+		old := time.Now().UTC().Add(-4 * 24 * time.Hour)
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-window", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"old"}`),
+			old,
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+			Window: 3 * 24 * time.Hour,
+		})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected 0 events with 3d window vs 4d-old annotation; got %d", len(events))
+		}
+	})
+}

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -47,7 +47,6 @@ templ feedActiveFilterBanner(p FeedProps) {
 }
 
 // ── Hero band ─────────────────────────────────────────────────────────────
-
 templ feedHero(p FeedProps) {
 	<header class="mb-6">
 		<div class="flex flex-wrap items-end justify-between gap-3 mb-4">
@@ -107,6 +106,12 @@ templ feedHeroSyncTile(p FeedProps) {
 			<div class="text-[0.65rem] text-base-content/45 mt-1 truncate">
 				{ feedSyncSubLine(p.Hero.LastSyncStatus, p.Hero.LastSyncInstitution) }
 			</div>
+			if feedShowNextSync(p.Hero.LastSyncStatus, p.Hero.NextSyncRel) {
+				<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate flex items-center gap-1">
+					<i data-lucide="clock" class="w-3 h-3 shrink-0" aria-hidden="true"></i>
+					<span>Next sync { p.Hero.NextSyncRel }</span>
+				</div>
+			}
 		} else {
 			<div class="text-2xl font-bold tabular-nums tracking-tight mt-1.5 text-base-content/30">—</div>
 			<div class="text-[0.65rem] text-base-content/45 mt-1">No syncs yet</div>
@@ -115,7 +120,6 @@ templ feedHeroSyncTile(p FeedProps) {
 }
 
 // ── Pinned alerts ─────────────────────────────────────────────────────────
-
 templ feedAlerts(p FeedProps) {
 	<div class="space-y-2 mb-6">
 		for _, a := range p.ConnectionAlerts {
@@ -150,7 +154,6 @@ templ feedAlertCard(a FeedAlert) {
 }
 
 // ── Filters ───────────────────────────────────────────────────────────────
-
 templ feedFilters(p FeedProps) {
 	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto" aria-label="Feed filters">
 		@feedFilterChip("All", "", "layers", p.Filter)
@@ -175,7 +178,6 @@ templ feedFilterChip(label, slug, icon, current string) {
 }
 
 // ── Timeline + dispatch ───────────────────────────────────────────────────
-
 templ feedTimeline(p FeedProps) {
 	if len(p.Days) == 0 {
 		@feedEmptyState(p)
@@ -420,7 +422,6 @@ templ feedActorTile(actorType, actorID, version, name string) {
 // Each body lives inside the primitive's `flex-1 min-w-0 text-xs leading-6`
 // container. Multi-line bodies render the headline first (with an inline
 // timestamp pill) and any supporting content below.
-
 templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 	<div class="flex items-baseline gap-1.5 flex-wrap">
 		<a href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
@@ -827,6 +828,21 @@ func feedSyncSubLine(status, institution string) string {
 		return institution + " · syncing now"
 	}
 	return institution
+}
+
+// feedShowNextSync gates the "Next sync in ~6h" sub-line. We hide it when
+// the relative-time string is missing (e.g. test env with no scheduler) and
+// when the most recent sync errored — in the failing case the next cron
+// tick won't help until the user reauths, so showing an ETA there is just
+// noise.
+func feedShowNextSync(status, nextRel string) bool {
+	if nextRel == "" {
+		return false
+	}
+	if status == "error" {
+		return false
+	}
+	return true
 }
 
 func feedSyncTileBg(status string) string {

--- a/internal/templates/components/pages/feed_hero_test.go
+++ b/internal/templates/components/pages/feed_hero_test.go
@@ -1,0 +1,102 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedHeroNextSyncSubLine asserts the next-sync ETA sub-line under the
+// Last Sync hero tile is gated on (a) a non-empty NextSyncRel and (b) a
+// non-error LastSyncStatus. The tile renders the existing "Wells Fargo ·
+// healthy" line in either case — what we toggle is the second muted line
+// that points users at the upcoming cron fire.
+//
+// Pure templ render, no DB — runs under `go test ./...`.
+func TestFeedHeroNextSyncSubLine(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name        string
+		hero        FeedHero
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "healthy_with_next_sync_eta",
+			hero: FeedHero{
+				LastSyncAt:          now.Add(-38 * time.Minute),
+				LastSyncRel:         "38 minutes ago",
+				LastSyncStatus:      "success",
+				LastSyncInstitution: "Wells Fargo",
+				NextSyncRel:         "in ~6h",
+			},
+			mustContain: []string{
+				"Wells Fargo",
+				"healthy",
+				"Next sync in ~6h",
+				`data-lucide="clock"`,
+			},
+		},
+		{
+			name: "failing_hides_next_sync",
+			hero: FeedHero{
+				LastSyncAt:          now.Add(-2 * time.Hour),
+				LastSyncRel:         "2 hours ago",
+				LastSyncStatus:      "error",
+				LastSyncInstitution: "Wells Fargo",
+				NextSyncRel:         "in ~6h",
+			},
+			mustContain: []string{
+				"Wells Fargo",
+				"failing",
+			},
+			mustOmit: []string{
+				"Next sync",
+			},
+		},
+		{
+			name: "healthy_without_eta_hides_sub_line",
+			hero: FeedHero{
+				LastSyncAt:          now.Add(-1 * time.Hour),
+				LastSyncRel:         "1 hour ago",
+				LastSyncStatus:      "success",
+				LastSyncInstitution: "Wells Fargo",
+				NextSyncRel:         "",
+			},
+			mustContain: []string{
+				"healthy",
+			},
+			mustOmit: []string{
+				"Next sync",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			props := FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Hero:           tc.hero,
+			}
+			var buf strings.Builder
+			if err := Feed(props).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes)", want, buf.Len())
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -72,6 +72,12 @@ type FeedHero struct {
 	LastSyncRel         string
 	LastSyncStatus      string
 	LastSyncInstitution string
+
+	// NextSyncRel is a human-readable countdown to the next scheduled cron
+	// fire (e.g. "in ~6h", "in 12m"). Empty when the scheduler is unset
+	// (test env) or when the connection is failing — in the failing case
+	// we suppress it because the next tick won't help until reauth.
+	NextSyncRel string
 }
 
 // FeedAlert is one pinned warning for a connection in error /


### PR DESCRIPTION
Surfaces the upcoming cron fire as a second muted sub-line under the Last Sync hero tile so the page answers "why no new transactions yet?" inline.

## Summary

- New `FeedHero.NextSyncRel` field, populated by the handler from `a.Scheduler.NextRun()` via the existing `formatNextSync` helper shared with `/settings` and `/dashboard`. Empty in test env (`Scheduler == nil`).
- Templ adds a clock-icon sub-line under the existing "Wells Fargo · healthy" line. Gated on `feedShowNextSync(status, nextRel)` — suppressed in the failing case (the next tick won't help until reauth) and when `NextSyncRel` is empty.
- Existing `LastSyncRel` / `LastSyncStatus` / `LastSyncInstitution` paths untouched.
- Unit test in `internal/templates/components/pages/feed_hero_test.go` covers all three branches: healthy renders the line, error suppresses it, and empty `NextSyncRel` omits it.

## Screenshot

Healthy connection, hero tile with the new sub-line:

<img src="https://i.img402.dev/hky3f17vth.jpg" width="800" alt="/feed hero — Last Sync tile with next-sync ETA">

The screenshot is rendered through the real `pages.Feed` templ via a tiny driver program (not committed) — same code path as the live handler, just fed a synthetic healthy `FeedHero` so the new line is exercised. Hidden state was also validated against the live shared dev DB (currently failing connection — the line correctly disappears).

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/admin/... ./internal/service/... ./internal/templates/... -count=1`
- [x] Visual: healthy state renders "Next sync in ~6h" with a clock icon under the existing institution line.
- [x] Visual: failing state hides the new line (verified on the live `/feed` page against the dev DB).
