### PR TITLE
ui(feed): add Load older activity pagination

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -36,6 +36,25 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		window := time.Duration(feedWindowDays) * 24 * time.Hour
 		filter := strings.TrimSpace(r.URL.Query().Get("filter"))
 
+		// `?before=<rfc3339>` lets the user roll the 3-day window backward
+		// in chunks via the "Load older activity" footer button. Cap at
+		// 30 days back from now — the service layer enforces the same
+		// ceiling, but clamping here keeps the rendered window/footer
+		// consistent and makes the cap discoverable from a single layer.
+		var beforeTime time.Time
+		if rawBefore := strings.TrimSpace(r.URL.Query().Get("before")); rawBefore != "" {
+			if parsed, err := time.Parse(time.RFC3339, rawBefore); err == nil {
+				beforeTime = parsed
+				minBefore := now.Add(-service.FeedMaxLookback)
+				if beforeTime.Before(minBefore) {
+					beforeTime = minBefore
+				}
+				if beforeTime.After(now) {
+					beforeTime = time.Time{}
+				}
+			}
+		}
+
 		// Resolve the session actor for the "me" chip. Prefer the linked
 		// household user_id; fall back to the auth_account id for the
 		// initial admin (which writes annotations against its account id).
@@ -72,6 +91,7 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			SampleLimit:   5,
 			Filter:        filter,
 			ActorID:       sessionActorID,
+			Before:        beforeTime,
 		})
 		if err != nil {
 			a.Logger.Error("feed: list events", "error", err)
@@ -99,7 +119,15 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			alerts = nil
 		}
 
-		// 4. Project FeedEvents onto templ-side FeedItems.
+		// 4. Project FeedEvents onto templ-side FeedItems. The window is
+		// anchored at `windowEnd` (now, or the `?before=` timestamp when
+		// paginating); `windowStart` is `windowEnd - window`.
+		windowEnd := now
+		if !beforeTime.IsZero() {
+			windowEnd = beforeTime
+		}
+		windowStart := windowEnd.Add(-window)
+
 		items := make([]pages.FeedItem, 0, len(events)+len(reports))
 		var lastSyncAt time.Time
 		var lastSyncStatus, lastSyncInstitution string
@@ -107,7 +135,7 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 
 		for _, ev := range events {
-			if ev.Timestamp.Before(now.Add(-window)) {
+			if ev.Timestamp.Before(windowStart) || ev.Timestamp.After(windowEnd) {
 				continue
 			}
 			it := projectFeedEvent(ev, tagDisplayFn, categoryDetail)
@@ -142,7 +170,7 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			if err != nil {
 				continue
 			}
-			if ts.Before(now.Add(-window)) {
+			if ts.Before(windowStart) || ts.After(windowEnd) {
 				continue
 			}
 			items = append(items, pages.FeedItem{
@@ -210,6 +238,26 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			"CurrentPage": "feed",
 			"CSRFToken":   GetCSRFToken(r),
 		}
+		// Compute the oldest visible event timestamp + the at-cap flag that
+		// drive the "Load older activity" button. We pass the oldest item's
+		// timestamp through so the button's href rolls the window backward
+		// in 3-day chunks. AtMaxLookback hides the button (replaced by
+		// "End of feed") when the next chunk would exceed the 30-day cap.
+		var oldestVisible time.Time
+		for _, it := range items {
+			if oldestVisible.IsZero() || it.Timestamp.Before(oldestVisible) {
+				oldestVisible = it.Timestamp
+			}
+		}
+		atMaxLookback := false
+		if !oldestVisible.IsZero() {
+			// Once the oldest visible event is older than (now - 30d), or
+			// the next-chunk's upper bound would be, treat as end-of-feed.
+			if oldestVisible.Before(now.Add(-service.FeedMaxLookback)) {
+				atMaxLookback = true
+			}
+		}
+
 		body := pages.Feed(pages.FeedProps{
 			CSRFToken:        GetCSRFToken(r),
 			Hero:             hero,
@@ -222,6 +270,8 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			HasConnections:   hasConnections,
 			LastSyncAt:       globalLastSyncAt,
 			IsAdmin:          IsAdmin(tr.sm, r),
+			OldestVisible:    oldestVisible,
+			AtMaxLookback:    atMaxLookback,
 		})
 		tr.RenderWithTempl(w, r, data, body)
 	}

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -244,6 +244,14 @@ type FeedEventsParams struct {
 	BulkThreshold int
 	SampleLimit   int
 
+	// Before, when non-zero, anchors the window's *upper* bound at this
+	// timestamp instead of "now". Used by the "Load older activity"
+	// pagination affordance — the page rolls backward in `Window`-sized
+	// chunks. The cutoff becomes `Before.Add(-Window)`. Default-window
+	// behaviour (no `Before`) is preserved verbatim: events newer than
+	// `now - Window` and up to `now`.
+	Before time.Time
+
 	// Filter scopes the resulting event slice to a single chip on the feed
 	// rail. Empty string means "no filter" — every grouped event is
 	// returned. See `filterFeedEvents` for the recognised values.
@@ -256,6 +264,12 @@ type FeedEventsParams struct {
 	// whether the auth_account is linked to a household user.
 	ActorID string
 }
+
+// FeedMaxLookback is the hard ceiling for `Before`-driven pagination on the
+// home feed. A user can scroll backward in 3-day chunks but cannot ask for
+// activity older than this — the unbounded read would walk the entire
+// annotations table for households with years of history.
+const FeedMaxLookback = 30 * 24 * time.Hour
 
 // ListFeedEvents returns grouped FeedEvents for the home Feed page,
 // already ordered newest-first.
@@ -290,15 +304,29 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 		params.SampleLimit = 5
 	}
 
-	cutoff := time.Now().Add(-params.Window)
+	now := time.Now()
+	// Clamp the upper bound to the lookback ceiling so callers asking for a
+	// timestamp deeper than `FeedMaxLookback` silently get the oldest still-
+	// addressable window. Keeps the handler's `?before=` clamp honoured at
+	// the service layer too — defence in depth, since this is the layer
+	// that actually owns the unbounded-query risk.
+	upper := now
+	if !params.Before.IsZero() {
+		upper = params.Before
+		minUpper := now.Add(-FeedMaxLookback)
+		if upper.Before(minUpper) {
+			upper = minUpper
+		}
+	}
+	cutoff := upper.Add(-params.Window)
 
-	annotationRows, err := s.fetchFeedAnnotations(ctx, cutoff)
+	annotationRows, err := s.fetchFeedAnnotations(ctx, cutoff, upper)
 	if err != nil {
 		return nil, err
 	}
 	annotationRows = enrichFeedActivityRows(annotationRows)
 
-	syncEvents, err := s.fetchFeedSyncEvents(ctx, cutoff, params.SampleLimit)
+	syncEvents, err := s.fetchFeedSyncEvents(ctx, cutoff, upper, params.SampleLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +430,7 @@ func filterEventsByActor(events []FeedEvent, actorID string) []FeedEvent {
 // surfaces both the live profile name (preferred over the frozen-at-
 // write-time `annotations.actor_name`) and the user's `updated_at` for
 // avatar cache-busting.
-func (s *Service) fetchFeedAnnotations(ctx context.Context, cutoff time.Time) ([]FeedActivityRow, error) {
+func (s *Service) fetchFeedAnnotations(ctx context.Context, cutoff, upper time.Time) ([]FeedActivityRow, error) {
 	const q = `
 SELECT
     a.id, a.short_id, a.transaction_id, a.kind, a.actor_type, a.actor_id, a.actor_name,
@@ -426,12 +454,13 @@ LEFT JOIN users u_direct
    AND u_direct.id::text = a.actor_id
 WHERE t.deleted_at IS NULL
   AND a.created_at >= $1
+  AND a.created_at <  $2
   AND a.kind NOT IN ('sync_started', 'sync_updated')
   AND COALESCE(a.payload->>'applied_by', '') <> 'sync'
 ORDER BY a.created_at DESC
 `
 
-	rows, err := s.Pool.Query(ctx, q, cutoff)
+	rows, err := s.Pool.Query(ctx, q, cutoff, upper)
 	if err != nil {
 		return nil, fmt.Errorf("list feed annotations: %w", err)
 	}
@@ -583,7 +612,7 @@ func enrichFeedActivityRows(in []FeedActivityRow) []FeedActivityRow {
 // fetchFeedSyncEvents returns one FeedEvent per sync run within the window
 // (failed runs always included; successful no-op runs filtered out).
 // Inline transaction samples are batched in a single follow-up query.
-func (s *Service) fetchFeedSyncEvents(ctx context.Context, cutoff time.Time, sampleLimit int) ([]FeedEvent, error) {
+func (s *Service) fetchFeedSyncEvents(ctx context.Context, cutoff, upper time.Time, sampleLimit int) ([]FeedEvent, error) {
 	const q = `
 SELECT
     sl.id, sl.connection_id,
@@ -594,10 +623,11 @@ SELECT
 FROM sync_logs sl
 JOIN bank_connections bc ON sl.connection_id = bc.id
 WHERE sl.started_at >= $1
+  AND sl.started_at <  $2
 ORDER BY sl.started_at DESC
 `
 
-	rows, err := s.Pool.Query(ctx, q, cutoff)
+	rows, err := s.Pool.Query(ctx, q, cutoff, upper)
 	if err != nil {
 		return nil, fmt.Errorf("list feed sync logs: %w", err)
 	}

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -486,6 +486,93 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		}
 	})
 
+	t.Run("BeforeAnchorsUpperBound", func(t *testing.T) {
+		// `Before` rolls the 3-day window backward — events newer than the
+		// upper bound must drop out of the result, while events inside
+		// `[Before-3d, Before)` come through. Validates the pagination
+		// affordance the /feed footer exposes.
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "before-window", 2)
+
+		now := time.Now().UTC()
+		// Recent comment (1 hour ago) — should be excluded by Before=now-2d.
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-recent", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"recent"}`),
+			now.Add(-1*time.Hour),
+		)
+		// Older comment (2.5 days ago) — should land inside the chunk
+		// `[Before-3d, Before)` where Before = now-2d.
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[1],
+			"comment", "user", "actor-older", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"older"}`),
+			now.Add(-60*time.Hour),
+		)
+
+		before := now.Add(-2 * 24 * time.Hour)
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+			Window: 3 * 24 * time.Hour,
+			Before: before,
+		})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "comment"); got != 1 {
+			t.Fatalf("expected 1 comment in `[before-3d, before)` chunk, got %d (%+v)", got, events)
+		}
+		// The single event must be the older one (the recent comment is
+		// past the upper bound).
+		c := findEventByType(events, "comment").Comment
+		if c.Content != "older" {
+			t.Errorf("Comment.Content = %q, want %q", c.Content, "older")
+		}
+	})
+
+	t.Run("BeforeIsCappedAt30Days", func(t *testing.T) {
+		// Asking for a `Before` deeper than 30 days clamps the upper bound
+		// to (now - FeedMaxLookback). With Window=3d the resulting chunk is
+		// `[now-33d, now-30d)`, so an annotation aged ~31 days ago lands
+		// inside it while a 90-day-old annotation does not.
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "before-cap", 2)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-cap-in", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"in-clamped-chunk"}`),
+			now.Add(-31*24*time.Hour),
+		)
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[1],
+			"comment", "user", "actor-cap-out", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"way-too-old"}`),
+			now.Add(-90*24*time.Hour),
+		)
+
+		// Caller asks for a `Before` 60 days back — service must clamp it
+		// to (now - FeedMaxLookback) so the 31-day-old annotation lands
+		// inside the resulting chunk while the 90-day-old one stays out.
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+			Window: 3 * 24 * time.Hour,
+			Before: now.Add(-60 * 24 * time.Hour),
+		})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "comment"); got != 1 {
+			t.Fatalf("expected 1 comment after clamping Before to -30d, got %d (%+v)", got, events)
+		}
+		c := findEventByType(events, "comment").Comment
+		if c.Content != "in-clamped-chunk" {
+			t.Errorf("Comment.Content = %q, want %q", c.Content, "in-clamped-chunk")
+		}
+	})
+
 	t.Run("WindowIsBounded", func(t *testing.T) {
 		svc, queries, pool := newService(t)
 		ctx := context.Background()

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -201,6 +201,30 @@ templ feedTimeline(p FeedProps) {
 				Showing the last { fmt.Sprintf("%d days", p.WindowDays) }.
 			</p>
 		}
+		@feedLoadOlder(p)
+	}
+}
+
+// feedLoadOlder renders the pagination affordance under the rail. Only
+// shows the button when the rail has at least one event (empty windows
+// don't get a "load older" since the user has no anchor). When the
+// earliest visible event is past the 30-day lookback ceiling we render
+// "End of feed" instead so users have a clear stop signal.
+templ feedLoadOlder(p FeedProps) {
+	if !p.OldestVisible.IsZero() {
+		<div class="flex items-center justify-center mt-3">
+			if p.AtMaxLookback {
+				<p class="text-xs text-base-content/40">End of feed</p>
+			} else {
+				<a
+					href={ templ.SafeURL(feedLoadOlderHRef(p)) }
+					class="btn btn-sm btn-ghost rounded-xl border border-base-300 text-base-content/65"
+				>
+					<i data-lucide="arrow-down" class="w-3.5 h-3.5"></i>
+					Load older activity
+				</a>
+			}
+		</div>
 	}
 }
 
@@ -987,6 +1011,18 @@ func feedFilterHRef(slug string) string {
 		return "/feed"
 	}
 	return "/feed?filter=" + slug
+}
+
+// feedLoadOlderHRef builds the href for the "Load older activity" button:
+// `/feed?before=<oldestVisible>` plus the active filter (so an active chip
+// survives pagination). The timestamp is RFC3339 so the handler's
+// `time.Parse(time.RFC3339, …)` round-trips it without any loss.
+func feedLoadOlderHRef(p FeedProps) string {
+	q := "before=" + p.OldestVisible.UTC().Format(time.RFC3339)
+	if p.Filter != "" {
+		q = "filter=" + p.Filter + "&" + q
+	}
+	return "/feed?" + q
 }
 
 // feedFilterLabel renders the chip-name string used in the active-filter

--- a/internal/templates/components/pages/feed_load_older_test.go
+++ b/internal/templates/components/pages/feed_load_older_test.go
@@ -1,0 +1,141 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedLoadOlderButton asserts the footer "Load older activity"
+// pagination affordance renders the right shape for each branch:
+//
+//   - empty rail (zero items, OldestVisible zero) → no button
+//   - in-window (oldest event < 30 days old) → button with the oldest
+//     timestamp threaded into `?before=…`, filter preserved
+//   - past the 30-day cap (AtMaxLookback) → "End of feed" sentence, no button
+//
+// Pure templ render, no DB — runs under `go test ./...`.
+func TestFeedLoadOlderButton(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	// One sync row in the rendered window — gives `feedTimeline` something
+	// to render so the load-older footer actually emits. Empty days would
+	// take the empty-state branch and skip the footer entirely.
+	syncDay := func(ts time.Time) []FeedDay {
+		return []FeedDay{{
+			Key:   ts.Format("2006-01-02"),
+			Label: "Today",
+			First: true,
+			Items: []FeedItem{{
+				Type:         "sync",
+				Timestamp:    ts,
+				TimestampStr: ts.UTC().Format(time.RFC3339),
+				Sync: &FeedSync{
+					SyncLogID:       "sync-1",
+					InstitutionName: "Wells Fargo",
+					Provider:        "plaid",
+					Status:          "success",
+					AddedCount:      3,
+					StartedAt:       ts,
+				},
+			}},
+		}}
+	}
+
+	cases := []struct {
+		name        string
+		props       FeedProps
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "in_window_renders_button_with_before_param",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Days:           syncDay(now.Add(-2 * time.Hour)),
+				TotalItems:     1,
+				OldestVisible:  now.Add(-2 * time.Hour),
+				AtMaxLookback:  false,
+			},
+			mustContain: []string{
+				"Load older activity",
+				`href="/feed?before=2026-04-28T10:00:00Z"`,
+				"Showing the last 3 days",
+			},
+			mustOmit: []string{
+				"End of feed",
+			},
+		},
+		{
+			name: "preserves_active_filter_in_load_older_href",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Days:           syncDay(now.Add(-90 * time.Minute)),
+				TotalItems:     1,
+				OldestVisible:  now.Add(-90 * time.Minute),
+				Filter:         "syncs",
+			},
+			mustContain: []string{
+				"Load older activity",
+				`href="/feed?filter=syncs&amp;before=2026-04-28T10:30:00Z"`,
+			},
+		},
+		{
+			name: "past_30_day_cap_shows_end_of_feed",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Days:           syncDay(now.Add(-31 * 24 * time.Hour)),
+				TotalItems:     1,
+				OldestVisible:  now.Add(-31 * 24 * time.Hour),
+				AtMaxLookback:  true,
+			},
+			mustContain: []string{
+				"End of feed",
+			},
+			mustOmit: []string{
+				"Load older activity",
+			},
+		},
+		{
+			name: "empty_rail_no_button",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Days:           nil,
+				TotalItems:     0,
+			},
+			mustOmit: []string{
+				"Load older activity",
+				"End of feed",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := Feed(tc.props).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes):\n%s", want, buf.Len(), html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -57,6 +57,23 @@ type FeedProps struct {
 	// is admin-only; non-admin members see the link to /transactions
 	// instead.
 	IsAdmin bool
+
+	// OldestVisible is the timestamp of the earliest event currently in the
+	// rendered window. Drives the "Load older activity" button's href —
+	// `?before=<oldestVisible.RFC3339>` rolls the window backward in
+	// `WindowDays`-sized chunks. Zero value means the rail is empty (no
+	// button should render).
+	OldestVisible time.Time
+
+	// AtMaxLookback is true when the oldest visible event is at-or-past the
+	// service-layer 30-day lookback cap. The footer renders an "End of
+	// feed" sentence instead of the load-older button so users have a
+	// clear stop signal.
+	AtMaxLookback bool
+
+	// Filter is forwarded into load-older hrefs so an active chip survives
+	// pagination. Already exists above; documented here as part of the
+	// pagination contract.
 }
 
 // FeedHero powers the at-a-glance band above the feed rail.


### PR DESCRIPTION
Adds a "Load older activity" footer button so users can scroll the home feed past the 3-day default window in 3-day chunks.

## Summary

- New `Before time.Time` field on `service.FeedEventsParams` — when set, anchors the window's upper bound at that timestamp instead of `now`. Default behaviour preserved verbatim (zero `Before` → existing path).
- Hard 30-day lookback cap exposed as `service.FeedMaxLookback`. Both the service and handler clamp `?before=…` deeper than that, so unbounded reads aren't reachable from the URL.
- Handler parses `?before=<rfc3339>`, clamps to (now − 30d), clamps future timestamps to zero, and threads it through. Items + reports are filtered against the windowed `[start, end)` bounds anchored at `Before` (or `now`).
- Templ adds `feedLoadOlder` under the rail. Renders a centered ghost button when the rail has events and the oldest visible event is < 30 days old; renders "End of feed" instead once the cap is hit; nothing when the rail is empty. Active filter chip survives via the href.

## Tests

- `internal/templates/components/pages/feed_load_older_test.go` — pure templ render, asserts the four branches (in-window button, filter preserved, end-of-feed sentence, empty rail).
- `internal/service/feed_integration_test.go` — `BeforeAnchorsUpperBound` and `BeforeIsCappedAt30Days` exercising the DB-backed window roll + clamp.

`go build ./...`, `go vet ./...`, and `go test ./...` (unit + the touched integration suite) all pass on the branch tip.

## Validation

Default `/feed` — new "Load older activity" button at the foot of the rail:

<img src="https://i.img402.dev/pvl1llzlww.jpg" width="800" alt="/feed default — Load older activity button at footer">

Paginated `/feed?before=2026-04-27T00:00:00Z` — older day-bucket (Apr 26) renders, button still visible for further pagination:

<img src="https://i.img402.dev/kv691gjjla.jpg" width="800" alt="/feed?before=… — paginated view shifts day buckets">

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./internal/admin/... ./internal/service/... ./internal/templates/...` clean
- [x] Integration: `BeforeAnchorsUpperBound`, `BeforeIsCappedAt30Days`, `WindowIsBounded` all green
- [x] Visual: button renders at footer, `?before=` shifts day buckets, active filter survives via href
- [x] No regression: zero `?before=` query → identical default-window behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)
