### PR TITLE
ui(feed): show pending pill on inline transaction-ref rows

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -496,6 +496,7 @@ func projectSampleTx(tx service.FeedSampleTx) pages.FeedTransactionRef {
 		Date:         tx.Date,
 		AccountName:  tx.AccountName,
 		Institution:  tx.Institution,
+		Pending:      tx.Pending,
 	}
 }
 

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -29,6 +29,7 @@ type FeedActivityRow struct {
 	Amount             float64
 	IsoCurrencyCode    string
 	TransactionDate    string
+	Pending            bool
 
 	AccountName     string
 	InstitutionName string
@@ -49,7 +50,7 @@ SELECT
     a.payload, a.tag_id, a.rule_id, a.session_id, a.created_at,
     COALESCE(u_via_account.name, u_direct.name, '')::text AS actor_user_name,
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
-    t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
+    t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
@@ -227,6 +228,12 @@ type FeedSampleTx struct {
 	Date         string
 	AccountName  string
 	Institution  string
+	// Pending mirrors `transactions.pending` so the feed card can render
+	// the same clock-icon pending mark used on `/transactions/{id}` and
+	// the transactions list — preliminary rows often re-show as posted
+	// later, and surfacing the lifecycle state inline gives users a
+	// "this is provisional" read.
+	Pending bool
 }
 
 // FeedRuleOutcome is one (rule, count) pair shown inline on a sync card.
@@ -437,7 +444,7 @@ SELECT
     a.payload, a.tag_id, a.rule_id, a.session_id, a.created_at,
     COALESCE(u_via_account.name, u_direct.name, '')::text AS actor_user_name,
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
-    t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
+    t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
@@ -502,6 +509,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		amount                              pgtype.Numeric
 		isoCcy                              pgtype.Text
 		txDate                              pgtype.Date
+		pending                             bool
 		accountName, institutionName        pgtype.Text
 	)
 
@@ -509,7 +517,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		&id, &shortID, &txnID, &kind, &actorType, &actorIDOpt, &actorName,
 		&payload, &tagID, &ruleID, &sessionID, &createdAt,
 		&actorUserName, &actorUpdatedAt,
-		&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate,
+		&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate, &pending,
 		&accountName, &institutionName,
 	); err != nil {
 		return FeedActivityRow{}, fmt.Errorf("scan feed activity row: %w", err)
@@ -566,6 +574,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		TransactionName:    txName,
 		MerchantName:       pgconv.TextOr(merchantName, ""),
 		IsoCurrencyCode:    pgconv.TextOr(isoCcy, "USD"),
+		Pending:            pending,
 		AccountName:        pgconv.TextOr(accountName, ""),
 		InstitutionName:    pgconv.TextOr(institutionName, ""),
 	}
@@ -772,7 +781,7 @@ func (s *Service) fetchSyncSampleTransactions(ctx context.Context, raws []syncRo
 
 	const q = `
 SELECT t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
-       t.created_at, ac.name, bc.id::text, bc.institution_name
+       t.created_at, t.pending, ac.name, bc.id::text, bc.institution_name
 FROM transactions t
 JOIN accounts ac ON ac.id = t.account_id
 JOIN bank_connections bc ON ac.connection_id = bc.id
@@ -802,11 +811,12 @@ ORDER BY t.created_at DESC
 			isoCcy            pgtype.Text
 			txDate            pgtype.Date
 			createdAt         pgtype.Timestamptz
+			pending           bool
 			accountName       pgtype.Text
 			connID            string
 			institutionName   pgtype.Text
 		)
-		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &accountName, &connID, &institutionName); err != nil {
+		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &pending, &accountName, &connID, &institutionName); err != nil {
 			return nil, err
 		}
 		t := txRow{
@@ -817,6 +827,7 @@ ORDER BY t.created_at DESC
 				Currency:     pgconv.TextOr(isoCcy, "USD"),
 				AccountName:  pgconv.TextOr(accountName, ""),
 				Institution:  pgconv.TextOr(institutionName, ""),
+				Pending:      pending,
 			},
 			ConnectionID: connID,
 			CreatedAt:    createdAt.Time.UTC(),
@@ -1239,6 +1250,7 @@ func sampleTxFromRow(r FeedActivityRow) FeedSampleTx {
 		Date:         r.TransactionDate,
 		AccountName:  r.AccountName,
 		Institution:  r.InstitutionName,
+		Pending:      r.Pending,
 	}
 }
 

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -667,6 +667,13 @@ templ feedCommentAvatar(c *FeedComment) {
 // surfaces.
 
 // feedTxRefRow renders one transaction-reference line.
+//
+// Pending transactions render a small clock-icon mark flush against the
+// amount — the same canonical pending visual used on `/transactions/{id}`
+// (`tx_row.templ`) and the transactions list (`tx_row_compact.templ`).
+// Pending rows often re-show as posted later, so surfacing the lifecycle
+// state inline gives users a "this is provisional" read without leaving
+// the feed.
 templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 	<a
 		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
@@ -680,8 +687,18 @@ templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 				<span class="text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>
 			}
 		</span>
-		<span class={ "tabular-nums font-medium shrink-0", feedAmountClass(tx.Amount) }>
-			{ feedAmountWithSign(tx.Amount, tx.Currency) }
+		<span class="flex items-center gap-1 shrink-0">
+			if tx.Pending {
+				<i
+					data-lucide="clock"
+					class="w-3 h-3 shrink-0 text-warning/70"
+					title="Pending — not yet posted"
+				></i>
+				<span class="sr-only">(pending)</span>
+			}
+			<span class={ "tabular-nums font-medium", feedAmountClass(tx.Amount) }>
+				{ feedAmountWithSign(tx.Amount, tx.Currency) }
+			</span>
 		</span>
 	</a>
 }

--- a/internal/templates/components/pages/feed_pending_test.go
+++ b/internal/templates/components/pages/feed_pending_test.go
@@ -1,0 +1,115 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedTxRefRowPendingPill asserts the inline transaction-reference row
+// renders the canonical clock-icon pending mark when the underlying
+// transaction is pending, and renders cleanly without it when posted.
+//
+// The clock-icon convention is the same used by `tx_row.templ` and
+// `tx_row_compact.templ` — pending rows often re-show as posted later so
+// the feed needs to surface the lifecycle state alongside the amount.
+//
+// Pure templ render, no DB. Drives the row through a sync-card so the
+// outer scaffolding (Feed) exercises the same branch the page uses.
+func TestFeedTxRefRowPendingPill(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	feedWith := func(tx FeedTransactionRef) FeedProps {
+		ts := now.Add(-2 * time.Hour)
+		return FeedProps{
+			Now:            now,
+			WindowDays:     3,
+			HasConnections: true,
+			TotalItems:     1,
+			Days: []FeedDay{{
+				Key:   ts.Format("2006-01-02"),
+				Label: "Today",
+				First: true,
+				Items: []FeedItem{{
+					Type:         "sync",
+					Timestamp:    ts,
+					TimestampStr: ts.UTC().Format(time.RFC3339),
+					Sync: &FeedSync{
+						SyncLogID:          "sync-1",
+						InstitutionName:    "Wells Fargo",
+						Provider:           "plaid",
+						Status:             "success",
+						AddedCount:         1,
+						StartedAt:          ts,
+						SampleTransactions: []FeedTransactionRef{tx},
+					},
+				}},
+			}},
+		}
+	}
+
+	cases := []struct {
+		name        string
+		tx          FeedTransactionRef
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "pending_renders_clock_icon_and_sr_text",
+			tx: FeedTransactionRef{
+				ShortID:      "tx12345a",
+				MerchantName: "Whole Foods",
+				Amount:       42.10,
+				Currency:     "USD",
+				AccountName:  "Chase Checking",
+				Pending:      true,
+			},
+			mustContain: []string{
+				`data-lucide="clock"`,
+				"text-warning/70",
+				"Pending — not yet posted",
+				"(pending)",
+				"Whole Foods",
+			},
+		},
+		{
+			name: "posted_omits_clock_icon",
+			tx: FeedTransactionRef{
+				ShortID:      "tx12345b",
+				MerchantName: "Whole Foods",
+				Amount:       42.10,
+				Currency:     "USD",
+				AccountName:  "Chase Checking",
+				Pending:      false,
+			},
+			mustContain: []string{
+				"Whole Foods",
+			},
+			mustOmit: []string{
+				"Pending — not yet posted",
+				"(pending)",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := Feed(feedWith(tc.tx)).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes):\n%s", want, buf.Len(), html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -142,6 +142,11 @@ type FeedTransactionRef struct {
 	Date         string
 	AccountName  string
 	Institution  string
+	// Pending mirrors `transactions.pending`. When true the inline tx-ref
+	// row renders the same small clock-icon mark used on the per-tx page
+	// and the transactions list, signalling the row is still preliminary
+	// (provider may re-issue it as posted later).
+	Pending bool
 }
 
 // FeedSync is the sync-card payload. Inline transaction samples and rule


### PR DESCRIPTION
Wire `transactions.pending` through to the inline tx-ref row on `/feed` so users can tell at-a-glance that a sample row is preliminary — pending rows often re-show as posted later, and without the mark a refunded-then-reposted card looks identical to a clean settled one.

## Summary

- Service: `fetchFeedAnnotations` and `fetchSyncSampleTransactions` now select `t.pending`. New `FeedSampleTx.Pending` and `FeedActivityRow.Pending` carry it through both grouped (annotations) and sync-sample paths.
- View model: `pages.FeedTransactionRef.Pending` mirrors the service flag; `projectSampleTx` populates it for every event type (sync, agent_session, bulk_action, comment).
- Templ: `feedTxRefRow` renders the same canonical clock-icon pending visual the per-tx page (`tx_row.templ`) and transaction list (`tx_row_compact.templ`) already use — Lucide `clock` at `w-3 h-3 text-warning/70` flush-left of the amount, plus a `(pending)` sr-only label. Posted rows are unchanged.
- Test: new `feed_pending_test.go` covers both the pending-renders-clock-icon and posted-omits-clock-icon variants via a `Feed(...)` render against a one-row sync card.

## Test plan

- [x] `templ generate && go build ./... && go vet ./...` clean
- [x] `go test ./internal/admin/... ./internal/service/... ./internal/templates/... -count=1` green
- [x] Full `go test ./...` green
- [ ] Visual check skipped — dev DB has no pending rows in the current window. Render covered by `TestFeedTxRefRowPendingPill/{pending,posted}`.

## Caveats

- Bottom of the stack (#957) must merge before this PR's CI can pass — same constraint as the rest of the feed-polish stack.
- No auto-merge.

Generated with [Claude Code](https://claude.com/claude-code)
