### PR TITLE
ui(feed): lift card surfaces in dark mode for WCAG contrast

### DIFF
--- a/input.css
+++ b/input.css
@@ -235,8 +235,21 @@
   }
 
   @media (prefers-color-scheme: dark) {
+    /* In dark mode the body background equals --color-base-100 (oklch 0.205),
+     * so a stock .bb-card painted bg-base-100 is invisible — same colour as
+     * the page underneath. Lift the card surface 4–5% toward white via
+     * color-mix so cards/tiles read as elevated panels. Targeted (no light-
+     * mode change). Pairs with the body=base-100 dark-theme convention; the
+     * cleaner alternative (flip body to base-200) was rejected as too high
+     * blast-radius. See PR for /feed dark-mode contrast pass. */
+    .bb-card {
+      background-color: color-mix(in oklch, var(--color-base-100) 92%, white 8%);
+    }
     .bb-card--interactive:hover {
       border-color: oklch(0.35 0 0);
+      /* Hover should read as more elevated than rest, not less. Default
+       * bg-base-200/50 in dark mode dips below the body — reverse that. */
+      background-color: color-mix(in oklch, var(--color-base-100) 86%, white 14%);
     }
   }
 
@@ -731,6 +744,18 @@
     @apply px-2 py-1 border-b border-base-200 whitespace-nowrap sm:whitespace-normal;
   }
   .bb-comment-bubble tbody tr:last-child td { @apply border-b-0; }
+
+  /* Dark-mode lift: in dark theme base-200 sits *below* the body bg
+   * (body = base-100 = oklch 0.205, base-200 = oklch 0.145), so the
+   * default base-200 comment bubble reads as a recessed hole. Bump the
+   * surface and border so the bubble floats above the conversation
+   * background. Light-mode untouched. */
+  @media (prefers-color-scheme: dark) {
+    .bb-comment-bubble {
+      background: color-mix(in oklch, var(--color-base-100) 88%, white 12%);
+      border-color: color-mix(in oklch, var(--color-base-300) 85%, white 15%);
+    }
+  }
 
   /* ── Activity timeline — prominent (main-content) variant ──
    * Used by the transaction-detail page to promote the activity timeline
@@ -2984,6 +3009,28 @@
   left: -7px;
   border-width: 8px 8px 8px 0;
   border-color: transparent var(--color-base-100) transparent transparent;
+}
+
+/* Dark-mode contrast lift for the prominent timeline's comment + composer
+ * cards. Both rules above paint `var(--color-base-100)`, which in the dark
+ * theme is identical to the body background — the cards disappear. Mix in
+ * 8% white so they read as elevated surfaces, matching the `.bb-card` lift
+ * used elsewhere on /feed. Light-mode is unaffected. */
+@media (prefers-color-scheme: dark) {
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1,
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 {
+    background: color-mix(in oklch, var(--color-base-100) 92%, white 8%);
+  }
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after,
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::after {
+    border-right-color: color-mix(in oklch, var(--color-base-100) 92%, white 8%);
+  }
+  /* Header bar inside the comment card uses base-200 60% — in dark that
+   * is base-200 (oklch 0.145) which is darker than the lifted card. Bump
+   * it slightly so the header reads as a defined band rather than a hole. */
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 > div:first-child {
+    background: color-mix(in oklch, var(--color-base-100) 86%, white 14%);
+  }
 }
 
 /* ── Activity timeline — inline chip fix ──

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -473,7 +473,7 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 		</div>
 	}
 	if s.Status == "error" && s.ErrorMessage != "" {
-		<div class="mt-1.5 text-error/90 bg-error/8 rounded-lg px-2.5 py-1.5 border border-error/20">
+		<div class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25">
 			<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
 			{ s.ErrorMessage }
 		</div>


### PR DESCRIPTION
Lifts card and comment-bubble surfaces in dark mode so /feed cards stop blending into the page background and clear WCAG AA contrast.

## Why

Root cause: the dark theme defines body bg = `oklch(0.205)` which is *also* `--color-base-100`. Every `.bb-card` painted `bg-base-100` therefore has the exact same colour as the page underneath. Hero tiles, the empty-state cards, the prominent timeline's comment cards, and the composer card all read as "no card at all" in dark mode. Light mode is fine because there `body=base-200` and cards=base-100 differ by ~3%.

## Fix (option B from the analysis)

Scoped lift in `@media (prefers-color-scheme: dark)` blocks — never touches light mode. Three targeted CSS rules:

- `.bb-card` background → `color-mix(in oklch, base-100 92%, white 8%)`. Tiles read as elevated panels.
- `.bb-comment-bubble` background → 12% white mix (the bubble was painting `base-200/75`, which in dark sits *below* the body bg — a recessed hole).
- `.bb-timeline-prominent` comment-card + composer-card chrome (and the tail triangle's right border) → 8% white mix, plus a slightly stronger header-bar (14% mix) so the "Name commented X ago" bar reads as a band rather than blending with the lifted card.

Also: bumped the inline sync-error block from `bg-error/8 border-error/20` to `bg-error/15 border-error/25`. The 8% tint was barely visible against the body in dark mode.

The cleaner alternative — flipping the dark theme's body bg from `base-100` to `base-200` — was rejected (option A): too high blast radius, every page changes. Comments in `input.css` document the trade-off so a future pass can revisit.

## Screenshots

<table>
<tr><th>Dark — before</th><th>Dark — after</th></tr>
<tr>
<td><img src="https://i.img402.dev/ub2kgbe4vt.jpg" width="420" alt="/feed dark mode before — cards invisible against body"></td>
<td><img src="https://i.img402.dev/89xq1a3if0.jpg" width="420" alt="/feed dark mode after — hero tiles, comment cards, sync-error block all readable"></td>
</tr>
</table>

Light mode regression check (no change expected):

<img src="https://i.img402.dev/0dru2qpqip.jpg" width="800" alt="/feed light mode after — unchanged">

## Test plan

- [x] `templ generate && go build ./... && go vet ./...`
- [x] `go test ./internal/admin/... ./internal/service/... ./internal/templates/... -count=1`
- [x] Captured `before/after` screenshots in dark mode using Chrome DevTools MCP `emulate({colorScheme: dark})`. Confirmed cards read as distinct elevated surfaces post-fix.
- [x] Verified light mode is unchanged (all overrides are inside `@media (prefers-color-scheme: dark)`).

## Caveats

- This pass is scoped to /feed-visible classes (`.bb-card`, `.bb-comment-bubble`, prominent timeline). Other pages that rely on `bg-base-100` cards in dark mode (e.g. `/transactions/{id}` activity timeline, settings panels) inherit the `.bb-card` lift automatically since the rule is class-scoped, not page-scoped — but I haven't audited each of them. A future iteration may want to re-validate those.
- The "Failing since 1 day ago · 49 attempts" retry-note line uses `text-base-content/55` which is fine in dark; left untouched.
- `bg-error/8` is also used on `/connections/{id}` and `/users` — left untouched there. Only the /feed inline sync-error row was bumped, since it's the most prominent error surface.
