### PR TITLE
ui(nav): replace static Feed New badge with unread-report count

### DIFF
--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -55,7 +55,9 @@ templ Nav(p NavProps) {
 		<a href="/feed" class={ "bb-sidebar-link", navActive(p.CurrentPage, "feed") }>
 			<i data-lucide="rss"></i>
 			<span class="flex-1">Feed</span>
-			<span class="bb-nav-badge" title="New activity-style home">New</span>
+			if p.UnreadReports > 0 {
+				<span class="bb-nav-badge" title={ fmt.Sprintf("%d unread reports", p.UnreadReports) }>{ badgeCount(p.UnreadReports) }</span>
+			}
 		</a>
 		<a href="/transactions" class={ "bb-sidebar-link", navActive(p.CurrentPage, "transactions") }>
 			<i data-lucide="receipt"></i> Transactions


### PR DESCRIPTION
Replace the static "New" badge on the sidebar Feed link with the live unread-report count, and hide the badge entirely when the inbox is clean — so it stops reading as a permanent marketing chip after launch.

## Summary

- Reuse `p.UnreadReports` (already populated by `NavBadgesMiddleware`) and the shared `badgeCount` helper, mirroring the Reports nav entry one row below.
- The badge only renders when `UnreadReports > 0`. Zero unread reports → no trailing badge on the Feed link, restoring a clean sidebar.
- Same `bb-nav-badge` class as before, so visual weight matches the Reports badge — they read as a single coordinated affordance.

## Visuals

Sidebar — clean (zero unread reports):

<img src="https://i.img402.dev/38tsmbhl39.jpg" width="800" alt="Feed nav link with no badge when there are zero unread reports">

Sidebar — with unread reports (badge synthesized in DevTools to mimic the rendered output, since the dev DB has no agent_reports rows; matches the templ output exactly):

<img src="https://i.img402.dev/91g6klclf7.jpg" width="800" alt="Feed nav link with unread-report count badge">

## Test plan

- [x] `templ generate && go build ./... && go vet ./... && go test ./...` all green.
- [x] `/feed` renders without the badge when `UnreadReports == 0`.
- [x] Reports nav entry's badge unchanged (same template, same helper).
- [x] No other nav entries touched.
