### PR TITLE
ui(feed): mobile fidelity polish — hero, filters, banner, bubbles

### DIFF
--- a/input.css
+++ b/input.css
@@ -696,6 +696,7 @@
     border-radius: 1rem;
     border-top-left-radius: 0.375rem;
     word-break: break-word;
+    overflow-wrap: anywhere;
   }
   /* Markdown element styling inside a comment bubble. Tuned to the
      bubble's compact scale — paragraph margins are tighter than the

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -39,7 +39,7 @@ templ Feed(p FeedProps) {
 // feedActiveFilterBanner makes the active chip explicit above the rail.
 // The chip strip alone is easy to miss when scanning a sparse rail.
 templ feedActiveFilterBanner(p FeedProps) {
-	<div class="flex items-center gap-2 text-xs text-base-content/60 mb-3 px-1">
+	<div class="flex flex-wrap items-center gap-2 text-xs text-base-content/60 mb-3 px-1">
 		<i data-lucide="filter" class="w-3 h-3"></i>
 		<span>Showing only: <span class="font-medium text-base-content/80">{ feedFilterLabel(p.Filter) }</span></span>
 		<a href="/feed" class="text-primary/80 hover:text-primary no-underline ml-1">Clear filter</a>
@@ -53,7 +53,8 @@ templ feedHero(p FeedProps) {
 			<div class="min-w-0">
 				<h1 class="text-3xl font-bold tracking-tight text-base-content">Feed</h1>
 				<p class="text-sm text-base-content/55 mt-1">
-					Everything that happened in your breadbox &middot; { p.Hero.Generated }
+					<span>Everything that happened in your breadbox</span>
+					<span class="hidden sm:inline">&middot; { p.Hero.Generated }</span>
 				</p>
 			</div>
 			<div class="flex items-center gap-2 shrink-0">
@@ -102,7 +103,7 @@ templ feedHeroSyncTile(p FeedProps) {
 			<span class={ "ml-auto inline-block w-1.5 h-1.5 rounded-full", feedSyncDotClass(p.Hero.LastSyncStatus) } aria-hidden="true"></span>
 		</div>
 		if p.Hero.LastSyncRel != "" {
-			<div class="text-2xl font-bold tabular-nums tracking-tight mt-1.5">{ p.Hero.LastSyncRel }</div>
+			<div class="text-xl sm:text-2xl font-bold tabular-nums tracking-tight mt-1.5">{ p.Hero.LastSyncRel }</div>
 			<div class="text-[0.65rem] text-base-content/45 mt-1 truncate">
 				{ feedSyncSubLine(p.Hero.LastSyncStatus, p.Hero.LastSyncInstitution) }
 			</div>
@@ -113,7 +114,7 @@ templ feedHeroSyncTile(p FeedProps) {
 				</div>
 			}
 		} else {
-			<div class="text-2xl font-bold tabular-nums tracking-tight mt-1.5 text-base-content/30">—</div>
+			<div class="text-xl sm:text-2xl font-bold tabular-nums tracking-tight mt-1.5 text-base-content/30">—</div>
 			<div class="text-[0.65rem] text-base-content/45 mt-1">No syncs yet</div>
 		}
 	</a>
@@ -155,7 +156,7 @@ templ feedAlertCard(a FeedAlert) {
 
 // ── Filters ───────────────────────────────────────────────────────────────
 templ feedFilters(p FeedProps) {
-	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto" aria-label="Feed filters">
+	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto [mask-image:linear-gradient(to_right,black_85%,transparent)] sm:[mask-image:none]" aria-label="Feed filters">
 		@feedFilterChip("All", "", "layers", p.Filter)
 		@feedFilterChip("Syncs", "syncs", "refresh-cw", p.Filter)
 		@feedFilterChip("Reports", "reports", "file-text", p.Filter)
@@ -473,7 +474,7 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 		</div>
 	}
 	if s.Status == "error" && s.ErrorMessage != "" {
-		<div class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25">
+		<div class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25 break-words">
 			<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
 			{ s.ErrorMessage }
 		</div>
@@ -679,9 +680,9 @@ templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
 		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content transition-colors no-underline group/txref"
 	>
-		<span class="flex items-center gap-2 min-w-0 flex-1">
+		<span class="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
 			<i data-lucide="receipt" class="w-3 h-3 text-base-content/35 shrink-0"></i>
-			<span class={ "font-medium truncate", templ.KV("text-base-content/65", dimmed) }>{ feedNonEmpty(tx.MerchantName, tx.Name) }</span>
+			<span class={ "font-medium truncate min-w-0", templ.KV("text-base-content/65", dimmed) }>{ feedNonEmpty(tx.MerchantName, tx.Name) }</span>
 			if tx.AccountName != "" {
 				<span class="text-base-content/35 hidden sm:inline">·</span>
 				<span class="text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>


### PR DESCRIPTION
Mobile fidelity polish for `/feed` — seven targeted fixes against the iPhone-class viewport (360-390px) discovered in the iteration-12 audit. No desktop regression.

## Summary

- **Hero "Last Sync" tile** — `text-xl sm:text-2xl` so "21 minutes ago" / "2 hours ago" no longer wraps and shoves the status dot below at 390px. Same fix for the empty-state em-dash.
- **Hero subtitle** — split into two spans; the date suffix (`· Tue, Apr 28`) is `hidden sm:inline` so the line stays single at iPhone widths.
- **Sample tx merchant overflow** — added `overflow-hidden` to the `feedTxRefRow` outer truncate ancestor and `min-w-0` to the merchant span so long names hard-truncate inside narrow rails.
- **Filter chip overflow affordance** — soft mask-image gradient on the right edge `<sm` so off-screen chips are discoverable; `sm:[mask-image:none]` keeps desktop pristine.
- **Comment bubble word-break** — added `overflow-wrap: anywhere` to `.bb-comment-bubble` (already had `word-break: break-word`) so unbroken URLs/strings can't expand a bubble past its container.
- **Active filter banner wrap** — `flex-wrap` on the parent so `Showing only: comments · Clear filter` can drop the link to a new line under pressure.
- **Sync error block** — added `break-words` directly so long teller / plaid error URLs wrap inside the error tile at every breakpoint.

## Screenshots

### Mobile — 390px

<img src="https://i.img402.dev/s34k3hymkf.jpg" width="390" alt="feed at 390px — hero/filters/timeline">

### Mobile — 360px

<img src="https://i.img402.dev/48e1hercgs.jpg" width="360" alt="feed at 360px — hero/filters/timeline">

### Mobile — 360px with active filter banner

<img src="https://i.img402.dev/82a0nixs5q.jpg" width="360" alt="feed at 360px with comments filter active">

### Tablet — 768px

<img src="https://i.img402.dev/5gqv67ydzl.jpg" width="768" alt="feed at 768px — desktop subtitle restored">

### Desktop — 1280px (no regression)

<img src="https://i.img402.dev/dv6mond9t8.jpg" width="800" alt="feed at 1280px — no regression">

## Test plan

- [x] `templ generate && go build ./... && go vet ./... && go test ./...` green
- [x] 390px: subtitle and Last Sync value render on single lines
- [x] 360px: filter chips show fade-out affordance on the right edge
- [x] 768px: subtitle gets the "· Tue, Apr 28" date suffix back
- [x] 1280px desktop: visually identical to baseline
- [ ] Verify in dark mode (no class change touches dark theme)

## Caveats

- `templ fmt` collapsed the literal " " before `&middot;` — browsers still collapse the inter-tag whitespace to a single space, so the rendered output reads "...breadbox · Tue, Apr 28" at `>=sm`.
- Out-of-scope follow-ups deferred: none observed during this pass.
