### PR TITLE
a11y(feed): aria labels, focus rings, active-chip semantics

### DIFF
--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -63,11 +63,12 @@ templ feedHero(p FeedProps) {
 					class="btn btn-sm btn-ghost rounded-xl"
 					onclick="window.location.reload()"
 					title="Refresh"
+					aria-label="Refresh feed"
 				>
 					<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
 					<span class="hidden sm:inline">Refresh</span>
 				</button>
-				<a href="/connections/new" class="btn btn-sm btn-primary rounded-xl">
+				<a href="/connections/new" class="btn btn-sm btn-primary rounded-xl" aria-label="Connect a new bank">
 					<i data-lucide="plus" class="w-3.5 h-3.5"></i>
 					<span class="hidden sm:inline">Connect bank</span>
 				</a>
@@ -96,7 +97,7 @@ templ feedHeroTile(icon, label, value, sub string) {
 }
 
 templ feedHeroSyncTile(p FeedProps) {
-	<a href="/logs?tab=syncs" class="bb-card bb-card--interactive p-4 no-underline group block">
+	<a href="/logs?tab=syncs" class="bb-card bb-card--interactive p-4 no-underline group block" aria-label="Last sync — view sync logs">
 		<div class="flex items-center gap-2">
 			<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content/40"></i>
 			<div class="text-[0.65rem] uppercase tracking-wider text-base-content/40">Last sync</div>
@@ -169,7 +170,10 @@ templ feedFilters(p FeedProps) {
 templ feedFilterChip(label, slug, icon, current string) {
 	<a
 		href={ templ.SafeURL(feedFilterHRef(slug)) }
-		class={ "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors no-underline whitespace-nowrap shrink-0",
+		if current == slug {
+			aria-current="page"
+		}
+		class={ "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors no-underline whitespace-nowrap shrink-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2",
 			templ.KV("bg-primary/10 border-primary/40 text-primary", current == slug),
 			templ.KV("border-base-300 text-base-content/65 hover:bg-base-200/70", current != slug) }
 	>
@@ -474,7 +478,7 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 		</div>
 	}
 	if s.Status == "error" && s.ErrorMessage != "" {
-		<div class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25 break-words">
+		<div role="alert" class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25 break-words">
 			<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
 			{ s.ErrorMessage }
 		</div>
@@ -678,7 +682,7 @@ templ feedCommentAvatar(c *FeedComment) {
 templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 	<a
 		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
-		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content transition-colors no-underline group/txref"
+		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content transition-colors no-underline group/txref focus-visible:bg-base-200/50 focus-visible:outline-none rounded-md"
 	>
 		<span class="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
 			<i data-lucide="receipt" class="w-3 h-3 text-base-content/35 shrink-0"></i>


### PR DESCRIPTION
A focused accessibility pass on `/feed` — fills aria/focus gaps without touching visual layout.

## Summary

Iteration 14 in the feed-polish stack. All changes in `feed.templ`:

- **Icon-only buttons get aria-labels** — `Refresh` button → `Refresh feed`; `Connect bank` link → `Connect a new bank`. Mobile collapses these to icons only via `hidden sm:inline`, so SRs needed an explicit name.
- **Last-sync KPI tile** (a `<a>` wrapping a stat card) gets `aria-label="Last sync — view sync logs"` so SRs read the link's purpose, not the entire tile content.
- **Filter chips** — active chip now carries `aria-current="page"`; all chips get `focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2` so keyboard nav has a visible ring.
- **Sample tx ref rows** (`feedTxRefRow`) — anchors get `focus-visible:bg-base-200/50 focus-visible:outline-none rounded-md` so the highlighted state is obvious without a default browser outline.
- **Sync error blocks** (`feedSyncBody` error branch) get `role="alert"` so screen readers announce failures inline.

## Verified-only (no edits)

- Pending pill — clock icon + sr-only `(pending)` already present.
- Actor avatars — meaningful `alt={ name + " avatar" }` + `title` already present.
- Day separators — `role="separator" aria-label={ label }` already correct in `TimelineDay`.
- Connection alert card — `role="alert"` already present.
- "Fix" button on connection alerts has visible text — no aria needed.
- "Load older activity" link text reads sensibly out of context.

## Visual evidence

Tab focus on the "Reports" filter chip — focus-visible outline (primary, 2px, offset 2px) + page layout intact:

<img src="https://i.img402.dev/yrazovqtx1.png" width="500" alt="/feed with keyboard focus on Reports chip — focus-visible outline visible">

## Tests

- `templ generate && go build ./... && go vet ./...` — clean.
- `go test ./internal/admin/... ./internal/service/... ./internal/templates/... -count=1` — green.
- Live verification on a local server: `aria-current="page"` resolves to `All`, all aria-labels query-selectable, sync-error blocks return as `role="alert"`, focus-visible matches and applies the primary outline color.

## Caveats / follow-ups (out of scope)

- daisyUI's default `:focus-visible` rule sets a near-black outline that is overridden by `outline-primary` in the themes that have a non-black primary; in this theme the primary happens to be near-black, so the ring color matches the daisy default. Picking a more contrasty focus token is a global design call, not a feed-only change.
- A wider a11y audit (heading levels, landmark roles, color contrast tokens) was explicitly out of scope and is not included here.
- No automated axe-core run — Chrome DevTools MCP doesn't ship one and the in-repo tooling doesn't include axe.
