### PR TITLE
feat(feed): fold agent runs into one card via wider bucket + report-anchoring

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -78,19 +78,39 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// 1. Grouped events from the service. Run this first so we can decide
-		// whether the (relatively expensive) tag + category lookups are even
-		// needed — they only feed bulk_action subject rendering. Skipping
-		// them on the common no-bulk path saves 5-10ms per request.
+		// 1. Reports — windowed to match the feed bound. Fetched ahead of
+		// the events call so the service can fold matching reports into
+		// bulk_action / agent_session events (one card per agent run
+		// instead of two adjacent cards). Skipped under the
+		// syncs/comments/sessions/me chips, which scope the page to events
+		// the service layer produces.
+		var reports []service.AgentReportResponse
+		if filter == "" || filter == "reports" {
+			t0 := time.Now()
+			var rerr error
+			reports, rerr = svc.ListAgentReports(ctx, 50)
+			qReports = time.Since(t0)
+			if rerr != nil {
+				a.Logger.Error("feed: list agent reports", "error", rerr)
+			}
+		}
+
+		// 2. Grouped events from the service. Run after the report fetch so
+		// the service can fold matching reports into bulk_action /
+		// agent_session events. Reports that don't fold into anything come
+		// back via `leftoverReports` for standalone-card rendering. We also
+		// decide here whether the (relatively expensive) tag + category
+		// lookups are needed — they only feed bulk_action subject rendering.
+		// Skipping them on the common no-bulk path saves 5-10ms per request.
 		t0 := time.Now()
-		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+		events, leftoverReports, err := svc.ListFeedEventsWithReports(ctx, service.FeedEventsParams{
 			Window:        window,
 			BulkThreshold: 3,
 			SampleLimit:   5,
 			Filter:        filter,
 			ActorID:       sessionActorID,
 			Before:        beforeTime,
-		})
+		}, reports)
 		qEvents = time.Since(t0)
 		if err != nil {
 			a.Logger.Error("feed: list events", "error", err)
@@ -130,19 +150,6 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			// no-op stubs so the call site stays simple.
 			categoryDetail = func(string) categoryDisplay { return categoryDisplay{} }
 			tagDisplayFn = func(string) tagDisplay { return tagDisplay{} }
-		}
-
-		// 2. Reports — windowed to match the feed bound. Skipped under the
-		// syncs/comments/sessions/me chips, which scope the page to events
-		// the service layer produces.
-		var reports []service.AgentReportResponse
-		if filter == "" || filter == "reports" {
-			t0 = time.Now()
-			reports, err = svc.ListAgentReports(ctx, 50)
-			qReports = time.Since(t0)
-			if err != nil {
-				a.Logger.Error("feed: list agent reports", "error", err)
-			}
 		}
 
 		// 3. Connection alerts + empty-state meta — current state, not
@@ -200,8 +207,11 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// 5. Append reports as their own feed items.
-		for _, rep := range reports {
+		// 5. Append leftover (un-folded) reports as their own feed items.
+		// Reports that the service folded into a bulk_action / agent_session
+		// card are NOT in `leftoverReports` — they render as part of that
+		// card's headline.
+		for _, rep := range leftoverReports {
 			if rep.CreatedAt == "" {
 				continue
 			}
@@ -480,6 +490,14 @@ func projectFeedAgentSession(s *service.FeedAgentSessionEvent) *pages.FeedAgentS
 		Commented:          s.KindCounts["comment"],
 		RuleApplied:        s.KindCounts["rule_applied"],
 	}
+	if s.Report != nil {
+		out.ReportID = s.Report.ID
+		out.ReportShortID = s.Report.ShortID
+		out.ReportTitle = s.Report.Title
+		out.ReportPriority = s.Report.Priority
+		out.ReportTags = s.Report.Tags
+		out.ReportIsUnread = s.Report.IsUnread
+	}
 	out.SampleTransactions = make([]pages.FeedTransactionRef, 0, len(s.SampleTransactions))
 	for _, tx := range s.SampleTransactions {
 		out.SampleTransactions = append(out.SampleTransactions, projectSampleTx(tx))
@@ -488,6 +506,10 @@ func projectFeedAgentSession(s *service.FeedAgentSessionEvent) *pages.FeedAgentS
 }
 
 func projectFeedBulkAction(b *service.FeedBulkActionEvent, tagDisplayFn func(string) tagDisplay, categoryDetail func(string) categoryDisplay) *pages.FeedBulkAction {
+	kindCounts := make(map[string]int, len(b.KindCounts))
+	for k, v := range b.KindCounts {
+		kindCounts[k] = v
+	}
 	out := &pages.FeedBulkAction{
 		ActorName:          b.ActorName,
 		ActorType:          b.ActorType,
@@ -495,8 +517,17 @@ func projectFeedBulkAction(b *service.FeedBulkActionEvent, tagDisplayFn func(str
 		ActorAvatarVersion: b.ActorAvatarVersion,
 		Kind:               b.Kind,
 		Count:              b.Count,
+		KindCounts:         kindCounts,
 		StartedAt:          b.StartedAt,
 		EndedAt:            b.EndedAt,
+	}
+	if b.Report != nil {
+		out.ReportID = b.Report.ID
+		out.ReportShortID = b.Report.ShortID
+		out.ReportTitle = b.Report.Title
+		out.ReportPriority = b.Report.Priority
+		out.ReportTags = b.Report.Tags
+		out.ReportIsUnread = b.Report.IsUnread
 	}
 	for _, sub := range b.Subjects {
 		display := pages.FeedBulkSubject{

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -168,19 +168,43 @@ type FeedAgentSessionEvent struct {
 	KindCounts map[string]int
 
 	SampleTransactions []FeedSampleTx
+
+	// Report, when non-nil, is an agent_report whose session_id matches
+	// this session. Populated by ListFeedEvents so a reporting agent run
+	// surfaces as a single feed row headlined by the report's title — the
+	// alternative (a separate report card adjacent to the session card) is
+	// noisy on the timeline.
+	Report *FeedReportRef
 }
 
-// FeedBulkActionEvent represents ≥ N annotations from the same actor of
-// the same kind within a soft time-bucket — typically a human running a
-// bulk recategorisation or an agent making changes outside an MCP session.
+// FeedBulkActionEvent represents ≥ N annotations from the same actor
+// within a soft time-bucket — typically a human running a bulk
+// recategorisation or an agent making changes outside an MCP session.
+//
+// As of iteration 13 the soft bucket is keyed by (actor, time-window) only
+// — the actor's `kind` is *not* part of the bucket key. A single agent run
+// that categorises 5 rows, removes a tag from 8, and updates 8 more in the
+// same 15-minute window collapses into one bulk_action card whose
+// `KindCounts` map exposes the per-kind breakdown for inline rendering
+// ("5 categorised · 8 tag-removed · 8 updated"). `Kind` is kept for the
+// homogeneous-bucket code path: when every annotation in the bucket
+// shares one kind the templ renders the dedicated verb/subject phrasing,
+// otherwise it falls back to the generic breakdown line.
 type FeedBulkActionEvent struct {
 	ActorName          string
 	ActorType          string
 	ActorID            string
 	ActorAvatarVersion string
 
-	Kind  string // "tag_added" | "tag_removed" | "category_set" | "rule_applied"
+	// Kind is the homogeneous kind of every annotation in this bucket, or
+	// "mixed" when the bucket folds annotations across kinds.
+	Kind  string
 	Count int
+
+	// KindCounts breaks the bucket's annotations down by kind so the card
+	// can render the breakdown line ("5 categorised · 8 tag-removed · 8
+	// updated") when the bucket spans multiple kinds.
+	KindCounts map[string]int
 
 	// Subjects is the deduped list of subject names (tag names, category
 	// names, rule names) that were applied. When all rows share one
@@ -193,6 +217,26 @@ type FeedBulkActionEvent struct {
 	EndedAt   time.Time
 
 	SampleTransactions []FeedSampleTx
+
+	// Report, when non-nil, is an agent_report whose actor + window
+	// matches this bucket. Folding the report in lets a reporting agent
+	// run render as a single card headlined by the report title rather
+	// than the generic "X categorised, Y tagged" line.
+	Report *FeedReportRef
+}
+
+// FeedReportRef is the slim projection of an agent report folded into a
+// bulk_action / agent_session card. The handler still owns the canonical
+// report card (rendered when the report wasn't folded into anything) — this
+// shape only carries enough to display the title + priority + tags inline
+// and a link to the full report.
+type FeedReportRef struct {
+	ID       string
+	ShortID  string
+	Title    string
+	Priority string
+	Tags     []string
+	IsUnread bool
 }
 
 // FeedBulkSubject is one (subject, count) pair inside a bulk-action card.
@@ -278,6 +322,18 @@ type FeedEventsParams struct {
 // annotations table for households with years of history.
 const FeedMaxLookback = 30 * 24 * time.Hour
 
+// feedSoftBucketWindow is the wall-clock window used by the unsessioned
+// soft-bucket grouping in `groupUnsessionedAnnotations`. An actor's
+// annotations within one window collapse into a single bulk_action card.
+//
+// 15 minutes is wide enough to capture an agent run end-to-end (categorise
+// → tag → comment → write report → leave) while still being narrow enough
+// that a human editing throughout the day stays as distinct buckets per
+// hour. Iteration 12 used 5 minutes which fragmented agent runs into 3-4
+// adjacent cards on the rail; widening collapsed those into one card per
+// run.
+const feedSoftBucketWindow = 15 * time.Minute
+
 // ListFeedEvents returns grouped FeedEvents for the home Feed page,
 // already ordered newest-first.
 //
@@ -291,16 +347,41 @@ const FeedMaxLookback = 30 * 24 * time.Hour
 //     into a single AgentSession event regardless of how many annotations
 //     it produced.
 //  3. Soft-bucket the remaining (un-sessioned) annotations by
-//     `(actor_id, kind, floor(time / 5min))`. Buckets with ≥ BulkThreshold
-//     events become BulkAction events; the rest of the un-sessioned
-//     annotations are dropped UNLESS they're standalone comments — those
-//     pass through as Comment events because every comment is high-signal.
+//     `(actor_id, floor(time / feedSoftBucketWindow))` — note that `kind`
+//     is intentionally absent from the key so a single agent run that
+//     categorises some rows and removes a tag from others collapses into
+//     ONE bulk_action card with a per-kind breakdown. Buckets with
+//     ≥ BulkThreshold events become BulkAction events; sub-threshold
+//     buckets pass through standalone comments individually.
 //  4. Sync logs from the window become Sync events with inline transaction
 //     samples and `RuleOutcomes` lifted from `sync_logs.rule_hits`.
+//  5. Agent reports inside the same window are folded into matching
+//     bulk_action / agent_session events when the actor or session_id
+//     lines up — a reporting agent run renders as one row headed by the
+//     report's title instead of two adjacent cards. Reports that don't
+//     match anything are returned in the consumed/unconsumed split for
+//     the handler to render as standalone report cards.
 //
-// Reports + connection alerts are returned by separate handler-level
-// queries, not by this function.
+// Connection alerts are returned by a separate handler-level query, not
+// by this function.
 func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) ([]FeedEvent, error) {
+	out, _, err := s.listFeedEventsWithReports(ctx, params, nil)
+	return out, err
+}
+
+// ListFeedEventsWithReports is the report-aware variant the home Feed
+// handler uses. It folds matching reports into bulk_action / agent_session
+// events and returns the leftover (un-folded) reports separately so the
+// handler can render them as standalone report cards.
+//
+// Splitting this from `ListFeedEvents` keeps the report-free entry-point
+// available for callers that don't have a windowed report list handy
+// (none today; preserved for symmetry with `ListFeedActivity`).
+func (s *Service) ListFeedEventsWithReports(ctx context.Context, params FeedEventsParams, reports []AgentReportResponse) ([]FeedEvent, []AgentReportResponse, error) {
+	return s.listFeedEventsWithReports(ctx, params, reports)
+}
+
+func (s *Service) listFeedEventsWithReports(ctx context.Context, params FeedEventsParams, reports []AgentReportResponse) ([]FeedEvent, []AgentReportResponse, error) {
 	if params.Window <= 0 {
 		params.Window = 3 * 24 * time.Hour
 	}
@@ -329,13 +410,13 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 
 	annotationRows, err := s.fetchFeedAnnotations(ctx, cutoff, upper)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	annotationRows = enrichFeedActivityRows(annotationRows)
 
 	syncEvents, err := s.fetchFeedSyncEvents(ctx, cutoff, upper, params.SampleLimit)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	sessionMeta, err := s.fetchFeedSessionMeta(ctx, annotationRows)
@@ -344,6 +425,10 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 	}
 
 	groupedEvents := groupAnnotationsIntoEvents(annotationRows, sessionMeta, params)
+
+	// Fold matching reports into bulk_action / agent_session events. The
+	// remainder is the standalone-card list returned to the handler.
+	leftoverReports := foldReportsIntoEvents(groupedEvents, reports)
 
 	out := make([]FeedEvent, 0, len(syncEvents)+len(groupedEvents))
 	out = append(out, syncEvents...)
@@ -354,7 +439,7 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 	})
 
 	out = filterFeedEvents(out, params.Filter, params.ActorID)
-	return out, nil
+	return out, leftoverReports, nil
 }
 
 // filterFeedEvents narrows a feed-event slice to the subset matching the
@@ -1068,19 +1153,26 @@ func buildAgentSessionEvent(sessionID string, rows []FeedActivityRow, meta feedS
 }
 
 // groupUnsessionedAnnotations buckets the remaining annotations by
-// (actor_id, kind, 5-min). Buckets at-or-above BulkThreshold collapse into
-// a FeedBulkActionEvent; smaller buckets pass through annotations
-// individually but only `comment` rows are kept (other singleton
-// recategorisations are too low-signal for the home feed).
+// `(actor_id, floor(time / feedSoftBucketWindow))` — note that `kind` is
+// NOT part of the bucket key. Buckets at-or-above BulkThreshold collapse
+// into a single FeedBulkActionEvent regardless of how many distinct kinds
+// the annotations carry; the per-kind breakdown is preserved on the
+// event's `KindCounts` map so the templ can render the breakdown line.
+//
+// Sub-threshold buckets pass through standalone comments individually
+// (other singleton recategorisations are too low-signal for the home
+// feed). When ≥3 standalone comments share a bucket they collapse into a
+// bulk_action event whose Kind == "comment" — we don't want a feed full
+// of identical "Alice commented on transaction" rows when Alice was
+// triaging.
 func groupUnsessionedAnnotations(rows []FeedActivityRow, params FeedEventsParams) []FeedEvent {
 	if len(rows) == 0 {
 		return nil
 	}
-	const bucketWindow = 5 * time.Minute
+	bucketSeconds := int64(feedSoftBucketWindow.Seconds())
 
 	type bucketKey struct {
 		actorID string
-		kind    string
 		bucket  int64
 	}
 
@@ -1096,8 +1188,7 @@ func groupUnsessionedAnnotations(rows []FeedActivityRow, params FeedEventsParams
 		}
 		k := bucketKey{
 			actorID: actorID,
-			kind:    r.Annotation.Kind,
-			bucket:  r.Annotation.CreatedAtTime.Unix() / int64(bucketWindow.Seconds()),
+			bucket:  r.Annotation.CreatedAtTime.Unix() / bucketSeconds,
 		}
 		if _, ok := buckets[k]; !ok {
 			keyOrder = append(keyOrder, k)
@@ -1117,7 +1208,7 @@ func groupUnsessionedAnnotations(rows []FeedActivityRow, params FeedEventsParams
 			})
 			continue
 		}
-		// Below threshold — only standalone comments survive in v2.
+		// Below threshold — only standalone comments survive.
 		for _, r := range bucket {
 			if r.Annotation.Kind != "comment" || r.Annotation.IsDeleted {
 				continue
@@ -1142,12 +1233,16 @@ func groupUnsessionedAnnotations(rows []FeedActivityRow, params FeedEventsParams
 	return out
 }
 
-// buildBulkActionEvent collapses one (actor, kind, time-bucket) cluster of
+// buildBulkActionEvent collapses one (actor, time-bucket) cluster of
 // annotations into a single FeedBulkActionEvent, summarising the subjects
-// (tag names, category names, rule names) the actor applied.
+// (tag names, category names, rule names) the actor applied. When every
+// row in the bucket shares one kind, `Kind` is set to that homogeneous
+// kind so the templ can render the dedicated verb phrasing; otherwise
+// `Kind` is "mixed" and the templ renders the per-kind breakdown line.
 func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedBulkActionEvent {
 	ev := FeedBulkActionEvent{
-		Count: len(rows),
+		Count:      len(rows),
+		KindCounts: make(map[string]int),
 	}
 	subjectCounts := make(map[string]int)
 	subjectMeta := make(map[string]FeedBulkSubject)
@@ -1159,11 +1254,11 @@ func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedB
 			ev.ActorName = ann.ActorName
 			ev.ActorType = ann.ActorType
 			ev.ActorAvatarVersion = ann.ActorAvatarVersion
-			ev.Kind = ann.Kind
 			if ann.ActorID != nil {
 				ev.ActorID = *ann.ActorID
 			}
 		}
+		ev.KindCounts[ann.Kind]++
 		if ev.StartedAt.IsZero() || ann.CreatedAtTime.Before(ev.StartedAt) {
 			ev.StartedAt = ann.CreatedAtTime
 		}
@@ -1183,6 +1278,19 @@ func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedB
 		if _, ok := uniqueTx[r.TransactionShortID]; !ok {
 			uniqueTx[r.TransactionShortID] = sampleTxFromRow(r)
 		}
+	}
+
+	// Single-kind buckets keep the dedicated kind so the templ can render
+	// the canonical verb phrasing ("Alice categorised 12 transactions").
+	// Mixed-kind buckets get "mixed" so the templ falls back to the
+	// generic "Alice updated N transactions" headline plus the per-kind
+	// breakdown line.
+	if len(ev.KindCounts) == 1 {
+		for k := range ev.KindCounts {
+			ev.Kind = k
+		}
+	} else {
+		ev.Kind = "mixed"
 	}
 
 	subjects := make([]FeedBulkSubject, 0, len(subjectCounts))
@@ -1208,6 +1316,118 @@ func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedB
 	}
 	ev.SampleTransactions = samples
 	return ev
+}
+
+// foldReportsIntoEvents pairs each report with a matching bulk_action or
+// agent_session event in `events` so the report renders as part of that
+// card's headline instead of as its own row. Matching is:
+//
+//   - SessionID equality with an agent_session event, OR
+//   - actor (id, type+name fallback) equality plus the report's timestamp
+//     falling inside the bulk_action's [StartedAt-15m, EndedAt+15m] window.
+//
+// Mutates the matched events in place (sets `ev.BulkAction.Report` /
+// `ev.AgentSession.Report`) and returns the un-folded reports for the
+// handler to render as standalone report cards.
+func foldReportsIntoEvents(events []FeedEvent, reports []AgentReportResponse) []AgentReportResponse {
+	if len(events) == 0 || len(reports) == 0 {
+		return reports
+	}
+
+	leftover := make([]AgentReportResponse, 0, len(reports))
+	for _, rep := range reports {
+		if folded := tryFoldReport(events, rep); !folded {
+			leftover = append(leftover, rep)
+		}
+	}
+	return leftover
+}
+
+// tryFoldReport attempts to attach `rep` to a matching event in `events`.
+// Returns true if a match was found and the event was mutated.
+func tryFoldReport(events []FeedEvent, rep AgentReportResponse) bool {
+	ref := reportRefFromResponse(rep)
+
+	// 1. Session match wins. If the report's session_id lines up with an
+	//    agent_session event, fold there regardless of timestamps.
+	if rep.SessionID != nil && *rep.SessionID != "" {
+		for i := range events {
+			if events[i].Type != "agent_session" {
+				continue
+			}
+			if events[i].AgentSession == nil {
+				continue
+			}
+			if events[i].AgentSession.SessionID == *rep.SessionID {
+				if events[i].AgentSession.Report == nil {
+					events[i].AgentSession.Report = &ref
+				}
+				return true
+			}
+		}
+	}
+
+	// 2. Actor + window match into a bulk_action event. The report's
+	//    `created_at` must fall inside the bucket window (with a slack
+	//    of feedSoftBucketWindow on either side so a report written
+	//    seconds after the last annotation still anchors).
+	repTime, err := time.Parse(time.RFC3339, rep.CreatedAt)
+	if err != nil {
+		return false
+	}
+	repActorID := ""
+	if rep.CreatedByID != nil {
+		repActorID = *rep.CreatedByID
+	}
+	repActorKey := repActorID
+	if repActorKey == "" {
+		repActorKey = rep.CreatedByType + ":" + rep.CreatedByName
+	}
+
+	for i := range events {
+		if events[i].Type != "bulk_action" {
+			continue
+		}
+		ba := events[i].BulkAction
+		if ba == nil {
+			continue
+		}
+		baKey := ba.ActorID
+		if baKey == "" {
+			baKey = ba.ActorType + ":" + ba.ActorName
+		}
+		if baKey != repActorKey {
+			continue
+		}
+		windowStart := ba.StartedAt.Add(-feedSoftBucketWindow)
+		windowEnd := ba.EndedAt.Add(feedSoftBucketWindow)
+		if repTime.Before(windowStart) || repTime.After(windowEnd) {
+			continue
+		}
+		if ba.Report == nil {
+			ba.Report = &ref
+		}
+		// Take the report's timestamp as the event timestamp so the row
+		// sorts at the report's wall-clock position (typically the run's
+		// last action). Prevents the row drifting earlier than the
+		// report itself.
+		if repTime.After(events[i].Timestamp) {
+			events[i].Timestamp = repTime
+		}
+		return true
+	}
+	return false
+}
+
+func reportRefFromResponse(r AgentReportResponse) FeedReportRef {
+	return FeedReportRef{
+		ID:       r.ID,
+		ShortID:  r.ShortID,
+		Title:    r.Title,
+		Priority: r.Priority,
+		Tags:     r.Tags,
+		IsUnread: r.ReadAt == nil,
+	}
 }
 
 func bulkSubjectKey(a Annotation) string {

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -573,6 +573,215 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		}
 	})
 
+	t.Run("BulkActionFoldsAcrossKinds", func(t *testing.T) {
+		// Iteration-13 widening: a single actor that touches multiple kinds
+		// in one 15-minute window collapses into ONE bulk_action card whose
+		// KindCounts surfaces the breakdown. Previously each kind got its
+		// own bucket and the rail showed 3 adjacent cards for one agent run.
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "mixedkind", 21)
+
+		// Anchor inserts well inside a single 15-min bucket window so
+		// the floor(unix/15m) key is identical for every annotation. We
+		// step back 1 hour from real wall-time and snap to the bucket
+		// centre — the resulting timestamp is comfortably inside the 3-day
+		// fetch window and clear of any 15-min boundary.
+		anchor := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(7 * time.Minute)
+		actorID := "actor-mixed-kind"
+		var i int
+		// 5 category_set
+		for j := 0; j < 5; j++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"category_set", "user", actorID, "Alice",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				anchor.Add(time.Duration(j)*time.Second),
+			)
+			i++
+		}
+		// 8 tag_removed
+		for j := 0; j < 8; j++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"tag_removed", "user", actorID, "Alice",
+				pgtype.UUID{},
+				[]byte(`{"tag_slug":"needs-review"}`),
+				anchor.Add(time.Duration(10+j)*time.Second),
+			)
+			i++
+		}
+		// 8 comments from the same actor in the same window. Together with
+		// the bursts above they prove the bucket is kind-agnostic — without
+		// this iteration's widening, each kind would produce its own card.
+		for j := 0; j < 8; j++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"comment", "user", actorID, "Alice",
+				pgtype.UUID{},
+				[]byte(`{"content":"thinking"}`),
+				anchor.Add(time.Duration(20+j)*time.Second),
+			)
+			i++
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event (kind-agnostic bucket), got %d", got)
+		}
+		if got := countEventsByType(events, "comment"); got != 0 {
+			t.Errorf("expected 0 standalone comment events (folded into bulk), got %d", got)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Count != 21 {
+			t.Errorf("Count = %d, want 21", ev.Count)
+		}
+		if ev.Kind != "mixed" {
+			t.Errorf("Kind = %q, want %q", ev.Kind, "mixed")
+		}
+		if ev.KindCounts["category_set"] != 5 {
+			t.Errorf("KindCounts[category_set] = %d, want 5", ev.KindCounts["category_set"])
+		}
+		if ev.KindCounts["tag_removed"] != 8 {
+			t.Errorf("KindCounts[tag_removed] = %d, want 8", ev.KindCounts["tag_removed"])
+		}
+		if ev.KindCounts["comment"] != 8 {
+			t.Errorf("KindCounts[comment] = %d, want 8", ev.KindCounts["comment"])
+		}
+	})
+
+	t.Run("CommentsBucketIfThree", func(t *testing.T) {
+		// Three same-actor comments in a 15-min window collapse into a
+		// bulk_action with Kind="comment" Count=3. Two comments in the same
+		// window stay as individual comment cards (sub-threshold).
+		t.Run("ThreeFold", func(t *testing.T) {
+			svc, queries, pool := newService(t)
+			ctx := context.Background()
+			seed := seedFeedFixture(t, queries, "comments3", 3)
+
+			anchor := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(7 * time.Minute)
+			actorID := "actor-3-comments"
+			for j := 0; j < 3; j++ {
+				insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[j],
+					"comment", "user", actorID, "Alice",
+					pgtype.UUID{},
+					[]byte(`{"content":"hi"}`),
+					anchor.Add(time.Duration(j)*time.Second),
+				)
+			}
+
+			events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+			if err != nil {
+				t.Fatalf("ListFeedEvents: %v", err)
+			}
+			if got := countEventsByType(events, "bulk_action"); got != 1 {
+				t.Fatalf("expected 1 bulk_action (≥3 comments), got %d", got)
+			}
+			if got := countEventsByType(events, "comment"); got != 0 {
+				t.Errorf("expected 0 standalone comments, got %d", got)
+			}
+			ev := findEventByType(events, "bulk_action").BulkAction
+			if ev.Kind != "comment" {
+				t.Errorf("Kind = %q, want %q", ev.Kind, "comment")
+			}
+			if ev.Count != 3 {
+				t.Errorf("Count = %d, want 3", ev.Count)
+			}
+		})
+		t.Run("TwoStandalone", func(t *testing.T) {
+			svc, queries, pool := newService(t)
+			ctx := context.Background()
+			seed := seedFeedFixture(t, queries, "comments2", 2)
+
+			anchor := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(7 * time.Minute)
+			actorID := "actor-2-comments"
+			for j := 0; j < 2; j++ {
+				insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[j],
+					"comment", "user", actorID, "Alice",
+					pgtype.UUID{},
+					[]byte(`{"content":"hi"}`),
+					anchor.Add(time.Duration(j)*time.Second),
+				)
+			}
+
+			events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+			if err != nil {
+				t.Fatalf("ListFeedEvents: %v", err)
+			}
+			if got := countEventsByType(events, "bulk_action"); got != 0 {
+				t.Errorf("expected 0 bulk_action (sub-threshold), got %d", got)
+			}
+			if got := countEventsByType(events, "comment"); got != 2 {
+				t.Errorf("expected 2 standalone comments, got %d", got)
+			}
+		})
+	})
+
+	t.Run("ReportFoldsIntoBulkAction", func(t *testing.T) {
+		// A reporting agent run: 8 same-actor annotations in a 5-minute
+		// span plus an agent report at the bucket center (same actor).
+		// The report folds into the bulk_action card; only ONE event
+		// surfaces, with the report title in the headline.
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "reportfold", 8)
+
+		anchor := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(7 * time.Minute)
+		actorID := "agent-report-fold"
+		for j := 0; j < 8; j++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[j],
+				"category_set", "agent", actorID, "ReportingAgent",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				anchor.Add(time.Duration(j)*time.Second),
+			)
+		}
+
+		// Report from the same agent created in the middle of the bucket.
+		actor := service.Actor{Type: "agent", ID: actorID, Name: "ReportingAgent"}
+		report, err := svc.CreateAgentReport(ctx, "Reviewed and cleared 8 transactions",
+			"All 8 looked clean.",
+			actor, "info", []string{"review"}, "", "")
+		if err != nil {
+			t.Fatalf("CreateAgentReport: %v", err)
+		}
+		// Backdate the report into the middle of the bulk_action's
+		// time window so the actor+window fold check passes.
+		if _, err := pool.Exec(ctx,
+			"UPDATE agent_reports SET created_at = $1 WHERE id::text = $2",
+			anchor.Add(10*time.Second), report.ID,
+		); err != nil {
+			t.Fatalf("backdate report: %v", err)
+		}
+		// Re-fetch the report so the SessionID/CreatedAt round-trip.
+		fetched, err := svc.GetAgentReport(ctx, report.ID)
+		if err != nil {
+			t.Fatalf("GetAgentReport: %v", err)
+		}
+
+		events, leftover, err := svc.ListFeedEventsWithReports(ctx,
+			service.FeedEventsParams{},
+			[]service.AgentReportResponse{fetched},
+		)
+		if err != nil {
+			t.Fatalf("ListFeedEventsWithReports: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event, got %d", got)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("expected 0 leftover reports (folded into bulk), got %d (%+v)", len(leftover), leftover)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Report == nil {
+			t.Fatalf("BulkAction.Report = nil, want non-nil with title %q", "Reviewed and cleared 8 transactions")
+		}
+		if ev.Report.Title != "Reviewed and cleared 8 transactions" {
+			t.Errorf("BulkAction.Report.Title = %q, want %q", ev.Report.Title, "Reviewed and cleared 8 transactions")
+		}
+	})
+
 	t.Run("WindowIsBounded", func(t *testing.T) {
 		svc, queries, pool := newService(t)
 		ctx := context.Background()

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -22,6 +22,14 @@ type AgentReportResponse struct {
 	Author        *string  `json:"author,omitempty"`
 	ReadAt        *string  `json:"read_at"`
 	CreatedAt     string   `json:"created_at"`
+
+	// SessionID, when populated, links this report to the MCP session that
+	// produced it. Surfacing it in the response lets the home Feed fold a
+	// report into the matching agent_session card so an agent run shows up
+	// as a single row headed by the report title rather than two adjacent
+	// cards (the report + the session). Nil when the report wasn't anchored
+	// to a session at write time (older reports, or human-authored ones).
+	SessionID *string `json:"session_id,omitempty"`
 }
 
 func agentReportFromRow(r db.AgentReport) AgentReportResponse {
@@ -29,7 +37,7 @@ func agentReportFromRow(r db.AgentReport) AgentReportResponse {
 	if tags == nil {
 		tags = []string{}
 	}
-	return AgentReportResponse{
+	out := AgentReportResponse{
 		ID:            formatUUID(r.ID),
 		ShortID:       r.ShortID,
 		Title:         r.Title,
@@ -43,6 +51,11 @@ func agentReportFromRow(r db.AgentReport) AgentReportResponse {
 		ReadAt:        timestampStr(r.ReadAt),
 		CreatedAt:     pgconv.TimestampStr(r.CreatedAt),
 	}
+	if r.SessionID.Valid {
+		s := formatUUID(r.SessionID)
+		out.SessionID = &s
+	}
+	return out
 }
 
 // ValidReportPriorities lists allowed priority values.

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -16,14 +16,12 @@ import (
 // transaction activity log on /transactions/{id}. The home feed is just a
 // global, grouped view of the same shape.
 templ Feed(p FeedProps) {
-	<!-- Comment bubbles use the shared markdown scanner so a comment posted
-	     from the per-transaction composer renders identically when it
-	     surfaces here. Same marked + DOMPurify versions / SRI as the
-	     per-transaction page. The scanner is idempotent — safe on every
-	     feed visit. -->
-	<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
-	<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js" integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7" crossorigin="anonymous"></script>
-	<script src="/static/js/admin/markdown.js"></script>
+	<!-- Comment rows on the home feed render the meta line only ("Alice
+	     commented on Whole Foods") — the body lives on the per-tx page.
+	     Dropping the markdown bubble here lets us drop the marked /
+	     DOMPurify / markdown-scanner script trio entirely; the global
+	     feed is a glance surface, and a click-through to /transactions/{id}
+	     is the right home for the comment body. -->
 	<div x-data x-init="$store.shortcuts.setScope('feed')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	@feedHero(p)
 	if len(p.ConnectionAlerts) > 0 {
@@ -550,65 +548,157 @@ templ feedReportBody(it FeedItem, r *FeedReport, now time.Time) {
 }
 
 templ feedAgentSessionBody(it FeedItem, s *FeedAgentSession, now time.Time) {
-	<div class="flex items-baseline gap-1.5 flex-wrap">
-		<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
-		<span class="text-base-content/55">ran a session</span>
-		<span class="text-base-content/30">·</span>
-		<span class="font-medium text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
-		@feedRowTimestamp(it.TimestampStr, now)
-	</div>
-	if breakdown := feedSessionBreakdown(s); breakdown != "" {
+	if s.ReportTitle != "" {
+		// Report folded into this session — use the report title as the
+		// headline and the session description sinks beneath it. Mirrors
+		// how the bulk_action card folds a report (see feedBulkActionBody).
+		<div class="flex items-baseline gap-1.5 flex-wrap">
+			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
+				{ s.ReportTitle }
+			</a>
+			if s.ReportIsUnread {
+				<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
+			}
+			if s.ReportPriority == "critical" {
+				<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
+			} else if s.ReportPriority == "warning" {
+				<span class="badge badge-warning badge-xs uppercase tracking-wide">Warning</span>
+			}
+			@feedRowTimestamp(it.TimestampStr, now)
+		</div>
 		<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-			<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
-			<span>{ breakdown }</span>
-			if dur := feedSessionDuration(s); dur != "" {
+			<i data-lucide="bot" class="w-3 h-3"></i>
+			<span class="font-medium text-base-content/75">{ feedSessionActorName(s) }</span>
+			<span class="text-base-content/30">·</span>
+			<span class="tabular-nums">{ fmt.Sprintf("%d transaction%s", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
+			if breakdown := feedSessionBreakdown(s); breakdown != "" {
+				<span class="text-base-content/30">·</span>
+				<span>{ breakdown }</span>
+			}
+			if len(s.ReportTags) > 0 {
 				<span class="text-base-content/30 mx-1">·</span>
-				<i data-lucide="clock" class="w-3 h-3"></i>
-				<span>{ dur }</span>
+				for _, t := range s.ReportTags {
+					<span class="inline-flex items-center px-1.5 py-0.5 rounded-md bg-base-200 text-[0.65rem] font-medium text-base-content/65">{ t }</span>
+				}
 			}
 		</div>
+	} else {
+		<div class="flex items-baseline gap-1.5 flex-wrap">
+			<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
+			<span class="text-base-content/55">ran a session</span>
+			<span class="text-base-content/30">·</span>
+			<span class="font-medium text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
+			@feedRowTimestamp(it.TimestampStr, now)
+		</div>
+		if breakdown := feedSessionBreakdown(s); breakdown != "" {
+			<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+				<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
+				<span>{ breakdown }</span>
+				if dur := feedSessionDuration(s); dur != "" {
+					<span class="text-base-content/30 mx-1">·</span>
+					<i data-lucide="clock" class="w-3 h-3"></i>
+					<span>{ dur }</span>
+				}
+			</div>
+		}
 	}
 	if len(s.SampleTransactions) > 0 {
 		<div class="mt-2">
 			@feedTxRefList(s.SampleTransactions, max0(s.UniqueTransactions-len(s.SampleTransactions)))
 		</div>
 	}
-	if s.SessionShortID != "" {
-		<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-primary/70 hover:text-primary transition-colors mt-1.5 inline-flex items-center gap-1 no-underline">
-			Open session log
-			<i data-lucide="arrow-right" class="w-3 h-3"></i>
-		</a>
-	}
+	<div class="mt-1.5 flex items-center gap-3 flex-wrap">
+		if s.ReportTitle != "" && s.ReportID != "" {
+			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="text-primary/70 hover:text-primary transition-colors inline-flex items-center gap-1 no-underline">
+				Read the full report
+				<i data-lucide="arrow-right" class="w-3 h-3"></i>
+			</a>
+		}
+		if s.SessionShortID != "" {
+			<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-primary/70 hover:text-primary transition-colors inline-flex items-center gap-1 no-underline">
+				Open session log
+				<i data-lucide="arrow-right" class="w-3 h-3"></i>
+			</a>
+		}
+	</div>
 }
 
 templ feedBulkActionBody(it FeedItem, b *FeedBulkAction, now time.Time) {
-	<div class="flex items-baseline gap-1.5 flex-wrap">
-		<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
-		<span class="text-base-content/65">{ feedBulkVerb(b.Kind) }</span>
-		<span class="font-semibold text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
-		if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
-			<span class="text-base-content/65">{ subjectLabel }</span>
-		}
-		@feedRowTimestamp(it.TimestampStr, now)
-	</div>
-	if len(b.Subjects) > 1 {
+	if b.ReportTitle != "" {
+		// Report folded into this bucket — use the report title as the
+		// headline. Mirrors the agent_session card's report-folded layout.
+		<div class="flex items-baseline gap-1.5 flex-wrap">
+			<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
+				{ b.ReportTitle }
+			</a>
+			if b.ReportIsUnread {
+				<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
+			}
+			if b.ReportPriority == "critical" {
+				<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
+			} else if b.ReportPriority == "warning" {
+				<span class="badge badge-warning badge-xs uppercase tracking-wide">Warning</span>
+			}
+			@feedRowTimestamp(it.TimestampStr, now)
+		</div>
 		<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-			for i, sub := range b.Subjects {
-				if i >= 4 {
-					<span class="text-base-content/40">+ { fmt.Sprintf("%d more", len(b.Subjects)-4) }</span>
-					break
+			<i data-lucide="bot" class="w-3 h-3"></i>
+			<span class="font-medium text-base-content/75">{ feedActorDisplay(b.ActorName, b.ActorType) }</span>
+			<span class="text-base-content/30">·</span>
+			<span class="tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
+			if breakdown := feedBulkKindBreakdown(b); breakdown != "" {
+				<span class="text-base-content/30">·</span>
+				<span>{ breakdown }</span>
+			}
+			if len(b.ReportTags) > 0 {
+				<span class="text-base-content/30 mx-1">·</span>
+				for _, t := range b.ReportTags {
+					<span class="inline-flex items-center px-1.5 py-0.5 rounded-md bg-base-200 text-[0.65rem] font-medium text-base-content/65">{ t }</span>
 				}
-				<span class="inline-flex items-center gap-1 bg-base-200 px-1.5 py-0.5 rounded-md">
-					<span class="font-medium text-base-content/85">{ sub.Name }</span>
-					<span class="text-base-content/55 tabular-nums">&times;{ fmt.Sprintf("%d", sub.Count) }</span>
-				</span>
 			}
 		</div>
+	} else {
+		<div class="flex items-baseline gap-1.5 flex-wrap">
+			<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
+			<span class="text-base-content/65">{ feedBulkVerb(b.Kind) }</span>
+			<span class="font-semibold text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
+			if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
+				<span class="text-base-content/65">{ subjectLabel }</span>
+			}
+			@feedRowTimestamp(it.TimestampStr, now)
+		</div>
+		if b.Kind == "mixed" {
+			if breakdown := feedBulkKindBreakdown(b); breakdown != "" {
+				<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+					<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
+					<span>{ breakdown }</span>
+				</div>
+			}
+		} else if len(b.Subjects) > 1 {
+			<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+				for i, sub := range b.Subjects {
+					if i >= 4 {
+						<span class="text-base-content/40">+ { fmt.Sprintf("%d more", len(b.Subjects)-4) }</span>
+						break
+					}
+					<span class="inline-flex items-center gap-1 bg-base-200 px-1.5 py-0.5 rounded-md">
+						<span class="font-medium text-base-content/85">{ sub.Name }</span>
+						<span class="text-base-content/55 tabular-nums">&times;{ fmt.Sprintf("%d", sub.Count) }</span>
+					</span>
+				}
+			</div>
+		}
 	}
 	if len(b.SampleTransactions) > 0 {
 		<div class="mt-2">
 			@feedTxRefList(b.SampleTransactions, max0(b.Count-len(b.SampleTransactions)))
 		</div>
+	}
+	if b.ReportTitle != "" && b.ReportID != "" {
+		<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="text-primary/70 hover:text-primary transition-colors mt-1.5 inline-flex items-center gap-1 no-underline">
+			Read the full report
+			<i data-lucide="arrow-right" class="w-3 h-3"></i>
+		</a>
 	}
 }
 
@@ -629,10 +719,11 @@ templ feedRowTimestamp(timestamp string, now time.Time) {
 //
 // Comments wrap the existing TimelineCommentRowRaw primitive so the meta
 // line and avatar tile match the per-transaction activity log byte-for-
-// byte. The bubble body uses the shared `.bb-comment-bubble` CSS class
-// (defined in input.css) and the same data-markdown attribute the per-tx
-// page consumes — so a comment posted from the per-tx composer renders
-// identically when it surfaces on the home feed.
+// byte. As of iteration 13 the home feed renders only the meta line — no
+// markdown bubble. The body lives on the per-tx page (click-through via
+// the transaction ref). Reasoning: a global feed is a glance surface, and
+// rendering bodies inline duplicated the markdown-scanner cost across
+// every feed visit. Click-through is the right read for full content.
 templ feedCommentRow(it FeedItem, c *FeedComment, now time.Time) {
 	@components.TimelineCommentRowRaw(feedCommentAvatar(c), nil) {
 		<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6 min-w-0">
@@ -643,9 +734,6 @@ templ feedCommentRow(it FeedItem, c *FeedComment, now time.Time) {
 			</a>
 			@feedRowTimestamp(it.TimestampStr, now)
 		</div>
-		if c.Content != "" {
-			<div class="bb-comment-bubble mt-1" data-markdown={ c.Content } data-markdown-breaks="true"></div>
-		}
 	}
 }
 
@@ -811,8 +899,47 @@ func feedBulkVerb(kind string) string {
 		return "categorised"
 	case "rule_applied":
 		return "ran a rule on"
+	case "comment":
+		return "commented on"
 	}
 	return "updated"
+}
+
+// feedBulkKindBreakdown renders the per-kind breakdown line ("5 categorised
+// · 8 tag-removed · 8 updated") used by mixed-kind bulk_action cards and
+// the report-folded variants. Returns "" when the bucket only carries one
+// kind (the dedicated verb already conveys it). Order is fixed so the
+// rendered string is stable across renders even when the underlying
+// `KindCounts` map iterates differently.
+func feedBulkKindBreakdown(b *FeedBulkAction) string {
+	if len(b.KindCounts) == 0 {
+		return ""
+	}
+	order := []struct {
+		kind  string
+		label string
+	}{
+		{"category_set", "categorised"},
+		{"tag_added", "tag-added"},
+		{"tag_removed", "tag-removed"},
+		{"rule_applied", "rule-applied"},
+		{"comment", "commented"},
+	}
+	parts := []string{}
+	seen := map[string]bool{}
+	for _, o := range order {
+		if c := b.KindCounts[o.kind]; c > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", c, o.label))
+			seen[o.kind] = true
+		}
+	}
+	for k, c := range b.KindCounts {
+		if seen[k] || c <= 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", c, k))
+	}
+	return strings.Join(parts, " · ")
 }
 
 func feedBulkSubjectLabel(b *FeedBulkAction) string {

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -237,18 +237,44 @@ type FeedAgentSession struct {
 	RuleApplied    int
 
 	SampleTransactions []FeedTransactionRef
+
+	// Report fields are populated when the service folded an agent_report
+	// whose `session_id` matches this session into the card. The templ
+	// uses ReportTitle as the headline (instead of the generic "ran a
+	// session" line) and renders priority badges + tags inline. Empty
+	// when no report was folded — render the plain session card.
+	ReportID       string
+	ReportShortID  string
+	ReportTitle    string
+	ReportPriority string
+	ReportTags     []string
+	ReportIsUnread bool
 }
 
-// FeedBulkAction is the rich card that collapses ≥3 same-actor same-kind
-// annotations from a 5-minute bucket into a single row.
+// FeedBulkAction is the rich card that collapses ≥3 same-actor
+// annotations from a 15-minute bucket into a single row. As of iteration
+// 13 the bucket key is (actor, time-window) only — `kind` is absent — so
+// a single agent run that categorises some rows, removes a tag from
+// others, and updates more in the same window collapses into ONE
+// bulk_action card. KindCounts surfaces the per-kind breakdown for inline
+// rendering ("5 categorised · 8 tag-removed · 8 updated").
 type FeedBulkAction struct {
 	ActorName          string
 	ActorType          string
 	ActorID            string
 	ActorAvatarVersion string
 
+	// Kind is "mixed" when the bucket spans multiple kinds; otherwise the
+	// single homogeneous kind. The templ branches on "mixed" to render
+	// the per-kind breakdown line in lieu of a dedicated verb phrasing.
 	Kind  string
 	Count int
+
+	// KindCounts breaks the bucket down by kind. Always populated; the
+	// templ renders it as the "5 categorised · 8 tag-removed · 8 updated"
+	// breakdown when Kind == "mixed", or skips it for homogeneous
+	// buckets (the dedicated verb phrasing already conveys the kind).
+	KindCounts map[string]int
 
 	Subjects []FeedBulkSubject
 
@@ -256,6 +282,18 @@ type FeedBulkAction struct {
 	EndedAt   time.Time
 
 	SampleTransactions []FeedTransactionRef
+
+	// Report fields are populated when the service folded a matching
+	// agent_report into the card (see service.foldReportsIntoEvents). The
+	// templ uses ReportTitle as the bold headline instead of the generic
+	// "Alice updated N transactions" line and renders priority badges +
+	// tags inline. Empty when no report was folded.
+	ReportID       string
+	ReportShortID  string
+	ReportTitle    string
+	ReportPriority string
+	ReportTags     []string
+	ReportIsUnread bool
 }
 
 // FeedBulkSubject is one (subject, count) chip inside a bulk-action card.


### PR DESCRIPTION
Collapses the 4-cards-per-agent-run pattern from production into one row by widening the soft-bucket window, dropping `kind` from the bucket key, and folding matching agent reports into the bulk_action / agent_session card they originated from.

## What's in the cards

**Before**: an agent run that categorised 5, removed a tag from 8, updated 8, and wrote a report rendered as 4 adjacent cards on the rail (one per kind, plus the report). Comment cards inlined the markdown body, costing a marked + DOMPurify + scanner trio on every visit.

**After**: same actor + 15-minute window collapses into one card with `KindCounts` for the per-kind breakdown line ("5 categorised · 8 tag-removed · 8 commented"). When a report shares the actor (or session_id), it folds in and the card's headline becomes the report title — one row per agent run.

## Design rules shipped

1. Comment cards on the feed render meta-line only — markdown bubble removed; marked + DOMPurify + markdown.js dropped from the page chrome (no other consumer on /feed).
2. Bulk-action soft bucket widened from 5m → 15m; `kind` removed from the bucket key.
3. Reports anchored into matching bulk_action / agent_session events via session_id (preferred) or actor + window. Folded reports do NOT render as standalone cards.
4. Standalone comments still group when ≥3 share an actor + window (`Kind == "comment"` bulk_action).
5. New `feedSoftBucketWindow` const at the top of `feed.go`.
6. mcp_session hard-grouping still wins; AgentSession also tries to anchor a matching report.

## Side-by-side

<table>
  <tr><th>Before (12-a11y)</th><th>After (this PR)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/92ruhkja7m.jpg" width="420" alt="feed before"></td>
    <td><img src="https://i.img402.dev/1ucaej9nk0.jpg" width="420" alt="feed after"></td>
  </tr>
</table>

In the after screenshot, look at the "Apr 26" cluster — `updated 3 transactions · 1 tag-added · 2 tag-removed` and `updated 6 transactions · 1 tag-added · 1 tag-removed · 4 commented` are mixed-kind bulk_actions that previously each split into 3 separate cards. Comment markdown bubbles are gone; click-through to /transactions/{id} for the body.

## Test plan

- [x] `go test ./...` (unit) — green
- [x] `go vet ./...` — clean
- [x] `go test -tags integration -count=1 -p 1 ./internal/service/... ./internal/admin/...` — green
- [x] New integration tests: `BulkActionFoldsAcrossKinds`, `CommentsBucketIfThree` (3-fold + 2-standalone subtests), `ReportFoldsIntoBulkAction`
- [x] Manual `/feed` validation against dev DB (screenshots above)
- [ ] Reviewer: confirm a real production feed view shows the 4→1 fold the user asked for
