### PR TITLE
ui(feed): comment-icon rail tile + shared inline-actor across surfaces

### DIFF
--- a/input.css
+++ b/input.css
@@ -2874,15 +2874,14 @@
   --tw-ring-color: var(--color-base-200);
 }
 /* Inner tile pills painted `bg-base-200` (sync, deleted-comment trash,
- * neutral review, unknown-kind fallback) match the base-200 page surface
- * in prominent mode and disappear. Lift the fill to base-300 so the
- * circle reads as a defined shape on the rail. Targets only direct
- * children of the rail-mask wrapper so the inner lucide icon's color
- * isn't touched. Comment rows are excluded — their initials/image/agent
- * avatars rely on the GitHub-style 1px base-300 outline below (added in
- * #927) instead of a fill bump, since the fill approach didn't help
- * image avatars that already carry their own background. */
-.bb-timeline-prominent .bb-timeline > li:not(:has(.bb-comment-bubble)) > div:first-child > .bg-base-200 {
+ * neutral review, comment message-circle, unknown-kind fallback) match
+ * the base-200 page surface in prominent mode and disappear. Lift the
+ * fill to base-300 so the circle reads as a defined shape on the rail.
+ * Targets only direct children of the rail-mask wrapper so the inner
+ * lucide icon's color isn't touched. As of #969 comment rows are
+ * included — they use the same neutral message-circle tile as every
+ * other system row, so the same fill bump applies uniformly. */
+.bb-timeline-prominent .bb-timeline > li > div:first-child > .bg-base-200 {
   background-color: var(--color-base-300);
 }
 /* Slightly thicker ring for the bigger tile so the colour pill reads
@@ -2915,17 +2914,10 @@
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
 }
-/* GitHub-style 1px outline on comment-row avatars. The rail mask is
- * base-200, so without an outline a neutral avatar (image / agent /
- * initials) reads as floating without a defined edge. base-300 is our
- * "border" colour and works in both themes — subtle gray-on-white in
- * light mode, subtle lift on near-black in dark mode. We use `border`
- * (not box-shadow) so it works on `<img>` too — replaced elements
- * ignore inset shadows. With box-sizing:border-box the outer 28px
- * stays intact, so the rail still threads through the avatar centre. */
-.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div:first-child .ring-4 {
-  border: 1px solid var(--color-base-300);
-}
+/* As of #969 comment rows use the same neutral message-circle tile as
+ * every other system-event row, so the bespoke 1px outline that used to
+ * sit on the avatar is gone — the shared `bg-base-200 + ring-4` chrome
+ * already gives every rail tile a defined edge against the rail mask. */
 .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 {
   position: relative;
   background: var(--color-base-100);

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -717,38 +717,51 @@ templ feedRowTimestamp(timestamp string, now time.Time) {
 
 // ── Comment row ───────────────────────────────────────────────────────────
 //
-// Comments wrap the existing TimelineCommentRowRaw primitive so the meta
-// line and avatar tile match the per-transaction activity log byte-for-
-// byte. As of iteration 13 the home feed renders only the meta line — no
+// Comment rows render the same rail tile as every other system-event row —
+// a 24px message-circle icon — and move the actor's avatar inline before
+// their bolded name (matching the per-tx activity log's tag / category
+// sentences). The shared `TimelineCommentTile` + `TimelineActorInline`
+// primitives in `components/timeline.templ` are the single source of truth
+// for that pair, used by both /feed (here) and /transactions/{id} so the
+// surfaces stay byte-equivalent.
+//
+// As of iteration 13 the home feed renders only the meta line — no
 // markdown bubble. The body lives on the per-tx page (click-through via
 // the transaction ref). Reasoning: a global feed is a glance surface, and
 // rendering bodies inline duplicated the markdown-scanner cost across
 // every feed visit. Click-through is the right read for full content.
 templ feedCommentRow(it FeedItem, c *FeedComment, now time.Time) {
-	@components.TimelineCommentRowRaw(feedCommentAvatar(c), nil) {
-		<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6 min-w-0">
-			<strong class="font-semibold text-base-content truncate min-w-0 max-w-[10rem] sm:max-w-none">{ feedActorDisplay(c.ActorName, c.ActorType) }</strong>
-			<span class="text-base-content/65 shrink-0 font-normal">commented on</span>
-			<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline truncate min-w-0">
-				{ feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name) }
-			</a>
-			@feedRowTimestamp(it.TimestampStr, now)
-		</div>
-	}
+	@components.TimelineSystemRowCustomTile(
+		"", "", now,
+		components.TimelineCommentTile(),
+		feedCommentRowBody(it, c, now),
+		nil,
+	)
 }
 
-templ feedCommentAvatar(c *FeedComment) {
+templ feedCommentRowBody(it FeedItem, c *FeedComment, now time.Time) {
+	<div class="flex items-center gap-1.5 flex-wrap text-xs leading-6 min-w-0">
+		@components.TimelineActorInline(feedCommentActor(c))
+		<span class="text-base-content/65 shrink-0 font-normal">commented on</span>
+		<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline truncate min-w-0">
+			{ feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name) }
+		</a>
+		@feedRowTimestamp(it.TimestampStr, now)
+	</div>
+}
+
+// feedCommentActor builds the shared TimelineActor for a feed comment so
+// the inline-actor renderer can do its job uniformly. Users get an avatar
+// URL (or fall through to initials when the ID is missing); agents get the
+// bot fallback; system actors render as just the name (no glyph).
+func feedCommentActor(c *FeedComment) components.TimelineActor {
+	a := components.TimelineActor{Name: feedActorDisplay(c.ActorName, c.ActorType)}
 	if c.ActorType == "user" && c.ActorID != "" {
-		<img src={ feedAvatarURL(c.ActorID, c.ActorAvatarVersion) } alt={ c.ActorName + " avatar" } class="w-6 h-6 rounded-full object-cover ring-4 ring-base-200" title={ c.ActorName }/>
+		a.AvatarURL = feedAvatarURL(c.ActorID, c.ActorAvatarVersion)
 	} else if c.ActorType == "agent" {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary/12 ring-4 ring-base-200" aria-hidden="true" title={ c.ActorName }>
-			<i data-lucide="bot" class="w-3 h-3 text-primary"></i>
-		</span>
-	} else {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-200" aria-hidden="true" title={ c.ActorName }>
-			<span class="text-[10px] font-semibold text-base-content/60 leading-none">{ feedFirstChar(c.ActorName) }</span>
-		</span>
+		a.IsAgent = true
 	}
+	return a
 }
 
 // ── Shared transaction-reference helpers ──────────────────────────────────

--- a/internal/templates/components/pages/feed_comment_test.go
+++ b/internal/templates/components/pages/feed_comment_test.go
@@ -1,0 +1,205 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"breadbox/internal/templates/components"
+)
+
+// TestFeedCommentRowUsesSharedCommentTile verifies the consolidation done in
+// #969: every /feed comment row renders the shared `TimelineCommentTile`
+// (a neutral 24px message-circle on the rail) and the actor's avatar moves
+// inline before the bolded actor name. The old per-feed avatar tile has
+// been retired, so neither `feedCommentAvatar` markup nor a 24px <img>
+// avatar should appear inside the rail anchor anymore.
+//
+// Pure templ render — no DB. Drives the row through a full Feed render so
+// the surrounding scaffolding exercises the same code path users hit.
+func TestFeedCommentRowUsesSharedCommentTile(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	ts := now.Add(-15 * time.Minute)
+
+	feedWith := func(c FeedComment) FeedProps {
+		return FeedProps{
+			Now:            now,
+			WindowDays:     3,
+			HasConnections: true,
+			TotalItems:     1,
+			Days: []FeedDay{{
+				Key:   ts.Format("2006-01-02"),
+				Label: "Today",
+				First: true,
+				Items: []FeedItem{{
+					Type:         "comment",
+					Timestamp:    ts,
+					TimestampStr: ts.UTC().Format(time.RFC3339),
+					Comment:      &c,
+				}},
+			}},
+		}
+	}
+
+	cases := []struct {
+		name        string
+		comment     FeedComment
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "user_comment_renders_message_circle_tile_and_inline_avatar",
+			comment: FeedComment{
+				ActorType:          "user",
+				ActorID:            "user-abc",
+				ActorName:          "Alice",
+				ActorAvatarVersion: "v1",
+				Transaction: FeedTransactionRef{
+					ShortID:      "tx9000aa",
+					MerchantName: "Whole Foods",
+					Amount:       42.10,
+					Currency:     "USD",
+				},
+			},
+			mustContain: []string{
+				// Rail tile is the shared message-circle, not an avatar.
+				`data-lucide="message-circle"`,
+				// Inline avatar uses the 16px treatment from
+				// TimelineActorInline.
+				`inline-block w-4 h-4 rounded-full object-cover align-text-bottom`,
+				// Bold actor name + verb.
+				`Alice`,
+				`commented on`,
+				`Whole Foods`,
+			},
+			mustOmit: []string{
+				// Old 24px avatar tile classes used to scaffold the
+				// rail before #969.
+				`w-6 h-6 rounded-full object-cover ring-4 ring-base-200`,
+			},
+		},
+		{
+			name: "agent_comment_renders_message_circle_tile_and_inline_bot",
+			comment: FeedComment{
+				ActorType: "agent",
+				ActorName: "Categorizer",
+				Transaction: FeedTransactionRef{
+					ShortID:      "tx9000bb",
+					MerchantName: "Costco",
+					Amount:       12.34,
+					Currency:     "USD",
+				},
+			},
+			mustContain: []string{
+				`data-lucide="message-circle"`,
+				// Inline bot tile, 16px (w-4 h-4) — distinct from the
+				// 24px (w-6 h-6) rail tile that used to be there.
+				`inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary/10`,
+				`Categorizer`,
+				`commented on`,
+			},
+			mustOmit: []string{
+				`bg-primary/12 ring-4 ring-base-200`,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := Feed(feedWith(tc.comment)).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes):\n%s", want, buf.Len(), html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}
+
+// TestFeedAndTxDetailShareInlineActor asserts the shared
+// `components.TimelineActorInline` primitive renders the same actor markup
+// no matter which surface it's invoked from. We don't need to render the
+// whole transaction-detail page to prove the consolidation — both
+// `feedCommentActor` and the equivalent tx-detail adapter ultimately hand
+// the same `TimelineActor` shape to the same primitive, so rendering
+// `TimelineActorInline` directly with that shape is the byte-equivalent
+// of what each page would emit.
+func TestFeedAndTxDetailShareInlineActor(t *testing.T) {
+	cases := []struct {
+		name      string
+		actor     components.TimelineActor
+		mustHave  []string
+		mustOmit  []string
+	}{
+		{
+			name: "user_with_avatar",
+			actor: components.TimelineActor{
+				Name:      "Alice",
+				AvatarURL: "/avatars/user-abc?v=v1",
+			},
+			mustHave: []string{
+				`<img src="/avatars/user-abc?v=v1"`,
+				`inline-block w-4 h-4 rounded-full object-cover align-text-bottom mr-1`,
+				`<strong class="font-semibold text-base-content">Alice</strong>`,
+			},
+		},
+		{
+			name: "agent_renders_bot_tile",
+			actor: components.TimelineActor{
+				Name:    "Categorizer",
+				IsAgent: true,
+			},
+			mustHave: []string{
+				`bg-primary/10`,
+				`data-lucide="bot"`,
+				`<strong class="font-semibold text-base-content">Categorizer</strong>`,
+			},
+			mustOmit: []string{
+				`<img`,
+			},
+		},
+		{
+			name: "system_actor_renders_only_bold_name",
+			actor: components.TimelineActor{
+				Name: "Breadbox",
+			},
+			mustHave: []string{
+				`<strong class="font-semibold text-base-content">Breadbox</strong>`,
+			},
+			mustOmit: []string{
+				`<img`,
+				`data-lucide="bot"`,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := components.TimelineActorInline(tc.actor).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustHave {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected %q in:\n%s", want, html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected to omit %q in:\n%s", omit, html)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -359,6 +359,15 @@ templ txdActivity(p TransactionDetailProps) {
 // custom-tile primitive so the page-local txdSystemIcon palette continues to
 // drive the 24px tile while the primitive owns the rail anchor, leading-6
 // text container, and timestamp/origin suffix.
+//
+// As of #969 the live-comment branch also uses TimelineSystemRowCustomTile
+// — the rail tile is now the shared `TimelineCommentTile` (a neutral
+// message-circle) and the actor's avatar moves inline into the meta line
+// via `TimelineActorInline`. Both surfaces (/feed and /transactions/{id})
+// render the same primitive shape so the design system stays uniform.
+// `data-comment-id` is still attached to the row's <li> so the optimistic-
+// update flow in transaction_detail.js can swap a bubble for a tombstone in
+// place without re-rendering the timeline.
 templ txdTimelineRow(e service.ActivityEntry, now time.Time) {
 	if e.Type == "comment" {
 		if e.IsDeleted {
@@ -371,9 +380,12 @@ templ txdTimelineRow(e service.ActivityEntry, now time.Time) {
 				templ.Attributes{"data-comment-id": e.CommentID},
 			)
 		} else {
-			@components.TimelineCommentRowRaw(txdCommentAvatar(e), templ.Attributes{"data-comment-id": e.CommentID}) {
-				@txdCommentBubbleBody(e, now)
-			}
+			@components.TimelineSystemRowCustomTile(
+				"", "", now,
+				components.TimelineCommentTile(),
+				txdCommentBubbleBody(e, now),
+				templ.Attributes{"data-comment-id": e.CommentID},
+			)
 		}
 	} else {
 		@components.TimelineSystemRowCustomTile(
@@ -463,18 +475,23 @@ templ txdSystemSentence(e service.ActivityEntry) {
 }
 
 // txdActorInline renders an actor reference inside a system-event sentence:
-// a tiny (16px) avatar followed by the bold name. Users get their photo;
-// agents get a bot tile; system/anonymous actors fall back to the bold name
-// alone since there is no actor identity to surface visually.
+// a tiny (16px) avatar followed by the bold name. Delegates to the shared
+// `TimelineActorInline` primitive in `components/timeline.templ` so /feed
+// and /transactions/{id} render the same actor identically.
 templ txdActorInline(e service.ActivityEntry) {
+	@components.TimelineActorInline(txdActor(e))
+}
+
+// txdActor adapts a system-event ActivityEntry into the shared
+// TimelineActor shape used by `TimelineActorInline`.
+func txdActor(e service.ActivityEntry) components.TimelineActor {
+	a := components.TimelineActor{Name: e.ActorName}
 	if e.ActorType == "user" && e.ActorID != nil && *e.ActorID != "" {
-		<img src={ avatarURLStr(*e.ActorID, e.ActorAvatarVersion) } alt="" class="inline-block w-4 h-4 rounded-full object-cover align-text-bottom mr-1" aria-hidden="true"/>
+		a.AvatarURL = avatarURLStr(*e.ActorID, e.ActorAvatarVersion)
 	} else if e.ActorType == "agent" {
-		<span class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary/10 align-text-bottom mr-1" aria-hidden="true">
-			<i data-lucide="bot" class="w-2.5 h-2.5 text-primary"></i>
-		</span>
+		a.IsAgent = true
 	}
-	<strong class="font-semibold text-base-content">{ e.ActorName }</strong>
+	return a
 }
 
 // txdSystemIcon renders the small (24px) kind-specific icon tile that sits
@@ -545,12 +562,16 @@ templ txdCategoryIcon(e service.ActivityEntry) {
 }
 
 // txdCommentBubbleBody renders the body slot for a live comment row — the
-// meta line (actor / "commented" / timestamp / delete button) above the
-// rounded message bubble. Wrapped by components.TimelineCommentRowRaw which
-// owns the row's <li>, rail anchor, and avatar tile.
+// meta line (inline avatar / actor / "commented" / timestamp / delete
+// button) above the rounded message bubble. Wrapped by
+// `components.TimelineSystemRowCustomTile` which owns the row's <li>, rail
+// anchor, and the shared message-circle tile. The actor's avatar is
+// rendered inline via `TimelineActorInline` so the same actor renders
+// identically on /feed (system-row sentence) and on /transactions/{id}
+// (the meta line above each bubble).
 templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 	<!--
-		Meta line shares a 24px line-box with the avatar so the actor
+		Meta line shares a 24px line-box with the rail tile so the actor
 		baseline sits dead-center on the rail circle. Keeping every
 		label at text-xs / leading-6 also matches the system-event
 		rows above for a uniform actor + timestamp treatment.
@@ -561,9 +582,7 @@ templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 		far right; on mobile it follows naturally after the timestamp.
 	-->
 	<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6 min-w-0">
-		if e.ActorName != "" {
-			<strong class="font-semibold text-base-content truncate min-w-0 max-w-[10rem] sm:max-w-none">{ e.ActorName }</strong>
-		}
+		@components.TimelineActorInline(txdCommentActor(e))
 		<span class="text-base-content/55 shrink-0">commented</span>
 		if e.Timestamp != "" {
 			<span class="tooltip tooltip-top shrink-0" data-tip={ formatDateTimeStr(e.Timestamp) }>
@@ -592,20 +611,18 @@ templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 	}
 }
 
-// txdCommentAvatar renders the 24px avatar for a comment. User actors get
-// their image; agents get a bot icon; anonymous/system gets initials.
-templ txdCommentAvatar(e service.ActivityEntry) {
+// txdCommentActor adapts a comment ActivityEntry into the shared
+// TimelineActor shape so `TimelineActorInline` can render its 16px
+// avatar. Users get an image URL; agents get the bot fallback; system
+// actors render as just the bold name.
+func txdCommentActor(e service.ActivityEntry) components.TimelineActor {
+	a := components.TimelineActor{Name: e.ActorName}
 	if e.ActorType == "user" && e.ActorID != nil && *e.ActorID != "" {
-		<img src={ avatarURLStr(*e.ActorID, e.ActorAvatarVersion) } alt={ e.ActorName + " avatar" } class="w-6 h-6 rounded-full object-cover ring-4 ring-base-100" title={ e.ActorName }/>
+		a.AvatarURL = avatarURLStr(*e.ActorID, e.ActorAvatarVersion)
 	} else if e.ActorType == "agent" {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 ring-4 ring-base-100" aria-hidden="true" title={ e.ActorName }>
-			<i data-lucide="bot" class="w-3 h-3 text-primary"></i>
-		</span>
-	} else {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true" title={ e.ActorName }>
-			<span class="text-[10px] font-semibold text-base-content/60 leading-none">{ components.FirstChar(e.ActorName) }</span>
-		</span>
+		a.IsAgent = true
 	}
+	return a
 }
 
 // txdTimelineComposer renders the inline comment composer at the bottom of

--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -341,3 +341,47 @@ templ timelineCommentAvatar(actor TimelineActor) {
 		</span>
 	}
 }
+
+// TimelineCommentTile renders the 24px rail tile for a comment row — the
+// neutral chrome shared with other system-event rows (sync, review, etc.).
+// As of #969 comment rows render a message-circle icon on the rail and move
+// the actor's avatar inline (see TimelineActorInline) so every rail tile on
+// the feed and per-tx timeline looks like the same primitive shape: a
+// 24px filled circle with a 4px ring against the page surface.
+//
+// The ring colour is `ring-base-100` because that's what the rest of the
+// timeline primitives ship with; the prominent variant's input.css remap
+// shifts ring-base-100 → base-200 so the seam disappears against a page
+// background. The card variant keeps base-100 verbatim.
+templ TimelineCommentTile() {
+	<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
+		<i data-lucide="message-circle" class="w-3 h-3 text-base-content/55"></i>
+	</span>
+}
+
+// TimelineActorInline renders the inline actor reference used inside system
+// row sentences and comment meta lines: a tiny (16px) avatar followed by the
+// bold actor name. Users get their photo; agents get a bot tile in primary
+// tint; system / anonymous actors fall back to the bold name alone.
+//
+// Shared between /feed (FeedComment, FeedAgentSession, FeedBulkAction) and
+// /transactions/{id} (txdActorInline → tag/category sentences, comment meta
+// lines) so the actor representation looks identical on both surfaces. The
+// avatar slot uses `align-text-bottom` so the baseline lines up with the
+// surrounding `leading-6` text, and `mr-1` reproduces the legacy spacing.
+templ TimelineActorInline(actor TimelineActor) {
+	if actor.AvatarURL != "" {
+		<img src={ actor.AvatarURL } alt="" class="inline-block w-4 h-4 rounded-full object-cover align-text-bottom mr-1" aria-hidden="true"/>
+	} else if actor.IsAgent {
+		<span class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary/10 align-text-bottom mr-1" aria-hidden="true">
+			<i data-lucide="bot" class="w-2.5 h-2.5 text-primary"></i>
+		</span>
+	}
+	if actor.Name != "" {
+		if actor.HRef != "" {
+			<a href={ templ.SafeURL(actor.HRef) } class="font-semibold text-base-content hover:text-primary transition-colors">{ actor.Name }</a>
+		} else {
+			<strong class="font-semibold text-base-content">{ actor.Name }</strong>
+		}
+	}
+}


### PR DESCRIPTION
Move /feed and /transactions/{id} comment rows onto a shared neutral message-circle tile and lift the actor's avatar inline before the bolded name, so the same actor renders identically on both surfaces.

## Summary

- New `TimelineCommentTile` primitive renders the 24px message-circle rail tile shared by every comment row across surfaces.
- New `TimelineActorInline(TimelineActor)` primitive owns the 16px inline-avatar + bold-name pattern; both `feedCommentRow` and `txdCommentBubbleBody` route through it.
- `txdActorInline` (already inline) now delegates to the shared primitive too — system-event sentences and comment meta lines render the same actor markup.
- Audited rail tile chrome: the 1px border outline that used to single out comment-row avatars is gone (CSS rule removed), and the prominent variant's `bg-base-200 → bg-base-300` lift now applies uniformly to every neutral tile (no more `:not(:has(.bb-comment-bubble))` carve-out).
- Removed the now-unused `feedCommentAvatar` (feed.templ) and `txdCommentAvatar` (transaction_detail.templ) helpers.
- Live comments still attach `data-comment-id` to the row's `<li>` (via `TimelineSystemRowCustomTile`'s `attrs`) so the optimistic-update flow in `transaction_detail.js` keeps swapping bubble ↔ tombstone in place. Tombstone rows still render the trash-icon tile via the existing `txdDeletedCommentTile` branch — no regression.

## Tests

`internal/templates/components/pages/feed_comment_test.go`:

- `TestFeedCommentRowUsesSharedCommentTile` — asserts user / agent comment rows render `data-lucide="message-circle"` in the rail tile and the 16px inline avatar (and explicitly omits the old 24px ring-4 ring-base-200 avatar markup).
- `TestFeedAndTxDetailShareInlineActor` — renders `components.TimelineActorInline` directly with three actor shapes (user with avatar, agent, system) and asserts the byte-equivalent output every caller will receive.

`go vet ./... && go test ./internal/admin/... ./internal/service/... ./internal/templates/... -count=1` passes.

## Screenshots

<table>
<tr>
<td><strong>/feed</strong></td>
<td><strong>/transactions/{id}</strong></td>
</tr>
<tr>
<td><img src="https://i.img402.dev/6si1y17v37.jpg" width="480" alt="Feed page — Charlie's comment row uses the shared message-circle rail tile, with the avatar inline before the bolded name. Sync row above carries the same ring chrome."></td>
<td><img src="https://i.img402.dev/r0bgoqovj0.jpg" width="480" alt="Transaction detail — same comment-icon rail tile, same inline avatar; bubble body and composer below remain unchanged."></td>
</tr>
</table>

## Test plan

- [x] `go build ./... && go vet ./... && go test ./internal/admin/... ./internal/service/... ./internal/templates/... -count=1` green.
- [x] `/feed` renders comment rows with the message-circle rail tile and inline avatar; rail tiles consistent across sync / comment / day-separator.
- [x] `/transactions/{id}` renders the same comment-row shape; bubble body still inflates with markdown via the shared scanner; composer below is untouched.
- [ ] Optimistic delete still works on `/transactions/{id}` (delete a comment → row swaps to tombstone in place).
- [ ] Dark mode (#961), mobile (#965), a11y (#966) still hold — only template + a single CSS-rule swap, no theme-specific tokens introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
