### PR TITLE
feat(feed): consolidated polish stack — grouping, mobile, dark-mode, a11y, perf, typography, comment-icon, tx-row

### DIFF
--- a/input.css
+++ b/input.css
@@ -2874,15 +2874,14 @@
   --tw-ring-color: var(--color-base-200);
 }
 /* Inner tile pills painted `bg-base-200` (sync, deleted-comment trash,
- * neutral review, unknown-kind fallback) match the base-200 page surface
- * in prominent mode and disappear. Lift the fill to base-300 so the
- * circle reads as a defined shape on the rail. Targets only direct
- * children of the rail-mask wrapper so the inner lucide icon's color
- * isn't touched. Comment rows are excluded — their initials/image/agent
- * avatars rely on the GitHub-style 1px base-300 outline below (added in
- * #927) instead of a fill bump, since the fill approach didn't help
- * image avatars that already carry their own background. */
-.bb-timeline-prominent .bb-timeline > li:not(:has(.bb-comment-bubble)) > div:first-child > .bg-base-200 {
+ * neutral review, comment message-circle, unknown-kind fallback) match
+ * the base-200 page surface in prominent mode and disappear. Lift the
+ * fill to base-300 so the circle reads as a defined shape on the rail.
+ * Targets only direct children of the rail-mask wrapper so the inner
+ * lucide icon's color isn't touched. As of #969 comment rows are
+ * included — they use the same neutral message-circle tile as every
+ * other system row, so the same fill bump applies uniformly. */
+.bb-timeline-prominent .bb-timeline > li > div:first-child > .bg-base-200 {
   background-color: var(--color-base-300);
 }
 /* Slightly thicker ring for the bigger tile so the colour pill reads
@@ -2915,17 +2914,10 @@
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
 }
-/* GitHub-style 1px outline on comment-row avatars. The rail mask is
- * base-200, so without an outline a neutral avatar (image / agent /
- * initials) reads as floating without a defined edge. base-300 is our
- * "border" colour and works in both themes — subtle gray-on-white in
- * light mode, subtle lift on near-black in dark mode. We use `border`
- * (not box-shadow) so it works on `<img>` too — replaced elements
- * ignore inset shadows. With box-sizing:border-box the outer 28px
- * stays intact, so the rail still threads through the avatar centre. */
-.bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div:first-child .ring-4 {
-  border: 1px solid var(--color-base-300);
-}
+/* As of #969 comment rows use the same neutral message-circle tile as
+ * every other system-event row, so the bespoke 1px outline that used to
+ * sit on the avatar is gone — the shared `bg-base-200 + ring-4` chrome
+ * already gives every rail tile a defined edge against the rail mask. */
 .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 {
   position: relative;
   background: var(--color-base-100);

--- a/input.css
+++ b/input.css
@@ -235,8 +235,21 @@
   }
 
   @media (prefers-color-scheme: dark) {
+    /* In dark mode the body background equals --color-base-100 (oklch 0.205),
+     * so a stock .bb-card painted bg-base-100 is invisible — same colour as
+     * the page underneath. Lift the card surface 4–5% toward white via
+     * color-mix so cards/tiles read as elevated panels. Targeted (no light-
+     * mode change). Pairs with the body=base-100 dark-theme convention; the
+     * cleaner alternative (flip body to base-200) was rejected as too high
+     * blast-radius. See PR for /feed dark-mode contrast pass. */
+    .bb-card {
+      background-color: color-mix(in oklch, var(--color-base-100) 92%, white 8%);
+    }
     .bb-card--interactive:hover {
       border-color: oklch(0.35 0 0);
+      /* Hover should read as more elevated than rest, not less. Default
+       * bg-base-200/50 in dark mode dips below the body — reverse that. */
+      background-color: color-mix(in oklch, var(--color-base-100) 86%, white 14%);
     }
   }
 
@@ -731,6 +744,18 @@
     @apply px-2 py-1 border-b border-base-200 whitespace-nowrap sm:whitespace-normal;
   }
   .bb-comment-bubble tbody tr:last-child td { @apply border-b-0; }
+
+  /* Dark-mode lift: in dark theme base-200 sits *below* the body bg
+   * (body = base-100 = oklch 0.205, base-200 = oklch 0.145), so the
+   * default base-200 comment bubble reads as a recessed hole. Bump the
+   * surface and border so the bubble floats above the conversation
+   * background. Light-mode untouched. */
+  @media (prefers-color-scheme: dark) {
+    .bb-comment-bubble {
+      background: color-mix(in oklch, var(--color-base-100) 88%, white 12%);
+      border-color: color-mix(in oklch, var(--color-base-300) 85%, white 15%);
+    }
+  }
 
   /* ── Activity timeline — prominent (main-content) variant ──
    * Used by the transaction-detail page to promote the activity timeline
@@ -2984,6 +3009,28 @@
   left: -7px;
   border-width: 8px 8px 8px 0;
   border-color: transparent var(--color-base-100) transparent transparent;
+}
+
+/* Dark-mode contrast lift for the prominent timeline's comment + composer
+ * cards. Both rules above paint `var(--color-base-100)`, which in the dark
+ * theme is identical to the body background — the cards disappear. Mix in
+ * 8% white so they read as elevated surfaces, matching the `.bb-card` lift
+ * used elsewhere on /feed. Light-mode is unaffected. */
+@media (prefers-color-scheme: dark) {
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1,
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1 {
+    background: color-mix(in oklch, var(--color-base-100) 92%, white 8%);
+  }
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1::after,
+  .bb-timeline-prominent .bb-timeline > li:has([data-composer-anchor]) > div.flex-1::after {
+    border-right-color: color-mix(in oklch, var(--color-base-100) 92%, white 8%);
+  }
+  /* Header bar inside the comment card uses base-200 60% — in dark that
+   * is base-200 (oklch 0.145) which is darker than the lifted card. Bump
+   * it slightly so the header reads as a defined band rather than a hole. */
+  .bb-timeline-prominent .bb-timeline > li:has(.bb-comment-bubble) > div.flex-1 > div:first-child {
+    background: color-mix(in oklch, var(--color-base-100) 86%, white 14%);
+  }
 }
 
 /* ── Activity timeline — inline chip fix ──

--- a/input.css
+++ b/input.css
@@ -696,6 +696,7 @@
     border-radius: 1rem;
     border-top-left-radius: 0.375rem;
     word-break: break-word;
+    overflow-wrap: anywhere;
   }
   /* Markdown element styling inside a comment bubble. Tuned to the
      bubble's compact scale — paragraph margins are tighter than the

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -496,6 +496,7 @@ func projectSampleTx(tx service.FeedSampleTx) pages.FeedTransactionRef {
 		Date:         tx.Date,
 		AccountName:  tx.AccountName,
 		Institution:  tx.Institution,
+		Pending:      tx.Pending,
 	}
 }
 

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -78,19 +78,39 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// 1. Grouped events from the service. Run this first so we can decide
-		// whether the (relatively expensive) tag + category lookups are even
-		// needed — they only feed bulk_action subject rendering. Skipping
-		// them on the common no-bulk path saves 5-10ms per request.
+		// 1. Reports — windowed to match the feed bound. Fetched ahead of
+		// the events call so the service can fold matching reports into
+		// bulk_action / agent_session events (one card per agent run
+		// instead of two adjacent cards). Skipped under the
+		// syncs/comments/sessions/me chips, which scope the page to events
+		// the service layer produces.
+		var reports []service.AgentReportResponse
+		if filter == "" || filter == "reports" {
+			t0 := time.Now()
+			var rerr error
+			reports, rerr = svc.ListAgentReports(ctx, 50)
+			qReports = time.Since(t0)
+			if rerr != nil {
+				a.Logger.Error("feed: list agent reports", "error", rerr)
+			}
+		}
+
+		// 2. Grouped events from the service. Run after the report fetch so
+		// the service can fold matching reports into bulk_action /
+		// agent_session events. Reports that don't fold into anything come
+		// back via `leftoverReports` for standalone-card rendering. We also
+		// decide here whether the (relatively expensive) tag + category
+		// lookups are needed — they only feed bulk_action subject rendering.
+		// Skipping them on the common no-bulk path saves 5-10ms per request.
 		t0 := time.Now()
-		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+		events, leftoverReports, err := svc.ListFeedEventsWithReports(ctx, service.FeedEventsParams{
 			Window:        window,
 			BulkThreshold: 3,
 			SampleLimit:   5,
 			Filter:        filter,
 			ActorID:       sessionActorID,
 			Before:        beforeTime,
-		})
+		}, reports)
 		qEvents = time.Since(t0)
 		if err != nil {
 			a.Logger.Error("feed: list events", "error", err)
@@ -130,19 +150,6 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			// no-op stubs so the call site stays simple.
 			categoryDetail = func(string) categoryDisplay { return categoryDisplay{} }
 			tagDisplayFn = func(string) tagDisplay { return tagDisplay{} }
-		}
-
-		// 2. Reports — windowed to match the feed bound. Skipped under the
-		// syncs/comments/sessions/me chips, which scope the page to events
-		// the service layer produces.
-		var reports []service.AgentReportResponse
-		if filter == "" || filter == "reports" {
-			t0 = time.Now()
-			reports, err = svc.ListAgentReports(ctx, 50)
-			qReports = time.Since(t0)
-			if err != nil {
-				a.Logger.Error("feed: list agent reports", "error", err)
-			}
 		}
 
 		// 3. Connection alerts + empty-state meta — current state, not
@@ -200,8 +207,11 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// 5. Append reports as their own feed items.
-		for _, rep := range reports {
+		// 5. Append leftover (un-folded) reports as their own feed items.
+		// Reports that the service folded into a bulk_action / agent_session
+		// card are NOT in `leftoverReports` — they render as part of that
+		// card's headline.
+		for _, rep := range leftoverReports {
 			if rep.CreatedAt == "" {
 				continue
 			}
@@ -480,6 +490,14 @@ func projectFeedAgentSession(s *service.FeedAgentSessionEvent) *pages.FeedAgentS
 		Commented:          s.KindCounts["comment"],
 		RuleApplied:        s.KindCounts["rule_applied"],
 	}
+	if s.Report != nil {
+		out.ReportID = s.Report.ID
+		out.ReportShortID = s.Report.ShortID
+		out.ReportTitle = s.Report.Title
+		out.ReportPriority = s.Report.Priority
+		out.ReportTags = s.Report.Tags
+		out.ReportIsUnread = s.Report.IsUnread
+	}
 	out.SampleTransactions = make([]pages.FeedTransactionRef, 0, len(s.SampleTransactions))
 	for _, tx := range s.SampleTransactions {
 		out.SampleTransactions = append(out.SampleTransactions, projectSampleTx(tx))
@@ -488,6 +506,10 @@ func projectFeedAgentSession(s *service.FeedAgentSessionEvent) *pages.FeedAgentS
 }
 
 func projectFeedBulkAction(b *service.FeedBulkActionEvent, tagDisplayFn func(string) tagDisplay, categoryDetail func(string) categoryDisplay) *pages.FeedBulkAction {
+	kindCounts := make(map[string]int, len(b.KindCounts))
+	for k, v := range b.KindCounts {
+		kindCounts[k] = v
+	}
 	out := &pages.FeedBulkAction{
 		ActorName:          b.ActorName,
 		ActorType:          b.ActorType,
@@ -495,8 +517,17 @@ func projectFeedBulkAction(b *service.FeedBulkActionEvent, tagDisplayFn func(str
 		ActorAvatarVersion: b.ActorAvatarVersion,
 		Kind:               b.Kind,
 		Count:              b.Count,
+		KindCounts:         kindCounts,
 		StartedAt:          b.StartedAt,
 		EndedAt:            b.EndedAt,
+	}
+	if b.Report != nil {
+		out.ReportID = b.Report.ID
+		out.ReportShortID = b.Report.ShortID
+		out.ReportTitle = b.Report.Title
+		out.ReportPriority = b.Report.Priority
+		out.ReportTags = b.Report.Tags
+		out.ReportIsUnread = b.Report.IsUnread
 	}
 	for _, sub := range b.Subjects {
 		display := pages.FeedBulkSubject{

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -197,6 +197,13 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		if !lastSyncAt.IsZero() {
 			hero.LastSyncRel = relativeTime(lastSyncAt)
 		}
+		// Next-sync ETA — drives the "Next sync in ~6h" sub-line under the
+		// Last Sync hero tile so the page answers "why no new transactions
+		// yet?" inline. The scheduler is nil in test env (no cron); leave
+		// the field empty there and the templ hides the sub-line.
+		if a.Scheduler != nil {
+			hero.NextSyncRel = formatNextSync(a.Scheduler.NextRun())
+		}
 
 		data := map[string]any{
 			"PageTitle":   "Feed",

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -36,6 +36,25 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		window := time.Duration(feedWindowDays) * 24 * time.Hour
 		filter := strings.TrimSpace(r.URL.Query().Get("filter"))
 
+		// `?before=<rfc3339>` lets the user roll the 3-day window backward
+		// in chunks via the "Load older activity" footer button. Cap at
+		// 30 days back from now — the service layer enforces the same
+		// ceiling, but clamping here keeps the rendered window/footer
+		// consistent and makes the cap discoverable from a single layer.
+		var beforeTime time.Time
+		if rawBefore := strings.TrimSpace(r.URL.Query().Get("before")); rawBefore != "" {
+			if parsed, err := time.Parse(time.RFC3339, rawBefore); err == nil {
+				beforeTime = parsed
+				minBefore := now.Add(-service.FeedMaxLookback)
+				if beforeTime.Before(minBefore) {
+					beforeTime = minBefore
+				}
+				if beforeTime.After(now) {
+					beforeTime = time.Time{}
+				}
+			}
+		}
+
 		// Resolve the session actor for the "me" chip. Prefer the linked
 		// household user_id; fall back to the auth_account id for the
 		// initial admin (which writes annotations against its account id).
@@ -72,6 +91,7 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			SampleLimit:   5,
 			Filter:        filter,
 			ActorID:       sessionActorID,
+			Before:        beforeTime,
 		})
 		if err != nil {
 			a.Logger.Error("feed: list events", "error", err)
@@ -99,7 +119,15 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			alerts = nil
 		}
 
-		// 4. Project FeedEvents onto templ-side FeedItems.
+		// 4. Project FeedEvents onto templ-side FeedItems. The window is
+		// anchored at `windowEnd` (now, or the `?before=` timestamp when
+		// paginating); `windowStart` is `windowEnd - window`.
+		windowEnd := now
+		if !beforeTime.IsZero() {
+			windowEnd = beforeTime
+		}
+		windowStart := windowEnd.Add(-window)
+
 		items := make([]pages.FeedItem, 0, len(events)+len(reports))
 		var lastSyncAt time.Time
 		var lastSyncStatus, lastSyncInstitution string
@@ -107,7 +135,7 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 
 		for _, ev := range events {
-			if ev.Timestamp.Before(now.Add(-window)) {
+			if ev.Timestamp.Before(windowStart) || ev.Timestamp.After(windowEnd) {
 				continue
 			}
 			it := projectFeedEvent(ev, tagDisplayFn, categoryDetail)
@@ -142,7 +170,7 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			if err != nil {
 				continue
 			}
-			if ts.Before(now.Add(-window)) {
+			if ts.Before(windowStart) || ts.After(windowEnd) {
 				continue
 			}
 			items = append(items, pages.FeedItem{
@@ -210,6 +238,26 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			"CurrentPage": "feed",
 			"CSRFToken":   GetCSRFToken(r),
 		}
+		// Compute the oldest visible event timestamp + the at-cap flag that
+		// drive the "Load older activity" button. We pass the oldest item's
+		// timestamp through so the button's href rolls the window backward
+		// in 3-day chunks. AtMaxLookback hides the button (replaced by
+		// "End of feed") when the next chunk would exceed the 30-day cap.
+		var oldestVisible time.Time
+		for _, it := range items {
+			if oldestVisible.IsZero() || it.Timestamp.Before(oldestVisible) {
+				oldestVisible = it.Timestamp
+			}
+		}
+		atMaxLookback := false
+		if !oldestVisible.IsZero() {
+			// Once the oldest visible event is older than (now - 30d), or
+			// the next-chunk's upper bound would be, treat as end-of-feed.
+			if oldestVisible.Before(now.Add(-service.FeedMaxLookback)) {
+				atMaxLookback = true
+			}
+		}
+
 		body := pages.Feed(pages.FeedProps{
 			CSRFToken:        GetCSRFToken(r),
 			Hero:             hero,
@@ -222,6 +270,8 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			HasConnections:   hasConnections,
 			LastSyncAt:       globalLastSyncAt,
 			IsAdmin:          IsAdmin(tr.sm, r),
+			OldestVisible:    oldestVisible,
+			AtMaxLookback:    atMaxLookback,
 		})
 		tr.RenderWithTempl(w, r, data, body)
 	}

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -36,6 +36,13 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		window := time.Duration(feedWindowDays) * 24 * time.Hour
 		filter := strings.TrimSpace(r.URL.Query().Get("filter"))
 
+		// Per-query timings, emitted as a single structured slog line at the
+		// end of the request so we can spot regressions in production logs.
+		// Zero-value durations indicate "skipped" — e.g. q_categories=0 when
+		// there are no bulk_action events to resolve.
+		reqStart := time.Now()
+		var qCategories, qTags, qEvents, qReports, qAlerts time.Duration
+
 		// `?before=<rfc3339>` lets the user roll the 3-day window backward
 		// in chunks via the "Load older activity" footer button. Cap at
 		// 30 days back from now — the service layer enforces the same
@@ -71,20 +78,11 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// Display lookups so bulk-action subjects render with friendly tag
-		// and category display names instead of raw slugs.
-		categoryTree, err := svc.ListCategories(ctx)
-		if err != nil {
-			a.Logger.Error("feed: list categories", "error", err)
-		}
-		categoryDetail := categoryDetailLookup(categoryTree)
-		tags, err := svc.ListTags(ctx)
-		if err != nil {
-			a.Logger.Error("feed: list tags", "error", err)
-		}
-		tagDisplayFn := tagDisplayLookup(tags)
-
-		// 1. Grouped events from the service.
+		// 1. Grouped events from the service. Run this first so we can decide
+		// whether the (relatively expensive) tag + category lookups are even
+		// needed — they only feed bulk_action subject rendering. Skipping
+		// them on the common no-bulk path saves 5-10ms per request.
+		t0 := time.Now()
 		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
 			Window:        window,
 			BulkThreshold: 3,
@@ -93,8 +91,45 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			ActorID:       sessionActorID,
 			Before:        beforeTime,
 		})
+		qEvents = time.Since(t0)
 		if err != nil {
 			a.Logger.Error("feed: list events", "error", err)
+		}
+
+		// Display lookups so bulk-action subjects render with friendly tag
+		// and category display names instead of raw slugs. Only fetched when
+		// at least one bulk_action event is present — the common case (sync
+		// + comment + agent_session events only) skips both queries.
+		hasBulkAction := false
+		for _, ev := range events {
+			if ev.Type == "bulk_action" {
+				hasBulkAction = true
+				break
+			}
+		}
+		var categoryDetail func(string) categoryDisplay
+		var tagDisplayFn func(string) tagDisplay
+		if hasBulkAction {
+			t0 = time.Now()
+			categoryTree, cerr := svc.ListCategories(ctx)
+			qCategories = time.Since(t0)
+			if cerr != nil {
+				a.Logger.Error("feed: list categories", "error", cerr)
+			}
+			categoryDetail = categoryDetailLookup(categoryTree)
+			t0 = time.Now()
+			tags, terr := svc.ListTags(ctx)
+			qTags = time.Since(t0)
+			if terr != nil {
+				a.Logger.Error("feed: list tags", "error", terr)
+			}
+			tagDisplayFn = tagDisplayLookup(tags)
+		} else {
+			// projectFeedBulkAction won't fire on this path, but
+			// projectFeedEvent unconditionally accepts the lookups. Provide
+			// no-op stubs so the call site stays simple.
+			categoryDetail = func(string) categoryDisplay { return categoryDisplay{} }
+			tagDisplayFn = func(string) tagDisplay { return tagDisplay{} }
 		}
 
 		// 2. Reports — windowed to match the feed bound. Skipped under the
@@ -102,7 +137,9 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		// the service layer produces.
 		var reports []service.AgentReportResponse
 		if filter == "" || filter == "reports" {
+			t0 = time.Now()
 			reports, err = svc.ListAgentReports(ctx, 50)
+			qReports = time.Since(t0)
 			if err != nil {
 				a.Logger.Error("feed: list agent reports", "error", err)
 			}
@@ -114,7 +151,9 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		// unfiltered "All" page. The meta (hasConnections + global last-
 		// sync-at) is always collected so the empty-state branch can pick
 		// the right copy regardless of filter.
+		t0 = time.Now()
 		alerts, hasConnections, globalLastSyncAt := buildFeedConnectionMeta(ctx, a)
+		qAlerts = time.Since(t0)
 		if filter != "" {
 			alerts = nil
 		}
@@ -273,6 +312,21 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			OldestVisible:    oldestVisible,
 			AtMaxLookback:    atMaxLookback,
 		})
+		// Single structured log line per request — read in production logs
+		// to spot regressions across the per-query timings. Durations are
+		// rounded to milliseconds; q_categories=0 means "skipped" (no bulk
+		// action events to resolve).
+		a.Logger.Info("feed: rendered",
+			"duration_ms", time.Since(reqStart).Milliseconds(),
+			"events", len(items),
+			"reports", len(reports),
+			"q_categories_ms", qCategories.Milliseconds(),
+			"q_tags_ms", qTags.Milliseconds(),
+			"q_events_total_ms", qEvents.Milliseconds(),
+			"q_reports_ms", qReports.Milliseconds(),
+			"q_alerts_ms", qAlerts.Milliseconds(),
+		)
+
 		tr.RenderWithTempl(w, r, data, body)
 	}
 }

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -573,15 +573,19 @@ func projectFeedBulkAction(b *service.FeedBulkActionEvent, tagDisplayFn func(str
 
 func projectSampleTx(tx service.FeedSampleTx) pages.FeedTransactionRef {
 	return pages.FeedTransactionRef{
-		ShortID:      tx.ShortID,
-		Name:         tx.Name,
-		MerchantName: tx.MerchantName,
-		Amount:       tx.Amount,
-		Currency:     tx.Currency,
-		Date:         tx.Date,
-		AccountName:  tx.AccountName,
-		Institution:  tx.Institution,
-		Pending:      tx.Pending,
+		ShortID:             tx.ShortID,
+		Name:                tx.Name,
+		MerchantName:        tx.MerchantName,
+		Amount:              tx.Amount,
+		Currency:            tx.Currency,
+		Date:                tx.Date,
+		AccountName:         tx.AccountName,
+		Institution:         tx.Institution,
+		Pending:             tx.Pending,
+		CategoryDisplayName: tx.CategoryDisplayName,
+		CategoryColor:       tx.CategoryColor,
+		CategoryIcon:        tx.CategoryIcon,
+		CategorySlug:        tx.CategorySlug,
 	}
 }
 

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -88,12 +88,15 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			}
 		}
 
-		// 3. Connection alerts — current state, not windowed. Hidden under
-		// any active chip so the filtered view is exclusively the chip's
-		// scope; the alerts re-appear on the unfiltered "All" page.
-		var alerts []pages.FeedAlert
-		if filter == "" {
-			alerts = buildFeedConnectionAlerts(ctx, a)
+		// 3. Connection alerts + empty-state meta — current state, not
+		// windowed. Alerts hide under any active chip so the filtered view
+		// is exclusively the chip's scope; the alerts re-appear on the
+		// unfiltered "All" page. The meta (hasConnections + global last-
+		// sync-at) is always collected so the empty-state branch can pick
+		// the right copy regardless of filter.
+		alerts, hasConnections, globalLastSyncAt := buildFeedConnectionMeta(ctx, a)
+		if filter != "" {
+			alerts = nil
 		}
 
 		// 4. Project FeedEvents onto templ-side FeedItems.
@@ -209,22 +212,33 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 			WindowDays:       feedWindowDays,
 			Now:              now,
 			Filter:           filter,
+			HasConnections:   hasConnections,
+			LastSyncAt:       globalLastSyncAt,
+			IsAdmin:          IsAdmin(tr.sm, r),
 		})
 		tr.RenderWithTempl(w, r, data, body)
 	}
 }
 
-// buildFeedConnectionAlerts collects the pinned warning cards rendered above
-// the rail. Each alert maps one bank connection currently in error or
-// pending_reauth state to a `pages.FeedAlert`.
-func buildFeedConnectionAlerts(ctx context.Context, a *app.App) []pages.FeedAlert {
+// buildFeedConnectionMeta does one ListBankConnections pass and projects out
+// three things the page needs: the pinned alert cards (for connections in
+// error/pending_reauth), whether *any* connection exists (drives the first-
+// run empty state), and the most recent successful sync time across the
+// household (drives the "quiet around here · last sync was {rel}" empty
+// state). Co-locating the projections means the empty-state branch can
+// pick the right copy without a second query.
+func buildFeedConnectionMeta(ctx context.Context, a *app.App) (alerts []pages.FeedAlert, hasConnections bool, globalLastSyncAt time.Time) {
 	bankConnections, err := a.Queries.ListBankConnections(ctx)
 	if err != nil {
 		a.Logger.Error("feed: list bank connections", "error", err)
-		return nil
+		return nil, false, time.Time{}
 	}
-	out := make([]pages.FeedAlert, 0)
+	alerts = make([]pages.FeedAlert, 0)
 	for _, conn := range bankConnections {
+		hasConnections = true
+		if conn.LastSyncedAt.Valid && conn.LastSyncedAt.Time.After(globalLastSyncAt) {
+			globalLastSyncAt = conn.LastSyncedAt.Time
+		}
 		status := string(conn.Status)
 		if status != "error" && status != "pending_reauth" {
 			continue
@@ -241,9 +255,9 @@ func buildFeedConnectionAlerts(ctx context.Context, a *app.App) []pages.FeedAler
 		if conn.LastSyncedAt.Valid {
 			alert.LastSyncedAt = relativeTime(conn.LastSyncedAt.Time)
 		}
-		out = append(out, alert)
+		alerts = append(alerts, alert)
 	}
-	return out
+	return alerts, hasConnections, globalLastSyncAt
 }
 
 // projectFeedEvent maps one service-layer FeedEvent onto its templ-side

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -29,6 +29,7 @@ type FeedActivityRow struct {
 	Amount             float64
 	IsoCurrencyCode    string
 	TransactionDate    string
+	Pending            bool
 
 	AccountName     string
 	InstitutionName string
@@ -49,7 +50,7 @@ SELECT
     a.payload, a.tag_id, a.rule_id, a.session_id, a.created_at,
     COALESCE(u_via_account.name, u_direct.name, '')::text AS actor_user_name,
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
-    t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
+    t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
@@ -227,6 +228,12 @@ type FeedSampleTx struct {
 	Date         string
 	AccountName  string
 	Institution  string
+	// Pending mirrors `transactions.pending` so the feed card can render
+	// the same clock-icon pending mark used on `/transactions/{id}` and
+	// the transactions list — preliminary rows often re-show as posted
+	// later, and surfacing the lifecycle state inline gives users a
+	// "this is provisional" read.
+	Pending bool
 }
 
 // FeedRuleOutcome is one (rule, count) pair shown inline on a sync card.
@@ -437,7 +444,7 @@ SELECT
     a.payload, a.tag_id, a.rule_id, a.session_id, a.created_at,
     COALESCE(u_via_account.name, u_direct.name, '')::text AS actor_user_name,
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
-    t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
+    t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
@@ -502,6 +509,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		amount                              pgtype.Numeric
 		isoCcy                              pgtype.Text
 		txDate                              pgtype.Date
+		pending                             bool
 		accountName, institutionName        pgtype.Text
 	)
 
@@ -509,7 +517,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		&id, &shortID, &txnID, &kind, &actorType, &actorIDOpt, &actorName,
 		&payload, &tagID, &ruleID, &sessionID, &createdAt,
 		&actorUserName, &actorUpdatedAt,
-		&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate,
+		&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate, &pending,
 		&accountName, &institutionName,
 	); err != nil {
 		return FeedActivityRow{}, fmt.Errorf("scan feed activity row: %w", err)
@@ -566,6 +574,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		TransactionName:    txName,
 		MerchantName:       pgconv.TextOr(merchantName, ""),
 		IsoCurrencyCode:    pgconv.TextOr(isoCcy, "USD"),
+		Pending:            pending,
 		AccountName:        pgconv.TextOr(accountName, ""),
 		InstitutionName:    pgconv.TextOr(institutionName, ""),
 	}
@@ -772,7 +781,7 @@ func (s *Service) fetchSyncSampleTransactions(ctx context.Context, raws []syncRo
 
 	const q = `
 SELECT t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
-       t.created_at, ac.name, bc.id::text, bc.institution_name
+       t.created_at, t.pending, ac.name, bc.id::text, bc.institution_name
 FROM transactions t
 JOIN accounts ac ON ac.id = t.account_id
 JOIN bank_connections bc ON ac.connection_id = bc.id
@@ -802,11 +811,12 @@ ORDER BY t.created_at DESC
 			isoCcy            pgtype.Text
 			txDate            pgtype.Date
 			createdAt         pgtype.Timestamptz
+			pending           bool
 			accountName       pgtype.Text
 			connID            string
 			institutionName   pgtype.Text
 		)
-		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &accountName, &connID, &institutionName); err != nil {
+		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &pending, &accountName, &connID, &institutionName); err != nil {
 			return nil, err
 		}
 		t := txRow{
@@ -817,6 +827,7 @@ ORDER BY t.created_at DESC
 				Currency:     pgconv.TextOr(isoCcy, "USD"),
 				AccountName:  pgconv.TextOr(accountName, ""),
 				Institution:  pgconv.TextOr(institutionName, ""),
+				Pending:      pending,
 			},
 			ConnectionID: connID,
 			CreatedAt:    createdAt.Time.UTC(),
@@ -1239,6 +1250,7 @@ func sampleTxFromRow(r FeedActivityRow) FeedSampleTx {
 		Date:         r.TransactionDate,
 		AccountName:  r.AccountName,
 		Institution:  r.InstitutionName,
+		Pending:      r.Pending,
 	}
 }
 

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -168,19 +168,43 @@ type FeedAgentSessionEvent struct {
 	KindCounts map[string]int
 
 	SampleTransactions []FeedSampleTx
+
+	// Report, when non-nil, is an agent_report whose session_id matches
+	// this session. Populated by ListFeedEvents so a reporting agent run
+	// surfaces as a single feed row headlined by the report's title — the
+	// alternative (a separate report card adjacent to the session card) is
+	// noisy on the timeline.
+	Report *FeedReportRef
 }
 
-// FeedBulkActionEvent represents ≥ N annotations from the same actor of
-// the same kind within a soft time-bucket — typically a human running a
-// bulk recategorisation or an agent making changes outside an MCP session.
+// FeedBulkActionEvent represents ≥ N annotations from the same actor
+// within a soft time-bucket — typically a human running a bulk
+// recategorisation or an agent making changes outside an MCP session.
+//
+// As of iteration 13 the soft bucket is keyed by (actor, time-window) only
+// — the actor's `kind` is *not* part of the bucket key. A single agent run
+// that categorises 5 rows, removes a tag from 8, and updates 8 more in the
+// same 15-minute window collapses into one bulk_action card whose
+// `KindCounts` map exposes the per-kind breakdown for inline rendering
+// ("5 categorised · 8 tag-removed · 8 updated"). `Kind` is kept for the
+// homogeneous-bucket code path: when every annotation in the bucket
+// shares one kind the templ renders the dedicated verb/subject phrasing,
+// otherwise it falls back to the generic breakdown line.
 type FeedBulkActionEvent struct {
 	ActorName          string
 	ActorType          string
 	ActorID            string
 	ActorAvatarVersion string
 
-	Kind  string // "tag_added" | "tag_removed" | "category_set" | "rule_applied"
+	// Kind is the homogeneous kind of every annotation in this bucket, or
+	// "mixed" when the bucket folds annotations across kinds.
+	Kind  string
 	Count int
+
+	// KindCounts breaks the bucket's annotations down by kind so the card
+	// can render the breakdown line ("5 categorised · 8 tag-removed · 8
+	// updated") when the bucket spans multiple kinds.
+	KindCounts map[string]int
 
 	// Subjects is the deduped list of subject names (tag names, category
 	// names, rule names) that were applied. When all rows share one
@@ -193,6 +217,26 @@ type FeedBulkActionEvent struct {
 	EndedAt   time.Time
 
 	SampleTransactions []FeedSampleTx
+
+	// Report, when non-nil, is an agent_report whose actor + window
+	// matches this bucket. Folding the report in lets a reporting agent
+	// run render as a single card headlined by the report title rather
+	// than the generic "X categorised, Y tagged" line.
+	Report *FeedReportRef
+}
+
+// FeedReportRef is the slim projection of an agent report folded into a
+// bulk_action / agent_session card. The handler still owns the canonical
+// report card (rendered when the report wasn't folded into anything) — this
+// shape only carries enough to display the title + priority + tags inline
+// and a link to the full report.
+type FeedReportRef struct {
+	ID       string
+	ShortID  string
+	Title    string
+	Priority string
+	Tags     []string
+	IsUnread bool
 }
 
 // FeedBulkSubject is one (subject, count) pair inside a bulk-action card.
@@ -278,6 +322,18 @@ type FeedEventsParams struct {
 // annotations table for households with years of history.
 const FeedMaxLookback = 30 * 24 * time.Hour
 
+// feedSoftBucketWindow is the wall-clock window used by the unsessioned
+// soft-bucket grouping in `groupUnsessionedAnnotations`. An actor's
+// annotations within one window collapse into a single bulk_action card.
+//
+// 15 minutes is wide enough to capture an agent run end-to-end (categorise
+// → tag → comment → write report → leave) while still being narrow enough
+// that a human editing throughout the day stays as distinct buckets per
+// hour. Iteration 12 used 5 minutes which fragmented agent runs into 3-4
+// adjacent cards on the rail; widening collapsed those into one card per
+// run.
+const feedSoftBucketWindow = 15 * time.Minute
+
 // ListFeedEvents returns grouped FeedEvents for the home Feed page,
 // already ordered newest-first.
 //
@@ -291,16 +347,41 @@ const FeedMaxLookback = 30 * 24 * time.Hour
 //     into a single AgentSession event regardless of how many annotations
 //     it produced.
 //  3. Soft-bucket the remaining (un-sessioned) annotations by
-//     `(actor_id, kind, floor(time / 5min))`. Buckets with ≥ BulkThreshold
-//     events become BulkAction events; the rest of the un-sessioned
-//     annotations are dropped UNLESS they're standalone comments — those
-//     pass through as Comment events because every comment is high-signal.
+//     `(actor_id, floor(time / feedSoftBucketWindow))` — note that `kind`
+//     is intentionally absent from the key so a single agent run that
+//     categorises some rows and removes a tag from others collapses into
+//     ONE bulk_action card with a per-kind breakdown. Buckets with
+//     ≥ BulkThreshold events become BulkAction events; sub-threshold
+//     buckets pass through standalone comments individually.
 //  4. Sync logs from the window become Sync events with inline transaction
 //     samples and `RuleOutcomes` lifted from `sync_logs.rule_hits`.
+//  5. Agent reports inside the same window are folded into matching
+//     bulk_action / agent_session events when the actor or session_id
+//     lines up — a reporting agent run renders as one row headed by the
+//     report's title instead of two adjacent cards. Reports that don't
+//     match anything are returned in the consumed/unconsumed split for
+//     the handler to render as standalone report cards.
 //
-// Reports + connection alerts are returned by separate handler-level
-// queries, not by this function.
+// Connection alerts are returned by a separate handler-level query, not
+// by this function.
 func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) ([]FeedEvent, error) {
+	out, _, err := s.listFeedEventsWithReports(ctx, params, nil)
+	return out, err
+}
+
+// ListFeedEventsWithReports is the report-aware variant the home Feed
+// handler uses. It folds matching reports into bulk_action / agent_session
+// events and returns the leftover (un-folded) reports separately so the
+// handler can render them as standalone report cards.
+//
+// Splitting this from `ListFeedEvents` keeps the report-free entry-point
+// available for callers that don't have a windowed report list handy
+// (none today; preserved for symmetry with `ListFeedActivity`).
+func (s *Service) ListFeedEventsWithReports(ctx context.Context, params FeedEventsParams, reports []AgentReportResponse) ([]FeedEvent, []AgentReportResponse, error) {
+	return s.listFeedEventsWithReports(ctx, params, reports)
+}
+
+func (s *Service) listFeedEventsWithReports(ctx context.Context, params FeedEventsParams, reports []AgentReportResponse) ([]FeedEvent, []AgentReportResponse, error) {
 	if params.Window <= 0 {
 		params.Window = 3 * 24 * time.Hour
 	}
@@ -329,13 +410,13 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 
 	annotationRows, err := s.fetchFeedAnnotations(ctx, cutoff, upper)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	annotationRows = enrichFeedActivityRows(annotationRows)
 
 	syncEvents, err := s.fetchFeedSyncEvents(ctx, cutoff, upper, params.SampleLimit)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	sessionMeta, err := s.fetchFeedSessionMeta(ctx, annotationRows)
@@ -344,6 +425,10 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 	}
 
 	groupedEvents := groupAnnotationsIntoEvents(annotationRows, sessionMeta, params)
+
+	// Fold matching reports into bulk_action / agent_session events. The
+	// remainder is the standalone-card list returned to the handler.
+	leftoverReports := foldReportsIntoEvents(groupedEvents, reports)
 
 	out := make([]FeedEvent, 0, len(syncEvents)+len(groupedEvents))
 	out = append(out, syncEvents...)
@@ -354,7 +439,7 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 	})
 
 	out = filterFeedEvents(out, params.Filter, params.ActorID)
-	return out, nil
+	return out, leftoverReports, nil
 }
 
 // filterFeedEvents narrows a feed-event slice to the subset matching the
@@ -1068,19 +1153,26 @@ func buildAgentSessionEvent(sessionID string, rows []FeedActivityRow, meta feedS
 }
 
 // groupUnsessionedAnnotations buckets the remaining annotations by
-// (actor_id, kind, 5-min). Buckets at-or-above BulkThreshold collapse into
-// a FeedBulkActionEvent; smaller buckets pass through annotations
-// individually but only `comment` rows are kept (other singleton
-// recategorisations are too low-signal for the home feed).
+// `(actor_id, floor(time / feedSoftBucketWindow))` — note that `kind` is
+// NOT part of the bucket key. Buckets at-or-above BulkThreshold collapse
+// into a single FeedBulkActionEvent regardless of how many distinct kinds
+// the annotations carry; the per-kind breakdown is preserved on the
+// event's `KindCounts` map so the templ can render the breakdown line.
+//
+// Sub-threshold buckets pass through standalone comments individually
+// (other singleton recategorisations are too low-signal for the home
+// feed). When ≥3 standalone comments share a bucket they collapse into a
+// bulk_action event whose Kind == "comment" — we don't want a feed full
+// of identical "Alice commented on transaction" rows when Alice was
+// triaging.
 func groupUnsessionedAnnotations(rows []FeedActivityRow, params FeedEventsParams) []FeedEvent {
 	if len(rows) == 0 {
 		return nil
 	}
-	const bucketWindow = 5 * time.Minute
+	bucketSeconds := int64(feedSoftBucketWindow.Seconds())
 
 	type bucketKey struct {
 		actorID string
-		kind    string
 		bucket  int64
 	}
 
@@ -1096,8 +1188,7 @@ func groupUnsessionedAnnotations(rows []FeedActivityRow, params FeedEventsParams
 		}
 		k := bucketKey{
 			actorID: actorID,
-			kind:    r.Annotation.Kind,
-			bucket:  r.Annotation.CreatedAtTime.Unix() / int64(bucketWindow.Seconds()),
+			bucket:  r.Annotation.CreatedAtTime.Unix() / bucketSeconds,
 		}
 		if _, ok := buckets[k]; !ok {
 			keyOrder = append(keyOrder, k)
@@ -1117,7 +1208,7 @@ func groupUnsessionedAnnotations(rows []FeedActivityRow, params FeedEventsParams
 			})
 			continue
 		}
-		// Below threshold — only standalone comments survive in v2.
+		// Below threshold — only standalone comments survive.
 		for _, r := range bucket {
 			if r.Annotation.Kind != "comment" || r.Annotation.IsDeleted {
 				continue
@@ -1142,12 +1233,16 @@ func groupUnsessionedAnnotations(rows []FeedActivityRow, params FeedEventsParams
 	return out
 }
 
-// buildBulkActionEvent collapses one (actor, kind, time-bucket) cluster of
+// buildBulkActionEvent collapses one (actor, time-bucket) cluster of
 // annotations into a single FeedBulkActionEvent, summarising the subjects
-// (tag names, category names, rule names) the actor applied.
+// (tag names, category names, rule names) the actor applied. When every
+// row in the bucket shares one kind, `Kind` is set to that homogeneous
+// kind so the templ can render the dedicated verb phrasing; otherwise
+// `Kind` is "mixed" and the templ renders the per-kind breakdown line.
 func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedBulkActionEvent {
 	ev := FeedBulkActionEvent{
-		Count: len(rows),
+		Count:      len(rows),
+		KindCounts: make(map[string]int),
 	}
 	subjectCounts := make(map[string]int)
 	subjectMeta := make(map[string]FeedBulkSubject)
@@ -1159,11 +1254,11 @@ func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedB
 			ev.ActorName = ann.ActorName
 			ev.ActorType = ann.ActorType
 			ev.ActorAvatarVersion = ann.ActorAvatarVersion
-			ev.Kind = ann.Kind
 			if ann.ActorID != nil {
 				ev.ActorID = *ann.ActorID
 			}
 		}
+		ev.KindCounts[ann.Kind]++
 		if ev.StartedAt.IsZero() || ann.CreatedAtTime.Before(ev.StartedAt) {
 			ev.StartedAt = ann.CreatedAtTime
 		}
@@ -1183,6 +1278,19 @@ func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedB
 		if _, ok := uniqueTx[r.TransactionShortID]; !ok {
 			uniqueTx[r.TransactionShortID] = sampleTxFromRow(r)
 		}
+	}
+
+	// Single-kind buckets keep the dedicated kind so the templ can render
+	// the canonical verb phrasing ("Alice categorised 12 transactions").
+	// Mixed-kind buckets get "mixed" so the templ falls back to the
+	// generic "Alice updated N transactions" headline plus the per-kind
+	// breakdown line.
+	if len(ev.KindCounts) == 1 {
+		for k := range ev.KindCounts {
+			ev.Kind = k
+		}
+	} else {
+		ev.Kind = "mixed"
 	}
 
 	subjects := make([]FeedBulkSubject, 0, len(subjectCounts))
@@ -1208,6 +1316,118 @@ func buildBulkActionEvent(rows []FeedActivityRow, params FeedEventsParams) FeedB
 	}
 	ev.SampleTransactions = samples
 	return ev
+}
+
+// foldReportsIntoEvents pairs each report with a matching bulk_action or
+// agent_session event in `events` so the report renders as part of that
+// card's headline instead of as its own row. Matching is:
+//
+//   - SessionID equality with an agent_session event, OR
+//   - actor (id, type+name fallback) equality plus the report's timestamp
+//     falling inside the bulk_action's [StartedAt-15m, EndedAt+15m] window.
+//
+// Mutates the matched events in place (sets `ev.BulkAction.Report` /
+// `ev.AgentSession.Report`) and returns the un-folded reports for the
+// handler to render as standalone report cards.
+func foldReportsIntoEvents(events []FeedEvent, reports []AgentReportResponse) []AgentReportResponse {
+	if len(events) == 0 || len(reports) == 0 {
+		return reports
+	}
+
+	leftover := make([]AgentReportResponse, 0, len(reports))
+	for _, rep := range reports {
+		if folded := tryFoldReport(events, rep); !folded {
+			leftover = append(leftover, rep)
+		}
+	}
+	return leftover
+}
+
+// tryFoldReport attempts to attach `rep` to a matching event in `events`.
+// Returns true if a match was found and the event was mutated.
+func tryFoldReport(events []FeedEvent, rep AgentReportResponse) bool {
+	ref := reportRefFromResponse(rep)
+
+	// 1. Session match wins. If the report's session_id lines up with an
+	//    agent_session event, fold there regardless of timestamps.
+	if rep.SessionID != nil && *rep.SessionID != "" {
+		for i := range events {
+			if events[i].Type != "agent_session" {
+				continue
+			}
+			if events[i].AgentSession == nil {
+				continue
+			}
+			if events[i].AgentSession.SessionID == *rep.SessionID {
+				if events[i].AgentSession.Report == nil {
+					events[i].AgentSession.Report = &ref
+				}
+				return true
+			}
+		}
+	}
+
+	// 2. Actor + window match into a bulk_action event. The report's
+	//    `created_at` must fall inside the bucket window (with a slack
+	//    of feedSoftBucketWindow on either side so a report written
+	//    seconds after the last annotation still anchors).
+	repTime, err := time.Parse(time.RFC3339, rep.CreatedAt)
+	if err != nil {
+		return false
+	}
+	repActorID := ""
+	if rep.CreatedByID != nil {
+		repActorID = *rep.CreatedByID
+	}
+	repActorKey := repActorID
+	if repActorKey == "" {
+		repActorKey = rep.CreatedByType + ":" + rep.CreatedByName
+	}
+
+	for i := range events {
+		if events[i].Type != "bulk_action" {
+			continue
+		}
+		ba := events[i].BulkAction
+		if ba == nil {
+			continue
+		}
+		baKey := ba.ActorID
+		if baKey == "" {
+			baKey = ba.ActorType + ":" + ba.ActorName
+		}
+		if baKey != repActorKey {
+			continue
+		}
+		windowStart := ba.StartedAt.Add(-feedSoftBucketWindow)
+		windowEnd := ba.EndedAt.Add(feedSoftBucketWindow)
+		if repTime.Before(windowStart) || repTime.After(windowEnd) {
+			continue
+		}
+		if ba.Report == nil {
+			ba.Report = &ref
+		}
+		// Take the report's timestamp as the event timestamp so the row
+		// sorts at the report's wall-clock position (typically the run's
+		// last action). Prevents the row drifting earlier than the
+		// report itself.
+		if repTime.After(events[i].Timestamp) {
+			events[i].Timestamp = repTime
+		}
+		return true
+	}
+	return false
+}
+
+func reportRefFromResponse(r AgentReportResponse) FeedReportRef {
+	return FeedReportRef{
+		ID:       r.ID,
+		ShortID:  r.ShortID,
+		Title:    r.Title,
+		Priority: r.Priority,
+		Tags:     r.Tags,
+		IsUnread: r.ReadAt == nil,
+	}
 }
 
 func bulkSubjectKey(a Annotation) string {

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -244,6 +244,14 @@ type FeedEventsParams struct {
 	BulkThreshold int
 	SampleLimit   int
 
+	// Before, when non-zero, anchors the window's *upper* bound at this
+	// timestamp instead of "now". Used by the "Load older activity"
+	// pagination affordance — the page rolls backward in `Window`-sized
+	// chunks. The cutoff becomes `Before.Add(-Window)`. Default-window
+	// behaviour (no `Before`) is preserved verbatim: events newer than
+	// `now - Window` and up to `now`.
+	Before time.Time
+
 	// Filter scopes the resulting event slice to a single chip on the feed
 	// rail. Empty string means "no filter" — every grouped event is
 	// returned. See `filterFeedEvents` for the recognised values.
@@ -256,6 +264,12 @@ type FeedEventsParams struct {
 	// whether the auth_account is linked to a household user.
 	ActorID string
 }
+
+// FeedMaxLookback is the hard ceiling for `Before`-driven pagination on the
+// home feed. A user can scroll backward in 3-day chunks but cannot ask for
+// activity older than this — the unbounded read would walk the entire
+// annotations table for households with years of history.
+const FeedMaxLookback = 30 * 24 * time.Hour
 
 // ListFeedEvents returns grouped FeedEvents for the home Feed page,
 // already ordered newest-first.
@@ -290,15 +304,29 @@ func (s *Service) ListFeedEvents(ctx context.Context, params FeedEventsParams) (
 		params.SampleLimit = 5
 	}
 
-	cutoff := time.Now().Add(-params.Window)
+	now := time.Now()
+	// Clamp the upper bound to the lookback ceiling so callers asking for a
+	// timestamp deeper than `FeedMaxLookback` silently get the oldest still-
+	// addressable window. Keeps the handler's `?before=` clamp honoured at
+	// the service layer too — defence in depth, since this is the layer
+	// that actually owns the unbounded-query risk.
+	upper := now
+	if !params.Before.IsZero() {
+		upper = params.Before
+		minUpper := now.Add(-FeedMaxLookback)
+		if upper.Before(minUpper) {
+			upper = minUpper
+		}
+	}
+	cutoff := upper.Add(-params.Window)
 
-	annotationRows, err := s.fetchFeedAnnotations(ctx, cutoff)
+	annotationRows, err := s.fetchFeedAnnotations(ctx, cutoff, upper)
 	if err != nil {
 		return nil, err
 	}
 	annotationRows = enrichFeedActivityRows(annotationRows)
 
-	syncEvents, err := s.fetchFeedSyncEvents(ctx, cutoff, params.SampleLimit)
+	syncEvents, err := s.fetchFeedSyncEvents(ctx, cutoff, upper, params.SampleLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -402,7 +430,7 @@ func filterEventsByActor(events []FeedEvent, actorID string) []FeedEvent {
 // surfaces both the live profile name (preferred over the frozen-at-
 // write-time `annotations.actor_name`) and the user's `updated_at` for
 // avatar cache-busting.
-func (s *Service) fetchFeedAnnotations(ctx context.Context, cutoff time.Time) ([]FeedActivityRow, error) {
+func (s *Service) fetchFeedAnnotations(ctx context.Context, cutoff, upper time.Time) ([]FeedActivityRow, error) {
 	const q = `
 SELECT
     a.id, a.short_id, a.transaction_id, a.kind, a.actor_type, a.actor_id, a.actor_name,
@@ -426,12 +454,13 @@ LEFT JOIN users u_direct
    AND u_direct.id::text = a.actor_id
 WHERE t.deleted_at IS NULL
   AND a.created_at >= $1
+  AND a.created_at <  $2
   AND a.kind NOT IN ('sync_started', 'sync_updated')
   AND COALESCE(a.payload->>'applied_by', '') <> 'sync'
 ORDER BY a.created_at DESC
 `
 
-	rows, err := s.Pool.Query(ctx, q, cutoff)
+	rows, err := s.Pool.Query(ctx, q, cutoff, upper)
 	if err != nil {
 		return nil, fmt.Errorf("list feed annotations: %w", err)
 	}
@@ -583,7 +612,7 @@ func enrichFeedActivityRows(in []FeedActivityRow) []FeedActivityRow {
 // fetchFeedSyncEvents returns one FeedEvent per sync run within the window
 // (failed runs always included; successful no-op runs filtered out).
 // Inline transaction samples are batched in a single follow-up query.
-func (s *Service) fetchFeedSyncEvents(ctx context.Context, cutoff time.Time, sampleLimit int) ([]FeedEvent, error) {
+func (s *Service) fetchFeedSyncEvents(ctx context.Context, cutoff, upper time.Time, sampleLimit int) ([]FeedEvent, error) {
 	const q = `
 SELECT
     sl.id, sl.connection_id,
@@ -594,10 +623,11 @@ SELECT
 FROM sync_logs sl
 JOIN bank_connections bc ON sl.connection_id = bc.id
 WHERE sl.started_at >= $1
+  AND sl.started_at <  $2
 ORDER BY sl.started_at DESC
 `
 
-	rows, err := s.Pool.Query(ctx, q, cutoff)
+	rows, err := s.Pool.Query(ctx, q, cutoff, upper)
 	if err != nil {
 		return nil, fmt.Errorf("list feed sync logs: %w", err)
 	}

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -33,6 +33,15 @@ type FeedActivityRow struct {
 
 	AccountName     string
 	InstitutionName string
+
+	// Category presentation, threaded through so feed sample rows can
+	// render the same coloured-circle avatar as /transactions. Nil when
+	// uncategorised. Mirrors the LEFT JOIN on `categories` performed by
+	// every feed query.
+	CategoryDisplayName *string
+	CategoryColor       *string
+	CategoryIcon        *string
+	CategorySlug        *string
 }
 
 // ListFeedActivity returns the most recent annotations across every
@@ -51,11 +60,13 @@ SELECT
     COALESCE(u_via_account.name, u_direct.name, '')::text AS actor_user_name,
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
-    ac.name, bc.institution_name
+    ac.name, bc.institution_name,
+    cat.display_name, cat.color, cat.icon, cat.slug
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
 LEFT JOIN accounts ac ON t.account_id = ac.id
 LEFT JOIN bank_connections bc ON ac.connection_id = bc.id
+LEFT JOIN categories cat ON t.category_id = cat.id
 LEFT JOIN auth_accounts aa
     ON a.actor_type = 'user'
    AND aa.id::text = a.actor_id
@@ -278,6 +289,16 @@ type FeedSampleTx struct {
 	// later, and surfacing the lifecycle state inline gives users a
 	// "this is provisional" read.
 	Pending bool
+
+	// Category presentation, matched to `tx_row_compact.templ`. Populated
+	// when the underlying transaction is categorised so the inline tx-ref
+	// row can render the same coloured circle avatar (icon when set; first-
+	// letter fallback otherwise) as the /transactions list. Nil when
+	// uncategorised — the templ falls back to a neutral letter avatar.
+	CategoryDisplayName *string
+	CategoryColor       *string
+	CategoryIcon        *string
+	CategorySlug        *string
 }
 
 // FeedRuleOutcome is one (rule, count) pair shown inline on a sync card.
@@ -530,11 +551,13 @@ SELECT
     COALESCE(u_via_account.name, u_direct.name, '')::text AS actor_user_name,
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
-    ac.name, bc.institution_name
+    ac.name, bc.institution_name,
+    cat.display_name, cat.color, cat.icon, cat.slug
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
 LEFT JOIN accounts ac ON t.account_id = ac.id
 LEFT JOIN bank_connections bc ON ac.connection_id = bc.id
+LEFT JOIN categories cat ON t.category_id = cat.id
 LEFT JOIN auth_accounts aa
     ON a.actor_type = 'user'
    AND aa.id::text = a.actor_id
@@ -596,6 +619,8 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		txDate                              pgtype.Date
 		pending                             bool
 		accountName, institutionName        pgtype.Text
+		catDisplay, catColor                pgtype.Text
+		catIcon, catSlug                    pgtype.Text
 	)
 
 	if err := s.Scan(
@@ -604,6 +629,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		&actorUserName, &actorUpdatedAt,
 		&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate, &pending,
 		&accountName, &institutionName,
+		&catDisplay, &catColor, &catIcon, &catSlug,
 	); err != nil {
 		return FeedActivityRow{}, fmt.Errorf("scan feed activity row: %w", err)
 	}
@@ -670,6 +696,22 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 	}
 	if txDate.Valid {
 		row.TransactionDate = txDate.Time.Format("2006-01-02")
+	}
+	if catDisplay.Valid {
+		v := catDisplay.String
+		row.CategoryDisplayName = &v
+	}
+	if catColor.Valid {
+		v := catColor.String
+		row.CategoryColor = &v
+	}
+	if catIcon.Valid {
+		v := catIcon.String
+		row.CategoryIcon = &v
+	}
+	if catSlug.Valid {
+		v := catSlug.String
+		row.CategorySlug = &v
 	}
 	return row, nil
 }
@@ -866,10 +908,12 @@ func (s *Service) fetchSyncSampleTransactions(ctx context.Context, raws []syncRo
 
 	const q = `
 SELECT t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
-       t.created_at, t.pending, ac.name, bc.id::text, bc.institution_name
+       t.created_at, t.pending, ac.name, bc.id::text, bc.institution_name,
+       cat.display_name, cat.color, cat.icon, cat.slug
 FROM transactions t
 JOIN accounts ac ON ac.id = t.account_id
 JOIN bank_connections bc ON ac.connection_id = bc.id
+LEFT JOIN categories cat ON t.category_id = cat.id
 WHERE t.created_at >= $1
   AND t.deleted_at IS NULL
   AND bc.id::text = ANY($2::text[])
@@ -890,18 +934,20 @@ ORDER BY t.created_at DESC
 	var fetched []txRow
 	for rows.Next() {
 		var (
-			shortID, provName string
-			merchantName      pgtype.Text
-			amount            pgtype.Numeric
-			isoCcy            pgtype.Text
-			txDate            pgtype.Date
-			createdAt         pgtype.Timestamptz
-			pending           bool
-			accountName       pgtype.Text
-			connID            string
-			institutionName   pgtype.Text
+			shortID, provName    string
+			merchantName         pgtype.Text
+			amount               pgtype.Numeric
+			isoCcy               pgtype.Text
+			txDate               pgtype.Date
+			createdAt            pgtype.Timestamptz
+			pending              bool
+			accountName          pgtype.Text
+			connID               string
+			institutionName      pgtype.Text
+			catDisplay, catColor pgtype.Text
+			catIcon, catSlug     pgtype.Text
 		)
-		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &pending, &accountName, &connID, &institutionName); err != nil {
+		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &pending, &accountName, &connID, &institutionName, &catDisplay, &catColor, &catIcon, &catSlug); err != nil {
 			return nil, err
 		}
 		t := txRow{
@@ -924,6 +970,22 @@ ORDER BY t.created_at DESC
 		}
 		if txDate.Valid {
 			t.Date = txDate.Time.Format("2006-01-02")
+		}
+		if catDisplay.Valid {
+			v := catDisplay.String
+			t.CategoryDisplayName = &v
+		}
+		if catColor.Valid {
+			v := catColor.String
+			t.CategoryColor = &v
+		}
+		if catIcon.Valid {
+			v := catIcon.String
+			t.CategoryIcon = &v
+		}
+		if catSlug.Valid {
+			v := catSlug.String
+			t.CategorySlug = &v
 		}
 		fetched = append(fetched, t)
 	}
@@ -1462,15 +1524,19 @@ func sampleTxFromRow(r FeedActivityRow) FeedSampleTx {
 		merchant = r.TransactionName
 	}
 	return FeedSampleTx{
-		ShortID:      r.TransactionShortID,
-		Name:         r.TransactionName,
-		MerchantName: merchant,
-		Amount:       r.Amount,
-		Currency:     r.IsoCurrencyCode,
-		Date:         r.TransactionDate,
-		AccountName:  r.AccountName,
-		Institution:  r.InstitutionName,
-		Pending:      r.Pending,
+		ShortID:             r.TransactionShortID,
+		Name:                r.TransactionName,
+		MerchantName:        merchant,
+		Amount:              r.Amount,
+		Currency:            r.IsoCurrencyCode,
+		Date:                r.TransactionDate,
+		AccountName:         r.AccountName,
+		Institution:         r.InstitutionName,
+		Pending:             r.Pending,
+		CategoryDisplayName: r.CategoryDisplayName,
+		CategoryColor:       r.CategoryColor,
+		CategoryIcon:        r.CategoryIcon,
+		CategorySlug:        r.CategorySlug,
 	}
 }
 

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -486,6 +486,93 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		}
 	})
 
+	t.Run("BeforeAnchorsUpperBound", func(t *testing.T) {
+		// `Before` rolls the 3-day window backward — events newer than the
+		// upper bound must drop out of the result, while events inside
+		// `[Before-3d, Before)` come through. Validates the pagination
+		// affordance the /feed footer exposes.
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "before-window", 2)
+
+		now := time.Now().UTC()
+		// Recent comment (1 hour ago) — should be excluded by Before=now-2d.
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-recent", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"recent"}`),
+			now.Add(-1*time.Hour),
+		)
+		// Older comment (2.5 days ago) — should land inside the chunk
+		// `[Before-3d, Before)` where Before = now-2d.
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[1],
+			"comment", "user", "actor-older", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"older"}`),
+			now.Add(-60*time.Hour),
+		)
+
+		before := now.Add(-2 * 24 * time.Hour)
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+			Window: 3 * 24 * time.Hour,
+			Before: before,
+		})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "comment"); got != 1 {
+			t.Fatalf("expected 1 comment in `[before-3d, before)` chunk, got %d (%+v)", got, events)
+		}
+		// The single event must be the older one (the recent comment is
+		// past the upper bound).
+		c := findEventByType(events, "comment").Comment
+		if c.Content != "older" {
+			t.Errorf("Comment.Content = %q, want %q", c.Content, "older")
+		}
+	})
+
+	t.Run("BeforeIsCappedAt30Days", func(t *testing.T) {
+		// Asking for a `Before` deeper than 30 days clamps the upper bound
+		// to (now - FeedMaxLookback). With Window=3d the resulting chunk is
+		// `[now-33d, now-30d)`, so an annotation aged ~31 days ago lands
+		// inside it while a 90-day-old annotation does not.
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "before-cap", 2)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-cap-in", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"in-clamped-chunk"}`),
+			now.Add(-31*24*time.Hour),
+		)
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[1],
+			"comment", "user", "actor-cap-out", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"way-too-old"}`),
+			now.Add(-90*24*time.Hour),
+		)
+
+		// Caller asks for a `Before` 60 days back — service must clamp it
+		// to (now - FeedMaxLookback) so the 31-day-old annotation lands
+		// inside the resulting chunk while the 90-day-old one stays out.
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+			Window: 3 * 24 * time.Hour,
+			Before: now.Add(-60 * 24 * time.Hour),
+		})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "comment"); got != 1 {
+			t.Fatalf("expected 1 comment after clamping Before to -30d, got %d (%+v)", got, events)
+		}
+		c := findEventByType(events, "comment").Comment
+		if c.Content != "in-clamped-chunk" {
+			t.Errorf("Comment.Content = %q, want %q", c.Content, "in-clamped-chunk")
+		}
+	})
+
 	t.Run("WindowIsBounded", func(t *testing.T) {
 		svc, queries, pool := newService(t)
 		ctx := context.Background()

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -297,17 +297,20 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		ctx := context.Background()
 		seed := seedFeedFixture(t, queries, "bulk", 4)
 
-		now := time.Now().UTC()
+		// Anchor 2 minutes past the current 15-min bucket boundary so all
+		// seeded annotations land in one bucket regardless of when the
+		// test runs. Without this, runs that fire near a boundary split
+		// the seeds across two buckets and the count flakes.
+		now := time.Now().UTC().Truncate(15 * time.Minute).Add(2 * time.Minute)
 		actorID := "user-actor-bulk"
 		// 4 category_set annotations, same actor, 4 different transactions,
-		// all within ~30 seconds (well inside the 5-minute soft bucket and
-		// the 2-minute window the spec asks us to assert).
+		// all within ~30 seconds (well inside the 15-minute soft bucket).
 		for i := 0; i < 4; i++ {
 			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
 				"category_set", "user", actorID, "Alice",
 				pgtype.UUID{},
 				[]byte(`{"category_slug":"food_and_drink"}`),
-				now.Add(time.Duration(-30+i*10)*time.Second),
+				now.Add(time.Duration(i*5)*time.Second),
 			)
 		}
 
@@ -444,10 +447,12 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		rule := testutil.MustCreateTransactionRule(t, queries, "Coffee Rule", []byte(`[]`), []byte(`[]`), "on_create")
 		ruleShortID := rule.ShortID
 
-		now := time.Now().UTC()
+		// Anchor 2 minutes past the current 15-min bucket boundary so all
+		// seeds land in one bucket regardless of when the test fires.
+		now := time.Now().UTC().Truncate(15 * time.Minute).Add(2 * time.Minute)
 		actorID := "actor-retro"
 		// 5 rule_applied annotations, same actor, no `applied_by=sync`, all
-		// within ~30 seconds → should produce a single bulk_action event.
+		// within ~25 seconds → should produce a single bulk_action event.
 		for i := 0; i < 5; i++ {
 			params := db.InsertAnnotationParams{
 				TransactionID: seed.TxnIDs[i],
@@ -464,7 +469,7 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 			}
 			if _, err := pool.Exec(ctx,
 				"UPDATE annotations SET created_at = $1 WHERE id = $2",
-				now.Add(time.Duration(-30+i*5)*time.Second), ann.ID,
+				now.Add(time.Duration(i*5)*time.Second), ann.ID,
 			); err != nil {
 				t.Fatalf("backdate: %v", err)
 			}

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -573,6 +573,215 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		}
 	})
 
+	t.Run("BulkActionFoldsAcrossKinds", func(t *testing.T) {
+		// Iteration-13 widening: a single actor that touches multiple kinds
+		// in one 15-minute window collapses into ONE bulk_action card whose
+		// KindCounts surfaces the breakdown. Previously each kind got its
+		// own bucket and the rail showed 3 adjacent cards for one agent run.
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "mixedkind", 21)
+
+		// Anchor inserts well inside a single 15-min bucket window so
+		// the floor(unix/15m) key is identical for every annotation. We
+		// step back 1 hour from real wall-time and snap to the bucket
+		// centre — the resulting timestamp is comfortably inside the 3-day
+		// fetch window and clear of any 15-min boundary.
+		anchor := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(7 * time.Minute)
+		actorID := "actor-mixed-kind"
+		var i int
+		// 5 category_set
+		for j := 0; j < 5; j++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"category_set", "user", actorID, "Alice",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				anchor.Add(time.Duration(j)*time.Second),
+			)
+			i++
+		}
+		// 8 tag_removed
+		for j := 0; j < 8; j++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"tag_removed", "user", actorID, "Alice",
+				pgtype.UUID{},
+				[]byte(`{"tag_slug":"needs-review"}`),
+				anchor.Add(time.Duration(10+j)*time.Second),
+			)
+			i++
+		}
+		// 8 comments from the same actor in the same window. Together with
+		// the bursts above they prove the bucket is kind-agnostic — without
+		// this iteration's widening, each kind would produce its own card.
+		for j := 0; j < 8; j++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"comment", "user", actorID, "Alice",
+				pgtype.UUID{},
+				[]byte(`{"content":"thinking"}`),
+				anchor.Add(time.Duration(20+j)*time.Second),
+			)
+			i++
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event (kind-agnostic bucket), got %d", got)
+		}
+		if got := countEventsByType(events, "comment"); got != 0 {
+			t.Errorf("expected 0 standalone comment events (folded into bulk), got %d", got)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Count != 21 {
+			t.Errorf("Count = %d, want 21", ev.Count)
+		}
+		if ev.Kind != "mixed" {
+			t.Errorf("Kind = %q, want %q", ev.Kind, "mixed")
+		}
+		if ev.KindCounts["category_set"] != 5 {
+			t.Errorf("KindCounts[category_set] = %d, want 5", ev.KindCounts["category_set"])
+		}
+		if ev.KindCounts["tag_removed"] != 8 {
+			t.Errorf("KindCounts[tag_removed] = %d, want 8", ev.KindCounts["tag_removed"])
+		}
+		if ev.KindCounts["comment"] != 8 {
+			t.Errorf("KindCounts[comment] = %d, want 8", ev.KindCounts["comment"])
+		}
+	})
+
+	t.Run("CommentsBucketIfThree", func(t *testing.T) {
+		// Three same-actor comments in a 15-min window collapse into a
+		// bulk_action with Kind="comment" Count=3. Two comments in the same
+		// window stay as individual comment cards (sub-threshold).
+		t.Run("ThreeFold", func(t *testing.T) {
+			svc, queries, pool := newService(t)
+			ctx := context.Background()
+			seed := seedFeedFixture(t, queries, "comments3", 3)
+
+			anchor := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(7 * time.Minute)
+			actorID := "actor-3-comments"
+			for j := 0; j < 3; j++ {
+				insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[j],
+					"comment", "user", actorID, "Alice",
+					pgtype.UUID{},
+					[]byte(`{"content":"hi"}`),
+					anchor.Add(time.Duration(j)*time.Second),
+				)
+			}
+
+			events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+			if err != nil {
+				t.Fatalf("ListFeedEvents: %v", err)
+			}
+			if got := countEventsByType(events, "bulk_action"); got != 1 {
+				t.Fatalf("expected 1 bulk_action (≥3 comments), got %d", got)
+			}
+			if got := countEventsByType(events, "comment"); got != 0 {
+				t.Errorf("expected 0 standalone comments, got %d", got)
+			}
+			ev := findEventByType(events, "bulk_action").BulkAction
+			if ev.Kind != "comment" {
+				t.Errorf("Kind = %q, want %q", ev.Kind, "comment")
+			}
+			if ev.Count != 3 {
+				t.Errorf("Count = %d, want 3", ev.Count)
+			}
+		})
+		t.Run("TwoStandalone", func(t *testing.T) {
+			svc, queries, pool := newService(t)
+			ctx := context.Background()
+			seed := seedFeedFixture(t, queries, "comments2", 2)
+
+			anchor := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(7 * time.Minute)
+			actorID := "actor-2-comments"
+			for j := 0; j < 2; j++ {
+				insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[j],
+					"comment", "user", actorID, "Alice",
+					pgtype.UUID{},
+					[]byte(`{"content":"hi"}`),
+					anchor.Add(time.Duration(j)*time.Second),
+				)
+			}
+
+			events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+			if err != nil {
+				t.Fatalf("ListFeedEvents: %v", err)
+			}
+			if got := countEventsByType(events, "bulk_action"); got != 0 {
+				t.Errorf("expected 0 bulk_action (sub-threshold), got %d", got)
+			}
+			if got := countEventsByType(events, "comment"); got != 2 {
+				t.Errorf("expected 2 standalone comments, got %d", got)
+			}
+		})
+	})
+
+	t.Run("ReportFoldsIntoBulkAction", func(t *testing.T) {
+		// A reporting agent run: 8 same-actor annotations in a 5-minute
+		// span plus an agent report at the bucket center (same actor).
+		// The report folds into the bulk_action card; only ONE event
+		// surfaces, with the report title in the headline.
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "reportfold", 8)
+
+		anchor := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(7 * time.Minute)
+		actorID := "agent-report-fold"
+		for j := 0; j < 8; j++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[j],
+				"category_set", "agent", actorID, "ReportingAgent",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				anchor.Add(time.Duration(j)*time.Second),
+			)
+		}
+
+		// Report from the same agent created in the middle of the bucket.
+		actor := service.Actor{Type: "agent", ID: actorID, Name: "ReportingAgent"}
+		report, err := svc.CreateAgentReport(ctx, "Reviewed and cleared 8 transactions",
+			"All 8 looked clean.",
+			actor, "info", []string{"review"}, "", "")
+		if err != nil {
+			t.Fatalf("CreateAgentReport: %v", err)
+		}
+		// Backdate the report into the middle of the bulk_action's
+		// time window so the actor+window fold check passes.
+		if _, err := pool.Exec(ctx,
+			"UPDATE agent_reports SET created_at = $1 WHERE id::text = $2",
+			anchor.Add(10*time.Second), report.ID,
+		); err != nil {
+			t.Fatalf("backdate report: %v", err)
+		}
+		// Re-fetch the report so the SessionID/CreatedAt round-trip.
+		fetched, err := svc.GetAgentReport(ctx, report.ID)
+		if err != nil {
+			t.Fatalf("GetAgentReport: %v", err)
+		}
+
+		events, leftover, err := svc.ListFeedEventsWithReports(ctx,
+			service.FeedEventsParams{},
+			[]service.AgentReportResponse{fetched},
+		)
+		if err != nil {
+			t.Fatalf("ListFeedEventsWithReports: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event, got %d", got)
+		}
+		if len(leftover) != 0 {
+			t.Errorf("expected 0 leftover reports (folded into bulk), got %d (%+v)", len(leftover), leftover)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Report == nil {
+			t.Fatalf("BulkAction.Report = nil, want non-nil with title %q", "Reviewed and cleared 8 transactions")
+		}
+		if ev.Report.Title != "Reviewed and cleared 8 transactions" {
+			t.Errorf("BulkAction.Report.Title = %q, want %q", ev.Report.Title, "Reviewed and cleared 8 transactions")
+		}
+	})
+
 	t.Run("WindowIsBounded", func(t *testing.T) {
 		svc, queries, pool := newService(t)
 		ctx := context.Background()

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -1,0 +1,513 @@
+//go:build integration
+
+// Integration tests that pin down `Service.ListFeedEvents` grouping behaviour.
+//
+// The feed page intentionally collapses noisy clusters of annotations into a
+// handful of high-signal cards. The cases below seed real annotations + sync
+// logs + mcp_sessions + transactions and assert each grouping rule the
+// previous iterations of /feed established. They serve as a regression net so
+// future iterations can't quietly drop the dedup, bulk-bucket, or
+// session-collapse logic.
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// feedSeed bundles the IDs needed across the per-subtest seeders. Every
+// subtest gets a fresh, truncated DB via newService → testutil.Pool, so
+// helpers populate this struct top-down.
+type feedSeed struct {
+	UserID  pgtype.UUID
+	ConnID  pgtype.UUID
+	AcctID  pgtype.UUID
+	TxnIDs  []pgtype.UUID
+}
+
+// seedFeedFixture creates one user/connection/account plus `txnCount`
+// transactions so tests have transaction IDs to attach annotations to.
+func seedFeedFixture(t *testing.T, queries *db.Queries, suffix string, txnCount int) feedSeed {
+	t.Helper()
+	user := testutil.MustCreateUser(t, queries, "Alice "+suffix)
+	conn := testutil.MustCreateConnection(t, queries, user.ID, "feed_conn_"+suffix)
+	acct := testutil.MustCreateAccount(t, queries, conn.ID, "feed_acct_"+suffix, "Checking "+suffix)
+
+	out := feedSeed{UserID: user.ID, ConnID: conn.ID, AcctID: acct.ID}
+	for i := 0; i < txnCount; i++ {
+		txn := testutil.MustCreateTransaction(
+			t, queries, acct.ID,
+			fmt.Sprintf("feed_txn_%s_%d", suffix, i),
+			fmt.Sprintf("Merchant %s %d", suffix, i),
+			int64(1000+i*250),
+			"2026-04-15",
+		)
+		out.TxnIDs = append(out.TxnIDs, txn.ID)
+	}
+	return out
+}
+
+// insertAnnotation inserts an annotation and forces its `created_at` to the
+// supplied time. The sqlc-generated InsertAnnotation does not accept a
+// created_at parameter (the column defaults to NOW()), so we patch it after
+// the fact — mirrors what real history would look like once enough wall-time
+// has elapsed.
+func insertAnnotation(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	queries *db.Queries,
+	txnID pgtype.UUID,
+	kind, actorType, actorID, actorName string,
+	sessionID pgtype.UUID,
+	payload []byte,
+	createdAt time.Time,
+) pgtype.UUID {
+	t.Helper()
+	params := db.InsertAnnotationParams{
+		TransactionID: txnID,
+		Kind:          kind,
+		ActorType:     actorType,
+		ActorName:     actorName,
+		Payload:       payload,
+	}
+	if actorID != "" {
+		params.ActorID = pgtype.Text{String: actorID, Valid: true}
+	}
+	if sessionID.Valid {
+		params.SessionID = sessionID
+	}
+	ann, err := queries.InsertAnnotation(ctx, params)
+	if err != nil {
+		t.Fatalf("InsertAnnotation(%s): %v", kind, err)
+	}
+	if _, err := pool.Exec(ctx,
+		"UPDATE annotations SET created_at = $1 WHERE id = $2",
+		createdAt, ann.ID,
+	); err != nil {
+		t.Fatalf("backdate annotation: %v", err)
+	}
+	return ann.ID
+}
+
+// findEventByType returns the first FeedEvent of the requested type, or nil.
+func findEventByType(events []service.FeedEvent, eventType string) *service.FeedEvent {
+	for i := range events {
+		if events[i].Type == eventType {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+// countEventsByType counts events whose Type matches.
+func countEventsByType(events []service.FeedEvent, eventType string) int {
+	n := 0
+	for _, e := range events {
+		if e.Type == eventType {
+			n++
+		}
+	}
+	return n
+}
+
+func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
+	t.Run("SyncErrorDedup", func(t *testing.T) {
+		svc, queries, _ := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "syncerr", 0)
+
+		now := time.Now().UTC()
+		errMsg := pgtype.Text{String: "ITEM_LOGIN_REQUIRED", Valid: true}
+		// Five sync_logs, same connection + same error message, oldest →
+		// newest. The dedup key is (connection_id, error_message); these
+		// should collapse into one event with RetryCount == 4 and
+		// FirstFailureAt == oldest.
+		oldest := now.Add(-90 * time.Minute)
+		for i := 0; i < 5; i++ {
+			startedAt := now.Add(time.Duration(-90+i*15) * time.Minute)
+			if _, err := queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+				ConnectionID: seed.ConnID,
+				Trigger:      db.SyncTriggerCron,
+				Status:       db.SyncStatusError,
+				StartedAt:    pgconv.Timestamptz(startedAt),
+				CompletedAt:  pgconv.Timestamptz(startedAt.Add(2 * time.Second)),
+				ErrorMessage: errMsg,
+			}); err != nil {
+				t.Fatalf("CreateSyncLog %d: %v", i, err)
+			}
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "sync"); got != 1 {
+			t.Fatalf("expected 1 sync event after dedup, got %d", got)
+		}
+		ev := findEventByType(events, "sync").Sync
+		if ev.RetryCount != 4 {
+			t.Errorf("RetryCount = %d, want 4", ev.RetryCount)
+		}
+		if ev.Status != "error" {
+			t.Errorf("Status = %q, want %q", ev.Status, "error")
+		}
+		// FirstFailureAt is the oldest start. Compare at second precision —
+		// pgtype rounds to micro and time.Now() roundtrips through pg.
+		if !ev.FirstFailureAt.Truncate(time.Second).Equal(oldest.Truncate(time.Second)) {
+			t.Errorf("FirstFailureAt = %v, want %v", ev.FirstFailureAt, oldest)
+		}
+	})
+
+	t.Run("DifferentErrorsDoNotDedupe", func(t *testing.T) {
+		svc, queries, _ := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "differr", 0)
+
+		now := time.Now().UTC()
+		mkLog := func(offsetMin int, msg string) {
+			startedAt := now.Add(time.Duration(offsetMin) * time.Minute)
+			if _, err := queries.CreateSyncLog(ctx, db.CreateSyncLogParams{
+				ConnectionID: seed.ConnID,
+				Trigger:      db.SyncTriggerCron,
+				Status:       db.SyncStatusError,
+				StartedAt:    pgconv.Timestamptz(startedAt),
+				CompletedAt:  pgconv.Timestamptz(startedAt.Add(time.Second)),
+				ErrorMessage: pgtype.Text{String: msg, Valid: true},
+			}); err != nil {
+				t.Fatalf("CreateSyncLog: %v", err)
+			}
+		}
+		// Three with err A, two with err B.
+		for i := 0; i < 3; i++ {
+			mkLog(-90+i*5, "ITEM_LOGIN_REQUIRED")
+		}
+		for i := 0; i < 2; i++ {
+			mkLog(-30+i*5, "RATE_LIMIT_EXCEEDED")
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "sync"); got != 2 {
+			t.Fatalf("expected 2 sync events (one per distinct error), got %d", got)
+		}
+	})
+
+	t.Run("HardGroupBySessionID", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "session", 5)
+
+		// Create one MCP session + 12 annotations across 5 transactions
+		// (4 category_set, 4 tag_added, 4 comment), all with session_id.
+		session, err := queries.CreateMCPSession(ctx, db.CreateMCPSessionParams{
+			ApiKeyID:   "00000000-0000-0000-0000-000000000abc",
+			ApiKeyName: "review-bot",
+			Purpose:    "categorize",
+		})
+		if err != nil {
+			t.Fatalf("CreateMCPSession: %v", err)
+		}
+
+		// Need a tag for tag_added rows.
+		tag := testutil.MustCreateTag(t, queries, "needs-review", "Needs Review")
+
+		now := time.Now().UTC()
+		actorID := pgconv.FormatUUID(session.ID)
+		mk := func(kind string, txnIdx int, idx int) {
+			ts := now.Add(time.Duration(-30+idx) * time.Second)
+			params := db.InsertAnnotationParams{
+				TransactionID: seed.TxnIDs[txnIdx],
+				Kind:          kind,
+				ActorType:     "agent",
+				ActorID:       pgtype.Text{String: actorID, Valid: true},
+				ActorName:     "review-bot",
+				SessionID:     session.ID,
+				Payload:       []byte(`{}`),
+			}
+			if kind == "tag_added" {
+				params.TagID = tag.ID
+				params.Payload = []byte(`{"tag_slug":"needs-review"}`)
+			}
+			if kind == "category_set" {
+				params.Payload = []byte(`{"category_slug":"food_and_drink"}`)
+			}
+			ann, err := queries.InsertAnnotation(ctx, params)
+			if err != nil {
+				t.Fatalf("InsertAnnotation(%s): %v", kind, err)
+			}
+			if _, err := pool.Exec(ctx,
+				"UPDATE annotations SET created_at = $1 WHERE id = $2", ts, ann.ID,
+			); err != nil {
+				t.Fatalf("backdate: %v", err)
+			}
+		}
+		// 4 of each kind, distributed over 5 transactions.
+		for i := 0; i < 4; i++ {
+			mk("category_set", i%5, i)
+		}
+		for i := 0; i < 4; i++ {
+			mk("tag_added", (i+1)%5, 4+i)
+		}
+		for i := 0; i < 4; i++ {
+			mk("comment", (i+2)%5, 8+i)
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "agent_session"); got != 1 {
+			t.Fatalf("expected 1 agent_session event, got %d (events=%+v)", got, events)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 0 {
+			t.Errorf("expected 0 bulk_action events (sessioned annotations should not bucket), got %d", got)
+		}
+		if got := countEventsByType(events, "comment"); got != 0 {
+			t.Errorf("expected 0 comment events (sessioned comments should fold into the session), got %d", got)
+		}
+		ev := findEventByType(events, "agent_session").AgentSession
+		if ev.AnnotationCount != 12 {
+			t.Errorf("AnnotationCount = %d, want 12", ev.AnnotationCount)
+		}
+		if ev.UniqueTransactions != 5 {
+			t.Errorf("UniqueTransactions = %d, want 5", ev.UniqueTransactions)
+		}
+		for _, kind := range []string{"category_set", "tag_added", "comment"} {
+			if ev.KindCounts[kind] != 4 {
+				t.Errorf("KindCounts[%s] = %d, want 4", kind, ev.KindCounts[kind])
+			}
+		}
+	})
+
+	t.Run("SoftBucketBulkAction", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "bulk", 4)
+
+		now := time.Now().UTC()
+		actorID := "user-actor-bulk"
+		// 4 category_set annotations, same actor, 4 different transactions,
+		// all within ~30 seconds (well inside the 5-minute soft bucket and
+		// the 2-minute window the spec asks us to assert).
+		for i := 0; i < 4; i++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"category_set", "user", actorID, "Alice",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				now.Add(time.Duration(-30+i*10)*time.Second),
+			)
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event, got %d", got)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Kind != "category_set" {
+			t.Errorf("Kind = %q, want %q", ev.Kind, "category_set")
+		}
+		if ev.Count != 4 {
+			t.Errorf("Count = %d, want 4", ev.Count)
+		}
+	})
+
+	t.Run("BelowThresholdDropsStandaloneCategorySet", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "below", 2)
+
+		now := time.Now().UTC()
+		// Two category_set annotations from the same actor in the same
+		// minute. Default BulkThreshold is 3 → bucket count 2 falls through,
+		// and only `comment` rows survive sub-threshold, so these category
+		// rows should disappear from the feed.
+		for i := 0; i < 2; i++ {
+			insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[i],
+				"category_set", "user", "actor-below", "Alice",
+				pgtype.UUID{},
+				[]byte(`{"category_slug":"food_and_drink"}`),
+				now.Add(time.Duration(-10+i*5)*time.Second),
+			)
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 0 {
+			t.Errorf("expected 0 bulk_action events (under threshold), got %d", got)
+		}
+		if got := countEventsByType(events, "comment"); got != 0 {
+			t.Errorf("expected 0 comment events, got %d", got)
+		}
+		// The whole feed should be empty for this fixture (no sync logs were
+		// seeded either).
+		if len(events) != 0 {
+			t.Errorf("expected 0 events total, got %d (%+v)", len(events), events)
+		}
+	})
+
+	t.Run("StandaloneCommentSurvives", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "comment", 1)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-comment", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"Looks like a duplicate"}`),
+			now.Add(-5*time.Minute),
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "comment"); got != 1 {
+			t.Fatalf("expected 1 comment event, got %d", got)
+		}
+	})
+
+	t.Run("SyncStartedAndUpdatedExcluded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "syncann", 1)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"sync_started", "system", "", "Plaid Sync",
+			pgtype.UUID{},
+			[]byte(`{}`),
+			now.Add(-30*time.Second),
+		)
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"sync_updated", "system", "", "Plaid Sync",
+			pgtype.UUID{},
+			[]byte(`{}`),
+			now.Add(-20*time.Second),
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected sync_started/sync_updated annotations to be excluded; got %d events: %+v", len(events), events)
+		}
+	})
+
+	t.Run("RuleAppliedDuringSyncExcluded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "rulesync", 1)
+
+		now := time.Now().UTC()
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"rule_applied", "system", "", "Plaid Sync",
+			pgtype.UUID{},
+			[]byte(`{"applied_by":"sync"}`),
+			now.Add(-30*time.Second),
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected rule_applied(applied_by=sync) to be excluded; got %d events", len(events))
+		}
+	})
+
+	t.Run("RuleAppliedRetroactiveIncluded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "ruleretro", 5)
+
+		// Need a real rule so rule_applied annotations have an FK target.
+		rule := testutil.MustCreateTransactionRule(t, queries, "Coffee Rule", []byte(`[]`), []byte(`[]`), "on_create")
+		ruleShortID := rule.ShortID
+
+		now := time.Now().UTC()
+		actorID := "actor-retro"
+		// 5 rule_applied annotations, same actor, no `applied_by=sync`, all
+		// within ~30 seconds → should produce a single bulk_action event.
+		for i := 0; i < 5; i++ {
+			params := db.InsertAnnotationParams{
+				TransactionID: seed.TxnIDs[i],
+				Kind:          "rule_applied",
+				ActorType:     "user",
+				ActorID:       pgtype.Text{String: actorID, Valid: true},
+				ActorName:     "Alice",
+				RuleID:        rule.ID,
+				Payload:       []byte(fmt.Sprintf(`{"rule_short_id":%q}`, ruleShortID)),
+			}
+			ann, err := queries.InsertAnnotation(ctx, params)
+			if err != nil {
+				t.Fatalf("InsertAnnotation %d: %v", i, err)
+			}
+			if _, err := pool.Exec(ctx,
+				"UPDATE annotations SET created_at = $1 WHERE id = $2",
+				now.Add(time.Duration(-30+i*5)*time.Second), ann.ID,
+			); err != nil {
+				t.Fatalf("backdate: %v", err)
+			}
+		}
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if got := countEventsByType(events, "bulk_action"); got != 1 {
+			t.Fatalf("expected 1 bulk_action event, got %d (%+v)", got, events)
+		}
+		ev := findEventByType(events, "bulk_action").BulkAction
+		if ev.Kind != "rule_applied" {
+			t.Errorf("Kind = %q, want %q", ev.Kind, "rule_applied")
+		}
+		if ev.Count != 5 {
+			t.Errorf("Count = %d, want 5", ev.Count)
+		}
+	})
+
+	t.Run("WindowIsBounded", func(t *testing.T) {
+		svc, queries, pool := newService(t)
+		ctx := context.Background()
+		seed := seedFeedFixture(t, queries, "window", 1)
+
+		// Annotation aged 4 days ago, with a 3-day window: must be excluded.
+		old := time.Now().UTC().Add(-4 * 24 * time.Hour)
+		insertAnnotation(t, ctx, pool, queries, seed.TxnIDs[0],
+			"comment", "user", "actor-window", "Alice",
+			pgtype.UUID{},
+			[]byte(`{"content":"old"}`),
+			old,
+		)
+
+		events, err := svc.ListFeedEvents(ctx, service.FeedEventsParams{
+			Window: 3 * 24 * time.Hour,
+		})
+		if err != nil {
+			t.Fatalf("ListFeedEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Errorf("expected 0 events with 3d window vs 4d-old annotation; got %d", len(events))
+		}
+	})
+}

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -24,12 +24,11 @@ type AgentReportResponse struct {
 	CreatedAt     string   `json:"created_at"`
 
 	// SessionID, when populated, links this report to the MCP session that
-	// produced it. Surfacing it in the response lets the home Feed fold a
-	// report into the matching agent_session card so an agent run shows up
-	// as a single row headed by the report title rather than two adjacent
-	// cards (the report + the session). Nil when the report wasn't anchored
-	// to a session at write time (older reports, or human-authored ones).
-	SessionID *string `json:"session_id,omitempty"`
+	// produced it. Available to Go consumers (the home Feed folds a report
+	// into the matching agent_session card by session_id) but suppressed
+	// from JSON output so the MCP `submit_report` response contract stays
+	// stable — the link is server-side internal, not a public field.
+	SessionID *string `json:"-"`
 }
 
 func agentReportFromRow(r db.AgentReport) AgentReportResponse {

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -22,6 +22,14 @@ type AgentReportResponse struct {
 	Author        *string  `json:"author,omitempty"`
 	ReadAt        *string  `json:"read_at"`
 	CreatedAt     string   `json:"created_at"`
+
+	// SessionID, when populated, links this report to the MCP session that
+	// produced it. Surfacing it in the response lets the home Feed fold a
+	// report into the matching agent_session card so an agent run shows up
+	// as a single row headed by the report title rather than two adjacent
+	// cards (the report + the session). Nil when the report wasn't anchored
+	// to a session at write time (older reports, or human-authored ones).
+	SessionID *string `json:"session_id,omitempty"`
 }
 
 func agentReportFromRow(r db.AgentReport) AgentReportResponse {
@@ -29,7 +37,7 @@ func agentReportFromRow(r db.AgentReport) AgentReportResponse {
 	if tags == nil {
 		tags = []string{}
 	}
-	return AgentReportResponse{
+	out := AgentReportResponse{
 		ID:            formatUUID(r.ID),
 		ShortID:       r.ShortID,
 		Title:         r.Title,
@@ -43,6 +51,11 @@ func agentReportFromRow(r db.AgentReport) AgentReportResponse {
 		ReadAt:        timestampStr(r.ReadAt),
 		CreatedAt:     pgconv.TimestampStr(r.CreatedAt),
 	}
+	if r.SessionID.Valid {
+		s := formatUUID(r.SessionID)
+		out.SessionID = &s
+	}
+	return out
 }
 
 // ValidReportPriorities lists allowed priority values.

--- a/internal/templates/components/helpers.go
+++ b/internal/templates/components/helpers.go
@@ -245,6 +245,12 @@ func CommaAmount(f float64) string { return commaAmount(f) }
 // mixed-case input untouched. See titleCase.
 func TitleCase(s string) string { return titleCase(s) }
 
+// TxAvatarColorStyle is the exported wrapper around `txAvatarColorStyle`
+// (defined in tx_row.templ) so subpackages — notably `templates/components/
+// pages` — can render the same coloured-circle avatar used by
+// `tx_row_compact.templ` without copying the fallback color.
+func TxAvatarColorStyle(color *string) string { return txAvatarColorStyle(color) }
+
 // PluralS returns "" for n == 1, else "s". See pluralS.
 func PluralS[T pluralInt](n T) string { return pluralS(n) }
 

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -55,7 +55,9 @@ templ Nav(p NavProps) {
 		<a href="/feed" class={ "bb-sidebar-link", navActive(p.CurrentPage, "feed") }>
 			<i data-lucide="rss"></i>
 			<span class="flex-1">Feed</span>
-			<span class="bb-nav-badge" title="New activity-style home">New</span>
+			if p.UnreadReports > 0 {
+				<span class="bb-nav-badge" title={ fmt.Sprintf("%d unread reports", p.UnreadReports) }>{ badgeCount(p.UnreadReports) }</span>
+			}
 		</a>
 		<a href="/transactions" class={ "bb-sidebar-link", navActive(p.CurrentPage, "transactions") }>
 			<i data-lucide="receipt"></i> Transactions

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -16,14 +16,12 @@ import (
 // transaction activity log on /transactions/{id}. The home feed is just a
 // global, grouped view of the same shape.
 templ Feed(p FeedProps) {
-	<!-- Comment bubbles use the shared markdown scanner so a comment posted
-	     from the per-transaction composer renders identically when it
-	     surfaces here. Same marked + DOMPurify versions / SRI as the
-	     per-transaction page. The scanner is idempotent — safe on every
-	     feed visit. -->
-	<script src="https://cdn.jsdelivr.net/npm/marked@15.0.12/marked.min.js" integrity="sha384-948ahk4ZmxYVYOc+rxN1H2gM1EJ2Duhp7uHtZ4WSLkV4Vtx5MUqnV+l7u9B+jFv+" crossorigin="anonymous"></script>
-	<script src="https://cdn.jsdelivr.net/npm/dompurify@3.4.0/dist/purify.min.js" integrity="sha384-lExbHoPFNjOW+xMze1tJWzpODN3bi/yx3zhbwRoZWaIYxjl89HxJcI2BxPTNa9M7" crossorigin="anonymous"></script>
-	<script src="/static/js/admin/markdown.js"></script>
+	<!-- Comment rows on the home feed render the meta line only ("Alice
+	     commented on Whole Foods") — the body lives on the per-tx page.
+	     Dropping the markdown bubble here lets us drop the marked /
+	     DOMPurify / markdown-scanner script trio entirely; the global
+	     feed is a glance surface, and a click-through to /transactions/{id}
+	     is the right home for the comment body. -->
 	<div x-data x-init="$store.shortcuts.setScope('feed')" x-destroy="$store.shortcuts.setScope('global')"></div>
 	@feedHero(p)
 	if len(p.ConnectionAlerts) > 0 {
@@ -550,65 +548,157 @@ templ feedReportBody(it FeedItem, r *FeedReport, now time.Time) {
 }
 
 templ feedAgentSessionBody(it FeedItem, s *FeedAgentSession, now time.Time) {
-	<div class="flex items-baseline gap-1.5 flex-wrap">
-		<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
-		<span class="text-base-content/55">ran a session</span>
-		<span class="text-base-content/30">·</span>
-		<span class="font-medium text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
-		@feedRowTimestamp(it.TimestampStr, now)
-	</div>
-	if breakdown := feedSessionBreakdown(s); breakdown != "" {
+	if s.ReportTitle != "" {
+		// Report folded into this session — use the report title as the
+		// headline and the session description sinks beneath it. Mirrors
+		// how the bulk_action card folds a report (see feedBulkActionBody).
+		<div class="flex items-baseline gap-1.5 flex-wrap">
+			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
+				{ s.ReportTitle }
+			</a>
+			if s.ReportIsUnread {
+				<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
+			}
+			if s.ReportPriority == "critical" {
+				<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
+			} else if s.ReportPriority == "warning" {
+				<span class="badge badge-warning badge-xs uppercase tracking-wide">Warning</span>
+			}
+			@feedRowTimestamp(it.TimestampStr, now)
+		</div>
 		<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-			<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
-			<span>{ breakdown }</span>
-			if dur := feedSessionDuration(s); dur != "" {
+			<i data-lucide="bot" class="w-3 h-3"></i>
+			<span class="font-medium text-base-content/75">{ feedSessionActorName(s) }</span>
+			<span class="text-base-content/30">·</span>
+			<span class="tabular-nums">{ fmt.Sprintf("%d transaction%s", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
+			if breakdown := feedSessionBreakdown(s); breakdown != "" {
+				<span class="text-base-content/30">·</span>
+				<span>{ breakdown }</span>
+			}
+			if len(s.ReportTags) > 0 {
 				<span class="text-base-content/30 mx-1">·</span>
-				<i data-lucide="clock" class="w-3 h-3"></i>
-				<span>{ dur }</span>
+				for _, t := range s.ReportTags {
+					<span class="inline-flex items-center px-1.5 py-0.5 rounded-md bg-base-200 text-[0.65rem] font-medium text-base-content/65">{ t }</span>
+				}
 			}
 		</div>
+	} else {
+		<div class="flex items-baseline gap-1.5 flex-wrap">
+			<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
+			<span class="text-base-content/55">ran a session</span>
+			<span class="text-base-content/30">·</span>
+			<span class="font-medium text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
+			@feedRowTimestamp(it.TimestampStr, now)
+		</div>
+		if breakdown := feedSessionBreakdown(s); breakdown != "" {
+			<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+				<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
+				<span>{ breakdown }</span>
+				if dur := feedSessionDuration(s); dur != "" {
+					<span class="text-base-content/30 mx-1">·</span>
+					<i data-lucide="clock" class="w-3 h-3"></i>
+					<span>{ dur }</span>
+				}
+			</div>
+		}
 	}
 	if len(s.SampleTransactions) > 0 {
 		<div class="mt-2">
 			@feedTxRefList(s.SampleTransactions, max0(s.UniqueTransactions-len(s.SampleTransactions)))
 		</div>
 	}
-	if s.SessionShortID != "" {
-		<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-primary/70 hover:text-primary transition-colors mt-1.5 inline-flex items-center gap-1 no-underline">
-			Open session log
-			<i data-lucide="arrow-right" class="w-3 h-3"></i>
-		</a>
-	}
+	<div class="mt-1.5 flex items-center gap-3 flex-wrap">
+		if s.ReportTitle != "" && s.ReportID != "" {
+			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="text-primary/70 hover:text-primary transition-colors inline-flex items-center gap-1 no-underline">
+				Read the full report
+				<i data-lucide="arrow-right" class="w-3 h-3"></i>
+			</a>
+		}
+		if s.SessionShortID != "" {
+			<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-primary/70 hover:text-primary transition-colors inline-flex items-center gap-1 no-underline">
+				Open session log
+				<i data-lucide="arrow-right" class="w-3 h-3"></i>
+			</a>
+		}
+	</div>
 }
 
 templ feedBulkActionBody(it FeedItem, b *FeedBulkAction, now time.Time) {
-	<div class="flex items-baseline gap-1.5 flex-wrap">
-		<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
-		<span class="text-base-content/65">{ feedBulkVerb(b.Kind) }</span>
-		<span class="font-semibold text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
-		if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
-			<span class="text-base-content/65">{ subjectLabel }</span>
-		}
-		@feedRowTimestamp(it.TimestampStr, now)
-	</div>
-	if len(b.Subjects) > 1 {
+	if b.ReportTitle != "" {
+		// Report folded into this bucket — use the report title as the
+		// headline. Mirrors the agent_session card's report-folded layout.
+		<div class="flex items-baseline gap-1.5 flex-wrap">
+			<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
+				{ b.ReportTitle }
+			</a>
+			if b.ReportIsUnread {
+				<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
+			}
+			if b.ReportPriority == "critical" {
+				<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
+			} else if b.ReportPriority == "warning" {
+				<span class="badge badge-warning badge-xs uppercase tracking-wide">Warning</span>
+			}
+			@feedRowTimestamp(it.TimestampStr, now)
+		</div>
 		<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
-			for i, sub := range b.Subjects {
-				if i >= 4 {
-					<span class="text-base-content/40">+ { fmt.Sprintf("%d more", len(b.Subjects)-4) }</span>
-					break
+			<i data-lucide="bot" class="w-3 h-3"></i>
+			<span class="font-medium text-base-content/75">{ feedActorDisplay(b.ActorName, b.ActorType) }</span>
+			<span class="text-base-content/30">·</span>
+			<span class="tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
+			if breakdown := feedBulkKindBreakdown(b); breakdown != "" {
+				<span class="text-base-content/30">·</span>
+				<span>{ breakdown }</span>
+			}
+			if len(b.ReportTags) > 0 {
+				<span class="text-base-content/30 mx-1">·</span>
+				for _, t := range b.ReportTags {
+					<span class="inline-flex items-center px-1.5 py-0.5 rounded-md bg-base-200 text-[0.65rem] font-medium text-base-content/65">{ t }</span>
 				}
-				<span class="inline-flex items-center gap-1 bg-base-200 px-1.5 py-0.5 rounded-md">
-					<span class="font-medium text-base-content/85">{ sub.Name }</span>
-					<span class="text-base-content/55 tabular-nums">&times;{ fmt.Sprintf("%d", sub.Count) }</span>
-				</span>
 			}
 		</div>
+	} else {
+		<div class="flex items-baseline gap-1.5 flex-wrap">
+			<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
+			<span class="text-base-content/65">{ feedBulkVerb(b.Kind) }</span>
+			<span class="font-semibold text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
+			if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
+				<span class="text-base-content/65">{ subjectLabel }</span>
+			}
+			@feedRowTimestamp(it.TimestampStr, now)
+		</div>
+		if b.Kind == "mixed" {
+			if breakdown := feedBulkKindBreakdown(b); breakdown != "" {
+				<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+					<i data-lucide="sparkles" class="w-3 h-3 text-primary/70"></i>
+					<span>{ breakdown }</span>
+				</div>
+			}
+		} else if len(b.Subjects) > 1 {
+			<div class="mt-0.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+				for i, sub := range b.Subjects {
+					if i >= 4 {
+						<span class="text-base-content/40">+ { fmt.Sprintf("%d more", len(b.Subjects)-4) }</span>
+						break
+					}
+					<span class="inline-flex items-center gap-1 bg-base-200 px-1.5 py-0.5 rounded-md">
+						<span class="font-medium text-base-content/85">{ sub.Name }</span>
+						<span class="text-base-content/55 tabular-nums">&times;{ fmt.Sprintf("%d", sub.Count) }</span>
+					</span>
+				}
+			</div>
+		}
 	}
 	if len(b.SampleTransactions) > 0 {
 		<div class="mt-2">
 			@feedTxRefList(b.SampleTransactions, max0(b.Count-len(b.SampleTransactions)))
 		</div>
+	}
+	if b.ReportTitle != "" && b.ReportID != "" {
+		<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="text-primary/70 hover:text-primary transition-colors mt-1.5 inline-flex items-center gap-1 no-underline">
+			Read the full report
+			<i data-lucide="arrow-right" class="w-3 h-3"></i>
+		</a>
 	}
 }
 
@@ -629,10 +719,11 @@ templ feedRowTimestamp(timestamp string, now time.Time) {
 //
 // Comments wrap the existing TimelineCommentRowRaw primitive so the meta
 // line and avatar tile match the per-transaction activity log byte-for-
-// byte. The bubble body uses the shared `.bb-comment-bubble` CSS class
-// (defined in input.css) and the same data-markdown attribute the per-tx
-// page consumes — so a comment posted from the per-tx composer renders
-// identically when it surfaces on the home feed.
+// byte. As of iteration 13 the home feed renders only the meta line — no
+// markdown bubble. The body lives on the per-tx page (click-through via
+// the transaction ref). Reasoning: a global feed is a glance surface, and
+// rendering bodies inline duplicated the markdown-scanner cost across
+// every feed visit. Click-through is the right read for full content.
 templ feedCommentRow(it FeedItem, c *FeedComment, now time.Time) {
 	@components.TimelineCommentRowRaw(feedCommentAvatar(c), nil) {
 		<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6 min-w-0">
@@ -643,9 +734,6 @@ templ feedCommentRow(it FeedItem, c *FeedComment, now time.Time) {
 			</a>
 			@feedRowTimestamp(it.TimestampStr, now)
 		</div>
-		if c.Content != "" {
-			<div class="bb-comment-bubble mt-1" data-markdown={ c.Content } data-markdown-breaks="true"></div>
-		}
 	}
 }
 
@@ -811,8 +899,47 @@ func feedBulkVerb(kind string) string {
 		return "categorised"
 	case "rule_applied":
 		return "ran a rule on"
+	case "comment":
+		return "commented on"
 	}
 	return "updated"
+}
+
+// feedBulkKindBreakdown renders the per-kind breakdown line ("5 categorised
+// · 8 tag-removed · 8 updated") used by mixed-kind bulk_action cards and
+// the report-folded variants. Returns "" when the bucket only carries one
+// kind (the dedicated verb already conveys it). Order is fixed so the
+// rendered string is stable across renders even when the underlying
+// `KindCounts` map iterates differently.
+func feedBulkKindBreakdown(b *FeedBulkAction) string {
+	if len(b.KindCounts) == 0 {
+		return ""
+	}
+	order := []struct {
+		kind  string
+		label string
+	}{
+		{"category_set", "categorised"},
+		{"tag_added", "tag-added"},
+		{"tag_removed", "tag-removed"},
+		{"rule_applied", "rule-applied"},
+		{"comment", "commented"},
+	}
+	parts := []string{}
+	seen := map[string]bool{}
+	for _, o := range order {
+		if c := b.KindCounts[o.kind]; c > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", c, o.label))
+			seen[o.kind] = true
+		}
+	}
+	for k, c := range b.KindCounts {
+		if seen[k] || c <= 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%d %s", c, k))
+	}
+	return strings.Join(parts, " · ")
 }
 
 func feedBulkSubjectLabel(b *FeedBulkAction) string {

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -744,7 +744,7 @@ templ feedCommentRowBody(it FeedItem, c *FeedComment, now time.Time) {
 		@components.TimelineActorInline(feedCommentActor(c))
 		<span class="text-base-content/65 shrink-0 font-normal">commented on</span>
 		<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline truncate min-w-0">
-			{ feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name) }
+			{ components.TitleCase(feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name)) }
 		</a>
 		@feedRowTimestamp(it.TimestampStr, now)
 	</div>
@@ -783,16 +783,30 @@ func feedCommentActor(c *FeedComment) components.TimelineActor {
 templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 	<a
 		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
-		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content hover:bg-base-200/40 -mx-1 px-1 rounded-md transition-colors no-underline group/txref focus-visible:bg-base-200/50 focus-visible:outline-none"
+		class="flex items-center gap-2 text-base-content/85 hover:text-base-content hover:bg-base-200/70 -mx-1 px-1 py-1 rounded-md transition-colors duration-150 no-underline group/txref focus-visible:bg-base-200/70 focus-visible:outline-none"
 	>
-		<span class="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
-			<i data-lucide="receipt" class="w-3 h-3 text-base-content/35 shrink-0"></i>
-			<span class={ "font-medium truncate min-w-0", templ.KV("text-base-content/65", dimmed) }>{ feedNonEmpty(tx.MerchantName, tx.Name) }</span>
-			if tx.AccountName != "" {
-				<span class="text-base-content/35 hidden sm:inline">·</span>
-				<span class="text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>
+		<!-- Category avatar — mirrors tx_row_compact.templ so feed sample
+		     rows pick up the same coloured circle as /transactions. -->
+		<span class="relative shrink-0">
+			if tx.CategoryIcon != nil {
+				<span class="bb-tx-avatar bb-tx-avatar--sm" style={ components.TxAvatarColorStyle(tx.CategoryColor) }>
+					<i data-lucide={ *tx.CategoryIcon } class="w-3.5 h-3.5"></i>
+				</span>
+			} else {
+				<span class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
+					<span>{ components.FirstChar(feedNonEmpty(tx.MerchantName, tx.Name)) }</span>
+				</span>
 			}
 		</span>
+		<span class="flex flex-col min-w-0 flex-1 overflow-hidden">
+			<span class={ "font-medium truncate min-w-0", templ.KV("text-base-content/65", dimmed) }>{ components.TitleCase(feedNonEmpty(tx.MerchantName, tx.Name)) }</span>
+			if tx.AccountName != "" {
+				<span class="text-xs text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>
+			}
+		</span>
+		if tx.Date != "" {
+			<span class="text-xs text-base-content/40 tabular-nums shrink-0 hidden sm:inline">{ components.RelativeDate(tx.Date) }</span>
+		}
 		<span class="flex items-center gap-1 shrink-0">
 			if tx.Pending {
 				<i

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -39,7 +39,7 @@ templ Feed(p FeedProps) {
 // feedActiveFilterBanner makes the active chip explicit above the rail.
 // The chip strip alone is easy to miss when scanning a sparse rail.
 templ feedActiveFilterBanner(p FeedProps) {
-	<div class="flex items-center gap-2 text-xs text-base-content/60 mb-3 px-1">
+	<div class="flex flex-wrap items-center gap-2 text-xs text-base-content/60 mb-3 px-1">
 		<i data-lucide="filter" class="w-3 h-3"></i>
 		<span>Showing only: <span class="font-medium text-base-content/80">{ feedFilterLabel(p.Filter) }</span></span>
 		<a href="/feed" class="text-primary/80 hover:text-primary no-underline ml-1">Clear filter</a>
@@ -53,7 +53,8 @@ templ feedHero(p FeedProps) {
 			<div class="min-w-0">
 				<h1 class="text-3xl font-bold tracking-tight text-base-content">Feed</h1>
 				<p class="text-sm text-base-content/55 mt-1">
-					Everything that happened in your breadbox &middot; { p.Hero.Generated }
+					<span>Everything that happened in your breadbox</span>
+					<span class="hidden sm:inline">&middot; { p.Hero.Generated }</span>
 				</p>
 			</div>
 			<div class="flex items-center gap-2 shrink-0">
@@ -102,7 +103,7 @@ templ feedHeroSyncTile(p FeedProps) {
 			<span class={ "ml-auto inline-block w-1.5 h-1.5 rounded-full", feedSyncDotClass(p.Hero.LastSyncStatus) } aria-hidden="true"></span>
 		</div>
 		if p.Hero.LastSyncRel != "" {
-			<div class="text-2xl font-bold tabular-nums tracking-tight mt-1.5">{ p.Hero.LastSyncRel }</div>
+			<div class="text-xl sm:text-2xl font-bold tabular-nums tracking-tight mt-1.5">{ p.Hero.LastSyncRel }</div>
 			<div class="text-[0.65rem] text-base-content/45 mt-1 truncate">
 				{ feedSyncSubLine(p.Hero.LastSyncStatus, p.Hero.LastSyncInstitution) }
 			</div>
@@ -113,7 +114,7 @@ templ feedHeroSyncTile(p FeedProps) {
 				</div>
 			}
 		} else {
-			<div class="text-2xl font-bold tabular-nums tracking-tight mt-1.5 text-base-content/30">—</div>
+			<div class="text-xl sm:text-2xl font-bold tabular-nums tracking-tight mt-1.5 text-base-content/30">—</div>
 			<div class="text-[0.65rem] text-base-content/45 mt-1">No syncs yet</div>
 		}
 	</a>
@@ -155,7 +156,7 @@ templ feedAlertCard(a FeedAlert) {
 
 // ── Filters ───────────────────────────────────────────────────────────────
 templ feedFilters(p FeedProps) {
-	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto" aria-label="Feed filters">
+	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto [mask-image:linear-gradient(to_right,black_85%,transparent)] sm:[mask-image:none]" aria-label="Feed filters">
 		@feedFilterChip("All", "", "layers", p.Filter)
 		@feedFilterChip("Syncs", "syncs", "refresh-cw", p.Filter)
 		@feedFilterChip("Reports", "reports", "file-text", p.Filter)
@@ -473,7 +474,7 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 		</div>
 	}
 	if s.Status == "error" && s.ErrorMessage != "" {
-		<div class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25">
+		<div class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25 break-words">
 			<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
 			{ s.ErrorMessage }
 		</div>
@@ -679,9 +680,9 @@ templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
 		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content transition-colors no-underline group/txref"
 	>
-		<span class="flex items-center gap-2 min-w-0 flex-1">
+		<span class="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
 			<i data-lucide="receipt" class="w-3 h-3 text-base-content/35 shrink-0"></i>
-			<span class={ "font-medium truncate", templ.KV("text-base-content/65", dimmed) }>{ feedNonEmpty(tx.MerchantName, tx.Name) }</span>
+			<span class={ "font-medium truncate min-w-0", templ.KV("text-base-content/65", dimmed) }>{ feedNonEmpty(tx.MerchantName, tx.Name) }</span>
 			if tx.AccountName != "" {
 				<span class="text-base-content/35 hidden sm:inline">·</span>
 				<span class="text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -178,13 +178,7 @@ templ feedFilterChip(label, slug, icon, current string) {
 
 templ feedTimeline(p FeedProps) {
 	if len(p.Days) == 0 {
-		<div class="bb-card p-12 text-center">
-			<i data-lucide="rss" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
-			<h2 class="text-lg font-semibold mb-1">Nothing in your feed yet</h2>
-			<p class="text-sm text-base-content/50">
-				As bank syncs run, agents post reports, and household members tag transactions, they'll show up here.
-			</p>
-		</div>
+		@feedEmptyState(p)
 	} else {
 		@components.Timeline(components.TimelineProps{
 			Heading:     "Activity",
@@ -206,6 +200,134 @@ templ feedTimeline(p FeedProps) {
 			</p>
 		}
 	}
+}
+
+// ── Empty states ──────────────────────────────────────────────────────────
+//
+// The /feed page has four distinct empty cases, each with its own copy
+// and CTA. We dispatch off (HasConnections, Filter, LastSyncAt) so the
+// right card renders in each scenario.
+
+// feedEmptyState picks the right empty-state variant. Order matters:
+//   1. No connections at all → first-run onboarding card.
+//   2. Filter active → "No <chip-label>" card with a clear-filter link.
+//   3. Otherwise → "Quiet around here" with a Sync now / browse-history CTA.
+templ feedEmptyState(p FeedProps) {
+	if !p.HasConnections {
+		@feedEmptyFirstRun()
+	} else if p.Filter != "" {
+		@feedEmptyFiltered(p.Filter)
+	} else {
+		@feedEmptyNoRecent(p)
+	}
+}
+
+// feedEmptyFirstRun is shown when zero bank connections exist. The CTA is
+// the only path forward — connect a bank — so we render it as a primary
+// button rather than a quiet link.
+templ feedEmptyFirstRun() {
+	<div class="bb-card p-10 sm:p-12 text-center">
+		<i data-lucide="landmark" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+		<h2 class="text-lg font-semibold mb-1">Welcome to Breadbox</h2>
+		<p class="text-sm text-base-content/55 max-w-md mx-auto mb-5">
+			Connect your first bank to start filling your feed.
+		</p>
+		<a href="/connections/new" class="btn btn-primary btn-sm rounded-xl">
+			<i data-lucide="plus" class="w-3.5 h-3.5"></i>
+			Connect a bank
+		</a>
+	</div>
+}
+
+// feedEmptyFiltered is shown when a chip filter is active but produced
+// zero rows. The CTA is "Clear filter" — the same affordance the active-
+// filter banner offers, repeated here so a user landing in an empty state
+// has a clear way out without scrolling back up.
+templ feedEmptyFiltered(filter string) {
+	<div class="bb-card p-10 sm:p-12 text-center">
+		<i data-lucide="filter" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+		<h2 class="text-lg font-semibold mb-1">{ feedEmptyFilteredHeadline(filter) }</h2>
+		<p class="text-sm text-base-content/55 mb-5">
+			Nothing in this slice today.
+		</p>
+		<a href="/feed" class="btn btn-sm btn-ghost rounded-xl border border-base-300">
+			<i data-lucide="x" class="w-3.5 h-3.5"></i>
+			Clear filter
+		</a>
+	</div>
+}
+
+// feedEmptyNoRecent is the "all caught up" card for households that have
+// connections but no events in the windowed feed. Admins get a "Sync now"
+// button (POST /-/connections/sync-all → reload); members see only the
+// browse-history link, since sync-all is admin-only.
+templ feedEmptyNoRecent(p FeedProps) {
+	if p.IsAdmin {
+		<script src="/static/js/admin/components/feed.js"></script>
+		<div class="bb-card p-10 sm:p-12 text-center" x-data="feedSyncNow">
+			<i data-lucide="moon" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+			<h2 class="text-lg font-semibold mb-1">Quiet around here</h2>
+			<p class="text-sm text-base-content/55 mb-5">
+				{ feedEmptyNoRecentSubline(p.LastSyncAt) }
+			</p>
+			<div class="flex items-center justify-center gap-2 flex-wrap">
+				<button
+					type="button"
+					class="btn btn-primary btn-sm rounded-xl"
+					x-bind:disabled="state !== 'idle'"
+					x-on:click="triggerSyncNow()"
+				>
+					<i data-lucide="refresh-cw" class="w-3.5 h-3.5" x-bind:class="state === 'syncing' ? 'animate-spin' : ''"></i>
+					<span x-text="state === 'syncing' ? 'Syncing…' : (state === 'done' ? 'Sync queued' : 'Sync now')"></span>
+				</button>
+				<a href="/transactions" class="btn btn-sm btn-ghost rounded-xl border border-base-300">
+					<i data-lucide="receipt" class="w-3.5 h-3.5"></i>
+					Browse transactions
+				</a>
+			</div>
+		</div>
+	} else {
+		<div class="bb-card p-10 sm:p-12 text-center">
+			<i data-lucide="moon" class="w-10 h-10 mx-auto mb-3 text-base-content/20"></i>
+			<h2 class="text-lg font-semibold mb-1">Quiet around here</h2>
+			<p class="text-sm text-base-content/55 mb-5">
+				{ feedEmptyNoRecentSubline(p.LastSyncAt) }
+			</p>
+			<a href="/transactions" class="btn btn-sm btn-ghost rounded-xl border border-base-300">
+				<i data-lucide="receipt" class="w-3.5 h-3.5"></i>
+				Browse transactions
+			</a>
+		</div>
+	}
+}
+
+// feedEmptyFilteredHeadline maps a chip slug onto its empty-state
+// headline. Mirrors feedFilterLabel but pluralises for the headline copy.
+func feedEmptyFilteredHeadline(filter string) string {
+	switch filter {
+	case "syncs":
+		return "No syncs in the last 3 days"
+	case "reports":
+		return "No reports in the last 3 days"
+	case "comments":
+		return "No comments in the last 3 days"
+	case "sessions":
+		return "No agent sessions in the last 3 days"
+	case "me":
+		return "Nothing from you in the last 3 days"
+	}
+	return "No matches"
+}
+
+// feedEmptyNoRecentSubline composes the supporting copy for the "quiet
+// around here" empty state. Mentions the last successful sync time when
+// we have one — gives operators a quick read on whether sync is broken
+// or genuinely quiet.
+func feedEmptyNoRecentSubline(lastSync time.Time) string {
+	if lastSync.IsZero() {
+		return "No activity in the last 3 days. Try syncing to pull the latest from your banks."
+	}
+	return "No activity in the last 3 days. Last sync was " + timefmt.Relative(lastSync) + "."
 }
 
 // feedRow dispatches each FeedItem to the right primitive. Comments use

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -473,7 +473,7 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 		</div>
 	}
 	if s.Status == "error" && s.ErrorMessage != "" {
-		<div class="mt-1.5 text-error/90 bg-error/8 rounded-lg px-2.5 py-1.5 border border-error/20">
+		<div class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25">
 			<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
 			{ s.ErrorMessage }
 		</div>

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -201,6 +201,30 @@ templ feedTimeline(p FeedProps) {
 				Showing the last { fmt.Sprintf("%d days", p.WindowDays) }.
 			</p>
 		}
+		@feedLoadOlder(p)
+	}
+}
+
+// feedLoadOlder renders the pagination affordance under the rail. Only
+// shows the button when the rail has at least one event (empty windows
+// don't get a "load older" since the user has no anchor). When the
+// earliest visible event is past the 30-day lookback ceiling we render
+// "End of feed" instead so users have a clear stop signal.
+templ feedLoadOlder(p FeedProps) {
+	if !p.OldestVisible.IsZero() {
+		<div class="flex items-center justify-center mt-3">
+			if p.AtMaxLookback {
+				<p class="text-xs text-base-content/40">End of feed</p>
+			} else {
+				<a
+					href={ templ.SafeURL(feedLoadOlderHRef(p)) }
+					class="btn btn-sm btn-ghost rounded-xl border border-base-300 text-base-content/65"
+				>
+					<i data-lucide="arrow-down" class="w-3.5 h-3.5"></i>
+					Load older activity
+				</a>
+			}
+		</div>
 	}
 }
 
@@ -987,6 +1011,18 @@ func feedFilterHRef(slug string) string {
 		return "/feed"
 	}
 	return "/feed?filter=" + slug
+}
+
+// feedLoadOlderHRef builds the href for the "Load older activity" button:
+// `/feed?before=<oldestVisible>` plus the active filter (so an active chip
+// survives pagination). The timestamp is RFC3339 so the handler's
+// `time.Parse(time.RFC3339, …)` round-trips it without any loss.
+func feedLoadOlderHRef(p FeedProps) string {
+	q := "before=" + p.OldestVisible.UTC().Format(time.RFC3339)
+	if p.Filter != "" {
+		q = "filter=" + p.Filter + "&" + q
+	}
+	return "/feed?" + q
 }
 
 // feedFilterLabel renders the chip-name string used in the active-filter

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -47,7 +47,6 @@ templ feedActiveFilterBanner(p FeedProps) {
 }
 
 // ── Hero band ─────────────────────────────────────────────────────────────
-
 templ feedHero(p FeedProps) {
 	<header class="mb-6">
 		<div class="flex flex-wrap items-end justify-between gap-3 mb-4">
@@ -107,6 +106,12 @@ templ feedHeroSyncTile(p FeedProps) {
 			<div class="text-[0.65rem] text-base-content/45 mt-1 truncate">
 				{ feedSyncSubLine(p.Hero.LastSyncStatus, p.Hero.LastSyncInstitution) }
 			</div>
+			if feedShowNextSync(p.Hero.LastSyncStatus, p.Hero.NextSyncRel) {
+				<div class="text-[0.65rem] text-base-content/45 mt-0.5 truncate flex items-center gap-1">
+					<i data-lucide="clock" class="w-3 h-3 shrink-0" aria-hidden="true"></i>
+					<span>Next sync { p.Hero.NextSyncRel }</span>
+				</div>
+			}
 		} else {
 			<div class="text-2xl font-bold tabular-nums tracking-tight mt-1.5 text-base-content/30">—</div>
 			<div class="text-[0.65rem] text-base-content/45 mt-1">No syncs yet</div>
@@ -115,7 +120,6 @@ templ feedHeroSyncTile(p FeedProps) {
 }
 
 // ── Pinned alerts ─────────────────────────────────────────────────────────
-
 templ feedAlerts(p FeedProps) {
 	<div class="space-y-2 mb-6">
 		for _, a := range p.ConnectionAlerts {
@@ -150,7 +154,6 @@ templ feedAlertCard(a FeedAlert) {
 }
 
 // ── Filters ───────────────────────────────────────────────────────────────
-
 templ feedFilters(p FeedProps) {
 	<nav class="flex items-center gap-1.5 mb-5 overflow-x-auto" aria-label="Feed filters">
 		@feedFilterChip("All", "", "layers", p.Filter)
@@ -175,7 +178,6 @@ templ feedFilterChip(label, slug, icon, current string) {
 }
 
 // ── Timeline + dispatch ───────────────────────────────────────────────────
-
 templ feedTimeline(p FeedProps) {
 	if len(p.Days) == 0 {
 		@feedEmptyState(p)
@@ -420,7 +422,6 @@ templ feedActorTile(actorType, actorID, version, name string) {
 // Each body lives inside the primitive's `flex-1 min-w-0 text-xs leading-6`
 // container. Multi-line bodies render the headline first (with an inline
 // timestamp pill) and any supporting content below.
-
 templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 	<div class="flex items-baseline gap-1.5 flex-wrap">
 		<a href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
@@ -827,6 +828,21 @@ func feedSyncSubLine(status, institution string) string {
 		return institution + " · syncing now"
 	}
 	return institution
+}
+
+// feedShowNextSync gates the "Next sync in ~6h" sub-line. We hide it when
+// the relative-time string is missing (e.g. test env with no scheduler) and
+// when the most recent sync errored — in the failing case the next cron
+// tick won't help until the user reauths, so showing an ETA there is just
+// noise.
+func feedShowNextSync(status, nextRel string) bool {
+	if nextRel == "" {
+		return false
+	}
+	if status == "error" {
+		return false
+	}
+	return true
 }
 
 func feedSyncTileBg(status string) string {

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -717,38 +717,51 @@ templ feedRowTimestamp(timestamp string, now time.Time) {
 
 // ── Comment row ───────────────────────────────────────────────────────────
 //
-// Comments wrap the existing TimelineCommentRowRaw primitive so the meta
-// line and avatar tile match the per-transaction activity log byte-for-
-// byte. As of iteration 13 the home feed renders only the meta line — no
+// Comment rows render the same rail tile as every other system-event row —
+// a 24px message-circle icon — and move the actor's avatar inline before
+// their bolded name (matching the per-tx activity log's tag / category
+// sentences). The shared `TimelineCommentTile` + `TimelineActorInline`
+// primitives in `components/timeline.templ` are the single source of truth
+// for that pair, used by both /feed (here) and /transactions/{id} so the
+// surfaces stay byte-equivalent.
+//
+// As of iteration 13 the home feed renders only the meta line — no
 // markdown bubble. The body lives on the per-tx page (click-through via
 // the transaction ref). Reasoning: a global feed is a glance surface, and
 // rendering bodies inline duplicated the markdown-scanner cost across
 // every feed visit. Click-through is the right read for full content.
 templ feedCommentRow(it FeedItem, c *FeedComment, now time.Time) {
-	@components.TimelineCommentRowRaw(feedCommentAvatar(c), nil) {
-		<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6 min-w-0">
-			<strong class="font-semibold text-base-content truncate min-w-0 max-w-[10rem] sm:max-w-none">{ feedActorDisplay(c.ActorName, c.ActorType) }</strong>
-			<span class="text-base-content/65 shrink-0 font-normal">commented on</span>
-			<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline truncate min-w-0">
-				{ feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name) }
-			</a>
-			@feedRowTimestamp(it.TimestampStr, now)
-		</div>
-	}
+	@components.TimelineSystemRowCustomTile(
+		"", "", now,
+		components.TimelineCommentTile(),
+		feedCommentRowBody(it, c, now),
+		nil,
+	)
 }
 
-templ feedCommentAvatar(c *FeedComment) {
+templ feedCommentRowBody(it FeedItem, c *FeedComment, now time.Time) {
+	<div class="flex items-center gap-1.5 flex-wrap text-xs leading-6 min-w-0">
+		@components.TimelineActorInline(feedCommentActor(c))
+		<span class="text-base-content/65 shrink-0 font-normal">commented on</span>
+		<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline truncate min-w-0">
+			{ feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name) }
+		</a>
+		@feedRowTimestamp(it.TimestampStr, now)
+	</div>
+}
+
+// feedCommentActor builds the shared TimelineActor for a feed comment so
+// the inline-actor renderer can do its job uniformly. Users get an avatar
+// URL (or fall through to initials when the ID is missing); agents get the
+// bot fallback; system actors render as just the name (no glyph).
+func feedCommentActor(c *FeedComment) components.TimelineActor {
+	a := components.TimelineActor{Name: feedActorDisplay(c.ActorName, c.ActorType)}
 	if c.ActorType == "user" && c.ActorID != "" {
-		<img src={ feedAvatarURL(c.ActorID, c.ActorAvatarVersion) } alt={ c.ActorName + " avatar" } class="w-6 h-6 rounded-full object-cover ring-4 ring-base-200" title={ c.ActorName }/>
+		a.AvatarURL = feedAvatarURL(c.ActorID, c.ActorAvatarVersion)
 	} else if c.ActorType == "agent" {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary/12 ring-4 ring-base-200" aria-hidden="true" title={ c.ActorName }>
-			<i data-lucide="bot" class="w-3 h-3 text-primary"></i>
-		</span>
-	} else {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-200" aria-hidden="true" title={ c.ActorName }>
-			<span class="text-[10px] font-semibold text-base-content/60 leading-none">{ feedFirstChar(c.ActorName) }</span>
-		</span>
+		a.IsAgent = true
 	}
+	return a
 }
 
 // ── Shared transaction-reference helpers ──────────────────────────────────

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -63,11 +63,12 @@ templ feedHero(p FeedProps) {
 					class="btn btn-sm btn-ghost rounded-xl"
 					onclick="window.location.reload()"
 					title="Refresh"
+					aria-label="Refresh feed"
 				>
 					<i data-lucide="refresh-cw" class="w-3.5 h-3.5"></i>
 					<span class="hidden sm:inline">Refresh</span>
 				</button>
-				<a href="/connections/new" class="btn btn-sm btn-primary rounded-xl">
+				<a href="/connections/new" class="btn btn-sm btn-primary rounded-xl" aria-label="Connect a new bank">
 					<i data-lucide="plus" class="w-3.5 h-3.5"></i>
 					<span class="hidden sm:inline">Connect bank</span>
 				</a>
@@ -96,7 +97,7 @@ templ feedHeroTile(icon, label, value, sub string) {
 }
 
 templ feedHeroSyncTile(p FeedProps) {
-	<a href="/logs?tab=syncs" class="bb-card bb-card--interactive p-4 no-underline group block">
+	<a href="/logs?tab=syncs" class="bb-card bb-card--interactive p-4 no-underline group block" aria-label="Last sync — view sync logs">
 		<div class="flex items-center gap-2">
 			<i data-lucide="refresh-cw" class="w-3.5 h-3.5 text-base-content/40"></i>
 			<div class="text-[0.65rem] uppercase tracking-wider text-base-content/40">Last sync</div>
@@ -169,7 +170,10 @@ templ feedFilters(p FeedProps) {
 templ feedFilterChip(label, slug, icon, current string) {
 	<a
 		href={ templ.SafeURL(feedFilterHRef(slug)) }
-		class={ "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors no-underline whitespace-nowrap shrink-0",
+		if current == slug {
+			aria-current="page"
+		}
+		class={ "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors no-underline whitespace-nowrap shrink-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2",
 			templ.KV("bg-primary/10 border-primary/40 text-primary", current == slug),
 			templ.KV("border-base-300 text-base-content/65 hover:bg-base-200/70", current != slug) }
 	>
@@ -474,7 +478,7 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 		</div>
 	}
 	if s.Status == "error" && s.ErrorMessage != "" {
-		<div class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25 break-words">
+		<div role="alert" class="mt-1.5 text-error/90 bg-error/15 rounded-lg px-2.5 py-1.5 border border-error/25 break-words">
 			<i data-lucide="alert-circle" class="w-3 h-3 inline-block align-text-bottom mr-1"></i>
 			{ s.ErrorMessage }
 		</div>
@@ -678,7 +682,7 @@ templ feedCommentAvatar(c *FeedComment) {
 templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 	<a
 		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
-		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content transition-colors no-underline group/txref"
+		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content transition-colors no-underline group/txref focus-visible:bg-base-200/50 focus-visible:outline-none rounded-md"
 	>
 		<span class="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
 			<i data-lucide="receipt" class="w-3 h-3 text-base-content/35 shrink-0"></i>

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -451,8 +451,8 @@ templ feedActorTile(actorType, actorID, version, name string) {
 // timestamp pill) and any supporting content below.
 templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 	<div class="flex items-baseline gap-1.5 flex-wrap">
-		<a href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
-			{ feedSyncHeadline(s) }
+		<a href={ templ.SafeURL("/logs/sync-logs/" + s.SyncLogID) } class="text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline">
+			<span class="font-semibold">{ feedSyncAction(s) }</span><span class="text-base-content/75">{ feedSyncSubject(s) }</span>
 		</a>
 		if lab := feedProviderLabel(s.Provider); lab != "" {
 			<span class="text-base-content/45">{ lab }</span>
@@ -488,12 +488,12 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 		}
 	}
 	if len(s.SampleTransactions) > 0 {
-		<div class="mt-2">
+		<div class="mt-1.5">
 			@feedTxRefList(s.SampleTransactions, s.AdditionalCount)
 		</div>
 	}
 	if len(s.RuleOutcomes) > 0 {
-		<div class="mt-1.5 flex items-center gap-1.5 flex-wrap text-base-content/55">
+		<div class="mt-1 flex items-center gap-1.5 flex-wrap text-base-content/55">
 			<i data-lucide="zap" class="w-3 h-3 text-primary/70"></i>
 			for i, ro := range s.RuleOutcomes {
 				if i > 0 {
@@ -519,7 +519,7 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 
 templ feedReportBody(it FeedItem, r *FeedReport, now time.Time) {
 	<div class="flex items-baseline gap-1.5 flex-wrap">
-		<a href={ templ.SafeURL("/reports/" + r.ID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
+		<a href={ templ.SafeURL("/reports/" + r.ID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline">
 			{ r.Title }
 		</a>
 		if r.IsUnread {
@@ -553,7 +553,7 @@ templ feedAgentSessionBody(it FeedItem, s *FeedAgentSession, now time.Time) {
 		// headline and the session description sinks beneath it. Mirrors
 		// how the bulk_action card folds a report (see feedBulkActionBody).
 		<div class="flex items-baseline gap-1.5 flex-wrap">
-			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
+			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline">
 				{ s.ReportTitle }
 			</a>
 			if s.ReportIsUnread {
@@ -585,9 +585,9 @@ templ feedAgentSessionBody(it FeedItem, s *FeedAgentSession, now time.Time) {
 	} else {
 		<div class="flex items-baseline gap-1.5 flex-wrap">
 			<strong class="font-semibold text-base-content">{ feedSessionActorName(s) }</strong>
-			<span class="text-base-content/55">ran a session</span>
+			<span class="text-base-content/65 font-normal">ran a session</span>
 			<span class="text-base-content/30">·</span>
-			<span class="font-medium text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
+			<span class="text-base-content/75 font-normal tabular-nums">{ fmt.Sprintf("%d transaction%s touched", s.UniqueTransactions, pluralFeedS(s.UniqueTransactions)) }</span>
 			@feedRowTimestamp(it.TimestampStr, now)
 		</div>
 		if breakdown := feedSessionBreakdown(s); breakdown != "" {
@@ -603,19 +603,19 @@ templ feedAgentSessionBody(it FeedItem, s *FeedAgentSession, now time.Time) {
 		}
 	}
 	if len(s.SampleTransactions) > 0 {
-		<div class="mt-2">
+		<div class="mt-1.5">
 			@feedTxRefList(s.SampleTransactions, max0(s.UniqueTransactions-len(s.SampleTransactions)))
 		</div>
 	}
-	<div class="mt-1.5 flex items-center gap-3 flex-wrap">
+	<div class="mt-1 flex items-center gap-3 flex-wrap">
 		if s.ReportTitle != "" && s.ReportID != "" {
-			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="text-primary/70 hover:text-primary transition-colors inline-flex items-center gap-1 no-underline">
+			<a href={ templ.SafeURL("/reports/" + s.ReportID) } class="text-primary/70 hover:text-primary hover:underline underline-offset-2 decoration-primary/30 transition-colors inline-flex items-center gap-1 no-underline">
 				Read the full report
 				<i data-lucide="arrow-right" class="w-3 h-3"></i>
 			</a>
 		}
 		if s.SessionShortID != "" {
-			<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-primary/70 hover:text-primary transition-colors inline-flex items-center gap-1 no-underline">
+			<a href={ templ.SafeURL("/logs/sessions/" + s.SessionShortID) } class="text-primary/70 hover:text-primary hover:underline underline-offset-2 decoration-primary/30 transition-colors inline-flex items-center gap-1 no-underline">
 				Open session log
 				<i data-lucide="arrow-right" class="w-3 h-3"></i>
 			</a>
@@ -628,7 +628,7 @@ templ feedBulkActionBody(it FeedItem, b *FeedBulkAction, now time.Time) {
 		// Report folded into this bucket — use the report title as the
 		// headline. Mirrors the agent_session card's report-folded layout.
 		<div class="flex items-baseline gap-1.5 flex-wrap">
-			<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="font-semibold text-base-content hover:text-primary transition-colors no-underline">
+			<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline">
 				{ b.ReportTitle }
 			</a>
 			if b.ReportIsUnread {
@@ -660,10 +660,10 @@ templ feedBulkActionBody(it FeedItem, b *FeedBulkAction, now time.Time) {
 	} else {
 		<div class="flex items-baseline gap-1.5 flex-wrap">
 			<strong class="font-semibold text-base-content">{ feedActorDisplay(b.ActorName, b.ActorType) }</strong>
-			<span class="text-base-content/65">{ feedBulkVerb(b.Kind) }</span>
-			<span class="font-semibold text-base-content tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
+			<span class="text-base-content/75 font-normal">{ feedBulkVerb(b.Kind) }</span>
+			<span class="text-base-content/75 font-normal tabular-nums">{ fmt.Sprintf("%d transaction%s", b.Count, pluralFeedS(b.Count)) }</span>
 			if subjectLabel := feedBulkSubjectLabel(b); subjectLabel != "" {
-				<span class="text-base-content/65">{ subjectLabel }</span>
+				<span class="text-base-content/65 font-normal">{ subjectLabel }</span>
 			}
 			@feedRowTimestamp(it.TimestampStr, now)
 		</div>
@@ -690,12 +690,12 @@ templ feedBulkActionBody(it FeedItem, b *FeedBulkAction, now time.Time) {
 		}
 	}
 	if len(b.SampleTransactions) > 0 {
-		<div class="mt-2">
+		<div class="mt-1.5">
 			@feedTxRefList(b.SampleTransactions, max0(b.Count-len(b.SampleTransactions)))
 		</div>
 	}
 	if b.ReportTitle != "" && b.ReportID != "" {
-		<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="text-primary/70 hover:text-primary transition-colors mt-1.5 inline-flex items-center gap-1 no-underline">
+		<a href={ templ.SafeURL("/reports/" + b.ReportID) } class="text-primary/70 hover:text-primary hover:underline underline-offset-2 decoration-primary/30 transition-colors mt-1 inline-flex items-center gap-1 no-underline">
 			Read the full report
 			<i data-lucide="arrow-right" class="w-3 h-3"></i>
 		</a>
@@ -728,8 +728,8 @@ templ feedCommentRow(it FeedItem, c *FeedComment, now time.Time) {
 	@components.TimelineCommentRowRaw(feedCommentAvatar(c), nil) {
 		<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6 min-w-0">
 			<strong class="font-semibold text-base-content truncate min-w-0 max-w-[10rem] sm:max-w-none">{ feedActorDisplay(c.ActorName, c.ActorType) }</strong>
-			<span class="text-base-content/55 shrink-0">commented on</span>
-			<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-medium text-base-content hover:text-primary transition-colors no-underline truncate min-w-0">
+			<span class="text-base-content/65 shrink-0 font-normal">commented on</span>
+			<a href={ templ.SafeURL("/transactions/" + c.Transaction.ShortID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline truncate min-w-0">
 				{ feedNonEmpty(c.Transaction.MerchantName, c.Transaction.Name) }
 			</a>
 			@feedRowTimestamp(it.TimestampStr, now)
@@ -770,7 +770,7 @@ templ feedCommentAvatar(c *FeedComment) {
 templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 	<a
 		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
-		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content transition-colors no-underline group/txref focus-visible:bg-base-200/50 focus-visible:outline-none rounded-md"
+		class="flex items-center justify-between gap-2 text-base-content/85 hover:text-base-content hover:bg-base-200/40 -mx-1 px-1 rounded-md transition-colors no-underline group/txref focus-visible:bg-base-200/50 focus-visible:outline-none"
 	>
 		<span class="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
 			<i data-lucide="receipt" class="w-3 h-3 text-base-content/35 shrink-0"></i>
@@ -1079,23 +1079,57 @@ func feedReportIcon(priority string) string {
 }
 
 func feedSyncHeadline(s *FeedSync) string {
+	// Retained for backwards compatibility; new render path uses
+	// feedSyncAction + feedSyncSubject so the action is bold and the
+	// subject ("from Wells Fargo") renders in regular weight.
+	return feedSyncAction(s) + feedSyncSubject(s)
+}
+
+// feedSyncAction is the bolded prefix of the sync headline — the
+// "what happened" half. Examples:
+//   - "2 new transactions"
+//   - "Sync failed"
+//   - "5 transactions updated"
+func feedSyncAction(s *FeedSync) string {
+	if s.Status == "error" {
+		return "Sync failed"
+	}
+	if s.AddedCount > 0 {
+		return fmt.Sprintf("%d new transaction%s", s.AddedCount, pluralFeedS(s.AddedCount))
+	}
+	if s.ModifiedCount > 0 {
+		return fmt.Sprintf("%d transaction%s updated", s.ModifiedCount, pluralFeedS(s.ModifiedCount))
+	}
+	if s.RemovedCount > 0 {
+		return fmt.Sprintf("%d transaction%s removed", s.RemovedCount, pluralFeedS(s.RemovedCount))
+	}
+	return "Synced"
+}
+
+// feedSyncSubject is the unbolded trailing half — the "where it
+// happened" context. Always begins with a leading space so the
+// concatenation reads naturally. Returns "" when there's no bank
+// context to show (rare — a sync without an institution still gets
+// "Your bank" so we keep the line balanced).
+func feedSyncSubject(s *FeedSync) string {
 	bank := s.InstitutionName
 	if bank == "" {
 		bank = "Your bank"
 	}
-	if s.Status == "error" {
-		return "Sync failed at " + bank
+	connector := " from "
+	switch s.Status {
+	case "error":
+		connector = " at "
+	default:
+		if s.AddedCount > 0 {
+			connector = " from "
+		} else if s.ModifiedCount > 0 || s.RemovedCount > 0 {
+			connector = " at "
+		} else {
+			connector = " "
+		}
 	}
-	if s.AddedCount > 0 {
-		return fmt.Sprintf("%d new transaction%s from %s", s.AddedCount, pluralFeedS(s.AddedCount), bank)
-	}
-	if s.ModifiedCount > 0 {
-		return fmt.Sprintf("%d transaction%s updated at %s", s.ModifiedCount, pluralFeedS(s.ModifiedCount), bank)
-	}
-	if s.RemovedCount > 0 {
-		return fmt.Sprintf("%d transaction%s removed at %s", s.RemovedCount, pluralFeedS(s.RemovedCount), bank)
-	}
-	return "Synced " + bank
+	return connector + bank
 }
 
 func feedSyncRetryLabel(s *FeedSync) string {

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -667,6 +667,13 @@ templ feedCommentAvatar(c *FeedComment) {
 // surfaces.
 
 // feedTxRefRow renders one transaction-reference line.
+//
+// Pending transactions render a small clock-icon mark flush against the
+// amount — the same canonical pending visual used on `/transactions/{id}`
+// (`tx_row.templ`) and the transactions list (`tx_row_compact.templ`).
+// Pending rows often re-show as posted later, so surfacing the lifecycle
+// state inline gives users a "this is provisional" read without leaving
+// the feed.
 templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 	<a
 		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
@@ -680,8 +687,18 @@ templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
 				<span class="text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>
 			}
 		</span>
-		<span class={ "tabular-nums font-medium shrink-0", feedAmountClass(tx.Amount) }>
-			{ feedAmountWithSign(tx.Amount, tx.Currency) }
+		<span class="flex items-center gap-1 shrink-0">
+			if tx.Pending {
+				<i
+					data-lucide="clock"
+					class="w-3 h-3 shrink-0 text-warning/70"
+					title="Pending — not yet posted"
+				></i>
+				<span class="sr-only">(pending)</span>
+			}
+			<span class={ "tabular-nums font-medium", feedAmountClass(tx.Amount) }>
+				{ feedAmountWithSign(tx.Amount, tx.Currency) }
+			</span>
 		</span>
 	</a>
 }

--- a/internal/templates/components/pages/feed_comment_test.go
+++ b/internal/templates/components/pages/feed_comment_test.go
@@ -1,0 +1,205 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"breadbox/internal/templates/components"
+)
+
+// TestFeedCommentRowUsesSharedCommentTile verifies the consolidation done in
+// #969: every /feed comment row renders the shared `TimelineCommentTile`
+// (a neutral 24px message-circle on the rail) and the actor's avatar moves
+// inline before the bolded actor name. The old per-feed avatar tile has
+// been retired, so neither `feedCommentAvatar` markup nor a 24px <img>
+// avatar should appear inside the rail anchor anymore.
+//
+// Pure templ render — no DB. Drives the row through a full Feed render so
+// the surrounding scaffolding exercises the same code path users hit.
+func TestFeedCommentRowUsesSharedCommentTile(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	ts := now.Add(-15 * time.Minute)
+
+	feedWith := func(c FeedComment) FeedProps {
+		return FeedProps{
+			Now:            now,
+			WindowDays:     3,
+			HasConnections: true,
+			TotalItems:     1,
+			Days: []FeedDay{{
+				Key:   ts.Format("2006-01-02"),
+				Label: "Today",
+				First: true,
+				Items: []FeedItem{{
+					Type:         "comment",
+					Timestamp:    ts,
+					TimestampStr: ts.UTC().Format(time.RFC3339),
+					Comment:      &c,
+				}},
+			}},
+		}
+	}
+
+	cases := []struct {
+		name        string
+		comment     FeedComment
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "user_comment_renders_message_circle_tile_and_inline_avatar",
+			comment: FeedComment{
+				ActorType:          "user",
+				ActorID:            "user-abc",
+				ActorName:          "Alice",
+				ActorAvatarVersion: "v1",
+				Transaction: FeedTransactionRef{
+					ShortID:      "tx9000aa",
+					MerchantName: "Whole Foods",
+					Amount:       42.10,
+					Currency:     "USD",
+				},
+			},
+			mustContain: []string{
+				// Rail tile is the shared message-circle, not an avatar.
+				`data-lucide="message-circle"`,
+				// Inline avatar uses the 16px treatment from
+				// TimelineActorInline.
+				`inline-block w-4 h-4 rounded-full object-cover align-text-bottom`,
+				// Bold actor name + verb.
+				`Alice`,
+				`commented on`,
+				`Whole Foods`,
+			},
+			mustOmit: []string{
+				// Old 24px avatar tile classes used to scaffold the
+				// rail before #969.
+				`w-6 h-6 rounded-full object-cover ring-4 ring-base-200`,
+			},
+		},
+		{
+			name: "agent_comment_renders_message_circle_tile_and_inline_bot",
+			comment: FeedComment{
+				ActorType: "agent",
+				ActorName: "Categorizer",
+				Transaction: FeedTransactionRef{
+					ShortID:      "tx9000bb",
+					MerchantName: "Costco",
+					Amount:       12.34,
+					Currency:     "USD",
+				},
+			},
+			mustContain: []string{
+				`data-lucide="message-circle"`,
+				// Inline bot tile, 16px (w-4 h-4) — distinct from the
+				// 24px (w-6 h-6) rail tile that used to be there.
+				`inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary/10`,
+				`Categorizer`,
+				`commented on`,
+			},
+			mustOmit: []string{
+				`bg-primary/12 ring-4 ring-base-200`,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := Feed(feedWith(tc.comment)).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes):\n%s", want, buf.Len(), html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}
+
+// TestFeedAndTxDetailShareInlineActor asserts the shared
+// `components.TimelineActorInline` primitive renders the same actor markup
+// no matter which surface it's invoked from. We don't need to render the
+// whole transaction-detail page to prove the consolidation — both
+// `feedCommentActor` and the equivalent tx-detail adapter ultimately hand
+// the same `TimelineActor` shape to the same primitive, so rendering
+// `TimelineActorInline` directly with that shape is the byte-equivalent
+// of what each page would emit.
+func TestFeedAndTxDetailShareInlineActor(t *testing.T) {
+	cases := []struct {
+		name      string
+		actor     components.TimelineActor
+		mustHave  []string
+		mustOmit  []string
+	}{
+		{
+			name: "user_with_avatar",
+			actor: components.TimelineActor{
+				Name:      "Alice",
+				AvatarURL: "/avatars/user-abc?v=v1",
+			},
+			mustHave: []string{
+				`<img src="/avatars/user-abc?v=v1"`,
+				`inline-block w-4 h-4 rounded-full object-cover align-text-bottom mr-1`,
+				`<strong class="font-semibold text-base-content">Alice</strong>`,
+			},
+		},
+		{
+			name: "agent_renders_bot_tile",
+			actor: components.TimelineActor{
+				Name:    "Categorizer",
+				IsAgent: true,
+			},
+			mustHave: []string{
+				`bg-primary/10`,
+				`data-lucide="bot"`,
+				`<strong class="font-semibold text-base-content">Categorizer</strong>`,
+			},
+			mustOmit: []string{
+				`<img`,
+			},
+		},
+		{
+			name: "system_actor_renders_only_bold_name",
+			actor: components.TimelineActor{
+				Name: "Breadbox",
+			},
+			mustHave: []string{
+				`<strong class="font-semibold text-base-content">Breadbox</strong>`,
+			},
+			mustOmit: []string{
+				`<img`,
+				`data-lucide="bot"`,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := components.TimelineActorInline(tc.actor).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustHave {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected %q in:\n%s", want, html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected to omit %q in:\n%s", omit, html)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_empty_test.go
+++ b/internal/templates/components/pages/feed_empty_test.go
@@ -1,0 +1,165 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedEmptyStateVariants asserts the right empty-state copy + CTA
+// renders for each of the four scenarios the dispatcher in feedTimeline
+// covers. Each variant is constructed with a minimal FeedProps and
+// rendered to a strings.Builder; we then probe for distinguishing text.
+//
+// This is a no-DB unit test — pure templ rendering — so it lives in the
+// pages package alongside the component it exercises and runs under
+// `go test ./...` without any integration build tag.
+func TestFeedEmptyStateVariants(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name        string
+		props       FeedProps
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "first_run_no_connections",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: false,
+			},
+			mustContain: []string{
+				"Welcome to Breadbox",
+				"Connect your first bank to start filling your feed.",
+				`href="/connections/new"`,
+				"btn-primary",
+			},
+			mustOmit: []string{
+				"Quiet around here",
+				"Clear filter",
+				"feedSyncNow",
+			},
+		},
+		{
+			name: "no_recent_admin_with_last_sync",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				LastSyncAt:     now.Add(-2 * time.Hour),
+				IsAdmin:        true,
+			},
+			mustContain: []string{
+				"Quiet around here",
+				"Last sync was",
+				"Sync now",
+				// The sync-all kickoff lives in static/js/admin/components/feed.js;
+				// the page wires it in via x-data="feedSyncNow" on the empty-state
+				// card and a <script src=…feed.js> tag immediately above. Asserting
+				// on `feedSyncNow` covers both ends without coupling the test to
+				// the inline URL string.
+				"feedSyncNow",
+				`/static/js/admin/components/feed.js`,
+				`href="/transactions"`,
+			},
+			mustOmit: []string{
+				"Welcome to Breadbox",
+				"Clear filter",
+			},
+		},
+		{
+			name: "no_recent_member_no_sync_button",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				LastSyncAt:     now.Add(-26 * time.Hour),
+				IsAdmin:        false,
+			},
+			mustContain: []string{
+				"Quiet around here",
+				`href="/transactions"`,
+			},
+			mustOmit: []string{
+				// non-admin members never see the sync trigger — neither the
+				// button copy nor the wiring to the sync-all kickoff factory.
+				"Sync now",
+				"feedSyncNow",
+			},
+		},
+		{
+			name: "no_recent_no_sync_yet",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				IsAdmin:        true,
+			},
+			mustContain: []string{
+				"Quiet around here",
+				"Try syncing to pull the latest",
+				"Sync now",
+			},
+			mustOmit: []string{
+				"Last sync was",
+			},
+		},
+		{
+			name: "filtered_no_match_comments",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Filter:         "comments",
+				LastSyncAt:     now.Add(-1 * time.Hour),
+			},
+			mustContain: []string{
+				"No comments in the last 3 days",
+				"Clear filter",
+				`href="/feed"`,
+			},
+			mustOmit: []string{
+				"Welcome to Breadbox",
+				"Quiet around here",
+				"Sync now",
+				"feedSyncNow",
+			},
+		},
+		{
+			name: "filtered_no_match_reports",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Filter:         "reports",
+			},
+			mustContain: []string{
+				"No reports in the last 3 days",
+				"Clear filter",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := Feed(tc.props).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes):\n%s", want, buf.Len(), html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_hero_test.go
+++ b/internal/templates/components/pages/feed_hero_test.go
@@ -1,0 +1,102 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedHeroNextSyncSubLine asserts the next-sync ETA sub-line under the
+// Last Sync hero tile is gated on (a) a non-empty NextSyncRel and (b) a
+// non-error LastSyncStatus. The tile renders the existing "Wells Fargo ·
+// healthy" line in either case — what we toggle is the second muted line
+// that points users at the upcoming cron fire.
+//
+// Pure templ render, no DB — runs under `go test ./...`.
+func TestFeedHeroNextSyncSubLine(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name        string
+		hero        FeedHero
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "healthy_with_next_sync_eta",
+			hero: FeedHero{
+				LastSyncAt:          now.Add(-38 * time.Minute),
+				LastSyncRel:         "38 minutes ago",
+				LastSyncStatus:      "success",
+				LastSyncInstitution: "Wells Fargo",
+				NextSyncRel:         "in ~6h",
+			},
+			mustContain: []string{
+				"Wells Fargo",
+				"healthy",
+				"Next sync in ~6h",
+				`data-lucide="clock"`,
+			},
+		},
+		{
+			name: "failing_hides_next_sync",
+			hero: FeedHero{
+				LastSyncAt:          now.Add(-2 * time.Hour),
+				LastSyncRel:         "2 hours ago",
+				LastSyncStatus:      "error",
+				LastSyncInstitution: "Wells Fargo",
+				NextSyncRel:         "in ~6h",
+			},
+			mustContain: []string{
+				"Wells Fargo",
+				"failing",
+			},
+			mustOmit: []string{
+				"Next sync",
+			},
+		},
+		{
+			name: "healthy_without_eta_hides_sub_line",
+			hero: FeedHero{
+				LastSyncAt:          now.Add(-1 * time.Hour),
+				LastSyncRel:         "1 hour ago",
+				LastSyncStatus:      "success",
+				LastSyncInstitution: "Wells Fargo",
+				NextSyncRel:         "",
+			},
+			mustContain: []string{
+				"healthy",
+			},
+			mustOmit: []string{
+				"Next sync",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			props := FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Hero:           tc.hero,
+			}
+			var buf strings.Builder
+			if err := Feed(props).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes)", want, buf.Len())
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_load_older_test.go
+++ b/internal/templates/components/pages/feed_load_older_test.go
@@ -1,0 +1,141 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedLoadOlderButton asserts the footer "Load older activity"
+// pagination affordance renders the right shape for each branch:
+//
+//   - empty rail (zero items, OldestVisible zero) → no button
+//   - in-window (oldest event < 30 days old) → button with the oldest
+//     timestamp threaded into `?before=…`, filter preserved
+//   - past the 30-day cap (AtMaxLookback) → "End of feed" sentence, no button
+//
+// Pure templ render, no DB — runs under `go test ./...`.
+func TestFeedLoadOlderButton(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	// One sync row in the rendered window — gives `feedTimeline` something
+	// to render so the load-older footer actually emits. Empty days would
+	// take the empty-state branch and skip the footer entirely.
+	syncDay := func(ts time.Time) []FeedDay {
+		return []FeedDay{{
+			Key:   ts.Format("2006-01-02"),
+			Label: "Today",
+			First: true,
+			Items: []FeedItem{{
+				Type:         "sync",
+				Timestamp:    ts,
+				TimestampStr: ts.UTC().Format(time.RFC3339),
+				Sync: &FeedSync{
+					SyncLogID:       "sync-1",
+					InstitutionName: "Wells Fargo",
+					Provider:        "plaid",
+					Status:          "success",
+					AddedCount:      3,
+					StartedAt:       ts,
+				},
+			}},
+		}}
+	}
+
+	cases := []struct {
+		name        string
+		props       FeedProps
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "in_window_renders_button_with_before_param",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Days:           syncDay(now.Add(-2 * time.Hour)),
+				TotalItems:     1,
+				OldestVisible:  now.Add(-2 * time.Hour),
+				AtMaxLookback:  false,
+			},
+			mustContain: []string{
+				"Load older activity",
+				`href="/feed?before=2026-04-28T10:00:00Z"`,
+				"Showing the last 3 days",
+			},
+			mustOmit: []string{
+				"End of feed",
+			},
+		},
+		{
+			name: "preserves_active_filter_in_load_older_href",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Days:           syncDay(now.Add(-90 * time.Minute)),
+				TotalItems:     1,
+				OldestVisible:  now.Add(-90 * time.Minute),
+				Filter:         "syncs",
+			},
+			mustContain: []string{
+				"Load older activity",
+				`href="/feed?filter=syncs&amp;before=2026-04-28T10:30:00Z"`,
+			},
+		},
+		{
+			name: "past_30_day_cap_shows_end_of_feed",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Days:           syncDay(now.Add(-31 * 24 * time.Hour)),
+				TotalItems:     1,
+				OldestVisible:  now.Add(-31 * 24 * time.Hour),
+				AtMaxLookback:  true,
+			},
+			mustContain: []string{
+				"End of feed",
+			},
+			mustOmit: []string{
+				"Load older activity",
+			},
+		},
+		{
+			name: "empty_rail_no_button",
+			props: FeedProps{
+				Now:            now,
+				WindowDays:     3,
+				HasConnections: true,
+				Days:           nil,
+				TotalItems:     0,
+			},
+			mustOmit: []string{
+				"Load older activity",
+				"End of feed",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := Feed(tc.props).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes):\n%s", want, buf.Len(), html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_pending_test.go
+++ b/internal/templates/components/pages/feed_pending_test.go
@@ -1,0 +1,115 @@
+package pages
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFeedTxRefRowPendingPill asserts the inline transaction-reference row
+// renders the canonical clock-icon pending mark when the underlying
+// transaction is pending, and renders cleanly without it when posted.
+//
+// The clock-icon convention is the same used by `tx_row.templ` and
+// `tx_row_compact.templ` — pending rows often re-show as posted later so
+// the feed needs to surface the lifecycle state alongside the amount.
+//
+// Pure templ render, no DB. Drives the row through a sync-card so the
+// outer scaffolding (Feed) exercises the same branch the page uses.
+func TestFeedTxRefRowPendingPill(t *testing.T) {
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	feedWith := func(tx FeedTransactionRef) FeedProps {
+		ts := now.Add(-2 * time.Hour)
+		return FeedProps{
+			Now:            now,
+			WindowDays:     3,
+			HasConnections: true,
+			TotalItems:     1,
+			Days: []FeedDay{{
+				Key:   ts.Format("2006-01-02"),
+				Label: "Today",
+				First: true,
+				Items: []FeedItem{{
+					Type:         "sync",
+					Timestamp:    ts,
+					TimestampStr: ts.UTC().Format(time.RFC3339),
+					Sync: &FeedSync{
+						SyncLogID:          "sync-1",
+						InstitutionName:    "Wells Fargo",
+						Provider:           "plaid",
+						Status:             "success",
+						AddedCount:         1,
+						StartedAt:          ts,
+						SampleTransactions: []FeedTransactionRef{tx},
+					},
+				}},
+			}},
+		}
+	}
+
+	cases := []struct {
+		name        string
+		tx          FeedTransactionRef
+		mustContain []string
+		mustOmit    []string
+	}{
+		{
+			name: "pending_renders_clock_icon_and_sr_text",
+			tx: FeedTransactionRef{
+				ShortID:      "tx12345a",
+				MerchantName: "Whole Foods",
+				Amount:       42.10,
+				Currency:     "USD",
+				AccountName:  "Chase Checking",
+				Pending:      true,
+			},
+			mustContain: []string{
+				`data-lucide="clock"`,
+				"text-warning/70",
+				"Pending — not yet posted",
+				"(pending)",
+				"Whole Foods",
+			},
+		},
+		{
+			name: "posted_omits_clock_icon",
+			tx: FeedTransactionRef{
+				ShortID:      "tx12345b",
+				MerchantName: "Whole Foods",
+				Amount:       42.10,
+				Currency:     "USD",
+				AccountName:  "Chase Checking",
+				Pending:      false,
+			},
+			mustContain: []string{
+				"Whole Foods",
+			},
+			mustOmit: []string{
+				"Pending — not yet posted",
+				"(pending)",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := Feed(feedWith(tc.tx)).Render(context.Background(), &buf); err != nil {
+				t.Fatalf("Render returned error: %v", err)
+			}
+			html := buf.String()
+			for _, want := range tc.mustContain {
+				if !strings.Contains(html, want) {
+					t.Errorf("expected rendered HTML to contain %q\nrendered (%d bytes):\n%s", want, buf.Len(), html)
+				}
+			}
+			for _, omit := range tc.mustOmit {
+				if strings.Contains(html, omit) {
+					t.Errorf("expected rendered HTML to omit %q (was found)", omit)
+				}
+			}
+		})
+	}
+}

--- a/internal/templates/components/pages/feed_pending_test.go
+++ b/internal/templates/components/pages/feed_pending_test.go
@@ -7,6 +7,10 @@ import (
 	"time"
 )
 
+// ptrString returns &s — handy for building FeedTransactionRef.Category*
+// pointers inline in test cases without intermediate variables.
+func ptrString(s string) *string { return &s }
+
 // TestFeedTxRefRowPendingPill asserts the inline transaction-reference row
 // renders the canonical clock-icon pending mark when the underlying
 // transaction is pending, and renders cleanly without it when posted.
@@ -89,6 +93,51 @@ func TestFeedTxRefRowPendingPill(t *testing.T) {
 			mustOmit: []string{
 				"Pending — not yet posted",
 				"(pending)",
+			},
+		},
+		{
+			// All-caps merchant from a provider feed must be rendered in
+			// title-case so the row matches the /transactions list. Tests
+			// the `titleCase` pipeline applied to feedTxRefRow as part of
+			// the tx-row consistency pass (PR #970).
+			name: "all_caps_merchant_renders_title_case",
+			tx: FeedTransactionRef{
+				ShortID:      "tx12345c",
+				MerchantName: "WATER SUPPLY COMPANY",
+				Amount:       102.40,
+				Currency:     "USD",
+				AccountName:  "Essential Savings",
+				Pending:      false,
+			},
+			mustContain: []string{
+				"Water Supply Company",
+			},
+			mustOmit: []string{
+				"WATER SUPPLY COMPANY",
+			},
+		},
+		{
+			// When a category icon + color are present the row must render
+			// the same coloured-circle avatar used by tx_row_compact.templ
+			// (the /transactions list). Letter avatar fallback otherwise.
+			name: "category_avatar_renders_lucide_icon",
+			tx: FeedTransactionRef{
+				ShortID:             "tx12345d",
+				MerchantName:        "Whole Foods",
+				Amount:              42.10,
+				Currency:            "USD",
+				AccountName:         "Chase Checking",
+				CategoryDisplayName: ptrString("Groceries"),
+				CategoryColor:       ptrString("oklch(0.7 0.15 140)"),
+				CategoryIcon:        ptrString("shopping-cart"),
+				CategorySlug:        ptrString("food_and_drink_groceries"),
+			},
+			mustContain: []string{
+				`data-lucide="shopping-cart"`,
+				"bb-tx-avatar bb-tx-avatar--sm",
+			},
+			mustOmit: []string{
+				"bb-tx-avatar--letter",
 			},
 		},
 	}

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -57,6 +57,23 @@ type FeedProps struct {
 	// is admin-only; non-admin members see the link to /transactions
 	// instead.
 	IsAdmin bool
+
+	// OldestVisible is the timestamp of the earliest event currently in the
+	// rendered window. Drives the "Load older activity" button's href —
+	// `?before=<oldestVisible.RFC3339>` rolls the window backward in
+	// `WindowDays`-sized chunks. Zero value means the rail is empty (no
+	// button should render).
+	OldestVisible time.Time
+
+	// AtMaxLookback is true when the oldest visible event is at-or-past the
+	// service-layer 30-day lookback cap. The footer renders an "End of
+	// feed" sentence instead of the load-older button so users have a
+	// clear stop signal.
+	AtMaxLookback bool
+
+	// Filter is forwarded into load-older hrefs so an active chip survives
+	// pagination. Already exists above; documented here as part of the
+	// pagination contract.
 }
 
 // FeedHero powers the at-a-glance band above the feed rail.

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -237,18 +237,44 @@ type FeedAgentSession struct {
 	RuleApplied    int
 
 	SampleTransactions []FeedTransactionRef
+
+	// Report fields are populated when the service folded an agent_report
+	// whose `session_id` matches this session into the card. The templ
+	// uses ReportTitle as the headline (instead of the generic "ran a
+	// session" line) and renders priority badges + tags inline. Empty
+	// when no report was folded — render the plain session card.
+	ReportID       string
+	ReportShortID  string
+	ReportTitle    string
+	ReportPriority string
+	ReportTags     []string
+	ReportIsUnread bool
 }
 
-// FeedBulkAction is the rich card that collapses ≥3 same-actor same-kind
-// annotations from a 5-minute bucket into a single row.
+// FeedBulkAction is the rich card that collapses ≥3 same-actor
+// annotations from a 15-minute bucket into a single row. As of iteration
+// 13 the bucket key is (actor, time-window) only — `kind` is absent — so
+// a single agent run that categorises some rows, removes a tag from
+// others, and updates more in the same window collapses into ONE
+// bulk_action card. KindCounts surfaces the per-kind breakdown for inline
+// rendering ("5 categorised · 8 tag-removed · 8 updated").
 type FeedBulkAction struct {
 	ActorName          string
 	ActorType          string
 	ActorID            string
 	ActorAvatarVersion string
 
+	// Kind is "mixed" when the bucket spans multiple kinds; otherwise the
+	// single homogeneous kind. The templ branches on "mixed" to render
+	// the per-kind breakdown line in lieu of a dedicated verb phrasing.
 	Kind  string
 	Count int
+
+	// KindCounts breaks the bucket down by kind. Always populated; the
+	// templ renders it as the "5 categorised · 8 tag-removed · 8 updated"
+	// breakdown when Kind == "mixed", or skips it for homogeneous
+	// buckets (the dedicated verb phrasing already conveys the kind).
+	KindCounts map[string]int
 
 	Subjects []FeedBulkSubject
 
@@ -256,6 +282,18 @@ type FeedBulkAction struct {
 	EndedAt   time.Time
 
 	SampleTransactions []FeedTransactionRef
+
+	// Report fields are populated when the service folded a matching
+	// agent_report into the card (see service.foldReportsIntoEvents). The
+	// templ uses ReportTitle as the bold headline instead of the generic
+	// "Alice updated N transactions" line and renders priority badges +
+	// tags inline. Empty when no report was folded.
+	ReportID       string
+	ReportShortID  string
+	ReportTitle    string
+	ReportPriority string
+	ReportTags     []string
+	ReportIsUnread bool
 }
 
 // FeedBulkSubject is one (subject, count) chip inside a bulk-action card.

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -39,6 +39,24 @@ type FeedProps struct {
 	// "agents", "me") parsed from the ?filter= query param. Renders chip
 	// state only — actual filtering applies at the handler layer.
 	Filter string
+
+	// HasConnections is true when at least one bank connection exists,
+	// regardless of status. Drives the empty-state branch — first-run
+	// (no connections) gets a different copy + CTA than "quiet around
+	// here" (has connections, no events in window).
+	HasConnections bool
+
+	// LastSyncAt is the most recent successful sync timestamp across the
+	// household, mirrored from FeedHero so the empty-state copy can
+	// render "Last sync was {relative-time}" without re-deriving it.
+	// Zero value means "no sync yet".
+	LastSyncAt time.Time
+
+	// IsAdmin is true when the current session has the admin role. The
+	// "Sync now" empty-state CTA POSTs to /-/connections/sync-all which
+	// is admin-only; non-admin members see the link to /transactions
+	// instead.
+	IsAdmin bool
 }
 
 // FeedHero powers the at-a-glance band above the feed rail.

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -72,6 +72,12 @@ type FeedHero struct {
 	LastSyncRel         string
 	LastSyncStatus      string
 	LastSyncInstitution string
+
+	// NextSyncRel is a human-readable countdown to the next scheduled cron
+	// fire (e.g. "in ~6h", "in 12m"). Empty when the scheduler is unset
+	// (test env) or when the connection is failing — in the failing case
+	// we suppress it because the next tick won't help until reauth.
+	NextSyncRel string
 }
 
 // FeedAlert is one pinned warning for a connection in error /

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -147,6 +147,15 @@ type FeedTransactionRef struct {
 	// and the transactions list, signalling the row is still preliminary
 	// (provider may re-issue it as posted later).
 	Pending bool
+
+	// Category presentation, mirrored from `tx_row_compact.templ`. When the
+	// underlying transaction is categorised the inline tx-ref row renders
+	// the same coloured-circle avatar used on /transactions; nil falls back
+	// to a neutral letter avatar so feed sample rows match the list layout.
+	CategoryDisplayName *string
+	CategoryColor       *string
+	CategoryIcon        *string
+	CategorySlug        *string
 }
 
 // FeedSync is the sync-card payload. Inline transaction samples and rule

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -142,6 +142,11 @@ type FeedTransactionRef struct {
 	Date         string
 	AccountName  string
 	Institution  string
+	// Pending mirrors `transactions.pending`. When true the inline tx-ref
+	// row renders the same small clock-icon mark used on the per-tx page
+	// and the transactions list, signalling the row is still preliminary
+	// (provider may re-issue it as posted later).
+	Pending bool
 }
 
 // FeedSync is the sync-card payload. Inline transaction samples and rule

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -359,6 +359,15 @@ templ txdActivity(p TransactionDetailProps) {
 // custom-tile primitive so the page-local txdSystemIcon palette continues to
 // drive the 24px tile while the primitive owns the rail anchor, leading-6
 // text container, and timestamp/origin suffix.
+//
+// As of #969 the live-comment branch also uses TimelineSystemRowCustomTile
+// — the rail tile is now the shared `TimelineCommentTile` (a neutral
+// message-circle) and the actor's avatar moves inline into the meta line
+// via `TimelineActorInline`. Both surfaces (/feed and /transactions/{id})
+// render the same primitive shape so the design system stays uniform.
+// `data-comment-id` is still attached to the row's <li> so the optimistic-
+// update flow in transaction_detail.js can swap a bubble for a tombstone in
+// place without re-rendering the timeline.
 templ txdTimelineRow(e service.ActivityEntry, now time.Time) {
 	if e.Type == "comment" {
 		if e.IsDeleted {
@@ -371,9 +380,12 @@ templ txdTimelineRow(e service.ActivityEntry, now time.Time) {
 				templ.Attributes{"data-comment-id": e.CommentID},
 			)
 		} else {
-			@components.TimelineCommentRowRaw(txdCommentAvatar(e), templ.Attributes{"data-comment-id": e.CommentID}) {
-				@txdCommentBubbleBody(e, now)
-			}
+			@components.TimelineSystemRowCustomTile(
+				"", "", now,
+				components.TimelineCommentTile(),
+				txdCommentBubbleBody(e, now),
+				templ.Attributes{"data-comment-id": e.CommentID},
+			)
 		}
 	} else {
 		@components.TimelineSystemRowCustomTile(
@@ -463,18 +475,23 @@ templ txdSystemSentence(e service.ActivityEntry) {
 }
 
 // txdActorInline renders an actor reference inside a system-event sentence:
-// a tiny (16px) avatar followed by the bold name. Users get their photo;
-// agents get a bot tile; system/anonymous actors fall back to the bold name
-// alone since there is no actor identity to surface visually.
+// a tiny (16px) avatar followed by the bold name. Delegates to the shared
+// `TimelineActorInline` primitive in `components/timeline.templ` so /feed
+// and /transactions/{id} render the same actor identically.
 templ txdActorInline(e service.ActivityEntry) {
+	@components.TimelineActorInline(txdActor(e))
+}
+
+// txdActor adapts a system-event ActivityEntry into the shared
+// TimelineActor shape used by `TimelineActorInline`.
+func txdActor(e service.ActivityEntry) components.TimelineActor {
+	a := components.TimelineActor{Name: e.ActorName}
 	if e.ActorType == "user" && e.ActorID != nil && *e.ActorID != "" {
-		<img src={ avatarURLStr(*e.ActorID, e.ActorAvatarVersion) } alt="" class="inline-block w-4 h-4 rounded-full object-cover align-text-bottom mr-1" aria-hidden="true"/>
+		a.AvatarURL = avatarURLStr(*e.ActorID, e.ActorAvatarVersion)
 	} else if e.ActorType == "agent" {
-		<span class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary/10 align-text-bottom mr-1" aria-hidden="true">
-			<i data-lucide="bot" class="w-2.5 h-2.5 text-primary"></i>
-		</span>
+		a.IsAgent = true
 	}
-	<strong class="font-semibold text-base-content">{ e.ActorName }</strong>
+	return a
 }
 
 // txdSystemIcon renders the small (24px) kind-specific icon tile that sits
@@ -545,12 +562,16 @@ templ txdCategoryIcon(e service.ActivityEntry) {
 }
 
 // txdCommentBubbleBody renders the body slot for a live comment row — the
-// meta line (actor / "commented" / timestamp / delete button) above the
-// rounded message bubble. Wrapped by components.TimelineCommentRowRaw which
-// owns the row's <li>, rail anchor, and avatar tile.
+// meta line (inline avatar / actor / "commented" / timestamp / delete
+// button) above the rounded message bubble. Wrapped by
+// `components.TimelineSystemRowCustomTile` which owns the row's <li>, rail
+// anchor, and the shared message-circle tile. The actor's avatar is
+// rendered inline via `TimelineActorInline` so the same actor renders
+// identically on /feed (system-row sentence) and on /transactions/{id}
+// (the meta line above each bubble).
 templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 	<!--
-		Meta line shares a 24px line-box with the avatar so the actor
+		Meta line shares a 24px line-box with the rail tile so the actor
 		baseline sits dead-center on the rail circle. Keeping every
 		label at text-xs / leading-6 also matches the system-event
 		rows above for a uniform actor + timestamp treatment.
@@ -561,9 +582,7 @@ templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 		far right; on mobile it follows naturally after the timestamp.
 	-->
 	<div class="flex items-center gap-1.5 px-1 flex-wrap text-xs leading-6 min-w-0">
-		if e.ActorName != "" {
-			<strong class="font-semibold text-base-content truncate min-w-0 max-w-[10rem] sm:max-w-none">{ e.ActorName }</strong>
-		}
+		@components.TimelineActorInline(txdCommentActor(e))
 		<span class="text-base-content/55 shrink-0">commented</span>
 		if e.Timestamp != "" {
 			<span class="tooltip tooltip-top shrink-0" data-tip={ formatDateTimeStr(e.Timestamp) }>
@@ -592,20 +611,18 @@ templ txdCommentBubbleBody(e service.ActivityEntry, now time.Time) {
 	}
 }
 
-// txdCommentAvatar renders the 24px avatar for a comment. User actors get
-// their image; agents get a bot icon; anonymous/system gets initials.
-templ txdCommentAvatar(e service.ActivityEntry) {
+// txdCommentActor adapts a comment ActivityEntry into the shared
+// TimelineActor shape so `TimelineActorInline` can render its 16px
+// avatar. Users get an image URL; agents get the bot fallback; system
+// actors render as just the bold name.
+func txdCommentActor(e service.ActivityEntry) components.TimelineActor {
+	a := components.TimelineActor{Name: e.ActorName}
 	if e.ActorType == "user" && e.ActorID != nil && *e.ActorID != "" {
-		<img src={ avatarURLStr(*e.ActorID, e.ActorAvatarVersion) } alt={ e.ActorName + " avatar" } class="w-6 h-6 rounded-full object-cover ring-4 ring-base-100" title={ e.ActorName }/>
+		a.AvatarURL = avatarURLStr(*e.ActorID, e.ActorAvatarVersion)
 	} else if e.ActorType == "agent" {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-primary/10 ring-4 ring-base-100" aria-hidden="true" title={ e.ActorName }>
-			<i data-lucide="bot" class="w-3 h-3 text-primary"></i>
-		</span>
-	} else {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true" title={ e.ActorName }>
-			<span class="text-[10px] font-semibold text-base-content/60 leading-none">{ components.FirstChar(e.ActorName) }</span>
-		</span>
+		a.IsAgent = true
 	}
+	return a
 }
 
 // txdTimelineComposer renders the inline comment composer at the bottom of

--- a/internal/templates/components/timeline.templ
+++ b/internal/templates/components/timeline.templ
@@ -341,3 +341,47 @@ templ timelineCommentAvatar(actor TimelineActor) {
 		</span>
 	}
 }
+
+// TimelineCommentTile renders the 24px rail tile for a comment row — the
+// neutral chrome shared with other system-event rows (sync, review, etc.).
+// As of #969 comment rows render a message-circle icon on the rail and move
+// the actor's avatar inline (see TimelineActorInline) so every rail tile on
+// the feed and per-tx timeline looks like the same primitive shape: a
+// 24px filled circle with a 4px ring against the page surface.
+//
+// The ring colour is `ring-base-100` because that's what the rest of the
+// timeline primitives ship with; the prominent variant's input.css remap
+// shifts ring-base-100 → base-200 so the seam disappears against a page
+// background. The card variant keeps base-100 verbatim.
+templ TimelineCommentTile() {
+	<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
+		<i data-lucide="message-circle" class="w-3 h-3 text-base-content/55"></i>
+	</span>
+}
+
+// TimelineActorInline renders the inline actor reference used inside system
+// row sentences and comment meta lines: a tiny (16px) avatar followed by the
+// bold actor name. Users get their photo; agents get a bot tile in primary
+// tint; system / anonymous actors fall back to the bold name alone.
+//
+// Shared between /feed (FeedComment, FeedAgentSession, FeedBulkAction) and
+// /transactions/{id} (txdActorInline → tag/category sentences, comment meta
+// lines) so the actor representation looks identical on both surfaces. The
+// avatar slot uses `align-text-bottom` so the baseline lines up with the
+// surrounding `leading-6` text, and `mr-1` reproduces the legacy spacing.
+templ TimelineActorInline(actor TimelineActor) {
+	if actor.AvatarURL != "" {
+		<img src={ actor.AvatarURL } alt="" class="inline-block w-4 h-4 rounded-full object-cover align-text-bottom mr-1" aria-hidden="true"/>
+	} else if actor.IsAgent {
+		<span class="inline-flex items-center justify-center w-4 h-4 rounded-full bg-primary/10 align-text-bottom mr-1" aria-hidden="true">
+			<i data-lucide="bot" class="w-2.5 h-2.5 text-primary"></i>
+		</span>
+	}
+	if actor.Name != "" {
+		if actor.HRef != "" {
+			<a href={ templ.SafeURL(actor.HRef) } class="font-semibold text-base-content hover:text-primary transition-colors">{ actor.Name }</a>
+		} else {
+			<strong class="font-semibold text-base-content">{ actor.Name }</strong>
+		}
+	}
+}

--- a/static/js/admin/components/feed.js
+++ b/static/js/admin/components/feed.js
@@ -1,0 +1,39 @@
+// Feed page Alpine factories for /feed.
+//
+// Convention reference: docs/design-system.md → "Alpine page components".
+//
+//   - `feedSyncNow` — backs the "Sync now" button on the empty-state card.
+//     Triggers a household-wide sync (POST /-/connections/sync-all) and
+//     reloads the page once the kickoff returns 2xx so the freshly written
+//     sync_logs surface in the feed timeline. Admin-only; the templ guards
+//     the button with `if p.IsAdmin`, so this factory is only ever bound
+//     under an admin session.
+
+document.addEventListener('alpine:init', function () {
+  Alpine.data('feedSyncNow', function () {
+    return {
+      state: 'idle',
+
+      triggerSyncNow: function () {
+        if (this.state !== 'idle') return;
+        this.state = 'syncing';
+        var self = this;
+        fetch('/-/connections/sync-all', { method: 'POST' })
+          .then(function (res) {
+            if (res.ok) {
+              self.state = 'done';
+              window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Sync triggered. Reloading…', type: 'success' } }));
+              setTimeout(function () { window.location.reload(); }, 1200);
+            } else {
+              self.state = 'idle';
+              window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Failed to trigger sync.', type: 'error' } }));
+            }
+          })
+          .catch(function () {
+            self.state = 'idle';
+            window.dispatchEvent(new CustomEvent('bb-toast', { detail: { message: 'Network error. Please try again.', type: 'error' } }));
+          });
+      },
+    };
+  });
+});


### PR DESCRIPTION
## Consolidated /feed polish stack

This PR rolls up the entire `stack/feed-polish` series into a single squash-merge against main. Each prior PR represented one polish iteration that was reviewed independently; rebasing the tip onto main brings every iteration in cleanly via 14 commits.

## Iterations included (one commit each, in order)

1. Empty-state polish — first-run / quiet / filtered variants (was #955)
2. Integration tests for `ListFeedEvents` grouping/dedup/window (was #956)
3. Next-sync ETA sub-line on the Last Sync hero tile (was #958)
4. "Load older activity" pagination beyond the 3-day window (was #959)
5. Pending pill on inline transaction-ref rows (was #960)
6. Dark-mode pass — lift card surfaces for WCAG contrast (was #961)
7. Real Feed nav badge — unread-report count, drop static "New" (was #962)
8. Perf — query timings + skip lookups when no bulk events (was #964)
9. Mobile fidelity polish — hero, filters, banner, bubbles (was #965)
10. A11y pass — aria labels, focus-visible, active-chip semantics (was #966)
11. **Aggressive agent-run grouping** — wider 15-min bucket across kinds + report-anchoring (was #967)
12. Selective bolding + tighter spacing + hover affordances (was #968)
13. Comment-icon rail tile + shared inline-actor across /feed and /transactions/{id} (was #969)
14. Tx-row visual consistency — title-case, category avatar, hover, date column (was #970)

PR #963 (docs) is **not** included here — it's Y-branched off the dark-mode iteration and will merge separately after this lands.

## Why a consolidation rather than 14 sequential merges

Mid-merge of the original 17-PR stack, several PRs squashed into the wrong base branches and a few got auto-closed by GitHub when their parent branches were deleted. Rebasing the tip cleanly onto main was the lowest-risk way to recover all the work without losing content.

## Test plan
- [ ] Visit `/feed` and confirm rail, filter chips, hero, alerts, and grouping all render
- [ ] Verify the agent-run grouping collapses multi-kind same-actor bursts (the iteration-11 fix the user explicitly flagged)
- [ ] Toggle dark mode (OS setting) — cards should be visibly lifted from body bg
- [ ] Resize to 360px — hero subtitle suppresses date suffix; filter chip strip has fade-edge mask
- [ ] Tab through chips — focus-visible outline appears
- [ ] Visit `/transactions/{id}` with comments — comment row uses message-circle rail tile + inline avatar (matches /feed exactly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)