### PR TITLE
fix(feed): bring prominent timeline line-height back to 1.5rem

### DIFF
--- a/input.css
+++ b/input.css
@@ -2855,7 +2855,10 @@
 /* Lift the text leading on row sentences so the first-line baseline stays
  * vertically centred against the larger 28px tile next to it. */
 .bb-timeline-prominent .bb-timeline > li > div.flex-1.text-sm.leading-6 {
-  line-height: 1.75rem; /* 28px — matches the tile height */
+  line-height: 1.5rem; /* 24px — tighter row rhythm; the 28px tile and
+                        * its 4px ring still anchor the row's vertical
+                        * extent, this just brings the body's leading
+                        * back in line with the rest of the page. */
 }
 
 /* Rail mask. The 28px tile bg + ring are still painted with base-100


### PR DESCRIPTION
Bring the prominent timeline body container's line-height back to 1.5rem (24px) — the prior 1.75rem (28px) read too airy with the new text-sm body content.

## Summary

- The override at `.bb-timeline-prominent .bb-timeline > li > div.flex-1.text-sm.leading-6` was bumped to `1.75rem` to match the larger 28px tile in prominent mode.
- The 28px tile + its 4px ring already anchor the row's vertical extent, so the body doesn't need to match. Drop to `1.5rem` for a tighter rhythm that still centers the avatar against the rail tile.

## Test plan

- [ ] `/feed` rows read tighter without crowding the rail tile
- [ ] Avatar + text visual center still aligns with the rail tile in light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)
