### PR TITLE
fix(feed): re-center prominent tile against 1.5rem body line

### DIFF
--- a/input.css
+++ b/input.css
@@ -2859,6 +2859,12 @@
                         * its 4px ring still anchor the row's vertical
                         * extent, this just brings the body's leading
                         * back in line with the rest of the page. */
+  /* The 28px tile is 4px taller than the 24px meta line, so under
+   * `items-start` the tile center lands 2px below the text center.
+   * Pad the body 2px so every first-line content (sync action, report
+   * title, comment meta, bulk_action sentence) re-centers against the
+   * tile vertically. */
+  padding-top: 0.125rem;
 }
 
 /* Rail mask. The 28px tile bg + ring are still painted with base-100


### PR DESCRIPTION
Re-center the prominent timeline rail tile against the 1.5rem body line that #972 introduced.

## Summary

- The rail tile in prominent mode is bumped to 28px (4px taller than the now-24px meta line). With the row's default `items-start`, the tile center sat 2px below the text center — visible on /feed comment rows where the avatar drifted off-axis from the message-square tile.
- Pad the body container `padding-top: 0.125rem` (2px) so every first-line content (sync action, report title, comment meta line, bulk_action sentence) re-aligns vertically with the tile.

Follow-up to #972 (line-height 1.75rem → 1.5rem) which left the 28px tile vertically off-axis from the new 24px meta line under the row's `items-start` alignment.

## Test plan

- [ ] /feed comment rows: avatar + actor name vertically centered with the message-square tile
- [ ] Sync / report / bulk_action rows: headline first line vertically centered with their tile
- [ ] Light + dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)