### PR TITLE
feat(feed): TxRowFeed one-liner — dense tx reference for sample lists

### DIFF
--- a/input.css
+++ b/input.css
@@ -1126,8 +1126,11 @@
     @apply w-3.5 h-3.5;
   }
 
-  .bb-tx-avatar--letter {
-    @apply text-xs font-semibold;
+  /* Uncategorized: a neutral grey circle with a question-mark icon. Used
+   * across every tx-row variant (full, compact, feed one-liner) when a
+   * transaction has no category yet, so the visual signal "needs a
+   * category" is consistent regardless of where the row appears. */
+  .bb-tx-avatar--uncategorized {
     --avatar-color: oklch(0.205 0 0);
     background: oklch(0.205 0 0 / 0.06);
     color: oklch(0.205 0 0 / 0.45);
@@ -1137,7 +1140,7 @@
     .bb-tx-avatar {
       background: color-mix(in oklch, var(--avatar-color) 18%, transparent);
     }
-    .bb-tx-avatar--letter {
+    .bb-tx-avatar--uncategorized {
       background: oklch(0.985 0 0 / 0.08);
       color: oklch(0.985 0 0 / 0.45);
     }

--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -587,6 +587,7 @@ func projectSampleTx(tx service.FeedSampleTx) pages.FeedTransactionRef {
 		CategoryColor:       tx.CategoryColor,
 		CategoryIcon:        tx.CategoryIcon,
 		CategorySlug:        tx.CategorySlug,
+		TagCount:            tx.TagCount,
 	}
 }
 

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -42,6 +42,12 @@ type FeedActivityRow struct {
 	CategoryColor       *string
 	CategoryIcon        *string
 	CategorySlug        *string
+
+	// TagCount is the current number of tags on the transaction (live
+	// `transaction_tags` rows, not historical add/remove annotations).
+	// Drives the small "tag · N" chip on the feed one-liner so a quick
+	// glance at the rail surfaces "this row has labels worth checking".
+	TagCount int
 }
 
 // ListFeedActivity returns the most recent annotations across every
@@ -61,7 +67,8 @@ SELECT
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name,
-    cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug
+    cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug,
+    (SELECT COUNT(*)::int FROM transaction_tags tt WHERE tt.transaction_id = t.id) AS tag_count
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
 LEFT JOIN accounts ac ON t.account_id = ac.id
@@ -305,6 +312,11 @@ type FeedSampleTx struct {
 	CategoryColor       *string
 	CategoryIcon        *string
 	CategorySlug        *string
+
+	// TagCount is the current number of tags on the transaction. Surfaces
+	// on the feed one-liner as a small `[tag] N` chip so users can see at
+	// a glance which sample rows already carry labels.
+	TagCount int
 }
 
 // FeedRuleOutcome is one (rule, count) pair shown inline on a sync card.
@@ -558,7 +570,8 @@ SELECT
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name,
-    cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug
+    cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug,
+    (SELECT COUNT(*)::int FROM transaction_tags tt WHERE tt.transaction_id = t.id) AS tag_count
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
 LEFT JOIN accounts ac ON t.account_id = ac.id
@@ -629,6 +642,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		accountName, institutionName        pgtype.Text
 		catDisplay, catColor                pgtype.Text
 		catIcon, catSlug                    pgtype.Text
+		tagCount                            int
 	)
 
 	if err := s.Scan(
@@ -638,6 +652,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		&txShort, &txName, &merchantName, &amount, &isoCcy, &txDate, &pending,
 		&accountName, &institutionName,
 		&catDisplay, &catColor, &catIcon, &catSlug,
+		&tagCount,
 	); err != nil {
 		return FeedActivityRow{}, fmt.Errorf("scan feed activity row: %w", err)
 	}
@@ -696,6 +711,7 @@ func scanFeedActivityRow(s scanner) (FeedActivityRow, error) {
 		Pending:            pending,
 		AccountName:        pgconv.TextOr(accountName, ""),
 		InstitutionName:    pgconv.TextOr(institutionName, ""),
+		TagCount:           tagCount,
 	}
 	if amount.Valid {
 		if f, err := amount.Float64Value(); err == nil && f.Valid {
@@ -917,7 +933,8 @@ func (s *Service) fetchSyncSampleTransactions(ctx context.Context, raws []syncRo
 	const q = `
 SELECT t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
        t.created_at, t.pending, ac.name, bc.id::text, bc.institution_name,
-       cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug
+       cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug,
+       (SELECT COUNT(*)::int FROM transaction_tags tt WHERE tt.transaction_id = t.id) AS tag_count
 FROM transactions t
 JOIN accounts ac ON ac.id = t.account_id
 JOIN bank_connections bc ON ac.connection_id = bc.id
@@ -955,8 +972,9 @@ ORDER BY t.created_at DESC
 			institutionName      pgtype.Text
 			catDisplay, catColor pgtype.Text
 			catIcon, catSlug     pgtype.Text
+			tagCount             int
 		)
-		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &pending, &accountName, &connID, &institutionName, &catDisplay, &catColor, &catIcon, &catSlug); err != nil {
+		if err := rows.Scan(&shortID, &provName, &merchantName, &amount, &isoCcy, &txDate, &createdAt, &pending, &accountName, &connID, &institutionName, &catDisplay, &catColor, &catIcon, &catSlug, &tagCount); err != nil {
 			return nil, err
 		}
 		t := txRow{
@@ -968,6 +986,7 @@ ORDER BY t.created_at DESC
 				AccountName:  pgconv.TextOr(accountName, ""),
 				Institution:  pgconv.TextOr(institutionName, ""),
 				Pending:      pending,
+				TagCount:     tagCount,
 			},
 			ConnectionID: connID,
 			CreatedAt:    createdAt.Time.UTC(),
@@ -1547,6 +1566,7 @@ func sampleTxFromRow(r FeedActivityRow) FeedSampleTx {
 		CategoryColor:       r.CategoryColor,
 		CategoryIcon:        r.CategoryIcon,
 		CategorySlug:        r.CategorySlug,
+		TagCount:            r.TagCount,
 	}
 }
 

--- a/internal/service/feed.go
+++ b/internal/service/feed.go
@@ -61,12 +61,13 @@ SELECT
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name,
-    cat.display_name, cat.color, cat.icon, cat.slug
+    cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
 LEFT JOIN accounts ac ON t.account_id = ac.id
 LEFT JOIN bank_connections bc ON ac.connection_id = bc.id
 LEFT JOIN categories cat ON t.category_id = cat.id
+LEFT JOIN categories pcat ON cat.parent_id = pcat.id
 LEFT JOIN auth_accounts aa
     ON a.actor_type = 'user'
    AND aa.id::text = a.actor_id
@@ -557,12 +558,13 @@ SELECT
     COALESCE(u_via_account.updated_at, u_direct.updated_at) AS actor_updated_at,
     t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date, t.pending,
     ac.name, bc.institution_name,
-    cat.display_name, cat.color, cat.icon, cat.slug
+    cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug
 FROM annotations a
 JOIN transactions t ON a.transaction_id = t.id
 LEFT JOIN accounts ac ON t.account_id = ac.id
 LEFT JOIN bank_connections bc ON ac.connection_id = bc.id
 LEFT JOIN categories cat ON t.category_id = cat.id
+LEFT JOIN categories pcat ON cat.parent_id = pcat.id
 LEFT JOIN auth_accounts aa
     ON a.actor_type = 'user'
    AND aa.id::text = a.actor_id
@@ -915,11 +917,12 @@ func (s *Service) fetchSyncSampleTransactions(ctx context.Context, raws []syncRo
 	const q = `
 SELECT t.short_id, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, t.date,
        t.created_at, t.pending, ac.name, bc.id::text, bc.institution_name,
-       cat.display_name, cat.color, cat.icon, cat.slug
+       cat.display_name, COALESCE(cat.color, pcat.color) AS cat_color, cat.icon, cat.slug
 FROM transactions t
 JOIN accounts ac ON ac.id = t.account_id
 JOIN bank_connections bc ON ac.connection_id = bc.id
 LEFT JOIN categories cat ON t.category_id = cat.id
+LEFT JOIN categories pcat ON cat.parent_id = pcat.id
 WHERE t.created_at >= $1
   AND t.deleted_at IS NULL
   AND bc.id::text = ANY($2::text[])

--- a/internal/service/feed_integration_test.go
+++ b/internal/service/feed_integration_test.go
@@ -297,11 +297,15 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		ctx := context.Background()
 		seed := seedFeedFixture(t, queries, "bulk", 4)
 
-		// Anchor 2 minutes past the current 15-min bucket boundary so all
-		// seeded annotations land in one bucket regardless of when the
-		// test runs. Without this, runs that fire near a boundary split
-		// the seeds across two buckets and the count flakes.
-		now := time.Now().UTC().Truncate(15 * time.Minute).Add(2 * time.Minute)
+		// Anchor 2 minutes past a 15-min bucket boundary an hour ago so all
+		// seeded annotations land in one bucket AND safely in the past
+		// relative to the service's `time.Now()`. The earlier `Add(-1h)`
+		// guards against the test firing in the first ~2 minutes of a
+		// bucket — without it, `Truncate(15m).Add(2m)` lands in the
+		// FUTURE and the SQL window's `created_at < now` upper bound
+		// drops every seeded row. Mirrors the safer anchor pattern used
+		// by every other Truncate-based test below in this file.
+		now := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(2 * time.Minute)
 		actorID := "user-actor-bulk"
 		// 4 category_set annotations, same actor, 4 different transactions,
 		// all within ~30 seconds (well inside the 15-minute soft bucket).
@@ -447,9 +451,11 @@ func TestListFeedEvents_GroupingBehaviors(t *testing.T) {
 		rule := testutil.MustCreateTransactionRule(t, queries, "Coffee Rule", []byte(`[]`), []byte(`[]`), "on_create")
 		ruleShortID := rule.ShortID
 
-		// Anchor 2 minutes past the current 15-min bucket boundary so all
-		// seeds land in one bucket regardless of when the test fires.
-		now := time.Now().UTC().Truncate(15 * time.Minute).Add(2 * time.Minute)
+		// Anchor an hour back, snapped to a 15-min bucket + 2 min, so the
+		// seeds bucket together AND land in the past — mirrors the
+		// SoftBucketBulkAction fix above. See that comment for why the
+		// straight `Truncate(15m).Add(2m)` form was flaky.
+		now := time.Now().UTC().Add(-1 * time.Hour).Truncate(15 * time.Minute).Add(2 * time.Minute)
 		actorID := "actor-retro"
 		// 5 rule_applied annotations, same actor, no `applied_by=sync`, all
 		// within ~25 seconds → should produce a single bulk_action event.

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -824,71 +824,44 @@ func feedCommentActor(c *FeedComment) components.TimelineActor {
 
 // ── Shared transaction-reference helpers ──────────────────────────────────
 //
-// `feedTxRefRow` is the canonical inline reference to a transaction —
-// receipt icon, merchant name, optional account name, signed amount.
-// Used inside sync, agent_session, and bulk_action bodies. Keeping a
-// single source of truth so the sample list looks identical wherever it
-// surfaces.
-
-// feedTxRefRow renders one transaction-reference line.
+// Sample lists inside sync, agent_session, and bulk_action cards delegate
+// to the shared `components.TxRowFeed` one-liner so every feed surface
+// renders the same dense, glanceable transaction reference. The adapter
+// below maps the page-side `FeedTransactionRef` shape onto the
+// component's `TxRowFeedProps`.
 //
-// Pending transactions render a small clock-icon mark flush against the
-// amount — the same canonical pending visual used on `/transactions/{id}`
-// (`tx_row.templ`) and the transactions list (`tx_row_compact.templ`).
-// Pending rows often re-show as posted later, so surfacing the lifecycle
-// state inline gives users a "this is provisional" read without leaving
-// the feed.
-templ feedTxRefRow(tx FeedTransactionRef, dimmed bool) {
-	<a
-		href={ templ.SafeURL("/transactions/" + tx.ShortID) }
-		class="flex items-center gap-2 text-base-content/85 hover:text-base-content hover:bg-base-200/70 -mx-1 px-1 py-1 rounded-md transition-colors duration-150 no-underline group/txref focus-visible:bg-base-200/70 focus-visible:outline-none"
-	>
-		<!-- Category avatar — mirrors tx_row_compact.templ so feed sample
-		     rows pick up the same coloured circle as /transactions. -->
-		<span class="relative shrink-0">
-			if tx.CategoryIcon != nil {
-				<span class="bb-tx-avatar bb-tx-avatar--sm" style={ components.TxAvatarColorStyle(tx.CategoryColor) }>
-					<i data-lucide={ *tx.CategoryIcon } class="w-3.5 h-3.5"></i>
-				</span>
-			} else {
-				<span class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
-					<span>{ components.FirstChar(feedNonEmpty(tx.MerchantName, tx.Name)) }</span>
-				</span>
-			}
-		</span>
-		<span class="flex flex-col min-w-0 flex-1 overflow-hidden">
-			<span class={ "font-medium truncate min-w-0", templ.KV("text-base-content/65", dimmed) }>{ components.TitleCase(feedNonEmpty(tx.MerchantName, tx.Name)) }</span>
-			if tx.AccountName != "" {
-				<span class="text-xs text-base-content/45 truncate hidden sm:inline">{ tx.AccountName }</span>
-			}
-		</span>
-		if tx.Date != "" {
-			<span class="text-xs text-base-content/40 tabular-nums shrink-0 hidden sm:inline">{ components.RelativeDate(tx.Date) }</span>
-		}
-		<span class="flex items-center gap-1 shrink-0">
-			if tx.Pending {
-				<i
-					data-lucide="clock"
-					class="w-3 h-3 shrink-0 text-warning/70"
-					title="Pending — not yet posted"
-				></i>
-				<span class="sr-only">(pending)</span>
-			}
-			<span class={ "tabular-nums font-medium", feedAmountClass(tx.Amount) }>
-				{ feedAmountWithSign(tx.Amount, tx.Currency) }
-			</span>
-		</span>
-	</a>
+// The component pulls the transaction *description* (raw provider text)
+// rather than the cleaned merchant name — see `tx_row_feed.templ` for
+// the rationale. Falling back to merchant name when description is
+// empty preserves a sensible read for pre-fill backfills that haven't
+// stamped a description yet.
+
+// feedTxRowProps adapts a `FeedTransactionRef` to the shared
+// `components.TxRowFeed` props. Exported as a templ-side helper so
+// both `feedTxRefList` and any future feed surface (e.g. a comment row
+// that wants the full row instead of an inline merchant link) can lean
+// on the same mapping.
+func feedTxRowProps(tx FeedTransactionRef, dimmed bool) components.TxRowFeedProps {
+	return components.TxRowFeedProps{
+		ShortID:       tx.ShortID,
+		Description:   feedNonEmpty(tx.Name, tx.MerchantName),
+		Amount:        tx.Amount,
+		Currency:      tx.Currency,
+		Pending:       tx.Pending,
+		CategoryColor: tx.CategoryColor,
+		CategoryIcon:  tx.CategoryIcon,
+		Dimmed:        dimmed,
+	}
 }
 
-// feedTxRefList wraps `feedTxRefRow` for the multi-sample case used by
-// sync / session / bulk-action bodies. Mobile collapses to 3 visible rows
-// via `hidden sm:flex` on samples ≥ index 3; desktop shows up to 5.
+// feedTxRefList renders the sample-list pattern used by sync,
+// agent_session, and bulk_action cards. Mobile collapses to 3 visible
+// rows via `hidden sm:block` on samples ≥ index 3; desktop shows up to 5.
 templ feedTxRefList(samples []FeedTransactionRef, additional int) {
 	<ul class="space-y-0.5" role="list">
 		for i, tx := range samples {
 			<li class={ templ.KV("hidden sm:block", i >= 3) }>
-				@feedTxRefRow(tx, false)
+				@components.TxRowFeed(feedTxRowProps(tx, false))
 			</li>
 		}
 		if additional > 0 {
@@ -1309,28 +1282,6 @@ func feedFilterLabel(slug string) string {
 		return "From me"
 	}
 	return slug
-}
-
-func feedAmountClass(amount float64) string {
-	if amount < 0 {
-		return "text-success"
-	}
-	return "text-base-content"
-}
-
-func feedAmountWithSign(amount float64, currency string) string {
-	abs := amount
-	if abs < 0 {
-		abs = -abs
-	}
-	formatted := components.FormatBalance(abs)
-	if amount < 0 {
-		return "+" + formatted
-	}
-	if amount > 0 {
-		return "−" + formatted
-	}
-	return formatted
 }
 
 func pluralFeedS(n int) string {

--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -850,6 +850,7 @@ func feedTxRowProps(tx FeedTransactionRef, dimmed bool) components.TxRowFeedProp
 		Pending:       tx.Pending,
 		CategoryColor: tx.CategoryColor,
 		CategoryIcon:  tx.CategoryIcon,
+		TagCount:      tx.TagCount,
 		Dimmed:        dimmed,
 	}
 }

--- a/internal/templates/components/pages/feed_types.go
+++ b/internal/templates/components/pages/feed_types.go
@@ -156,6 +156,10 @@ type FeedTransactionRef struct {
 	CategoryColor       *string
 	CategoryIcon        *string
 	CategorySlug        *string
+
+	// TagCount is the current number of tags on the transaction. Drives
+	// the small `[tag] N` chip on the feed one-liner when > 0.
+	TagCount int
 }
 
 // FeedSync is the sync-card payload. Inline transaction samples and rule

--- a/internal/templates/components/pages/transaction_detail.templ
+++ b/internal/templates/components/pages/transaction_detail.templ
@@ -551,11 +551,11 @@ templ txdCategoryIcon(e service.ActivityEntry) {
 			}
 		</span>
 	} else if e.CategoryIcon != nil && *e.CategoryIcon != "" {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-100 border border-base-300 ring-4 ring-base-100" aria-hidden="true">
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
 			<i data-lucide={ *e.CategoryIcon } class="w-3 h-3 text-base-content/60"></i>
 		</span>
 	} else {
-		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-100 border border-base-300 ring-4 ring-base-100" aria-hidden="true">
+		<span class="flex items-center justify-center w-6 h-6 rounded-full bg-base-200 ring-4 ring-base-100" aria-hidden="true">
 			<i data-lucide="folder" class="w-3 h-3 text-base-content/50"></i>
 		</span>
 	}

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -57,7 +57,7 @@ templ TxRow(tx service.AdminTransactionRow) {
 					</div>
 				} else {
 					<div class="bb-tx-avatar bb-tx-avatar--uncategorized">
-						<i data-lucide="help-circle" class="w-4 h-4"></i>
+						<i data-lucide="circle-off" class="w-4 h-4"></i>
 					</div>
 				}
 			</div>

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -47,13 +47,17 @@ templ TxRow(tx service.AdminTransactionRow) {
 			     class lets CSS hide the slot on mobile while selection mode is on
 			     so the bulk-select checkbox doesn't squeeze the name column. -->
 			<div class="relative shrink-0 bb-tx-avatar-slot">
-				if tx.CategoryIcon != nil {
+				if tx.CategoryIcon != nil || tx.CategoryColor != nil {
 					<div class="bb-tx-avatar" style={ txAvatarColorStyle(tx.CategoryColor) }>
-						<i data-lucide={ deref(tx.CategoryIcon) } class="w-4 h-4"></i>
+						if tx.CategoryIcon != nil {
+							<i data-lucide={ deref(tx.CategoryIcon) } class="w-4 h-4"></i>
+						} else {
+							<i data-lucide="folder" class="w-4 h-4"></i>
+						}
 					</div>
 				} else {
-					<div class="bb-tx-avatar bb-tx-avatar--letter">
-						<span>{ firstChar(tx.Name) }</span>
+					<div class="bb-tx-avatar bb-tx-avatar--uncategorized">
+						<i data-lucide="help-circle" class="w-4 h-4"></i>
 					</div>
 				}
 			</div>

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -7,15 +7,21 @@ import "breadbox/internal/service"
 // category picker, no expand panel. Mirrors the "tx-row-compact" partial.
 templ TxRowCompact(tx service.AdminTransactionRow) {
 	<a href={ templ.SafeURL("/transactions/" + tx.ID) } class="bb-tx-row-compact flex items-center gap-3 py-2.5 px-2 rounded-lg hover:bg-base-200/40 transition-colors duration-150 -mx-1 no-underline">
-		<!-- Category avatar -->
+		<!-- Category avatar. Categorised rows (any color or icon) render the
+		     coloured circle; uncategorised rows render a neutral grey
+		     question-mark — same convention used in tx_row + tx_row_feed. -->
 		<div class="relative shrink-0">
-			if tx.CategoryIcon != nil {
+			if tx.CategoryIcon != nil || tx.CategoryColor != nil {
 				<div class="bb-tx-avatar bb-tx-avatar--sm" style={ txAvatarColorStyle(tx.CategoryColor) }>
-					<i data-lucide={ deref(tx.CategoryIcon) } class="w-3.5 h-3.5"></i>
+					if tx.CategoryIcon != nil {
+						<i data-lucide={ deref(tx.CategoryIcon) } class="w-3.5 h-3.5"></i>
+					} else {
+						<i data-lucide="folder" class="w-3.5 h-3.5"></i>
+					}
 				</div>
 			} else {
-				<div class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
-					<span>{ firstChar(tx.Name) }</span>
+				<div class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--uncategorized">
+					<i data-lucide="help-circle" class="w-3.5 h-3.5"></i>
 				</div>
 			}
 		</div>

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -21,7 +21,7 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 				</div>
 			} else {
 				<div class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--uncategorized">
-					<i data-lucide="help-circle" class="w-3.5 h-3.5"></i>
+					<i data-lucide="circle-off" class="w-3.5 h-3.5"></i>
 				</div>
 			}
 		</div>

--- a/internal/templates/components/tx_row_feed.templ
+++ b/internal/templates/components/tx_row_feed.templ
@@ -1,0 +1,100 @@
+package components
+
+// TxRowFeed is the dense, single-line transaction row used by the home
+// /feed inside sync, agent_session, and bulk_action sample lists. Trades
+// the two-line `tx_row_compact` layout (name + meta) for one glanceable
+// row of [avatar · description · amount] so a stack of 5+ samples reads
+// at a single scan.
+//
+// Differences from `TxRowCompact`:
+//   - Uses the transaction's *description* (raw provider text) instead of
+//     the cleaned merchant name. Households scanning the feed recognise
+//     their own bank descriptors faster than a cleaned merchant string,
+//     and the description carries detail the merchant strip removes
+//     (location, last 4, "PURCHASE AUTHORIZED", etc.).
+//   - One visual line. Account, date, and category-name chrome are
+//     dropped — in feed context the parent card already pins the
+//     when/who/why; this row only needs to answer "which transaction".
+//   - Pending state surfaces inline as a small clock-icon before the
+//     amount, mirroring `tx_row_compact` so the lifecycle visual stays
+//     consistent across surfaces.
+//
+// Reusable beyond /feed wherever a dense one-liner fits — pass the
+// `Dimmed` flag for de-emphasised reference rows (e.g. transactions
+// referenced inside a longer card body).
+type TxRowFeedProps struct {
+	ShortID       string
+	Description   string  // raw provider description; not the cleaned merchant
+	Amount        float64 // breadbox sign convention: positive = outflow, negative = inflow
+	Currency      string
+	Pending       bool
+	CategoryColor *string
+	CategoryIcon  *string
+	Dimmed        bool
+}
+
+templ TxRowFeed(p TxRowFeedProps) {
+	<a
+		href={ templ.SafeURL("/transactions/" + p.ShortID) }
+		class="bb-tx-row-feed flex items-center gap-2 py-1 px-1 -mx-1 rounded-md hover:bg-base-200/70 focus-visible:bg-base-200/70 focus-visible:outline-none transition-colors duration-150 no-underline"
+	>
+		<!-- Category avatar — mirrors TxRowCompact so the feed's coloured
+		     circle reads identically to the /transactions list. -->
+		<span class="relative shrink-0">
+			if p.CategoryIcon != nil {
+				<span class="bb-tx-avatar bb-tx-avatar--sm" style={ TxAvatarColorStyle(p.CategoryColor) }>
+					<i data-lucide={ *p.CategoryIcon } class="w-3.5 h-3.5"></i>
+				</span>
+			} else {
+				<span class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
+					<span>{ FirstChar(p.Description) }</span>
+				</span>
+			}
+		</span>
+		<!-- Description (single line, truncated). Uses provider text, not
+		     merchant name — see component doc. Title-cased so all-caps
+		     bank descriptors ("WHOLEFDS NEW YORK 12345") match the
+		     /transactions list visual. -->
+		<span class={ "text-sm font-medium truncate flex-1 min-w-0", templ.KV("text-base-content/65", p.Dimmed) }>
+			{ TitleCase(p.Description) }
+		</span>
+		<!-- Pending mark, kept inline so the row height stays stable. -->
+		if p.Pending {
+			<i data-lucide="clock" class="w-3 h-3 shrink-0 text-warning/70" title="Pending — not yet posted"></i>
+			<span class="sr-only">(pending)</span>
+		}
+		<!-- Amount: leading sign so income (negative in our convention)
+		     reads as "+$X" without the user having to know the sign rule. -->
+		<span class={ "tabular-nums font-medium shrink-0", txRowFeedAmountClass(p.Amount), templ.KV("bb-tx-amount--pending", p.Pending) }>
+			{ TxRowFeedAmountWithSign(p.Amount, p.Currency) }
+		</span>
+	</a>
+}
+
+func txRowFeedAmountClass(amount float64) string {
+	if amount < 0 {
+		return "text-success"
+	}
+	return "text-base-content"
+}
+
+// TxRowFeedAmountWithSign formats an amount for the feed one-liner: a
+// leading "+" for income (breadbox negative) and "−" for outflow so the
+// direction is unambiguous without the reader having to remember the
+// sign convention. Uses an en-dash (U+2212) for the minus so the glyph
+// matches the bookkeeping convention used elsewhere in the admin UI.
+func TxRowFeedAmountWithSign(amount float64, _currency string) string {
+	abs := amount
+	if abs < 0 {
+		abs = -abs
+	}
+	formatted := FormatBalance(abs)
+	switch {
+	case amount < 0:
+		return "+" + formatted
+	case amount > 0:
+		return "−" + formatted
+	default:
+		return formatted
+	}
+}

--- a/internal/templates/components/tx_row_feed.templ
+++ b/internal/templates/components/tx_row_feed.templ
@@ -1,5 +1,7 @@
 package components
 
+import "fmt"
+
 // TxRowFeed is the dense, single-line transaction row used by the home
 // /feed inside sync, agent_session, and bulk_action sample lists. Trades
 // the two-line `tx_row_compact` layout (name + meta) for one glanceable
@@ -30,7 +32,11 @@ type TxRowFeedProps struct {
 	Pending       bool
 	CategoryColor *string
 	CategoryIcon  *string
-	Dimmed        bool
+	// TagCount surfaces inline as a small `[tag] N` chip when > 0 so a
+	// quick scan of the row hints "this transaction already carries
+	// labels". Zero hides the chip entirely.
+	TagCount int
+	Dimmed   bool
 }
 
 templ TxRowFeed(p TxRowFeedProps) {
@@ -64,6 +70,14 @@ templ TxRowFeed(p TxRowFeedProps) {
 		<span class={ "text-sm font-medium truncate flex-1 min-w-0", templ.KV("text-base-content/65", p.Dimmed) }>
 			{ TitleCase(p.Description) }
 		</span>
+		<!-- Tag chip — surfaces a `[tag] N` hint when the tx already
+		     carries labels. Hidden on zero so the row stays clean. -->
+		if p.TagCount > 0 {
+			<span class="inline-flex items-center gap-0.5 text-xs text-base-content/45 tabular-nums shrink-0" title={ TxRowFeedTagTitle(p.TagCount) }>
+				<i data-lucide="tag" class="w-3 h-3"></i>
+				<span>{ fmt.Sprintf("%d", p.TagCount) }</span>
+			</span>
+		}
 		<!-- Pending mark, kept inline so the row height stays stable. -->
 		if p.Pending {
 			<i data-lucide="clock" class="w-3 h-3 shrink-0 text-warning/70" title="Pending — not yet posted"></i>
@@ -82,6 +96,15 @@ func txRowFeedAmountClass(amount float64) string {
 		return "text-success"
 	}
 	return "text-base-content"
+}
+
+// TxRowFeedTagTitle returns the tooltip text for the inline tag chip,
+// pluralised so a single-tag row reads "1 tag" instead of "1 tags".
+func TxRowFeedTagTitle(n int) string {
+	if n == 1 {
+		return "1 tag"
+	}
+	return fmt.Sprintf("%d tags", n)
 }
 
 // TxRowFeedAmountWithSign formats an amount for the feed one-liner: a

--- a/internal/templates/components/tx_row_feed.templ
+++ b/internal/templates/components/tx_row_feed.templ
@@ -39,15 +39,21 @@ templ TxRowFeed(p TxRowFeedProps) {
 		class="bb-tx-row-feed flex items-center gap-2 py-1 px-1 -mx-1 rounded-md hover:bg-base-200/70 focus-visible:bg-base-200/70 focus-visible:outline-none transition-colors duration-150 no-underline"
 	>
 		<!-- Category avatar — mirrors TxRowCompact so the feed's coloured
-		     circle reads identically to the /transactions list. -->
+		     circle reads identically to the /transactions list. Categorised
+		     rows (any color or icon) render the coloured circle; rows
+		     without a category render a neutral grey question-mark. -->
 		<span class="relative shrink-0">
-			if p.CategoryIcon != nil {
+			if p.CategoryIcon != nil || p.CategoryColor != nil {
 				<span class="bb-tx-avatar bb-tx-avatar--sm" style={ TxAvatarColorStyle(p.CategoryColor) }>
-					<i data-lucide={ *p.CategoryIcon } class="w-3.5 h-3.5"></i>
+					if p.CategoryIcon != nil {
+						<i data-lucide={ *p.CategoryIcon } class="w-3.5 h-3.5"></i>
+					} else {
+						<i data-lucide="folder" class="w-3.5 h-3.5"></i>
+					}
 				</span>
 			} else {
-				<span class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--letter">
-					<span>{ FirstChar(p.Description) }</span>
+				<span class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--uncategorized">
+					<i data-lucide="help-circle" class="w-3.5 h-3.5"></i>
 				</span>
 			}
 		</span>

--- a/internal/templates/components/tx_row_feed.templ
+++ b/internal/templates/components/tx_row_feed.templ
@@ -53,7 +53,7 @@ templ TxRowFeed(p TxRowFeedProps) {
 				</span>
 			} else {
 				<span class="bb-tx-avatar bb-tx-avatar--sm bb-tx-avatar--uncategorized">
-					<i data-lucide="help-circle" class="w-3.5 h-3.5"></i>
+					<i data-lucide="circle-off" class="w-3.5 h-3.5"></i>
 				</span>
 			}
 		</span>

--- a/static/js/admin/components/tx_row_helpers.js
+++ b/static/js/admin/components/tx_row_helpers.js
@@ -57,12 +57,16 @@ function updateRowCategory(txId, slug) {
       avatarWrap.replaceChildren(avatar);
       if (typeof lucide !== 'undefined') lucide.createIcons({ nodes: [avatarWrap] });
     } else {
-      var name = (row.querySelector('a[href*="/transactions/"]') && row.querySelector('a[href*="/transactions/"]').textContent.trim()) || '?';
-      avatar.className = 'bb-tx-avatar bb-tx-avatar--letter';
-      var letter = document.createElement('span');
-      letter.textContent = name.charAt(0).toUpperCase();
-      avatar.appendChild(letter);
+      // Uncategorised — neutral grey question-mark, same as the templ
+      // primitives. Mirrors `bb-tx-avatar--uncategorized` rendered server-
+      // side by tx_row.templ / tx_row_compact.templ / tx_row_feed.templ.
+      avatar.className = 'bb-tx-avatar bb-tx-avatar--uncategorized';
+      var iconEl = document.createElement('i');
+      iconEl.setAttribute('data-lucide', 'help-circle');
+      iconEl.className = 'w-4 h-4';
+      avatar.appendChild(iconEl);
       avatarWrap.replaceChildren(avatar);
+      if (typeof lucide !== 'undefined') lucide.createIcons({ nodes: [avatarWrap] });
     }
   }
 

--- a/static/js/admin/components/tx_row_helpers.js
+++ b/static/js/admin/components/tx_row_helpers.js
@@ -62,7 +62,7 @@ function updateRowCategory(txId, slug) {
       // side by tx_row.templ / tx_row_compact.templ / tx_row_feed.templ.
       avatar.className = 'bb-tx-avatar bb-tx-avatar--uncategorized';
       var iconEl = document.createElement('i');
-      iconEl.setAttribute('data-lucide', 'help-circle');
+      iconEl.setAttribute('data-lucide', 'circle-off');
       iconEl.className = 'w-4 h-4';
       avatar.appendChild(iconEl);
       avatarWrap.replaceChildren(avatar);


### PR DESCRIPTION
## Summary

Replace the two-line `feedTxRefRow` (name + meta sub-line + amount block) with a new shared `components.TxRowFeed` one-liner used inside sync, agent_session, and bulk_action sample lists. Sample stacks now read at a glance instead of taking 2× the vertical real estate per row.

### Component (`internal/templates/components/tx_row_feed.templ`)

- Exports `TxRowFeed` + `TxRowFeedProps`. Reusable beyond `/feed` wherever a dense one-liner fits — pass `Dimmed` for de-emphasised reference rows.
- Layout: `[avatar][description][pending?][amount]` on a single line.
- Reuses `bb-tx-avatar` / `FormatBalance` / `FirstChar` so the visual lines up with `tx_row_compact` cross-surface.

### Description, not merchant name

Households scanning their feed recognise their own *raw bank descriptors* faster than a homogenised merchant string, and the description carries detail the merchant-strip drops (location, last-4, "PURCHASE AUTHORIZED", etc.). Falls back to `MerchantName` when description is empty (CSV-imported / pre-stamp rows). Title-cases the result so all-caps descriptors ("WHOLEFDS NEW YORK 12345") match the visual cadence of `/transactions`.

### Sign convention

Leading "+" for income (breadbox negative) and "−" for outflow so direction is unambiguous without the reader having to remember the sign rule. Same as the prior `feedAmountWithSign` — preserved verbatim, just lifted into the component.

### Cleanup

`feed.templ` keeps:
- `feedTxRefList` — multi-sample list wrapper (mobile collapse + "+ N more" tail)
- `feedTxRowProps` — shape adapter from `FeedTransactionRef` → `TxRowFeedProps`

Drops now-unused `feedAmountClass` / `feedAmountWithSign` / `feedTxRefRow`.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — green
- [x] Existing `feed_pending_test.go` cases still pass (pending pill, title-case all-caps, category-icon avatar)
- [ ] Manual: /feed sync / agent_session / bulk_action sample lists render as one-liners; mobile 3-row collapse + "+ N more" tail still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)