### PR TITLE
feat(nav): rename Help to Resources and feature Agent Prompts

### DIFF
--- a/input.css
+++ b/input.css
@@ -415,6 +415,25 @@
     @apply opacity-100;
   }
 
+  /* ── Sparkle accent for highlighted sidebar links (e.g. Agent Prompts) ── */
+  /* Trailing sparkle icon — overrides the generic icon rule above so it
+     gets its own size, accent colour, and a gentle pulse to draw the eye. */
+  .bb-sidebar-link .bb-sidebar-sparkle,
+  .bb-sidebar-link .bb-sidebar-sparkle svg {
+    @apply w-3.5 h-3.5 opacity-90;
+    animation: bb-sparkle-pulse 2.4s ease-in-out infinite;
+  }
+  .bb-sidebar-link:hover .bb-sidebar-sparkle,
+  .bb-sidebar-link:hover .bb-sidebar-sparkle svg,
+  .bb-sidebar-link--active .bb-sidebar-sparkle,
+  .bb-sidebar-link--active .bb-sidebar-sparkle svg {
+    @apply opacity-100;
+  }
+  @keyframes bb-sparkle-pulse {
+    0%, 100% { opacity: 0.65; transform: scale(1); }
+    50%      { opacity: 1;    transform: scale(1.12); }
+  }
+
   /* ── External-link arrow (Documentation / GitHub buttons) ── */
   /* Always visible on mobile (no hover affordance there), hidden by
      default and faded in on hover at lg+. Kept inside the

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -94,21 +94,23 @@ templ Nav(p NavProps) {
 		}
 		if p.IsEditor {
 			<div class="bb-sidebar-section">System</div>
-			<a href="/agent-prompts" class={ "bb-sidebar-link", navActive(p.CurrentPage, "agent-prompts") }>
-				<i data-lucide="bot-message-square"></i> Agent Prompts
-			</a>
-		}
-		if p.IsAdmin {
-			<a href="/logs" class={ "bb-sidebar-link", navActive(p.CurrentPage, "logs") }>
-				<i data-lucide="scroll-text"></i> Logs
-			</a>
-		}
-		if p.IsEditor {
+			if p.IsAdmin {
+				<a href="/logs" class={ "bb-sidebar-link", navActive(p.CurrentPage, "logs") }>
+					<i data-lucide="scroll-text"></i> Logs
+				</a>
+			}
 			<a href="/settings" class={ navActiveSettings(p.CurrentPage) }>
 				<i data-lucide="settings"></i> Settings
 			</a>
 		}
-		<div class="bb-sidebar-section">Help</div>
+		<div class="bb-sidebar-section">Resources</div>
+		if p.IsEditor {
+			<a href="/agent-prompts" class={ "bb-sidebar-link", navActive(p.CurrentPage, "agent-prompts") }>
+				<i data-lucide="bot-message-square"></i>
+				<span>Agent Prompts</span>
+				<i data-lucide="sparkles" class="bb-sidebar-sparkle ml-auto !text-amber-400"></i>
+			</a>
+		}
 		@navExternalLink("https://docs.breadbox.sh", "book-open", "Documentation")
 		@navExternalLink("https://github.com/canalesb93/breadbox", "github", "GitHub")
 	</nav>


### PR DESCRIPTION
## Summary
- Renamed the sidebar **Help** section to **Resources** and moved **Agent Prompts** into it.
- Added a small amber sparkle next to Agent Prompts (with a gentle pulse) so it stands out as the agentic-feature differentiator.
- Cleaned up the **System** group so Logs (admin) and Settings sit there together for both editor and admin roles.

## Screenshot
<img src="https://i.img402.dev/jwdbs1rkny.jpg" width="800" alt="Sidebar — Resources section with sparkle on Agent Prompts">

## Test plan
- [x] `go build ./...` and `go vet ./...` pass.
- [x] `go test ./internal/templates/...` passes.
- [x] Local dev server (`make dev` on port 8085) shows the renamed section, the moved entry, and the animated sparkle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
