### PR TITLE
fix(settings): full-width household member cards

### DIFF
--- a/internal/templates/components/pages/users.templ
+++ b/internal/templates/components/pages/users.templ
@@ -36,7 +36,7 @@ templ Users(p UsersProps) {
 		@usersUnlinkedPrompt(p)
 	}
 	if len(p.EnrichedUsers) > 0 {
-		<div class="grid grid-cols-1 lg:grid-cols-2 gap-5 bb-stagger">
+		<div class="flex flex-col gap-5 bb-stagger">
 			for _, u := range p.EnrichedUsers {
 				@usersMemberCard(u)
 			}


### PR DESCRIPTION
## Summary

Stack household member cards vertically (`flex flex-col`) instead of capping them at a 2-column grid on `lg:` so each card spans the full width of the settings content column.

## Evidence

<img src="https://i.img402.dev/ojxefuqx39.jpg" width="800" alt="Household cards full width with vertical settings rail">

## Test plan

- [x] `go build ./...` passes
- [x] `/settings/household` renders one card per row, full-width
- [ ] Reviewer eyeballs `/settings/household` with multiple members (only one in dev data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)