### PR TITLE
fix(ui): restore mobile navbar background

### DIFF
--- a/input.css
+++ b/input.css
@@ -309,15 +309,15 @@
     z-index: 30;
     border-bottom: 1px solid oklch(0 0 0 / 0.06);
     /* Subtle backdrop blur for depth when content scrolls underneath */
-    backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
-    background-color: oklch(var(--b1) / 0.92);
+            backdrop-filter: blur(8px);
+    background-color: color-mix(in oklch, var(--color-base-100) 92%, transparent);
   }
 
   @media (prefers-color-scheme: dark) {
     .bb-mobile-navbar {
       border-bottom-color: oklch(1 0 0 / 0.08);
-      background-color: oklch(var(--b1) / 0.88);
+      background-color: color-mix(in oklch, var(--color-base-100) 88%, transparent);
     }
   }
 


### PR DESCRIPTION
## Summary

The sticky mobile navbar was rendering fully transparent — `oklch(var(--b1) / 0.92)` is invalid under DaisyUI v5 (which uses `--color-base-100` with a full `oklch(...)` value, not the v4 channel-triplet `--b1`), so the browser fell back to transparent and content scrolled into the navbar's space.

- Switch the background to `color-mix(in oklch, var(--color-base-100) 92%, transparent)` (88% in dark mode), matching the existing pattern elsewhere in `input.css`.
- Reorder the `backdrop-filter` declarations (`-webkit-` first, unprefixed second) so Lightning CSS keeps both — without this, the minifier dropped the unprefixed property and Chrome saw no blur.

## Before / after — mobile (390×844), scrolled

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/vb69w698ci.jpg" width="400" alt="navbar transparent — content bleeds through"></td>
    <td><img src="https://i.img402.dev/5vy61fii62.jpg" width="400" alt="navbar with translucent background and backdrop blur"></td>
  </tr>
</table>

## Test plan

- [x] Verified the bug repro on `/transactions` at 390×844, scrolled past the fold
- [x] Confirmed `getComputedStyle(navbar).backgroundColor` is `oklch(1 0 0 / 0.92)` and `backdropFilter` is `blur(8px)` after the fix
- [x] Verified light + dark @supports branches both emit a real translucent color in the built CSS
