### PR TITLE
feat(tx): swap agent-reviewed bot icon for live comment count

### DIFF
--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -670,10 +670,10 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 		"t.date, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, " +
 		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, " +
-		// "Agent reviewed" is inferred from a category_set annotation authored
-		// by an agent. "Pending review" is the presence of the needs-review
-		// tag.
-		"EXISTS(SELECT 1 FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'category_set' AND ann.actor_type = 'agent') AS agent_reviewed, " +
+		// "Comment count" is the number of live (non-tombstoned) comment
+		// annotations on this row. "Pending review" is the presence of the
+		// needs-review tag.
+		"(SELECT COUNT(*) FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'comment' AND ann.deleted_at IS NULL) AS comment_count, " +
 		"EXISTS(SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = 'needs-review') AS has_pending_review, " +
 		"t.created_at, t.updated_at, " +
 		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id " +
@@ -912,7 +912,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			catColor         pgtype.Text
 			categoryOverride bool
 			pending          bool
-			agentReviewed    bool
+			commentCount     int64
 			hasPendingReview bool
 			createdAt        pgtype.Timestamptz
 			updatedAt        pgtype.Timestamptz
@@ -924,7 +924,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			&institutionName, &userName,
 			&date, &name, &merchantName, &amount, &isoCurrencyCode,
 			&categoryID, &catDisplayName, &catSlug, &catIcon, &catColor,
-			&categoryOverride, &pending, &agentReviewed, &hasPendingReview, &createdAt, &updatedAt,
+			&categoryOverride, &pending, &commentCount, &hasPendingReview, &createdAt, &updatedAt,
 			&effectiveUserID,
 		); err != nil {
 			return nil, fmt.Errorf("scan admin transaction: %w", err)
@@ -965,7 +965,7 @@ func (s *Service) ListTransactionsAdmin(ctx context.Context, params AdminTransac
 			CategoryColor:       textPtr(catColor),
 			CategoryOverride:    categoryOverride,
 			Pending:             pending,
-			AgentReviewed:       agentReviewed,
+			CommentCount:        int(commentCount),
 			HasPendingReview:    hasPendingReview,
 			CreatedAt:           pgconv.TimestampStr(createdAt),
 			UpdatedAt:           pgconv.TimestampStr(updatedAt),
@@ -1062,7 +1062,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 		"t.date, t.provider_name, t.provider_merchant_name, t.amount, t.iso_currency_code, " +
 		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, " +
-		"EXISTS(SELECT 1 FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'category_set' AND ann.actor_type = 'agent') AS agent_reviewed, " +
+		"(SELECT COUNT(*) FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'comment' AND ann.deleted_at IS NULL) AS comment_count, " +
 		"EXISTS(SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = 'needs-review') AS has_pending_review, " +
 		"t.created_at, t.updated_at, " +
 		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id " +
@@ -1101,7 +1101,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 			catColor         pgtype.Text
 			categoryOverride bool
 			pending          bool
-			agentReviewed    bool
+			commentCount     int64
 			hasPendingReview bool
 			createdAt        pgtype.Timestamptz
 			updatedAt        pgtype.Timestamptz
@@ -1112,7 +1112,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 			&institutionName, &userName,
 			&date, &name, &merchantName, &amount, &isoCurrencyCode,
 			&categoryID, &catDisplayName, &catSlug, &catIcon, &catColor,
-			&categoryOverride, &pending, &agentReviewed, &hasPendingReview, &createdAt, &updatedAt,
+			&categoryOverride, &pending, &commentCount, &hasPendingReview, &createdAt, &updatedAt,
 			&effectiveUserID,
 		); err != nil {
 			return nil, fmt.Errorf("scan admin transaction: %w", err)
@@ -1150,7 +1150,7 @@ func (s *Service) GetAdminTransactionRowsByIDs(ctx context.Context, ids []string
 			CategoryColor:       textPtr(catColor),
 			CategoryOverride:    categoryOverride,
 			Pending:             pending,
-			AgentReviewed:       agentReviewed,
+			CommentCount:        int(commentCount),
 			HasPendingReview:    hasPendingReview,
 			CreatedAt:           pgconv.TimestampStr(createdAt),
 			UpdatedAt:           pgconv.TimestampStr(updatedAt),

--- a/internal/service/transactions_bench_test.go
+++ b/internal/service/transactions_bench_test.go
@@ -296,7 +296,7 @@ func benchBuildAdminListQuery(params benchAdminListParams) (string, []any) {
 		"t.date, t.name, t.merchant_name, t.amount, t.iso_currency_code, " +
 		"t.category_id, c.display_name AS cat_display_name, c.slug AS cat_slug, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"t.category_override, t.pending, " +
-		"EXISTS(SELECT 1 FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'category_set' AND ann.actor_type = 'agent') AS agent_reviewed, " +
+		"(SELECT COUNT(*) FROM annotations ann WHERE ann.transaction_id = t.id AND ann.kind = 'comment' AND ann.deleted_at IS NULL) AS comment_count, " +
 		"EXISTS(SELECT 1 FROM transaction_tags tt JOIN tags tag ON tag.id = tt.tag_id WHERE tt.transaction_id = t.id AND tag.slug = 'needs-review') AS has_pending_review, " +
 		"t.created_at, t.updated_at, " +
 		"COALESCE(t.attributed_user_id, bc.user_id) AS effective_user_id " +

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -310,7 +310,7 @@ type AdminTransactionRow struct {
 	CategoryColor       *string
 	CategoryOverride    bool
 	Pending             bool
-	AgentReviewed       bool
+	CommentCount        int
 	HasPendingReview    bool
 	CreatedAt           string
 	UpdatedAt           string

--- a/internal/templates/components/tx_row.templ
+++ b/internal/templates/components/tx_row.templ
@@ -87,10 +87,14 @@ templ TxRow(tx service.AdminTransactionRow) {
 						<span class="text-base-content/20 hidden xl:inline">&middot;</span>
 						<span class="text-base-content/40 truncate hidden xl:inline">{ titleCase(deref(tx.MerchantName)) }</span>
 					}
-					if tx.AgentReviewed {
+					if tx.CommentCount > 0 {
 						<span class="text-base-content/20">&middot;</span>
-						<span class="inline-flex items-center gap-0.5 text-primary/60" title="Categorized by AI agent">
-							<i data-lucide="bot" class="w-3 h-3"></i>
+						<span
+							class="inline-flex items-center gap-0.5 text-base-content/40"
+							title={ fmt.Sprintf("%d comment%s", tx.CommentCount, pluralS(tx.CommentCount)) }
+						>
+							<i data-lucide="messages-square" class="w-3 h-3"></i>
+							<span class="text-[0.65rem] tabular-nums font-medium">{ strconv.Itoa(tx.CommentCount) }</span>
 						</span>
 					}
 					<!-- Tag container — updated in place by JS on add/remove. Leading
@@ -152,10 +156,14 @@ templ TxRow(tx service.AdminTransactionRow) {
 							<span class="text-[0.65rem] tabular-nums font-medium">{ strconv.Itoa(len(tx.Tags)) }</span>
 						</span>
 					}
-					if tx.AgentReviewed {
+					if tx.CommentCount > 0 {
 						<span class="text-base-content/20">&middot;</span>
-						<span class="inline-flex items-center gap-0.5 text-primary/60 shrink-0" title="Categorized by AI agent">
-							<i data-lucide="bot" class="w-3 h-3"></i>
+						<span
+							class="inline-flex items-center gap-0.5 text-base-content/40 shrink-0"
+							title={ fmt.Sprintf("%d comment%s", tx.CommentCount, pluralS(tx.CommentCount)) }
+						>
+							<i data-lucide="messages-square" class="w-3 h-3"></i>
+							<span class="text-[0.65rem] tabular-nums font-medium">{ strconv.Itoa(tx.CommentCount) }</span>
 						</span>
 					}
 				</div>

--- a/internal/templates/components/tx_row_compact.templ
+++ b/internal/templates/components/tx_row_compact.templ
@@ -1,6 +1,11 @@
 package components
 
-import "breadbox/internal/service"
+import (
+	"fmt"
+	"strconv"
+
+	"breadbox/internal/service"
+)
 
 // TxRowCompact is the lightweight sibling of TxRow used in dense contexts
 // (dashboard recent txns, rule detail tables). No selection, no inline
@@ -48,10 +53,14 @@ templ TxRowCompact(tx service.AdminTransactionRow) {
 						<span class="text-base-content/50 truncate max-w-24">{ deref(tx.CategoryDisplayName) }</span>
 					</span>
 				}
-				if tx.AgentReviewed {
+				if tx.CommentCount > 0 {
 					<span class="text-base-content/20 shrink-0">&middot;</span>
-					<span class="inline-flex items-center gap-0.5 text-primary/60 shrink-0" title="Categorized by AI agent">
-						<i data-lucide="bot" class="w-3 h-3"></i>
+					<span
+						class="inline-flex items-center gap-0.5 text-base-content/40 shrink-0"
+						title={ fmt.Sprintf("%d comment%s", tx.CommentCount, pluralS(tx.CommentCount)) }
+					>
+						<i data-lucide="messages-square" class="w-3 h-3"></i>
+						<span class="text-[0.65rem] tabular-nums font-medium">{ strconv.Itoa(tx.CommentCount) }</span>
 					</span>
 				}
 			</div>


### PR DESCRIPTION
## Summary

- Removes the \`bot\` indicator that lit up whenever an agent had ever set a category on a row (driven by an EXISTS over \`category_set\` annotations with \`actor_type='agent'\`). It surfaced AI activity but missed every human-only comment thread, and once an agent had ever touched the row the icon stayed forever even after a human override.
- Replaces it with a \`messages-square\` icon + count, styled like the existing tag-count badge — visible at a glance regardless of who left the comments. Tooltip is "N comment(s)" via the shared \`pluralS\` helper.
- Counts only live comments: \`SELECT COUNT(*) FROM annotations WHERE kind='comment' AND deleted_at IS NULL\`. Soft-delete tombstones (PR adding \`deleted_at\` on annotations) are excluded so the badge tracks real, current threads.

## Implementation

- \`AdminTransactionRow.AgentReviewed bool\` → \`CommentCount int\`. Both \`ListTransactionsAdmin\` queries (paginated list + by-IDs lookup) and the bench mirror updated in lockstep.
- Three render sites updated: \`tx_row.templ\` desktop meta line + mobile sub-line, and \`tx_row_compact.templ\` (TxRowFeed dense list). All three now hide when \`CommentCount == 0\`.
- Color shifts from \`text-primary/60\` (special-case AI flag) to \`text-base-content/40\` to match the tag-count chip — comment count is generic metadata, not an AI marker.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/templates/... ./internal/service/...\` (unit) passes — including the templ scripts lint
- [ ] Browse \`/transactions\` and confirm rows with comments show the \`messages-square\` + count, rows without comments stay clean. (Skipped in this session: Chrome MCP profile was locked by another session and I didn't want to clobber an active browser.)
- [ ] Confirm soft-deleted comments don't inflate the count

🤖 Generated with [Claude Code](https://claude.com/claude-code)