### PR TITLE
feat(feed): comment-style report rows with linked title bubble

### DIFF
--- a/internal/templates/components/pages/feed.templ
+++ b/internal/templates/components/pages/feed.templ
@@ -517,14 +517,16 @@ templ feedSyncBody(it FeedItem, s *FeedSync, now time.Time) {
 	}
 }
 
+// feedReportBody renders a report row as a chat-bubble shape that mirrors
+// the per-tx activity-timeline comment row: an inline actor on the meta
+// line, then the report title in a `bb-comment-bubble`. The whole bubble
+// is the click target into /reports/{id}. Priority badges still live on
+// the meta line; the unread "New" pill is intentionally dropped — the
+// report tile's tint already carries that signal.
 templ feedReportBody(it FeedItem, r *FeedReport, now time.Time) {
-	<div class="flex items-baseline gap-1.5 flex-wrap">
-		<a href={ templ.SafeURL("/reports/" + r.ID) } class="font-semibold text-base-content hover:text-primary hover:underline underline-offset-2 decoration-base-content/30 transition-colors no-underline">
-			{ r.Title }
-		</a>
-		if r.IsUnread {
-			<span class="badge badge-primary badge-xs uppercase tracking-wide">New</span>
-		}
+	<div class="flex items-center gap-1.5 px-1 flex-wrap text-sm leading-6 min-w-0">
+		@components.TimelineActorInline(feedReportActor(r))
+		<span class="text-base-content/55 shrink-0">filed a report</span>
 		if r.Priority == "critical" {
 			<span class="badge badge-error badge-xs uppercase tracking-wide">Critical</span>
 		} else if r.Priority == "warning" {
@@ -532,19 +534,20 @@ templ feedReportBody(it FeedItem, r *FeedReport, now time.Time) {
 		}
 		@feedRowTimestamp(it.TimestampStr, now)
 	</div>
-	if r.BodyExcerpt != "" {
-		<p class="text-base-content/65 leading-relaxed mt-0.5 line-clamp-2">{ r.BodyExcerpt }</p>
+	<a href={ templ.SafeURL("/reports/" + r.ID) } class="bb-comment-bubble mt-1 no-underline font-semibold text-base-content hover:text-primary hover:bg-primary/5 hover:border-primary/30 transition-colors">
+		{ r.Title }
+	</a>
+}
+
+// feedReportActor builds the shared TimelineActor for the report author so
+// the inline-actor renderer renders an agent avatar + bold name. Reports
+// are always agent-authored today; if a future report carries a user
+// author this stays correct as long as DisplayAuthor is set.
+func feedReportActor(r *FeedReport) components.TimelineActor {
+	return components.TimelineActor{
+		Name:    r.DisplayAuthor,
+		IsAgent: true,
 	}
-	<div class="mt-1 flex items-center gap-1.5 flex-wrap text-base-content/55">
-		<i data-lucide="bot" class="w-3 h-3"></i>
-		<span>{ r.DisplayAuthor }</span>
-		if len(r.Tags) > 0 {
-			<span class="text-base-content/30 mx-1">·</span>
-			for _, t := range r.Tags {
-				<span class="inline-flex items-center px-1.5 py-0.5 rounded-md bg-base-200 text-[0.65rem] font-medium text-base-content/65">{ t }</span>
-			}
-		}
-	</div>
 }
 
 templ feedAgentSessionBody(it FeedItem, s *FeedAgentSession, now time.Time) {


### PR DESCRIPTION
## Summary

Reports in the home feed now render with the same actor + bubble shape as comment events on /transactions/{id}. The bubble carries only the title and links into the report; hover tints primary so it reads as a click target.

- Drop the `New` pill — the rail tile's priority tint already conveys unread/severity.
- Inline avatar + bold author name + "filed a report" verb on the meta line, mirroring the per-tx comment row.
- Title in a `bb-comment-bubble` linked to `/reports/{id}`, with `hover:text-primary hover:bg-primary/5 hover:border-primary/30`.

## Screenshot

<img src="https://i.img402.dev/nhw1xixr1d.jpg" width="800" alt="feed — comment-style report row">

## Test plan

- [ ] Visit `/` and confirm reports render with the new layout.
- [ ] Hover the bubble — text + bg + border tint primary.
- [ ] Click the bubble — lands on `/reports/{id}`.
- [ ] Critical / warning priority badges still show on the meta line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
