### PR TITLE
feat(nav): rename Home to Feed, drop reports badge from row

### DIFF
--- a/internal/admin/feed.go
+++ b/internal/admin/feed.go
@@ -293,8 +293,8 @@ func FeedHandler(a *app.App, svc *service.Service, tr *TemplateRenderer) http.Ha
 		}
 
 		data := map[string]any{
-			"PageTitle":   "Home",
-			"CurrentPage": "home",
+			"PageTitle":   "Feed",
+			"CurrentPage": "feed",
 			"CSRFToken":   GetCSRFToken(r),
 		}
 		// Compute the oldest visible event timestamp + the at-cap flag that

--- a/internal/templates/components/nav.templ
+++ b/internal/templates/components/nav.templ
@@ -48,12 +48,9 @@ templ Nav(p NavProps) {
 			</a>
 		}
 		<div class="bb-sidebar-section">Overview</div>
-		<a href="/" class={ "bb-sidebar-link", navActive(p.CurrentPage, "home") }>
-			<i data-lucide="house"></i>
-			<span class="flex-1">Home</span>
-			if p.UnreadReports > 0 {
-				<span class="bb-nav-badge" title={ fmt.Sprintf("%d unread reports", p.UnreadReports) }>{ badgeCount(p.UnreadReports) }</span>
-			}
+		<a href="/" class={ "bb-sidebar-link", navActive(p.CurrentPage, "feed") }>
+			<i data-lucide="rss"></i>
+			<span class="flex-1">Feed</span>
 		</a>
 		<a href="/transactions" class={ "bb-sidebar-link", navActive(p.CurrentPage, "transactions") }>
 			<i data-lucide="receipt"></i> Transactions

--- a/internal/templates/components/pages/errors.templ
+++ b/internal/templates/components/pages/errors.templ
@@ -14,7 +14,7 @@ templ NotFound() {
 		<p class="bb-error-message">The page you're looking for doesn't exist or has been moved.</p>
 		<a href="/" class="btn btn-primary rounded-xl px-6">
 			<i data-lucide="arrow-left" class="w-4 h-4"></i>
-			Back to Home
+			Back to Feed
 		</a>
 	</div>
 }
@@ -35,7 +35,7 @@ templ InternalError() {
 				Try Again
 			</a>
 			<a href="/" class="btn btn-ghost rounded-xl px-6">
-				Home
+				Feed
 			</a>
 		</div>
 	</div>

--- a/internal/templates/layout/base.html
+++ b/internal/templates/layout/base.html
@@ -1485,7 +1485,7 @@
       // palette hint updates automatically.
       var allItems = [
         // Overview
-        { id: 'nav-home', shortcutId: 'global.go.d', group: 'Overview', title: 'Home', desc: 'Activity feed across the household', icon: 'house', href: '/', keywords: 'home feed activity dashboard overview' },
+        { id: 'nav-feed', shortcutId: 'global.go.d', group: 'Overview', title: 'Feed', desc: 'Activity feed across the household', icon: 'rss', href: '/', keywords: 'home feed activity dashboard overview' },
         { id: 'nav-transactions', shortcutId: 'global.go.t', group: 'Overview', title: 'Transactions', desc: 'View all transactions', icon: 'receipt', href: '/transactions', keywords: 'payments expenses spending' },
         { id: 'nav-reports', group: 'Overview', title: 'Reports', desc: 'Agent reports and findings', icon: 'file-text', href: '/reports', keywords: 'agent summaries notifications' },
         // Manage
@@ -2055,7 +2055,7 @@
       // "Go to" navigation — source of truth for `g+<x>` chords. Still exported
       // as plain maps so M0.5 can reuse them to seed palette entries.
       var goRoutes = {
-        d: { path: '/',                   label: 'Go to Home' },
+        d: { path: '/',                   label: 'Go to Feed' },
         t: { path: '/transactions',       label: 'Go to Transactions' },
         c: { path: '/connections',        label: 'Go to Connections' },
         r: { path: '/reviews',            label: 'Go to Reviews' },


### PR DESCRIPTION
## Summary

- Sidebar and command palette now show **Feed** (icon: `rss`) instead of **Home** — matches the page heading and the recent retire-dashboard / feed-as-root work (#981).
- Removes the unread-reports badge from the Feed sidebar row. That count already lives on the **Reports** row, so it was rendered twice.
- Also tweaks: 'Go to Home' shortcut label → 'Go to Feed'; 404/500 error page CTAs use 'Feed'; `CurrentPage` for `/` is `feed`.

## Screenshots

Sidebar:

<img src="https://i.img402.dev/pxq0e2ux7v.jpg" width="800" alt="Sidebar — Feed entry, no badge, rss icon">

Command palette (⌘K):

<img src="https://i.img402.dev/ou5e2btfrk.jpg" width="800" alt="Command palette — Feed entry">

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/templates/... ./internal/admin/...` passes
- [x] Sidebar shows "Feed" with `rss` icon and no unread-reports badge
- [x] Reports row still shows the badge count
- [x] ⌘K palette shows "Feed" + "Activity feed across the household"

🤖 Generated with [Claude Code](https://claude.com/claude-code)