### PR TITLE
mcp(short_id): collapse account_id pair on TransactionResponse

### DIFF
--- a/internal/service/fields.go
+++ b/internal/service/fields.go
@@ -115,9 +115,6 @@ func FilterTransactionFields(t TransactionResponse, fields map[string]bool) map[
 			m["short_id"] = t.ShortID
 		case "account_id":
 			m["account_id"] = t.AccountID
-			if t.AccountShortID != nil {
-				m["account_short_id"] = t.AccountShortID
-			}
 		case "account_name":
 			m["account_name"] = t.AccountName
 		case "user_name":

--- a/internal/service/fields_test.go
+++ b/internal/service/fields_test.go
@@ -326,42 +326,23 @@ func TestFilterTransactionFields_UserNameFallsBackToOwner(t *testing.T) {
 	}
 }
 
-// When AccountShortID is set, filtering account_id must also emit account_short_id.
-func TestFilterTransactionFields_AccountShortIDIncluded(t *testing.T) {
-	accountID := "acct-uuid-123"
+// account_id carries the account's short_id (single field, no paired
+// account_short_id sibling).
+func TestFilterTransactionFields_AccountIDIsShort(t *testing.T) {
 	accountShort := "Ab12CdEf"
 	txn := TransactionResponse{
-		ID:             "txn-1",
-		AccountID:      &accountID,
-		AccountShortID: &accountShort,
-	}
-
-	fields := map[string]bool{"id": true, "account_id": true}
-	result := FilterTransactionFields(txn, fields)
-
-	if gotID, _ := result["account_id"].(*string); gotID == nil || *gotID != accountID {
-		t.Errorf("expected account_id %q, got %v", accountID, result["account_id"])
-	}
-	gotShort, ok := result["account_short_id"].(*string)
-	if !ok || *gotShort != accountShort {
-		t.Errorf("expected account_short_id %q, got %v", accountShort, result["account_short_id"])
-	}
-}
-
-// When AccountShortID is nil, account_short_id must be absent from the result
-// (the key is omitted entirely, not set to a nil pointer).
-func TestFilterTransactionFields_AccountShortIDOmittedWhenNil(t *testing.T) {
-	accountID := "acct-uuid-123"
-	txn := TransactionResponse{
 		ID:        "txn-1",
-		AccountID: &accountID,
+		AccountID: &accountShort,
 	}
 
 	fields := map[string]bool{"id": true, "account_id": true}
 	result := FilterTransactionFields(txn, fields)
 
+	if gotID, _ := result["account_id"].(*string); gotID == nil || *gotID != accountShort {
+		t.Errorf("expected account_id %q, got %v", accountShort, result["account_id"])
+	}
 	if _, present := result["account_short_id"]; present {
-		t.Error("account_short_id should be omitted when AccountShortID is nil")
+		t.Error("account_short_id should not be emitted (collapsed into account_id)")
 	}
 }
 

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -99,7 +99,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 	args := make([]any, 0, 16)
 	argN := 1
 
-	buf.WriteString("SELECT t.id, t.short_id, t.account_id, t.provider_transaction_id, t.provider_pending_transaction_id, " +
+	buf.WriteString("SELECT t.id, t.short_id, t.provider_transaction_id, t.provider_pending_transaction_id, " +
 		"t.amount, t.iso_currency_code, t.unofficial_currency_code, t.date, t.authorized_date, " +
 		"t.datetime, t.authorized_datetime, t.provider_name, t.provider_merchant_name, " +
 		"t.provider_category_primary, t.provider_category_detailed, t.provider_category_confidence, " +
@@ -316,7 +316,6 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		var (
 			id                     pgtype.UUID
 			shortID                string
-			accountID              pgtype.UUID
 			externalTransactionID  string
 			pendingTransactionID   pgtype.Text
 			amount                 pgtype.Numeric
@@ -353,7 +352,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		)
 
 		if err := rows.Scan(
-			&id, &shortID, &accountID, &externalTransactionID, &pendingTransactionID,
+			&id, &shortID, &externalTransactionID, &pendingTransactionID,
 			&amount, &isoCurrencyCode, &unofficialCurrencyCode,
 			&date, &authorizedDate, &datetime, &authorizedDatetime,
 			&name, &merchantName, &categoryPrimary, &categoryDetailed,
@@ -399,8 +398,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		transactions = append(transactions, TransactionResponse{
 			ID:                  formatUUID(id),
 			ShortID:             shortID,
-			AccountID:           uuidPtr(accountID),
-			AccountShortID:      &accountShortIDVal,
+			AccountID:           &accountShortIDVal,
 			AccountName:         &accountName,
 			UserName:            textPtr(userName),
 			AttributedUserID:    uuidPtr(attributedUserID),
@@ -1211,8 +1209,53 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 	if err != nil {
 		return nil, ErrNotFound
 	}
-	txn, err := s.Queries.GetTransaction(ctx, uid)
-	if err != nil {
+
+	// Dynamic SQL with JOIN so account_id can carry the account's short_id
+	// directly (matching ListTransactions). Avoids a second round-trip just to
+	// look up the FK's short_id.
+	const q = `
+		SELECT t.id, t.short_id, a.short_id AS account_short_id,
+			t.amount, t.iso_currency_code, t.date, t.authorized_date,
+			t.datetime, t.authorized_datetime, t.provider_name, t.provider_merchant_name,
+			t.provider_category_primary, t.provider_category_detailed, t.provider_category_confidence,
+			t.provider_payment_channel, t.pending, t.created_at, t.updated_at,
+			t.category_id, t.category_override
+		FROM transactions t
+		LEFT JOIN accounts a ON a.id = t.account_id
+		WHERE t.id = $1 AND t.deleted_at IS NULL
+	`
+
+	var (
+		txID                pgtype.UUID
+		shortID             string
+		accountShortID      pgtype.Text
+		amount              pgtype.Numeric
+		isoCurrencyCode     pgtype.Text
+		date                pgtype.Date
+		authorizedDate      pgtype.Date
+		datetime            pgtype.Timestamptz
+		authorizedDatetime  pgtype.Timestamptz
+		providerName        string
+		providerMerchant    pgtype.Text
+		providerCatPrimary  pgtype.Text
+		providerCatDetailed pgtype.Text
+		providerCatConf     pgtype.Text
+		providerChannel     pgtype.Text
+		pending             bool
+		createdAt           pgtype.Timestamptz
+		updatedAt           pgtype.Timestamptz
+		categoryID          pgtype.UUID
+		categoryOverride    bool
+	)
+
+	if err := s.Pool.QueryRow(ctx, q, uid).Scan(
+		&txID, &shortID, &accountShortID,
+		&amount, &isoCurrencyCode, &date, &authorizedDate,
+		&datetime, &authorizedDatetime, &providerName, &providerMerchant,
+		&providerCatPrimary, &providerCatDetailed, &providerCatConf,
+		&providerChannel, &pending, &createdAt, &updatedAt,
+		&categoryID, &categoryOverride,
+	); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrNotFound
 		}
@@ -1220,40 +1263,39 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 	}
 
 	amountVal := 0.0
-	if f := numericFloat(txn.Amount); f != nil {
+	if f := numericFloat(amount); f != nil {
 		amountVal = *f
 	}
 
 	var dateVal string
-	if ds := dateStr(txn.Date); ds != nil {
+	if ds := dateStr(date); ds != nil {
 		dateVal = *ds
 	}
 
 	resp := &TransactionResponse{
-		ID:                  formatUUID(txn.ID),
-		ShortID:             txn.ShortID,
-		AccountID:           uuidPtr(txn.AccountID),
-		Amount:              amountVal,
-		IsoCurrencyCode:     textPtr(txn.IsoCurrencyCode),
-		Date:                dateVal,
-		AuthorizedDate:      dateStr(txn.AuthorizedDate),
-		Datetime:            timestampStr(txn.Datetime),
-		AuthorizedDatetime:  timestampStr(txn.AuthorizedDatetime),
-		ProviderName:               txn.ProviderName,
-		ProviderMerchantName:       textPtr(txn.ProviderMerchantName),
-		ProviderCategoryPrimary:    textPtr(txn.ProviderCategoryPrimary),
-		ProviderCategoryDetailed:   textPtr(txn.ProviderCategoryDetailed),
-		ProviderCategoryConfidence: textPtr(txn.ProviderCategoryConfidence),
-		CategoryOverride:           txn.CategoryOverride,
-		ProviderPaymentChannel:     textPtr(txn.ProviderPaymentChannel),
-		Pending:             txn.Pending,
-		CreatedAt:           pgconv.TimestampStr(txn.CreatedAt),
-		UpdatedAt:           pgconv.TimestampStr(txn.UpdatedAt),
+		ID:                         formatUUID(txID),
+		ShortID:                    shortID,
+		AccountID:                  textPtr(accountShortID),
+		Amount:                     amountVal,
+		IsoCurrencyCode:            textPtr(isoCurrencyCode),
+		Date:                       dateVal,
+		AuthorizedDate:             dateStr(authorizedDate),
+		Datetime:                   timestampStr(datetime),
+		AuthorizedDatetime:         timestampStr(authorizedDatetime),
+		ProviderName:               providerName,
+		ProviderMerchantName:       textPtr(providerMerchant),
+		ProviderCategoryPrimary:    textPtr(providerCatPrimary),
+		ProviderCategoryDetailed:   textPtr(providerCatDetailed),
+		ProviderCategoryConfidence: textPtr(providerCatConf),
+		CategoryOverride:           categoryOverride,
+		ProviderPaymentChannel:     textPtr(providerChannel),
+		Pending:                    pending,
+		CreatedAt:                  pgconv.TimestampStr(createdAt),
+		UpdatedAt:                  pgconv.TimestampStr(updatedAt),
 	}
 
-	// Load structured category info if category_id is set
-	if txn.CategoryID.Valid {
-		cat, err := s.Queries.GetCategoryByID(ctx, txn.CategoryID)
+	if categoryID.Valid {
+		cat, err := s.Queries.GetCategoryByID(ctx, categoryID)
 		if err == nil {
 			catID := formatUUID(cat.ID)
 			catInfo := &TransactionCategoryInfo{

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -38,7 +38,6 @@ type TransactionResponse struct {
 	ID                  string                   `json:"id"`
 	ShortID             string                   `json:"short_id"`
 	AccountID           *string                  `json:"account_id"`
-	AccountShortID      *string                  `json:"account_short_id,omitempty"`
 	AccountName         *string                  `json:"account_name"`
 	UserName            *string                  `json:"user_name"`
 	AttributedUserID    *string                  `json:"attributed_user_id,omitempty"`


### PR DESCRIPTION
## Summary

First PR in the **mcp-shortid-fks** stack. Goal of the stack: every FK reference returned by service methods carries the referenced row's `short_id` directly — one field, one type, no `*_short_id` siblings. This eliminates the duplicate-FK pattern and removes the inconsistency where some FKs emit short_ids and others leak UUIDs.

This PR collapses the only paired field that exists on `TransactionResponse`:

- **Drop `AccountShortID`** field from `TransactionResponse` (`internal/service/types.go`).
- **`AccountID` now carries the account's short_id** value, populated from `a.short_id` via the existing JOIN. `ListTransactions` simply stops selecting `t.account_id`.
- **`GetTransaction`** swaps the sqlc `SELECT *` for a small dynamic query that LEFT JOINs `accounts` and pulls `a.short_id`. Single round-trip; previously the field was unset on this path.
- **`fields.go`** drops the dual-emit branch — `account_id` is one field again.
- **Tests**: `TestFilterTransactionFields_AccountShortIDIncluded` / `_OmittedWhenNil` collapse into a single `_AccountIDIsShort` test asserting the new contract.

## What does and doesn't change

- **MCP wire format**: `account_id` is now always the 8-char short, never a UUID. (Previously: short on `query_transactions`, UUID on individual fetches — quietly inconsistent.)
- **REST wire format**: `account_id` carries the short value. The `?fields=account_id` filter no longer emits a paired `account_short_id`. Resolvers (`resolveAccountID`) accept either format, so any consumer that round-trips the value through a service call still works. Admin templates use `p.AccountID` to build `/accounts/<id>` URLs — those routes accept short_ids too.
- **`compactIDsBytes` FK branch** is unchanged. It still works on synthetic inputs but no production response shape feeds it FK pairs after this PR. The dead-code removal lands in a later PR.

## What's still inconsistent (next PRs)

- `attributed_user_id` and `effective_user_id` on `TransactionResponse` still emit UUIDs.
- `Account` and `Connection` responses still emit UUIDs for `connection_id`, `user_id`, `institution_id`.
- Annotation rows (`transaction_id`, `author_id`, `actor_id`, `review_id`, `comment_id`) still emit UUIDs.
- `RuleID` + `RuleShortID` pair on annotation/feed rows is still split.
- Rules and matches still emit UUIDs for their FKs.

Each of these is its own PR in the stack.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (unit)
- [x] `make test-integration` (full suite)
- [x] `internal/mcp/response_shapes_integration_test.go` regression harness still passes
