### PR TITLE
mcp(short_id): connection_id, user_id on AccountResponse and ConnectionResponse

### DIFF
--- a/internal/admin/transactions.go
+++ b/internal/admin/transactions.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/alexedwards/scs/v2"
 	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // DateGroup holds transactions grouped by a single date.
@@ -737,11 +736,11 @@ func TransactionDetailHandler(a *app.App, sm *scs.SessionManager, tr *TemplateRe
 					connectionID = *acct.ConnectionID
 				}
 				// Fetch user name from the account's user_id.
+				// acct.UserID carries the user's short_id (resolved at the
+				// SQL layer in ListAccounts/GetAccount).
 				if acct.UserID != nil {
-					var uid pgtype.UUID
-					if scanErr := uid.Scan(*acct.UserID); scanErr == nil {
-						u, uErr := a.Queries.GetUser(ctx, uid)
-						if uErr == nil {
+					if uid, err := a.Queries.GetUserUUIDByShortID(ctx, *acct.UserID); err == nil {
+						if u, uErr := a.Queries.GetUser(ctx, uid); uErr == nil {
 							userName = u.Name
 						}
 					}

--- a/internal/db/queries/accounts.sql
+++ b/internal/db/queries/accounts.sql
@@ -35,18 +35,36 @@ FROM accounts WHERE external_account_id = $1;
 SELECT id FROM accounts WHERE short_id = $1;
 
 -- name: ListAccounts :many
-SELECT a.*, bc.institution_name, bc.user_id, bc.status as connection_status
-FROM accounts a LEFT JOIN bank_connections bc ON a.connection_id = bc.id
+SELECT a.*,
+  bc.short_id AS connection_short_id,
+  bc.institution_name,
+  u.short_id AS user_short_id,
+  bc.status as connection_status
+FROM accounts a
+LEFT JOIN bank_connections bc ON a.connection_id = bc.id
+LEFT JOIN users u ON u.id = bc.user_id
 ORDER BY bc.institution_name, a.name;
 
 -- name: ListAccountsByUser :many
-SELECT a.*, bc.institution_name, bc.user_id, bc.status as connection_status
-FROM accounts a JOIN bank_connections bc ON a.connection_id = bc.id
+SELECT a.*,
+  bc.short_id AS connection_short_id,
+  bc.institution_name,
+  u.short_id AS user_short_id,
+  bc.status as connection_status
+FROM accounts a
+JOIN bank_connections bc ON a.connection_id = bc.id
+LEFT JOIN users u ON u.id = bc.user_id
 WHERE bc.user_id = $1 ORDER BY bc.institution_name, a.name;
 
 -- name: GetAccount :one
-SELECT a.*, bc.institution_name, bc.user_id, bc.status as connection_status
-FROM accounts a LEFT JOIN bank_connections bc ON a.connection_id = bc.id
+SELECT a.*,
+  bc.short_id AS connection_short_id,
+  bc.institution_name,
+  u.short_id AS user_short_id,
+  bc.status as connection_status
+FROM accounts a
+LEFT JOIN bank_connections bc ON a.connection_id = bc.id
+LEFT JOIN users u ON u.id = bc.user_id
 WHERE a.id = $1;
 
 -- name: UpdateAccountDisplayName :one

--- a/internal/db/queries/bank_connections.sql
+++ b/internal/db/queries/bank_connections.sql
@@ -87,21 +87,21 @@ SELECT * FROM bank_connections WHERE status = 'active';
 SELECT id, short_id, provider, external_id, encrypted_credentials, sync_cursor, user_id FROM bank_connections WHERE id = $1 AND status != 'disconnected';
 
 -- name: ListConnectionsForAPI :many
-SELECT bc.id, bc.short_id, bc.user_id, bc.provider, bc.institution_id, bc.institution_name,
+SELECT bc.id, bc.short_id, u.short_id AS user_short_id, bc.provider, bc.institution_id, bc.institution_name,
        bc.status, bc.error_code, bc.error_message, bc.last_synced_at,
        bc.created_at, bc.updated_at, u.name as user_name
 FROM bank_connections bc LEFT JOIN users u ON bc.user_id = u.id
 WHERE bc.status != 'disconnected' ORDER BY bc.created_at;
 
 -- name: ListConnectionsByUserForAPI :many
-SELECT bc.id, bc.short_id, bc.user_id, bc.provider, bc.institution_id, bc.institution_name,
+SELECT bc.id, bc.short_id, u.short_id AS user_short_id, bc.provider, bc.institution_id, bc.institution_name,
        bc.status, bc.error_code, bc.error_message, bc.last_synced_at,
        bc.created_at, bc.updated_at, u.name as user_name
 FROM bank_connections bc LEFT JOIN users u ON bc.user_id = u.id
 WHERE bc.user_id = $1 AND bc.status != 'disconnected' ORDER BY bc.created_at;
 
 -- name: GetConnectionForAPI :one
-SELECT bc.id, bc.short_id, bc.user_id, bc.provider, bc.institution_id, bc.institution_name,
+SELECT bc.id, bc.short_id, u.short_id AS user_short_id, bc.provider, bc.institution_id, bc.institution_name,
        bc.status, bc.error_code, bc.error_message, bc.last_synced_at,
        bc.created_at, bc.updated_at, u.name as user_name
 FROM bank_connections bc LEFT JOIN users u ON bc.user_id = u.id

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -77,7 +77,9 @@ func (s *Service) GetAccountDetail(ctx context.Context, id string) (*AdminAccoun
 
 	if acct.ConnectionID != nil {
 		detail.ConnectionID = *acct.ConnectionID
-		connID, err := pgconv.ParseUUID(*acct.ConnectionID)
+		// acct.ConnectionID carries the connection's short_id; resolve through
+		// the service helper (accepts UUID or short_id) before fetching.
+		connID, err := s.resolveConnectionID(ctx, *acct.ConnectionID)
 		if err == nil {
 			conn, err := s.Queries.GetBankConnection(ctx, connID)
 			if err == nil {
@@ -95,8 +97,8 @@ func accountFromAllRow(r db.ListAccountsRow) AccountResponse {
 	return AccountResponse{
 		ID:                formatUUID(r.ID),
 		ShortID:           r.ShortID,
-		ConnectionID:      uuidPtr(r.ConnectionID),
-		UserID:            uuidPtr(r.UserID),
+		ConnectionID:      textPtr(r.ConnectionShortID),
+		UserID:            textPtr(r.UserShortID),
 		InstitutionName:   textPtr(r.InstitutionName),
 		Name:              r.Name,
 		OfficialName:      textPtr(r.OfficialName),
@@ -116,11 +118,12 @@ func accountFromAllRow(r db.ListAccountsRow) AccountResponse {
 }
 
 func accountFromUserRow(r db.ListAccountsByUserRow) AccountResponse {
+	connShort := r.ConnectionShortID
 	return AccountResponse{
 		ID:                formatUUID(r.ID),
 		ShortID:           r.ShortID,
-		ConnectionID:      uuidPtr(r.ConnectionID),
-		UserID:            uuidPtr(r.UserID),
+		ConnectionID:      &connShort,
+		UserID:            textPtr(r.UserShortID),
 		InstitutionName:   textPtr(r.InstitutionName),
 		Name:              r.Name,
 		OfficialName:      textPtr(r.OfficialName),
@@ -143,8 +146,8 @@ func accountFromGetRow(r db.GetAccountRow) AccountResponse {
 	return AccountResponse{
 		ID:                formatUUID(r.ID),
 		ShortID:           r.ShortID,
-		ConnectionID:      uuidPtr(r.ConnectionID),
-		UserID:            uuidPtr(r.UserID),
+		ConnectionID:      textPtr(r.ConnectionShortID),
+		UserID:            textPtr(r.UserShortID),
 		InstitutionName:   textPtr(r.InstitutionName),
 		Name:              r.Name,
 		OfficialName:      textPtr(r.OfficialName),

--- a/internal/service/connections.go
+++ b/internal/service/connections.go
@@ -25,7 +25,7 @@ func (s *Service) ListConnections(ctx context.Context, userID *string) ([]Connec
 			result[i] = ConnectionResponse{
 				ID:              formatUUID(r.ID),
 				ShortID:         r.ShortID,
-				UserID:          uuidPtr(r.UserID),
+				UserID:          textPtr(r.UserShortID),
 				UserName:        textPtr(r.UserName),
 				Provider:        string(r.Provider),
 				InstitutionID:   textPtr(r.InstitutionID),
@@ -50,7 +50,7 @@ func (s *Service) ListConnections(ctx context.Context, userID *string) ([]Connec
 		result[i] = ConnectionResponse{
 			ID:              formatUUID(r.ID),
 			ShortID:         r.ShortID,
-			UserID:          uuidPtr(r.UserID),
+			UserID:          textPtr(r.UserShortID),
 			UserName:        textPtr(r.UserName),
 			Provider:        string(r.Provider),
 			InstitutionID:   textPtr(r.InstitutionID),
@@ -84,7 +84,7 @@ func (s *Service) GetConnectionStatus(ctx context.Context, id string) (*Connecti
 		ConnectionResponse: ConnectionResponse{
 			ID:              formatUUID(conn.ID),
 			ShortID:         conn.ShortID,
-			UserID:          uuidPtr(conn.UserID),
+			UserID:          textPtr(conn.UserShortID),
 			UserName:        textPtr(conn.UserName),
 			Provider:        string(conn.Provider),
 			InstitutionID:   textPtr(conn.InstitutionID),
@@ -109,7 +109,7 @@ func (s *Service) GetConnectionStatus(ctx context.Context, id string) (*Connecti
 		slResp := SyncLogResponse{
 			ID:            formatUUID(syncLog.ID),
 			ShortID:       syncLog.ShortID,
-			ConnectionID:  formatUUID(syncLog.ConnectionID),
+			ConnectionID:  conn.ShortID,
 			Trigger:       string(syncLog.Trigger),
 			Status:        string(syncLog.Status),
 			AddedCount:    syncLog.AddedCount,


### PR DESCRIPTION
## Summary

Third PR in the **mcp-shortid-fks** stack. Account and connection responses now carry short_ids for their FK references — `connection_id` and `user_id` on `AccountResponse`, `user_id` on `ConnectionResponse`, and `connection_id` on `SyncLogResponse`.

## Changes

**SQL queries (sqlc):**

- `accounts.sql` — `ListAccounts`, `ListAccountsByUser`, `GetAccount`: add `LEFT JOIN users u ON u.id = bc.user_id` and select `bc.short_id AS connection_short_id`, `u.short_id AS user_short_id`.
- `bank_connections.sql` — `ListConnectionsForAPI`, `ListConnectionsByUserForAPI`, `GetConnectionForAPI`: replace `bc.user_id` (UUID) with `u.short_id AS user_short_id`.

**Service layer:**

- `accounts.go` — `accountFromAllRow` / `accountFromUserRow` / `accountFromGetRow` populate `ConnectionID` and `UserID` from the new `*ShortID` columns.
- `accounts.go` `GetAccountDetail` — switch the connection lookup from `pgconv.ParseUUID(*acct.ConnectionID)` to `s.resolveConnectionID(...)` since `ConnectionID` is now a short_id.
- `connections.go` — `ConnectionResponse.UserID` populated from `r.UserShortID`. `SyncLogResponse.ConnectionID` populated from the parent `conn.ShortID` (already on the row).

**Admin handler fix:**

- `internal/admin/transactions.go` — the `acct.UserID` → user-name lookup used `pgtype.UUID.Scan` directly. Switch to `Queries.GetUserUUIDByShortID` since the field is now a short_id. Drop the unused `pgtype` import.

## Wire-format impact

- MCP/REST: `account.connection_id`, `account.user_id`, `connection.user_id`, `sync_log.connection_id` are now 8-char short_ids.
- `institution_id` is unchanged — it's an external string identifier (Plaid `ins_…` / Teller institution code), not a FK to a local row, so there's no short_id to resolve to.
- Resolvers (`resolveConnectionID`, `resolveUserID`, etc.) accept either UUID or short_id, so internal callers that round-trip these values through service methods continue to work.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (unit)
- [x] `make test-integration` — all packages green, including `TestShortID_InAccountResponse` and `TestShortID_InConnectionResponse`
- [x] sqlc 1.30 in CI compatible with local 1.23 — schema additions only, no exotic features
