### PR TITLE
mcp(short_id): drop tag_id, collapse rule_id pair on mcpAnnotation

### DIFF
--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -199,8 +199,12 @@ func mapAnnotationKinds(kinds []string) ([]string, error) {
 // payload keys; the underlying `payload` is preserved for raw access.
 // `subject` is the canonical object of the event (tag display name,
 // category display name, rule name, or comment body preview), and the
-// top-level resource refs (`tag_slug`, `category_slug`, `rule_name`) make
-// cross-linking cheap.
+// top-level resource refs (`tag_slug`, `category_slug`, `rule_name`,
+// `rule_id`) make cross-linking cheap.
+//
+// Tags and categories are referenced by slug only — the slug is the canonical
+// stable handle for both. Rules are referenced by `rule_id` carrying the
+// rule's 8-char short_id (no separate `rule_short_id`).
 type mcpAnnotation struct {
 	ID            string                 `json:"id"`
 	ShortID       string                 `json:"short_id"`
@@ -216,13 +220,12 @@ type mcpAnnotation struct {
 	TagSlug       string                 `json:"tag_slug,omitempty"`
 	CategorySlug  string                 `json:"category_slug,omitempty"`
 	RuleName      string                 `json:"rule_name,omitempty"`
+	RuleID        string                 `json:"rule_id,omitempty"`
 	ActorType     string                 `json:"actor_type"`
 	ActorID       *string                `json:"actor_id,omitempty"`
 	ActorName     string                 `json:"actor_name"`
 	SessionID     *string                `json:"session_id,omitempty"`
 	Payload       map[string]interface{} `json:"payload,omitempty"`
-	TagID         *string                `json:"tag_id,omitempty"`
-	RuleID        *string                `json:"rule_id,omitempty"`
 	CreatedAt     string                 `json:"created_at"`
 }
 
@@ -274,15 +277,31 @@ func toMCPAnnotation(a service.Annotation) mcpAnnotation {
 		TagSlug:       a.TagSlug,
 		CategorySlug:  a.CategorySlug,
 		RuleName:      a.RuleName,
+		// Surface the rule's short_id as `rule_id` (canonical handle for
+		// agents). Falls back to the FK column's UUID for raw rows where
+		// enrichment hasn't populated RuleShortID yet.
+		RuleID:        ruleHandle(a),
 		ActorType:     a.ActorType,
 		ActorID:       a.ActorID,
 		ActorName:     a.ActorName,
 		SessionID:     a.SessionID,
 		Payload:       a.Payload,
-		TagID:         a.TagID,
-		RuleID:        a.RuleID,
 		CreatedAt:     a.CreatedAt,
 	}
+}
+
+// ruleHandle picks the rule's short_id when the enrichment pipeline has
+// surfaced it; falls back to the raw rule_id UUID otherwise so rows fetched
+// in Raw mode still link to a real entity. Empty when the annotation has no
+// rule (most kinds).
+func ruleHandle(a service.Annotation) string {
+	if a.RuleShortID != "" {
+		return a.RuleShortID
+	}
+	if a.RuleID != nil {
+		return *a.RuleID
+	}
+	return ""
 }
 
 func toMCPAnnotations(in []service.Annotation) []mcpAnnotation {


### PR DESCRIPTION
## Summary

Fourth PR in the **mcp-shortid-fks** stack. Cleans up the wire format for `mcpAnnotation` (returned by `list_annotations` and the deprecated `list_transaction_comments`) so tag and rule references follow the slug / single-short-id pattern the rest of the API uses:

- **Drop `tag_id`** from the wire format. `tag_slug` was already there and is the canonical stable handle for tags — same pattern as categories (which dropped to slug-only earlier in the stack design).
- **Collapse `rule_id` (UUID) + `rule_short_id`** into a single **`rule_id`** carrying the rule's 8-char short_id. Matches the convention from PR-01 (`account_id` was collapsed the same way).

## What this is and isn't

This PR only touches the **MCP wire format** — `internal/mcp/tools_tags.go`. The service-layer `service.Annotation` type still carries `RuleID` (UUID), `RuleShortID` (short), and `TagID` (UUID) for admin/HTML consumers that read it directly. Cleaning those up requires SQL changes (JOIN on `rules.id`/`tags.id` for short_ids) and a follow-up PR.

The `ruleHandle` helper picks `RuleShortID` when enrichment has populated it, falling back to the raw `RuleID` UUID — so list_annotations(`raw=true`) responses still surface a non-empty handle.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (unit)
- [x] `make test-integration` — `internal/mcp` and `internal/service` suites green, including `response_shapes_integration_test.go`

## Stack

- 01 #987 — TransactionResponse account_id pair collapse
- 02 #988 — TransactionResponse user FKs
- 03 #989 — Account / Connection FKs
- **04 (this PR)** — mcpAnnotation tag_id drop + rule_id collapse
- (next) Service-layer Annotation FK shorts (transaction_id, actor_id, session_id, comment_id, review_id; collapse RuleID/RuleShortID at the source via a rules JOIN)
- (next) Rules + matches FKs
- (last) Drop FK branch of compactIDsBytes + docs
