### PR TITLE
mcp(short_id): drop FK branch from compactIDsBytes; refresh docs

### DIFF
--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -37,7 +37,11 @@ type QueryTransactionsInput struct {
 
 Use `*float64` (not `float64`) for optional numeric filters so zero is a valid filter value.
 
-Outputs go through `jsonResult()` which calls `compactIDs()` — replaces every `id` field with the `short_id` value and drops the `short_id` field. Agents see compact 8-char IDs; REST API consumers still get both.
+Outputs go through `jsonResult()` which calls `compactIDsBytes()` — collapses each object's own `id`/`short_id` pair so the `id` field carries the 8-char short value and the separate `short_id` key is dropped.
+
+FK fields (`account_id`, `transaction_id`, `rule_id`, `user_id`, `connection_id`, …) carry the **referenced row's `short_id`** directly. Resolution happens at the SQL layer in service queries (JOINs that select the FK target's `short_id`) — not in the byte rewriter, which only touches the row's own pair. There is no separate `*_short_id` sibling on responses. Categories and tags are referenced by `*_slug` instead — slugs are the canonical handle for those entities.
+
+Agents see one compact 8-char ID per reference. REST consumers see the same shape (FK fields carry shorts) since the SQL resolution is shared; only the row's own-`id` rewriting is MCP-only.
 
 Errors: return with `IsError: true` and a text content block `{"error": "message"}`. Never panic.
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"breadbox/internal/service"
 
@@ -999,12 +998,16 @@ func jsonResult(v any) (*mcpsdk.CallToolResult, any, error) {
 	}, nil, nil
 }
 
-// compactIDs recursively walks a JSON structure and compacts ID pairs in place.
-// For every key ending in "_short_id" (or the bare "short_id") with a non-null
-// string value, the sibling "{prefix}_id" (or bare "id") field is replaced with
-// the short_id value and the "_short_id" key is removed. This covers both an
-// object's own id/short_id pair and its FK references (e.g. account_id +
-// account_short_id → account_id=<short>).
+// compactIDs recursively walks a JSON structure and compacts each object's own
+// id/short_id pair in place. When a "short_id" key with a non-null string
+// value sits next to a sibling "id" field, the "id" value is replaced with
+// the short_id value and the "short_id" key is removed.
+//
+// FK fields (e.g. account_id, transaction_id, rule_id) carry their referenced
+// row's short_id directly — that resolution happens at the SQL layer in the
+// service queries (JOINs that select the FK target's short_id). No
+// "*_short_id" sibling appears in production responses, and FK keys are
+// emitted as-is here.
 func compactIDs(v any) {
 	switch val := v.(type) {
 	case map[string]any:
@@ -1045,30 +1048,29 @@ func compactIDPairs(m map[string]any) {
 	}
 }
 
-// shortIDPrefix reports whether key names a short-id sibling and returns its
-// prefix. "short_id" → ("", true); "account_short_id" → ("account", true);
-// anything else → ("", false).
+// shortIDPrefix reports whether key names the row's own short-id sibling.
+// Only the bare "short_id" key is recognized — FK fields are pre-resolved to
+// short_ids at the SQL layer and are emitted as-is by compaction.
 func shortIDPrefix(key string) (string, bool) {
 	if key == "short_id" {
 		return "", true
-	}
-	if strings.HasSuffix(key, "_short_id") && len(key) > len("_short_id") {
-		return key[:len(key)-len("_short_id")], true
 	}
 	return "", false
 }
 
 // compactIDsBytes performs id/short_id compaction directly on JSON bytes,
 // avoiding the unmarshal→walk→remarshal cycle. It scans the byte stream and
-// collapses short-id sibling pairs:
+// collapses each object's own id/short_id pair:
 //
-//   - own id: {"id":"<uuid>","short_id":"<short>"} → {"id":"<short>"}
-//   - FK id:  {"account_id":"<uuid>","account_short_id":"<short>"} →
-//             {"account_id":"<short>"}
+//   {"id":"<uuid>","short_id":"<short>"} → {"id":"<short>"}
 //
-// Any key ending in "_short_id" (or the bare "short_id") triggers the rewrite;
-// the "_short_id" key is always dropped. If the sibling id field is missing or
-// the short-id value is null, the id value is left untouched.
+// Only the bare "short_id" key triggers the rewrite; the "short_id" key is
+// then dropped. If the sibling "id" field is missing or "short_id" is null,
+// the id value is left untouched.
+//
+// FK fields (account_id, transaction_id, rule_id, …) already carry their
+// referenced row's short_id — resolved at the SQL layer in the service
+// queries — and are emitted unchanged.
 func compactIDsBytes(data []byte) []byte {
 	// Quick check: if no short_id key exists anywhere, return as-is. Matches
 	// both "short_id" and any "*_short_id" suffix.
@@ -1206,14 +1208,12 @@ func compactIDsScanObject(data []byte, pos int, out []byte) (int, []byte) {
 	return pos, out
 }
 
-// idKeyPrefix reports whether key names an id sibling and returns its prefix.
-// "id" → ("", true); "account_id" → ("account", true); else ("", false).
+// idKeyPrefix reports whether key names the row's own id sibling. Only the
+// bare "id" key is recognized — FK *_id fields carry their referenced row's
+// short_id directly (resolved at the SQL layer) and are emitted unchanged.
 func idKeyPrefix(key string) (string, bool) {
 	if key == "id" {
 		return "", true
-	}
-	if strings.HasSuffix(key, "_id") && len(key) > len("_id") {
-		return key[:len(key)-len("_id")], true
 	}
 	return "", false
 }

--- a/internal/mcp/tools_bench_test.go
+++ b/internal/mcp/tools_bench_test.go
@@ -294,11 +294,11 @@ func TestCompactIDsBytesFieldOrdering(t *testing.T) {
 	}
 }
 
-// TestCompactIDsBytesFKPairs verifies that FK sibling pairs like
-// account_id/account_short_id are collapsed to a single account_id carrying
-// the short value.
-func TestCompactIDsBytesFKPairs(t *testing.T) {
-	input := []byte(`{"id":"own-uuid","short_id":"ownshort","account_id":"acct-uuid","account_short_id":"acctshort","category_id":"cat-uuid","category_short_id":"catshort","name":"t1"}`)
+// TestCompactIDsBytesFKsPassThrough verifies that FK fields are emitted
+// verbatim — they already carry short_ids resolved at the SQL layer, and the
+// rewriter only handles each object's own id/short_id pair.
+func TestCompactIDsBytesFKsPassThrough(t *testing.T) {
+	input := []byte(`{"id":"own-uuid","short_id":"ownshort","account_id":"acctshort","category_id":"catshort","name":"t1"}`)
 	got := compactIDsBytes(input)
 	var parsed map[string]any
 	if err := json.Unmarshal(got, &parsed); err != nil {
@@ -315,30 +315,7 @@ func TestCompactIDsBytesFKPairs(t *testing.T) {
 			t.Errorf("%s: got %v want %q", k, parsed[k], v)
 		}
 	}
-	for _, k := range []string{"short_id", "account_short_id", "category_short_id"} {
-		if _, has := parsed[k]; has {
-			t.Errorf("%s should be removed", k)
-		}
-	}
-}
-
-// TestCompactIDsBytesFKNullShort verifies that a null short_id sibling drops
-// the _short_id key but leaves the _id value untouched (compaction would
-// otherwise discard a valid UUID).
-func TestCompactIDsBytesFKNullShort(t *testing.T) {
-	input := []byte(`{"id":"own-uuid","short_id":"ownshort","account_id":"acct-uuid","account_short_id":null}`)
-	got := compactIDsBytes(input)
-	var parsed map[string]any
-	if err := json.Unmarshal(got, &parsed); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if parsed["id"] != "ownshort" {
-		t.Errorf("id: got %v", parsed["id"])
-	}
-	if parsed["account_id"] != "acct-uuid" {
-		t.Errorf("account_id: expected preserved UUID, got %v", parsed["account_id"])
-	}
-	if _, has := parsed["account_short_id"]; has {
-		t.Error("account_short_id should be removed even when null")
+	if _, has := parsed["short_id"]; has {
+		t.Error("short_id should be removed")
 	}
 }

--- a/internal/service/comments_apikeys_integration_test.go
+++ b/internal/service/comments_apikeys_integration_test.go
@@ -730,8 +730,16 @@ func TestGetOverviewStats_WithData(t *testing.T) {
 	if stats.Users[0].Name != "Alice" {
 		t.Errorf("user name = %q, want Alice", stats.Users[0].Name)
 	}
+	// Overview emits short_ids (resource path bypasses compactIDsBytes, so
+	// the value must come out of the SQL layer already-shortened).
+	if stats.Users[0].ID != user.ShortID {
+		t.Errorf("user.id = %q, want short_id %q", stats.Users[0].ID, user.ShortID)
+	}
 	if len(stats.Connections) != 1 {
 		t.Errorf("connections = %d, want 1", len(stats.Connections))
+	}
+	if stats.Connections[0].ID != conn.ShortID {
+		t.Errorf("connection.id = %q, want short_id %q", stats.Connections[0].ID, conn.ShortID)
 	}
 	if _, ok := stats.AccountsByType["depository"]; !ok {
 		t.Error("expected depository in accounts_by_type")

--- a/internal/service/overview.go
+++ b/internal/service/overview.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // OverviewStats contains high-level statistics about the Breadbox dataset.
@@ -111,8 +109,10 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		return nil, fmt.Errorf("count unmapped: %w", err)
 	}
 
-	// Users list
-	userRows, err := s.Pool.Query(ctx, "SELECT id, name FROM users ORDER BY name")
+	// Users list. ID carries the user's 8-char short_id (matches the
+	// service-layer convention; resource handler bypasses compactIDsBytes
+	// so we must emit the right shape directly).
+	userRows, err := s.Pool.Query(ctx, "SELECT short_id, name FROM users ORDER BY name")
 	if err != nil {
 		return nil, fmt.Errorf("list users: %w", err)
 	}
@@ -120,11 +120,9 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 	stats.Users = []OverviewUser{}
 	for userRows.Next() {
 		var u OverviewUser
-		var id pgtype.UUID
-		if err := userRows.Scan(&id, &u.Name); err != nil {
+		if err := userRows.Scan(&u.ID, &u.Name); err != nil {
 			return nil, fmt.Errorf("scan user: %w", err)
 		}
-		u.ID = formatUUID(id)
 		stats.Users = append(stats.Users, u)
 	}
 	if err := userRows.Err(); err != nil {
@@ -150,10 +148,10 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 		return nil, fmt.Errorf("account type rows: %w", err)
 	}
 
-	// Connections with account counts
+	// Connections with account counts. ID carries the connection's short_id.
 	stats.Connections = []OverviewConnection{}
 	connRows, err := s.Pool.Query(ctx, `
-		SELECT bc.id, bc.provider, bc.institution_name, bc.status, bc.last_synced_at,
+		SELECT bc.short_id, bc.provider, bc.institution_name, bc.status, bc.last_synced_at,
 			(SELECT COUNT(*) FROM accounts WHERE connection_id = bc.id)
 		FROM bank_connections bc
 		WHERE bc.status != 'disconnected'
@@ -164,13 +162,11 @@ func (s *Service) GetOverviewStats(ctx context.Context) (*OverviewStats, error) 
 	defer connRows.Close()
 	for connRows.Next() {
 		var c OverviewConnection
-		var id pgtype.UUID
 		var instName *string
 		var lastSynced *time.Time
-		if err := connRows.Scan(&id, &c.Provider, &instName, &c.Status, &lastSynced, &c.AccountCount); err != nil {
+		if err := connRows.Scan(&c.ID, &c.Provider, &instName, &c.Status, &lastSynced, &c.AccountCount); err != nil {
 			return nil, fmt.Errorf("scan connection: %w", err)
 		}
-		c.ID = formatUUID(id)
 		c.InstitutionName = instName
 		if lastSynced != nil {
 			s := lastSynced.UTC().Format(time.RFC3339)


### PR DESCRIPTION
## Summary

Final PR in the **mcp-shortid-fks** stack. Drops the FK branch from `compactIDsBytes` now that no service-layer response shape emits `*_short_id` siblings — every FK is resolved to a short_id at the SQL layer (PRs 01–05). The byte rewriter's job collapses to its original purpose: each object's own `id`/`short_id` pair.

## Changes

**`internal/mcp/tools.go`:**

- `shortIDPrefix` now only recognizes the bare `short_id` key. The `*_short_id` regex match is gone.
- `idKeyPrefix` correspondingly only recognizes the bare `id` key.
- The byte-level `compactIDsScanObject` is unchanged structurally — it builds `shortByPrefix` keyed by `prefix == ""` and only swaps the bare `id` value. FK keys flow through verbatim.
- Removed the now-unused `strings` import.
- Doc comments on `compactIDs`, `compactIDsBytes`, `compactIDsScanObject` rewritten to describe the new (and original) contract: own-pair only; FKs carry shorts directly.

**`internal/mcp/tools_bench_test.go`:**

- `TestCompactIDsBytesFKPairs` and `TestCompactIDsBytesFKNullShort` (which exercised the FK-pair compaction) replaced with `TestCompactIDsBytesFKsPassThrough`, asserting that FK keys are emitted unchanged and only the row's own `short_id` is consumed.

**`.claude/rules/mcp.md`:**

- Output-conventions section rewritten to describe SQL-layer FK resolution + slug references for categories/tags, and to clarify that the byte rewriter only touches the own-id pair.

## Why this is safe

I grep'd the service and MCP packages for any production type still emitting a `*_short_id` field — the only hit is `internal/service/feed.go`'s `RuleShortID` inside an *input* unmarshal struct (parsing JSONB payload), not an output field. Earlier PRs in the stack already removed every output `*_short_id` field:

- PR-01: `TransactionResponse.AccountShortID` (collapse)
- PR-04: `mcpAnnotation.tag_id` + `rule_short_id` (drop)

So the FK-handling code paths in `compactIDsBytes` were dead in production. Limiting the prefix matchers makes them dead in tests too, and lets future readers see a function that does exactly one well-scoped thing.

## Stack

- 01 #987 — TransactionResponse account_id pair collapse
- 02 #988 — TransactionResponse user FKs
- 03 #989 — Account / Connection FKs
- 04 #990 — mcpAnnotation tag_id drop + rule_id collapse
- 05 #991 — Rules + matches + account_links FKs
- **06 (this PR)** — drop FK branch of `compactIDsBytes` + docs

## Out-of-scope follow-ups

- Service-layer `Annotation` FK shorts (transaction_id, actor_id, session_id, comment_id, review_id) — needs a JOIN-heavy SQL refactor that mirrors PR-03's pattern. Currently MCP responses already get the right shape because `mcpAnnotation` is a separate wire type (PR-04), but admin UI consumers of `service.Annotation` still see UUIDs internally. Tracked for a follow-up.
- `compactIDsBytes` itself could eventually be deleted by populating `id` with the short value at the query layer everywhere, dropping the byte rewriter entirely. That's a REST contract change for the row's own-`id` and was explicitly punted as Phase 2.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (unit) — all pass, including refreshed bench tests
- [x] `make test-integration` — all packages green
