### PR TITLE
mcp: add resource templates for per-entity drilldowns

### DIFF
--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -85,3 +85,13 @@ Bounded reference data is exposed two ways:
 - **Tool mirrors (compat)** — `get_overview`, `list_accounts`, `list_categories`, `list_tags`, `list_users`, `list_transaction_rules`, `get_sync_status`. Same payload, called as tools. Kept because not every MCP client implements the resources/* methods — without these, those clients can't read this data at all.
 
 Both surfaces share the same service-layer call path (no logic duplication), so payload shape stays in sync. When adding a new bounded reference resource, register both: a resource handler in `resources.go` and a tool mirror in `tools_reads.go`.
+
+## Resource templates (drill-downs)
+
+Per-entity detail views are exposed as MCP resource templates registered with `Server.AddResourceTemplate`:
+
+- `breadbox://transaction/{short_id}` — `{transaction, annotations}`
+- `breadbox://account/{short_id}` — `{account, recent_transactions}` (capped at 25)
+- `breadbox://user/{short_id}` — `{user, accounts}`
+
+Template handlers parse the trailing `{short_id}` via `extractTemplateParam`, resolve through the standard service `Get*` methods (which accept either UUID or short_id), and return `mcpsdk.ResourceNotFoundError(uri)` on miss. URIs come back to chat as clickable items via `resource_link` content blocks emitted by tools (planned in a follow-up PR).

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -3,7 +3,10 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"breadbox/internal/service"
@@ -220,3 +223,139 @@ var (
 	audienceUserAndAssistant = []mcpsdk.Role{"user", "assistant"}
 	audienceAssistantOnly    = []mcpsdk.Role{"assistant"}
 )
+
+// --- Resource templates ---
+//
+// Templates resolve parameterized URIs that drill into a single entity. They
+// are how `resource_link` content blocks emitted by tool results (PR 05) turn
+// into clickable, attachable items in chat. The template URI format follows
+// RFC 6570 ("breadbox://transaction/{short_id}"); the SDK matches incoming
+// URIs against the template and routes to the handler.
+//
+// Discoverability today: most MCP hosts surface templates through the same
+// attachment menu as plain resources, but template-parameter UI is uneven.
+// The reliable path is `resource_link` blocks emitted from tool results —
+// those render as clickable rows the user can attach. PR 03 of this stack
+// adds those links; PR 04 (this PR) just makes the URIs resolvable.
+
+// templateRecentTransactionLimit caps the recent-transactions slice on
+// account/user template responses. Keeps payloads bounded for UI rendering.
+const templateRecentTransactionLimit = 25
+
+// templateAnnotationLimit caps the annotation tail on transaction template
+// responses. Most transaction timelines are short, but a noisy rule could
+// produce dozens of rows; cap mirrors list_annotations' default-friendly
+// budget.
+const templateAnnotationLimit = 50
+
+// extractTemplateParam pulls the trailing path segment from a templated URI.
+// "breadbox://transaction/abc12345" → "abc12345". Returns the URL-decoded
+// value (URLs may percent-encode special characters).
+func extractTemplateParam(uri, prefix string) (string, error) {
+	if !strings.HasPrefix(uri, prefix) {
+		return "", fmt.Errorf("uri %q does not match template prefix %q", uri, prefix)
+	}
+	tail := strings.TrimPrefix(uri, prefix)
+	if tail == "" {
+		return "", fmt.Errorf("uri %q is missing template parameter", uri)
+	}
+	// Reject any further path segments — templates only support a single
+	// trailing identifier today.
+	if strings.Contains(tail, "/") {
+		return "", fmt.Errorf("uri %q has unexpected path segment", uri)
+	}
+	decoded, err := url.PathUnescape(tail)
+	if err != nil {
+		return "", fmt.Errorf("decode template parameter: %w", err)
+	}
+	return decoded, nil
+}
+
+// templateNotFound returns the SDK's standard resource-not-found error so
+// clients can branch on the canonical -32002 error code.
+func templateNotFound(uri string) error {
+	return mcpsdk.ResourceNotFoundError(uri)
+}
+
+func (s *MCPServer) handleTransactionTemplate(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	uri := req.Params.URI
+	id, err := extractTemplateParam(uri, "breadbox://transaction/")
+	if err != nil {
+		return nil, err
+	}
+
+	txn, err := s.svc.GetTransaction(ctx, id)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return nil, templateNotFound(uri)
+		}
+		return nil, fmt.Errorf("get transaction %s: %w", id, err)
+	}
+
+	annotations, err := s.svc.ListAnnotations(ctx, id, service.ListAnnotationsParams{
+		Limit: templateAnnotationLimit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list annotations for %s: %w", id, err)
+	}
+
+	return jsonResourceResult(uri, map[string]any{
+		"transaction": txn,
+		"annotations": toMCPAnnotations(annotations),
+	})
+}
+
+func (s *MCPServer) handleAccountTemplate(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	uri := req.Params.URI
+	id, err := extractTemplateParam(uri, "breadbox://account/")
+	if err != nil {
+		return nil, err
+	}
+
+	acct, err := s.svc.GetAccount(ctx, id)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return nil, templateNotFound(uri)
+		}
+		return nil, fmt.Errorf("get account %s: %w", id, err)
+	}
+
+	recent, err := s.svc.ListTransactions(ctx, service.TransactionListParams{
+		AccountID: &id,
+		Limit:     templateRecentTransactionLimit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list transactions for %s: %w", id, err)
+	}
+
+	return jsonResourceResult(uri, map[string]any{
+		"account":             acct,
+		"recent_transactions": recent.Transactions,
+	})
+}
+
+func (s *MCPServer) handleUserTemplate(ctx context.Context, req *mcpsdk.ReadResourceRequest) (*mcpsdk.ReadResourceResult, error) {
+	uri := req.Params.URI
+	id, err := extractTemplateParam(uri, "breadbox://user/")
+	if err != nil {
+		return nil, err
+	}
+
+	user, err := s.svc.GetUser(ctx, id)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			return nil, templateNotFound(uri)
+		}
+		return nil, fmt.Errorf("get user %s: %w", id, err)
+	}
+
+	accounts, err := s.svc.ListAccounts(ctx, &id)
+	if err != nil {
+		return nil, fmt.Errorf("list accounts for %s: %w", id, err)
+	}
+
+	return jsonResourceResult(uri, map[string]any{
+		"user":     user,
+		"accounts": accounts,
+	})
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -444,6 +444,38 @@ func (s *MCPServer) registerResources(server *mcpsdk.Server) {
 		MIMEType:    "text/markdown",
 		Annotations: resourceAnnotations(audienceAssistantOnly, 0.7, staticPromptModTime),
 	}, staticMarkdownResource("breadbox://rule-dsl", DefaultRuleDSL))
+
+	// --- Resource templates ---
+	// Drill-downs into a single entity. URIs come back from tool results as
+	// `resource_link` blocks (PR 05 in this stack) and resolve through these
+	// handlers. dual-audience so they appear in template-aware pickers as
+	// well; priority is below top-level resources.
+	server.AddResourceTemplate(&mcpsdk.ResourceTemplate{
+		Name:        "Transaction",
+		Title:       "Transaction Detail",
+		URITemplate: "breadbox://transaction/{short_id}",
+		Description: "Single transaction with its activity timeline (annotations). short_id is the 8-char base62 id surfaced everywhere by query_transactions.",
+		MIMEType:    "application/json",
+		Annotations: resourceAnnotations(audienceUserAndAssistant, 0.7, liveResourceModTime),
+	}, s.handleTransactionTemplate)
+
+	server.AddResourceTemplate(&mcpsdk.ResourceTemplate{
+		Name:        "Account",
+		Title:       "Account Detail",
+		URITemplate: "breadbox://account/{short_id}",
+		Description: "Single bank account with balance, currency, and the most recent 25 transactions. short_id is the 8-char base62 id surfaced by list_accounts.",
+		MIMEType:    "application/json",
+		Annotations: resourceAnnotations(audienceUserAndAssistant, 0.7, liveResourceModTime),
+	}, s.handleAccountTemplate)
+
+	server.AddResourceTemplate(&mcpsdk.ResourceTemplate{
+		Name:        "Household Member",
+		Title:       "Household Member Detail",
+		URITemplate: "breadbox://user/{short_id}",
+		Description: "Single household member with their connected accounts. short_id is the 8-char base62 id surfaced by list_users.",
+		MIMEType:    "application/json",
+		Annotations: resourceAnnotations(audienceUserAndAssistant, 0.7, liveResourceModTime),
+	}, s.handleUserTemplate)
 }
 
 // AllToolDefs returns the full tool registry for admin display.

--- a/internal/service/users.go
+++ b/internal/service/users.go
@@ -2,10 +2,13 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
+
+	"github.com/jackc/pgx/v5"
 )
 
 func (s *Service) ListUsers(ctx context.Context) ([]UserResponse, error) {
@@ -18,6 +21,22 @@ func (s *Service) ListUsers(ctx context.Context) ([]UserResponse, error) {
 		result[i] = userFromRow(r)
 	}
 	return result, nil
+}
+
+func (s *Service) GetUser(ctx context.Context, id string) (*UserResponse, error) {
+	uid, err := s.resolveUserID(ctx, id)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+	row, err := s.Queries.GetUser(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+	resp := userFromRow(row)
+	return &resp, nil
 }
 
 func userFromRow(r db.User) UserResponse {

--- a/prompts/mcp/instructions.md
+++ b/prompts/mcp/instructions.md
@@ -11,6 +11,11 @@ Bounded reference data has both a resource and a tool mirror with the same paylo
 - `breadbox://sync-status` ↔ `get_sync_status`
 - `breadbox://rules` ↔ `list_transaction_rules`
 
+Per-entity drilldowns are exposed as resource templates (resolve a single short_id):
+- `breadbox://transaction/{short_id}` — full transaction + recent annotations
+- `breadbox://account/{short_id}` — account detail + last 25 transactions
+- `breadbox://user/{short_id}` — household member + connected accounts
+
 ## Conventions
 - **Amount sign**: positive = money out, negative = money in. Never sum across `iso_currency_code`.
 - **Compact IDs**: to save on tokens, tools/resources use a 8-char base62 `short_id`; prefer over long form id (uuid)


### PR DESCRIPTION
Adds three MCP resource templates for per-entity drilldowns. Each resolves a short_id into a detail view, sharing the same compact-ID and service-call conventions as the static reference resources.

## Summary

- `breadbox://transaction/{short_id}` → `{transaction, annotations}` (annotations capped at 50)
- `breadbox://account/{short_id}` → `{account, recent_transactions}` (capped at 25)
- `breadbox://user/{short_id}` → `{user, accounts}`
- New `Service.GetUser` to back the user template (the underlying sqlc query already existed).
- Templates are dual-audience (user + assistant) and priority 0.7 so they appear in template-aware pickers; in template-blind hosts they're reachable via `resource_link` content blocks emitted by tool results (planned follow-up).
- Returns `mcpsdk.ResourceNotFoundError(uri)` on miss so clients see the canonical -32002 code.

## Test plan

- [x] `go build`, `go vet`, `go vet -tags integration`
- [x] Existing unit + service test suites still green
- [ ] Integration tests added in the next PR (04.5)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
