### PR TITLE
mcp: title + annotation hints on every tool

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -92,6 +92,45 @@ type ToolDef struct {
 	register func(server *mcpsdk.Server)
 }
 
+// ToolSpec is the input shape for makeToolDefLogged. Carries the user-facing
+// metadata the SDK exposes (Title, Annotations) alongside the runtime fields
+// the registry needs (Name, Classification). Title surfaces in Claude.ai's
+// Settings → Connectors → Configure Tools list; Annotations drive
+// confirmation prompts and tool-list rendering. Leaving Annotations nil lets
+// the registry fill in classification-derived defaults.
+type ToolSpec struct {
+	Name           string
+	Title          string
+	Description    string
+	Classification ToolClassification
+	Annotations    *mcpsdk.ToolAnnotations
+}
+
+// boolPtr returns a pointer to v. Used for optional bool fields on
+// ToolAnnotations where nil means "not set" (the SDK defaults specified in
+// the protocol take effect).
+func boolPtr(v bool) *bool { return &v }
+
+// defaultAnnotations builds the baseline ToolAnnotations for a tool from its
+// classification when the registration site doesn't override it. Read tools
+// get ReadOnlyHint=true; write tools default to non-destructive (the per-tool
+// registration opts in to DestructiveHint=true for the few tools that delete
+// or reset state). OpenWorldHint is left at the SDK default (true) — Breadbox
+// is a closed-world server, but the protocol's default already covers that
+// when ReadOnlyHint=true and the tool annotation block is otherwise empty.
+func defaultAnnotations(classification ToolClassification, title string) *mcpsdk.ToolAnnotations {
+	a := &mcpsdk.ToolAnnotations{Title: title}
+	switch classification {
+	case ToolRead:
+		a.ReadOnlyHint = true
+	case ToolWrite:
+		// Default writes to non-destructive so hosts only confirm the few
+		// tools that actually delete or reset state.
+		a.DestructiveHint = boolPtr(false)
+	}
+	return a
+}
+
 // MCPServerConfig holds runtime MCP permissions loaded from app_config + API key.
 type MCPServerConfig struct {
 	Mode          string   // "read_only" or "read_write"
@@ -130,114 +169,166 @@ func (s *MCPServer) buildToolRegistry() {
 		// Audit session — explicit handle so write tools can be tied to a
 		// logical task. (A future PR replaces this with transport-bound
 		// session binding via MCP-Session-Id.)
-		makeToolDefLogged("create_session", ToolWrite,
-			"Start an audit session before performing write operations. Returns a session_id to include on all subsequent tool calls. One session per logical task (e.g. 'weekly transaction review', 'rule creation for dining').",
-			s.handleCreateSession, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "create_session", Title: "Start Audit Session", Classification: ToolWrite,
+			Description: "Start an audit session before performing write operations. Returns a session_id to include on all subsequent tool calls. One session per logical task (e.g. 'weekly transaction review', 'rule creation for dining').",
+		}, s.handleCreateSession, svc),
 
 		// --- Reference data (mirrors resources for clients without resource support) ---
 		// Resources are the preferred surface: breadbox://overview, ://accounts,
 		// ://categories, ://tags, ://users, ://sync-status, ://rules. These tool
 		// mirrors keep clients that don't implement resources/* unblocked.
-		makeToolDefLogged("get_overview", ToolRead,
-			"Get a household snapshot: scope (users, accounts, currencies), freshness (latest sync, errored connections, recent transactions), and backlog (pending review queue). Mirror of breadbox://overview — call this when your client doesn't support MCP resources, or when you want the snapshot inline as a tool result. Read once at the top of a session to ground every later filter (account ids, currency, attribution).",
-			s.handleGetOverview, svc),
-		makeToolDefLogged("list_accounts", ToolRead,
-			"List bank accounts. Mirror of breadbox://accounts. Each account carries balance, type, currency, and the connection it belongs to. Filter by user_id to scope to a specific household member.",
-			s.handleListAccounts, svc),
-		makeToolDefLogged("list_categories", ToolRead,
-			"List the category taxonomy as a flat array. Mirror of breadbox://categories. Use the returned slugs (e.g. 'food_and_drink_groceries') as the canonical handle for category filters and category_slug fields on writes.",
-			s.handleListCategories, svc),
-		makeToolDefLogged("list_users", ToolRead,
-			"List household members. Mirror of breadbox://users. Each user carries display name, role, and short_id — use the short_id as user_id on transaction filters and account scoping.",
-			s.handleListUsers, svc),
-		makeToolDefLogged("list_tags", ToolRead,
-			"List the tag vocabulary. Mirror of breadbox://tags. Tags are referenced by slug everywhere (filter, add, remove). New tag slugs auto-register the first time update_transactions adds them — read this list before authoring rules to avoid accidental near-duplicates.",
-			s.handleListTags, svc),
-		makeToolDefLogged("get_sync_status", ToolRead,
-			"Get connection sync status: provider, status (active|error|pending_reauth|disconnected), last sync time, last error. Mirror of breadbox://sync-status. Call this before reasoning about freshness — an errored or pending_reauth connection means transactions you'd expect to be there might not be.",
-			s.handleGetSyncStatus, svc),
-		makeToolDefLogged("list_transaction_rules", ToolRead,
-			"List transaction rules with their conditions, actions, and pipeline stage. Mirror of breadbox://rules. Filter by category_slug, enabled, or search by name. Read this before authoring new rules to avoid duplicates.",
-			s.handleListTransactionRules, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "get_overview", Title: "Household Overview", Classification: ToolRead,
+			Description: "Get a household snapshot: scope (users, accounts, currencies), freshness (latest sync, errored connections, recent transactions), and backlog (pending review queue). Mirror of breadbox://overview — call this when your client doesn't support MCP resources, or when you want the snapshot inline as a tool result. Read once at the top of a session to ground every later filter (account ids, currency, attribution).",
+		}, s.handleGetOverview, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "list_accounts", Title: "List Accounts", Classification: ToolRead,
+			Description: "List bank accounts. Mirror of breadbox://accounts. Each account carries balance, type, currency, and the connection it belongs to. Filter by user_id to scope to a specific household member.",
+		}, s.handleListAccounts, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "list_categories", Title: "List Categories", Classification: ToolRead,
+			Description: "List the category taxonomy as a flat array. Mirror of breadbox://categories. Use the returned slugs (e.g. 'food_and_drink_groceries') as the canonical handle for category filters and category_slug fields on writes.",
+		}, s.handleListCategories, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "list_users", Title: "List Household Members", Classification: ToolRead,
+			Description: "List household members. Mirror of breadbox://users. Each user carries display name, role, and short_id — use the short_id as user_id on transaction filters and account scoping.",
+		}, s.handleListUsers, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "list_tags", Title: "List Tags", Classification: ToolRead,
+			Description: "List the tag vocabulary. Mirror of breadbox://tags. Tags are referenced by slug everywhere (filter, add, remove). New tag slugs auto-register the first time update_transactions adds them — read this list before authoring rules to avoid accidental near-duplicates.",
+		}, s.handleListTags, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "get_sync_status", Title: "Sync Status", Classification: ToolRead,
+			Description: "Get connection sync status: provider, status (active|error|pending_reauth|disconnected), last sync time, last error. Mirror of breadbox://sync-status. Call this before reasoning about freshness — an errored or pending_reauth connection means transactions you'd expect to be there might not be.",
+		}, s.handleGetSyncStatus, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "list_transaction_rules", Title: "List Rules", Classification: ToolRead,
+			Description: "List transaction rules with their conditions, actions, and pipeline stage. Mirror of breadbox://rules. Filter by category_slug, enabled, or search by name. Read this before authoring new rules to avoid duplicates.",
+		}, s.handleListTransactionRules, svc),
 
 		// --- Query + aggregate ---
-		makeToolDefLogged("query_transactions", ToolRead,
-			"Query bank transactions with optional filters and cursor-based pagination. Amounts: positive = money out (debit), negative = money in (credit). Dates: YYYY-MM-DD, start_date inclusive, end_date exclusive. Filter by category_slug (see breadbox://categories for the slug list); parent slugs include all children. Results ordered by date desc by default. Pagination: pass next_cursor from response. Use the fields parameter to request only the fields you need (e.g., fields=core,category) to significantly reduce response size.",
-			s.handleQueryTransactions, svc),
-		makeToolDefLogged("count_transactions", ToolRead,
-			"Count transactions matching optional filters. Same filters as query_transactions except cursor, limit, sort_by, and sort_order. Use this to get totals before paginating, or to compare counts across date ranges or categories.",
-			s.handleCountTransactions, svc),
-		makeToolDefLogged("transaction_summary", ToolRead,
-			"Get aggregated transaction totals grouped by category and/or time period. Replaces the need to paginate through thousands of individual transactions for spending analysis. Amounts follow the convention: positive = money out (debit), negative = money in (credit). Only includes non-deleted, non-pending transactions by default.",
-			s.handleTransactionSummary, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "query_transactions", Title: "Query Transactions", Classification: ToolRead,
+			Description: "Query bank transactions with optional filters and cursor-based pagination. Amounts: positive = money out (debit), negative = money in (credit). Dates: YYYY-MM-DD, start_date inclusive, end_date exclusive. Filter by category_slug (see breadbox://categories for the slug list); parent slugs include all children. Results ordered by date desc by default. Pagination: pass next_cursor from response. Use the fields parameter to request only the fields you need (e.g., fields=core,category) to significantly reduce response size.",
+		}, s.handleQueryTransactions, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "count_transactions", Title: "Count Transactions", Classification: ToolRead,
+			Description: "Count transactions matching optional filters. Same filters as query_transactions except cursor, limit, sort_by, and sort_order. Use this to get totals before paginating, or to compare counts across date ranges or categories.",
+		}, s.handleCountTransactions, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "transaction_summary", Title: "Spending Summary", Classification: ToolRead,
+			Description: "Get aggregated transaction totals grouped by category and/or time period. Replaces the need to paginate through thousands of individual transactions for spending analysis. Amounts follow the convention: positive = money out (debit), negative = money in (credit). Only includes non-deleted, non-pending transactions by default.",
+		}, s.handleTransactionSummary, svc),
 
 		// --- Apply review decisions ---
 		// update_transactions is the universal write for review work. It
 		// absorbs the per-row variants (categorize, batch-categorize, tag
 		// add/remove, comment, reset-category) so an agent can land a full
-		// decision atomically per transaction.
-		makeToolDefLogged("update_transactions", ToolWrite,
-			"Compound write for up to 50 transactions at once. Each operation can: set a category (category_slug), add tags (tags_to_add), remove tags (tags_to_remove), and attach a comment — all atomically per transaction, with annotations written for every change. The canonical tool for closing review work (set category + remove needs-review + explain) in one call. Use the `comment` field to capture decision rationale; tag adds/removes carry no per-action note — keep all narrative in the comment. Example operation: {\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\"}],\"comment\":\"Clearly groceries — Costco run.\"}. on_error: 'continue' (default — each op in its own DB tx, partial failures OK) or 'abort' (one DB tx, rolls back on first error).",
-			s.handleUpdateTransactions, svc),
+		// decision atomically per transaction. Idempotent: re-running the
+		// same op produces the same final state (the annotations rotate but
+		// the row settles in the same place), so hosts can retry safely.
+		makeToolDefLogged(ToolSpec{
+			Name: "update_transactions", Title: "Update Transactions", Classification: ToolWrite,
+			Description: "Compound write for up to 50 transactions at once. Each operation can: set a category (category_slug), add tags (tags_to_add), remove tags (tags_to_remove), and attach a comment — all atomically per transaction, with annotations written for every change. The canonical tool for closing review work (set category + remove needs-review + explain) in one call. Use the `comment` field to capture decision rationale; tag adds/removes carry no per-action note — keep all narrative in the comment. Example operation: {\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\"}],\"comment\":\"Clearly groceries — Costco run.\"}. on_error: 'continue' (default — each op in its own DB tx, partial failures OK) or 'abort' (one DB tx, rolls back on first error).",
+			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: true},
+		}, s.handleUpdateTransactions, svc),
 
 		// --- Activity timeline ---
-		makeToolDefLogged("list_annotations", ToolRead,
-			"List the activity timeline for a transaction, ordered by created_at ASC. Each row carries a generic `kind` (comment | rule | tag | category) plus an `action` (added | removed | set | applied) for the specific event — branch on `action` when the distinction matters (e.g. tag added vs removed). Payload carries kind-specific fields (content for comments, slug for tag events, rule_name for rule applications). Filters compose: `kinds=['comment']` is the comment-only view; `actor_types=['user']` is the canonical 'any human input?' check (drops rule churn + agent activity); `since` (RFC3339) skips rows you've already seen; `limit` returns the most recent N (capped at 200). Empty filters return the full timeline. Recommended pattern: before overriding your own categorization, call list_annotations(transaction_id, actor_types=['user']) — if any row exists, a human has weighed in and that decision wins.",
-			s.handleListAnnotations, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "list_annotations", Title: "List Activity Timeline", Classification: ToolRead,
+			Description: "List the activity timeline for a transaction, ordered by created_at ASC. Each row carries a generic `kind` (comment | rule | tag | category) plus an `action` (added | removed | set | applied) for the specific event — branch on `action` when the distinction matters (e.g. tag added vs removed). Payload carries kind-specific fields (content for comments, slug for tag events, rule_name for rule applications). Filters compose: `kinds=['comment']` is the comment-only view; `actor_types=['user']` is the canonical 'any human input?' check (drops rule churn + agent activity); `since` (RFC3339) skips rows you've already seen; `limit` returns the most recent N (capped at 200). Empty filters return the full timeline. Recommended pattern: before overriding your own categorization, call list_annotations(transaction_id, actor_types=['user']) — if any row exists, a human has weighed in and that decision wins.",
+		}, s.handleListAnnotations, svc),
 
 		// --- Rules ---
 		// See breadbox://rule-dsl for the condition grammar and breadbox://rules
 		// for the current ruleset.
-		makeToolDefLogged("create_transaction_rule", ToolWrite,
-			"Create a transaction rule for automatic categorization, tagging, or commenting. Rules match condition trees against transactions during sync and fire in pipeline-stage order (priority ASC — lower = earlier). Pass `stage` (one of baseline|standard|refinement|override) instead of a raw priority so rules from different agents compose predictably; stage resolves to priority 0/10/50/100. Earlier-stage rules' tag and category mutations feed later-stage rules' conditions, so rules compose: rule A tags 'coffee', rule B conditioned on tags-contains-coffee sets category. Before creating, read breadbox://rules to avoid duplicates; prefer `contains` over exact matches (bank feeds format merchant names inconsistently). Full DSL: breadbox://rule-dsl.",
-			s.handleCreateTransactionRule, svc),
-		makeToolDefLogged("batch_create_rules", ToolWrite,
-			"Create multiple transaction rules at once. More efficient than looping create_transaction_rule. Ideal for composable pipelines — use `stage` (baseline|standard|refinement|override) on each item to order rules so earlier-stage rules set up tags/categories that later-stage rules react to. `stage` is preferred over raw `priority` for cross-agent consistency; if both are supplied, priority wins. Each item follows the same shape as create_transaction_rule. Returns created rules plus any per-item errors so partial success is recoverable.",
-			s.handleBatchCreateRules, svc),
-		makeToolDefLogged("update_transaction_rule", ToolWrite,
-			"Update a transaction rule's fields. Every field is optional; omit to leave unchanged. Pass conditions={} to explicitly clear conditions (match-all). Pass actions=[...] to replace the entire action set (rules must retain at least one action). Pass expires_at=\"\" to clear expiry. Pass `stage` (baseline|standard|refinement|override) to re-slot a rule into the pipeline without guessing a numeric priority. See breadbox://rule-dsl.",
-			s.handleUpdateTransactionRule, svc),
-		makeToolDefLogged("delete_transaction_rule", ToolWrite,
-			"Delete a transaction rule by ID. System-seeded rules (like the needs-review tagger) cannot be deleted — disable them instead with update_transaction_rule.enabled=false.",
-			s.handleDeleteTransactionRule, svc),
-		makeToolDefLogged("apply_rules", ToolWrite,
-			"Apply rules retroactively to existing transactions. Pass rule_id to run a single rule in isolation, or omit to run the full active-rule pipeline in priority-ASC order (same chaining semantics as sync). Materializes set_category (respects category_override), add_tag, and remove_tag. add_comment is sync-only and won't fire here. Hit count increments per condition match, matching sync-time semantics. Use for initial setup or explicit back-fills only — routine syncs apply rules automatically.",
-			s.handleApplyRules, svc),
-		makeToolDefLogged("preview_rule", ToolRead,
-			"Dry-run a condition tree against existing transactions without any writes. Returns match_count + total_scanned + a sample of matching transactions. IMPORTANT: this evaluates only the supplied condition in isolation — it does NOT simulate the full rule pipeline, so tags or categories that other rules would have added mid-pass aren't visible. Use this to answer 'what does this condition match today' before creating a rule.",
-			s.handlePreviewRule, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "create_transaction_rule", Title: "Create Rule", Classification: ToolWrite,
+			Description: "Create a transaction rule for automatic categorization, tagging, or commenting. Rules match condition trees against transactions during sync and fire in pipeline-stage order (priority ASC — lower = earlier). Pass `stage` (one of baseline|standard|refinement|override) instead of a raw priority so rules from different agents compose predictably; stage resolves to priority 0/10/50/100. Earlier-stage rules' tag and category mutations feed later-stage rules' conditions, so rules compose: rule A tags 'coffee', rule B conditioned on tags-contains-coffee sets category. Before creating, read breadbox://rules to avoid duplicates; prefer `contains` over exact matches (bank feeds format merchant names inconsistently). Full DSL: breadbox://rule-dsl.",
+		}, s.handleCreateTransactionRule, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "batch_create_rules", Title: "Create Rules in Batch", Classification: ToolWrite,
+			Description: "Create multiple transaction rules at once. More efficient than looping create_transaction_rule. Ideal for composable pipelines — use `stage` (baseline|standard|refinement|override) on each item to order rules so earlier-stage rules set up tags/categories that later-stage rules react to. `stage` is preferred over raw `priority` for cross-agent consistency; if both are supplied, priority wins. Each item follows the same shape as create_transaction_rule. Returns created rules plus any per-item errors so partial success is recoverable.",
+		}, s.handleBatchCreateRules, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "update_transaction_rule", Title: "Update Rule", Classification: ToolWrite,
+			Description: "Update a transaction rule's fields. Every field is optional; omit to leave unchanged. Pass conditions={} to explicitly clear conditions (match-all). Pass actions=[...] to replace the entire action set (rules must retain at least one action). Pass expires_at=\"\" to clear expiry. Pass `stage` (baseline|standard|refinement|override) to re-slot a rule into the pipeline without guessing a numeric priority. See breadbox://rule-dsl.",
+			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: true},
+		}, s.handleUpdateTransactionRule, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "delete_transaction_rule", Title: "Delete Rule", Classification: ToolWrite,
+			Description: "Delete a transaction rule by ID. System-seeded rules (like the needs-review tagger) cannot be deleted — disable them instead with update_transaction_rule.enabled=false.",
+			// Destructive: deletes the rule row. Re-running with the same id
+			// is a no-op (already gone) so still IdempotentHint=true.
+			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(true), IdempotentHint: true},
+		}, s.handleDeleteTransactionRule, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "apply_rules", Title: "Apply Rules Retroactively", Classification: ToolWrite,
+			Description: "Apply rules retroactively to existing transactions. Pass rule_id to run a single rule in isolation, or omit to run the full active-rule pipeline in priority-ASC order (same chaining semantics as sync). Materializes set_category (respects category_override), add_tag, and remove_tag. add_comment is sync-only and won't fire here. Hit count increments per condition match, matching sync-time semantics. Use for initial setup or explicit back-fills only — routine syncs apply rules automatically.",
+			// Not idempotent — hit_count increments on every run.
+		}, s.handleApplyRules, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "preview_rule", Title: "Preview Rule", Classification: ToolRead,
+			Description: "Dry-run a condition tree against existing transactions without any writes. Returns match_count + total_scanned + a sample of matching transactions. IMPORTANT: this evaluates only the supplied condition in isolation — it does NOT simulate the full rule pipeline, so tags or categories that other rules would have added mid-pass aren't visible. Use this to answer 'what does this condition match today' before creating a rule.",
+		}, s.handlePreviewRule, svc),
 
 		// --- Tag admin ---
 		// Most agents won't need these — add_tag-on-transaction implicitly
 		// creates new tag slugs via update_transactions. These are for
 		// curating the tag vocabulary itself (renames, deletes, deliberate
 		// up-front display_name/color/icon).
-		makeToolDefLogged("create_tag", ToolWrite,
-			"Register a new tag in the system. Most agents can skip this — passing a new tag slug to update_transactions auto-creates the tag. Use create_tag only when you need to set display_name/color/icon up front. Slug regex: ^[a-z0-9][a-z0-9\\-:]*[a-z0-9]$.",
-			s.handleCreateTag, svc),
-		makeToolDefLogged("update_tag", ToolWrite,
-			"Update a tag's mutable fields (display_name, description, color, icon). Slug is immutable — to rename, create a new tag + bulk re-tag + delete old. Identify the tag by UUID, short ID, or slug.",
-			s.handleUpdateTag, svc),
-		makeToolDefLogged("delete_tag", ToolWrite,
-			"Delete a tag. Cascades to transaction_tags (removes the tag from every transaction). Annotations that reference the tag keep their rows with tag_id=NULL (preserves audit trail). Identify the tag by UUID, short ID, or slug.",
-			s.handleDeleteTag, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "create_tag", Title: "Create Tag", Classification: ToolWrite,
+			Description: "Register a new tag in the system. Most agents can skip this — passing a new tag slug to update_transactions auto-creates the tag. Use create_tag only when you need to set display_name/color/icon up front. Slug regex: ^[a-z0-9][a-z0-9\\-:]*[a-z0-9]$.",
+		}, s.handleCreateTag, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "update_tag", Title: "Update Tag", Classification: ToolWrite,
+			Description: "Update a tag's mutable fields (display_name, description, color, icon). Slug is immutable — to rename, create a new tag + bulk re-tag + delete old. Identify the tag by UUID, short ID, or slug.",
+			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: true},
+		}, s.handleUpdateTag, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "delete_tag", Title: "Delete Tag", Classification: ToolWrite,
+			Description: "Delete a tag. Cascades to transaction_tags (removes the tag from every transaction). Annotations that reference the tag keep their rows with tag_id=NULL (preserves audit trail). Identify the tag by UUID, short ID, or slug.",
+			// Destructive: cascades to transaction_tags. Idempotent on
+			// re-run (already gone).
+			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(true), IdempotentHint: true},
+		}, s.handleDeleteTag, svc),
 
 		// --- Reporting ---
-		makeToolDefLogged("submit_report", ToolWrite,
-			"Send a message to the family's dashboard. The title is the main message — write it as a concise, self-contained 1-2 sentence summary the family can understand at a glance without expanding. The body provides the detailed breakdown (markdown with headers, bullets, transaction links). Use priority to signal urgency and author to identify your role. See breadbox://report-format for structure conventions.",
-			s.handleSubmitReport, svc),
+		makeToolDefLogged(ToolSpec{
+			Name: "submit_report", Title: "Submit Report", Classification: ToolWrite,
+			Description: "Send a message to the family's dashboard. The title is the main message — write it as a concise, self-contained 1-2 sentence summary the family can understand at a glance without expanding. The body provides the detailed breakdown (markdown with headers, bullets, transaction links). Use priority to signal urgency and author to identify your role. See breadbox://report-format for structure conventions.",
+			// Not idempotent — every call posts a new dashboard message.
+		}, s.handleSubmitReport, svc),
 	}
 }
 
 // makeToolDefLogged creates a ToolDef with logging and session enforcement.
-// This is called during buildToolRegistry when s.svc is available.
-func makeToolDefLogged[T any](name string, classification ToolClassification, description string, handler func(context.Context, *mcpsdk.CallToolRequest, T) (*mcpsdk.CallToolResult, any, error), svc *service.Service) ToolDef {
+// This is called during buildToolRegistry when s.svc is available. If
+// spec.Annotations is nil, defaults are derived from the classification (read
+// → ReadOnlyHint=true, write → DestructiveHint=false).
+func makeToolDefLogged[T any](spec ToolSpec, handler func(context.Context, *mcpsdk.CallToolRequest, T) (*mcpsdk.CallToolResult, any, error), svc *service.Service) ToolDef {
+	annotations := spec.Annotations
+	if annotations == nil {
+		annotations = defaultAnnotations(spec.Classification, spec.Title)
+	} else if annotations.Title == "" {
+		// Hosts that surface the annotation Title (some pre-spec-2025-06-18
+		// clients) need it populated even when the registration site only
+		// set hint flags. Tool.Title is the spec field the modern picker
+		// reads; ToolAnnotations.Title is the legacy fallback.
+		annotations.Title = spec.Title
+	}
+	tool := mcpsdk.Tool{
+		Name:        spec.Name,
+		Title:       spec.Title,
+		Description: spec.Description,
+		Annotations: annotations,
+	}
+
 	return ToolDef{
-		Tool: mcpsdk.Tool{
-			Name:        name,
-			Description: description,
-		},
-		Classification: classification,
+		Tool:           tool,
+		Classification: spec.Classification,
 		register: func(server *mcpsdk.Server) {
 			wrappedHandler := func(ctx context.Context, req *mcpsdk.CallToolRequest, input T) (*mcpsdk.CallToolResult, any, error) {
 				// Extract session context via interface.
@@ -248,7 +339,7 @@ func makeToolDefLogged[T any](name string, classification ToolClassification, de
 				}
 
 				// Enforce session_id + reason on write tools (except create_session).
-				if classification == ToolWrite && name != "create_session" {
+				if spec.Classification == ToolWrite && spec.Name != "create_session" {
 					if sessionID == "" {
 						return errorResult(fmt.Errorf("session_id is required for write operations; call create_session first")), nil, nil
 					}
@@ -281,8 +372,8 @@ func makeToolDefLogged[T any](name string, classification ToolClassification, de
 					isErr := (result != nil && result.IsError) || err != nil
 					svc.LogToolCall(logCtx, service.ToolCallLogInput{
 						SessionID:      sessionID,
-						ToolName:       name,
-						Classification: string(classification),
+						ToolName:       spec.Name,
+						Classification: string(spec.Classification),
 						Reason:         reason,
 						RequestJSON:    reqJSON,
 						ResponseJSON:   respJSON,
@@ -294,10 +385,10 @@ func makeToolDefLogged[T any](name string, classification ToolClassification, de
 
 				return result, out, err
 			}
-			mcpsdk.AddTool(server, &mcpsdk.Tool{
-				Name:        name,
-				Description: description,
-			}, wrappedHandler)
+			// Pass the same Tool we stored on the def so titles and
+			// annotations land on the wire identically to AllToolDefs() output.
+			toolForRegistration := tool
+			mcpsdk.AddTool(server, &toolForRegistration, wrappedHandler)
 		},
 	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -169,6 +169,61 @@ func TestToolRegistryScopeContract(t *testing.T) {
 	}
 }
 
+// TestToolAnnotationsContract pins the per-tool MCP metadata that hosts use
+// to render the connector picker (Title) and decide whether to confirm a
+// call (Annotations.DestructiveHint). A registration that forgets to set
+// Title would render as the tool's snake_case name in Claude.ai's Settings →
+// Connectors → Configure tools list; one that drops DestructiveHint=true
+// from a delete_* tool would let the host invoke it without prompting.
+//
+// Asserts:
+//   - every tool has a non-empty Title.
+//   - every read tool has Annotations.ReadOnlyHint=true.
+//   - the canonical destructive set (delete_*) carries
+//     DestructiveHint=true. Reversible writes default to false.
+func TestToolAnnotationsContract(t *testing.T) {
+	s := NewMCPServer(nil, "test")
+	defs := s.AllToolDefs()
+
+	wantDestructive := map[string]bool{
+		"delete_tag":              true,
+		"delete_transaction_rule": true,
+	}
+
+	for _, td := range defs {
+		name := td.Tool.Name
+		if td.Tool.Title == "" {
+			t.Errorf("tool %q: missing Title (would render as snake_case in connector picker)", name)
+		}
+		if td.Tool.Annotations == nil {
+			t.Errorf("tool %q: missing Annotations", name)
+			continue
+		}
+		ann := td.Tool.Annotations
+
+		// Read tools must advertise ReadOnlyHint=true so hosts that suppress
+		// confirmation prompts based on it can flow read calls through
+		// without friction.
+		if td.Classification == ToolRead && !ann.ReadOnlyHint {
+			t.Errorf("tool %q: ToolRead must set Annotations.ReadOnlyHint=true", name)
+		}
+
+		// Destructive contract: the canonical destructive set must opt in;
+		// every other write must explicitly opt out (DestructiveHint=false)
+		// so hosts don't fall back to the spec's true default.
+		if td.Classification == ToolWrite && name != "create_session" {
+			want := wantDestructive[name]
+			if ann.DestructiveHint == nil {
+				t.Errorf("tool %q: write tool must set DestructiveHint explicitly", name)
+				continue
+			}
+			if got := *ann.DestructiveHint; got != want {
+				t.Errorf("tool %q: DestructiveHint = %v, want %v", name, got, want)
+			}
+		}
+	}
+}
+
 func TestCompactIDs_FullRoundTrip(t *testing.T) {
 	type testStruct struct {
 		ID      string `json:"id"`


### PR DESCRIPTION
Populate the MCP-spec metadata that drives connector pickers and confirmation prompts. Tools today set only Name + Description; this PR adds Title + ToolAnnotations to every registration.

## Summary

- **Title** on every tool — what users see in Claude.ai's Settings → Connectors → Configure tools list. Without this, tools render as their snake_case names.
- **ReadOnlyHint=true** on all read tools so hosts can route them without write-style confirmations.
- **DestructiveHint=true** on the canonical destructive set (`delete_tag`, `delete_transaction_rule`); `DestructiveHint=false` on every other write so hosts don't fall back to the spec default of `true` (which makes hosts prompt on every reversible write).
- **IdempotentHint=true** where re-running with the same input lands the row in the same state (`update_transactions`, `update_tag`, `update_transaction_rule`, plus the deletes).
- New `ToolSpec` struct carries metadata through `makeToolDefLogged`; `defaultAnnotations(classification, title)` fills in classification-derived defaults so per-tool registrations only override when they differ.

## Test plan

- [x] `TestToolAnnotationsContract` — pins the contract (Title + ReadOnlyHint + DestructiveHint set per tool).
- [x] Full `go test -tags integration -count=1 -p 1 ./...` suite green locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
