### PR TITLE
mcp: populate StructuredContent on every tool response

### DIFF
--- a/internal/mcp/response_shapes_integration_test.go
+++ b/internal/mcp/response_shapes_integration_test.go
@@ -155,6 +155,11 @@ func formatUUIDTest(t *testing.T, u pgtype.UUID) string {
 // decodeToolResult returns the JSON-decoded payload from a tool's
 // CallToolResult. Fails the test when IsError is true so shape regressions are
 // diagnosable without hunting error envelopes.
+//
+// Also asserts StructuredContent parity with the TextContent block — every
+// successful tool response must populate both, and the two views must
+// marshal back to identical JSON. Locks the dual-output contract on every
+// tool exercised by the integration suite without per-test boilerplate.
 func decodeToolResult[T any](t *testing.T, name string, res *mcpsdk.CallToolResult, err error) T {
 	t.Helper()
 	if err != nil {
@@ -177,6 +182,17 @@ func decodeToolResult[T any](t *testing.T, name string, res *mcpsdk.CallToolResu
 	tc, ok := res.Content[0].(*mcpsdk.TextContent)
 	if !ok {
 		t.Fatalf("%s: expected TextContent, got %T", name, res.Content[0])
+	}
+	if res.StructuredContent == nil {
+		t.Errorf("%s: StructuredContent missing — every jsonResult-backed tool must populate both views", name)
+	} else {
+		structuredBytes, marshalErr := json.Marshal(res.StructuredContent)
+		if marshalErr != nil {
+			t.Errorf("%s: marshal StructuredContent: %v", name, marshalErr)
+		} else if string(structuredBytes) != tc.Text {
+			t.Errorf("%s: StructuredContent / TextContent drift\n  text:       %s\n  structured: %s",
+				name, tc.Text, string(structuredBytes))
+		}
 	}
 	var out T
 	if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1,8 +1,11 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // TestBuildServerAllTools verifies that all MCP tool input schemas are valid.
@@ -221,6 +224,67 @@ func TestToolAnnotationsContract(t *testing.T) {
 				t.Errorf("tool %q: DestructiveHint = %v, want %v", name, got, want)
 			}
 		}
+	}
+}
+
+// TestJSONResult_StructuredContent locks the dual-output contract on
+// jsonResult: every tool response carries the JSON in BOTH the TextContent
+// block (for backwards compatibility with pre-2025-06-18 clients) AND the
+// StructuredContent slot (for newer clients that validate against
+// OutputSchema). The two views must be byte-identical after compaction so
+// hosts that branch on either field see the same data.
+//
+// Catches a regression where someone re-orders the unmarshal step or skips
+// compaction on one path — agents would silently see different short_id
+// values across the two views.
+func TestJSONResult_StructuredContent(t *testing.T) {
+	type row struct {
+		ID      string `json:"id"`
+		ShortID string `json:"short_id"`
+		Name    string `json:"name"`
+	}
+	type result struct {
+		Rows []row `json:"rows"`
+	}
+
+	v := result{Rows: []row{
+		{ID: "long-uuid-1", ShortID: "Aa11Bb22", Name: "First"},
+		{ID: "long-uuid-2", ShortID: "Cc33Dd44", Name: "Second"},
+	}}
+
+	res, _, err := jsonResult(v)
+	if err != nil {
+		t.Fatalf("jsonResult: %v", err)
+	}
+	if res.StructuredContent == nil {
+		t.Fatal("StructuredContent missing")
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("Content len = %d, want 1", len(res.Content))
+	}
+	tc, ok := res.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("Content[0] type = %T, want *TextContent", res.Content[0])
+	}
+
+	// Round-trip the structured value back to bytes and compare against the
+	// text block. They must be the same JSON — same fields, same compacted
+	// short_id value on every row.
+	structuredBytes, err := json.Marshal(res.StructuredContent)
+	if err != nil {
+		t.Fatalf("marshal structured: %v", err)
+	}
+	if string(structuredBytes) != tc.Text {
+		t.Errorf("StructuredContent / TextContent drift:\n  text:       %s\n  structured: %s",
+			tc.Text, string(structuredBytes))
+	}
+
+	// Both views must show the compacted id (Aa11Bb22), not the long UUID.
+	if !bytes.Contains(structuredBytes, []byte(`"id":"Aa11Bb22"`)) {
+		t.Errorf("StructuredContent did not compact id: %s", string(structuredBytes))
+	}
+	if bytes.Contains(structuredBytes, []byte("short_id")) {
+		t.Errorf("StructuredContent still carries short_id field: %s", string(structuredBytes))
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -662,10 +662,24 @@ func jsonResult(v any) (*mcpsdk.CallToolResult, any, error) {
 	// Operates directly on JSON bytes to avoid unmarshal→remarshal overhead.
 	data = compactIDsBytes(data)
 
+	// StructuredContent is the post-2025-06-18 spec slot for typed tool
+	// output. We populate it alongside the TextContent block so:
+	//   - clients on the new spec get the structured payload they can
+	//     validate against an OutputSchema (added incrementally on per-tool
+	//     defs).
+	//   - clients still on the older spec keep getting the same TextContent
+	//     bytes they always have — backwards-compatible.
+	// Stash the *compacted* bytes as a json.RawMessage rather than
+	// unmarshalling into any. Round-tripping through map[string]any sorts
+	// keys alphabetically on the remarshal, which would silently drift the
+	// structured view from the text view; RawMessage is encoding/json's
+	// designated escape hatch — Marshal emits the bytes verbatim.
+
 	return &mcpsdk.CallToolResult{
 		Content: []mcpsdk.Content{
 			&mcpsdk.TextContent{Text: string(data)},
 		},
+		StructuredContent: json.RawMessage(data),
 	}, nil, nil
 }
 


### PR DESCRIPTION
Populate `CallToolResult.StructuredContent` on every tool response. The 2025-06-18 MCP spec adds it as the typed slot alongside the legacy `TextContent` block — new-spec clients can validate against an `OutputSchema` and parse it programmatically; old-spec clients still get the same `TextContent` they always have.

## Summary

- `jsonResult` now sets both views with byte-identical compacted JSON. Uses `json.RawMessage` rather than unmarshalling to `any` — round-tripping through `map[string]any` would alphabetically reorder keys and silently drift the two views.
- Unit test `TestJSONResult_StructuredContent` exercises jsonResult against a synthetic struct: asserts both views remarshal to identical bytes and the compactID rewrite hits both views.
- Integration helper `decodeToolResult` now asserts `StructuredContent` parity on every tool the response_shapes integration suite touches — locks the dual-output contract without per-test boilerplate.
- **OutputSchema deferred.** Auto-inferring it requires typing the `ToolHandlerFor[In, Out]` handlers (today they all return `any` for Out so the SDK skips schema inference). Hand-writing schemas per tool is also feasible but doesn't change the wire format. Splitting into a follow-up PR keeps this one focused on the immediate compatibility win.

## Test plan

- [x] `TestJSONResult_StructuredContent` passes.
- [x] Full `go test -tags integration -count=1 -p 1 ./...` suite green locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
