### PR TITLE
mcp: bind audit sessions to the transport connection

### DIFF
--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -24,6 +24,14 @@ paths:
 2. Tool name is in `mcp_disabled_tools` JSON array
 3. API key scope is `read_only`
 
+## Audit sessions (transport-bound)
+
+Every tool call is logged under an `mcp_sessions` row keyed off the transport connection — `MCP-Session-Id` for Streamable HTTP, a per-process fallback id for stdio. The dispatcher in `makeToolDefLogged` resolves the session via `MCPServer.ensureAuditSession`, which lazy-creates the row on first call and stamps it with `clientInfo` from the `initialize` request. There is no `create_session` tool — the binding is implicit.
+
+Per-call labels travel via `tools/call._meta.reason` (`metaReason(req)`); the dispatcher pulls it and stamps it on the `mcp_tool_calls.reason` column. Tool input schemas no longer carry `session_id` or `reason` fields.
+
+Handlers that need to bind a created row to the session (e.g. `submit_report` → `agent_reports.session_id`) read the resolved id from context via `auditSessionFromContext(ctx)` — the dispatcher stamps it before invoking the handler.
+
 ## Input/output conventions
 
 Tool inputs are typed structs with `jsonschema` tags:

--- a/internal/db/migrations/20260501050949_mcp_sessions_transport.sql
+++ b/internal/db/migrations/20260501050949_mcp_sessions_transport.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+
+-- transport_id is the per-connection identity from the MCP transport
+-- layer: the MCP-Session-Id header value for Streamable HTTP, or a
+-- process-start short_id for stdio. Lets us attach an audit-session
+-- row to the same logical client connection without round-tripping a
+-- create_session tool call.
+ALTER TABLE mcp_sessions
+    ADD COLUMN IF NOT EXISTS transport_id TEXT NULL;
+
+-- clientInfo from the initialize request — name/version are required
+-- per spec; title/description/website_url are optional fields (SEP-973)
+-- that hosts may set for richer audit display. All nullable so old
+-- rows without a transport binding remain valid.
+ALTER TABLE mcp_sessions
+    ADD COLUMN IF NOT EXISTS client_name        TEXT NULL,
+    ADD COLUMN IF NOT EXISTS client_version     TEXT NULL,
+    ADD COLUMN IF NOT EXISTS client_title       TEXT NULL,
+    ADD COLUMN IF NOT EXISTS client_description TEXT NULL,
+    ADD COLUMN IF NOT EXISTS client_website_url TEXT NULL;
+
+-- Look-up index: the dispatcher resolves the transport_id every tool
+-- call, so this stays hot. Partial index keeps it small (legacy rows
+-- without a transport binding don't bloat it).
+CREATE INDEX IF NOT EXISTS idx_mcp_sessions_transport
+    ON mcp_sessions(transport_id)
+    WHERE transport_id IS NOT NULL;
+
+-- +goose Down
+
+DROP INDEX IF EXISTS idx_mcp_sessions_transport;
+
+ALTER TABLE mcp_sessions
+    DROP COLUMN IF EXISTS client_website_url,
+    DROP COLUMN IF EXISTS client_description,
+    DROP COLUMN IF EXISTS client_title,
+    DROP COLUMN IF EXISTS client_version,
+    DROP COLUMN IF EXISTS client_name,
+    DROP COLUMN IF EXISTS transport_id;

--- a/internal/db/queries/mcp_sessions.sql
+++ b/internal/db/queries/mcp_sessions.sql
@@ -3,6 +3,23 @@ INSERT INTO mcp_sessions (api_key_id, api_key_name, purpose)
 VALUES ($1, $2, $3)
 RETURNING *;
 
+-- name: CreateMCPSessionWithTransport :one
+INSERT INTO mcp_sessions (
+    api_key_id, api_key_name, purpose,
+    transport_id,
+    client_name, client_version, client_title, client_description, client_website_url
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING *;
+
+-- name: GetMCPSessionByTransportID :one
+-- Latest session for a given transport id. Used by the tool-call
+-- dispatcher to resolve the audit-session row without a round-trip.
+SELECT * FROM mcp_sessions
+WHERE transport_id = $1
+ORDER BY created_at DESC
+LIMIT 1;
+
 -- name: GetMCPSessionByID :one
 SELECT * FROM mcp_sessions WHERE id = $1;
 

--- a/internal/mcp/response_shapes_integration_test.go
+++ b/internal/mcp/response_shapes_integration_test.go
@@ -397,47 +397,16 @@ func TestListAnnotationsKindsFilter(t *testing.T) {
 	}
 }
 
-// TestListTransactionMatchesResponseShape pins matched_on (not matched_fields),
-// match_confidence (not confidence), account_link_id (not link_id), plus
-// the denormalized txn fields agents rely on.
-// TestCreateSessionResponseShape pins session response fields; `actor` and
-// `completed_at` must not appear.
-func TestCreateSessionResponseShape(t *testing.T) {
-	f := seedFixtures(t)
-	res, _, err := f.svc.handleCreateSession(f.ctx, nil, createSessionInput{
-		Purpose: "shape regression test",
-	})
-	out := decodeToolResult[map[string]any](t, "create_session", res, err)
-	requireKeys(t, "create_session", out,
-		"id", "purpose", "api_key_name", "created_at",
-	)
-	requireAbsent(t, "create_session", out, "actor", "completed_at")
-}
-
 // TestSubmitReportResponseShape pins created_by_* fields + body/read_at, and
 // guards against re-introducing a `session_id` echo (the link is server-side
-// only).
+// only — sourced from the transport-bound audit session, not from input).
 func TestSubmitReportResponseShape(t *testing.T) {
 	f := seedFixtures(t)
 
-	// submit_report requires a prior session id (enforced by the wrapper around
-	// write tools). Handlers invoked directly bypass that check, but we still
-	// pass a valid session_id/reason so the signature matches the real call
-	// path documented in rules.
-	sessRes, _, err := f.svc.handleCreateSession(f.ctx, nil, createSessionInput{
-		Purpose: "regression: submit_report",
-	})
-	sessOut := decodeToolResult[map[string]any](t, "create_session", sessRes, err)
-	sessionID, _ := sessOut["id"].(string)
-	if sessionID == "" {
-		t.Fatalf("create_session did not return id: %v", sessOut)
-	}
-
 	res, _, err := f.svc.handleSubmitReport(f.ctx, nil, submitReportInput{
-		WriteSessionContext: WriteSessionContext{SessionID: sessionID, Reason: "shape test"},
-		Title:               "Shape regression report",
-		Body:                "## Summary\nRegression check.",
-		Priority:            "info",
+		Title:    "Shape regression report",
+		Body:     "## Summary\nRegression check.",
+		Priority: "info",
 	})
 	out := decodeToolResult[map[string]any](t, "submit_report", res, err)
 	requireKeys(t, "submit_report", out,
@@ -838,17 +807,7 @@ func TestUpdateTransactionsHandler_ResetCategoryShape(t *testing.T) {
 		t.Fatalf("seed override: %v", err)
 	}
 
-	sessRes, _, err := f.svc.handleCreateSession(f.ctx, nil, createSessionInput{
-		Purpose: "regression: update_transactions reset_category",
-	})
-	sessOut := decodeToolResult[map[string]any](t, "create_session", sessRes, err)
-	sessionID, _ := sessOut["id"].(string)
-	if sessionID == "" {
-		t.Fatalf("create_session did not return id")
-	}
-
 	res, _, err := f.svc.handleUpdateTransactions(f.ctx, nil, updateTransactionsInput{
-		WriteSessionContext: WriteSessionContext{SessionID: sessionID, Reason: "reset shape test"},
 		Operations: []transactionOperationInput{{
 			TransactionID: f.txnID,
 			ResetCategory: true,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,6 +11,7 @@ import (
 
 	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
+	"breadbox/internal/shortid"
 	"breadbox/prompts"
 	"breadbox/static"
 
@@ -144,16 +145,122 @@ type MCPServer struct {
 	svc      *service.Service
 	version  string
 	allTools []ToolDef
+	// stdioFallbackTransportID is the per-process transport id used when
+	// the underlying connection has no native session id (stdio). Stable
+	// for the lifetime of the process so every tool call from the same
+	// `breadbox mcp-stdio` invocation lands on the same audit-session
+	// row. HTTP requests get the real MCP-Session-Id from the SDK and
+	// ignore this field.
+	stdioFallbackTransportID string
 }
 
 // NewMCPServer creates a new MCP server with all tools registered in a registry.
 func NewMCPServer(svc *service.Service, version string) *MCPServer {
 	s := &MCPServer{
-		svc:     svc,
-		version: version,
+		svc:                      svc,
+		version:                  version,
+		stdioFallbackTransportID: stdioFallbackID(),
 	}
 	s.buildToolRegistry()
 	return s
+}
+
+// stdioFallbackID returns a stable per-process transport id for stdio
+// connections that don't surface a native session id. Defends against the
+// shortid generator's error path by falling back to a fixed prefix — better
+// to land every call on one row than to scatter them.
+func stdioFallbackID() string {
+	id, err := shortid.Generate()
+	if err != nil || id == "" {
+		return "stdio-fallback"
+	}
+	return "stdio-" + id
+}
+
+// resolveTransportID returns the transport-level identity for an in-flight
+// tool call. Streamable HTTP gives every connection a session id (the value
+// of MCP-Session-Id, surfaced via req.Session.ID()); stdio has none, so we
+// substitute the per-process fallback so audit logging still groups calls
+// from one `breadbox mcp-stdio` invocation under one row.
+func (s *MCPServer) resolveTransportID(req *mcpsdk.CallToolRequest) string {
+	if req == nil || req.Session == nil {
+		return s.stdioFallbackTransportID
+	}
+	if id := req.Session.ID(); id != "" {
+		return id
+	}
+	return s.stdioFallbackTransportID
+}
+
+// ensureAuditSession resolves (lazy-creating on first call) the
+// mcp_sessions row bound to a transport id and returns its UUID as a
+// string for LogToolCall. Captures clientInfo from the initialize
+// request so the audit row carries the host's name/version. Logging
+// failures are swallowed here — the audit trail must not block tool
+// execution. Returns "" when the actor isn't an API key (the row schema
+// treats that as legacy).
+func (s *MCPServer) ensureAuditSession(ctx context.Context, req *mcpsdk.CallToolRequest, transportID string) string {
+	if transportID == "" {
+		return ""
+	}
+	actor := service.ActorFromContext(ctx)
+
+	var info service.MCPClientInfo
+	if req != nil && req.Session != nil {
+		if ip := req.Session.InitializeParams(); ip != nil && ip.ClientInfo != nil {
+			// SDK v1.5.0's Implementation block exposes Name, Title,
+			// Version, WebsiteURL, Icons. There's no Description field
+			// today; leave the column empty when the host doesn't
+			// supply one.
+			info = service.MCPClientInfo{
+				Name:       ip.ClientInfo.Name,
+				Version:    ip.ClientInfo.Version,
+				Title:      ip.ClientInfo.Title,
+				WebsiteURL: ip.ClientInfo.WebsiteURL,
+			}
+		}
+	}
+
+	session, err := s.svc.EnsureMCPSessionForTransport(ctx, transportID, actor, info)
+	if err != nil {
+		return ""
+	}
+	return session.ID
+}
+
+// metaReason pulls the optional "reason" string out of a tool call's
+// _meta block. Hosts use this to label the call ("processing review
+// queue") without polluting the tool's input schema.
+func metaReason(req *mcpsdk.CallToolRequest) string {
+	if req == nil || req.Params == nil {
+		return ""
+	}
+	meta := req.Params.GetMeta()
+	if meta == nil {
+		return ""
+	}
+	if v, ok := meta["reason"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// auditSessionContextKey carries the resolved audit-session UUID through
+// to handlers that need to bind a created row to it (e.g. submit_report
+// → agent_reports.session_id). The dispatcher stamps this on ctx after
+// resolving the transport binding, before invoking the handler.
+type auditSessionContextKey struct{}
+
+func contextWithAuditSession(ctx context.Context, sessionID string) context.Context {
+	if sessionID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, auditSessionContextKey{}, sessionID)
+}
+
+func auditSessionFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(auditSessionContextKey{}).(string)
+	return v
 }
 
 // buildToolRegistry populates the allTools slice with all available tools and
@@ -164,15 +271,11 @@ func NewMCPServer(svc *service.Service, version string) *MCPServer {
 // file — but each resource also has a tool mirror in tools_reads.go so MCP
 // clients that don't implement the resources/* methods can still read it.
 func (s *MCPServer) buildToolRegistry() {
-	svc := s.svc
 	s.allTools = []ToolDef{
-		// Audit session — explicit handle so write tools can be tied to a
-		// logical task. (A future PR replaces this with transport-bound
-		// session binding via MCP-Session-Id.)
-		makeToolDefLogged(ToolSpec{
-			Name: "create_session", Title: "Start Audit Session", Classification: ToolWrite,
-			Description: "Start an audit session before performing write operations. Returns a session_id to include on all subsequent tool calls. One session per logical task (e.g. 'weekly transaction review', 'rule creation for dining').",
-		}, s.handleCreateSession, svc),
+		// Audit sessions are bound to the transport connection (MCP-Session-Id
+		// for HTTP, the per-process fallback id for stdio). Each tool call
+		// resolves its session via resolveTransportID + ensureAuditSession in
+		// the dispatcher, so agents no longer need to call create_session.
 
 		// --- Reference data (mirrors resources for clients without resource support) ---
 		// Resources are the preferred surface: breadbox://overview, ://accounts,
@@ -181,45 +284,45 @@ func (s *MCPServer) buildToolRegistry() {
 		makeToolDefLogged(ToolSpec{
 			Name: "get_overview", Title: "Household Overview", Classification: ToolRead,
 			Description: "Get a household snapshot: scope (users, accounts, currencies), freshness (latest sync, errored connections, recent transactions), and backlog (pending review queue). Mirror of breadbox://overview — call this when your client doesn't support MCP resources, or when you want the snapshot inline as a tool result. Read once at the top of a session to ground every later filter (account ids, currency, attribution).",
-		}, s.handleGetOverview, svc),
+		}, s.handleGetOverview, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "list_accounts", Title: "List Accounts", Classification: ToolRead,
 			Description: "List bank accounts. Mirror of breadbox://accounts. Each account carries balance, type, currency, and the connection it belongs to. Filter by user_id to scope to a specific household member.",
-		}, s.handleListAccounts, svc),
+		}, s.handleListAccounts, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "list_categories", Title: "List Categories", Classification: ToolRead,
 			Description: "List the category taxonomy as a flat array. Mirror of breadbox://categories. Use the returned slugs (e.g. 'food_and_drink_groceries') as the canonical handle for category filters and category_slug fields on writes.",
-		}, s.handleListCategories, svc),
+		}, s.handleListCategories, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "list_users", Title: "List Household Members", Classification: ToolRead,
 			Description: "List household members. Mirror of breadbox://users. Each user carries display name, role, and short_id — use the short_id as user_id on transaction filters and account scoping.",
-		}, s.handleListUsers, svc),
+		}, s.handleListUsers, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "list_tags", Title: "List Tags", Classification: ToolRead,
 			Description: "List the tag vocabulary. Mirror of breadbox://tags. Tags are referenced by slug everywhere (filter, add, remove). New tag slugs auto-register the first time update_transactions adds them — read this list before authoring rules to avoid accidental near-duplicates.",
-		}, s.handleListTags, svc),
+		}, s.handleListTags, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "get_sync_status", Title: "Sync Status", Classification: ToolRead,
 			Description: "Get connection sync status: provider, status (active|error|pending_reauth|disconnected), last sync time, last error. Mirror of breadbox://sync-status. Call this before reasoning about freshness — an errored or pending_reauth connection means transactions you'd expect to be there might not be.",
-		}, s.handleGetSyncStatus, svc),
+		}, s.handleGetSyncStatus, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "list_transaction_rules", Title: "List Rules", Classification: ToolRead,
 			Description: "List transaction rules with their conditions, actions, and pipeline stage. Mirror of breadbox://rules. Filter by category_slug, enabled, or search by name. Read this before authoring new rules to avoid duplicates.",
-		}, s.handleListTransactionRules, svc),
+		}, s.handleListTransactionRules, s),
 
 		// --- Query + aggregate ---
 		makeToolDefLogged(ToolSpec{
 			Name: "query_transactions", Title: "Query Transactions", Classification: ToolRead,
 			Description: "Query bank transactions with optional filters and cursor-based pagination. Amounts: positive = money out (debit), negative = money in (credit). Dates: YYYY-MM-DD, start_date inclusive, end_date exclusive. Filter by category_slug (see breadbox://categories for the slug list); parent slugs include all children. Results ordered by date desc by default. Pagination: pass next_cursor from response. Use the fields parameter to request only the fields you need (e.g., fields=core,category) to significantly reduce response size.",
-		}, s.handleQueryTransactions, svc),
+		}, s.handleQueryTransactions, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "count_transactions", Title: "Count Transactions", Classification: ToolRead,
 			Description: "Count transactions matching optional filters. Same filters as query_transactions except cursor, limit, sort_by, and sort_order. Use this to get totals before paginating, or to compare counts across date ranges or categories.",
-		}, s.handleCountTransactions, svc),
+		}, s.handleCountTransactions, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "transaction_summary", Title: "Spending Summary", Classification: ToolRead,
 			Description: "Get aggregated transaction totals grouped by category and/or time period. Replaces the need to paginate through thousands of individual transactions for spending analysis. Amounts follow the convention: positive = money out (debit), negative = money in (credit). Only includes non-deleted, non-pending transactions by default.",
-		}, s.handleTransactionSummary, svc),
+		}, s.handleTransactionSummary, s),
 
 		// --- Apply review decisions ---
 		// update_transactions is the universal write for review work. It
@@ -232,13 +335,13 @@ func (s *MCPServer) buildToolRegistry() {
 			Name: "update_transactions", Title: "Update Transactions", Classification: ToolWrite,
 			Description: "Compound write for up to 50 transactions at once. Each operation can: set a category (category_slug), add tags (tags_to_add), remove tags (tags_to_remove), and attach a comment — all atomically per transaction, with annotations written for every change. The canonical tool for closing review work (set category + remove needs-review + explain) in one call. Use the `comment` field to capture decision rationale; tag adds/removes carry no per-action note — keep all narrative in the comment. Example operation: {\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\"}],\"comment\":\"Clearly groceries — Costco run.\"}. on_error: 'continue' (default — each op in its own DB tx, partial failures OK) or 'abort' (one DB tx, rolls back on first error).",
 			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: true},
-		}, s.handleUpdateTransactions, svc),
+		}, s.handleUpdateTransactions, s),
 
 		// --- Activity timeline ---
 		makeToolDefLogged(ToolSpec{
 			Name: "list_annotations", Title: "List Activity Timeline", Classification: ToolRead,
 			Description: "List the activity timeline for a transaction, ordered by created_at ASC. Each row carries a generic `kind` (comment | rule | tag | category) plus an `action` (added | removed | set | applied) for the specific event — branch on `action` when the distinction matters (e.g. tag added vs removed). Payload carries kind-specific fields (content for comments, slug for tag events, rule_name for rule applications). Filters compose: `kinds=['comment']` is the comment-only view; `actor_types=['user']` is the canonical 'any human input?' check (drops rule churn + agent activity); `since` (RFC3339) skips rows you've already seen; `limit` returns the most recent N (capped at 200). Empty filters return the full timeline. Recommended pattern: before overriding your own categorization, call list_annotations(transaction_id, actor_types=['user']) — if any row exists, a human has weighed in and that decision wins.",
-		}, s.handleListAnnotations, svc),
+		}, s.handleListAnnotations, s),
 
 		// --- Rules ---
 		// See breadbox://rule-dsl for the condition grammar and breadbox://rules
@@ -246,32 +349,32 @@ func (s *MCPServer) buildToolRegistry() {
 		makeToolDefLogged(ToolSpec{
 			Name: "create_transaction_rule", Title: "Create Rule", Classification: ToolWrite,
 			Description: "Create a transaction rule for automatic categorization, tagging, or commenting. Rules match condition trees against transactions during sync and fire in pipeline-stage order (priority ASC — lower = earlier). Pass `stage` (one of baseline|standard|refinement|override) instead of a raw priority so rules from different agents compose predictably; stage resolves to priority 0/10/50/100. Earlier-stage rules' tag and category mutations feed later-stage rules' conditions, so rules compose: rule A tags 'coffee', rule B conditioned on tags-contains-coffee sets category. Before creating, read breadbox://rules to avoid duplicates; prefer `contains` over exact matches (bank feeds format merchant names inconsistently). Full DSL: breadbox://rule-dsl.",
-		}, s.handleCreateTransactionRule, svc),
+		}, s.handleCreateTransactionRule, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "batch_create_rules", Title: "Create Rules in Batch", Classification: ToolWrite,
 			Description: "Create multiple transaction rules at once. More efficient than looping create_transaction_rule. Ideal for composable pipelines — use `stage` (baseline|standard|refinement|override) on each item to order rules so earlier-stage rules set up tags/categories that later-stage rules react to. `stage` is preferred over raw `priority` for cross-agent consistency; if both are supplied, priority wins. Each item follows the same shape as create_transaction_rule. Returns created rules plus any per-item errors so partial success is recoverable.",
-		}, s.handleBatchCreateRules, svc),
+		}, s.handleBatchCreateRules, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "update_transaction_rule", Title: "Update Rule", Classification: ToolWrite,
 			Description: "Update a transaction rule's fields. Every field is optional; omit to leave unchanged. Pass conditions={} to explicitly clear conditions (match-all). Pass actions=[...] to replace the entire action set (rules must retain at least one action). Pass expires_at=\"\" to clear expiry. Pass `stage` (baseline|standard|refinement|override) to re-slot a rule into the pipeline without guessing a numeric priority. See breadbox://rule-dsl.",
 			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: true},
-		}, s.handleUpdateTransactionRule, svc),
+		}, s.handleUpdateTransactionRule, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "delete_transaction_rule", Title: "Delete Rule", Classification: ToolWrite,
 			Description: "Delete a transaction rule by ID. System-seeded rules (like the needs-review tagger) cannot be deleted — disable them instead with update_transaction_rule.enabled=false.",
 			// Destructive: deletes the rule row. Re-running with the same id
 			// is a no-op (already gone) so still IdempotentHint=true.
 			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(true), IdempotentHint: true},
-		}, s.handleDeleteTransactionRule, svc),
+		}, s.handleDeleteTransactionRule, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "apply_rules", Title: "Apply Rules Retroactively", Classification: ToolWrite,
 			Description: "Apply rules retroactively to existing transactions. Pass rule_id to run a single rule in isolation, or omit to run the full active-rule pipeline in priority-ASC order (same chaining semantics as sync). Materializes set_category (respects category_override), add_tag, and remove_tag. add_comment is sync-only and won't fire here. Hit count increments per condition match, matching sync-time semantics. Use for initial setup or explicit back-fills only — routine syncs apply rules automatically.",
 			// Not idempotent — hit_count increments on every run.
-		}, s.handleApplyRules, svc),
+		}, s.handleApplyRules, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "preview_rule", Title: "Preview Rule", Classification: ToolRead,
 			Description: "Dry-run a condition tree against existing transactions without any writes. Returns match_count + total_scanned + a sample of matching transactions. IMPORTANT: this evaluates only the supplied condition in isolation — it does NOT simulate the full rule pipeline, so tags or categories that other rules would have added mid-pass aren't visible. Use this to answer 'what does this condition match today' before creating a rule.",
-		}, s.handlePreviewRule, svc),
+		}, s.handlePreviewRule, s),
 
 		// --- Tag admin ---
 		// Most agents won't need these — add_tag-on-transaction implicitly
@@ -281,34 +384,37 @@ func (s *MCPServer) buildToolRegistry() {
 		makeToolDefLogged(ToolSpec{
 			Name: "create_tag", Title: "Create Tag", Classification: ToolWrite,
 			Description: "Register a new tag in the system. Most agents can skip this — passing a new tag slug to update_transactions auto-creates the tag. Use create_tag only when you need to set display_name/color/icon up front. Slug regex: ^[a-z0-9][a-z0-9\\-:]*[a-z0-9]$.",
-		}, s.handleCreateTag, svc),
+		}, s.handleCreateTag, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "update_tag", Title: "Update Tag", Classification: ToolWrite,
 			Description: "Update a tag's mutable fields (display_name, description, color, icon). Slug is immutable — to rename, create a new tag + bulk re-tag + delete old. Identify the tag by UUID, short ID, or slug.",
 			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(false), IdempotentHint: true},
-		}, s.handleUpdateTag, svc),
+		}, s.handleUpdateTag, s),
 		makeToolDefLogged(ToolSpec{
 			Name: "delete_tag", Title: "Delete Tag", Classification: ToolWrite,
 			Description: "Delete a tag. Cascades to transaction_tags (removes the tag from every transaction). Annotations that reference the tag keep their rows with tag_id=NULL (preserves audit trail). Identify the tag by UUID, short ID, or slug.",
 			// Destructive: cascades to transaction_tags. Idempotent on
 			// re-run (already gone).
 			Annotations: &mcpsdk.ToolAnnotations{DestructiveHint: boolPtr(true), IdempotentHint: true},
-		}, s.handleDeleteTag, svc),
+		}, s.handleDeleteTag, s),
 
 		// --- Reporting ---
 		makeToolDefLogged(ToolSpec{
 			Name: "submit_report", Title: "Submit Report", Classification: ToolWrite,
 			Description: "Send a message to the family's dashboard. The title is the main message — write it as a concise, self-contained 1-2 sentence summary the family can understand at a glance without expanding. The body provides the detailed breakdown (markdown with headers, bullets, transaction links). Use priority to signal urgency and author to identify your role. See breadbox://report-format for structure conventions.",
 			// Not idempotent — every call posts a new dashboard message.
-		}, s.handleSubmitReport, svc),
+		}, s.handleSubmitReport, s),
 	}
 }
 
-// makeToolDefLogged creates a ToolDef with logging and session enforcement.
-// This is called during buildToolRegistry when s.svc is available. If
-// spec.Annotations is nil, defaults are derived from the classification (read
-// → ReadOnlyHint=true, write → DestructiveHint=false).
-func makeToolDefLogged[T any](spec ToolSpec, handler func(context.Context, *mcpsdk.CallToolRequest, T) (*mcpsdk.CallToolResult, any, error), svc *service.Service) ToolDef {
+// makeToolDefLogged creates a ToolDef with logging and transport-bound audit
+// session resolution. This is called during buildToolRegistry; the *MCPServer
+// argument carries the service handle plus the transport-binding helpers
+// (resolveTransportID, ensureAuditSession). If spec.Annotations is nil,
+// defaults are derived from the classification (read → ReadOnlyHint=true,
+// write → DestructiveHint=false).
+func makeToolDefLogged[T any](spec ToolSpec, handler func(context.Context, *mcpsdk.CallToolRequest, T) (*mcpsdk.CallToolResult, any, error), s *MCPServer) ToolDef {
+	svc := s.svc
 	annotations := spec.Annotations
 	if annotations == nil {
 		annotations = defaultAnnotations(spec.Classification, spec.Title)
@@ -331,22 +437,28 @@ func makeToolDefLogged[T any](spec ToolSpec, handler func(context.Context, *mcps
 		Classification: spec.Classification,
 		register: func(server *mcpsdk.Server) {
 			wrappedHandler := func(ctx context.Context, req *mcpsdk.CallToolRequest, input T) (*mcpsdk.CallToolResult, any, error) {
-				// Extract session context via interface.
-				var sessionID, reason string
-				if sc, ok := any(input).(sessionContextProvider); ok {
-					sessionID = sc.GetSessionID()
-					reason = sc.GetReason()
-				}
+				// Resolve the audit session bound to this transport
+				// connection. For Streamable HTTP that's keyed off the
+				// MCP-Session-Id header (req.Session.ID()); for stdio
+				// the session has no native id, so we fall back to the
+				// MCPServer's per-process id stamped at NewMCPServer.
+				// Lazy-create the mcp_sessions row on first call so the
+				// audit trail captures clientInfo without requiring
+				// agents to explicitly call create_session.
+				transportID := s.resolveTransportID(req)
+				auditSessionID := s.ensureAuditSession(ctx, req, transportID)
 
-				// Enforce session_id + reason on write tools (except create_session).
-				if spec.Classification == ToolWrite && spec.Name != "create_session" {
-					if sessionID == "" {
-						return errorResult(fmt.Errorf("session_id is required for write operations; call create_session first")), nil, nil
-					}
-					if reason == "" {
-						return errorResult(fmt.Errorf("reason is required for write operations")), nil, nil
-					}
-				}
+				// Optional per-call reason via _meta.reason — replaces the
+				// previously-required `reason` input field on every write
+				// tool. Hosts can keep tagging high-cardinality writes
+				// without polluting the tool's input schema.
+				reason := metaReason(req)
+
+				// Stash the resolved audit-session id on the context so
+				// handlers that bind their created rows to it
+				// (submit_report → agent_reports.session_id) don't have
+				// to re-resolve the transport binding themselves.
+				ctx = contextWithAuditSession(ctx, auditSessionID)
 
 				start := time.Now()
 				result, out, err := handler(ctx, req, input)
@@ -371,7 +483,7 @@ func makeToolDefLogged[T any](spec ToolSpec, handler func(context.Context, *mcps
 					actor := service.ActorFromContext(ctx)
 					isErr := (result != nil && result.IsError) || err != nil
 					svc.LogToolCall(logCtx, service.ToolCallLogInput{
-						SessionID:      sessionID,
+						SessionID:      auditSessionID,
 						ToolName:       spec.Name,
 						Classification: string(spec.Classification),
 						Reason:         reason,

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -312,3 +312,60 @@ func TestCompactIDs_FullRoundTrip(t *testing.T) {
 		t.Fatal("expected short_id removed from output")
 	}
 }
+
+// TestTransportBindingHelpers locks the contract for the transport-bound
+// audit session helpers introduced in PR 07. resolveTransportID must always
+// return a non-empty string (so every call lands on a row, even stdio with
+// no native session id), metaReason must read tools/call._meta.reason
+// without panicking on nil paths, and contextWithAuditSession round-trips
+// through auditSessionFromContext. A regression that drops the stdio
+// fallback would leave stdio tool calls unbound.
+func TestTransportBindingHelpers(t *testing.T) {
+	s := NewMCPServer(nil, "test")
+
+	// resolveTransportID with nil request → stdio fallback.
+	if got := s.resolveTransportID(nil); got == "" {
+		t.Error("resolveTransportID(nil): empty fallback id")
+	}
+	// resolveTransportID with no Session → stdio fallback.
+	if got := s.resolveTransportID(&mcpsdk.CallToolRequest{}); got == "" {
+		t.Error("resolveTransportID(no-session): empty fallback id")
+	}
+	// Two NewMCPServer instances should differ on stdio fallback so concurrent
+	// stdio invocations don't collide on the same audit row. (shortid is
+	// random; we just assert non-empty + uniqueness when generation succeeds.)
+	s2 := NewMCPServer(nil, "test2")
+	if s.stdioFallbackTransportID == s2.stdioFallbackTransportID {
+		// Acceptable only if shortid generation failed and both fell back
+		// to "stdio-fallback". Don't fail the test on that path.
+		if s.stdioFallbackTransportID != "stdio-fallback" {
+			t.Errorf("stdio fallbacks collided: %q", s.stdioFallbackTransportID)
+		}
+	}
+
+	// metaReason: nil-safe + reads the optional reason key.
+	if got := metaReason(nil); got != "" {
+		t.Errorf("metaReason(nil) = %q, want \"\"", got)
+	}
+	emptyReq := &mcpsdk.CallToolRequest{Params: &mcpsdk.CallToolParamsRaw{}}
+	if got := metaReason(emptyReq); got != "" {
+		t.Errorf("metaReason(no-meta) = %q, want \"\"", got)
+	}
+	withReasonReq := &mcpsdk.CallToolRequest{Params: &mcpsdk.CallToolParamsRaw{
+		Meta: mcpsdk.Meta{"reason": "weekly review"},
+	}}
+	if got := metaReason(withReasonReq); got != "weekly review" {
+		t.Errorf("metaReason(with-meta) = %q, want \"weekly review\"", got)
+	}
+
+	// auditSession context round-trip.
+	ctx := contextWithAuditSession(t.Context(), "abc12345")
+	if got := auditSessionFromContext(ctx); got != "abc12345" {
+		t.Errorf("auditSessionFromContext = %q, want \"abc12345\"", got)
+	}
+	// Empty session id → no-op (don't store empty values on ctx).
+	emptyCtx := contextWithAuditSession(t.Context(), "")
+	if got := auditSessionFromContext(emptyCtx); got != "" {
+		t.Errorf("auditSessionFromContext(empty) = %q, want \"\"", got)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -12,42 +12,9 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// --- Session context types ---
-
-// sessionContextProvider extracts session tracking fields from tool inputs.
-type sessionContextProvider interface {
-	GetSessionID() string
-	GetReason() string
-}
-
-// WriteSessionContext is embedded in write tool inputs. session_id and reason are required.
-type WriteSessionContext struct {
-	SessionID string `json:"session_id" jsonschema:"required,Session ID from create_session tool. Call create_session first."`
-	Reason    string `json:"reason" jsonschema:"required,Brief reason for this action (e.g. 'categorizing grocery transactions')."`
-}
-
-func (w WriteSessionContext) GetSessionID() string { return w.SessionID }
-func (w WriteSessionContext) GetReason() string    { return w.Reason }
-
-// ReadSessionContext is embedded in read tool inputs. Both fields are optional.
-type ReadSessionContext struct {
-	SessionID string `json:"session_id,omitempty" jsonschema:"Optional session ID to associate this read with a session."`
-	Reason    string `json:"reason,omitempty" jsonschema:"Optional brief reason for this query."`
-}
-
-func (r ReadSessionContext) GetSessionID() string { return r.SessionID }
-func (r ReadSessionContext) GetReason() string    { return r.Reason }
-
-// --- Session tool input ---
-
-type createSessionInput struct {
-	Purpose string `json:"purpose" jsonschema:"required,Brief label for this session (e.g. 'weekly transaction review', 'rule creation for dining')."`
-}
-
 // --- Input types ---
 
 type queryTransactionsInput struct {
-	ReadSessionContext
 	StartDate     string   `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD) inclusive"`
 	EndDate       string   `json:"end_date,omitempty" jsonschema:"End date (YYYY-MM-DD) exclusive"`
 	AccountID     string   `json:"account_id,omitempty" jsonschema:"Filter by account ID"`
@@ -69,7 +36,6 @@ type queryTransactionsInput struct {
 }
 
 type countTransactionsInput struct {
-	ReadSessionContext
 	StartDate     string   `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD) inclusive"`
 	EndDate       string   `json:"end_date,omitempty" jsonschema:"End date (YYYY-MM-DD) exclusive"`
 	AccountID     string   `json:"account_id,omitempty" jsonschema:"Filter by account ID"`
@@ -86,7 +52,6 @@ type countTransactionsInput struct {
 }
 
 type transactionSummaryInput struct {
-	ReadSessionContext
 	StartDate      string `json:"start_date,omitempty" jsonschema:"Start date (YYYY-MM-DD) inclusive. Defaults to 30 days ago."`
 	EndDate        string `json:"end_date,omitempty" jsonschema:"End date (YYYY-MM-DD) exclusive. Defaults to today."`
 	GroupBy        string `json:"group_by" jsonschema:"required,How to group results: category, month, week, day, or category_month"`
@@ -97,21 +62,6 @@ type transactionSummaryInput struct {
 }
 
 // --- Handlers ---
-
-func (s *MCPServer) handleCreateSession(reqCtx context.Context, _ *mcpsdk.CallToolRequest, input createSessionInput) (*mcpsdk.CallToolResult, any, error) {
-	if err := s.checkWritePermission(reqCtx); err != nil {
-		return errorResult(err), nil, nil
-	}
-	if input.Purpose == "" {
-		return errorResult(fmt.Errorf("purpose is required")), nil, nil
-	}
-	actor := service.ActorFromContext(reqCtx)
-	session, err := s.svc.CreateMCPSession(context.Background(), actor, input.Purpose)
-	if err != nil {
-		return errorResult(err), nil, nil
-	}
-	return jsonResult(session)
-}
 
 // handleQueryTransactions runs the canonical transaction read.
 //
@@ -279,7 +229,6 @@ func (s *MCPServer) handleTransactionSummary(_ context.Context, _ *mcpsdk.CallTo
 // --- Transaction Rules ---
 
 type createTransactionRuleInput struct {
-	WriteSessionContext
 	Name               string              `json:"name" jsonschema:"required,Name for this rule (human-readable description)"`
 	Conditions         map[string]any      `json:"conditions,omitempty" jsonschema:"JSON condition tree. Omit or pass {} to match every transaction. Leaf: {\"field\":\"...\",\"op\":\"...\",\"value\":...}. Combinators: {\"and\":[...]}, {\"or\":[...]}, {\"not\":{...}} (nest freely, max depth 10). Fields: provider_name provider_merchant_name amount provider_category_primary provider_category_detailed category(assigned slug, live-updated by earlier-stage rules) pending provider account_id account_name user_id user_name tags. Ops: string/category=eq|neq|contains|not_contains|matches(RE2)|in; numeric=eq|neq|gt|gte|lt|lte; bool=eq|neq; tags=contains|not_contains|in. Nested example: {\"or\":[{\"and\":[{\"field\":\"provider_merchant_name\",\"op\":\"contains\",\"value\":\"starbucks\"},{\"field\":\"amount\",\"op\":\"gte\",\"value\":5}]},{\"field\":\"tags\",\"op\":\"contains\",\"value\":\"coffee\"}]}. Full spec: docs/rule-dsl.md."`
 	Actions            []map[string]string `json:"actions,omitempty" jsonschema:"Array of typed actions. {\"type\":\"set_category\",\"category_slug\":\"...\"} | {\"type\":\"add_tag\",\"tag_slug\":\"...\"} | {\"type\":\"remove_tag\",\"tag_slug\":\"...\"} | {\"type\":\"add_comment\",\"content\":\"...\"}. Actions compose: a rule can set a category AND add a tag AND add a comment in the same match. add_comment fires only at sync time (not on retroactive apply). remove_tag net-diffs against add_tag within the same sync pass. If omitted, use category_slug instead."`
@@ -292,7 +241,6 @@ type createTransactionRuleInput struct {
 }
 
 type updateTransactionRuleInput struct {
-	WriteSessionContext
 	ID           string               `json:"id" jsonschema:"required,UUID of the rule to update"`
 	Name         *string              `json:"name,omitempty" jsonschema:"New name for the rule. Omit to leave unchanged."`
 	Conditions   map[string]any       `json:"conditions,omitempty" jsonschema:"New condition tree (same format as create). Pass {} to explicitly change to match-all. Omit entirely to leave conditions unchanged."`
@@ -306,12 +254,10 @@ type updateTransactionRuleInput struct {
 }
 
 type deleteTransactionRuleInput struct {
-	WriteSessionContext
 	ID string `json:"id" jsonschema:"required,UUID of the rule to delete"`
 }
 
 type batchCreateRulesInput struct {
-	WriteSessionContext
 	Rules []batchRuleItem `json:"rules" jsonschema:"required,Array of rules to create. Ideal for composable pipelines. Example — tagging then categorizing then flagging: [{\"name\":\"Tag coffee shops\",\"priority\":0,\"conditions\":{\"field\":\"provider_merchant_name\",\"op\":\"contains\",\"value\":\"starbucks\"},\"actions\":[{\"type\":\"add_tag\",\"tag_slug\":\"coffee\"}]},{\"name\":\"Categorize coffee-tagged\",\"priority\":10,\"conditions\":{\"field\":\"tags\",\"op\":\"contains\",\"value\":\"coffee\"},\"actions\":[{\"type\":\"set_category\",\"category_slug\":\"food_and_drink_coffee\"}]},{\"name\":\"Flag expensive coffee\",\"priority\":50,\"conditions\":{\"and\":[{\"field\":\"tags\",\"op\":\"contains\",\"value\":\"coffee\"},{\"field\":\"amount\",\"op\":\"gt\",\"value\":15}]},\"actions\":[{\"type\":\"add_tag\",\"tag_slug\":\"expensive\"}]}]"`
 }
 
@@ -327,12 +273,10 @@ type batchRuleItem struct {
 }
 
 type applyRulesInput struct {
-	WriteSessionContext
 	RuleID string `json:"rule_id,omitempty" jsonschema:"Optional ID (UUID or short_id) of a specific rule to apply. When supplied, only that rule runs — no chaining. Omit to apply all active rules in pipeline-stage order (priority ASC); earlier rules' tag/category mutations feed later rules' conditions, exactly like sync-time. Materializes set_category / add_tag / remove_tag; add_comment stays sync-only. Ignores rule.trigger (retroactive is a bulk op)."`
 }
 
 type previewRuleInput struct {
-	ReadSessionContext
 	Conditions map[string]any `json:"conditions" jsonschema:"required,Condition tree to evaluate against existing transactions. Same grammar as create_transaction_rule.conditions. Preview evaluates this single condition in isolation against stored data — it does NOT simulate the full rule pipeline, so tags or categories that other rules would have added don't influence the result. Use this to answer 'what does this condition match today' before creating the rule."`
 	SampleSize int            `json:"sample_size,omitempty" jsonschema:"Number of sample matching transactions to return (default 10, max 50). The match_count in the response reflects the full match set, not just the sample."`
 }
@@ -584,7 +528,6 @@ func (s *MCPServer) handleBatchCreateRules(ctx context.Context, _ *mcpsdk.CallTo
 // --- Agent Reports ---
 
 type submitReportInput struct {
-	WriteSessionContext
 	Title    string   `json:"title" jsonschema:"required,A concise 1-2 sentence summary that reads like a notification or message. This is the primary thing the family sees on their dashboard — make it informative and self-contained. Good: 'Reviewed 47 transactions this week — 3 recategorized and no suspicious activity found.' Bad: 'Weekly Review Complete' (too vague to be useful without opening the full report)."`
 	Body     string   `json:"body" jsonschema:"required,Detailed breakdown in markdown format with supporting data. This is shown when the user expands the report for more detail. Use headers and bullet points and transaction links: [Transaction Name](/transactions/TRANSACTION_ID)."`
 	Priority string   `json:"priority" jsonschema:"Severity level. Valid values: info (default — routine updates and summaries), warning (needs attention soon), critical (urgent action required)"`
@@ -600,7 +543,12 @@ func (s *MCPServer) handleSubmitReport(reqCtx context.Context, _ *mcpsdk.CallToo
 	}
 
 	actor := service.ActorFromContext(reqCtx)
-	report, err := s.svc.CreateAgentReport(ctx, input.Title, input.Body, actor, input.Priority, input.Tags, input.Author, input.SessionID)
+	// session_id is no longer an input field — the dispatcher resolves
+	// the transport-bound audit session and stamps it on the request
+	// context. Reports created via submit_report still link back to the
+	// surrounding session row in the audit timeline.
+	sessionID := auditSessionFromContext(reqCtx)
+	report, err := s.svc.CreateAgentReport(ctx, input.Title, input.Body, actor, input.Priority, input.Tags, input.Author, sessionID)
 	if err != nil {
 		return errorResult(err), nil, nil
 	}

--- a/internal/mcp/tools_reads.go
+++ b/internal/mcp/tools_reads.go
@@ -20,32 +20,25 @@ import (
 // --- Input types ---
 
 type listAccountsInput struct {
-	ReadSessionContext
 	UserID string `json:"user_id,omitempty" jsonschema:"Filter accounts by user ID"`
 }
 
 type listCategoriesInput struct {
-	ReadSessionContext
 }
 
 type listUsersInput struct {
-	ReadSessionContext
 }
 
 type listTagsInput struct {
-	ReadSessionContext
 }
 
 type getSyncStatusInput struct {
-	ReadSessionContext
 }
 
 type getOverviewInput struct {
-	ReadSessionContext
 }
 
 type listTransactionRulesInput struct {
-	ReadSessionContext
 	CategorySlug string `json:"category_slug,omitempty" jsonschema:"Filter by category slug"`
 	Enabled      *bool  `json:"enabled,omitempty" jsonschema:"Filter by enabled status"`
 	Search       string `json:"search,omitempty" jsonschema:"Search by rule name. Comma-separated values are ORed."`

--- a/internal/mcp/tools_tags.go
+++ b/internal/mcp/tools_tags.go
@@ -14,7 +14,6 @@ import (
 // --- Input types ---
 
 type listAnnotationsInput struct {
-	ReadSessionContext
 	TransactionID string   `json:"transaction_id" jsonschema:"required,UUID or short ID of the transaction"`
 	Kinds         []string `json:"kinds,omitempty" jsonschema:"Optional kind filter: any of comment, rule, tag, category, sync. Empty = all kinds. Pass ['comment'] for the comment-only timeline. Pass ['tag'] to see both add+remove events; the response carries an 'action' field (added|removed|set|applied|started|updated) for the specific event. Pass ['sync'] to see initial-import + pending-flip rows."`
 	ActorTypes    []string `json:"actor_types,omitempty" jsonschema:"Optional actor-type filter: any of user, agent, system. Empty = all actors. Pass ['user'] for the canonical 'any human input?' check — drops rule churn and prior agent activity in one filter. Combine with kinds for fine-grained slices."`
@@ -23,7 +22,6 @@ type listAnnotationsInput struct {
 }
 
 type createTagInput struct {
-	WriteSessionContext
 	Slug        string  `json:"slug" jsonschema:"required,Tag slug. Lowercase alphanumerics with hyphens/colons, e.g. 'needs-review' or 'subscription:monthly'."`
 	DisplayName string  `json:"display_name" jsonschema:"required,Human-readable name (e.g. 'Needs Review')."`
 	Description string  `json:"description,omitempty" jsonschema:"Optional description."`
@@ -32,7 +30,6 @@ type createTagInput struct {
 }
 
 type updateTagInput struct {
-	WriteSessionContext
 	ID          string  `json:"id" jsonschema:"required,Tag UUID, short ID, or slug."`
 	DisplayName *string `json:"display_name,omitempty" jsonschema:"New display name."`
 	Description *string `json:"description,omitempty" jsonschema:"New description."`
@@ -41,7 +38,6 @@ type updateTagInput struct {
 }
 
 type deleteTagInput struct {
-	WriteSessionContext
 	ID string `json:"id" jsonschema:"required,Tag UUID, short ID, or slug."`
 }
 

--- a/internal/mcp/tools_update_transactions.go
+++ b/internal/mcp/tools_update_transactions.go
@@ -11,7 +11,6 @@ import (
 
 // updateTransactionsInput is the top-level input for the update_transactions tool.
 type updateTransactionsInput struct {
-	WriteSessionContext
 	Operations []transactionOperationInput `json:"operations" jsonschema:"required,Array of per-transaction operations. Max 50. Each item can set a category AND add/remove tags AND attach a comment in a single atomic op. Use the 'comment' field to record decision rationale; tag adds/removes carry no per-action note. Example: [{\"transaction_id\":\"k7Xm9pQ2\",\"category_slug\":\"food_and_drink_groceries\",\"tags_to_remove\":[{\"slug\":\"needs-review\"}],\"comment\":\"clearly groceries\"}]"`
 	OnError    string                      `json:"on_error,omitempty" jsonschema:"\"continue\" (default — each op runs in its own DB tx, partial failures don't undo successful items) or \"abort\" (whole batch is one DB tx, rolls back on first error)."`
 }

--- a/internal/service/mcp_sessions.go
+++ b/internal/service/mcp_sessions.go
@@ -86,6 +86,78 @@ func (s *Service) CreateMCPSession(ctx context.Context, actor Actor, purpose str
 	return mcpSessionFromRow(row), nil
 }
 
+// MCPClientInfo mirrors the MCP `clientInfo` block from the initialize
+// request. Name + Version are required by the spec; Title /
+// Description / WebsiteURL are SEP-973 additions hosts may set for
+// richer audit display. All optional fields are pgtype-friendly via
+// pgconv.TextIfNotEmpty at the call site.
+type MCPClientInfo struct {
+	Name        string
+	Version     string
+	Title       string
+	Description string
+	WebsiteURL  string
+}
+
+// EnsureMCPSessionForTransport returns the audit-session row bound to a
+// transport-level identity (MCP-Session-Id for HTTP, a process-start
+// id for stdio), creating one on first use. Subsequent tool calls on
+// the same transport reuse the row so every call lands under one
+// audit session without an explicit create_session round-trip.
+//
+// transportID = "" disables the binding; the caller falls back to a
+// per-call ad-hoc row (legacy code path).
+func (s *Service) EnsureMCPSessionForTransport(ctx context.Context, transportID string, actor Actor, client MCPClientInfo) (MCPSessionResponse, error) {
+	if transportID == "" {
+		return MCPSessionResponse{}, fmt.Errorf("%w: transport_id is required", ErrInvalidParameter)
+	}
+
+	if row, err := s.Queries.GetMCPSessionByTransportID(ctx, pgconv.TextIfNotEmpty(transportID)); err == nil {
+		return mcpSessionFromRow(row), nil
+	}
+
+	purpose := client.purposeLabel()
+
+	row, err := s.Queries.CreateMCPSessionWithTransport(ctx, db.CreateMCPSessionWithTransportParams{
+		ApiKeyID:          actor.ID,
+		ApiKeyName:        actor.Name,
+		Purpose:           purpose,
+		TransportID:       pgconv.TextIfNotEmpty(transportID),
+		ClientName:        pgconv.TextIfNotEmpty(client.Name),
+		ClientVersion:     pgconv.TextIfNotEmpty(client.Version),
+		ClientTitle:       pgconv.TextIfNotEmpty(client.Title),
+		ClientDescription: pgconv.TextIfNotEmpty(client.Description),
+		ClientWebsiteUrl:  pgconv.TextIfNotEmpty(client.WebsiteURL),
+	})
+	if err != nil {
+		// Race: another concurrent first call may have just inserted
+		// the row. Re-read once before giving up.
+		if row2, err2 := s.Queries.GetMCPSessionByTransportID(ctx, pgconv.TextIfNotEmpty(transportID)); err2 == nil {
+			return mcpSessionFromRow(row2), nil
+		}
+		return MCPSessionResponse{}, fmt.Errorf("create mcp session for transport: %w", err)
+	}
+	return mcpSessionFromRow(row), nil
+}
+
+// purposeLabel renders a human-readable purpose for the audit row when
+// the binding is implicit (no create_session call). The format mirrors
+// what an agent would have typed if asked.
+func (c MCPClientInfo) purposeLabel() string {
+	switch {
+	case c.Title != "" && c.Version != "":
+		return fmt.Sprintf("%s %s session", c.Title, c.Version)
+	case c.Title != "":
+		return fmt.Sprintf("%s session", c.Title)
+	case c.Name != "" && c.Version != "":
+		return fmt.Sprintf("%s %s session", c.Name, c.Version)
+	case c.Name != "":
+		return fmt.Sprintf("%s session", c.Name)
+	default:
+		return "MCP session"
+	}
+}
+
 // GetMCPSession retrieves a session by ID or short_id.
 func (s *Service) GetMCPSession(ctx context.Context, idOrShort string) (MCPSessionResponse, error) {
 	if idOrShort == "" {

--- a/prompts/mcp/instructions.md
+++ b/prompts/mcp/instructions.md
@@ -19,3 +19,4 @@ Per-entity drilldowns are exposed as resource templates (resolve a single short_
 ## Conventions
 - **Amount sign**: positive = money out, negative = money in. Never sum across `iso_currency_code`.
 - **Compact IDs**: to save on tokens, tools/resources use a 8-char base62 `short_id`; prefer over long form id (uuid)
+- **Audit sessions are automatic.** Every tool call is logged under an audit-session row keyed off the transport connection (the `MCP-Session-Id` header for HTTP, a per-process id for stdio). Agents no longer need to call `create_session` — the row is lazy-created on first tool call and inherits `clientInfo` from the `initialize` request. To label a specific call, pass an optional `reason` string in `tools/call._meta` (the spec's per-request metadata slot); it surfaces in the audit timeline alongside the call.


### PR DESCRIPTION
Replace the explicit `create_session` tool + per-call `session_id` / `reason` input fields with implicit transport-bound audit sessions. The MCP spec already gives us per-connection identity (`MCP-Session-Id` header for Streamable HTTP) and per-call metadata (`tools/call._meta`), so the application-layer round-trip and schema pollution were redundant.

## Summary

- **Migration**: nullable `transport_id` + `clientInfo` columns on `mcp_sessions`, partial index on `transport_id`.
- **Service**: `EnsureMCPSessionForTransport(ctx, transportID, actor, clientInfo)` lazy-creates an audit row keyed by transport id, capturing clientInfo from the initialize request.
- **Dispatcher**: `makeToolDefLogged` now resolves the transport id via `req.Session.ID()` (HTTP) with a per-process fallback for stdio. Pulls `_meta.reason` for the per-call label. Stamps the resolved audit-session id on the request context so handlers like `submit_report` can bind their created rows to it.
- **Tools**: `WriteSessionContext` / `ReadSessionContext` / `sessionContextProvider` gone. Every write-tool input struct loses `session_id` + `reason`. `handleCreateSession` + `createSessionInput` removed.
- **Tests**: `TestCreateSessionResponseShape` removed; `TestSubmitReportResponseShape` and `TestUpdateTransactionsHandler_ResetCategoryShape` updated to drop the embed. New `TestTransportBindingHelpers` pins the helper contracts.
- **Docs**: `prompts/mcp/instructions.md` and `.claude/rules/mcp.md` document the new binding.

## Breaking change

Agents calling `create_session` or passing `session_id` / `reason` on writes will get JSON-validation errors. Deliberate — no deprecation shim. The canonical caller (Claude.ai's MCP integration) reads tool schemas at connect time and adapts.

## Test plan

- [x] Full `go test -tags integration -count=1 -p 1 ./...` suite green locally.
- [x] `TestTransportBindingHelpers` covers `resolveTransportID` / `metaReason` / context round-trip.
- [ ] CI green.
- [ ] Manual smoke via Inspector + Claude.ai connector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
