### PR TITLE
fix: switch v2 SPA build to oven/bun image (unbreaks main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
-# Stage 1: Build (runs natively on the build host, cross-compiles Go)
+# Stage 1: Build the v2 SPA bundle. Pinned bun image, runs natively on
+# BUILDPLATFORM (not under QEMU). Output (web/dist/) is copied into the Go
+# builder below.
+FROM --platform=$BUILDPLATFORM oven/bun:1 AS web-builder
+WORKDIR /web
+COPY web/package.json web/bun.lock ./
+RUN bun install --frozen-lockfile
+COPY web/ ./
+RUN bun run build
+
+# Stage 2: Build Go binary (runs natively on the build host, cross-compiles Go)
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 ARG VERSION=dev
@@ -9,6 +19,10 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
+
+# Replace the committed dist/.gitkeep stub with the real SPA bundle from the
+# web-builder stage so //go:embed all:dist picks up the real files.
+COPY --from=web-builder /web/dist/ ./web/dist/
 
 # Generate sqlc code (generated files are gitignored)
 # Use pre-built binary — compiling from source is very slow under QEMU emulation.
@@ -28,19 +42,11 @@ RUN apk add --no-cache libstdc++ libgcc \
     && chmod +x tailwindcss-extra \
     && ./tailwindcss-extra -i input.css -o static/css/styles.css --minify
 
-# Build v2 SPA: install bun, then bundle web/dist via Vite. The stub
-# dist/index.html committed to the repo is overwritten here. Runs natively on
-# BUILDPLATFORM (not under QEMU) to avoid emulated-Node slowness.
-RUN apk add --no-cache bash unzip \
-    && curl -fsSL https://bun.sh/install | bash \
-    && /root/.bun/bin/bun install --frozen-lockfile --cwd web \
-    && /root/.bun/bin/bun run --cwd web build
-
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -trimpath \
     -ldflags="-s -w -X main.version=${VERSION}" \
     -o /breadbox ./cmd/breadbox
 
-# Stage 2: Runtime
+# Stage 3: Runtime
 FROM alpine:3.21
 
 # CA certificates: required for TLS connections to Plaid API and PostgreSQL


### PR DESCRIPTION
**Hotfix — main is currently broken.** The push-to-main after #1004 merged triggered Build & Push, which failed at the bun install step:

\`\`\`
/bin/sh: curl: not found
/bin/sh: /root/.bun/bin/bun: not found
process \"... && curl -fsSL https://bun.sh/install | bash && ...\" did not complete successfully: exit code: 127
\`\`\`

Two issues with the previous approach:
1. \`curl\` isn't in the base alpine image (\`apk add bash unzip\` didn't include it)
2. Even with curl, bun's default Linux binary is glibc-only — alpine ships musl, would need extra detection in the install script

## Fix

Switch to a pinned \`oven/bun:1\` stage that builds \`web/dist/\`, then \`COPY\` the output into the Go builder. Stays on \`BUILDPLATFORM\` (no QEMU emulation), removes the \`apk add\` + bun installer + bun runtime libs from the Go builder layer entirely.

\`\`\`dockerfile
FROM --platform=\$BUILDPLATFORM oven/bun:1 AS web-builder
WORKDIR /web
COPY web/package.json web/bun.lock ./
RUN bun install --frozen-lockfile
COPY web/ ./
RUN bun run build

FROM --platform=\$BUILDPLATFORM golang:1.25-alpine AS builder
...
COPY --from=web-builder /web/dist/ ./web/dist/
\`\`\`

Verified locally: \`docker build --target builder\` completes — ~6s for the SPA, ~13s for the Go binary. Deploy to \`breadbox.exe.xyz\` will fire as soon as this lands on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)