### PR TITLE
headless-api: add POST /sync integration tests

### DIFF
--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -16,11 +16,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"breadbox/internal/db"
 	mw "breadbox/internal/middleware"
 	"breadbox/internal/pgconv"
 	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
 	"breadbox/internal/testutil"
 
 	"github.com/go-chi/chi/v5"
@@ -45,7 +47,12 @@ type testEnv struct {
 func setupTestEnv(t *testing.T) *testEnv {
 	t.Helper()
 	pool, queries := testutil.ServicePool(t)
-	svc := service.New(queries, pool, nil, slog.Default())
+	// Construct a real sync engine with no providers so that TriggerSyncHandler's
+	// background goroutine has a non-nil receiver. Without a registered provider
+	// the goroutine logs "unknown provider" and exits — exactly what we want for
+	// tests that only assert on the synchronous response.
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
 
 	keyResult, err := svc.CreateAPIKey(t.Context(), "test-key", "full_access")
 	if err != nil {
@@ -69,7 +76,8 @@ func setupTestEnv(t *testing.T) *testEnv {
 func setupReadOnlyEnv(t *testing.T) *testEnv {
 	t.Helper()
 	pool, queries := testutil.ServicePool(t)
-	svc := service.New(queries, pool, nil, slog.Default())
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
 
 	keyResult, err := svc.CreateAPIKey(t.Context(), "readonly-key", "read_only")
 	if err != nil {
@@ -146,6 +154,7 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Patch("/reports/{id}/read", MarkReportReadHandler(svc))
 			r.Post("/transactions/{id}/tags", AddTransactionTagHandler(svc))
 			r.Delete("/transactions/{id}/tags/{slug}", RemoveTransactionTagHandler(svc))
+			r.Post("/sync", TriggerSyncHandler(svc))
 		})
 	})
 	return r
@@ -1816,4 +1825,143 @@ func TestAPI_ReadOnlyKeyAllowsMerchantSummaryRead(t *testing.T) {
 	resp := env.doGet(t, "/api/v1/transactions/merchants")
 	assertStatus(t, resp, http.StatusOK)
 	resp.Body.Close()
+}
+
+// ============================================================
+// TriggerSync Handler Tests (POST /sync)
+// ============================================================
+//
+// The handler returns 202 immediately and runs the sync in a background
+// goroutine. The Service in these tests is wired with a real *sync.Engine
+// that has no providers registered, so the goroutine logs an "unknown
+// provider" error and exits — letting us assert on the synchronous
+// request/response without needing real Plaid/Teller fixtures.
+
+// assertSyncTriggered reads the 202 envelope and confirms the canonical
+// {"status":"sync_triggered"} body.
+func assertSyncTriggered(t *testing.T, resp *http.Response) {
+	t.Helper()
+	assertStatus(t, resp, http.StatusAccepted)
+	var body map[string]string
+	parseJSON(t, resp, &body)
+	if body["status"] != "sync_triggered" {
+		t.Errorf("want status %q, got %q", "sync_triggered", body["status"])
+	}
+}
+
+// waitForSyncDrain registers a t.Cleanup that waits for the trigger
+// handler's background goroutines to finish writing to sync_logs. The
+// handler returns 202 immediately and runs Sync in a goroutine; without
+// this drain, the next test's TRUNCATE races with the goroutine's writes
+// and deadlocks. We wait for sync_logs to stay quiet across consecutive
+// polls, with a hard cap.
+func waitForSyncDrain(t *testing.T, env *testEnv) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		var prev int64 = -1
+		stable := 0
+		for {
+			var inProgress, total int64
+			err := env.Pool.QueryRow(ctx, `SELECT
+				COUNT(*) FILTER (WHERE status = 'in_progress'),
+				COUNT(*)
+			FROM sync_logs`).Scan(&inProgress, &total)
+			if err != nil {
+				t.Logf("waitForSyncDrain: query error: %v", err)
+				return
+			}
+			if inProgress == 0 && total == prev {
+				stable++
+				if stable >= 3 {
+					return
+				}
+			} else {
+				stable = 0
+			}
+			prev = total
+			select {
+			case <-ctx.Done():
+				t.Logf("waitForSyncDrain: timed out (in_progress=%d, total=%d)", inProgress, total)
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+	})
+}
+
+func TestTriggerSync_Success_AllConnections(t *testing.T) {
+	env := setupTestEnv(t)
+	waitForSyncDrain(t, env)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	// Two active connections; SyncAll should enqueue both.
+	testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_active_1")
+	testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_active_2")
+
+	resp := env.doPost(t, "/api/v1/sync", nil)
+	assertSyncTriggered(t, resp)
+}
+
+func TestTriggerSync_Success_SingleConnection(t *testing.T) {
+	env := setupTestEnv(t)
+	waitForSyncDrain(t, env)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_single")
+
+	// short_id form — exercises the resolver path.
+	resp := env.doPost(t, "/api/v1/sync", map[string]string{
+		"connection_id": conn.ShortID,
+	})
+	assertSyncTriggered(t, resp)
+}
+
+func TestTriggerSync_Success_SingleConnection_UUID(t *testing.T) {
+	env := setupTestEnv(t)
+	waitForSyncDrain(t, env)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_single_uuid")
+
+	resp := env.doPost(t, "/api/v1/sync", map[string]string{
+		"connection_id": pgconv.FormatUUID(conn.ID),
+	})
+	assertSyncTriggered(t, resp)
+}
+
+func TestTriggerSync_Unknown_Connection(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Well-formed but non-existent UUID.
+	resp := env.doPost(t, "/api/v1/sync", map[string]string{
+		"connection_id": "00000000-0000-0000-0000-000000000000",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestTriggerSync_Disconnected_Connection(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_disc")
+
+	// Flip the connection to disconnected; GetBankConnectionForSync filters
+	// these out and the service returns ErrNotFound, mapped to 404.
+	if err := env.Queries.UpdateBankConnectionStatus(t.Context(), db.UpdateBankConnectionStatusParams{
+		ID:     conn.ID,
+		Status: db.ConnectionStatusDisconnected,
+	}); err != nil {
+		t.Fatalf("set disconnected: %v", err)
+	}
+
+	resp := env.doPost(t, "/api/v1/sync", map[string]string{
+		"connection_id": conn.ShortID,
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestTriggerSync_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+
+	resp := env.doPost(t, "/api/v1/sync", nil)
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
 }


### PR DESCRIPTION
## Summary

Bundle 04 of the headless-api plan. The two doc fixes the bundle called for (`limit` default and `POST /sync` body) had already landed in [#1016 / 64400c05](https://github.com/canalesb93/breadbox/commit/64400c05) on the integration branch, so this PR ships **only the missing test coverage**.

`TriggerSyncHandler` previously had zero integration coverage. Adds six tests covering the documented contract:

- `TestTriggerSync_Success_AllConnections` — empty body, two active connections, `202 sync_triggered`
- `TestTriggerSync_Success_SingleConnection` — `connection_id` as short_id, `202 sync_triggered`
- `TestTriggerSync_Success_SingleConnection_UUID` — `connection_id` as UUID, `202 sync_triggered`
- `TestTriggerSync_Unknown_Connection` — non-existent UUID, `404 NOT_FOUND`
- `TestTriggerSync_Disconnected_Connection` — `status='disconnected'` filtered by `GetBankConnectionForSync`, `404 NOT_FOUND`
- `TestTriggerSync_RequiresWriteScope` — `read_only` key, `403 INSUFFICIENT_SCOPE`

## Implementation notes

- `setupTestEnv` / `setupReadOnlyEnv` now wire a real `*sync.Engine` with **no providers**. Without this the handler's background goroutine NPEs on a nil `SyncEngine`; with this it logs `"unknown provider"` and exits cleanly. No production code changed.
- `waitForSyncDrain` registers a `t.Cleanup` that waits for `sync_logs` activity to settle (no `in_progress` rows + total stable across 3 polls) before returning. Without it the goroutine's writes race the next test's `TRUNCATE` and deadlock.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/api/...` (unit) — pass
- [x] `make test-integration` — pass (full suite, including the 6 new tests)
- [x] `go test -tags integration -run TestTriggerSync ./internal/api/...` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
