### PR TITLE
headless-api: POST /transactions/update (atomic multi-field batch)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -49,6 +49,7 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 | DELETE | `/transactions/{id}/category` | Write | Reset transaction category to provider default |
 | POST | `/transactions/batch-categorize` | Write | Batch categorize multiple transactions (max 500) |
 | POST | `/transactions/bulk-recategorize` | Write | Bulk recategorize by filter (server-side UPDATE) |
+| POST | `/transactions/update` | Write | Atomic multi-field batch (category + tags + comment per row, max 50 ops) |
 
 ### Transaction Query Parameters
 
@@ -122,6 +123,43 @@ The handler returns `202 Accepted` immediately and runs the sync asynchronously;
 ```json
 { "status": "sync_triggered" }
 ```
+
+### POST `/transactions/update`
+
+Atomic multi-field batch. Each operation can set a category (or clear an override), add/remove tags, and attach a comment — all atomic per transaction. REST sibling of the MCP `update_transactions` tool.
+
+**Body**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `operations` | array | Required. Up to 50 ops. |
+| `on_error` | string | `"continue"` (default — each op runs in its own DB tx, partial failures don't undo successful items) or `"abort"` (whole batch is one DB tx, rolls back on first error). |
+
+Each operation:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transaction_id` | string | Required. UUID or short_id. |
+| `category_slug` | string | Optional. Sets `category_override=true`. Mutually exclusive with `reset_category`. |
+| `reset_category` | bool | Optional. Clears the override and drops the transaction back to `uncategorized` so rules can re-categorize. |
+| `tags_to_add` | array | `[{"slug":"..."}]`. Auto-creates the tag if the slug is not yet registered. |
+| `tags_to_remove` | array | `[{"slug":"..."}]`. Unknown slugs are a no-op. |
+| `comment` | string | Optional annotation, attributed to your API key. Max 10000 chars. |
+
+**Response** `200 OK`
+
+```json
+{
+  "results": [
+    {"transaction_id": "k7Xm9pQ2", "status": "ok"},
+    {"transaction_id": "x4Lz1mNa", "status": "error", "error": {"code": "NOT_FOUND", "message": "..."}}
+  ],
+  "succeeded": 1,
+  "failed": 1
+}
+```
+
+Per-op errors are reported inside `results[]`; the top-level response is still `200`. The whole call returns `400 INVALID_PARAMETER` only on malformed input (empty `operations`, more than 50, bad `on_error`). In `abort` mode a partial-batch failure rolls back the DB transaction and the response includes `aborted: true` plus the partial per-op outcomes.
 
 ## Transaction Comments
 

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -143,6 +143,7 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Delete("/transactions/{transaction_id}/comments/{id}", DeleteCommentHandler(svc))
 			r.Post("/transactions/batch-categorize", BatchCategorizeHandler(svc))
 			r.Post("/transactions/bulk-recategorize", BulkRecategorizeHandler(svc))
+			r.Post("/transactions/update", UpdateTransactionsHandler(svc))
 			r.Post("/account-links", CreateAccountLinkHandler(svc))
 			r.Put("/account-links/{id}", UpdateAccountLinkHandler(svc))
 			r.Delete("/account-links/{id}", DeleteAccountLinkHandler(svc))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -97,6 +97,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/rules/preview", PreviewRuleHandler(svc))
 			r.Post("/transactions/batch-categorize", BatchCategorizeHandler(svc))
 			r.Post("/transactions/bulk-recategorize", BulkRecategorizeHandler(svc))
+			r.Post("/transactions/update", UpdateTransactionsHandler(svc))
 			r.Post("/account-links", CreateAccountLinkHandler(svc))
 			r.Put("/account-links/{id}", UpdateAccountLinkHandler(svc))
 			r.Delete("/account-links/{id}", DeleteAccountLinkHandler(svc))

--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -455,6 +455,104 @@ func BatchCategorizeHandler(svc *service.Service) http.HandlerFunc {
 	}
 }
 
+// updateTransactionsRequest mirrors the MCP `update_transactions` tool's
+// input shape 1:1 (snake_case, identical field names). REST sibling of
+// internal/mcp/tools_update_transactions.go.
+type updateTransactionsRequest struct {
+	Operations []updateTransactionsOpRequest `json:"operations"`
+	OnError    string                        `json:"on_error"`
+}
+
+// updateTransactionsOpRequest is a single per-transaction compound operation.
+type updateTransactionsOpRequest struct {
+	TransactionID string             `json:"transaction_id"`
+	CategorySlug  *string            `json:"category_slug,omitempty"`
+	ResetCategory bool               `json:"reset_category,omitempty"`
+	TagsToAdd     []updateTagOpEntry `json:"tags_to_add,omitempty"`
+	TagsToRemove  []updateTagOpEntry `json:"tags_to_remove,omitempty"`
+	Comment       *string            `json:"comment,omitempty"`
+}
+
+// updateTagOpEntry is a single tag add/remove entry.
+type updateTagOpEntry struct {
+	Slug string `json:"slug"`
+}
+
+// UpdateTransactionsHandler is the REST sibling of the MCP `update_transactions`
+// tool. Each operation can set a category (or clear an override), add/remove
+// tags, and attach a comment — all atomic per transaction. Up to 50 ops per
+// call. Per-op errors live inside `results[]`; the top-level call returns
+// `200 OK` unless the input itself is malformed (empty/oversized operations,
+// invalid `on_error`), in which case it returns `400 INVALID_PARAMETER`.
+//
+// POST /transactions/update
+func UpdateTransactionsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var input updateTransactionsRequest
+		if !decodeJSON(w, r, &input) {
+			return
+		}
+
+		ops := make([]service.UpdateTransactionsOp, len(input.Operations))
+		for i, op := range input.Operations {
+			ops[i] = service.UpdateTransactionsOp{
+				TransactionID: op.TransactionID,
+				CategorySlug:  op.CategorySlug,
+				ResetCategory: op.ResetCategory,
+				Comment:       op.Comment,
+			}
+			for _, t := range op.TagsToAdd {
+				ops[i].TagsToAdd = append(ops[i].TagsToAdd, service.UpdateTransactionsTagOp{Slug: t.Slug})
+			}
+			for _, t := range op.TagsToRemove {
+				ops[i].TagsToRemove = append(ops[i].TagsToRemove, service.UpdateTransactionsTagOp{Slug: t.Slug})
+			}
+		}
+
+		actor := service.ActorFromContext(r.Context())
+		results, err := svc.UpdateTransactions(r.Context(), service.UpdateTransactionsParams{
+			Operations: ops,
+			OnError:    input.OnError,
+			Actor:      actor,
+		})
+		// Top-level validation errors (empty ops, > 50 ops, bad on_error)
+		// surface as 400. Per-op errors live inside `results[]`.
+		if err != nil && len(results) == 0 {
+			if errors.Is(err, service.ErrInvalidParameter) {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update transactions")
+			return
+		}
+
+		// abort mode with a partial-batch failure: results is populated AND
+		// err is set. Mirror the MCP envelope — return 200 with the partial
+		// results plus an `aborted` flag, so callers can see the per-op
+		// outcomes before the rollback.
+		succeeded := 0
+		failed := 0
+		for _, r := range results {
+			if r.Status == "ok" {
+				succeeded++
+			} else {
+				failed++
+			}
+		}
+
+		payload := map[string]any{
+			"results":   results,
+			"succeeded": succeeded,
+			"failed":    failed,
+		}
+		if err != nil {
+			payload["aborted"] = true
+			payload["error"] = err.Error()
+		}
+		writeData(w, payload)
+	}
+}
+
 // BulkRecategorizeHandler handles POST /api/v1/transactions/bulk-recategorize.
 func BulkRecategorizeHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/transactions_update_integration_test.go
+++ b/internal/api/transactions_update_integration_test.go
@@ -1,0 +1,379 @@
+//go:build integration
+
+// Integration tests for POST /api/v1/transactions/update — the REST sibling
+// of the MCP `update_transactions` tool. Run with:
+//
+//	DATABASE_URL="postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable" \
+//	  go test -tags integration -count=1 -p 1 -v ./internal/api/... -run TestUpdateTransactions_
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// TestUpdateTransactions_AtomicMultiField applies category + tag-add + comment
+// in a single op and confirms all three writes landed.
+func TestUpdateTransactions_AtomicMultiField(t *testing.T) {
+	env := setupTestEnv(t)
+	_ = seedUncategorized(t, env.Queries)
+	cat := testutil.MustCreateCategory(t, env.Queries, "food_and_drink_groceries", "Groceries")
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	body := map[string]any{
+		"operations": []map[string]any{{
+			"transaction_id": txnID,
+			"category_slug":  cat.Slug,
+			"tags_to_add":    []map[string]string{{"slug": "needs-review"}},
+			"comment":        "clearly groceries",
+		}},
+	}
+	resp := env.doPost(t, "/api/v1/transactions/update", body)
+	assertStatus(t, resp, http.StatusOK)
+
+	var out struct {
+		Results []struct {
+			TransactionID string `json:"transaction_id"`
+			Status        string `json:"status"`
+		} `json:"results"`
+		Succeeded int `json:"succeeded"`
+		Failed    int `json:"failed"`
+	}
+	parseJSON(t, resp, &out)
+	if out.Succeeded != 1 || out.Failed != 0 {
+		t.Fatalf("want succeeded=1 failed=0, got succeeded=%d failed=%d (results=%+v)", out.Succeeded, out.Failed, out.Results)
+	}
+	if len(out.Results) != 1 || out.Results[0].Status != "ok" {
+		t.Fatalf("want one ok result, got %+v", out.Results)
+	}
+
+	// Verify the transaction is recategorized (override set to cat).
+	got, err := env.Service.GetTransaction(t.Context(), txnID)
+	if err != nil {
+		t.Fatalf("get transaction: %v", err)
+	}
+	if got.Category == nil || got.Category.Slug == nil || *got.Category.Slug != cat.Slug {
+		t.Fatalf("want category %q, got %+v", cat.Slug, got.Category)
+	}
+	if !got.CategoryOverride {
+		t.Fatalf("want category_override=true after manual set")
+	}
+
+	// Verify the tag is attached.
+	tagsAttached, err := env.Queries.ListTagsByTransaction(t.Context(), txn.ID)
+	if err != nil {
+		t.Fatalf("list tags for txn: %v", err)
+	}
+	foundTag := false
+	for _, tg := range tagsAttached {
+		if tg.Slug == "needs-review" {
+			foundTag = true
+		}
+	}
+	if !foundTag {
+		t.Fatalf("expected tag needs-review attached, got %+v", tagsAttached)
+	}
+
+	// Verify a comment annotation row exists.
+	annots, err := env.Service.ListAnnotations(t.Context(), txnID, service.ListAnnotationsParams{
+		Kinds: []string{"comment"},
+		Raw:   true,
+	})
+	if err != nil {
+		t.Fatalf("list annotations: %v", err)
+	}
+	if len(annots) == 0 {
+		t.Fatalf("expected at least one comment annotation, got 0")
+	}
+}
+
+// TestUpdateTransactions_BatchContinueMode runs two ops; the second references
+// a non-existent transaction. Continue mode commits the first op and reports
+// the second op's per-row error inside results[].
+func TestUpdateTransactions_BatchContinueMode(t *testing.T) {
+	env := setupTestEnv(t)
+	_ = seedUncategorized(t, env.Queries)
+	cat := testutil.MustCreateCategory(t, env.Queries, "groceries", "Groceries")
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	body := map[string]any{
+		"on_error": "continue",
+		"operations": []map[string]any{
+			{
+				"transaction_id": txnID,
+				"category_slug":  cat.Slug,
+			},
+			{
+				"transaction_id": "zzzzzzzz", // non-existent short_id
+				"category_slug":  cat.Slug,
+			},
+		},
+	}
+	resp := env.doPost(t, "/api/v1/transactions/update", body)
+	assertStatus(t, resp, http.StatusOK)
+
+	var out struct {
+		Results []struct {
+			TransactionID string `json:"transaction_id"`
+			Status        string `json:"status"`
+			Error         *struct {
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error,omitempty"`
+		} `json:"results"`
+		Succeeded int `json:"succeeded"`
+		Failed    int `json:"failed"`
+	}
+	parseJSON(t, resp, &out)
+	if out.Succeeded != 1 || out.Failed != 1 {
+		t.Fatalf("want succeeded=1 failed=1, got succeeded=%d failed=%d (results=%+v)", out.Succeeded, out.Failed, out.Results)
+	}
+	if out.Results[0].Status != "ok" {
+		t.Fatalf("want first op ok, got %+v", out.Results[0])
+	}
+	if out.Results[1].Status != "error" || out.Results[1].Error == nil || out.Results[1].Error.Code != "NOT_FOUND" {
+		t.Fatalf("want second op error NOT_FOUND, got %+v", out.Results[1])
+	}
+
+	// First op committed.
+	got, err := env.Service.GetTransaction(t.Context(), txnID)
+	if err != nil {
+		t.Fatalf("get transaction: %v", err)
+	}
+	if got.Category == nil || got.Category.Slug == nil || *got.Category.Slug != cat.Slug {
+		t.Fatalf("first op should have committed category, got %+v", got.Category)
+	}
+}
+
+// TestUpdateTransactions_BatchAbortMode is the same shape as continue mode
+// but with on_error=abort. The whole batch rolls back when the second op
+// fails — the first op's category change must NOT persist.
+func TestUpdateTransactions_BatchAbortMode(t *testing.T) {
+	env := setupTestEnv(t)
+	uncat := seedUncategorized(t, env.Queries)
+	cat := testutil.MustCreateCategory(t, env.Queries, "groceries", "Groceries")
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	body := map[string]any{
+		"on_error": "abort",
+		"operations": []map[string]any{
+			{
+				"transaction_id": txnID,
+				"category_slug":  cat.Slug,
+			},
+			{
+				"transaction_id": "zzzzzzzz",
+				"category_slug":  cat.Slug,
+			},
+		},
+	}
+	resp := env.doPost(t, "/api/v1/transactions/update", body)
+	assertStatus(t, resp, http.StatusOK)
+
+	var out struct {
+		Results []struct {
+			TransactionID string `json:"transaction_id"`
+			Status        string `json:"status"`
+			Error         *struct {
+				Code string `json:"code"`
+			} `json:"error,omitempty"`
+		} `json:"results"`
+		Succeeded int  `json:"succeeded"`
+		Failed    int  `json:"failed"`
+		Aborted   bool `json:"aborted"`
+	}
+	parseJSON(t, resp, &out)
+	if !out.Aborted {
+		t.Fatalf("want aborted=true on abort failure, got %+v", out)
+	}
+	// The service contract for updateTransactionsAbort: each op result
+	// reflects what happened at op-time (op[0] computed ok before op[1]
+	// failed). Trailing ops AFTER the failure get an ABORTED placeholder.
+	// The DB tx is rolled back regardless, which is what the
+	// "first-op rollback" assertion below actually proves.
+	if out.Results[1].Status != "error" || out.Results[1].Error == nil || out.Results[1].Error.Code != "NOT_FOUND" {
+		t.Fatalf("want second op error NOT_FOUND, got %+v", out.Results[1])
+	}
+
+	// First op rolled back: txn must still carry the original category
+	// (uncategorized seeded by MustCreateTransaction's default).
+	got, err := env.Service.GetTransaction(t.Context(), txnID)
+	if err != nil {
+		t.Fatalf("get transaction: %v", err)
+	}
+	if got.Category != nil && got.Category.Slug != nil && *got.Category.Slug == cat.Slug {
+		t.Fatalf("abort mode should have rolled back; category should not be %q (uncat=%s)", cat.Slug, uncat.Slug)
+	}
+	if got.CategoryOverride {
+		t.Fatalf("abort mode should have rolled back; category_override should be false")
+	}
+}
+
+// TestUpdateTransactions_ResetCategory clears a manual override.
+func TestUpdateTransactions_ResetCategory(t *testing.T) {
+	env := setupTestEnv(t)
+	_ = seedUncategorized(t, env.Queries)
+	cat := testutil.MustCreateCategory(t, env.Queries, "groceries", "Groceries")
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	// Set a manual override first via the service. SetTransactionCategory
+	// accepts UUID/short_id (not slug), so use the short_id.
+	if err := env.Service.SetTransactionCategory(t.Context(), txnID, cat.ShortID, service.SystemActor()); err != nil {
+		t.Fatalf("seed override: %v", err)
+	}
+
+	body := map[string]any{
+		"operations": []map[string]any{{
+			"transaction_id": txnID,
+			"reset_category": true,
+		}},
+	}
+	resp := env.doPost(t, "/api/v1/transactions/update", body)
+	assertStatus(t, resp, http.StatusOK)
+
+	var out struct {
+		Succeeded int `json:"succeeded"`
+		Failed    int `json:"failed"`
+	}
+	parseJSON(t, resp, &out)
+	if out.Succeeded != 1 || out.Failed != 0 {
+		t.Fatalf("want succeeded=1 failed=0, got %+v", out)
+	}
+
+	got, err := env.Service.GetTransaction(t.Context(), txnID)
+	if err != nil {
+		t.Fatalf("get transaction: %v", err)
+	}
+	if got.CategoryOverride {
+		t.Fatalf("expected category_override cleared after reset, still true")
+	}
+}
+
+// TestUpdateTransactions_RejectsEmptyOperations — empty operations array is
+// a top-level INVALID_PARAMETER (400), not a per-op error.
+func TestUpdateTransactions_RejectsEmptyOperations(t *testing.T) {
+	env := setupTestEnv(t)
+
+	body := map[string]any{"operations": []map[string]any{}}
+	resp := env.doPost(t, "/api/v1/transactions/update", body)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// TestUpdateTransactions_RejectsTooMany — > 50 ops returns 400.
+func TestUpdateTransactions_RejectsTooMany(t *testing.T) {
+	env := setupTestEnv(t)
+
+	ops := make([]map[string]any, 51)
+	for i := range ops {
+		ops[i] = map[string]any{"transaction_id": "zzzzzzzz"}
+	}
+	body := map[string]any{"operations": ops}
+	resp := env.doPost(t, "/api/v1/transactions/update", body)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// TestUpdateTransactions_RequiresWriteScope — read-only API key is blocked.
+func TestUpdateTransactions_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+
+	body := map[string]any{
+		"operations": []map[string]any{{"transaction_id": "zzzzzzzz"}},
+	}
+	resp := env.doPost(t, "/api/v1/transactions/update", body)
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+// TestUpdateTransactions_RejectsBothCategoryAndReset — category_slug and
+// reset_category are mutually exclusive. The service rejects per-op, so the
+// top-level call still returns 200 but the result reports INVALID_PARAMETER.
+func TestUpdateTransactions_RejectsBothCategoryAndReset(t *testing.T) {
+	env := setupTestEnv(t)
+	_ = seedUncategorized(t, env.Queries)
+	cat := testutil.MustCreateCategory(t, env.Queries, "groceries", "Groceries")
+
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	body := map[string]any{
+		"operations": []map[string]any{{
+			"transaction_id": txnID,
+			"category_slug":  cat.Slug,
+			"reset_category": true,
+		}},
+	}
+	resp := env.doPost(t, "/api/v1/transactions/update", body)
+	assertStatus(t, resp, http.StatusOK)
+
+	var out struct {
+		Results []struct {
+			Status string `json:"status"`
+			Error  *struct {
+				Code string `json:"code"`
+			} `json:"error,omitempty"`
+		} `json:"results"`
+		Failed int `json:"failed"`
+	}
+	parseJSON(t, resp, &out)
+	if out.Failed != 1 {
+		t.Fatalf("want failed=1, got %+v", out)
+	}
+	if out.Results[0].Status != "error" || out.Results[0].Error == nil || out.Results[0].Error.Code != "INVALID_PARAMETER" {
+		t.Fatalf("want INVALID_PARAMETER per-op error, got %+v", out.Results[0])
+	}
+}
+
+// TestUpdateTransactions_AutoCreatesTagSlug — referencing a brand-new tag
+// slug in tags_to_add auto-creates it (matches MCP behavior via
+// getOrCreateTagBySlug).
+func TestUpdateTransactions_AutoCreatesTagSlug(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	const newSlug = "freshly-minted"
+
+	body := map[string]any{
+		"operations": []map[string]any{{
+			"transaction_id": txnID,
+			"tags_to_add":    []map[string]string{{"slug": newSlug}},
+		}},
+	}
+	resp := env.doPost(t, "/api/v1/transactions/update", body)
+	assertStatus(t, resp, http.StatusOK)
+
+	var out struct {
+		Succeeded int `json:"succeeded"`
+		Failed    int `json:"failed"`
+	}
+	parseJSON(t, resp, &out)
+	if out.Succeeded != 1 || out.Failed != 0 {
+		t.Fatalf("want succeeded=1 failed=0, got %+v", out)
+	}
+
+	// Verify the tag was registered (auto-created).
+	tags, err := env.Service.ListTags(t.Context())
+	if err != nil {
+		t.Fatalf("list tags: %v", err)
+	}
+	found := false
+	for _, tg := range tags {
+		if tg.Slug == newSlug {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected auto-created tag %q in registry, got %+v", newSlug, tags)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/transactions/update` — atomic multi-field batch update — as a REST sibling to MCP `update_transactions`. Bundle 02 of the headless-api plan.

- Mirrors the MCP tool's request/response shape 1:1 (snake_case, same field names)
- Wraps `service.UpdateTransactions` with no service changes
- Mounts under `RequireWriteScope`
- Per-op errors inside `results[]`; top-level 400 only on malformed input
- Up to 50 ops per call; `on_error: "continue" | "abort"`

This closes the biggest gap for headless agents — previously a single decision (set category + remove `needs-review` tag + add a rationale comment) required three separate REST calls. Now it's one atomic op.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `make test-integration` — full suite green
- [x] 9 new integration tests cover: atomic multi-field, continue/abort modes, reset_category, validation (empty/oversized/category+reset mutex), scope enforcement, auto-tag-creation

## Files

- `internal/api/transactions.go` — handler + request types
- `internal/api/router.go` — route registration under `RequireWriteScope`
- `internal/api/api_integration_test.go` — test router wiring
- `internal/api/transactions_update_integration_test.go` — 9 integration tests (new file)
- `docs/api-reference.md` — endpoint table row + long-form section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
