### PR TITLE
headless-api: soft-delete + restore for transactions

### DIFF
--- a/docs/activity-timeline.md
+++ b/docs/activity-timeline.md
@@ -173,6 +173,8 @@ Today's `Type` values:
 | `sync`     | `sync_started`, `sync_updated`   | `txdTimelineSystem`     |
 | `review`   | (legacy, retained for fallback)  | `txdTimelineSystem`     |
 
+The `transaction_deleted` and `transaction_restored` kinds are written by the REST API soft-delete / restore endpoints (`internal/service/transactions_lifecycle.go`) but are **not yet rendered** by `activityEntryFromAnnotation` — the renderer drops them as unknown. Surfacing them in the timeline is tracked as a follow-up to the headless-api bundle (see `docs/headless-api-plan.md` bundle 03). Until then they're visible to MCP via `list_annotations` (`Raw: true` or filtered by kind) and via the raw annotations table for audit.
+
 `syncEntryType` collapses both DB-level `sync_*` kinds onto a single `sync`
 type because they share an icon (`landmark`) and the differentiated verb
 already lives on the `Summary` string.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -50,6 +50,8 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 | POST | `/transactions/batch-categorize` | Write | Batch categorize multiple transactions (max 500) |
 | POST | `/transactions/bulk-recategorize` | Write | Bulk recategorize by filter (server-side UPDATE) |
 | POST | `/transactions/update` | Write | Atomic multi-field batch (category + tags + comment per row, max 50 ops) |
+| DELETE | `/transactions/{id}` | Write | Soft-delete a transaction (sets `deleted_at`; hidden from all reads). |
+| POST | `/transactions/{id}/restore` | Write | Restore a soft-deleted transaction. |
 
 ### Transaction Query Parameters
 
@@ -160,6 +162,19 @@ Each operation:
 ```
 
 Per-op errors are reported inside `results[]`; the top-level response is still `200`. The whole call returns `400 INVALID_PARAMETER` only on malformed input (empty `operations`, more than 50, bad `on_error`). In `abort` mode a partial-batch failure rolls back the DB transaction and the response includes `aborted: true` plus the partial per-op outcomes.
+
+### DELETE `/transactions/{id}` and POST `/transactions/{id}/restore`
+
+Soft-delete and undo. `DELETE /transactions/{id}` sets the row's `deleted_at` timestamp; every read endpoint (list, get, summary, merchants, count, …) filters on `deleted_at IS NULL`, so a deleted transaction immediately disappears from all responses. The DB row is preserved so `POST /transactions/{id}/restore` can clear `deleted_at` and bring it back.
+
+Both endpoints return `204 No Content` on success and write a `transaction_deleted` / `transaction_restored` annotation on the activity timeline attributed to the calling API key.
+
+Both are idempotent at the API surface — a no-op returns `404 NOT_FOUND`:
+
+- `DELETE` on a transaction that doesn't exist or is already soft-deleted → `404`.
+- `POST /restore` on a transaction that doesn't exist or isn't currently soft-deleted → `404`.
+
+Path id accepts either a UUID or short_id for live (non-deleted) rows. Restore on a soft-deleted row must use the UUID — the short_id resolver itself filters on `deleted_at IS NULL` and won't find a deleted row by its short id.
 
 ## Transaction Comments
 

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -144,6 +144,8 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Post("/transactions/batch-categorize", BatchCategorizeHandler(svc))
 			r.Post("/transactions/bulk-recategorize", BulkRecategorizeHandler(svc))
 			r.Post("/transactions/update", UpdateTransactionsHandler(svc))
+			r.Delete("/transactions/{id}", DeleteTransactionHandler(svc))
+			r.Post("/transactions/{id}/restore", RestoreTransactionHandler(svc))
 			r.Post("/account-links", CreateAccountLinkHandler(svc))
 			r.Put("/account-links/{id}", UpdateAccountLinkHandler(svc))
 			r.Delete("/account-links/{id}", DeleteAccountLinkHandler(svc))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -98,6 +98,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/transactions/batch-categorize", BatchCategorizeHandler(svc))
 			r.Post("/transactions/bulk-recategorize", BulkRecategorizeHandler(svc))
 			r.Post("/transactions/update", UpdateTransactionsHandler(svc))
+			r.Delete("/transactions/{id}", DeleteTransactionHandler(svc))
+			r.Post("/transactions/{id}/restore", RestoreTransactionHandler(svc))
 			r.Post("/account-links", CreateAccountLinkHandler(svc))
 			r.Put("/account-links/{id}", UpdateAccountLinkHandler(svc))
 			r.Delete("/account-links/{id}", DeleteAccountLinkHandler(svc))

--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -430,6 +430,53 @@ func ResetTransactionCategoryHandler(svc *service.Service) http.HandlerFunc {
 	}
 }
 
+// DeleteTransactionHandler soft-deletes a transaction by setting its
+// `deleted_at` timestamp. All read paths filter on `deleted_at IS NULL`, so
+// the row immediately disappears from list/get/summary/etc. The DB row is
+// preserved so a subsequent restore call can bring it back.
+//
+// DELETE /transactions/{id}
+//
+// Returns 204 on success. Returns 404 NOT_FOUND when the transaction
+// doesn't exist or is already soft-deleted — the call is idempotent at the
+// API surface (already-gone == not found).
+func DeleteTransactionHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		actor := service.ActorFromContext(r.Context())
+		if err := svc.SoftDeleteTransaction(r.Context(), id, actor); err != nil {
+			writeServiceError(w, err, "Transaction not found", "Failed to delete transaction")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// RestoreTransactionHandler clears the soft-delete flag on a previously
+// deleted transaction, bringing it back into all read paths.
+//
+// POST /transactions/{id}/restore
+//
+// Returns 204 on success. Returns 404 NOT_FOUND when the transaction
+// doesn't exist or isn't currently soft-deleted (nothing to restore).
+//
+// Note: the path-id must be a UUID for soft-deleted rows because the
+// short_id → UUID resolver itself filters on `deleted_at IS NULL` and
+// won't find a deleted row by short_id. Live (non-deleted) ids resolve
+// via either form, but they fall through to the "not currently deleted"
+// 404 anyway.
+func RestoreTransactionHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		actor := service.ActorFromContext(r.Context())
+		if err := svc.RestoreTransaction(r.Context(), id, actor); err != nil {
+			writeServiceError(w, err, "Transaction not found", "Failed to restore transaction")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
 // BatchCategorizeHandler handles POST /api/v1/transactions/batch-categorize.
 func BatchCategorizeHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/transactions_lifecycle_integration_test.go
+++ b/internal/api/transactions_lifecycle_integration_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+// Integration tests for DELETE /api/v1/transactions/{id} (soft-delete) and
+// POST /api/v1/transactions/{id}/restore (undo). Run with:
+//
+//	DATABASE_URL="postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable" \
+//	  go test -tags integration -count=1 -p 1 -v ./internal/api/... -run TestDeleteTransaction_ -run TestRestoreTransaction_
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+)
+
+// TestDeleteTransaction_SoftDeletes confirms DELETE returns 204, the row
+// disappears from GET, and the summary excludes it.
+func TestDeleteTransaction_SoftDeletes(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doDelete(t, "/api/v1/transactions/"+txnID)
+	assertStatus(t, resp, http.StatusNoContent)
+	resp.Body.Close()
+
+	// Subsequent GET returns 404 — row is hidden from the read path.
+	getResp := env.doGet(t, "/api/v1/transactions/"+txnID)
+	readErrorCode(t, getResp, http.StatusNotFound, "NOT_FOUND")
+
+	// CountTransactions filters on deleted_at IS NULL, so the deleted row
+	// must not show up. We seeded exactly one txn — count should be zero.
+	count, err := env.Service.CountTransactions(t.Context())
+	if err != nil {
+		t.Fatalf("count transactions: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("want count=0 after delete, got %d", count)
+	}
+
+	// Annotation row is written attributed to the API key actor.
+	annots, err := env.Service.ListAnnotations(t.Context(), txnID, service.ListAnnotationsParams{
+		Kinds: []string{"transaction_deleted"},
+		Raw:   true,
+	})
+	if err != nil {
+		t.Fatalf("list annotations: %v", err)
+	}
+	if len(annots) != 1 {
+		t.Fatalf("want 1 transaction_deleted annotation, got %d", len(annots))
+	}
+	if annots[0].ActorType != "agent" {
+		t.Fatalf("want actor_type=agent, got %q", annots[0].ActorType)
+	}
+}
+
+// TestDeleteTransaction_NotFound — DELETE on a fake UUID returns 404.
+func TestDeleteTransaction_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doDelete(t, "/api/v1/transactions/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// TestDeleteTransaction_AlreadyDeleted — DELETE twice; second call returns 404.
+func TestDeleteTransaction_AlreadyDeleted(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	first := env.doDelete(t, "/api/v1/transactions/"+txnID)
+	assertStatus(t, first, http.StatusNoContent)
+	first.Body.Close()
+
+	second := env.doDelete(t, "/api/v1/transactions/"+txnID)
+	readErrorCode(t, second, http.StatusNotFound, "NOT_FOUND")
+}
+
+// TestRestoreTransaction_Restores — soft-delete, then POST /restore;
+// subsequent GET returns the row again.
+func TestRestoreTransaction_Restores(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	delResp := env.doDelete(t, "/api/v1/transactions/"+txnID)
+	assertStatus(t, delResp, http.StatusNoContent)
+	delResp.Body.Close()
+
+	resResp := env.doPost(t, "/api/v1/transactions/"+txnID+"/restore", nil)
+	assertStatus(t, resResp, http.StatusNoContent)
+	resResp.Body.Close()
+
+	getResp := env.doGet(t, "/api/v1/transactions/"+txnID)
+	assertStatus(t, getResp, http.StatusOK)
+	getResp.Body.Close()
+
+	// `transaction_restored` annotation is recorded.
+	annots, err := env.Service.ListAnnotations(t.Context(), txnID, service.ListAnnotationsParams{
+		Kinds: []string{"transaction_restored"},
+		Raw:   true,
+	})
+	if err != nil {
+		t.Fatalf("list annotations: %v", err)
+	}
+	if len(annots) != 1 {
+		t.Fatalf("want 1 transaction_restored annotation, got %d", len(annots))
+	}
+}
+
+// TestRestoreTransaction_NotDeleted — POST /restore on a live (non-deleted)
+// transaction returns 404 NOT_FOUND.
+func TestRestoreTransaction_NotDeleted(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/restore", nil)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// TestRestoreTransaction_NotFound — POST /restore on a fake UUID returns 404.
+func TestRestoreTransaction_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doPost(t, "/api/v1/transactions/00000000-0000-0000-0000-000000000000/restore", nil)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// TestDeleteTransaction_RequiresWriteScope — read-only key gets 403
+// INSUFFICIENT_SCOPE before reaching the handler.
+func TestDeleteTransaction_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doDelete(t, "/api/v1/transactions/"+txnID)
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+// TestRestoreTransaction_RequiresWriteScope — read-only key gets 403
+// INSUFFICIENT_SCOPE before reaching the handler.
+func TestRestoreTransaction_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/restore", nil)
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+// TestDeleteTransaction_AcceptsShortID — DELETE works with a short_id, not
+// just a UUID. Confirms resolveTransactionID's short-id path is wired into
+// the handler.
+func TestDeleteTransaction_AcceptsShortID(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+
+	if txn.ShortID == "" {
+		t.Fatalf("expected short_id on seeded txn, got empty")
+	}
+
+	resp := env.doDelete(t, "/api/v1/transactions/"+txn.ShortID)
+	assertStatus(t, resp, http.StatusNoContent)
+	resp.Body.Close()
+
+	// The row should now be hidden — GET by short_id returns 404 because the
+	// short-id resolver itself filters on deleted_at IS NULL.
+	getResp := env.doGet(t, "/api/v1/transactions/"+txn.ShortID)
+	readErrorCode(t, getResp, http.StatusNotFound, "NOT_FOUND")
+}

--- a/internal/db/migrations/20260510034930_annotations_lifecycle_kinds.sql
+++ b/internal/db/migrations/20260510034930_annotations_lifecycle_kinds.sql
@@ -1,0 +1,42 @@
+-- +goose Up
+-- Extend the annotations.kind CHECK constraint to recognise transaction
+-- lifecycle events on the activity timeline:
+--   - transaction_deleted: written when a transaction is soft-deleted via the
+--     REST API (DELETE /transactions/{id}).
+--   - transaction_restored: written when a soft-deleted transaction is
+--     restored via POST /transactions/{id}/restore.
+--
+-- Drop + add must run in a single SQL transaction so the table is never
+-- without a constraint. Goose wraps each migration in a transaction by
+-- default, which gives us the atomicity we need; we just drop and re-add
+-- inline.
+--
+-- Additive in the shared-DB sense — older `breadbox serve` processes never
+-- write the new kinds, so they keep working even before they pick up the
+-- code that emits them.
+ALTER TABLE annotations DROP CONSTRAINT IF EXISTS annotations_kind_check;
+ALTER TABLE annotations ADD CONSTRAINT annotations_kind_check
+  CHECK (kind IN (
+    'comment',
+    'rule_applied',
+    'tag_added',
+    'tag_removed',
+    'category_set',
+    'sync_started',
+    'sync_updated',
+    'transaction_deleted',
+    'transaction_restored'
+  ));
+
+-- +goose Down
+ALTER TABLE annotations DROP CONSTRAINT IF EXISTS annotations_kind_check;
+ALTER TABLE annotations ADD CONSTRAINT annotations_kind_check
+  CHECK (kind IN (
+    'comment',
+    'rule_applied',
+    'tag_added',
+    'tag_removed',
+    'category_set',
+    'sync_started',
+    'sync_updated'
+  ));

--- a/internal/db/queries/transactions.sql
+++ b/internal/db/queries/transactions.sql
@@ -55,6 +55,16 @@ UPDATE transactions SET deleted_at = NOW()
 WHERE account_id IN (SELECT id FROM accounts WHERE connection_id = $1)
   AND deleted_at IS NULL;
 
+-- name: SoftDeleteTransactionByID :execrows
+UPDATE transactions
+SET deleted_at = NOW()
+WHERE id = $1 AND deleted_at IS NULL;
+
+-- name: RestoreTransactionByID :execrows
+UPDATE transactions
+SET deleted_at = NULL
+WHERE id = $1 AND deleted_at IS NOT NULL;
+
 -- name: GetTransaction :one
 SELECT * FROM transactions WHERE id = $1 AND deleted_at IS NULL;
 

--- a/internal/service/transactions_lifecycle.go
+++ b/internal/service/transactions_lifecycle.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"breadbox/internal/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// SoftDeleteTransaction marks a transaction as deleted by setting its
+// deleted_at timestamp. All read paths in the service layer filter on
+// `deleted_at IS NULL`, so a soft-deleted row immediately disappears from
+// list/get/summary endpoints — no separate write happens elsewhere.
+//
+// The call is idempotent at the API surface in the sense that a second call
+// returns ErrNotFound (because the row is no longer "live"). The REST
+// handler maps that to 404, signalling "no live row matches this id" — which
+// is the same response a non-existent id would produce.
+//
+// Writes a `transaction_deleted` annotation row attributed to the supplied
+// actor in the same DB transaction as the soft-delete update so the activity
+// timeline records who deleted what and when.
+func (s *Service) SoftDeleteTransaction(ctx context.Context, txnID string, actor Actor) error {
+	txnUID, err := s.resolveTransactionID(ctx, txnID)
+	if err != nil {
+		return ErrNotFound
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin soft_delete_transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	rowsAffected, err := qtx.SoftDeleteTransactionByID(ctx, txnUID)
+	if err != nil {
+		return fmt.Errorf("soft delete transaction: %w", err)
+	}
+	if rowsAffected == 0 {
+		// Row is already deleted (or doesn't exist) — treat as not found so
+		// the REST handler returns 404 and the call is idempotent at the
+		// API surface.
+		return ErrNotFound
+	}
+
+	if err := writeLifecycleAnnotation(ctx, qtx, txnUID, actor, "transaction_deleted"); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit soft_delete_transaction: %w", err)
+	}
+	return nil
+}
+
+// RestoreTransaction clears the deleted_at flag on a previously soft-deleted
+// transaction, bringing it back into all read paths. Returns ErrNotFound if
+// the transaction doesn't exist or isn't currently soft-deleted (nothing to
+// restore) — the REST handler maps that to 404 so restore is idempotent at
+// the API surface.
+//
+// Writes a `transaction_restored` annotation row attributed to the supplied
+// actor in the same DB transaction as the restore update.
+//
+// Note: resolveTransactionID hits GetTransactionUUIDByShortID, which itself
+// filters on `deleted_at IS NULL`, so short_id input for a soft-deleted row
+// won't resolve. UUID input still works because the resolver short-circuits
+// when the input parses as a UUID — that's the path used by the REST
+// handler when restoring.
+func (s *Service) RestoreTransaction(ctx context.Context, txnID string, actor Actor) error {
+	txnUID, err := s.resolveTransactionID(ctx, txnID)
+	if err != nil {
+		return ErrNotFound
+	}
+
+	tx, err := s.Pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin restore_transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	qtx := s.Queries.WithTx(tx)
+
+	rowsAffected, err := qtx.RestoreTransactionByID(ctx, txnUID)
+	if err != nil {
+		return fmt.Errorf("restore transaction: %w", err)
+	}
+	if rowsAffected == 0 {
+		// Row exists but isn't soft-deleted — nothing to restore.
+		return ErrNotFound
+	}
+
+	if err := writeLifecycleAnnotation(ctx, qtx, txnUID, actor, "transaction_restored"); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit restore_transaction: %w", err)
+	}
+	return nil
+}
+
+// writeLifecycleAnnotation writes a transaction lifecycle annotation
+// (`transaction_deleted` or `transaction_restored`). Falls back to the
+// SystemActor when the caller didn't pass one — defensive, since both
+// service entry points always have a context-derived actor in practice.
+func writeLifecycleAnnotation(ctx context.Context, q *db.Queries, txnUID pgtype.UUID, actor Actor, kind string) error {
+	if actor.Type == "" {
+		actor = SystemActor()
+	}
+	return writeAnnotation(ctx, q, writeAnnotationParams{
+		TransactionID: txnUID,
+		Kind:          kind,
+		ActorType:     normalizeAnnotationActorType(actor.Type),
+		ActorID:       actor.ID,
+		ActorName:     actor.Name,
+		Payload: map[string]interface{}{
+			"source": "rest_api",
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds soft-delete + restore for transactions. Bundle 03 of the headless-api plan.

- `DELETE /api/v1/transactions/{id}` → 204; sets `deleted_at`. Existing reads filter on `deleted_at IS NULL` so the row simply disappears from list/get/summary/etc.
- `POST /api/v1/transactions/{id}/restore` → 204; clears `deleted_at`.
- Both 404 on no-op (already-gone for delete; not-currently-deleted for restore) — the call is idempotent at the API surface.
- Annotation rows (`transaction_deleted` / `transaction_restored`) are written via the standard timeline pattern, attributed to the API key actor. The activity-timeline renderer doesn't yet surface these new kinds — they're visible via `list_annotations` and the raw table; UI surfacing is tracked as a follow-up in `docs/activity-timeline.md`.
- Adds an additive migration extending the `annotations.kind` CHECK constraint with the two new kinds.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` (unit)
- [x] `make test-integration` (api + service packages, full suites green)
- [x] 9 integration tests cover happy paths, idempotent 404s, scope enforcement, short_id resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)
