### PR TITLE
headless-api: route service errors through writeServiceError

### DIFF
--- a/internal/api/comments.go
+++ b/internal/api/comments.go
@@ -1,15 +1,35 @@
 package api
 
 import (
-	"errors"
 	"net/http"
-	"strings"
 
 	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
 )
+
+// writeCommentServiceError maps a service error from a comment handler to the
+// canonical envelope, overriding NOT_FOUND and FORBIDDEN messages with
+// resource-specific text. Falls back to a 500 INTERNAL_ERROR for anything not
+// covered by the service-error sentinel set.
+func writeCommentServiceError(w http.ResponseWriter, err error, notFoundMessage, forbiddenMessage, internalMessage string) {
+	if resp, ok := mw.MapServiceError(err); ok {
+		switch resp.Code {
+		case "NOT_FOUND":
+			if notFoundMessage != "" {
+				resp.Message = notFoundMessage
+			}
+		case "FORBIDDEN":
+			if forbiddenMessage != "" {
+				resp.Message = forbiddenMessage
+			}
+		}
+		mw.WriteError(w, resp.Status, resp.Code, resp.Message)
+		return
+	}
+	mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", internalMessage)
+}
 
 // ListCommentsHandler returns all comments for a transaction.
 func ListCommentsHandler(svc *service.Service) http.HandlerFunc {
@@ -18,11 +38,7 @@ func ListCommentsHandler(svc *service.Service) http.HandlerFunc {
 
 		comments, err := svc.ListComments(r.Context(), txnID)
 		if err != nil {
-			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
-				return
-			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list comments")
+			writeServiceError(w, err, "Transaction not found", "Failed to list comments")
 			return
 		}
 
@@ -50,15 +66,7 @@ func CreateCommentHandler(svc *service.Service) http.HandlerFunc {
 			Actor:         actor,
 		})
 		if err != nil {
-			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Transaction not found")
-				return
-			}
-			if strings.Contains(err.Error(), "content must be") {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
-				return
-			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create comment")
+			writeServiceError(w, err, "Transaction not found", "Failed to create comment")
 			return
 		}
 
@@ -85,19 +93,7 @@ func UpdateCommentHandler(svc *service.Service) http.HandlerFunc {
 			Actor:   actor,
 		})
 		if err != nil {
-			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Comment not found")
-				return
-			}
-			if errors.Is(err, service.ErrForbidden) {
-				mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "You can only edit your own comments")
-				return
-			}
-			if strings.Contains(err.Error(), "content must be") {
-				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
-				return
-			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update comment")
+			writeCommentServiceError(w, err, "Comment not found", "You can only edit your own comments", "Failed to update comment")
 			return
 		}
 
@@ -112,15 +108,7 @@ func DeleteCommentHandler(svc *service.Service) http.HandlerFunc {
 		actor := service.ActorFromContext(r.Context())
 
 		if err := svc.DeleteComment(r.Context(), commentID, actor); err != nil {
-			if errors.Is(err, service.ErrNotFound) {
-				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Comment not found")
-				return
-			}
-			if errors.Is(err, service.ErrForbidden) {
-				mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "You can only delete your own comments")
-				return
-			}
-			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete comment")
+			writeCommentServiceError(w, err, "Comment not found", "You can only delete your own comments", "Failed to delete comment")
 			return
 		}
 

--- a/internal/api/error_envelope_integration_test.go
+++ b/internal/api/error_envelope_integration_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+// Integration tests covering the canonical error envelope returned by REST
+// handlers — specifically the sentinel-to-status mapping that flows through
+// writeServiceError. These tests pin behavior so future refactors can't
+// regress 404s back into 400s the way MarkReportReadHandler did before
+// bundle 07.
+
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"breadbox/internal/pgconv"
+)
+
+// ---------- Reports ----------
+
+func TestReports_MarkRead_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// A syntactically-valid UUID that doesn't correspond to any report.
+	resp := env.doPatch(t, "/api/v1/reports/00000000-0000-0000-0000-000000000000/read", nil)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestReports_MarkRead_InvalidID(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPatch(t, "/api/v1/reports/not-a-uuid/read", nil)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// ---------- Comments ----------
+
+func TestComments_Update_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	// Comment ID is a valid UUID that does not exist.
+	resp := env.doPut(
+		t,
+		fmt.Sprintf("/api/v1/transactions/%s/comments/00000000-0000-0000-0000-000000000000", txnID),
+		map[string]string{"content": "updated"},
+	)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestComments_Delete_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doDelete(
+		t,
+		fmt.Sprintf("/api/v1/transactions/%s/comments/00000000-0000-0000-0000-000000000000", txnID),
+	)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestComments_Update_EmptyContent_InvalidParameter(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	// Create a real comment so we exercise the validation path, not NOT_FOUND.
+	create := env.doPost(t, "/api/v1/transactions/"+txnID+"/comments", map[string]string{
+		"content": "original",
+	})
+	assertStatus(t, create, http.StatusCreated)
+	var comment map[string]any
+	parseJSON(t, create, &comment)
+	commentID := comment["id"].(string)
+
+	resp := env.doPut(
+		t,
+		fmt.Sprintf("/api/v1/transactions/%s/comments/%s", txnID, commentID),
+		map[string]string{"content": ""},
+	)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestComments_Create_EmptyContent_InvalidParameter(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/comments", map[string]string{
+		"content": "",
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestComments_Create_TooLong_InvalidParameter(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	long := strings.Repeat("x", 100_000)
+	resp := env.doPost(t, "/api/v1/transactions/"+txnID+"/comments", map[string]string{
+		"content": long,
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}

--- a/internal/api/reports.go
+++ b/internal/api/reports.go
@@ -50,11 +50,10 @@ func CreateReportHandler(svc *service.Service) http.HandlerFunc {
 		actor := service.ActorFromContext(r.Context())
 		report, err := svc.CreateAgentReport(r.Context(), req.Title, req.Body, actor, req.Priority, req.Tags, req.Author, "")
 		if err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeServiceError(w, err, "", "Failed to create report")
 			return
 		}
-		w.WriteHeader(http.StatusCreated)
-		writeData(w, report)
+		writeJSON(w, http.StatusCreated, report)
 	}
 }
 
@@ -63,7 +62,7 @@ func MarkReportReadHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := chi.URLParam(r, "id")
 		if err := svc.MarkAgentReportRead(r.Context(), id); err != nil {
-			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			writeServiceError(w, err, "Report not found", "Failed to mark report as read")
 			return
 		}
 		writeData(w, map[string]bool{"ok": true})

--- a/internal/service/comments.go
+++ b/internal/service/comments.go
@@ -26,7 +26,7 @@ const MaxCommentLength = 10000
 func (s *Service) CreateComment(ctx context.Context, params CreateCommentParams) (*CommentResponse, error) {
 	content := strings.TrimSpace(params.Content)
 	if content == "" || len(content) > MaxCommentLength {
-		return nil, fmt.Errorf("content must be between 1 and %d characters", MaxCommentLength)
+		return nil, fmt.Errorf("%w: content must be between 1 and %d characters", ErrInvalidParameter, MaxCommentLength)
 	}
 
 	// Verify transaction exists and is not soft-deleted.
@@ -132,7 +132,7 @@ func (s *Service) ListComments(ctx context.Context, transactionID string) ([]Com
 func (s *Service) UpdateComment(ctx context.Context, id string, params UpdateCommentParams) (*CommentResponse, error) {
 	content := strings.TrimSpace(params.Content)
 	if content == "" || len(content) > MaxCommentLength {
-		return nil, fmt.Errorf("content must be between 1 and %d characters", MaxCommentLength)
+		return nil, fmt.Errorf("%w: content must be between 1 and %d characters", ErrInvalidParameter, MaxCommentLength)
 	}
 
 	annID, err := s.resolveAnnotationID(ctx, id)

--- a/internal/service/reports.go
+++ b/internal/service/reports.go
@@ -160,22 +160,53 @@ func (s *Service) GetAgentReport(ctx context.Context, reportID string) (AgentRep
 	return agentReportFromRow(row), nil
 }
 
-// MarkAgentReportRead marks a single report as read.
+// MarkAgentReportRead marks a single report as read. Returns ErrNotFound if no
+// report with the given ID exists. Returns nil (idempotent) if the report
+// exists but is already read.
 func (s *Service) MarkAgentReportRead(ctx context.Context, reportID string) error {
 	uid, err := pgconv.ParseUUID(reportID)
 	if err != nil {
 		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
 	}
-	return s.Queries.MarkAgentReportRead(ctx, uid)
+	// Use Pool.Exec directly to inspect rows affected — sqlc's :exec discards
+	// the CommandTag. The generated query has `AND read_at IS NULL`, so a
+	// row-affected count of zero is ambiguous (missing vs already read). To
+	// distinguish, fall back to a SELECT EXISTS check before declaring
+	// not-found.
+	tag, err := s.Pool.Exec(ctx,
+		"UPDATE agent_reports SET read_at = NOW() WHERE id = $1 AND read_at IS NULL", uid)
+	if err != nil {
+		return fmt.Errorf("mark agent report read: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		var exists bool
+		if err := s.Pool.QueryRow(ctx,
+			"SELECT EXISTS(SELECT 1 FROM agent_reports WHERE id = $1)", uid).Scan(&exists); err != nil {
+			return fmt.Errorf("mark agent report read: %w", err)
+		}
+		if !exists {
+			return ErrNotFound
+		}
+	}
+	return nil
 }
 
-// MarkAgentReportUnread clears read_at on a single report, returning it to the unread queue.
+// MarkAgentReportUnread clears read_at on a single report, returning it to the
+// unread queue. Returns ErrNotFound if no report with the given ID exists.
 func (s *Service) MarkAgentReportUnread(ctx context.Context, reportID string) error {
 	uid, err := pgconv.ParseUUID(reportID)
 	if err != nil {
 		return fmt.Errorf("%w: invalid report ID", ErrInvalidParameter)
 	}
-	return s.Queries.MarkAgentReportUnread(ctx, uid)
+	tag, err := s.Pool.Exec(ctx,
+		"UPDATE agent_reports SET read_at = NULL WHERE id = $1", uid)
+	if err != nil {
+		return fmt.Errorf("mark agent report unread: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
 }
 
 // MarkAllAgentReportsRead marks all unread reports as read.


### PR DESCRIPTION
## Summary

Cleans up hand-rolled service-error mappings in `internal/api/reports.go` and `internal/api/comments.go`, routing them through `writeServiceError` for consistent sentinel-to-status mapping.

Bundle 07 of the headless-api plan.

### Bugs fixed

- `MarkReportReadHandler` returned `400 INVALID_PARAMETER` for `service.ErrNotFound` — now `404 NOT_FOUND`. The handler was mapping `err.Error()` straight onto `INVALID_PARAMETER` regardless of which sentinel came out of the service.
- `CreateReportHandler` had the same shape — every service error came back as 400, so a hypothetical 404/forbidden would have been mis-coded too. Now goes through `writeServiceError`.
- `UpdateCommentHandler` / `DeleteCommentHandler` previously hand-rolled `errors.Is(err, service.ErrNotFound)` / `ErrForbidden` chains plus a brittle `strings.Contains(err.Error(), "content must be")` branch for the validation case. Now centralized: validation errors are wrapped with `ErrInvalidParameter` at the service layer, and the handler maps everything through a small `writeCommentServiceError` helper that preserves the resource-specific NOT_FOUND / FORBIDDEN messages.
- Service-layer fix: `MarkAgentReportRead` / `MarkAgentReportUnread` previously discarded the rows-affected count (sqlc `:exec` doesn't expose it), so they returned `nil` for non-existent reports, and the API silently 200'd. Both now use `Pool.Exec` and return `ErrNotFound` when no row matches. The Read variant additionally runs a `SELECT EXISTS` to disambiguate "missing" from "already read" since the underlying UPDATE filters with `AND read_at IS NULL`.

### Audit

Swept all of `internal/api/*.go` for `mw.WriteError(w, http.Status...)` calls mapping service errors. **No further regressions found** outside reports / comments. Notes:

- `categories.go` and `rules.go` have many hand-rolled `errors.Is` mappings, but each one returns the correct status code (404 for not-found, 409 for slug conflict, 422 for validation, etc.). Converting them to `writeServiceError` would be a stylistic refactor, not a bug fix, so they're left alone.
- `transactions.go` is being touched concurrently by Bundle B03, so it's deliberately untouched here.

### Bonus cleanup

- Replaced `w.WriteHeader(http.StatusCreated); writeData(w, ...)` in `CreateReportHandler` with a single `writeJSON(w, http.StatusCreated, ...)` call to silence the existing "superfluous response.WriteHeader" log line.

## Test plan

- [x] `go build ./... && go vet ./...` clean.
- [x] `go test ./...` (unit) passes.
- [x] New integration tests in `internal/api/error_envelope_integration_test.go` (7 tests) all pass:
  - `TestReports_MarkRead_NotFound` — non-existent report -> 404 NOT_FOUND (regression test for the headline bug).
  - `TestReports_MarkRead_InvalidID` — malformed UUID -> 400 INVALID_PARAMETER.
  - `TestComments_Update_NotFound`, `TestComments_Delete_NotFound` — non-existent comment -> 404 NOT_FOUND.
  - `TestComments_Update_EmptyContent_InvalidParameter`, `TestComments_Create_EmptyContent_InvalidParameter`, `TestComments_Create_TooLong_InvalidParameter` — content-length validation -> 400 INVALID_PARAMETER.
- [x] Existing `TestAPI_*Report*` / `TestAPI_*Comment*` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
