### PR TITLE
headless-api: tag CRUD endpoints

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -192,10 +192,14 @@ The review queue is a tag. Transactions carrying the seeded `needs-review` tag (
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
 | GET | `/tags` | Read | List all registered tags |
+| POST | `/tags` | Write | Create a tag. Body: `{"slug":"...","display_name":"...","description":"...","color":"#abc123","icon":"tag"}`. Slug must match `^[a-z0-9][a-z0-9\-:]*[a-z0-9]$`. Returns `409 SLUG_CONFLICT` if the slug is already registered. |
+| GET | `/tags/{slug}` | Read | Get a single tag by UUID, short_id, or slug |
+| PATCH | `/tags/{slug}` | Write | Partial update — every field optional: `{"display_name":"...","description":"...","color":"...","icon":"...","lifecycle":"persistent\|ephemeral"}`. Slug is immutable. |
+| DELETE | `/tags/{slug}` | Write | Delete a tag. Cascades to `transaction_tags`; annotations referencing the tag retain `tag_id=NULL`. Returns `204 No Content`. |
 | POST | `/transactions/{id}/tags` | Write | Attach a tag to a transaction (body: `{"slug":"...","note":"..."}`). Auto-creates the tag if the slug is not yet registered. Idempotent — returns `already_present: true` on repeat calls. |
 | DELETE | `/transactions/{id}/tags/{slug}` | Write | Detach a tag from a transaction. Optional `?note=...` or JSON body `{"note":"..."}` recorded on the `tag_removed` annotation. Idempotent — returns `already_absent: true` when the tag isn't attached. |
 
-Tag CRUD (create/update/delete tag records themselves) remains on the admin dashboard and MCP (`create_tag`, `update_tag`, `delete_tag`) for now; REST CRUD is tracked as a follow-up. For filtering, pass `tags=slug1,slug2` (AND) or `any_tag=slug1,slug2` (OR) to `/transactions` and `/transactions/count`.
+For filtering, pass `tags=slug1,slug2` (AND) or `any_tag=slug1,slug2` (OR) to `/transactions` and `/transactions/count`.
 
 Additional tag-touching operations exposed via MCP: `list_tags`, `add_transaction_tag`, `remove_transaction_tag`, `create_tag`, `update_tag`, `delete_tag`, `update_transactions`, `list_annotations`. The admin dashboard covers the same ground at `/tags`, `/transactions/:id/edit`, and bulk actions on `/transactions`.
 

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -124,6 +124,7 @@ func buildTestRouter(svc *service.Service) http.Handler {
 		r.Get("/reports", ListReportsHandler(svc))
 		r.Get("/reports/unread-count", UnreadReportCountHandler(svc))
 		r.Get("/tags", ListTagsHandler(svc))
+		r.Get("/tags/{slug}", GetTagHandler(svc))
 
 		// Write endpoints — require full_access scope
 		r.Group(func(r chi.Router) {
@@ -157,6 +158,9 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Patch("/reports/{id}/read", MarkReportReadHandler(svc))
 			r.Post("/transactions/{id}/tags", AddTransactionTagHandler(svc))
 			r.Delete("/transactions/{id}/tags/{slug}", RemoveTransactionTagHandler(svc))
+			r.Post("/tags", CreateTagHandler(svc))
+			r.Patch("/tags/{slug}", UpdateTagHandler(svc))
+			r.Delete("/tags/{slug}", DeleteTagHandler(svc))
 			r.Post("/sync", TriggerSyncHandler(svc))
 		})
 	})

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -74,6 +74,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/reports", ListReportsHandler(svc))
 		r.Get("/reports/unread-count", UnreadReportCountHandler(svc))
 		r.Get("/tags", ListTagsHandler(svc))
+		r.Get("/tags/{slug}", GetTagHandler(svc))
 
 		// Write endpoints — full_access API keys only.
 		r.Group(func(r chi.Router) {
@@ -111,6 +112,9 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Patch("/reports/{id}/read", MarkReportReadHandler(svc))
 			r.Post("/transactions/{id}/tags", AddTransactionTagHandler(svc))
 			r.Delete("/transactions/{id}/tags/{slug}", RemoveTransactionTagHandler(svc))
+			r.Post("/tags", CreateTagHandler(svc))
+			r.Patch("/tags/{slug}", UpdateTagHandler(svc))
+			r.Delete("/tags/{slug}", DeleteTagHandler(svc))
 		})
 	})
 

--- a/internal/api/tags.go
+++ b/internal/api/tags.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -8,6 +9,7 @@ import (
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // ListTagsHandler returns all registered tags.
@@ -20,6 +22,114 @@ func ListTagsHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 		writeData(w, map[string]any{"tags": tags})
+	}
+}
+
+// createTagRequest is the JSON body shape for POST /api/v1/tags. Mirrors
+// service.CreateTagParams plus an optional Color/Icon (both pointers so
+// callers can omit to keep them NULL).
+type createTagRequest struct {
+	Slug        string  `json:"slug"`
+	DisplayName string  `json:"display_name"`
+	Description string  `json:"description"`
+	Color       *string `json:"color,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+}
+
+// CreateTagHandler creates a new tag record.
+// POST /api/v1/tags — mirrors the create_tag MCP tool.
+func CreateTagHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var input createTagRequest
+		if !decodeJSON(w, r, &input) {
+			return
+		}
+
+		tag, err := svc.CreateTag(r.Context(), service.CreateTagParams{
+			Slug:        input.Slug,
+			DisplayName: input.DisplayName,
+			Description: input.Description,
+			Color:       input.Color,
+			Icon:        input.Icon,
+		})
+		if err != nil {
+			// Postgres returns 23505 (unique_violation) when the slug already
+			// exists. The service surfaces it as a wrapped DB error rather
+			// than a sentinel, so we map at the boundary.
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				mw.WriteError(w, http.StatusConflict, "SLUG_CONFLICT", "A tag with this slug already exists")
+				return
+			}
+			writeServiceError(w, err, "Tag not found", "Failed to create tag")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, tag)
+	}
+}
+
+// GetTagHandler returns a single tag by UUID, short_id, or slug.
+// GET /api/v1/tags/{slug}.
+func GetTagHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idOrSlug := chi.URLParam(r, "slug")
+		tag, err := svc.GetTag(r.Context(), idOrSlug)
+		if err != nil {
+			writeServiceError(w, err, "Tag not found", "Failed to get tag")
+			return
+		}
+		writeData(w, tag)
+	}
+}
+
+// updateTagRequest is the JSON body shape for PATCH /api/v1/tags/{slug}.
+// Every field is optional; omitted fields stay unchanged.
+type updateTagRequest struct {
+	DisplayName *string `json:"display_name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Color       *string `json:"color,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+	Lifecycle   *string `json:"lifecycle,omitempty"`
+}
+
+// UpdateTagHandler partially updates mutable tag fields. Slug is immutable.
+// PATCH /api/v1/tags/{slug} — mirrors the update_tag MCP tool.
+func UpdateTagHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idOrSlug := chi.URLParam(r, "slug")
+
+		var input updateTagRequest
+		if !decodeJSON(w, r, &input) {
+			return
+		}
+
+		tag, err := svc.UpdateTag(r.Context(), idOrSlug, service.UpdateTagParams{
+			DisplayName: input.DisplayName,
+			Description: input.Description,
+			Color:       input.Color,
+			Icon:        input.Icon,
+			Lifecycle:   input.Lifecycle,
+		})
+		if err != nil {
+			writeServiceError(w, err, "Tag not found", "Failed to update tag")
+			return
+		}
+		writeData(w, tag)
+	}
+}
+
+// DeleteTagHandler removes a tag. Cascades to transaction_tags rows;
+// annotations referencing the tag retain tag_id=NULL.
+// DELETE /api/v1/tags/{slug} — mirrors the delete_tag MCP tool.
+func DeleteTagHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		idOrSlug := chi.URLParam(r, "slug")
+		if err := svc.DeleteTag(r.Context(), idOrSlug); err != nil {
+			writeServiceError(w, err, "Tag not found", "Failed to delete tag")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/api/tags_crud_integration_test.go
+++ b/internal/api/tags_crud_integration_test.go
@@ -1,0 +1,295 @@
+//go:build integration
+
+// Integration tests for the tag CRUD endpoints (POST /tags, GET/PATCH/DELETE
+// /tags/{slug}). The {slug} URL param accepts UUID, short_id, or slug — see
+// service.GetTag.
+//
+// Run with: DATABASE_URL=... go test -tags integration -count=1 -p 1 -v -run Tag ./internal/api/...
+
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"breadbox/internal/service"
+)
+
+// --- helpers ---------------------------------------------------------------
+
+// createTagVia POSTs /api/v1/tags and decodes the resulting TagResponse. Fails
+// the test on non-201.
+func createTagVia(t *testing.T, env *testEnv, body map[string]any) service.TagResponse {
+	t.Helper()
+	resp := env.doPost(t, "/api/v1/tags", body)
+	assertStatus(t, resp, http.StatusCreated)
+	var tag service.TagResponse
+	parseJSON(t, resp, &tag)
+	return tag
+}
+
+// --- POST /tags ------------------------------------------------------------
+
+func TestCreateTag_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/tags", map[string]any{
+		"slug":         "needs-review",
+		"display_name": "Needs Review",
+		"description":  "Triage queue",
+		"color":        "#abc123",
+		"icon":         "tag",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+
+	var tag service.TagResponse
+	parseJSON(t, resp, &tag)
+
+	if tag.Slug != "needs-review" {
+		t.Errorf("slug: got %q, want needs-review", tag.Slug)
+	}
+	if tag.DisplayName != "Needs Review" {
+		t.Errorf("display_name: got %q, want Needs Review", tag.DisplayName)
+	}
+	if tag.Description != "Triage queue" {
+		t.Errorf("description: got %q, want Triage queue", tag.Description)
+	}
+	if tag.Color == nil || *tag.Color != "#abc123" {
+		t.Errorf("color: got %v, want #abc123", tag.Color)
+	}
+	if tag.Icon == nil || *tag.Icon != "tag" {
+		t.Errorf("icon: got %v, want tag", tag.Icon)
+	}
+	if tag.ShortID == "" {
+		t.Errorf("short_id should be set")
+	}
+	if tag.ID == "" {
+		t.Errorf("id should be set")
+	}
+	if tag.Lifecycle != "persistent" {
+		t.Errorf("lifecycle default: got %q, want persistent", tag.Lifecycle)
+	}
+}
+
+func TestCreateTag_DuplicateSlug(t *testing.T) {
+	env := setupTestEnv(t)
+
+	_ = createTagVia(t, env, map[string]any{
+		"slug":         "duplicate-slug",
+		"display_name": "First",
+	})
+	resp := env.doPost(t, "/api/v1/tags", map[string]any{
+		"slug":         "duplicate-slug",
+		"display_name": "Second",
+	})
+	readErrorCode(t, resp, http.StatusConflict, "SLUG_CONFLICT")
+}
+
+func TestCreateTag_InvalidSlug(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/tags", map[string]any{
+		"slug":         "Invalid Slug!", // spaces + uppercase + bang
+		"display_name": "Bad",
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestCreateTag_EmptyDisplayName(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/tags", map[string]any{
+		"slug":         "no-name",
+		"display_name": "   ", // trims to empty
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// --- GET /tags/{slug} ------------------------------------------------------
+
+func TestGetTag_BySlug(t *testing.T) {
+	env := setupTestEnv(t)
+	created := createTagVia(t, env, map[string]any{
+		"slug":         "by-slug",
+		"display_name": "By Slug",
+	})
+
+	resp := env.doGet(t, "/api/v1/tags/by-slug")
+	assertStatus(t, resp, http.StatusOK)
+
+	var got service.TagResponse
+	parseJSON(t, resp, &got)
+	if got.ID != created.ID {
+		t.Errorf("id mismatch: got %s, want %s", got.ID, created.ID)
+	}
+}
+
+func TestGetTag_ByShortID(t *testing.T) {
+	env := setupTestEnv(t)
+	created := createTagVia(t, env, map[string]any{
+		"slug":         "by-short",
+		"display_name": "By Short",
+	})
+
+	resp := env.doGet(t, "/api/v1/tags/"+created.ShortID)
+	assertStatus(t, resp, http.StatusOK)
+
+	var got service.TagResponse
+	parseJSON(t, resp, &got)
+	if got.Slug != "by-short" {
+		t.Errorf("slug: got %q, want by-short", got.Slug)
+	}
+}
+
+func TestGetTag_ByUUID(t *testing.T) {
+	env := setupTestEnv(t)
+	created := createTagVia(t, env, map[string]any{
+		"slug":         "by-uuid",
+		"display_name": "By UUID",
+	})
+
+	resp := env.doGet(t, "/api/v1/tags/"+created.ID)
+	assertStatus(t, resp, http.StatusOK)
+
+	var got service.TagResponse
+	parseJSON(t, resp, &got)
+	if got.Slug != "by-uuid" {
+		t.Errorf("slug: got %q, want by-uuid", got.Slug)
+	}
+}
+
+func TestGetTag_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doGet(t, "/api/v1/tags/no-such-tag")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// --- PATCH /tags/{slug} ----------------------------------------------------
+
+func TestUpdateTag_PatchPartial(t *testing.T) {
+	env := setupTestEnv(t)
+
+	color := "#111111"
+	icon := "old-icon"
+	created := createTagVia(t, env, map[string]any{
+		"slug":         "patch-me",
+		"display_name": "Original",
+		"description":  "original desc",
+		"color":        color,
+		"icon":         icon,
+	})
+
+	// Only update display_name; everything else should stay.
+	resp := env.doPatch(t, "/api/v1/tags/patch-me", map[string]any{
+		"display_name": "Updated",
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var got service.TagResponse
+	parseJSON(t, resp, &got)
+
+	if got.DisplayName != "Updated" {
+		t.Errorf("display_name: got %q, want Updated", got.DisplayName)
+	}
+	if got.Description != created.Description {
+		t.Errorf("description should be preserved: got %q, want %q", got.Description, created.Description)
+	}
+	if got.Color == nil || *got.Color != color {
+		t.Errorf("color should be preserved: got %v, want %s", got.Color, color)
+	}
+	if got.Icon == nil || *got.Icon != icon {
+		t.Errorf("icon should be preserved: got %v, want %s", got.Icon, icon)
+	}
+	if got.Lifecycle != created.Lifecycle {
+		t.Errorf("lifecycle should be preserved: got %q, want %q", got.Lifecycle, created.Lifecycle)
+	}
+}
+
+func TestUpdateTag_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doPatch(t, "/api/v1/tags/no-such-tag", map[string]any{
+		"display_name": "Whatever",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestUpdateTag_EmptyDisplayName(t *testing.T) {
+	env := setupTestEnv(t)
+	_ = createTagVia(t, env, map[string]any{
+		"slug":         "patch-empty",
+		"display_name": "Original",
+	})
+
+	resp := env.doPatch(t, "/api/v1/tags/patch-empty", map[string]any{
+		"display_name": "   ", // trims to empty
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// --- DELETE /tags/{slug} ---------------------------------------------------
+
+func TestDeleteTag_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	_ = createTagVia(t, env, map[string]any{
+		"slug":         "delete-me",
+		"display_name": "Delete Me",
+	})
+
+	resp := env.doDelete(t, "/api/v1/tags/delete-me")
+	assertStatus(t, resp, http.StatusNoContent)
+
+	// Subsequent GET should 404.
+	getResp := env.doGet(t, "/api/v1/tags/delete-me")
+	readErrorCode(t, getResp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestDeleteTag_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doDelete(t, "/api/v1/tags/no-such-tag")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// --- Scope enforcement -----------------------------------------------------
+
+func TestCreateTag_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	resp := env.doPost(t, "/api/v1/tags", map[string]any{
+		"slug":         "ro-create",
+		"display_name": "Nope",
+	})
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+func TestPatchTag_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	resp := env.doPatch(t, "/api/v1/tags/anything", map[string]any{
+		"display_name": "Nope",
+	})
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+func TestDeleteTag_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	resp := env.doDelete(t, "/api/v1/tags/anything")
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+func TestGetTag_AllowsReadScope(t *testing.T) {
+	// Read-only key should be able to GET. Seed via a full-access env first,
+	// then re-issue the GET with a read-only key on a fresh server.
+	env := setupTestEnv(t)
+	_ = createTagVia(t, env, map[string]any{
+		"slug":         "read-me",
+		"display_name": "Read Me",
+	})
+
+	// Same DB, new env with read-only key.
+	roKey, err := env.Service.CreateAPIKey(t.Context(), "ro-read-tag", "read_only")
+	if err != nil {
+		t.Fatalf("create read-only API key: %v", err)
+	}
+	roEnv := &testEnv{Server: env.Server, APIKey: roKey.PlaintextKey, Service: env.Service, Queries: env.Queries, Pool: env.Pool}
+
+	resp := roEnv.doGet(t, "/api/v1/tags/read-me")
+	assertStatus(t, resp, http.StatusOK)
+}


### PR DESCRIPTION
## Summary

Adds tag CRUD endpoints (Bundle 05 of headless-api).

- `POST /api/v1/tags` (Write) — create
- `GET /api/v1/tags/{slug}` (Read) — get by UUID/short_id/slug
- `PATCH /api/v1/tags/{slug}` (Write) — partial update
- `DELETE /api/v1/tags/{slug}` (Write) — delete

Wraps existing service methods 1:1; no service-layer changes. Closes the doc-tracked tag-CRUD follow-up.

`service.CreateTag` does not surface a sentinel for duplicate-slug — Postgres returns 23505 unwrapped — so the handler maps that one DB error code at the boundary to `409 SLUG_CONFLICT` (mirrors the existing pattern in `CreateCategoryHandler`). Everything else flows through `writeServiceError`.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `make test-integration`
- [x] 17 integration tests cover happy paths, duplicate slug, validation, scope enforcement, and all three identifier forms (UUID/short_id/slug)

## Files

- `internal/api/tags.go` — `CreateTagHandler`, `GetTagHandler`, `UpdateTagHandler`, `DeleteTagHandler`
- `internal/api/router.go` — route registration (read + write groups)
- `internal/api/api_integration_test.go` — test router wiring
- `internal/api/tags_crud_integration_test.go` — 17 integration tests (new file)
- `docs/api-reference.md` — replaces follow-up note with full CRUD table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
