### PR TITLE
headless-api: GET /transactions/{id}/annotations

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -45,6 +45,7 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 | GET | `/transactions/summary` | Read | Aggregated totals by category, month, week, day |
 | GET | `/transactions/merchants` | Read | Merchant-level stats (count, total, avg) |
 | GET | `/transactions/{id}` | Read | Get a single transaction |
+| GET | `/transactions/{id}/annotations` | Read | List the activity-timeline rows for a transaction (comments, rule applications, tag/category changes). Mirror of MCP `list_annotations`. |
 | PATCH | `/transactions/{id}/category` | Write | Set transaction category (override) |
 | DELETE | `/transactions/{id}/category` | Write | Reset transaction category to provider default |
 | POST | `/transactions/batch-categorize` | Write | Batch categorize multiple transactions (max 500) |
@@ -184,6 +185,46 @@ Path id accepts either a UUID or short_id for live (non-deleted) rows. Restore o
 | POST | `/transactions/{id}/comments` | Write | Add a comment to a transaction |
 | PUT | `/transactions/{id}/comments/{comment_id}` | Write | Update a comment |
 | DELETE | `/transactions/{id}/comments/{comment_id}` | Write | Delete a comment |
+
+## Transaction Annotations
+
+`GET /transactions/{id}/annotations` returns the activity-timeline rows for a single transaction — comments, rule applications, tag adds/removes, and category sets. Same payload as the MCP `list_annotations` tool, wrapped in a `{ "annotations": [...] }` envelope. The rendering contract (dedup, soft-delete tombstones, system-event kinds) is documented in `docs/activity-timeline.md`.
+
+Path id accepts either a UUID or short_id (the same resolver as the rest of the transaction endpoints).
+
+| Query param | Type | Description |
+|-------------|------|-------------|
+| `kind` | string (repeatable, comma-separated) | Filter by raw DB kind: `comment`, `rule_applied`, `tag_added`, `tag_removed`, `category_set`, `sync_started`, `sync_updated`. Both `?kind=comment&kind=rule_applied` and `?kind=comment,rule_applied` are accepted. |
+| `actor_type` | string (repeatable, comma-separated) | Filter by actor type: `user`, `agent`, `system`. Same repeatable / comma-separated handling as `kind`. |
+| `since` | string (RFC3339) | Return only rows created strictly after this timestamp. Pair with `limit` to bound a delta read. |
+| `limit` | int | Cap the returned rows to the most recent N (timeline tail), still ordered ASC. `0` (default) returns the full timeline; the server caps at `200`. Negative values are rejected. |
+| `raw` | bool | When `true`, bypass enrichment and dedup. Returns the unmodified DB view — rule-source duplicates and same-actor adjacent comment-vs-tag-note pairs survive, and the derived `summary` / `action` / `subject` fields are empty. |
+
+Example:
+
+```bash
+curl -H "X-API-Key: $BB_API_KEY" \
+  "https://breadbox.example.com/api/v1/transactions/abc12345/annotations?kind=comment&limit=5"
+```
+
+```json
+{
+  "annotations": [
+    {
+      "id": "01J...",
+      "short_id": "ann7zk2x",
+      "transaction_id": "01J...",
+      "kind": "comment",
+      "actor_type": "user",
+      "actor_name": "Alice",
+      "content": "needs receipt",
+      "created_at": "2026-04-26T12:00:00Z"
+    }
+  ]
+}
+```
+
+A 400 `INVALID_PARAMETER` is returned for malformed `since` timestamps or non-numeric / negative `limit` values; 404 `NOT_FOUND` is returned when the path id can't be resolved (the same MCP-shared limitation applies — a syntactically valid but unknown UUID returns an empty list rather than 404).
 
 ## Tags & Reviews
 

--- a/internal/api/annotations.go
+++ b/internal/api/annotations.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// ListAnnotationsHandler returns the activity-timeline rows for a transaction.
+// REST sibling of the MCP list_annotations tool. Wraps service.ListAnnotations
+// 1:1 with no service changes.
+//
+// Path param `{id}` accepts UUID or short_id (the service resolver handles
+// both). Query params:
+//
+//   - kind: repeatable or comma-separated (e.g. ?kind=comment&kind=rule_applied
+//     or ?kind=comment,rule_applied) — maps to ListAnnotationsParams.Kinds.
+//     Values are the raw DB kinds (comment, rule_applied, tag_added,
+//     tag_removed, category_set, sync_started, sync_updated). The MCP tool
+//     exposes a coarser generic-kind alias set; REST uses raw kinds for
+//     parity with the underlying schema.
+//   - actor_type: repeatable or comma-separated (user | agent | system) —
+//     maps to ActorTypes.
+//   - since: RFC3339 timestamp; only annotations strictly after this time —
+//     maps to Since.
+//   - limit: integer; 0 (default) = full timeline, capped server-side at
+//     service.MaxAnnotationLimit — maps to Limit.
+//   - raw: boolean (true/1/yes); bypass enrichment + dedup — maps to Raw.
+func ListAnnotationsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		q := r.URL.Query()
+
+		kinds := parseCSVParam(q, "kind")
+		actorTypes := parseCSVParam(q, "actor_type")
+
+		var since time.Time
+		if raw := q.Get("since"); raw != "" {
+			t, err := parseSinceParam(raw)
+			if err != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				return
+			}
+			since = t
+		}
+
+		limit := 0
+		if raw := q.Get("limit"); raw != "" {
+			n, err := strconv.Atoi(raw)
+			if err != nil || n < 0 {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "limit must be a non-negative integer")
+				return
+			}
+			limit = n
+		}
+
+		rawMode := false
+		if raw := q.Get("raw"); raw != "" {
+			b, err := strconv.ParseBool(raw)
+			if err != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "raw must be true or false")
+				return
+			}
+			rawMode = b
+		}
+
+		annotations, err := svc.ListAnnotations(r.Context(), id, service.ListAnnotationsParams{
+			Kinds:      kinds,
+			ActorTypes: actorTypes,
+			Since:      since,
+			Limit:      limit,
+			Raw:        rawMode,
+		})
+		if err != nil {
+			writeServiceError(w, err, "Transaction not found", "Failed to list annotations")
+			return
+		}
+
+		// Always return a non-nil slice so the JSON shape is `[]` not `null`.
+		if annotations == nil {
+			annotations = []service.Annotation{}
+		}
+
+		writeData(w, map[string]any{"annotations": annotations})
+	}
+}
+
+// errInvalidSince is returned when the since query param doesn't parse as
+// RFC3339 / RFC3339Nano. The handler maps this to a 400 INVALID_PARAMETER.
+var errInvalidSince = errors.New("since must be an RFC3339 timestamp (e.g. 2026-04-26T12:00:00Z)")
+
+// parseSinceParam accepts an RFC3339 (or RFC3339Nano) timestamp. Mirrors the
+// MCP parseSince behavior so REST and MCP agents see the same accepted shapes.
+func parseSinceParam(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	return time.Time{}, errInvalidSince
+}

--- a/internal/api/annotations_integration_test.go
+++ b/internal/api/annotations_integration_test.go
@@ -1,0 +1,461 @@
+//go:build integration
+
+// Integration tests for GET /api/v1/transactions/{id}/annotations.
+// Run with:
+//   DATABASE_URL="postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable" \
+//   go test -tags integration -count=1 -p 1 -v ./internal/api/... -run TestAPI_ListAnnotations
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+)
+
+// annotationRow mirrors the per-row JSON shape the handler emits, with the
+// fields each test checks. Unrecognized fields are tolerated.
+type annotationRow struct {
+	ID            string         `json:"id"`
+	ShortID       string         `json:"short_id"`
+	TransactionID string         `json:"transaction_id"`
+	Kind          string         `json:"kind"`
+	ActorType     string         `json:"actor_type"`
+	ActorName     string         `json:"actor_name"`
+	Content       string         `json:"content,omitempty"`
+	Summary       string         `json:"summary,omitempty"`
+	Action        string         `json:"action,omitempty"`
+	CreatedAt     string         `json:"created_at"`
+	Payload       map[string]any `json:"payload,omitempty"`
+}
+
+// listAnnotations issues GET /api/v1/transactions/{txnID}/annotations[?query]
+// and returns the parsed row list. Fails the test on unexpected status.
+func listAnnotations(t *testing.T, env *testEnv, txnID, query string) []annotationRow {
+	t.Helper()
+	path := "/api/v1/transactions/" + txnID + "/annotations"
+	if query != "" {
+		path += "?" + query
+	}
+	resp := env.doGet(t, path)
+	assertStatus(t, resp, http.StatusOK)
+	var body struct {
+		Annotations []annotationRow `json:"annotations"`
+	}
+	parseJSON(t, resp, &body)
+	return body.Annotations
+}
+
+// userActor builds a service.Actor for a human user. Tests seed annotations
+// directly via service methods (which bypass HTTP middleware) and so pass the
+// actor explicitly.
+func userActor(name string) service.Actor {
+	return service.Actor{Type: "user", ID: "", Name: name}
+}
+
+// TestAPI_ListAnnotations_Empty: a transaction with no activity returns an
+// empty annotations array (and 200 OK).
+func TestAPI_ListAnnotations_Empty(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+
+	rows := listAnnotations(t, env, pgconv.FormatUUID(txn.ID), "")
+	if len(rows) != 0 {
+		t.Fatalf("want empty annotations, got %d rows: %+v", len(rows), rows)
+	}
+}
+
+// TestAPI_ListAnnotations_AfterComment: a single comment surfaces with the
+// expected fields populated.
+func TestAPI_ListAnnotations_AfterComment(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	if _, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "needs receipt",
+		Actor:         userActor("Alice"),
+	}); err != nil {
+		t.Fatalf("seed comment: %v", err)
+	}
+
+	rows := listAnnotations(t, env, txnID, "")
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d: %+v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.Kind != "comment" {
+		t.Errorf("want kind=comment, got %q", row.Kind)
+	}
+	if row.ActorType != "user" {
+		t.Errorf("want actor_type=user, got %q", row.ActorType)
+	}
+	if row.ActorName != "Alice" {
+		t.Errorf("want actor_name=Alice, got %q", row.ActorName)
+	}
+	if row.Content != "needs receipt" {
+		t.Errorf("want content='needs receipt', got %q", row.Content)
+	}
+	if row.ID == "" || row.ShortID == "" {
+		t.Errorf("want id and short_id populated, got id=%q short_id=%q", row.ID, row.ShortID)
+	}
+	if row.TransactionID == "" {
+		t.Error("want transaction_id populated")
+	}
+}
+
+// TestAPI_ListAnnotations_AfterMultipleEvents: category set + tag added +
+// comment all surface, ordered ASC by created_at.
+func TestAPI_ListAnnotations_AfterMultipleEvents(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	cat := seedUncategorized(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	if err := env.Service.SetTransactionCategory(t.Context(), txnID, pgconv.FormatUUID(cat.ID), userActor("Alice")); err != nil {
+		t.Fatalf("set category: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if _, _, err := env.Service.AddTransactionTag(t.Context(), txnID, "needs-review", userActor("Alice")); err != nil {
+		t.Fatalf("add tag: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if _, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "follow up",
+		Actor:         userActor("Alice"),
+	}); err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+
+	rows := listAnnotations(t, env, txnID, "")
+	if len(rows) < 3 {
+		t.Fatalf("want at least 3 rows, got %d: %+v", len(rows), rows)
+	}
+
+	// Verify ASC ordering by parsing created_at as RFC3339.
+	for i := 1; i < len(rows); i++ {
+		prev, err1 := time.Parse(time.RFC3339, rows[i-1].CreatedAt)
+		curr, err2 := time.Parse(time.RFC3339, rows[i].CreatedAt)
+		if err1 != nil || err2 != nil {
+			t.Fatalf("parse created_at: %v / %v", err1, err2)
+		}
+		if curr.Before(prev) {
+			t.Errorf("rows not ASC at index %d: %s before %s", i, rows[i].CreatedAt, rows[i-1].CreatedAt)
+		}
+	}
+
+	// Verify the kinds we produced are present (enrichment may dedup
+	// adjacent comment-vs-tag-note rows, but our comment is not a tag note
+	// so all three rows should survive).
+	kinds := make(map[string]int)
+	for _, r := range rows {
+		kinds[r.Kind]++
+	}
+	if kinds["category_set"] == 0 {
+		t.Errorf("want a category_set row, got kinds=%+v", kinds)
+	}
+	if kinds["tag_added"] == 0 {
+		t.Errorf("want a tag_added row, got kinds=%+v", kinds)
+	}
+	if kinds["comment"] == 0 {
+		t.Errorf("want a comment row, got kinds=%+v", kinds)
+	}
+}
+
+// TestAPI_ListAnnotations_FilterByKind: ?kind=comment returns only the
+// comment row.
+func TestAPI_ListAnnotations_FilterByKind(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	cat := seedUncategorized(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	if err := env.Service.SetTransactionCategory(t.Context(), txnID, pgconv.FormatUUID(cat.ID), userActor("Alice")); err != nil {
+		t.Fatalf("set category: %v", err)
+	}
+	if _, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "comment-only",
+		Actor:         userActor("Alice"),
+	}); err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+
+	rows := listAnnotations(t, env, txnID, "kind=comment")
+	if len(rows) == 0 {
+		t.Fatalf("want at least 1 comment row, got 0")
+	}
+	for _, r := range rows {
+		if r.Kind != "comment" {
+			t.Errorf("kind=comment filter leaked %q row", r.Kind)
+		}
+	}
+}
+
+// TestAPI_ListAnnotations_FilterByMultipleKinds: ?kind=comment&kind=tag_added
+// returns the union of both kinds.
+func TestAPI_ListAnnotations_FilterByMultipleKinds(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	cat := seedUncategorized(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	if err := env.Service.SetTransactionCategory(t.Context(), txnID, pgconv.FormatUUID(cat.ID), userActor("Alice")); err != nil {
+		t.Fatalf("set category: %v", err)
+	}
+	if _, _, err := env.Service.AddTransactionTag(t.Context(), txnID, "needs-review", userActor("Alice")); err != nil {
+		t.Fatalf("add tag: %v", err)
+	}
+	if _, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "hello",
+		Actor:         userActor("Alice"),
+	}); err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+
+	// Repeatable form: ?kind=comment&kind=tag_added
+	rows := listAnnotations(t, env, txnID, "kind=comment&kind=tag_added")
+	for _, r := range rows {
+		if r.Kind != "comment" && r.Kind != "tag_added" {
+			t.Errorf("multi-kind filter leaked %q row", r.Kind)
+		}
+	}
+	saw := map[string]bool{}
+	for _, r := range rows {
+		saw[r.Kind] = true
+	}
+	if !saw["comment"] || !saw["tag_added"] {
+		t.Errorf("want both kinds present, got %+v", saw)
+	}
+
+	// Comma-separated form: ?kind=comment,tag_added
+	csvRows := listAnnotations(t, env, txnID, "kind=comment,tag_added")
+	if len(csvRows) != len(rows) {
+		t.Errorf("comma-form returned %d rows, repeatable returned %d", len(csvRows), len(rows))
+	}
+}
+
+// TestAPI_ListAnnotations_FilterByActorType: ?actor_type=user excludes
+// non-user rows.
+func TestAPI_ListAnnotations_FilterByActorType(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	// User comment.
+	if _, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "human",
+		Actor:         userActor("Alice"),
+	}); err != nil {
+		t.Fatalf("user comment: %v", err)
+	}
+	// Agent comment.
+	if _, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "robot",
+		Actor:         service.Actor{Type: "agent", ID: "key-1", Name: "TestAgent"},
+	}); err != nil {
+		t.Fatalf("agent comment: %v", err)
+	}
+
+	rows := listAnnotations(t, env, txnID, "actor_type=user")
+	if len(rows) == 0 {
+		t.Fatalf("want at least 1 user-actor row, got 0")
+	}
+	for _, r := range rows {
+		if r.ActorType != "user" {
+			t.Errorf("actor_type=user filter leaked %q row", r.ActorType)
+		}
+	}
+}
+
+// TestAPI_ListAnnotations_Since: with a cursor between two annotations, only
+// the second is returned.
+func TestAPI_ListAnnotations_Since(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	first, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "first",
+		Actor:         userActor("Alice"),
+	})
+	if err != nil {
+		t.Fatalf("first comment: %v", err)
+	}
+
+	// Sleep beyond second precision to make the RFC3339 cursor unambiguous.
+	time.Sleep(1100 * time.Millisecond)
+	cursor := time.Now().UTC()
+	time.Sleep(1100 * time.Millisecond)
+
+	if _, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+		TransactionID: txnID,
+		Content:       "second",
+		Actor:         userActor("Alice"),
+	}); err != nil {
+		t.Fatalf("second comment: %v", err)
+	}
+
+	rows := listAnnotations(t, env, txnID, "since="+cursor.Format(time.RFC3339))
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row after since cursor, got %d: %+v (first=%q)", len(rows), rows, first.ID)
+	}
+	if rows[0].Content != "second" {
+		t.Errorf("want content='second', got %q", rows[0].Content)
+	}
+}
+
+// TestAPI_ListAnnotations_Limit: with N annotations, ?limit=2 returns the
+// most recent 2.
+func TestAPI_ListAnnotations_Limit(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	for i, content := range []string{"one", "two", "three", "four"} {
+		if _, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+			TransactionID: txnID,
+			Content:       content,
+			Actor:         userActor("Alice"),
+		}); err != nil {
+			t.Fatalf("comment %d: %v", i, err)
+		}
+		// Spread events so ASC ordering is deterministic.
+		time.Sleep(15 * time.Millisecond)
+	}
+
+	rows := listAnnotations(t, env, txnID, "limit=2")
+	if len(rows) != 2 {
+		t.Fatalf("want 2 rows, got %d: %+v", len(rows), rows)
+	}
+	// limit returns the tail, still ASC. So the last two created rows.
+	if rows[0].Content != "three" || rows[1].Content != "four" {
+		t.Errorf("want tail [three, four], got [%q, %q]", rows[0].Content, rows[1].Content)
+	}
+}
+
+// TestAPI_ListAnnotations_Raw: ?raw=true bypasses enrichment, so the
+// derived Summary field is empty (enriched runs populate it for non-comment
+// kinds; for comments raw vs enriched both leave Summary empty, but the
+// rule_applied dedup is also disabled — for this test we just assert that
+// raw mode does not blow up and returns the rows.
+func TestAPI_ListAnnotations_Raw(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	cat := seedUncategorized(t, env.Queries)
+	txnID := pgconv.FormatUUID(txn.ID)
+
+	if err := env.Service.SetTransactionCategory(t.Context(), txnID, pgconv.FormatUUID(cat.ID), userActor("Alice")); err != nil {
+		t.Fatalf("set category: %v", err)
+	}
+
+	enriched := listAnnotations(t, env, txnID, "")
+	raw := listAnnotations(t, env, txnID, "raw=true")
+
+	if len(raw) == 0 {
+		t.Fatalf("raw mode returned 0 rows")
+	}
+
+	// In enriched mode the category_set row carries a populated Summary
+	// (e.g. "Alice set category to Uncategorized"). In raw mode the Summary
+	// is empty because enrichment is the thing that builds it.
+	var enrichedCatRow, rawCatRow *annotationRow
+	for i := range enriched {
+		if enriched[i].Kind == "category_set" {
+			enrichedCatRow = &enriched[i]
+			break
+		}
+	}
+	for i := range raw {
+		if raw[i].Kind == "category_set" {
+			rawCatRow = &raw[i]
+			break
+		}
+	}
+	if enrichedCatRow == nil || rawCatRow == nil {
+		t.Fatalf("missing category_set row: enriched=%v raw=%v", enrichedCatRow, rawCatRow)
+	}
+	if enrichedCatRow.Summary == "" {
+		t.Errorf("enriched category_set row should carry Summary, got empty")
+	}
+	if rawCatRow.Summary != "" {
+		t.Errorf("raw category_set row should not carry Summary, got %q", rawCatRow.Summary)
+	}
+}
+
+// TestAPI_ListAnnotations_NotFound: unknown short_id → 404 NOT_FOUND.
+//
+// Mirrors the existing service behavior shared with the MCP list_annotations
+// tool: short_id resolution misses cleanly to ErrNotFound (the DB lookup
+// returns no rows, the resolver maps that to NOT_FOUND). A syntactically
+// valid UUID that doesn't match any row is treated as resolved and returns
+// an empty list — the resolver doesn't probe the transactions table for raw
+// UUIDs. Both behaviors are intentional and shared with the MCP tool.
+func TestAPI_ListAnnotations_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/transactions/00000000/annotations")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// TestAPI_ListAnnotations_AcceptsShortID: lookup by short_id resolves to the
+// same row set as lookup by UUID.
+func TestAPI_ListAnnotations_AcceptsShortID(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+	if _, err := env.Service.CreateComment(t.Context(), service.CreateCommentParams{
+		TransactionID: pgconv.FormatUUID(txn.ID),
+		Content:       "via short id",
+		Actor:         userActor("Alice"),
+	}); err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+
+	rows := listAnnotations(t, env, txn.ShortID, "")
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row via short_id, got %d", len(rows))
+	}
+	if rows[0].Content != "via short id" {
+		t.Errorf("want content via short id, got %q", rows[0].Content)
+	}
+}
+
+// TestAPI_ListAnnotations_BadSince: malformed timestamp → 400 INVALID_PARAMETER.
+func TestAPI_ListAnnotations_BadSince(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+
+	resp := env.doGet(t, "/api/v1/transactions/"+pgconv.FormatUUID(txn.ID)+"/annotations?since=not-a-timestamp")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// TestAPI_ListAnnotations_BadLimit: negative limit → 400 INVALID_PARAMETER.
+func TestAPI_ListAnnotations_BadLimit(t *testing.T) {
+	env := setupTestEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+
+	resp := env.doGet(t, "/api/v1/transactions/"+pgconv.FormatUUID(txn.ID)+"/annotations?limit=-1")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+
+	resp = env.doGet(t, "/api/v1/transactions/"+pgconv.FormatUUID(txn.ID)+"/annotations?limit=notanumber")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// TestAPI_ListAnnotations_AllowsReadOnlyKey: read-only API key can list
+// annotations (read scope).
+func TestAPI_ListAnnotations_AllowsReadOnlyKey(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	_, _, txn := seedFixture(t, env.Queries)
+
+	resp := env.doGet(t, "/api/v1/transactions/"+pgconv.FormatUUID(txn.ID)+"/annotations")
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+}

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -118,6 +118,7 @@ func buildTestRouter(svc *service.Service) http.Handler {
 		r.Get("/rules", ListRulesHandler(svc))
 		r.Get("/rules/{id}", GetRuleHandler(svc))
 		r.Get("/transactions/{transaction_id}/comments", ListCommentsHandler(svc))
+		r.Get("/transactions/{id}/annotations", ListAnnotationsHandler(svc))
 		r.Get("/account-links", ListAccountLinksHandler(svc))
 		r.Get("/account-links/{id}", GetAccountLinkHandler(svc))
 		r.Get("/account-links/{id}/matches", ListTransactionMatchesHandler(svc))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -66,6 +66,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/connections", ListConnectionsHandler(svc))
 		r.Get("/connections/{id}/status", GetConnectionStatusHandler(svc))
 		r.Get("/transactions/{transaction_id}/comments", ListCommentsHandler(svc))
+		r.Get("/transactions/{id}/annotations", ListAnnotationsHandler(svc))
 		r.Get("/rules", ListRulesHandler(svc))
 		r.Get("/rules/{id}", GetRuleHandler(svc))
 		r.Get("/account-links", ListAccountLinksHandler(svc))


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/transactions/{id}/annotations` — REST sibling of MCP `list_annotations`. Bundle 06 of headless-api.

- `?kind=`, `?actor_type=` — repeatable or comma-separated
- `?since=` — RFC3339 timestamp, ASC
- `?limit=` — 0 = unlimited, server-capped
- `?raw=true` — bypass enrichment + dedup
- 404 for unknown transactions (short_id miss); a syntactically valid but unknown UUID returns an empty list, matching MCP behavior
- Read-scope (any API key)

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `make test-integration` (full suite green)
- [x] 14 integration tests cover empty, single/multi event, filters (kind, actor_type, since, limit, raw), 404, short_id, bad input, scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)
