### PR TITLE
headless-api: Plaid re-auth REST endpoints

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -107,6 +107,8 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 | POST | `/connections/{id}/paused` | Write | Pause or resume scheduled syncs for a connection |
 | POST | `/connections/{id}/sync-interval` | Write | Set or clear a per-connection sync-interval override |
 | DELETE | `/connections/{id}` | Write | Soft-disconnect a connection (clears tokens, hides from list) |
+| POST | `/connections/{id}/reauth` | Write | Start the provider re-auth flow — returns a fresh link token |
+| POST | `/connections/{id}/reauth-complete` | Write | Mark connection active again after the user finishes the re-auth flow |
 
 `{id}` accepts either the connection's UUID or 8-char short_id.
 
@@ -179,6 +181,47 @@ Soft-disconnect: flips status to `disconnected`, wipes the encrypted access toke
 Returns `204 No Content`. Calling on a missing or already-disconnected connection returns `404 NOT_FOUND` (idempotent at the API surface).
 
 Provider-side credential revocation (e.g. Plaid's `/item/remove`) is **not** performed by the REST endpoint — it is admin-handler-only because the public service layer doesn't carry the provider registry. The connection is unusable from Breadbox's side regardless.
+
+### POST `/connections/{id}/reauth`
+
+Starts a provider re-auth flow for a connection in `pending_reauth` (or any
+broken) state. Calls the provider for a short-lived link token; the client
+hands the token to the provider's UI (Plaid Link, Teller Connect, etc.) and
+calls `/reauth-complete` once the user finishes.
+
+Body: none.
+
+Returns `200`:
+
+```json
+{
+  "link_token": "link-sandbox-...",
+  "expiration": "2026-05-09T16:30:00Z"
+}
+```
+
+Errors:
+
+- `404 NOT_FOUND` — connection doesn't exist.
+- `400 INVALID_PARAMETER` — connection's provider isn't configured on this server.
+- `502 PROVIDER_ERROR` — upstream provider call failed.
+
+### POST `/connections/{id}/reauth-complete`
+
+Marks a previously broken connection active again and clears `error_code` /
+`error_message`. Call this after the user has completed the provider re-auth
+UI started by `/reauth`. Body is ignored — Plaid's OAuth redirect path
+exchanges the public token out-of-band, so no payload is required today.
+
+Returns `200`:
+
+```json
+{ "status": "active" }
+```
+
+Errors:
+
+- `404 NOT_FOUND` — connection doesn't exist.
 
 ## Sync
 

--- a/internal/api/connections_reauth.go
+++ b/internal/api/connections_reauth.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"breadbox/internal/app"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// reauthLinkTokenResponse is the JSON shape returned by
+// POST /api/v1/connections/{id}/reauth. Mirrors the admin
+// linkTokenResponse field-for-field so SDK clients see one contract for
+// link-token issuance regardless of which surface called it.
+type reauthLinkTokenResponse struct {
+	LinkToken  string `json:"link_token"`
+	Expiration string `json:"expiration"`
+}
+
+// ConnectionReauthHandler serves POST /api/v1/connections/{id}/reauth.
+// Mirrors the admin ConnectionReauthAPIHandler but speaks the standard REST
+// error envelope and accepts short_id alongside UUID. Takes *app.App
+// directly because the service layer does not carry the provider registry.
+func ConnectionReauthHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		id := chi.URLParam(r, "id")
+
+		uid, err := a.Service.ResolveConnectionUUID(ctx, id)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
+				return
+			}
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid connection id")
+			return
+		}
+
+		conn, err := a.Queries.GetBankConnection(ctx, uid)
+		if err != nil {
+			mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
+			return
+		}
+
+		prov, ok := a.Providers[string(conn.Provider)]
+		if !ok {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"Provider "+string(conn.Provider)+" is not configured")
+			return
+		}
+
+		provConn := provider.Connection{
+			ProviderName:         string(conn.Provider),
+			ExternalID:           conn.ExternalID.String,
+			EncryptedCredentials: conn.EncryptedCredentials,
+			UserID:               pgconv.FormatUUID(conn.UserID),
+		}
+
+		session, err := prov.CreateReauthSession(ctx, provConn)
+		if err != nil {
+			a.Logger.Error("create reauth session", "error", err, "connection_id", pgconv.FormatUUID(uid))
+			mw.WriteError(w, http.StatusBadGateway, "PROVIDER_ERROR", "Failed to create reauth link token")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, reauthLinkTokenResponse{
+			LinkToken:  session.Token,
+			Expiration: session.Expiry.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+}
+
+// ConnectionReauthCompleteHandler serves
+// POST /api/v1/connections/{id}/reauth-complete. Marks the connection
+// active again after the user finished the provider's re-auth flow.
+//
+// The body is intentionally ignored — the admin handler takes none either,
+// and Plaid's link/oauth-redirect path completes the token exchange
+// out-of-band. Future provider flows that need a public_token can extend the
+// payload backwards-compatibly.
+func ConnectionReauthCompleteHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		actor := service.ActorFromContext(r.Context())
+
+		if err := a.Service.ReactivateConnection(r.Context(), id, actor); err != nil {
+			writeServiceError(w, err, "Connection not found", "Failed to reactivate connection")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, map[string]string{"status": "active"})
+	}
+}

--- a/internal/api/connections_reauth_integration_test.go
+++ b/internal/api/connections_reauth_integration_test.go
@@ -1,0 +1,284 @@
+//go:build integration
+
+// Integration tests for the reauth REST endpoints.
+//
+// These exercise the provider-touching code path that the rest of the API
+// suite skirts, so they wire a fake provider into a *app.App rather than
+// re-using the svc-only buildTestRouter helper from api_integration_test.go.
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
+	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// fakeProvider implements provider.Provider for reauth tests. Only the
+// methods exercised by the reauth handlers are functional; the rest panic so
+// any unexpected call is loud.
+type fakeProvider struct {
+	name             string
+	reauthSession    provider.LinkSession
+	reauthErr        error
+	reauthCalls      int
+	lastReauthConnID string
+}
+
+func (f *fakeProvider) CreateReauthSession(_ context.Context, conn provider.Connection) (provider.LinkSession, error) {
+	f.reauthCalls++
+	f.lastReauthConnID = conn.ExternalID
+	if f.reauthErr != nil {
+		return provider.LinkSession{}, f.reauthErr
+	}
+	return f.reauthSession, nil
+}
+
+func (f *fakeProvider) CreateLinkSession(context.Context, string) (provider.LinkSession, error) {
+	panic("fakeProvider.CreateLinkSession not implemented")
+}
+func (f *fakeProvider) ExchangeToken(context.Context, string) (provider.Connection, []provider.Account, error) {
+	panic("fakeProvider.ExchangeToken not implemented")
+}
+func (f *fakeProvider) SyncTransactions(context.Context, provider.Connection, string) (provider.SyncResult, error) {
+	panic("fakeProvider.SyncTransactions not implemented")
+}
+func (f *fakeProvider) GetBalances(context.Context, provider.Connection) ([]provider.AccountBalance, error) {
+	panic("fakeProvider.GetBalances not implemented")
+}
+func (f *fakeProvider) HandleWebhook(context.Context, provider.WebhookPayload) (provider.WebhookEvent, error) {
+	panic("fakeProvider.HandleWebhook not implemented")
+}
+func (f *fakeProvider) RemoveConnection(context.Context, provider.Connection) error {
+	panic("fakeProvider.RemoveConnection not implemented")
+}
+
+// reauthEnv is the per-test harness for the reauth endpoints.
+type reauthEnv struct {
+	Server   *httptest.Server
+	APIKey   string
+	App      *app.App
+	Service  *service.Service
+	Queries  *db.Queries
+	Provider *fakeProvider
+}
+
+func setupReauthEnv(t *testing.T, scope string) *reauthEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "reauth-test-key", scope)
+	if err != nil {
+		t.Fatalf("create API key: %v", err)
+	}
+
+	fp := &fakeProvider{
+		name: "plaid",
+		reauthSession: provider.LinkSession{
+			Token:  "link-sandbox-fake-token",
+			Expiry: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC),
+		},
+	}
+	a := &app.App{
+		DB:        pool,
+		Queries:   queries,
+		Logger:    slog.Default(),
+		Service:   svc,
+		Providers: map[string]provider.Provider{"plaid": fp},
+	}
+
+	r := buildReauthTestRouter(svc, a)
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &reauthEnv{
+		Server:   server,
+		APIKey:   keyResult.PlaintextKey,
+		App:      a,
+		Service:  svc,
+		Queries:  queries,
+		Provider: fp,
+	}
+}
+
+// buildReauthTestRouter mounts only the routes exercised by these tests
+// (auth + reauth pair). Mirrors the production wiring: API key auth runs
+// outside the write-scope group; both reauth endpoints sit inside it.
+func buildReauthTestRouter(svc *service.Service, a *app.App) http.Handler {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/connections/{id}/reauth", ConnectionReauthHandler(a))
+			r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))
+		})
+	})
+	return r
+}
+
+func (e *reauthEnv) doPost(t *testing.T, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("POST", e.Server.URL+path, nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("X-API-Key", e.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+func TestConnectionReauth_Success(t *testing.T) {
+	env := setupReauthEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_reauth_ok")
+
+	resp := env.doPost(t, "/api/v1/connections/"+pgconv.FormatUUID(conn.ID)+"/reauth")
+	assertStatus(t, resp, http.StatusOK)
+
+	var body reauthLinkTokenResponse
+	parseJSON(t, resp, &body)
+	if body.LinkToken != "link-sandbox-fake-token" {
+		t.Errorf("want link_token %q, got %q", "link-sandbox-fake-token", body.LinkToken)
+	}
+	if body.Expiration != "2030-01-02T03:04:05Z" {
+		t.Errorf("want expiration %q, got %q", "2030-01-02T03:04:05Z", body.Expiration)
+	}
+	if env.Provider.reauthCalls != 1 {
+		t.Errorf("want 1 provider call, got %d", env.Provider.reauthCalls)
+	}
+	if env.Provider.lastReauthConnID != "ext_reauth_ok" {
+		t.Errorf("want provider received external_id %q, got %q",
+			"ext_reauth_ok", env.Provider.lastReauthConnID)
+	}
+}
+
+func TestConnectionReauth_AcceptsShortID(t *testing.T) {
+	env := setupReauthEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_reauth_short")
+
+	resp := env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/reauth")
+	assertStatus(t, resp, http.StatusOK)
+
+	var body reauthLinkTokenResponse
+	parseJSON(t, resp, &body)
+	if body.LinkToken == "" {
+		t.Error("want non-empty link_token from short_id lookup")
+	}
+}
+
+func TestConnectionReauth_NotFound(t *testing.T) {
+	env := setupReauthEnv(t, "full_access")
+	// Random valid UUID — no matching row.
+	resp := env.doPost(t, "/api/v1/connections/00000000-0000-0000-0000-000000000000/reauth")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+	if env.Provider.reauthCalls != 0 {
+		t.Errorf("provider should not be called for missing connection, got %d calls", env.Provider.reauthCalls)
+	}
+}
+
+func TestConnectionReauth_NoProvider(t *testing.T) {
+	env := setupReauthEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Bob")
+	// Teller connection but only "plaid" registered → INVALID_PARAMETER.
+	conn := testutil.MustCreateTellerConnection(t, env.Queries, user.ID, "ext_no_prov")
+
+	resp := env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/reauth")
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestConnectionReauth_ProviderError(t *testing.T) {
+	env := setupReauthEnv(t, "full_access")
+	env.Provider.reauthErr = errors.New("plaid: ITEM_LOGIN_REQUIRED")
+
+	user := testutil.MustCreateUser(t, env.Queries, "Carol")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_reauth_err")
+
+	resp := env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/reauth")
+	readErrorCode(t, resp, http.StatusBadGateway, "PROVIDER_ERROR")
+}
+
+func TestConnectionReauthComplete_Success(t *testing.T) {
+	env := setupReauthEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Dan")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_complete_ok")
+
+	// Push the connection into the broken state we expect to recover from.
+	if err := env.Queries.UpdateBankConnectionStatus(t.Context(), db.UpdateBankConnectionStatusParams{
+		ID:           conn.ID,
+		Status:       db.ConnectionStatusPendingReauth,
+		ErrorCode:    pgtype.Text{String: "ITEM_LOGIN_REQUIRED", Valid: true},
+		ErrorMessage: pgtype.Text{String: "user revoked access", Valid: true},
+	}); err != nil {
+		t.Fatalf("seed pending_reauth: %v", err)
+	}
+
+	resp := env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/reauth-complete")
+	assertStatus(t, resp, http.StatusOK)
+
+	var body map[string]string
+	parseJSON(t, resp, &body)
+	if body["status"] != "active" {
+		t.Errorf("want status=active in body, got %q", body["status"])
+	}
+
+	// Confirm DB state: status flipped, error fields cleared.
+	got, err := env.Queries.GetBankConnection(t.Context(), conn.ID)
+	if err != nil {
+		t.Fatalf("reload connection: %v", err)
+	}
+	if got.Status != db.ConnectionStatusActive {
+		t.Errorf("want status=active, got %q", got.Status)
+	}
+	if got.ErrorCode.Valid {
+		t.Errorf("want error_code cleared, got %q", got.ErrorCode.String)
+	}
+	if got.ErrorMessage.Valid {
+		t.Errorf("want error_message cleared, got %q", got.ErrorMessage.String)
+	}
+}
+
+func TestConnectionReauthComplete_NotFound(t *testing.T) {
+	env := setupReauthEnv(t, "full_access")
+	resp := env.doPost(t, "/api/v1/connections/00000000-0000-0000-0000-000000000000/reauth-complete")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestConnectionReauth_RequiresWriteScope(t *testing.T) {
+	env := setupReauthEnv(t, "read_only")
+	user := testutil.MustCreateUser(t, env.Queries, "Eve")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_reauth_scope")
+
+	resp := env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/reauth")
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+func TestConnectionReauthComplete_RequiresWriteScope(t *testing.T) {
+	env := setupReauthEnv(t, "read_only")
+	user := testutil.MustCreateUser(t, env.Queries, "Frank")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_complete_scope")
+
+	resp := env.doPost(t, "/api/v1/connections/"+conn.ShortID+"/reauth-complete")
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -98,6 +98,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/connections/{id}/paused", PauseConnectionHandler(svc))
 			r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(svc))
 			r.Delete("/connections/{id}", DeleteConnectionHandler(svc))
+			r.Post("/connections/{id}/reauth", ConnectionReauthHandler(a))
+			r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))
 			r.Post("/transactions/{transaction_id}/comments", CreateCommentHandler(svc))
 			r.Put("/transactions/{transaction_id}/comments/{id}", UpdateCommentHandler(svc))
 			r.Delete("/transactions/{transaction_id}/comments/{id}", DeleteCommentHandler(svc))

--- a/internal/service/connections.go
+++ b/internal/service/connections.go
@@ -269,6 +269,45 @@ func (s *Service) UpdateConnectionSyncInterval(ctx context.Context, id string, i
 	return buildConnectionDetailResponse(conn), nil
 }
 
+// ResolveConnectionUUID resolves a UUID-or-short_id input into a pgtype.UUID
+// without fetching the row. Returns ErrNotFound for an unknown short_id and a
+// wrapped parse error for an invalid UUID. Public so non-service callers
+// (admin handlers, REST handlers that need to call providers directly) can
+// honor the same short-id contract the service layer enforces internally.
+func (s *Service) ResolveConnectionUUID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
+	return s.resolveConnectionID(ctx, idOrShort)
+}
+
+// ReactivateConnection clears a broken connection's error state and flips
+// status back to 'active'. Used by the reauth-complete flow after the user
+// has completed the provider's re-authentication UI. Returns ErrNotFound
+// when the row is missing.
+func (s *Service) ReactivateConnection(ctx context.Context, id string, _ Actor) error {
+	uid, err := s.resolveConnectionID(ctx, id)
+	if err != nil {
+		return ErrNotFound
+	}
+
+	// UpdateBankConnectionStatus is :exec and silently succeeds against a
+	// missing id, so verify existence first to keep the 404 contract.
+	if _, err := s.Queries.GetBankConnection(ctx, uid); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("get bank connection: %w", err)
+	}
+
+	if err := s.Queries.UpdateBankConnectionStatus(ctx, db.UpdateBankConnectionStatusParams{
+		ID:           uid,
+		Status:       db.ConnectionStatusActive,
+		ErrorCode:    pgtype.Text{},
+		ErrorMessage: pgtype.Text{},
+	}); err != nil {
+		return fmt.Errorf("reactivate bank connection: %w", err)
+	}
+	return nil
+}
+
 func buildConnectionDetailResponse(conn db.GetConnectionForAPIRow) *ConnectionDetailResponse {
 	resp := &ConnectionDetailResponse{
 		ConnectionResponse: ConnectionResponse{


### PR DESCRIPTION
## Summary

Plaid re-auth REST endpoints (Bundle 09 of headless-api):

- `POST /api/v1/connections/{id}/reauth` — start
- `POST /api/v1/connections/{id}/reauth-complete` — finish

Wraps the existing admin handlers; same provider-call + DB-update flow. Required so headless deployments can recover from `pending_reauth` state.

The reauth handler takes `*app.App` directly because the service layer does not carry the provider registry — same shape as other admin REST handlers that hit `a.Providers`. Reauth-complete is plain DB work and goes through a new `service.ReactivateConnection` so the actor + 404 contract is consistent with the rest of the connection-management endpoints.

Both endpoints accept either UUID or 8-char `short_id`, and a fake `provider.Provider` in the integration tests exercises happy paths, missing connection, missing-provider, and provider error.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `DATABASE_URL=... go test -tags integration -count=1 -p 1 ./internal/api/... ./internal/service/...` — all green, includes the 9 new reauth integration tests
- [x] 9 integration tests cover happy paths, 404, no-provider, provider error, scope, short_id

Generated with Claude Code.
