### PR TITLE
headless-api: Plaid link flow REST endpoints

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -109,6 +109,8 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 | DELETE | `/connections/{id}` | Write | Soft-disconnect a connection (clears tokens, hides from list) |
 | POST | `/connections/{id}/reauth` | Write | Start the provider re-auth flow — returns a fresh link token |
 | POST | `/connections/{id}/reauth-complete` | Write | Mark connection active again after the user finishes the re-auth flow |
+| POST | `/connections/plaid/link-token` | Write | Start a new Plaid Link flow — returns a fresh link token |
+| POST | `/connections/plaid/exchange` | Write | Exchange the Plaid public token for a stored connection + accounts |
 
 `{id}` accepts either the connection's UUID or 8-char short_id.
 
@@ -222,6 +224,83 @@ Returns `200`:
 Errors:
 
 - `404 NOT_FOUND` — connection doesn't exist.
+
+### Plaid Link flow (new connection)
+
+Connecting a new Plaid bank account is a three-step dance:
+
+1. Server: `POST /connections/plaid/link-token` → returns a `link_token`.
+2. Client / host: hand `link_token` to Plaid Link. The user authenticates with
+   their bank inside Plaid's UI; on success Plaid returns a `public_token`
+   plus institution and account metadata to the host's `onSuccess` callback.
+3. Server: `POST /connections/plaid/exchange` with the `public_token` →
+   Breadbox exchanges it for a long-lived access token, encrypts it,
+   creates the `BankConnection` row, and upserts the accounts Plaid
+   reports. Subsequent syncs run automatically on the global cron.
+
+These endpoints mirror the admin `POST /admin/api/link-token` and
+`POST /admin/api/exchange-token` handlers and persist data through the same
+service-layer write path.
+
+### POST `/connections/plaid/link-token`
+
+Starts a new Plaid Link session for a household member.
+
+**Body**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `user_id` | string | Required. UUID **or** 8-char short_id of the user the new connection will be attached to. |
+
+Returns `200`:
+
+```json
+{
+  "link_token": "link-sandbox-abc123",
+  "expiration": "2026-05-09T16:30:00Z"
+}
+```
+
+Errors:
+
+- `400 INVALID_PARAMETER` — `user_id` missing or malformed; Plaid provider not configured on this server.
+- `404 NOT_FOUND` — `user_id` doesn't match any household member.
+- `502 PROVIDER_ERROR` — upstream Plaid call failed.
+
+### POST `/connections/plaid/exchange`
+
+Exchanges the `public_token` Plaid returned in Link's `onSuccess` for a
+stored `BankConnection` and the accounts Plaid authoritatively reports.
+
+**Body**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `public_token` | string | Required. The token Plaid handed back in `onSuccess`. |
+| `user_id` | string | Required. UUID or 8-char short_id of the owning user. |
+| `institution_id` | string | Required. Plaid institution identifier (e.g. `ins_109511`). |
+| `institution_name` | string | Required. Display name (e.g. `Chase`). |
+| `accounts` | array | Optional. The account metadata array Plaid Link's `onSuccess` returns (id / name / type / subtype / mask). **Informational only** — the rows persisted come from the provider's exchange response, not from this field. |
+
+Returns `201`:
+
+```json
+{
+  "connection_id": "abc12345",
+  "institution_name": "Chase",
+  "status": "active"
+}
+```
+
+`connection_id` is the new connection's 8-char short_id (use it in any
+downstream `/connections/{id}/...` call).
+
+Errors:
+
+- `400 INVALID_PARAMETER` — required field missing; Plaid provider not configured on this server.
+- `404 NOT_FOUND` — `user_id` doesn't match any household member.
+- `502 PROVIDER_ERROR` — upstream Plaid token exchange failed.
+- `500 INTERNAL_ERROR` — DB write failed (the provider call already succeeded; safe to retry).
 
 ## Sync
 

--- a/internal/admin/connections.go
+++ b/internal/admin/connections.go
@@ -522,43 +522,25 @@ func ExchangeTokenHandler(a *app.App) http.HandlerFunc {
 			return
 		}
 
-		// Create the bank connection record.
-		bankConn, err := a.Queries.CreateBankConnection(r.Context(), db.CreateBankConnectionParams{
-			UserID:           userID,
-			Provider:         db.ProviderType(providerName),
-			InstitutionID:    pgconv.Text(req.InstitutionID),
-			InstitutionName:  pgconv.Text(req.InstitutionName),
-			ExternalID:           pgconv.Text(conn.ExternalID),
-			EncryptedCredentials: conn.EncryptedCredentials,
-			Status:           db.ConnectionStatusActive,
+		// Persist the connection + accounts via the shared service helper.
+		// REST (api.PlaidExchangeHandler) calls the same path so both
+		// surfaces stay byte-identical on what lands in the DB.
+		result, err := a.Service.RegisterNewConnection(r.Context(), service.RegisterNewConnectionParams{
+			UserID:          userID,
+			Provider:        providerName,
+			InstitutionID:   req.InstitutionID,
+			InstitutionName: req.InstitutionName,
+			Conn:            conn,
+			Accounts:        accounts,
 		})
 		if err != nil {
-			a.Logger.Error("create bank connection", "error", err)
+			a.Logger.Error("register new connection", "error", err)
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to save connection"})
 			return
 		}
 
-		// Upsert accounts from the exchange response.
-		for _, acct := range accounts {
-			_, err := a.Queries.UpsertAccount(r.Context(), db.UpsertAccountParams{
-				ConnectionID:      bankConn.ID,
-				ExternalAccountID: acct.ExternalID,
-				Name:              acct.Name,
-				OfficialName:      pgconv.TextIfNotEmpty(acct.OfficialName),
-				Type:              acct.Type,
-				Subtype:           pgconv.TextIfNotEmpty(acct.Subtype),
-				Mask:              pgconv.TextIfNotEmpty(acct.Mask),
-				IsoCurrencyCode:   pgconv.TextIfNotEmpty(acct.ISOCurrencyCode),
-			})
-			if err != nil {
-				a.Logger.Error("upsert account", "error", err, "external_id", acct.ExternalID)
-			}
-		}
-
-		connID := pgconv.FormatUUID(bankConn.ID)
-
 		writeJSON(w, http.StatusCreated, exchangeTokenResponse{
-			ConnectionID:    connID,
+			ConnectionID:    pgconv.FormatUUID(result.ID),
 			InstitutionName: req.InstitutionName,
 			Status:          "active",
 		})

--- a/internal/api/connections_plaid_link.go
+++ b/internal/api/connections_plaid_link.go
@@ -1,0 +1,173 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"breadbox/internal/app"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+)
+
+// plaidLinkTokenRequest is the JSON body for POST /api/v1/connections/plaid/link-token.
+type plaidLinkTokenRequest struct {
+	UserID string `json:"user_id"`
+}
+
+// plaidLinkTokenResponse mirrors the admin linkTokenResponse so the SDK
+// surface is uniform across reauth (api.reauthLinkTokenResponse) and
+// new-connection link-token issuance.
+type plaidLinkTokenResponse struct {
+	LinkToken  string `json:"link_token"`
+	Expiration string `json:"expiration"`
+}
+
+// plaidExchangeRequest is the JSON body for POST /api/v1/connections/plaid/exchange.
+//
+// Mirrors the admin exchangeTokenRequest minus the `provider` discriminator —
+// this endpoint is Plaid-specific. The `accounts` slice is the metadata
+// Plaid Link's onSuccess callback returns; it is informational only —
+// persistence uses the accounts the provider returns from ExchangeToken.
+type plaidExchangeRequest struct {
+	PublicToken     string                `json:"public_token"`
+	UserID          string                `json:"user_id"`
+	InstitutionID   string                `json:"institution_id"`
+	InstitutionName string                `json:"institution_name"`
+	Accounts        []plaidExchangeAcctMD `json:"accounts"`
+}
+
+type plaidExchangeAcctMD struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Subtype string `json:"subtype"`
+	Mask    string `json:"mask"`
+}
+
+// plaidExchangeResponse is the JSON response for POST /api/v1/connections/plaid/exchange.
+type plaidExchangeResponse struct {
+	ConnectionID    string `json:"connection_id"`
+	InstitutionName string `json:"institution_name"`
+	Status          string `json:"status"`
+}
+
+// PlaidLinkTokenHandler serves POST /api/v1/connections/plaid/link-token.
+// Returns a fresh Plaid link token that the host can hand to Plaid Link to
+// start a new bank connection. Mirrors the admin LinkTokenHandler but
+// speaks the standard REST error envelope and accepts short_id alongside
+// UUID for user_id.
+func PlaidLinkTokenHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		var req plaidLinkTokenRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		if req.UserID == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "user_id is required")
+			return
+		}
+
+		// Validate the user exists before paying the provider round trip.
+		uid, err := a.Service.ResolveUserUUID(ctx, req.UserID)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "User not found")
+				return
+			}
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid user_id")
+			return
+		}
+
+		prov, ok := a.Providers["plaid"]
+		if !ok {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"Plaid provider is not configured on this server")
+			return
+		}
+
+		// Plaid expects the host's user identifier as a string; pass the
+		// canonical UUID so retries land on the same Plaid `client_user_id`
+		// regardless of whether the caller used a short_id at the API edge.
+		session, err := prov.CreateLinkSession(ctx, pgconv.FormatUUID(uid))
+		if err != nil {
+			a.Logger.Error("create plaid link session", "error", err)
+			mw.WriteError(w, http.StatusBadGateway, "PROVIDER_ERROR", "Failed to create link token")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, plaidLinkTokenResponse{
+			LinkToken:  session.Token,
+			Expiration: session.Expiry.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+}
+
+// PlaidExchangeHandler serves POST /api/v1/connections/plaid/exchange.
+// Exchanges the public token Plaid returned in Link's onSuccess for a
+// stored BankConnection and the accounts Plaid returned alongside it.
+//
+// The request `accounts` field is informational; the rows persisted come
+// from the provider's ExchangeToken response so the DB matches what Plaid
+// authoritatively reports.
+func PlaidExchangeHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		var req plaidExchangeRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		if req.PublicToken == "" || req.UserID == "" || req.InstitutionID == "" || req.InstitutionName == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"public_token, user_id, institution_id, and institution_name are required")
+			return
+		}
+
+		uid, err := a.Service.ResolveUserUUID(ctx, req.UserID)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "User not found")
+				return
+			}
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid user_id")
+			return
+		}
+
+		prov, ok := a.Providers["plaid"]
+		if !ok {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"Plaid provider is not configured on this server")
+			return
+		}
+
+		conn, accounts, err := prov.ExchangeToken(ctx, req.PublicToken)
+		if err != nil {
+			a.Logger.Error("exchange plaid public token", "error", err)
+			mw.WriteError(w, http.StatusBadGateway, "PROVIDER_ERROR", "Failed to exchange public token")
+			return
+		}
+
+		result, err := a.Service.RegisterNewConnection(ctx, service.RegisterNewConnectionParams{
+			UserID:          uid,
+			Provider:        "plaid",
+			InstitutionID:   req.InstitutionID,
+			InstitutionName: req.InstitutionName,
+			Conn:            conn,
+			Accounts:        accounts,
+		})
+		if err != nil {
+			a.Logger.Error("register plaid connection", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to save connection")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, plaidExchangeResponse{
+			ConnectionID:    result.ShortID,
+			InstitutionName: req.InstitutionName,
+			Status:          "active",
+		})
+	}
+}

--- a/internal/api/connections_plaid_link_integration_test.go
+++ b/internal/api/connections_plaid_link_integration_test.go
@@ -1,0 +1,449 @@
+//go:build integration
+
+// Integration tests for the Plaid link-flow REST endpoints
+// (POST /api/v1/connections/plaid/link-token,
+//  POST /api/v1/connections/plaid/exchange).
+//
+// Mirrors the fake-provider pattern from
+// connections_reauth_integration_test.go: a stub provider implementing the
+// link-session + exchange-token entry points is wired into a *app.App,
+// driven through the public REST router with API-key auth + write-scope
+// enforced just like production.
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
+	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// fakePlaidProvider implements provider.Provider for the link-flow tests.
+// Only CreateLinkSession and ExchangeToken are functional; everything else
+// panics so any unexpected call is loud during testing.
+type fakePlaidProvider struct {
+	linkSession        provider.LinkSession
+	linkErr            error
+	linkCalls          int
+	lastLinkUserID     string
+	exchangeConn      provider.Connection
+	exchangeAccounts  []provider.Account
+	exchangeErr       error
+	exchangeCalls     int
+	lastExchangeToken string
+}
+
+func (f *fakePlaidProvider) CreateLinkSession(_ context.Context, userID string) (provider.LinkSession, error) {
+	f.linkCalls++
+	f.lastLinkUserID = userID
+	if f.linkErr != nil {
+		return provider.LinkSession{}, f.linkErr
+	}
+	return f.linkSession, nil
+}
+
+func (f *fakePlaidProvider) ExchangeToken(_ context.Context, publicToken string) (provider.Connection, []provider.Account, error) {
+	f.exchangeCalls++
+	f.lastExchangeToken = publicToken
+	if f.exchangeErr != nil {
+		return provider.Connection{}, nil, f.exchangeErr
+	}
+	return f.exchangeConn, f.exchangeAccounts, nil
+}
+
+func (f *fakePlaidProvider) CreateReauthSession(context.Context, provider.Connection) (provider.LinkSession, error) {
+	panic("fakePlaidProvider.CreateReauthSession not implemented")
+}
+func (f *fakePlaidProvider) SyncTransactions(context.Context, provider.Connection, string) (provider.SyncResult, error) {
+	panic("fakePlaidProvider.SyncTransactions not implemented")
+}
+func (f *fakePlaidProvider) GetBalances(context.Context, provider.Connection) ([]provider.AccountBalance, error) {
+	panic("fakePlaidProvider.GetBalances not implemented")
+}
+func (f *fakePlaidProvider) HandleWebhook(context.Context, provider.WebhookPayload) (provider.WebhookEvent, error) {
+	panic("fakePlaidProvider.HandleWebhook not implemented")
+}
+func (f *fakePlaidProvider) RemoveConnection(context.Context, provider.Connection) error {
+	panic("fakePlaidProvider.RemoveConnection not implemented")
+}
+
+// plaidLinkEnv is the per-test harness for the link-flow endpoints.
+type plaidLinkEnv struct {
+	Server   *httptest.Server
+	APIKey   string
+	App      *app.App
+	Service  *service.Service
+	Queries  *db.Queries
+	Provider *fakePlaidProvider
+}
+
+func setupPlaidLinkEnv(t *testing.T, scope string, registerProvider bool) *plaidLinkEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "plaid-link-test-key", scope)
+	if err != nil {
+		t.Fatalf("create API key: %v", err)
+	}
+
+	fp := &fakePlaidProvider{
+		linkSession: provider.LinkSession{
+			Token:  "link-sandbox-fake-token",
+			Expiry: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC),
+		},
+		exchangeConn: provider.Connection{
+			ProviderName:         "plaid",
+			ExternalID:           "ext_new_item_123",
+			EncryptedCredentials: []byte("encrypted-access-token"),
+		},
+		exchangeAccounts: []provider.Account{
+			{
+				ExternalID:      "ext_acct_chk_1",
+				Name:            "Plaid Checking",
+				OfficialName:    "Plaid Gold Standard 0% Interest Checking",
+				Type:            "depository",
+				Subtype:         "checking",
+				Mask:            "0000",
+				ISOCurrencyCode: "USD",
+			},
+			{
+				ExternalID:      "ext_acct_sav_1",
+				Name:            "Plaid Saving",
+				Type:            "depository",
+				Subtype:         "savings",
+				Mask:            "1111",
+				ISOCurrencyCode: "USD",
+			},
+		},
+	}
+
+	providers := map[string]provider.Provider{}
+	if registerProvider {
+		providers["plaid"] = fp
+	}
+	a := &app.App{
+		DB:        pool,
+		Queries:   queries,
+		Logger:    slog.Default(),
+		Service:   svc,
+		Providers: providers,
+	}
+
+	r := buildPlaidLinkTestRouter(svc, a)
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &plaidLinkEnv{
+		Server:   server,
+		APIKey:   keyResult.PlaintextKey,
+		App:      a,
+		Service:  svc,
+		Queries:  queries,
+		Provider: fp,
+	}
+}
+
+// buildPlaidLinkTestRouter mounts only the routes exercised by these tests.
+// Mirrors the production wiring: API key auth runs outside the write-scope
+// group; both Plaid endpoints sit inside it.
+func buildPlaidLinkTestRouter(svc *service.Service, a *app.App) http.Handler {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/connections/plaid/link-token", PlaidLinkTokenHandler(a))
+			r.Post("/connections/plaid/exchange", PlaidExchangeHandler(a))
+		})
+	})
+	return r
+}
+
+func (e *plaidLinkEnv) doPostJSON(t *testing.T, path string, body any) *http.Response {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+	}
+	req, err := http.NewRequest("POST", e.Server.URL+path, &buf)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", e.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// ---- Link-token tests ----
+
+func TestPlaidLinkToken_Success(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/link-token", map[string]string{
+		"user_id": pgconv.FormatUUID(user.ID),
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var body plaidLinkTokenResponse
+	parseJSON(t, resp, &body)
+	if body.LinkToken != "link-sandbox-fake-token" {
+		t.Errorf("want link_token %q, got %q", "link-sandbox-fake-token", body.LinkToken)
+	}
+	if body.Expiration != "2030-01-02T03:04:05Z" {
+		t.Errorf("want expiration %q, got %q", "2030-01-02T03:04:05Z", body.Expiration)
+	}
+	if env.Provider.linkCalls != 1 {
+		t.Errorf("want 1 provider call, got %d", env.Provider.linkCalls)
+	}
+	if env.Provider.lastLinkUserID != pgconv.FormatUUID(user.ID) {
+		t.Errorf("want provider received user_id %q, got %q",
+			pgconv.FormatUUID(user.ID), env.Provider.lastLinkUserID)
+	}
+}
+
+func TestPlaidLinkToken_AcceptsShortIDForUser(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/link-token", map[string]string{
+		"user_id": user.ShortID,
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	// Provider should always see the canonical UUID (not the short_id) so
+	// retries land on the same Plaid client_user_id regardless of caller
+	// preference at the API edge.
+	if env.Provider.lastLinkUserID != pgconv.FormatUUID(user.ID) {
+		t.Errorf("want canonical UUID forwarded to provider, got %q", env.Provider.lastLinkUserID)
+	}
+}
+
+func TestPlaidLinkToken_NoProvider(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", false)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/link-token", map[string]string{
+		"user_id": pgconv.FormatUUID(user.ID),
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestPlaidLinkToken_ProviderError(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+	env.Provider.linkErr = errors.New("plaid: INVALID_REQUEST")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/link-token", map[string]string{
+		"user_id": pgconv.FormatUUID(user.ID),
+	})
+	readErrorCode(t, resp, http.StatusBadGateway, "PROVIDER_ERROR")
+}
+
+func TestPlaidLinkToken_NotFound_User(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/link-token", map[string]string{
+		"user_id": "abc12345", // valid short_id format but no matching row
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+	if env.Provider.linkCalls != 0 {
+		t.Errorf("provider should not be called for missing user, got %d calls", env.Provider.linkCalls)
+	}
+}
+
+func TestPlaidLinkToken_BadInput_MissingUserID(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/link-token", map[string]string{})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestPlaidLinkToken_RequiresWriteScope(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "read_only", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/link-token", map[string]string{
+		"user_id": pgconv.FormatUUID(user.ID),
+	})
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+// ---- Exchange tests ----
+
+func validExchangeBody(userID string) map[string]any {
+	return map[string]any{
+		"public_token":     "public-sandbox-fake-public-token",
+		"user_id":          userID,
+		"institution_id":   "ins_109511",
+		"institution_name": "Chase",
+		"accounts": []map[string]string{
+			{"id": "ext_acct_chk_1", "name": "Plaid Checking", "type": "depository", "subtype": "checking", "mask": "0000"},
+		},
+	}
+}
+
+func TestPlaidExchange_Success(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/exchange",
+		validExchangeBody(pgconv.FormatUUID(user.ID)))
+	assertStatus(t, resp, http.StatusCreated)
+
+	var body plaidExchangeResponse
+	parseJSON(t, resp, &body)
+	if body.ConnectionID == "" {
+		t.Fatal("want non-empty connection_id (short_id) in response")
+	}
+	if body.InstitutionName != "Chase" {
+		t.Errorf("want institution_name %q, got %q", "Chase", body.InstitutionName)
+	}
+	if body.Status != "active" {
+		t.Errorf("want status %q, got %q", "active", body.Status)
+	}
+	if env.Provider.exchangeCalls != 1 {
+		t.Errorf("want 1 provider exchange call, got %d", env.Provider.exchangeCalls)
+	}
+	if env.Provider.lastExchangeToken != "public-sandbox-fake-public-token" {
+		t.Errorf("want provider received public_token %q, got %q",
+			"public-sandbox-fake-public-token", env.Provider.lastExchangeToken)
+	}
+
+	// Verify DB persistence: connection by short_id, with both accounts
+	// from the provider response (NOT the request body).
+	uid, err := env.Service.ResolveConnectionUUID(t.Context(), body.ConnectionID)
+	if err != nil {
+		t.Fatalf("resolve persisted connection short_id: %v", err)
+	}
+	conn, err := env.Queries.GetBankConnection(t.Context(), uid)
+	if err != nil {
+		t.Fatalf("reload connection: %v", err)
+	}
+	if conn.Status != db.ConnectionStatusActive {
+		t.Errorf("want connection status=active, got %q", conn.Status)
+	}
+	if conn.Provider != db.ProviderTypePlaid {
+		t.Errorf("want provider=plaid, got %q", conn.Provider)
+	}
+	if conn.ExternalID.String != "ext_new_item_123" {
+		t.Errorf("want external_id %q, got %q", "ext_new_item_123", conn.ExternalID.String)
+	}
+	if conn.InstitutionName.String != "Chase" {
+		t.Errorf("want institution_name %q, got %q", "Chase", conn.InstitutionName.String)
+	}
+	if string(conn.EncryptedCredentials) != "encrypted-access-token" {
+		t.Errorf("want encrypted credentials persisted verbatim from provider, got %q",
+			string(conn.EncryptedCredentials))
+	}
+
+	accts, err := env.Queries.ListAccountsByConnection(t.Context(), uid)
+	if err != nil {
+		t.Fatalf("list accounts: %v", err)
+	}
+	if len(accts) != 2 {
+		t.Fatalf("want 2 accounts persisted from provider response, got %d", len(accts))
+	}
+}
+
+func TestPlaidExchange_AcceptsShortIDForUser(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/exchange", validExchangeBody(user.ShortID))
+	assertStatus(t, resp, http.StatusCreated)
+
+	var body plaidExchangeResponse
+	parseJSON(t, resp, &body)
+	if body.ConnectionID == "" {
+		t.Fatal("want non-empty connection_id from short_id-based call")
+	}
+
+	// The persisted connection should belong to the resolved user.
+	uid, _ := env.Service.ResolveConnectionUUID(t.Context(), body.ConnectionID)
+	conn, err := env.Queries.GetBankConnection(t.Context(), uid)
+	if err != nil {
+		t.Fatalf("reload connection: %v", err)
+	}
+	if pgconv.FormatUUID(conn.UserID) != pgconv.FormatUUID(user.ID) {
+		t.Errorf("want connection.user_id %q, got %q",
+			pgconv.FormatUUID(user.ID), pgconv.FormatUUID(conn.UserID))
+	}
+}
+
+func TestPlaidExchange_BadInput_MissingPublicToken(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := validExchangeBody(pgconv.FormatUUID(user.ID))
+	delete(body, "public_token")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/exchange", body)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+	if env.Provider.exchangeCalls != 0 {
+		t.Errorf("provider should not be called when validation fails, got %d", env.Provider.exchangeCalls)
+	}
+}
+
+func TestPlaidExchange_NoProvider(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", false)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/exchange",
+		validExchangeBody(pgconv.FormatUUID(user.ID)))
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestPlaidExchange_ProviderError(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+	env.Provider.exchangeErr = errors.New("plaid: INVALID_PUBLIC_TOKEN")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/exchange",
+		validExchangeBody(pgconv.FormatUUID(user.ID)))
+	readErrorCode(t, resp, http.StatusBadGateway, "PROVIDER_ERROR")
+}
+
+func TestPlaidExchange_NotFound_User(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "full_access", true)
+
+	body := validExchangeBody("abc12345") // valid short_id format, no row
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/exchange", body)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+	if env.Provider.exchangeCalls != 0 {
+		t.Errorf("provider should not be called for missing user, got %d", env.Provider.exchangeCalls)
+	}
+}
+
+func TestPlaidExchange_RequiresWriteScope(t *testing.T) {
+	env := setupPlaidLinkEnv(t, "read_only", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/exchange",
+		validExchangeBody(pgconv.FormatUUID(user.ID)))
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -101,6 +101,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Delete("/connections/{id}", DeleteConnectionHandler(svc))
 			r.Post("/connections/{id}/reauth", ConnectionReauthHandler(a))
 			r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))
+			r.Post("/connections/plaid/link-token", PlaidLinkTokenHandler(a))
+			r.Post("/connections/plaid/exchange", PlaidExchangeHandler(a))
 			r.Post("/transactions/{transaction_id}/comments", CreateCommentHandler(svc))
 			r.Put("/transactions/{transaction_id}/comments/{id}", UpdateCommentHandler(svc))
 			r.Delete("/transactions/{transaction_id}/comments/{id}", DeleteCommentHandler(svc))

--- a/internal/service/connections.go
+++ b/internal/service/connections.go
@@ -7,10 +7,77 @@ import (
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// RegisterNewConnectionParams is the input for RegisterNewConnection. The
+// caller (REST or admin handler) has already exchanged the provider's public
+// token and produced an encrypted credentials blob — this method only
+// performs the DB writes (CreateBankConnection + UpsertAccount per account)
+// so both surfaces share one persistence path.
+type RegisterNewConnectionParams struct {
+	UserID          pgtype.UUID
+	Provider        string
+	InstitutionID   string
+	InstitutionName string
+	Conn            provider.Connection
+	Accounts        []provider.Account
+}
+
+// RegisterNewConnectionResult carries the freshly-persisted connection's
+// stable identifiers so the caller can shape its API response.
+type RegisterNewConnectionResult struct {
+	ID      pgtype.UUID
+	ShortID string
+}
+
+// RegisterNewConnection persists a freshly-exchanged bank connection plus
+// the accounts the provider returned. Account upsert errors are logged but
+// do not fail the call — the connection itself is the source of truth and
+// we'd rather have a connection with N-1 accounts than no connection at all
+// (matches admin ExchangeTokenHandler behavior).
+//
+// The provider exchange (and the encryption of the access token) must
+// already have happened — Conn.EncryptedCredentials and Conn.ExternalID are
+// stored verbatim. This keeps the service layer provider-agnostic.
+func (s *Service) RegisterNewConnection(ctx context.Context, p RegisterNewConnectionParams) (RegisterNewConnectionResult, error) {
+	bankConn, err := s.Queries.CreateBankConnection(ctx, db.CreateBankConnectionParams{
+		UserID:               p.UserID,
+		Provider:             db.ProviderType(p.Provider),
+		InstitutionID:        pgconv.Text(p.InstitutionID),
+		InstitutionName:      pgconv.Text(p.InstitutionName),
+		ExternalID:           pgconv.Text(p.Conn.ExternalID),
+		EncryptedCredentials: p.Conn.EncryptedCredentials,
+		Status:               db.ConnectionStatusActive,
+	})
+	if err != nil {
+		return RegisterNewConnectionResult{}, fmt.Errorf("create bank connection: %w", err)
+	}
+
+	for _, acct := range p.Accounts {
+		if _, err := s.Queries.UpsertAccount(ctx, db.UpsertAccountParams{
+			ConnectionID:      bankConn.ID,
+			ExternalAccountID: acct.ExternalID,
+			Name:              acct.Name,
+			OfficialName:      pgconv.TextIfNotEmpty(acct.OfficialName),
+			Type:              acct.Type,
+			Subtype:           pgconv.TextIfNotEmpty(acct.Subtype),
+			Mask:              pgconv.TextIfNotEmpty(acct.Mask),
+			IsoCurrencyCode:   pgconv.TextIfNotEmpty(acct.ISOCurrencyCode),
+		}); err != nil {
+			s.Logger.Error("upsert account during connection register",
+				"error", err,
+				"external_id", acct.ExternalID,
+				"connection_id", pgconv.FormatUUID(bankConn.ID),
+			)
+		}
+	}
+
+	return RegisterNewConnectionResult{ID: bankConn.ID, ShortID: bankConn.ShortID}, nil
+}
 
 func (s *Service) ListConnections(ctx context.Context, userID *string) ([]ConnectionResponse, error) {
 	if userID != nil {
@@ -276,6 +343,14 @@ func (s *Service) UpdateConnectionSyncInterval(ctx context.Context, id string, i
 // honor the same short-id contract the service layer enforces internally.
 func (s *Service) ResolveConnectionUUID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
 	return s.resolveConnectionID(ctx, idOrShort)
+}
+
+// ResolveUserUUID resolves a UUID-or-short_id input into a pgtype.UUID
+// without fetching the row. Same contract as ResolveConnectionUUID — public so
+// non-service callers (admin and REST handlers) can honor the short-id
+// contract uniformly when they need a user UUID for direct DB writes.
+func (s *Service) ResolveUserUUID(ctx context.Context, idOrShort string) (pgtype.UUID, error) {
+	return s.resolveUserID(ctx, idOrShort)
 }
 
 // ReactivateConnection clears a broken connection's error state and flips


### PR DESCRIPTION
## Summary

Plaid link-flow REST endpoints (Bundle 11 of headless-api):

- `POST /api/v1/connections/plaid/link-token` (Write) — fetches a Plaid Link token for a user
- `POST /api/v1/connections/plaid/exchange` (Write) — exchanges a Plaid public token for a stored connection + accounts

Together these let a headless deployment connect a new Plaid bank account without an admin UI session: the host calls `/link-token`, runs Plaid Link with the returned token, and on success POSTs the `public_token` back to `/exchange`. Mirrors the admin `LinkTokenHandler` + `ExchangeTokenHandler` flow.

Extracts the connection-registration DB writes (`CreateBankConnection` + per-account `UpsertAccount`) into a new `service.RegisterNewConnection` helper. The admin `ExchangeTokenHandler` is refactored to call it too — same DB writes, same response shape, just one code path now. Encryption still happens inside the provider's `ExchangeToken`; the service helper only does the writes.

`user_id` accepts UUID or 8-char short_id on both endpoints, mirroring the rest of the public REST surface. The provider always sees the canonical UUID as Plaid's `client_user_id` regardless of which form the caller used.

Doc: `docs/api-reference.md` Connections section.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./internal/api/... ./internal/service/...`
- [x] `make test-integration`
- [x] 14 new integration tests in `internal/api/connections_plaid_link_integration_test.go` cover happy paths (link-token + exchange), no-provider, provider error, missing required fields, missing user (404), write-scope enforcement (403), and short_id resolution for `user_id` on both endpoints
- [x] `TestPlaidExchange_Success` verifies the persisted connection has the provider's `external_id`, encrypted credentials, both accounts from the provider response (NOT from the request body), and `status=active`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
