### PR TITLE
headless-api: PATCH /accounts/{id} + detail endpoint

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -35,6 +35,42 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 |--------|----------|------|-------------|
 | GET | `/accounts` | Read | List all accounts |
 | GET | `/accounts/{id}` | Read | Get a single account |
+| GET | `/accounts/{id}/detail` | Read | Get account detail with last 25 transactions and per-currency balances |
+| PATCH | `/accounts/{id}` | Write | Partially update mutable fields on a single account |
+
+### `GET /accounts/{id}/detail`
+
+Returns the standard `AccountResponse` fields plus:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `display_name` | string \| null | User-supplied display label (overrides `name` in admin UI) |
+| `excluded` | bool | When true, the account is hidden from totals and skipped during sync |
+| `provider` | string | `plaid`, `teller`, or `csv` |
+| `connection_user_name` | string | Household member who owns the connection (display name) |
+| `connection_short_id` | string | Connection short_id (also surfaced as `connection_id` on the base shape) |
+| `balances` | array | One entry per currency (single-element today; future-proofs for multi-currency accounts). Each entry has `iso_currency_code`, `balance_current`, `balance_available`, `balance_limit`. |
+| `recent_transactions` | array | Up to 25 most recent transactions for this account, sorted date-DESC. Each entry uses the standard `TransactionResponse` shape. |
+
+### `PATCH /accounts/{id}`
+
+Body: every field is optional. Omit a key to leave the corresponding column unchanged. To clear `display_name` and fall back to the institution-supplied `name`, send an explicit empty string.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `display_name` | string | User-supplied label. Empty string clears the override. |
+| `is_excluded` | bool | Hide the account from totals and skip it during sync. |
+| `is_dependent_linked` | bool | Whether the account participates in dependent-link attribution. Normally driven by `account_links` lifecycle; exposed here for parity with the admin UI. |
+
+```json
+{
+  "display_name": "Joint Checking",
+  "is_excluded": false,
+  "is_dependent_linked": true
+}
+```
+
+Response: `200 OK` with the updated `AccountResponse`. Returns `404 NOT_FOUND` when the account doesn't exist.
 
 ## Transactions
 

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -42,3 +42,54 @@ func GetAccountHandler(svc *service.Service) http.HandlerFunc {
 		writeData(w, account)
 	}
 }
+
+// GetAccountDetailHandler returns the full detail payload for an account,
+// including the most recent transactions and balances by currency.
+// GET /api/v1/accounts/{id}/detail
+func GetAccountDetailHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		detail, err := svc.GetAccountDetailResponse(r.Context(), id, 25)
+		if err != nil {
+			writeServiceError(w, err, "Account not found", "Failed to get account detail")
+			return
+		}
+
+		writeData(w, detail)
+	}
+}
+
+// updateAccountRequest is the JSON body for PATCH /accounts/{id}. Every
+// field is optional; omit a key to leave the corresponding column unchanged.
+// To clear `display_name`, send an explicit empty string.
+type updateAccountRequest struct {
+	DisplayName       *string `json:"display_name,omitempty"`
+	IsExcluded        *bool   `json:"is_excluded,omitempty"`
+	IsDependentLinked *bool   `json:"is_dependent_linked,omitempty"`
+}
+
+// UpdateAccountHandler partially updates a single account.
+// PATCH /api/v1/accounts/{id}
+func UpdateAccountHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		var req updateAccountRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+
+		account, err := svc.UpdateAccount(r.Context(), id, service.UpdateAccountParams{
+			DisplayName:       req.DisplayName,
+			IsExcluded:        req.IsExcluded,
+			IsDependentLinked: req.IsDependentLinked,
+		})
+		if err != nil {
+			writeServiceError(w, err, "Account not found", "Failed to update account")
+			return
+		}
+
+		writeData(w, account)
+	}
+}

--- a/internal/api/accounts_mgmt_integration_test.go
+++ b/internal/api/accounts_mgmt_integration_test.go
@@ -1,0 +1,325 @@
+//go:build integration
+
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/testutil"
+)
+
+// seedAccountForMgmt creates a user, connection, account, and the requested
+// number of transactions (dated descending from 2025-03-15). Returns the
+// account row for assertions.
+func seedAccountForMgmt(t *testing.T, env *testEnv, txnCount int) db.Account {
+	t.Helper()
+	user := testutil.MustCreateUser(t, env.Queries, "Account Owner")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "item_acct_mgmt")
+	acct := testutil.MustCreateAccount(t, env.Queries, conn.ID, "ext_acct_mgmt", "Joint Checking")
+
+	base := time.Date(2025, 3, 15, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < txnCount; i++ {
+		date := base.AddDate(0, 0, -i).Format("2006-01-02")
+		ext := "ext_txn_mgmt_" + date + "_" + itoa(i)
+		testutil.MustCreateTransaction(t, env.Queries, acct.ID, ext, "Coffee Shop", int64(100+i), date)
+	}
+	return acct
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	negative := i < 0
+	if negative {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if negative {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}
+
+// ============================================================
+// GET /accounts/{id}/detail
+// ============================================================
+
+func TestGetAccountDetail_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	acct := seedAccountForMgmt(t, env, 5)
+
+	resp := env.doGet(t, "/api/v1/accounts/"+acct.ShortID+"/detail")
+	assertStatus(t, resp, http.StatusOK)
+
+	var detail struct {
+		ShortID            string `json:"short_id"`
+		Name               string `json:"name"`
+		Excluded           bool   `json:"excluded"`
+		Balances           []struct {
+			IsoCurrencyCode *string  `json:"iso_currency_code"`
+			BalanceCurrent  *float64 `json:"balance_current"`
+		} `json:"balances"`
+		RecentTransactions []struct {
+			ShortID string `json:"short_id"`
+			Date    string `json:"date"`
+		} `json:"recent_transactions"`
+	}
+	parseJSON(t, resp, &detail)
+
+	if detail.ShortID != acct.ShortID {
+		t.Errorf("short_id: want %q got %q", acct.ShortID, detail.ShortID)
+	}
+	if detail.Name != "Joint Checking" {
+		t.Errorf("name: want %q got %q", "Joint Checking", detail.Name)
+	}
+	if len(detail.Balances) != 1 {
+		t.Fatalf("expected exactly 1 balance entry, got %d", len(detail.Balances))
+	}
+	if len(detail.RecentTransactions) != 5 {
+		t.Errorf("expected 5 recent transactions, got %d", len(detail.RecentTransactions))
+	}
+	// Recent txns should be date-DESC.
+	if len(detail.RecentTransactions) >= 2 && detail.RecentTransactions[0].Date < detail.RecentTransactions[1].Date {
+		t.Errorf("recent_transactions not date-DESC: %q before %q",
+			detail.RecentTransactions[0].Date, detail.RecentTransactions[1].Date)
+	}
+}
+
+func TestGetAccountDetail_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doGet(t, "/api/v1/accounts/00000000-0000-0000-0000-000000000000/detail")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestGetAccountDetail_AcceptsShortID(t *testing.T) {
+	env := setupTestEnv(t)
+	acct := seedAccountForMgmt(t, env, 1)
+
+	// Same short_id flow as Success, but explicitly assert short_id resolution path.
+	resp := env.doGet(t, "/api/v1/accounts/"+acct.ShortID+"/detail")
+	assertStatus(t, resp, http.StatusOK)
+	var detail struct {
+		ShortID string `json:"short_id"`
+	}
+	parseJSON(t, resp, &detail)
+	if detail.ShortID != acct.ShortID {
+		t.Errorf("short_id: want %q got %q", acct.ShortID, detail.ShortID)
+	}
+}
+
+func TestGetAccountDetail_LastNCap(t *testing.T) {
+	env := setupTestEnv(t)
+	acct := seedAccountForMgmt(t, env, 30)
+
+	resp := env.doGet(t, "/api/v1/accounts/"+acct.ShortID+"/detail")
+	assertStatus(t, resp, http.StatusOK)
+	var detail struct {
+		RecentTransactions []map[string]any `json:"recent_transactions"`
+	}
+	parseJSON(t, resp, &detail)
+	if got := len(detail.RecentTransactions); got != 25 {
+		t.Errorf("expected last-25 cap, got %d", got)
+	}
+}
+
+func TestGetAccountDetail_AllowsReadScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	acct := seedAccountForMgmt(t, env, 2)
+
+	resp := env.doGet(t, "/api/v1/accounts/"+acct.ShortID+"/detail")
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+}
+
+// ============================================================
+// PATCH /accounts/{id}
+// ============================================================
+
+func TestUpdateAccount_DisplayName(t *testing.T) {
+	env := setupTestEnv(t)
+	acct := seedAccountForMgmt(t, env, 0)
+
+	resp := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{
+		"display_name": "Renamed Checking",
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var got map[string]any
+	parseJSON(t, resp, &got)
+	// The base AccountResponse exposes Name (not DisplayName); DisplayName is
+	// only on the detail payload. Verify by re-reading detail.
+	resp2 := env.doGet(t, "/api/v1/accounts/"+acct.ShortID+"/detail")
+	assertStatus(t, resp2, http.StatusOK)
+	var detail struct {
+		DisplayName *string `json:"display_name"`
+	}
+	parseJSON(t, resp2, &detail)
+	if detail.DisplayName == nil || *detail.DisplayName != "Renamed Checking" {
+		t.Errorf("display_name: want %q got %v", "Renamed Checking", detail.DisplayName)
+	}
+}
+
+func TestUpdateAccount_DisplayNameClear(t *testing.T) {
+	env := setupTestEnv(t)
+	acct := seedAccountForMgmt(t, env, 0)
+
+	// Set then clear via empty string.
+	resp1 := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{
+		"display_name": "Temporary",
+	})
+	assertStatus(t, resp1, http.StatusOK)
+	resp1.Body.Close()
+
+	resp2 := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{
+		"display_name": "",
+	})
+	assertStatus(t, resp2, http.StatusOK)
+	resp2.Body.Close()
+
+	resp3 := env.doGet(t, "/api/v1/accounts/"+acct.ShortID+"/detail")
+	var detail struct {
+		DisplayName *string `json:"display_name"`
+	}
+	parseJSON(t, resp3, &detail)
+	if detail.DisplayName != nil {
+		t.Errorf("expected display_name cleared (nil), got %q", *detail.DisplayName)
+	}
+}
+
+func TestUpdateAccount_IsExcludedToggle(t *testing.T) {
+	env := setupTestEnv(t)
+	acct := seedAccountForMgmt(t, env, 0)
+
+	excluded := true
+	resp := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{
+		"is_excluded": excluded,
+	})
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	// Verify the column was actually updated.
+	row, err := env.Queries.GetAccount(t.Context(), acct.ID)
+	if err != nil {
+		t.Fatalf("get account: %v", err)
+	}
+	if !row.Excluded {
+		t.Error("expected excluded=true after PATCH")
+	}
+
+	// Toggle back off.
+	resp2 := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{
+		"is_excluded": false,
+	})
+	assertStatus(t, resp2, http.StatusOK)
+	resp2.Body.Close()
+	row2, err := env.Queries.GetAccount(t.Context(), acct.ID)
+	if err != nil {
+		t.Fatalf("get account: %v", err)
+	}
+	if row2.Excluded {
+		t.Error("expected excluded=false after second PATCH")
+	}
+}
+
+func TestUpdateAccount_IsDependentLinkedToggle(t *testing.T) {
+	env := setupTestEnv(t)
+	acct := seedAccountForMgmt(t, env, 0)
+
+	resp := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{
+		"is_dependent_linked": true,
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var body map[string]any
+	parseJSON(t, resp, &body)
+	if v, _ := body["is_dependent_linked"].(bool); !v {
+		t.Errorf("expected is_dependent_linked=true in response, got %v", body["is_dependent_linked"])
+	}
+
+	row, err := env.Queries.GetAccount(t.Context(), acct.ID)
+	if err != nil {
+		t.Fatalf("get account: %v", err)
+	}
+	if !row.IsDependentLinked {
+		t.Error("expected is_dependent_linked=true in DB")
+	}
+}
+
+func TestUpdateAccount_NotFound_Account(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPatch(t, "/api/v1/accounts/00000000-0000-0000-0000-000000000000", map[string]any{
+		"display_name": "Nope",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestUpdateAccount_PartialPreserves(t *testing.T) {
+	env := setupTestEnv(t)
+	acct := seedAccountForMgmt(t, env, 0)
+
+	// Set both display_name and excluded.
+	resp1 := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{
+		"display_name": "Pinned",
+		"is_excluded":  true,
+	})
+	assertStatus(t, resp1, http.StatusOK)
+	resp1.Body.Close()
+
+	// PATCH only is_dependent_linked — display_name and excluded must persist.
+	resp2 := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{
+		"is_dependent_linked": true,
+	})
+	assertStatus(t, resp2, http.StatusOK)
+	resp2.Body.Close()
+
+	row, err := env.Queries.GetAccount(t.Context(), acct.ID)
+	if err != nil {
+		t.Fatalf("get account: %v", err)
+	}
+	if !row.Excluded {
+		t.Error("expected excluded preserved as true after partial PATCH")
+	}
+	if !row.IsDependentLinked {
+		t.Error("expected is_dependent_linked set to true")
+	}
+	if !row.DisplayName.Valid || row.DisplayName.String != "Pinned" {
+		t.Errorf("expected display_name preserved as %q, got %+v", "Pinned", row.DisplayName)
+	}
+}
+
+func TestUpdateAccount_NoFields(t *testing.T) {
+	env := setupTestEnv(t)
+	acct := seedAccountForMgmt(t, env, 0)
+
+	// PATCH with empty body — should be a no-op (200 + current state).
+	resp := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{})
+	assertStatus(t, resp, http.StatusOK)
+	var got map[string]any
+	parseJSON(t, resp, &got)
+	if got["short_id"] != acct.ShortID {
+		t.Errorf("short_id: want %q got %v", acct.ShortID, got["short_id"])
+	}
+}
+
+func TestUpdateAccount_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	acct := seedAccountForMgmt(t, env, 0)
+
+	resp := env.doPatch(t, "/api/v1/accounts/"+acct.ShortID, map[string]any{
+		"display_name": "Blocked",
+	})
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -106,6 +106,7 @@ func buildTestRouter(svc *service.Service) http.Handler {
 		// Read endpoints
 		r.Get("/accounts", ListAccountsHandler(svc))
 		r.Get("/accounts/{id}", GetAccountHandler(svc))
+		r.Get("/accounts/{id}/detail", GetAccountDetailHandler(svc))
 		r.Get("/transactions", ListTransactionsHandler(svc))
 		r.Get("/transactions/count", CountTransactionsHandler(svc))
 		r.Get("/transactions/summary", TransactionSummaryHandler(svc))
@@ -137,6 +138,7 @@ func buildTestRouter(svc *service.Service) http.Handler {
 		// Write endpoints — require full_access scope
 		r.Group(func(r chi.Router) {
 			r.Use(mw.RequireWriteScope())
+			r.Patch("/accounts/{id}", UpdateAccountHandler(svc))
 			r.Patch("/transactions/{id}/category", SetTransactionCategoryHandler(svc))
 			r.Delete("/transactions/{id}/category", ResetTransactionCategoryHandler(svc))
 			r.Post("/categories", CreateCategoryHandler(svc))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -54,6 +54,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		// Read endpoints — all API keys.
 		r.Get("/accounts", ListAccountsHandler(svc))
 		r.Get("/accounts/{id}", GetAccountHandler(svc))
+		r.Get("/accounts/{id}/detail", GetAccountDetailHandler(svc))
 		r.Get("/transactions", ListTransactionsHandler(svc))
 		r.Get("/transactions/count", CountTransactionsHandler(svc))
 		r.Get("/transactions/summary", TransactionSummaryHandler(svc))
@@ -87,6 +88,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		// Write endpoints — full_access API keys only.
 		r.Group(func(r chi.Router) {
 			r.Use(mw.RequireWriteScope())
+			r.Patch("/accounts/{id}", UpdateAccountHandler(svc))
 			r.Patch("/transactions/{id}/category", SetTransactionCategoryHandler(svc))
 			r.Delete("/transactions/{id}/category", ResetTransactionCategoryHandler(svc))
 			r.Post("/categories", CreateCategoryHandler(svc))

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -55,6 +55,133 @@ func (s *Service) GetAccount(ctx context.Context, id string) (*AccountResponse, 
 	return &resp, nil
 }
 
+// UpdateAccountParams carries the optional, mutable fields a caller can
+// patch on an account. nil fields are left untouched. Only one DB write is
+// performed regardless of how many fields are set; nothing is written when
+// every field is nil.
+type UpdateAccountParams struct {
+	// DisplayName: nil = no change, non-nil "" = clear (NULL),
+	// non-nil value = set.
+	DisplayName *string
+	// IsExcluded toggles whether the account participates in totals/sync.
+	IsExcluded *bool
+	// IsDependentLinked controls the dependent-linked flag (normally driven
+	// by account_links lifecycle but exposed here for parity with admin).
+	IsDependentLinked *bool
+}
+
+// UpdateAccount partially updates a single account. Returns the refreshed
+// AccountResponse. ErrNotFound when the id resolves to no account.
+func (s *Service) UpdateAccount(ctx context.Context, id string, params UpdateAccountParams) (*AccountResponse, error) {
+	uid, err := s.resolveAccountID(ctx, id)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+	if _, err := s.Queries.GetAccount(ctx, uid); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get account: %w", err)
+	}
+
+	if params.DisplayName == nil && params.IsExcluded == nil && params.IsDependentLinked == nil {
+		// Nothing to do — return the current state.
+		return s.GetAccount(ctx, id)
+	}
+
+	// Build a single COALESCE-style UPDATE so all mutable fields land in one
+	// statement. We pass typed sentinels for "no change" (nil) so each
+	// column is left as its current value.
+	const q = `
+		UPDATE accounts SET
+		  display_name        = CASE WHEN $2::bool THEN $3::text ELSE display_name        END,
+		  excluded            = CASE WHEN $4::bool THEN $5::bool ELSE excluded            END,
+		  is_dependent_linked = CASE WHEN $6::bool THEN $7::bool ELSE is_dependent_linked END,
+		  updated_at = NOW()
+		WHERE id = $1`
+
+	dnSet := params.DisplayName != nil
+	var dnVal any
+	if dnSet {
+		// Treat empty string as a "clear" (NULL).
+		if *params.DisplayName == "" {
+			dnVal = nil
+		} else {
+			dnVal = *params.DisplayName
+		}
+	}
+
+	exSet := params.IsExcluded != nil
+	var exVal any
+	if exSet {
+		exVal = *params.IsExcluded
+	} else {
+		exVal = false
+	}
+
+	dlSet := params.IsDependentLinked != nil
+	var dlVal any
+	if dlSet {
+		dlVal = *params.IsDependentLinked
+	} else {
+		dlVal = false
+	}
+
+	if _, err := s.Pool.Exec(ctx, q, uid, dnSet, dnVal, exSet, exVal, dlSet, dlVal); err != nil {
+		return nil, fmt.Errorf("update account: %w", err)
+	}
+
+	return s.GetAccount(ctx, id)
+}
+
+// GetAccountDetailResponse returns the public REST detail payload for an
+// account, including the most recent N transactions and balances by
+// currency. Wraps GetAccountDetail (admin-shape) and ListTransactions for
+// the recent-transactions slice. limit defaults to 25 when <= 0 and is
+// capped at 100.
+func (s *Service) GetAccountDetailResponse(ctx context.Context, id string, limit int) (*AccountDetailResponse, error) {
+	detail, err := s.GetAccountDetail(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	acctID := detail.AccountResponse.ShortID
+	txnList, err := s.ListTransactions(ctx, TransactionListParams{
+		Limit:     limit,
+		AccountID: &acctID,
+		// Account detail surfaces dependent-linked rows too — they're
+		// part of this account's history regardless of attribution.
+		IncludeDependent: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list account transactions: %w", err)
+	}
+
+	resp := &AccountDetailResponse{
+		AccountResponse:    detail.AccountResponse,
+		DisplayName:        detail.DisplayName,
+		Excluded:           detail.Excluded,
+		Provider:           detail.Provider,
+		UserName:           detail.UserName,
+		ConnectionShortID:  detail.ConnectionID,
+		Balances: []AccountBalance{{
+			IsoCurrencyCode:  detail.AccountResponse.IsoCurrencyCode,
+			BalanceCurrent:   detail.AccountResponse.BalanceCurrent,
+			BalanceAvailable: detail.AccountResponse.BalanceAvailable,
+			BalanceLimit:     detail.AccountResponse.BalanceLimit,
+		}},
+		RecentTransactions: txnList.Transactions,
+	}
+	return resp, nil
+}
+
 func (s *Service) GetAccountDetail(ctx context.Context, id string) (*AdminAccountDetail, error) {
 	uid, err := s.resolveAccountID(ctx, id)
 	if err != nil {

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -356,6 +356,34 @@ type AdminAccountDetail struct {
 	ConnectionID    string
 }
 
+// AccountDetailResponse is the public REST detail payload returned from
+// GET /api/v1/accounts/{id}/detail. It composes the standard
+// AccountResponse with a few admin-only fields and the most recent
+// transactions for the account. Per-currency balances are returned on
+// the embedded AccountResponse fields (BalanceCurrent / IsoCurrencyCode);
+// `Balances` is the array form for forward compatibility with multi-currency
+// accounts (always single-element today).
+type AccountDetailResponse struct {
+	AccountResponse
+	DisplayName        *string                  `json:"display_name"`
+	Excluded           bool                     `json:"excluded"`
+	Provider           string                   `json:"provider,omitempty"`
+	UserName           string                   `json:"connection_user_name,omitempty"`
+	ConnectionShortID  string                   `json:"connection_short_id,omitempty"`
+	Balances           []AccountBalance         `json:"balances"`
+	RecentTransactions []TransactionResponse    `json:"recent_transactions"`
+}
+
+// AccountBalance represents a balance in a single currency. Today every
+// Breadbox account has a single balance; the slice shape exists so the
+// payload stays stable if multi-currency accounts ever land.
+type AccountBalance struct {
+	IsoCurrencyCode  *string  `json:"iso_currency_code"`
+	BalanceCurrent   *float64 `json:"balance_current"`
+	BalanceAvailable *float64 `json:"balance_available"`
+	BalanceLimit     *float64 `json:"balance_limit"`
+}
+
 // Comment types
 
 type CreateCommentParams struct {


### PR DESCRIPTION
## Summary

Account update + detail endpoints (Bundle 16 of headless-api):

- `PATCH /api/v1/accounts/{id}` (Write) — partial update of `display_name`, `is_excluded`, `is_dependent_linked`. Empty `display_name` clears the override (matches the admin path).
- `GET /api/v1/accounts/{id}/detail` (Read) — wraps `service.GetAccountDetail`, plus the last 25 transactions and a per-currency `balances` array (single-element today; future-proofs multi-currency).

Adds `service.UpdateAccount` and `service.GetAccountDetailResponse`. Admin handlers (`UpdateAccountExcludedHandler`, `UpdateAccountDisplayNameHandler`) are untouched to keep their wire shapes (raw `db.Account` JSON) pinned for the existing Alpine UI.

### Note on `attributed_user_id`

The bundle spec mentioned `attributed_user_id` as a PATCHable field, but `accounts` has no such column — `attributed_user_id` is a transactions-only attribution (set by `account_links` on match). Omitted from this PR; would require a separate migration to add an account-level attribution override.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (and with `-tags integration`)
- [x] `go test ./...` (unit, all packages green)
- [x] `make test-integration` for `internal/api/...` (all green)
- [x] 13 new integration tests:
  - `GET /accounts/{id}/detail`: success, 404, short_id, last-25 cap, read scope (5)
  - `PATCH /accounts/{id}`: display_name set + clear, is_excluded toggle, is_dependent_linked toggle, partial preserves, empty body no-op, 404, write scope (8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
