### PR TITLE
headless-api: POST /connections/teller setup endpoint

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -111,6 +111,7 @@ API keys are created from the admin dashboard under **API Keys**. Keys can be sc
 | POST | `/connections/{id}/reauth-complete` | Write | Mark connection active again after the user finishes the re-auth flow |
 | POST | `/connections/plaid/link-token` | Write | Start a new Plaid Link flow — returns a fresh link token |
 | POST | `/connections/plaid/exchange` | Write | Exchange the Plaid public token for a stored connection + accounts |
+| POST | `/connections/teller` | Write | Register a Teller connection from the enrollment payload Teller Connect returns |
 
 `{id}` accepts either the connection's UUID or 8-char short_id.
 
@@ -300,6 +301,62 @@ Errors:
 - `400 INVALID_PARAMETER` — required field missing; Plaid provider not configured on this server.
 - `404 NOT_FOUND` — `user_id` doesn't match any household member.
 - `502 PROVIDER_ERROR` — upstream Plaid token exchange failed.
+- `500 INTERNAL_ERROR` — DB write failed (the provider call already succeeded; safe to retry).
+
+### Teller Connect flow (new connection)
+
+Teller's enrollment flow is materially different from Plaid's: Teller Connect
+runs entirely client-side without a server-issued init token, so there is **no
+link-token step**. Just one POST to register the connection:
+
+1. Client / host: load Teller Connect with the application's `TELLER_APP_ID`
+   (returned by `GET /settings/providers` so the host doesn't have to hard-code
+   it). The user authenticates with their bank inside Teller's UI; on success
+   Teller fires `onSuccess` with an `enrollment` payload containing
+   `access_token`, `enrollment.id`, the matched institution, and the accounts
+   it discovered.
+2. Server: `POST /connections/teller` with the enrollment payload →
+   Breadbox calls Teller's `GET /accounts` with the access token to confirm
+   the discovered accounts, encrypts the access token, creates the
+   `BankConnection` row, and upserts the accounts Teller authoritatively
+   reports. Subsequent syncs run automatically on the global cron.
+
+This endpoint mirrors the admin `POST /admin/api/exchange-token` handler with
+`provider: "teller"` and persists data through the same service-layer write
+path as `POST /connections/plaid/exchange`.
+
+### POST `/connections/teller`
+
+Registers a new Teller connection.
+
+**Body**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `user_id` | string | Required. UUID or 8-char short_id of the owning user. |
+| `institution_id` | string | Optional. Teller institution identifier (e.g. `chase`). |
+| `institution_name` | string | Required. Display name (e.g. `Chase`). Forwarded to the Teller exchange so the persisted connection carries the right label. |
+| `access_token` | string | Required. The `access_token` Teller handed back in `onSuccess`. |
+| `enrollment_id` | string | Required. The `enrollment.id` Teller handed back in `onSuccess`. Becomes the connection's `external_id`. |
+| `accounts` | array | Optional. The account metadata array Teller's `onSuccess` returns (id / name / type / subtype / last_four). **Informational only** — the rows persisted come from Teller's `GET /accounts` response, not from this field. |
+
+Returns `201`:
+
+```json
+{
+  "connection_id": "abc12345",
+  "institution_name": "Chase",
+  "status": "active"
+}
+```
+
+`connection_id` is the new connection's 8-char short_id.
+
+Errors:
+
+- `400 INVALID_PARAMETER` — required field missing; Teller provider not configured on this server.
+- `404 NOT_FOUND` — `user_id` doesn't match any household member.
+- `502 PROVIDER_ERROR` — upstream Teller call failed.
 - `500 INTERNAL_ERROR` — DB write failed (the provider call already succeeded; safe to retry).
 
 ## Sync

--- a/internal/api/connections_teller_setup.go
+++ b/internal/api/connections_teller_setup.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"breadbox/internal/app"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+)
+
+// tellerSetupRequest is the JSON body for POST /api/v1/connections/teller.
+//
+// Teller's enrollment flow is materially different from Plaid's: Teller
+// Connect runs entirely client-side without a server-issued init token, so
+// there's no `link-token` step. The host runs Teller Connect, the user
+// enrolls with their bank, and Teller's onSuccess callback hands back an
+// `enrollment` payload (access_token + enrollment.id + institution + the
+// accounts it discovered). Forward that payload here to register the
+// connection.
+//
+// The `accounts` slice is informational only — the rows persisted come
+// from the provider's `ExchangeToken` response (which calls Teller's
+// `GET /accounts` with the freshly-issued access token), matching the
+// behavior of POST /connections/plaid/exchange.
+type tellerSetupRequest struct {
+	UserID          string                 `json:"user_id"`
+	InstitutionID   string                 `json:"institution_id"`
+	InstitutionName string                 `json:"institution_name"`
+	AccessToken     string                 `json:"access_token"`
+	EnrollmentID    string                 `json:"enrollment_id"`
+	Accounts        []tellerSetupAccountMD `json:"accounts"`
+}
+
+type tellerSetupAccountMD struct {
+	ID       string `json:"id"`
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Subtype  string `json:"subtype"`
+	LastFour string `json:"last_four"`
+}
+
+// tellerSetupResponse mirrors plaidExchangeResponse so the SDK surface stays
+// uniform across providers.
+type tellerSetupResponse struct {
+	ConnectionID    string `json:"connection_id"`
+	InstitutionName string `json:"institution_name"`
+	Status          string `json:"status"`
+}
+
+// tellerExchangeBlob is the JSON shape provider/teller.ExchangeToken
+// expects as its `publicToken` argument. Keeping this private to the
+// handler keeps the service layer provider-agnostic — the encoding
+// detail belongs at the HTTP boundary, not in the persistence path.
+type tellerExchangeBlob struct {
+	AccessToken     string `json:"access_token"`
+	EnrollmentID    string `json:"enrollment_id"`
+	InstitutionName string `json:"institution_name"`
+}
+
+// TellerSetupHandler serves POST /api/v1/connections/teller.
+//
+// Registers a Teller connection from the enrollment payload Teller Connect
+// returns on success. Builds the access_token + enrollment_id blob the
+// Teller provider's `ExchangeToken` accepts, then reuses
+// `service.RegisterNewConnection` (shared with the admin handler and
+// PlaidExchangeHandler) for persistence so all three surfaces leave the
+// DB in identical shape.
+func TellerSetupHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		var req tellerSetupRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		if req.UserID == "" || req.InstitutionName == "" || req.AccessToken == "" || req.EnrollmentID == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"user_id, institution_name, access_token, and enrollment_id are required")
+			return
+		}
+
+		uid, err := a.Service.ResolveUserUUID(ctx, req.UserID)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "User not found")
+				return
+			}
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid user_id")
+			return
+		}
+
+		prov, ok := a.Providers["teller"]
+		if !ok {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"Teller provider is not configured on this server")
+			return
+		}
+
+		blob, err := buildTellerExchangeBlob(req)
+		if err != nil {
+			// Should be unreachable — JSON marshal of a fixed struct
+			// of strings doesn't fail in practice. Treat as 500 for safety.
+			a.Logger.Error("encode teller exchange blob", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to prepare provider call")
+			return
+		}
+
+		conn, accounts, err := prov.ExchangeToken(ctx, blob)
+		if err != nil {
+			a.Logger.Error("exchange teller enrollment", "error", err)
+			mw.WriteError(w, http.StatusBadGateway, "PROVIDER_ERROR", "Failed to exchange enrollment payload")
+			return
+		}
+
+		result, err := a.Service.RegisterNewConnection(ctx, service.RegisterNewConnectionParams{
+			UserID:          uid,
+			Provider:        "teller",
+			InstitutionID:   req.InstitutionID,
+			InstitutionName: req.InstitutionName,
+			Conn:            conn,
+			Accounts:        accounts,
+		})
+		if err != nil {
+			a.Logger.Error("register teller connection", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to save connection")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, tellerSetupResponse{
+			ConnectionID:    result.ShortID,
+			InstitutionName: req.InstitutionName,
+			Status:          "active",
+		})
+	}
+}
+
+// buildTellerExchangeBlob serializes the access_token + enrollment_id +
+// institution_name triple into the JSON string the Teller provider's
+// ExchangeToken accepts. Lives here (not in the service layer) so the
+// service stays oblivious to Teller-specific encoding.
+func buildTellerExchangeBlob(req tellerSetupRequest) (string, error) {
+	b, err := json.Marshal(tellerExchangeBlob{
+		AccessToken:     req.AccessToken,
+		EnrollmentID:    req.EnrollmentID,
+		InstitutionName: req.InstitutionName,
+	})
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/api/connections_teller_setup_integration_test.go
+++ b/internal/api/connections_teller_setup_integration_test.go
@@ -1,0 +1,415 @@
+//go:build integration
+
+// Integration tests for the Teller setup REST endpoint
+// (POST /api/v1/connections/teller).
+//
+// Mirrors the fake-provider pattern from
+// connections_plaid_link_integration_test.go: a stub provider implementing
+// just the ExchangeToken entry point is wired into a *app.App, driven
+// through the public REST router with API-key auth + write-scope enforced
+// just like production.
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
+	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// fakeTellerProvider implements provider.Provider for the setup-flow tests.
+// Only ExchangeToken and Name are functional; everything else panics so any
+// unexpected call is loud during testing.
+type fakeTellerProvider struct {
+	exchangeConn      provider.Connection
+	exchangeAccounts  []provider.Account
+	exchangeErr       error
+	exchangeCalls     int
+	lastExchangeToken string
+}
+
+func (f *fakeTellerProvider) CreateLinkSession(context.Context, string) (provider.LinkSession, error) {
+	panic("fakeTellerProvider.CreateLinkSession not implemented")
+}
+
+func (f *fakeTellerProvider) ExchangeToken(_ context.Context, publicToken string) (provider.Connection, []provider.Account, error) {
+	f.exchangeCalls++
+	f.lastExchangeToken = publicToken
+	if f.exchangeErr != nil {
+		return provider.Connection{}, nil, f.exchangeErr
+	}
+	return f.exchangeConn, f.exchangeAccounts, nil
+}
+
+func (f *fakeTellerProvider) CreateReauthSession(context.Context, provider.Connection) (provider.LinkSession, error) {
+	panic("fakeTellerProvider.CreateReauthSession not implemented")
+}
+func (f *fakeTellerProvider) SyncTransactions(context.Context, provider.Connection, string) (provider.SyncResult, error) {
+	panic("fakeTellerProvider.SyncTransactions not implemented")
+}
+func (f *fakeTellerProvider) GetBalances(context.Context, provider.Connection) ([]provider.AccountBalance, error) {
+	panic("fakeTellerProvider.GetBalances not implemented")
+}
+func (f *fakeTellerProvider) HandleWebhook(context.Context, provider.WebhookPayload) (provider.WebhookEvent, error) {
+	panic("fakeTellerProvider.HandleWebhook not implemented")
+}
+func (f *fakeTellerProvider) RemoveConnection(context.Context, provider.Connection) error {
+	panic("fakeTellerProvider.RemoveConnection not implemented")
+}
+
+// tellerSetupEnv is the per-test harness for the setup endpoint.
+type tellerSetupEnv struct {
+	Server   *httptest.Server
+	APIKey   string
+	App      *app.App
+	Service  *service.Service
+	Queries  *db.Queries
+	Provider *fakeTellerProvider
+}
+
+func setupTellerSetupEnv(t *testing.T, scope string, registerProvider bool) *tellerSetupEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "teller-setup-test-key", scope)
+	if err != nil {
+		t.Fatalf("create API key: %v", err)
+	}
+
+	fp := &fakeTellerProvider{
+		exchangeConn: provider.Connection{
+			ProviderName:         "teller",
+			ExternalID:           "enr_xyz_999",
+			EncryptedCredentials: []byte("encrypted-teller-token"),
+			InstitutionName:      "Chase",
+		},
+		exchangeAccounts: []provider.Account{
+			{
+				ExternalID:      "acc_chk_provider_1",
+				Name:            "Chase Checking",
+				Type:            "depository",
+				Subtype:         "checking",
+				Mask:            "1234",
+				ISOCurrencyCode: "USD",
+			},
+			{
+				ExternalID:      "acc_sav_provider_2",
+				Name:            "Chase Savings",
+				Type:            "depository",
+				Subtype:         "savings",
+				Mask:            "5678",
+				ISOCurrencyCode: "USD",
+			},
+		},
+	}
+
+	providers := map[string]provider.Provider{}
+	if registerProvider {
+		providers["teller"] = fp
+	}
+	a := &app.App{
+		DB:        pool,
+		Queries:   queries,
+		Logger:    slog.Default(),
+		Service:   svc,
+		Providers: providers,
+	}
+
+	r := buildTellerSetupTestRouter(svc, a)
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &tellerSetupEnv{
+		Server:   server,
+		APIKey:   keyResult.PlaintextKey,
+		App:      a,
+		Service:  svc,
+		Queries:  queries,
+		Provider: fp,
+	}
+}
+
+// buildTellerSetupTestRouter mounts only the route exercised by these tests.
+// Mirrors the production wiring: API key auth runs outside the write-scope
+// group; the Teller setup endpoint sits inside it.
+func buildTellerSetupTestRouter(svc *service.Service, a *app.App) http.Handler {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/connections/teller", TellerSetupHandler(a))
+		})
+	})
+	return r
+}
+
+func (e *tellerSetupEnv) doPostJSON(t *testing.T, path string, body any) *http.Response {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+	}
+	req, err := http.NewRequest("POST", e.Server.URL+path, &buf)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", e.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+func validTellerSetupBody(userID string) map[string]any {
+	return map[string]any{
+		"user_id":          userID,
+		"institution_id":   "ins_chase",
+		"institution_name": "Chase",
+		"access_token":     "token-sandbox-fake-teller",
+		"enrollment_id":    "enr_abc123",
+		"accounts": []map[string]string{
+			{"id": "acc_chk_request_1", "name": "Chase Checking", "type": "depository", "subtype": "checking", "last_four": "1234"},
+		},
+	}
+}
+
+func TestTellerSetup_Success(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/teller",
+		validTellerSetupBody(pgconv.FormatUUID(user.ID)))
+	assertStatus(t, resp, http.StatusCreated)
+
+	var body tellerSetupResponse
+	parseJSON(t, resp, &body)
+	if body.ConnectionID == "" {
+		t.Fatal("want non-empty connection_id (short_id) in response")
+	}
+	if body.InstitutionName != "Chase" {
+		t.Errorf("want institution_name %q, got %q", "Chase", body.InstitutionName)
+	}
+	if body.Status != "active" {
+		t.Errorf("want status %q, got %q", "active", body.Status)
+	}
+	if env.Provider.exchangeCalls != 1 {
+		t.Errorf("want 1 provider exchange call, got %d", env.Provider.exchangeCalls)
+	}
+
+	// The provider must receive the JSON-encoded blob with access_token,
+	// enrollment_id, and institution_name — that's the contract Teller's
+	// provider.ExchangeToken parses (see internal/provider/teller/link.go).
+	var seen tellerExchangeBlob
+	if err := json.Unmarshal([]byte(env.Provider.lastExchangeToken), &seen); err != nil {
+		t.Fatalf("provider received non-JSON publicToken: %v (raw=%q)", err, env.Provider.lastExchangeToken)
+	}
+	if seen.AccessToken != "token-sandbox-fake-teller" {
+		t.Errorf("want forwarded access_token %q, got %q", "token-sandbox-fake-teller", seen.AccessToken)
+	}
+	if seen.EnrollmentID != "enr_abc123" {
+		t.Errorf("want forwarded enrollment_id %q, got %q", "enr_abc123", seen.EnrollmentID)
+	}
+	if seen.InstitutionName != "Chase" {
+		t.Errorf("want forwarded institution_name %q, got %q", "Chase", seen.InstitutionName)
+	}
+
+	// Verify DB persistence: connection by short_id with provider's external_id.
+	uid, err := env.Service.ResolveConnectionUUID(t.Context(), body.ConnectionID)
+	if err != nil {
+		t.Fatalf("resolve persisted connection short_id: %v", err)
+	}
+	conn, err := env.Queries.GetBankConnection(t.Context(), uid)
+	if err != nil {
+		t.Fatalf("reload connection: %v", err)
+	}
+	if conn.Status != db.ConnectionStatusActive {
+		t.Errorf("want connection status=active, got %q", conn.Status)
+	}
+	if conn.Provider != db.ProviderTypeTeller {
+		t.Errorf("want provider=teller, got %q", conn.Provider)
+	}
+	if conn.ExternalID.String != "enr_xyz_999" {
+		t.Errorf("want external_id %q (from provider), got %q", "enr_xyz_999", conn.ExternalID.String)
+	}
+	if conn.InstitutionName.String != "Chase" {
+		t.Errorf("want institution_name %q, got %q", "Chase", conn.InstitutionName.String)
+	}
+	if string(conn.EncryptedCredentials) != "encrypted-teller-token" {
+		t.Errorf("want encrypted credentials persisted verbatim from provider, got %q",
+			string(conn.EncryptedCredentials))
+	}
+}
+
+func TestTellerSetup_BadInput_MissingAccessToken(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := validTellerSetupBody(pgconv.FormatUUID(user.ID))
+	delete(body, "access_token")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/teller", body)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+	if env.Provider.exchangeCalls != 0 {
+		t.Errorf("provider should not be called when validation fails, got %d", env.Provider.exchangeCalls)
+	}
+}
+
+func TestTellerSetup_BadInput_MissingEnrollmentID(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := validTellerSetupBody(pgconv.FormatUUID(user.ID))
+	delete(body, "enrollment_id")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/teller", body)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+	if env.Provider.exchangeCalls != 0 {
+		t.Errorf("provider should not be called when validation fails, got %d", env.Provider.exchangeCalls)
+	}
+}
+
+func TestTellerSetup_BadInput_MissingUserID(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", true)
+
+	body := validTellerSetupBody("")
+	delete(body, "user_id")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/teller", body)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestTellerSetup_BadInput_MissingInstitutionName(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := validTellerSetupBody(pgconv.FormatUUID(user.ID))
+	delete(body, "institution_name")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/teller", body)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestTellerSetup_NoProvider(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", false)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/teller",
+		validTellerSetupBody(pgconv.FormatUUID(user.ID)))
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestTellerSetup_ProviderError(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", true)
+	env.Provider.exchangeErr = errors.New("teller: HTTP 401")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/teller",
+		validTellerSetupBody(pgconv.FormatUUID(user.ID)))
+	readErrorCode(t, resp, http.StatusBadGateway, "PROVIDER_ERROR")
+}
+
+func TestTellerSetup_NotFound_User(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", true)
+
+	body := validTellerSetupBody("abc12345") // valid short_id format, no row
+	resp := env.doPostJSON(t, "/api/v1/connections/teller", body)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+	if env.Provider.exchangeCalls != 0 {
+		t.Errorf("provider should not be called for missing user, got %d", env.Provider.exchangeCalls)
+	}
+}
+
+func TestTellerSetup_RequiresWriteScope(t *testing.T) {
+	env := setupTellerSetupEnv(t, "read_only", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/teller",
+		validTellerSetupBody(pgconv.FormatUUID(user.ID)))
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+func TestTellerSetup_AcceptsShortIDForUser(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/connections/teller", validTellerSetupBody(user.ShortID))
+	assertStatus(t, resp, http.StatusCreated)
+
+	var body tellerSetupResponse
+	parseJSON(t, resp, &body)
+	if body.ConnectionID == "" {
+		t.Fatal("want non-empty connection_id from short_id-based call")
+	}
+
+	// The persisted connection should belong to the resolved user.
+	uid, _ := env.Service.ResolveConnectionUUID(t.Context(), body.ConnectionID)
+	conn, err := env.Queries.GetBankConnection(t.Context(), uid)
+	if err != nil {
+		t.Fatalf("reload connection: %v", err)
+	}
+	if pgconv.FormatUUID(conn.UserID) != pgconv.FormatUUID(user.ID) {
+		t.Errorf("want connection.user_id %q, got %q",
+			pgconv.FormatUUID(user.ID), pgconv.FormatUUID(conn.UserID))
+	}
+}
+
+func TestTellerSetup_PersistsAccountsFromProvider(t *testing.T) {
+	env := setupTellerSetupEnv(t, "full_access", true)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	// Request body has 1 account; provider returns 2. The 2 from the
+	// provider are what should land in the DB — matching the Plaid handler's
+	// behavior (the request `accounts` field is informational only).
+	resp := env.doPostJSON(t, "/api/v1/connections/teller",
+		validTellerSetupBody(pgconv.FormatUUID(user.ID)))
+	assertStatus(t, resp, http.StatusCreated)
+
+	var body tellerSetupResponse
+	parseJSON(t, resp, &body)
+	uid, err := env.Service.ResolveConnectionUUID(t.Context(), body.ConnectionID)
+	if err != nil {
+		t.Fatalf("resolve persisted connection: %v", err)
+	}
+	accts, err := env.Queries.ListAccountsByConnection(t.Context(), uid)
+	if err != nil {
+		t.Fatalf("list accounts: %v", err)
+	}
+	if len(accts) != 2 {
+		t.Fatalf("want 2 accounts persisted from provider response, got %d", len(accts))
+	}
+	// Sanity: external IDs should match the provider's, not the request's.
+	gotExternalIDs := map[string]bool{}
+	for _, a := range accts {
+		gotExternalIDs[a.ExternalAccountID] = true
+	}
+	for _, want := range []string{"acc_chk_provider_1", "acc_sav_provider_2"} {
+		if !gotExternalIDs[want] {
+			t.Errorf("want persisted account external_id %q, missing from %v", want, gotExternalIDs)
+		}
+	}
+	if gotExternalIDs["acc_chk_request_1"] {
+		t.Errorf("request-body account external_id leaked into persistence")
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -103,6 +103,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/connections/{id}/reauth-complete", ConnectionReauthCompleteHandler(a))
 			r.Post("/connections/plaid/link-token", PlaidLinkTokenHandler(a))
 			r.Post("/connections/plaid/exchange", PlaidExchangeHandler(a))
+			r.Post("/connections/teller", TellerSetupHandler(a))
 			r.Post("/transactions/{transaction_id}/comments", CreateCommentHandler(svc))
 			r.Put("/transactions/{transaction_id}/comments/{id}", UpdateCommentHandler(svc))
 			r.Delete("/transactions/{transaction_id}/comments/{id}", DeleteCommentHandler(svc))


### PR DESCRIPTION
## Summary

Teller setup REST endpoint (Bundle 12 of headless-api):

- `POST /api/v1/connections/teller` (Write) — registers a Teller connection from the enrollment payload Teller Connect returns. No link-token step (Teller Connect runs entirely client-side, no server-issued init token).

The handler builds the JSON `{access_token, enrollment_id, institution_name}` blob the Teller provider's `ExchangeToken` accepts (matching `internal/provider/teller/link.go`), then reuses `service.RegisterNewConnection` (extracted in B11) for persistence so the admin Teller flow, Plaid exchange, and this endpoint all leave the DB in identical shape. Same response envelope as `POST /connections/plaid/exchange`.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `make test-integration`
- [x] 11 integration tests cover happy path, validation (4), no-provider, provider error, scope, not-found, short_id, accounts-from-provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)
