### PR TITLE
headless-api: users CRUD endpoints

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -131,6 +131,55 @@ Response: `200 OK` with the updated `AccountResponse`. Returns `404 NOT_FOUND` w
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
 | GET | `/users` | Read | List all family members |
+| GET | `/users/{id}` | Read | Get a single household member |
+| POST | `/users` | Write | Create a household member |
+| PATCH | `/users/{id}` | Write | Update mutable fields (name, email) |
+| DELETE | `/users/{id}` | Write | Delete a household member (refused while bank connections still attach) |
+| POST | `/users/{id}/wipe-data` | Write | Destructive — remove all bank connections, accounts, and transactions belonging to this user |
+
+`{id}` accepts either the user's UUID or 8-char short_id.
+
+### POST `/users`
+
+Create a household member. Mirrors the admin "Add family member" form.
+
+```json
+{
+  "name": "Charlie",
+  "email": "charlie@example.com"
+}
+```
+
+- `name` (required) — trimmed; empty value returns `400 INVALID_PARAMETER`.
+- `email` (optional) — must parse as RFC 5322. A duplicate email returns `409 EMAIL_CONFLICT`.
+
+Responds `201` with the created `UserResponse`.
+
+### PATCH `/users/{id}`
+
+Partial update — every field is optional, omitted fields stay unchanged. Pass `email: ""` (a non-null empty string) to clear the stored email.
+
+```json
+{ "name": "Renamed", "email": "new@example.com" }
+```
+
+Responds `200` with the updated `UserResponse`. `404 NOT_FOUND` when the id cannot be resolved; `409 EMAIL_CONFLICT` when the new email is already taken.
+
+### DELETE `/users/{id}`
+
+Hard delete. Refuses with `409 USER_HAS_DEPENDENTS` whenever the user still owns one or more bank connections — call `POST /users/{id}/wipe-data` first if you really mean to remove them.
+
+Responds `204` on success, `404 NOT_FOUND` when the id is unknown.
+
+### POST `/users/{id}/wipe-data`
+
+Destructive: deletes every `bank_connections`, `accounts`, and `transactions` row attached to this user, in a single transaction. Useful as a prerequisite to `DELETE /users/{id}` and as a "reset" hook for development.
+
+```json
+{ "status": "ok", "deleted_transactions": 3 }
+```
+
+Responds `200` with the count of removed transactions, `404 NOT_FOUND` when the user does not exist.
 
 ## Connections
 

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -116,6 +116,7 @@ func buildTestRouter(svc *service.Service) http.Handler {
 		r.Get("/categories/export", ExportCategoriesTSVHandler(svc))
 		r.Get("/categories/{id}", GetCategoryHandler(svc))
 		r.Get("/users", ListUsersHandler(svc))
+		r.Get("/users/{id}", GetUserHandler(svc))
 		r.Get("/connections", ListConnectionsHandler(svc))
 		r.Get("/connections/{id}", GetConnectionHandler(svc))
 		r.Get("/connections/{id}/status", GetConnectionStatusHandler(svc))
@@ -178,6 +179,10 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Post("/connections/{id}/paused", PauseConnectionHandler(svc))
 			r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(svc))
 			r.Delete("/connections/{id}", DeleteConnectionHandler(svc))
+			r.Post("/users", CreateUserHandler(svc))
+			r.Patch("/users/{id}", UpdateUserHandler(svc))
+			r.Delete("/users/{id}", DeleteUserHandler(svc))
+			r.Post("/users/{id}/wipe-data", WipeUserDataHandler(svc))
 		})
 	})
 	return r

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -64,6 +64,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/categories/export", ExportCategoriesTSVHandler(svc))
 		r.Get("/categories/{id}", GetCategoryHandler(svc))
 		r.Get("/users", ListUsersHandler(svc))
+		r.Get("/users/{id}", GetUserHandler(svc))
 		r.Get("/connections", ListConnectionsHandler(svc))
 		r.Get("/connections/{id}", GetConnectionHandler(svc))
 		r.Get("/connections/{id}/status", GetConnectionStatusHandler(svc))
@@ -135,6 +136,10 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Delete("/tags/{slug}", DeleteTagHandler(svc))
 			r.Put("/settings/providers/plaid", UpdatePlaidConfigHandler(a))
 			r.Put("/settings/providers/teller", UpdateTellerConfigHandler(a))
+			r.Post("/users", CreateUserHandler(svc))
+			r.Patch("/users/{id}", UpdateUserHandler(svc))
+			r.Delete("/users/{id}", DeleteUserHandler(svc))
+			r.Post("/users/{id}/wipe-data", WipeUserDataHandler(svc))
 		})
 	})
 

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -5,6 +5,8 @@ import (
 
 	mw "breadbox/internal/middleware"
 	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
 )
 
 // ListUsersHandler returns all users.
@@ -17,5 +19,119 @@ func ListUsersHandler(svc *service.Service) http.HandlerFunc {
 		}
 
 		writeData(w, users)
+	}
+}
+
+// GetUserHandler returns a single household member by UUID or short_id.
+// GET /api/v1/users/{id}.
+func GetUserHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		user, err := svc.GetUser(r.Context(), id)
+		if err != nil {
+			writeServiceError(w, err, "User not found", "Failed to get user")
+			return
+		}
+		writeData(w, user)
+	}
+}
+
+// createUserRequest is the JSON body shape for POST /api/v1/users.
+type createUserRequest struct {
+	Name  string  `json:"name"`
+	Email *string `json:"email,omitempty"`
+}
+
+// CreateUserHandler creates a new household member.
+// POST /api/v1/users — name required, email optional.
+func CreateUserHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var input createUserRequest
+		if !decodeJSON(w, r, &input) {
+			return
+		}
+
+		user, err := svc.CreateUser(r.Context(), service.CreateUserParams{
+			Name:  input.Name,
+			Email: input.Email,
+		})
+		if err != nil {
+			writeServiceError(w, err, "User not found", "Failed to create user")
+			return
+		}
+		writeJSON(w, http.StatusCreated, user)
+	}
+}
+
+// updateUserRequest is the JSON body shape for PATCH /api/v1/users/{id}.
+// Every field is optional. Pass `email: ""` (non-null empty string) to
+// clear the stored email.
+type updateUserRequest struct {
+	Name  *string `json:"name,omitempty"`
+	Email *string `json:"email,omitempty"`
+}
+
+// UpdateUserHandler partially updates a household member.
+// PATCH /api/v1/users/{id}.
+func UpdateUserHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		var input updateUserRequest
+		if !decodeJSON(w, r, &input) {
+			return
+		}
+
+		user, err := svc.UpdateUser(r.Context(), id, service.UpdateUserParams{
+			Name:  input.Name,
+			Email: input.Email,
+		})
+		if err != nil {
+			writeServiceError(w, err, "User not found", "Failed to update user")
+			return
+		}
+		writeData(w, user)
+	}
+}
+
+// DeleteUserHandler removes a household member. Refuses (409) when the
+// user still has bank connections attached — callers should hit
+// POST /users/{id}/wipe-data first.
+// DELETE /api/v1/users/{id}.
+func DeleteUserHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		if err := svc.DeleteUser(r.Context(), id); err != nil {
+			writeServiceError(w, err, "User not found", "Failed to delete user")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// WipeUserDataHandler is a destructive endpoint that removes all bank
+// connections, accounts, and transactions belonging to a household
+// member. Mirrors the admin /-/users/{id}/wipe action; protected by
+// the write scope.
+// POST /api/v1/users/{id}/wipe-data.
+func WipeUserDataHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+		// Verify the user exists up-front so we can return 404 with a
+		// clean message rather than a wrapped "invalid user_id" error.
+		if _, err := svc.GetUser(r.Context(), id); err != nil {
+			writeServiceError(w, err, "User not found", "Failed to wipe user data")
+			return
+		}
+
+		count, err := svc.WipeUserData(r.Context(), id)
+		if err != nil {
+			writeServiceError(w, err, "User not found", "Failed to wipe user data")
+			return
+		}
+		writeData(w, map[string]any{
+			"status":               "ok",
+			"deleted_transactions": count,
+		})
 	}
 }

--- a/internal/api/users_crud_integration_test.go
+++ b/internal/api/users_crud_integration_test.go
@@ -1,0 +1,260 @@
+//go:build integration
+
+// Integration tests for the user CRUD endpoints (GET /users/{id}, POST
+// /users, PATCH /users/{id}, DELETE /users/{id}, POST /users/{id}/wipe-data).
+// The {id} URL param accepts UUID or short_id — see service.resolveUserID.
+//
+// Run with: DATABASE_URL=... go test -tags integration -count=1 -p 1 -v -run User ./internal/api/...
+
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+// --- helpers ---------------------------------------------------------------
+
+func createUserVia(t *testing.T, env *testEnv, body map[string]any) service.UserResponse {
+	t.Helper()
+	resp := env.doPost(t, "/api/v1/users", body)
+	assertStatus(t, resp, http.StatusCreated)
+	var user service.UserResponse
+	parseJSON(t, resp, &user)
+	return user
+}
+
+// --- GET /users/{id} -------------------------------------------------------
+
+func TestGetUser_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	u := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doGet(t, "/api/v1/users/"+pgconv.FormatUUID(u.ID))
+	assertStatus(t, resp, http.StatusOK)
+
+	var got service.UserResponse
+	parseJSON(t, resp, &got)
+	if got.Name != "Alice" {
+		t.Errorf("name: got %q, want Alice", got.Name)
+	}
+	if got.ShortID == "" {
+		t.Errorf("short_id should be set")
+	}
+	if got.ID != pgconv.FormatUUID(u.ID) {
+		t.Errorf("id: got %q, want %q", got.ID, pgconv.FormatUUID(u.ID))
+	}
+}
+
+func TestGetUser_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doGet(t, "/api/v1/users/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestGetUser_AcceptsShortID(t *testing.T) {
+	env := setupTestEnv(t)
+	u := testutil.MustCreateUser(t, env.Queries, "Bob")
+
+	resp := env.doGet(t, "/api/v1/users/"+u.ShortID)
+	assertStatus(t, resp, http.StatusOK)
+
+	var got service.UserResponse
+	parseJSON(t, resp, &got)
+	if got.ShortID != u.ShortID {
+		t.Errorf("short_id: got %q, want %q", got.ShortID, u.ShortID)
+	}
+}
+
+// --- POST /users -----------------------------------------------------------
+
+func TestCreateUser_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	resp := env.doPost(t, "/api/v1/users", map[string]any{
+		"name":  "Charlie",
+		"email": "charlie@example.com",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+
+	var got service.UserResponse
+	parseJSON(t, resp, &got)
+	if got.Name != "Charlie" {
+		t.Errorf("name: got %q, want Charlie", got.Name)
+	}
+	if got.Email == nil || *got.Email != "charlie@example.com" {
+		t.Errorf("email: got %v, want charlie@example.com", got.Email)
+	}
+	if got.ID == "" || got.ShortID == "" {
+		t.Errorf("id and short_id must be set")
+	}
+}
+
+func TestCreateUser_EmptyName(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doPost(t, "/api/v1/users", map[string]any{
+		"name": "   ",
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestCreateUser_DuplicateEmail(t *testing.T) {
+	env := setupTestEnv(t)
+	_ = createUserVia(t, env, map[string]any{
+		"name":  "First",
+		"email": "dup@example.com",
+	})
+	resp := env.doPost(t, "/api/v1/users", map[string]any{
+		"name":  "Second",
+		"email": "dup@example.com",
+	})
+	readErrorCode(t, resp, http.StatusConflict, "EMAIL_CONFLICT")
+}
+
+// --- PATCH /users/{id} -----------------------------------------------------
+
+func TestUpdateUser_PartialPatch(t *testing.T) {
+	env := setupTestEnv(t)
+	u := createUserVia(t, env, map[string]any{
+		"name":  "Original",
+		"email": "orig@example.com",
+	})
+
+	newName := "Renamed"
+	resp := env.doPatch(t, "/api/v1/users/"+u.ID, map[string]any{
+		"name": newName,
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var got service.UserResponse
+	parseJSON(t, resp, &got)
+	if got.Name != newName {
+		t.Errorf("name: got %q, want %q", got.Name, newName)
+	}
+	if got.Email == nil || *got.Email != "orig@example.com" {
+		t.Errorf("email should remain unchanged, got %v", got.Email)
+	}
+}
+
+func TestUpdateUser_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doPatch(t, "/api/v1/users/00000000-0000-0000-0000-000000000000", map[string]any{
+		"name": "Anyone",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// --- DELETE /users/{id} ----------------------------------------------------
+
+func TestDeleteUser_NoDependents(t *testing.T) {
+	env := setupTestEnv(t)
+	u := testutil.MustCreateUser(t, env.Queries, "Detachable")
+
+	resp := env.doDelete(t, "/api/v1/users/"+pgconv.FormatUUID(u.ID))
+	assertStatus(t, resp, http.StatusNoContent)
+	resp.Body.Close()
+
+	get := env.doGet(t, "/api/v1/users/"+pgconv.FormatUUID(u.ID))
+	readErrorCode(t, get, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestDeleteUser_BlockedByDependents(t *testing.T) {
+	env := setupTestEnv(t)
+	u := testutil.MustCreateUser(t, env.Queries, "WithConnection")
+	_ = testutil.MustCreateConnection(t, env.Queries, u.ID, "item_block_delete")
+
+	resp := env.doDelete(t, "/api/v1/users/"+pgconv.FormatUUID(u.ID))
+	readErrorCode(t, resp, http.StatusConflict, "USER_HAS_DEPENDENTS")
+}
+
+func TestDeleteUser_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doDelete(t, "/api/v1/users/00000000-0000-0000-0000-000000000000")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// --- POST /users/{id}/wipe-data --------------------------------------------
+
+func TestWipeUserData_RemovesAttributedRows(t *testing.T) {
+	env := setupTestEnv(t)
+	u := testutil.MustCreateUser(t, env.Queries, "Wipey")
+	conn := testutil.MustCreateConnection(t, env.Queries, u.ID, "item_wipe")
+	acct := testutil.MustCreateAccount(t, env.Queries, conn.ID, "ext_acct_wipe", "Checking")
+	for i, ext := range []string{"a", "b", "c"} {
+		_ = testutil.MustCreateTransaction(t, env.Queries, acct.ID, "ext_txn_wipe_"+ext, "Coffee", int64(100+i), "2025-01-15")
+	}
+
+	resp := env.doPost(t, "/api/v1/users/"+pgconv.FormatUUID(u.ID)+"/wipe-data", map[string]any{})
+	assertStatus(t, resp, http.StatusOK)
+
+	var body struct {
+		Status              string `json:"status"`
+		DeletedTransactions int64  `json:"deleted_transactions"`
+	}
+	parseJSON(t, resp, &body)
+	if body.Status != "ok" {
+		t.Errorf("status: got %q, want ok", body.Status)
+	}
+	if body.DeletedTransactions != 3 {
+		t.Errorf("deleted_transactions: got %d, want 3", body.DeletedTransactions)
+	}
+
+	count, err := env.Queries.CountConnectionsByUser(t.Context(), u.ID)
+	if err != nil {
+		t.Fatalf("count connections: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 connections after wipe, got %d", count)
+	}
+}
+
+func TestWipeUserData_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	resp := env.doPost(t, "/api/v1/users/00000000-0000-0000-0000-000000000000/wipe-data", map[string]any{})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// --- Scope checks ----------------------------------------------------------
+
+func TestUserCrud_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	u := testutil.MustCreateUser(t, env.Queries, "ScopedReadOnly")
+	uid := pgconv.FormatUUID(u.ID)
+
+	cases := []struct {
+		name string
+		do   func() *http.Response
+	}{
+		{"POST /users", func() *http.Response {
+			return env.doPost(t, "/api/v1/users", map[string]any{"name": "Nope"})
+		}},
+		{"PATCH /users/{id}", func() *http.Response {
+			return env.doPatch(t, "/api/v1/users/"+uid, map[string]any{"name": "Renamed"})
+		}},
+		{"DELETE /users/{id}", func() *http.Response {
+			return env.doDelete(t, "/api/v1/users/"+uid)
+		}},
+		{"POST /users/{id}/wipe-data", func() *http.Response {
+			return env.doPost(t, "/api/v1/users/"+uid+"/wipe-data", map[string]any{})
+		}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			readErrorCode(t, c.do(), http.StatusForbidden, "INSUFFICIENT_SCOPE")
+		})
+	}
+}
+
+func TestGetUser_AllowsReadScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	u := testutil.MustCreateUser(t, env.Queries, "ReadableUser")
+
+	resp := env.doGet(t, "/api/v1/users/"+pgconv.FormatUUID(u.ID))
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+}

--- a/internal/db/queries/users.sql
+++ b/internal/db/queries/users.sql
@@ -20,6 +20,12 @@ SELECT id FROM users WHERE short_id = $1;
 -- name: CountUsers :one
 SELECT count(*) FROM users;
 
+-- name: DeleteUser :exec
+DELETE FROM users WHERE id = $1;
+
+-- name: CountConnectionsByUser :one
+SELECT count(*) FROM bank_connections WHERE user_id = $1;
+
 -- name: ListUsersWithoutAuthAccount :many
 SELECT u.* FROM users u
 LEFT JOIN auth_accounts aa ON aa.user_id = u.id

--- a/internal/middleware/service_errors.go
+++ b/internal/middleware/service_errors.go
@@ -39,6 +39,10 @@ func MapServiceError(err error) (ServiceErrorResponse, bool) {
 		return ServiceErrorResponse{Status: http.StatusForbidden, Code: "FORBIDDEN", Message: err.Error()}, true
 	case errors.Is(err, service.ErrSyncInProgress):
 		return ServiceErrorResponse{Status: http.StatusConflict, Code: "SYNC_IN_PROGRESS", Message: err.Error()}, true
+	case errors.Is(err, service.ErrUserHasDependents):
+		return ServiceErrorResponse{Status: http.StatusConflict, Code: "USER_HAS_DEPENDENTS", Message: err.Error()}, true
+	case errors.Is(err, service.ErrEmailConflict):
+		return ServiceErrorResponse{Status: http.StatusConflict, Code: "EMAIL_CONFLICT", Message: err.Error()}, true
 	case errors.Is(err, service.ErrInvalidAPIKey):
 		return ServiceErrorResponse{Status: http.StatusUnauthorized, Code: "INVALID_API_KEY", Message: err.Error()}, true
 	case errors.Is(err, service.ErrRevokedAPIKey):

--- a/internal/service/users.go
+++ b/internal/service/users.go
@@ -4,12 +4,42 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/mail"
+	"strings"
 
 	"breadbox/internal/db"
 	"breadbox/internal/pgconv"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
 )
+
+// CreateUserParams is the input for CreateUser. Mirrors the admin
+// /-/users/new form: name is required, email is optional. The schema does
+// not (yet) carry display_name or is_dependent for users — both belong on
+// accounts/account-links — so they are intentionally absent here.
+type CreateUserParams struct {
+	Name  string
+	Email *string
+}
+
+// UpdateUserParams is the input for UpdateUser. Every field is optional;
+// nil leaves the existing value unchanged. To clear the email, pass a
+// non-nil empty string.
+type UpdateUserParams struct {
+	Name  *string
+	Email *string
+}
+
+// ErrUserHasDependents is returned by DeleteUser when there are bank
+// connections still attached to the user. Handlers map this to a 409
+// CONFLICT with a hint to wipe-data first.
+var ErrUserHasDependents = errors.New("user has dependent connections; wipe data before deleting")
+
+// ErrEmailConflict is returned when CreateUser/UpdateUser would violate
+// the unique constraint on users.email.
+var ErrEmailConflict = errors.New("a household member with this email already exists")
 
 func (s *Service) ListUsers(ctx context.Context) ([]UserResponse, error) {
 	rows, err := s.Queries.ListUsers(ctx)
@@ -48,4 +78,134 @@ func userFromRow(r db.User) UserResponse {
 		CreatedAt: pgconv.TimestampStr(r.CreatedAt),
 		UpdatedAt: pgconv.TimestampStr(r.UpdatedAt),
 	}
+}
+
+// CreateUser inserts a new household member. Name is required and trimmed;
+// email is optional but, when present, must parse as an RFC 5322 address.
+// A unique-constraint violation on the email column is mapped to
+// ErrEmailConflict so handlers can surface a 409.
+func (s *Service) CreateUser(ctx context.Context, params CreateUserParams) (*UserResponse, error) {
+	name := strings.TrimSpace(params.Name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: name is required", ErrInvalidParameter)
+	}
+
+	var emailText pgtype.Text
+	if params.Email != nil && strings.TrimSpace(*params.Email) != "" {
+		trimmed := strings.TrimSpace(*params.Email)
+		if _, err := mail.ParseAddress(trimmed); err != nil {
+			return nil, fmt.Errorf("%w: invalid email", ErrInvalidParameter)
+		}
+		emailText = pgconv.Text(trimmed)
+	}
+
+	row, err := s.Queries.CreateUser(ctx, db.CreateUserParams{
+		Name:  name,
+		Email: emailText,
+	})
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, ErrEmailConflict
+		}
+		return nil, fmt.Errorf("create user: %w", err)
+	}
+	resp := userFromRow(row)
+	return &resp, nil
+}
+
+// UpdateUser applies a partial update to a household member. nil fields
+// leave existing values untouched; a non-nil empty Email clears the
+// stored email. Returns ErrNotFound when the id cannot be resolved or
+// the row no longer exists.
+func (s *Service) UpdateUser(ctx context.Context, id string, params UpdateUserParams) (*UserResponse, error) {
+	uid, err := s.resolveUserID(ctx, id)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+
+	existing, err := s.Queries.GetUser(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("load user: %w", err)
+	}
+
+	name := existing.Name
+	if params.Name != nil {
+		trimmed := strings.TrimSpace(*params.Name)
+		if trimmed == "" {
+			return nil, fmt.Errorf("%w: name must not be empty", ErrInvalidParameter)
+		}
+		name = trimmed
+	}
+
+	email := existing.Email
+	if params.Email != nil {
+		trimmed := strings.TrimSpace(*params.Email)
+		if trimmed == "" {
+			email = pgtype.Text{}
+		} else {
+			if _, err := mail.ParseAddress(trimmed); err != nil {
+				return nil, fmt.Errorf("%w: invalid email", ErrInvalidParameter)
+			}
+			email = pgconv.Text(trimmed)
+		}
+	}
+
+	row, err := s.Queries.UpdateUser(ctx, db.UpdateUserParams{
+		ID:    uid,
+		Name:  name,
+		Email: email,
+	})
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, ErrEmailConflict
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("update user: %w", err)
+	}
+	resp := userFromRow(row)
+	return &resp, nil
+}
+
+// DeleteUser hard-deletes a household member. The schema is permissive —
+// bank_connections.user_id and transactions.attributed_user_id are
+// ON DELETE SET NULL, and auth_accounts.user_id is ON DELETE CASCADE — but
+// silently orphaning a household's connections (and along with them every
+// account and transaction) is almost never what the caller intended. We
+// therefore refuse to delete while any bank_connections row still points
+// at the user and surface ErrUserHasDependents so the caller can choose
+// to call WipeUserData first.
+func (s *Service) DeleteUser(ctx context.Context, id string) error {
+	uid, err := s.resolveUserID(ctx, id)
+	if err != nil {
+		return ErrNotFound
+	}
+
+	// Verify the row exists so callers see a clean 404 rather than a
+	// no-op DELETE.
+	if _, err := s.Queries.GetUser(ctx, uid); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("load user: %w", err)
+	}
+
+	count, err := s.Queries.CountConnectionsByUser(ctx, uid)
+	if err != nil {
+		return fmt.Errorf("count connections: %w", err)
+	}
+	if count > 0 {
+		return ErrUserHasDependents
+	}
+
+	if err := s.Queries.DeleteUser(ctx, uid); err != nil {
+		return fmt.Errorf("delete user: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Users CRUD (Bundle 18 of headless-api):

- `GET /api/v1/users/{id}` (Read)
- `POST /api/v1/users` (Write)
- `PATCH /api/v1/users/{id}` (Write)
- `DELETE /api/v1/users/{id}` (Write) — protected by FK dependents (returns `409 USER_HAS_DEPENDENTS` when bank connections still attach; call `wipe-data` first)
- `POST /api/v1/users/{id}/wipe-data` (Write) — destructive: removes every bank connection, account, and transaction belonging to the user

Adds `CreateUser`, `UpdateUser`, `DeleteUser` to the service layer; reuses existing `GetUser` + `WipeUserData`. New `ErrEmailConflict` + `ErrUserHasDependents` sentinels are mapped centrally in `MapServiceError`.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `make test-integration` (api + service + middleware tests pass)
- [x] 15 integration tests cover happy paths, validation, FK protection, scope, short_id, wipe-data

🤖 Generated with [Claude Code](https://claude.com/claude-code)
