### PR TITLE
headless-api: login-account CRUD endpoints

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -181,6 +181,100 @@ Destructive: deletes every `bank_connections`, `accounts`, and `transactions` ro
 
 Responds `200` with the count of removed transactions, `404 NOT_FOUND` when the user does not exist.
 
+### Login accounts
+
+A "login account" is the auth identity that can sign in to the admin UI; each
+one is linked to exactly one household member (user). Headless deployments
+manage these via the endpoints below to provision admin access without an
+interactive setup session.
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET    | `/users/{user_id}/login` | Write | List the login account(s) for a user |
+| POST   | `/users/{user_id}/login` | Write | Create a login account for a user; returns the one-time `setup_token` |
+| PATCH  | `/users/{user_id}/login/{login_id}` | Write | Update the role (`admin`, `editor`, or `viewer`) |
+| DELETE | `/users/{user_id}/login/{login_id}` | Write | Delete the login account (does not delete the user) |
+| POST   | `/users/{user_id}/login/{login_id}/regenerate-token` | Write | Regenerate the setup token; returns the new plaintext token |
+
+All login-account endpoints require **write scope** even for reads — the list
+of login identities is sensitive (it lets a leaked key enumerate who can sign
+in).
+
+`{user_id}` accepts either the user's UUID or 8-char `short_id`. `{login_id}`
+is the auth-account UUID (returned as `id` on every response).
+
+#### `POST /users/{user_id}/login`
+
+Request:
+
+```json
+{
+  "username": "alice@example.com",
+  "role": "admin"
+}
+```
+
+`username` is treated as an email address (validated) and must be unique
+across the entire deployment. `role` is one of `admin`, `editor`, or
+`viewer`.
+
+Success response (`201 Created`):
+
+```json
+{
+  "id": "0d6a8e02-...",
+  "user_id": "8c3f...",
+  "user_name": "Alice",
+  "user_email": null,
+  "username": "alice@example.com",
+  "role": "admin",
+  "has_password": false,
+  "setup_token": "f3a1c4...",
+  "setup_token_expires_at": "2026-05-16T12:34:56Z",
+  "created_at": "2026-05-09T12:34:56Z",
+  "updated_at": "2026-05-09T12:34:56Z"
+}
+```
+
+The `setup_token` is the one-time secret the user redeems to set their
+initial password. **It is exposed only on this `POST` response and on
+`POST .../regenerate-token`.** Subsequent `GET` and `PATCH` responses never
+include it; if it's lost, regenerate a fresh one.
+
+Error codes:
+
+- `400 INVALID_PARAMETER` — missing/invalid `username` (must be an email),
+  missing `role`, or unknown `role`.
+- `404 NOT_FOUND` — `user_id` does not exist.
+- `409 USERNAME_TAKEN` — another login already uses that username.
+- `409 LOGIN_EXISTS` — this user already has a login account.
+
+#### `PATCH /users/{user_id}/login/{login_id}`
+
+Request:
+
+```json
+{ "role": "viewer" }
+```
+
+Returns `200 OK` with the updated login account (no `setup_token`).
+
+#### `DELETE /users/{user_id}/login/{login_id}`
+
+Returns `204 No Content`. The linked household member is **not** deleted; only
+the auth identity is removed.
+
+#### `POST /users/{user_id}/login/{login_id}/regenerate-token`
+
+Returns `200 OK` with a fresh plaintext token:
+
+```json
+{ "setup_token": "9b2d4f..." }
+```
+
+Fails with `409 PASSWORD_ALREADY_SET` if the account already redeemed a token
+and chose a password — there's nothing to regenerate at that point.
+
 ## Connections
 
 | Method | Endpoint | Auth | Description |

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -194,6 +194,11 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Patch("/users/{id}", UpdateUserHandler(svc))
 			r.Delete("/users/{id}", DeleteUserHandler(svc))
 			r.Post("/users/{id}/wipe-data", WipeUserDataHandler(svc))
+			r.Get("/users/{user_id}/login", ListUserLoginsHandler(svc))
+			r.Post("/users/{user_id}/login", CreateUserLoginHandler(svc))
+			r.Patch("/users/{user_id}/login/{login_id}", UpdateUserLoginHandler(svc))
+			r.Delete("/users/{user_id}/login/{login_id}", DeleteUserLoginHandler(svc))
+			r.Post("/users/{user_id}/login/{login_id}/regenerate-token", RegenerateLoginTokenHandler(svc))
 		})
 	})
 	return r

--- a/internal/api/login_accounts.go
+++ b/internal/api/login_accounts.go
@@ -1,0 +1,280 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/mail"
+	"strings"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Login-account CRUD endpoints. A "login account" is the auth identity that
+// can sign into the admin UI; it's linked to a household member (user). All
+// endpoints in this file are write-scope — listing login accounts lets a
+// leaked key enumerate sign-in identities, so it's intentionally not exposed
+// to read-only keys.
+//
+// The setup_token returned on create + regenerate is the one-time secret the
+// member uses to set their initial password. It is never echoed by the list
+// endpoint and cannot be retrieved later — if lost, regenerate.
+
+// createLoginRequest is the JSON body for POST /users/{user_id}/login.
+type createLoginRequest struct {
+	Username string `json:"username"`
+	Role     string `json:"role"`
+}
+
+// updateLoginRequest is the JSON body for PATCH /users/{user_id}/login/{login_id}.
+type updateLoginRequest struct {
+	Role string `json:"role"`
+}
+
+// ListUserLoginsHandler returns the login account(s) attached to a user.
+// GET /api/v1/users/{user_id}/login
+//
+// Returns a bare JSON array. setup_token is never included — it only appears
+// at create + regenerate.
+func ListUserLoginsHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userIDParam := chi.URLParam(r, "user_id")
+
+		// Resolve and verify the user exists; this gives us the canonical
+		// UUID to filter by.
+		user, err := svc.GetUser(r.Context(), userIDParam)
+		if err != nil {
+			writeServiceError(w, err, "User not found", "Failed to look up user")
+			return
+		}
+
+		all, err := svc.ListLoginAccounts(r.Context())
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to list login accounts")
+			return
+		}
+
+		filtered := make([]service.LoginAccountResponse, 0, 1)
+		for _, acct := range all {
+			if acct.UserID != user.ID {
+				continue
+			}
+			// Belt-and-suspenders: setup_token is *not* part of the
+			// list contract. Strip it even if the underlying query
+			// happens to surface it.
+			acct.SetupToken = ""
+			acct.SetupTokenExpiresAt = nil
+			filtered = append(filtered, acct)
+		}
+
+		writeData(w, filtered)
+	}
+}
+
+// CreateUserLoginHandler creates a new login account for an existing user.
+// POST /api/v1/users/{user_id}/login
+//
+// Response includes the plaintext setup_token — this is the only time it is
+// exposed. The member redeems it via the /setup-password flow.
+func CreateUserLoginHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userIDParam := chi.URLParam(r, "user_id")
+
+		var req createLoginRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+
+		req.Username = strings.TrimSpace(req.Username)
+		if req.Username == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "username is required")
+			return
+		}
+		if len(req.Username) > 64 {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "username must be 64 characters or fewer")
+			return
+		}
+		// The admin UI uses email-as-username; mirror that validation here so
+		// the headless contract stays consistent with the canonical flow.
+		if _, err := mail.ParseAddress(req.Username); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "username must be a valid email address")
+			return
+		}
+
+		if req.Role == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "role is required (admin, editor, or viewer)")
+			return
+		}
+
+		// Verify the user exists up front so we return a clean 404 instead
+		// of a 400 wrapped around the service-layer "invalid user_id" error.
+		user, err := svc.GetUser(r.Context(), userIDParam)
+		if err != nil {
+			writeServiceError(w, err, "User not found", "Failed to look up user")
+			return
+		}
+
+		account, err := svc.CreateLoginAccount(r.Context(), service.CreateLoginAccountParams{
+			UserID:   user.ID,
+			Username: req.Username,
+			Role:     req.Role,
+		})
+		if err != nil {
+			writeLoginCreateError(w, err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, account)
+	}
+}
+
+// UpdateUserLoginHandler updates the role on an existing login account.
+// PATCH /api/v1/users/{user_id}/login/{login_id}
+func UpdateUserLoginHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userIDParam := chi.URLParam(r, "user_id")
+		loginID := chi.URLParam(r, "login_id")
+
+		var req updateLoginRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+
+		// Confirm the login exists and belongs to this user so we return
+		// 404 on a typoed user_id rather than silently mutating an
+		// unrelated login.
+		acct, err := findLoginForUser(r.Context(), svc, userIDParam, loginID)
+		if err != nil {
+			writeServiceError(w, err, "Login account not found", "Failed to look up login account")
+			return
+		}
+
+		if err := svc.UpdateLoginAccountRole(r.Context(), acct.ID, req.Role); err != nil {
+			if strings.Contains(err.Error(), "invalid role") {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to update login account")
+			return
+		}
+
+		// Re-read so the response reflects the updated role.
+		updated, err := findLoginForUser(r.Context(), svc, userIDParam, loginID)
+		if err != nil {
+			writeServiceError(w, err, "Login account not found", "Failed to re-read login account")
+			return
+		}
+		updated.SetupToken = ""
+		updated.SetupTokenExpiresAt = nil
+		writeData(w, updated)
+	}
+}
+
+// DeleteUserLoginHandler removes a login account.
+// DELETE /api/v1/users/{user_id}/login/{login_id}
+//
+// Does not delete the linked household member.
+func DeleteUserLoginHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userIDParam := chi.URLParam(r, "user_id")
+		loginID := chi.URLParam(r, "login_id")
+
+		acct, err := findLoginForUser(r.Context(), svc, userIDParam, loginID)
+		if err != nil {
+			writeServiceError(w, err, "Login account not found", "Failed to look up login account")
+			return
+		}
+
+		if err := svc.DeleteLoginAccount(r.Context(), acct.ID); err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to delete login account")
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// RegenerateLoginTokenHandler issues a new setup token for an existing login
+// that has not yet had a password set. The previous token is invalidated.
+// POST /api/v1/users/{user_id}/login/{login_id}/regenerate-token
+//
+// Like create, the plaintext token is returned exactly once.
+func RegenerateLoginTokenHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		userIDParam := chi.URLParam(r, "user_id")
+		loginID := chi.URLParam(r, "login_id")
+
+		acct, err := findLoginForUser(r.Context(), svc, userIDParam, loginID)
+		if err != nil {
+			writeServiceError(w, err, "Login account not found", "Failed to look up login account")
+			return
+		}
+
+		token, err := svc.RegenerateSetupToken(r.Context(), acct.ID)
+		if err != nil {
+			if strings.Contains(err.Error(), "already has a password") {
+				mw.WriteError(w, http.StatusConflict, "PASSWORD_ALREADY_SET", "This login already has a password set; cannot regenerate setup token")
+				return
+			}
+			if strings.Contains(err.Error(), "account not found") {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Login account not found")
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to regenerate setup token")
+			return
+		}
+
+		writeData(w, map[string]any{
+			"setup_token": token,
+		})
+	}
+}
+
+// findLoginForUser returns the login account identified by loginID, but only
+// if it belongs to userID. Returns service.ErrNotFound when either side
+// doesn't match so callers can lean on the canonical 404 path.
+func findLoginForUser(ctx context.Context, svc *service.Service, userIDParam, loginID string) (*service.LoginAccountResponse, error) {
+	user, err := svc.GetUser(ctx, userIDParam)
+	if err != nil {
+		return nil, err
+	}
+
+	all, err := svc.ListLoginAccounts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, acct := range all {
+		if acct.UserID != user.ID {
+			continue
+		}
+		if acct.ID != loginID {
+			continue
+		}
+		out := acct
+		return &out, nil
+	}
+	return nil, service.ErrNotFound
+}
+
+// writeLoginCreateError maps service-layer create errors to the canonical
+// error envelope. The service surfaces conflicts and validation failures via
+// fmt.Errorf strings (no sentinels), so we string-match the same way the
+// admin handler does.
+func writeLoginCreateError(w http.ResponseWriter, err error) {
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "username already taken"):
+		mw.WriteError(w, http.StatusConflict, "USERNAME_TAKEN", "A login with that username already exists")
+	case strings.Contains(msg, "already has a login account"):
+		mw.WriteError(w, http.StatusConflict, "LOGIN_EXISTS", "This user already has a login account")
+	case strings.Contains(msg, "invalid role"):
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", msg)
+	case strings.Contains(msg, "invalid user_id"), errors.Is(err, service.ErrNotFound):
+		mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "User not found")
+	default:
+		mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to create login account")
+	}
+}

--- a/internal/api/login_accounts_integration_test.go
+++ b/internal/api/login_accounts_integration_test.go
@@ -1,0 +1,433 @@
+//go:build integration
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/testutil"
+)
+
+// loginAccountResponse mirrors service.LoginAccountResponse for test parsing.
+// Defined locally so the tests don't depend on the service package's
+// (potentially) evolving omitempty rules.
+type loginAccountResponse struct {
+	ID                  string  `json:"id"`
+	UserID              string  `json:"user_id"`
+	UserName            string  `json:"user_name"`
+	UserEmail           *string `json:"user_email"`
+	Username            string  `json:"username"`
+	Role                string  `json:"role"`
+	HasPassword         bool    `json:"has_password"`
+	SetupToken          string  `json:"setup_token,omitempty"`
+	SetupTokenExpiresAt *string `json:"setup_token_expires_at,omitempty"`
+	CreatedAt           string  `json:"created_at"`
+	UpdatedAt           string  `json:"updated_at"`
+}
+
+// ============================================================
+// Login account CRUD
+// ============================================================
+
+func TestCreateUserLogin_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	resp := env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{
+		"username": "alice@example.com",
+		"role":     "admin",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+
+	var got loginAccountResponse
+	parseJSON(t, resp, &got)
+	if got.UserID != uid {
+		t.Fatalf("user_id = %q, want %q", got.UserID, uid)
+	}
+	if got.Username != "alice@example.com" {
+		t.Fatalf("username = %q", got.Username)
+	}
+	if got.Role != "admin" {
+		t.Fatalf("role = %q", got.Role)
+	}
+	if got.SetupToken == "" {
+		t.Fatalf("setup_token is empty; create response must expose it")
+	}
+	if got.HasPassword {
+		t.Fatalf("has_password should be false on a fresh login")
+	}
+	if got.ID == "" {
+		t.Fatalf("login id is empty")
+	}
+}
+
+func TestCreateUserLogin_NotFound_User(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// A well-formed UUID that doesn't correspond to any user.
+	resp := env.doPost(t, "/api/v1/users/00000000-0000-0000-0000-000000000000/login", map[string]string{
+		"username": "ghost@example.com",
+		"role":     "viewer",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestCreateUserLogin_DuplicateEmail(t *testing.T) {
+	env := setupTestEnv(t)
+	u1 := testutil.MustCreateUser(t, env.Queries, "Alice")
+	u2 := testutil.MustCreateUser(t, env.Queries, "Bob")
+
+	// First login claims the username.
+	resp := env.doPost(t, "/api/v1/users/"+pgconv.FormatUUID(u1.ID)+"/login", map[string]string{
+		"username": "shared@example.com",
+		"role":     "admin",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	// Second login on a different user with the same username fails.
+	resp = env.doPost(t, "/api/v1/users/"+pgconv.FormatUUID(u2.ID)+"/login", map[string]string{
+		"username": "shared@example.com",
+		"role":     "viewer",
+	})
+	readErrorCode(t, resp, http.StatusConflict, "USERNAME_TAKEN")
+}
+
+func TestCreateUserLogin_BadRole(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPost(t, "/api/v1/users/"+pgconv.FormatUUID(user.ID)+"/login", map[string]string{
+		"username": "alice@example.com",
+		"role":     "superuser",
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestCreateUserLogin_BadUsername(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	resp := env.doPost(t, "/api/v1/users/"+pgconv.FormatUUID(user.ID)+"/login", map[string]string{
+		"username": "not-an-email",
+		"role":     "admin",
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestCreateUserLogin_AlreadyHasLogin(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	resp := env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{
+		"username": "alice@example.com",
+		"role":     "admin",
+	})
+	assertStatus(t, resp, http.StatusCreated)
+	resp.Body.Close()
+
+	resp = env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{
+		"username": "alice2@example.com",
+		"role":     "admin",
+	})
+	readErrorCode(t, resp, http.StatusConflict, "LOGIN_EXISTS")
+}
+
+func TestListUserLogins_AfterCreate(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	createResp := env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{
+		"username": "alice@example.com",
+		"role":     "editor",
+	})
+	assertStatus(t, createResp, http.StatusCreated)
+	createResp.Body.Close()
+
+	listResp := env.doGet(t, "/api/v1/users/"+uid+"/login")
+	assertStatus(t, listResp, http.StatusOK)
+	var list []loginAccountResponse
+	parseJSON(t, listResp, &list)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 login, got %d", len(list))
+	}
+	if list[0].Username != "alice@example.com" {
+		t.Fatalf("username = %q", list[0].Username)
+	}
+	if list[0].Role != "editor" {
+		t.Fatalf("role = %q", list[0].Role)
+	}
+	if list[0].SetupToken != "" {
+		t.Fatalf("setup_token must NOT appear in list responses; got %q", list[0].SetupToken)
+	}
+	if list[0].SetupTokenExpiresAt != nil {
+		t.Fatalf("setup_token_expires_at must NOT appear in list responses")
+	}
+}
+
+func TestListUserLogins_NoneForUser(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Solo")
+
+	resp := env.doGet(t, "/api/v1/users/"+pgconv.FormatUUID(user.ID)+"/login")
+	assertStatus(t, resp, http.StatusOK)
+	var list []loginAccountResponse
+	parseJSON(t, resp, &list)
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %d entries", len(list))
+	}
+}
+
+func TestListUserLogins_FiltersByUser(t *testing.T) {
+	env := setupTestEnv(t)
+	u1 := testutil.MustCreateUser(t, env.Queries, "Alice")
+	u2 := testutil.MustCreateUser(t, env.Queries, "Bob")
+
+	// Two unrelated logins.
+	r := env.doPost(t, "/api/v1/users/"+pgconv.FormatUUID(u1.ID)+"/login", map[string]string{
+		"username": "alice@example.com", "role": "admin",
+	})
+	assertStatus(t, r, http.StatusCreated)
+	r.Body.Close()
+	r = env.doPost(t, "/api/v1/users/"+pgconv.FormatUUID(u2.ID)+"/login", map[string]string{
+		"username": "bob@example.com", "role": "viewer",
+	})
+	assertStatus(t, r, http.StatusCreated)
+	r.Body.Close()
+
+	listResp := env.doGet(t, "/api/v1/users/"+pgconv.FormatUUID(u1.ID)+"/login")
+	assertStatus(t, listResp, http.StatusOK)
+	var list []loginAccountResponse
+	parseJSON(t, listResp, &list)
+	if len(list) != 1 {
+		t.Fatalf("expected exactly 1 login for u1, got %d", len(list))
+	}
+	if list[0].Username != "alice@example.com" {
+		t.Fatalf("expected alice, got %q", list[0].Username)
+	}
+}
+
+func TestUpdateUserLogin_Role(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	createResp := env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{
+		"username": "alice@example.com",
+		"role":     "viewer",
+	})
+	assertStatus(t, createResp, http.StatusCreated)
+	var created loginAccountResponse
+	parseJSON(t, createResp, &created)
+
+	patchResp := env.doPatch(t, "/api/v1/users/"+uid+"/login/"+created.ID, map[string]string{
+		"role": "admin",
+	})
+	assertStatus(t, patchResp, http.StatusOK)
+	var got loginAccountResponse
+	parseJSON(t, patchResp, &got)
+	if got.Role != "admin" {
+		t.Fatalf("role = %q, want admin", got.Role)
+	}
+	if got.SetupToken != "" {
+		t.Fatalf("setup_token must NOT appear in update responses; got %q", got.SetupToken)
+	}
+}
+
+func TestUpdateUserLogin_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	resp := env.doPatch(t, "/api/v1/users/"+uid+"/login/00000000-0000-0000-0000-000000000000", map[string]string{
+		"role": "admin",
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestUpdateUserLogin_BadRole(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	createResp := env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{
+		"username": "alice@example.com",
+		"role":     "viewer",
+	})
+	assertStatus(t, createResp, http.StatusCreated)
+	var created loginAccountResponse
+	parseJSON(t, createResp, &created)
+
+	resp := env.doPatch(t, "/api/v1/users/"+uid+"/login/"+created.ID, map[string]string{
+		"role": "wizard",
+	})
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+func TestDeleteUserLogin_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	createResp := env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{
+		"username": "alice@example.com",
+		"role":     "viewer",
+	})
+	assertStatus(t, createResp, http.StatusCreated)
+	var created loginAccountResponse
+	parseJSON(t, createResp, &created)
+
+	delResp := env.doDelete(t, "/api/v1/users/"+uid+"/login/"+created.ID)
+	if delResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete status = %d, want 204", delResp.StatusCode)
+	}
+	delResp.Body.Close()
+
+	listResp := env.doGet(t, "/api/v1/users/"+uid+"/login")
+	assertStatus(t, listResp, http.StatusOK)
+	var list []loginAccountResponse
+	parseJSON(t, listResp, &list)
+	if len(list) != 0 {
+		t.Fatalf("expected empty list after delete, got %d", len(list))
+	}
+}
+
+func TestRegenerateLoginToken_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	createResp := env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{
+		"username": "alice@example.com",
+		"role":     "viewer",
+	})
+	assertStatus(t, createResp, http.StatusCreated)
+	var created loginAccountResponse
+	parseJSON(t, createResp, &created)
+	firstToken := created.SetupToken
+
+	regenResp := env.doPost(t, "/api/v1/users/"+uid+"/login/"+created.ID+"/regenerate-token", nil)
+	assertStatus(t, regenResp, http.StatusOK)
+	var body map[string]any
+	parseJSON(t, regenResp, &body)
+	tok, _ := body["setup_token"].(string)
+	if tok == "" {
+		t.Fatalf("regenerate response missing setup_token: %#v", body)
+	}
+	if tok == firstToken {
+		t.Fatalf("regenerated token equal to original; expected a fresh token")
+	}
+}
+
+func TestRegenerateLoginToken_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	resp := env.doPost(t, "/api/v1/users/"+uid+"/login/00000000-0000-0000-0000-000000000000/regenerate-token", nil)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestLoginEndpoints_RequireWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	cases := []struct {
+		name string
+		fn   func() *http.Response
+	}{
+		{"list", func() *http.Response { return env.doGet(t, "/api/v1/users/"+uid+"/login") }},
+		{"create", func() *http.Response {
+			return env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{"username": "a@b.com", "role": "viewer"})
+		}},
+		{"patch", func() *http.Response {
+			return env.doPatch(t, "/api/v1/users/"+uid+"/login/00000000-0000-0000-0000-000000000000", map[string]string{"role": "admin"})
+		}},
+		{"delete", func() *http.Response {
+			return env.doDelete(t, "/api/v1/users/"+uid+"/login/00000000-0000-0000-0000-000000000000")
+		}},
+		{"regenerate", func() *http.Response {
+			return env.doPost(t, "/api/v1/users/"+uid+"/login/00000000-0000-0000-0000-000000000000/regenerate-token", nil)
+		}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp := c.fn()
+			readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+		})
+	}
+}
+
+// TestSetupToken_NotInListResponse explicitly guards the contract that the
+// plaintext setup token only appears at create + regenerate. A regression
+// here would leak a long-lived secret to anyone who can list logins.
+func TestSetupToken_NotInListResponse(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	createResp := env.doPost(t, "/api/v1/users/"+uid+"/login", map[string]string{
+		"username": "alice@example.com",
+		"role":     "viewer",
+	})
+	assertStatus(t, createResp, http.StatusCreated)
+	var created loginAccountResponse
+	parseJSON(t, createResp, &created)
+	tokenFromCreate := created.SetupToken
+	if tokenFromCreate == "" {
+		t.Fatalf("expected setup_token on create")
+	}
+
+	// Read the list response as raw bytes and verify the token substring is absent.
+	listResp := env.doGet(t, "/api/v1/users/"+uid+"/login")
+	assertStatus(t, listResp, http.StatusOK)
+	var list []loginAccountResponse
+	parseJSON(t, listResp, &list)
+	if len(list) != 1 {
+		t.Fatalf("expected 1 login, got %d", len(list))
+	}
+	if list[0].SetupToken != "" {
+		t.Fatalf("list response leaked setup_token: %q", list[0].SetupToken)
+	}
+	if list[0].SetupTokenExpiresAt != nil {
+		t.Fatalf("list response leaked setup_token_expires_at")
+	}
+
+	// And again from the PATCH response — updating the role must not
+	// re-expose the token.
+	patchResp := env.doPatch(t, "/api/v1/users/"+uid+"/login/"+created.ID, map[string]string{
+		"role": "admin",
+	})
+	assertStatus(t, patchResp, http.StatusOK)
+	var patched loginAccountResponse
+	parseJSON(t, patchResp, &patched)
+	if patched.SetupToken != "" {
+		t.Fatalf("patch response leaked setup_token: %q", patched.SetupToken)
+	}
+
+	// Sanity: the original create-time token must not be a substring of any
+	// of the surface forms above. Belt-and-suspenders against future
+	// stringification helpers.
+	if strings.Contains(stringify(t, list), tokenFromCreate) {
+		t.Fatalf("setup_token from create appears in list response payload")
+	}
+}
+
+// stringify re-marshals v as JSON for substring assertions.
+func stringify(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -150,6 +150,11 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Patch("/users/{id}", UpdateUserHandler(svc))
 			r.Delete("/users/{id}", DeleteUserHandler(svc))
 			r.Post("/users/{id}/wipe-data", WipeUserDataHandler(svc))
+			r.Get("/users/{user_id}/login", ListUserLoginsHandler(svc))
+			r.Post("/users/{user_id}/login", CreateUserLoginHandler(svc))
+			r.Patch("/users/{user_id}/login/{login_id}", UpdateUserLoginHandler(svc))
+			r.Delete("/users/{user_id}/login/{login_id}", DeleteUserLoginHandler(svc))
+			r.Post("/users/{user_id}/login/{login_id}/regenerate-token", RegenerateLoginTokenHandler(svc))
 		})
 	})
 


### PR DESCRIPTION
## Summary

Login-account CRUD (Bundle 19 of headless-api):

- `GET /api/v1/users/{user_id}/login` — list (sensitive; write-scope)
- `POST /api/v1/users/{user_id}/login` — create; response includes plaintext `setup_token` (only here)
- `PATCH /api/v1/users/{user_id}/login/{login_id}` — update role
- `DELETE /api/v1/users/{user_id}/login/{login_id}` — remove
- `POST /api/v1/users/{user_id}/login/{login_id}/regenerate-token` — new setup token

Wraps existing `service.{Create,List,UpdateRole,Delete}LoginAccount` and `service.RegenerateSetupToken` 1:1 — no service-layer changes. Filtering by `user_id` is performed at the handler tier (the service returns the full set).

All endpoints are write-scope, on purpose: a leaked read-only key shouldn't be able to enumerate the deployment's sign-in identities. The plaintext `setup_token` only appears in the create + regenerate responses; list and patch responses strip it explicitly, and a regression test (`TestSetupToken_NotInListResponse`) re-marshals the list payload to assert the create-time token can't reappear by accident.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] 17 integration assertions across the 5 endpoints (setup-token leak guard, write-scope guard, duplicate-username conflict, missing-user 404, bad role/email rejection)
- [x] Admin login flow (`internal/admin/...`) tests still pass — no shared code paths changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
