### PR TITLE
headless-api: CSV preview + import REST endpoints

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -291,8 +291,63 @@ and chose a password — there's nothing to regenerate at that point.
 | POST | `/connections/plaid/link-token` | Write | Start a new Plaid Link flow — returns a fresh link token |
 | POST | `/connections/plaid/exchange` | Write | Exchange the Plaid public token for a stored connection + accounts |
 | POST | `/connections/teller` | Write | Register a Teller connection from the enrollment payload Teller Connect returns |
+| POST | `/connections/csv/preview` | Write | Parse a CSV upload and return inferred columns + the first N rows. No persistence. |
+| POST | `/connections/csv/import` | Write | Import a CSV. Creates a new connection if `connection_id` is omitted, otherwise appends to the existing one. |
 
 `{id}` accepts either the connection's UUID or 8-char short_id.
+
+### CSV import (`POST /connections/csv/preview`, `POST /connections/csv/import`)
+
+The CSV endpoints are the headless analog of the admin "Import CSV" wizard. They cover deployments without Plaid or Teller.
+
+Both endpoints accept **two transports** with identical configuration fields. Pick whichever your client makes easier:
+
+| Transport | How the file arrives | How config arrives |
+|-----------|----------------------|--------------------|
+| `multipart/form-data` | `file` form-file field | other fields as form values; `column_mapping` as a JSON string |
+| `application/json` | `csv_base64` (or `csv_data`) string with the file base64-encoded | sibling JSON fields |
+
+**Configuration fields**
+
+| Field | Type | Required for | Notes |
+|-------|------|--------------|-------|
+| `column_mapping` | object `{name: index}` | import | maps the canonical fields (`date`, `amount`, `description`, optional `category`, `merchant_name`, `debit`, `credit`) to 0-indexed CSV columns |
+| `date_format` | string | recommended | Go time-layout (e.g. `"2006-01-02"`); auto-detected when omitted |
+| `positive_is_debit` | bool | optional | bank convention defaults to `false` (positive = credit); set `true` when the source CSV already follows the Breadbox convention (positive = money out) |
+| `has_debit_credit` | bool | optional | set `true` for Capital-One-style two-column amount CSVs; pair with `debit` and `credit` keys in `column_mapping` |
+| `user_id` | string | new connection | UUID or short_id of the household member; falls back to the only user in single-user households |
+| `account_name` | string | new connection | display name; defaults to `"CSV Import"` |
+| `connection_id` | string | append-only | existing CSV connection's UUID or short_id; the new rows attach to its first account |
+| `limit` | int | preview only | max preview rows, default 10, capped at 100 |
+
+`POST /connections/csv/preview` returns `200 OK` with parsed headers, the first N rows, and inferred column mapping; nothing is persisted. `template_name`, `positive_is_debit`, `date_format`, and `has_debit_credit` are emitted only when a known bank template is auto-detected.
+
+`POST /connections/csv/import` returns `201 Created`:
+
+```json
+{
+  "connection_id": "ab12cd34",
+  "account_id": "ef56gh78",
+  "imported_transactions": 125,
+  "updated_transactions": 0,
+  "skipped_duplicates": 3,
+  "total_rows": 128
+}
+```
+
+Re-importing the same CSV is a safe no-op — every row hashes to the same `provider_transaction_id` and the upsert detects the dedup. **Manual category overrides (`category_override = true`) are preserved** across re-imports.
+
+Errors:
+
+| Status | Code | When |
+|--------|------|------|
+| 400 | `INVALID_PARAMETER` | missing/bad fields, malformed CSV, missing `column_mapping` |
+| 404 | `NOT_FOUND` | `connection_id` provided but doesn't exist (or isn't a CSV connection) |
+| 413 | `PAYLOAD_TOO_LARGE` | upload exceeds 50 MB |
+| 415 | `UNSUPPORTED_MEDIA_TYPE` | `Content-Type` is neither multipart nor JSON |
+| 500 | `INTERNAL_ERROR` | unexpected server failure |
+
+See `docs/csv-import.md` for the full CSV format reference (supported delimiters, BOM handling, dedup hash, bank template list).
 
 ### GET `/connections/{id}`
 

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -186,6 +186,8 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Patch("/tags/{slug}", UpdateTagHandler(svc))
 			r.Delete("/tags/{slug}", DeleteTagHandler(svc))
 			r.Post("/sync", TriggerSyncHandler(svc))
+			r.Post("/connections/csv/preview", CSVPreviewHandler(svc))
+			r.Post("/connections/csv/import", CSVImportHandler(svc))
 			r.Post("/connections/{id}/sync", SyncConnectionHandler(svc))
 			r.Post("/connections/{id}/paused", PauseConnectionHandler(svc))
 			r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(svc))

--- a/internal/api/csv_import.go
+++ b/internal/api/csv_import.go
@@ -1,0 +1,516 @@
+package api
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	csvpkg "breadbox/internal/provider/csv"
+	"breadbox/internal/service"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// maxCSVRESTUploadSize caps both multipart and JSON CSV uploads on the
+// public REST API. 50MB is generous for hand-exported bank CSVs (the parser
+// itself enforces a 50,000-row ceiling) while protecting the server from
+// accidental large uploads.
+const maxCSVRESTUploadSize = 50 << 20 // 50MB
+
+// csvPreviewRequest is the JSON body shape for POST /connections/csv/preview.
+//
+// Either `csv_base64` or `csv_data` carries the file content base64-encoded.
+// Multipart callers send `file` as a regular form-file field plus the same
+// configuration fields as form values.
+type csvPreviewRequest struct {
+	CSVBase64       string         `json:"csv_base64,omitempty"`
+	CSVData         string         `json:"csv_data,omitempty"`
+	ColumnMapping   map[string]int `json:"column_mapping,omitempty"`
+	PositiveIsDebit bool           `json:"positive_is_debit,omitempty"`
+	DateFormat      string         `json:"date_format,omitempty"`
+	HasDebitCredit  bool           `json:"has_debit_credit,omitempty"`
+	Limit           int            `json:"limit,omitempty"`
+}
+
+// csvImportRequest is the JSON body shape for POST /connections/csv/import.
+type csvImportRequest struct {
+	CSVBase64       string         `json:"csv_base64,omitempty"`
+	CSVData         string         `json:"csv_data,omitempty"`
+	UserID          string         `json:"user_id,omitempty"`
+	AccountName     string         `json:"account_name,omitempty"`
+	ColumnMapping   map[string]int `json:"column_mapping,omitempty"`
+	PositiveIsDebit bool           `json:"positive_is_debit,omitempty"`
+	DateFormat      string         `json:"date_format,omitempty"`
+	ConnectionID    string         `json:"connection_id,omitempty"`
+	HasDebitCredit  bool           `json:"has_debit_credit,omitempty"`
+}
+
+// csvPayload holds the parsed CSV file plus all configuration fields. It is
+// produced by readCSVPayload regardless of whether the request body was
+// multipart/form-data or application/json.
+type csvPayload struct {
+	Raw             []byte
+	ColumnMapping   map[string]int
+	PositiveIsDebit bool
+	DateFormat      string
+	HasDebitCredit  bool
+	UserID          string
+	AccountName     string
+	ConnectionID    string
+	Limit           int
+}
+
+// readCSVPayload extracts the CSV bytes + configuration from the request,
+// supporting both multipart/form-data and application/json bodies. It
+// enforces maxCSVRESTUploadSize on both paths.
+//
+// On error it writes the appropriate error envelope and returns nil; callers
+// must return immediately when the result is nil.
+func readCSVPayload(w http.ResponseWriter, r *http.Request) *csvPayload {
+	// Always cap the body length so a malicious client can't exhaust memory.
+	r.Body = http.MaxBytesReader(w, r.Body, maxCSVRESTUploadSize)
+
+	contentType := r.Header.Get("Content-Type")
+	mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0]))
+
+	switch mediaType {
+	case "multipart/form-data":
+		return readCSVPayloadMultipart(w, r)
+	case "application/json", "":
+		return readCSVPayloadJSON(w, r)
+	default:
+		mw.WriteError(w, http.StatusUnsupportedMediaType, "UNSUPPORTED_MEDIA_TYPE",
+			"Content-Type must be multipart/form-data or application/json")
+		return nil
+	}
+}
+
+func readCSVPayloadMultipart(w http.ResponseWriter, r *http.Request) *csvPayload {
+	if err := r.ParseMultipartForm(maxCSVRESTUploadSize); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			mw.WriteError(w, http.StatusRequestEntityTooLarge, "PAYLOAD_TOO_LARGE",
+				fmt.Sprintf("CSV upload exceeds %d bytes", maxCSVRESTUploadSize))
+			return nil
+		}
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "failed to parse multipart form: "+err.Error())
+		return nil
+	}
+
+	file, _, err := r.FormFile("file")
+	if err != nil {
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "missing 'file' field in multipart form")
+		return nil
+	}
+	defer file.Close()
+
+	raw, err := io.ReadAll(file)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			mw.WriteError(w, http.StatusRequestEntityTooLarge, "PAYLOAD_TOO_LARGE",
+				fmt.Sprintf("CSV upload exceeds %d bytes", maxCSVRESTUploadSize))
+			return nil
+		}
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "failed to read uploaded file")
+		return nil
+	}
+
+	p := &csvPayload{
+		Raw:             raw,
+		PositiveIsDebit: parseFormBool(r, "positive_is_debit"),
+		HasDebitCredit:  parseFormBool(r, "has_debit_credit"),
+		DateFormat:      r.FormValue("date_format"),
+		UserID:          r.FormValue("user_id"),
+		AccountName:     r.FormValue("account_name"),
+		ConnectionID:    r.FormValue("connection_id"),
+	}
+
+	// `column_mapping` arrives as a JSON object embedded in a form field —
+	// matches the admin UI convention so callers can copy the same shape
+	// across both transports.
+	if mapping := r.FormValue("column_mapping"); mapping != "" {
+		var m map[string]int
+		if err := json.Unmarshal([]byte(mapping), &m); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "column_mapping must be a JSON object of {column_name: column_index}")
+			return nil
+		}
+		p.ColumnMapping = m
+	}
+
+	if limitStr := r.FormValue("limit"); limitStr != "" {
+		var limit int
+		if _, err := fmt.Sscanf(limitStr, "%d", &limit); err == nil {
+			p.Limit = limit
+		}
+	}
+
+	return p
+}
+
+func readCSVPayloadJSON(w http.ResponseWriter, r *http.Request) *csvPayload {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			mw.WriteError(w, http.StatusRequestEntityTooLarge, "PAYLOAD_TOO_LARGE",
+				fmt.Sprintf("CSV upload exceeds %d bytes", maxCSVRESTUploadSize))
+			return nil
+		}
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "failed to read request body")
+		return nil
+	}
+
+	// Both preview and import accept a superset of fields — decoding into the
+	// import shape captures everything; the preview handler ignores
+	// import-only fields it doesn't need.
+	var req csvImportRequest
+	if len(body) > 0 {
+		if err := json.Unmarshal(body, &req); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Invalid JSON body")
+			return nil
+		}
+	}
+
+	encoded := req.CSVBase64
+	if encoded == "" {
+		encoded = req.CSVData
+	}
+	if encoded == "" {
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "csv_base64 (or csv_data) is required")
+		return nil
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		// Permit URL-safe base64 too — agents sometimes send it without
+		// noticing the difference.
+		raw, err = base64.URLEncoding.DecodeString(encoded)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "csv_base64 is not valid base64")
+			return nil
+		}
+	}
+
+	if len(raw) > maxCSVRESTUploadSize {
+		mw.WriteError(w, http.StatusRequestEntityTooLarge, "PAYLOAD_TOO_LARGE",
+			fmt.Sprintf("CSV upload exceeds %d bytes", maxCSVRESTUploadSize))
+		return nil
+	}
+
+	// `Limit` arrives directly on the preview JSON shape — re-decode into
+	// the preview struct so the import shape can stay clean.
+	var preview csvPreviewRequest
+	_ = json.Unmarshal(body, &preview)
+
+	return &csvPayload{
+		Raw:             raw,
+		ColumnMapping:   req.ColumnMapping,
+		PositiveIsDebit: req.PositiveIsDebit,
+		DateFormat:      req.DateFormat,
+		HasDebitCredit:  req.HasDebitCredit,
+		UserID:          req.UserID,
+		AccountName:     req.AccountName,
+		ConnectionID:    req.ConnectionID,
+		Limit:           preview.Limit,
+	}
+}
+
+func parseFormBool(r *http.Request, key string) bool {
+	v := strings.ToLower(strings.TrimSpace(r.FormValue(key)))
+	return v == "true" || v == "1" || v == "yes" || v == "on"
+}
+
+// CSVPreviewHandler parses a CSV upload and returns the first N rows mapped
+// to fields without persisting anything. Useful for headless agents that
+// want to confirm a column mapping or detect the bank template before
+// committing to an import.
+//
+// Body: multipart/form-data with a `file` field, OR application/json with
+// `csv_base64` carrying the file. Either way the response shape is the
+// same.
+func CSVPreviewHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		payload := readCSVPayload(w, r)
+		if payload == nil {
+			return
+		}
+
+		parsed, err := csvpkg.ParseFile(payload.Raw)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "failed to parse CSV: "+err.Error())
+			return
+		}
+
+		// Auto-detect a bank template + sensible defaults if the caller
+		// didn't supply a mapping. Mirrors the admin upload flow so the
+		// REST surface is just as useful for agents that don't know what
+		// they're looking at.
+		template := csvpkg.DetectTemplate(parsed.Headers)
+		inferred := csvpkg.DetectColumns(parsed.Headers)
+		if template != nil {
+			for i, h := range parsed.Headers {
+				if strings.EqualFold(h, template.DateColumn) {
+					inferred["date"] = i
+				}
+				if strings.EqualFold(h, template.AmountColumn) {
+					inferred["amount"] = i
+				}
+				if strings.EqualFold(h, template.DescriptionColumn) {
+					inferred["description"] = i
+				}
+				if template.CategoryColumn != "" && strings.EqualFold(h, template.CategoryColumn) {
+					inferred["category"] = i
+				}
+				if template.MerchantColumn != "" && strings.EqualFold(h, template.MerchantColumn) {
+					inferred["merchant_name"] = i
+				}
+				if template.HasDebitCredit {
+					if strings.EqualFold(h, template.DebitColumn) {
+						inferred["debit"] = i
+					}
+					if strings.EqualFold(h, template.CreditColumn) {
+						inferred["credit"] = i
+					}
+				}
+			}
+		}
+
+		limit := payload.Limit
+		if limit <= 0 {
+			limit = 10
+		}
+		if limit > 100 {
+			limit = 100
+		}
+
+		previewRows := parsed.Rows
+		if len(previewRows) > limit {
+			previewRows = previewRows[:limit]
+		}
+
+		delim := ","
+		switch parsed.Delimiter {
+		case '\t':
+			delim = "tab"
+		case ';':
+			delim = ";"
+		case '|':
+			delim = "|"
+		}
+
+		resp := map[string]any{
+			"headers":          parsed.Headers,
+			"preview_rows":     previewRows,
+			"total_rows":       len(parsed.Rows),
+			"delimiter":        delim,
+			"inferred_mapping": inferred,
+		}
+		if template != nil {
+			resp["template_name"] = template.Name
+			resp["positive_is_debit"] = template.PositiveIsDebit
+			resp["date_format"] = template.DateFormat
+			resp["has_debit_credit"] = template.HasDebitCredit
+		}
+
+		writeJSON(w, http.StatusOK, resp)
+	}
+}
+
+// csvImportResponse is the success shape for POST /connections/csv/import.
+// Keys mirror the headless-api plan so the contract stays stable across
+// language clients.
+type csvImportResponse struct {
+	ConnectionID         string `json:"connection_id"`
+	AccountID            string `json:"account_id"`
+	ImportedTransactions int    `json:"imported_transactions"`
+	UpdatedTransactions  int    `json:"updated_transactions"`
+	SkippedDuplicates    int    `json:"skipped_duplicates"`
+	TotalRows            int    `json:"total_rows"`
+}
+
+// CSVImportHandler imports a CSV into Breadbox. It either creates a brand
+// new CSV connection (no `connection_id`) or appends to an existing one.
+// service.ImportCSV does the heavy lifting (parsing rows, dedup-by-hash,
+// sync log bookkeeping); this handler is purely a transport adapter.
+func CSVImportHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		payload := readCSVPayload(w, r)
+		if payload == nil {
+			return
+		}
+
+		parsed, err := csvpkg.ParseFile(payload.Raw)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "failed to parse CSV: "+err.Error())
+			return
+		}
+
+		if len(payload.ColumnMapping) == 0 {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "column_mapping is required (use the preview endpoint to detect a mapping)")
+			return
+		}
+
+		// If `connection_id` is provided, validate up-front so we return 404
+		// before service.ImportCSV opens a sync_log row that would later
+		// fail on the missing connection. The connection's user is also
+		// the implicit user_id when extending an existing import (the
+		// service.ImportCSV happy path always parses a UUID, even when it
+		// would otherwise ignore it).
+		var (
+			connUUIDStr string
+			userUUIDStr string
+		)
+		if payload.ConnectionID != "" {
+			connUUID, errResp := resolveCSVImportConnection(r.Context(), svc, payload.ConnectionID)
+			if errResp != nil {
+				mw.WriteError(w, errResp.Status, errResp.Code, errResp.Message)
+				return
+			}
+			connUUIDStr = pgconv.FormatUUID(connUUID)
+			conn, err := svc.Queries.GetBankConnection(r.Context(), connUUID)
+			if err != nil {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
+				return
+			}
+			userUUIDStr = pgconv.FormatUUID(conn.UserID)
+		} else {
+			// Resolve the user. Either the explicit `user_id` (UUID or
+			// short_id) wins, or — for one-user households — we fall back
+			// to the only user in the system.
+			s, errResp := resolveCSVImportUser(r.Context(), svc, payload)
+			if errResp != nil {
+				mw.WriteError(w, errResp.Status, errResp.Code, errResp.Message)
+				return
+			}
+			userUUIDStr = s
+		}
+
+		params := service.CSVImportParams{
+			UserID:          userUUIDStr,
+			AccountName:     payload.AccountName,
+			ColumnMapping:   payload.ColumnMapping,
+			Rows:            parsed.Rows,
+			PositiveIsDebit: payload.PositiveIsDebit,
+			DateFormat:      payload.DateFormat,
+			ConnectionID:    connUUIDStr,
+			HasDebitCredit:  payload.HasDebitCredit,
+		}
+
+		result, err := svc.ImportCSV(r.Context(), params)
+		if err != nil {
+			writeServiceError(w, err, "", "CSV import failed: "+err.Error())
+			return
+		}
+
+		// Translate full UUIDs into compact short_ids for the response.
+		// Falls back to the UUID if the lookup fails — the import already
+		// succeeded, so we never want this to 500 on what is purely a
+		// presentation step.
+		connShortID := result.ConnectionID
+		acctShortID := result.AccountID
+		if connID, err := pgconv.ParseUUID(result.ConnectionID); err == nil {
+			if conn, err := svc.Queries.GetBankConnection(r.Context(), connID); err == nil {
+				connShortID = conn.ShortID
+			}
+		}
+		if acctID, err := pgconv.ParseUUID(result.AccountID); err == nil {
+			if acct, err := svc.Queries.GetAccount(r.Context(), acctID); err == nil {
+				acctShortID = acct.ShortID
+			}
+		}
+
+		writeJSON(w, http.StatusCreated, csvImportResponse{
+			ConnectionID:         connShortID,
+			AccountID:            acctShortID,
+			ImportedTransactions: result.NewCount,
+			UpdatedTransactions:  result.UpdatedCount,
+			SkippedDuplicates:    result.SkippedCount,
+			TotalRows:            result.TotalRows,
+		})
+	}
+}
+
+// errorResp is a minimal carrier so the user/connection resolvers can
+// surface the right HTTP status + error code without leaking pgx errors.
+type errorResp struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+// resolveCSVImportUser figures out which user owns the imported data.
+//
+//   - Prefer the explicit `user_id` (UUID or short_id).
+//   - As a last resort, fall back to the only household user. Multi-user
+//     households without an explicit user_id are an error.
+//
+// The connection-id branch is handled in the caller because we need the
+// existing connection's user to satisfy service.ImportCSV's UUID parse.
+func resolveCSVImportUser(ctx context.Context, svc *service.Service, payload *csvPayload) (string, *errorResp) {
+	if payload.UserID != "" {
+		uuid, errResp := lookupUserUUID(ctx, svc, payload.UserID)
+		if errResp != nil {
+			return "", errResp
+		}
+		return pgconv.FormatUUID(uuid), nil
+	}
+
+	users, err := svc.Queries.ListUsers(ctx)
+	if err != nil {
+		return "", &errorResp{Status: http.StatusInternalServerError, Code: "INTERNAL_ERROR", Message: "failed to list users"}
+	}
+	if len(users) == 0 {
+		return "", &errorResp{Status: http.StatusBadRequest, Code: "INVALID_PARAMETER", Message: "no users exist — create one before importing a CSV"}
+	}
+	if len(users) > 1 {
+		return "", &errorResp{Status: http.StatusBadRequest, Code: "INVALID_PARAMETER", Message: "user_id is required when multiple household members exist"}
+	}
+	return pgconv.FormatUUID(users[0].ID), nil
+}
+
+func lookupUserUUID(ctx context.Context, svc *service.Service, idOrShort string) (pgtype.UUID, *errorResp) {
+	if len(idOrShort) == 8 {
+		uuid, err := svc.Queries.GetUserUUIDByShortID(ctx, idOrShort)
+		if err != nil {
+			return pgtype.UUID{}, &errorResp{Status: http.StatusNotFound, Code: "NOT_FOUND", Message: "User not found"}
+		}
+		return uuid, nil
+	}
+	uuid, err := pgconv.ParseUUID(idOrShort)
+	if err != nil {
+		return pgtype.UUID{}, &errorResp{Status: http.StatusBadRequest, Code: "INVALID_PARAMETER", Message: "invalid user_id: " + err.Error()}
+	}
+	return uuid, nil
+}
+
+func resolveCSVImportConnection(ctx context.Context, svc *service.Service, idOrShort string) (pgtype.UUID, *errorResp) {
+	var uuid pgtype.UUID
+	var err error
+	if len(idOrShort) == 8 {
+		uuid, err = svc.Queries.GetConnectionUUIDByShortID(ctx, idOrShort)
+		if err != nil {
+			return pgtype.UUID{}, &errorResp{Status: http.StatusNotFound, Code: "NOT_FOUND", Message: "Connection not found"}
+		}
+	} else {
+		uuid, err = pgconv.ParseUUID(idOrShort)
+		if err != nil {
+			return pgtype.UUID{}, &errorResp{Status: http.StatusBadRequest, Code: "INVALID_PARAMETER", Message: "invalid connection_id: " + err.Error()}
+		}
+	}
+	conn, err := svc.Queries.GetBankConnection(ctx, uuid)
+	if err != nil {
+		return pgtype.UUID{}, &errorResp{Status: http.StatusNotFound, Code: "NOT_FOUND", Message: "Connection not found"}
+	}
+	if string(conn.Provider) != "csv" {
+		return pgtype.UUID{}, &errorResp{Status: http.StatusBadRequest, Code: "INVALID_PARAMETER", Message: "connection is not a CSV connection"}
+	}
+	return uuid, nil
+}

--- a/internal/api/csv_import_integration_test.go
+++ b/internal/api/csv_import_integration_test.go
@@ -1,0 +1,428 @@
+//go:build integration
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"testing"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/testutil"
+)
+
+// sampleCSV is a small, deterministic CSV used across all the CSV import
+// integration tests. Two distinct rows; trivially detectable column
+// mapping (date / amount / description).
+const sampleCSV = "date,amount,description\n" +
+	"2025-01-15,12.50,Coffee Shop\n" +
+	"2025-01-16,42.00,Grocery Store\n"
+
+// sampleCSVColumnMapping is the column mapping that matches sampleCSV.
+func sampleCSVColumnMapping() map[string]int {
+	return map[string]int{"date": 0, "amount": 1, "description": 2}
+}
+
+// sampleCSVMultipart builds a multipart/form-data body for sampleCSV plus
+// the supplied form fields. Returns the body, content-type header value,
+// and any error.
+func sampleCSVMultipart(t *testing.T, body string, fields map[string]string) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	part, err := mw.CreateFormFile("file", "sample.csv")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := io.WriteString(part, body); err != nil {
+		t.Fatalf("write form file: %v", err)
+	}
+
+	for k, v := range fields {
+		if err := mw.WriteField(k, v); err != nil {
+			t.Fatalf("write field %q: %v", k, err)
+		}
+	}
+
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close multipart: %v", err)
+	}
+	return &buf, mw.FormDataContentType()
+}
+
+// doRaw sends an arbitrary request body with an explicit Content-Type. Use
+// this for multipart and oversized payload tests.
+func (e *testEnv) doRaw(t *testing.T, method, path, contentType string, body io.Reader) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, e.Server.URL+path, body)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("X-API-Key", e.APIKey)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// ------------------------------------------------------------
+// Preview
+// ------------------------------------------------------------
+
+func TestCSVPreview_JSON_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	body := map[string]any{
+		"csv_base64": base64.StdEncoding.EncodeToString([]byte(sampleCSV)),
+	}
+	resp := env.doPost(t, "/api/v1/connections/csv/preview", body)
+	assertStatus(t, resp, http.StatusOK)
+
+	var out map[string]any
+	parseJSON(t, resp, &out)
+
+	headers, _ := out["headers"].([]any)
+	if len(headers) != 3 {
+		t.Fatalf("want 3 headers, got %d (%v)", len(headers), headers)
+	}
+	if headers[0] != "date" {
+		t.Fatalf("want first header 'date', got %v", headers[0])
+	}
+	preview, _ := out["preview_rows"].([]any)
+	if len(preview) != 2 {
+		t.Fatalf("want 2 preview rows, got %d", len(preview))
+	}
+	mapping, _ := out["inferred_mapping"].(map[string]any)
+	if mapping == nil {
+		t.Fatalf("want inferred_mapping, got nil")
+	}
+	// Generic header detection should at least find date + description.
+	if _, ok := mapping["date"]; !ok {
+		t.Fatalf("want inferred_mapping.date, got %v", mapping)
+	}
+}
+
+func TestCSVPreview_Multipart_Success(t *testing.T) {
+	env := setupTestEnv(t)
+
+	body, ct := sampleCSVMultipart(t, sampleCSV, nil)
+	resp := env.doRaw(t, "POST", "/api/v1/connections/csv/preview", ct, body)
+	assertStatus(t, resp, http.StatusOK)
+
+	var out map[string]any
+	parseJSON(t, resp, &out)
+
+	headers, _ := out["headers"].([]any)
+	if len(headers) != 3 {
+		t.Fatalf("want 3 headers, got %d", len(headers))
+	}
+}
+
+func TestCSVPreview_BadCSV(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Single row — fails the parser's "at least 2 rows" check.
+	body := map[string]any{
+		"csv_base64": base64.StdEncoding.EncodeToString([]byte("date\n")),
+	}
+	resp := env.doPost(t, "/api/v1/connections/csv/preview", body)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// ------------------------------------------------------------
+// Import
+// ------------------------------------------------------------
+
+func TestCSVImport_JSON_NewConnection_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	seedUncategorized(t, env.Queries)
+
+	body := map[string]any{
+		"csv_base64":     base64.StdEncoding.EncodeToString([]byte(sampleCSV)),
+		"user_id":        pgconv.FormatUUID(user.ID),
+		"account_name":   "Test Bank",
+		"column_mapping": sampleCSVColumnMapping(),
+		"date_format":    "2006-01-02",
+	}
+	resp := env.doPost(t, "/api/v1/connections/csv/import", body)
+	assertStatus(t, resp, http.StatusCreated)
+
+	var out csvImportResponse
+	parseJSON(t, resp, &out)
+
+	if out.ConnectionID == "" {
+		t.Fatalf("want connection_id, got empty")
+	}
+	if out.AccountID == "" {
+		t.Fatalf("want account_id, got empty")
+	}
+	if out.ImportedTransactions != 2 {
+		t.Fatalf("want 2 imported, got %d (%+v)", out.ImportedTransactions, out)
+	}
+
+	// Confirm the connection exists and is a CSV connection.
+	var provider string
+	if err := env.Pool.QueryRow(context.Background(),
+		`SELECT provider::text FROM bank_connections WHERE user_id = $1`, user.ID).Scan(&provider); err != nil {
+		t.Fatalf("read connection: %v", err)
+	}
+	if provider != "csv" {
+		t.Fatalf("want csv provider, got %s", provider)
+	}
+}
+
+func TestCSVImport_JSON_ExistingConnection(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Bob")
+	seedUncategorized(t, env.Queries)
+
+	// First import creates the connection.
+	first := map[string]any{
+		"csv_base64":     base64.StdEncoding.EncodeToString([]byte(sampleCSV)),
+		"user_id":        pgconv.FormatUUID(user.ID),
+		"account_name":   "Existing Bank",
+		"column_mapping": sampleCSVColumnMapping(),
+		"date_format":    "2006-01-02",
+	}
+	resp := env.doPost(t, "/api/v1/connections/csv/import", first)
+	assertStatus(t, resp, http.StatusCreated)
+	var firstOut csvImportResponse
+	parseJSON(t, resp, &firstOut)
+
+	// Second import targets the same connection by short_id and adds a new
+	// row. Use a distinct date+description so it doesn't collide on the
+	// dedup hash.
+	extraCSV := "date,amount,description\n" +
+		"2025-02-01,99.00,Brand New Charge\n"
+	second := map[string]any{
+		"csv_base64":     base64.StdEncoding.EncodeToString([]byte(extraCSV)),
+		"connection_id":  firstOut.ConnectionID,
+		"column_mapping": sampleCSVColumnMapping(),
+		"date_format":    "2006-01-02",
+	}
+	resp = env.doPost(t, "/api/v1/connections/csv/import", second)
+	assertStatus(t, resp, http.StatusCreated)
+
+	var secondOut csvImportResponse
+	parseJSON(t, resp, &secondOut)
+
+	if secondOut.ConnectionID != firstOut.ConnectionID {
+		t.Fatalf("want same connection_id, got first=%s second=%s", firstOut.ConnectionID, secondOut.ConnectionID)
+	}
+	if secondOut.ImportedTransactions != 1 {
+		t.Fatalf("want 1 imported, got %d", secondOut.ImportedTransactions)
+	}
+}
+
+func TestCSVImport_DeduplicatesProviderTransactionID(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Carol")
+	seedUncategorized(t, env.Queries)
+
+	body := map[string]any{
+		"csv_base64":     base64.StdEncoding.EncodeToString([]byte(sampleCSV)),
+		"user_id":        pgconv.FormatUUID(user.ID),
+		"account_name":   "Dedup Bank",
+		"column_mapping": sampleCSVColumnMapping(),
+		"date_format":    "2006-01-02",
+	}
+	resp := env.doPost(t, "/api/v1/connections/csv/import", body)
+	assertStatus(t, resp, http.StatusCreated)
+	var first csvImportResponse
+	parseJSON(t, resp, &first)
+	if first.ImportedTransactions != 2 {
+		t.Fatalf("first import: want 2 new, got %d", first.ImportedTransactions)
+	}
+
+	// Re-import the same CSV against the same connection — every row
+	// generates the same dedup hash, so the upsert path runs as a no-op.
+	// The strong invariant is that the *physical row count* doesn't grow,
+	// regardless of how the service classifies the row internally.
+	body["connection_id"] = first.ConnectionID
+	delete(body, "user_id")
+	resp = env.doPost(t, "/api/v1/connections/csv/import", body)
+	assertStatus(t, resp, http.StatusCreated)
+	var second csvImportResponse
+	parseJSON(t, resp, &second)
+
+	// The transactions table should still have exactly 2 rows for this
+	// account. This is the real dedup contract — counts in the response
+	// payload are advisory.
+	var txnCount int
+	if err := env.Pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM transactions t
+         JOIN accounts a ON a.id = t.account_id
+         JOIN bank_connections bc ON bc.id = a.connection_id
+         WHERE bc.user_id = $1`, user.ID).Scan(&txnCount); err != nil {
+		t.Fatalf("count transactions: %v", err)
+	}
+	if txnCount != 2 {
+		t.Fatalf("dedup failed: want 2 transactions in DB, got %d (response: %+v)", txnCount, second)
+	}
+}
+
+func TestCSVImport_Multipart_Success(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Dave")
+	seedUncategorized(t, env.Queries)
+
+	mappingJSON, _ := json.Marshal(sampleCSVColumnMapping())
+	body, ct := sampleCSVMultipart(t, sampleCSV, map[string]string{
+		"user_id":        pgconv.FormatUUID(user.ID),
+		"account_name":   "Multipart Bank",
+		"column_mapping": string(mappingJSON),
+		"date_format":    "2006-01-02",
+	})
+	resp := env.doRaw(t, "POST", "/api/v1/connections/csv/import", ct, body)
+	assertStatus(t, resp, http.StatusCreated)
+
+	var out csvImportResponse
+	parseJSON(t, resp, &out)
+	if out.ImportedTransactions != 2 {
+		t.Fatalf("want 2 imported, got %d", out.ImportedTransactions)
+	}
+}
+
+func TestCSVImport_BadConnection_NotFound(t *testing.T) {
+	env := setupTestEnv(t)
+	seedUncategorized(t, env.Queries)
+
+	body := map[string]any{
+		"csv_base64":     base64.StdEncoding.EncodeToString([]byte(sampleCSV)),
+		"connection_id":  "00000000-0000-0000-0000-000000000000",
+		"column_mapping": sampleCSVColumnMapping(),
+		"date_format":    "2006-01-02",
+	}
+	resp := env.doPost(t, "/api/v1/connections/csv/import", body)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestCSVImport_PayloadTooLarge(t *testing.T) {
+	env := setupTestEnv(t)
+
+	// Use a small, valid-looking JSON body whose base64 payload decodes
+	// to something larger than maxCSVRESTUploadSize. The base64 form
+	// stays well below MaxBytesReader's 50MB cap (so the request
+	// reaches the handler), but the post-decode length check trips and
+	// returns 413. This keeps the test fast and avoids HTTP-level
+	// flakiness around streaming a huge body.
+	//
+	// We trigger the check by lying about the encoded length: send a
+	// tiny payload but tell the handler it represents something
+	// enormous via a custom test handler. Simpler: just exceed the
+	// MaxBytesReader cap directly, but with a body that's only a few KB
+	// over the limit so the test runs quickly.
+	overflow := make([]byte, maxCSVRESTUploadSize+128)
+	for i := range overflow {
+		overflow[i] = 'A'
+	}
+	resp := env.doRaw(t, "POST", "/api/v1/connections/csv/preview",
+		"application/json", bytes.NewReader(overflow))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		t.Fatalf("want 413, got %d, body: %s", resp.StatusCode, bodyBytes)
+	}
+}
+
+func TestCSVImport_RequiresWriteScope(t *testing.T) {
+	env := setupReadOnlyEnv(t)
+
+	body := map[string]any{
+		"csv_base64": base64.StdEncoding.EncodeToString([]byte(sampleCSV)),
+	}
+
+	resp := env.doPost(t, "/api/v1/connections/csv/preview", body)
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+
+	resp = env.doPost(t, "/api/v1/connections/csv/import", body)
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+func TestCSVImport_PreservesCategoryOverride(t *testing.T) {
+	env := setupTestEnv(t)
+	user := testutil.MustCreateUser(t, env.Queries, "Eve")
+	uncat := seedUncategorized(t, env.Queries)
+	groceries := testutil.MustCreateCategory(t, env.Queries, "groceries", "Groceries")
+
+	// Initial import.
+	body := map[string]any{
+		"csv_base64":     base64.StdEncoding.EncodeToString([]byte(sampleCSV)),
+		"user_id":        pgconv.FormatUUID(user.ID),
+		"account_name":   "Override Bank",
+		"column_mapping": sampleCSVColumnMapping(),
+		"date_format":    "2006-01-02",
+	}
+	resp := env.doPost(t, "/api/v1/connections/csv/import", body)
+	assertStatus(t, resp, http.StatusCreated)
+	var first csvImportResponse
+	parseJSON(t, resp, &first)
+	if first.ImportedTransactions != 2 {
+		t.Fatalf("first import: want 2 imported, got %+v", first)
+	}
+
+	// Pick the "Grocery Store" transaction by description and force a
+	// manual category override. The rest of the test asserts that
+	// re-importing the same CSV does NOT clobber that override.
+	var groceriesTxnID = ""
+	if err := env.Pool.QueryRow(context.Background(),
+		`SELECT id::text FROM transactions WHERE provider_name = 'Grocery Store'`).Scan(&groceriesTxnID); err != nil {
+		t.Fatalf("locate grocery txn: %v", err)
+	}
+
+	if _, err := env.Pool.Exec(context.Background(),
+		`UPDATE transactions SET category_id = $1, category_override = TRUE WHERE id = $2`,
+		groceries.ID, groceriesTxnID); err != nil {
+		t.Fatalf("set override: %v", err)
+	}
+
+	// Sanity: the row really is overridden.
+	var beforeOverride bool
+	var beforeCategory string
+	if err := env.Pool.QueryRow(context.Background(),
+		`SELECT category_override, category_id::text FROM transactions WHERE id = $1`,
+		groceriesTxnID).Scan(&beforeOverride, &beforeCategory); err != nil {
+		t.Fatalf("read pre-state: %v", err)
+	}
+	if !beforeOverride {
+		t.Fatalf("override flag did not stick")
+	}
+
+	// Re-import the same CSV.
+	body["connection_id"] = first.ConnectionID
+	delete(body, "user_id")
+	resp = env.doPost(t, "/api/v1/connections/csv/import", body)
+	assertStatus(t, resp, http.StatusCreated)
+
+	// Override must still be true and category must still point at
+	// groceries — not be reset to uncategorized.
+	var afterOverride bool
+	var afterCategory string
+	if err := env.Pool.QueryRow(context.Background(),
+		`SELECT category_override, category_id::text FROM transactions WHERE id = $1`,
+		groceriesTxnID).Scan(&afterOverride, &afterCategory); err != nil {
+		t.Fatalf("read post-state: %v", err)
+	}
+	if !afterOverride {
+		t.Fatalf("re-import cleared category_override flag")
+	}
+	if afterCategory != beforeCategory {
+		t.Fatalf("re-import changed category_id (was %s, now %s); should have respected override", beforeCategory, afterCategory)
+	}
+	if afterCategory == pgconv.FormatUUID(uncat.ID) {
+		t.Fatalf("re-import reset to uncategorized; override was sacred")
+	}
+}
+
+

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -155,6 +155,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Patch("/users/{user_id}/login/{login_id}", UpdateUserLoginHandler(svc))
 			r.Delete("/users/{user_id}/login/{login_id}", DeleteUserLoginHandler(svc))
 			r.Post("/users/{user_id}/login/{login_id}/regenerate-token", RegenerateLoginTokenHandler(svc))
+			r.Post("/connections/csv/preview", CSVPreviewHandler(svc))
+			r.Post("/connections/csv/import", CSVImportHandler(svc))
 		})
 	})
 


### PR DESCRIPTION
## Summary

CSV import REST endpoints (Bundle 13 of headless-api):

- `POST /api/v1/connections/csv/preview` (Write) — preview without persisting
- `POST /api/v1/connections/csv/import` (Write) — persist; creates connection if absent

Both endpoints accept `multipart/form-data` and `application/json` (with `csv_base64`). Response carries `imported_transactions`, `updated_transactions`, `skipped_duplicates`, `total_rows`. Provider-transaction-ID deduplication is preserved, and **manual category overrides (`category_override = true`) survive re-imports** — the existing `UpsertTransaction` `WHEN transactions.category_override THEN transactions.category_id` branch already handles this and the new test pins it down.

This is the only ingest path for deployments without Plaid or Teller — necessary for the headless surface to be useful out of the box.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go vet -tags integration ./...`
- [x] `make test-integration` (full suite green)
- [x] 11 new integration tests cover both content types, dedup, scope, size cap, and the `category_override` invariant on re-import:
  - `TestCSVPreview_JSON_Success`
  - `TestCSVPreview_Multipart_Success`
  - `TestCSVPreview_BadCSV`
  - `TestCSVImport_JSON_NewConnection_Success`
  - `TestCSVImport_JSON_ExistingConnection`
  - `TestCSVImport_DeduplicatesProviderTransactionID`
  - `TestCSVImport_Multipart_Success`
  - `TestCSVImport_BadConnection_NotFound`
  - `TestCSVImport_PayloadTooLarge`
  - `TestCSVImport_RequiresWriteScope`
  - `TestCSVImport_PreservesCategoryOverride`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
