### PR TITLE
docs: terse API endpoint catalog + upkeep rule

### DIFF
--- a/.claude/rules/api-endpoints.md
+++ b/.claude/rules/api-endpoints.md
@@ -1,0 +1,72 @@
+# API endpoint catalog upkeep
+
+`docs/api-endpoints.md` is the terse human-readable index of every REST endpoint Breadbox exposes. It pairs with the canonical `openapi.yaml` (machine-readable, drift-tested) and `docs/api-reference.md` (long-form prose).
+
+## The rule
+
+**Any change to `internal/api/router.go` that adds, removes, renames, or re-scopes a route MUST update `docs/api-endpoints.md` in the same commit.**
+
+Specifically, if you change:
+
+- `r.Get / Post / Patch / Put / Delete("/...")` calls under `/api/v1/`
+- The `RequireWriteScope` grouping (read ↔ write)
+- The auth requirements for a route
+- A route's request/response semantic (a sentence summary in the table is enough; full details belong in `openapi.yaml` + `docs/api-reference.md`)
+
+…then `docs/api-endpoints.md` must reflect it in the same PR. The OpenAPI drift test catches the spec; nothing catches drift in this Markdown file except discipline.
+
+## What goes in the table row
+
+```
+| METHOD | `/path/with/{params}` | R or W | One-sentence description in present tense |
+```
+
+- **Method** matches chi's call (`GET`, `POST`, `PATCH`, `PUT`, `DELETE`).
+- **Path** is the public path (skip the `/api/v1` prefix — it's in the doc's preamble).
+- **Scope** is `R` (any API key) or `W` (`full_access` required). Some endpoints are write-only even on read intent for sensitivity reasons (API keys list, login accounts list) — mark them `W` and that's fine.
+- **Description** is 5–15 words, present tense, no marketing fluff. Be specific about side effects.
+
+## Where the row lives
+
+Group rows by resource — match the existing section order:
+
+1. Health / meta
+2. Accounts
+3. Transactions (+ comments, tags-on-transactions)
+4. Categories
+5. Tags
+6. Rules
+7. Annotations (cross-reference)
+8. Comments (cross-reference)
+9. Connections (+ provider-specific link flows + CSV)
+10. Sync
+11. Users (+ Login accounts subsection)
+12. Account links
+13. Reports
+14. API keys
+15. Provider settings
+
+Add a new top-level section if you're introducing a new resource family; don't bury new resources inside an unrelated section.
+
+## Cross-references
+
+If your change has a security or correctness implication (encryption at rest, one-time tokens, soft-vs-hard delete, FK protection), note it in the section's prose — not just the table. Examples already in the doc:
+
+- "Empty sensitive fields on PUT preserve the stored value"
+- "Response includes plaintext `setup_token` (one-time only)"
+- "All sensitive fields are AES-256-GCM encrypted at rest"
+
+## What does NOT belong in `docs/api-endpoints.md`
+
+- Full request/response shapes (those live in `docs/api-reference.md` and `openapi.yaml`)
+- MCP tool docs (separate surface — `docs/mcp-tools-reference.md`)
+- Admin handlers under `/-/*` (this file is the **public REST** index)
+- Webhook handlers (separate `/webhooks/:provider` surface)
+
+## When in doubt
+
+- A new endpoint that's pure parity with an existing one (e.g. another bulk variant): still add it. Discoverability matters.
+- A renamed endpoint kept as a deprecated alias: keep both rows; tag the old one `*deprecated — use `<new>` instead*`.
+- Internal-only endpoints (e.g. token-gated `/connect/*` for hosted-link surfaces): add them under a clearly marked section so readers don't think they're general-purpose.
+
+If you forget and a PR lands without updating this file, open a follow-up PR with `docs(api-endpoints):` as the prefix. Don't let the index rot.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,8 @@ Canonical specs in `docs/`:
 
 - `data-model.md` — schema and enums (canonical)
 - `architecture.md` — provider interface and layer boundaries
-- `api-reference.md` — REST endpoints
+- `api-reference.md` — REST endpoints (long-form prose with examples)
+- `api-endpoints.md` — **terse index of every REST endpoint**; keep in sync per `.claude/rules/api-endpoints.md`
 - `mcp-tools-reference.md` — MCP tools
 - `rule-dsl.md` — **canonical transaction-rule DSL**: condition grammar, actions, triggers, pipeline-stage priority, sync-vs-retroactive, chaining
 - `design-system.md` — CSS framework, components, icons
@@ -129,6 +130,7 @@ Scoped rules in `.claude/rules/` load when you touch matching files:
 - `testing.md` — test patterns and fixtures
 - `service.md` — service-layer conventions
 - `api.md` — REST/admin handler conventions
+- `api-endpoints.md` — upkeep rule for `docs/api-endpoints.md` (the endpoint catalog)
 - `mcp.md` — MCP tool and permission patterns
 - `providers.md` — provider integrations
 - `sync.md` — sync engine patterns

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -1,0 +1,212 @@
+# API endpoints
+
+A terse catalog of every REST endpoint Breadbox exposes. The canonical machine-readable spec is [`openapi.yaml`](../openapi.yaml); this file is the human-readable index. **Keep both in sync** — see `.claude/rules/api-endpoints.md` for the upkeep rule.
+
+All endpoints live under `/api/v1/` and require `X-API-Key` unless noted. Scope column: **R** = readable with any key, **W** = requires `full_access` scope. Auth and CSRF details live in `.claude/rules/api.md`.
+
+## Health / meta
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/health` | none | Basic liveness, no DB ping |
+| GET | `/health/live` | none | Alias of `/health` |
+| GET | `/health/ready` | none | DB + scheduler readiness |
+| GET | `/api/v1/version` | none | Build version + upgrade check |
+
+## Accounts
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/accounts` | R | List all household accounts |
+| GET | `/accounts/{id}` | R | Single account summary |
+| GET | `/accounts/{id}/detail` | R | Detail incl. last 25 transactions and per-currency balances |
+| PATCH | `/accounts/{id}` | W | Update `display_name`, `is_excluded`, `is_dependent_linked` |
+
+## Transactions
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/transactions` | R | Cursor-paginated list with filters; supports `?fields=` selection |
+| GET | `/transactions/count` | R | Count matching the same filters |
+| GET | `/transactions/summary` | R | Aggregates by category / month / week / day |
+| GET | `/transactions/merchants` | R | Merchant-level stats (count, total, avg) |
+| GET | `/transactions/{id}` | R | Single transaction |
+| GET | `/transactions/{id}/annotations` | R | Activity-timeline rows; mirrors MCP `list_annotations` |
+| GET | `/transactions/{transaction_id}/comments` | R | List comments on a transaction |
+| POST | `/transactions/update` | W | Atomic multi-field batch (category + tags + comment per row, max 50) |
+| POST | `/transactions/batch-categorize` | W | Set category on many transactions (max 500) |
+| POST | `/transactions/bulk-recategorize` | W | Server-side recategorize by filter |
+| PATCH | `/transactions/{id}/category` | W | Set category (`category_override=true`) |
+| DELETE | `/transactions/{id}/category` | W | Reset category to provider default |
+| DELETE | `/transactions/{id}` | W | Soft-delete (sets `deleted_at`) |
+| POST | `/transactions/{id}/restore` | W | Restore a soft-deleted transaction |
+| POST | `/transactions/{id}/tags` | W | Attach a tag to a transaction |
+| DELETE | `/transactions/{id}/tags/{slug}` | W | Detach a tag from a transaction |
+| POST | `/transactions/{transaction_id}/comments` | W | Add a comment |
+| PUT | `/transactions/{transaction_id}/comments/{id}` | W | Edit a comment |
+| DELETE | `/transactions/{transaction_id}/comments/{id}` | W | Delete a comment |
+
+## Categories
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/categories` | R | List all categories |
+| GET | `/categories/{id}` | R | Single category |
+| GET | `/categories/export` | R | Export as TSV |
+| POST | `/categories` | W | Create a category |
+| POST | `/categories/import` | W | Import categories from TSV |
+| POST | `/categories/{id}/merge` | W | Merge one category into another (transactions migrate, source removed) |
+| PUT | `/categories/{id}` | W | Replace category |
+| DELETE | `/categories/{id}` | W | Delete (blocked if any transactions reference it; clear them first) |
+
+## Tags
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/tags` | R | List tag vocabulary |
+| GET | `/tags/{slug}` | R | Single tag (accepts UUID, short_id, or slug) |
+| POST | `/tags` | W | Create a tag (slug must match `^[a-z0-9][a-z0-9\-:]*[a-z0-9]$`) |
+| PATCH | `/tags/{slug}` | W | Partial update of display_name/description/color/icon/lifecycle |
+| DELETE | `/tags/{slug}` | W | Delete a tag |
+
+## Rules
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/rules` | R | Cursor-paginated list |
+| GET | `/rules/{id}` | R | Single rule |
+| GET | `/rules/{id}/sync-history` | R | Last N sync runs that triggered this rule |
+| POST | `/rules` | W | Create a rule |
+| POST | `/rules/batch` | W | Bulk create; per-op results, `on_error: continue\|abort` |
+| POST | `/rules/preview` | W | Dry-run — show which transactions would match |
+| POST | `/rules/{id}/apply` | W | Apply one rule retroactively (respects `category_override`) |
+| POST | `/rules/apply-all` | W | Apply every active rule retroactively |
+| PUT | `/rules/{id}` | W | Replace a rule |
+| DELETE | `/rules/{id}` | W | Delete a rule |
+
+## Annotations
+
+Annotations are read-only via the transaction endpoint: `GET /transactions/{id}/annotations` above. Writes happen implicitly through comments, tag adds/removes, category changes, and rule applications — never directly.
+
+## Comments
+
+See the Transactions table — comments are nested under `/transactions/{transaction_id}/comments`.
+
+## Connections
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/connections` | R | List active connections |
+| GET | `/connections/{id}` | R | Connection detail (provider, status, paused, sync interval, account count) |
+| GET | `/connections/{id}/status` | R | Status + last sync info |
+| POST | `/connections/{id}/sync` | W | Trigger sync for one connection (202; runs async) |
+| POST | `/connections/{id}/paused` | W | Pause or resume scheduled syncs |
+| POST | `/connections/{id}/sync-interval` | W | Set or clear per-connection interval override |
+| POST | `/connections/{id}/reauth` | W | Start re-auth flow; returns a fresh link token |
+| POST | `/connections/{id}/reauth-complete` | W | Mark connection active again after the user finishes re-auth |
+| DELETE | `/connections/{id}` | W | Soft-disconnect (wipes encrypted tokens, transactions soft-deleted) |
+| POST | `/connections/plaid/link-token` | W | Plaid: get a fresh Link token to start a new connection |
+| POST | `/connections/plaid/exchange` | W | Plaid: exchange the public_token Plaid Link returned, persist connection + accounts |
+| POST | `/connections/teller` | W | Teller: register a connection from the enrollment payload (no link-token step) |
+| POST | `/connections/csv/preview` | W | Preview a CSV (multipart or JSON+base64) — no persist |
+| POST | `/connections/csv/import` | W | Import a CSV — creates connection if absent, deduplicates by provider txn id |
+
+## Sync
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| POST | `/sync` | W | Trigger sync — all active connections, or one via `{"connection_id": "..."}` |
+| GET | `/sync/logs` | R | Paginated history; filters `connection_id`, `status`, `trigger`, `from`, `to` |
+| GET | `/sync/logs/{id}` | R | Single log + per-account rows |
+| GET | `/sync/health` | R | Aggregate stats (success rate, p50 duration) |
+| GET | `/sync/health/providers` | R | Per-provider stats |
+| GET | `/sync/stats` | R | Totals matching the same filter set as `/sync/logs` |
+
+## Users
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/users` | R | List household members |
+| GET | `/users/{id}` | R | Single member |
+| POST | `/users` | W | Create a household member |
+| PATCH | `/users/{id}` | W | Update name / email |
+| DELETE | `/users/{id}` | W | Delete (blocked by FK; hit `/wipe-data` first if needed) |
+| POST | `/users/{id}/wipe-data` | W | **Destructive.** Removes all rows attributed to this user |
+
+### Login accounts (sensitive — all write-scope)
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/users/{user_id}/login` | W | List logins for the user |
+| POST | `/users/{user_id}/login` | W | Create a login. **Response includes plaintext `setup_token` (one-time only)** |
+| PATCH | `/users/{user_id}/login/{login_id}` | W | Update role |
+| DELETE | `/users/{user_id}/login/{login_id}` | W | Remove a login |
+| POST | `/users/{user_id}/login/{login_id}/regenerate-token` | W | Issue a fresh setup token |
+
+## Account links (dependent-account mirroring)
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/account-links` | R | List links |
+| GET | `/account-links/{id}` | R | Single link |
+| GET | `/account-links/{id}/matches` | R | Cursor-paginated matched-transaction list |
+| POST | `/account-links` | W | Create a link between a primary and dependent account |
+| PUT | `/account-links/{id}` | W | Update link |
+| DELETE | `/account-links/{id}` | W | Delete link |
+| POST | `/account-links/{id}/reconcile` | W | Re-run matcher across both accounts |
+| POST | `/transaction-matches/{id}/confirm` | W | Confirm a candidate match |
+| POST | `/transaction-matches/{id}/reject` | W | Reject a candidate match |
+| POST | `/transaction-matches/manual` | W | Create a manual match between two transactions |
+
+## Reports
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/reports` | R | List agent reports |
+| GET | `/reports/unread-count` | R | Unread badge count |
+| GET | `/reports/{id}` | R | Single report |
+| POST | `/reports` | W | Create a report (typically from an agent) |
+| PATCH | `/reports/{id}/read` | W | Mark report read |
+| PATCH | `/reports/{id}/unread` | W | Mark report unread |
+| POST | `/reports/read-all` | W | Mark every report read |
+| DELETE | `/reports/{id}` | W | Delete a report |
+
+## API keys (write-scope only — listing is sensitive)
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/api-keys` | W | List keys (hashed prefixes only — never plaintext) |
+| POST | `/api-keys` | W | Create. **Response includes plaintext `key` once.** |
+| DELETE | `/api-keys/{id}` | W | Soft-revoke a key |
+
+## Provider settings
+
+| Method | Path | Scope | Description |
+|--------|------|-------|-------------|
+| GET | `/settings/providers` | R | Redacted view (`{configured, secret_set, certificate_set}`) — never raw secrets |
+| PUT | `/settings/providers/plaid` | W | Set/update Plaid `client_id`, `secret`, `environment`, `webhook_url` |
+| PUT | `/settings/providers/teller` | W | Set/update Teller `application_id`, cert + private key PEM |
+
+Empty sensitive fields on PUT preserve the stored value (so you can update `webhook_url` without retyping the secret). All sensitive fields are AES-256-GCM encrypted at rest.
+
+## Rate limiting
+
+All `/api/v1/*` routes (except `/health/*` and `/api/v1/version`) are rate-limited per API key. Defaults: **120 req/min, burst 60**. Env vars `API_RATE_LIMIT_RPM` / `API_RATE_LIMIT_BURST`. Over-limit responses: `429 RATE_LIMITED` with `X-RateLimit-Limit/Remaining/Reset` + `Retry-After`.
+
+## Error envelope
+
+Every error response uses:
+
+```json
+{ "error": { "code": "UPPER_SNAKE_CASE", "message": "..." } }
+```
+
+Common codes: `VALIDATION_ERROR`, `INVALID_PARAMETER`, `NOT_FOUND`, `UNAUTHORIZED`, `FORBIDDEN`, `INSUFFICIENT_SCOPE`, `RATE_LIMITED`, `CONFLICT`, `PROVIDER_ERROR`, `INTERNAL_ERROR`. Codes are stable contracts — never rename.
+
+## See also
+
+- [`openapi.yaml`](../openapi.yaml) — machine-readable spec; the drift test (`internal/api/openapi_drift_test.go`) fails CI when chi routes and the spec disagree
+- [`docs/api-reference.md`](api-reference.md) — long-form prose with request/response examples
+- [`docs/headless-api-plan.md`](headless-api-plan.md) — design context for the headless control plane
+- [`.claude/rules/api.md`](../.claude/rules/api.md) — handler/auth conventions
+- [`.claude/rules/api-endpoints.md`](../.claude/rules/api-endpoints.md) — upkeep rule for this file


### PR DESCRIPTION
## Summary

Adds a terse human-readable index of every REST endpoint, plus a rule to keep it in sync.

- **`docs/api-endpoints.md`** — one table per resource family, ~5–15-word descriptions, scope column (R/W). Pairs with `openapi.yaml` (canonical, drift-tested) and `docs/api-reference.md` (long-form prose).
- **`.claude/rules/api-endpoints.md`** — upkeep rule: any change to `internal/api/router.go` that adds, removes, renames, or re-scopes a route MUST update the catalog in the same commit. Spells out row format, section order, and what does NOT belong here (response shapes, MCP tools, admin handlers).
- **`CLAUDE.md`** — links to both new files.

The OpenAPI drift test guards the spec; this Markdown file is discipline-only, hence the explicit rule.

## Test plan

- [x] Doc renders cleanly
- [x] `CLAUDE.md` lists both new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
