### PR TITLE
headless-api: generic /providers + /connections endpoints

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -279,6 +279,38 @@ and chose a password — there's nothing to regenerate at that point.
 
 ## Connections
 
+### Provider registry (preferred)
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/providers` | Read | List configured providers with capabilities + credential schema |
+| GET | `/providers/{name}` | Read | Single provider entry (same shape as one entry in the list) |
+| POST | `/providers/{name}/link-session` | Write | Start the hosted-UI session for `name`. Returns `{link_token, expiration}` for providers that need one; `204 No Content` for Teller/CSV. |
+| POST | `/connections` | Write | Create a connection. Body has a `provider` discriminator + `credentials` blob whose shape depends on `provider`. Also accepts `multipart/form-data` when `provider=csv`. |
+
+`POST /connections` body:
+
+```json
+{
+  "provider": "plaid",
+  "user_id": "<uuid-or-short-id>",
+  "credentials": { "public_token": "...", "institution_id": "...", "institution_name": "..." }
+}
+```
+
+`GET /providers` returns a bare JSON array with `name`, `configured`, `needs_link_session`, `capabilities`, and `credentials_schema`. Unconfigured providers still appear with `configured: false` so clients can render a "set me up" CTA without guessing. Discover supported providers and credential shapes programmatically rather than hardcoding the list.
+
+Errors on `POST /connections`:
+
+| Status | Code | When |
+|--------|------|------|
+| 400 | `INVALID_PARAMETER` | missing required credential per the provider schema |
+| 404 | `NOT_FOUND` | unknown provider name, unknown user |
+| 502 | `PROVIDER_ERROR` | exchange failed at the upstream provider |
+| 500 | `INTERNAL_ERROR` | unexpected server failure |
+
+### Other connection endpoints
+
 | Method | Endpoint | Auth | Description |
 |--------|----------|------|-------------|
 | GET | `/connections` | Read | List all bank connections |
@@ -290,11 +322,11 @@ and chose a password — there's nothing to regenerate at that point.
 | DELETE | `/connections/{id}` | Write | Soft-disconnect a connection (clears tokens, hides from list) |
 | POST | `/connections/{id}/reauth` | Write | Start the provider re-auth flow — returns a fresh link token |
 | POST | `/connections/{id}/reauth-complete` | Write | Mark connection active again after the user finishes the re-auth flow |
-| POST | `/connections/plaid/link-token` | Write | Start a new Plaid Link flow — returns a fresh link token |
-| POST | `/connections/plaid/exchange` | Write | Exchange the Plaid public token for a stored connection + accounts |
-| POST | `/connections/teller` | Write | Register a Teller connection from the enrollment payload Teller Connect returns |
+| POST | `/connections/plaid/link-token` | Write | _Deprecated — use `POST /providers/plaid/link-session`._ |
+| POST | `/connections/plaid/exchange` | Write | _Deprecated — use `POST /connections` with `provider:"plaid"`._ |
+| POST | `/connections/teller` | Write | _Deprecated — use `POST /connections` with `provider:"teller"`._ |
 | POST | `/connections/csv/preview` | Write | Parse a CSV upload and return inferred columns + the first N rows. No persistence. |
-| POST | `/connections/csv/import` | Write | Import a CSV. Creates a new connection if `connection_id` is omitted, otherwise appends to the existing one. |
+| POST | `/connections/csv/import` | Write | _Deprecated — use `POST /connections` with `provider:"csv"`._ |
 
 `{id}` accepts either the connection's UUID or 8-char short_id.
 

--- a/internal/api/connections_generic_integration_test.go
+++ b/internal/api/connections_generic_integration_test.go
@@ -1,0 +1,466 @@
+//go:build integration
+
+// Integration tests for the generic POST /api/v1/connections endpoint plus
+// the backward-compat shims (POST /connections/plaid/exchange,
+// POST /connections/teller, POST /connections/csv/import).
+//
+// Reuses fakePlaidProvider + fakeTellerProvider from the per-provider test
+// files in this package.
+package api
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
+	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// genericCreateEnv is the per-test harness for POST /connections. Both
+// Plaid and Teller fakes are registered so the dispatch table can reach them.
+type genericCreateEnv struct {
+	Server  *httptest.Server
+	APIKey  string
+	App     *app.App
+	Service *service.Service
+	Queries *db.Queries
+	Plaid   *fakePlaidProvider
+	Teller  *fakeTellerProvider
+}
+
+func setupGenericCreateEnv(t *testing.T, scope string) *genericCreateEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "generic-create-test-key", scope)
+	if err != nil {
+		t.Fatalf("create API key: %v", err)
+	}
+
+	fp := &fakePlaidProvider{
+		exchangeConn: provider.Connection{
+			ProviderName:         "plaid",
+			ExternalID:           "ext_new_item_456",
+			EncryptedCredentials: []byte("encrypted-access-token"),
+		},
+		exchangeAccounts: []provider.Account{
+			{ExternalID: "ext_acct_chk_1", Name: "Plaid Checking", Type: "depository", Subtype: "checking", Mask: "0000", ISOCurrencyCode: "USD"},
+		},
+	}
+	ft := &fakeTellerProvider{
+		exchangeConn: provider.Connection{
+			ProviderName:         "teller",
+			ExternalID:           "enr_xyz_888",
+			EncryptedCredentials: []byte("encrypted-teller-token"),
+			InstitutionName:      "Chase",
+		},
+		exchangeAccounts: []provider.Account{
+			{ExternalID: "acc_chk_1", Name: "Chase Checking", Type: "depository", Subtype: "checking", Mask: "1234", ISOCurrencyCode: "USD"},
+		},
+	}
+
+	a := &app.App{
+		DB:        pool,
+		Queries:   queries,
+		Logger:    slog.Default(),
+		Service:   svc,
+		Providers: map[string]provider.Provider{"plaid": fp, "teller": ft},
+	}
+
+	r := buildGenericCreateTestRouter(svc, a)
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &genericCreateEnv{
+		Server:  server,
+		APIKey:  keyResult.PlaintextKey,
+		App:     a,
+		Service: svc,
+		Queries: queries,
+		Plaid:   fp,
+		Teller:  ft,
+	}
+}
+
+// buildGenericCreateTestRouter wires the new generic routes plus the legacy
+// per-provider routes that this test file asserts backward compatibility for.
+func buildGenericCreateTestRouter(svc *service.Service, a *app.App) http.Handler {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/connections", CreateConnectionHandler(a))
+			// Backward-compat: keep the per-provider routes wired so we can
+			// assert they still return the canonical envelope.
+			r.Post("/connections/plaid/exchange", PlaidExchangeHandler(a))
+			r.Post("/connections/teller", TellerSetupHandler(a))
+			r.Post("/connections/csv/import", CSVImportHandler(svc))
+		})
+	})
+	return r
+}
+
+func (e *genericCreateEnv) doPostJSON(t *testing.T, path string, body any) *http.Response {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+	}
+	req, err := http.NewRequest("POST", e.Server.URL+path, &buf)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", e.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+func (e *genericCreateEnv) doPostMultipart(t *testing.T, path string, body io.Reader, contentType string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("POST", e.Server.URL+path, body)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("X-API-Key", e.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// ---- Plaid via generic endpoint ----
+
+func TestCreateConnection_Plaid_Success(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := map[string]any{
+		"provider": "plaid",
+		"user_id":  pgconv.FormatUUID(user.ID),
+		"credentials": map[string]any{
+			"public_token":     "public-sandbox-fake-public-token",
+			"institution_id":   "ins_109511",
+			"institution_name": "Chase",
+		},
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections", body)
+	assertStatus(t, resp, http.StatusCreated)
+
+	var out connectionEnvelope
+	parseJSON(t, resp, &out)
+	if out.ConnectionID == "" {
+		t.Fatal("want non-empty connection_id")
+	}
+	if out.InstitutionName != "Chase" {
+		t.Errorf("want institution_name=Chase, got %q", out.InstitutionName)
+	}
+	if out.Status != "active" {
+		t.Errorf("want status=active, got %q", out.Status)
+	}
+	if env.Plaid.exchangeCalls != 1 {
+		t.Errorf("want 1 exchange call on plaid provider, got %d", env.Plaid.exchangeCalls)
+	}
+
+	// Verify DB persistence: same shape as the legacy exchange handler.
+	uid, err := env.Service.ResolveConnectionUUID(t.Context(), out.ConnectionID)
+	if err != nil {
+		t.Fatalf("resolve persisted connection: %v", err)
+	}
+	conn, err := env.Queries.GetBankConnection(t.Context(), uid)
+	if err != nil {
+		t.Fatalf("reload connection: %v", err)
+	}
+	if conn.Provider != db.ProviderTypePlaid {
+		t.Errorf("want provider=plaid, got %q", conn.Provider)
+	}
+	if conn.ExternalID.String != "ext_new_item_456" {
+		t.Errorf("want external_id from provider, got %q", conn.ExternalID.String)
+	}
+}
+
+func TestCreateConnection_Teller_Success(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := map[string]any{
+		"provider": "teller",
+		"user_id":  pgconv.FormatUUID(user.ID),
+		"credentials": map[string]any{
+			"access_token":     "token-sandbox-fake-teller",
+			"enrollment_id":    "enr_abc123",
+			"institution_id":   "ins_chase",
+			"institution_name": "Chase",
+		},
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections", body)
+	assertStatus(t, resp, http.StatusCreated)
+
+	var out connectionEnvelope
+	parseJSON(t, resp, &out)
+	if out.ConnectionID == "" {
+		t.Fatal("want non-empty connection_id")
+	}
+	if env.Teller.exchangeCalls != 1 {
+		t.Errorf("want 1 exchange call on teller provider, got %d", env.Teller.exchangeCalls)
+	}
+
+	// The provider sees the JSON-encoded blob, identical to legacy path.
+	var seen tellerExchangeBlob
+	if err := json.Unmarshal([]byte(env.Teller.lastExchangeToken), &seen); err != nil {
+		t.Fatalf("provider received non-JSON token: %v", err)
+	}
+	if seen.AccessToken != "token-sandbox-fake-teller" {
+		t.Errorf("want access_token forwarded, got %q", seen.AccessToken)
+	}
+}
+
+func TestCreateConnection_CSV_JSON_Success(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	seedUncategorized(t, env.Queries)
+
+	body := map[string]any{
+		"provider": "csv",
+		"user_id":  pgconv.FormatUUID(user.ID),
+		"credentials": map[string]any{
+			"csv_base64":     base64.StdEncoding.EncodeToString([]byte(sampleCSV)),
+			"column_mapping": sampleCSVColumnMapping(),
+			"account_name":   "Generic CSV",
+			"date_format":    "2006-01-02",
+		},
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections", body)
+	assertStatus(t, resp, http.StatusCreated)
+
+	var out csvImportResponse
+	parseJSON(t, resp, &out)
+	if out.ConnectionID == "" {
+		t.Fatal("want non-empty connection_id")
+	}
+	if out.ImportedTransactions != 2 {
+		t.Errorf("want 2 imported, got %d", out.ImportedTransactions)
+	}
+}
+
+func TestCreateConnection_CSV_Multipart_Success(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	seedUncategorized(t, env.Queries)
+
+	// Build a multipart body with `provider=csv`, the canonical CSV form
+	// fields the legacy handler accepts, and the resolved user_id.
+	var buf bytes.Buffer
+	mwriter := multipart.NewWriter(&buf)
+	part, err := mwriter.CreateFormFile("file", "sample.csv")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := io.WriteString(part, sampleCSV); err != nil {
+		t.Fatalf("write form file: %v", err)
+	}
+	_ = mwriter.WriteField("provider", "csv")
+	_ = mwriter.WriteField("user_id", pgconv.FormatUUID(user.ID))
+	_ = mwriter.WriteField("account_name", "Multipart CSV")
+	_ = mwriter.WriteField("date_format", "2006-01-02")
+	mappingJSON, _ := json.Marshal(sampleCSVColumnMapping())
+	_ = mwriter.WriteField("column_mapping", string(mappingJSON))
+	if err := mwriter.Close(); err != nil {
+		t.Fatalf("close multipart: %v", err)
+	}
+
+	resp := env.doPostMultipart(t, "/api/v1/connections", &buf, mwriter.FormDataContentType())
+	assertStatus(t, resp, http.StatusCreated)
+
+	var out csvImportResponse
+	parseJSON(t, resp, &out)
+	if out.ConnectionID == "" {
+		t.Fatal("want non-empty connection_id")
+	}
+	if out.ImportedTransactions != 2 {
+		t.Errorf("want 2 imported, got %d", out.ImportedTransactions)
+	}
+}
+
+func TestCreateConnection_UnknownProvider(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := map[string]any{
+		"provider":    "moneykit",
+		"user_id":     pgconv.FormatUUID(user.ID),
+		"credentials": map[string]any{},
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections", body)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestCreateConnection_MissingRequiredCredentials(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := map[string]any{
+		"provider": "plaid",
+		"user_id":  pgconv.FormatUUID(user.ID),
+		"credentials": map[string]any{
+			"public_token": "public-sandbox-fake",
+			// missing institution_id and institution_name
+		},
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections", body)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+	if env.Plaid.exchangeCalls != 0 {
+		t.Errorf("provider should not be called when validation fails, got %d", env.Plaid.exchangeCalls)
+	}
+}
+
+func TestCreateConnection_NotFound_User(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+
+	body := map[string]any{
+		"provider": "plaid",
+		"user_id":  "abc12345",
+		"credentials": map[string]any{
+			"public_token":     "public-sandbox-fake",
+			"institution_id":   "ins_109511",
+			"institution_name": "Chase",
+		},
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections", body)
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+	if env.Plaid.exchangeCalls != 0 {
+		t.Errorf("provider should not be called for missing user, got %d", env.Plaid.exchangeCalls)
+	}
+}
+
+func TestCreateConnection_ProviderError(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	env.Plaid.exchangeErr = errors.New("plaid: INVALID_PUBLIC_TOKEN")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := map[string]any{
+		"provider": "plaid",
+		"user_id":  pgconv.FormatUUID(user.ID),
+		"credentials": map[string]any{
+			"public_token":     "public-sandbox-fake",
+			"institution_id":   "ins_109511",
+			"institution_name": "Chase",
+		},
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections", body)
+	readErrorCode(t, resp, http.StatusBadGateway, "PROVIDER_ERROR")
+}
+
+func TestCreateConnection_RequiresWriteScope(t *testing.T) {
+	env := setupGenericCreateEnv(t, "read_only")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := map[string]any{
+		"provider": "plaid",
+		"user_id":  pgconv.FormatUUID(user.ID),
+		"credentials": map[string]any{
+			"public_token":     "public-sandbox-fake",
+			"institution_id":   "ins_109511",
+			"institution_name": "Chase",
+		},
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections", body)
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+// ---- Backward compat: legacy routes still work ----
+
+func TestCreateConnection_BackwardCompat_PlaidExchangeStillWorks(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := map[string]any{
+		"public_token":     "public-sandbox-fake-public-token",
+		"user_id":          pgconv.FormatUUID(user.ID),
+		"institution_id":   "ins_109511",
+		"institution_name": "Chase",
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections/plaid/exchange", body)
+	assertStatus(t, resp, http.StatusCreated)
+
+	var out plaidExchangeResponse
+	parseJSON(t, resp, &out)
+	if out.ConnectionID == "" {
+		t.Fatal("legacy route should still return connection_id")
+	}
+	if out.Status != "active" {
+		t.Errorf("legacy route should still return status=active, got %q", out.Status)
+	}
+}
+
+func TestCreateConnection_BackwardCompat_TellerStillWorks(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+
+	body := map[string]any{
+		"user_id":          pgconv.FormatUUID(user.ID),
+		"institution_id":   "ins_chase",
+		"institution_name": "Chase",
+		"access_token":     "token-sandbox-fake-teller",
+		"enrollment_id":    "enr_abc123",
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections/teller", body)
+	assertStatus(t, resp, http.StatusCreated)
+
+	var out tellerSetupResponse
+	parseJSON(t, resp, &out)
+	if out.ConnectionID == "" {
+		t.Fatal("legacy route should still return connection_id")
+	}
+}
+
+func TestCreateConnection_BackwardCompat_CSVImportStillWorks(t *testing.T) {
+	env := setupGenericCreateEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	seedUncategorized(t, env.Queries)
+
+	body := map[string]any{
+		"csv_base64":     base64.StdEncoding.EncodeToString([]byte(sampleCSV)),
+		"user_id":        pgconv.FormatUUID(user.ID),
+		"column_mapping": sampleCSVColumnMapping(),
+		"account_name":   "Legacy CSV",
+		"date_format":    "2006-01-02",
+	}
+	resp := env.doPostJSON(t, "/api/v1/connections/csv/import", body)
+	assertStatus(t, resp, http.StatusCreated)
+
+	var out csvImportResponse
+	parseJSON(t, resp, &out)
+	if out.ConnectionID == "" {
+		t.Fatal("legacy route should still return connection_id")
+	}
+	if out.ImportedTransactions != 2 {
+		t.Errorf("want 2 imported, got %d", out.ImportedTransactions)
+	}
+}

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -1,0 +1,374 @@
+package api
+
+// Generic provider registry + dispatch for the public REST API.
+//
+// This file collapses the per-provider endpoint sprawl
+// (POST /connections/plaid/link-token, /plaid/exchange, /teller,
+// /csv/import, ...) into a self-describing surface:
+//
+//   GET  /api/v1/providers                         — list with capabilities + credential schema
+//   GET  /api/v1/providers/{name}                  — single provider entry
+//   POST /api/v1/providers/{name}/link-session     — generic link-token start (204 for providers without one)
+//   POST /api/v1/connections                       — provider-discriminated create
+//
+// Adding a new provider (MoneyKit, Salt Edge, Tink, ...) becomes a pure
+// backend change: register a new entry in providerRegistry and the four
+// generic endpoints surface it automatically. The old per-provider routes
+// remain wired as deprecated shims (see connections_plaid_link.go,
+// connections_teller_setup.go, csv_import.go) so existing clients —
+// including the admin UI's wizard — keep working.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"breadbox/internal/app"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// CredentialField is the hand-authored JSON-schema-ish description of one
+// field in a provider's credentials blob. It mirrors the slimmest useful
+// subset of JSON Schema: type + required + a free-form description. Keeping
+// it tiny avoids pulling in a full schema library and keeps the response
+// payload small enough for SDKs to consume directly.
+type CredentialField struct {
+	Type        string `json:"type"`                  // "string", "array", "object", "file"
+	Required    any    `json:"required"`              // bool, or "alt" for "one of N alternatives"
+	Description string `json:"description,omitempty"` // human-readable
+}
+
+// providerInfo is the wire shape of one entry in the GET /providers list.
+type providerInfo struct {
+	Name              string                     `json:"name"`
+	Configured        bool                       `json:"configured"`
+	NeedsLinkSession  bool                       `json:"needs_link_session"`
+	Capabilities      []string                   `json:"capabilities"`
+	CredentialsSchema map[string]CredentialField `json:"credentials_schema"`
+}
+
+// providerEntry is the dispatch-table row for one provider. It carries the
+// static descriptor (name, capabilities, schema) plus the two function
+// pointers the generic POST /connections handler needs:
+//
+//   - extractFromJSON parses an application/json body's `credentials` field
+//     into the shape this provider's exchange step expects.
+//   - extractFromMultipart parses a multipart/form-data body. Optional —
+//     leave nil for providers that don't accept multipart (Plaid, Teller).
+//   - exchange runs the actual provider call + service.RegisterNewConnection
+//     (or service.ImportCSV for CSV). It returns the canonical envelope.
+type providerEntry struct {
+	name              string
+	needsLinkSession  bool
+	capabilities      []string
+	credentialsSchema map[string]CredentialField
+	// extractFromJSON parses the `credentials` object out of a JSON request.
+	// On validation failure it writes the error envelope and returns nil.
+	extractFromJSON func(w http.ResponseWriter, raw json.RawMessage) any
+	// extractFromMultipart parses a multipart form. Optional. Returns nil
+	// (and writes the error) when the body is missing required fields.
+	extractFromMultipart func(w http.ResponseWriter, r *http.Request) any
+	// exchange takes the parsed credentials + user UUID and persists the
+	// connection. Writes the response on success or error.
+	exchange func(a *app.App, w http.ResponseWriter, r *http.Request, uid pgtype.UUID, creds any)
+}
+
+// connectionEnvelope is the shared 201-Created shape across all providers.
+// All three current handlers (Plaid, Teller, CSV) already converged on
+// this shape; the generic endpoint cements it.
+type connectionEnvelope struct {
+	ConnectionID    string `json:"connection_id"`
+	InstitutionName string `json:"institution_name"`
+	Status          string `json:"status"`
+}
+
+// providerRegistry is keyed by provider name. The list order is preserved
+// for GET /providers via providerOrder so the response is deterministic
+// (helpful for clients that cache or diff the list).
+var (
+	providerOrder    = []string{"plaid", "teller", "csv"}
+	providerRegistry = map[string]providerEntry{
+		"plaid":  plaidEntry,
+		"teller": tellerEntry,
+		"csv":    csvEntry,
+	}
+)
+
+// ---- GET /api/v1/providers ----
+
+// ListProvidersHandler serves GET /api/v1/providers.
+//
+// Returns a bare JSON array (bounded resource per the API conventions in
+// .claude/rules/api.md). Unconfigured providers still appear with
+// `configured: false` so clients can render a "set me up" CTA without
+// guessing what providers exist.
+func ListProvidersHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		out := make([]providerInfo, 0, len(providerOrder))
+		for _, name := range providerOrder {
+			entry, ok := providerRegistry[name]
+			if !ok {
+				continue
+			}
+			out = append(out, providerInfoFor(a, entry))
+		}
+		writeJSON(w, http.StatusOK, out)
+	}
+}
+
+// GetProviderHandler serves GET /api/v1/providers/{name}.
+func GetProviderHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		name := strings.ToLower(chi.URLParam(r, "name"))
+		entry, ok := providerRegistry[name]
+		if !ok {
+			mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Unknown provider")
+			return
+		}
+		writeJSON(w, http.StatusOK, providerInfoFor(a, entry))
+	}
+}
+
+func providerInfoFor(a *app.App, entry providerEntry) providerInfo {
+	return providerInfo{
+		Name:              entry.name,
+		Configured:        isProviderConfigured(a, entry.name),
+		NeedsLinkSession:  entry.needsLinkSession,
+		Capabilities:      entry.capabilities,
+		CredentialsSchema: entry.credentialsSchema,
+	}
+}
+
+// isProviderConfigured mirrors the live-provider check used elsewhere
+// (a.Providers[name] != nil) for Plaid/Teller, and is always-true for CSV
+// because the CSV "provider" is just an import code path — no external
+// credentials needed.
+func isProviderConfigured(a *app.App, name string) bool {
+	if name == "csv" {
+		return true
+	}
+	_, ok := a.Providers[name]
+	return ok
+}
+
+// ---- POST /api/v1/providers/{name}/link-session ----
+
+type linkSessionRequest struct {
+	UserID string `json:"user_id"`
+}
+
+type linkSessionResponse struct {
+	LinkToken  string `json:"link_token"`
+	Expiration string `json:"expiration"`
+}
+
+// LinkSessionHandler serves POST /api/v1/providers/{name}/link-session.
+//
+// Returns:
+//   - 200 OK with {link_token, expiration} for providers that issue a token
+//     (Plaid today; MoneyKit / Salt Edge in the future).
+//   - 204 No Content for providers where the link flow is fully client-side
+//     and no init token is needed (Teller, CSV).
+//   - 404 NOT_FOUND for an unknown provider name.
+//   - 400 INVALID_PARAMETER when the provider isn't configured.
+func LinkSessionHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		name := strings.ToLower(chi.URLParam(r, "name"))
+		entry, ok := providerRegistry[name]
+		if !ok {
+			mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Unknown provider")
+			return
+		}
+
+		var req linkSessionRequest
+		if !decodeJSON(w, r, &req) {
+			return
+		}
+		if req.UserID == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "user_id is required")
+			return
+		}
+
+		uid, err := a.Service.ResolveUserUUID(ctx, req.UserID)
+		if err != nil {
+			if errors.Is(err, service.ErrNotFound) {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "User not found")
+				return
+			}
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid user_id")
+			return
+		}
+
+		// Providers that don't need an init token return 204. The client
+		// proceeds straight to POST /connections with the credentials it
+		// gathered from the provider's hosted UI.
+		if !entry.needsLinkSession {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		prov, ok := a.Providers[name]
+		if !ok {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"Provider is not configured on this server")
+			return
+		}
+
+		session, err := prov.CreateLinkSession(ctx, pgconv.FormatUUID(uid))
+		if err != nil {
+			a.Logger.Error("create link session", "provider", name, "error", err)
+			mw.WriteError(w, http.StatusBadGateway, "PROVIDER_ERROR", "Failed to create link token")
+			return
+		}
+
+		writeJSON(w, http.StatusOK, linkSessionResponse{
+			LinkToken:  session.Token,
+			Expiration: session.Expiry.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+}
+
+// ---- POST /api/v1/connections ----
+
+// createConnectionRequest is the JSON shape for the generic create endpoint.
+// `credentials` is left as raw JSON so we can hand it to the provider-specific
+// extractor that knows the shape. Multipart bodies bypass this struct entirely.
+type createConnectionRequest struct {
+	Provider    string          `json:"provider"`
+	UserID      string          `json:"user_id"`
+	Credentials json.RawMessage `json:"credentials"`
+}
+
+// CreateConnectionHandler serves POST /api/v1/connections.
+//
+// Dispatches on `provider`. JSON bodies decode the `credentials` field via
+// the provider's extractor; multipart bodies (CSV only today) read the raw
+// form fields the existing csv_import handler already supports.
+func CreateConnectionHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		contentType := r.Header.Get("Content-Type")
+		mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(contentType, ";", 2)[0]))
+
+		switch mediaType {
+		case "multipart/form-data":
+			// Multipart bodies don't have a `provider` field as JSON — but
+			// the client must still tell us which provider this body
+			// targets. Accept it from a regular form field of the same name.
+			if err := r.ParseMultipartForm(maxCSVRESTUploadSize); err != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "failed to parse multipart form: "+err.Error())
+				return
+			}
+			providerName := strings.ToLower(strings.TrimSpace(r.FormValue("provider")))
+			if providerName == "" {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "provider is required")
+				return
+			}
+			entry, ok := providerRegistry[providerName]
+			if !ok {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Unknown provider")
+				return
+			}
+			if entry.extractFromMultipart == nil {
+				mw.WriteError(w, http.StatusUnsupportedMediaType, "UNSUPPORTED_MEDIA_TYPE",
+					"provider does not accept multipart/form-data; use application/json")
+				return
+			}
+			userIDRaw := r.FormValue("user_id")
+			// Multipart-only providers may resolve the user themselves
+			// (CSV has the single-user-fallback rule); pass an empty UUID
+			// when no user_id is supplied and let extract handle it.
+			var uid pgtype.UUID
+			if userIDRaw != "" {
+				var err error
+				uid, err = a.Service.ResolveUserUUID(ctx, userIDRaw)
+				if err != nil {
+					if errors.Is(err, service.ErrNotFound) {
+						mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "User not found")
+						return
+					}
+					mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid user_id")
+					return
+				}
+			}
+			creds := entry.extractFromMultipart(w, r)
+			if creds == nil {
+				return
+			}
+			entry.exchange(a, w, r, uid, creds)
+			return
+
+		case "application/json", "":
+			var req createConnectionRequest
+			if !decodeJSON(w, r, &req) {
+				return
+			}
+			providerName := strings.ToLower(strings.TrimSpace(req.Provider))
+			if providerName == "" {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "provider is required")
+				return
+			}
+			entry, ok := providerRegistry[providerName]
+			if !ok {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Unknown provider")
+				return
+			}
+
+			// CSV is the one provider that may resolve the user implicitly
+			// (single-user household, or existing connection_id branch).
+			// Skip user_id validation here so the CSV extractor can fall
+			// through to its own resolver. Plaid/Teller require user_id.
+			var uid pgtype.UUID
+			if providerName != "csv" {
+				if req.UserID == "" {
+					mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "user_id is required")
+					return
+				}
+				var err error
+				uid, err = a.Service.ResolveUserUUID(ctx, req.UserID)
+				if err != nil {
+					if errors.Is(err, service.ErrNotFound) {
+						mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "User not found")
+						return
+					}
+					mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid user_id")
+					return
+				}
+			} else if req.UserID != "" {
+				// CSV with an explicit user_id still validates the UUID
+				// up-front so callers get an early 404 on a missing user.
+				var err error
+				uid, err = a.Service.ResolveUserUUID(ctx, req.UserID)
+				if err != nil {
+					if errors.Is(err, service.ErrNotFound) {
+						mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "User not found")
+						return
+					}
+					mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Invalid user_id")
+					return
+				}
+			}
+
+			creds := entry.extractFromJSON(w, req.Credentials)
+			if creds == nil {
+				return
+			}
+			entry.exchange(a, w, r, uid, creds)
+			return
+
+		default:
+			mw.WriteError(w, http.StatusUnsupportedMediaType, "UNSUPPORTED_MEDIA_TYPE",
+				"Content-Type must be application/json or multipart/form-data")
+			return
+		}
+	}
+}

--- a/internal/api/providers_csv.go
+++ b/internal/api/providers_csv.go
@@ -1,0 +1,276 @@
+package api
+
+// CSV entry in the generic provider dispatch table.
+//
+// CSV is the only provider that accepts both application/json and
+// multipart/form-data on POST /connections (the existing /connections/csv/import
+// handler already supports that dual transport). The extractor + exchange
+// functions reuse the same csvPayload + service.ImportCSV machinery so the
+// generic path is byte-equivalent to the legacy one.
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+
+	"breadbox/internal/app"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	csvpkg "breadbox/internal/provider/csv"
+	"breadbox/internal/service"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// base64DecodeFlexible accepts either standard or URL-safe base64. Agents
+// sometimes send the wrong variant without noticing the difference.
+func base64DecodeFlexible(encoded string) ([]byte, error) {
+	if encoded == "" {
+		return nil, nil
+	}
+	if raw, err := base64.StdEncoding.DecodeString(encoded); err == nil {
+		return raw, nil
+	}
+	return base64.URLEncoding.DecodeString(encoded)
+}
+
+// csvCredentials is the JSON shape under `credentials` for
+// POST /api/v1/connections with provider:"csv". Mirrors csvImportRequest
+// minus user_id (which lives on the outer envelope).
+type csvCredentials struct {
+	CSVBase64       string         `json:"csv_base64,omitempty"`
+	CSVData         string         `json:"csv_data,omitempty"`
+	AccountName     string         `json:"account_name,omitempty"`
+	ColumnMapping   map[string]int `json:"column_mapping,omitempty"`
+	PositiveIsDebit bool           `json:"positive_is_debit,omitempty"`
+	DateFormat      string         `json:"date_format,omitempty"`
+	ConnectionID    string         `json:"connection_id,omitempty"`
+	HasDebitCredit  bool           `json:"has_debit_credit,omitempty"`
+}
+
+var csvEntry = providerEntry{
+	name:             "csv",
+	needsLinkSession: false, // CSV has no hosted UI; client just uploads bytes
+	capabilities:     []string{"transactions"},
+	credentialsSchema: map[string]CredentialField{
+		"csv_base64": {
+			Type:        "string",
+			Required:    "alt",
+			Description: "Base64-encoded CSV body (alternative to multipart file upload)",
+		},
+		"file": {
+			Type:        "file",
+			Required:    "alt",
+			Description: "Multipart file upload (alternative to csv_base64)",
+		},
+		"column_mapping": {
+			Type:        "object",
+			Required:    true,
+			Description: "Maps canonical fields (date, amount, description, ...) to 0-indexed CSV columns",
+		},
+		"account_name": {
+			Type:        "string",
+			Required:    false,
+			Description: "Display name for the new account (defaults to 'CSV Import')",
+		},
+		"connection_id": {
+			Type:        "string",
+			Required:    false,
+			Description: "Existing CSV connection UUID or short_id; appends to it instead of creating a new connection",
+		},
+		"date_format": {
+			Type:        "string",
+			Required:    false,
+			Description: "Go time-layout (e.g. 2006-01-02); auto-detected when omitted",
+		},
+		"positive_is_debit": {
+			Type:        "string",
+			Required:    false,
+			Description: "Set true when the CSV already follows the Breadbox convention (positive = money out)",
+		},
+		"has_debit_credit": {
+			Type:        "string",
+			Required:    false,
+			Description: "Set true for Capital-One-style two-column amount CSVs",
+		},
+	},
+	extractFromJSON: func(w http.ResponseWriter, raw json.RawMessage) any {
+		var creds csvCredentials
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &creds); err != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY",
+					"credentials must be a JSON object")
+				return nil
+			}
+		}
+		// The legacy csv_import handler does all its own validation
+		// (decoding base64, parsing the CSV, validating column_mapping). We
+		// only check the cross-cutting requirement here so the dispatch
+		// layer never proceeds with an obviously empty payload.
+		if creds.CSVBase64 == "" && creds.CSVData == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"credentials.csv_base64 is required")
+			return nil
+		}
+		return &creds
+	},
+	extractFromMultipart: func(w http.ResponseWriter, r *http.Request) any {
+		// Reuse readCSVPayloadMultipart's body parsing: it already validated
+		// the multipart form when the dispatch layer called ParseMultipartForm
+		// up front, so we re-parse here only to pull out the form fields.
+		// readCSVPayload's multipart branch is the canonical path; reuse it
+		// directly via a small adapter that bypasses the content-type check.
+		return readCSVPayloadMultipartAdapted(w, r)
+	},
+	exchange: func(a *app.App, w http.ResponseWriter, r *http.Request, uid pgtype.UUID, raw any) {
+		ctx := r.Context()
+		payload := buildCSVPayload(raw, uid)
+		runCSVImportFromPayload(ctx, a.Service, w, payload)
+	},
+}
+
+// readCSVPayloadMultipartAdapted is a wrapper around readCSVPayloadMultipart
+// that assumes ParseMultipartForm has already been called by the caller (the
+// generic dispatch did that to read the `provider` form field). Calling
+// ParseMultipartForm twice is a no-op on the second call, so we can safely
+// delegate.
+func readCSVPayloadMultipartAdapted(w http.ResponseWriter, r *http.Request) *csvPayload {
+	// Cap the body via MaxBytesReader — same protection readCSVPayload
+	// applies on first entry. ParseMultipartForm has already consumed the
+	// body in this code path, but the wrapper is cheap and matches the
+	// invariants readCSVPayloadMultipart documents.
+	r.Body = http.MaxBytesReader(w, r.Body, maxCSVRESTUploadSize)
+	return readCSVPayloadMultipart(w, r)
+}
+
+// buildCSVPayload merges the parsed credentials/multipart payload with the
+// resolved user UUID into the shape runCSVImportFromPayload expects.
+// `raw` is either *csvCredentials (JSON path) or *csvPayload (multipart path).
+func buildCSVPayload(raw any, uid pgtype.UUID) *csvPayload {
+	if p, ok := raw.(*csvPayload); ok {
+		// Multipart already produced a csvPayload; thread the resolved UUID
+		// into UserID so resolveCSVImportUser can pick it up.
+		if uid.Valid && p.UserID == "" {
+			p.UserID = pgconv.FormatUUID(uid)
+		}
+		return p
+	}
+	creds := raw.(*csvCredentials)
+	p := &csvPayload{
+		ColumnMapping:   creds.ColumnMapping,
+		PositiveIsDebit: creds.PositiveIsDebit,
+		DateFormat:      creds.DateFormat,
+		HasDebitCredit:  creds.HasDebitCredit,
+		AccountName:     creds.AccountName,
+		ConnectionID:    creds.ConnectionID,
+	}
+	if uid.Valid {
+		p.UserID = pgconv.FormatUUID(uid)
+	}
+	// Decode the base64 body here so the rest of the pipeline matches
+	// readCSVPayloadJSON's invariants.
+	encoded := creds.CSVBase64
+	if encoded == "" {
+		encoded = creds.CSVData
+	}
+	raw64, err := base64DecodeFlexible(encoded)
+	if err != nil {
+		// Mark the payload as invalid; runCSVImportFromPayload will see an
+		// empty Raw and writeServiceError will surface the right code.
+		p.Raw = nil
+		return p
+	}
+	p.Raw = raw64
+	return p
+}
+
+// runCSVImportFromPayload runs the same persistence path as CSVImportHandler
+// over a pre-built csvPayload. Centralizing the logic keeps the legacy and
+// generic entry points byte-equivalent.
+func runCSVImportFromPayload(ctx context.Context, svc *service.Service, w http.ResponseWriter, payload *csvPayload) {
+	if payload == nil {
+		return
+	}
+	if len(payload.Raw) == 0 {
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+			"csv_base64 is required (and must be valid base64)")
+		return
+	}
+
+	parsed, err := csvpkg.ParseFile(payload.Raw)
+	if err != nil {
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "failed to parse CSV: "+err.Error())
+		return
+	}
+	if len(payload.ColumnMapping) == 0 {
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+			"column_mapping is required (use the preview endpoint to detect a mapping)")
+		return
+	}
+
+	var (
+		connUUIDStr string
+		userUUIDStr string
+	)
+	if payload.ConnectionID != "" {
+		connUUID, errResp := resolveCSVImportConnection(ctx, svc, payload.ConnectionID)
+		if errResp != nil {
+			mw.WriteError(w, errResp.Status, errResp.Code, errResp.Message)
+			return
+		}
+		connUUIDStr = pgconv.FormatUUID(connUUID)
+		conn, err := svc.Queries.GetBankConnection(ctx, connUUID)
+		if err != nil {
+			mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
+			return
+		}
+		userUUIDStr = pgconv.FormatUUID(conn.UserID)
+	} else {
+		s, errResp := resolveCSVImportUser(ctx, svc, payload)
+		if errResp != nil {
+			mw.WriteError(w, errResp.Status, errResp.Code, errResp.Message)
+			return
+		}
+		userUUIDStr = s
+	}
+
+	params := service.CSVImportParams{
+		UserID:          userUUIDStr,
+		AccountName:     payload.AccountName,
+		ColumnMapping:   payload.ColumnMapping,
+		Rows:            parsed.Rows,
+		PositiveIsDebit: payload.PositiveIsDebit,
+		DateFormat:      payload.DateFormat,
+		ConnectionID:    connUUIDStr,
+		HasDebitCredit:  payload.HasDebitCredit,
+	}
+
+	result, err := svc.ImportCSV(ctx, params)
+	if err != nil {
+		writeServiceError(w, err, "", "CSV import failed: "+err.Error())
+		return
+	}
+
+	connShortID := result.ConnectionID
+	acctShortID := result.AccountID
+	if connID, err := pgconv.ParseUUID(result.ConnectionID); err == nil {
+		if conn, err := svc.Queries.GetBankConnection(ctx, connID); err == nil {
+			connShortID = conn.ShortID
+		}
+	}
+	if acctID, err := pgconv.ParseUUID(result.AccountID); err == nil {
+		if acct, err := svc.Queries.GetAccount(ctx, acctID); err == nil {
+			acctShortID = acct.ShortID
+		}
+	}
+
+	writeJSON(w, http.StatusCreated, csvImportResponse{
+		ConnectionID:         connShortID,
+		AccountID:            acctShortID,
+		ImportedTransactions: result.NewCount,
+		UpdatedTransactions:  result.UpdatedCount,
+		SkippedDuplicates:    result.SkippedCount,
+		TotalRows:            result.TotalRows,
+	})
+}

--- a/internal/api/providers_generic_integration_test.go
+++ b/internal/api/providers_generic_integration_test.go
@@ -1,0 +1,333 @@
+//go:build integration
+
+// Integration tests for the generic provider registry endpoints
+// (GET /api/v1/providers, GET /api/v1/providers/{name},
+//  POST /api/v1/providers/{name}/link-session).
+//
+// Uses the same fake-provider pattern as
+// connections_plaid_link_integration_test.go and
+// connections_teller_setup_integration_test.go — the fake providers from
+// those test files are reused here so we don't duplicate stubs.
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"breadbox/internal/app"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
+	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// providersEnv is the harness for the registry tests. It bundles an app
+// with both Plaid and Teller fakes registered so list/get can observe
+// `configured: true` for them.
+type providersEnv struct {
+	Server   *httptest.Server
+	APIKey   string
+	App      *app.App
+	Service  *service.Service
+	Plaid    *fakePlaidProvider
+	Teller   *fakeTellerProvider
+}
+
+func setupProvidersEnv(t *testing.T, scope string, registerPlaid, registerTeller bool) *providersEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "providers-test-key", scope)
+	if err != nil {
+		t.Fatalf("create API key: %v", err)
+	}
+
+	fp := &fakePlaidProvider{
+		linkSession: provider.LinkSession{
+			Token:  "link-sandbox-fake-token",
+			Expiry: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC),
+		},
+	}
+	ft := &fakeTellerProvider{}
+
+	providers := map[string]provider.Provider{}
+	if registerPlaid {
+		providers["plaid"] = fp
+	}
+	if registerTeller {
+		providers["teller"] = ft
+	}
+	a := &app.App{
+		DB:        pool,
+		Queries:   queries,
+		Logger:    slog.Default(),
+		Service:   svc,
+		Providers: providers,
+	}
+
+	r := buildProvidersTestRouter(svc, a)
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &providersEnv{
+		Server:  server,
+		APIKey:  keyResult.PlaintextKey,
+		App:     a,
+		Service: svc,
+		Plaid:   fp,
+		Teller:  ft,
+	}
+}
+
+// buildProvidersTestRouter mirrors the production wiring for the four
+// generic provider endpoints plus the legacy CSV import the CSV exchange
+// path reuses.
+func buildProvidersTestRouter(svc *service.Service, a *app.App) http.Handler {
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		// Read endpoints are outside the write-scope group.
+		r.Get("/providers", ListProvidersHandler(a))
+		r.Get("/providers/{name}", GetProviderHandler(a))
+		// Write endpoints — full_access only.
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/providers/{name}/link-session", LinkSessionHandler(a))
+			r.Post("/connections", CreateConnectionHandler(a))
+		})
+	})
+	return r
+}
+
+func (e *providersEnv) doGet(t *testing.T, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("GET", e.Server.URL+path, nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("X-API-Key", e.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+func (e *providersEnv) doPostJSON(t *testing.T, path string, body any) *http.Response {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		if err := json.NewEncoder(&buf).Encode(body); err != nil {
+			t.Fatalf("encode body: %v", err)
+		}
+	}
+	req, err := http.NewRequest("POST", e.Server.URL+path, &buf)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", e.APIKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// ---- List / Get ----
+
+func TestListProviders_ReturnsAll(t *testing.T) {
+	env := setupProvidersEnv(t, "full_access", true, true)
+
+	resp := env.doGet(t, "/api/v1/providers")
+	assertStatus(t, resp, http.StatusOK)
+
+	var out []providerInfo
+	parseJSON(t, resp, &out)
+	if len(out) < 3 {
+		t.Fatalf("want at least 3 providers, got %d", len(out))
+	}
+	gotByName := map[string]providerInfo{}
+	for _, p := range out {
+		gotByName[p.Name] = p
+	}
+	for _, want := range []string{"plaid", "teller", "csv"} {
+		if _, ok := gotByName[want]; !ok {
+			t.Errorf("missing provider %q in response", want)
+		}
+	}
+	if !gotByName["plaid"].Configured {
+		t.Errorf("plaid should be configured (provider registered), got configured=false")
+	}
+	if !gotByName["teller"].Configured {
+		t.Errorf("teller should be configured (provider registered), got configured=false")
+	}
+	if !gotByName["csv"].Configured {
+		t.Errorf("csv should always be configured (no external deps), got configured=false")
+	}
+	if !gotByName["plaid"].NeedsLinkSession {
+		t.Errorf("plaid should need link session")
+	}
+	if gotByName["teller"].NeedsLinkSession {
+		t.Errorf("teller should not need link session")
+	}
+	if gotByName["csv"].NeedsLinkSession {
+		t.Errorf("csv should not need link session")
+	}
+}
+
+func TestListProviders_UnconfiguredStillAppears(t *testing.T) {
+	env := setupProvidersEnv(t, "full_access", false, false)
+
+	resp := env.doGet(t, "/api/v1/providers")
+	assertStatus(t, resp, http.StatusOK)
+
+	var out []providerInfo
+	parseJSON(t, resp, &out)
+	gotByName := map[string]providerInfo{}
+	for _, p := range out {
+		gotByName[p.Name] = p
+	}
+	if gotByName["plaid"].Configured {
+		t.Errorf("plaid should NOT be configured (provider absent)")
+	}
+	if gotByName["teller"].Configured {
+		t.Errorf("teller should NOT be configured (provider absent)")
+	}
+}
+
+func TestListProviders_SchemaIncludesRequiredFields(t *testing.T) {
+	env := setupProvidersEnv(t, "full_access", true, true)
+
+	resp := env.doGet(t, "/api/v1/providers")
+	assertStatus(t, resp, http.StatusOK)
+
+	var out []providerInfo
+	parseJSON(t, resp, &out)
+	gotByName := map[string]providerInfo{}
+	for _, p := range out {
+		gotByName[p.Name] = p
+	}
+	// Spot-check that each provider's schema names the canonical required
+	// fields. The schema map values aren't structurally enforced by the
+	// type system; this is the regression guard.
+	plaid := gotByName["plaid"].CredentialsSchema
+	for _, key := range []string{"public_token", "institution_id", "institution_name"} {
+		if _, ok := plaid[key]; !ok {
+			t.Errorf("plaid schema missing field %q", key)
+		}
+	}
+	teller := gotByName["teller"].CredentialsSchema
+	for _, key := range []string{"access_token", "enrollment_id", "institution_name"} {
+		if _, ok := teller[key]; !ok {
+			t.Errorf("teller schema missing field %q", key)
+		}
+	}
+	csv := gotByName["csv"].CredentialsSchema
+	for _, key := range []string{"csv_base64", "column_mapping"} {
+		if _, ok := csv[key]; !ok {
+			t.Errorf("csv schema missing field %q", key)
+		}
+	}
+}
+
+func TestGetProvider_Plaid(t *testing.T) {
+	env := setupProvidersEnv(t, "full_access", true, true)
+
+	resp := env.doGet(t, "/api/v1/providers/plaid")
+	assertStatus(t, resp, http.StatusOK)
+
+	var out providerInfo
+	parseJSON(t, resp, &out)
+	if out.Name != "plaid" {
+		t.Errorf("want name=plaid, got %q", out.Name)
+	}
+	if !out.Configured {
+		t.Errorf("want configured=true (provider registered)")
+	}
+	if !out.NeedsLinkSession {
+		t.Errorf("want needs_link_session=true for plaid")
+	}
+}
+
+func TestGetProvider_Unknown(t *testing.T) {
+	env := setupProvidersEnv(t, "full_access", true, true)
+
+	resp := env.doGet(t, "/api/v1/providers/moneykit")
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+// ---- Link session ----
+
+func TestLinkSession_Plaid(t *testing.T) {
+	env := setupProvidersEnv(t, "full_access", true, true)
+	user := testutil.MustCreateUser(t, env.App.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/providers/plaid/link-session", map[string]string{
+		"user_id": pgconv.FormatUUID(user.ID),
+	})
+	assertStatus(t, resp, http.StatusOK)
+
+	var body linkSessionResponse
+	parseJSON(t, resp, &body)
+	if body.LinkToken != "link-sandbox-fake-token" {
+		t.Errorf("want link_token %q, got %q", "link-sandbox-fake-token", body.LinkToken)
+	}
+	if body.Expiration != "2030-01-02T03:04:05Z" {
+		t.Errorf("want expiration %q, got %q", "2030-01-02T03:04:05Z", body.Expiration)
+	}
+	if env.Plaid.linkCalls != 1 {
+		t.Errorf("want 1 link call to provider, got %d", env.Plaid.linkCalls)
+	}
+}
+
+func TestLinkSession_Teller(t *testing.T) {
+	env := setupProvidersEnv(t, "full_access", true, true)
+	user := testutil.MustCreateUser(t, env.App.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/providers/teller/link-session", map[string]string{
+		"user_id": pgconv.FormatUUID(user.ID),
+	})
+	assertStatus(t, resp, http.StatusNoContent)
+}
+
+func TestLinkSession_CSV(t *testing.T) {
+	env := setupProvidersEnv(t, "full_access", true, true)
+	user := testutil.MustCreateUser(t, env.App.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/providers/csv/link-session", map[string]string{
+		"user_id": pgconv.FormatUUID(user.ID),
+	})
+	assertStatus(t, resp, http.StatusNoContent)
+}
+
+func TestLinkSession_UnknownProvider(t *testing.T) {
+	env := setupProvidersEnv(t, "full_access", true, true)
+	user := testutil.MustCreateUser(t, env.App.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/providers/moneykit/link-session", map[string]string{
+		"user_id": pgconv.FormatUUID(user.ID),
+	})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestLinkSession_RequiresWriteScope(t *testing.T) {
+	env := setupProvidersEnv(t, "read_only", true, true)
+	user := testutil.MustCreateUser(t, env.App.Queries, "Alice")
+
+	resp := env.doPostJSON(t, "/api/v1/providers/plaid/link-session", map[string]string{
+		"user_id": pgconv.FormatUUID(user.ID),
+	})
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}

--- a/internal/api/providers_plaid.go
+++ b/internal/api/providers_plaid.go
@@ -1,0 +1,110 @@
+package api
+
+// Plaid entry in the generic provider dispatch table. The JSON-credentials
+// shape matches what POST /connections/plaid/exchange has accepted since
+// Bundle 8 — same field names, same semantics — so the deprecated route
+// can be implemented as a thin pass-through.
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"breadbox/internal/app"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// plaidCredentials is the JSON shape required under `credentials` for
+// POST /api/v1/connections with provider:"plaid". Mirrors the legacy
+// plaidExchangeRequest fields one-to-one (minus user_id, which lives at
+// the top level of the generic body).
+type plaidCredentials struct {
+	PublicToken     string                `json:"public_token"`
+	InstitutionID   string                `json:"institution_id"`
+	InstitutionName string                `json:"institution_name"`
+	Accounts        []plaidExchangeAcctMD `json:"accounts"`
+}
+
+var plaidEntry = providerEntry{
+	name:             "plaid",
+	needsLinkSession: true,
+	capabilities:     []string{"transactions", "balances"},
+	credentialsSchema: map[string]CredentialField{
+		"public_token": {
+			Type:        "string",
+			Required:    true,
+			Description: "One-time public token returned by Plaid Link's onSuccess callback",
+		},
+		"institution_id": {
+			Type:        "string",
+			Required:    true,
+			Description: "Plaid institution identifier (e.g. ins_109511)",
+		},
+		"institution_name": {
+			Type:        "string",
+			Required:    true,
+			Description: "Human-readable institution name",
+		},
+		"accounts": {
+			Type:        "array",
+			Required:    false,
+			Description: "Informational; accounts persisted come from the provider's exchange response",
+		},
+	},
+	extractFromJSON: func(w http.ResponseWriter, raw json.RawMessage) any {
+		var creds plaidCredentials
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &creds); err != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY",
+					"credentials must be a JSON object")
+				return nil
+			}
+		}
+		if creds.PublicToken == "" || creds.InstitutionID == "" || creds.InstitutionName == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"credentials.public_token, credentials.institution_id, and credentials.institution_name are required")
+			return nil
+		}
+		return creds
+	},
+	exchange: func(a *app.App, w http.ResponseWriter, r *http.Request, uid pgtype.UUID, raw any) {
+		creds := raw.(plaidCredentials)
+		ctx := r.Context()
+
+		prov, ok := a.Providers["plaid"]
+		if !ok {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"Plaid provider is not configured on this server")
+			return
+		}
+
+		conn, accounts, err := prov.ExchangeToken(ctx, creds.PublicToken)
+		if err != nil {
+			a.Logger.Error("exchange plaid public token", "error", err)
+			mw.WriteError(w, http.StatusBadGateway, "PROVIDER_ERROR", "Failed to exchange public token")
+			return
+		}
+
+		result, err := a.Service.RegisterNewConnection(ctx, service.RegisterNewConnectionParams{
+			UserID:          uid,
+			Provider:        "plaid",
+			InstitutionID:   creds.InstitutionID,
+			InstitutionName: creds.InstitutionName,
+			Conn:            conn,
+			Accounts:        accounts,
+		})
+		if err != nil {
+			a.Logger.Error("register plaid connection", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to save connection")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, connectionEnvelope{
+			ConnectionID:    result.ShortID,
+			InstitutionName: creds.InstitutionName,
+			Status:          "active",
+		})
+	},
+}

--- a/internal/api/providers_teller.go
+++ b/internal/api/providers_teller.go
@@ -1,0 +1,128 @@
+package api
+
+// Teller entry in the generic provider dispatch table. Mirrors the legacy
+// POST /connections/teller body (minus the top-level user_id, which is on
+// the outer envelope of POST /connections).
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"breadbox/internal/app"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// tellerCredentials is the JSON shape required under `credentials` for
+// POST /api/v1/connections with provider:"teller".
+type tellerCredentials struct {
+	AccessToken     string                 `json:"access_token"`
+	EnrollmentID    string                 `json:"enrollment_id"`
+	InstitutionID   string                 `json:"institution_id"`
+	InstitutionName string                 `json:"institution_name"`
+	Accounts        []tellerSetupAccountMD `json:"accounts"`
+}
+
+var tellerEntry = providerEntry{
+	name:             "teller",
+	needsLinkSession: false, // Teller Connect runs entirely client-side; no init token
+	capabilities:     []string{"transactions", "balances"},
+	credentialsSchema: map[string]CredentialField{
+		"access_token": {
+			Type:        "string",
+			Required:    true,
+			Description: "Long-lived access token returned by Teller Connect's onSuccess callback",
+		},
+		"enrollment_id": {
+			Type:        "string",
+			Required:    true,
+			Description: "Teller enrollment identifier (e.g. enr_abc123)",
+		},
+		"institution_id": {
+			Type:        "string",
+			Required:    false,
+			Description: "Teller institution identifier (optional; not always provided by Teller)",
+		},
+		"institution_name": {
+			Type:        "string",
+			Required:    true,
+			Description: "Human-readable institution name",
+		},
+		"accounts": {
+			Type:        "array",
+			Required:    false,
+			Description: "Informational; accounts persisted come from the provider's exchange response",
+		},
+	},
+	extractFromJSON: func(w http.ResponseWriter, raw json.RawMessage) any {
+		var creds tellerCredentials
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &creds); err != nil {
+				mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY",
+					"credentials must be a JSON object")
+				return nil
+			}
+		}
+		if creds.AccessToken == "" || creds.EnrollmentID == "" || creds.InstitutionName == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"credentials.access_token, credentials.enrollment_id, and credentials.institution_name are required")
+			return nil
+		}
+		return creds
+	},
+	exchange: func(a *app.App, w http.ResponseWriter, r *http.Request, uid pgtype.UUID, raw any) {
+		creds := raw.(tellerCredentials)
+		ctx := r.Context()
+
+		prov, ok := a.Providers["teller"]
+		if !ok {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
+				"Teller provider is not configured on this server")
+			return
+		}
+
+		// Teller's ExchangeToken signature takes a `publicToken` string; the
+		// provider treats it as an opaque JSON blob carrying access_token +
+		// enrollment_id + institution_name. Build the same blob the legacy
+		// handler does so persistence is byte-identical.
+		blob, err := json.Marshal(tellerExchangeBlob{
+			AccessToken:     creds.AccessToken,
+			EnrollmentID:    creds.EnrollmentID,
+			InstitutionName: creds.InstitutionName,
+		})
+		if err != nil {
+			a.Logger.Error("encode teller exchange blob", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to prepare provider call")
+			return
+		}
+
+		conn, accounts, err := prov.ExchangeToken(ctx, string(blob))
+		if err != nil {
+			a.Logger.Error("exchange teller enrollment", "error", err)
+			mw.WriteError(w, http.StatusBadGateway, "PROVIDER_ERROR", "Failed to exchange enrollment payload")
+			return
+		}
+
+		result, err := a.Service.RegisterNewConnection(ctx, service.RegisterNewConnectionParams{
+			UserID:          uid,
+			Provider:        "teller",
+			InstitutionID:   creds.InstitutionID,
+			InstitutionName: creds.InstitutionName,
+			Conn:            conn,
+			Accounts:        accounts,
+		})
+		if err != nil {
+			a.Logger.Error("register teller connection", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to save connection")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, connectionEnvelope{
+			ConnectionID:    result.ShortID,
+			InstitutionName: creds.InstitutionName,
+			Status:          "active",
+		})
+	},
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -87,6 +87,8 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/tags", ListTagsHandler(svc))
 		r.Get("/tags/{slug}", GetTagHandler(svc))
 		r.Get("/settings/providers", GetProviderConfigHandler(a))
+		r.Get("/providers", ListProvidersHandler(a))
+		r.Get("/providers/{name}", GetProviderHandler(a))
 
 		// Write endpoints — full_access API keys only.
 		r.Group(func(r chi.Router) {
@@ -157,6 +159,11 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/users/{user_id}/login/{login_id}/regenerate-token", RegenerateLoginTokenHandler(svc))
 			r.Post("/connections/csv/preview", CSVPreviewHandler(svc))
 			r.Post("/connections/csv/import", CSVImportHandler(svc))
+			// Generic provider create + link-session — supersede the
+			// per-provider routes above. The old routes remain wired as
+			// deprecated shims (callers will see identical behavior).
+			r.Post("/providers/{name}/link-session", LinkSessionHandler(a))
+			r.Post("/connections", CreateConnectionHandler(a))
 		})
 	})
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -674,6 +674,64 @@ paths:
               schema:
                 type: array
                 items: { $ref: "#/components/schemas/Connection" }
+    post:
+      tags: [Connections]
+      summary: Create a connection
+      description: |
+        Generic, provider-discriminated create. Supersedes
+        `POST /connections/plaid/exchange`, `POST /connections/teller`, and
+        `POST /connections/csv/import`.
+
+        The `credentials` shape depends on `provider`:
+
+        - **plaid** — `{public_token, institution_id, institution_name, accounts?}`
+        - **teller** — `{access_token, enrollment_id, institution_id?, institution_name, accounts?}`
+        - **csv** — `{csv_base64, column_mapping, account_name?, date_format?, ...}`
+          (also accepts `multipart/form-data` with a `file` field plus the
+          same configuration fields as form values).
+
+        Returns the same `{connection_id, institution_name, status}` envelope
+        all three legacy routes produce. **Requires `full_access` scope.**
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [provider]
+              properties:
+                provider: { type: string, enum: [plaid, teller, csv] }
+                user_id: { type: string, description: "UUID or short_id" }
+                credentials:
+                  type: object
+                  additionalProperties: true
+          multipart/form-data:
+            schema:
+              type: object
+              required: [provider, file]
+              properties:
+                provider: { type: string, enum: [csv] }
+                user_id: { type: string }
+                file: { type: string, format: binary }
+                column_mapping: { type: string, description: "JSON object {column_name: column_index}" }
+                date_format: { type: string }
+                positive_is_debit: { type: string }
+                has_debit_credit: { type: string }
+                account_name: { type: string }
+                connection_id: { type: string }
+      responses:
+        "201":
+          description: Created connection.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Connection" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "502":
+          description: Provider exchange failed.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
   /api/v1/connections/{id}:
     parameters: [{ $ref: "#/components/parameters/IDPath" }]
     get:
@@ -796,11 +854,96 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Connection" }
+  /api/v1/providers:
+    get:
+      tags: [Connections]
+      summary: List configured providers
+      description: |
+        Returns the self-describing registry of bank-data providers this server
+        supports, including which are configured, their capabilities, and the
+        shape of credentials they accept on `POST /connections`.
+
+        Unconfigured providers still appear with `configured: false` so clients
+        can render a "set me up" CTA without guessing what providers exist.
+
+        Response is a bare JSON array (bounded resource — see API conventions).
+      responses:
+        "200":
+          description: Provider registry.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: "#/components/schemas/ProviderInfo" }
+  /api/v1/providers/{name}:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema: { type: string, enum: [plaid, teller, csv] }
+    get:
+      tags: [Connections]
+      summary: Get a single provider entry
+      description: Same shape as one entry in `GET /providers`.
+      responses:
+        "200":
+          description: Provider entry.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ProviderInfo" }
+        "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/providers/{name}/link-session:
+    parameters:
+      - name: name
+        in: path
+        required: true
+        schema: { type: string, enum: [plaid, teller, csv] }
+    post:
+      tags: [Connections]
+      summary: Start a provider link session
+      description: |
+        Generic link-token start. Replaces the deprecated provider-specific
+        link-token routes.
+
+        - Providers that need a server-issued init token (Plaid today;
+          MoneyKit / Salt Edge in the future) return `200 OK` with
+          `{link_token, expiration}`.
+        - Providers whose hosted UI runs entirely client-side (Teller, CSV)
+          return `204 No Content` — the client proceeds straight to
+          `POST /connections` with the credentials it collected.
+
+        **Requires `full_access` scope.**
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [user_id]
+              properties:
+                user_id: { type: string, description: "UUID or short_id" }
+      responses:
+        "200":
+          description: Link token issued.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  link_token: { type: string }
+                  expiration: { type: string, format: date-time }
+        "204": { description: "No init token needed; proceed to POST /connections." }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
   /api/v1/connections/plaid/link-token:
     post:
       tags: [Connections]
+      deprecated: true
       summary: Issue a Plaid Link token
       description: |
+        **Deprecated** — use `POST /api/v1/providers/plaid/link-session` instead.
+        This route remains as a thin pass-through to the generic dispatch path.
+
         Returns a Plaid-issued `link_token` for initial connection (or update mode
         when `connection_id` is supplied). **Requires `full_access` scope.**
       requestBody:
@@ -823,8 +966,12 @@ paths:
   /api/v1/connections/plaid/exchange:
     post:
       tags: [Connections]
+      deprecated: true
       summary: Exchange a Plaid public_token
       description: |
+        **Deprecated** — use `POST /api/v1/connections` with `provider:"plaid"` instead.
+        This route remains as a thin pass-through to the generic dispatch path.
+
         Trades a one-time `public_token` for a long-lived access token, persists
         the connection, and triggers an initial sync. **Requires `full_access` scope.**
       requestBody:
@@ -849,8 +996,13 @@ paths:
   /api/v1/connections/teller:
     post:
       tags: [Connections]
+      deprecated: true
       summary: Create a Teller connection
-      description: Persists a Teller `enrollment_id` + access token after the Connect.js flow. **Requires `full_access` scope.**
+      description: |
+        **Deprecated** — use `POST /api/v1/connections` with `provider:"teller"` instead.
+        This route remains as a thin pass-through to the generic dispatch path.
+
+        Persists a Teller `enrollment_id` + access token after the Connect.js flow. **Requires `full_access` scope.**
       requestBody:
         required: true
         content:
@@ -891,8 +1043,13 @@ paths:
   /api/v1/connections/csv/import:
     post:
       tags: [Connections]
+      deprecated: true
       summary: Import a CSV
-      description: Persists CSV rows as transactions under a CSV-type connection. **Requires `full_access` scope.**
+      description: |
+        **Deprecated** — use `POST /api/v1/connections` with `provider:"csv"` instead.
+        This route remains as a thin pass-through to the generic dispatch path.
+
+        Persists CSV rows as transactions under a CSV-type connection. **Requires `full_access` scope.**
       requestBody:
         required: true
         content:
@@ -1967,6 +2124,29 @@ components:
         parent_id: { type: string, nullable: true }
         kind: { type: string }
         archived: { type: boolean }
+    ProviderInfo:
+      type: object
+      required: [name, configured, needs_link_session, capabilities, credentials_schema]
+      properties:
+        name: { type: string, description: "Provider identifier (plaid, teller, csv, ...)" }
+        configured: { type: boolean, description: "True when this provider's config is set on this server." }
+        needs_link_session: { type: boolean, description: "True when POST /providers/{name}/link-session returns a token; false when it returns 204." }
+        capabilities:
+          type: array
+          items: { type: string }
+          description: "Informational; e.g. transactions, balances."
+        credentials_schema:
+          type: object
+          description: "Per-field descriptor for the `credentials` payload on POST /connections."
+          additionalProperties:
+            type: object
+            properties:
+              type: { type: string }
+              required:
+                oneOf:
+                  - { type: boolean }
+                  - { type: string }
+              description: { type: string }
     Connection:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Generic provider API (Bundle 23, sequel to the headless-api rollup).

### New endpoints
- `GET /api/v1/providers` — list (configured + capabilities + credential schema)
- `GET /api/v1/providers/{name}` — single entry
- `POST /api/v1/providers/{name}/link-session` — generic link-token start (204 for Teller/CSV)
- `POST /api/v1/connections` — provider-discriminated create (JSON or multipart for CSV)

### Deprecated (still routed via the new dispatch)
- `POST /connections/plaid/link-token` → use `/providers/plaid/link-session`
- `POST /connections/plaid/exchange` → use `POST /connections` with `provider:"plaid"`
- `POST /connections/teller` → use `POST /connections` with `provider:"teller"`
- `POST /connections/csv/import` → use `POST /connections` with `provider:"csv"`
- `POST /connections/csv/preview` is **not** marked deprecated — there's no analogue on the new surface yet.

### OpenAPI spec
- 4 new endpoints documented + new `ProviderInfo` schema
- 4 old endpoints marked `deprecated: true`
- Drift test still passes

### Why
Today every new provider adds 2–3 routes. At 5+ providers that won't scale. With the dispatch table, adding MoneyKit / Salt Edge / Tink becomes a pure backend change — register one entry in `providerRegistry` and the four generic endpoints surface it automatically.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `make test-integration` (full suite green)
- [x] 22 new integration tests cover the registry, link-session, generic create (JSON + multipart), and the three backward-compat aliases
- [x] OpenAPI drift test passes — all 4 new endpoints present in `openapi.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
