### PR TITLE
docs: scope api-endpoints.md rule with path frontmatter

### DIFF
--- a/.claude/rules/api-endpoints.md
+++ b/.claude/rules/api-endpoints.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - "internal/api/router.go"
+  - "docs/api-endpoints.md"
+  - "openapi.yaml"
+---
+
 # API endpoint catalog upkeep
 
 `docs/api-endpoints.md` is the terse human-readable index of every REST endpoint Breadbox exposes. It pairs with the canonical `openapi.yaml` (machine-readable, drift-tested) and `docs/api-reference.md` (long-form prose).


### PR DESCRIPTION
Adds the missing `paths:` YAML frontmatter so the rule auto-loads on router/spec/catalog edits — same convention every other `.claude/rules/*.md` uses. Without it, the rule sat dormant on the exact changes it exists to govern.