### PR TITLE
docs(api-endpoints): catalog generic providers + deprecated shims (B23)

### DIFF
--- a/.claude/rules/api-endpoints.md
+++ b/.claude/rules/api-endpoints.md
@@ -45,7 +45,7 @@ Group rows by resource — match the existing section order:
 6. Rules
 7. Annotations (cross-reference)
 8. Comments (cross-reference)
-9. Connections (+ provider-specific link flows + CSV)
+9. Connections (+ providers dispatch + per-provider link flows + CSV)
 10. Sync
 11. Users (+ Login accounts subsection)
 12. Account links

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -99,17 +99,23 @@ See the Transactions table — comments are nested under `/transactions/{transac
 | GET | `/connections` | R | List active connections |
 | GET | `/connections/{id}` | R | Connection detail (provider, status, paused, sync interval, account count) |
 | GET | `/connections/{id}/status` | R | Status + last sync info |
+| GET | `/providers` | R | List installed providers (`{name, configured, needs_link_session}`) |
+| GET | `/providers/{name}` | R | Single provider entry — capability flags for one provider |
+| POST | `/providers/{name}/link-session` | W | Start a link/auth session — returns a provider token when needed; `204` when no link step |
+| POST | `/connections` | W | Create from a provider payload (`provider` discriminator: `plaid`, `teller`) |
 | POST | `/connections/{id}/sync` | W | Trigger sync for one connection (202; runs async) |
 | POST | `/connections/{id}/paused` | W | Pause or resume scheduled syncs |
 | POST | `/connections/{id}/sync-interval` | W | Set or clear per-connection interval override |
 | POST | `/connections/{id}/reauth` | W | Start re-auth flow; returns a fresh link token |
 | POST | `/connections/{id}/reauth-complete` | W | Mark connection active again after the user finishes re-auth |
 | DELETE | `/connections/{id}` | W | Soft-disconnect (wipes encrypted tokens, transactions soft-deleted) |
-| POST | `/connections/plaid/link-token` | W | Plaid: get a fresh Link token to start a new connection |
-| POST | `/connections/plaid/exchange` | W | Plaid: exchange the public_token Plaid Link returned, persist connection + accounts |
-| POST | `/connections/teller` | W | Teller: register a connection from the enrollment payload (no link-token step) |
 | POST | `/connections/csv/preview` | W | Preview a CSV (multipart or JSON+base64) — no persist |
 | POST | `/connections/csv/import` | W | Import a CSV — creates connection if absent, deduplicates by provider txn id |
+| POST | `/connections/plaid/link-token` | W | *Deprecated — use `POST /providers/plaid/link-session`.* Returns a fresh Plaid Link token |
+| POST | `/connections/plaid/exchange` | W | *Deprecated — use `POST /connections` with `provider: "plaid"`.* Exchanges Plaid `public_token` |
+| POST | `/connections/teller` | W | *Deprecated — use `POST /connections` with `provider: "teller"`.* Registers from the Teller enrollment payload |
+
+Prefer `POST /providers/{name}/link-session` + `POST /connections` for new integrations — the OpenAPI spec treats them as canonical and the per-provider routes above are kept only as shims.
 
 ## Sync
 


### PR DESCRIPTION
## Summary

The B23 generic provider dispatch landed in `internal/api/router.go` (#1037) without a matching update to `docs/api-endpoints.md`. The OpenAPI spec was kept in sync — and already marks the per-provider routes `deprecated: true` — but the human-readable catalog still listed `/connections/plaid/*` and `/connections/teller` as canonical and omitted the four new generic routes entirely.

This is the `docs(api-endpoints):` follow-up the upkeep rule prescribes.

## What changes

In the Connections table:

- **New rows** (the canonical generic surface):
  - `GET /providers`
  - `GET /providers/{name}`
  - `POST /providers/{name}/link-session`
  - `POST /connections` (generic create with `provider` discriminator)
- **Existing per-provider routes** marked inline with `*Deprecated — use <new>*`:
  - `POST /connections/plaid/link-token` → `POST /providers/plaid/link-session`
  - `POST /connections/plaid/exchange` → `POST /connections` (`provider: "plaid"`)
  - `POST /connections/teller` → `POST /connections` (`provider: "teller"`)

A single trailing sentence steers new integrations to the canonical pair.

Per [`.claude/rules/api-endpoints.md`](../.claude/rules/api-endpoints.md), deprecated aliases stay in the same table rather than a separate subsection — discoverability > tidiness, and there's no "deprecated zone" pattern elsewhere in the doc.

## Test plan

- [x] Cross-checked every chi route in `internal/api/router.go` against the new table
- [x] Verified each new row matches the corresponding `openapi.yaml` path entry (incl. the `deprecated: true` flags)
- [x] No `internal/api/router.go` change in this PR, so no drift test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
