### PR TITLE
hosted-link: schema + service for hosted_link_sessions

### DIFF
--- a/internal/db/migrations/20260512033351_hosted_link_sessions.sql
+++ b/internal/db/migrations/20260512033351_hosted_link_sessions.sql
@@ -1,0 +1,43 @@
+-- +goose Up
+
+-- hosted_link_sessions backs the agent-shareable bank-linking surface.
+-- An agent mints a session + token; the user opens the link in a browser
+-- and the page (added in a later PR) wraps Plaid Link / Teller Connect.
+-- The plaintext token is never stored; only its SHA-256 hash sits in
+-- token_hash and the bearer middleware (PR3) compares hashes there.
+--
+-- Status lifecycle: pending -> active (page opened) -> completed | failed.
+-- expires_at is enforced in the service layer and (later) by a cleanup job.
+-- This migration is additive — safe for the shared dev DB.
+
+CREATE TABLE hosted_link_sessions (
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    short_id              TEXT NOT NULL DEFAULT '',
+    token_hash            TEXT NOT NULL UNIQUE,
+    user_id               UUID NOT NULL REFERENCES users(id),
+    provider              TEXT,
+    action                TEXT NOT NULL,
+    connection_id         UUID REFERENCES bank_connections(id) ON DELETE SET NULL,
+    single_use            BOOLEAN NOT NULL DEFAULT FALSE,
+    redirect_url          TEXT,
+    label                 TEXT,
+    status                TEXT NOT NULL DEFAULT 'pending',
+    error_code            TEXT,
+    error_message         TEXT,
+    result_connection_ids UUID[] NOT NULL DEFAULT '{}',
+    expires_at            TIMESTAMPTZ NOT NULL,
+    started_at            TIMESTAMPTZ,
+    completed_at          TIMESTAMPTZ,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX hosted_link_sessions_short_id_idx ON hosted_link_sessions (short_id);
+CREATE INDEX hosted_link_sessions_user_id_idx ON hosted_link_sessions (user_id);
+
+CREATE TRIGGER set_hosted_link_sessions_short_id
+    BEFORE INSERT ON hosted_link_sessions
+    FOR EACH ROW EXECUTE FUNCTION set_short_id();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS set_hosted_link_sessions_short_id ON hosted_link_sessions;
+DROP TABLE IF EXISTS hosted_link_sessions;

--- a/internal/db/queries/hosted_link_sessions.sql
+++ b/internal/db/queries/hosted_link_sessions.sql
@@ -1,0 +1,56 @@
+-- name: CreateHostedLinkSession :one
+INSERT INTO hosted_link_sessions (
+    token_hash,
+    user_id,
+    provider,
+    action,
+    connection_id,
+    single_use,
+    redirect_url,
+    label,
+    expires_at
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+RETURNING *;
+
+-- name: GetHostedLinkSessionByID :one
+SELECT * FROM hosted_link_sessions WHERE id = $1;
+
+-- name: GetHostedLinkSessionByShortID :one
+SELECT * FROM hosted_link_sessions WHERE short_id = $1;
+
+-- name: GetHostedLinkSessionByTokenHash :one
+-- Used by the bearer middleware (PR3) to resolve a session from the
+-- plaintext token without ever storing the plaintext at rest.
+SELECT * FROM hosted_link_sessions WHERE token_hash = $1;
+
+-- name: UpdateHostedLinkSessionStatus :one
+-- Single status-transition write that the service composes around. Pass
+-- nulls (e.g. via pgtype.Timestamptz{}) for any field that should not
+-- change; passing a value overwrites it (including clearing an error by
+-- writing empty strings).
+UPDATE hosted_link_sessions
+SET status        = $2,
+    error_code    = $3,
+    error_message = $4,
+    started_at    = COALESCE($5, started_at),
+    completed_at  = COALESCE($6, completed_at)
+WHERE id = $1
+RETURNING *;
+
+-- name: AppendHostedLinkSessionResult :exec
+-- Append a newly created bank_connections.id to result_connection_ids.
+-- array_append is idempotent in shape (no de-dup); the service guards
+-- against duplicate appends if/when needed.
+UPDATE hosted_link_sessions
+SET result_connection_ids = array_append(result_connection_ids, sqlc.arg(connection_id)::uuid)
+WHERE id = sqlc.arg(id);
+
+-- name: ExpireHostedLinkSessions :execrows
+-- Bulk-expire pending/active sessions whose TTL has elapsed. Returns the
+-- number of rows updated so a cleanup job can log it. Idempotent — running
+-- twice in a row yields 0 the second time.
+UPDATE hosted_link_sessions
+SET status = 'expired'
+WHERE expires_at < NOW()
+  AND status IN ('pending', 'active');

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -10,4 +10,9 @@ var (
 	ErrInvalidParameter = errors.New("invalid parameter")
 	ErrSyncInProgress   = errors.New("sync already in progress")
 	ErrForbidden        = errors.New("forbidden")
+	// ErrInvalidState signals that an entity is in a state that disallows the
+	// requested transition (e.g. completing an already-expired hosted-link
+	// session). Distinct from ErrInvalidParameter (bad input) and ErrNotFound
+	// (no such row).
+	ErrInvalidState = errors.New("invalid state")
 )

--- a/internal/service/hosted_links.go
+++ b/internal/service/hosted_links.go
@@ -1,0 +1,459 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"breadbox/internal/db"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/shortid"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Hosted-link session statuses. Mirrors the values written to the
+// hosted_link_sessions.status column.
+const (
+	HostedLinkStatusPending   = "pending"
+	HostedLinkStatusActive    = "active"
+	HostedLinkStatusCompleted = "completed"
+	HostedLinkStatusFailed    = "failed"
+	// HostedLinkStatusExpired is only ever surfaced by GetHostedLinkSession's
+	// in-memory override (and the future cleanup job). Live writes from this
+	// service use the four values above.
+	HostedLinkStatusExpired = "expired"
+)
+
+// Hosted-link actions.
+const (
+	HostedLinkActionLink   = "link"
+	HostedLinkActionRelink = "relink"
+)
+
+// TTL bounds for hosted-link sessions. Clamped inside CreateHostedLink.
+const (
+	hostedLinkDefaultTTL = 15 * time.Minute
+	hostedLinkMaxTTL     = 60 * time.Minute
+)
+
+// CreateHostedLinkParams is the input for minting a new hosted-link session.
+// UserID is required; Provider is optional ("plaid" / "teller" / "") — empty
+// means the hosted page presents a picker. Action is "link" or "relink";
+// "relink" requires ConnectionID.
+type CreateHostedLinkParams struct {
+	UserID       string
+	Provider     string
+	Action       string
+	ConnectionID string
+	SingleUse    bool
+	RedirectURL  string
+	Label        string
+	TTL          time.Duration
+	Actor        Actor
+}
+
+// HostedLinkSession is the service-layer view of a hosted_link_sessions row.
+// Nullable timestamps surface as *time.Time so callers can omit them from
+// JSON. The plaintext token is never carried on this struct — it's returned
+// exactly once from CreateHostedLink in CreateHostedLinkResult.Token.
+type HostedLinkSession struct {
+	ID                  string
+	ShortID             string
+	UserID              string
+	Provider            string
+	Action              string
+	ConnectionID        string
+	SingleUse           bool
+	RedirectURL         string
+	Label               string
+	Status              string
+	ErrorCode           string
+	ErrorMessage        string
+	ResultConnectionIDs []string
+	ExpiresAt           time.Time
+	StartedAt           *time.Time
+	CompletedAt         *time.Time
+	CreatedAt           time.Time
+}
+
+// CreateHostedLinkResult bundles the newly-created session with the
+// plaintext token. The token is returned to the caller exactly once at
+// creation time and is never stored at rest — token_hash on the row is a
+// SHA-256 hex digest that the bearer middleware (added in a later PR)
+// compares against the incoming Authorization header.
+type CreateHostedLinkResult struct {
+	Session HostedLinkSession
+	Token   string
+}
+
+// CreateHostedLink mints a new hosted_link_sessions row plus a one-time
+// bearer token. TTL is clamped: 0 → 15m default, >60m → 60m. Provider must
+// be empty, "plaid", or "teller". Action "relink" requires ConnectionID and
+// derives Provider from the connection row when the caller leaves it empty.
+func (s *Service) CreateHostedLink(ctx context.Context, p CreateHostedLinkParams) (CreateHostedLinkResult, error) {
+	// Action validation.
+	switch p.Action {
+	case HostedLinkActionLink, HostedLinkActionRelink:
+	default:
+		return CreateHostedLinkResult{}, fmt.Errorf("%w: action must be %q or %q", ErrInvalidParameter, HostedLinkActionLink, HostedLinkActionRelink)
+	}
+
+	// Provider validation. Empty means the hosted page will show a picker.
+	provider := p.Provider
+	switch provider {
+	case "", "plaid", "teller":
+	default:
+		return CreateHostedLinkResult{}, fmt.Errorf("%w: provider must be %q or %q", ErrInvalidParameter, "plaid", "teller")
+	}
+
+	// User resolution.
+	if p.UserID == "" {
+		return CreateHostedLinkResult{}, fmt.Errorf("%w: user_id is required", ErrInvalidParameter)
+	}
+	userUUID, err := s.ResolveUserUUID(ctx, p.UserID)
+	if err != nil {
+		return CreateHostedLinkResult{}, fmt.Errorf("%w: invalid user_id", ErrInvalidParameter)
+	}
+	// resolveUserID returns ErrNotFound when the short id misses, but for a
+	// raw UUID it succeeds without verifying existence. Verify here so we
+	// fail fast rather than emit an orphan FK error on insert.
+	if _, err := s.Queries.GetUser(ctx, userUUID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return CreateHostedLinkResult{}, fmt.Errorf("%w: user not found", ErrNotFound)
+		}
+		return CreateHostedLinkResult{}, fmt.Errorf("get user: %w", err)
+	}
+
+	// Relink-specific validation + provider derivation.
+	var connUUID pgtype.UUID
+	if p.Action == HostedLinkActionRelink {
+		if p.ConnectionID == "" {
+			return CreateHostedLinkResult{}, fmt.Errorf("%w: connection_id is required for relink", ErrInvalidParameter)
+		}
+		cuid, err := s.ResolveConnectionUUID(ctx, p.ConnectionID)
+		if err != nil {
+			return CreateHostedLinkResult{}, fmt.Errorf("%w: invalid connection_id", ErrInvalidParameter)
+		}
+		conn, err := s.Queries.GetBankConnection(ctx, cuid)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return CreateHostedLinkResult{}, fmt.Errorf("%w: connection not found", ErrNotFound)
+			}
+			return CreateHostedLinkResult{}, fmt.Errorf("get connection: %w", err)
+		}
+		connUUID = cuid
+
+		connProvider := string(conn.Provider)
+		if provider == "" {
+			provider = connProvider
+		} else if provider != connProvider {
+			return CreateHostedLinkResult{}, fmt.Errorf("%w: provider %q does not match connection provider %q", ErrInvalidParameter, provider, connProvider)
+		}
+		if provider == "" {
+			// Defensive: a relink without any provider knowledge cannot
+			// route to a working bank flow.
+			return CreateHostedLinkResult{}, fmt.Errorf("%w: provider is required for relink", ErrInvalidParameter)
+		}
+	}
+
+	// TTL clamp. 0 → default; over the max ceiling → max.
+	ttl := p.TTL
+	if ttl <= 0 {
+		ttl = hostedLinkDefaultTTL
+	} else if ttl > hostedLinkMaxTTL {
+		ttl = hostedLinkMaxTTL
+	}
+	expiresAt := time.Now().UTC().Add(ttl)
+
+	// Token: 16 random bytes → base64url (22 chars, 128 bits of entropy).
+	// SHA-256 hex digest is what lives in the DB.
+	token, tokenHash, err := generateHostedLinkToken()
+	if err != nil {
+		return CreateHostedLinkResult{}, fmt.Errorf("generate token: %w", err)
+	}
+
+	row, err := s.Queries.CreateHostedLinkSession(ctx, db.CreateHostedLinkSessionParams{
+		TokenHash:    tokenHash,
+		UserID:       userUUID,
+		Provider:     pgconv.TextIfNotEmpty(provider),
+		Action:       p.Action,
+		ConnectionID: connUUID,
+		SingleUse:    p.SingleUse,
+		RedirectUrl:  pgconv.TextIfNotEmpty(p.RedirectURL),
+		Label:        pgconv.TextIfNotEmpty(p.Label),
+		ExpiresAt:    pgconv.Timestamptz(expiresAt),
+	})
+	if err != nil {
+		return CreateHostedLinkResult{}, fmt.Errorf("create hosted_link_session: %w", err)
+	}
+
+	return CreateHostedLinkResult{
+		Session: hostedLinkSessionFromRow(row, time.Now()),
+		Token:   token,
+	}, nil
+}
+
+// GetHostedLinkSession returns the session by UUID or short_id. Reads are
+// cheap and don't mutate the DB even on expiry — instead, if the underlying
+// status is still pending/active and expires_at has passed, the returned
+// struct surfaces Status="expired" so callers (and the future REST handler)
+// see a consistent expired view without a write on every read.
+func (s *Service) GetHostedLinkSession(ctx context.Context, idOrShortID string) (HostedLinkSession, error) {
+	row, err := s.fetchHostedLinkRow(ctx, idOrShortID)
+	if err != nil {
+		return HostedLinkSession{}, err
+	}
+	return hostedLinkSessionFromRow(row, time.Now()), nil
+}
+
+// ResolveHostedLinkSessionByToken hashes the plaintext token (SHA-256) and
+// looks up the matching row. Returns ErrNotFound on miss. The bearer
+// middleware (PR3) layers on the freshness check (status==active &&
+// not-expired) — this method only resolves the row.
+func (s *Service) ResolveHostedLinkSessionByToken(ctx context.Context, token string) (HostedLinkSession, error) {
+	if token == "" {
+		return HostedLinkSession{}, ErrNotFound
+	}
+	row, err := s.Queries.GetHostedLinkSessionByTokenHash(ctx, hashHostedLinkToken(token))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return HostedLinkSession{}, ErrNotFound
+		}
+		return HostedLinkSession{}, fmt.Errorf("get hosted_link_session by token: %w", err)
+	}
+	return hostedLinkSessionFromRow(row, time.Now()), nil
+}
+
+// MarkHostedLinkStarted transitions a pending session to active and stamps
+// started_at on first call. Calling on an already-active session is a no-op
+// and returns nil — the page may legitimately load twice. Calling on a
+// completed/failed/expired session returns ErrInvalidState.
+func (s *Service) MarkHostedLinkStarted(ctx context.Context, id string) error {
+	row, err := s.fetchHostedLinkRow(ctx, id)
+	if err != nil {
+		return err
+	}
+	now := time.Now()
+	if isHostedLinkExpired(row, now) {
+		return fmt.Errorf("%w: session is expired", ErrInvalidState)
+	}
+	switch row.Status {
+	case HostedLinkStatusActive:
+		return nil
+	case HostedLinkStatusPending:
+		// proceed
+	default:
+		return fmt.Errorf("%w: cannot start a %s session", ErrInvalidState, row.Status)
+	}
+
+	startedAt := pgconv.Timestamptz(now)
+	if row.StartedAt.Valid {
+		startedAt = pgtype.Timestamptz{} // preserve existing via COALESCE
+	}
+	if _, err := s.Queries.UpdateHostedLinkSessionStatus(ctx, db.UpdateHostedLinkSessionStatusParams{
+		ID:           row.ID,
+		Status:       HostedLinkStatusActive,
+		ErrorCode:    row.ErrorCode,
+		ErrorMessage: row.ErrorMessage,
+		StartedAt:    startedAt,
+	}); err != nil {
+		return fmt.Errorf("update hosted_link_session status: %w", err)
+	}
+	return nil
+}
+
+// AppendHostedLinkResult records a newly-created bank_connections.id on the
+// session. The session must be active — calling on pending / completed /
+// failed / expired returns ErrInvalidState.
+func (s *Service) AppendHostedLinkResult(ctx context.Context, id, connectionID string) error {
+	row, err := s.fetchHostedLinkRow(ctx, id)
+	if err != nil {
+		return err
+	}
+	if isHostedLinkExpired(row, time.Now()) {
+		return fmt.Errorf("%w: session is expired", ErrInvalidState)
+	}
+	if row.Status != HostedLinkStatusActive {
+		return fmt.Errorf("%w: cannot append to a %s session", ErrInvalidState, row.Status)
+	}
+	connUUID, err := s.ResolveConnectionUUID(ctx, connectionID)
+	if err != nil {
+		return fmt.Errorf("%w: invalid connection_id", ErrInvalidParameter)
+	}
+	if err := s.Queries.AppendHostedLinkSessionResult(ctx, db.AppendHostedLinkSessionResultParams{
+		ID:           row.ID,
+		ConnectionID: connUUID,
+	}); err != nil {
+		return fmt.Errorf("append hosted_link_session result: %w", err)
+	}
+	return nil
+}
+
+// CompleteHostedLink flips an active session to completed and stamps
+// completed_at. Calling on any other live status returns ErrInvalidState;
+// calling on an already-completed session is a no-op (idempotent for retry
+// safety on the page's success callback).
+func (s *Service) CompleteHostedLink(ctx context.Context, id string) error {
+	row, err := s.fetchHostedLinkRow(ctx, id)
+	if err != nil {
+		return err
+	}
+	if isHostedLinkExpired(row, time.Now()) {
+		return fmt.Errorf("%w: session is expired", ErrInvalidState)
+	}
+	switch row.Status {
+	case HostedLinkStatusCompleted:
+		return nil
+	case HostedLinkStatusActive:
+		// proceed
+	default:
+		return fmt.Errorf("%w: cannot complete a %s session", ErrInvalidState, row.Status)
+	}
+	if _, err := s.Queries.UpdateHostedLinkSessionStatus(ctx, db.UpdateHostedLinkSessionStatusParams{
+		ID:           row.ID,
+		Status:       HostedLinkStatusCompleted,
+		ErrorCode:    row.ErrorCode,
+		ErrorMessage: row.ErrorMessage,
+		CompletedAt:  pgconv.Timestamptz(time.Now()),
+	}); err != nil {
+		return fmt.Errorf("update hosted_link_session status: %w", err)
+	}
+	return nil
+}
+
+// FailHostedLink terminates a session with an error code/message. Allowed
+// from pending or active; calling on completed / failed / expired is
+// ErrInvalidState (we don't overwrite terminal states). Stamps completed_at
+// so the audit trail shows when the failure was recorded.
+func (s *Service) FailHostedLink(ctx context.Context, id, code, message string) error {
+	row, err := s.fetchHostedLinkRow(ctx, id)
+	if err != nil {
+		return err
+	}
+	if isHostedLinkExpired(row, time.Now()) {
+		return fmt.Errorf("%w: session is expired", ErrInvalidState)
+	}
+	switch row.Status {
+	case HostedLinkStatusPending, HostedLinkStatusActive:
+		// proceed
+	default:
+		return fmt.Errorf("%w: cannot fail a %s session", ErrInvalidState, row.Status)
+	}
+	if _, err := s.Queries.UpdateHostedLinkSessionStatus(ctx, db.UpdateHostedLinkSessionStatusParams{
+		ID:           row.ID,
+		Status:       HostedLinkStatusFailed,
+		ErrorCode:    pgconv.TextIfNotEmpty(code),
+		ErrorMessage: pgconv.TextIfNotEmpty(message),
+		CompletedAt:  pgconv.Timestamptz(time.Now()),
+	}); err != nil {
+		return fmt.Errorf("update hosted_link_session status: %w", err)
+	}
+	return nil
+}
+
+// fetchHostedLinkRow resolves either a UUID or short_id to the underlying
+// hosted_link_sessions row. Returns ErrNotFound for any miss / parse error.
+func (s *Service) fetchHostedLinkRow(ctx context.Context, idOrShortID string) (db.HostedLinkSession, error) {
+	if idOrShortID == "" {
+		return db.HostedLinkSession{}, ErrNotFound
+	}
+	if shortid.IsShortID(idOrShortID) {
+		row, err := s.Queries.GetHostedLinkSessionByShortID(ctx, idOrShortID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return db.HostedLinkSession{}, ErrNotFound
+			}
+			return db.HostedLinkSession{}, fmt.Errorf("get hosted_link_session by short_id: %w", err)
+		}
+		return row, nil
+	}
+	uid, err := pgconv.ParseUUID(idOrShortID)
+	if err != nil {
+		return db.HostedLinkSession{}, ErrNotFound
+	}
+	row, err := s.Queries.GetHostedLinkSessionByID(ctx, uid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return db.HostedLinkSession{}, ErrNotFound
+		}
+		return db.HostedLinkSession{}, fmt.Errorf("get hosted_link_session by id: %w", err)
+	}
+	return row, nil
+}
+
+// isHostedLinkExpired returns true when the row's status is still
+// pending/active but its expires_at has passed. Terminal statuses (completed
+// / failed / expired) keep their own status untouched by this check.
+func isHostedLinkExpired(row db.HostedLinkSession, now time.Time) bool {
+	switch row.Status {
+	case HostedLinkStatusPending, HostedLinkStatusActive:
+	default:
+		return false
+	}
+	return row.ExpiresAt.Valid && row.ExpiresAt.Time.Before(now)
+}
+
+// hostedLinkSessionFromRow flattens the DB row into a service-layer struct,
+// applying the in-memory expiry override (see GetHostedLinkSession).
+func hostedLinkSessionFromRow(row db.HostedLinkSession, now time.Time) HostedLinkSession {
+	out := HostedLinkSession{
+		ID:           formatUUID(row.ID),
+		ShortID:      row.ShortID,
+		UserID:       formatUUID(row.UserID),
+		Provider:     pgconv.TextOr(row.Provider, ""),
+		Action:       row.Action,
+		ConnectionID: formatUUID(row.ConnectionID),
+		SingleUse:    row.SingleUse,
+		RedirectURL:  pgconv.TextOr(row.RedirectUrl, ""),
+		Label:        pgconv.TextOr(row.Label, ""),
+		Status:       row.Status,
+		ErrorCode:    pgconv.TextOr(row.ErrorCode, ""),
+		ErrorMessage: pgconv.TextOr(row.ErrorMessage, ""),
+		ExpiresAt:    row.ExpiresAt.Time,
+		CreatedAt:    row.CreatedAt.Time,
+	}
+	if row.StartedAt.Valid {
+		t := row.StartedAt.Time
+		out.StartedAt = &t
+	}
+	if row.CompletedAt.Valid {
+		t := row.CompletedAt.Time
+		out.CompletedAt = &t
+	}
+	if len(row.ResultConnectionIds) > 0 {
+		ids := make([]string, 0, len(row.ResultConnectionIds))
+		for _, u := range row.ResultConnectionIds {
+			ids = append(ids, formatUUID(u))
+		}
+		out.ResultConnectionIDs = ids
+	}
+	if isHostedLinkExpired(row, now) {
+		out.Status = HostedLinkStatusExpired
+	}
+	return out
+}
+
+// generateHostedLinkToken returns (plaintext, hash). 16 random bytes encoded
+// as unpadded base64url yields a 22-character token with 128 bits of
+// entropy. The hash is SHA-256(plaintext) as lowercase hex — the column
+// stores only this hash, never the plaintext.
+func generateHostedLinkToken() (string, string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", "", fmt.Errorf("read random bytes: %w", err)
+	}
+	token := base64.RawURLEncoding.EncodeToString(buf[:])
+	return token, hashHostedLinkToken(token), nil
+}
+
+func hashHostedLinkToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/service/hosted_links_test.go
+++ b/internal/service/hosted_links_test.go
@@ -1,0 +1,365 @@
+//go:build integration
+
+// Integration coverage for service.HostedLink* methods. Locks the lifecycle
+// contract that PR2 (REST handlers) and PR3 (bearer middleware + page) will
+// build on top of:
+//   - token plaintext returned only at creation, hash matches at rest
+//   - TTL clamps (0 → default, > max → max)
+//   - provider/action validation
+//   - relink requires a connection
+//   - pending → active → append → completed timeline
+//   - in-memory expiry view (status overridden without DB write)
+//
+// TestMain lives in integration_test.go for this package; do not duplicate it.
+
+package service_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+)
+
+func TestHostedLink_CreateAndGet(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+
+	user := testutil.MustCreateUser(t, q, "Alice")
+
+	res, err := svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID:   pgconv.FormatUUID(user.ID),
+		Provider: "plaid",
+		Action:   "link",
+		Label:    "Bank",
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedLink: %v", err)
+	}
+	if res.Token == "" {
+		t.Fatal("expected non-empty token")
+	}
+	// 16 random bytes → base64.RawURLEncoding = 22 characters.
+	if got := len(res.Token); got != 22 {
+		t.Errorf("token length = %d, want 22", got)
+	}
+	if res.Session.ID == "" || res.Session.ShortID == "" {
+		t.Errorf("missing ids: id=%q short=%q", res.Session.ID, res.Session.ShortID)
+	}
+	if res.Session.Status != "pending" {
+		t.Errorf("status = %q, want pending", res.Session.Status)
+	}
+	if res.Session.Provider != "plaid" {
+		t.Errorf("provider = %q, want plaid", res.Session.Provider)
+	}
+	if res.Session.Action != "link" {
+		t.Errorf("action = %q, want link", res.Session.Action)
+	}
+	if res.Session.UserID != pgconv.FormatUUID(user.ID) {
+		t.Errorf("user_id = %q, want %q", res.Session.UserID, pgconv.FormatUUID(user.ID))
+	}
+
+	// Fetch by UUID and by short_id.
+	gotByID, err := svc.GetHostedLinkSession(ctx, res.Session.ID)
+	if err != nil {
+		t.Fatalf("GetHostedLinkSession(uuid): %v", err)
+	}
+	if gotByID.ShortID != res.Session.ShortID {
+		t.Errorf("short_id mismatch on UUID lookup")
+	}
+
+	gotByShort, err := svc.GetHostedLinkSession(ctx, res.Session.ShortID)
+	if err != nil {
+		t.Fatalf("GetHostedLinkSession(short_id): %v", err)
+	}
+	if gotByShort.ID != res.Session.ID {
+		t.Errorf("id mismatch on short_id lookup")
+	}
+
+	// Token resolves to the same row; hash matches the SHA-256 of plaintext.
+	resolved, err := svc.ResolveHostedLinkSessionByToken(ctx, res.Token)
+	if err != nil {
+		t.Fatalf("ResolveHostedLinkSessionByToken: %v", err)
+	}
+	if resolved.ID != res.Session.ID {
+		t.Errorf("token resolved to different session: %q vs %q", resolved.ID, res.Session.ID)
+	}
+
+	// Verify the at-rest hash matches sha256(plaintext) — fetch via the same
+	// pool the service uses (no extra truncation).
+	sum := sha256.Sum256([]byte(res.Token))
+	wantHash := hex.EncodeToString(sum[:])
+	var gotHash string
+	if err := pool.QueryRow(ctx,
+		`SELECT token_hash FROM hosted_link_sessions WHERE id = $1::uuid`, resolved.ID,
+	).Scan(&gotHash); err != nil {
+		t.Fatalf("scan token_hash: %v", err)
+	}
+	if gotHash != wantHash {
+		t.Errorf("token_hash mismatch: got %q want %q", gotHash, wantHash)
+	}
+
+	// Unknown token resolves to ErrNotFound.
+	if _, err := svc.ResolveHostedLinkSessionByToken(ctx, "definitely-not-a-real-token"); !errors.Is(err, service.ErrNotFound) {
+		t.Errorf("expected ErrNotFound for unknown token, got %v", err)
+	}
+}
+
+func TestHostedLink_TTLClamps(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+	user := testutil.MustCreateUser(t, q, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	// TTL = 0 → 15 minutes default.
+	before := time.Now()
+	res, err := svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID: uid,
+		Action: "link",
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedLink(default): %v", err)
+	}
+	ttl := res.Session.ExpiresAt.Sub(before)
+	if ttl < 14*time.Minute || ttl > 16*time.Minute {
+		t.Errorf("default TTL ≈ %s, want ~15m", ttl)
+	}
+
+	// TTL = 2h → clamped to 60 minutes.
+	before = time.Now()
+	res, err = svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID: uid,
+		Action: "link",
+		TTL:    2 * time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedLink(2h): %v", err)
+	}
+	ttl = res.Session.ExpiresAt.Sub(before)
+	if ttl < 59*time.Minute || ttl > 61*time.Minute {
+		t.Errorf("clamped TTL ≈ %s, want ~60m", ttl)
+	}
+}
+
+func TestHostedLink_ProviderValidation(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+	user := testutil.MustCreateUser(t, q, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	// Empty provider is allowed (the page shows a picker).
+	if _, err := svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID: uid,
+		Action: "link",
+	}); err != nil {
+		t.Errorf("empty provider should be allowed: %v", err)
+	}
+
+	// "plaid" and "teller" are accepted.
+	for _, p := range []string{"plaid", "teller"} {
+		if _, err := svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+			UserID:   uid,
+			Provider: p,
+			Action:   "link",
+		}); err != nil {
+			t.Errorf("provider %q rejected: %v", p, err)
+		}
+	}
+
+	// Anything else is ErrInvalidParameter.
+	_, err := svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID:   uid,
+		Provider: "yodlee",
+		Action:   "link",
+	})
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter, got %v", err)
+	}
+
+	// Invalid action rejected.
+	_, err = svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID: uid,
+		Action: "delete",
+	})
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter for bad action, got %v", err)
+	}
+}
+
+func TestHostedLink_RelinkRequiresConnection(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+	user := testutil.MustCreateUser(t, q, "Alice")
+	uid := pgconv.FormatUUID(user.ID)
+
+	// Missing connection_id → invalid.
+	_, err := svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID: uid,
+		Action: "relink",
+	})
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter for relink without connection_id, got %v", err)
+	}
+
+	// With a real connection, provider is derived if caller leaves it empty.
+	conn := testutil.MustCreateConnection(t, q, user.ID, "item_relink")
+	res, err := svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID:       uid,
+		Action:       "relink",
+		ConnectionID: pgconv.FormatUUID(conn.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedLink(relink): %v", err)
+	}
+	if res.Session.Provider != "plaid" {
+		t.Errorf("expected derived provider plaid, got %q", res.Session.Provider)
+	}
+	if res.Session.ConnectionID != pgconv.FormatUUID(conn.ID) {
+		t.Errorf("connection_id not propagated: got %q", res.Session.ConnectionID)
+	}
+
+	// Mismatched provider rejected.
+	_, err = svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID:       uid,
+		Provider:     "teller",
+		Action:       "relink",
+		ConnectionID: pgconv.FormatUUID(conn.ID),
+	})
+	if !errors.Is(err, service.ErrInvalidParameter) {
+		t.Errorf("expected ErrInvalidParameter for provider mismatch, got %v", err)
+	}
+}
+
+func TestHostedLink_AppendAndComplete(t *testing.T) {
+	svc, q, _ := newService(t)
+	ctx := context.Background()
+	user := testutil.MustCreateUser(t, q, "Alice")
+
+	res, err := svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID:   pgconv.FormatUUID(user.ID),
+		Provider: "plaid",
+		Action:   "link",
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedLink: %v", err)
+	}
+	id := res.Session.ID
+
+	// Pending → AppendResult is invalid.
+	conn := testutil.MustCreateConnection(t, q, user.ID, "item_appended")
+	err = svc.AppendHostedLinkResult(ctx, id, pgconv.FormatUUID(conn.ID))
+	if !errors.Is(err, service.ErrInvalidState) {
+		t.Errorf("expected ErrInvalidState appending to pending session, got %v", err)
+	}
+
+	// Start the session.
+	if err := svc.MarkHostedLinkStarted(ctx, id); err != nil {
+		t.Fatalf("MarkHostedLinkStarted: %v", err)
+	}
+	started, err := svc.GetHostedLinkSession(ctx, id)
+	if err != nil {
+		t.Fatalf("GetHostedLinkSession: %v", err)
+	}
+	if started.Status != "active" {
+		t.Errorf("status = %q, want active", started.Status)
+	}
+	if started.StartedAt == nil {
+		t.Error("expected StartedAt set")
+	}
+
+	// MarkStarted is idempotent.
+	if err := svc.MarkHostedLinkStarted(ctx, id); err != nil {
+		t.Errorf("second MarkHostedLinkStarted: %v", err)
+	}
+
+	// Append a connection result.
+	if err := svc.AppendHostedLinkResult(ctx, id, pgconv.FormatUUID(conn.ID)); err != nil {
+		t.Fatalf("AppendHostedLinkResult: %v", err)
+	}
+
+	// Complete the session.
+	if err := svc.CompleteHostedLink(ctx, id); err != nil {
+		t.Fatalf("CompleteHostedLink: %v", err)
+	}
+
+	final, err := svc.GetHostedLinkSession(ctx, id)
+	if err != nil {
+		t.Fatalf("GetHostedLinkSession(final): %v", err)
+	}
+	if final.Status != "completed" {
+		t.Errorf("status = %q, want completed", final.Status)
+	}
+	if final.CompletedAt == nil {
+		t.Error("expected CompletedAt set")
+	}
+	if len(final.ResultConnectionIDs) != 1 || final.ResultConnectionIDs[0] != pgconv.FormatUUID(conn.ID) {
+		t.Errorf("result_connection_ids = %v, want [%s]", final.ResultConnectionIDs, pgconv.FormatUUID(conn.ID))
+	}
+
+	// Completing again is idempotent.
+	if err := svc.CompleteHostedLink(ctx, id); err != nil {
+		t.Errorf("second CompleteHostedLink: %v", err)
+	}
+
+	// Appending after completion is invalid.
+	err = svc.AppendHostedLinkResult(ctx, id, pgconv.FormatUUID(conn.ID))
+	if !errors.Is(err, service.ErrInvalidState) {
+		t.Errorf("expected ErrInvalidState appending after complete, got %v", err)
+	}
+}
+
+func TestHostedLink_ExpiryView(t *testing.T) {
+	svc, q, pool := newService(t)
+	ctx := context.Background()
+	user := testutil.MustCreateUser(t, q, "Alice")
+
+	res, err := svc.CreateHostedLink(ctx, service.CreateHostedLinkParams{
+		UserID: pgconv.FormatUUID(user.ID),
+		Action: "link",
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedLink: %v", err)
+	}
+
+	// Force the row's expires_at into the past via direct SQL.
+	if _, err := pool.Exec(ctx,
+		`UPDATE hosted_link_sessions SET expires_at = NOW() - INTERVAL '1 minute' WHERE id = $1::uuid`,
+		res.Session.ID,
+	); err != nil {
+		t.Fatalf("expire row: %v", err)
+	}
+
+	// GetHostedLinkSession returns status="expired" in memory; the underlying
+	// row's status remains "pending" (no DB write on read).
+	got, err := svc.GetHostedLinkSession(ctx, res.Session.ID)
+	if err != nil {
+		t.Fatalf("GetHostedLinkSession: %v", err)
+	}
+	if got.Status != "expired" {
+		t.Errorf("Status = %q, want expired", got.Status)
+	}
+
+	var dbStatus string
+	if err := pool.QueryRow(ctx,
+		`SELECT status FROM hosted_link_sessions WHERE id = $1::uuid`, res.Session.ID,
+	).Scan(&dbStatus); err != nil {
+		t.Fatalf("scan status: %v", err)
+	}
+	if dbStatus != "pending" {
+		t.Errorf("DB status = %q, want pending (no write on read)", dbStatus)
+	}
+
+	// Subsequent lifecycle transitions should refuse with ErrInvalidState.
+	if err := svc.MarkHostedLinkStarted(ctx, res.Session.ID); !errors.Is(err, service.ErrInvalidState) {
+		t.Errorf("MarkStarted on expired: expected ErrInvalidState, got %v", err)
+	}
+	if err := svc.CompleteHostedLink(ctx, res.Session.ID); !errors.Is(err, service.ErrInvalidState) {
+		t.Errorf("Complete on expired: expected ErrInvalidState, got %v", err)
+	}
+}


### PR DESCRIPTION
PR 1 of 3 in the hosted-link stack — adds the DB schema, sqlc queries, and service layer for hosted link sessions. No HTTP yet (REST in PR2; standalone page in PR3).

## Why

The agent-shareable bank-linking surface needs a server-owned session resource: agent mints a URL, user opens it, page wraps Plaid Link / Teller Connect. This PR lays the foundation; nothing user-visible changes.

## What's in this PR

- New table `hosted_link_sessions` (additive migration, short_id trigger, FK to `users` + nullable FK to `bank_connections` with `ON DELETE SET NULL`)
- sqlc queries for create / lookup (by id, short_id, token_hash) / status transitions / result append / expiry sweep
- `service.HostedLink*` methods with token gen (16-byte base64url, SHA-256 hash at rest), TTL clamp (15m default, 60m max), and lifecycle invariants
- New `service.ErrInvalidState` sentinel for lifecycle transitions that don't match the current row status
- Integration tests covering happy path, token-hash round-trip, TTL clamps, provider/action validation, relink-requires-connection (and provider derivation/mismatch), full pending → active → append → completed lifecycle, and the in-memory expiry view (no DB write on read)

## What's NOT in this PR

- REST endpoints (PR2)
- Bearer middleware + hosted page + internal `/_link/{token}/*` endpoints (PR3)
- OpenAPI spec entries (PR2 — the surface isn't reachable yet)

## Lifecycle invariants enforced

- `CreateHostedLink`: validates action ∈ {link, relink} and provider ∈ {"", plaid, teller}; verifies user exists; for `relink`, requires `ConnectionID` and derives provider from the connection when caller leaves it empty (rejects mismatched providers).
- `MarkHostedLinkStarted`: pending → active (idempotent on active); rejects completed/failed/expired.
- `AppendHostedLinkResult`: requires active status; appends `connection_id` to `result_connection_ids`.
- `CompleteHostedLink` / `FailHostedLink`: only valid from active (Complete also idempotent on completed). Fail also allowed from pending.
- `GetHostedLinkSession`: surfaces `status="expired"` in the returned struct when the underlying row is still pending/active but `expires_at` has passed — without writing back to the DB.

## Token format

- Plaintext: 16 random bytes → `base64.RawURLEncoding` = 22-char URL-safe string, 128 bits of entropy
- At rest: SHA-256(plaintext) as lowercase hex in `token_hash` (`UNIQUE`)
- Plaintext returned to the caller exactly once from `CreateHostedLink`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (unit)
- [x] `make test-integration` — full suite + new `TestHostedLink_*` tests
- [x] Migration applies cleanly on `breadbox_test`
