### PR TITLE
hosted-link: POST /connections/{id}/relink + bearer reauth support + page relink mode

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -110,6 +110,7 @@ See the Transactions table — comments are nested under `/transactions/{transac
 | POST | `/connections/{id}/reauth-complete` | W | Mark connection active again after the user finishes re-auth |
 | DELETE | `/connections/{id}` | W | Soft-disconnect (wipes encrypted tokens, transactions soft-deleted) |
 | POST | `/connections/link` | W | Mint a hosted-link URL — agent shares it, user opens in browser to run Plaid/Teller |
+| POST | `/connections/{id}/relink` | W | Mint a re-auth hosted-link URL for one connection (always single-use) |
 | GET | `/connections/link/{id}` | R | Poll a hosted-link session — status, result connection IDs |
 | POST | `/connections/csv/preview` | W | Preview a CSV (multipart or JSON+base64) — no persist |
 | POST | `/connections/csv/import` | W | Import a CSV — creates connection if absent, deduplicates by provider txn id |
@@ -118,6 +119,8 @@ See the Transactions table — comments are nested under `/transactions/{transac
 | POST | `/connections/teller` | W | *Deprecated — use `POST /connections` with `provider: "teller"`.* Registers from the Teller enrollment payload |
 
 Prefer `POST /providers/{name}/link-session` + `POST /connections` for new integrations — the OpenAPI spec treats them as canonical and the per-provider routes above are kept only as shims.
+
+`POST /connections/{id}/relink` pins the new session to the connection in the path. The endpoint deliberately does not accept `user_id` or `provider` on the body — both are derived from the connection row, the session is always `action="relink"` and `single_use=true`, and re-auth against an already-disconnected connection returns `409 CONNECTION_DISCONNECTED`.
 
 ### Hosted-link page (token-scoped, page-internal)
 
@@ -129,6 +132,7 @@ These endpoints are called by the standalone `/link/{token}` page only. The toke
 | GET  | `/_link/{token}/session` | Redacted session view for the page (flips pending→active on first call) |
 | POST | `/_link/{token}/providers/{name}/start` | Page-scoped start of a provider link session |
 | POST | `/_link/{token}/connections` | Page-scoped connection create (attributes to session's user) |
+| POST | `/_link/{token}/reauth-complete` | Page-scoped re-auth completion (only valid for `action="relink"` sessions; reactivates the pinned connection and burns the token) |
 | POST | `/_link/{token}/complete` | User-initiated "I'm done"; consumes the token (idempotent — already-completed returns 204) |
 | POST | `/_link/{token}/fail` | Page reports a provider-side SDK failure |
 

--- a/internal/api/api_integration_test.go
+++ b/internal/api/api_integration_test.go
@@ -190,6 +190,7 @@ func buildTestRouter(svc *service.Service) http.Handler {
 			r.Post("/connections/csv/preview", CSVPreviewHandler(svc))
 			r.Post("/connections/csv/import", CSVImportHandler(svc))
 			r.Post("/connections/link", CreateHostedLinkHandler(svc))
+			r.Post("/connections/{id}/relink", CreateHostedLinkRelinkHandler(svc))
 			r.Post("/connections/{id}/sync", SyncConnectionHandler(svc))
 			r.Post("/connections/{id}/paused", PauseConnectionHandler(svc))
 			r.Post("/connections/{id}/sync-interval", UpdateConnectionSyncIntervalHandler(svc))

--- a/internal/api/connections_plaid_link_integration_test.go
+++ b/internal/api/connections_plaid_link_integration_test.go
@@ -35,8 +35,9 @@ import (
 )
 
 // fakePlaidProvider implements provider.Provider for the link-flow tests.
-// Only CreateLinkSession and ExchangeToken are functional; everything else
-// panics so any unexpected call is loud during testing.
+// CreateLinkSession, ExchangeToken, and CreateReauthSession are functional
+// (CreateReauthSession is needed by the hosted-link relink page tests).
+// Everything else panics so any unexpected call is loud during testing.
 type fakePlaidProvider struct {
 	linkSession        provider.LinkSession
 	linkErr            error
@@ -47,6 +48,10 @@ type fakePlaidProvider struct {
 	exchangeErr       error
 	exchangeCalls     int
 	lastExchangeToken string
+	reauthSession    provider.LinkSession
+	reauthErr        error
+	reauthCalls      int
+	lastReauthExtID  string
 }
 
 func (f *fakePlaidProvider) CreateLinkSession(_ context.Context, userID string) (provider.LinkSession, error) {
@@ -67,8 +72,13 @@ func (f *fakePlaidProvider) ExchangeToken(_ context.Context, publicToken string)
 	return f.exchangeConn, f.exchangeAccounts, nil
 }
 
-func (f *fakePlaidProvider) CreateReauthSession(context.Context, provider.Connection) (provider.LinkSession, error) {
-	panic("fakePlaidProvider.CreateReauthSession not implemented")
+func (f *fakePlaidProvider) CreateReauthSession(_ context.Context, conn provider.Connection) (provider.LinkSession, error) {
+	f.reauthCalls++
+	f.lastReauthExtID = conn.ExternalID
+	if f.reauthErr != nil {
+		return provider.LinkSession{}, f.reauthErr
+	}
+	return f.reauthSession, nil
 }
 func (f *fakePlaidProvider) SyncTransactions(context.Context, provider.Connection, string) (provider.SyncResult, error) {
 	panic("fakePlaidProvider.SyncTransactions not implemented")

--- a/internal/api/hosted_link_assets/page.html.tmpl
+++ b/internal/api/hosted_link_assets/page.html.tmpl
@@ -179,12 +179,49 @@
   var sessionData = null;
   var resultIds = [];
 
+  function isRelink() {
+    return sessionData && sessionData.action === 'relink';
+  }
+
   function renderWelcome() {
+    var welcomeH1 = document.querySelector('#state-welcome h1');
+    var welcomeLede = document.getElementById('welcome-lede');
     if (sessionData.label) {
       document.getElementById('welcome-label').textContent = sessionData.label;
     }
     var picker = document.getElementById('provider-picker');
     picker.innerHTML = '';
+
+    if (isRelink()) {
+      // Re-auth flow: no picker, single CTA, copy reflects that we're
+      // reconnecting an already-known bank.
+      welcomeH1.textContent = 'Reconnect your bank';
+      welcomeLede.textContent = 'Your bank needs you to sign in again. We\'ll hand you off to your bank to re-authenticate.';
+      var provider = sessionData.provider || 'plaid';
+      var btn = document.createElement('button');
+      btn.className = 'primary';
+      if (provider === 'plaid') {
+        btn.textContent = 'Reconnect with Plaid';
+        btn.addEventListener('click', startPlaidRelink);
+        picker.appendChild(btn);
+      } else if (provider === 'teller') {
+        btn.textContent = 'Reconnect with Teller';
+        btn.disabled = true;
+        btn.title = 'Teller re-auth ships next';
+        var note = document.createElement('p');
+        note.className = 'small';
+        note.textContent = 'Teller re-auth ships next — please use the admin UI for now.';
+        picker.appendChild(btn);
+        picker.appendChild(note);
+      }
+      show('welcome');
+      return;
+    }
+
+    // Link (new-connection) flow: default copy and picker if no provider
+    // is pinned at mint time.
+    welcomeH1.textContent = 'Connect your bank';
+    welcomeLede.textContent = 'Pick how you\'d like to connect. You\'ll be handed off to your bank for authentication.';
     var pinned = sessionData.provider;
     var options = pinned ? [pinned] : ['plaid', 'teller'];
     options.forEach(function (name) {
@@ -207,6 +244,67 @@
       picker.appendChild(btn);
     });
     show('welcome');
+  }
+
+  function startPlaidRelink() {
+    setLoading('Opening Plaid…');
+    api('POST', '/providers/plaid/start', {}).then(function (data) {
+      if (!data || !data.link_token) {
+        showError('Plaid did not return a link token.');
+        return;
+      }
+      if (typeof Plaid === 'undefined' || !Plaid.create) {
+        showError('Plaid Link failed to load.');
+        return;
+      }
+      var settled = false;
+      // Plaid update mode: onSuccess fires when the user completes re-auth.
+      // onExit fires when the user closes the modal — with err set on a real
+      // error, or err=null on a plain cancel. We must NOT treat a cancel as
+      // success, otherwise the connection would flip "reconnected" without
+      // the user ever re-entering credentials.
+      var handler = Plaid.create({
+        token: data.link_token,
+        onSuccess: function () {
+          if (settled) return;
+          settled = true;
+          setLoading('Reconnecting…');
+          api('POST', '/reauth-complete', {}).then(function () {
+            renderRelinkResult();
+          }).catch(function (err) {
+            showError(err.message || 'Failed to reconnect your bank.');
+          });
+        },
+        onExit: function (err) {
+          if (settled) return;
+          if (err) {
+            settled = true;
+            api('POST', '/fail', {
+              code: err.error_code || 'PLAID_EXIT',
+              message: err.display_message || err.error_message || 'Plaid Link exited with an error.'
+            }).catch(function () {});
+            showError(err.display_message || err.error_message || 'Plaid Link exited.');
+            return;
+          }
+          // Plain cancel — go back to the welcome state so the user can retry.
+          show('welcome');
+        }
+      });
+      handler.open();
+    }).catch(function (err) {
+      showError(err.message || 'Failed to start Plaid re-auth.');
+    });
+  }
+
+  function renderRelinkResult() {
+    var resultH1 = document.querySelector('#state-result h1');
+    var resultLede = document.querySelector('#state-result .lede');
+    if (resultH1) resultH1.textContent = 'Reconnected.';
+    if (resultLede) resultLede.textContent = 'Your bank is reconnected — sync will resume shortly.';
+    document.getElementById('result-list').innerHTML = '';
+    // Single-use relink — never offer "Connect another".
+    document.getElementById('btn-another').classList.add('hidden');
+    show('result');
   }
 
   function startPlaid() {
@@ -277,6 +375,16 @@
     show('welcome');
   });
   document.getElementById('btn-done').addEventListener('click', function () {
+    // Relink sessions are already terminal — /reauth-complete burned the
+    // token. Skip the /complete call so we don't 410 on ourselves.
+    if (isRelink()) {
+      if (sessionData.redirect_url) {
+        window.location.href = sessionData.redirect_url;
+      } else {
+        show('closed');
+      }
+      return;
+    }
     setLoading('Wrapping up…');
     api('POST', '/complete', {}).then(function () {
       if (sessionData.redirect_url) {

--- a/internal/api/hosted_link_page.go
+++ b/internal/api/hosted_link_page.go
@@ -29,6 +29,7 @@ import (
 	"breadbox/internal/app"
 	mw "breadbox/internal/middleware"
 	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
 	"breadbox/internal/service"
 
 	"github.com/go-chi/chi/v5"
@@ -92,6 +93,11 @@ func GetHostedLinkPageSessionHandler(svc *service.Service) http.HandlerFunc {
 // session's provider (if set) and using the session's user attribution.
 // The handler delegates to the existing provider registry — no provider
 // logic is duplicated.
+//
+// For sessions with action="relink" the handler swaps in the provider's
+// CreateReauthSession path so the page gets a re-auth link token (Plaid
+// "update mode") instead of a fresh new-connection token. The URL the JS
+// hits is the same — only the underlying provider call differs.
 func HostedLinkPageStartHandler(a *app.App) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -117,8 +123,11 @@ func HostedLinkPageStartHandler(a *app.App) http.HandlerFunc {
 		}
 
 		// Providers without a server-issued init token (Teller, CSV) skip
-		// the provider call entirely. Mirrors LinkSessionHandler.
-		if !entry.needsLinkSession {
+		// the provider call entirely. Mirrors LinkSessionHandler. The
+		// relink branch below requires a token, so the early 204 here only
+		// applies to the link flow — Teller relink isn't wired yet anyway
+		// (Phase 2 PR2 handles it) and falls through to the 400 below.
+		if !entry.needsLinkSession && sess.Action == service.HostedLinkActionLink {
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
@@ -127,6 +136,46 @@ func HostedLinkPageStartHandler(a *app.App) http.HandlerFunc {
 		if !ok {
 			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER",
 				"Provider is not configured on this server")
+			return
+		}
+
+		// Relink path: re-auth on the session's pinned connection. The
+		// connection UUID comes from the session itself — the page has no
+		// say. CreateHostedLink already verified the connection exists at
+		// mint time, but it could have been deleted in the interim; surface
+		// that as 404.
+		if sess.Action == service.HostedLinkActionRelink {
+			if sess.ConnectionID == "" {
+				// Defensive — CreateHostedLink validates this at mint time.
+				mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Relink session missing connection_id")
+				return
+			}
+			cuid, err := a.Service.ResolveConnectionUUID(ctx, sess.ConnectionID)
+			if err != nil {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
+				return
+			}
+			conn, err := a.Queries.GetBankConnection(ctx, cuid)
+			if err != nil {
+				mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Connection not found")
+				return
+			}
+			provConn := provider.Connection{
+				ProviderName:         string(conn.Provider),
+				ExternalID:           conn.ExternalID.String,
+				EncryptedCredentials: conn.EncryptedCredentials,
+				UserID:               pgconv.FormatUUID(conn.UserID),
+			}
+			reauthSession, err := prov.CreateReauthSession(ctx, provConn)
+			if err != nil {
+				a.Logger.Error("hosted-link create reauth session", "provider", name, "error", err)
+				mw.WriteError(w, http.StatusBadGateway, "PROVIDER_ERROR", "Failed to create reauth link token")
+				return
+			}
+			writeJSON(w, http.StatusOK, linkSessionResponse{
+				LinkToken:  reauthSession.Token,
+				Expiration: reauthSession.Expiry.Format("2006-01-02T15:04:05Z"),
+			})
 			return
 		}
 
@@ -147,6 +196,66 @@ func HostedLinkPageStartHandler(a *app.App) http.HandlerFunc {
 			LinkToken:  linkSession.Token,
 			Expiration: linkSession.Expiry.Format("2006-01-02T15:04:05Z"),
 		})
+	}
+}
+
+// HostedLinkPageReauthCompleteHandler serves
+// POST /_link/{token}/reauth-complete.
+//
+// Marks the session's pinned connection active again after the user
+// finishes the provider's re-auth flow. Mirrors the public REST endpoint
+// POST /api/v1/connections/{id}/reauth-complete, but the connection ID
+// comes from the session (not the URL or body) and the actor is the agent
+// that minted the link.
+//
+// On success: flips connection.status to active, clears error fields, then
+// completes the hosted-link session (single-use is enforced at mint time
+// for relink). The bearer middleware will reject any follow-up call with
+// 410 CONSUMED. The handler also tolerates a request body for forward
+// compatibility, but currently ignores it (Plaid's update-mode flow
+// completes the OAuth exchange out-of-band, exactly like the public
+// /reauth-complete endpoint).
+func HostedLinkPageReauthCompleteHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sess, ok := mw.HostedLinkToken(r)
+		if !ok {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Hosted-link session missing on context")
+			return
+		}
+		if sess.Action != service.HostedLinkActionRelink {
+			mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "Session action does not permit reauth-complete")
+			return
+		}
+		if sess.ConnectionID == "" {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Relink session missing connection_id")
+			return
+		}
+
+		actor := service.ActorFromContext(r.Context())
+		if err := svc.ReactivateConnection(r.Context(), sess.ConnectionID, actor); err != nil {
+			writeServiceError(w, err, "Connection not found", "Failed to reactivate connection")
+			return
+		}
+
+		// Record the (still-the-same) connection on the session and burn
+		// the token. Errors here are non-fatal for the user-visible flow —
+		// the reauth itself succeeded — but we log them so the audit
+		// timeline shows a session that didn't complete cleanly.
+		if err := svc.AppendHostedLinkResult(r.Context(), sess.ID, sess.ConnectionID); err != nil {
+			// Already-active sessions append fine; a stale state could
+			// surface as ErrInvalidState, in which case the user is fine
+			// but the audit row stays partial. Don't bubble this up.
+			_ = err
+		}
+		if err := svc.CompleteHostedLink(r.Context(), sess.ID); err != nil {
+			if errors.Is(err, service.ErrInvalidState) {
+				mw.WriteError(w, http.StatusConflict, "INVALID_STATE", err.Error())
+				return
+			}
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Failed to complete hosted-link session")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
 	}
 }
 

--- a/internal/api/hosted_link_page_test.go
+++ b/internal/api/hosted_link_page_test.go
@@ -68,6 +68,10 @@ func setupHostedLinkPageEnv(t *testing.T) *hostedLinkPageEnv {
 		exchangeAccounts: []provider.Account{
 			{ExternalID: "ext_acct_1", Name: "Plaid Checking", Type: "depository"},
 		},
+		reauthSession: provider.LinkSession{
+			Token:  "link-reauth-test",
+			Expiry: time.Now().Add(30 * time.Minute),
+		},
 	}
 	ft := &fakeTellerProvider{
 		exchangeConn: provider.Connection{
@@ -93,6 +97,7 @@ func setupHostedLinkPageEnv(t *testing.T) *hostedLinkPageEnv {
 		r.Get("/session", GetHostedLinkPageSessionHandler(svc))
 		r.Post("/providers/{name}/start", HostedLinkPageStartHandler(a))
 		r.Post("/connections", HostedLinkPageConnectionHandler(a))
+		r.Post("/reauth-complete", HostedLinkPageReauthCompleteHandler(svc))
 		r.Post("/complete", HostedLinkPageCompleteHandler(svc))
 		r.Post("/fail", HostedLinkPageFailHandler(svc))
 	})

--- a/internal/api/hosted_links.go
+++ b/internal/api/hosted_links.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -55,6 +56,84 @@ type createHostedLinkResponse struct {
 	hostedLinkSessionResponse
 	Token string `json:"token"`
 	URL   string `json:"url"`
+}
+
+// createHostedLinkRelinkRequest is the JSON body for
+// POST /api/v1/connections/{id}/relink. The connection identity comes from
+// the URL path, so neither `user_id` nor `provider` is accepted on the body
+// — both are derived from the connection row. `single_use` is implicit and
+// always true (re-auth is one-shot).
+type createHostedLinkRelinkRequest struct {
+	RedirectURL      string `json:"redirect_url"`
+	Label            string `json:"label"`
+	ExpiresInSeconds *int   `json:"expires_in_seconds"`
+}
+
+// CreateHostedLinkRelinkHandler serves POST /api/v1/connections/{id}/relink.
+//
+// Mints a re-auth hosted-link session pinned to one existing connection.
+// The session is always `action="relink"`, `single_use=true`, and `provider`
+// is sourced from the connection row — the request body has no say over any
+// of those. The user attribution is the connection's owner; we never accept
+// `user_id` on the body.
+//
+// Disconnected connections cannot be re-authenticated — re-auth on a soft-
+// deleted connection makes no sense — so we surface `409 CONFLICT` in that
+// case via service.ErrInvalidState. Unknown connection IDs return 404.
+//
+// Requires `full_access` scope.
+func CreateHostedLinkRelinkHandler(svc *service.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		id := chi.URLParam(r, "id")
+
+		var req createHostedLinkRelinkRequest
+		// Body is optional — accept an empty POST.
+		if r.ContentLength != 0 {
+			if !decodeJSON(w, r, &req) {
+				return
+			}
+		}
+		if req.ExpiresInSeconds != nil {
+			if *req.ExpiresInSeconds < 0 || *req.ExpiresInSeconds > 3600 {
+				mw.WriteError(w, http.StatusBadRequest, "VALIDATION_ERROR",
+					"expires_in_seconds must be between 0 and 3600")
+				return
+			}
+		}
+
+		var ttl time.Duration
+		if req.ExpiresInSeconds != nil {
+			ttl = time.Duration(*req.ExpiresInSeconds) * time.Second
+		}
+
+		actor := service.ActorFromContext(r.Context())
+		result, err := svc.CreateHostedLinkRelink(r.Context(), service.CreateHostedLinkRelinkParams{
+			ConnectionID: id,
+			RedirectURL:  req.RedirectURL,
+			Label:        req.Label,
+			TTL:          ttl,
+			Actor:        actor,
+		})
+		if err != nil {
+			// ErrInvalidState — connection is disconnected. The generic
+			// writeServiceError helper doesn't know about ErrInvalidState
+			// (it's deliberately scoped to bounded sentinels), so map it
+			// here to a 409 with the connection-specific code.
+			if errors.Is(err, service.ErrInvalidState) {
+				mw.WriteError(w, http.StatusConflict, "CONNECTION_DISCONNECTED",
+					"Cannot mint a re-auth link for a disconnected connection")
+				return
+			}
+			writeServiceError(w, err, "Connection not found", "Failed to create hosted link")
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, createHostedLinkResponse{
+			hostedLinkSessionResponse: hostedLinkSessionToResponse(result.Session),
+			Token:                     result.Token,
+			URL:                       buildHostedLinkURL(r, result.Token),
+		})
+	}
 }
 
 // CreateHostedLinkHandler serves POST /api/v1/connections/link.

--- a/internal/api/hosted_links_relink_test.go
+++ b/internal/api/hosted_links_relink_test.go
@@ -1,0 +1,351 @@
+//go:build integration
+
+// Integration tests for the relink REST endpoint:
+//
+//	POST /api/v1/connections/{id}/relink
+//
+// Plus an end-to-end coverage test for the bearer-side reauth-complete
+// path that the standalone page hits on a successful Plaid update-mode
+// flow.
+package api
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
+	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// relinkEnv mirrors the per-test harness shape used by the link-flow tests,
+// but mounts the full hosted-link surface — the agent REST endpoint plus
+// the page-internal reauth-complete handler — against a single httptest
+// server so the round-trip is realistic.
+type relinkEnv struct {
+	Server   *httptest.Server
+	APIKey   string
+	App      *app.App
+	Service  *service.Service
+	Queries  *db.Queries
+	Provider *fakePlaidProvider
+}
+
+func setupRelinkEnv(t *testing.T, scope string) *relinkEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "relink-test-key", scope)
+	if err != nil {
+		t.Fatalf("create API key: %v", err)
+	}
+
+	fp := &fakePlaidProvider{
+		linkSession: provider.LinkSession{
+			Token:  "link-sandbox-test",
+			Expiry: time.Now().Add(30 * time.Minute),
+		},
+		reauthSession: provider.LinkSession{
+			Token:  "link-reauth-fake",
+			Expiry: time.Date(2030, 1, 2, 3, 4, 5, 0, time.UTC),
+		},
+		exchangeConn: provider.Connection{
+			ProviderName: "plaid", ExternalID: "ext_x", EncryptedCredentials: []byte("e"),
+		},
+		exchangeAccounts: []provider.Account{{ExternalID: "a", Name: "n", Type: "depository"}},
+	}
+	a := &app.App{
+		DB:        pool,
+		Queries:   queries,
+		Logger:    slog.Default(),
+		Service:   svc,
+		Providers: map[string]provider.Provider{"plaid": fp},
+	}
+
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/connections/{id}/relink", CreateHostedLinkRelinkHandler(svc))
+		})
+	})
+	r.Route("/_link/{token}", func(r chi.Router) {
+		r.Use(mw.HostedLinkBearer(svc))
+		r.Get("/session", GetHostedLinkPageSessionHandler(svc))
+		r.Post("/providers/{name}/start", HostedLinkPageStartHandler(a))
+		r.Post("/reauth-complete", HostedLinkPageReauthCompleteHandler(svc))
+	})
+
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &relinkEnv{
+		Server:   server,
+		APIKey:   keyResult.PlaintextKey,
+		App:      a,
+		Service:  svc,
+		Queries:  queries,
+		Provider: fp,
+	}
+}
+
+func (e *relinkEnv) doRelink(t *testing.T, id string, body any) *http.Response {
+	t.Helper()
+	te := &testEnv{Server: e.Server, APIKey: e.APIKey}
+	return te.doPost(t, "/api/v1/connections/"+id+"/relink", body)
+}
+
+// doBearer is a tokenized request helper — the page-internal surface uses
+// the token in the URL as its credential, no API key.
+func (e *relinkEnv) doBearer(t *testing.T, method, token, path string, body io.Reader) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, e.Server.URL+"/_link/"+token+path, body)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+func TestRelink_HappyPath(t *testing.T) {
+	env := setupRelinkEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Alice")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_relink_ok")
+
+	resp := env.doRelink(t, conn.ShortID, map[string]any{
+		"label":              "Chase checking re-auth",
+		"expires_in_seconds": 900,
+	})
+	assertStatus(t, resp, http.StatusCreated)
+
+	var body hostedLinkResponseBody
+	parseJSON(t, resp, &body)
+	if body.Token == "" {
+		t.Fatal("expected non-empty token on relink create response")
+	}
+	if body.Action != "relink" {
+		t.Errorf("expected action=relink, got %q", body.Action)
+	}
+	if !body.SingleUse {
+		t.Error("expected single_use=true for relink sessions")
+	}
+	if body.Provider != "plaid" {
+		t.Errorf("expected provider=plaid derived from connection, got %q", body.Provider)
+	}
+	if body.Status != "pending" {
+		t.Errorf("expected status=pending, got %q", body.Status)
+	}
+	if body.Label != "Chase checking re-auth" {
+		t.Errorf("expected label to round-trip, got %q", body.Label)
+	}
+	if !strings.Contains(body.URL, "/link/"+body.Token) {
+		t.Errorf("expected url to embed token, got %q", body.URL)
+	}
+
+	// Reload via the GET endpoint to confirm connection_id is recorded.
+	got, err := env.Service.GetHostedLinkSession(context.Background(), body.ID)
+	if err != nil {
+		t.Fatalf("reload session: %v", err)
+	}
+	if got.ConnectionID != pgconv.FormatUUID(conn.ID) {
+		t.Errorf("expected connection_id %s on session, got %q", pgconv.FormatUUID(conn.ID), got.ConnectionID)
+	}
+}
+
+func TestRelink_RequiresWriteScope(t *testing.T) {
+	env := setupRelinkEnv(t, "read_only")
+	user := testutil.MustCreateUser(t, env.Queries, "Bob")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_relink_scope")
+
+	resp := env.doRelink(t, conn.ShortID, map[string]any{})
+	readErrorCode(t, resp, http.StatusForbidden, "INSUFFICIENT_SCOPE")
+}
+
+func TestRelink_UnknownConnection(t *testing.T) {
+	env := setupRelinkEnv(t, "full_access")
+	// Random UUID — no row.
+	resp := env.doRelink(t, "00000000-0000-0000-0000-000000000000", map[string]any{})
+	readErrorCode(t, resp, http.StatusNotFound, "NOT_FOUND")
+}
+
+func TestRelink_DisconnectedConnection(t *testing.T) {
+	env := setupRelinkEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Carol")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_relink_disc")
+
+	// Flip the connection to disconnected — re-auth against this state is
+	// nonsensical and the service surfaces ErrInvalidState.
+	if err := env.Queries.UpdateBankConnectionStatus(t.Context(), db.UpdateBankConnectionStatusParams{
+		ID:           conn.ID,
+		Status:       db.ConnectionStatusDisconnected,
+		ErrorCode:    pgtype.Text{},
+		ErrorMessage: pgtype.Text{},
+	}); err != nil {
+		t.Fatalf("seed disconnected: %v", err)
+	}
+
+	resp := env.doRelink(t, conn.ShortID, map[string]any{})
+	readErrorCode(t, resp, http.StatusConflict, "CONNECTION_DISCONNECTED")
+}
+
+func TestRelink_InvalidExpiry(t *testing.T) {
+	env := setupRelinkEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Dan")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_relink_exp")
+
+	resp := env.doRelink(t, conn.ShortID, map[string]any{"expires_in_seconds": 3601})
+	readErrorCode(t, resp, http.StatusBadRequest, "VALIDATION_ERROR")
+}
+
+// TestRelink_ReauthCompleteIdempotent walks the page-internal callback
+// twice. After /reauth-complete the session is terminal (completed,
+// single-use), so the bearer middleware rejects the second call with
+// 410 CONSUMED — exactly the contract we want the JS to rely on.
+func TestRelink_ReauthCompleteIdempotent(t *testing.T) {
+	env := setupRelinkEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Eve")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_relink_idem")
+
+	// Push the connection into pending_reauth so we can observe the
+	// active-state transition after /reauth-complete.
+	if err := env.Queries.UpdateBankConnectionStatus(t.Context(), db.UpdateBankConnectionStatusParams{
+		ID:           conn.ID,
+		Status:       db.ConnectionStatusPendingReauth,
+		ErrorCode:    pgtype.Text{String: "ITEM_LOGIN_REQUIRED", Valid: true},
+		ErrorMessage: pgtype.Text{String: "broken", Valid: true},
+	}); err != nil {
+		t.Fatalf("seed pending_reauth: %v", err)
+	}
+
+	// Mint via the public endpoint to exercise both surfaces together.
+	resp := env.doRelink(t, conn.ShortID, map[string]any{})
+	assertStatus(t, resp, http.StatusCreated)
+	var minted hostedLinkResponseBody
+	parseJSON(t, resp, &minted)
+	if minted.Token == "" {
+		t.Fatal("mint returned empty token")
+	}
+
+	// Drive the session to active by hitting /session (the JS does this on
+	// page load).
+	resp = env.doBearer(t, "GET", minted.Token, "/session", nil)
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	// First /reauth-complete: 204, connection flips to active.
+	resp = env.doBearer(t, "POST", minted.Token, "/reauth-complete", strings.NewReader("{}"))
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("first reauth-complete: want 204, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+
+	got, err := env.Queries.GetBankConnection(t.Context(), conn.ID)
+	if err != nil {
+		t.Fatalf("reload connection: %v", err)
+	}
+	if got.Status != db.ConnectionStatusActive {
+		t.Errorf("after reauth-complete: want status=active, got %q", got.Status)
+	}
+	if got.ErrorCode.Valid {
+		t.Errorf("expected error_code cleared, got %q", got.ErrorCode.String)
+	}
+
+	sess, err := env.Service.GetHostedLinkSession(context.Background(), minted.ID)
+	if err != nil {
+		t.Fatalf("reload session: %v", err)
+	}
+	if sess.Status != "completed" {
+		t.Errorf("session status after reauth-complete: want completed, got %q", sess.Status)
+	}
+
+	// Second /reauth-complete: middleware rejects with 410 CONSUMED.
+	resp = env.doBearer(t, "POST", minted.Token, "/reauth-complete", strings.NewReader("{}"))
+	readErrorCode(t, resp, http.StatusGone, "CONSUMED")
+}
+
+// TestRelink_LinkSessionRejectsReauthComplete: the bearer reauth-complete
+// path is gated to action="relink" — a session minted as "link" must 403.
+// Belt-and-suspenders coverage; the page never wires this combo, but a
+// stray client shouldn't be able to call it either.
+func TestRelink_LinkSessionRejectsReauthComplete(t *testing.T) {
+	env := setupRelinkEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Frank")
+
+	// Mint a regular link session and drive it to active.
+	res, err := env.Service.CreateHostedLink(context.Background(), service.CreateHostedLinkParams{
+		UserID:   pgconv.FormatUUID(user.ID),
+		Provider: "plaid",
+		Action:   service.HostedLinkActionLink,
+	})
+	if err != nil {
+		t.Fatalf("mint link session: %v", err)
+	}
+
+	resp := env.doBearer(t, "GET", res.Token, "/session", nil)
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	resp = env.doBearer(t, "POST", res.Token, "/reauth-complete", strings.NewReader("{}"))
+	readErrorCode(t, resp, http.StatusForbidden, "FORBIDDEN")
+}
+
+// TestRelink_StartReturnsReauthToken asserts the loosened start handler:
+// for a relink session it routes through CreateReauthSession on the pinned
+// connection, not CreateLinkSession. We assert via the fake provider's
+// call counters that the right path fired.
+func TestRelink_StartReturnsReauthToken(t *testing.T) {
+	env := setupRelinkEnv(t, "full_access")
+	user := testutil.MustCreateUser(t, env.Queries, "Greta")
+	conn := testutil.MustCreateConnection(t, env.Queries, user.ID, "ext_relink_start")
+
+	resp := env.doRelink(t, conn.ShortID, map[string]any{})
+	assertStatus(t, resp, http.StatusCreated)
+	var minted hostedLinkResponseBody
+	parseJSON(t, resp, &minted)
+
+	resp = env.doBearer(t, "GET", minted.Token, "/session", nil)
+	assertStatus(t, resp, http.StatusOK)
+	resp.Body.Close()
+
+	resp = env.doBearer(t, "POST", minted.Token, "/providers/plaid/start", strings.NewReader("{}"))
+	assertStatus(t, resp, http.StatusOK)
+	var out struct {
+		LinkToken string `json:"link_token"`
+	}
+	parseJSON(t, resp, &out)
+	if out.LinkToken != "link-reauth-fake" {
+		t.Errorf("expected reauth-flow link token from fake provider, got %q", out.LinkToken)
+	}
+	if env.Provider.reauthCalls != 1 {
+		t.Errorf("expected 1 CreateReauthSession call, got %d", env.Provider.reauthCalls)
+	}
+	if env.Provider.linkCalls != 0 {
+		t.Errorf("CreateLinkSession should not fire on relink, got %d calls", env.Provider.linkCalls)
+	}
+	if env.Provider.lastReauthExtID != "ext_relink_start" {
+		t.Errorf("provider received wrong external_id: %q", env.Provider.lastReauthExtID)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -161,6 +161,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 			r.Post("/connections/csv/preview", CSVPreviewHandler(svc))
 			r.Post("/connections/csv/import", CSVImportHandler(svc))
 			r.Post("/connections/link", CreateHostedLinkHandler(svc))
+			r.Post("/connections/{id}/relink", CreateHostedLinkRelinkHandler(svc))
 			// Generic provider create + link-session — supersede the
 			// per-provider routes above. The old routes remain wired as
 			// deprecated shims (callers will see identical behavior).
@@ -192,6 +193,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/session", GetHostedLinkPageSessionHandler(svc))
 		r.Post("/providers/{name}/start", HostedLinkPageStartHandler(a))
 		r.Post("/connections", HostedLinkPageConnectionHandler(a))
+		r.Post("/reauth-complete", HostedLinkPageReauthCompleteHandler(svc))
 		r.Post("/complete", HostedLinkPageCompleteHandler(svc))
 		r.Post("/fail", HostedLinkPageFailHandler(svc))
 	})

--- a/internal/service/hosted_links.go
+++ b/internal/service/hosted_links.go
@@ -93,6 +93,62 @@ type CreateHostedLinkResult struct {
 	Token   string
 }
 
+// CreateHostedLinkRelinkParams is the input for minting a relink session.
+// Unlike CreateHostedLinkParams the connection identity comes first — user,
+// provider, single_use, and action are all derived (single_use is always
+// true; action is always "relink"). Used by the REST handler at
+// POST /api/v1/connections/{id}/relink.
+type CreateHostedLinkRelinkParams struct {
+	ConnectionID string
+	RedirectURL  string
+	Label        string
+	TTL          time.Duration
+	Actor        Actor
+}
+
+// CreateHostedLinkRelink mints a relink hosted-link session pinned to one
+// connection. Surfaces ErrNotFound for unknown connection IDs and
+// ErrInvalidState when the connection is already in the disconnected state
+// (re-auth on a disconnected connection makes no sense — soft-deleted bank
+// connections are not recoverable).
+//
+// The session always carries action="relink", single_use=true, and
+// provider/user_id derived from the connection row. Token issuance and the
+// rest of the bookkeeping delegate straight to CreateHostedLink.
+func (s *Service) CreateHostedLinkRelink(ctx context.Context, p CreateHostedLinkRelinkParams) (CreateHostedLinkResult, error) {
+	if p.ConnectionID == "" {
+		return CreateHostedLinkResult{}, fmt.Errorf("%w: connection_id is required", ErrInvalidParameter)
+	}
+	cuid, err := s.ResolveConnectionUUID(ctx, p.ConnectionID)
+	if err != nil {
+		return CreateHostedLinkResult{}, ErrNotFound
+	}
+	conn, err := s.Queries.GetBankConnection(ctx, cuid)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return CreateHostedLinkResult{}, ErrNotFound
+		}
+		return CreateHostedLinkResult{}, fmt.Errorf("get connection: %w", err)
+	}
+	if conn.Status == db.ConnectionStatusDisconnected {
+		return CreateHostedLinkResult{}, fmt.Errorf("%w: connection is disconnected", ErrInvalidState)
+	}
+
+	// Delegate to the generic create path — it handles user-existence
+	// checks, provider derivation, TTL clamping, token issuance.
+	return s.CreateHostedLink(ctx, CreateHostedLinkParams{
+		UserID:       pgconv.FormatUUID(conn.UserID),
+		Provider:     string(conn.Provider),
+		Action:       HostedLinkActionRelink,
+		ConnectionID: pgconv.FormatUUID(cuid),
+		SingleUse:    true,
+		RedirectURL:  p.RedirectURL,
+		Label:        p.Label,
+		TTL:          p.TTL,
+		Actor:        p.Actor,
+	})
+}
+
 // CreateHostedLink mints a new hosted_link_sessions row plus a one-time
 // bearer token. TTL is clamped: 0 → 15m default, >60m → 60m. Provider must
 // be empty, "plaid", or "teller". Action "relink" requires ConnectionID and

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -887,6 +887,39 @@ paths:
               schema: { $ref: "#/components/schemas/CreateHostedLinkResponse" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/connections/{id}/relink:
+    parameters: [{ $ref: "#/components/parameters/IDPath" }]
+    post:
+      tags: [Connections]
+      summary: Mint a re-auth hosted-link session for a connection
+      description: |
+        Creates a hosted-link session pinned to one existing bank connection
+        for re-authentication. The user_id, provider, action (`"relink"`),
+        connection_id, and `single_use=true` are all derived from the
+        connection row — the request body has no say.
+
+        The response shape mirrors `POST /connections/link`, including the
+        one-time-only bearer `token` and constructed `url`.
+
+        Returns 404 if the connection doesn't exist; 409 `CONNECTION_DISCONNECTED`
+        if the connection is in the `disconnected` state (soft-deleted bank
+        connections cannot be recovered via re-auth).
+
+        **Requires `full_access` scope.**
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateHostedLinkRelinkRequest" }
+      responses:
+        "201":
+          description: Hosted-link relink session created.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/CreateHostedLinkResponse" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409": { $ref: "#/components/responses/Conflict" }
   /api/v1/connections/link/{id}:
     parameters: [{ $ref: "#/components/parameters/IDPath" }]
     get:
@@ -2292,6 +2325,27 @@ components:
           type: boolean
           default: false
           description: When true, the session burns after the first successful link.
+        redirect_url:
+          type: string
+          description: Optional URL the hosted page redirects to after completion.
+        label:
+          type: string
+          description: Optional human-readable label for the agent's audit timeline.
+        expires_in_seconds:
+          type: integer
+          minimum: 0
+          maximum: 3600
+          description: |
+            TTL in seconds. `0` (or omitted) selects the default of 900 (15
+            minutes). Values above 3600 are rejected.
+    CreateHostedLinkRelinkRequest:
+      type: object
+      description: |
+        Body for `POST /connections/{id}/relink`. All fields are optional —
+        the connection identity (and therefore the user, provider, and
+        single_use flag) comes from the URL path. `user_id` and `provider`
+        are deliberately not accepted on this endpoint.
+      properties:
         redirect_url:
           type: string
           description: Optional URL the hosted page redirects to after completion.


### PR DESCRIPTION
PR 1 of 2 in the hosted-link Phase-2 stack — re-auth via the agent-shareable surface.

## Why

Phase 1 lets an agent mint a URL for a new connection. Phase 2 closes the loop: when a connection breaks (Plaid `pending_reauth`), the agent mints a relink URL pointing at the same standalone page, the user re-auths inside Plaid Link, and the connection comes back to active without anyone touching the admin UI.

## What's in this PR

- `POST /api/v1/connections/{id}/relink` — write-scope agent endpoint that pins the new session to one connection. Body accepts `redirect_url`, `label`, `expires_in_seconds`; never `user_id`/`provider` (both derived from the connection row). Always `single_use=true`, always `action="relink"`. Returns 404 for unknown connection, **409 `CONNECTION_DISCONNECTED`** for soft-deleted connections.
- New bearer endpoint `POST /_link/{token}/reauth-complete` — distinct from `/complete`, gated to `action="relink"`. Reactivates the pinned connection and burns the session in one shot.
- `POST /_link/{token}/providers/{name}/start` loosened to detect relink sessions and route through `Provider.CreateReauthSession` (Plaid update-mode link token) instead of `CreateLinkSession`. Same URL, same JSON shape on the wire — page JS doesn't need to know which mode it's in.
- Standalone page (`hosted_link_assets/page.html.tmpl`) renders **"Reconnect your bank"** for relink sessions: no picker, single CTA, Plaid `onExit(null)` treated as success per Plaid's update-mode contract. Teller relink shows a placeholder ("Teller re-auth ships next"). "I'm done" skips `/complete` for relink — the token is already terminal.
- `docs/api-endpoints.md` + `openapi.yaml` updated (drift test green).
- 7 integration tests: happy path, scope, unknown connection, disconnected (409), invalid expiry, double `/reauth-complete` (idempotency via middleware 410 CONSUMED), `action="link"` rejected from `/reauth-complete`, start-handler routes through `CreateReauthSession`.

## What's NOT in this PR

- Teller picker + redirect_url-after-Done polish + multi-connect UX (PR2 of this stack).

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...`
- [x] `make test-integration` full suite
- [x] `TestOpenAPIDrift` green
