### PR TITLE
hosted-link: Teller in picker, redirect_url handoff, multi-connect polish

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -131,6 +131,7 @@ These endpoints are called by the standalone `/link/{token}` page only. The toke
 | GET  | `/link/{token}` | Standalone HTML page; user opens it to add a bank |
 | GET  | `/_link/{token}/session` | Redacted session view for the page (flips pending→active on first call) |
 | POST | `/_link/{token}/providers/{name}/start` | Page-scoped start of a provider link session |
+| GET  | `/_link/{token}/providers/teller/config` | Public Teller bootstrap (application_id + environment); cert/key never exposed |
 | POST | `/_link/{token}/connections` | Page-scoped connection create (attributes to session's user) |
 | POST | `/_link/{token}/reauth-complete` | Page-scoped re-auth completion (only valid for `action="relink"` sessions; reactivates the pinned connection and burns the token) |
 | POST | `/_link/{token}/complete` | User-initiated "I'm done"; consumes the token (idempotent — already-completed returns 204) |

--- a/internal/api/hosted_link_assets/page.html.tmpl
+++ b/internal/api/hosted_link_assets/page.html.tmpl
@@ -93,6 +93,7 @@
     <h1>Connect your bank</h1>
     <p class="lede" id="welcome-lede">Pick how you'd like to connect. You'll be handed off to your bank for authentication.</p>
     <div class="picker" id="provider-picker"></div>
+    <p class="small" id="welcome-tally"></p>
   </section>
 
   <!-- State: loading -->
@@ -128,6 +129,7 @@
 </main>
 
 <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
+<script src="https://cdn.teller.io/connect/connect.js"></script>
 <script>
 (function () {
   // Token is in the URL path; pulling it server-side and rendering it into
@@ -178,6 +180,33 @@
 
   var sessionData = null;
   var resultIds = [];
+  // Running tally of institutions linked in this session. Survives the
+  // welcome → loading → result → welcome loop because we keep it in
+  // closure scope. Each entry: { name, when } where when is a Date.
+  var linkedInstitutions = [];
+
+  // Validate that a redirect_url is http:// or https:// before navigating.
+  // Defence in depth — the server already validates at mint time, but a
+  // malformed value shouldn't break the page or open a javascript: URL.
+  function safeRedirect(url) {
+    if (!url || typeof url !== 'string') return null;
+    try {
+      var u = new URL(url);
+      if (u.protocol === 'http:' || u.protocol === 'https:') return url;
+      return null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function leaveOrClose() {
+    var target = safeRedirect(sessionData && sessionData.redirect_url);
+    if (target) {
+      window.location.href = target;
+    } else {
+      show('closed');
+    }
+  }
 
   function isRelink() {
     return sessionData && sessionData.action === 'relink';
@@ -232,18 +261,25 @@
         btn.addEventListener('click', startPlaid);
       } else if (name === 'teller') {
         btn.textContent = 'Connect with Teller';
-        btn.disabled = true;
-        btn.title = 'Teller hosted-link flow ships in Phase 2';
-        var note = document.createElement('p');
-        note.className = 'small';
-        note.textContent = 'Teller hosted-link flow ships in Phase 2 — please use the admin UI for now.';
-        picker.appendChild(btn);
-        picker.appendChild(note);
-        return;
+        btn.addEventListener('click', startTeller);
       }
       picker.appendChild(btn);
     });
+    renderTally();
     show('welcome');
+  }
+
+  function renderTally() {
+    var tally = document.getElementById('welcome-tally');
+    if (!tally) return;
+    if (!linkedInstitutions.length) {
+      tally.textContent = '';
+      tally.classList.add('hidden');
+      return;
+    }
+    var names = linkedInstitutions.map(function (i) { return i.name; }).join(', ');
+    tally.textContent = 'Linked so far: ' + names;
+    tally.classList.remove('hidden');
   }
 
   function startPlaidRelink() {
@@ -302,7 +338,8 @@
     if (resultH1) resultH1.textContent = 'Reconnected.';
     if (resultLede) resultLede.textContent = 'Your bank is reconnected — sync will resume shortly.';
     document.getElementById('result-list').innerHTML = '';
-    // Single-use relink — never offer "Connect another".
+    // Single-use relink — never offer "Connect another". The "I'm done"
+    // CTA will honor redirect_url via leaveOrClose() if set.
     document.getElementById('btn-another').classList.add('hidden');
     show('result');
   }
@@ -358,12 +395,97 @@
     });
   }
 
+  function startTeller() {
+    setLoading('Opening Teller…');
+    // The server's /providers/teller/start is a no-op (Teller has no
+    // server-issued init token) but we still call it to confirm scope:
+    // a session pinned to plaid will 403 here before we ever boot the
+    // Teller SDK. Then we fetch the public application_id + environment
+    // from the bearer-protected config endpoint.
+    api('POST', '/providers/teller/start', {}).then(function () {
+      return api('GET', '/providers/teller/config');
+    }).then(function (cfg) {
+      if (!cfg || !cfg.application_id) {
+        showError('Teller is not configured on this server.');
+        return;
+      }
+      if (typeof TellerConnect === 'undefined' || !TellerConnect.setup) {
+        showError('Teller Connect failed to load.');
+        return;
+      }
+      var teller = TellerConnect.setup({
+        applicationId: cfg.application_id,
+        environment: cfg.environment || 'sandbox',
+        onInit: function () { /* no-op */ },
+        onSuccess: function (enrollment) {
+          setLoading('Saving your connection…');
+          // Teller's enrollment payload (per docs):
+          //   { accessToken, user: {id}, enrollment: {id, institution: {id, name}} }
+          var enr = (enrollment && enrollment.enrollment) || {};
+          var inst = (enr && enr.institution) || {};
+          api('POST', '/connections', {
+            provider: 'teller',
+            credentials: {
+              access_token: (enrollment && enrollment.accessToken) || '',
+              enrollment_id: enr.id || '',
+              institution_id: inst.id || '',
+              institution_name: inst.name || ''
+            }
+          }).then(function (conn) {
+            if (conn && conn.connection_id) {
+              resultIds.push(conn);
+            }
+            renderResult();
+          }).catch(function (err) {
+            showError(err.message || 'Failed to save your connection.');
+          });
+        },
+        onExit: function () {
+          // Teller's onExit fires on a plain cancel — no error payload.
+          // SDK-level failures come through onFailure (below).
+          show('welcome');
+        },
+        onFailure: function (failure) {
+          var code = (failure && failure.type) || 'TELLER_EXIT';
+          var msg = (failure && failure.message) || 'Teller Connect exited with an error.';
+          api('POST', '/fail', { code: code, message: msg }).catch(function () {});
+          showError(msg);
+        }
+      });
+      teller.open();
+    }).catch(function (err) {
+      showError(err.message || 'Failed to start Teller.');
+    });
+  }
+
   function renderResult() {
+    // Materialize the most recent connection into the running tally so
+    // that bouncing back through "Connect another bank" shows it on the
+    // welcome card. resultIds is the cumulative list; linkedInstitutions
+    // mirrors it but is the display-friendly view.
+    while (linkedInstitutions.length < resultIds.length) {
+      var conn = resultIds[linkedInstitutions.length];
+      linkedInstitutions.push({
+        name: (conn && conn.institution_name) || 'Connection',
+        when: new Date()
+      });
+    }
     var list = document.getElementById('result-list');
     list.innerHTML = '';
-    resultIds.forEach(function (conn) {
+    linkedInstitutions.forEach(function (entry) {
       var li = document.createElement('li');
-      li.textContent = (conn.institution_name || 'Connection') + ' — ' + conn.connection_id;
+      var name = document.createElement('div');
+      name.textContent = entry.name;
+      var stamp = document.createElement('div');
+      stamp.className = 'small';
+      stamp.style.marginTop = '2px';
+      try {
+        stamp.textContent = entry.when.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+      } catch (e) {
+        stamp.textContent = '';
+      }
+      li.appendChild(name);
+      li.appendChild(stamp);
       list.appendChild(li);
     });
     var another = document.getElementById('btn-another');
@@ -378,29 +500,17 @@
     // Relink sessions are already terminal — /reauth-complete burned the
     // token. Skip the /complete call so we don't 410 on ourselves.
     if (isRelink()) {
-      if (sessionData.redirect_url) {
-        window.location.href = sessionData.redirect_url;
-      } else {
-        show('closed');
-      }
+      leaveOrClose();
       return;
     }
     setLoading('Wrapping up…');
     api('POST', '/complete', {}).then(function () {
-      if (sessionData.redirect_url) {
-        window.location.href = sessionData.redirect_url;
-      } else {
-        show('closed');
-      }
+      leaveOrClose();
     }).catch(function (err) {
-      // Even on a complete failure, surface the closed state — the page
-      // is done from the user's POV. Log to console for debugging.
+      // Even on a complete failure, surface the closed/redirect state —
+      // the page is done from the user's POV. Log to console for debug.
       console.error('complete failed', err);
-      if (sessionData.redirect_url) {
-        window.location.href = sessionData.redirect_url;
-      } else {
-        show('closed');
-      }
+      leaveOrClose();
     });
   });
   document.getElementById('btn-retry').addEventListener('click', function () {

--- a/internal/api/hosted_link_page.go
+++ b/internal/api/hosted_link_page.go
@@ -199,6 +199,50 @@ func HostedLinkPageStartHandler(a *app.App) http.HandlerFunc {
 	}
 }
 
+// hostedLinkTellerConfigResponse is the redacted Teller config the page
+// needs to bootstrap the Teller Connect SDK. Cert/key material is
+// deliberately omitted — only the public-facing application id and
+// environment (sandbox / development / production) are surfaced. The
+// bearer token in the URL gates access.
+type hostedLinkTellerConfigResponse struct {
+	ApplicationID string `json:"application_id"`
+	Environment   string `json:"environment"`
+}
+
+// HostedLinkPageTellerConfigHandler serves
+// GET /_link/{token}/providers/teller/config.
+//
+// Returns just the public Teller Connect bootstrap values
+// (application_id + environment). Cert/key PEMs are never exposed on this
+// surface; they live server-side and the Teller exchange happens after the
+// page POSTs the enrollment access_token to /connections.
+//
+// Scope-pinned the same way HostedLinkPageStartHandler is: a session
+// pinned to a non-teller provider returns 403 FORBIDDEN.
+func HostedLinkPageTellerConfigHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		sess, ok := mw.HostedLinkToken(r)
+		if !ok {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Hosted-link session missing on context")
+			return
+		}
+		// Scope-pin: if the session declared a provider at mint time, only
+		// teller-pinned (or open-picker) sessions may read teller config.
+		if sess.Provider != "" && sess.Provider != "teller" {
+			mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "Provider does not match the hosted-link session")
+			return
+		}
+		if a.Config == nil || a.Config.TellerAppID == "" {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Teller is not configured on this server")
+			return
+		}
+		writeJSON(w, http.StatusOK, hostedLinkTellerConfigResponse{
+			ApplicationID: a.Config.TellerAppID,
+			Environment:   a.Config.TellerEnv,
+		})
+	}
+}
+
 // HostedLinkPageReauthCompleteHandler serves
 // POST /_link/{token}/reauth-complete.
 //

--- a/internal/api/hosted_link_teller_test.go
+++ b/internal/api/hosted_link_teller_test.go
@@ -1,0 +1,236 @@
+//go:build integration
+
+// Integration tests for Phase-2 page-polish surface:
+//
+//   GET  /_link/{token}/providers/teller/config
+//
+// Plus a redirect_url smoke test asserting POST /_link/{token}/complete still
+// returns 204 — the redirect itself happens client-side, the server does not
+// emit a Location header.
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"breadbox/internal/app"
+	"breadbox/internal/config"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/provider"
+	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// hostedLinkTellerEnv mounts only the page-internal routes needed for the
+// teller-config + complete tests. We construct a real *config.Config so the
+// new handler can read TellerAppID + TellerEnv off App.Config.
+type hostedLinkTellerEnv struct {
+	Server  *httptest.Server
+	App     *app.App
+	Service *service.Service
+	Queries *db.Queries
+}
+
+func setupHostedLinkTellerEnv(t *testing.T, cfg *config.Config) *hostedLinkTellerEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
+
+	fp := &fakePlaidProvider{
+		linkSession: provider.LinkSession{
+			Token:  "link-sandbox-test",
+			Expiry: time.Now().Add(30 * time.Minute),
+		},
+	}
+	ft := &fakeTellerProvider{
+		exchangeConn: provider.Connection{
+			ProviderName: "teller", ExternalID: "enr_x", EncryptedCredentials: []byte("e"),
+		},
+		exchangeAccounts: []provider.Account{
+			{ExternalID: "acc_1", Name: "Chase Checking", Type: "depository"},
+		},
+	}
+
+	a := &app.App{
+		DB:        pool,
+		Queries:   queries,
+		Config:    cfg,
+		Logger:    slog.Default(),
+		Service:   svc,
+		Providers: map[string]provider.Provider{"plaid": fp, "teller": ft},
+	}
+
+	r := chi.NewRouter()
+	r.Route("/_link/{token}", func(r chi.Router) {
+		r.Use(mw.HostedLinkBearer(svc))
+		r.Get("/session", GetHostedLinkPageSessionHandler(svc))
+		r.Get("/providers/teller/config", HostedLinkPageTellerConfigHandler(a))
+		r.Post("/complete", HostedLinkPageCompleteHandler(svc))
+	})
+	server := httptest.NewServer(r)
+	t.Cleanup(server.Close)
+
+	return &hostedLinkTellerEnv{
+		Server:  server,
+		App:     a,
+		Service: svc,
+		Queries: queries,
+	}
+}
+
+func (e *hostedLinkTellerEnv) mintSession(t *testing.T, p service.CreateHostedLinkParams) (service.HostedLinkSession, string) {
+	t.Helper()
+	if p.UserID == "" {
+		u := testutil.MustCreateUser(t, e.Queries, "TellerTest")
+		p.UserID = pgconv.FormatUUID(u.ID)
+	}
+	if p.Action == "" {
+		p.Action = service.HostedLinkActionLink
+	}
+	res, err := e.Service.CreateHostedLink(context.Background(), p)
+	if err != nil {
+		t.Fatalf("mint hosted-link session: %v", err)
+	}
+	return res.Session, res.Token
+}
+
+func (e *hostedLinkTellerEnv) doReq(t *testing.T, method, path string, body io.Reader) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, e.Server.URL+path, body)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	return resp
+}
+
+// configuredTellerCfg returns a *config.Config wired with the public
+// Teller bootstrap fields (app id + env). Cert/key PEMs are deliberately
+// omitted — the bearer config handler must never read them.
+func configuredTellerCfg() *config.Config {
+	return &config.Config{
+		TellerAppID: "app_teller_test_123",
+		TellerEnv:   "sandbox",
+	}
+}
+
+func TestHostedLink_TellerConfig_HappyPath(t *testing.T) {
+	env := setupHostedLinkTellerEnv(t, configuredTellerCfg())
+	// Open-picker session — no provider pin, so teller is allowed.
+	_, token := env.mintSession(t, service.CreateHostedLinkParams{})
+
+	resp := env.doReq(t, "GET", "/_link/"+token+"/providers/teller/config", nil)
+	assertStatus(t, resp, http.StatusOK)
+	var got struct {
+		ApplicationID string `json:"application_id"`
+		Environment   string `json:"environment"`
+	}
+	parseJSON(t, resp, &got)
+	if got.ApplicationID != "app_teller_test_123" {
+		t.Errorf("application_id: want app_teller_test_123, got %q", got.ApplicationID)
+	}
+	if got.Environment != "sandbox" {
+		t.Errorf("environment: want sandbox, got %q", got.Environment)
+	}
+}
+
+func TestHostedLink_TellerConfig_RejectsPlaidPinned(t *testing.T) {
+	env := setupHostedLinkTellerEnv(t, configuredTellerCfg())
+	// Pin to plaid; the teller config endpoint must 403.
+	_, token := env.mintSession(t, service.CreateHostedLinkParams{Provider: "plaid"})
+
+	resp := env.doReq(t, "GET", "/_link/"+token+"/providers/teller/config", nil)
+	readErrorCode(t, resp, http.StatusForbidden, "FORBIDDEN")
+}
+
+func TestHostedLink_TellerConfig_HidesCertificate(t *testing.T) {
+	cfg := configuredTellerCfg()
+	// Wire fake PEM bytes — these must NEVER appear in the response. The
+	// handler returns a fixed struct that has no cert/key field, but we
+	// assert at the byte level too to catch future regressions if someone
+	// "helpfully" reflects more of *config.Config back to the page.
+	cfg.TellerCertPEM = []byte("-----BEGIN CERTIFICATE-----\nSECRET-CERT\n-----END CERTIFICATE-----")
+	cfg.TellerKeyPEM = []byte("-----BEGIN PRIVATE KEY-----\nSECRET-KEY\n-----END PRIVATE KEY-----")
+	env := setupHostedLinkTellerEnv(t, cfg)
+	_, token := env.mintSession(t, service.CreateHostedLinkParams{Provider: "teller"})
+
+	resp := env.doReq(t, "GET", "/_link/"+token+"/providers/teller/config", nil)
+	assertStatus(t, resp, http.StatusOK)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	body := string(raw)
+
+	bannedSubstrings := []string{
+		"BEGIN CERTIFICATE", "SECRET-CERT",
+		"BEGIN PRIVATE KEY", "SECRET-KEY",
+		"certificate", "private_key", "cert_pem", "key_pem",
+	}
+	for _, banned := range bannedSubstrings {
+		if strings.Contains(body, banned) {
+			t.Errorf("teller config response leaks %q: %s", banned, body)
+		}
+	}
+	// Re-parse to confirm only the two public fields are populated.
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("expected exactly 2 keys (application_id, environment), got %d: %v", len(got), got)
+	}
+}
+
+func TestHostedLink_TellerConfig_NotConfigured(t *testing.T) {
+	// Empty config — TellerAppID is unset; handler must 400 cleanly rather
+	// than surface a half-configured response.
+	env := setupHostedLinkTellerEnv(t, &config.Config{})
+	_, token := env.mintSession(t, service.CreateHostedLinkParams{Provider: "teller"})
+
+	resp := env.doReq(t, "GET", "/_link/"+token+"/providers/teller/config", nil)
+	readErrorCode(t, resp, http.StatusBadRequest, "INVALID_PARAMETER")
+}
+
+// TestHostedLink_CompleteRedirectsWhenSet verifies that the bearer-side
+// /complete handler is unaffected by redirect_url — it still returns 204,
+// and the page is responsible for navigating client-side. We assert this
+// because future maintainers might be tempted to issue a 303 here; that
+// would break the SPA's "show 'closed' on no-redirect" branch.
+func TestHostedLink_CompleteRedirectsWhenSet(t *testing.T) {
+	env := setupHostedLinkTellerEnv(t, configuredTellerCfg())
+	sess, token := env.mintSession(t, service.CreateHostedLinkParams{
+		Provider:    "plaid",
+		RedirectURL: "https://chat.example.com/return?ok=1",
+	})
+	if err := env.Service.MarkHostedLinkStarted(context.Background(), sess.ID); err != nil {
+		t.Fatalf("mark started: %v", err)
+	}
+
+	resp := env.doReq(t, "POST", "/_link/"+token+"/complete", strings.NewReader("{}"))
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("complete with redirect_url: want 204, got %d", resp.StatusCode)
+	}
+	// No-redirect contract: the server must not emit a Location header.
+	if loc := resp.Header.Get("Location"); loc != "" {
+		t.Errorf("complete should not emit Location header, got %q", loc)
+	}
+	resp.Body.Close()
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -192,6 +192,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Use(mw.HostedLinkBearer(svc))
 		r.Get("/session", GetHostedLinkPageSessionHandler(svc))
 		r.Post("/providers/{name}/start", HostedLinkPageStartHandler(a))
+		r.Get("/providers/teller/config", HostedLinkPageTellerConfigHandler(a))
 		r.Post("/connections", HostedLinkPageConnectionHandler(a))
 		r.Post("/reauth-complete", HostedLinkPageReauthCompleteHandler(svc))
 		r.Post("/complete", HostedLinkPageCompleteHandler(svc))


### PR DESCRIPTION
PR 2 of 2 in the hosted-link Phase-2 stack — closes the picker (Teller active), wires the agent's `redirect_url` for the "I'm done" handoff, and tightens the multi-connect loop.

## Why

Phase 1 shipped the page with Plaid only. PR1 of this stack added relink. PR2 brings Teller into the picker so a single hosted URL covers both providers, and ties the loop UX together: agents can pass a "back to chat" URL, and users can connect multiple banks in one session without bouncing.

## What's in this PR

- Teller SDK loaded; `startTeller` mirrors `startPlaid`; success → generic `POST /_link/{token}/connections` (no server changes needed — generic dispatch already routes Teller)
- New `GET /_link/{token}/providers/teller/config` — bearer-protected, returns just `application_id` + `environment` (no cert/key). Scope-pinned: plaid-pinned sessions get 403.
- On "I'm done": if `redirect_url` is set (and is `http://` / `https://`), navigate there post-complete; else show "close window" copy
- Multi-connect: success card shows a running list of institutions linked this session with a small timestamp; "Connect another bank" returns to picker with `Linked so far: ...` rendered on the welcome state
- 5 integration tests covering bearer scope, config redaction, not-configured branch, complete-with-redirect contract

## What's NOT in this PR

- SSE / webhook completion (Phase 3)
- Mobile-specific tweaks (Phase 3)
- Branding (Phase 3)

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...`
- [x] `make test-integration` full suite
- [x] `TestOpenAPIDrift` green (page-internal endpoints not in spec — by design)
- [ ] Manual: open a picker-mode link, connect Plaid sandbox + Teller sandbox in one session, observe running list and final redirect (reviewer)
