### PR TITLE
cli: design doc + upkeep rule for the headless CLI

### DIFF
--- a/.claude/rules/cli-commands.md
+++ b/.claude/rules/cli-commands.md
@@ -1,0 +1,62 @@
+---
+paths:
+  - "cmd/breadbox/**"
+  - "internal/cli/**"
+  - "docs/cli-commands.md"
+---
+
+# CLI command catalog upkeep
+
+`docs/cli-commands.md` is the human-readable index of every command the `breadbox` CLI exposes. It pairs with the cobra command tree under `internal/cli/` (machine-readable, exercised by `breadbox completion`-generated specs).
+
+## The rule
+
+**Any change to the cobra command tree that adds, removes, renames, or re-scopes a command MUST update `docs/cli-commands.md` in the same commit.**
+
+Specifically, if you change:
+
+- `cobra.Command{Use: ...}` calls under `internal/cli/`
+- A command's scope (R / W / L) — i.e., whether it requires `full_access`, only reads, or skips the API entirely
+- A command's standard-flag set (e.g., adds `--wait`, drops `--all`)
+- The verb hierarchy of a noun (e.g., flattens `transactions comments add` → `transactions comment`)
+
+…then `docs/cli-commands.md` must reflect it in the same PR. There is no automated drift check yet; nothing catches drift except discipline.
+
+## What goes in the table row
+
+```
+| `breadbox <noun> <verb> [args] [flags]` | R / W / L / — | One-sentence description in present tense |
+```
+
+- **Command** matches what the user types. Show common flags inline; full flag set lives in `breadbox <noun> <verb> --help`.
+- **Scope** is `R` (any API key), `W` (`full_access` required), `L` (local-only, talks to service layer or DB), or `—` (no auth, e.g. `version`).
+- **Description** is 5–15 words, present tense, no marketing fluff. Be specific about side effects (mutations, network calls, side-channel output).
+
+## Where the row lives
+
+Group rows by section — match the existing section order (auth, server, accounts, transactions, …). The full ordering mirrors `docs/api-endpoints.md` where the noun maps to a REST resource; CLI-only commands (auth, server, backup, webhooks) get their own top-of-file sections.
+
+Add a new top-level section if you're introducing a new noun; don't bury a new noun inside an unrelated section.
+
+## Standard flags — don't re-document them
+
+`--host`, `--json`, `--ndjson`, `--fields`, `--limit`, `--all`, `--quiet`, `--debug` apply to every command. The doc preamble lists them once; do **not** repeat them per command. Per-command flags (e.g., `--wait` on `connections create`) DO go in the table.
+
+## Exit codes are a contract
+
+`0` success, `1` runtime, `2` usage, `3` auth, `4` upstream, `5` validation. Agents branch on these. Don't add new exit codes without updating the doc preamble.
+
+## What does NOT belong in `docs/cli-commands.md`
+
+- Full flag references (those live in `breadbox <noun> <verb> --help` and the cobra source)
+- Cookbook examples (those belong in `docs/headless-deploy.md` once we write it)
+- REST endpoint details (those live in `docs/api-endpoints.md` and `openapi.yaml`)
+- MCP tool docs (separate surface — `docs/mcp-tools-reference.md`)
+
+## When in doubt
+
+- A new command that's pure parity with an existing one (e.g. another bulk variant): still add it. Discoverability matters.
+- A renamed command kept as an alias: keep both rows; tag the old one `*deprecated — use `<new>` instead*`.
+- Internal-only or hidden commands (debug helpers, completion script): add them under a clearly marked section so readers don't think they're stable.
+
+If you forget and a PR lands without updating this file, open a follow-up PR with `docs(cli):` as the prefix. Don't let the index rot.

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,0 +1,243 @@
+# CLI commands
+
+A terse catalog of every command the `breadbox` CLI exposes. The CLI drives the same surface documented in [`docs/api-endpoints.md`](api-endpoints.md) — every data command is a thin shell over the REST API, plus a handful of server-only commands (`serve`, `migrate`, `init`, `mcp-stdio`) that talk to the service layer directly because there's no server to talk to. **Keep this file in sync with the cobra command tree** — see `.claude/rules/cli-commands.md` for the upkeep rule.
+
+## Architecture
+
+- **One binary, multiple roles.** `breadbox` is the same binary as the server. It can run as a server (`serve`), as an MCP stdio host (`mcp-stdio`), or as a CLI that drives a local or remote breadbox over HTTP. The dashboard and CLI share one process when needed; nothing is reimplemented.
+- **Local vs remote, same commands.** `breadbox transactions list` works against `http://localhost:8080` (default), a Unix socket, or `--host my-remote-server`. The CLI never reaches into the DB *except* when bootstrapping (`init`, `migrate`, `auth bootstrap` when no server is running) — in those cases there's no API to call.
+- **Build tags.**
+  - Default build: full binary (server + CLI + dashboard).
+  - `-tags=headless`: server + CLI, no dashboard assets.
+  - `-tags=lite`: CLI-only, no server packages, no DB drivers. Ships as `breadbox-cli` for remote agents.
+  - See `.claude/rules/build-tags.md` for the exclusion matrix.
+- **Auth.** Per-host credentials live in `~/.config/breadbox/hosts.toml`. Add a host with `breadbox auth login` (interactive device-code) or `breadbox auth login --host=URL --token=bb_...`. Switch with `--host <name>` or `BREADBOX_HOST=<name>`. On a local box you've never logged into, `breadbox auth bootstrap` mints a key automatically.
+- **Output.** Default is a human table on stdout. Add `--json` for machine-readable JSON, `--ndjson` for streaming large lists, `--fields=core,timestamps` to pass through API field selection.
+- **Standard flags** (apply to every command): `--host`, `--json`, `--ndjson`, `--fields`, `--limit`, `--all`, `--quiet`, `--debug`. Per-command flags are listed in `breadbox <noun> <verb> --help`.
+- **Exit codes.** `0` success, `1` runtime error, `2` usage error, `3` auth error (missing or revoked key), `4` upstream API error (server returned 5xx), `5` validation error (server returned 4xx). Agents can branch on these reliably.
+
+Scope column: **R** = readable with any API key, **W** = requires `full_access` scope, **L** = local-only (talks to service layer / DB; no API call).
+
+## Auth
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox auth login [--host URL] [--token KEY]` | — | Add a host; interactive device-code by default |
+| `breadbox auth logout [--host NAME]` | — | Drop credentials for a host |
+| `breadbox auth status` | — | List configured hosts + which is default |
+| `breadbox auth use <name>` | — | Set the default host |
+| `breadbox auth bootstrap` | L | Local-only: mint a `full_access` key without prompting |
+| `breadbox auth whoami` | R | Print the API key's actor (type + name) and host |
+
+## Server / process
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox serve [--no-dashboard]` | L | Start the HTTP server (REST + MCP + dashboard) |
+| `breadbox mcp-stdio` | L | MCP server over stdio (for Claude Desktop and CLI agents) |
+| `breadbox init` | L | First-run setup: encryption key, first login account, first API key |
+| `breadbox migrate [--down] [--to N]` | L | Run goose migrations against `DATABASE_URL` |
+| `breadbox doctor` | R | Health check; consumes `GET /api/v1/headless/bootstrap` + `/health/ready` |
+| `breadbox version` | — | Print build version, commit, and upgrade check |
+| `breadbox completion [bash\|zsh\|fish]` | — | Shell completion script |
+
+## Health / meta
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox version` | — | Local + server version diff |
+| `breadbox doctor` | R | Reports what's configured / missing (B22 bootstrap report) |
+
+## Accounts
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox accounts list` | R | List household bank accounts |
+| `breadbox accounts get <id>` | R | Single account summary |
+| `breadbox accounts detail <id>` | R | Detail + last 25 transactions + per-currency balances |
+| `breadbox accounts update <id> [--name] [--excluded] [--dependent-linked]` | W | Patch display name and flags |
+
+## Transactions
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox transactions list [filters]` | R | Cursor-paginated list; `--all` walks every page |
+| `breadbox transactions get <id>` | R | Single transaction |
+| `breadbox transactions count [filters]` | R | Count matching the same filters |
+| `breadbox transactions summary [--by=category\|month\|week\|day]` | R | Aggregates |
+| `breadbox transactions merchants [filters]` | R | Merchant stats (count, total, avg) |
+| `breadbox transactions update <id> [--category] [--note] [--tags]` | W | Atomic multi-field update |
+| `breadbox transactions batch <file>` | W | Batch update from JSON (max 50 rows) |
+| `breadbox transactions categorize <id> <category>` | W | Set category (override) |
+| `breadbox transactions uncategorize <id>` | W | Reset to provider default |
+| `breadbox transactions recategorize --filter --category` | W | Server-side recategorize by filter |
+| `breadbox transactions delete <id>` | W | Soft-delete |
+| `breadbox transactions restore <id>` | W | Restore a soft-deleted transaction |
+| `breadbox transactions tag <id> <slug>` | W | Attach a tag |
+| `breadbox transactions untag <id> <slug>` | W | Detach a tag |
+| `breadbox transactions annotations <id>` | R | Activity-timeline rows |
+| `breadbox transactions comments add <id> <message>` | W | Add a comment |
+| `breadbox transactions comments list <id>` | R | List comments |
+| `breadbox transactions comments edit <id> <comment-id> <message>` | W | Edit a comment |
+| `breadbox transactions comments delete <id> <comment-id>` | W | Delete a comment |
+
+## Categories
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox categories list` | R | List all categories |
+| `breadbox categories get <id>` | R | Single category |
+| `breadbox categories create [--name] [--parent]` | W | Create a category |
+| `breadbox categories update <id> [...]` | W | Update name / parent |
+| `breadbox categories delete <id>` | W | Delete (blocked if any transactions reference it) |
+| `breadbox categories merge <from> <to>` | W | Merge `from` → `to` (migrate transactions, drop source) |
+| `breadbox categories export [--format=tsv\|json]` | R | Dump categories |
+| `breadbox categories import <file>` | W | Import from TSV |
+
+## Tags
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox tags list` | R | List all tags |
+| `breadbox tags get <slug>` | R | Single tag |
+| `breadbox tags create <slug> [--label] [--color]` | W | Create a tag |
+| `breadbox tags update <slug> [...]` | W | Update label / color |
+| `breadbox tags delete <slug>` | W | Delete a tag |
+
+## Rules
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox rules list [--enabled]` | R | List transaction rules |
+| `breadbox rules get <id>` | R | Single rule |
+| `breadbox rules create --json <file>` | W | Create a rule from a DSL JSON file |
+| `breadbox rules update <id> --json <file>` | W | Update a rule |
+| `breadbox rules delete <id>` | W | Delete a rule |
+| `breadbox rules preview <id>` | R | Preview matches without applying |
+| `breadbox rules apply <id>` | W | Apply retroactively to existing transactions |
+| `breadbox rules batch <file>` | W | Create / update many rules atomically |
+
+## Reviews
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox reviews list [--status]` | R | List pending reviews |
+| `breadbox reviews get <id>` | R | Single review |
+| `breadbox reviews approve <id> [--category]` | W | Approve a review |
+| `breadbox reviews reject <id>` | W | Reject a review |
+| `breadbox reviews skip <id>` | W | Skip a review |
+
+## Connections
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox connections list` | R | List bank connections (active + disconnected) |
+| `breadbox connections get <id>` | R | Single connection |
+| `breadbox connections create [--provider=plaid\|teller] [--wait]` | W | Mint hosted-link, print URL; `--wait` polls until completed |
+| `breadbox connections relink <id> [--wait]` | W | Mint a relink session for an existing connection |
+| `breadbox connections disconnect <id>` | W | Mark connection disconnected (preserves history) |
+| `breadbox connections delete <id>` | W | Hard delete (accounts/transactions FK-SET-NULL) |
+
+## Sync
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox sync trigger [--connection] [--account]` | W | Kick a manual sync |
+| `breadbox sync status` | R | Last sync per connection + scheduler state |
+| `breadbox sync logs [--connection] [--limit] [--follow]` | R | Sync history; `--follow` tails new entries |
+
+## CSV
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox csv preview <file> [--account]` | R | Dry-run parse + dedupe report |
+| `breadbox csv import <file> --account <id>` | W | Import a CSV into an account |
+
+## Providers
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox providers list` | R | What's configured + provider status |
+| `breadbox providers config plaid [--client-id] [--secret] [--env]` | W | Set Plaid credentials |
+| `breadbox providers config teller [--app-id] [--signing-secret] [--pem-file]` | W | Set Teller credentials |
+| `breadbox providers test <provider>` | W | Round-trip a credentials check |
+| `breadbox providers disable <provider>` | W | Disable a provider (existing connections keep working) |
+
+## Users
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox users list` | R | List household members |
+| `breadbox users get <id>` | R | Single user |
+| `breadbox users create [--name] [--email] [--role]` | W | Add a household member |
+| `breadbox users update <id> [...]` | W | Update member |
+| `breadbox users delete <id>` | W | Remove member |
+
+## Logins
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox logins list` | W | List admin login accounts |
+| `breadbox logins create [--email] [--user]` | W | Create a login account linked to a household user |
+| `breadbox logins update <id> [...]` | W | Update login |
+| `breadbox logins delete <id>` | W | Delete login |
+| `breadbox logins reset-password <id>` | W | Generate a one-time reset token |
+
+## Account links
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox links list` | R | List account ↔ user links |
+| `breadbox links create --account --user` | W | Link an account to a user |
+| `breadbox links delete <id>` | W | Remove an account-user link |
+
+## Reports
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox reports list [--kind] [--status]` | R | List agent reports |
+| `breadbox reports get <id>` | R | Single report |
+| `breadbox reports submit --kind --json <file>` | W | Submit a report on behalf of the current actor |
+| `breadbox reports read <id>` | W | Mark report read |
+| `breadbox reports unread <id>` | W | Mark report unread |
+
+## API keys
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox keys list` | W | List all API keys (full key never returned) |
+| `breadbox keys create [--scope=read_only\|full_access] [--actor=user\|agent\|system] [--name]` | W | Mint a new key (full secret returned once) |
+| `breadbox keys revoke <id>` | W | Soft-revoke a key |
+
+## App config
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox config list` | W | List app_config entries (with source: env / db / default) |
+| `breadbox config get <key>` | W | Get one config value |
+| `breadbox config set <key> <value>` | W | Set a config value (db source) |
+| `breadbox config unset <key>` | W | Remove a db-sourced value (falls back to env / default) |
+
+## Backup
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox backup create [--out path]` | L | Dump the database (pg_dump under the hood) |
+| `breadbox backup list` | L | List existing backups |
+| `breadbox backup restore <file>` | L | Restore from a backup (server must be stopped) |
+
+## Webhooks
+
+| Command | Scope | Description |
+|---------|-------|-------------|
+| `breadbox webhooks tail [--provider]` | W | Tail recent webhook events (SSE from server) |
+| `breadbox webhooks replay <id>` | W | Re-process a webhook event |
+
+## Headless / agent surface
+
+Agents can drive Breadbox via the CLI as a more direct alternative to MCP. Two recommended patterns:
+
+- **Local same-host agent.** Agent runs on the same machine as `breadbox serve`. Get a key with `breadbox keys create --actor=agent --name="<agent-name>"`, store it as the agent's `BREADBOX_TOKEN`. All commands work over loopback (or Unix socket for speed).
+- **Remote agent (lite CLI).** Build `-tags=lite` (`breadbox-cli` binary) and ship it to the agent host. User provisions a key via `breadbox keys create --actor=agent --name=...` on the server side, hands it to the agent; agent runs `breadbox-cli auth login --host=https://your-breadbox --token=<key>`. From there, every data command works identically.
+
+The CLI prints JSON to stdout when stdout isn't a TTY, so agents don't need to pass `--json` — piping just works.

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,10 +1,10 @@
 # CLI commands
 
-A terse catalog of every command the `breadbox` CLI exposes. The CLI drives the same surface documented in [`docs/api-endpoints.md`](api-endpoints.md) — every data command is a thin shell over the REST API, plus a handful of server-only commands (`serve`, `migrate`, `init`, `mcp-stdio`) that talk to the service layer directly because there's no server to talk to. **Keep this file in sync with the cobra command tree** — see `.claude/rules/cli-commands.md` for the upkeep rule.
+A terse catalog of every command the `breadbox` CLI exposes. The CLI drives the same surface documented in [`docs/api-endpoints.md`](api-endpoints.md) — every data command is a thin shell over the REST API, plus a handful of server-only commands (`serve`, `mcp`, `init`, `migrate`, `backup`) that talk to the service layer directly because there's no server to talk to. **Keep this file in sync with the cobra command tree** — see `.claude/rules/cli-commands.md` for the upkeep rule.
 
 ## Architecture
 
-- **One binary, multiple roles.** `breadbox` is the same binary as the server. It can run as a server (`serve`), as an MCP stdio host (`mcp-stdio`), or as a CLI that drives a local or remote breadbox over HTTP. The dashboard and CLI share one process when needed; nothing is reimplemented.
+- **One binary, multiple roles.** `breadbox` is the same binary as the server. It can run as a server (`serve`), as an MCP stdio host (`mcp`), or as a CLI that drives a local or remote breadbox over HTTP. The dashboard and CLI share one process when needed; nothing is reimplemented.
 - **Local vs remote, same commands.** `breadbox transactions list` works against `http://localhost:8080` (default), a Unix socket, or `--host my-remote-server`. The CLI never reaches into the DB *except* when bootstrapping (`init`, `migrate`, `auth bootstrap` when no server is running) — in those cases there's no API to call.
 - **Build tags.**
   - Default build: full binary (server + CLI + dashboard).
@@ -33,20 +33,17 @@ Scope column: **R** = readable with any API key, **W** = requires `full_access` 
 
 | Command | Scope | Description |
 |---------|-------|-------------|
-| `breadbox serve [--no-dashboard]` | L | Start the HTTP server (REST + MCP + dashboard) |
-| `breadbox mcp-stdio` | L | MCP server over stdio (for Claude Desktop and CLI agents) |
-| `breadbox init` | L | First-run setup: encryption key, first login account, first API key |
-| `breadbox migrate [--down] [--to N]` | L | Run goose migrations against `DATABASE_URL` |
-| `breadbox doctor` | R | Health check; consumes `GET /api/v1/headless/bootstrap` + `/health/ready` |
-| `breadbox version` | — | Print build version, commit, and upgrade check |
-| `breadbox completion [bash\|zsh\|fish]` | — | Shell completion script |
-
-## Health / meta
+These commands operate on the local box (filesystem, DB, embedded migrations) — they do not call the REST API. They're stripped from the `-tags=lite` build.
 
 | Command | Scope | Description |
 |---------|-------|-------------|
-| `breadbox version` | — | Local + server version diff |
-| `breadbox doctor` | R | Reports what's configured / missing (B22 bootstrap report) |
+| `breadbox serve [--no-dashboard]` | L | Start the HTTP server (REST + MCP-over-HTTP + dashboard) |
+| `breadbox mcp` | L | MCP server over stdio; Claude Desktop spawns this per session, blocks until stdin closes |
+| `breadbox init` | L | First-run setup: encryption key, first login account, first API key |
+| `breadbox migrate [--down] [--to N]` | L | Run goose migrations against `DATABASE_URL` (local-only — there is no remote migration endpoint by design) |
+| `breadbox doctor` | R | Health check; consumes `GET /api/v1/headless/bootstrap` + `/health/ready` |
+| `breadbox version` | — | Print build version, commit, and upgrade check |
+| `breadbox completion [bash\|zsh\|fish]` | — | Print a shell-completion script (e.g. `breadbox completion zsh > _breadbox`) for tab-completion of nouns/verbs/flags — same pattern as `gh`, `kubectl` |
 
 ## Accounts
 
@@ -55,7 +52,10 @@ Scope column: **R** = readable with any API key, **W** = requires `full_access` 
 | `breadbox accounts list` | R | List household bank accounts |
 | `breadbox accounts get <id>` | R | Single account summary |
 | `breadbox accounts detail <id>` | R | Detail + last 25 transactions + per-currency balances |
-| `breadbox accounts update <id> [--name] [--excluded] [--dependent-linked]` | W | Patch display name and flags |
+| `breadbox accounts update <id> [--name] [--excluded] [--dependent-linked]` | W | Patch display name, `--excluded` (hide from views), `--dependent-linked` (exclude from household totals — e.g., a kid's account you fund but don't count toward your spending) |
+| `breadbox accounts links list <id>` | R | List user-links on an account (which household members own / share it) |
+| `breadbox accounts links add <id> --user <user-id>` | W | Link an account to a household user |
+| `breadbox accounts links remove <id> <link-id>` | W | Unlink a user from an account |
 
 ## Transactions
 
@@ -65,7 +65,6 @@ Scope column: **R** = readable with any API key, **W** = requires `full_access` 
 | `breadbox transactions get <id>` | R | Single transaction |
 | `breadbox transactions count [filters]` | R | Count matching the same filters |
 | `breadbox transactions summary [--by=category\|month\|week\|day]` | R | Aggregates |
-| `breadbox transactions merchants [filters]` | R | Merchant stats (count, total, avg) |
 | `breadbox transactions update <id> [--category] [--note] [--tags]` | W | Atomic multi-field update |
 | `breadbox transactions batch <file>` | W | Batch update from JSON (max 50 rows) |
 | `breadbox transactions categorize <id> <category>` | W | Set category (override) |
@@ -117,24 +116,17 @@ Scope column: **R** = readable with any API key, **W** = requires `full_access` 
 | `breadbox rules apply <id>` | W | Apply retroactively to existing transactions |
 | `breadbox rules batch <file>` | W | Create / update many rules atomically |
 
-## Reviews
-
-| Command | Scope | Description |
-|---------|-------|-------------|
-| `breadbox reviews list [--status]` | R | List pending reviews |
-| `breadbox reviews get <id>` | R | Single review |
-| `breadbox reviews approve <id> [--category]` | W | Approve a review |
-| `breadbox reviews reject <id>` | W | Reject a review |
-| `breadbox reviews skip <id>` | W | Skip a review |
-
 ## Connections
+
+A **connection** is a bank-side OAuth link (Plaid item, Teller enrollment, or CSV-import bucket). Different from account-links (which live under `breadbox accounts links` and map household users to bank accounts).
 
 | Command | Scope | Description |
 |---------|-------|-------------|
 | `breadbox connections list` | R | List bank connections (active + disconnected) |
 | `breadbox connections get <id>` | R | Single connection |
-| `breadbox connections create [--provider=plaid\|teller] [--wait]` | W | Mint hosted-link, print URL; `--wait` polls until completed |
-| `breadbox connections relink <id> [--wait]` | W | Mint a relink session for an existing connection |
+| `breadbox connections link [--provider=plaid\|teller] [--user] [--wait]` | W | Mint a hosted-link session (`POST /connections/link`), print the URL agents and users can open in a browser; `--wait` polls until completed |
+| `breadbox connections link get <session-id>` | R | Check a hosted-link session's status (`active` / `completed` / `failed` / `expired`) and the resulting connection IDs |
+| `breadbox connections relink <connection-id> [--wait]` | W | Mint a relink hosted-link session for an existing (broken or pending-reauth) connection |
 | `breadbox connections disconnect <id>` | W | Mark connection disconnected (preserves history) |
 | `breadbox connections delete <id>` | W | Hard delete (accounts/transactions FK-SET-NULL) |
 
@@ -182,14 +174,6 @@ Scope column: **R** = readable with any API key, **W** = requires `full_access` 
 | `breadbox logins update <id> [...]` | W | Update login |
 | `breadbox logins delete <id>` | W | Delete login |
 | `breadbox logins reset-password <id>` | W | Generate a one-time reset token |
-
-## Account links
-
-| Command | Scope | Description |
-|---------|-------|-------------|
-| `breadbox links list` | R | List account ↔ user links |
-| `breadbox links create --account --user` | W | Link an account to a user |
-| `breadbox links delete <id>` | W | Remove an account-user link |
 
 ## Reports
 


### PR DESCRIPTION
First PR on the `feat/cli-headless` long-lived branch. Lands the design doc + upkeep rule that the implementation PRs will point at — no behavior change.

## What's here

- **`docs/cli-commands.md`** — terse catalog of every command the headless CLI will expose, keyed by noun. Mirrors `docs/api-endpoints.md`. Sections: auth, server, accounts, transactions, categories, tags, rules, reviews, connections, sync, csv, providers, users, logins, links, reports, keys, config, backup, webhooks.
- **`.claude/rules/cli-commands.md`** — upkeep rule (same shape as `.claude/rules/api-endpoints.md`): any change to the cobra command tree must update the doc in the same PR.

## Design calls captured in the doc

1. **One binary, three roles.** Same `breadbox` binary runs as server, MCP stdio host, or CLI client. CLI is HTTP-by-default; commands that *must* run with no server (`init`, `migrate`, `auth bootstrap` fallback, `backup restore`) call the service layer directly — that class is marked `L` in the scope column.
2. **Build tags.** Default = full. `-tags=headless` = no dashboard. `-tags=lite` = CLI-only, no DB drivers (ships as `breadbox-cli` for remote agents).
3. **Auth.** `~/.config/breadbox/hosts.toml`. `breadbox auth login` is interactive device-code by default; `--token` for paste; `auth bootstrap` for local convenience.
4. **Output.** Human table on TTY, JSON when piped, `--ndjson` for streaming.
5. **Exit codes are a contract.** `0/1/2/3/4/5` documented in the preamble; agents branch on these.

## Sprint sequencing this unlocks

- S0 (this stack): design doc + build-tag wiring + `serve --no-dashboard` + B22 (`/headless/bootstrap`)
- S1: cobra scaffolding + identity (`actor_type`/`actor_name` columns + stdio fallback)
- S2: device-code remote auth (moved up from the original Stage 6)
- S3–S6: read → write → connections → admin/ops
- S7: lite build proof
- S8: merge `feat/cli-headless` → `main`

## Test plan

- [x] `go build ./...` — no behavior change yet, doc-only commit
- [ ] Reviewer red-lines the catalog (command surface, scope assignments, exit codes)
