### PR TITLE
cli: build-tags rule + serve --no-dashboard + headless bootstrap

### DIFF
--- a/.claude/rules/build-tags.md
+++ b/.claude/rules/build-tags.md
@@ -1,0 +1,106 @@
+---
+paths:
+  - "internal/**"
+  - "cmd/breadbox/**"
+  - ".github/workflows/**"
+  - "Makefile"
+---
+
+# Build tags
+
+The `breadbox` binary supports two orthogonal build tags that shrink what compiles in. This rule documents the policy. The actual `//go:build` constraints land in **PR-03** of the `feat/cli-headless` stack; this PR (PR-02) ships the rule + the runtime `--no-dashboard` flag side of the same story.
+
+## Policy
+
+Default build = full (everything). Two tags layer on top:
+
+- `-tags=headless` — server + CLI, **no dashboard assets**. The `internal/admin`, `internal/templates`, and `internal/webui`+`web/` SPA trees are excluded. The same binary still serves REST + MCP + OAuth + hosted-link endpoints + webhooks.
+- `-tags=lite` — **CLI-only**. No server packages, no DB drivers, no provider SDKs. Ships as `breadbox-cli` (same source, `-o breadbox-cli`) for remote agents that only need to drive a Breadbox over HTTP.
+
+The two tags are orthogonal; `-tags=headless,lite` is meaningless (lite already excludes the server). CI runs the cells of the matrix that matter: default, `-tags=headless`, `-tags=lite`.
+
+## Package matrix
+
+Apply build tags to **every Go file** in the package — including tests, with the caveat in the anti-patterns section.
+
+### Dashboard-excluded (`//go:build !headless`)
+
+These packages are dashboard-only. They never run under `-tags=headless`:
+
+- `internal/admin/**` — session manager, admin handlers, template renderer
+- `internal/webui/**` — v2 SPA bridge (`/web/v1/*`, `/v2/*`, embedded bundle)
+- `internal/templates/**` — `html/template` pages + templ components
+
+Any cross-package reference to a symbol in these trees needs a `//go:build headless` stub that returns a typed zero/nil so callers compile. As of PR-02 there are no such references; `--no-dashboard` gates registration at runtime instead. PR-03 introduces stubs only if it discovers callers.
+
+### Server-excluded (`//go:build !lite`)
+
+These packages compile only into the server binary. Under `-tags=lite` they are absent:
+
+- `internal/app` — DB pool + provider init
+- `internal/api`, `internal/middleware` — chi router + middleware
+- `internal/mcp` — MCP server (Streamable HTTP + tool registry)
+- `internal/service` — service layer (depends on `internal/db`)
+- `internal/db` — sqlc-generated code + migrations
+- `internal/sync`, `internal/scheduler` — sync engine + cron
+- `internal/provider/**` — Plaid, Teller, CSV
+- `internal/webhook`, `internal/appconfig`, `internal/crypto`
+- Plus the dashboard packages above (lite excludes them transitively via `!lite`; they also carry `!headless`)
+
+### Tag-free (compile in both lite and full)
+
+- `internal/cli/**` — cobra command tree (added in Stage 1)
+- `internal/client/**` — HTTP client the CLI uses (added in Stage 1)
+- `internal/version`, `internal/shortid`, `internal/pgconv` (pure helpers)
+- `internal/config` — CLI also reads `~/.config/breadbox/hosts.toml` from here
+
+If a "tag-free" package starts importing a server package, **fix the import**, don't slap a build tag on the consumer.
+
+### `cmd/breadbox/main.go`
+
+Split into two files compiled into the same binary name:
+
+- `main_full.go` (`//go:build !lite`) — wires `serve`, `migrate`, `seed`, `mcp-stdio`, `create-admin`, `reset-password`, `doctor` (server-side checks), `version`.
+- `main_lite.go` (`//go:build lite`) — wires CLI-only entry (`auth`, all the noun verbs, `doctor` over HTTP, `version`).
+
+`func main()` lives in whichever file the build picked. Lite is renamed at link time (`go build -o breadbox-cli -tags=lite ./cmd/breadbox`), not by package name.
+
+## CI matrix
+
+Three jobs in `.github/workflows/ci.yml` once PR-03 ships:
+
+1. **default** — `go build ./...`, `go vet ./...`, `go test -tags integration -p 1 ./...`
+2. **headless** — `go build -tags=headless ./...`, `go vet -tags=headless ./...`, `go test -tags=headless,integration -p 1 ./...` (the integration suite still runs; dashboard-only tests are gated by `!headless` on their files)
+3. **lite** — `go build -tags=lite ./...`, `go vet -tags=lite ./...`, `go test -tags=lite ./...` (no integration tag; lite cannot reach a DB)
+
+All three are required for merge. The Makefile gains `build-headless` and `build-lite` once PR-03 lands.
+
+## The rule — triage every new file
+
+When adding a `.go` file, ask in order:
+
+1. **Does this file render or import dashboard assets?** (templates, session manager, sm-wrapped handlers, embedded `web/`) → `//go:build !headless` at the top.
+2. **Does this file need a server runtime?** (chi, pgx, providers, sync engine) → `//go:build !lite`.
+3. **Neither?** → no tag.
+
+Examples:
+
+- New REST handler in `internal/api/` → `!lite` (the whole package is server-only).
+- New admin page in `internal/templates/` → `!headless` (and the package's umbrella `!headless` already applies).
+- New cobra command in `internal/cli/` → no tag.
+- New service helper that's shared by CLI local-mode and the server → no tag, and **must not import anything `!lite`**.
+
+## Anti-patterns
+
+- **Tagged test, untagged prod.** Don't put `//go:build !headless` on `foo_test.go` when `foo.go` has no tag. The test will silently stop compiling under `-tags=headless` and you won't know it broke.
+- **Tagged service code.** `internal/service/` stays untagged when consumed by tag-free CLI local commands. If a service helper imports a tagged package, factor the helper into a tag-free sub-package and the tagged glue stays in the consumer.
+- **`//go:build !lite && !headless`.** Two negations on one file usually means the file is in the wrong package. The dashboard packages get `!headless`; their server dependencies get `!lite`. A file rarely needs both.
+- **Build-tag drift in CI.** Don't add a new tag (`-tags=foo`) without adding a CI job for it. Untested tags rot in a release.
+
+## What's NOT in this rule
+
+- **Runtime flags.** `breadbox serve --no-dashboard` is a runtime gate, not a compile-time one. It's documented in `breadbox serve --help` (and in `docs/cli-commands.md`). The build-tag side that *removes the assets entirely* is `-tags=headless`.
+- **MCP transport modes.** `--mcp-mode=read_only` and friends are runtime config in `app_config`, not build tags.
+- **Per-provider opt-out.** If a deployment doesn't want Plaid, leave the env vars unset — providers self-register from config. No build tag for that.
+
+When in doubt, default to no tag and let the import graph tell you what's broken.

--- a/cmd/breadbox/doctor.go
+++ b/cmd/breadbox/doctor.go
@@ -7,14 +7,11 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -242,7 +239,7 @@ func checkDatabase(ctx context.Context, cfg *config.Config) (doctorCheck, doctor
 
 // checkMigrations compares the applied goose_db_version against embedded migration files.
 func checkMigrations(ctx context.Context, databaseURL string) doctorCheck {
-	latest, err := latestEmbeddedMigration()
+	latest, err := db.LatestEmbeddedMigration()
 	if err != nil {
 		return doctorCheck{
 			Name:        "migrations",
@@ -303,36 +300,6 @@ func checkMigrations(ctx context.Context, databaseURL string) doctorCheck {
 		Status:  doctorStatusPass,
 		Message: fmt.Sprintf("up-to-date (version %d)", applied),
 	}
-}
-
-// latestEmbeddedMigration returns the highest numeric prefix among embedded migrations.
-func latestEmbeddedMigration() (int64, error) {
-	entries, err := fs.ReadDir(db.Migrations, "migrations")
-	if err != nil {
-		return 0, err
-	}
-	prefix := regexp.MustCompile(`^(\d+)_`)
-	var versions []int64
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
-			continue
-		}
-		m := prefix.FindStringSubmatch(e.Name())
-		if len(m) != 2 {
-			continue
-		}
-		var v int64
-		_, err := fmt.Sscanf(m[1], "%d", &v)
-		if err != nil {
-			continue
-		}
-		versions = append(versions, v)
-	}
-	if len(versions) == 0 {
-		return 0, fmt.Errorf("no migrations found")
-	}
-	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
-	return versions[len(versions)-1], nil
 }
 
 // checkEncryptionKey validates ENCRYPTION_KEY is set and hex-decodes to 32 bytes.

--- a/cmd/breadbox/doctor_test.go
+++ b/cmd/breadbox/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"breadbox/internal/config"
+	"breadbox/internal/db"
 )
 
 func TestCheckEncryptionKey(t *testing.T) {
@@ -173,9 +174,9 @@ func TestCheckPublicURL(t *testing.T) {
 }
 
 func TestLatestEmbeddedMigration(t *testing.T) {
-	v, err := latestEmbeddedMigration()
+	v, err := db.LatestEmbeddedMigration()
 	if err != nil {
-		t.Fatalf("latestEmbeddedMigration: %v", err)
+		t.Fatalf("LatestEmbeddedMigration: %v", err)
 	}
 	if v <= 0 {
 		t.Fatalf("expected a positive version, got %d", v)

--- a/cmd/breadbox/main.go
+++ b/cmd/breadbox/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -133,6 +134,18 @@ func runServe() error {
 	if err != nil {
 		return fmt.Errorf("load config: %w", err)
 	}
+
+	// Parse serve-specific flags. Env (BREADBOX_NO_DASHBOARD) sets the default;
+	// the flag, if supplied, wins. Use ContinueOnError so unknown flags don't
+	// kill the process via flag.ExitOnError's os.Exit before we can format a
+	// useful error.
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	noDashboard := fs.Bool("no-dashboard", cfg.NoDashboard, "disable the admin dashboard, v2 SPA, and /web/v1 routes (REST + MCP + OAuth stay up)")
+	if err := fs.Parse(os.Args[2:]); err != nil {
+		return fmt.Errorf("parse serve flags: %w", err)
+	}
+	cfg.NoDashboard = *noDashboard
+
 	cfg.Version = version
 	cfg.StartTime = time.Now()
 
@@ -299,7 +312,11 @@ func runServe() error {
 	if cfg.EncryptionKey == nil {
 		logger.Warn("ENCRYPTION_KEY not set — encrypted provider credentials will not work")
 	}
-	if adminCount == 0 {
+	if cfg.NoDashboard {
+		logger.Info("dashboard disabled", "mode", "headless-runtime")
+	} else if adminCount == 0 {
+		// Only nag about the admin account when the dashboard is actually
+		// reachable; under --no-dashboard there's nothing to log in to.
 		logger.Warn("no admin account — create one at /setup or via 'breadbox create-admin'")
 	}
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -12,6 +12,7 @@ All endpoints live under `/api/v1/` and require `X-API-Key` unless noted. Scope 
 | GET | `/health/live` | none | Alias of `/health` |
 | GET | `/health/ready` | none | DB + scheduler readiness |
 | GET | `/api/v1/version` | none | Build version + upgrade check |
+| GET | `/api/v1/headless/bootstrap` | R | Setup readiness report (consumed by `breadbox doctor`) |
 
 ## Accounts
 

--- a/internal/api/headless.go
+++ b/internal/api/headless.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"net/http"
+
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+)
+
+// HeadlessBootstrapHandler returns a one-shot readiness report for the CLI's
+// `doctor` command (and any external orchestrator). Mounted under
+// /api/v1/headless/bootstrap; any API key (read or write) is sufficient.
+//
+// The response shape is HeadlessBootstrapResponse in internal/service; see
+// also docs/api-endpoints.md and the OpenAPI spec.
+func HeadlessBootstrapHandler(svc *service.Service, a *app.App, version string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		in := service.HeadlessBootstrapInput{
+			Version:          version,
+			EncryptionKeySet: a.Config.EncryptionKey != nil,
+			SchedulerRunning: a.Scheduler != nil && a.Scheduler.IsRunning(),
+			Providers:        collectProviderStatus(a),
+		}
+		// Latest embedded migration version — used to compute
+		// "migrations_current". Best-effort: if the embed read fails the
+		// report still goes out, just with version=0 and current=false.
+		if latest, err := db.LatestEmbeddedMigration(); err == nil {
+			in.LatestMigrationVersion = latest
+		}
+
+		resp, err := svc.HeadlessBootstrap(r.Context(), in)
+		if err != nil {
+			// Service only surfaces an error when the DB is unreachable.
+			// Return 503 so a healthcheck can flag the box as not-ready;
+			// the body still carries whatever partial info we have.
+			mw.WriteError(w, http.StatusServiceUnavailable, "DB_UNAVAILABLE", err.Error())
+			return
+		}
+		writeData(w, resp)
+	}
+}
+
+// collectProviderStatus walks the configured providers and reports which are
+// wired. Order is stable (plaid, teller) so the report doesn't churn between
+// calls. Provider env (sandbox / production / etc.) is only emitted when the
+// provider is configured — keeps the JSON tidy for `breadbox doctor` output.
+func collectProviderStatus(a *app.App) []service.HeadlessProvider {
+	out := []service.HeadlessProvider{
+		{Name: "plaid", Configured: a.Config.PlaidClientID != ""},
+		{Name: "teller", Configured: a.Config.TellerAppID != ""},
+	}
+	if out[0].Configured {
+		out[0].Env = a.Config.PlaidEnv
+	}
+	if out[1].Configured {
+		out[1].Env = a.Config.TellerEnv
+	}
+	return out
+}

--- a/internal/api/headless_integration_test.go
+++ b/internal/api/headless_integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/app"
+	"breadbox/internal/config"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+	bsync "breadbox/internal/sync"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// TestHeadlessBootstrap exercises GET /api/v1/headless/bootstrap end-to-end:
+// the handler stitches process-scoped facts (encryption key, providers,
+// scheduler) onto DB-derived counts. We don't run a scheduler in the test
+// (it would race with other integration tests), so SchedulerRunning stays
+// false; everything else is covered.
+func TestHeadlessBootstrap(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "headless-test", "read_only")
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	cfg := &config.Config{
+		EncryptionKey: []byte("01234567890123456789012345678901"), // 32 bytes
+		PlaidClientID: "plaid-test-id",
+		PlaidEnv:      "sandbox",
+		// Teller deliberately unconfigured.
+	}
+	a := &app.App{
+		DB:      pool,
+		Queries: queries,
+		Config:  cfg,
+		Logger:  slog.Default(),
+	}
+
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Get("/headless/bootstrap", HeadlessBootstrapHandler(svc, a, "v0.test"))
+	})
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequest("GET", srv.URL+"/api/v1/headless/bootstrap", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("X-API-Key", keyResult.PlaintextKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", resp.StatusCode)
+	}
+
+	var report service.HeadlessBootstrapResponse
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+
+	if report.Version != "v0.test" {
+		t.Errorf("version: got %q, want v0.test", report.Version)
+	}
+	if !report.EncryptionKeySet {
+		t.Errorf("encryption_key_set: got false, want true")
+	}
+	if !report.Database.Connected {
+		t.Errorf("database.connected: got false, want true")
+	}
+	if report.Database.MigrationsCurrent != true {
+		t.Errorf("database.migrations_current: got false (applied=%d) — test DB should have all migrations applied via TestMain", report.Database.MigrationVersion)
+	}
+	// First-run: fresh test DB has no api key created by service — but we
+	// created one above, and no login accounts. So first_run should be true
+	// (login_accounts_count is the gate, not api_keys_count).
+	if !report.FirstRun {
+		t.Errorf("first_run: got false, want true (no login accounts in fixture)")
+	}
+	if report.LoginAccountsCount != 0 {
+		t.Errorf("login_accounts_count: got %d, want 0", report.LoginAccountsCount)
+	}
+	if report.APIKeysCount < 1 {
+		t.Errorf("api_keys_count: got %d, want >=1 (we created one)", report.APIKeysCount)
+	}
+
+	// Provider rows — order is stable.
+	if len(report.Providers) != 2 {
+		t.Fatalf("providers: got %d rows, want 2", len(report.Providers))
+	}
+	if report.Providers[0].Name != "plaid" || !report.Providers[0].Configured || report.Providers[0].Env != "sandbox" {
+		t.Errorf("providers[0] plaid: %+v", report.Providers[0])
+	}
+	if report.Providers[1].Name != "teller" || report.Providers[1].Configured {
+		t.Errorf("providers[1] teller: %+v (want unconfigured)", report.Providers[1])
+	}
+
+	// Scheduler is not running in this test fixture.
+	if report.SchedulerRunning {
+		t.Errorf("scheduler_running: got true, want false (no scheduler in fixture)")
+	}
+}
+
+// TestHeadlessBootstrap_NoEncryptionKey verifies the encryption_key_set
+// field flips when the key is unset.
+func TestHeadlessBootstrap_NoEncryptionKey(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+	svc := service.New(queries, pool, engine, slog.Default())
+
+	keyResult, err := svc.CreateAPIKey(t.Context(), "headless-no-key", "read_only")
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	a := &app.App{
+		DB:      pool,
+		Queries: queries,
+		Config:  &config.Config{}, // EncryptionKey nil
+		Logger:  slog.Default(),
+	}
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Get("/headless/bootstrap", HeadlessBootstrapHandler(svc, a, "v0.test"))
+	})
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	req, _ := http.NewRequest("GET", srv.URL+"/api/v1/headless/bootstrap", nil)
+	req.Header.Set("X-API-Key", keyResult.PlaintextKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var report service.HeadlessBootstrapResponse
+	if err := json.NewDecoder(resp.Body).Decode(&report); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if report.EncryptionKeySet {
+		t.Errorf("encryption_key_set: got true, want false")
+	}
+}

--- a/internal/api/no_dashboard_integration_test.go
+++ b/internal/api/no_dashboard_integration_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/app"
+	"breadbox/internal/config"
+	bsync "breadbox/internal/sync"
+	"breadbox/internal/testutil"
+)
+
+// TestNoDashboard_GatesAdminButKeepsAPIAndDiscovery exercises the runtime
+// --no-dashboard switch. We build a real chi router via api.NewRouter so the
+// gating logic in router.go is what gets tested. The dashboard surface must
+// 404; the REST API + OAuth discovery + version endpoints must stay up.
+func TestNoDashboard_GatesAdminButKeepsAPIAndDiscovery(t *testing.T) {
+	pool, queries := testutil.ServicePool(t)
+	engine := bsync.NewEngine(queries, pool, nil, slog.Default())
+
+	cfg := &config.Config{
+		ServerPort:        "0",
+		Environment:       "local",
+		NoDashboard:       true,
+		APIRateLimitRPM:   120,
+		APIRateLimitBurst: 60,
+	}
+	a := &app.App{
+		DB:         pool,
+		Queries:    queries,
+		Config:     cfg,
+		Logger:     slog.Default(),
+		SyncEngine: engine,
+		Providers:  nil,
+	}
+
+	// "dev" version short-circuits VersionHandler's GitHub probe (which
+	// would otherwise NPE on the nil VersionChecker — populated only by
+	// runServe). The endpoint still returns 200 with update_available=false.
+	router := NewRouter(a, "dev")
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	cases := []struct {
+		name     string
+		path     string
+		wantCode int
+	}{
+		// REST + meta — must stay up.
+		{"version", "/api/v1/version", http.StatusOK},
+		{"health_live", "/health/live", http.StatusOK},
+		// OAuth 2.1 discovery — MCP clients depend on this.
+		{"oauth_metadata", "/.well-known/oauth-authorization-server", http.StatusOK},
+		{"oauth_resource", "/.well-known/oauth-protected-resource", http.StatusOK},
+		// Dashboard — must be gone.
+		{"admin_root", "/", http.StatusNotFound},
+		{"v2_spa", "/v2/", http.StatusNotFound},
+		{"web_v1_me", "/web/v1/me", http.StatusNotFound},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Get(srv.URL + tc.path)
+			if err != nil {
+				t.Fatalf("get %s: %v", tc.path, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != tc.wantCode {
+				t.Errorf("%s: status got %d, want %d", tc.path, resp.StatusCode, tc.wantCode)
+			}
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -90,6 +90,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Get("/settings/providers", GetProviderConfigHandler(a))
 		r.Get("/providers", ListProvidersHandler(a))
 		r.Get("/providers/{name}", GetProviderHandler(a))
+		r.Get("/headless/bootstrap", HeadlessBootstrapHandler(svc, a, version))
 
 		// Write endpoints — full_access API keys only.
 		r.Group(func(r chi.Router) {
@@ -210,34 +211,41 @@ func NewRouter(a *app.App, version string) http.Handler {
 	r.Post("/oauth/token", admin.OAuthTokenHandler(svc))
 	r.Post("/oauth/register", admin.OAuthRegisterHandler(svc))
 
-	// Admin dashboard: session manager + template renderer + admin router.
-	isSecure := a.Config.Environment == "production" || a.Config.Environment == "docker"
-	sm := admin.NewSessionManager(a.DB, isSecure)
+	// Admin dashboard, v2 SPA, and /web/v1 — all gated by the runtime
+	// --no-dashboard flag. When disabled, REST + MCP + OAuth + webhooks stay
+	// reachable; the dashboard surface is silently absent (no admin router
+	// mounted on "/" — bare GET / returns 404). The build-tag side that
+	// strips the assets entirely is `-tags=headless` (see
+	// .claude/rules/build-tags.md).
+	if !a.Config.NoDashboard {
+		isSecure := a.Config.Environment == "production" || a.Config.Environment == "docker"
+		sm := admin.NewSessionManager(a.DB, isSecure)
 
-	// v2 SPA — internal frontend API and embedded static bundle.
-	// /web/v1/* is session-only, never accepts API keys, and carries zero
-	// stability promise (it is exclusively consumed by the v2 SPA).
-	r.Group(func(r chi.Router) {
-		r.Use(sm.LoadAndSave)
-		r.Route("/web/v1", func(r chi.Router) {
-			r.Use(webui.RequireSessionJSON(sm))
-			r.Get("/me", webui.MeHandler(sm))
+		// v2 SPA — internal frontend API and embedded static bundle.
+		// /web/v1/* is session-only, never accepts API keys, and carries zero
+		// stability promise (it is exclusively consumed by the v2 SPA).
+		r.Group(func(r chi.Router) {
+			r.Use(sm.LoadAndSave)
+			r.Route("/web/v1", func(r chi.Router) {
+				r.Use(webui.RequireSessionJSON(sm))
+				r.Get("/me", webui.MeHandler(sm))
+			})
+			// /v2/* — embedded SPA static bundle. The session middleware lets
+			// the SPA shell load on /login, but the SPA's own queries
+			// (/web/v1/me) gate the authenticated content.
+			r.Handle("/v2", http.RedirectHandler("/v2/", http.StatusMovedPermanently))
+			r.Handle("/v2/*", webui.Handler())
 		})
-		// /v2/* — embedded SPA static bundle. The session middleware lets
-		// the SPA shell load on /login, but the SPA's own queries
-		// (/web/v1/me) gate the authenticated content.
-		r.Handle("/v2", http.RedirectHandler("/v2/", http.StatusMovedPermanently))
-		r.Handle("/v2/*", webui.Handler())
-	})
 
-	tr, err := admin.NewTemplateRenderer(sm)
-	if err != nil {
-		a.Logger.Error("failed to initialize template renderer", "error", err)
-	} else {
-		tr.SetVersion(a.Config.Version)
-		tr.SetVersionChecker(a.VersionChecker)
-		adminRouter := admin.NewAdminRouter(a, sm, tr, svc, mcpServer)
-		r.Mount("/", adminRouter)
+		tr, err := admin.NewTemplateRenderer(sm)
+		if err != nil {
+			a.Logger.Error("failed to initialize template renderer", "error", err)
+		} else {
+			tr.SetVersion(a.Config.Version)
+			tr.SetVersionChecker(a.VersionChecker)
+			adminRouter := admin.NewAdminRouter(a, sm, tr, svc, mcpServer)
+			r.Mount("/", adminRouter)
+		}
 	}
 
 	return r

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,14 @@ type Config struct {
 	APIRateLimitRPM   int // API_RATE_LIMIT_RPM, default 120
 	APIRateLimitBurst int // API_RATE_LIMIT_BURST, default 60
 
+	// Runtime gates. NoDashboard, when true, prevents the HTTP router from
+	// registering the admin dashboard, the v2 SPA, and the /web/v1 routes.
+	// REST, MCP, OAuth discovery, and webhooks stay up. Set by
+	// `breadbox serve --no-dashboard` or BREADBOX_NO_DASHBOARD=true. The
+	// build-tag side that strips the assets entirely is `-tags=headless`
+	// (see .claude/rules/build-tags.md).
+	NoDashboard bool
+
 	// Runtime metadata (set at startup)
 	Version   string
 	StartTime time.Time

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"breadbox/internal/crypto"
 
@@ -105,7 +106,19 @@ func Load() (*Config, error) {
 	cfg.APIRateLimitRPM = getEnvInt("API_RATE_LIMIT_RPM", 120)
 	cfg.APIRateLimitBurst = getEnvInt("API_RATE_LIMIT_BURST", 60)
 
+	// Dashboard gate. Truthy values: "1", "true", "yes", "on" (case-insensitive).
+	cfg.NoDashboard = parseBool(os.Getenv("BREADBOX_NO_DASHBOARD"))
+
 	return cfg, nil
+}
+
+// parseBool returns true for "1", "true", "yes", "on" (case-insensitive); false otherwise.
+func parseBool(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 // LoadWithDB merges app_config table values into the config. Environment

--- a/internal/db/migration_version.go
+++ b/internal/db/migration_version.go
@@ -1,0 +1,45 @@
+package db
+
+import (
+	"fmt"
+	"io/fs"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// LatestEmbeddedMigration returns the highest numeric prefix across the
+// embedded migrations directory. Goose sorts by this prefix, so the value
+// equals the version id stamped into goose_db_version once everything has
+// been applied. Used by `breadbox doctor` and the headless bootstrap
+// endpoint to detect "schema is behind embedded migrations".
+//
+// Returns 0 + an error if no migrations are present (which indicates the
+// binary was built without the embed root).
+func LatestEmbeddedMigration() (int64, error) {
+	entries, err := fs.ReadDir(Migrations, "migrations")
+	if err != nil {
+		return 0, err
+	}
+	prefix := regexp.MustCompile(`^(\d+)_`)
+	var versions []int64
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		m := prefix.FindStringSubmatch(e.Name())
+		if len(m) != 2 {
+			continue
+		}
+		var v int64
+		if _, err := fmt.Sscanf(m[1], "%d", &v); err != nil {
+			continue
+		}
+		versions = append(versions, v)
+	}
+	if len(versions) == 0 {
+		return 0, fmt.Errorf("no migrations found")
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+	return versions[len(versions)-1], nil
+}

--- a/internal/service/headless.go
+++ b/internal/service/headless.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"fmt"
+)
+
+// HeadlessBootstrapInput carries the process-scoped facts the service can't
+// derive from the database alone (encryption key presence, provider config,
+// scheduler state, version). The handler at /api/v1/headless/bootstrap fills
+// it in from *app.App and *config.Config and hands it to HeadlessBootstrap;
+// the service stitches that together with DB-derived counts.
+type HeadlessBootstrapInput struct {
+	Version          string
+	EncryptionKeySet bool
+	SchedulerRunning bool
+	Providers        []HeadlessProvider
+	// LatestMigrationVersion is the highest embedded migration version
+	// (from cmd/breadbox/doctor.go::latestEmbeddedMigration). The handler
+	// supplies it so the service stays free of `io/fs` migration reads.
+	LatestMigrationVersion int64
+}
+
+// HeadlessProvider is one provider row in the bootstrap report.
+type HeadlessProvider struct {
+	Name       string `json:"name"`
+	Configured bool   `json:"configured"`
+	Env        string `json:"env,omitempty"`
+}
+
+// HeadlessDatabase reports on DB readiness for the bootstrap report.
+type HeadlessDatabase struct {
+	Connected         bool  `json:"connected"`
+	MigrationsCurrent bool  `json:"migrations_current"`
+	MigrationVersion  int64 `json:"migration_version"`
+}
+
+// HeadlessBootstrapResponse is the JSON shape returned by
+// GET /api/v1/headless/bootstrap. Used by `breadbox doctor` and any
+// orchestrator that wants a one-shot readiness summary.
+type HeadlessBootstrapResponse struct {
+	Version                string             `json:"version"`
+	EncryptionKeySet       bool               `json:"encryption_key_set"`
+	Database               HeadlessDatabase   `json:"database"`
+	Providers              []HeadlessProvider `json:"providers"`
+	UsersCount             int64              `json:"users_count"`
+	LoginAccountsCount     int64              `json:"login_accounts_count"`
+	APIKeysCount           int64              `json:"api_keys_count"`
+	ActiveConnectionsCount int64              `json:"active_connections_count"`
+	SchedulerRunning       bool               `json:"scheduler_running"`
+	FirstRun               bool               `json:"first_run"`
+}
+
+// HeadlessBootstrap returns a one-shot readiness report for the CLI's
+// `doctor` command (and any external orchestrator).
+//
+// The service is responsible for the DB-derived rows (counts, applied
+// migration version) and stitches the process-scoped facts from `in` onto
+// the response. If a count query fails the field stays zero — the report is
+// best-effort and never blocks a CLI session.
+func (s *Service) HeadlessBootstrap(ctx context.Context, in HeadlessBootstrapInput) (*HeadlessBootstrapResponse, error) {
+	resp := &HeadlessBootstrapResponse{
+		Version:          in.Version,
+		EncryptionKeySet: in.EncryptionKeySet,
+		Providers:        in.Providers,
+		SchedulerRunning: in.SchedulerRunning,
+	}
+	if resp.Providers == nil {
+		resp.Providers = []HeadlessProvider{}
+	}
+
+	// DB ping doubles as "are we connected": if the pool's Ping fails we
+	// surface that, but the request itself only got here because the DB
+	// pool is alive. We still call Ping so the result reflects reality at
+	// call time rather than assuming.
+	resp.Database.Connected = s.Pool.Ping(ctx) == nil
+
+	// Applied goose version. Query the goose_db_version table directly so we
+	// don't pull goose's runtime into the service layer. If the table is
+	// missing (fresh DB), applied stays 0 and migrations_current is false.
+	var applied int64
+	err := s.Pool.QueryRow(ctx,
+		"SELECT COALESCE(MAX(version_id), 0) FROM goose_db_version WHERE is_applied = true",
+	).Scan(&applied)
+	if err != nil {
+		s.Logger.Warn("headless bootstrap: read goose_db_version failed", "error", err)
+	}
+	resp.Database.MigrationVersion = applied
+	resp.Database.MigrationsCurrent = in.LatestMigrationVersion > 0 && applied >= in.LatestMigrationVersion
+
+	// Counts. Each failure is best-effort logged; the field stays zero.
+	if n, err := s.Queries.CountUsers(ctx); err == nil {
+		resp.UsersCount = n
+	} else {
+		s.Logger.Warn("headless bootstrap: count users failed", "error", err)
+	}
+	if n, err := s.Queries.CountAuthAccounts(ctx); err == nil {
+		resp.LoginAccountsCount = n
+	} else {
+		s.Logger.Warn("headless bootstrap: count auth accounts failed", "error", err)
+	}
+	if n, err := s.Queries.CountActiveApiKeys(ctx); err == nil {
+		resp.APIKeysCount = n
+	} else {
+		s.Logger.Warn("headless bootstrap: count api keys failed", "error", err)
+	}
+	// "Active" connections — status='active', un-paused. Soft-disconnected
+	// connections are excluded so the count matches "what's syncing".
+	var activeConns int64
+	if err := s.Pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM bank_connections WHERE status = 'active'`,
+	).Scan(&activeConns); err != nil {
+		s.Logger.Warn("headless bootstrap: count active connections failed", "error", err)
+	}
+	resp.ActiveConnectionsCount = activeConns
+
+	// first_run mirrors the admin redirect heuristic: zero login accounts
+	// means the operator hasn't completed setup yet.
+	resp.FirstRun = resp.LoginAccountsCount == 0
+
+	// Defensive: surface a non-nil error only when DB is plainly unreachable.
+	if !resp.Database.Connected {
+		return resp, fmt.Errorf("database is not reachable")
+	}
+	return resp, nil
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -137,6 +137,29 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/VersionResponse" }
 
+  /api/v1/headless/bootstrap:
+    get:
+      tags: [Health]
+      summary: Setup readiness report
+      description: |
+        Returns a one-shot readiness/setup summary intended for the
+        `breadbox doctor` CLI command. Any API key (read or write) works.
+        Fields are best-effort — a per-row failure stays zero and the report
+        still ships. The endpoint returns 503 only when the database is
+        plainly unreachable.
+      responses:
+        "200":
+          description: Bootstrap report.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/HeadlessBootstrapResponse" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "503":
+          description: Database is not reachable; partial report in body.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorEnvelope" }
+
   # -- Accounts --
   /api/v1/accounts:
     get:
@@ -2068,6 +2091,83 @@ components:
         version: { type: string }
         latest: { type: string, nullable: true }
         update_available: { type: boolean }
+    HeadlessBootstrapResponse:
+      type: object
+      description: Readiness/setup summary consumed by `breadbox doctor`.
+      required:
+        [
+          version,
+          encryption_key_set,
+          database,
+          providers,
+          users_count,
+          login_accounts_count,
+          api_keys_count,
+          active_connections_count,
+          scheduler_running,
+          first_run,
+        ]
+      properties:
+        version: { type: string, description: Server build version. }
+        encryption_key_set:
+          { type: boolean, description: True when ENCRYPTION_KEY is set. }
+        database:
+          type: object
+          required: [connected, migrations_current, migration_version]
+          properties:
+            connected: { type: boolean }
+            migrations_current:
+              {
+                type: boolean,
+                description: True when the applied goose version meets or exceeds the highest embedded migration.,
+              }
+            migration_version:
+              {
+                type: integer,
+                format: int64,
+                description: Highest version_id applied in goose_db_version (0 if unread).,
+              }
+        providers:
+          type: array
+          description: Provider configuration status. Order is stable (plaid, teller).
+          items:
+            type: object
+            required: [name, configured]
+            properties:
+              name: { type: string, enum: [plaid, teller] }
+              configured: { type: boolean }
+              env:
+                {
+                  type: string,
+                  description: "Environment label (e.g. sandbox, production). Omitted when not configured.",
+                }
+        users_count:
+          { type: integer, format: int64, description: Household user count. }
+        login_accounts_count:
+          {
+            type: integer,
+            format: int64,
+            description: Admin / dashboard login account count.,
+          }
+        api_keys_count:
+          {
+            type: integer,
+            format: int64,
+            description: Active (un-revoked) API key count.,
+          }
+        active_connections_count:
+          {
+            type: integer,
+            format: int64,
+            description: Bank connections in 'active' status.,
+          }
+        scheduler_running:
+          { type: boolean, description: True when the sync scheduler has active cron entries. }
+        first_run:
+          {
+            type: boolean,
+            description: True when `login_accounts_count == 0` — the same signal used by the admin first-run redirect.,
+          }
     Account:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Stage 0 PR-02 on the `feat/cli-headless` branch. Three foundational pieces for the headless CLI work — no CLI changes yet (those start in Stage 1):

1. **`.claude/rules/build-tags.md`** — written policy for the `headless` and `lite` build tags. Documents the package matrix, the CI matrix, the triage rule for new files, and anti-patterns. The actual `//go:build` annotations land in PR-03; this PR just establishes the contract.
2. **`breadbox serve --no-dashboard`** — runtime flag that skips registering the admin dashboard, the v2 SPA, and `/web/v1/*`. REST + MCP + OAuth discovery + webhooks stay reachable. Also available via `BREADBOX_NO_DASHBOARD=true`.
3. **`GET /api/v1/headless/bootstrap`** (B22) — readiness/setup report for the CLI's upcoming `doctor` command. Returns version, encryption-key presence, DB connection + migration status, per-provider config, counts (users / login accounts / api keys / active connections), scheduler state, and a `first_run` flag mirroring the admin first-run redirect.

## What changed

### `.claude/rules/build-tags.md` (new)
Companion rule alongside `cli-commands.md` and `api-endpoints.md`. Points forward to PR-03 for the actual constraints.

### `breadbox serve --no-dashboard`
- New `NoDashboard bool` field on `internal/config.Config`, loaded from `BREADBOX_NO_DASHBOARD`.
- `cmd/breadbox/main.go::runServe` now parses a small `flag.FlagSet` for serve-specific options; the flag overrides the env default.
- `internal/api/router.go` wraps the dashboard block (session manager + `/web/v1` + v2 SPA mount + admin router) in `if !a.Config.NoDashboard`. OAuth discovery, OAuth token/register, and `/webhooks/{provider}` stay outside the gate.
- Logs `dashboard disabled mode=headless-runtime` at startup; suppresses the "no admin account" warning when there's no dashboard to log into.

### `GET /api/v1/headless/bootstrap`
- `internal/service/headless.go` — `HeadlessBootstrap(ctx, in)` returning `HeadlessBootstrapResponse`. Service does DB counts (users / auth_accounts / active api keys / active connections), reads `goose_db_version` directly to avoid pulling goose into the service layer, and stitches in process-scoped facts (version, encryption-key flag, scheduler state, providers) via the input struct.
- `internal/api/headless.go` — handler glues `*app.App` + `*config.Config` onto the service call.
- `internal/db/migration_version.go` — `LatestEmbeddedMigration()` helper, factored out of `cmd/breadbox/doctor.go` so the handler can use it without duplicating the regex/sort logic. The doctor command and its test now call the shared helper.
- `openapi.yaml` — new path + `HeadlessBootstrapResponse` schema (drift test passes).
- `docs/api-endpoints.md` — row under Health/meta.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` (unit) green
- [x] `make test-integration` green, including:
  - [x] `TestHeadlessBootstrap` — verifies version, encryption-key flag, db.connected/migrations_current, provider rows, counts, first_run heuristic
  - [x] `TestHeadlessBootstrap_NoEncryptionKey` — flag flips with key unset
  - [x] `TestNoDashboard_GatesAdminButKeepsAPIAndDiscovery` — `/api/v1/version`, `/health/live`, `/.well-known/oauth-*` return 200 with `NoDashboard: true`; `/`, `/v2/`, `/web/v1/me` return 404
  - [x] `TestOpenAPIDrift` — router and spec agree

## Sequencing

- **Base**: `feat/cli-headless`. Do **not** target `main`.
- **PR-03** picks up this rule and applies the actual `//go:build !headless` / `!lite` constraints across the listed packages. Once that lands the Makefile + CI matrix will grow `build-headless` and `build-lite` cells.
- **Stage 1** will add the cobra CLI; `breadbox doctor` will consume the new bootstrap endpoint.
