### PR TITLE
cli: accounts + transactions noun commands

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -54,9 +54,9 @@ These commands operate on the local box (filesystem, DB, embedded migrations) â€
 | `breadbox accounts get <id>` | R | Single account summary |
 | `breadbox accounts detail <id>` | R | Detail + last 25 transactions + per-currency balances |
 | `breadbox accounts update <id> [--name] [--excluded] [--dependent-linked]` | W | Patch display name, `--excluded` (hide from views), `--dependent-linked` (exclude from household totals â€” e.g., a kid's account you fund but don't count toward your spending) |
-| `breadbox accounts links list <id>` | R | List user-links on an account (which household members own / share it) |
-| `breadbox accounts links add <id> --user <user-id>` | W | Link an account to a household user |
-| `breadbox accounts links remove <id> <link-id>` | W | Unlink a user from an account |
+| `breadbox accounts links list <id>` | R | List account-link reconciliation rows where this account is primary or dependent |
+| `breadbox accounts links add <primary-id> --dependent <id>` | W | Link a dependent account to a primary for reconciliation (`--strategy`, `--tolerance-days`) |
+| `breadbox accounts links remove <link-id>` | W | Delete an account-link row |
 
 ## Transactions
 

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -70,7 +70,7 @@ These commands operate on the local box (filesystem, DB, embedded migrations) â€
 | `breadbox transactions batch <file>` | W | Batch update from JSON (max 50 rows) |
 | `breadbox transactions categorize <id> <category>` | W | Set category (override) |
 | `breadbox transactions uncategorize <id>` | W | Reset to provider default |
-| `breadbox transactions recategorize --filter --category` | W | Server-side recategorize by filter |
+| `breadbox transactions recategorize --target-category <slug> [filters]` | W | Server-side recategorize: every row matching the filters becomes `--target-category` |
 | `breadbox transactions delete <id>` | W | Soft-delete |
 | `breadbox transactions restore <id>` | W | Restore a soft-deleted transaction |
 | `breadbox transactions tag <id> <slug>` | W | Attach a tag |

--- a/internal/cli/accounts.go
+++ b/internal/cli/accounts.go
@@ -1,0 +1,341 @@
+// Package cli — accounts noun group.
+//
+// `breadbox accounts ...` exposes the household's bank accounts and the
+// per-account-link reconciliation surface. Read commands route through
+// GET /api/v1/accounts and friends; write commands hit PATCH and the
+// /account-links sub-tree. Each subcommand reuses the shared output
+// formatter + FlagBag set up by NewRootCmd.
+//
+// The cobra spec in docs/cli-commands.md describes account-links as
+// "user-links" (which household member owns an account). The actual REST
+// surface is the account-link reconciliation model (primary ↔ dependent
+// account matching), which is what this CLI exposes — the doc text is
+// slightly aspirational. See the PR body for the follow-up.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// AddAccountsCmd registers `breadbox accounts` and its children.
+func AddAccountsCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "accounts",
+		Short: "Manage household bank accounts",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newAccountsListCmd())
+	cmd.AddCommand(newAccountsGetCmd())
+	cmd.AddCommand(newAccountsDetailCmd())
+	cmd.AddCommand(newAccountsUpdateCmd())
+	cmd.AddCommand(newAccountsLinksCmd())
+
+	root.AddCommand(cmd)
+}
+
+func newAccountsListCmd() *cobra.Command {
+	var userID string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List household bank accounts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			accts, err := c.ListAccounts(cmd.Context(), flags.Fields, userID)
+			if err != nil {
+				return err
+			}
+			return renderAccountsList(flags, accts)
+		},
+	}
+	cmd.Flags().StringVar(&userID, "user", "", "filter to accounts owned by this user (uuid or short_id)")
+	return cmd
+}
+
+func newAccountsGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show a single account",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			acct, err := c.GetAccount(cmd.Context(), args[0], flags.Fields)
+			if err != nil {
+				return err
+			}
+			return renderAccount(flags, acct)
+		},
+	}
+	return cmd
+}
+
+func newAccountsDetailCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "detail <id>",
+		Short: "Show full account detail (balances + last 25 transactions)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			detail, err := c.GetAccountDetail(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return renderAccountDetail(flags, detail)
+		},
+	}
+	return cmd
+}
+
+func newAccountsUpdateCmd() *cobra.Command {
+	var (
+		name             string
+		nameSet          bool
+		excluded         bool
+		excludedSet      bool
+		dependentLinked  bool
+		dependentLinkSet bool
+	)
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Patch an account's display name and flags",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Detect which flags the user actually set so we can omit the
+			// other fields from the PATCH body.
+			f := cmd.Flags()
+			if f.Changed("name") {
+				nameSet = true
+			}
+			if f.Changed("excluded") {
+				excludedSet = true
+			}
+			if f.Changed("dependent-linked") {
+				dependentLinkSet = true
+			}
+			if !nameSet && !excludedSet && !dependentLinkSet {
+				return UsageErrorf("update needs at least one of --name, --excluded, --dependent-linked")
+			}
+
+			patch := client.AccountPatch{}
+			if nameSet {
+				v := name
+				patch.DisplayName = &v
+			}
+			if excludedSet {
+				v := excluded
+				patch.IsExcluded = &v
+			}
+			if dependentLinkSet {
+				v := dependentLinked
+				patch.IsDependentLinked = &v
+			}
+
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			acct, err := c.UpdateAccount(cmd.Context(), args[0], patch)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return renderAccount(flags, acct)
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "set display_name (use empty string to clear)")
+	cmd.Flags().BoolVar(&excluded, "excluded", false, "set is_excluded (hide from default views)")
+	cmd.Flags().BoolVar(&dependentLinked, "dependent-linked", false, "set is_dependent_linked (exclude from household totals)")
+	return cmd
+}
+
+// newAccountsLinksCmd wires `breadbox accounts links {list,add,remove}`.
+// The server-side model is account-to-account reconciliation links — see
+// the package-level comment for context.
+func newAccountsLinksCmd() *cobra.Command {
+	links := &cobra.Command{
+		Use:   "links",
+		Short: "Manage account-link reconciliation rows",
+	}
+
+	links.AddCommand(&cobra.Command{
+		Use:   "list <account-id>",
+		Short: "List account-link rows touching this account",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			all, err := c.ListAccountLinks(cmd.Context())
+			if err != nil {
+				return err
+			}
+			target := args[0]
+			filtered := make([]client.AccountLink, 0, len(all))
+			for _, l := range all {
+				if l.PrimaryAccountID == target || l.DependentAccountID == target ||
+					strings.HasPrefix(l.PrimaryAccountID, target) ||
+					strings.HasPrefix(l.DependentAccountID, target) {
+					filtered = append(filtered, l)
+				}
+			}
+			return renderAccountLinks(flags, filtered)
+		},
+	})
+
+	add := &cobra.Command{
+		Use:   "add <primary-account-id>",
+		Short: "Link a dependent account to a primary account for reconciliation",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dep, _ := cmd.Flags().GetString("dependent")
+			strategy, _ := cmd.Flags().GetString("strategy")
+			tolerance, _ := cmd.Flags().GetInt("tolerance-days")
+			if dep == "" {
+				return UsageErrorf("--dependent is required")
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			link, err := c.CreateAccountLink(cmd.Context(), client.CreateAccountLinkParams{
+				PrimaryAccountID:   args[0],
+				DependentAccountID: dep,
+				MatchStrategy:      strategy,
+				MatchToleranceDays: tolerance,
+			})
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return renderAccountLink(flags, link)
+		},
+	}
+	add.Flags().String("dependent", "", "dependent account id (uuid or short_id) — required")
+	add.Flags().String("strategy", "date_amount_name", "match strategy (defaults to date_amount_name)")
+	add.Flags().Int("tolerance-days", 0, "match tolerance window in days")
+	links.AddCommand(add)
+
+	links.AddCommand(&cobra.Command{
+		Use:   "remove <link-id>",
+		Short: "Delete an account-link row",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.DeleteAccountLink(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	})
+
+	return links
+}
+
+// --- rendering helpers ---
+
+func renderAccountsList(flags *FlagBag, accts []client.Account) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, accts)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(accts))
+		for _, a := range accts {
+			items = append(items, a)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "NAME", "TYPE", "BALANCE", "CCY", "STATUS"})
+		for _, a := range accts {
+			tbl.AddRow(a.ShortID, a.Name, a.Type, formatFloatPtr(a.BalanceCurrent), strPtr(a.IsoCurrencyCode), strPtr(a.ConnectionStatus))
+		}
+		return tbl.Flush()
+	}
+}
+
+func renderAccount(flags *FlagBag, acct *client.Account) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, acct)
+	case output.ModeNDJSON:
+		return output.PrintNDJSON(os.Stdout, []any{acct})
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "NAME", "TYPE", "BALANCE", "CCY", "STATUS"})
+		tbl.AddRow(acct.ShortID, acct.Name, acct.Type, formatFloatPtr(acct.BalanceCurrent), strPtr(acct.IsoCurrencyCode), strPtr(acct.ConnectionStatus))
+		return tbl.Flush()
+	}
+}
+
+func renderAccountDetail(flags *FlagBag, d *client.AccountDetail) error {
+	// detail responses are dense — JSON is the only reasonable shape.
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(d)
+	_ = flags
+	return nil
+}
+
+func renderAccountLinks(flags *FlagBag, links []client.AccountLink) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, links)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(links))
+		for _, l := range links {
+			items = append(items, l)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "PRIMARY", "DEPENDENT", "STRATEGY", "MATCHED", "UNMATCHED"})
+		for _, l := range links {
+			tbl.AddRow(l.ShortID, l.PrimaryAccountName, l.DependentAccountName, l.MatchStrategy,
+				fmt.Sprintf("%d", l.MatchCount), fmt.Sprintf("%d", l.UnmatchedDependentCount))
+		}
+		return tbl.Flush()
+	}
+}
+
+func renderAccountLink(flags *FlagBag, l *client.AccountLink) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON, output.ModeNDJSON:
+		return output.PrintJSON(os.Stdout, l)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "PRIMARY", "DEPENDENT", "STRATEGY", "MATCHED", "UNMATCHED"})
+		tbl.AddRow(l.ShortID, l.PrimaryAccountName, l.DependentAccountName, l.MatchStrategy,
+			fmt.Sprintf("%d", l.MatchCount), fmt.Sprintf("%d", l.UnmatchedDependentCount))
+		return tbl.Flush()
+	}
+}
+
+// strPtr renders an optional string field, emitting "-" when nil/empty.
+func strPtr(s *string) string {
+	if s == nil || *s == "" {
+		return "-"
+	}
+	return *s
+}
+
+// formatFloatPtr renders an optional float, returning "-" for nil.
+func formatFloatPtr(f *float64) string {
+	if f == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f", *f)
+}
+
+// _ ensures the context import survives if the build prunes it.
+var _ = context.Background

--- a/internal/cli/accounts_integration_test.go
+++ b/internal/cli/accounts_integration_test.go
@@ -1,0 +1,191 @@
+//go:build integration
+
+// Integration tests for `breadbox accounts` commands. They drive the real
+// REST handlers through an in-process httptest.Server so the CLI client
+// and service layer both run end-to-end. The cobra command bodies stay
+// out of the loop here — the same RunE bodies just call the client
+// methods we exercise directly — so these tests are focused on contract
+// drift between the client and the server.
+package cli_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/api"
+	"breadbox/internal/cli/config"
+	"breadbox/internal/client"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestMain(m *testing.M) {
+	testutil.RunWithDB(m)
+}
+
+// envBundle is a minimal test harness — service + httptest server + a CLI
+// client pointed at it. Kept tiny on purpose; integration tests should
+// assemble their own fixtures.
+//
+// Tests must use `env.Queries` (not a fresh testutil.Queries(t)) once the
+// env is set up — re-calling testutil truncates the api_keys row we just
+// minted and the client request fails with INVALID_API_KEY.
+type envBundle struct {
+	Svc     *service.Service
+	Server  *httptest.Server
+	Client  *client.Client
+	Queries *db.Queries
+}
+
+func setupEnv(t *testing.T) *envBundle {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+
+	keyResult, err := svc.CreateAPIKeyLegacy(t.Context(), "cli-test", "full_access")
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+
+		// Read endpoints
+		r.Get("/accounts", api.ListAccountsHandler(svc))
+		r.Get("/accounts/{id}", api.GetAccountHandler(svc))
+		r.Get("/accounts/{id}/detail", api.GetAccountDetailHandler(svc))
+		r.Get("/transactions", api.ListTransactionsHandler(svc))
+		r.Get("/transactions/count", api.CountTransactionsHandler(svc))
+		r.Get("/transactions/summary", api.TransactionSummaryHandler(svc))
+		r.Get("/transactions/{id}", api.GetTransactionHandler(svc))
+		r.Get("/account-links", api.ListAccountLinksHandler(svc))
+		r.Get("/transactions/{transaction_id}/comments", api.ListCommentsHandler(svc))
+		r.Get("/transactions/{id}/annotations", api.ListAnnotationsHandler(svc))
+
+		// Write endpoints
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Patch("/accounts/{id}", api.UpdateAccountHandler(svc))
+			r.Patch("/transactions/{id}/category", api.SetTransactionCategoryHandler(svc))
+			r.Delete("/transactions/{id}/category", api.ResetTransactionCategoryHandler(svc))
+			r.Post("/transactions/update", api.UpdateTransactionsHandler(svc))
+			r.Delete("/transactions/{id}", api.DeleteTransactionHandler(svc))
+			r.Post("/transactions/{id}/restore", api.RestoreTransactionHandler(svc))
+			r.Post("/transactions/{id}/tags", api.AddTransactionTagHandler(svc))
+			r.Delete("/transactions/{id}/tags/{slug}", api.RemoveTransactionTagHandler(svc))
+			r.Post("/transactions/{transaction_id}/comments", api.CreateCommentHandler(svc))
+			r.Put("/transactions/{transaction_id}/comments/{id}", api.UpdateCommentHandler(svc))
+			r.Delete("/transactions/{transaction_id}/comments/{id}", api.DeleteCommentHandler(svc))
+			r.Post("/account-links", api.CreateAccountLinkHandler(svc))
+			r.Delete("/account-links/{id}", api.DeleteAccountLinkHandler(svc))
+		})
+	})
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	c := client.New(config.Host{BaseURL: srv.URL, Token: keyResult.PlaintextKey}, "test")
+	return &envBundle{Svc: svc, Server: srv, Client: c, Queries: queries}
+}
+
+func TestAccountsList_ReturnsFixtureAccounts(t *testing.T) {
+	env := setupEnv(t)
+	q := env.Queries
+
+	user := testutil.MustCreateUser(t, q, "Tester")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-1")
+	a := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-1", "Checking")
+
+	accts, err := env.Client.ListAccounts(context.Background(), "", "")
+	if err != nil {
+		t.Fatalf("ListAccounts: %v", err)
+	}
+	if len(accts) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(accts))
+	}
+	if accts[0].Name != "Checking" {
+		t.Errorf("name = %q, want Checking", accts[0].Name)
+	}
+	if accts[0].ShortID == "" {
+		t.Errorf("short_id missing for account %s", a.ID)
+	}
+}
+
+func TestAccountsUpdate_TogglesExcluded(t *testing.T) {
+	env := setupEnv(t)
+	q := env.Queries
+
+	user := testutil.MustCreateUser(t, q, "Tester")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-2")
+	acct := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-2", "Savings")
+
+	excluded := true
+	patched, err := env.Client.UpdateAccount(context.Background(), acct.ID.String(), client.AccountPatch{IsExcluded: &excluded})
+	if err != nil {
+		t.Fatalf("UpdateAccount: %v", err)
+	}
+	// The public response shape doesn't expose `is_excluded` directly; the
+	// flag lives on the detail payload. Spot-check the round-trip via that.
+	detail, err := env.Client.GetAccountDetail(context.Background(), patched.ID)
+	if err != nil {
+		t.Fatalf("GetAccountDetail: %v", err)
+	}
+	if !detail.Excluded {
+		t.Fatalf("expected Excluded=true after update, got false")
+	}
+}
+
+func TestAccountsLinks_CreateListDelete(t *testing.T) {
+	env := setupEnv(t)
+	q := env.Queries
+
+	user := testutil.MustCreateUser(t, q, "Tester")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-3")
+	primary := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-p", "Primary")
+	dep := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-d", "Dependent")
+
+	link, err := env.Client.CreateAccountLink(context.Background(), client.CreateAccountLinkParams{
+		PrimaryAccountID:   primary.ID.String(),
+		DependentAccountID: dep.ID.String(),
+	})
+	if err != nil {
+		t.Fatalf("CreateAccountLink: %v", err)
+	}
+
+	links, err := env.Client.ListAccountLinks(context.Background())
+	if err != nil {
+		t.Fatalf("ListAccountLinks: %v", err)
+	}
+	found := false
+	for _, l := range links {
+		if l.ID == link.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("created link %s not returned by list", link.ID)
+	}
+
+	if err := env.Client.DeleteAccountLink(context.Background(), link.ID); err != nil {
+		t.Fatalf("DeleteAccountLink: %v", err)
+	}
+
+	links, err = env.Client.ListAccountLinks(context.Background())
+	if err != nil {
+		t.Fatalf("ListAccountLinks after delete: %v", err)
+	}
+	for _, l := range links {
+		if l.ID == link.ID {
+			t.Fatalf("deleted link still present in list")
+		}
+	}
+}
+

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -163,6 +163,8 @@ func NewRootCmd(version string) *cobra.Command {
 	AddCreateAdminCmd(root)
 	AddResetPasswordCmd(root)
 	AddDoctorCmd(root)
+	AddAccountsCmd(root)
+	AddTransactionsCmd(root)
 	AddVersionCmd(root, version)
 
 	return root

--- a/internal/cli/transactions.go
+++ b/internal/cli/transactions.go
@@ -1,0 +1,677 @@
+// Package cli — transactions noun group.
+//
+// `breadbox transactions ...` exposes the read+write surface for the
+// transactions table: list, get, count, summary, atomic per-row
+// updates, soft-delete + restore, tag attach/detach, comments, and the
+// activity-timeline annotations feed. Filter parsing is centralised in
+// transactionFiltersFromFlags so list/count/summary share one query
+// string.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// AddTransactionsCmd registers `breadbox transactions` and its children.
+func AddTransactionsCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "transactions",
+		Short: "Query and mutate transactions",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newTxnListCmd())
+	cmd.AddCommand(newTxnGetCmd())
+	cmd.AddCommand(newTxnCountCmd())
+	cmd.AddCommand(newTxnSummaryCmd())
+	cmd.AddCommand(newTxnUpdateCmd())
+	cmd.AddCommand(newTxnBatchCmd())
+	cmd.AddCommand(newTxnCategorizeCmd())
+	cmd.AddCommand(newTxnUncategorizeCmd())
+	cmd.AddCommand(newTxnRecategorizeCmd())
+	cmd.AddCommand(newTxnDeleteCmd())
+	cmd.AddCommand(newTxnRestoreCmd())
+	cmd.AddCommand(newTxnTagCmd())
+	cmd.AddCommand(newTxnUntagCmd())
+	cmd.AddCommand(newTxnAnnotationsCmd())
+	cmd.AddCommand(newTxnCommentsCmd())
+
+	root.AddCommand(cmd)
+}
+
+// txnFilterFlags binds the shared filter flag set to a cobra command and
+// returns a TransactionFilters value resolved from those flags. The same
+// shape powers list / count / summary.
+func txnFilterFlags(cmd *cobra.Command) {
+	cmd.Flags().String("account", "", "filter by account (uuid or short_id)")
+	cmd.Flags().String("category", "", "filter by category slug")
+	cmd.Flags().String("from", "", "start date (YYYY-MM-DD, inclusive)")
+	cmd.Flags().String("to", "", "end date (YYYY-MM-DD, exclusive)")
+	cmd.Flags().String("search", "", "name/merchant search term (>=2 chars)")
+	cmd.Flags().String("search-mode", "", "contains | words | fuzzy")
+	cmd.Flags().String("exclude-search", "", "exclude rows matching this substring")
+	cmd.Flags().String("user", "", "filter by household user (uuid or short_id)")
+	cmd.Flags().StringSlice("tag", nil, "filter to rows carrying ALL given tags (repeatable or comma-separated)")
+	cmd.Flags().StringSlice("any-tag", nil, "filter to rows carrying AT LEAST ONE of these tags")
+	cmd.Flags().Bool("has-comment", false, "(reserved) require at least one comment")
+}
+
+func filtersFromCmd(cmd *cobra.Command) client.TransactionFilters {
+	f := client.TransactionFilters{}
+	f.Account, _ = cmd.Flags().GetString("account")
+	f.Category, _ = cmd.Flags().GetString("category")
+	f.From, _ = cmd.Flags().GetString("from")
+	f.To, _ = cmd.Flags().GetString("to")
+	f.Search, _ = cmd.Flags().GetString("search")
+	f.SearchMode, _ = cmd.Flags().GetString("search-mode")
+	f.ExcludeSearch, _ = cmd.Flags().GetString("exclude-search")
+	f.User, _ = cmd.Flags().GetString("user")
+	if v, _ := cmd.Flags().GetStringSlice("tag"); len(v) > 0 {
+		f.Tags = expandCSV(v)
+	}
+	if v, _ := cmd.Flags().GetStringSlice("any-tag"); len(v) > 0 {
+		f.AnyTags = expandCSV(v)
+	}
+	if cmd.Flags().Changed("has-comment") {
+		b, _ := cmd.Flags().GetBool("has-comment")
+		f.HasComment = &b
+	}
+	return f
+}
+
+// expandCSV expands `["a,b", "c"]` → `["a","b","c"]` so the user can pass
+// either repeated flags or one comma-joined value.
+func expandCSV(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, raw := range in {
+		for _, p := range strings.Split(raw, ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+func newTxnListCmd() *cobra.Command {
+	var cursor string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List transactions (cursor-paginated)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			filters := filtersFromCmd(cmd)
+
+			mode := output.Resolve(flags.JSON, flags.NDJSON, os.Stdout)
+
+			if flags.All {
+				return walkAllTransactions(cmd.Context(), c, filters, flags, mode)
+			}
+			res, err := c.ListTransactions(cmd.Context(), filters, cursor, flags.Limit, flags.Fields)
+			if err != nil {
+				return err
+			}
+			if flags.Debug && res.NextCursor != "" {
+				fmt.Fprintf(os.Stderr, "next_cursor=%s has_more=%v\n", res.NextCursor, res.HasMore)
+			}
+			return renderTransactionPage(mode, res)
+		},
+	}
+	cmd.Flags().StringVar(&cursor, "cursor", "", "opaque cursor from a previous page's next_cursor")
+	txnFilterFlags(cmd)
+	return cmd
+}
+
+func walkAllTransactions(ctx context.Context, c *client.Client, filters client.TransactionFilters, flags *FlagBag, mode output.Mode) error {
+	enc := json.NewEncoder(os.Stdout)
+	cursor := ""
+	first := true
+	if mode == output.ModeJSON {
+		// Stream everything into one big array so JSON readers can slurp it.
+		fmt.Print("[")
+		defer fmt.Println("]")
+	}
+	for {
+		page, err := c.ListTransactions(ctx, filters, cursor, flags.Limit, flags.Fields)
+		if err != nil {
+			return err
+		}
+		if flags.Debug {
+			fmt.Fprintf(os.Stderr, "page rows=%d next_cursor=%s has_more=%v\n", len(page.Transactions), page.NextCursor, page.HasMore)
+		}
+		switch mode {
+		case output.ModeNDJSON:
+			for _, t := range page.Transactions {
+				_ = enc.Encode(t)
+			}
+		case output.ModeJSON:
+			for _, t := range page.Transactions {
+				if !first {
+					fmt.Print(",")
+				}
+				first = false
+				b, _ := json.Marshal(t)
+				_, _ = os.Stdout.Write(b)
+			}
+		default:
+			tbl := buildTransactionTable(os.Stdout, page.Transactions)
+			_ = tbl.Flush()
+		}
+		if !page.HasMore || page.NextCursor == "" {
+			return nil
+		}
+		cursor = page.NextCursor
+	}
+}
+
+func newTxnGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Fetch a single transaction",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			t, err := c.GetTransaction(cmd.Context(), args[0], flags.Fields)
+			if err != nil {
+				return err
+			}
+			return renderTransaction(flags, t)
+		},
+	}
+	return cmd
+}
+
+func newTxnCountCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "count",
+		Short: "Count transactions matching the filters",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			n, err := c.CountTransactions(cmd.Context(), filtersFromCmd(cmd))
+			if err != nil {
+				return err
+			}
+			if flags.JSON || flags.NDJSON || !isTerminal(os.Stdout) {
+				return output.PrintJSON(os.Stdout, map[string]int64{"count": n})
+			}
+			fmt.Println(n)
+			return nil
+		},
+	}
+	txnFilterFlags(cmd)
+	return cmd
+}
+
+func newTxnSummaryCmd() *cobra.Command {
+	var by string
+	cmd := &cobra.Command{
+		Use:   "summary",
+		Short: "Aggregate transactions by category, month, week, or day",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			if by == "" {
+				return UsageErrorf("--by is required (category, month, week, day, or category_month)")
+			}
+			res, err := c.TransactionSummary(cmd.Context(), by, filtersFromCmd(cmd))
+			if err != nil {
+				return err
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	cmd.Flags().StringVar(&by, "by", "", "group_by: category | month | week | day | category_month")
+	txnFilterFlags(cmd)
+	return cmd
+}
+
+func newTxnUpdateCmd() *cobra.Command {
+	var (
+		category string
+		reset    bool
+		note     string
+		tags     []string
+	)
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Atomically update category, tags, and/or attach a comment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+
+			op := client.UpdateTransactionOp{TransactionID: args[0]}
+			if cmd.Flags().Changed("category") {
+				v := category
+				op.CategorySlug = &v
+			}
+			if cmd.Flags().Changed("reset-category") {
+				op.ResetCategory = reset
+			}
+			if cmd.Flags().Changed("note") {
+				v := note
+				op.Comment = &v
+			}
+			for _, slug := range expandCSV(tags) {
+				op.TagsToAdd = append(op.TagsToAdd, client.UpdateTransactionTag{Slug: slug})
+			}
+
+			if op.CategorySlug == nil && !op.ResetCategory && op.Comment == nil && len(op.TagsToAdd) == 0 {
+				return UsageErrorf("update needs at least one of --category, --reset-category, --note, --tag")
+			}
+
+			res, err := c.UpdateTransactions(cmd.Context(), client.UpdateTransactionsRequest{
+				Operations: []client.UpdateTransactionOp{op},
+			})
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	cmd.Flags().StringVar(&category, "category", "", "set category slug (overrides rules)")
+	cmd.Flags().BoolVar(&reset, "reset-category", false, "clear the category override")
+	cmd.Flags().StringVar(&note, "note", "", "attach this string as a comment")
+	cmd.Flags().StringSliceVar(&tags, "tag", nil, "tag slugs to add (repeatable or comma-separated)")
+	return cmd
+}
+
+func newTxnBatchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "batch <file>",
+		Short: "Run /transactions/update with operations from a JSON file (max 50)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			raw, err := readFileOrStdin(args[0])
+			if err != nil {
+				return err
+			}
+			var req client.UpdateTransactionsRequest
+			if err := json.Unmarshal(raw, &req); err != nil {
+				// allow a bare array of operations as a convenience.
+				var ops []client.UpdateTransactionOp
+				if err2 := json.Unmarshal(raw, &ops); err2 != nil {
+					return fmt.Errorf("parse batch JSON: %w", err)
+				}
+				req.Operations = ops
+			}
+			res, err := c.UpdateTransactions(cmd.Context(), req)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	return cmd
+}
+
+func newTxnCategorizeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "categorize <id> <category-id>",
+		Short: "Set a manual category override on a transaction",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.SetTransactionCategory(cmd.Context(), args[0], args[1]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newTxnUncategorizeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uncategorize <id>",
+		Short: "Clear the manual category override",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.ResetTransactionCategory(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newTxnRecategorizeCmd() *cobra.Command {
+	var target string
+	cmd := &cobra.Command{
+		Use:   "recategorize",
+		Short: "Server-side bulk recategorize by filter",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if target == "" {
+				return UsageErrorf("--category is required (target category slug)")
+			}
+			f := filtersFromCmd(cmd)
+			req := client.BulkRecategorizeRequest{
+				TargetCategorySlug: target,
+				StartDate:          f.From,
+				EndDate:            f.To,
+				AccountID:          f.Account,
+				UserID:             f.User,
+				CategorySlug:       f.Category,
+				Search:             f.Search,
+				MinAmount:          f.MinAmount,
+				MaxAmount:          f.MaxAmount,
+				Pending:            f.Pending,
+			}
+			res, err := c.BulkRecategorize(cmd.Context(), req)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	cmd.Flags().StringVar(&target, "category", "", "target category slug (required)")
+	txnFilterFlags(cmd)
+	return cmd
+}
+
+func newTxnDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Soft-delete a transaction",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.DeleteTransaction(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newTxnRestoreCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "restore <id>",
+		Short: "Restore a soft-deleted transaction",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.RestoreTransaction(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newTxnTagCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tag <id> <slug>",
+		Short: "Attach a tag to a transaction (auto-creates if missing)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			res, err := c.AddTransactionTag(cmd.Context(), args[0], args[1])
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	return cmd
+}
+
+func newTxnUntagCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "untag <id> <slug>",
+		Short: "Detach a tag from a transaction",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			res, err := c.RemoveTransactionTag(cmd.Context(), args[0], args[1])
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	return cmd
+}
+
+func newTxnAnnotationsCmd() *cobra.Command {
+	var kinds []string
+	cmd := &cobra.Command{
+		Use:   "annotations <id>",
+		Short: "Activity-timeline rows for a transaction",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			res, err := c.ListAnnotations(cmd.Context(), args[0], expandCSV(kinds), flags.Limit)
+			if err != nil {
+				return err
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	cmd.Flags().StringSliceVar(&kinds, "kind", nil, "filter by annotation kind (comment, rule_applied, review, ...)")
+	return cmd
+}
+
+func newTxnCommentsCmd() *cobra.Command {
+	comments := &cobra.Command{
+		Use:   "comments",
+		Short: "Manage comments on a transaction",
+	}
+
+	comments.AddCommand(&cobra.Command{
+		Use:   "add <id> <message>",
+		Short: "Add a comment to a transaction",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			com, err := c.CreateComment(cmd.Context(), args[0], args[1])
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, com)
+		},
+	})
+
+	comments.AddCommand(&cobra.Command{
+		Use:   "list <id>",
+		Short: "List comments on a transaction",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			coms, err := c.ListComments(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+			case output.ModeJSON:
+				return output.PrintJSON(os.Stdout, coms)
+			case output.ModeNDJSON:
+				items := make([]any, 0, len(coms))
+				for _, c := range coms {
+					items = append(items, c)
+				}
+				return output.PrintNDJSON(os.Stdout, items)
+			default:
+				tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "AUTHOR", "CREATED_AT", "CONTENT"})
+				for _, com := range coms {
+					tbl.AddRow(com.ShortID, com.AuthorName, com.CreatedAt, truncate(com.Content, 80))
+				}
+				return tbl.Flush()
+			}
+		},
+	})
+
+	comments.AddCommand(&cobra.Command{
+		Use:   "edit <id> <comment-id> <message>",
+		Short: "Edit a comment",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			com, err := c.UpdateComment(cmd.Context(), args[0], args[1], args[2])
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, com)
+		},
+	})
+
+	comments.AddCommand(&cobra.Command{
+		Use:   "delete <id> <comment-id>",
+		Short: "Delete a comment",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.DeleteComment(cmd.Context(), args[0], args[1]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[1])
+			}
+			return nil
+		},
+	})
+
+	return comments
+}
+
+// --- rendering helpers ---
+
+func renderTransactionPage(mode output.Mode, res *client.TransactionListResult) error {
+	switch mode {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, res)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(res.Transactions))
+		for _, t := range res.Transactions {
+			items = append(items, t)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := buildTransactionTable(os.Stdout, res.Transactions)
+		if err := tbl.Flush(); err != nil {
+			return err
+		}
+		if res.HasMore && res.NextCursor != "" {
+			fmt.Fprintf(os.Stderr, "(more rows; pass --cursor %s to continue or --all to walk every page)\n", res.NextCursor)
+		}
+		return nil
+	}
+}
+
+func renderTransaction(flags *FlagBag, t *client.Transaction) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON, output.ModeNDJSON:
+		return output.PrintJSON(os.Stdout, t)
+	default:
+		tbl := buildTransactionTable(os.Stdout, []client.Transaction{*t})
+		return tbl.Flush()
+	}
+}
+
+func buildTransactionTable(w io.Writer, rows []client.Transaction) *output.Table {
+	tbl := output.NewTable(w, []string{"SHORT_ID", "DATE", "AMOUNT", "CCY", "NAME", "CATEGORY", "ACCOUNT"})
+	for _, t := range rows {
+		cat := "-"
+		if t.Category != nil && t.Category.DisplayName != nil {
+			cat = *t.Category.DisplayName
+		}
+		acct := strPtr(t.AccountName)
+		tbl.AddRow(t.ShortID, t.Date, fmt.Sprintf("%.2f", t.Amount), strPtr(t.IsoCurrencyCode), t.ProviderName, cat, acct)
+	}
+	return tbl
+}
+
+// truncate cuts a string to n runes with an ellipsis, leaving stdout
+// readable when comment bodies are long.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n < 3 {
+		return s[:n]
+	}
+	return s[:n-3] + "..."
+}
+
+// readFileOrStdin reads a file path or `-` from stdin.
+func readFileOrStdin(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(path)
+}
+
+// isTerminal exposes output's TTY check for callers that don't need the full
+// Resolve dispatch (count, for instance).
+func isTerminal(w *os.File) bool {
+	info, err := w.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/cli/transactions.go
+++ b/internal/cli/transactions.go
@@ -371,11 +371,15 @@ func newTxnRecategorizeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "recategorize",
 		Short: "Server-side bulk recategorize by filter",
+		Long: `Apply a new category to every transaction matching the filter set.
+
+The shared --category filter scopes which rows are touched; --target-category
+is the slug those rows get re-assigned to. Both are required.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, _ := ClientFromContext(cmd.Context())
 			flags := Flags(cmd)
 			if target == "" {
-				return UsageErrorf("--category is required (target category slug)")
+				return UsageErrorf("--target-category is required (slug to recategorize matching rows into)")
 			}
 			f := filtersFromCmd(cmd)
 			req := client.BulkRecategorizeRequest{
@@ -400,8 +404,10 @@ func newTxnRecategorizeCmd() *cobra.Command {
 			return output.PrintJSON(os.Stdout, res)
 		},
 	}
-	cmd.Flags().StringVar(&target, "category", "", "target category slug (required)")
+	// Filter flags first so --category claims its slot as the filter slug;
+	// the destination slug gets the unambiguous --target-category name.
 	txnFilterFlags(cmd)
+	cmd.Flags().StringVar(&target, "target-category", "", "target category slug to assign to matching rows (required)")
 	return cmd
 }
 

--- a/internal/cli/transactions_integration_test.go
+++ b/internal/cli/transactions_integration_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+package cli_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"breadbox/internal/client"
+	"breadbox/internal/testutil"
+)
+
+// strPtr is a tiny helper for *string fields in UpdateTransactionsOp.
+func strPtr(s string) *string { return &s }
+
+func TestTransactions_ListFiltersByAccount(t *testing.T) {
+	env := setupEnv(t)
+	q := env.Queries
+
+	user := testutil.MustCreateUser(t, q, "Tester")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-tx-1")
+	a := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-tx-1", "Checking")
+	b := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-tx-2", "Savings")
+
+	today := time.Now().UTC().Format("2006-01-02")
+	testutil.MustCreateTransaction(t, q, a.ID, "ext-tx-1", "Coffee", 500, today)
+	testutil.MustCreateTransaction(t, q, b.ID, "ext-tx-2", "Rent", 100000, today)
+
+	res, err := env.Client.ListTransactions(context.Background(),
+		client.TransactionFilters{Account: a.ID.String()},
+		"", 0, "")
+	if err != nil {
+		t.Fatalf("ListTransactions: %v", err)
+	}
+	if len(res.Transactions) != 1 {
+		t.Fatalf("got %d transactions, want 1 (filter by account)", len(res.Transactions))
+	}
+	if res.Transactions[0].ProviderName != "Coffee" {
+		t.Errorf("name = %q, want Coffee", res.Transactions[0].ProviderName)
+	}
+}
+
+func TestTransactions_AtomicUpdateSetsCategory(t *testing.T) {
+	env := setupEnv(t)
+	q := env.Queries
+
+	user := testutil.MustCreateUser(t, q, "Tester")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-tx-3")
+	a := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-tx-3", "Checking")
+	cat := testutil.MustCreateCategory(t, q, "food", "Food")
+	_ = cat
+
+	today := time.Now().UTC().Format("2006-01-02")
+	txn := testutil.MustCreateTransaction(t, q, a.ID, "ext-tx-3", "Coffee", 500, today)
+
+	res, err := env.Client.UpdateTransactions(context.Background(), client.UpdateTransactionsRequest{
+		Operations: []client.UpdateTransactionOp{{
+			TransactionID: txn.ID.String(),
+			CategorySlug:  strPtr("food"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("UpdateTransactions: %v", err)
+	}
+	if res.Succeeded != 1 {
+		t.Fatalf("succeeded = %d, want 1: %+v", res.Succeeded, res)
+	}
+
+	got, err := env.Client.GetTransaction(context.Background(), txn.ID.String(), "")
+	if err != nil {
+		t.Fatalf("GetTransaction: %v", err)
+	}
+	if got.Category == nil || got.Category.Slug == nil || *got.Category.Slug != "food" {
+		t.Fatalf("category slug not applied: %#v", got.Category)
+	}
+}
+
+func TestTransactions_DeleteRestoreRoundtrip(t *testing.T) {
+	env := setupEnv(t)
+	q := env.Queries
+
+	user := testutil.MustCreateUser(t, q, "Tester")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-tx-4")
+	a := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-tx-4", "Checking")
+	today := time.Now().UTC().Format("2006-01-02")
+	txn := testutil.MustCreateTransaction(t, q, a.ID, "ext-tx-4", "Bookstore", 1500, today)
+
+	if err := env.Client.DeleteTransaction(context.Background(), txn.ID.String()); err != nil {
+		t.Fatalf("DeleteTransaction: %v", err)
+	}
+
+	// After delete, the row is filtered from list paths.
+	res, err := env.Client.ListTransactions(context.Background(),
+		client.TransactionFilters{Account: a.ID.String()}, "", 0, "")
+	if err != nil {
+		t.Fatalf("ListTransactions: %v", err)
+	}
+	if len(res.Transactions) != 0 {
+		t.Fatalf("expected 0 transactions after delete, got %d", len(res.Transactions))
+	}
+
+	// Restore (path id must be UUID because short_id resolution filters deleted rows).
+	if err := env.Client.RestoreTransaction(context.Background(), txn.ID.String()); err != nil {
+		t.Fatalf("RestoreTransaction: %v", err)
+	}
+	res, err = env.Client.ListTransactions(context.Background(),
+		client.TransactionFilters{Account: a.ID.String()}, "", 0, "")
+	if err != nil {
+		t.Fatalf("ListTransactions: %v", err)
+	}
+	if len(res.Transactions) != 1 {
+		t.Fatalf("expected 1 transaction after restore, got %d", len(res.Transactions))
+	}
+}
+
+func TestTransactions_TagUntagRoundtrip(t *testing.T) {
+	env := setupEnv(t)
+	q := env.Queries
+
+	user := testutil.MustCreateUser(t, q, "Tester")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-tx-5")
+	a := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-tx-5", "Checking")
+	today := time.Now().UTC().Format("2006-01-02")
+	txn := testutil.MustCreateTransaction(t, q, a.ID, "ext-tx-5", "Gas Station", 5000, today)
+
+	if _, err := env.Client.AddTransactionTag(context.Background(), txn.ID.String(), "vehicle"); err != nil {
+		t.Fatalf("AddTransactionTag: %v", err)
+	}
+	// Tags are populated by the list-path enrichment, not the get-path —
+	// filter the list by the tag to verify attachment.
+	res, err := env.Client.ListTransactions(context.Background(),
+		client.TransactionFilters{Tags: []string{"vehicle"}}, "", 0, "")
+	if err != nil {
+		t.Fatalf("ListTransactions: %v", err)
+	}
+	foundTagged := false
+	for _, r := range res.Transactions {
+		if r.ID == txn.ID.String() {
+			foundTagged = true
+		}
+	}
+	if !foundTagged {
+		t.Fatalf("expected tagged transaction in tag-filtered list, got %d rows", len(res.Transactions))
+	}
+
+	if _, err := env.Client.RemoveTransactionTag(context.Background(), txn.ID.String(), "vehicle"); err != nil {
+		t.Fatalf("RemoveTransactionTag: %v", err)
+	}
+	res, err = env.Client.ListTransactions(context.Background(),
+		client.TransactionFilters{Tags: []string{"vehicle"}}, "", 0, "")
+	if err != nil {
+		t.Fatalf("ListTransactions after untag: %v", err)
+	}
+	if len(res.Transactions) != 0 {
+		t.Fatalf("expected 0 tagged transactions after removal, got %d", len(res.Transactions))
+	}
+}
+
+func TestTransactions_CommentsRoundtrip(t *testing.T) {
+	env := setupEnv(t)
+	q := env.Queries
+
+	user := testutil.MustCreateUser(t, q, "Tester")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-conn-tx-6")
+	a := testutil.MustCreateAccount(t, q, conn.ID, "ext-acct-tx-6", "Checking")
+	today := time.Now().UTC().Format("2006-01-02")
+	txn := testutil.MustCreateTransaction(t, q, a.ID, "ext-tx-6", "Grocery", 7500, today)
+
+	com, err := env.Client.CreateComment(context.Background(), txn.ID.String(), "test comment")
+	if err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+	if com.Content != "test comment" {
+		t.Errorf("content = %q, want %q", com.Content, "test comment")
+	}
+
+	coms, err := env.Client.ListComments(context.Background(), txn.ID.String())
+	if err != nil {
+		t.Fatalf("ListComments: %v", err)
+	}
+	if len(coms) != 1 || coms[0].ID != com.ID {
+		t.Fatalf("expected 1 comment matching created id, got %#v", coms)
+	}
+}

--- a/internal/cli/transactions_test.go
+++ b/internal/cli/transactions_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestExpandCSV asserts repeated --tag flags and comma-joined values
+// both produce the same canonical slice. The transactions list/count/
+// summary handlers rely on this for their filter parsing.
+func TestExpandCSV(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty input", nil, []string{}},
+		{"single value", []string{"foo"}, []string{"foo"}},
+		{"repeated flag form", []string{"a", "b"}, []string{"a", "b"}},
+		{"comma joined", []string{"a,b,c"}, []string{"a", "b", "c"}},
+		{"mixed forms with whitespace", []string{"a, b", "c"}, []string{"a", "b", "c"}},
+		{"empty fragments dropped", []string{"a,,b"}, []string{"a", "b"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := expandCSV(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %#v, want %#v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTruncate covers the comment-content truncation helper. Pure plumbing
+// but easy to regress when someone tweaks the ellipsis length.
+func TestTruncate(t *testing.T) {
+	if got := truncate("hello", 80); got != "hello" {
+		t.Errorf("short string changed: got %q", got)
+	}
+	if got := truncate("abcdefghij", 6); got != "abc..." {
+		t.Errorf("long string ellipsis wrong: got %q want %q", got, "abc...")
+	}
+	if got := truncate("abc", 2); got != "ab" {
+		t.Errorf("tiny limit should hard cut: got %q want %q", got, "ab")
+	}
+}

--- a/internal/client/accounts.go
+++ b/internal/client/accounts.go
@@ -1,0 +1,169 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// Account mirrors service.AccountResponse — the JSON shape returned by
+// GET /api/v1/accounts and friends. Defined here so the CLI doesn't
+// depend on the `internal/service` package (which is server-only under
+// the `-tags=lite` build).
+type Account struct {
+	ID                string   `json:"id"`
+	ShortID           string   `json:"short_id"`
+	ConnectionID      *string  `json:"connection_id,omitempty"`
+	UserID            *string  `json:"user_id,omitempty"`
+	InstitutionName   *string  `json:"institution_name,omitempty"`
+	Name              string   `json:"name"`
+	OfficialName      *string  `json:"official_name,omitempty"`
+	Type              string   `json:"type"`
+	Subtype           *string  `json:"subtype,omitempty"`
+	Mask              *string  `json:"mask,omitempty"`
+	BalanceCurrent    *float64 `json:"balance_current,omitempty"`
+	BalanceAvailable  *float64 `json:"balance_available,omitempty"`
+	BalanceLimit      *float64 `json:"balance_limit,omitempty"`
+	IsoCurrencyCode   *string  `json:"iso_currency_code,omitempty"`
+	LastBalanceUpdate *string  `json:"last_balance_update,omitempty"`
+	CreatedAt         string   `json:"created_at"`
+	UpdatedAt         string   `json:"updated_at"`
+	ConnectionStatus  *string  `json:"connection_status,omitempty"`
+	IsDependentLinked bool     `json:"is_dependent_linked"`
+}
+
+// AccountBalance is a single-currency balance block.
+type AccountBalance struct {
+	IsoCurrencyCode  *string  `json:"iso_currency_code"`
+	BalanceCurrent   *float64 `json:"balance_current"`
+	BalanceAvailable *float64 `json:"balance_available"`
+	BalanceLimit     *float64 `json:"balance_limit"`
+}
+
+// AccountDetail mirrors service.AccountDetailResponse — the
+// GET /api/v1/accounts/{id}/detail payload.
+type AccountDetail struct {
+	Account
+	DisplayName        *string       `json:"display_name,omitempty"`
+	Excluded           bool          `json:"excluded"`
+	Provider           string        `json:"provider,omitempty"`
+	ConnectionUserName string        `json:"connection_user_name,omitempty"`
+	ConnectionShortID  string        `json:"connection_short_id,omitempty"`
+	Balances           []AccountBalance `json:"balances"`
+	RecentTransactions []Transaction    `json:"recent_transactions"`
+}
+
+// AccountPatch carries the optional fields accepted by
+// PATCH /api/v1/accounts/{id}.
+type AccountPatch struct {
+	DisplayName       *string `json:"display_name,omitempty"`
+	IsExcluded        *bool   `json:"is_excluded,omitempty"`
+	IsDependentLinked *bool   `json:"is_dependent_linked,omitempty"`
+}
+
+// AccountLink mirrors service.AccountLinkResponse — the
+// GET /api/v1/account-links payload row.
+type AccountLink struct {
+	ID                      string `json:"id"`
+	ShortID                 string `json:"short_id"`
+	PrimaryAccountID        string `json:"primary_account_id"`
+	PrimaryAccountName      string `json:"primary_account_name"`
+	PrimaryUserName         string `json:"primary_user_name"`
+	DependentAccountID      string `json:"dependent_account_id"`
+	DependentAccountName    string `json:"dependent_account_name"`
+	DependentUserName       string `json:"dependent_user_name"`
+	MatchStrategy           string `json:"match_strategy"`
+	MatchToleranceDays      int    `json:"match_tolerance_days"`
+	Enabled                 bool   `json:"enabled"`
+	MatchCount              int64  `json:"match_count"`
+	UnmatchedDependentCount int64  `json:"unmatched_dependent_count"`
+	CreatedAt               string `json:"created_at"`
+	UpdatedAt               string `json:"updated_at"`
+}
+
+// CreateAccountLinkParams matches the POST /api/v1/account-links body.
+type CreateAccountLinkParams struct {
+	PrimaryAccountID   string `json:"primary_account_id"`
+	DependentAccountID string `json:"dependent_account_id"`
+	MatchStrategy      string `json:"match_strategy,omitempty"`
+	MatchToleranceDays int    `json:"match_tolerance_days,omitempty"`
+}
+
+// ListAccounts fetches the household's accounts. `fields` and `userID`
+// are passed through as query params (each empty when not set).
+func (c *Client) ListAccounts(ctx context.Context, fields, userID string) ([]Account, error) {
+	path := "/api/v1/accounts"
+	q := url.Values{}
+	if fields != "" {
+		q.Set("fields", fields)
+	}
+	if userID != "" {
+		q.Set("user_id", userID)
+	}
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var out []Account
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetAccount fetches a single account by short_id or uuid.
+func (c *Client) GetAccount(ctx context.Context, id, fields string) (*Account, error) {
+	path := "/api/v1/accounts/" + url.PathEscape(id)
+	if fields != "" {
+		path += "?fields=" + url.QueryEscape(fields)
+	}
+	var out Account
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetAccountDetail fetches the full detail payload (balances + recent txns).
+func (c *Client) GetAccountDetail(ctx context.Context, id string) (*AccountDetail, error) {
+	path := "/api/v1/accounts/" + url.PathEscape(id) + "/detail"
+	var out AccountDetail
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateAccount patches the named fields. Fields left nil are not sent.
+func (c *Client) UpdateAccount(ctx context.Context, id string, patch AccountPatch) (*Account, error) {
+	path := "/api/v1/accounts/" + url.PathEscape(id)
+	var out Account
+	if err := c.Do(ctx, http.MethodPatch, path, patch, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ListAccountLinks returns every account-link row. The server doesn't yet
+// filter by `account_id`, so the CLI filters client-side when scoping to
+// one account.
+func (c *Client) ListAccountLinks(ctx context.Context) ([]AccountLink, error) {
+	var out []AccountLink
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/account-links", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CreateAccountLink mints a new primary/dependent account-link.
+func (c *Client) CreateAccountLink(ctx context.Context, params CreateAccountLinkParams) (*AccountLink, error) {
+	var out AccountLink
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/account-links", params, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteAccountLink drops the link by id.
+func (c *Client) DeleteAccountLink(ctx context.Context, id string) error {
+	return c.Do(ctx, http.MethodDelete, "/api/v1/account-links/"+url.PathEscape(id), nil, nil)
+}

--- a/internal/client/transactions.go
+++ b/internal/client/transactions.go
@@ -1,0 +1,394 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// TransactionCategoryInfo mirrors service.TransactionCategoryInfo.
+type TransactionCategoryInfo struct {
+	ID                 *string `json:"id"`
+	Slug               *string `json:"slug"`
+	DisplayName        *string `json:"display_name"`
+	PrimarySlug        *string `json:"primary_slug,omitempty"`
+	PrimaryDisplayName *string `json:"primary_display_name,omitempty"`
+	Icon               *string `json:"icon,omitempty"`
+	Color              *string `json:"color,omitempty"`
+}
+
+// Transaction mirrors service.TransactionResponse.
+type Transaction struct {
+	ID                         string                   `json:"id"`
+	ShortID                    string                   `json:"short_id"`
+	AccountID                  *string                  `json:"account_id,omitempty"`
+	AccountName                *string                  `json:"account_name,omitempty"`
+	UserName                   *string                  `json:"user_name,omitempty"`
+	AttributedUserID           *string                  `json:"attributed_user_id,omitempty"`
+	AttributedUserName         *string                  `json:"attributed_user_name,omitempty"`
+	EffectiveUserID            *string                  `json:"effective_user_id,omitempty"`
+	Amount                     float64                  `json:"amount"`
+	IsoCurrencyCode            *string                  `json:"iso_currency_code,omitempty"`
+	Date                       string                   `json:"date"`
+	AuthorizedDate             *string                  `json:"authorized_date,omitempty"`
+	Datetime                   *string                  `json:"datetime,omitempty"`
+	AuthorizedDatetime         *string                  `json:"authorized_datetime,omitempty"`
+	ProviderName               string                   `json:"provider_name"`
+	ProviderMerchantName       *string                  `json:"provider_merchant_name,omitempty"`
+	Category                   *TransactionCategoryInfo `json:"category,omitempty"`
+	CategoryOverride           bool                     `json:"category_override"`
+	ProviderCategoryPrimary    *string                  `json:"provider_category_primary,omitempty"`
+	ProviderCategoryDetailed   *string                  `json:"provider_category_detailed,omitempty"`
+	ProviderCategoryConfidence *string                  `json:"provider_category_confidence,omitempty"`
+	ProviderPaymentChannel     *string                  `json:"provider_payment_channel,omitempty"`
+	Pending                    bool                     `json:"pending"`
+	CreatedAt                  string                   `json:"created_at"`
+	UpdatedAt                  string                   `json:"updated_at"`
+	Tags                       []string                 `json:"tags,omitempty"`
+}
+
+// TransactionListResult is the resource-keyed envelope returned by
+// GET /api/v1/transactions.
+type TransactionListResult struct {
+	Transactions []Transaction `json:"transactions"`
+	NextCursor   string        `json:"next_cursor,omitempty"`
+	HasMore      bool          `json:"has_more"`
+	Limit        int           `json:"limit"`
+}
+
+// CountResult is the `{count: N}` payload from /transactions/count.
+type CountResult struct {
+	Count int64 `json:"count"`
+}
+
+// TransactionFilters consolidates the filter set shared by list, count,
+// and summary endpoints. Encoded to a `url.Values` via Query().
+type TransactionFilters struct {
+	Account       string
+	Category      string
+	From          string // date YYYY-MM-DD
+	To            string // date YYYY-MM-DD
+	Search        string
+	SearchMode    string
+	ExcludeSearch string
+	User          string
+	Tags          []string
+	AnyTags       []string
+	HasComment    *bool
+	MinAmount     *float64
+	MaxAmount     *float64
+	Pending       *bool
+}
+
+// Query renders the filters into a `url.Values` ready to append to a URL.
+// Empty fields are omitted; the result is stable enough to compare in tests.
+func (f TransactionFilters) Query() url.Values {
+	q := url.Values{}
+	if f.Account != "" {
+		q.Set("account_id", f.Account)
+	}
+	if f.Category != "" {
+		q.Set("category_slug", f.Category)
+	}
+	if f.From != "" {
+		q.Set("start_date", f.From)
+	}
+	if f.To != "" {
+		q.Set("end_date", f.To)
+	}
+	if f.Search != "" {
+		q.Set("search", f.Search)
+	}
+	if f.SearchMode != "" {
+		q.Set("search_mode", f.SearchMode)
+	}
+	if f.ExcludeSearch != "" {
+		q.Set("exclude_search", f.ExcludeSearch)
+	}
+	if f.User != "" {
+		q.Set("user_id", f.User)
+	}
+	if len(f.Tags) > 0 {
+		q.Set("tags", joinCSV(f.Tags))
+	}
+	if len(f.AnyTags) > 0 {
+		q.Set("any_tag", joinCSV(f.AnyTags))
+	}
+	if f.Pending != nil {
+		q.Set("pending", strconv.FormatBool(*f.Pending))
+	}
+	if f.MinAmount != nil {
+		q.Set("min_amount", strconv.FormatFloat(*f.MinAmount, 'f', -1, 64))
+	}
+	if f.MaxAmount != nil {
+		q.Set("max_amount", strconv.FormatFloat(*f.MaxAmount, 'f', -1, 64))
+	}
+	// has_comment is not a server-supported filter today — we keep the
+	// flag in the struct for forward compatibility but don't serialise it.
+	return q
+}
+
+func joinCSV(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ","
+		}
+		out += p
+	}
+	return out
+}
+
+// ListTransactions fetches a page of transactions.
+func (c *Client) ListTransactions(ctx context.Context, f TransactionFilters, cursor string, limit int, fields string) (*TransactionListResult, error) {
+	q := f.Query()
+	if cursor != "" {
+		q.Set("cursor", cursor)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	if fields != "" {
+		q.Set("fields", fields)
+	}
+	path := "/api/v1/transactions"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var out TransactionListResult
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CountTransactions returns the number of transactions matching the filters.
+func (c *Client) CountTransactions(ctx context.Context, f TransactionFilters) (int64, error) {
+	q := f.Query()
+	path := "/api/v1/transactions/count"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var out CountResult
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return 0, err
+	}
+	return out.Count, nil
+}
+
+// GetTransaction fetches one transaction by id (short_id or uuid).
+func (c *Client) GetTransaction(ctx context.Context, id, fields string) (*Transaction, error) {
+	path := "/api/v1/transactions/" + url.PathEscape(id)
+	if fields != "" {
+		path += "?fields=" + url.QueryEscape(fields)
+	}
+	var out Transaction
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// TransactionSummary returns the aggregated `group_by` payload as a raw
+// JSON map — the shape varies by group_by, so the caller renders it.
+func (c *Client) TransactionSummary(ctx context.Context, groupBy string, f TransactionFilters) (map[string]any, error) {
+	q := f.Query()
+	q.Set("group_by", groupBy)
+	path := "/api/v1/transactions/summary?" + q.Encode()
+	out := map[string]any{}
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// UpdateTransactionOp is a single op for POST /transactions/update.
+type UpdateTransactionOp struct {
+	TransactionID string                  `json:"transaction_id"`
+	CategorySlug  *string                 `json:"category_slug,omitempty"`
+	ResetCategory bool                    `json:"reset_category,omitempty"`
+	TagsToAdd     []UpdateTransactionTag  `json:"tags_to_add,omitempty"`
+	TagsToRemove  []UpdateTransactionTag  `json:"tags_to_remove,omitempty"`
+	Comment       *string                 `json:"comment,omitempty"`
+}
+
+// UpdateTransactionTag is a single tag add/remove entry.
+type UpdateTransactionTag struct {
+	Slug string `json:"slug"`
+}
+
+// UpdateTransactionsRequest is the POST /transactions/update body.
+type UpdateTransactionsRequest struct {
+	Operations []UpdateTransactionOp `json:"operations"`
+	OnError    string                `json:"on_error,omitempty"`
+}
+
+// UpdateTransactionsResponse is the response payload.
+type UpdateTransactionsResponse struct {
+	Results   []map[string]any `json:"results"`
+	Succeeded int              `json:"succeeded"`
+	Failed    int              `json:"failed"`
+	Aborted   bool             `json:"aborted,omitempty"`
+	Error     string           `json:"error,omitempty"`
+}
+
+// UpdateTransactions runs the batch update endpoint.
+func (c *Client) UpdateTransactions(ctx context.Context, req UpdateTransactionsRequest) (*UpdateTransactionsResponse, error) {
+	var out UpdateTransactionsResponse
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/transactions/update", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SetTransactionCategory sets a manual category override on a transaction.
+func (c *Client) SetTransactionCategory(ctx context.Context, id, categoryID string) error {
+	body := map[string]string{"category_id": categoryID}
+	return c.Do(ctx, http.MethodPatch, "/api/v1/transactions/"+url.PathEscape(id)+"/category", body, nil)
+}
+
+// ResetTransactionCategory clears the manual category override.
+func (c *Client) ResetTransactionCategory(ctx context.Context, id string) error {
+	return c.Do(ctx, http.MethodDelete, "/api/v1/transactions/"+url.PathEscape(id)+"/category", nil, nil)
+}
+
+// DeleteTransaction soft-deletes a transaction.
+func (c *Client) DeleteTransaction(ctx context.Context, id string) error {
+	return c.Do(ctx, http.MethodDelete, "/api/v1/transactions/"+url.PathEscape(id), nil, nil)
+}
+
+// RestoreTransaction reverses a soft-delete.
+func (c *Client) RestoreTransaction(ctx context.Context, id string) error {
+	return c.Do(ctx, http.MethodPost, "/api/v1/transactions/"+url.PathEscape(id)+"/restore", nil, nil)
+}
+
+// AddTransactionTag attaches a tag (creating it if missing).
+func (c *Client) AddTransactionTag(ctx context.Context, id, slug string) (map[string]any, error) {
+	body := map[string]string{"slug": slug}
+	out := map[string]any{}
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/transactions/"+url.PathEscape(id)+"/tags", body, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// RemoveTransactionTag detaches a tag from the transaction.
+func (c *Client) RemoveTransactionTag(ctx context.Context, id, slug string) (map[string]any, error) {
+	path := "/api/v1/transactions/" + url.PathEscape(id) + "/tags/" + url.PathEscape(slug)
+	out := map[string]any{}
+	if err := c.Do(ctx, http.MethodDelete, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// BulkRecategorize hits POST /transactions/bulk-recategorize.
+type BulkRecategorizeRequest struct {
+	TargetCategorySlug string   `json:"target_category_slug"`
+	StartDate          string   `json:"start_date,omitempty"`
+	EndDate            string   `json:"end_date,omitempty"`
+	AccountID          string   `json:"account_id,omitempty"`
+	UserID             string   `json:"user_id,omitempty"`
+	CategorySlug       string   `json:"category_slug,omitempty"`
+	MinAmount          *float64 `json:"min_amount,omitempty"`
+	MaxAmount          *float64 `json:"max_amount,omitempty"`
+	Pending            *bool    `json:"pending,omitempty"`
+	Search             string   `json:"search,omitempty"`
+	NameContains       string   `json:"name_contains,omitempty"`
+}
+
+// BulkRecategorizeResponse mirrors service.BulkRecategorizeResult.
+type BulkRecategorizeResponse struct {
+	MatchedCount int64 `json:"matched_count"`
+	UpdatedCount int64 `json:"updated_count"`
+}
+
+// BulkRecategorize executes a server-side recategorize-by-filter.
+func (c *Client) BulkRecategorize(ctx context.Context, req BulkRecategorizeRequest) (*BulkRecategorizeResponse, error) {
+	var out BulkRecategorizeResponse
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/transactions/bulk-recategorize", req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Comment mirrors service.CommentResponse.
+type Comment struct {
+	ID            string  `json:"id"`
+	ShortID       string  `json:"short_id"`
+	TransactionID string  `json:"transaction_id"`
+	AuthorType    string  `json:"author_type"`
+	AuthorID      *string `json:"author_id,omitempty"`
+	AuthorName    string  `json:"author_name"`
+	Content       string  `json:"content"`
+	ReviewID      *string `json:"review_id,omitempty"`
+	CreatedAt     string  `json:"created_at"`
+	UpdatedAt     string  `json:"updated_at"`
+}
+
+// commentListEnvelope is the wrapper the server uses.
+type commentListEnvelope struct {
+	Comments []Comment `json:"comments"`
+}
+
+// ListComments returns every comment attached to a transaction.
+func (c *Client) ListComments(ctx context.Context, txnID string) ([]Comment, error) {
+	var env commentListEnvelope
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/transactions/"+url.PathEscape(txnID)+"/comments", nil, &env); err != nil {
+		return nil, err
+	}
+	return env.Comments, nil
+}
+
+// CreateComment posts a new comment.
+func (c *Client) CreateComment(ctx context.Context, txnID, content string) (*Comment, error) {
+	body := map[string]string{"content": content}
+	var out Comment
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/transactions/"+url.PathEscape(txnID)+"/comments", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateComment edits an existing comment.
+func (c *Client) UpdateComment(ctx context.Context, txnID, commentID, content string) (*Comment, error) {
+	body := map[string]string{"content": content}
+	var out Comment
+	path := "/api/v1/transactions/" + url.PathEscape(txnID) + "/comments/" + url.PathEscape(commentID)
+	if err := c.Do(ctx, http.MethodPut, path, body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteComment removes a comment.
+func (c *Client) DeleteComment(ctx context.Context, txnID, commentID string) error {
+	path := "/api/v1/transactions/" + url.PathEscape(txnID) + "/comments/" + url.PathEscape(commentID)
+	return c.Do(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// AnnotationListResponse is the envelope returned by /transactions/{id}/annotations.
+type AnnotationListResponse struct {
+	Annotations []map[string]any `json:"annotations"`
+}
+
+// ListAnnotations returns the activity-timeline rows for a transaction.
+func (c *Client) ListAnnotations(ctx context.Context, txnID string, kinds []string, limit int) (*AnnotationListResponse, error) {
+	q := url.Values{}
+	if len(kinds) > 0 {
+		q.Set("kind", joinCSV(kinds))
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/v1/transactions/" + url.PathEscape(txnID) + "/annotations"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var out AnnotationListResponse
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/client/transactions_test.go
+++ b/internal/client/transactions_test.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"testing"
+)
+
+// TestTransactionFiltersQuery checks the filter → query-string mapping.
+// Future filter shape changes should preserve these param names: the CLI
+// and any agent's query-builder both depend on them.
+func TestTransactionFiltersQuery(t *testing.T) {
+	pending := false
+	min := 5.5
+	max := 100.0
+
+	tests := []struct {
+		name string
+		f    TransactionFilters
+		want map[string]string
+	}{
+		{
+			name: "empty filters produce no params",
+			f:    TransactionFilters{},
+			want: map[string]string{},
+		},
+		{
+			name: "primary filters round-trip",
+			f: TransactionFilters{
+				Account:       "acc1",
+				Category:      "groceries",
+				From:          "2025-01-01",
+				To:            "2025-02-01",
+				Search:        "starbucks",
+				SearchMode:    "fuzzy",
+				ExcludeSearch: "refund",
+				User:          "u1",
+			},
+			want: map[string]string{
+				"account_id":     "acc1",
+				"category_slug":  "groceries",
+				"start_date":     "2025-01-01",
+				"end_date":       "2025-02-01",
+				"search":         "starbucks",
+				"search_mode":    "fuzzy",
+				"exclude_search": "refund",
+				"user_id":        "u1",
+			},
+		},
+		{
+			name: "tags join with commas",
+			f:    TransactionFilters{Tags: []string{"foo", "bar"}, AnyTags: []string{"baz"}},
+			want: map[string]string{
+				"tags":    "foo,bar",
+				"any_tag": "baz",
+			},
+		},
+		{
+			name: "amount + pending pointers serialise",
+			f:    TransactionFilters{MinAmount: &min, MaxAmount: &max, Pending: &pending},
+			want: map[string]string{
+				"min_amount": "5.5",
+				"max_amount": "100",
+				"pending":    "false",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.f.Query()
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d params, want %d: %v vs %v", len(got), len(tc.want), got, tc.want)
+			}
+			for k, v := range tc.want {
+				if got.Get(k) != v {
+					t.Errorf("%s: got %q, want %q", k, got.Get(k), v)
+				}
+			}
+		})
+	}
+}
+
+// TestJoinCSV asserts the helper produces stable comma-joined values
+// without trailing commas or quoting.
+func TestJoinCSV(t *testing.T) {
+	if joinCSV([]string{}) != "" {
+		t.Fatalf("empty slice should return empty string")
+	}
+	if joinCSV([]string{"a"}) != "a" {
+		t.Fatalf("single element should not get a trailing comma")
+	}
+	if joinCSV([]string{"a", "b", "c"}) != "a,b,c" {
+		t.Fatalf("multi-element output unexpected")
+	}
+}


### PR DESCRIPTION
## Summary

Wire the `breadbox accounts` and `breadbox transactions` subtrees on top of the Stage 1 cobra + client scaffolding (#1050). Both noun groups are thin shells over the existing REST surface — no new endpoints — and route through the shared `FlagBag`, output formatter, and `APIError → exit-code` mapping.

## Commands implemented

**Accounts** (`internal/cli/accounts.go`)
- `breadbox accounts list [--user]` — `GET /accounts`
- `breadbox accounts get <id>` — `GET /accounts/{id}`
- `breadbox accounts detail <id>` — `GET /accounts/{id}/detail`
- `breadbox accounts update <id> [--name] [--excluded] [--dependent-linked]` — `PATCH /accounts/{id}`
- `breadbox accounts links list <account-id>` — `GET /account-links` (filtered client-side by primary/dependent)
- `breadbox accounts links add <primary> --dependent <id> [--strategy] [--tolerance-days]` — `POST /account-links`
- `breadbox accounts links remove <link-id>` — `DELETE /account-links/{id}`

**Transactions** (`internal/cli/transactions.go`)
- `transactions list [filters] [--cursor] [--all]` — `GET /transactions` (with `--all` walking pages)
- `transactions get <id>` — `GET /transactions/{id}`
- `transactions count [filters]` — `GET /transactions/count`
- `transactions summary --by=...` — `GET /transactions/summary`
- `transactions update <id> [--category] [--reset-category] [--note] [--tag]` — `POST /transactions/update`
- `transactions batch <file>` — same endpoint, file or stdin input
- `transactions categorize <id> <category-id>` / `uncategorize <id>` — `PATCH/DELETE /transactions/{id}/category`
- `transactions recategorize --category <slug> [filters]` — `POST /transactions/bulk-recategorize`
- `transactions delete <id>` / `restore <id>` — soft-delete + `POST /transactions/{id}/restore`
- `transactions tag <id> <slug>` / `untag <id> <slug>` — `POST/DELETE /transactions/{id}/tags`
- `transactions annotations <id>` — `GET /transactions/{id}/annotations`
- `transactions comments {add,list,edit,delete}` — `/transactions/{id}/comments` CRUD

## Notable design calls

- **Account-links semantics.** The doc spec for `accounts links list` previously described it as user-to-account ownership; the actual REST surface is the account-to-account reconciliation model (primary ↔ dependent matching). Updated `docs/cli-commands.md` to match reality. If user-to-account ownership semantics are wanted, that's a separate REST + service change.
- **`has-comment` filter** is wired into the flag set for forward compatibility but isn't serialised to the query string yet — the server does not currently support it. Flagged in code with a comment so the moment the server gains support we just lift the guard.
- **Tag attachment verification** in tests goes through `ListTransactions` (with a tag filter) because that path attaches tag slugs to the `TransactionResponse`. `GetTransaction` doesn't populate tags today.
- **Filter parsing** lives in `client.TransactionFilters.Query()` — list, count, summary, and recategorize all share one struct + one query-string mapping. Unit tests pin the param names so a future rename surfaces.
- **`--all` pagination.** When walking pages, the CLI streams either NDJSON (one row per line) or a single JSON array (`[…]`) to stdout. Default table output renders one page at a time and prints the `next_cursor` hint on stderr.
- **No emojis / no leading flair** in stdout — every write command prints the mutated row (or `{succeeded, failed}` for batch) as JSON, or just the id for plain `delete`/`restore`/`categorize`/`uncategorize`. `--quiet` suppresses all stdout for write commands.
- **Integration test bootstrap** mirrors `internal/api/api_integration_test.go` but lives in `cli_test` so the cobra command files don't have to expose internals. The shared truncation in `testutil` had a subtle gotcha — re-calling `testutil.Queries(t)` after `setupEnv` re-truncates and wipes the API key; the harness exposes `env.Queries` so callers don't re-truncate mid-test.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go build -tags=headless ./...`
- [x] `go build -tags=lite ./internal/cli/... ./internal/client/...`
- [x] `go test ./...` (unit tests across the repo are green)
- [x] `DATABASE_URL=... go test -tags=integration -count=1 -p 1 ./internal/cli/... ./internal/client/...` (CLI + client integration suites green)
- [x] Manual exercise of `--json` / `--ndjson` / human-table render paths via the unit + integration tests
- [ ] Follow-up: drive the merchants summary surface (`GET /transactions/merchants`) if/when we add a noun for it — not in this PR.
