### PR TITLE
cli: categories + tags + rules + reports noun commands

### DIFF
--- a/internal/cli/categories.go
+++ b/internal/cli/categories.go
@@ -1,0 +1,333 @@
+// Package cli — categories noun group.
+//
+// `breadbox categories ...` is a thin shell over /api/v1/categories. It
+// adds list/get/create/update/delete/merge plus TSV export/import. The
+// service treats categories as bounded reference data, so the list
+// command returns a bare array (no cursor pagination).
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// AddCategoriesCmd registers `breadbox categories` and its children.
+func AddCategoriesCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "categories",
+		Short: "Manage transaction categories",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newCategoriesListCmd())
+	cmd.AddCommand(newCategoriesGetCmd())
+	cmd.AddCommand(newCategoriesCreateCmd())
+	cmd.AddCommand(newCategoriesUpdateCmd())
+	cmd.AddCommand(newCategoriesDeleteCmd())
+	cmd.AddCommand(newCategoriesMergeCmd())
+	cmd.AddCommand(newCategoriesExportCmd())
+	cmd.AddCommand(newCategoriesImportCmd())
+
+	root.AddCommand(cmd)
+}
+
+func newCategoriesListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all categories",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			cats, err := c.ListCategories(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return renderCategoriesList(flags, cats)
+		},
+	}
+}
+
+func newCategoriesGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show a single category",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			cat, err := c.GetCategory(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return renderCategory(flags, cat)
+		},
+	}
+}
+
+func newCategoriesCreateCmd() *cobra.Command {
+	var (
+		name   string
+		slug   string
+		parent string
+		icon   string
+		color  string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a new category",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" {
+				return UsageErrorf("--name is required")
+			}
+			params := client.CreateCategoryParams{DisplayName: name, Slug: slug}
+			if parent != "" {
+				v := parent
+				params.ParentID = &v
+			}
+			if icon != "" {
+				v := icon
+				params.Icon = &v
+			}
+			if color != "" {
+				v := color
+				params.Color = &v
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			out, err := c.CreateCategory(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return renderCategory(flags, out)
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "display name (required)")
+	cmd.Flags().StringVar(&slug, "slug", "", "stable slug (auto-generated when omitted)")
+	cmd.Flags().StringVar(&parent, "parent", "", "parent category id (uuid or short_id)")
+	cmd.Flags().StringVar(&icon, "icon", "", "icon name")
+	cmd.Flags().StringVar(&color, "color", "", "hex color (e.g. #ff0000)")
+	return cmd
+}
+
+func newCategoriesUpdateCmd() *cobra.Command {
+	var (
+		name      string
+		icon      string
+		color     string
+		sortOrder int32
+		hidden    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update an existing category",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("name") && !cmd.Flags().Changed("icon") &&
+				!cmd.Flags().Changed("color") && !cmd.Flags().Changed("sort-order") &&
+				!cmd.Flags().Changed("hidden") {
+				return UsageErrorf("update needs at least one of --name, --icon, --color, --sort-order, --hidden")
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			// The server's PUT requires display_name; fetch the current row
+			// when --name is omitted so we preserve it.
+			if !cmd.Flags().Changed("name") {
+				cur, err := c.GetCategory(cmd.Context(), args[0])
+				if err != nil {
+					return err
+				}
+				name = cur.DisplayName
+			}
+			params := client.UpdateCategoryParams{DisplayName: name, SortOrder: sortOrder, Hidden: hidden}
+			if cmd.Flags().Changed("icon") {
+				v := icon
+				params.Icon = &v
+			}
+			if cmd.Flags().Changed("color") {
+				v := color
+				params.Color = &v
+			}
+			flags := Flags(cmd)
+			out, err := c.UpdateCategory(cmd.Context(), args[0], params)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return renderCategory(flags, out)
+		},
+	}
+	cmd.Flags().StringVar(&name, "name", "", "display name")
+	cmd.Flags().StringVar(&icon, "icon", "", "icon name")
+	cmd.Flags().StringVar(&color, "color", "", "hex color")
+	cmd.Flags().Int32Var(&sortOrder, "sort-order", 0, "sort order")
+	cmd.Flags().BoolVar(&hidden, "hidden", false, "hide from default category pickers")
+	return cmd
+}
+
+func newCategoriesDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a category (server blocks if transactions reference it)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			affected, err := c.DeleteCategory(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			if flags.JSON || flags.NDJSON || !isTerminal(os.Stdout) {
+				return output.PrintJSON(os.Stdout, map[string]any{
+					"id":                    args[0],
+					"affected_transactions": affected,
+				})
+			}
+			fmt.Println(args[0])
+			return nil
+		},
+	}
+}
+
+func newCategoriesMergeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "merge <from> <to>",
+		Short: "Merge `from` into `to` (migrate transactions, drop source)",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.MergeCategories(cmd.Context(), args[0], args[1]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+}
+
+func newCategoriesExportCmd() *cobra.Command {
+	var format string
+	cmd := &cobra.Command{
+		Use:   "export",
+		Short: "Dump categories (--format tsv|json)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			switch format {
+			case "", "tsv":
+				body, err := c.ExportCategoriesTSV(cmd.Context())
+				if err != nil {
+					return err
+				}
+				fmt.Print(body)
+				return nil
+			case "json":
+				cats, err := c.ListCategories(cmd.Context())
+				if err != nil {
+					return err
+				}
+				return renderCategoriesList(flags, cats)
+			default:
+				return UsageErrorf("--format must be tsv or json (got %q)", format)
+			}
+		},
+	}
+	cmd.Flags().StringVar(&format, "format", "tsv", "tsv | json")
+	return cmd
+}
+
+func newCategoriesImportCmd() *cobra.Command {
+	var replace bool
+	cmd := &cobra.Command{
+		Use:   "import <file>",
+		Short: "Import categories from a TSV file (use `-` for stdin)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			body, err := readFileOrStdin(args[0])
+			if err != nil {
+				return err
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			res, err := c.ImportCategoriesTSV(cmd.Context(), body, replace)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	cmd.Flags().BoolVar(&replace, "replace", false, "drop existing non-system categories before importing")
+	return cmd
+}
+
+// --- rendering helpers ---
+
+func renderCategoriesList(flags *FlagBag, cats []client.Category) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, cats)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(cats))
+		for _, c := range cats {
+			items = append(items, c)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "SLUG", "NAME", "PARENT", "HIDDEN"})
+		for _, c := range cats {
+			renderCategoryRow(tbl, c, "")
+		}
+		return tbl.Flush()
+	}
+}
+
+func renderCategoryRow(tbl *output.Table, c client.Category, prefix string) {
+	parent := "-"
+	if c.ParentSlug != nil && *c.ParentSlug != "" {
+		parent = *c.ParentSlug
+	}
+	hidden := "no"
+	if c.Hidden {
+		hidden = "yes"
+	}
+	tbl.AddRow(c.ShortID, c.Slug, prefix+c.DisplayName, parent, hidden)
+	for _, ch := range c.Children {
+		renderCategoryRow(tbl, ch, prefix+"  ")
+	}
+}
+
+func renderCategory(flags *FlagBag, c *client.Category) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON, output.ModeNDJSON:
+		return output.PrintJSON(os.Stdout, c)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "SLUG", "NAME", "PARENT", "HIDDEN"})
+		parent := "-"
+		if c.ParentSlug != nil && *c.ParentSlug != "" {
+			parent = *c.ParentSlug
+		}
+		hidden := "no"
+		if c.Hidden {
+			hidden = "yes"
+		}
+		tbl.AddRow(c.ShortID, c.Slug, c.DisplayName, parent, hidden)
+		return tbl.Flush()
+	}
+}

--- a/internal/cli/categories_integration_test.go
+++ b/internal/cli/categories_integration_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+// Integration tests for the categories noun group. Drives the real REST
+// handlers via an in-process httptest server.
+package cli_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/api"
+	"breadbox/internal/cli/config"
+	"breadbox/internal/client"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func setupCatEnv(t *testing.T) *envBundle {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+
+	keyResult, err := svc.CreateAPIKeyLegacy(t.Context(), "cli-test", "full_access")
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Get("/categories", api.ListCategoriesHandler(svc))
+		r.Get("/categories/export", api.ExportCategoriesTSVHandler(svc))
+		r.Get("/categories/{id}", api.GetCategoryHandler(svc))
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/categories", api.CreateCategoryHandler(svc))
+			r.Post("/categories/import", api.ImportCategoriesTSVHandler(svc))
+			r.Put("/categories/{id}", api.UpdateCategoryHandler(svc))
+			r.Delete("/categories/{id}", api.DeleteCategoryHandler(svc))
+			r.Post("/categories/{id}/merge", api.MergeCategoriesHandler(svc))
+		})
+	})
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	c := client.New(config.Host{BaseURL: srv.URL, Token: keyResult.PlaintextKey}, "test")
+	return &envBundle{Svc: svc, Server: srv, Client: c, Queries: queries}
+}
+
+func TestCategories_ListReturnsFixtures(t *testing.T) {
+	env := setupCatEnv(t)
+	testutil.MustCreateCategory(t, env.Queries, "groceries", "Groceries")
+
+	cats, err := env.Client.ListCategories(context.Background())
+	if err != nil {
+		t.Fatalf("ListCategories: %v", err)
+	}
+	if len(cats) == 0 {
+		t.Fatalf("expected at least one category, got 0")
+	}
+}
+
+func TestCategories_CreateMergeDelete(t *testing.T) {
+	env := setupCatEnv(t)
+
+	// The seed migration's uncategorized row is dropped by the truncate
+	// between tests; the DELETE handler reassigns orphaned transactions to
+	// it, so we recreate it for this test.
+	testutil.MustCreateCategory(t, env.Queries, "uncategorized", "Uncategorized")
+
+	src, err := env.Client.CreateCategory(context.Background(), client.CreateCategoryParams{
+		DisplayName: "Source",
+		Slug:        "source-cli",
+	})
+	if err != nil {
+		t.Fatalf("CreateCategory source: %v", err)
+	}
+	tgt, err := env.Client.CreateCategory(context.Background(), client.CreateCategoryParams{
+		DisplayName: "Target",
+		Slug:        "target-cli",
+	})
+	if err != nil {
+		t.Fatalf("CreateCategory target: %v", err)
+	}
+
+	if err := env.Client.MergeCategories(context.Background(), src.ID, tgt.ID); err != nil {
+		t.Fatalf("MergeCategories: %v", err)
+	}
+
+	// After merge, the source row is gone.
+	if _, err := env.Client.GetCategory(context.Background(), src.ID); err == nil {
+		t.Fatalf("expected merged source to be deleted, but Get succeeded")
+	}
+	// Target survives the merge.
+	if _, err := env.Client.GetCategory(context.Background(), tgt.ID); err != nil {
+		t.Fatalf("GetCategory target after merge: %v", err)
+	}
+}

--- a/internal/cli/reports.go
+++ b/internal/cli/reports.go
@@ -1,0 +1,229 @@
+// Package cli — reports noun group.
+//
+// `breadbox reports ...` is a thin shell over /api/v1/reports. Submit
+// posts a JSON body authored by an agent; the CLI applies a minimal
+// client-side sanity check (file is JSON with a `title` and `body`) and
+// forwards the rest verbatim. The optional `--kind` flag is added to the
+// payload as the `priority` field — the canonical agent_report schema
+// doesn't have a `kind` column, but the spec uses that term as a synonym
+// for priority/category. Tags filtering on list is applied client-side.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// AddReportsCmd registers `breadbox reports` and its children.
+func AddReportsCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "reports",
+		Short: "Manage agent reports",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newReportsListCmd())
+	cmd.AddCommand(newReportsGetCmd())
+	cmd.AddCommand(newReportsSubmitCmd())
+	cmd.AddCommand(newReportsReadCmd())
+	cmd.AddCommand(newReportsUnreadCmd())
+
+	root.AddCommand(cmd)
+}
+
+func newReportsListCmd() *cobra.Command {
+	var (
+		kind   string
+		status string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List agent reports",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			reports, err := c.ListReports(cmd.Context())
+			if err != nil {
+				return err
+			}
+			// The server returns the full list; --kind / --status are applied
+			// client-side because the public endpoint doesn't accept them.
+			filtered := reports[:0]
+			for _, r := range reports {
+				if kind != "" && !strings.EqualFold(r.Priority, kind) {
+					continue
+				}
+				if status != "" {
+					read := r.ReadAt != nil && *r.ReadAt != ""
+					if strings.EqualFold(status, "unread") && read {
+						continue
+					}
+					if strings.EqualFold(status, "read") && !read {
+						continue
+					}
+				}
+				filtered = append(filtered, r)
+			}
+			return renderReportsList(flags, filtered)
+		},
+	}
+	cmd.Flags().StringVar(&kind, "kind", "", "filter by priority/kind (info, warning, critical)")
+	cmd.Flags().StringVar(&status, "status", "", "filter by read state (read | unread)")
+	return cmd
+}
+
+func newReportsGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show a single report",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			r, err := c.GetReport(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return renderReport(flags, r)
+		},
+	}
+}
+
+func newReportsSubmitCmd() *cobra.Command {
+	var (
+		kind string
+		file string
+	)
+	cmd := &cobra.Command{
+		Use:   "submit",
+		Short: "Submit a new report (--kind --json <file>)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if kind == "" {
+				return UsageErrorf("--kind is required (info | warning | critical)")
+			}
+			if file == "" {
+				return UsageErrorf("--json <file> is required")
+			}
+			raw, err := readFileOrStdin(file)
+			if err != nil {
+				return err
+			}
+			var payload map[string]any
+			if err := json.Unmarshal(raw, &payload); err != nil {
+				return UsageErrorf("report file must be a JSON object: %v", err)
+			}
+			if _, ok := payload["title"]; !ok {
+				return UsageErrorf("report file missing required keys: title")
+			}
+			if _, ok := payload["body"]; !ok {
+				return UsageErrorf("report file missing required keys: body")
+			}
+			// Inject --kind as priority when the file doesn't already set it.
+			if _, ok := payload["priority"]; !ok {
+				payload["priority"] = kind
+			}
+			body, err := json.Marshal(payload)
+			if err != nil {
+				return fmt.Errorf("marshal report payload: %w", err)
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			r, err := c.CreateReport(cmd.Context(), json.RawMessage(body))
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return renderReport(flags, r)
+		},
+	}
+	cmd.Flags().StringVar(&kind, "kind", "", "report priority/kind (info | warning | critical)")
+	cmd.Flags().StringVar(&file, "json", "", "path to report JSON body (use `-` for stdin)")
+	return cmd
+}
+
+func newReportsReadCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "read <id>",
+		Short: "Mark a report as read",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.MarkReportRead(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+}
+
+func newReportsUnreadCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unread <id>",
+		Short: "Mark a report as unread",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.MarkReportUnread(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+}
+
+// --- rendering helpers ---
+
+func renderReportsList(flags *FlagBag, reports []client.Report) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, reports)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(reports))
+		for _, r := range reports {
+			items = append(items, r)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "TITLE", "PRIORITY", "AUTHOR", "READ", "CREATED"})
+		for _, r := range reports {
+			read := "no"
+			if r.ReadAt != nil && *r.ReadAt != "" {
+				read = "yes"
+			}
+			tbl.AddRow(r.ShortID, truncate(r.Title, 60), r.Priority, r.CreatedByName, read, r.CreatedAt)
+		}
+		return tbl.Flush()
+	}
+}
+
+func renderReport(flags *FlagBag, r *client.Report) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON, output.ModeNDJSON:
+		return output.PrintJSON(os.Stdout, r)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "TITLE", "PRIORITY", "AUTHOR", "READ", "CREATED"})
+		read := "no"
+		if r.ReadAt != nil && *r.ReadAt != "" {
+			read = "yes"
+		}
+		tbl.AddRow(r.ShortID, truncate(r.Title, 60), r.Priority, r.CreatedByName, read, r.CreatedAt)
+		return tbl.Flush()
+	}
+}

--- a/internal/cli/reports_integration_test.go
+++ b/internal/cli/reports_integration_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+// Integration tests for the reports noun group.
+package cli_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/api"
+	"breadbox/internal/cli/config"
+	"breadbox/internal/client"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func setupReportsEnv(t *testing.T) *envBundle {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+
+	keyResult, err := svc.CreateAPIKeyLegacy(t.Context(), "cli-test", "full_access")
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Get("/reports", api.ListReportsHandler(svc))
+		r.Get("/reports/{id}", api.GetReportHandler(svc))
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/reports", api.CreateReportHandler(svc))
+			r.Patch("/reports/{id}/read", api.MarkReportReadHandler(svc))
+			r.Patch("/reports/{id}/unread", api.MarkReportUnreadHandler(svc))
+		})
+	})
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	c := client.New(config.Host{BaseURL: srv.URL, Token: keyResult.PlaintextKey}, "test")
+	return &envBundle{Svc: svc, Server: srv, Client: c, Queries: queries}
+}
+
+func TestReports_SubmitListRead(t *testing.T) {
+	env := setupReportsEnv(t)
+
+	body := []byte(`{"title":"weekly review","body":"all good","priority":"info","tags":["weekly"]}`)
+	created, err := env.Client.CreateReport(context.Background(), json.RawMessage(body))
+	if err != nil {
+		t.Fatalf("CreateReport: %v", err)
+	}
+	if created.Title != "weekly review" {
+		t.Fatalf("title = %q, want weekly review", created.Title)
+	}
+
+	list, err := env.Client.ListReports(context.Background())
+	if err != nil {
+		t.Fatalf("ListReports: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatalf("expected at least one report, got 0")
+	}
+
+	if err := env.Client.MarkReportRead(context.Background(), created.ID); err != nil {
+		t.Fatalf("MarkReportRead: %v", err)
+	}
+	got, err := env.Client.GetReport(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	if got.ReadAt == nil {
+		t.Fatalf("expected read_at to be populated after MarkReportRead")
+	}
+
+	if err := env.Client.MarkReportUnread(context.Background(), created.ID); err != nil {
+		t.Fatalf("MarkReportUnread: %v", err)
+	}
+	got, err = env.Client.GetReport(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("GetReport after unread: %v", err)
+	}
+	if got.ReadAt != nil {
+		t.Fatalf("expected read_at to be nil after MarkReportUnread, got %v", *got.ReadAt)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -173,6 +173,10 @@ func NewRootCmd(version string) *cobra.Command {
 	AddConfigCmd(root)
 	AddBackupCmd(root)
 	AddWebhooksCmd(root)
+	AddCategoriesCmd(root)
+	AddTagsCmd(root)
+	AddRulesCmd(root)
+	AddReportsCmd(root)
 	AddVersionCmd(root, version)
 
 	return root

--- a/internal/cli/rules.go
+++ b/internal/cli/rules.go
@@ -1,0 +1,340 @@
+// Package cli — rules noun group.
+//
+// `breadbox rules ...` is a thin shell over /api/v1/rules. Create and
+// update accept a JSON file matching the canonical rule-DSL spec
+// (docs/rule-dsl.md). The CLI does a minimal client-side check (file is
+// JSON, has required top-level keys) and forwards the rest verbatim;
+// the server validates the full grammar.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// AddRulesCmd registers `breadbox rules` and its children.
+func AddRulesCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "rules",
+		Short: "Manage transaction rules",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newRulesListCmd())
+	cmd.AddCommand(newRulesGetCmd())
+	cmd.AddCommand(newRulesCreateCmd())
+	cmd.AddCommand(newRulesUpdateCmd())
+	cmd.AddCommand(newRulesDeleteCmd())
+	cmd.AddCommand(newRulesPreviewCmd())
+	cmd.AddCommand(newRulesApplyCmd())
+	cmd.AddCommand(newRulesBatchCmd())
+
+	root.AddCommand(cmd)
+}
+
+func newRulesListCmd() *cobra.Command {
+	var (
+		enabled bool
+		cursor  string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List transaction rules (cursor-paginated)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			params := client.RuleListParams{
+				Cursor: cursor,
+				Limit:  flags.Limit,
+			}
+			if cmd.Flags().Changed("enabled") {
+				v := enabled
+				params.Enabled = &v
+			}
+			res, err := c.ListRules(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+			return renderRulesList(flags, res)
+		},
+	}
+	cmd.Flags().BoolVar(&enabled, "enabled", true, "filter by enabled state (true|false)")
+	cmd.Flags().StringVar(&cursor, "cursor", "", "opaque cursor from a previous page")
+	return cmd
+}
+
+func newRulesGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show a single rule",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			r, err := c.GetRule(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return renderRule(flags, r)
+		},
+	}
+}
+
+// validateRuleFile sanity-checks that the file contents are JSON and
+// contain a `name` plus either `conditions` + `actions` or a
+// `category_slug` shortcut. The server is the source of truth for the
+// rest of the DSL grammar.
+func validateRuleFile(raw []byte) (json.RawMessage, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, UsageErrorf("rule file must be a JSON object: %v", err)
+	}
+	if _, ok := obj["name"]; !ok {
+		return nil, UsageErrorf("rule file missing required keys: name")
+	}
+	_, hasActions := obj["actions"]
+	_, hasCategorySlug := obj["category_slug"]
+	if !hasActions && !hasCategorySlug {
+		return nil, UsageErrorf("rule file missing required keys: actions (or category_slug)")
+	}
+	return json.RawMessage(raw), nil
+}
+
+func newRulesCreateCmd() *cobra.Command {
+	var file string
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a rule from a DSL JSON file (--json)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if file == "" {
+				return UsageErrorf("--json <file> is required")
+			}
+			raw, err := readFileOrStdin(file)
+			if err != nil {
+				return err
+			}
+			body, err := validateRuleFile(raw)
+			if err != nil {
+				return err
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			r, err := c.CreateRule(cmd.Context(), body)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return renderRule(flags, r)
+		},
+	}
+	cmd.Flags().StringVar(&file, "json", "", "path to rule DSL JSON file (use `-` for stdin)")
+	return cmd
+}
+
+func newRulesUpdateCmd() *cobra.Command {
+	var file string
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update a rule from a DSL JSON file (--json)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if file == "" {
+				return UsageErrorf("--json <file> is required")
+			}
+			raw, err := readFileOrStdin(file)
+			if err != nil {
+				return err
+			}
+			// Update accepts partial patches, so we only check it's an object.
+			var probe map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &probe); err != nil {
+				return UsageErrorf("rule file must be a JSON object: %v", err)
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			r, err := c.UpdateRule(cmd.Context(), args[0], json.RawMessage(raw))
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return renderRule(flags, r)
+		},
+	}
+	cmd.Flags().StringVar(&file, "json", "", "path to rule DSL patch JSON file (use `-` for stdin)")
+	return cmd
+}
+
+func newRulesDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a rule",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.DeleteRule(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+}
+
+func newRulesPreviewCmd() *cobra.Command {
+	var sample int
+	cmd := &cobra.Command{
+		Use:   "preview <id>",
+		Short: "Preview which transactions a rule would match",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			// PreviewRule expects a Condition body, so resolve the rule's
+			// stored conditions first and forward them to the server.
+			r, err := c.GetRule(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			cond := r.Conditions
+			if len(cond) == 0 {
+				cond = json.RawMessage("{}")
+			}
+			req := client.PreviewRuleRequest{Conditions: cond, SampleSize: sample}
+			res, err := c.PreviewRule(cmd.Context(), req)
+			if err != nil {
+				return err
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	cmd.Flags().IntVar(&sample, "sample-size", 0, "max number of matched rows the server returns")
+	return cmd
+}
+
+func newRulesApplyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "apply <id>",
+		Short: "Apply a rule retroactively to existing transactions",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			res, err := c.ApplyRule(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+}
+
+func newRulesBatchCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "batch <file>",
+		Short: "Create many rules in one call (JSON array or {rules:[...]})",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			raw, err := readFileOrStdin(args[0])
+			if err != nil {
+				return err
+			}
+			// Accept either a bare array of rule objects or an envelope
+			// {"rules":[...], "on_error":"continue|abort"} matching the
+			// server's POST /rules/batch shape.
+			trimmed := raw
+			for len(trimmed) > 0 && (trimmed[0] == ' ' || trimmed[0] == '\n' || trimmed[0] == '\t' || trimmed[0] == '\r') {
+				trimmed = trimmed[1:]
+			}
+			var body []byte
+			if len(trimmed) > 0 && trimmed[0] == '[' {
+				wrap := map[string]json.RawMessage{"rules": json.RawMessage(raw)}
+				b, err := json.Marshal(wrap)
+				if err != nil {
+					return fmt.Errorf("wrap batch array: %w", err)
+				}
+				body = b
+			} else {
+				// Ensure it parses as an object up front so we return a usage
+				// error rather than a 400 from the server.
+				var probe map[string]json.RawMessage
+				if err := json.Unmarshal(raw, &probe); err != nil {
+					return UsageErrorf("batch file must be a JSON array or {rules:[...]} object: %v", err)
+				}
+				body = raw
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			res, err := c.BatchCreateRules(cmd.Context(), json.RawMessage(body))
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	return cmd
+}
+
+// --- rendering helpers ---
+
+func renderRulesList(flags *FlagBag, res *client.RuleListResult) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, res)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(res.Rules))
+		for _, r := range res.Rules {
+			items = append(items, r)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "NAME", "TRIGGER", "PRIORITY", "ENABLED", "HITS"})
+		for _, r := range res.Rules {
+			tbl.AddRow(r.ShortID, r.Name, r.Trigger, fmt.Sprintf("%d", r.Priority),
+				boolYN(r.Enabled), fmt.Sprintf("%d", r.HitCount))
+		}
+		if err := tbl.Flush(); err != nil {
+			return err
+		}
+		if res.HasMore && res.NextCursor != "" {
+			fmt.Fprintf(os.Stderr, "(more rows; pass --cursor %s to continue)\n", res.NextCursor)
+		}
+		return nil
+	}
+}
+
+func renderRule(flags *FlagBag, r *client.Rule) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON, output.ModeNDJSON:
+		return output.PrintJSON(os.Stdout, r)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "NAME", "TRIGGER", "PRIORITY", "ENABLED", "HITS"})
+		tbl.AddRow(r.ShortID, r.Name, r.Trigger, fmt.Sprintf("%d", r.Priority),
+			boolYN(r.Enabled), fmt.Sprintf("%d", r.HitCount))
+		return tbl.Flush()
+	}
+}
+
+func boolYN(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/cli/rules_integration_test.go
+++ b/internal/cli/rules_integration_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+// Integration tests for the rules noun group.
+package cli_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/api"
+	"breadbox/internal/cli/config"
+	"breadbox/internal/client"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func setupRulesEnv(t *testing.T) *envBundle {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+
+	keyResult, err := svc.CreateAPIKeyLegacy(t.Context(), "cli-test", "full_access")
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Get("/rules", api.ListRulesHandler(svc))
+		r.Get("/rules/{id}", api.GetRuleHandler(svc))
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/rules", api.CreateRuleHandler(svc))
+			r.Post("/rules/batch", api.BatchCreateRulesHandler(svc))
+			r.Put("/rules/{id}", api.UpdateRuleHandler(svc))
+			r.Delete("/rules/{id}", api.DeleteRuleHandler(svc))
+			r.Post("/rules/{id}/apply", api.ApplyRuleHandler(svc))
+			r.Post("/rules/preview", api.PreviewRuleHandler(svc))
+		})
+	})
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	c := client.New(config.Host{BaseURL: srv.URL, Token: keyResult.PlaintextKey}, "test")
+	return &envBundle{Svc: svc, Server: srv, Client: c, Queries: queries}
+}
+
+func TestRules_CreatePreviewApplyDelete(t *testing.T) {
+	env := setupRulesEnv(t)
+	q := env.Queries
+
+	// Seed a category referenced by the rule's action.
+	testutil.MustCreateCategory(t, q, "groceries", "Groceries")
+
+	body := []byte(`{
+		"name":"cli-test-rule",
+		"conditions":{"field":"provider_name","op":"contains","value":"trader joe"},
+		"actions":[{"type":"set_category","category_slug":"groceries"}],
+		"trigger":"on_create"
+	}`)
+
+	rule, err := env.Client.CreateRule(context.Background(), json.RawMessage(body))
+	if err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+	if rule.Name != "cli-test-rule" {
+		t.Fatalf("name = %q, want cli-test-rule", rule.Name)
+	}
+
+	// Preview against the stored conditions — server returns matches +
+	// stats; we just check the call round-trips.
+	preview, err := env.Client.PreviewRule(context.Background(), client.PreviewRuleRequest{
+		Conditions: rule.Conditions,
+		SampleSize: 5,
+	})
+	if err != nil {
+		t.Fatalf("PreviewRule: %v", err)
+	}
+	if preview == nil {
+		t.Fatalf("preview returned nil")
+	}
+
+	apply, err := env.Client.ApplyRule(context.Background(), rule.ID)
+	if err != nil {
+		t.Fatalf("ApplyRule: %v", err)
+	}
+	if apply.RuleID == "" {
+		t.Fatalf("ApplyRule returned empty rule_id")
+	}
+
+	if err := env.Client.DeleteRule(context.Background(), rule.ID); err != nil {
+		t.Fatalf("DeleteRule: %v", err)
+	}
+}
+
+func TestRules_BatchCreate(t *testing.T) {
+	env := setupRulesEnv(t)
+	q := env.Queries
+	testutil.MustCreateCategory(t, q, "dining", "Dining")
+
+	body := []byte(`{"rules":[
+		{"name":"rule-a","conditions":{"field":"provider_name","op":"contains","value":"chipotle"},"actions":[{"type":"set_category","category_slug":"dining"}],"trigger":"on_create"},
+		{"name":"rule-b","conditions":{"field":"provider_name","op":"contains","value":"sweetgreen"},"actions":[{"type":"set_category","category_slug":"dining"}],"trigger":"on_create"}
+	]}`)
+
+	res, err := env.Client.BatchCreateRules(context.Background(), json.RawMessage(body))
+	if err != nil {
+		t.Fatalf("BatchCreateRules: %v", err)
+	}
+	if got, ok := res["succeeded"].(float64); !ok || int(got) != 2 {
+		t.Fatalf("expected succeeded=2, got %v", res["succeeded"])
+	}
+}

--- a/internal/cli/rules_test.go
+++ b/internal/cli/rules_test.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateRuleFile_OK asserts a well-formed rule body passes the
+// client-side sanity check.
+func TestValidateRuleFile_OK(t *testing.T) {
+	body := []byte(`{"name":"test","conditions":{"field":"name","op":"contains","value":"x"},"actions":[{"type":"set_category","category_slug":"food"}]}`)
+	if _, err := validateRuleFile(body); err != nil {
+		t.Fatalf("validateRuleFile: %v", err)
+	}
+}
+
+// TestValidateRuleFile_CategoryShortcut accepts the actions shortcut
+// where only category_slug is supplied (server creates the implicit
+// set_category action).
+func TestValidateRuleFile_CategoryShortcut(t *testing.T) {
+	body := []byte(`{"name":"test","conditions":{"field":"name","op":"contains","value":"x"},"category_slug":"food"}`)
+	if _, err := validateRuleFile(body); err != nil {
+		t.Fatalf("validateRuleFile: %v", err)
+	}
+}
+
+// TestValidateRuleFile_MissingKeys produces a usage error mentioning the
+// missing key — surfaced as exit code 2 to the caller.
+func TestValidateRuleFile_MissingKeys(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"no name", `{"actions":[]}`, "name"},
+		{"no actions or category", `{"name":"x"}`, "actions"},
+		{"not an object", `[]`, "JSON object"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateRuleFile([]byte(tc.body))
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q did not mention %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestBoolYN spot-checks the rendering helper.
+func TestBoolYN(t *testing.T) {
+	if got := boolYN(true); got != "yes" {
+		t.Errorf("boolYN(true) = %q, want yes", got)
+	}
+	if got := boolYN(false); got != "no" {
+		t.Errorf("boolYN(false) = %q, want no", got)
+	}
+}

--- a/internal/cli/tags.go
+++ b/internal/cli/tags.go
@@ -1,0 +1,224 @@
+// Package cli — tags noun group.
+//
+// `breadbox tags ...` is a thin shell over /api/v1/tags. Tags are bounded
+// reference data (no cursor pagination); slug is the canonical handle —
+// uuid and short_id are accepted for parity with other endpoints.
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// AddTagsCmd registers `breadbox tags` and its children.
+func AddTagsCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "tags",
+		Short: "Manage transaction tags",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newTagsListCmd())
+	cmd.AddCommand(newTagsGetCmd())
+	cmd.AddCommand(newTagsCreateCmd())
+	cmd.AddCommand(newTagsUpdateCmd())
+	cmd.AddCommand(newTagsDeleteCmd())
+
+	root.AddCommand(cmd)
+}
+
+func newTagsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List all tags",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			tags, err := c.ListTags(cmd.Context())
+			if err != nil {
+				return err
+			}
+			return renderTagsList(flags, tags)
+		},
+	}
+}
+
+func newTagsGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <slug>",
+		Short: "Show a single tag (accepts slug, uuid, or short_id)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			tag, err := c.GetTag(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return renderTag(flags, tag)
+		},
+	}
+}
+
+func newTagsCreateCmd() *cobra.Command {
+	var (
+		label string
+		desc  string
+		color string
+		icon  string
+	)
+	cmd := &cobra.Command{
+		Use:   "create <slug>",
+		Short: "Create a new tag",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			displayName := label
+			if displayName == "" {
+				displayName = args[0]
+			}
+			params := client.CreateTagParams{
+				Slug:        args[0],
+				DisplayName: displayName,
+				Description: desc,
+			}
+			if color != "" {
+				v := color
+				params.Color = &v
+			}
+			if icon != "" {
+				v := icon
+				params.Icon = &v
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			out, err := c.CreateTag(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return renderTag(flags, out)
+		},
+	}
+	cmd.Flags().StringVar(&label, "label", "", "human-readable display name (defaults to slug)")
+	cmd.Flags().StringVar(&desc, "description", "", "long-form description")
+	cmd.Flags().StringVar(&color, "color", "", "hex color")
+	cmd.Flags().StringVar(&icon, "icon", "", "icon name")
+	return cmd
+}
+
+func newTagsUpdateCmd() *cobra.Command {
+	var (
+		label     string
+		desc      string
+		color     string
+		icon      string
+		lifecycle string
+	)
+	cmd := &cobra.Command{
+		Use:   "update <slug>",
+		Short: "Update an existing tag (slug is immutable)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !cmd.Flags().Changed("label") && !cmd.Flags().Changed("description") &&
+				!cmd.Flags().Changed("color") && !cmd.Flags().Changed("icon") &&
+				!cmd.Flags().Changed("lifecycle") {
+				return UsageErrorf("update needs at least one of --label, --description, --color, --icon, --lifecycle")
+			}
+			params := client.UpdateTagParams{}
+			if cmd.Flags().Changed("label") {
+				v := label
+				params.DisplayName = &v
+			}
+			if cmd.Flags().Changed("description") {
+				v := desc
+				params.Description = &v
+			}
+			if cmd.Flags().Changed("color") {
+				v := color
+				params.Color = &v
+			}
+			if cmd.Flags().Changed("icon") {
+				v := icon
+				params.Icon = &v
+			}
+			if cmd.Flags().Changed("lifecycle") {
+				v := lifecycle
+				params.Lifecycle = &v
+			}
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			out, err := c.UpdateTag(cmd.Context(), args[0], params)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return renderTag(flags, out)
+		},
+	}
+	cmd.Flags().StringVar(&label, "label", "", "display name")
+	cmd.Flags().StringVar(&desc, "description", "", "long-form description")
+	cmd.Flags().StringVar(&color, "color", "", "hex color")
+	cmd.Flags().StringVar(&icon, "icon", "", "icon name")
+	cmd.Flags().StringVar(&lifecycle, "lifecycle", "", "lifecycle state (e.g. active, archived)")
+	return cmd
+}
+
+func newTagsDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <slug>",
+		Short: "Delete a tag",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.DeleteTag(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+}
+
+// --- rendering helpers ---
+
+func renderTagsList(flags *FlagBag, tags []client.Tag) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, tags)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(tags))
+		for _, t := range tags {
+			items = append(items, t)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "SLUG", "LABEL", "LIFECYCLE", "COLOR"})
+		for _, t := range tags {
+			tbl.AddRow(t.ShortID, t.Slug, t.DisplayName, t.Lifecycle, strPtr(t.Color))
+		}
+		return tbl.Flush()
+	}
+}
+
+func renderTag(flags *FlagBag, t *client.Tag) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON, output.ModeNDJSON:
+		return output.PrintJSON(os.Stdout, t)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "SLUG", "LABEL", "LIFECYCLE", "COLOR"})
+		tbl.AddRow(t.ShortID, t.Slug, t.DisplayName, t.Lifecycle, strPtr(t.Color))
+		return tbl.Flush()
+	}
+}

--- a/internal/cli/tags_integration_test.go
+++ b/internal/cli/tags_integration_test.go
@@ -1,0 +1,110 @@
+//go:build integration
+
+// Integration tests for the tags noun group.
+package cli_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"breadbox/internal/api"
+	"breadbox/internal/cli/config"
+	"breadbox/internal/client"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func setupTagsEnv(t *testing.T) *envBundle {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+
+	keyResult, err := svc.CreateAPIKeyLegacy(t.Context(), "cli-test", "full_access")
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+		r.Get("/tags", api.ListTagsHandler(svc))
+		r.Get("/tags/{slug}", api.GetTagHandler(svc))
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/tags", api.CreateTagHandler(svc))
+			r.Patch("/tags/{slug}", api.UpdateTagHandler(svc))
+			r.Delete("/tags/{slug}", api.DeleteTagHandler(svc))
+		})
+	})
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	c := client.New(config.Host{BaseURL: srv.URL, Token: keyResult.PlaintextKey}, "test")
+	return &envBundle{Svc: svc, Server: srv, Client: c, Queries: queries}
+}
+
+func TestTags_CreateListDelete(t *testing.T) {
+	env := setupTagsEnv(t)
+
+	created, err := env.Client.CreateTag(context.Background(), client.CreateTagParams{
+		Slug:        "needs-review",
+		DisplayName: "Needs Review",
+		Description: "Flagged for human eyes",
+	})
+	if err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+	if created.Slug != "needs-review" {
+		t.Fatalf("slug = %q, want needs-review", created.Slug)
+	}
+
+	tags, err := env.Client.ListTags(context.Background())
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+	found := false
+	for _, tg := range tags {
+		if tg.Slug == "needs-review" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("created tag not returned by list")
+	}
+
+	if err := env.Client.DeleteTag(context.Background(), "needs-review"); err != nil {
+		t.Fatalf("DeleteTag: %v", err)
+	}
+	if _, err := env.Client.GetTag(context.Background(), "needs-review"); err == nil {
+		t.Fatalf("expected GetTag to fail after delete")
+	}
+}
+
+func TestTags_UpdateLabel(t *testing.T) {
+	env := setupTagsEnv(t)
+
+	if _, err := env.Client.CreateTag(context.Background(), client.CreateTagParams{
+		Slug:        "subscription",
+		DisplayName: "Subscription",
+	}); err != nil {
+		t.Fatalf("CreateTag: %v", err)
+	}
+
+	newLabel := "Recurring Subscription"
+	updated, err := env.Client.UpdateTag(context.Background(), "subscription", client.UpdateTagParams{
+		DisplayName: &newLabel,
+	})
+	if err != nil {
+		t.Fatalf("UpdateTag: %v", err)
+	}
+	if updated.DisplayName != newLabel {
+		t.Fatalf("display_name = %q, want %q", updated.DisplayName, newLabel)
+	}
+}

--- a/internal/client/categories.go
+++ b/internal/client/categories.go
@@ -1,0 +1,131 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// Category mirrors service.CategoryResponse — the JSON shape returned by
+// GET /api/v1/categories and friends. Defined here so the CLI doesn't
+// depend on the `internal/service` package (which is server-only under
+// the `-tags=lite` build).
+type Category struct {
+	ID                string     `json:"id"`
+	ShortID           string     `json:"short_id"`
+	Slug              string     `json:"slug"`
+	DisplayName       string     `json:"display_name"`
+	ParentID          *string    `json:"parent_id"`
+	ParentSlug        *string    `json:"parent_slug,omitempty"`
+	ParentDisplayName *string    `json:"parent_display_name,omitempty"`
+	Icon              *string    `json:"icon"`
+	Color             *string    `json:"color"`
+	SortOrder         int32      `json:"sort_order"`
+	IsSystem          bool       `json:"is_system"`
+	Hidden            bool       `json:"hidden"`
+	Children          []Category `json:"children,omitempty"`
+	CreatedAt         string     `json:"created_at"`
+	UpdatedAt         string     `json:"updated_at"`
+}
+
+// CreateCategoryParams matches the POST /api/v1/categories body.
+type CreateCategoryParams struct {
+	DisplayName string  `json:"display_name"`
+	Slug        string  `json:"slug,omitempty"`
+	ParentID    *string `json:"parent_id,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+	Color       *string `json:"color,omitempty"`
+	SortOrder   int32   `json:"sort_order,omitempty"`
+}
+
+// UpdateCategoryParams matches the PUT /api/v1/categories/{id} body.
+type UpdateCategoryParams struct {
+	DisplayName string  `json:"display_name"`
+	Icon        *string `json:"icon,omitempty"`
+	Color       *string `json:"color,omitempty"`
+	SortOrder   int32   `json:"sort_order"`
+	Hidden      bool    `json:"hidden"`
+}
+
+// CategoryImportResult mirrors service.CategoryImportResult — the import
+// summary payload returned by POST /api/v1/categories/import.
+type CategoryImportResult struct {
+	Inserted int      `json:"inserted"`
+	Updated  int      `json:"updated"`
+	Skipped  int      `json:"skipped"`
+	Errors   []string `json:"errors,omitempty"`
+}
+
+// ListCategories fetches the full category tree (parents with children).
+func (c *Client) ListCategories(ctx context.Context) ([]Category, error) {
+	var out []Category
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/categories", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetCategory fetches a single category by id (short_id or uuid).
+func (c *Client) GetCategory(ctx context.Context, id string) (*Category, error) {
+	var out Category
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/categories/"+url.PathEscape(id), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateCategory creates a new category.
+func (c *Client) CreateCategory(ctx context.Context, params CreateCategoryParams) (*Category, error) {
+	var out Category
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/categories", params, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateCategory updates an existing category.
+func (c *Client) UpdateCategory(ctx context.Context, id string, params UpdateCategoryParams) (*Category, error) {
+	var out Category
+	if err := c.Do(ctx, http.MethodPut, "/api/v1/categories/"+url.PathEscape(id), params, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteCategory deletes a category by id. Returns the count of
+// affected (re-assigned) transactions; non-zero only when the server
+// re-points transactions to the uncategorized bucket.
+func (c *Client) DeleteCategory(ctx context.Context, id string) (int64, error) {
+	out := map[string]int64{}
+	if err := c.Do(ctx, http.MethodDelete, "/api/v1/categories/"+url.PathEscape(id), nil, &out); err != nil {
+		return 0, err
+	}
+	return out["affected_transactions"], nil
+}
+
+// MergeCategories merges the source into the target category.
+func (c *Client) MergeCategories(ctx context.Context, sourceID, targetID string) error {
+	body := map[string]string{"target_id": targetID}
+	return c.Do(ctx, http.MethodPost, "/api/v1/categories/"+url.PathEscape(sourceID)+"/merge", body, nil)
+}
+
+// ExportCategoriesTSV fetches the TSV dump as a raw string. The server
+// returns text/tab-separated-values; this helper bypasses Do()'s JSON
+// decoder.
+func (c *Client) ExportCategoriesTSV(ctx context.Context) (string, error) {
+	return c.rawGET(ctx, "/api/v1/categories/export")
+}
+
+// ImportCategoriesTSV uploads a TSV body. `replace` toggles the replace-mode
+// query parameter (server-side: drop existing non-system categories first).
+func (c *Client) ImportCategoriesTSV(ctx context.Context, body []byte, replace bool) (*CategoryImportResult, error) {
+	path := "/api/v1/categories/import"
+	if replace {
+		path += "?replace=true"
+	}
+	out := CategoryImportResult{}
+	if err := c.doRaw(ctx, http.MethodPost, path, body, "text/tab-separated-values", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -157,6 +157,88 @@ func (c *Client) Do(ctx context.Context, method, path string, body any, out any)
 	return nil
 }
 
+// rawGET fetches a path and returns the response body as a string. Used
+// for non-JSON endpoints like /categories/export (TSV).
+func (c *Client) rawGET(ctx context.Context, path string) (string, error) {
+	u, err := c.url(path)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	if c.host.Token != "" {
+		req.Header.Set("X-API-Key", c.host.Token)
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("call GET %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		var env errorEnvelope
+		_ = json.Unmarshal(body, &env)
+		apiErr := env.Error
+		apiErr.Status = resp.StatusCode
+		if apiErr.Message == "" && len(body) > 0 {
+			apiErr.Message = strings.TrimSpace(string(body))
+		}
+		return "", &apiErr
+	}
+	return string(body), nil
+}
+
+// doRaw is like Do but sends `body` verbatim with a caller-chosen
+// Content-Type (instead of JSON-encoding it). Used for endpoints whose
+// request body is a plain text payload (e.g., TSV import).
+func (c *Client) doRaw(ctx context.Context, method, path string, body []byte, contentType string, out any) error {
+	u, err := c.url(path)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, strings.NewReader(string(body)))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	if c.host.Token != "" {
+		req.Header.Set("X-API-Key", c.host.Token)
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("call %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		var env errorEnvelope
+		_ = json.Unmarshal(raw, &env)
+		apiErr := env.Error
+		apiErr.Status = resp.StatusCode
+		if apiErr.Message == "" && len(raw) > 0 {
+			apiErr.Message = strings.TrimSpace(string(raw))
+		}
+		return &apiErr
+	}
+	if out == nil || resp.StatusCode == http.StatusNoContent || len(raw) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
 // url builds the absolute URL for an API path. `path` must start with
 // `/api/v1/...` (or another root-level path like `/health`).
 func (c *Client) url(path string) (string, error) {

--- a/internal/client/reports.go
+++ b/internal/client/reports.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+// Report mirrors service.AgentReportResponse — the JSON shape returned
+// by GET /api/v1/reports and friends.
+type Report struct {
+	ID            string   `json:"id"`
+	ShortID       string   `json:"short_id"`
+	Title         string   `json:"title"`
+	Body          string   `json:"body"`
+	CreatedByType string   `json:"created_by_type"`
+	CreatedByID   *string  `json:"created_by_id,omitempty"`
+	CreatedByName string   `json:"created_by_name"`
+	Priority      string   `json:"priority"`
+	Tags          []string `json:"tags"`
+	Author        *string  `json:"author,omitempty"`
+	ReadAt        *string  `json:"read_at,omitempty"`
+	CreatedAt     string   `json:"created_at"`
+}
+
+// CreateReportParams matches the POST /api/v1/reports body.
+type CreateReportParams struct {
+	Title    string   `json:"title"`
+	Body     string   `json:"body"`
+	Priority string   `json:"priority,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
+	Author   string   `json:"author,omitempty"`
+}
+
+// ListReports returns the most recent reports (server-capped to 50).
+func (c *Client) ListReports(ctx context.Context) ([]Report, error) {
+	var out []Report
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/reports", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetReport fetches a single report.
+func (c *Client) GetReport(ctx context.Context, id string) (*Report, error) {
+	var out Report
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/reports/"+url.PathEscape(id), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateReport submits a new agent report. The CLI lets callers either
+// pass a CreateReportParams directly or hand it a raw JSON body — the
+// latter is what `breadbox reports submit --json <file>` uses.
+func (c *Client) CreateReport(ctx context.Context, body json.RawMessage) (*Report, error) {
+	var out Report
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/reports", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// MarkReportRead flips the read flag.
+func (c *Client) MarkReportRead(ctx context.Context, id string) error {
+	return c.Do(ctx, http.MethodPatch, "/api/v1/reports/"+url.PathEscape(id)+"/read", nil, nil)
+}
+
+// MarkReportUnread flips the read flag back.
+func (c *Client) MarkReportUnread(ctx context.Context, id string) error {
+	return c.Do(ctx, http.MethodPatch, "/api/v1/reports/"+url.PathEscape(id)+"/unread", nil, nil)
+}

--- a/internal/client/rules.go
+++ b/internal/client/rules.go
@@ -1,0 +1,156 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// Rule mirrors service.TransactionRuleResponse. The DSL payload is kept
+// as a raw json.RawMessage so the CLI can pass user-authored rule files
+// through verbatim without re-validating the DSL grammar (server does
+// that).
+type Rule struct {
+	ID            string          `json:"id"`
+	ShortID       string          `json:"short_id"`
+	Name          string          `json:"name"`
+	Conditions    json.RawMessage `json:"conditions,omitempty"`
+	Actions       json.RawMessage `json:"actions,omitempty"`
+	Trigger       string          `json:"trigger"`
+	CategorySlug  *string         `json:"category_slug,omitempty"`
+	CategoryName  *string         `json:"category_display_name,omitempty"`
+	Priority      int             `json:"priority"`
+	Enabled       bool            `json:"enabled"`
+	ExpiresAt     *string         `json:"expires_at,omitempty"`
+	CreatedByType string          `json:"created_by_type"`
+	CreatedByName string          `json:"created_by_name"`
+	HitCount      int             `json:"hit_count"`
+	LastHitAt     *string         `json:"last_hit_at,omitempty"`
+	CreatedAt     string          `json:"created_at"`
+	UpdatedAt     string          `json:"updated_at"`
+}
+
+// RuleListResult mirrors service.TransactionRuleListResult.
+type RuleListResult struct {
+	Rules      []Rule `json:"rules"`
+	NextCursor string `json:"next_cursor,omitempty"`
+	HasMore    bool   `json:"has_more"`
+	Total      int64  `json:"total"`
+}
+
+// RuleListParams carries the supported query params for GET /rules.
+type RuleListParams struct {
+	Enabled      *bool
+	CategorySlug string
+	Search       string
+	Cursor       string
+	Limit        int
+}
+
+// ListRules fetches a page of rules.
+func (c *Client) ListRules(ctx context.Context, p RuleListParams) (*RuleListResult, error) {
+	q := url.Values{}
+	if p.Enabled != nil {
+		q.Set("enabled", strconv.FormatBool(*p.Enabled))
+	}
+	if p.CategorySlug != "" {
+		q.Set("category_slug", p.CategorySlug)
+	}
+	if p.Search != "" {
+		q.Set("search", p.Search)
+	}
+	if p.Cursor != "" {
+		q.Set("cursor", p.Cursor)
+	}
+	if p.Limit > 0 {
+		q.Set("limit", strconv.Itoa(p.Limit))
+	}
+	path := "/api/v1/rules"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var out RuleListResult
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetRule fetches a single rule by id (short_id or uuid).
+func (c *Client) GetRule(ctx context.Context, id string) (*Rule, error) {
+	var out Rule
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/rules/"+url.PathEscape(id), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateRule POSTs the raw DSL JSON body to /api/v1/rules. The CLI does
+// only minimal client-side validation; server validates the full grammar.
+func (c *Client) CreateRule(ctx context.Context, body json.RawMessage) (*Rule, error) {
+	var out Rule
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/rules", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateRule PUTs the raw DSL JSON body to /api/v1/rules/{id}.
+func (c *Client) UpdateRule(ctx context.Context, id string, body json.RawMessage) (*Rule, error) {
+	var out Rule
+	if err := c.Do(ctx, http.MethodPut, "/api/v1/rules/"+url.PathEscape(id), body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteRule removes a rule by id.
+func (c *Client) DeleteRule(ctx context.Context, id string) error {
+	return c.Do(ctx, http.MethodDelete, "/api/v1/rules/"+url.PathEscape(id), nil, nil)
+}
+
+// ApplyRuleResult is the response payload from POST /api/v1/rules/{id}/apply.
+type ApplyRuleResult struct {
+	RuleID        string `json:"rule_id"`
+	AffectedCount int64  `json:"affected_count"`
+}
+
+// ApplyRule applies a rule retroactively.
+func (c *Client) ApplyRule(ctx context.Context, id string) (*ApplyRuleResult, error) {
+	var out ApplyRuleResult
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/rules/"+url.PathEscape(id)+"/apply", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// PreviewRuleRequest mirrors the POST /api/v1/rules/preview body.
+type PreviewRuleRequest struct {
+	Conditions json.RawMessage `json:"conditions"`
+	SampleSize int             `json:"sample_size,omitempty"`
+}
+
+// PreviewRule fetches matching transactions for the given conditions.
+// The response shape is dynamic (service.RulePreviewResult); we surface
+// it as a generic map so the CLI can render it without taking a hard
+// dependency on the server-side type.
+func (c *Client) PreviewRule(ctx context.Context, req PreviewRuleRequest) (map[string]any, error) {
+	out := map[string]any{}
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/rules/preview", req, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// BatchCreateRules sends an array of rule definitions to /rules/batch.
+// The server validates each entry; per-op errors live in the response's
+// `results[]`.
+func (c *Client) BatchCreateRules(ctx context.Context, body json.RawMessage) (map[string]any, error) {
+	out := map[string]any{}
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/rules/batch", body, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/client/tags.go
+++ b/internal/client/tags.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// Tag mirrors service.TagResponse — the JSON shape returned by
+// GET /api/v1/tags and friends.
+type Tag struct {
+	ID          string  `json:"id"`
+	ShortID     string  `json:"short_id"`
+	Slug        string  `json:"slug"`
+	DisplayName string  `json:"display_name"`
+	Description string  `json:"description"`
+	Color       *string `json:"color,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+	Lifecycle   string  `json:"lifecycle"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
+}
+
+// tagsEnvelope wraps the server's `{"tags":[...]}` payload.
+type tagsEnvelope struct {
+	Tags []Tag `json:"tags"`
+}
+
+// CreateTagParams matches the POST /api/v1/tags body.
+type CreateTagParams struct {
+	Slug        string  `json:"slug"`
+	DisplayName string  `json:"display_name"`
+	Description string  `json:"description,omitempty"`
+	Color       *string `json:"color,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+}
+
+// UpdateTagParams matches the PATCH /api/v1/tags/{slug} body. Every
+// field is optional; omitted fields stay unchanged on the server.
+type UpdateTagParams struct {
+	DisplayName *string `json:"display_name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Color       *string `json:"color,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+	Lifecycle   *string `json:"lifecycle,omitempty"`
+}
+
+// ListTags returns every registered tag.
+func (c *Client) ListTags(ctx context.Context) ([]Tag, error) {
+	var env tagsEnvelope
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/tags", nil, &env); err != nil {
+		return nil, err
+	}
+	return env.Tags, nil
+}
+
+// GetTag fetches a tag by slug, uuid, or short_id.
+func (c *Client) GetTag(ctx context.Context, slug string) (*Tag, error) {
+	var out Tag
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/tags/"+url.PathEscape(slug), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateTag creates a new tag.
+func (c *Client) CreateTag(ctx context.Context, params CreateTagParams) (*Tag, error) {
+	var out Tag
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/tags", params, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// UpdateTag patches mutable tag fields. Slug is immutable.
+func (c *Client) UpdateTag(ctx context.Context, slug string, params UpdateTagParams) (*Tag, error) {
+	var out Tag
+	if err := c.Do(ctx, http.MethodPatch, "/api/v1/tags/"+url.PathEscape(slug), params, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DeleteTag removes a tag record. Cascades to transaction_tags rows.
+func (c *Client) DeleteTag(ctx context.Context, slug string) error {
+	return c.Do(ctx, http.MethodDelete, "/api/v1/tags/"+url.PathEscape(slug), nil, nil)
+}


### PR DESCRIPTION
## Summary

Adds the next batch of `breadbox <noun>` subtrees over the existing REST surface, following the pattern landed in #1051. Four new noun groups: `categories`, `tags`, `rules`, `reports`.

## Commands implemented

**Categories** (`/api/v1/categories`):
- `breadbox categories list`
- `breadbox categories get <id>`
- `breadbox categories create [--name] [--slug] [--parent] [--icon] [--color]`
- `breadbox categories update <id> [...]` — fetches the current row when `--name` is omitted to preserve it through PUT
- `breadbox categories delete <id>`
- `breadbox categories merge <from> <to>`
- `breadbox categories export [--format=tsv|json]`
- `breadbox categories import <file> [--replace]`

**Tags** (`/api/v1/tags`):
- `breadbox tags list`
- `breadbox tags get <slug>` — accepts slug, uuid, or short_id
- `breadbox tags create <slug> [--label] [--description] [--color] [--icon]`
- `breadbox tags update <slug> [--label] [--description] [--color] [--icon] [--lifecycle]`
- `breadbox tags delete <slug>`

**Rules** (`/api/v1/rules`):
- `breadbox rules list [--enabled] [--cursor]`
- `breadbox rules get <id>`
- `breadbox rules create --json <file>` — minimal client-side check; server validates the DSL grammar
- `breadbox rules update <id> --json <file>` — partial patches
- `breadbox rules delete <id>`
- `breadbox rules preview <id>` — resolves the rule's stored conditions and forwards them to `POST /rules/preview`
- `breadbox rules apply <id>`
- `breadbox rules batch <file>` — accepts either a bare array or `{rules:[...]}`

**Reports** (`/api/v1/reports`):
- `breadbox reports list [--kind] [--status]` — filters applied client-side
- `breadbox reports get <id>`
- `breadbox reports submit --kind <kind> --json <file>` — injects `--kind` as the `priority` field when the body doesn't already set it
- `breadbox reports read <id>`
- `breadbox reports unread <id>`

## Server extensions

None. The existing `PATCH /api/v1/reports/{id}/read` and `/unread` endpoints already exist as public routes — no admin-only mirror needed.

## Notable design calls

- **Rule DSL pass-through.** `rules create --json` only checks the file is a JSON object with `name` plus either `actions` or `category_slug`. Everything else flows verbatim to the server, which is the source of truth for the DSL grammar (`docs/rule-dsl.md`).
- **Reports `--kind` ↔ `priority`.** The canonical `agent_reports` schema uses `priority` (info/warning/critical) and `tags[]`. The spec asked for `--kind`, so the CLI injects it as `priority` when the JSON body doesn't already set one.
- **Categories update preserves display_name.** The server's PUT requires `display_name`. When the user runs `update <id> --hidden` (or any flag *other* than `--name`), the CLI fetches the current row first and forwards the stored display_name.
- **TSV passthrough.** New `rawGET` / `doRaw` helpers in `internal/client/client.go` handle the non-JSON `categories/export` (response) and `categories/import` (request) endpoints.
- **Bounded lists vs cursor pagination.** Categories, tags, reports return bare arrays; rules uses the resource-keyed cursor envelope (`{rules, next_cursor, has_more}`).

## Test plan

- [x] `go build ./...` (default, `-tags=lite`, `-tags=headless`)
- [x] `go vet ./...`
- [x] `go test ./internal/cli/... ./internal/client/...` (unit)
- [x] Integration: `TestCategories_*`, `TestTags_*`, `TestRules_*`, `TestReports_*` pass against the live DB
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
