### PR TITLE
cli: connections + sync + csv (hosted-link integration)

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -129,7 +129,7 @@ A **connection** is a bank-side OAuth link (Plaid item, Teller enrollment, or CS
 | `breadbox connections link get <session-id>` | R | Check a hosted-link session's status (`active` / `completed` / `failed` / `expired`) and the resulting connection IDs |
 | `breadbox connections relink <connection-id> [--wait]` | W | Mint a relink hosted-link session for an existing (broken or pending-reauth) connection |
 | `breadbox connections disconnect <id>` | W | Mark connection disconnected (preserves history) |
-| `breadbox connections delete <id>` | W | Hard delete (accounts/transactions FK-SET-NULL) |
+| `breadbox connections delete <id>` | W | *Currently aliases `disconnect`* — the REST surface has no hard-delete endpoint today; both verbs hit `DELETE /connections/{id}` (soft-disconnect). |
 
 ## Sync
 

--- a/internal/cli/connections.go
+++ b/internal/cli/connections.go
@@ -1,0 +1,371 @@
+// Package cli — connections noun group.
+//
+// `breadbox connections ...` exposes the bank-connection management
+// surface, including the hosted-link flow that PRs #1043–#1047 introduced.
+// The centerpiece is `connections link` — it mints a hosted-link session
+// via POST /connections/link and prints the URL that an end-user (or
+// agent driving a browser) opens to actually run the Plaid / Teller
+// onboarding. `--wait` polls the session until it reaches a terminal
+// status (completed / failed / expired) or the 5-minute timeout fires.
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// hostedLinkPollInterval is the cadence at which `--wait` polls the
+// session. 2s matches the spec.
+const hostedLinkPollInterval = 2 * time.Second
+
+// hostedLinkWaitTimeout is the upper bound on `--wait`. Anything longer
+// suggests the user walked away or the page is stuck; exit 4 so agents
+// can branch.
+const hostedLinkWaitTimeout = 5 * time.Minute
+
+// AddConnectionsCmd registers `breadbox connections` and its children.
+func AddConnectionsCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "connections",
+		Short: "Manage bank connections (Plaid / Teller / CSV)",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newConnectionsListCmd())
+	cmd.AddCommand(newConnectionsGetCmd())
+	cmd.AddCommand(newConnectionsLinkCmd())
+	cmd.AddCommand(newConnectionsRelinkCmd())
+	cmd.AddCommand(newConnectionsDisconnectCmd())
+	cmd.AddCommand(newConnectionsDeleteCmd())
+
+	root.AddCommand(cmd)
+}
+
+func newConnectionsListCmd() *cobra.Command {
+	var userID string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List bank connections",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			conns, err := c.ListConnections(cmd.Context(), userID)
+			if err != nil {
+				return err
+			}
+			return renderConnectionsList(flags, conns)
+		},
+	}
+	cmd.Flags().StringVar(&userID, "user", "", "filter to connections owned by this user (uuid or short_id)")
+	return cmd
+}
+
+func newConnectionsGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Show a single connection's detail",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			conn, err := c.GetConnection(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return renderConnectionDetail(flags, conn)
+		},
+	}
+	return cmd
+}
+
+// newConnectionsLinkCmd wires `breadbox connections link [--provider]
+// [--user] [--wait]` plus the `link get <session-id>` subcommand.
+//
+// The output is shaped to be friendly: print the URL big and obvious in
+// table mode, fall back to the raw `{url, session_id, expires_at}` JSON
+// for agents.
+func newConnectionsLinkCmd() *cobra.Command {
+	var (
+		provider string
+		userID   string
+		wait     bool
+		label    string
+	)
+	cmd := &cobra.Command{
+		Use:   "link",
+		Short: "Mint a hosted-link session for connecting a bank",
+		Long: `Mint a hosted-link URL that an end-user (or browser-driving agent) opens to
+run the Plaid / Teller onboarding flow.
+
+By default this prints { url, session_id, expires_at }. With --wait the
+CLI blocks until the session reaches a terminal state (completed / failed
+/ expired) and prints the final session payload — including the IDs of
+any connections that were created.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if userID == "" {
+				return UsageErrorf("--user is required (uuid or short_id of the household user owning the connection)")
+			}
+			params := client.CreateHostedLinkParams{
+				UserID:   userID,
+				Provider: provider,
+				Label:    label,
+			}
+			res, err := c.CreateHostedLink(cmd.Context(), params)
+			if err != nil {
+				return err
+			}
+
+			mode := output.Resolve(flags.JSON, flags.NDJSON, os.Stdout)
+			if !wait {
+				return renderHostedLinkCreate(mode, res)
+			}
+
+			// Print the URL up front so the user can act on it while
+			// we poll. Polling progress goes to stderr to avoid mixing
+			// it with the final JSON on stdout.
+			printHostedLinkBanner(res, true)
+			final, err := waitForHostedLink(cmd.Context(), c, res.ID, hostedLinkWaitTimeout)
+			if err != nil {
+				return err
+			}
+			return renderHostedLinkSession(mode, final)
+		},
+	}
+	cmd.Flags().StringVar(&provider, "provider", "", "plaid | teller (omit to let the hosted page show a picker)")
+	cmd.Flags().StringVar(&userID, "user", "", "household user that will own the resulting connection (uuid or short_id)")
+	cmd.Flags().BoolVar(&wait, "wait", false, "block until the session reaches a terminal status (5-minute timeout)")
+	cmd.Flags().StringVar(&label, "label", "", "human-readable label shown on the hosted page")
+
+	cmd.AddCommand(&cobra.Command{
+		Use:   "get <session-id>",
+		Short: "Fetch the current state of a hosted-link session",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			s, err := c.GetHostedLinkSession(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			return renderHostedLinkSession(output.Resolve(flags.JSON, flags.NDJSON, os.Stdout), s)
+		},
+	})
+
+	return cmd
+}
+
+func newConnectionsRelinkCmd() *cobra.Command {
+	var wait bool
+	cmd := &cobra.Command{
+		Use:   "relink <connection-id>",
+		Short: "Mint a re-auth hosted-link session for an existing connection",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			res, err := c.CreateRelink(cmd.Context(), args[0], client.CreateRelinkParams{})
+			if err != nil {
+				return err
+			}
+			mode := output.Resolve(flags.JSON, flags.NDJSON, os.Stdout)
+			if !wait {
+				return renderHostedLinkCreate(mode, res)
+			}
+			printHostedLinkBanner(res, true)
+			final, err := waitForHostedLink(cmd.Context(), c, res.ID, hostedLinkWaitTimeout)
+			if err != nil {
+				return err
+			}
+			return renderHostedLinkSession(mode, final)
+		},
+	}
+	cmd.Flags().BoolVar(&wait, "wait", false, "block until the session reaches a terminal status (5-minute timeout)")
+	return cmd
+}
+
+// newConnectionsDisconnectCmd is the canonical write-side endpoint —
+// DELETE /connections/{id} performs the soft-disconnect.
+func newConnectionsDisconnectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "disconnect <id>",
+		Short: "Soft-disconnect a connection (preserves history)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.DisconnectConnection(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// newConnectionsDeleteCmd. There is no hard-delete REST endpoint today —
+// DELETE /connections/{id} already performs the soft-disconnect that the
+// `disconnect` verb maps to. We keep `delete` as an alias so the verb
+// shape promised in docs/cli-commands.md works; the table doc notes the
+// deviation.
+func newConnectionsDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <id>",
+		Short: "Delete a connection (currently aliases disconnect — no hard delete yet)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			if err := c.DisconnectConnection(cmd.Context(), args[0]); err != nil {
+				return err
+			}
+			if !flags.Quiet {
+				fmt.Println(args[0])
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// waitForHostedLink polls the given session every hostedLinkPollInterval
+// until the session reaches a terminal status (completed / failed /
+// expired), the context is cancelled, or `timeout` elapses (returning
+// ErrHostedLinkTimeout, which the exit-code mapper turns into 4).
+func waitForHostedLink(ctx context.Context, c *client.Client, sessionID string, timeout time.Duration) (*client.HostedLinkSession, error) {
+	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(hostedLinkPollInterval)
+	defer ticker.Stop()
+
+	for {
+		session, err := c.GetHostedLinkSession(ctx, sessionID)
+		if err != nil {
+			return nil, err
+		}
+		switch session.Status {
+		case "completed", "failed", "expired":
+			fmt.Fprintln(os.Stderr) // newline after the dots
+			return session, nil
+		}
+
+		// Surface a single progress dot per poll on stderr — keeps stdout
+		// clean for the eventual JSON dump.
+		fmt.Fprint(os.Stderr, ".")
+
+		if time.Now().After(deadline) {
+			fmt.Fprintln(os.Stderr)
+			return nil, ErrHostedLinkTimeout
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			continue
+		}
+	}
+}
+
+// ErrHostedLinkTimeout is returned when `--wait` exhausts its budget. The
+// exit-code mapper maps this to ExitUpstream (4).
+var ErrHostedLinkTimeout = errors.New("hosted-link session did not complete within the wait timeout")
+
+// printHostedLinkBanner emits the friendly URL message on stderr (so
+// stdout stays clean for the eventual JSON payload in non-TTY mode).
+func printHostedLinkBanner(res *client.CreateHostedLinkResponse, isWaiting bool) {
+	fmt.Fprintln(os.Stderr, "Hosted-link session ready. Open this URL in a browser:")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "    "+res.URL)
+	fmt.Fprintln(os.Stderr)
+	if res.ExpiresAt != "" {
+		fmt.Fprintln(os.Stderr, "Expires at "+res.ExpiresAt)
+	}
+	if isWaiting {
+		fmt.Fprintln(os.Stderr, "Polling for completion (Ctrl+C to abort)…")
+	} else {
+		fmt.Fprintln(os.Stderr, "Re-run with --wait to block until completed.")
+	}
+}
+
+// renderHostedLinkCreate prints the create-time response: in TTY mode we
+// show the friendly banner on stderr + a tiny stdout summary; in JSON
+// mode we dump { url, session_id, expires_at } as documented.
+func renderHostedLinkCreate(mode output.Mode, res *client.CreateHostedLinkResponse) error {
+	switch mode {
+	case output.ModeJSON, output.ModeNDJSON:
+		return output.PrintJSON(os.Stdout, map[string]string{
+			"url":        res.URL,
+			"session_id": res.ID,
+			"expires_at": res.ExpiresAt,
+		})
+	default:
+		printHostedLinkBanner(res, false)
+		return nil
+	}
+}
+
+// renderHostedLinkSession prints a session payload — used both by `link
+// get <id>` and by the post-wait final dump.
+func renderHostedLinkSession(mode output.Mode, s *client.HostedLinkSession) error {
+	switch mode {
+	case output.ModeJSON, output.ModeNDJSON:
+		return output.PrintJSON(os.Stdout, s)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "PROVIDER", "ACTION", "STATUS", "CONNECTIONS", "EXPIRES_AT"})
+		conns := "-"
+		if len(s.ResultConnectionIDs) > 0 {
+			conns = fmt.Sprintf("%d", len(s.ResultConnectionIDs))
+		}
+		tbl.AddRow(s.ShortID, valOrDash(s.Provider), s.Action, s.Status, conns, s.ExpiresAt)
+		return tbl.Flush()
+	}
+}
+
+func renderConnectionsList(flags *FlagBag, conns []client.Connection) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, conns)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(conns))
+		for _, c := range conns {
+			items = append(items, c)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "PROVIDER", "INSTITUTION", "STATUS", "USER", "LAST_SYNCED"})
+		for _, c := range conns {
+			tbl.AddRow(c.ShortID, c.Provider, strPtr(c.InstitutionName), c.Status, strPtr(c.UserName), strPtr(c.LastSyncedAt))
+		}
+		return tbl.Flush()
+	}
+}
+
+func renderConnectionDetail(flags *FlagBag, c *client.ConnectionDetail) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON, output.ModeNDJSON:
+		return output.PrintJSON(os.Stdout, c)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"SHORT_ID", "PROVIDER", "INSTITUTION", "STATUS", "ACCOUNTS", "PAUSED"})
+		tbl.AddRow(c.ShortID, c.Provider, strPtr(c.InstitutionName), c.Status, fmt.Sprintf("%d", c.AccountCount), fmt.Sprintf("%v", c.Paused))
+		return tbl.Flush()
+	}
+}
+
+// valOrDash renders a string field, returning "-" when empty.
+func valOrDash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}

--- a/internal/cli/connections_integration_test.go
+++ b/internal/cli/connections_integration_test.go
@@ -1,0 +1,178 @@
+//go:build integration
+
+// Integration tests for `breadbox connections`. They drive the real REST
+// handlers via an in-process httptest.Server so the CLI client and
+// service layer both run end-to-end. The hosted-link flow is the
+// centerpiece — we mint a session, dereference the URL it returns, and
+// confirm the page renders.
+
+package cli_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"breadbox/internal/api"
+	"breadbox/internal/cli/config"
+	"breadbox/internal/client"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+	"breadbox/internal/testutil"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// connEnv extends envBundle with the connections + hosted-link routes
+// (plus the public /link/{token} page). Reused by every connection-flavor
+// test in this file.
+type connEnv struct {
+	Svc     *service.Service
+	Server  *httptest.Server
+	Client  *client.Client
+	Queries *db.Queries
+}
+
+func setupConnEnv(t *testing.T) *connEnv {
+	t.Helper()
+	pool, queries := testutil.ServicePool(t)
+	svc := service.New(queries, pool, nil, slog.Default())
+
+	keyResult, err := svc.CreateAPIKeyLegacy(t.Context(), "cli-conn-test", "full_access")
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.Route("/api/v1", func(r chi.Router) {
+		r.Use(mw.APIKeyAuth(svc))
+
+		// Read endpoints
+		r.Get("/connections", api.ListConnectionsHandler(svc))
+		r.Get("/connections/{id}", api.GetConnectionHandler(svc))
+		r.Get("/connections/link/{id}", api.GetHostedLinkSessionHandler(svc))
+		r.Get("/sync/health", api.SyncHealthHandler(svc))
+		r.Get("/sync/logs", api.ListSyncLogsHandler(svc))
+
+		// Write endpoints
+		r.Group(func(r chi.Router) {
+			r.Use(mw.RequireWriteScope())
+			r.Post("/sync", api.TriggerSyncHandler(svc))
+			r.Post("/connections/link", api.CreateHostedLinkHandler(svc))
+			r.Post("/connections/{id}/relink", api.CreateHostedLinkRelinkHandler(svc))
+			r.Delete("/connections/{id}", api.DeleteConnectionHandler(svc))
+			r.Post("/connections/csv/preview", api.CSVPreviewHandler(svc))
+			r.Post("/connections/csv/import", api.CSVImportHandler(svc))
+		})
+	})
+	// Standalone hosted-link page — used to verify the URL the CLI prints
+	// actually resolves to something the user can open.
+	r.Get("/link/{token}", api.HostedLinkPageHandler())
+
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	c := client.New(config.Host{BaseURL: srv.URL, Token: keyResult.PlaintextKey}, "test")
+	return &connEnv{Svc: svc, Server: srv, Client: c, Queries: queries}
+}
+
+func TestConnectionsList_ReturnsFixtures(t *testing.T) {
+	env := setupConnEnv(t)
+	q := env.Queries
+	user := testutil.MustCreateUser(t, q, "Alice")
+	testutil.MustCreateConnection(t, q, user.ID, "ext-conn-list")
+
+	conns, err := env.Client.ListConnections(context.Background(), "")
+	if err != nil {
+		t.Fatalf("ListConnections: %v", err)
+	}
+	if len(conns) == 0 {
+		t.Fatal("expected >=1 connection, got 0")
+	}
+}
+
+func TestConnectionsLink_MintsSessionAndPageRenders(t *testing.T) {
+	env := setupConnEnv(t)
+	q := env.Queries
+	user := testutil.MustCreateUser(t, q, "Alice")
+
+	res, err := env.Client.CreateHostedLink(context.Background(), client.CreateHostedLinkParams{
+		UserID:   pgconv.FormatUUID(user.ID),
+		Provider: "plaid",
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedLink: %v", err)
+	}
+	if res.URL == "" {
+		t.Fatal("expected URL on hosted-link response")
+	}
+	if !strings.Contains(res.URL, "/link/") {
+		t.Errorf("URL %q does not look like a hosted-link URL", res.URL)
+	}
+	if res.Token == "" {
+		t.Fatal("expected one-time token on the create response")
+	}
+
+	// Dereference the URL — page should render HTML.
+	resp, err := http.Get(res.URL)
+	if err != nil {
+		t.Fatalf("GET %s: %v", res.URL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("page status = %d, want 200", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", ct)
+	}
+}
+
+func TestConnectionsLinkGet_ReturnsSession(t *testing.T) {
+	env := setupConnEnv(t)
+	q := env.Queries
+	user := testutil.MustCreateUser(t, q, "Alice")
+
+	created, err := env.Client.CreateHostedLink(context.Background(), client.CreateHostedLinkParams{
+		UserID: pgconv.FormatUUID(user.ID),
+	})
+	if err != nil {
+		t.Fatalf("CreateHostedLink: %v", err)
+	}
+
+	fetched, err := env.Client.GetHostedLinkSession(context.Background(), created.ShortID)
+	if err != nil {
+		t.Fatalf("GetHostedLinkSession: %v", err)
+	}
+	if fetched.ID != created.ID {
+		t.Errorf("fetched.ID = %q, want %q", fetched.ID, created.ID)
+	}
+	// Poll endpoint must NOT echo the token or the URL.
+	// (We assert that by virtue of the typed struct not carrying them —
+	// the JSON shape is the same as `HostedLinkSession`.)
+}
+
+func TestConnectionsDisconnect_FlipsStatus(t *testing.T) {
+	env := setupConnEnv(t)
+	q := env.Queries
+	user := testutil.MustCreateUser(t, q, "Alice")
+	conn := testutil.MustCreateConnection(t, q, user.ID, "ext-disc")
+
+	if err := env.Client.DisconnectConnection(context.Background(), conn.ShortID); err != nil {
+		t.Fatalf("DisconnectConnection: %v", err)
+	}
+	// Re-fetch via the queries — after a soft-disconnect the row exists
+	// with status='disconnected'. The public list endpoint hides them so
+	// we look at the raw row.
+	row, err := q.GetBankConnection(context.Background(), conn.ID)
+	if err != nil {
+		t.Fatalf("GetBankConnection: %v", err)
+	}
+	if string(row.Status) != "disconnected" {
+		t.Errorf("status = %q, want disconnected", row.Status)
+	}
+}

--- a/internal/cli/connections_test.go
+++ b/internal/cli/connections_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"breadbox/internal/cli/config"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// TestConnectionsLinkRequiresUser asserts that the cobra command surfaces
+// a usage-tier error when `--user` is missing — the spec calls this out
+// because every hosted-link session is owner-attributed.
+func TestConnectionsLinkRequiresUser(t *testing.T) {
+	cmd := newConnectionsLinkCmd()
+	cmd.SetArgs([]string{})
+	// stash a FlagBag + a dummy client so RunE doesn't panic
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, ctxKeyFlags, &FlagBag{})
+	ctx = context.WithValue(ctx, ctxKeyClient, client.New(config.Host{BaseURL: "http://localhost"}, "test"))
+	cmd.SetContext(ctx)
+
+	err := cmd.RunE(cmd, nil)
+	if err == nil {
+		t.Fatalf("expected usage error, got nil")
+	}
+	var ue *usageError
+	if !errors.As(err, &ue) {
+		t.Fatalf("expected *usageError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "--user") {
+		t.Errorf("expected error to mention --user, got %q", err.Error())
+	}
+}
+
+// TestWaitForHostedLinkSuccess covers the happy-path poll loop: a session
+// that transitions from `active` → `completed` after a couple of polls
+// should be returned cleanly.
+func TestWaitForHostedLinkSuccess(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if n < 2 {
+			w.Write([]byte(`{"id":"abc","short_id":"sid","status":"active","result_connection_ids":[],"expires_at":"2030-01-01T00:00:00Z"}`))
+			return
+		}
+		w.Write([]byte(`{"id":"abc","short_id":"sid","status":"completed","result_connection_ids":["conn1"],"expires_at":"2030-01-01T00:00:00Z"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := client.New(config.Host{BaseURL: srv.URL, Token: "k"}, "test")
+	// Use a tiny poll interval via a hand-rolled poller — we can't tune
+	// the const directly. Instead, override deadline so the loop runs a
+	// few iterations within reason.
+	final, err := waitForHostedLink(context.Background(), c, "abc", 4*time.Second)
+	if err != nil {
+		t.Fatalf("waitForHostedLink: %v", err)
+	}
+	if final.Status != "completed" {
+		t.Fatalf("expected completed, got %q", final.Status)
+	}
+}
+
+// TestWaitForHostedLinkTimeout asserts that a session that never reaches
+// a terminal status returns ErrHostedLinkTimeout (so MapExitCode emits 4).
+func TestWaitForHostedLinkTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"abc","short_id":"sid","status":"active","result_connection_ids":[],"expires_at":"2030-01-01T00:00:00Z"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := client.New(config.Host{BaseURL: srv.URL, Token: "k"}, "test")
+	// 1ns timeout means the deadline trips on the first iteration.
+	_, err := waitForHostedLink(context.Background(), c, "abc", 1)
+	if !errors.Is(err, ErrHostedLinkTimeout) {
+		t.Fatalf("expected ErrHostedLinkTimeout, got %v", err)
+	}
+	// Confirm the exit-code mapper turns this into ExitUpstream (4).
+	if got := MapExitCode(err); got != ExitUpstream {
+		t.Errorf("MapExitCode(timeout) = %d, want %d", got, ExitUpstream)
+	}
+}
+
+// _ ensures the cobra import survives.
+var _ = cobra.Command{}

--- a/internal/cli/csv.go
+++ b/internal/cli/csv.go
@@ -1,0 +1,136 @@
+// Package cli — csv noun group.
+//
+// `breadbox csv {preview,import}` uploads CSV files via the
+// /connections/csv/preview and /connections/csv/import endpoints
+// (multipart/form-data). The handler infers a column mapping during
+// preview; import requires the user to pass one back (or to have an
+// existing connection_id).
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// AddCSVCmd registers `breadbox csv` and its children.
+func AddCSVCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "csv",
+		Short: "Preview and import bank CSVs",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newCSVPreviewCmd())
+	cmd.AddCommand(newCSVImportCmd())
+
+	root.AddCommand(cmd)
+}
+
+func newCSVPreviewCmd() *cobra.Command {
+	var accountID string
+	cmd := &cobra.Command{
+		Use:   "preview <file>",
+		Short: "Parse a CSV and return the inferred column mapping + preview rows",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("read CSV: %w", err)
+			}
+			opts := client.CSVOptions{ConnectionID: accountID}
+			res, err := c.PreviewCSV(cmd.Context(), filepath.Base(args[0]), data, opts)
+			if err != nil {
+				return err
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	cmd.Flags().StringVar(&accountID, "account", "", "(reserved) hint that we're appending to an existing CSV connection")
+	return cmd
+}
+
+func newCSVImportCmd() *cobra.Command {
+	var (
+		accountID    string
+		userID       string
+		accountName  string
+		connectionID string
+		dateFormat   string
+	)
+	cmd := &cobra.Command{
+		Use:   "import <file>",
+		Short: "Import a CSV into Breadbox (creates a new csv connection or appends)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			data, err := os.ReadFile(args[0])
+			if err != nil {
+				return fmt.Errorf("read CSV: %w", err)
+			}
+			// Run preview first to grab an inferred mapping — saves the
+			// user from passing --column-mapping by hand. Auto-detection
+			// is per-file and matches the admin upload flow.
+			preview, err := c.PreviewCSV(cmd.Context(), filepath.Base(args[0]), data, client.CSVOptions{})
+			if err != nil {
+				return err
+			}
+			mapping, _ := preview["inferred_mapping"].(map[string]any)
+			columnMapping := map[string]int{}
+			for k, v := range mapping {
+				if n, ok := v.(float64); ok {
+					columnMapping[k] = int(n)
+				}
+			}
+
+			conn := connectionID
+			if conn == "" && accountID != "" {
+				// `--account` is the spec's flag name; on import without
+				// an explicit connection we pass it through as the
+				// connection hint (matches the server's preference).
+				conn = accountID
+			}
+
+			opts := client.CSVOptions{
+				UserID:        userID,
+				AccountName:   accountName,
+				ConnectionID:  conn,
+				DateFormat:    dateFormat,
+				ColumnMapping: columnMapping,
+			}
+			// Auto-populate template-detected toggles when available so the
+			// import lines up with the same defaults the admin UI uses.
+			if v, ok := preview["positive_is_debit"].(bool); ok {
+				opts.PositiveIsDebit = v
+			}
+			if v, ok := preview["has_debit_credit"].(bool); ok {
+				opts.HasDebitCredit = v
+			}
+			if v, ok := preview["date_format"].(string); ok && opts.DateFormat == "" {
+				opts.DateFormat = v
+			}
+
+			res, err := c.ImportCSV(cmd.Context(), filepath.Base(args[0]), data, opts)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	cmd.Flags().StringVar(&accountID, "account", "", "existing CSV connection id (uuid or short_id) to append to")
+	cmd.Flags().StringVar(&userID, "user", "", "household user that will own the import (uuid or short_id)")
+	cmd.Flags().StringVar(&accountName, "account-name", "", "human-readable account name when creating a new csv connection")
+	cmd.Flags().StringVar(&connectionID, "connection", "", "alias for --account; existing csv connection id")
+	cmd.Flags().StringVar(&dateFormat, "date-format", "", "override Go date format string (e.g. 2006-01-02)")
+	return cmd
+}

--- a/internal/cli/csv_integration_test.go
+++ b/internal/cli/csv_integration_test.go
@@ -1,0 +1,82 @@
+//go:build integration
+
+package cli_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/client"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/testutil"
+)
+
+// sampleCSV is the same shape the api package's integration tests use —
+// `date,amount,description` with two rows. Easy to parse, easy to dedup.
+const sampleCSV = "date,amount,description\n" +
+	"2025-01-15,12.50,Coffee Shop\n" +
+	"2025-01-16,42.00,Grocery Store\n"
+
+func TestCSVPreview_ReturnsParseReport(t *testing.T) {
+	env := setupConnEnv(t)
+	q := env.Queries
+	// CSV preview doesn't need a user but ImportCSV's user-resolver
+	// requires either an explicit user_id or a single-user household.
+	testutil.MustCreateUser(t, q, "Alice")
+
+	res, err := env.Client.PreviewCSV(context.Background(), "sample.csv", []byte(sampleCSV), client.CSVOptions{})
+	if err != nil {
+		t.Fatalf("PreviewCSV: %v", err)
+	}
+	if total, ok := res["total_rows"].(float64); !ok || total != 2 {
+		t.Errorf("total_rows = %v, want 2", res["total_rows"])
+	}
+	if _, ok := res["inferred_mapping"].(map[string]any); !ok {
+		t.Error("expected inferred_mapping in preview response")
+	}
+}
+
+func TestCSVImport_CreatesTransactions(t *testing.T) {
+	env := setupConnEnv(t)
+	q := env.Queries
+	user := testutil.MustCreateUser(t, q, "Alice")
+	// service.ImportCSV defaults every row to the seeded `uncategorized`
+	// category; without it UpsertTransaction fails the NOT NULL on
+	// category_id and we get imported=0.
+	testutil.MustCreateCategory(t, q, "uncategorized", "Uncategorized")
+
+	// Run preview to extract the inferred mapping — matches what the CLI
+	// does in production.
+	preview, err := env.Client.PreviewCSV(context.Background(), "sample.csv", []byte(sampleCSV), client.CSVOptions{})
+	if err != nil {
+		t.Fatalf("PreviewCSV: %v", err)
+	}
+	mapping := map[string]int{}
+	if m, ok := preview["inferred_mapping"].(map[string]any); ok {
+		for k, v := range m {
+			if n, ok := v.(float64); ok {
+				mapping[k] = int(n)
+			}
+		}
+	}
+	if mapping["amount"] == 0 && mapping["description"] == 0 {
+		t.Fatalf("inferred mapping looks empty: %v", mapping)
+	}
+
+	res, err := env.Client.ImportCSV(context.Background(), "sample.csv", []byte(sampleCSV), client.CSVOptions{
+		UserID:        pgconv.FormatUUID(user.ID),
+		AccountName:   "Test Checking",
+		ColumnMapping: mapping,
+		DateFormat:    "2006-01-02",
+	})
+	if err != nil {
+		t.Fatalf("ImportCSV: %v", err)
+	}
+	if res.ImportedTransactions != 2 {
+		t.Errorf("imported = %d (skipped=%d, total=%d, updated=%d), want 2",
+			res.ImportedTransactions, res.SkippedDuplicates, res.TotalRows, res.UpdatedTransactions)
+	}
+	if res.AccountID == "" {
+		t.Error("expected account_id on import response")
+	}
+}

--- a/internal/cli/csv_test.go
+++ b/internal/cli/csv_test.go
@@ -1,0 +1,105 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"strings"
+	"testing"
+
+	"breadbox/internal/client"
+)
+
+// TestBuildCSVMultipart asserts the multipart body the client produces
+// carries the file under the `file` field name, the form values the
+// REST handler reads (positive_is_debit, column_mapping, etc.), and uses
+// the correct Content-Type. The CSV endpoint is the only place the CLI
+// ships multipart, so a regression here would silently break import.
+func TestBuildCSVMultipart(t *testing.T) {
+	data := []byte("date,amount,description\n2025-01-01,1.00,Test\n")
+	mapping := map[string]int{"date": 0, "amount": 1, "description": 2}
+	buf, contentType, err := client.BuildCSVMultipart("sample.csv", data, client.CSVOptions{
+		UserID:          "user-1",
+		AccountName:     "Checking",
+		ColumnMapping:   mapping,
+		PositiveIsDebit: true,
+		Limit:           5,
+	})
+	if err != nil {
+		t.Fatalf("BuildCSVMultipart: %v", err)
+	}
+	if !strings.HasPrefix(contentType, "multipart/form-data") {
+		t.Errorf("contentType = %q, want multipart/form-data; ...", contentType)
+	}
+
+	// Parse the body back out and assert each field landed.
+	_, params, err := mimeParse(contentType)
+	if err != nil {
+		t.Fatalf("parse Content-Type: %v", err)
+	}
+	mr := multipart.NewReader(buf, params["boundary"])
+	got := map[string]string{}
+	var file []byte
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("NextPart: %v", err)
+		}
+		body, err := io.ReadAll(p)
+		if err != nil {
+			t.Fatalf("read part: %v", err)
+		}
+		if p.FormName() == "file" {
+			file = body
+			continue
+		}
+		got[p.FormName()] = string(body)
+	}
+
+	if string(file) != string(data) {
+		t.Errorf("file body mismatch:\ngot  %q\nwant %q", file, data)
+	}
+	if got["user_id"] != "user-1" {
+		t.Errorf("user_id = %q, want user-1", got["user_id"])
+	}
+	if got["account_name"] != "Checking" {
+		t.Errorf("account_name = %q, want Checking", got["account_name"])
+	}
+	if got["positive_is_debit"] != "true" {
+		t.Errorf("positive_is_debit = %q, want true", got["positive_is_debit"])
+	}
+	if got["limit"] != "5" {
+		t.Errorf("limit = %q, want 5", got["limit"])
+	}
+	var mapBack map[string]int
+	if err := json.Unmarshal([]byte(got["column_mapping"]), &mapBack); err != nil {
+		t.Fatalf("decode column_mapping: %v", err)
+	}
+	if mapBack["amount"] != 1 {
+		t.Errorf("column_mapping[amount] = %d, want 1", mapBack["amount"])
+	}
+}
+
+// mimeParse is a tiny shim around mime.ParseMediaType so the test reads
+// without an extra import shuffle.
+func mimeParse(v string) (string, map[string]string, error) {
+	// inline minimal split — Content-Type is "multipart/form-data; boundary=xxx"
+	parts := strings.SplitN(v, ";", 2)
+	out := map[string]string{}
+	if len(parts) == 2 {
+		for _, kv := range strings.Split(parts[1], ";") {
+			kv = strings.TrimSpace(kv)
+			if i := strings.Index(kv, "="); i > 0 {
+				out[kv[:i]] = strings.Trim(kv[i+1:], `"`)
+			}
+		}
+	}
+	return parts[0], out, nil
+}
+
+// _ ensures the bytes import survives if pruned by formatter.
+var _ = bytes.NewBuffer

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -64,6 +64,9 @@ func MapExitCode(err error) int {
 	if errors.As(err, &expired) {
 		return ExitUpstream
 	}
+	if errors.Is(err, ErrHostedLinkTimeout) {
+		return ExitUpstream
+	}
 	var apiErr *client.APIError
 	if errors.As(err, &apiErr) {
 		switch {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -177,6 +177,9 @@ func NewRootCmd(version string) *cobra.Command {
 	AddTagsCmd(root)
 	AddRulesCmd(root)
 	AddReportsCmd(root)
+	AddConnectionsCmd(root)
+	AddSyncCmd(root)
+	AddCSVCmd(root)
 	AddVersionCmd(root, version)
 
 	return root

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1,0 +1,208 @@
+// Package cli — sync noun group.
+//
+// `breadbox sync ...` drives the manual-sync, health, and history surface
+// (POST /sync, GET /sync/health, GET /sync/logs). `sync logs --follow`
+// uses straightforward polling — the server doesn't (yet) expose SSE/WS
+// for sync events, so we emit fresh rows every 2s and stop on SIGINT.
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"breadbox/internal/cli/output"
+	"breadbox/internal/client"
+
+	"github.com/spf13/cobra"
+)
+
+// syncFollowPollInterval is how often `sync logs --follow` polls for new
+// rows. Matches the hosted-link cadence for consistency.
+const syncFollowPollInterval = 2 * time.Second
+
+// AddSyncCmd registers `breadbox sync` and its children.
+func AddSyncCmd(root *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "Trigger syncs and inspect sync state",
+	}
+	MarkRequiresHost(cmd)
+
+	cmd.AddCommand(newSyncTriggerCmd())
+	cmd.AddCommand(newSyncStatusCmd())
+	cmd.AddCommand(newSyncLogsCmd())
+
+	root.AddCommand(cmd)
+}
+
+func newSyncTriggerCmd() *cobra.Command {
+	var connectionID string
+	var accountID string
+	cmd := &cobra.Command{
+		Use:   "trigger",
+		Short: "Kick a manual sync (all connections, or one)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			// --account is accepted for parity with the spec but the
+			// REST endpoint scopes by connection_id, so we surface a
+			// usage hint if only account is passed.
+			if accountID != "" && connectionID == "" {
+				return UsageErrorf("sync trigger does not yet support --account; use --connection instead")
+			}
+			res, err := c.TriggerSync(cmd.Context(), connectionID)
+			if err != nil {
+				return err
+			}
+			if flags.Quiet {
+				return nil
+			}
+			return output.PrintJSON(os.Stdout, res)
+		},
+	}
+	cmd.Flags().StringVar(&connectionID, "connection", "", "scope to a single connection (uuid or short_id)")
+	cmd.Flags().StringVar(&accountID, "account", "", "(reserved) scope to a single account — not yet supported")
+	return cmd
+}
+
+func newSyncStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show aggregate sync health (last 24h)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+			status, err := c.SyncStatus(cmd.Context())
+			if err != nil {
+				return err
+			}
+			switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+			case output.ModeJSON, output.ModeNDJSON:
+				return output.PrintJSON(os.Stdout, status)
+			default:
+				tbl := output.NewTable(os.Stdout, []string{"OVERALL", "LAST_STATUS", "RECENT_SYNCS", "SUCCESS_RATE", "LAST_SYNC"})
+				last := "-"
+				if status.LastSyncTime != nil {
+					last = *status.LastSyncTime
+				}
+				tbl.AddRow(status.OverallHealth, status.LastSyncStatus,
+					fmt.Sprintf("%d", status.RecentSyncCount),
+					fmt.Sprintf("%.2f", status.RecentSuccessRate), last)
+				return tbl.Flush()
+			}
+		},
+	}
+	return cmd
+}
+
+func newSyncLogsCmd() *cobra.Command {
+	var (
+		connectionID string
+		follow       bool
+	)
+	cmd := &cobra.Command{
+		Use:   "logs",
+		Short: "Show recent sync log entries",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, _ := ClientFromContext(cmd.Context())
+			flags := Flags(cmd)
+
+			filters := client.SyncLogFilters{ConnectionID: connectionID}
+
+			if follow {
+				return followSyncLogs(cmd.Context(), c, filters, flags.Limit)
+			}
+
+			res, err := c.ListSyncLogs(cmd.Context(), filters, "", flags.Limit)
+			if err != nil {
+				return err
+			}
+			return renderSyncLogs(flags, res)
+		},
+	}
+	cmd.Flags().StringVar(&connectionID, "connection", "", "scope to a single connection (uuid or short_id)")
+	cmd.Flags().BoolVar(&follow, "follow", false, "tail new log rows — emits NDJSON, stops on Ctrl+C")
+	return cmd
+}
+
+// followSyncLogs implements `--follow`: poll /sync/logs every 2s and emit
+// any rows whose `id` we haven't already seen as NDJSON. Stops cleanly on
+// SIGINT / SIGTERM (exit code 0).
+func followSyncLogs(ctx context.Context, c *client.Client, filters client.SyncLogFilters, limit int) error {
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	enc := json.NewEncoder(os.Stdout)
+	seen := map[string]struct{}{}
+
+	// Seed `seen` with the current top of the log so we only print rows
+	// that arrive AFTER the user invoked the command.
+	first, err := c.ListSyncLogs(ctx, filters, "", limit)
+	if err != nil {
+		return err
+	}
+	for _, row := range first.SyncLogs {
+		seen[row.ID] = struct{}{}
+	}
+
+	ticker := time.NewTicker(syncFollowPollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+		page, err := c.ListSyncLogs(ctx, filters, "", limit)
+		if err != nil {
+			// Context cancellation surfaces here as an http error — treat
+			// it as a clean stop rather than a noisy non-zero exit.
+			if ctx.Err() != nil {
+				return nil
+			}
+			return err
+		}
+		// /sync/logs is sorted newest-first; emit oldest-first so the
+		// terminal reads chronologically.
+		for i := len(page.SyncLogs) - 1; i >= 0; i-- {
+			row := page.SyncLogs[i]
+			if _, ok := seen[row.ID]; ok {
+				continue
+			}
+			seen[row.ID] = struct{}{}
+			_ = enc.Encode(row)
+		}
+	}
+}
+
+func renderSyncLogs(flags *FlagBag, res *client.SyncLogsResult) error {
+	switch output.Resolve(flags.JSON, flags.NDJSON, os.Stdout) {
+	case output.ModeJSON:
+		return output.PrintJSON(os.Stdout, res)
+	case output.ModeNDJSON:
+		items := make([]any, 0, len(res.SyncLogs))
+		for _, r := range res.SyncLogs {
+			items = append(items, r)
+		}
+		return output.PrintNDJSON(os.Stdout, items)
+	default:
+		tbl := output.NewTable(os.Stdout, []string{"INSTITUTION", "TRIGGER", "STATUS", "ADDED", "MODIFIED", "REMOVED", "STARTED_AT"})
+		for _, r := range res.SyncLogs {
+			started := "-"
+			if r.StartedAt != nil {
+				started = *r.StartedAt
+			}
+			tbl.AddRow(r.InstitutionName, r.Trigger, r.Status,
+				fmt.Sprintf("%d", r.AddedCount),
+				fmt.Sprintf("%d", r.ModifiedCount),
+				fmt.Sprintf("%d", r.RemovedCount),
+				started)
+		}
+		return tbl.Flush()
+	}
+}

--- a/internal/cli/sync_integration_test.go
+++ b/internal/cli/sync_integration_test.go
@@ -1,0 +1,42 @@
+//go:build integration
+
+package cli_test
+
+import (
+	"context"
+	"testing"
+
+	"breadbox/internal/client"
+)
+
+// TestSyncTrigger_Returns202 is deliberately skipped here — the trigger
+// handler returns 202 synchronously and spawns the actual sync work on a
+// background goroutine that calls into svc.SyncEngine. The test env
+// passes nil for that engine (we don't want to wire up a real sync run
+// from a CLI integration test), so the spawned goroutine would panic
+// after the request returns. The handler is exercised exhaustively in
+// internal/api/*_integration_test.go.
+
+func TestSyncStatus_ReturnsHealth(t *testing.T) {
+	env := setupConnEnv(t)
+	// No connections is fine — handler still returns a summary row.
+	status, err := env.Client.SyncStatus(context.Background())
+	if err != nil {
+		t.Fatalf("SyncStatus: %v", err)
+	}
+	if status.OverallHealth == "" {
+		t.Error("expected non-empty overall_health")
+	}
+}
+
+func TestSyncLogs_ReturnsPage(t *testing.T) {
+	env := setupConnEnv(t)
+	// No fixtures — just assert the empty page shape lands as expected.
+	res, err := env.Client.ListSyncLogs(context.Background(), client.SyncLogFilters{}, "", 5)
+	if err != nil {
+		t.Fatalf("ListSyncLogs: %v", err)
+	}
+	if res.Limit != 5 {
+		t.Errorf("limit = %d, want 5", res.Limit)
+	}
+}

--- a/internal/client/connections.go
+++ b/internal/client/connections.go
@@ -1,0 +1,141 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+)
+
+// Connection mirrors service.ConnectionResponse — the JSON shape returned
+// by GET /api/v1/connections.
+type Connection struct {
+	ID              string  `json:"id"`
+	ShortID         string  `json:"short_id"`
+	UserID          *string `json:"user_id,omitempty"`
+	UserName        *string `json:"user_name,omitempty"`
+	Provider        string  `json:"provider"`
+	InstitutionID   *string `json:"institution_id,omitempty"`
+	InstitutionName *string `json:"institution_name,omitempty"`
+	Status          string  `json:"status"`
+	ErrorCode       *string `json:"error_code,omitempty"`
+	ErrorMessage    *string `json:"error_message,omitempty"`
+	LastSyncedAt    *string `json:"last_synced_at,omitempty"`
+	CreatedAt       string  `json:"created_at"`
+	UpdatedAt       string  `json:"updated_at"`
+}
+
+// ConnectionDetail mirrors service.ConnectionDetailResponse.
+type ConnectionDetail struct {
+	Connection
+	Paused                      bool   `json:"paused"`
+	SyncIntervalOverrideMinutes *int32 `json:"sync_interval_override_minutes,omitempty"`
+	ConsecutiveFailures         int32  `json:"consecutive_failures"`
+	AccountCount                int    `json:"account_count"`
+}
+
+// HostedLinkSession mirrors the wire shape of a hosted_link_sessions row
+// returned by GET /connections/link/{id} and the POST endpoints.
+type HostedLinkSession struct {
+	ID                  string   `json:"id"`
+	ShortID             string   `json:"short_id"`
+	UserID              string   `json:"user_id"`
+	Provider            string   `json:"provider"`
+	Action              string   `json:"action"`
+	ConnectionID        string   `json:"connection_id,omitempty"`
+	SingleUse           bool     `json:"single_use"`
+	RedirectURL         string   `json:"redirect_url,omitempty"`
+	Label               string   `json:"label,omitempty"`
+	Status              string   `json:"status"`
+	ErrorCode           string   `json:"error_code,omitempty"`
+	ErrorMessage        string   `json:"error_message,omitempty"`
+	ResultConnectionIDs []string `json:"result_connection_ids"`
+	ExpiresAt           string   `json:"expires_at"`
+	StartedAt           *string  `json:"started_at,omitempty"`
+	CompletedAt         *string  `json:"completed_at,omitempty"`
+	CreatedAt           string   `json:"created_at"`
+}
+
+// CreateHostedLinkResponse mirrors the POST /connections/link response —
+// the session plus the one-time-only `token` + `url`.
+type CreateHostedLinkResponse struct {
+	HostedLinkSession
+	Token string `json:"token"`
+	URL   string `json:"url"`
+}
+
+// CreateHostedLinkParams is the body of POST /connections/link.
+type CreateHostedLinkParams struct {
+	UserID           string `json:"user_id"`
+	Provider         string `json:"provider,omitempty"`
+	SingleUse        bool   `json:"single_use,omitempty"`
+	RedirectURL      string `json:"redirect_url,omitempty"`
+	Label            string `json:"label,omitempty"`
+	ExpiresInSeconds *int   `json:"expires_in_seconds,omitempty"`
+}
+
+// CreateRelinkParams is the body of POST /connections/{id}/relink.
+type CreateRelinkParams struct {
+	RedirectURL      string `json:"redirect_url,omitempty"`
+	Label            string `json:"label,omitempty"`
+	ExpiresInSeconds *int   `json:"expires_in_seconds,omitempty"`
+}
+
+// ListConnections returns the household's bank connections.
+func (c *Client) ListConnections(ctx context.Context, userID string) ([]Connection, error) {
+	path := "/api/v1/connections"
+	if userID != "" {
+		path += "?" + url.Values{"user_id": []string{userID}}.Encode()
+	}
+	var out []Connection
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// GetConnection fetches a single connection by short_id or uuid.
+func (c *Client) GetConnection(ctx context.Context, id string) (*ConnectionDetail, error) {
+	var out ConnectionDetail
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/connections/"+url.PathEscape(id), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateHostedLink mints a hosted-link session and returns the URL + token.
+func (c *Client) CreateHostedLink(ctx context.Context, params CreateHostedLinkParams) (*CreateHostedLinkResponse, error) {
+	var out CreateHostedLinkResponse
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/connections/link", params, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// GetHostedLinkSession polls the session by id (uuid or short_id).
+func (c *Client) GetHostedLinkSession(ctx context.Context, id string) (*HostedLinkSession, error) {
+	var out HostedLinkSession
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/connections/link/"+url.PathEscape(id), nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// CreateRelink mints a re-auth hosted-link session for an existing connection.
+func (c *Client) CreateRelink(ctx context.Context, connectionID string, params CreateRelinkParams) (*CreateHostedLinkResponse, error) {
+	var out CreateHostedLinkResponse
+	path := "/api/v1/connections/" + url.PathEscape(connectionID) + "/relink"
+	if err := c.Do(ctx, http.MethodPost, path, params, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// DisconnectConnection performs the server's soft-disconnect: DELETE
+// /connections/{id}. The server keeps the row + history; only credentials
+// are wiped and status flips to 'disconnected'.
+//
+// There is no hard-delete REST endpoint today — `breadbox connections
+// delete` aliases to this same call.
+func (c *Client) DisconnectConnection(ctx context.Context, id string) error {
+	return c.Do(ctx, http.MethodDelete, "/api/v1/connections/"+url.PathEscape(id), nil, nil)
+}

--- a/internal/client/csv.go
+++ b/internal/client/csv.go
@@ -1,0 +1,177 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+)
+
+// CSVPreviewResult is the loose-shape response from POST /connections/csv/preview.
+// The handler returns a free-form map (auto-detected mapping, template
+// fields, optional template metadata), so we mirror that.
+type CSVPreviewResult map[string]any
+
+// CSVImportResult mirrors api.csvImportResponse.
+type CSVImportResult struct {
+	ConnectionID         string `json:"connection_id"`
+	AccountID            string `json:"account_id"`
+	ImportedTransactions int    `json:"imported_transactions"`
+	UpdatedTransactions  int    `json:"updated_transactions"`
+	SkippedDuplicates    int    `json:"skipped_duplicates"`
+	TotalRows            int    `json:"total_rows"`
+}
+
+// CSVOptions carries the optional form fields the CSV endpoints accept.
+// Either ConnectionID or AccountName (with UserID for multi-user
+// households) drives the import path; the preview endpoint only reads the
+// CSV bytes.
+type CSVOptions struct {
+	UserID          string
+	AccountName     string
+	ConnectionID    string
+	DateFormat      string
+	ColumnMapping   map[string]int
+	PositiveIsDebit bool
+	HasDebitCredit  bool
+	Limit           int
+}
+
+// BuildCSVMultipart builds a multipart/form-data body for the CSV
+// endpoints. filename is shown to the server's parser but doesn't
+// otherwise matter. Exported so unit tests can assemble + inspect the
+// payload without hitting the network.
+func BuildCSVMultipart(filename string, data []byte, opts CSVOptions) (*bytes.Buffer, string, error) {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+
+	part, err := mw.CreateFormFile("file", filename)
+	if err != nil {
+		return nil, "", fmt.Errorf("create form file: %w", err)
+	}
+	if _, err := io.Copy(part, bytes.NewReader(data)); err != nil {
+		return nil, "", fmt.Errorf("write form file: %w", err)
+	}
+
+	add := func(k, v string) error {
+		if v == "" {
+			return nil
+		}
+		return mw.WriteField(k, v)
+	}
+	if err := add("user_id", opts.UserID); err != nil {
+		return nil, "", err
+	}
+	if err := add("account_name", opts.AccountName); err != nil {
+		return nil, "", err
+	}
+	if err := add("connection_id", opts.ConnectionID); err != nil {
+		return nil, "", err
+	}
+	if err := add("date_format", opts.DateFormat); err != nil {
+		return nil, "", err
+	}
+	if opts.PositiveIsDebit {
+		if err := mw.WriteField("positive_is_debit", "true"); err != nil {
+			return nil, "", err
+		}
+	}
+	if opts.HasDebitCredit {
+		if err := mw.WriteField("has_debit_credit", "true"); err != nil {
+			return nil, "", err
+		}
+	}
+	if opts.Limit > 0 {
+		if err := mw.WriteField("limit", fmt.Sprintf("%d", opts.Limit)); err != nil {
+			return nil, "", err
+		}
+	}
+	if len(opts.ColumnMapping) > 0 {
+		b, err := json.Marshal(opts.ColumnMapping)
+		if err != nil {
+			return nil, "", fmt.Errorf("marshal column_mapping: %w", err)
+		}
+		if err := mw.WriteField("column_mapping", string(b)); err != nil {
+			return nil, "", err
+		}
+	}
+	if err := mw.Close(); err != nil {
+		return nil, "", fmt.Errorf("close multipart: %w", err)
+	}
+	return &buf, mw.FormDataContentType(), nil
+}
+
+// postMultipart sends a multipart/form-data POST and decodes the response
+// into `out`. Mirrors Client.Do but specialised for file upload: bypasses
+// the JSON encoder on the request body. On non-2xx it still returns the
+// canonical *APIError so the CLI maps exit codes consistently.
+func (c *Client) postMultipart(ctx context.Context, path string, body io.Reader, contentType string, out any) error {
+	u, err := c.url(path)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, body)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	if c.host.Token != "" {
+		req.Header.Set("X-API-Key", c.host.Token)
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("call POST %s: %w", path, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		var env errorEnvelope
+		raw, _ := io.ReadAll(resp.Body)
+		_ = json.Unmarshal(raw, &env)
+		apiErr := env.Error
+		apiErr.Status = resp.StatusCode
+		if apiErr.Message == "" && len(raw) > 0 {
+			apiErr.Message = string(raw)
+		}
+		return &apiErr
+	}
+	if out == nil || resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil && err != io.EOF {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+// PreviewCSV uploads a CSV and returns the parse preview.
+func (c *Client) PreviewCSV(ctx context.Context, filename string, data []byte, opts CSVOptions) (CSVPreviewResult, error) {
+	buf, contentType, err := BuildCSVMultipart(filename, data, opts)
+	if err != nil {
+		return nil, err
+	}
+	out := CSVPreviewResult{}
+	if err := c.postMultipart(ctx, "/api/v1/connections/csv/preview", buf, contentType, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ImportCSV uploads a CSV and creates / extends a CSV connection.
+func (c *Client) ImportCSV(ctx context.Context, filename string, data []byte, opts CSVOptions) (*CSVImportResult, error) {
+	buf, contentType, err := BuildCSVMultipart(filename, data, opts)
+	if err != nil {
+		return nil, err
+	}
+	var out CSVImportResult
+	if err := c.postMultipart(ctx, "/api/v1/connections/csv/import", buf, contentType, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/internal/client/sync.go
+++ b/internal/client/sync.go
@@ -1,0 +1,128 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strconv"
+)
+
+// SyncTriggerRequest is the body of POST /sync.
+type SyncTriggerRequest struct {
+	ConnectionID *string `json:"connection_id,omitempty"`
+}
+
+// SyncTriggerResponse is the 202 envelope.
+type SyncTriggerResponse struct {
+	Status string `json:"status"`
+}
+
+// SyncHealth mirrors the GET /sync/health payload.
+type SyncHealth struct {
+	OverallHealth     string  `json:"overall_health"`
+	LastSyncTime      *string `json:"last_sync_time,omitempty"`
+	LastSyncStatus    string  `json:"last_sync_status"`
+	RecentSyncCount   int64   `json:"recent_sync_count"`
+	RecentSuccessRate float64 `json:"recent_success_rate"`
+	RecentErrorCount  int64   `json:"recent_error_count"`
+	ConnectionErrors  int64   `json:"connection_errors"`
+	NextSyncTime      string  `json:"next_sync_time,omitempty"`
+}
+
+// SyncLog mirrors one row of /sync/logs.
+type SyncLog struct {
+	ID                   string  `json:"id"`
+	ConnectionID         string  `json:"connection_id"`
+	InstitutionName      string  `json:"institution_name"`
+	Provider             string  `json:"provider,omitempty"`
+	Trigger              string  `json:"trigger"`
+	Status               string  `json:"status"`
+	AddedCount           int32   `json:"added_count"`
+	ModifiedCount        int32   `json:"modified_count"`
+	RemovedCount         int32   `json:"removed_count"`
+	UnchangedCount       int32   `json:"unchanged_count"`
+	ErrorMessage         *string `json:"error_message,omitempty"`
+	FriendlyErrorMessage *string `json:"friendly_error_message,omitempty"`
+	WarningMessage       *string `json:"warning_message,omitempty"`
+	StartedAt            *string `json:"started_at,omitempty"`
+	CompletedAt          *string `json:"completed_at,omitempty"`
+	Duration             *string `json:"duration,omitempty"`
+	DurationMs           *int32  `json:"duration_ms,omitempty"`
+	AccountsAffected     int64   `json:"accounts_affected"`
+}
+
+// SyncLogsResult is the envelope returned by GET /sync/logs.
+type SyncLogsResult struct {
+	SyncLogs   []SyncLog `json:"sync_logs"`
+	NextCursor *string   `json:"next_cursor"`
+	HasMore    bool      `json:"has_more"`
+	Limit      int       `json:"limit"`
+	Total      int64     `json:"total"`
+}
+
+// SyncLogFilters is the filter set for GET /sync/logs.
+type SyncLogFilters struct {
+	ConnectionID string
+	Status       string
+	Trigger      string
+	From         string // RFC3339
+	To           string // RFC3339
+}
+
+// TriggerSync hits POST /sync; pass connectionID empty to sync all.
+func (c *Client) TriggerSync(ctx context.Context, connectionID string) (*SyncTriggerResponse, error) {
+	body := SyncTriggerRequest{}
+	if connectionID != "" {
+		body.ConnectionID = &connectionID
+	}
+	var out SyncTriggerResponse
+	if err := c.Do(ctx, http.MethodPost, "/api/v1/sync", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// SyncStatus returns GET /sync/health.
+func (c *Client) SyncStatus(ctx context.Context) (*SyncHealth, error) {
+	var out SyncHealth
+	if err := c.Do(ctx, http.MethodGet, "/api/v1/sync/health", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ListSyncLogs returns a page of sync logs. `cursor` is the opaque value
+// from a previous page's NextCursor; pass empty for the first page.
+func (c *Client) ListSyncLogs(ctx context.Context, filters SyncLogFilters, cursor string, limit int) (*SyncLogsResult, error) {
+	q := url.Values{}
+	if filters.ConnectionID != "" {
+		q.Set("connection_id", filters.ConnectionID)
+	}
+	if filters.Status != "" {
+		q.Set("status", filters.Status)
+	}
+	if filters.Trigger != "" {
+		q.Set("trigger", filters.Trigger)
+	}
+	if filters.From != "" {
+		q.Set("from", filters.From)
+	}
+	if filters.To != "" {
+		q.Set("to", filters.To)
+	}
+	if cursor != "" {
+		q.Set("cursor", cursor)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/v1/sync/logs"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var out SyncLogsResult
+	if err := c.Do(ctx, http.MethodGet, path, nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}


### PR DESCRIPTION
## Summary

Third wave of CLI noun groups for the headless build. The centerpiece is **hosted-link integration** — `breadbox connections link` mints a session and (with `--wait`) blocks until the user finishes onboarding in a browser.

- `breadbox connections list | get | link [--wait] | link get | relink | disconnect | delete`
- `breadbox sync trigger | status | logs [--follow]`
- `breadbox csv preview | import`

## Hosted-link UX

```
$ breadbox connections link --provider=plaid --user=ricardo --wait
Hosted-link session ready. Open this URL in a browser:

    http://localhost:8080/link/<token>

Expires at 2026-05-12T01:48:11Z
Polling for completion (Ctrl+C to abort)…
...
```

- Banner + URL goes to **stderr** so stdout stays clean for the final session JSON.
- `--wait` polls every 2s, 5-minute timeout. Timeout returns `ErrHostedLinkTimeout` → exit code **4**.
- SIGINT during polling cancels via the cobra context and surfaces as a clean error from `c.GetHostedLinkSession`.
- In `--json` mode (or piped), the create response emits `{ url, session_id, expires_at }` as documented.

## Other notes

- **`sync logs --follow`** polls `/sync/logs` every 2s and emits NDJSON of new rows (sorted oldest-first per page so a tailing terminal reads chronologically). SIGINT/SIGTERM exits cleanly with code 0. No SSE plumbing — the endpoint doesn't expose it yet.
- **CSV multipart** — added `client.BuildCSVMultipart` (exported so unit tests can inspect the body) + a `postMultipart` helper on `*Client`. `csv import` auto-runs `csv preview` first to grab the inferred column mapping; saves the user from passing `--column-mapping` by hand. Template-detected toggles (`positive_is_debit`, `has_debit_credit`, `date_format`) are auto-forwarded when the preview detected a known template.
- **`connections delete`** — there's no hard-delete REST endpoint today. Both `disconnect` and `delete` hit `DELETE /connections/{id}` (the soft-disconnect path). `docs/cli-commands.md` is updated to note the alias.
- **`sync trigger --account`** is accepted for spec parity but errors with a usage hint — the server only supports `connection_id` scoping right now.

## Test plan

Unit (in `internal/cli/`):

- [x] `TestConnectionsLinkRequiresUser` — surfaces a usage-tier error when `--user` is missing
- [x] `TestWaitForHostedLinkSuccess` — happy-path poll loop returns the terminal session
- [x] `TestWaitForHostedLinkTimeout` — exhausted budget → `ErrHostedLinkTimeout` → exit 4
- [x] `TestBuildCSVMultipart` — round-trips file bytes + every form field through the multipart body

Integration (`-tags=integration`):

- [x] `TestConnectionsList_ReturnsFixtures`
- [x] `TestConnectionsLink_MintsSessionAndPageRenders` — fetches the printed URL, asserts the page returns 200 + text/html
- [x] `TestConnectionsLinkGet_ReturnsSession`
- [x] `TestConnectionsDisconnect_FlipsStatus`
- [x] `TestCSVPreview_ReturnsParseReport`
- [x] `TestCSVImport_CreatesTransactions`
- [x] `TestSyncStatus_ReturnsHealth`
- [x] `TestSyncLogs_ReturnsPage`

`TestSyncTrigger_Returns202` is deliberately omitted — the handler spawns the actual sync work on a background goroutine that needs a real `SyncEngine`. The CLI test env doesn't wire one up; `internal/api/*_integration_test.go` covers the handler exhaustively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
