### PR TITLE
v2: auto-follow system dark mode

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Breadbox v2</title>
+    <script>
+      (function () {
+        var mql = window.matchMedia("(prefers-color-scheme: dark)");
+        function apply(e) {
+          document.documentElement.classList.toggle("dark", e.matches);
+        }
+        apply(mql);
+        mql.addEventListener("change", apply);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Auto-follows system color scheme without an in-app toggle.

## Summary

- Inline script in `web/index.html` toggles `html.dark` based on `prefers-color-scheme` and subscribes to live OS changes.
- Color tokens for both light and dark are already in `web/src/globals.css`, so this PR just wires the class.
- No `<ModeToggle>` UI — the SPA respects the user's OS preference at all times.

## Why

A toggle is the wrong default for a self-hosted admin SPA: most users want it to match their OS, and an explicit toggle adds surface area (persistence, hydration, FOUC) without a real win. We can add one later if a real use case shows up.

## Risk

The inline script runs synchronously in `<head>` so the `dark` class lands before any CSS evaluates — no flash.

## Test plan

- [ ] Run `make build && ./breadbox serve`, open `/v2/`, confirm theme matches the system; flip system theme and confirm the SPA flips live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
