### PR TITLE
v2: toast, KBD tooltip, shortcut registry

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -16,9 +16,11 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.14.0",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.4",
       },
       "devDependencies": {
@@ -460,6 +462,8 @@
 
     "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
+    "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
+
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -493,6 +497,8 @@
     "seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
 
     "seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/web/index.html
+++ b/web/index.html
@@ -4,6 +4,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Breadbox v2</title>
+    <script>
+      (function () {
+        var mql = window.matchMedia("(prefers-color-scheme: dark)");
+        function apply(e) {
+          document.documentElement.classList.toggle("dark", e.matches);
+        }
+        apply(mql);
+        mql.addEventListener("change", apply);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/package.json
+++ b/web/package.json
@@ -22,9 +22,11 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {

--- a/web/src/components/kbd-tooltip.tsx
+++ b/web/src/components/kbd-tooltip.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+
+export interface KbdTooltipProps {
+  label: string;
+  keys?: string[];
+  side?: React.ComponentProps<typeof TooltipContent>["side"];
+  align?: React.ComponentProps<typeof TooltipContent>["align"];
+  children: React.ReactElement;
+}
+
+const DISPLAY: Record<string, string> = {
+  mod: "⌘",
+  cmd: "⌘",
+  ctrl: "Ctrl",
+  shift: "⇧",
+  alt: "⌥",
+  option: "⌥",
+};
+
+function display(k: string): string {
+  const lower = k.toLowerCase();
+  if (lower in DISPLAY) return DISPLAY[lower];
+  return k.length === 1 ? k.toUpperCase() : k;
+}
+
+export function KbdTooltip({
+  label,
+  keys,
+  side,
+  align,
+  children,
+}: KbdTooltipProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side={side} align={align} className="flex items-center gap-2">
+        <span>{label}</span>
+        {keys && keys.length > 0 && (
+          <KbdGroup>
+            {keys.map((k) => (
+              <Kbd key={k}>{display(k)}</Kbd>
+            ))}
+          </KbdGroup>
+        )}
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/web/src/components/ui/kbd.tsx
+++ b/web/src/components/ui/kbd.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils"
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+  return (
+    <kbd
+      data-slot="kbd"
+      className={cn(
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none",
+        "[&_svg:not([class*='size-'])]:size-3",
+        "[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <kbd
+      data-slot="kbd-group"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+export { Kbd, KbdGroup }

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -1,0 +1,38 @@
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react"
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      icons={{
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/web/src/lib/shortcuts.ts
+++ b/web/src/lib/shortcuts.ts
@@ -1,0 +1,96 @@
+import { useEffect } from "react";
+
+export interface Shortcut {
+  id: string;
+  keys: string[];
+  label: string;
+  group?: string;
+}
+
+const registry = new Map<string, Shortcut>();
+const listeners = new Set<() => void>();
+
+function notify() {
+  listeners.forEach((fn) => fn());
+}
+
+export function registerShortcut(shortcut: Shortcut): () => void {
+  registry.set(shortcut.id, shortcut);
+  notify();
+  return () => {
+    registry.delete(shortcut.id);
+    notify();
+  };
+}
+
+export function listShortcuts(): Shortcut[] {
+  return Array.from(registry.values());
+}
+
+export function subscribeShortcuts(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+interface KeyMatch {
+  key: string;
+  meta?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  ctrl?: boolean;
+}
+
+function parseKeys(keys: string[]): KeyMatch {
+  const match: KeyMatch = { key: "" };
+  for (const raw of keys) {
+    const k = raw.toLowerCase();
+    if (k === "mod" || k === "cmd" || k === "⌘") match.meta = true;
+    else if (k === "ctrl") match.ctrl = true;
+    else if (k === "shift" || k === "⇧") match.shift = true;
+    else if (k === "alt" || k === "option" || k === "⌥") match.alt = true;
+    else match.key = k;
+  }
+  return match;
+}
+
+export interface UseShortcutOptions {
+  label: string;
+  group?: string;
+  enabled?: boolean;
+}
+
+export function useShortcut(
+  keys: string[],
+  handler: (event: KeyboardEvent) => void,
+  options: UseShortcutOptions,
+): void {
+  const { label, group, enabled = true } = options;
+  const id = `${group ?? "global"}:${label}`;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const unregister = registerShortcut({ id, keys, label, group });
+    const match = parseKeys(keys);
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== match.key) return;
+      if (!!match.meta !== (event.metaKey || event.ctrlKey)) return;
+      if (!!match.shift !== event.shiftKey) return;
+      if (!!match.alt !== event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      handler(event);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      unregister();
+    };
+  }, [enabled, handler, id, keys, label, group]);
+}

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
+import { Toaster } from "@/components/ui/sonner";
 import { NAV_LEAVES, isNavMatch } from "@/lib/nav";
 import { useMe } from "@/api/queries/me";
 import { ApiError } from "@/api/client";
@@ -47,6 +48,7 @@ export function RootLayout() {
           <Outlet />
         </main>
       </SidebarInset>
+      <Toaster />
     </SidebarProvider>
   );
 }


### PR DESCRIPTION
Installs the toast + KBD-tooltip + shortcut-registry foundation that the command palette and the keyboard shortcut sheet (PR 4) both consume.

## Summary

- `bunx shadcn add sonner kbd form label`.
- `<Toaster />` mounted in `__root.tsx`.
- New composed `<KbdTooltip label="…" keys={["mod","k"]}>` wraps the shadcn `Tooltip` + `Kbd`/`KbdGroup` so the convention "tooltip with KBD chip" only has to be written once.
- New `web/src/lib/shortcuts.ts` exposes `useShortcut(keys, handler, opts)` plus a registry the shortcut sheet reads from. Inputs/textareas/contentEditable nodes are short-circuited so a `?` keypress in a search field doesn't open the sheet.

## Why

Toasts and shortcuts touch every feature; settling the pattern before page builds prevents inconsistent per-page implementations.

## Test plan

- [ ] `bun run lint` (already passes).
- [ ] PR 4 stacks on top and demonstrates the registry in use — verify shortcuts there land in the sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
