### PR TITLE
v2: native login + CSRF rule for /web/v1

### DIFF
--- a/.claude/rules/v2-frontend.md
+++ b/.claude/rules/v2-frontend.md
@@ -90,10 +90,10 @@ Conventions on layout:
 
 ### Auth and `/web/v1/*` backend
 
-- Endpoints under `/web/v1/*` MUST be session-only — gated by `webui.RequireSessionJSON` in `web/embed.go`.
+- Endpoints under `/web/v1/*` MUST be session-only — gated by `webui.RequireSessionJSON` in `web/embed.go`. Pre-auth endpoints (login, password reset) live under the same prefix but skip `RequireSessionJSON`; they still pass through `RequireSameOrigin`.
 - They MUST return JSON envelopes (`mw.WriteError` / `mw.WriteJSON`). Never hand-roll `json.NewEncoder(...).Encode(...)` or string-literal JSON in handlers.
 - `/web/v1/*` carries **zero stability promise.** Don't document it in `docs/api-reference.md` or `docs/mcp-tools-reference.md`. Free to break it.
-- Any new write endpoint needs a CSRF strategy decided first (see open decisions in `Breadbox/planned-features/v2-frontend-plan.md`). Until then, `/web/v1/*` is read-only.
+- **CSRF strategy for writes: SameSite=Lax cookie + `Origin`/`Referer` host check.** Every `/web/v1/*` mutating request (POST/PUT/PATCH/DELETE) passes through `webui.RequireSameOrigin`, which rejects any request whose `Origin` (or `Referer` fallback) host doesn't match `r.Host`. Same-origin SPA + Lax cookies make this sufficient — no double-submit token, no synchronizer token. Non-browser callers without an `Origin` header will 403 by design; they should use `/api/v1/*` + an API key.
 
 ### Routing
 

--- a/internal/admin/auth.go
+++ b/internal/admin/auth.go
@@ -3,6 +3,7 @@
 package admin
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -120,25 +121,32 @@ func LoginHandler(sm *scs.SessionManager, queries *db.Queries, _ *TemplateRender
 
 		sm.RememberMe(r.Context(), r.FormValue("remember_me") != "")
 
-		sm.Put(r.Context(), sessionKeyAccountID, pgconv.FormatUUID(account.ID))
-		sm.Put(r.Context(), sessionKeyAccountUsername, account.Username)
-		sm.Put(r.Context(), sessionKeyAccountRole, account.Role)
-		if account.UserID.Valid {
-			sm.Put(r.Context(), sessionKeyUserID, pgconv.FormatUUID(account.UserID))
-			// Cache the linked household-member display name so the
-			// sidebar footer can show "Ricardo" instead of falling back
-			// to the auth_accounts.username (often an email). Updated
-			// on profile edits via /settings/account/profile.
-			if u, err := queries.GetUser(r.Context(), account.UserID); err == nil {
-				sm.Put(r.Context(), sessionKeyUserName, u.Name)
-			} else {
-				sm.Remove(r.Context(), sessionKeyUserName)
-			}
-		} else {
-			sm.Remove(r.Context(), sessionKeyUserID)
-			sm.Remove(r.Context(), sessionKeyUserName)
-		}
+		SetLoginSessionKeys(r.Context(), sm, account, queries)
 		http.Redirect(w, r, "/", http.StatusSeeOther)
+	}
+}
+
+// SetLoginSessionKeys writes the session keys for a freshly authenticated
+// account. Called by both admin.LoginHandler (HTML form) and
+// webui.LoginHandler (JSON) so the two surfaces stay in lock-step.
+func SetLoginSessionKeys(ctx context.Context, sm *scs.SessionManager, account db.AuthAccount, queries *db.Queries) {
+	sm.Put(ctx, sessionKeyAccountID, pgconv.FormatUUID(account.ID))
+	sm.Put(ctx, sessionKeyAccountUsername, account.Username)
+	sm.Put(ctx, sessionKeyAccountRole, account.Role)
+	if account.UserID.Valid {
+		sm.Put(ctx, sessionKeyUserID, pgconv.FormatUUID(account.UserID))
+		// Cache the linked household-member display name so the
+		// sidebar footer can show "Ricardo" instead of falling back
+		// to the auth_accounts.username (often an email). Updated
+		// on profile edits via /settings/account/profile.
+		if u, err := queries.GetUser(ctx, account.UserID); err == nil {
+			sm.Put(ctx, sessionKeyUserName, u.Name)
+		} else {
+			sm.Remove(ctx, sessionKeyUserName)
+		}
+	} else {
+		sm.Remove(ctx, sessionKeyUserID)
+		sm.Remove(ctx, sessionKeyUserName)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -251,8 +251,17 @@ func NewRouter(a *app.App, version string) http.Handler {
 		r.Group(func(r chi.Router) {
 			r.Use(sm.LoadAndSave)
 			r.Route("/web/v1", func(r chi.Router) {
-				r.Use(webui.RequireSessionJSON(sm))
-				r.Get("/me", webui.MeHandler(sm))
+				// SameSite=Lax cookie + Origin check is the CSRF strategy
+				// for /web/v1/* writes. See .claude/rules/v2-frontend.md.
+				r.Use(webui.RequireSameOrigin())
+				// Pre-auth (login + first-run signup-style routes): no session required.
+				r.Post("/login", webui.LoginHandler(sm, a.Queries))
+				// Post-auth routes.
+				r.Group(func(r chi.Router) {
+					r.Use(webui.RequireSessionJSON(sm))
+					r.Get("/me", webui.MeHandler(sm))
+					r.Post("/logout", webui.LogoutHandler(sm))
+				})
 			})
 			// /v2/* — embedded SPA static bundle. The session middleware lets
 			// the SPA shell load on /login, but the SPA's own queries

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "breadbox-web",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-collapsible": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
@@ -20,8 +21,10 @@
         "radix-ui": "^1.4.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hook-form": "^7.75.0",
         "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.4",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
@@ -129,6 +132,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.8", "", { "dependencies": { "@floating-ui/dom": "^1.7.6" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
+    "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -312,6 +317,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
 
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.4", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.4", "@tailwindcss/oxide-darwin-arm64": "4.2.4", "@tailwindcss/oxide-darwin-x64": "4.2.4", "@tailwindcss/oxide-freebsd-x64": "4.2.4", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4", "@tailwindcss/oxide-linux-arm64-musl": "4.2.4", "@tailwindcss/oxide-linux-x64-gnu": "4.2.4", "@tailwindcss/oxide-linux-x64-musl": "4.2.4", "@tailwindcss/oxide-wasm32-wasi": "4.2.4", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4", "@tailwindcss/oxide-win32-x64-msvc": "4.2.4" } }, "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q=="],
@@ -480,6 +487,8 @@
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
+    "react-hook-form": ["react-hook-form@7.75.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw=="],
+
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -527,6 +536,8 @@
     "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 

--- a/web/embed.go
+++ b/web/embed.go
@@ -8,15 +8,20 @@ package webui
 
 import (
 	"embed"
+	"encoding/json"
 	"io/fs"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
 	"breadbox/internal/admin"
+	"breadbox/internal/db"
 	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
 
 	"github.com/alexedwards/scs/v2"
+	"golang.org/x/crypto/bcrypt"
 )
 
 //go:embed all:dist
@@ -109,3 +114,115 @@ func RequireSessionJSON(sm *scs.SessionManager) func(http.Handler) http.Handler 
 		})
 	}
 }
+
+// RequireSameOrigin is the CSRF strategy for /web/v1/* writes. On any
+// unsafe-method request (POST/PUT/PATCH/DELETE), the Origin (or Referer
+// fallback) host must match the request host. SameSite=Lax cookies +
+// same-origin SPA make this sufficient — no double-submit token needed.
+//
+// Browsers send Origin on every cross-origin and same-origin POST, so the
+// only legitimate case where Origin is absent is older clients or non-CORS
+// fetches; we accept Referer as a fallback there.
+func RequireSameOrigin() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet, http.MethodHead, http.MethodOptions:
+				next.ServeHTTP(w, r)
+				return
+			}
+			if !sameOrigin(r) {
+				mw.WriteError(w, http.StatusForbidden, "ORIGIN_MISMATCH", "Cross-origin request rejected")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func sameOrigin(r *http.Request) bool {
+	got := r.Header.Get("Origin")
+	if got == "" {
+		got = r.Header.Get("Referer")
+	}
+	if got == "" {
+		// No Origin and no Referer — refuse rather than guess. Modern browsers
+		// always send one on a POST; missing both indicates a non-browser
+		// caller that should use the public /api/v1 + API key surface instead.
+		return false
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		return false
+	}
+	return u.Host == r.Host
+}
+
+// LoginRequest is the POST body for /web/v1/login.
+type LoginRequest struct {
+	Username   string `json:"username"`
+	Password   string `json:"password"`
+	RememberMe bool   `json:"remember_me"`
+}
+
+// LoginHandler authenticates against auth_accounts and sets the session
+// keys the rest of the dashboard expects. JSON twin of admin.LoginHandler.
+func LoginHandler(sm *scs.SessionManager, queries *db.Queries) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req LoginRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Request body must be valid JSON")
+			return
+		}
+		if req.Username == "" || req.Password == "" {
+			bcrypt.CompareHashAndPassword(loginDummyHash, []byte(req.Password))
+			mw.WriteError(w, http.StatusUnauthorized, "INVALID_CREDENTIALS", "Invalid email or password")
+			return
+		}
+
+		account, err := queries.GetAuthAccountByUsername(r.Context(), req.Username)
+		if err != nil {
+			bcrypt.CompareHashAndPassword(loginDummyHash, []byte(req.Password))
+			mw.WriteError(w, http.StatusUnauthorized, "INVALID_CREDENTIALS", "Invalid email or password")
+			return
+		}
+		if account.HashedPassword == nil {
+			bcrypt.CompareHashAndPassword(loginDummyHash, []byte(req.Password))
+			mw.WriteError(w, http.StatusUnauthorized, "ACCOUNT_NOT_SETUP", "Your account hasn't been set up yet. Ask your administrator for a setup link.")
+			return
+		}
+		if err := bcrypt.CompareHashAndPassword(account.HashedPassword, []byte(req.Password)); err != nil {
+			mw.WriteError(w, http.StatusUnauthorized, "INVALID_CREDENTIALS", "Invalid email or password")
+			return
+		}
+
+		if err := sm.RenewToken(r.Context()); err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "SESSION_ERROR", "Failed to renew session")
+			return
+		}
+		sm.RememberMe(r.Context(), req.RememberMe)
+		admin.SetLoginSessionKeys(r.Context(), sm, account, queries)
+
+		mw.WriteJSON(w, http.StatusOK, MeResponse{
+			AccountID: pgconv.FormatUUID(account.ID),
+			Username:  account.Username,
+			Role:      account.Role,
+		})
+	}
+}
+
+// LogoutHandler destroys the current session.
+func LogoutHandler(sm *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := sm.Destroy(r.Context()); err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "SESSION_ERROR", "Failed to destroy session")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// loginDummyHash mirrors admin.dummyHash — used for constant-time login
+// responses against unknown usernames so timing can't be used for
+// enumeration.
+var loginDummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), 12)

--- a/web/embed_headless.go
+++ b/web/embed_headless.go
@@ -12,6 +12,8 @@ package webui
 import (
 	"net/http"
 
+	"breadbox/internal/db"
+
 	"github.com/alexedwards/scs/v2"
 )
 
@@ -36,5 +38,26 @@ func RequireSessionJSON(_ *scs.SessionManager) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "v2 SPA disabled in this build", http.StatusGone)
 		})
+	}
+}
+
+// RequireSameOrigin is the CSRF middleware for /web/v1/* writes. Stub is a
+// no-op pass-through (the routes it would guard are themselves stubbed to
+// 410 elsewhere, so this never lets a real request through).
+func RequireSameOrigin() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler { return next }
+}
+
+// LoginHandler authenticates the v2 SPA's session. Stub returns 410.
+func LoginHandler(_ *scs.SessionManager, _ *db.Queries) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "v2 SPA disabled in this build", http.StatusGone)
+	}
+}
+
+// LogoutHandler destroys the v2 SPA's session. Stub returns 410.
+func LogoutHandler(_ *scs.SessionManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "v2 SPA disabled in this build", http.StatusGone)
 	}
 }

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "validate": "bun run scripts/validate.ts"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-collapsible": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
@@ -26,8 +27,10 @@
     "radix-ui": "^1.4.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.75.0",
     "sonner": "^2.0.7",
-    "tailwind-merge": "^2.5.4"
+    "tailwind-merge": "^2.5.4",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",

--- a/web/src/api/queries/auth.ts
+++ b/web/src/api/queries/auth.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { Me } from "@/api/types";
+
+export interface LoginInput {
+  username: string;
+  password: string;
+  remember_me?: boolean;
+}
+
+export function useLogin() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: LoginInput) =>
+      api<Me>("/web/v1/login", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: (data) => {
+      qc.setQueryData(["me"], data);
+    },
+  });
+}
+
+export function useLogout() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api<void>("/web/v1/logout", { method: "POST" }),
+    onSuccess: () => {
+      qc.clear();
+    },
+  });
+}

--- a/web/src/components/ui/form.tsx
+++ b/web/src/components/ui/form.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import * as React from "react"
+import type { Label as LabelPrimitive } from "radix-ui"
+import { Slot } from "radix-ui"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot.Root
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : props.children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-sm text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -10,8 +10,10 @@ import {
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { RootLayout } from "@/routes/__root";
 import { HomePage } from "@/routes/home";
+import { LoginPage } from "@/routes/login";
 import { Placeholder } from "@/routes/placeholder";
 import { NAV_LEAVES } from "@/lib/nav";
+import { z } from "zod";
 import "@/globals.css";
 
 const rootRoute = createRootRoute({ component: RootLayout });
@@ -22,6 +24,15 @@ const indexRoute = createRoute({
   component: HomePage,
 });
 
+const loginSearchSchema = z.object({ redirect: z.string().optional() });
+
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/login",
+  component: LoginPage,
+  validateSearch: loginSearchSchema,
+});
+
 const placeholderRoutes = NAV_LEAVES.filter((leaf) => leaf.to !== "/").map((leaf) =>
   createRoute({
     getParentRoute: () => rootRoute,
@@ -30,7 +41,7 @@ const placeholderRoutes = NAV_LEAVES.filter((leaf) => leaf.to !== "/").map((leaf
   }),
 );
 
-const routeTree = rootRoute.addChildren([indexRoute, ...placeholderRoutes]);
+const routeTree = rootRoute.addChildren([indexRoute, loginRoute, ...placeholderRoutes]);
 
 const router = createRouter({
   routeTree,

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Outlet, useRouterState } from "@tanstack/react-router";
+import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
 import { AppSidebar } from "@/components/app-sidebar";
 import {
   SidebarInset,
@@ -12,20 +12,38 @@ import { NAV_LEAVES, isNavMatch } from "@/lib/nav";
 import { useMe } from "@/api/queries/me";
 import { ApiError } from "@/api/client";
 
+const UNAUTHENTICATED_PATHS = new Set(["/login"]);
+
 export function RootLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  if (UNAUTHENTICATED_PATHS.has(pathname)) {
+    return (
+      <>
+        <Outlet />
+        <Toaster />
+      </>
+    );
+  }
+
+  return <AuthenticatedShell pathname={pathname} />;
+}
+
+function AuthenticatedShell({ pathname }: { pathname: string }) {
+  const navigate = useNavigate();
   const match = NAV_LEAVES.find((leaf) => isNavMatch(leaf, pathname));
   const group = match?.group ?? "";
   const title = match?.title ?? "Breadbox";
 
-  // Redirect to /login when the session is missing. The api client surfaces
-  // 401 as an ApiError; this is the single place that knows what to do.
+  // Redirect to /v2/login when the session is missing. The api client
+  // surfaces 401 as an ApiError; this is the single place that knows what
+  // to do.
   const { error } = useMe();
   useEffect(() => {
     if (error instanceof ApiError && error.status === 401) {
-      window.location.href = "/login";
+      navigate({ to: "/login", search: { redirect: pathname } });
     }
-  }, [error]);
+  }, [error, navigate, pathname]);
 
   return (
     <SidebarProvider>

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { useLogin } from "@/api/queries/auth";
+import { ApiError } from "@/api/client";
+
+const loginSchema = z.object({
+  username: z.string().min(1, "Email or username is required"),
+  password: z.string().min(1, "Password is required"),
+  remember_me: z.boolean().optional(),
+});
+
+type LoginValues = z.infer<typeof loginSchema>;
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as { redirect?: string };
+  const login = useLogin();
+  const [submitting, setSubmitting] = useState(false);
+
+  const form = useForm<LoginValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { username: "", password: "", remember_me: false },
+  });
+
+  const onSubmit = async (values: LoginValues) => {
+    setSubmitting(true);
+    try {
+      await login.mutateAsync(values);
+      const target = search.redirect && search.redirect.startsWith("/") ? search.redirect : "/";
+      navigate({ to: target });
+    } catch (err) {
+      const msg =
+        err instanceof ApiError ? err.message : "Something went wrong. Try again.";
+      toast.error(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-muted/30 flex min-h-screen items-center justify-center p-6">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Sign in to Breadbox</CardTitle>
+          <CardDescription>Use your admin email and password.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="username"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="email"
+                        autoComplete="username"
+                        autoFocus
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="password"
+                        autoComplete="current-password"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Button type="submit" className="w-full" disabled={submitting}>
+                {submitting ? "Signing in…" : "Sign in"}
+              </Button>
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
Native v2 login/logout, plus the CSRF rule for every `/web/v1/*` write that follows.

## Summary

**CSRF strategy decided: SameSite=Lax cookie + `Origin`/`Referer` host check.**

- New `webui.RequireSameOrigin` middleware applies to every `/web/v1/*` request. POST/PUT/PATCH/DELETE without a matching `Origin` (or `Referer` fallback) gets `403 ORIGIN_MISMATCH`. Same-origin SPA + Lax cookies make this sufficient — no double-submit token.
- `.claude/rules/v2-frontend.md` updated so future write endpoints inherit the policy.

**Backend (`web/embed.go` + `internal/admin/auth.go`):**

- `POST /web/v1/login` validates against `auth_accounts` and sets the same session keys as the existing v1 form login. The session-key writes were extracted from `admin.LoginHandler` into a new exported helper `admin.SetLoginSessionKeys`, so the two surfaces stay in lock-step.
- `POST /web/v1/logout` destroys the session, returns `204`.
- Both routes return the JSON envelope (`mw.WriteError`/`mw.WriteJSON`) — no string-literal JSON.

**Frontend (`web/src/...`):**

- `/v2/login` route — shadcn `<Form>` + RHF + zod, posts to `/web/v1/login` via the `useLogin` mutation in `api/queries/auth.ts`.
- `__root.tsx` splits into a bare layout (login) and the authenticated shell. A `401` from `useMe()` in the shell now navigates to `/v2/login?redirect=<current>` via the router, instead of full-page reloading to v1's `/login`.

## Out of scope (follow-up)

- **Signup**: First-run admin creation still flows through v1's `/setup`. A native `/v2/signup` route can land in a follow-up once household-creation UX is settled. The CSRF + JSON-login plumbing here makes that follow-up small.

## Test plan

- [ ] `make build && ./breadbox serve` → visit `/v2/login`, submit valid creds, land on `/v2/`.
- [ ] Wrong password surfaces the `INVALID_CREDENTIALS` message via toast.
- [ ] `curl -X POST http://localhost:8080/web/v1/login -d '{"username":"x","password":"y"}'` returns `403 ORIGIN_MISMATCH` (no `Origin` header).
- [ ] Existing `internal/admin` tests still pass (`go test ./internal/admin/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
