### PR TITLE
v2: settings Account section + change-password endpoint

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -261,6 +261,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 					r.Use(webui.RequireSessionJSON(sm))
 					r.Get("/me", webui.MeHandler(sm))
 					r.Post("/logout", webui.LogoutHandler(sm))
+					r.Post("/account/password", webui.ChangePasswordHandler(sm, a.Queries))
 				})
 			})
 			// /v2/* — embedded SPA static bundle. The session middleware lets

--- a/web/embed.go
+++ b/web/embed.go
@@ -21,6 +21,7 @@ import (
 	"breadbox/internal/pgconv"
 
 	"github.com/alexedwards/scs/v2"
+	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -216,6 +217,73 @@ func LogoutHandler(sm *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := sm.Destroy(r.Context()); err != nil {
 			mw.WriteError(w, http.StatusInternalServerError, "SESSION_ERROR", "Failed to destroy session")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// ChangePasswordRequest is the POST body for /web/v1/account/password.
+type ChangePasswordRequest struct {
+	CurrentPassword string `json:"current_password"`
+	NewPassword     string `json:"new_password"`
+	ConfirmPassword string `json:"confirm_password"`
+}
+
+// ChangePasswordHandler updates the current session's password. Mirrors
+// admin.changePasswordForAccount validation rules: current password must
+// verify, new must be 8+ chars and match confirm.
+func ChangePasswordHandler(sm *scs.SessionManager, queries *db.Queries) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		accountIDStr := admin.SessionAccountID(sm, r)
+		if accountIDStr == "" {
+			mw.WriteError(w, http.StatusUnauthorized, "UNAUTHORIZED", "Session required")
+			return
+		}
+		var accountID pgtype.UUID
+		if err := accountID.Scan(accountIDStr); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_SESSION", "Invalid session")
+			return
+		}
+
+		var req ChangePasswordRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Request body must be valid JSON")
+			return
+		}
+
+		account, err := queries.GetAuthAccountByID(r.Context(), accountID)
+		if err != nil {
+			mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Account not found")
+			return
+		}
+		if account.HashedPassword == nil {
+			mw.WriteError(w, http.StatusUnprocessableEntity, "ACCOUNT_NOT_SETUP", "No password set. Contact your administrator.")
+			return
+		}
+		if err := bcrypt.CompareHashAndPassword(account.HashedPassword, []byte(req.CurrentPassword)); err != nil {
+			mw.WriteError(w, http.StatusUnauthorized, "INVALID_CURRENT_PASSWORD", "Current password is incorrect")
+			return
+		}
+		if len(req.NewPassword) < 8 {
+			mw.WriteError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "New password must be at least 8 characters")
+			return
+		}
+		if req.NewPassword != req.ConfirmPassword {
+			mw.WriteError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "New passwords do not match")
+			return
+		}
+
+		hashed, err := bcrypt.GenerateFromPassword([]byte(req.NewPassword), 12)
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "HASH_ERROR", "Failed to hash password")
+			return
+		}
+		if err := queries.UpdateAuthAccountPassword(r.Context(), db.UpdateAuthAccountPasswordParams{
+			ID:             accountID,
+			HashedPassword: hashed,
+		}); err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "UPDATE_FAILED", "Failed to update password")
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)

--- a/web/embed_headless.go
+++ b/web/embed_headless.go
@@ -61,3 +61,10 @@ func LogoutHandler(_ *scs.SessionManager) http.HandlerFunc {
 		http.Error(w, "v2 SPA disabled in this build", http.StatusGone)
 	}
 }
+
+// ChangePasswordHandler updates the session account password. Stub returns 410.
+func ChangePasswordHandler(_ *scs.SessionManager, _ *db.Queries) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "v2 SPA disabled in this build", http.StatusGone)
+	}
+}

--- a/web/src/api/queries/account.ts
+++ b/web/src/api/queries/account.ts
@@ -1,0 +1,18 @@
+import { useMutation } from "@tanstack/react-query";
+import { api } from "@/api/client";
+
+export interface ChangePasswordInput {
+  current_password: string;
+  new_password: string;
+  confirm_password: string;
+}
+
+export function useChangePassword() {
+  return useMutation({
+    mutationFn: (input: ChangePasswordInput) =>
+      api<void>("/web/v1/account/password", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+  });
+}

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 import { SETTINGS_SECTIONS, type SettingsSection } from "@/lib/settings-sections";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { closeModalSearch, openModalSearch, useActiveModal } from "@/lib/modals";
+import { AccountSection } from "@/features/settings/account-section";
 
 const SETTINGS_MODAL_KEY = "settings";
 
@@ -137,8 +138,20 @@ function SectionContent({
   section: SettingsSection;
   mobile?: boolean;
 }) {
+  const wrapper = mobile
+    ? "border-border border-t pt-4 first:border-t-0 first:pt-0"
+    : "";
+
+  if (section.slug === "account") {
+    return (
+      <div className={wrapper}>
+        <AccountSection />
+      </div>
+    );
+  }
+
   return (
-    <div className={cn(mobile ? "border-border space-y-2 border-t pt-4 first:border-t-0 first:pt-0" : "space-y-1")}>
+    <div className={cn(wrapper, mobile ? "space-y-2" : "space-y-1")}>
       <h2 className="text-lg font-medium">{section.title}</h2>
       <p className="text-muted-foreground text-sm">{section.description}</p>
       <p className="text-muted-foreground mt-4 text-sm">Coming soon.</p>

--- a/web/src/features/settings/account-section.tsx
+++ b/web/src/features/settings/account-section.tsx
@@ -1,0 +1,132 @@
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { useMe } from "@/api/queries/me";
+import { useChangePassword } from "@/api/queries/account";
+import { ApiError } from "@/api/client";
+
+const schema = z
+  .object({
+    current_password: z.string().min(1, "Current password is required"),
+    new_password: z.string().min(8, "Must be at least 8 characters"),
+    confirm_password: z.string().min(1, "Confirm your new password"),
+  })
+  .refine((v) => v.new_password === v.confirm_password, {
+    path: ["confirm_password"],
+    message: "Passwords do not match",
+  });
+
+type Values = z.infer<typeof schema>;
+
+export function AccountSection() {
+  const { data: me } = useMe();
+  const changePassword = useChangePassword();
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    defaultValues: { current_password: "", new_password: "", confirm_password: "" },
+  });
+
+  const onSubmit = async (values: Values) => {
+    try {
+      await changePassword.mutateAsync(values);
+      toast.success("Password updated.");
+      form.reset();
+    } catch (err) {
+      const msg =
+        err instanceof ApiError ? err.message : "Something went wrong. Try again.";
+      toast.error(msg);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-lg font-medium">Account</h2>
+        <p className="text-muted-foreground text-sm">
+          Your sign-in identity. The admin role is managed by the household owner.
+        </p>
+      </div>
+
+      <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Field label="Email" value={me?.username ?? "—"} />
+        <Field label="Role" value={me?.role ?? "—"} mono />
+      </dl>
+
+      <div className="border-border space-y-4 border-t pt-6">
+        <div className="space-y-1">
+          <h3 className="font-medium">Change password</h3>
+          <p className="text-muted-foreground text-sm">
+            At least 8 characters. You'll stay signed in.
+          </p>
+        </div>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="current_password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Current password</FormLabel>
+                  <FormControl>
+                    <Input type="password" autoComplete="current-password" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="new_password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>New password</FormLabel>
+                  <FormControl>
+                    <Input type="password" autoComplete="new-password" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="confirm_password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Confirm new password</FormLabel>
+                  <FormControl>
+                    <Input type="password" autoComplete="new-password" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <Button type="submit" disabled={changePassword.isPending}>
+              {changePassword.isPending ? "Updating…" : "Update password"}
+            </Button>
+          </form>
+        </Form>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="space-y-0.5">
+      <dt className="text-muted-foreground text-xs uppercase tracking-wider">{label}</dt>
+      <dd className={mono ? "font-mono text-sm" : "text-sm"}>{value}</dd>
+    </div>
+  );
+}


### PR DESCRIPTION
First real Settings section — the Account panel — so the shell isn't all "Coming soon".

## Summary

**Backend** (`web/embed.go` + headless stub):

- `POST /web/v1/account/password` — JSON twin of `admin.changePasswordForAccount`. Same validation: current password must verify (bcrypt), new password 8+ chars and match confirm. Returns `204` on success, the JSON error envelope on failure (`INVALID_CURRENT_PASSWORD`, `VALIDATION_ERROR`, …).
- Gated by `RequireSessionJSON` + `RequireSameOrigin` like every `/web/v1/*` write.

**Frontend:**

- `features/settings/account-section.tsx` — shadcn `Form` + RHF + zod. Shows the signed-in email + role (read-only) and a change-password form. Toasts on success/failure.
- `SettingsShell` routes the `account` slug to it; the other four sections still render the placeholder.

<img src="https://i.img402.dev/ak38lxm6ji.jpg" width="800" alt="Settings — Account section with change-password form">

## Test plan

- [x] Settings → Account renders email/role + form. Validated in Chrome DevTools.
- [x] Wrong current password → "Current password is incorrect" error toast (shown above).
- [ ] Correct current password + valid new password → "Password updated", form resets, session stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
