### PR TITLE
v2: page-zero hardening before Phase 1 pages

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -14,6 +14,7 @@
         "@radix-ui/react-tooltip": "^1.1.4",
         "@tanstack/react-query": "^5.59.0",
         "@tanstack/react-router": "^1.58.0",
+        "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -360,9 +361,13 @@
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
+    "@tanstack/react-table": ["@tanstack/react-table@8.21.3", "", { "dependencies": { "@tanstack/table-core": "8.21.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww=="],
+
     "@tanstack/router-core": ["@tanstack/router-core@1.169.1", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^3.0.0", "seroval": "^1.5.0", "seroval-plugins": "^1.5.0" }, "bin": { "intent": "bin/intent.js" } }, "sha512-x+2gIGKTTE1qAn7tLieGfrB5ciOviDmmi2ox9fAWUubRV+yTU5ruGFXocoCIWF+lB+SOtnHjo2E9BLSWyYoEmA=="],
 
     "@tanstack/store": ["@tanstack/store@0.9.3", "", {}, "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@8.21.3", "", {}, "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-tooltip": "^1.1.4",
     "@tanstack/react-query": "^5.59.0",
     "@tanstack/react-router": "^1.58.0",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -1,0 +1,137 @@
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+  type OnChangeFn,
+  type SortingState,
+} from "@tanstack/react-table";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+export interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+  isLoading?: boolean;
+  isError?: boolean;
+  /** Rendered in the table body when data is empty and not loading. */
+  emptyState?: React.ReactNode;
+  /** Rendered in the table body when isError is true. */
+  errorState?: React.ReactNode;
+  /** Number of skeleton rows to show while loading. */
+  loadingRows?: number;
+  /**
+   * Controlled sorting. Owned by the route (typically synced to URL search
+   * params), so DataTable stays presentational. Omit for an unsorted table.
+   */
+  sorting?: SortingState;
+  onSortingChange?: OnChangeFn<SortingState>;
+  /** Optional row click handler — e.g. navigate to a detail page. */
+  onRowClick?: (row: TData) => void;
+}
+
+// Shared table wrapper over @tanstack/react-table + the shadcn Table
+// primitive. Pagination and sorting state live in the calling route (URL
+// search params) — DataTable only renders. Every v2 list page uses this;
+// never hand-roll a <table>.
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  isLoading = false,
+  isError = false,
+  emptyState,
+  errorState,
+  loadingRows = 8,
+  sorting,
+  onSortingChange,
+  onRowClick,
+}: DataTableProps<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    manualSorting: true,
+    state: sorting ? { sorting } : undefined,
+    onSortingChange,
+  });
+
+  const colCount = columns.length;
+
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id}>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext(),
+                      )}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {isLoading ? (
+            Array.from({ length: loadingRows }).map((_, r) => (
+              <TableRow key={`skeleton-${r}`}>
+                {Array.from({ length: colCount }).map((__, c) => (
+                  <TableCell key={c}>
+                    <Skeleton className="h-4 w-full" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : isError ? (
+            <TableRow>
+              <TableCell colSpan={colCount} className="h-32 text-center">
+                {errorState ?? (
+                  <span className="text-muted-foreground text-sm">
+                    Couldn't load this data.
+                  </span>
+                )}
+              </TableCell>
+            </TableRow>
+          ) : table.getRowModel().rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={colCount} className="h-32 text-center">
+                {emptyState ?? (
+                  <span className="text-muted-foreground text-sm">
+                    Nothing here yet.
+                  </span>
+                )}
+              </TableCell>
+            </TableRow>
+          ) : (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                onClick={onRowClick ? () => onRowClick(row.original) : undefined}
+                className={cn(onRowClick && "cursor-pointer")}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/web/src/components/empty-state.tsx
+++ b/web/src/components/empty-state.tsx
@@ -1,0 +1,42 @@
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export interface EmptyStateProps {
+  icon?: LucideIcon;
+  title: string;
+  description?: string;
+  /** Optional call-to-action — usually a <Button>. */
+  action?: React.ReactNode;
+  className?: string;
+}
+
+// Zero-data state for a page or section that loaded fine but has nothing to
+// show. Distinct from routes/placeholder.tsx, which marks a page that hasn't
+// been built yet.
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-2 py-12 text-center",
+        className,
+      )}
+    >
+      {Icon && (
+        <div className="bg-muted text-muted-foreground mb-2 rounded-full p-3">
+          <Icon className="size-5" />
+        </div>
+      )}
+      <h3 className="font-medium">{title}</h3>
+      {description && (
+        <p className="text-muted-foreground max-w-sm text-sm">{description}</p>
+      )}
+      {action && <div className="mt-3">{action}</div>}
+    </div>
+  );
+}

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+export interface PageHeaderProps {
+  title: string;
+  description?: string;
+  /** Optional right-aligned actions — usually a <Button> or a cluster. */
+  actions?: React.ReactNode;
+  className?: string;
+}
+
+// Content-level page header, rendered inside <main>, below the shell's
+// breadcrumb bar. Every v2 page uses this so the title/description/action
+// layout stays consistent.
+export function PageHeader({
+  title,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "mb-6 flex items-start justify-between gap-4",
+        className,
+      )}
+    >
+      <div className="space-y-1">
+        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+        {description && (
+          <p className="text-muted-foreground text-sm">{description}</p>
+        )}
+      </div>
+      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/web/src/features/settings/account-section.tsx
+++ b/web/src/features/settings/account-section.tsx
@@ -1,7 +1,6 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -14,7 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useMe } from "@/api/queries/me";
 import { useChangePassword } from "@/api/queries/account";
-import { ApiError } from "@/api/client";
+import { withMutationToast } from "@/lib/mutation-toast";
 
 const schema = z
   .object({
@@ -39,15 +38,11 @@ export function AccountSection() {
   });
 
   const onSubmit = async (values: Values) => {
-    try {
-      await changePassword.mutateAsync(values);
-      toast.success("Password updated.");
-      form.reset();
-    } catch (err) {
-      const msg =
-        err instanceof ApiError ? err.message : "Something went wrong. Try again.";
-      toast.error(msg);
-    }
+    const ok = await withMutationToast(
+      () => changePassword.mutateAsync(values),
+      { success: "Password updated." },
+    );
+    if (ok) form.reset();
   };
 
   return (

--- a/web/src/lib/modals.ts
+++ b/web/src/lib/modals.ts
@@ -1,10 +1,21 @@
 import { useRouterState } from "@tanstack/react-router";
+import { z } from "zod";
 
 // Search-param convention for app-level overlays. A modal sets ?m=<key> and
 // optionally ?ms=<section>; the underlying route stays put so the modal
 // renders on top of whatever page the user was already on.
 export const MODAL_KEY = "m";
 export const MODAL_SECTION_KEY = "ms";
+
+// baseSearchSchema carries the modal params. It's applied to the *root*
+// route so `m`/`ms` are valid search params on every page — without it, the
+// moment a page declares its own `validateSearch` (typed filters/pagination),
+// the router would strip the undeclared modal params and overlays would stop
+// opening on that page. Page-level schemas merge with this automatically.
+export const baseSearchSchema = z.object({
+  [MODAL_KEY]: z.string().optional(),
+  [MODAL_SECTION_KEY]: z.string().optional(),
+});
 
 export function useActiveModal(): { key: string | null; section: string | null } {
   const search = useRouterState({ select: (s) => s.location.search }) as Record<

--- a/web/src/lib/mutation-toast.ts
+++ b/web/src/lib/mutation-toast.ts
@@ -1,0 +1,39 @@
+import { toast } from "sonner";
+import { ApiError } from "@/api/client";
+
+export interface MutationToastMessages {
+  success: string;
+  /** Fallback when the thrown error isn't an ApiError with a message. */
+  error?: string;
+}
+
+// Wraps a mutateAsync call with the standard toast handling: success toast on
+// resolve, the ApiError message (or a fallback) on reject. Resolves to true
+// on success and false on failure, so the caller can branch on the result
+// (e.g. form.reset()) without writing its own try/catch.
+//
+//   const ok = await withMutationToast(
+//     () => changePassword.mutateAsync(values),
+//     { success: "Password updated." },
+//   );
+//   if (ok) form.reset();
+//
+// Not a hook — it holds no React state, so it's callable conditionally and
+// inside event handlers without rules-of-hooks constraints.
+export async function withMutationToast(
+  run: () => Promise<unknown>,
+  messages: MutationToastMessages,
+): Promise<boolean> {
+  try {
+    await run();
+    toast.success(messages.success);
+    return true;
+  } catch (err) {
+    const msg =
+      err instanceof ApiError
+        ? err.message
+        : (messages.error ?? "Something went wrong. Try again.");
+    toast.error(msg);
+    return false;
+  }
+}

--- a/web/src/lib/pagination.ts
+++ b/web/src/lib/pagination.ts
@@ -1,0 +1,26 @@
+// Cursor-pagination shapes + helpers for the public /api/v1/* list endpoints.
+// Those use a resource-keyed envelope:
+//   { <resource>: T[], next_cursor: string | null, has_more: boolean, limit: number }
+// e.g. GET /api/v1/transactions → { transactions: [...], next_cursor, has_more, limit }
+
+export interface CursorMeta {
+  next_cursor: string | null;
+  has_more: boolean;
+  limit: number;
+}
+
+// getNextPageParam for useInfiniteQuery — the next cursor, or undefined when
+// the list is exhausted (which tells TanStack Query there are no more pages).
+export function nextCursor<P extends CursorMeta>(page: P): string | undefined {
+  return page.has_more && page.next_cursor ? page.next_cursor : undefined;
+}
+
+// Flattens useInfiniteQuery's `data.pages` into a single array. `key` is the
+// resource key on the envelope (e.g. "transactions").
+export function flattenPages<T>(
+  pages: Array<Record<string, unknown>> | undefined,
+  key: string,
+): T[] {
+  if (!pages) return [];
+  return pages.flatMap((p) => (p[key] as T[] | undefined) ?? []);
+}

--- a/web/src/lib/shortcuts.ts
+++ b/web/src/lib/shortcuts.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export interface Shortcut {
   id: string;
@@ -66,11 +66,20 @@ export function useShortcut(
 ): void {
   const { label, group, enabled = true } = options;
   const id = `${group ?? "global"}:${label}`;
+  // Both `keys` (inline array literal) and `handler` (inline arrow) are
+  // referentially unstable across renders. Without this, the effect tears
+  // down and re-adds the global keydown listener — and churns the registry —
+  // on every render of the calling component. Depend on a stable string for
+  // keys, and read the handler through a ref.
+  const keysKey = keys.join("+");
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
 
   useEffect(() => {
     if (!enabled) return;
-    const unregister = registerShortcut({ id, keys, label, group });
-    const match = parseKeys(keys);
+    const parsedKeys = keysKey.split("+");
+    const unregister = registerShortcut({ id, keys: parsedKeys, label, group });
+    const match = parseKeys(parsedKeys);
     const onKey = (event: KeyboardEvent) => {
       if (event.key.toLowerCase() !== match.key) return;
       if (!!match.meta !== (event.metaKey || event.ctrlKey)) return;
@@ -85,12 +94,12 @@ export function useShortcut(
       ) {
         return;
       }
-      handler(event);
+      handlerRef.current(event);
     };
     window.addEventListener("keydown", onKey);
     return () => {
       window.removeEventListener("keydown", onKey);
       unregister();
     };
-  }, [enabled, handler, id, keys, label, group]);
+  }, [enabled, id, keysKey, label, group]);
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -13,10 +14,16 @@ import { HomePage } from "@/routes/home";
 import { LoginPage } from "@/routes/login";
 import { Placeholder } from "@/routes/placeholder";
 import { NAV_LEAVES } from "@/lib/nav";
+import { baseSearchSchema } from "@/lib/modals";
 import { z } from "zod";
 import "@/globals.css";
 
-const rootRoute = createRootRoute({ component: RootLayout });
+// baseSearchSchema on the root route makes the modal params (`m`/`ms`) valid
+// search params everywhere; page-level schemas merge with it.
+const rootRoute = createRootRoute({
+  component: RootLayout,
+  validateSearch: baseSearchSchema,
+});
 
 const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
@@ -33,13 +40,24 @@ const loginRoute = createRoute({
   validateSearch: loginSearchSchema,
 });
 
-const placeholderRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
+// PAGE_COMPONENTS overrides the default Placeholder for a given path. To ship
+// a real page, add one entry here — e.g. `"/transactions": TransactionsPage`.
+// The page route is still derived from NAV_LEAVES (single source of truth for
+// paths), but the override *replaces* the placeholder rather than adding a
+// second route alongside it, so there's no way to silently shadow a real page.
+const PAGE_COMPONENTS: Record<string, () => ReactNode> = {
+  // "/transactions": TransactionsPage,
+};
+
+const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
   if (leaf.kind !== "link" || leaf.to === "/") return [];
+  const override = PAGE_COMPONENTS[leaf.to];
+  const component = override ?? (() => <Placeholder title={leaf.title} />);
   return [
     createRoute({
       getParentRoute: () => rootRoute,
       path: leaf.to,
-      component: () => <Placeholder title={leaf.title} />,
+      component,
     }),
   ];
 });
@@ -47,7 +65,7 @@ const placeholderRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
 const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
-  ...placeholderRoutes,
+  ...pageRoutes,
 ]);
 
 const router = createRouter({

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -47,8 +47,10 @@ export function LoginPage() {
     setSubmitting(true);
     try {
       await login.mutateAsync(values);
+      // `redirect` is an arbitrary pathname captured by the auth gate, not a
+      // statically-known route — cast past the typed-router `to` constraint.
       const target = search.redirect && search.redirect.startsWith("/") ? search.redirect : "/";
-      navigate({ to: target });
+      navigate({ to: target as string });
     } catch (err) {
       const msg =
         err instanceof ApiError ? err.message : "Something went wrong. Try again.";


### PR DESCRIPTION
Hardens the v2 SPA foundation before Phase 1 page-building — driven by a two-subagent review of everything merged so far.

## Why

Before building the ~8 real data pages, two reviewers (code-quality + architecture) audited the foundation. They surfaced two real bugs, two latent problems that would bite the first typed-search-param page, and a set of shared primitives the conventions doc references but that didn't actually exist. All addressed here so Home → Transactions build on solid ground.

## Fixes

- **`useShortcut` effect re-fire** (`lib/shortcuts.ts`) — both `keys` (inline array literal) and `handler` (inline arrow) are referentially unstable and were in the effect's dep array, so the global `keydown` listener was torn down + re-added — and the registry churned — on *every render* of the calling component. Now depends on a stable joined-key string and reads the handler through a ref.
- **Modal search-params vs typed routes** (`lib/modals.ts` + `main.tsx`) — added `baseSearchSchema` (`m`/`ms`) applied to the **root route**, so the modal params survive once a page declares its own `validateSearch`. Without it, Transactions' filter schema would strip `m`/`ms` and overlays would stop opening on that page.
- **Dynamic placeholder routes → explicit override map** (`main.tsx`) — replaced the `NAV_LEAVES.flatMap` generator with a `PAGE_COMPONENTS` override map. Shipping a real page is now one entry that *replaces* the placeholder — no way to silently shadow a real route by forgetting to remove a generated one.
- **`login.tsx`** — cast the redirect target past the typed-router `to` constraint (it's an arbitrary captured pathname, not a statically-known route).

## New shared primitives

- **`DataTable`** — generic wrapper over `@tanstack/react-table` + the shadcn `Table` primitive: built-in loading skeletons, empty/error slots, controlled sorting lifted to the route. Every list page uses this; no hand-rolled `<table>`.
- **`EmptyState`** — zero-data state (icon + title + description + optional CTA), distinct from `routes/placeholder.tsx` which marks unbuilt pages.
- **`PageHeader`** — content-level title/description/actions header, rendered inside `<main>` below the shell breadcrumb.
- **`lib/pagination.ts`** — cursor-pagination helpers (`nextCursor`, `flattenPages`) for the `/api/v1/*` resource-keyed list envelope.
- **`lib/mutation-toast.ts`** — `withMutationToast` wraps the standard `try/catch` + `toast.success`/`toast.error(ApiError.message)` pattern; `account-section.tsx` migrated as the reference call site.

## Test plan

- [x] `tsc -b` + `vite build` + `go build` (default & `-tags=headless`) + `go vet` all pass.
- [x] Browser smoke: login → nav → ⌘K palette → `?` shortcut sheet (both shortcuts registered) → Settings modal at `?m=settings` → placeholder route renders. No regressions.
- [ ] `DataTable` / `EmptyState` / `PageHeader` exercised for real when the Home and Transactions pages land on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
