### PR TITLE
v2: Transactions page

### DIFF
--- a/web/src/api/queries/transactions.ts
+++ b/web/src/api/queries/transactions.ts
@@ -1,0 +1,34 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { nextCursor } from "@/lib/pagination";
+import type { TransactionsPage } from "@/api/types";
+
+export interface TransactionFilters {
+  /** Free-text search; the API requires a minimum of 2 chars. */
+  search?: string;
+}
+
+const PAGE_LIMIT = 50;
+
+// useTransactions paginates GET /api/v1/transactions with cursor pagination.
+// The SPA reaches the public endpoint directly — session auth on /api/v1/*
+// (see internal/api/auth_session.go) makes the cookie sufficient.
+export function useTransactions(filters: TransactionFilters) {
+  // The API rejects a 1-char search; treat <2 chars as "no search".
+  const search =
+    filters.search && filters.search.trim().length >= 2
+      ? filters.search.trim()
+      : undefined;
+
+  return useInfiniteQuery({
+    queryKey: ["transactions", { search }],
+    queryFn: ({ pageParam }) => {
+      const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+      if (pageParam) params.set("cursor", pageParam);
+      if (search) params.set("search", search);
+      return api<TransactionsPage>(`/api/v1/transactions?${params.toString()}`);
+    },
+    initialPageParam: "",
+    getNextPageParam: (last) => nextCursor(last),
+  });
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -3,3 +3,47 @@ export interface Me {
   username: string;
   role: string;
 }
+
+// --- Transactions (public /api/v1/transactions) ---
+// Mirrors internal/service/types.go TransactionResponse. `provider_name` is
+// the raw transaction description from the bank; `provider_merchant_name` is
+// the cleaned merchant label (nullable). Amount sign: positive = money out,
+// negative = money in. Never sum across iso_currency_code.
+
+export interface TransactionCategory {
+  id: string | null;
+  slug: string | null;
+  display_name: string | null;
+  primary_slug?: string | null;
+  primary_display_name?: string | null;
+  icon?: string | null;
+  color?: string | null;
+}
+
+export interface Transaction {
+  id: string;
+  short_id: string;
+  account_id: string | null;
+  account_name: string | null;
+  user_name: string | null;
+  amount: number;
+  iso_currency_code: string | null;
+  date: string; // YYYY-MM-DD
+  datetime: string | null;
+  authorized_date: string | null;
+  provider_name: string;
+  provider_merchant_name: string | null;
+  category: TransactionCategory | null;
+  category_override: boolean;
+  pending: boolean;
+  tags?: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TransactionsPage {
+  transactions: Transaction[];
+  next_cursor?: string;
+  has_more: boolean;
+  limit: number;
+}

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -33,7 +33,7 @@ export function CommandPalette() {
     setOpen(false);
     navigate({
       to: ".",
-      search: (prev) => openModalSearch(prev as Record<string, unknown>, modalKey),
+      search: (prev: Record<string, unknown>) => openModalSearch(prev, modalKey),
     });
   };
 

--- a/web/src/components/nav-main.tsx
+++ b/web/src/components/nav-main.tsx
@@ -27,7 +27,8 @@ export function NavMain({ group }: { group: NavGroup }) {
             onOpenModal={(modalKey) =>
               navigate({
                 to: ".",
-                search: (prev) => openModalSearch(prev as Record<string, unknown>, modalKey),
+                search: (prev: Record<string, unknown>) =>
+                  openModalSearch(prev, modalKey),
               })
             }
           />

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -37,15 +37,15 @@ export function SettingsShell() {
     if (next) return;
     navigate({
       to: ".",
-      search: (prev) => closeModalSearch(prev as Record<string, unknown>),
+      search: (prev: Record<string, unknown>) => closeModalSearch(prev),
     });
   };
 
   const onSelect = (slug: string) => {
     navigate({
       to: ".",
-      search: (prev) =>
-        openModalSearch(prev as Record<string, unknown>, SETTINGS_MODAL_KEY, slug),
+      search: (prev: Record<string, unknown>) =>
+        openModalSearch(prev, SETTINGS_MODAL_KEY, slug),
     });
   };
 

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary:
+          "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/web/src/hooks/use-debounced-value.ts
+++ b/web/src/hooks/use-debounced-value.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+// Returns a debounced copy of `value` that only updates after `delayMs` of
+// no further changes. Used to keep URL search params (and the queries keyed
+// on them) from churning on every keystroke.
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/web/src/lib/modals.ts
+++ b/web/src/lib/modals.ts
@@ -18,7 +18,7 @@ export const baseSearchSchema = z.object({
 });
 
 export function useActiveModal(): { key: string | null; section: string | null } {
-  const search = useRouterState({ select: (s) => s.location.search }) as Record<
+  const search = useRouterState({ select: (s) => s.location.search }) as unknown as Record<
     string,
     unknown
   >;

--- a/web/src/lib/pagination.ts
+++ b/web/src/lib/pagination.ts
@@ -4,7 +4,9 @@
 // e.g. GET /api/v1/transactions → { transactions: [...], next_cursor, has_more, limit }
 
 export interface CursorMeta {
-  next_cursor: string | null;
+  // Optional: the Go side tags it `omitempty`, so it's absent (not null)
+  // when the list is exhausted.
+  next_cursor?: string | null;
   has_more: boolean;
   limit: number;
 }
@@ -16,11 +18,14 @@ export function nextCursor<P extends CursorMeta>(page: P): string | undefined {
 }
 
 // Flattens useInfiniteQuery's `data.pages` into a single array. `key` is the
-// resource key on the envelope (e.g. "transactions").
-export function flattenPages<T>(
-  pages: Array<Record<string, unknown>> | undefined,
+// resource key on the envelope (e.g. "transactions"). `P` is the page/envelope
+// type — any object; concrete interfaces (no index signature) are fine.
+export function flattenPages<T, P extends object = object>(
+  pages: P[] | undefined,
   key: string,
 ): T[] {
   if (!pages) return [];
-  return pages.flatMap((p) => (p[key] as T[] | undefined) ?? []);
+  return pages.flatMap(
+    (p) => ((p as Record<string, unknown>)[key] as T[] | undefined) ?? [],
+  );
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -9,10 +9,12 @@ import {
   createRoute,
 } from "@tanstack/react-router";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import type { AnyRoute } from "@tanstack/react-router";
 import { RootLayout } from "@/routes/__root";
 import { HomePage } from "@/routes/home";
 import { LoginPage } from "@/routes/login";
 import { Placeholder } from "@/routes/placeholder";
+import { TransactionsPage, transactionsSearchSchema } from "@/routes/transactions";
 import { NAV_LEAVES } from "@/lib/nav";
 import { baseSearchSchema } from "@/lib/modals";
 import { z } from "zod";
@@ -40,27 +42,38 @@ const loginRoute = createRoute({
   validateSearch: loginSearchSchema,
 });
 
-// PAGE_COMPONENTS overrides the default Placeholder for a given path. To ship
-// a real page, add one entry here — e.g. `"/transactions": TransactionsPage`.
-// The page route is still derived from NAV_LEAVES (single source of truth for
-// paths), but the override *replaces* the placeholder rather than adding a
-// second route alongside it, so there's no way to silently shadow a real page.
-const PAGE_COMPONENTS: Record<string, () => ReactNode> = {
-  // "/transactions": TransactionsPage,
+// PAGE_OVERRIDES swaps the default Placeholder for a real page on a given
+// path. To ship a page, add one entry — `component`, plus an optional
+// `validateSearch` zod schema for typed URL filters/pagination. The route is
+// still derived from NAV_LEAVES (single source of truth for paths), but the
+// override *replaces* the placeholder rather than adding a second route, so
+// there's no way to silently shadow a real page.
+interface PageOverride {
+  component: () => ReactNode;
+  validateSearch?: Parameters<typeof createRoute>[0]["validateSearch"];
+}
+
+const PAGE_OVERRIDES: Record<string, PageOverride> = {
+  "/transactions": {
+    component: TransactionsPage,
+    validateSearch: transactionsSearchSchema,
+  },
 };
 
 const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
   if (leaf.kind !== "link" || leaf.to === "/") return [];
-  const override = PAGE_COMPONENTS[leaf.to];
-  const component = override ?? (() => <Placeholder title={leaf.title} />);
+  const override = PAGE_OVERRIDES[leaf.to];
+  const component =
+    override?.component ?? (() => <Placeholder title={leaf.title} />);
   return [
     createRoute({
       getParentRoute: () => rootRoute,
       path: leaf.to,
       component,
+      validateSearch: override?.validateSearch,
     }),
   ];
-});
+}) as AnyRoute[];
 
 const routeTree = rootRoute.addChildren([
   indexRoute,

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { z } from "zod";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Receipt, Search } from "lucide-react";
+import { PageHeader } from "@/components/page-header";
+import { DataTable } from "@/components/data-table";
+import { EmptyState } from "@/components/empty-state";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useTransactions } from "@/api/queries/transactions";
+import { flattenPages } from "@/lib/pagination";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import type { Transaction } from "@/api/types";
+
+// Merges with the root route's baseSearchSchema (m/ms modal params).
+export const transactionsSearchSchema = z.object({
+  q: z.string().optional(),
+});
+
+type TransactionsSearch = z.infer<typeof transactionsSearchSchema>;
+
+function formatDate(date: string): string {
+  const d = new Date(`${date}T00:00:00`);
+  return Number.isNaN(d.getTime())
+    ? date
+    : d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatAmount(amount: number, currency: string | null): string {
+  const formatted = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency ?? "USD",
+  }).format(Math.abs(amount));
+  // Sign convention: positive = money out, negative = money in.
+  return amount < 0 ? `+${formatted}` : formatted;
+}
+
+const columns: ColumnDef<Transaction>[] = [
+  {
+    accessorKey: "date",
+    header: "Date",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground tabular-nums">
+        {formatDate(row.original.date)}
+      </span>
+    ),
+  },
+  {
+    id: "merchant",
+    header: "Merchant",
+    cell: ({ row }) => {
+      const t = row.original;
+      return (
+        <div className="flex items-center gap-2">
+          <span className="font-medium">
+            {t.provider_merchant_name ?? t.provider_name}
+          </span>
+          {t.pending && (
+            <Badge variant="outline" className="text-muted-foreground">
+              Pending
+            </Badge>
+          )}
+        </div>
+      );
+    },
+  },
+  {
+    id: "category",
+    header: "Category",
+    cell: ({ row }) => {
+      const cat = row.original.category;
+      if (!cat?.display_name) {
+        return <span className="text-muted-foreground">—</span>;
+      }
+      return <Badge variant="secondary">{cat.display_name}</Badge>;
+    },
+  },
+  {
+    accessorKey: "account_name",
+    header: "Account",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground">
+        {row.original.account_name ?? "—"}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "amount",
+    header: () => <div className="text-right">Amount</div>,
+    cell: ({ row }) => {
+      const t = row.original;
+      const isInflow = t.amount < 0;
+      return (
+        <div
+          className={
+            isInflow
+              ? "text-right font-medium tabular-nums text-emerald-600 dark:text-emerald-500"
+              : "text-right font-medium tabular-nums"
+          }
+        >
+          {formatAmount(t.amount, t.iso_currency_code)}
+        </div>
+      );
+    },
+  },
+];
+
+export function TransactionsPage() {
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as TransactionsSearch;
+
+  // Local input state → debounced → URL search param. The query is keyed on
+  // the URL value, so search is bookmarkable and survives reload.
+  const [query, setQuery] = useState(search.q ?? "");
+  const debounced = useDebouncedValue(query, 300);
+
+  useEffect(() => {
+    const next = debounced.trim() || undefined;
+    if (next === (search.q ?? undefined)) return;
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, q: next }),
+    });
+  }, [debounced, navigate, search.q]);
+
+  const transactions = useTransactions({ search: search.q });
+  const rows = flattenPages<Transaction>(transactions.data?.pages, "transactions");
+
+  return (
+    <div>
+      <PageHeader
+        title="Transactions"
+        description="Every transaction synced across your connected accounts."
+      />
+
+      <div className="mb-4 flex items-center gap-2">
+        <div className="relative w-full max-w-xs">
+          <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search merchant or description…"
+            className="pl-8"
+          />
+        </div>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={rows}
+        isLoading={transactions.isLoading}
+        isError={transactions.isError}
+        emptyState={
+          <EmptyState
+            icon={Receipt}
+            title={search.q ? "No matching transactions" : "No transactions yet"}
+            description={
+              search.q
+                ? "Try a different search term."
+                : "Transactions appear here once an account finishes syncing."
+            }
+          />
+        }
+      />
+
+      {transactions.hasNextPage && (
+        <div className="mt-4 flex justify-center">
+          <Button
+            variant="outline"
+            onClick={() => transactions.fetchNextPage()}
+            disabled={transactions.isFetchingNextPage}
+          >
+            {transactions.isFetchingNextPage ? "Loading…" : "Load more"}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
The first real v2 data page — and the end-to-end proof of the session-auth change beneath it.

## Summary

<img src="https://i.img402.dev/fgulv1sz3o.jpg" width="800" alt="v2 Transactions page — DataTable with date, merchant, category, account, amount columns">

- **`routes/transactions.tsx`** — `PageHeader` + a debounced search box synced to the `?q=` URL param + `DataTable` (Date, Merchant, Category, Account, Amount) + "Load more". Amount sign convention: positive = money out (plain), negative = money in (green, `+` prefix). `Pending` badge on unposted rows.
- **`api/queries/transactions.ts`** — `useTransactions`: `useInfiniteQuery` + cursor pagination through the page-zero `lib/pagination.ts` helpers (`nextCursor` / `flattenPages`).
- **`api/types.ts`** — `Transaction` / `TransactionCategory` / `TransactionsPage`, mirroring `internal/service/types.go`. (`provider_name` is the raw transaction description; `provider_merchant_name` is the cleaned merchant label.)
- **`main.tsx`** — `PAGE_OVERRIDES` now carries an optional per-page `validateSearch` schema, not just a component, so a real page can declare typed URL search params. `transactionsSearchSchema` (`q`) merges with the root `baseSearchSchema` (`m`/`ms`).
- **`hooks/use-debounced-value.ts`** — keeps the URL param (and the query keyed on it) from churning per keystroke.
- Knock-on TS fixes: typed `prev` in the `search:` callbacks and loosened `flattenPages`' page type — the root route now has a typed `validateSearch`, which tightened router inference repo-wide.

This is the page that exercises every page-zero primitive (`DataTable`, `EmptyState`, `PageHeader`, pagination helpers) and the `/api/v1/*` session-auth change in PR #1 — for real, in the browser.

## Test plan

- [x] `tsc` + `vite build` + `go build` (default & `-tags=headless`) pass.
- [x] Browser: `/v2/transactions` renders 50 real rows fetched via `/api/v1/transactions` with only the session cookie. Amount signs, Pending badges, breadcrumb all correct.
- [x] Search: typing `starbucks` debounces to `?q=starbucks` (bookmarkable) and filters to matching rows; clearing restores the full list.
- [x] "Load more" present when `has_more` — cursor pagination wired.

## Follow-ups (not in scope)

- More filters (account, category, date range) — the URL-search-param + DataTable plumbing is in place; each is additive.
- Row click → transaction detail page.
- Sorting (the API supports `sort_by`/`sort_order`; `DataTable` already accepts controlled sorting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
