### PR TITLE
v2: simplify-pass follow-up + Transactions Description column

### DIFF
--- a/internal/api/auth_session.go
+++ b/internal/api/auth_session.go
@@ -4,7 +4,6 @@ package api
 
 import (
 	"net/http"
-	"net/url"
 
 	"breadbox/internal/admin"
 	"breadbox/internal/db"
@@ -43,7 +42,7 @@ func sessionOrAPIKeyAuth(
 					// guard it with the same SameSite=Lax + Origin check the
 					// /web/v1/* routes use. Pure API-key clients send no cookie
 					// and never reach this branch.
-					if isUnsafeMethod(r.Method) && !sameOrigin(r) {
+					if mw.IsUnsafeMethod(r.Method) && !mw.SameOrigin(r) {
 						mw.WriteError(
 							w,
 							http.StatusForbidden,
@@ -97,31 +96,4 @@ func roleToScope(role string) string {
 		return "full_access"
 	}
 	return "read_only"
-}
-
-func isUnsafeMethod(m string) bool {
-	switch m {
-	case http.MethodGet, http.MethodHead, http.MethodOptions:
-		return false
-	default:
-		return true
-	}
-}
-
-// sameOrigin mirrors webui.RequireSameOrigin's check — the Origin (or Referer
-// fallback) host must match the request host. Duplicated rather than imported
-// because webui is a !headless package and this file compiles under headless.
-func sameOrigin(r *http.Request) bool {
-	got := r.Header.Get("Origin")
-	if got == "" {
-		got = r.Header.Get("Referer")
-	}
-	if got == "" {
-		return false
-	}
-	u, err := url.Parse(got)
-	if err != nil {
-		return false
-	}
-	return u.Host == r.Host
 }

--- a/internal/api/auth_session_test.go
+++ b/internal/api/auth_session_test.go
@@ -2,11 +2,7 @@
 
 package api
 
-import (
-	"net/http"
-	"net/http/httptest"
-	"testing"
-)
+import "testing"
 
 func TestRoleToScope(t *testing.T) {
 	cases := []struct {
@@ -16,61 +12,12 @@ func TestRoleToScope(t *testing.T) {
 		{"admin", "full_access"},
 		{"editor", "full_access"},
 		{"viewer", "read_only"},
-		{"", "read_only"},        // unknown / legacy → least privilege
+		{"", "read_only"}, // unknown / legacy → least privilege
 		{"something", "read_only"},
 	}
 	for _, c := range cases {
 		if got := roleToScope(c.role); got != c.want {
 			t.Errorf("roleToScope(%q) = %q, want %q", c.role, got, c.want)
 		}
-	}
-}
-
-func TestIsUnsafeMethod(t *testing.T) {
-	safe := []string{http.MethodGet, http.MethodHead, http.MethodOptions}
-	unsafe := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
-	for _, m := range safe {
-		if isUnsafeMethod(m) {
-			t.Errorf("isUnsafeMethod(%q) = true, want false", m)
-		}
-	}
-	for _, m := range unsafe {
-		if !isUnsafeMethod(m) {
-			t.Errorf("isUnsafeMethod(%q) = false, want true", m)
-		}
-	}
-}
-
-func TestSameOrigin(t *testing.T) {
-	cases := []struct {
-		name    string
-		host    string
-		origin  string
-		referer string
-		want    bool
-	}{
-		{"matching origin", "breadbox.example.com", "https://breadbox.example.com", "", true},
-		{"mismatched origin", "breadbox.example.com", "https://evil.com", "", false},
-		{"referer fallback matches", "breadbox.example.com", "", "https://breadbox.example.com/v2/transactions", true},
-		{"referer fallback mismatched", "breadbox.example.com", "", "https://evil.com/x", false},
-		{"no origin, no referer", "breadbox.example.com", "", "", false},
-		{"origin takes precedence over referer", "breadbox.example.com", "https://evil.com", "https://breadbox.example.com/x", false},
-		{"port-sensitive match", "localhost:8081", "http://localhost:8081", "", true},
-		{"port-sensitive mismatch", "localhost:8081", "http://localhost:9090", "", false},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			r := httptest.NewRequest(http.MethodPost, "http://"+c.host+"/api/v1/rules", nil)
-			r.Host = c.host
-			if c.origin != "" {
-				r.Header.Set("Origin", c.origin)
-			}
-			if c.referer != "" {
-				r.Header.Set("Referer", c.referer)
-			}
-			if got := sameOrigin(r); got != c.want {
-				t.Errorf("sameOrigin() = %v, want %v", got, c.want)
-			}
-		})
 	}
 }

--- a/internal/middleware/sameorigin.go
+++ b/internal/middleware/sameorigin.go
@@ -1,0 +1,41 @@
+//go:build !lite
+
+package middleware
+
+import (
+	"net/http"
+	"net/url"
+)
+
+// IsUnsafeMethod reports whether an HTTP method can change server state and
+// therefore needs CSRF protection. GET/HEAD/OPTIONS are safe.
+func IsUnsafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return false
+	default:
+		return true
+	}
+}
+
+// SameOrigin reports whether the request's Origin (or Referer fallback) host
+// matches the request host — the SameSite=Lax CSRF check shared by the
+// /web/v1/* routes and session-authed /api/v1/* writes.
+//
+// A request with neither header is treated as cross-origin: modern browsers
+// always send one on a state-changing request, so a caller that sends neither
+// should be using API-key auth, not a cookie.
+func SameOrigin(r *http.Request) bool {
+	got := r.Header.Get("Origin")
+	if got == "" {
+		got = r.Header.Get("Referer")
+	}
+	if got == "" {
+		return false
+	}
+	u, err := url.Parse(got)
+	if err != nil {
+		return false
+	}
+	return u.Host == r.Host
+}

--- a/internal/middleware/sameorigin_test.go
+++ b/internal/middleware/sameorigin_test.go
@@ -1,0 +1,58 @@
+//go:build !lite
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsUnsafeMethod(t *testing.T) {
+	safe := []string{http.MethodGet, http.MethodHead, http.MethodOptions}
+	unsafe := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+	for _, m := range safe {
+		if IsUnsafeMethod(m) {
+			t.Errorf("IsUnsafeMethod(%q) = true, want false", m)
+		}
+	}
+	for _, m := range unsafe {
+		if !IsUnsafeMethod(m) {
+			t.Errorf("IsUnsafeMethod(%q) = false, want true", m)
+		}
+	}
+}
+
+func TestSameOrigin(t *testing.T) {
+	cases := []struct {
+		name    string
+		host    string
+		origin  string
+		referer string
+		want    bool
+	}{
+		{"matching origin", "breadbox.example.com", "https://breadbox.example.com", "", true},
+		{"mismatched origin", "breadbox.example.com", "https://evil.com", "", false},
+		{"referer fallback matches", "breadbox.example.com", "", "https://breadbox.example.com/v2/transactions", true},
+		{"referer fallback mismatched", "breadbox.example.com", "", "https://evil.com/x", false},
+		{"no origin, no referer", "breadbox.example.com", "", "", false},
+		{"origin takes precedence over referer", "breadbox.example.com", "https://evil.com", "https://breadbox.example.com/x", false},
+		{"port-sensitive match", "localhost:8081", "http://localhost:8081", "", true},
+		{"port-sensitive mismatch", "localhost:8081", "http://localhost:9090", "", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "http://"+c.host+"/api/v1/rules", nil)
+			r.Host = c.host
+			if c.origin != "" {
+				r.Header.Set("Origin", c.origin)
+			}
+			if c.referer != "" {
+				r.Header.Set("Referer", c.referer)
+			}
+			if got := SameOrigin(r); got != c.want {
+				t.Errorf("SameOrigin() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/web/embed.go
+++ b/web/embed.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"io/fs"
 	"net/http"
-	"net/url"
 	"path"
 	"strings"
 
@@ -116,47 +115,20 @@ func RequireSessionJSON(sm *scs.SessionManager) func(http.Handler) http.Handler 
 	}
 }
 
-// RequireSameOrigin is the CSRF strategy for /web/v1/* writes. On any
-// unsafe-method request (POST/PUT/PATCH/DELETE), the Origin (or Referer
-// fallback) host must match the request host. SameSite=Lax cookies +
-// same-origin SPA make this sufficient — no double-submit token needed.
-//
-// Browsers send Origin on every cross-origin and same-origin POST, so the
-// only legitimate case where Origin is absent is older clients or non-CORS
-// fetches; we accept Referer as a fallback there.
+// RequireSameOrigin is the CSRF strategy for /web/v1/* writes: an
+// unsafe-method request must pass the shared SameSite=Lax + Origin check
+// (mw.SameOrigin). Same-origin SPA + Lax cookies make this sufficient — no
+// double-submit token needed.
 func RequireSameOrigin() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			switch r.Method {
-			case http.MethodGet, http.MethodHead, http.MethodOptions:
-				next.ServeHTTP(w, r)
-				return
-			}
-			if !sameOrigin(r) {
+			if mw.IsUnsafeMethod(r.Method) && !mw.SameOrigin(r) {
 				mw.WriteError(w, http.StatusForbidden, "ORIGIN_MISMATCH", "Cross-origin request rejected")
 				return
 			}
 			next.ServeHTTP(w, r)
 		})
 	}
-}
-
-func sameOrigin(r *http.Request) bool {
-	got := r.Header.Get("Origin")
-	if got == "" {
-		got = r.Header.Get("Referer")
-	}
-	if got == "" {
-		// No Origin and no Referer — refuse rather than guess. Modern browsers
-		// always send one on a POST; missing both indicates a non-browser
-		// caller that should use the public /api/v1 + API key surface instead.
-		return false
-	}
-	u, err := url.Parse(got)
-	if err != nil {
-		return false
-	}
-	return u.Host == r.Host
 }
 
 // LoginRequest is the POST body for /web/v1/login.

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -10,7 +10,7 @@ import {
   CommandSeparator,
 } from "@/components/ui/command";
 import { NAV, navKey } from "@/lib/nav";
-import { openModalSearch } from "@/lib/modals";
+import { openModal } from "@/lib/modals";
 import { useShortcut } from "@/lib/shortcuts";
 import { useLogout } from "@/api/queries/auth";
 
@@ -29,12 +29,9 @@ export function CommandPalette() {
     navigate({ to });
   };
 
-  const openModal = (modalKey: string) => {
+  const runOpenModal = (modalKey: string) => {
     setOpen(false);
-    navigate({
-      to: ".",
-      search: (prev: Record<string, unknown>) => openModalSearch(prev, modalKey),
-    });
+    navigate({ to: ".", search: openModal(modalKey) });
   };
 
   const runLogout = async () => {
@@ -57,7 +54,9 @@ export function CommandPalette() {
                   key={navKey(item)}
                   value={`${group.label} ${item.title}`}
                   onSelect={() =>
-                    item.kind === "link" ? go(item.to) : openModal(item.modalKey)
+                    item.kind === "link"
+                      ? go(item.to)
+                      : runOpenModal(item.modalKey)
                   }
                 >
                   <Icon className="size-4" />

--- a/web/src/components/nav-main.tsx
+++ b/web/src/components/nav-main.tsx
@@ -7,7 +7,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { isNavMatch, navKey, type NavGroup, type NavLeaf } from "@/lib/nav";
-import { openModalSearch, useActiveModal } from "@/lib/modals";
+import { openModal, useActiveModal } from "@/lib/modals";
 
 export function NavMain({ group }: { group: NavGroup }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
@@ -25,11 +25,7 @@ export function NavMain({ group }: { group: NavGroup }) {
             pathname={pathname}
             activeModal={activeModal}
             onOpenModal={(modalKey) =>
-              navigate({
-                to: ".",
-                search: (prev: Record<string, unknown>) =>
-                  openModalSearch(prev, modalKey),
-              })
+              navigate({ to: ".", search: openModal(modalKey) })
             }
           />
         ))}

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -16,7 +16,7 @@ import {
 import { cn } from "@/lib/utils";
 import { SETTINGS_SECTIONS, type SettingsSection } from "@/lib/settings-sections";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import { closeModalSearch, openModalSearch, useActiveModal } from "@/lib/modals";
+import { closeModal, openModal, useActiveModal } from "@/lib/modals";
 import { AccountSection } from "@/features/settings/account-section";
 
 const SETTINGS_MODAL_KEY = "settings";
@@ -35,18 +35,11 @@ export function SettingsShell() {
 
   const onOpenChange = (next: boolean) => {
     if (next) return;
-    navigate({
-      to: ".",
-      search: (prev: Record<string, unknown>) => closeModalSearch(prev),
-    });
+    navigate({ to: ".", search: closeModal() });
   };
 
   const onSelect = (slug: string) => {
-    navigate({
-      to: ".",
-      search: (prev: Record<string, unknown>) =>
-        openModalSearch(prev, SETTINGS_MODAL_KEY, slug),
-    });
+    navigate({ to: ".", search: openModal(SETTINGS_MODAL_KEY, slug) });
   };
 
   const body = (

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,33 @@
+// Shared display formatters. `Intl.*Format` construction is the expensive
+// part of the API — building one per cell render janks long lists — so
+// instances are cached and only `.format()` is called per value.
+
+const currencyFormatters = new Map<string, Intl.NumberFormat>();
+
+function currencyFormatter(currency: string): Intl.NumberFormat {
+  let f = currencyFormatters.get(currency);
+  if (!f) {
+    f = new Intl.NumberFormat("en-US", { style: "currency", currency });
+    currencyFormatters.set(currency, f);
+  }
+  return f;
+}
+
+// formatAmount renders a transaction amount. Sign convention: positive =
+// money out (plain), negative = money in (prefixed with +).
+export function formatAmount(amount: number, currency: string | null): string {
+  const formatted = currencyFormatter(currency ?? "USD").format(Math.abs(amount));
+  return amount < 0 ? `+${formatted}` : formatted;
+}
+
+const monthDayFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+});
+
+// formatDate renders a YYYY-MM-DD date as e.g. "Jan 2"; returns the input
+// unchanged if it isn't a parseable date.
+export function formatDate(date: string): string {
+  const d = new Date(`${date}T00:00:00`);
+  return Number.isNaN(d.getTime()) ? date : monthDayFormatter.format(d);
+}

--- a/web/src/lib/modals.ts
+++ b/web/src/lib/modals.ts
@@ -30,7 +30,7 @@ export function useActiveModal(): { key: string | null; section: string | null }
   return { key, section };
 }
 
-export function openModalSearch<S extends Record<string, unknown>>(
+function openModalSearch<S extends Record<string, unknown>>(
   prev: S,
   key: string,
   section?: string,
@@ -41,9 +41,20 @@ export function openModalSearch<S extends Record<string, unknown>>(
   return next as S;
 }
 
-export function closeModalSearch<S extends Record<string, unknown>>(prev: S): S {
+function closeModalSearch<S extends Record<string, unknown>>(prev: S): S {
   const next = { ...prev } as Record<string, unknown>;
   delete next[MODAL_KEY];
   delete next[MODAL_SECTION_KEY];
   return next as S;
+}
+
+// Search-param updater functions for `navigate({ search })`. Use these
+// directly — `navigate({ search: openModal(key) })` — instead of repeating
+// the `(prev) => ...` wrapper at every call site.
+export function openModal(key: string, section?: string) {
+  return (prev: Record<string, unknown>) => openModalSearch(prev, key, section);
+}
+
+export function closeModal() {
+  return (prev: Record<string, unknown>) => closeModalSearch(prev);
 }

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import type { ColumnDef } from "@tanstack/react-table";
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useTransactions } from "@/api/queries/transactions";
 import { flattenPages } from "@/lib/pagination";
+import { formatAmount, formatDate } from "@/lib/format";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import type { Transaction } from "@/api/types";
 
@@ -20,22 +21,6 @@ export const transactionsSearchSchema = z.object({
 });
 
 type TransactionsSearch = z.infer<typeof transactionsSearchSchema>;
-
-function formatDate(date: string): string {
-  const d = new Date(`${date}T00:00:00`);
-  return Number.isNaN(d.getTime())
-    ? date
-    : d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
-}
-
-function formatAmount(amount: number, currency: string | null): string {
-  const formatted = new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: currency ?? "USD",
-  }).format(Math.abs(amount));
-  // Sign convention: positive = money out, negative = money in.
-  return amount < 0 ? `+${formatted}` : formatted;
-}
 
 const columns: ColumnDef<Transaction>[] = [
   {
@@ -48,15 +33,13 @@ const columns: ColumnDef<Transaction>[] = [
     ),
   },
   {
-    id: "merchant",
-    header: "Merchant",
+    id: "description",
+    header: "Description",
     cell: ({ row }) => {
       const t = row.original;
       return (
         <div className="flex items-center gap-2">
-          <span className="font-medium">
-            {t.provider_merchant_name ?? t.provider_name}
-          </span>
+          <span className="font-medium">{t.provider_name}</span>
           {t.pending && (
             <Badge variant="outline" className="text-muted-foreground">
               Pending
@@ -111,22 +94,33 @@ export function TransactionsPage() {
   const navigate = useNavigate();
   const search = useSearch({ strict: false }) as TransactionsSearch;
 
-  // Local input state → debounced → URL search param. The query is keyed on
-  // the URL value, so search is bookmarkable and survives reload.
+  // `query` is local input state for responsive typing. It's debounced, then
+  // pushed to the URL (the bookmarkable source of truth). The forward effect
+  // is keyed only on `debounced` — never on `search.q` — so an external URL
+  // change (back/forward, command palette) doesn't re-trigger a push and
+  // fight the reverse sync below.
   const [query, setQuery] = useState(search.q ?? "");
   const debounced = useDebouncedValue(query, 300);
 
   useEffect(() => {
-    const next = debounced.trim() || undefined;
-    if (next === (search.q ?? undefined)) return;
+    const q = debounced.trim() || undefined;
     navigate({
       to: ".",
-      search: (prev: Record<string, unknown>) => ({ ...prev, q: next }),
+      search: (prev: Record<string, unknown>) => ({ ...prev, q }),
     });
-  }, [debounced, navigate, search.q]);
+  }, [debounced, navigate]);
+
+  // Adopt the URL value when it changes from outside this component.
+  // setQuery to an equal value is a no-op, so our own pushes don't loop.
+  useEffect(() => {
+    setQuery(search.q ?? "");
+  }, [search.q]);
 
   const transactions = useTransactions({ search: search.q });
-  const rows = flattenPages<Transaction>(transactions.data?.pages, "transactions");
+  const rows = useMemo(
+    () => flattenPages<Transaction>(transactions.data?.pages, "transactions"),
+    [transactions.data?.pages],
+  );
 
   return (
     <div>


### PR DESCRIPTION
Follow-up to the v2-transactions stack (#1070, #1071) — the `/simplify` review findings, plus the requested column rename. (#1070 and #1071 had already merged by the time these changes were ready, so they land as their own PR.)

## Column rename

- Transactions table: **"Merchant" → "Description"**, showing the raw `provider_name` instead of `provider_merchant_name ?? provider_name`.

## Real fixes from the review

- **Search box reverse sync** (`transactions.tsx`) — back/forward navigation or a command-palette URL change left the input box stale. Added a sync effect; the forward (debounce → URL) effect is now keyed only on `debounced`, never on `search.q`, so the two directions can't race and re-push a stale value. *(Caught a genuine bug — the naive first version had the two effects fighting; verified the fix in-browser: search → browser-back cleanly clears both URL and input.)*
- **Cached `Intl` formatters** — new `web/src/lib/format.ts` with `formatAmount`/`formatDate`. The inline `formatAmount` built a new `Intl.NumberFormat` on *every* Amount cell render — measurable jank on long lists. Now constructed once and cached per currency.
- **`useMemo` the `flattenPages` call** so the row array isn't rebuilt on every keystroke.

## Dedup

- New `internal/middleware/sameorigin.go` — `SameOrigin` + `IsUnsafeMethod`, shared by `webui.RequireSameOrigin` and the `/api/v1` session-auth path. Replaces the verbatim `sameOrigin` copy in `auth_session.go` and the inline switch in `web/embed.go`. Tests moved alongside.
- `lib/modals.ts` — `openModal()` / `closeModal()` updater factories replace the repeated `(prev: Record<string, unknown>) => openModalSearch(...)` wrapper across `command-palette`, `nav-main`, and `settings-shell`. `openModalSearch`/`closeModalSearch` are now unexported.

## Skipped (noted, not done)

- `maxPages` on the transactions `useInfiniteQuery` — would cap memory but drops earlier pages, breaking "Load more" UX. Deferred; revisit with virtualization if the list grows long.

## Test plan

- [x] `go build` default/headless/lite, `go vet`, `go test ./internal/api ./internal/middleware`, `tsc` — all pass.
- [x] Browser: Transactions shows "Description" column with raw descriptions; search → browser-back clears input + URL with no re-push; ⌘K palette + Settings modal still open through the refactored `openModal` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
