### PR TITLE
v2: transactions data layer + tag/category primitives

### DIFF
--- a/web/src/api/queries/annotations.ts
+++ b/web/src/api/queries/annotations.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { Annotation } from "@/api/types";
+
+// useAnnotations loads the activity timeline for a single transaction. The
+// server returns rows already enriched + deduped (summary, action, subject…),
+// so the UI renders them directly. Disabled until an id is supplied.
+export function useAnnotations(id: string | undefined) {
+  return useQuery({
+    queryKey: ["annotations", id],
+    queryFn: async () => {
+      const res = await api<{ annotations: Annotation[] }>(
+        `/api/v1/transactions/${id}/annotations`,
+      );
+      return res.annotations;
+    },
+    enabled: !!id,
+  });
+}

--- a/web/src/api/queries/categories.ts
+++ b/web/src/api/queries/categories.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { Category } from "@/api/types";
+
+// useCategories loads the full category tree (parents with nested children).
+// Bounded reference data — fetched once, held with a long staleTime.
+export function useCategories() {
+  return useQuery({
+    queryKey: ["categories"],
+    queryFn: async () => {
+      const res = await api<{ categories: Category[] }>("/api/v1/categories");
+      return res.categories;
+    },
+    staleTime: 5 * 60_000,
+  });
+}
+
+// flattenCategories walks the parent/children tree into a flat, depth-first
+// list — the shape category pickers want. Hidden categories are dropped.
+export function flattenCategories(tree: Category[] | undefined): Category[] {
+  if (!tree) return [];
+  const out: Category[] = [];
+  const walk = (nodes: Category[]) => {
+    for (const node of nodes) {
+      if (node.hidden) continue;
+      out.push(node);
+      if (node.children?.length) walk(node.children);
+    }
+  };
+  walk(tree);
+  return out;
+}

--- a/web/src/api/queries/tags.ts
+++ b/web/src/api/queries/tags.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { Tag } from "@/api/types";
+
+// useTags loads the full tag catalog. It's small, bounded reference data, so
+// it's fetched once and held with a long staleTime — list rows, the detail
+// page, and the bulk-tag picker all read from this one cache entry.
+export function useTags() {
+  return useQuery({
+    queryKey: ["tags"],
+    queryFn: async () => {
+      const res = await api<{ tags: Tag[] }>("/api/v1/tags");
+      return res.tags;
+    },
+    staleTime: 5 * 60_000,
+  });
+}

--- a/web/src/api/queries/transactions.ts
+++ b/web/src/api/queries/transactions.ts
@@ -1,7 +1,17 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { nextCursor } from "@/lib/pagination";
-import type { TransactionsPage } from "@/api/types";
+import type {
+  TransactionDetail,
+  TransactionsPage,
+  UpdateTransactionsRequest,
+  UpdateTransactionsResult,
+} from "@/api/types";
 
 export interface TransactionFilters {
   /** Free-text search; the API requires a minimum of 2 chars. */
@@ -30,5 +40,36 @@ export function useTransactions(filters: TransactionFilters) {
     },
     initialPageParam: "",
     getNextPageParam: (last) => nextCursor(last),
+  });
+}
+
+// useTransaction loads a single transaction by id or short_id. Disabled until
+// an id is supplied.
+export function useTransaction(id: string | undefined) {
+  return useQuery({
+    queryKey: ["transaction", id],
+    queryFn: () => api<TransactionDetail>(`/api/v1/transactions/${id}`),
+    enabled: !!id,
+  });
+}
+
+// useUpdateTransactions is the one batch-mutation path for transaction edits —
+// category set/reset, tag add/remove, comment append — used by both the detail
+// page (single-op batch) and select mode (many ops). On success it invalidates
+// every transaction-derived cache so list rows, the detail page, and timelines
+// re-fetch.
+export function useUpdateTransactions() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (req: UpdateTransactionsRequest) =>
+      api<UpdateTransactionsResult>("/api/v1/transactions/update", {
+        method: "POST",
+        body: JSON.stringify(req),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["transactions"] });
+      qc.invalidateQueries({ queryKey: ["transaction"] });
+      qc.invalidateQueries({ queryKey: ["annotations"] });
+    },
   });
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -39,11 +39,118 @@ export interface Transaction {
   tags?: string[];
   created_at: string;
   updated_at: string;
+
+  // Detail-only fields — present on GET /transactions/{id} and (by default)
+  // on the list endpoint, but a list call using `fields=` selection may omit
+  // them, so they're optional.
+  attributed_user_id?: string | null;
+  attributed_user_name?: string | null;
+  effective_user_id?: string | null;
+  authorized_datetime?: string | null;
+  provider_category_primary?: string | null;
+  provider_category_detailed?: string | null;
+  provider_category_confidence?: string | null;
+  provider_payment_channel?: string | null;
 }
+
+// GET /transactions/{id} returns the same shape as a list row.
+export type TransactionDetail = Transaction;
 
 export interface TransactionsPage {
   transactions: Transaction[];
   next_cursor?: string;
   has_more: boolean;
   limit: number;
+}
+
+// --- Tags (public /api/v1/tags) ---
+// Mirrors internal/client/tags.go Tag.
+export interface Tag {
+  id: string;
+  short_id: string;
+  slug: string;
+  display_name: string;
+  description: string;
+  color: string | null;
+  icon: string | null;
+  lifecycle: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// --- Categories (public /api/v1/categories) ---
+// Mirrors internal/client/categories.go Category — a parent/children tree.
+export interface Category {
+  id: string;
+  short_id: string;
+  slug: string;
+  display_name: string;
+  parent_id: string | null;
+  parent_slug: string | null;
+  parent_display_name: string | null;
+  icon: string | null;
+  color: string | null;
+  sort_order: number;
+  is_system: boolean;
+  hidden: boolean;
+  children: Category[];
+  created_at: string;
+  updated_at: string;
+}
+
+// --- Annotations / activity timeline (GET /transactions/{id}/annotations) ---
+// Mirrors internal/service/annotations.go Annotation. The derived fields
+// (action, summary, subject, …) are populated by server-side enrichment.
+export interface Annotation {
+  id: string;
+  short_id: string;
+  transaction_id: string;
+  kind: string; // comment | rule_applied | tag_added | tag_removed | category_set | sync_started | sync_updated
+  actor_type: string; // user | agent | system
+  actor_id?: string | null;
+  actor_name: string;
+  session_id?: string | null;
+  payload?: Record<string, unknown>;
+  tag_id?: string | null;
+  rule_id?: string | null;
+  created_at: string;
+  is_deleted?: boolean;
+
+  // Derived (enrichment) fields.
+  action?: string;
+  summary?: string;
+  subject?: string;
+  origin?: string;
+  source?: string;
+  content?: string;
+  note?: string;
+  tag_slug?: string;
+  category_slug?: string;
+  rule_name?: string;
+  rule_short_id?: string;
+}
+
+// --- Batch transaction update (POST /transactions/update) ---
+// Mirrors internal/service UpdateTransactionsOp. One atomic operation per
+// transaction: set/reset category, add/remove tags, append a comment.
+export interface UpdateTransactionsOp {
+  transaction_id: string;
+  category_slug?: string;
+  reset_category?: boolean;
+  tags_to_add?: { slug: string }[];
+  tags_to_remove?: { slug: string }[];
+  comment?: string;
+}
+
+export interface UpdateTransactionsRequest {
+  operations: UpdateTransactionsOp[];
+  on_error?: "continue" | "abort";
+}
+
+export interface UpdateTransactionsResult {
+  results: { transaction_id: string; status: "ok" | "error"; error?: string }[];
+  succeeded: number;
+  failed: number;
+  aborted?: boolean;
+  error?: string;
 }

--- a/web/src/components/category-badge.tsx
+++ b/web/src/components/category-badge.tsx
@@ -1,0 +1,45 @@
+import { Badge } from "@/components/ui/badge";
+import { DynamicIcon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+import type { TransactionCategory } from "@/api/types";
+
+interface CategoryBadgeProps {
+  category: TransactionCategory | null | undefined;
+  /** Show a subtle ring when the category was set by a manual override. */
+  overridden?: boolean;
+  className?: string;
+}
+
+// CategoryBadge is the single rendering of a transaction category across v2 —
+// list rows, the detail page, pickers. Icon + display name, tinted by the
+// category's own color. Renders an em-dash when there's no category.
+export function CategoryBadge({
+  category,
+  overridden,
+  className,
+}: CategoryBadgeProps) {
+  if (!category?.display_name) {
+    return (
+      <span className={cn("text-muted-foreground", className)}>—</span>
+    );
+  }
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "gap-1",
+        overridden && "ring-1 ring-primary/40",
+        className,
+      )}
+    >
+      {category.icon && (
+        <DynamicIcon
+          name={category.icon}
+          className="size-3"
+          style={category.color ? { color: category.color } : undefined}
+        />
+      )}
+      {category.display_name}
+    </Badge>
+  );
+}

--- a/web/src/components/tag-chip.tsx
+++ b/web/src/components/tag-chip.tsx
@@ -1,0 +1,76 @@
+import { X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { DynamicIcon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+import { useTags } from "@/api/queries/tags";
+import type { Tag } from "@/api/types";
+
+type TagLike = Pick<Tag, "slug" | "display_name" | "color" | "icon">;
+
+interface TagChipProps {
+  tag: TagLike;
+  /** When set, renders a remove (×) button that calls this on click. */
+  onRemove?: () => void;
+  className?: string;
+}
+
+// TagChip is the single rendering of one tag — icon + display name tinted by
+// the tag's color, with an optional remove button for editable contexts.
+export function TagChip({ tag, onRemove, className }: TagChipProps) {
+  const tint = tag.color ? { color: tag.color } : undefined;
+  return (
+    <Badge variant="outline" className={cn("gap-1", className)}>
+      {tag.icon && (
+        <DynamicIcon name={tag.icon} className="size-3" style={tint} />
+      )}
+      <span style={tint}>{tag.display_name}</span>
+      {onRemove && (
+        <button
+          type="button"
+          onClick={onRemove}
+          aria-label={`Remove ${tag.display_name}`}
+          className="text-muted-foreground hover:text-foreground -mr-0.5 ml-0.5 rounded-full"
+        >
+          <X className="size-3" />
+        </button>
+      )}
+    </Badge>
+  );
+}
+
+interface TagListProps {
+  /** Tag slugs as carried on a transaction row. */
+  slugs: string[] | undefined;
+  /** Cap the chips shown; the remainder collapse into a "+N" badge. */
+  max?: number;
+  className?: string;
+}
+
+// TagList resolves a transaction's tag slugs against the cached tag catalog
+// and renders chips. A slug with no matching tag still renders (display name
+// falls back to the slug) so a freshly-created tag never silently vanishes.
+export function TagList({ slugs, max, className }: TagListProps) {
+  const { data: tags } = useTags();
+  if (!slugs?.length) return null;
+
+  const bySlug = new Map((tags ?? []).map((t) => [t.slug, t]));
+  const resolved: TagLike[] = slugs.map(
+    (slug) =>
+      bySlug.get(slug) ?? { slug, display_name: slug, color: null, icon: null },
+  );
+  const shown = max ? resolved.slice(0, max) : resolved;
+  const overflow = resolved.length - shown.length;
+
+  return (
+    <div className={cn("flex flex-wrap items-center gap-1", className)}>
+      {shown.map((tag) => (
+        <TagChip key={tag.slug} tag={tag} />
+      ))}
+      {overflow > 0 && (
+        <Badge variant="outline" className="text-muted-foreground">
+          +{overflow}
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/icon.tsx
+++ b/web/src/lib/icon.tsx
@@ -1,0 +1,21 @@
+import {
+  DynamicIcon as LucideDynamicIcon,
+  dynamicIconImports,
+  type IconName,
+} from "lucide-react/dynamic";
+import type { LucideProps } from "lucide-react";
+
+// Category and tag `icon` values are stored kebab-case in the DB
+// ("shopping-cart") — the same keying lucide-react's DynamicIcon expects. We
+// wrap it to (a) tolerate the nullable DB string and (b) guard unknown names,
+// which lucide would otherwise console.error on. Each icon is lazily imported
+// and code-split, so this never pulls the full icon set into the bundle.
+
+interface DynamicIconProps extends Omit<LucideProps, "name"> {
+  name?: string | null;
+}
+
+export function DynamicIcon({ name, ...props }: DynamicIconProps) {
+  if (!name || !(name in dynamicIconImports)) return null;
+  return <LucideDynamicIcon name={name as IconName} {...props} />;
+}


### PR DESCRIPTION
Bottom of the v2-transactions stack — the data + presentational layer everything else builds on.

## Summary

Pure data + primitives; nothing is wired into a route yet, so the new modules tree-shake out until PR 02 consumes them.

- **types.ts** — `Tag`, `Category`, `Annotation`, `TransactionDetail`, and the `UpdateTransactions*` batch-mutation shapes (mirror `internal/service/types.go`).
- **queries** — `useTags`, `useCategories` (+ `flattenCategories`), `useAnnotations`, plus `useTransaction` and the `useUpdateTransactions` batch mutation.
- **CategoryBadge / TagChip + TagList** — the single rendering of categories and tags across v2: icon + color-tinted label. `TagList` resolves a row's tag slugs against the cached tag catalog.
- **lib/icon.tsx** — `DynamicIcon` wraps `lucide-react/dynamic` so DB-stored kebab-case icon names render lazily + code-split, never pulling the full icon set into the bundle.

## Test plan

- [x] `tsc -b && vite build` passes.
- [x] `go build ./...`, `go vet ./...` pass (no Go changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
