### PR TITLE
v2: reusable transaction row + richer table cells

### DIFF
--- a/web/src/components/category-icon-tile.tsx
+++ b/web/src/components/category-icon-tile.tsx
@@ -1,0 +1,50 @@
+import { Receipt } from "lucide-react";
+import { DynamicIcon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+
+const TILE_SIZE = {
+  sm: "size-7",
+  md: "size-9",
+  lg: "size-12",
+} as const;
+
+const ICON_SIZE = {
+  sm: "size-3.5",
+  md: "size-4",
+  lg: "size-5",
+} as const;
+
+interface CategoryIconTileProps {
+  icon?: string | null;
+  color?: string | null;
+  size?: keyof typeof TILE_SIZE;
+  className?: string;
+}
+
+// CategoryIconTile is the rounded icon chip that fronts a transaction — in
+// list rows and on the detail-page hero. The tile is tinted from the
+// category's own color (10% fill, full-strength icon); a category-less
+// transaction falls back to a neutral receipt glyph.
+export function CategoryIconTile({
+  icon,
+  color,
+  size = "md",
+  className,
+}: CategoryIconTileProps) {
+  return (
+    <div
+      className={cn(
+        "bg-muted text-muted-foreground flex shrink-0 items-center justify-center rounded-md",
+        TILE_SIZE[size],
+        className,
+      )}
+      style={color ? { backgroundColor: `${color}1a`, color } : undefined}
+    >
+      {icon ? (
+        <DynamicIcon name={icon} className={ICON_SIZE[size]} />
+      ) : (
+        <Receipt className={ICON_SIZE[size]} />
+      )}
+    </div>
+  );
+}

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -1,0 +1,104 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { Badge } from "@/components/ui/badge";
+import { CategoryBadge } from "@/components/category-badge";
+import { CategoryIconTile } from "@/components/category-icon-tile";
+import { TagList } from "@/components/tag-chip";
+import { formatAmount, formatDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { Transaction } from "@/api/types";
+
+// transactionColumns is the single column definition for the v2 transactions
+// table — kept out of the route so the row rendering is reusable and the
+// route file stays focused on data + URL state. Sorting, selection, and other
+// per-context columns are layered on by later PRs in this stack.
+export const transactionColumns: ColumnDef<Transaction>[] = [
+  {
+    accessorKey: "date",
+    header: "Date",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground tabular-nums whitespace-nowrap">
+        {formatDate(row.original.date)}
+      </span>
+    ),
+  },
+  {
+    id: "description",
+    header: "Description",
+    cell: ({ row }) => {
+      const t = row.original;
+      // provider_name is the raw bank description (the primary label, per the
+      // #1072 decision). provider_merchant_name is the cleaned merchant — show
+      // it as a subtitle only when it adds information.
+      const subtitle =
+        t.provider_merchant_name &&
+        t.provider_merchant_name !== t.provider_name
+          ? t.provider_merchant_name
+          : null;
+      return (
+        <div className="flex items-center gap-3">
+          <CategoryIconTile
+            icon={t.category?.icon}
+            color={t.category?.color}
+            size="sm"
+          />
+          <div className="min-w-0">
+            <div className="flex items-center gap-2">
+              <span className="truncate font-medium">{t.provider_name}</span>
+              {t.pending && (
+                <Badge
+                  variant="outline"
+                  className="text-muted-foreground shrink-0"
+                >
+                  Pending
+                </Badge>
+              )}
+            </div>
+            {subtitle && (
+              <div className="text-muted-foreground truncate text-xs">
+                {subtitle}
+              </div>
+            )}
+            <TagList slugs={t.tags} max={3} className="mt-1" />
+          </div>
+        </div>
+      );
+    },
+  },
+  {
+    id: "category",
+    header: "Category",
+    cell: ({ row }) => (
+      <CategoryBadge
+        category={row.original.category}
+        overridden={row.original.category_override}
+      />
+    ),
+  },
+  {
+    accessorKey: "account_name",
+    header: "Account",
+    cell: ({ row }) => (
+      <span className="text-muted-foreground whitespace-nowrap">
+        {row.original.account_name ?? "—"}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "amount",
+    header: () => <div className="text-right">Amount</div>,
+    cell: ({ row }) => {
+      const t = row.original;
+      const isInflow = t.amount < 0;
+      return (
+        <div
+          className={cn(
+            "text-right font-medium tabular-nums whitespace-nowrap",
+            isInflow && "text-emerald-600 dark:text-emerald-500",
+          )}
+        >
+          {formatAmount(t.amount, t.iso_currency_code)}
+        </div>
+      );
+    },
+  },
+];

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -1,17 +1,15 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
-import type { ColumnDef } from "@tanstack/react-table";
 import { Receipt, Search } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { DataTable } from "@/components/data-table";
 import { EmptyState } from "@/components/empty-state";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { transactionColumns } from "@/features/transactions/columns";
 import { useTransactions } from "@/api/queries/transactions";
 import { flattenPages } from "@/lib/pagination";
-import { formatAmount, formatDate } from "@/lib/format";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import type { Transaction } from "@/api/types";
 
@@ -21,74 +19,6 @@ export const transactionsSearchSchema = z.object({
 });
 
 type TransactionsSearch = z.infer<typeof transactionsSearchSchema>;
-
-const columns: ColumnDef<Transaction>[] = [
-  {
-    accessorKey: "date",
-    header: "Date",
-    cell: ({ row }) => (
-      <span className="text-muted-foreground tabular-nums">
-        {formatDate(row.original.date)}
-      </span>
-    ),
-  },
-  {
-    id: "description",
-    header: "Description",
-    cell: ({ row }) => {
-      const t = row.original;
-      return (
-        <div className="flex items-center gap-2">
-          <span className="font-medium">{t.provider_name}</span>
-          {t.pending && (
-            <Badge variant="outline" className="text-muted-foreground">
-              Pending
-            </Badge>
-          )}
-        </div>
-      );
-    },
-  },
-  {
-    id: "category",
-    header: "Category",
-    cell: ({ row }) => {
-      const cat = row.original.category;
-      if (!cat?.display_name) {
-        return <span className="text-muted-foreground">—</span>;
-      }
-      return <Badge variant="secondary">{cat.display_name}</Badge>;
-    },
-  },
-  {
-    accessorKey: "account_name",
-    header: "Account",
-    cell: ({ row }) => (
-      <span className="text-muted-foreground">
-        {row.original.account_name ?? "—"}
-      </span>
-    ),
-  },
-  {
-    accessorKey: "amount",
-    header: () => <div className="text-right">Amount</div>,
-    cell: ({ row }) => {
-      const t = row.original;
-      const isInflow = t.amount < 0;
-      return (
-        <div
-          className={
-            isInflow
-              ? "text-right font-medium tabular-nums text-emerald-600 dark:text-emerald-500"
-              : "text-right font-medium tabular-nums"
-          }
-        >
-          {formatAmount(t.amount, t.iso_currency_code)}
-        </div>
-      );
-    },
-  },
-];
 
 export function TransactionsPage() {
   const navigate = useNavigate();
@@ -142,7 +72,7 @@ export function TransactionsPage() {
       </div>
 
       <DataTable
-        columns={columns}
+        columns={transactionColumns}
         data={rows}
         isLoading={transactions.isLoading}
         isError={transactions.isError}


### PR DESCRIPTION
Extracts transaction row rendering into a reusable column definition and richens the table cells.

## Summary

- Column defs move out of the route into `features/transactions/columns.tsx` so row rendering is reusable and the route stays focused on data + URL state.
- New **CategoryIconTile** — the rounded, category-color-tinted icon chip that fronts a transaction (reused on the detail-page hero in PR 03).
- Description cell now leads with the icon tile, keeps `provider_name` as the primary label (per #1072), adds `provider_merchant_name` as a subtitle only when it differs, and shows inline tag chips (`TagList`, capped at 3).
- Category cell uses `CategoryBadge` with the manual-override ring.

**Bundle note:** the main bundle grows ~130 KB because `lucide-react/dynamic` ships a ~1500-entry icon import map. The icons themselves are lazily code-split into their own chunks; only the name map is eager. Acceptable for an internal admin SPA — revisit with a curated set if it becomes a problem.

## Test plan

- [x] `tsc -b && vite build` passes.
- [x] Browser: rows show the icon tile, merchant subtitle, inline tags, and override-aware category badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
