### PR TITLE
v2: transaction detail page

### DIFF
--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -1216,6 +1216,7 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 	// directly (matching ListTransactions). Avoids per-FK round-trips.
 	const q = `
 		SELECT t.id, t.short_id, a.short_id AS account_short_id,
+			COALESCE(a.display_name, a.name) AS account_name,
 			au.short_id AS attributed_user_short_id, au.name AS attributed_user_name,
 			COALESCE(au.short_id, u.short_id) AS effective_user_short_id,
 			COALESCE(au.name, u.name) AS user_name,
@@ -1236,6 +1237,7 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		txID                  pgtype.UUID
 		shortID               string
 		accountShortID        pgtype.Text
+		accountName           pgtype.Text
 		attributedUserShortID pgtype.Text
 		attributedUserName    pgtype.Text
 		effectiveUserShortID  pgtype.Text
@@ -1260,7 +1262,7 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 	)
 
 	if err := s.Pool.QueryRow(ctx, q, uid).Scan(
-		&txID, &shortID, &accountShortID,
+		&txID, &shortID, &accountShortID, &accountName,
 		&attributedUserShortID, &attributedUserName,
 		&effectiveUserShortID, &userName,
 		&amount, &isoCurrencyCode, &date, &authorizedDate,
@@ -1289,6 +1291,7 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 		ID:                         formatUUID(txID),
 		ShortID:                    shortID,
 		AccountID:                  textPtr(accountShortID),
+		AccountName:                textPtr(accountName),
 		UserName:                   textPtr(userName),
 		AttributedUserID:           textPtr(attributedUserShortID),
 		AttributedUserName:         textPtr(attributedUserName),
@@ -1332,6 +1335,14 @@ func (s *Service) GetTransaction(ctx context.Context, id string) (*TransactionRe
 			resp.Category = catInfo
 		}
 	}
+
+	// Populate Tags via the shared batched helper (one-element slice) so the
+	// detail endpoint returns the same enriched shape as list rows.
+	batch := []TransactionResponse{*resp}
+	if err := s.attachTagsToTransactions(ctx, batch); err != nil {
+		return nil, fmt.Errorf("get transaction tags: %w", err)
+	}
+	resp.Tags = batch[0].Tags
 
 	return resp, nil
 }

--- a/web/src/api/queries/categories.ts
+++ b/web/src/api/queries/categories.ts
@@ -3,14 +3,12 @@ import { api } from "@/api/client";
 import type { Category } from "@/api/types";
 
 // useCategories loads the full category tree (parents with nested children).
-// Bounded reference data — fetched once, held with a long staleTime.
+// Bounded reference data — fetched once, held with a long staleTime. The
+// endpoint returns a bare array (no envelope).
 export function useCategories() {
   return useQuery({
     queryKey: ["categories"],
-    queryFn: async () => {
-      const res = await api<{ categories: Category[] }>("/api/v1/categories");
-      return res.categories;
-    },
+    queryFn: () => api<Category[]>("/api/v1/categories"),
     staleTime: 5 * 60_000,
   });
 }

--- a/web/src/components/ui/popover.tsx
+++ b/web/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/web/src/features/transactions/activity-timeline.tsx
+++ b/web/src/features/transactions/activity-timeline.tsx
@@ -1,0 +1,160 @@
+import { useMemo } from "react";
+import {
+  Activity,
+  MessageSquare,
+  RefreshCw,
+  Shapes,
+  Tag,
+  Wand2,
+  type LucideIcon,
+} from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/empty-state";
+import { useAnnotations } from "@/api/queries/annotations";
+import { formatRelativeTime } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { Annotation } from "@/api/types";
+
+const KIND_ICON: Record<string, LucideIcon> = {
+  comment: MessageSquare,
+  rule_applied: Wand2,
+  tag_added: Tag,
+  tag_removed: Tag,
+  category_set: Shapes,
+  sync_started: RefreshCw,
+  sync_updated: RefreshCw,
+};
+
+const dayHeadingFormatter = new Intl.DateTimeFormat("en-US", {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+});
+
+function dayLabel(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const today = new Date();
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+  if (d.toDateString() === today.toDateString()) return "Today";
+  if (d.toDateString() === yesterday.toDateString()) return "Yesterday";
+  return dayHeadingFormatter.format(d);
+}
+
+interface DayGroup {
+  label: string;
+  rows: Annotation[];
+}
+
+// groupByDay buckets the (already newest-first) annotation list into calendar
+// days, preserving order.
+function groupByDay(annotations: Annotation[]): DayGroup[] {
+  const groups: DayGroup[] = [];
+  for (const row of annotations) {
+    const label = dayLabel(row.created_at);
+    const last = groups[groups.length - 1];
+    if (last && last.label === label) {
+      last.rows.push(row);
+    } else {
+      groups.push({ label, rows: [row] });
+    }
+  }
+  return groups;
+}
+
+// ActivityTimeline renders a transaction's enriched annotation feed — comments,
+// rule applications, tag/category changes, sync events — grouped by day. The
+// server hands back ready-to-render `summary` lines, so this stays a pure
+// layout component.
+export function ActivityTimeline({ transactionId }: { transactionId: string }) {
+  const { data, isLoading, isError } = useAnnotations(transactionId);
+  const groups = useMemo(() => groupByDay(data ?? []), [data]);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex gap-3">
+            <Skeleton className="size-7 shrink-0 rounded-full" />
+            <div className="flex-1 space-y-1.5 py-1">
+              <Skeleton className="h-3 w-3/4" />
+              <Skeleton className="h-3 w-1/4" />
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        Couldn't load the activity timeline.
+      </p>
+    );
+  }
+
+  if (!data?.length) {
+    return (
+      <EmptyState
+        icon={Activity}
+        title="No activity yet"
+        description="Comments, rule applications, and category changes show up here."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {groups.map((group) => (
+        <div key={group.label} className="space-y-3">
+          <h3 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            {group.label}
+          </h3>
+          <ol className="space-y-3">
+            {group.rows.map((row) => (
+              <TimelineRow key={row.id} annotation={row} />
+            ))}
+          </ol>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TimelineRow({ annotation }: { annotation: Annotation }) {
+  const Icon = KIND_ICON[annotation.kind] ?? Activity;
+  const deleted = annotation.is_deleted;
+  // Comments carry a body; everything else is fully described by `summary`.
+  const showBody = annotation.kind === "comment" && !deleted && annotation.content;
+
+  return (
+    <li className="flex gap-3">
+      <div
+        className={cn(
+          "bg-muted text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded-full",
+          deleted && "opacity-50",
+        )}
+      >
+        <Icon className="size-3.5" />
+      </div>
+      <div className={cn("min-w-0 flex-1 py-0.5", deleted && "opacity-60")}>
+        <p className="text-sm">
+          {deleted
+            ? `${annotation.actor_name} deleted a comment`
+            : (annotation.summary ??
+              `${annotation.actor_name} ${annotation.action ?? annotation.kind}`)}
+        </p>
+        {showBody && (
+          <p className="text-muted-foreground bg-muted/50 mt-1 rounded-md px-2.5 py-1.5 text-sm whitespace-pre-wrap">
+            {annotation.content}
+          </p>
+        )}
+        <p className="text-muted-foreground mt-0.5 text-xs">
+          {formatRelativeTime(annotation.created_at)}
+        </p>
+      </div>
+    </li>
+  );
+}

--- a/web/src/features/transactions/category-editor.tsx
+++ b/web/src/features/transactions/category-editor.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { Check, ChevronsUpDown, RotateCcw } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { CategoryBadge } from "@/components/category-badge";
+import { DynamicIcon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  useCategories,
+  flattenCategories,
+} from "@/api/queries/categories";
+import { useUpdateTransactions } from "@/api/queries/transactions";
+import type { TransactionCategory } from "@/api/types";
+
+interface CategoryEditorProps {
+  transactionId: string;
+  category: TransactionCategory | null;
+  /** True when the current category was set by a manual override. */
+  overridden: boolean;
+}
+
+// CategoryEditor is the single-transaction category picker on the detail
+// page. The trigger shows the current category; the popover is a searchable,
+// flattened category list. A reset entry appears only when the category was
+// manually overridden — that's the sole case where "provider default" differs
+// from what's shown.
+export function CategoryEditor({
+  transactionId,
+  category,
+  overridden,
+}: CategoryEditorProps) {
+  const [open, setOpen] = useState(false);
+  const { data: tree, isLoading } = useCategories();
+  const update = useUpdateTransactions();
+  const categories = flattenCategories(tree);
+
+  const apply = async (op: { category_slug?: string; reset_category?: boolean }) => {
+    setOpen(false);
+    await withMutationToast(
+      () =>
+        update.mutateAsync({
+          operations: [{ transaction_id: transactionId, ...op }],
+        }),
+      { success: "Category updated." },
+    );
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={update.isPending}
+          className="w-full justify-between"
+        >
+          <CategoryBadge category={category} overridden={overridden} />
+          <ChevronsUpDown className="text-muted-foreground size-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
+        <Command>
+          <CommandInput placeholder="Search categories…" />
+          <CommandList>
+            <CommandEmpty>
+              {isLoading ? "Loading…" : "No categories found."}
+            </CommandEmpty>
+            {overridden && (
+              <>
+                <CommandGroup>
+                  <CommandItem
+                    value="reset provider default"
+                    onSelect={() => apply({ reset_category: true })}
+                  >
+                    <RotateCcw className="size-4" />
+                    Reset to provider default
+                  </CommandItem>
+                </CommandGroup>
+                <CommandSeparator />
+              </>
+            )}
+            <CommandGroup>
+              {categories.map((c) => (
+                <CommandItem
+                  key={c.slug}
+                  value={`${c.display_name} ${c.parent_display_name ?? ""}`}
+                  onSelect={() => apply({ category_slug: c.slug })}
+                >
+                  <DynamicIcon
+                    name={c.icon}
+                    className="size-4"
+                    style={c.color ? { color: c.color } : undefined}
+                  />
+                  <span className={cn(c.parent_id && "text-muted-foreground")}>
+                    {c.parent_display_name
+                      ? `${c.parent_display_name} › ${c.display_name}`
+                      : c.display_name}
+                  </span>
+                  {category?.slug === c.slug && (
+                    <Check className="ml-auto size-4" />
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/features/transactions/tag-manager.tsx
+++ b/web/src/features/transactions/tag-manager.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { Check, Plus } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { TagChip } from "@/components/tag-chip";
+import { DynamicIcon } from "@/lib/icon";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { useTags } from "@/api/queries/tags";
+import { useUpdateTransactions } from "@/api/queries/transactions";
+
+interface TagManagerProps {
+  transactionId: string;
+  /** Tag slugs currently attached to the transaction. */
+  tags: string[];
+}
+
+// TagManager is the single-transaction tag editor on the detail page. Current
+// tags render as removable chips; the "Add tag" popover toggles attachment
+// against the full tag catalog. Each toggle is one batch operation — add or
+// remove a single slug — and the cache invalidation refetches the row.
+export function TagManager({ transactionId, tags }: TagManagerProps) {
+  const [open, setOpen] = useState(false);
+  const { data: catalog, isLoading } = useTags();
+  const update = useUpdateTransactions();
+
+  const attached = new Set(tags);
+  const bySlug = new Map((catalog ?? []).map((t) => [t.slug, t]));
+
+  const toggle = async (slug: string) => {
+    const isAttached = attached.has(slug);
+    await withMutationToast(
+      () =>
+        update.mutateAsync({
+          operations: [
+            {
+              transaction_id: transactionId,
+              ...(isAttached
+                ? { tags_to_remove: [{ slug }] }
+                : { tags_to_add: [{ slug }] }),
+            },
+          ],
+        }),
+      { success: isAttached ? "Tag removed." : "Tag added." },
+    );
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {tags.map((slug) => {
+        const tag = bySlug.get(slug) ?? {
+          slug,
+          display_name: slug,
+          color: null,
+          icon: null,
+        };
+        return (
+          <TagChip
+            key={slug}
+            tag={tag}
+            onRemove={update.isPending ? undefined : () => toggle(slug)}
+          />
+        );
+      })}
+
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 gap-1 rounded-full px-2 text-xs"
+            disabled={update.isPending}
+          >
+            <Plus className="size-3" />
+            Add tag
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-56 p-0" align="start">
+          <Command>
+            <CommandInput placeholder="Search tags…" />
+            <CommandList>
+              <CommandEmpty>
+                {isLoading ? "Loading…" : "No tags found."}
+              </CommandEmpty>
+              <CommandGroup>
+                {(catalog ?? []).map((tag) => (
+                  <CommandItem
+                    key={tag.slug}
+                    value={tag.display_name}
+                    onSelect={() => toggle(tag.slug)}
+                  >
+                    <DynamicIcon
+                      name={tag.icon}
+                      className="size-4"
+                      style={tag.color ? { color: tag.color } : undefined}
+                    />
+                    <span>{tag.display_name}</span>
+                    {attached.has(tag.slug) && (
+                      <Check className="ml-auto size-4" />
+                    )}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -31,3 +31,41 @@ export function formatDate(date: string): string {
   const d = new Date(`${date}T00:00:00`);
   return Number.isNaN(d.getTime()) ? date : monthDayFormatter.format(d);
 }
+
+const longDateFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+});
+
+// formatLongDate renders a YYYY-MM-DD date as e.g. "Jan 2, 2026".
+export function formatLongDate(date: string): string {
+  const d = new Date(`${date}T00:00:00`);
+  return Number.isNaN(d.getTime()) ? date : longDateFormatter.format(d);
+}
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat("en-US", {
+  numeric: "auto",
+});
+
+const RELATIVE_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ["year", 31_536_000],
+  ["month", 2_592_000],
+  ["week", 604_800],
+  ["day", 86_400],
+  ["hour", 3_600],
+  ["minute", 60],
+];
+
+// formatRelativeTime renders an RFC3339 timestamp as e.g. "3 hours ago" or
+// "in 2 days"; returns the input unchanged if it isn't a parseable date.
+export function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const diffSec = (then - Date.now()) / 1000;
+  const absSec = Math.abs(diffSec);
+  for (const [unit, secs] of RELATIVE_UNITS) {
+    if (absSec >= secs) {
+      return relativeTimeFormatter.format(Math.round(diffSec / secs), unit);
+    }
+  }
+  return relativeTimeFormatter.format(Math.round(diffSec), "second");
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -15,6 +15,7 @@ import { HomePage } from "@/routes/home";
 import { LoginPage } from "@/routes/login";
 import { Placeholder } from "@/routes/placeholder";
 import { TransactionsPage, transactionsSearchSchema } from "@/routes/transactions";
+import { TransactionDetailPage } from "@/routes/transaction-detail";
 import { NAV_LEAVES } from "@/lib/nav";
 import { baseSearchSchema } from "@/lib/modals";
 import { z } from "zod";
@@ -60,6 +61,15 @@ const PAGE_OVERRIDES: Record<string, PageOverride> = {
   },
 };
 
+// Detail routes aren't nav leaves, so they're registered explicitly rather
+// than derived from NAV_LEAVES. isNavMatch's prefix match keeps the
+// Transactions sidebar item active on /transactions/$id.
+const transactionDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/transactions/$id",
+  component: TransactionDetailPage,
+});
+
 const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
   if (leaf.kind !== "link" || leaf.to === "/") return [];
   const override = PAGE_OVERRIDES[leaf.to];
@@ -78,6 +88,7 @@ const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
 const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
+  transactionDetailRoute,
   ...pageRoutes,
 ]);
 

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -1,0 +1,188 @@
+import { Link, useParams } from "@tanstack/react-router";
+import { ArrowLeft, Receipt } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/empty-state";
+import { CategoryIconTile } from "@/components/category-icon-tile";
+import { CategoryEditor } from "@/features/transactions/category-editor";
+import { TagManager } from "@/features/transactions/tag-manager";
+import { ActivityTimeline } from "@/features/transactions/activity-timeline";
+import { useTransaction } from "@/api/queries/transactions";
+import { formatAmount, formatLongDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { Transaction } from "@/api/types";
+
+export function TransactionDetailPage() {
+  const { id } = useParams({ strict: false }) as { id?: string };
+  const { data, isLoading, isError } = useTransaction(id);
+
+  return (
+    <div className="mx-auto max-w-4xl">
+      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
+        <Link to="/transactions">
+          <ArrowLeft className="size-4" />
+          Transactions
+        </Link>
+      </Button>
+
+      {isLoading ? (
+        <DetailSkeleton />
+      ) : isError || !data ? (
+        <EmptyState
+          icon={Receipt}
+          title="Transaction not found"
+          description="It may have been deleted, or the link is wrong."
+          action={
+            <Button variant="outline" asChild>
+              <Link to="/transactions">Back to transactions</Link>
+            </Button>
+          }
+        />
+      ) : (
+        <DetailBody transaction={data} />
+      )}
+    </div>
+  );
+}
+
+function DetailBody({ transaction: t }: { transaction: Transaction }) {
+  const isInflow = t.amount < 0;
+  const subtitle =
+    t.provider_merchant_name && t.provider_merchant_name !== t.provider_name
+      ? t.provider_merchant_name
+      : null;
+
+  return (
+    <div className="space-y-6">
+      {/* Hero */}
+      <div className="flex items-start gap-4">
+        <CategoryIconTile
+          icon={t.category?.icon}
+          color={t.category?.color}
+          size="lg"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h1 className="truncate text-xl font-semibold tracking-tight">
+              {t.provider_name}
+            </h1>
+            {t.pending && (
+              <Badge variant="outline" className="text-muted-foreground">
+                Pending
+              </Badge>
+            )}
+          </div>
+          {subtitle && (
+            <p className="text-muted-foreground text-sm">{subtitle}</p>
+          )}
+          <p className="text-muted-foreground mt-0.5 text-sm">
+            {formatLongDate(t.date)}
+          </p>
+        </div>
+        <div
+          className={cn(
+            "text-xl font-semibold tabular-nums whitespace-nowrap",
+            isInflow && "text-emerald-600 dark:text-emerald-500",
+          )}
+        >
+          {formatAmount(t.amount, t.iso_currency_code)}
+        </div>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-[1fr_18rem]">
+        {/* Main column */}
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Details</CardTitle>
+            </CardHeader>
+            <CardContent className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+              <DetailRow label="Account" value={t.account_name} />
+              <DetailRow label="Household member" value={t.user_name} />
+              <DetailRow
+                label="Authorized"
+                value={t.authorized_date ? formatLongDate(t.authorized_date) : null}
+              />
+              <DetailRow
+                label="Payment channel"
+                value={t.provider_payment_channel}
+              />
+              <DetailRow
+                label="Provider category"
+                value={
+                  t.provider_category_detailed ?? t.provider_category_primary
+                }
+              />
+              <DetailRow label="Currency" value={t.iso_currency_code} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Activity</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ActivityTimeline transactionId={t.id} />
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          <section className="space-y-2">
+            <h2 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+              Category
+            </h2>
+            <CategoryEditor
+              transactionId={t.id}
+              category={t.category}
+              overridden={t.category_override}
+            />
+          </section>
+          <section className="space-y-2">
+            <h2 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+              Tags
+            </h2>
+            <TagManager transactionId={t.id} tags={t.tags ?? []} />
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | null | undefined;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd className={cn(!value && "text-muted-foreground")}>{value ?? "—"}</dd>
+    </div>
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start gap-4">
+        <Skeleton className="size-12 rounded-md" />
+        <div className="flex-1 space-y-2 py-1">
+          <Skeleton className="h-5 w-1/3" />
+          <Skeleton className="h-4 w-1/4" />
+        </div>
+        <Skeleton className="h-6 w-20" />
+      </div>
+      <div className="grid gap-6 md:grid-cols-[1fr_18rem]">
+        <Skeleton className="h-48 rounded-xl" />
+        <Skeleton className="h-32 rounded-xl" />
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -76,6 +76,9 @@ export function TransactionsPage() {
         data={rows}
         isLoading={transactions.isLoading}
         isError={transactions.isError}
+        onRowClick={(t) =>
+          navigate({ to: "/transactions/$id", params: { id: t.short_id } })
+        }
         emptyState={
           <EmptyState
             icon={Receipt}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, type ProxyOptions } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "node:path";
@@ -8,6 +8,25 @@ const backendPort = process.env.BREADBOX_BACKEND_PORT ?? "8080";
 // hook injects VITE_PORT, so parallel worktree sessions never collide.
 // Defaults to 5173 for solo / non-worktree dev.
 const vitePort = Number(process.env.VITE_PORT ?? 5173);
+
+const backendTarget = `http://localhost:${backendPort}`;
+
+// In dev the SPA is served from vitePort but the API lives on backendPort.
+// `changeOrigin` rewrites the Host header to the target — but the backend's
+// same-origin CSRF check (mw.SameOrigin) also inspects Origin, so it must be
+// rewritten to match or every session-authed write 403s in dev. In prod the
+// SPA is embedded same-origin, so this proxy never runs.
+const apiProxy: ProxyOptions = {
+  target: backendTarget,
+  changeOrigin: true,
+  configure: (proxy) => {
+    proxy.on("proxyReq", (proxyReq) => {
+      if (proxyReq.getHeader("origin")) {
+        proxyReq.setHeader("origin", backendTarget);
+      }
+    });
+  },
+};
 
 export default defineConfig({
   base: "/v2/",
@@ -19,8 +38,8 @@ export default defineConfig({
     port: vitePort,
     strictPort: true,
     proxy: {
-      "/api": { target: `http://localhost:${backendPort}`, changeOrigin: true },
-      "/web/v1": { target: `http://localhost:${backendPort}`, changeOrigin: true },
+      "/api": apiProxy,
+      "/web/v1": apiProxy,
     },
   },
   build: {


### PR DESCRIPTION
Adds a real `/transactions/$id` detail page with inline editing and an activity timeline.

## Summary

A row click navigates to a detail page: hero (icon tile + name + merchant subtitle + amount), a details card, an inline category editor, a tag manager, and a day-grouped activity timeline.

- **routes/transaction-detail.tsx** + an explicit route in `main.tsx` (detail routes aren't nav leaves; `isNavMatch`'s prefix match keeps the sidebar item active).
- **category-editor.tsx** — searchable popover over the flattened category tree; "reset to provider default" appears only when the category was manually overridden.
- **tag-manager.tsx** — current tags as removable chips + an add-tag popover; each toggle is one batch op.
- **activity-timeline.tsx** — enriched annotation feed grouped Today / Yesterday / weekday, kind-specific icons, tombstone handling.
- **lib/format.ts** — `formatLongDate` + `formatRelativeTime` (cached `Intl` instances).

**Backend:** `GetTransaction` now returns `account_name` and `tags`, matching the list endpoint — the detail endpoint was previously missing both. `categories.ts`: `GET /api/v1/categories` returns a bare array, not an envelope.

**Dev infra:** the vite proxy now rewrites the `Origin` header to the backend target. `changeOrigin` only rewrites `Host`; the backend's same-origin CSRF check also inspects `Origin`, so without this every session-authed write 403s in dev.

## Test plan

- [x] `tsc -b && vite build`, `go build ./...`, `go vet ./internal/...`, `go test ./internal/service` pass.
- [x] Browser: detail page renders; category editor + tag manager mutate and the activity timeline + hero update; account name and tag chips populate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
