### PR TITLE
v2: advanced transaction filtering

### DIFF
--- a/web/src/api/queries/accounts.ts
+++ b/web/src/api/queries/accounts.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { Account } from "@/api/types";
+
+// useAccounts loads the bank-account list. Bounded reference data — used by
+// the transactions account filter — so it's fetched once with a long
+// staleTime. The endpoint returns a bare array (no envelope).
+export function useAccounts() {
+  return useQuery({
+    queryKey: ["accounts"],
+    queryFn: () => api<Account[]>("/api/v1/accounts"),
+    staleTime: 5 * 60_000,
+  });
+}

--- a/web/src/api/queries/transactions.ts
+++ b/web/src/api/queries/transactions.ts
@@ -16,13 +16,27 @@ import type {
 export interface TransactionFilters {
   /** Free-text search; the API requires a minimum of 2 chars. */
   search?: string;
+  /** Account short_id. */
+  account?: string;
+  /** Category slug. */
+  category?: string;
+  /** Inclusive start / exclusive end date, YYYY-MM-DD. */
+  start?: string;
+  end?: string;
+  minAmount?: number;
+  maxAmount?: number;
+  /** true = pending only, false = posted only, undefined = both. */
+  pending?: boolean;
+  sortBy?: "date" | "amount";
+  sortOrder?: "asc" | "desc";
 }
 
 const PAGE_LIMIT = 50;
 
 // useTransactions paginates GET /api/v1/transactions with cursor pagination.
 // The SPA reaches the public endpoint directly — session auth on /api/v1/*
-// (see internal/api/auth_session.go) makes the cookie sufficient.
+// (see internal/api/auth_session.go) makes the cookie sufficient. Every
+// filter maps 1:1 to a documented query param.
 export function useTransactions(filters: TransactionFilters) {
   // The API rejects a 1-char search; treat <2 chars as "no search".
   const search =
@@ -30,12 +44,39 @@ export function useTransactions(filters: TransactionFilters) {
       ? filters.search.trim()
       : undefined;
 
+  // Normalised key — only the fields that actually narrow the query, so two
+  // filter objects that mean the same thing share a cache entry.
+  const key = {
+    search,
+    account: filters.account,
+    category: filters.category,
+    start: filters.start,
+    end: filters.end,
+    minAmount: filters.minAmount,
+    maxAmount: filters.maxAmount,
+    pending: filters.pending,
+    sortBy: filters.sortBy,
+    sortOrder: filters.sortOrder,
+  };
+
   return useInfiniteQuery({
-    queryKey: ["transactions", { search }],
+    queryKey: ["transactions", key],
     queryFn: ({ pageParam }) => {
       const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
       if (pageParam) params.set("cursor", pageParam);
       if (search) params.set("search", search);
+      if (filters.account) params.set("account_id", filters.account);
+      if (filters.category) params.set("category_slug", filters.category);
+      if (filters.start) params.set("start_date", filters.start);
+      if (filters.end) params.set("end_date", filters.end);
+      if (filters.minAmount != null)
+        params.set("min_amount", String(filters.minAmount));
+      if (filters.maxAmount != null)
+        params.set("max_amount", String(filters.maxAmount));
+      if (filters.pending != null)
+        params.set("pending", String(filters.pending));
+      if (filters.sortBy) params.set("sort_by", filters.sortBy);
+      if (filters.sortOrder) params.set("sort_order", filters.sortOrder);
       return api<TransactionsPage>(`/api/v1/transactions?${params.toString()}`);
     },
     initialPageParam: "",

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -63,6 +63,19 @@ export interface TransactionsPage {
   limit: number;
 }
 
+// --- Accounts (public /api/v1/accounts) ---
+// A trimmed view — the transactions filter only needs identity + labels.
+export interface Account {
+  id: string;
+  short_id: string;
+  name: string;
+  institution_name: string;
+  type: string;
+  subtype: string | null;
+  mask: string | null;
+  iso_currency_code: string | null;
+}
+
 // --- Tags (public /api/v1/tags) ---
 // Mirrors internal/client/tags.go Tag.
 export interface Tag {

--- a/web/src/features/transactions/filter-bar.tsx
+++ b/web/src/features/transactions/filter-bar.tsx
@@ -1,0 +1,367 @@
+import { useState, type ReactNode } from "react";
+import {
+  ArrowUpDown,
+  Banknote,
+  CalendarRange,
+  Check,
+  CircleDot,
+  DollarSign,
+  Shapes,
+  X,
+} from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { DynamicIcon } from "@/lib/icon";
+import { formatLongDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import { useAccounts } from "@/api/queries/accounts";
+import { useCategories, flattenCategories } from "@/api/queries/categories";
+import type { TransactionsSearch } from "@/routes/transactions";
+
+interface FilterBarProps {
+  search: TransactionsSearch;
+  /** Merge a patch into the URL search params. Pass undefined to clear a key. */
+  onChange: (patch: Partial<TransactionsSearch>) => void;
+}
+
+const SORT_OPTIONS: {
+  label: string;
+  sort: TransactionsSearch["sort"];
+  dir: TransactionsSearch["dir"];
+}[] = [
+  { label: "Newest first", sort: "date", dir: "desc" },
+  { label: "Oldest first", sort: "date", dir: "asc" },
+  { label: "Largest amount", sort: "amount", dir: "desc" },
+  { label: "Smallest amount", sort: "amount", dir: "asc" },
+];
+
+// FilterBar is the transactions filter strip: a row of popover-backed filter
+// pills plus a removable chip for every active filter. It's a controlled
+// component — all state lives in the URL, owned by the route.
+export function FilterBar({ search, onChange }: FilterBarProps) {
+  const { data: accounts } = useAccounts();
+  const { data: categoryTree } = useCategories();
+  const categories = flattenCategories(categoryTree);
+
+  const account = accounts?.find((a) => a.short_id === search.account);
+  const category = categories.find((c) => c.slug === search.category);
+  const activeSort =
+    SORT_OPTIONS.find((o) => o.sort === search.sort && o.dir === search.dir) ??
+    SORT_OPTIONS[0];
+
+  const chips: { key: keyof TransactionsSearch; label: string }[] = [];
+  if (account) chips.push({ key: "account", label: account.name });
+  if (category) chips.push({ key: "category", label: category.display_name });
+  if (search.start || search.end) {
+    const from = search.start ? formatLongDate(search.start) : "Any";
+    const to = search.end ? formatLongDate(search.end) : "Any";
+    chips.push({ key: "start", label: `${from} – ${to}` });
+  }
+  if (search.min != null || search.max != null) {
+    const lo = search.min != null ? `$${search.min}` : "Any";
+    const hi = search.max != null ? `$${search.max}` : "Any";
+    chips.push({ key: "min", label: `${lo} – ${hi}` });
+  }
+  if (search.pending) {
+    chips.push({
+      key: "pending",
+      label: search.pending === "true" ? "Pending only" : "Posted only",
+    });
+  }
+
+  const clearChip = (key: keyof TransactionsSearch) => {
+    if (key === "start") onChange({ start: undefined, end: undefined });
+    else if (key === "min") onChange({ min: undefined, max: undefined });
+    else onChange({ [key]: undefined } as Partial<TransactionsSearch>);
+  };
+
+  const clearAll = () =>
+    onChange({
+      account: undefined,
+      category: undefined,
+      start: undefined,
+      end: undefined,
+      min: undefined,
+      max: undefined,
+      pending: undefined,
+    });
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {/* Account */}
+        <FilterPill icon={Banknote} label="Account" active={!!account}>
+          <Command>
+            <CommandInput placeholder="Search accounts…" />
+            <CommandList>
+              <CommandEmpty>No accounts found.</CommandEmpty>
+              <CommandGroup>
+                {(accounts ?? []).map((a) => (
+                  <CommandItem
+                    key={a.short_id}
+                    value={`${a.name} ${a.institution_name}`}
+                    onSelect={() =>
+                      onChange({
+                        account:
+                          search.account === a.short_id
+                            ? undefined
+                            : a.short_id,
+                      })
+                    }
+                  >
+                    <span className="truncate">{a.name}</span>
+                    <span className="text-muted-foreground ml-1 truncate text-xs">
+                      {a.institution_name}
+                    </span>
+                    {search.account === a.short_id && (
+                      <Check className="ml-auto size-4" />
+                    )}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </FilterPill>
+
+        {/* Category */}
+        <FilterPill icon={Shapes} label="Category" active={!!category}>
+          <Command>
+            <CommandInput placeholder="Search categories…" />
+            <CommandList>
+              <CommandEmpty>No categories found.</CommandEmpty>
+              <CommandGroup>
+                {categories.map((c) => (
+                  <CommandItem
+                    key={c.slug}
+                    value={`${c.display_name} ${c.parent_display_name ?? ""}`}
+                    onSelect={() =>
+                      onChange({
+                        category:
+                          search.category === c.slug ? undefined : c.slug,
+                      })
+                    }
+                  >
+                    <DynamicIcon
+                      name={c.icon}
+                      className="size-4"
+                      style={c.color ? { color: c.color } : undefined}
+                    />
+                    <span className={cn(c.parent_id && "text-muted-foreground")}>
+                      {c.parent_display_name
+                        ? `${c.parent_display_name} › ${c.display_name}`
+                        : c.display_name}
+                    </span>
+                    {search.category === c.slug && (
+                      <Check className="ml-auto size-4" />
+                    )}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </FilterPill>
+
+        {/* Date range */}
+        <FilterPill
+          icon={CalendarRange}
+          label="Date"
+          active={!!(search.start || search.end)}
+          className="w-64 p-3"
+        >
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label className="text-xs">From</Label>
+              <Input
+                type="date"
+                value={search.start ?? ""}
+                onChange={(e) =>
+                  onChange({ start: e.target.value || undefined })
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs">To</Label>
+              <Input
+                type="date"
+                value={search.end ?? ""}
+                onChange={(e) => onChange({ end: e.target.value || undefined })}
+              />
+            </div>
+          </div>
+        </FilterPill>
+
+        {/* Amount range */}
+        <FilterPill
+          icon={DollarSign}
+          label="Amount"
+          active={search.min != null || search.max != null}
+          className="w-56 p-3"
+        >
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <Label className="text-xs">Min</Label>
+              <Input
+                type="number"
+                inputMode="decimal"
+                placeholder="0.00"
+                value={search.min ?? ""}
+                onChange={(e) =>
+                  onChange({
+                    min: e.target.value ? Number(e.target.value) : undefined,
+                  })
+                }
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label className="text-xs">Max</Label>
+              <Input
+                type="number"
+                inputMode="decimal"
+                placeholder="0.00"
+                value={search.max ?? ""}
+                onChange={(e) =>
+                  onChange({
+                    max: e.target.value ? Number(e.target.value) : undefined,
+                  })
+                }
+              />
+            </div>
+          </div>
+        </FilterPill>
+
+        {/* Pending */}
+        <FilterPill icon={CircleDot} label="Status" active={!!search.pending}>
+          <Command>
+            <CommandList>
+              <CommandGroup>
+                {(
+                  [
+                    { label: "Any status", value: undefined },
+                    { label: "Pending only", value: "true" as const },
+                    { label: "Posted only", value: "false" as const },
+                  ] satisfies { label: string; value: "true" | "false" | undefined }[]
+                ).map((opt) => (
+                  <CommandItem
+                    key={opt.label}
+                    value={opt.label}
+                    onSelect={() => onChange({ pending: opt.value })}
+                  >
+                    {opt.label}
+                    {search.pending === opt.value && (
+                      <Check className="ml-auto size-4" />
+                    )}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </FilterPill>
+
+        <div className="grow" />
+
+        {/* Sort */}
+        <FilterPill icon={ArrowUpDown} label={activeSort.label} active>
+          <Command>
+            <CommandList>
+              <CommandGroup>
+                {SORT_OPTIONS.map((opt) => (
+                  <CommandItem
+                    key={opt.label}
+                    value={opt.label}
+                    onSelect={() =>
+                      onChange({ sort: opt.sort, dir: opt.dir })
+                    }
+                  >
+                    {opt.label}
+                    {activeSort.label === opt.label && (
+                      <Check className="ml-auto size-4" />
+                    )}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </FilterPill>
+      </div>
+
+      {chips.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {chips.map((chip) => (
+            <Badge key={chip.key} variant="secondary" className="gap-1">
+              {chip.label}
+              <button
+                type="button"
+                onClick={() => clearChip(chip.key)}
+                aria-label={`Clear ${chip.label}`}
+                className="text-muted-foreground hover:text-foreground -mr-0.5"
+              >
+                <X className="size-3" />
+              </button>
+            </Badge>
+          ))}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={clearAll}
+            className="h-6 px-2 text-xs"
+          >
+            Clear all
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface FilterPillProps {
+  icon: typeof Banknote;
+  label: string;
+  active?: boolean;
+  className?: string;
+  children: ReactNode;
+}
+
+function FilterPill({
+  icon: Icon,
+  label,
+  active,
+  className,
+  children,
+}: FilterPillProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn("gap-1.5", active && "border-primary/50 text-primary")}
+        >
+          <Icon className="size-3.5" />
+          {label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className={cn("w-56 p-0", className)}
+      >
+        {children}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import { Receipt, Search } from "lucide-react";
@@ -8,17 +8,51 @@ import { EmptyState } from "@/components/empty-state";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { transactionColumns } from "@/features/transactions/columns";
+import { FilterBar } from "@/features/transactions/filter-bar";
 import { useTransactions } from "@/api/queries/transactions";
+import type { TransactionFilters } from "@/api/queries/transactions";
 import { flattenPages } from "@/lib/pagination";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import type { Transaction } from "@/api/types";
 
-// Merges with the root route's baseSearchSchema (m/ms modal params).
+// Merges with the root route's baseSearchSchema (m/ms modal params). Every
+// filter is a URL search param so the view is bookmarkable and shareable.
 export const transactionsSearchSchema = z.object({
   q: z.string().optional(),
+  account: z.string().optional(),
+  category: z.string().optional(),
+  start: z.string().optional(),
+  end: z.string().optional(),
+  min: z.coerce.number().optional(),
+  max: z.coerce.number().optional(),
+  pending: z.enum(["true", "false"]).optional(),
+  sort: z.enum(["date", "amount"]).optional(),
+  dir: z.enum(["asc", "desc"]).optional(),
 });
 
-type TransactionsSearch = z.infer<typeof transactionsSearchSchema>;
+export type TransactionsSearch = z.infer<typeof transactionsSearchSchema>;
+
+// searchToFilters maps the URL search params onto the query hook's filter
+// shape — the one place the param names and the API param names meet.
+function searchToFilters(search: TransactionsSearch): TransactionFilters {
+  return {
+    search: search.q,
+    account: search.account,
+    category: search.category,
+    start: search.start,
+    end: search.end,
+    minAmount: search.min,
+    maxAmount: search.max,
+    pending:
+      search.pending === "true"
+        ? true
+        : search.pending === "false"
+          ? false
+          : undefined,
+    sortBy: search.sort,
+    sortOrder: search.dir,
+  };
+}
 
 export function TransactionsPage() {
   const navigate = useNavigate();
@@ -46,11 +80,31 @@ export function TransactionsPage() {
     setQuery(search.q ?? "");
   }, [search.q]);
 
-  const transactions = useTransactions({ search: search.q });
+  const setFilter = useCallback(
+    (patch: Partial<TransactionsSearch>) => {
+      navigate({
+        to: ".",
+        search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
+      });
+    },
+    [navigate],
+  );
+
+  const transactions = useTransactions(searchToFilters(search));
   const rows = useMemo(
     () => flattenPages<Transaction>(transactions.data?.pages, "transactions"),
     [transactions.data?.pages],
   );
+
+  const hasActiveFilters =
+    !!search.q ||
+    !!search.account ||
+    !!search.category ||
+    !!search.start ||
+    !!search.end ||
+    search.min != null ||
+    search.max != null ||
+    !!search.pending;
 
   return (
     <div>
@@ -59,7 +113,7 @@ export function TransactionsPage() {
         description="Every transaction synced across your connected accounts."
       />
 
-      <div className="mb-4 flex items-center gap-2">
+      <div className="mb-4 space-y-3">
         <div className="relative w-full max-w-xs">
           <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
           <Input
@@ -69,6 +123,7 @@ export function TransactionsPage() {
             className="pl-8"
           />
         </div>
+        <FilterBar search={search} onChange={setFilter} />
       </div>
 
       <DataTable
@@ -82,10 +137,14 @@ export function TransactionsPage() {
         emptyState={
           <EmptyState
             icon={Receipt}
-            title={search.q ? "No matching transactions" : "No transactions yet"}
+            title={
+              hasActiveFilters
+                ? "No matching transactions"
+                : "No transactions yet"
+            }
             description={
-              search.q
-                ? "Try a different search term."
+              hasActiveFilters
+                ? "Try adjusting or clearing your filters."
                 : "Transactions appear here once an account finishes syncing."
             }
           />


### PR DESCRIPTION
Adds a filter strip above the transactions table — account, category, date, amount, status, sort.

## Summary

Every filter is a URL search param, so the view is bookmarkable and shareable.

- **features/transactions/filter-bar.tsx** — popover-backed filter pills + a removable chip for each active filter and a "clear all". Account and category pills are searchable command lists; date/amount are paired inputs.
- `transactionsSearchSchema` gains `account` / `category` / `start` / `end` / `min` / `max` / `pending` / `sort` / `dir`; `searchToFilters` maps them onto the query hook in one place.
- `useTransactions` accepts the full filter set and maps each 1:1 to a documented `/api/v1/transactions` query param; the cache key is normalised.
- New `useAccounts` query + `Account` type (bare-array endpoint) for the account filter.

## Test plan

- [x] `tsc -b && vite build` passes; `go build ./...` passes (no Go changes).
- [x] Browser: filter pills open, selecting a category filters the table and shows a removable chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
