### PR TITLE
v2: transactions select mode + bulk actions

### DIFF
--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -4,6 +4,7 @@ import {
   useReactTable,
   type ColumnDef,
   type OnChangeFn,
+  type RowSelectionState,
   type SortingState,
 } from "@tanstack/react-table";
 import {
@@ -36,6 +37,17 @@ export interface DataTableProps<TData, TValue> {
   onSortingChange?: OnChangeFn<SortingState>;
   /** Optional row click handler — e.g. navigate to a detail page. */
   onRowClick?: (row: TData) => void;
+  /**
+   * Controlled row selection. Like sorting, the state lives in the calling
+   * route; DataTable just renders it. `getRowId` should return a stable id
+   * (not the array index) so a selection survives pagination/refetch.
+   */
+  enableRowSelection?: boolean;
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: OnChangeFn<RowSelectionState>;
+  getRowId?: (row: TData) => string;
+  /** Passed through to the table instance — e.g. shift-range-select hooks. */
+  meta?: object;
 }
 
 // Shared table wrapper over @tanstack/react-table + the shadcn Table
@@ -53,14 +65,26 @@ export function DataTable<TData, TValue>({
   sorting,
   onSortingChange,
   onRowClick,
+  enableRowSelection,
+  rowSelection,
+  onRowSelectionChange,
+  getRowId,
+  meta,
 }: DataTableProps<TData, TValue>) {
   const table = useReactTable({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
     manualSorting: true,
-    state: sorting ? { sorting } : undefined,
+    state: {
+      ...(sorting ? { sorting } : {}),
+      ...(rowSelection ? { rowSelection } : {}),
+    },
     onSortingChange,
+    enableRowSelection,
+    onRowSelectionChange,
+    getRowId,
+    meta,
   });
 
   const colCount = columns.length;
@@ -119,6 +143,7 @@ export function DataTable<TData, TValue>({
             table.getRowModel().rows.map((row) => (
               <TableRow
                 key={row.id}
+                data-state={row.getIsSelected() ? "selected" : undefined}
                 onClick={onRowClick ? () => onRowClick(row.original) : undefined}
                 className={cn(onRowClick && "cursor-pointer")}
               >

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import { CheckIcon } from "lucide-react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CheckIcon className="size-3.5" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -1,5 +1,6 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { CategoryBadge } from "@/components/category-badge";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { TagList } from "@/components/tag-chip";
@@ -7,11 +8,49 @@ import { formatAmount, formatDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { Transaction } from "@/api/types";
 
-// transactionColumns is the single column definition for the v2 transactions
-// table — kept out of the route so the row rendering is reusable and the
-// route file stays focused on data + URL state. Sorting, selection, and other
-// per-context columns are layered on by later PRs in this stack.
-export const transactionColumns: ColumnDef<Transaction>[] = [
+// TransactionTableMeta is the shape passed through DataTable's `meta` prop so
+// the selection column can do shift-click range select without the column
+// definitions owning any state.
+export interface TransactionTableMeta {
+  onRangeSelect?: (toIndex: number) => void;
+  setLastIndex?: (index: number) => void;
+}
+
+const selectionColumn: ColumnDef<Transaction> = {
+  id: "select",
+  header: ({ table }) => (
+    <Checkbox
+      checked={
+        table.getIsAllPageRowsSelected() ||
+        (table.getIsSomePageRowsSelected() && "indeterminate")
+      }
+      onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+      aria-label="Select all"
+    />
+  ),
+  cell: ({ row, table }) => {
+    const meta = table.options.meta as TransactionTableMeta | undefined;
+    return (
+      <Checkbox
+        checked={row.getIsSelected()}
+        // Shift-click extends the selection from the last-toggled row. The
+        // normal onCheckedChange still fires and lands the current row in the
+        // same (selected) state the range sets, so no preventDefault needed.
+        onClick={(e) => {
+          if (e.shiftKey) meta?.onRangeSelect?.(row.index);
+        }}
+        onCheckedChange={(value) => {
+          row.toggleSelected(!!value);
+          meta?.setLastIndex?.(row.index);
+        }}
+        aria-label="Select row"
+      />
+    );
+  },
+  enableSorting: false,
+};
+
+const baseColumns: ColumnDef<Transaction>[] = [
   {
     accessorKey: "date",
     header: "Date",
@@ -102,3 +141,12 @@ export const transactionColumns: ColumnDef<Transaction>[] = [
     },
   },
 ];
+
+// buildTransactionColumns is the single column definition for the v2
+// transactions table. Kept out of the route so row rendering is reusable; the
+// `selection` option prepends a checkbox column for select mode.
+export function buildTransactionColumns(opts?: {
+  selection?: boolean;
+}): ColumnDef<Transaction>[] {
+  return opts?.selection ? [selectionColumn, ...baseColumns] : baseColumns;
+}

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import { Shapes, Tag, X } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { DynamicIcon } from "@/lib/icon";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { useCategories, flattenCategories } from "@/api/queries/categories";
+import { useTags } from "@/api/queries/tags";
+import { useUpdateTransactions } from "@/api/queries/transactions";
+import type { UpdateTransactionsOp } from "@/api/types";
+
+// The batch endpoint caps each call at 50 operations; larger selections are
+// split into sequential chunks.
+const BATCH_LIMIT = 50;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+interface SelectionActionBarProps {
+  selectedIds: string[];
+  onClear: () => void;
+}
+
+// SelectionActionBar is the floating bar that appears in select mode once at
+// least one row is selected — a count, bulk categorize / tag actions, and a
+// clear button. Each action fans the selection out into batch-update ops,
+// chunked to the endpoint's 50-op limit.
+export function SelectionActionBar({
+  selectedIds,
+  onClear,
+}: SelectionActionBarProps) {
+  const update = useUpdateTransactions();
+
+  const applyToAll = async (
+    op: Omit<UpdateTransactionsOp, "transaction_id">,
+    successMessage: string,
+  ) => {
+    const ok = await withMutationToast(
+      () =>
+        Promise.all(
+          chunk(selectedIds, BATCH_LIMIT).map((ids) =>
+            update.mutateAsync({
+              operations: ids.map((id) => ({ transaction_id: id, ...op })),
+            }),
+          ),
+        ),
+      { success: successMessage },
+    );
+    if (ok) onClear();
+  };
+
+  return (
+    <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
+      <div className="bg-popover text-popover-foreground flex items-center gap-1 rounded-full border p-1 pl-3 shadow-lg">
+        <span className="text-sm font-medium">
+          {selectedIds.length} selected
+        </span>
+        <Separator orientation="vertical" className="mx-1 h-5" />
+
+        <CategorizeAction
+          disabled={update.isPending}
+          onPick={(slug) =>
+            applyToAll({ category_slug: slug }, "Category applied.")
+          }
+        />
+        <TagAction
+          disabled={update.isPending}
+          onPick={(slug) =>
+            applyToAll({ tags_to_add: [{ slug }] }, "Tag applied.")
+          }
+        />
+
+        <Separator orientation="vertical" className="mx-1 h-5" />
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8 rounded-full"
+          onClick={onClear}
+          aria-label="Clear selection"
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CategorizeAction({
+  disabled,
+  onPick,
+}: {
+  disabled: boolean;
+  onPick: (slug: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const { data: tree } = useCategories();
+  const categories = flattenCategories(tree);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 gap-1.5 rounded-full"
+          disabled={disabled}
+        >
+          <Shapes className="size-4" />
+          Categorize
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-0" align="center" side="top">
+        <Command>
+          <CommandInput placeholder="Search categories…" />
+          <CommandList>
+            <CommandEmpty>No categories found.</CommandEmpty>
+            <CommandGroup>
+              {categories.map((c) => (
+                <CommandItem
+                  key={c.slug}
+                  value={`${c.display_name} ${c.parent_display_name ?? ""}`}
+                  onSelect={() => {
+                    setOpen(false);
+                    onPick(c.slug);
+                  }}
+                >
+                  <DynamicIcon
+                    name={c.icon}
+                    className="size-4"
+                    style={c.color ? { color: c.color } : undefined}
+                  />
+                  <span>
+                    {c.parent_display_name
+                      ? `${c.parent_display_name} › ${c.display_name}`
+                      : c.display_name}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function TagAction({
+  disabled,
+  onPick,
+}: {
+  disabled: boolean;
+  onPick: (slug: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const { data: tags } = useTags();
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-8 gap-1.5 rounded-full"
+          disabled={disabled}
+        >
+          <Tag className="size-4" />
+          Tag
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 p-0" align="center" side="top">
+        <Command>
+          <CommandInput placeholder="Search tags…" />
+          <CommandList>
+            <CommandEmpty>No tags found.</CommandEmpty>
+            <CommandGroup>
+              {(tags ?? []).map((tag) => (
+                <CommandItem
+                  key={tag.slug}
+                  value={tag.display_name}
+                  onSelect={() => {
+                    setOpen(false);
+                    onPick(tag.slug);
+                  }}
+                >
+                  <DynamicIcon
+                    name={tag.icon}
+                    className="size-4"
+                    style={tag.color ? { color: tag.color } : undefined}
+                  />
+                  <span>{tag.display_name}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -1,14 +1,25 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
-import { Receipt, Search } from "lucide-react";
+import type { RowSelectionState } from "@tanstack/react-table";
+import { CheckSquare, Receipt, Search, X } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { DataTable } from "@/components/data-table";
 import { EmptyState } from "@/components/empty-state";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { transactionColumns } from "@/features/transactions/columns";
+import {
+  buildTransactionColumns,
+  type TransactionTableMeta,
+} from "@/features/transactions/columns";
 import { FilterBar } from "@/features/transactions/filter-bar";
+import { SelectionActionBar } from "@/features/transactions/selection-action-bar";
 import { useTransactions } from "@/api/queries/transactions";
 import type { TransactionFilters } from "@/api/queries/transactions";
 import { flattenPages } from "@/lib/pagination";
@@ -96,6 +107,52 @@ export function TransactionsPage() {
     [transactions.data?.pages],
   );
 
+  // --- Select mode ---
+  const [selectMode, setSelectMode] = useState(false);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const lastIndexRef = useRef<number | null>(null);
+
+  const columns = useMemo(
+    () => buildTransactionColumns({ selection: selectMode }),
+    [selectMode],
+  );
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setRowSelection({});
+    lastIndexRef.current = null;
+  }, []);
+
+  // getRowId returns the transaction id, so rowSelection keys ARE ids.
+  const selectedIds = useMemo(
+    () => Object.keys(rowSelection).filter((id) => rowSelection[id]),
+    [rowSelection],
+  );
+
+  // Shift-click range select: every row between the last-toggled row and the
+  // shift-clicked one becomes selected.
+  const tableMeta: TransactionTableMeta = useMemo(
+    () => ({
+      setLastIndex: (index) => {
+        lastIndexRef.current = index;
+      },
+      onRangeSelect: (toIndex) => {
+        const from = lastIndexRef.current;
+        if (from == null) return;
+        const [lo, hi] = from < toIndex ? [from, toIndex] : [toIndex, from];
+        setRowSelection((prev) => {
+          const next = { ...prev };
+          for (let i = lo; i <= hi; i++) {
+            const id = rows[i]?.id;
+            if (id) next[id] = true;
+          }
+          return next;
+        });
+      },
+    }),
+    [rows],
+  );
+
   const hasActiveFilters =
     !!search.q ||
     !!search.account ||
@@ -111,6 +168,23 @@ export function TransactionsPage() {
       <PageHeader
         title="Transactions"
         description="Every transaction synced across your connected accounts."
+        actions={
+          selectMode ? (
+            <Button variant="secondary" size="sm" onClick={exitSelectMode}>
+              <X className="size-4" />
+              Done
+            </Button>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSelectMode(true)}
+            >
+              <CheckSquare className="size-4" />
+              Select
+            </Button>
+          )
+        }
       />
 
       <div className="mb-4 space-y-3">
@@ -127,12 +201,23 @@ export function TransactionsPage() {
       </div>
 
       <DataTable
-        columns={transactionColumns}
+        columns={columns}
         data={rows}
         isLoading={transactions.isLoading}
         isError={transactions.isError}
-        onRowClick={(t) =>
-          navigate({ to: "/transactions/$id", params: { id: t.short_id } })
+        getRowId={(t) => t.id}
+        enableRowSelection={selectMode}
+        rowSelection={selectMode ? rowSelection : undefined}
+        onRowSelectionChange={setRowSelection}
+        meta={tableMeta}
+        onRowClick={
+          selectMode
+            ? undefined
+            : (t) =>
+                navigate({
+                  to: "/transactions/$id",
+                  params: { id: t.short_id },
+                })
         }
         emptyState={
           <EmptyState
@@ -161,6 +246,13 @@ export function TransactionsPage() {
             {transactions.isFetchingNextPage ? "Loading…" : "Load more"}
           </Button>
         </div>
+      )}
+
+      {selectMode && selectedIds.length > 0 && (
+        <SelectionActionBar
+          selectedIds={selectedIds}
+          onClear={exitSelectMode}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Adds a Select-mode toggle with bulk categorize / tag — conceptually modelled on the v1 admin UI's bulk-selection flow.

## Summary

- **DataTable** gains controlled row-selection support (`rowSelection` / `onRowSelectionChange` / `getRowId` / `enableRowSelection`) plus a `meta` passthrough — selection state lives in the route, like sorting.
- **buildTransactionColumns** is now a factory; with `selection` it prepends a checkbox column. The header checkbox is select-all-on-page with an indeterminate state; row checkboxes support shift-click range select via the table `meta` hook (no per-column state).
- **SelectionActionBar** — the floating bar that appears once a row is selected: count + bulk Categorize / Tag, each fanning the selection into batch-update ops chunked to the endpoint's 50-op limit, then clearing on success.
- The transactions route owns `selectMode` + `rowSelection`; row click navigates to detail only when not in select mode.

## Test plan

- [x] `tsc -b && vite build` passes; `go build ./...` passes (no Go changes).
- [x] Browser: Select toggles checkboxes; the floating bar shows the count; bulk Categorize applies to all selected rows and clears the selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
