### PR TITLE
v2: keyboard shortcuts for the transactions list

### DIFF
--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import {
   flexRender,
   getCoreRowModel,
@@ -48,6 +49,11 @@ export interface DataTableProps<TData, TValue> {
   getRowId?: (row: TData) => string;
   /** Passed through to the table instance — e.g. shift-range-select hooks. */
   meta?: object;
+  /**
+   * Row id (matching getRowId) to render with a keyboard-focus ring and keep
+   * scrolled into view — drives j/k list navigation.
+   */
+  focusedRowId?: string;
 }
 
 // Shared table wrapper over @tanstack/react-table + the shadcn Table
@@ -70,7 +76,13 @@ export function DataTable<TData, TValue>({
   onRowSelectionChange,
   getRowId,
   meta,
+  focusedRowId,
 }: DataTableProps<TData, TValue>) {
+  const focusedRowRef = useRef<HTMLTableRowElement>(null);
+  useEffect(() => {
+    focusedRowRef.current?.scrollIntoView({ block: "nearest" });
+  }, [focusedRowId]);
+
   const table = useReactTable({
     data,
     columns,
@@ -140,12 +152,18 @@ export function DataTable<TData, TValue>({
               </TableCell>
             </TableRow>
           ) : (
-            table.getRowModel().rows.map((row) => (
+            table.getRowModel().rows.map((row) => {
+              const focused = row.id === focusedRowId;
+              return (
               <TableRow
                 key={row.id}
+                ref={focused ? focusedRowRef : undefined}
                 data-state={row.getIsSelected() ? "selected" : undefined}
                 onClick={onRowClick ? () => onRowClick(row.original) : undefined}
-                className={cn(onRowClick && "cursor-pointer")}
+                className={cn(
+                  onRowClick && "cursor-pointer",
+                  focused && "ring-primary ring-1 ring-inset",
+                )}
               >
                 {row.getVisibleCells().map((cell) => (
                   <TableCell key={cell.id}>
@@ -153,7 +171,8 @@ export function DataTable<TData, TValue>({
                   </TableCell>
                 ))}
               </TableRow>
-            ))
+              );
+            })
           )}
         </TableBody>
       </Table>

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -24,6 +24,7 @@ import { useTransactions } from "@/api/queries/transactions";
 import type { TransactionFilters } from "@/api/queries/transactions";
 import { flattenPages } from "@/lib/pagination";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useShortcut } from "@/lib/shortcuts";
 import type { Transaction } from "@/api/types";
 
 // Merges with the root route's baseSearchSchema (m/ms modal params). Every
@@ -76,6 +77,7 @@ export function TransactionsPage() {
   // fight the reverse sync below.
   const [query, setQuery] = useState(search.q ?? "");
   const debounced = useDebouncedValue(query, 300);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const q = debounced.trim() || undefined;
@@ -111,6 +113,8 @@ export function TransactionsPage() {
   const [selectMode, setSelectMode] = useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const lastIndexRef = useRef<number | null>(null);
+  // Keyboard-navigated row focus (j/k). Index into `rows`; null = no focus.
+  const [focusedIndex, setFocusedIndex] = useState<number | null>(null);
 
   const columns = useMemo(
     () => buildTransactionColumns({ selection: selectMode }),
@@ -153,6 +157,68 @@ export function TransactionsPage() {
     [rows],
   );
 
+  const focusedRowId =
+    focusedIndex != null ? rows[focusedIndex]?.id : undefined;
+
+  const openTransaction = useCallback(
+    (t: Transaction) =>
+      navigate({ to: "/transactions/$id", params: { id: t.short_id } }),
+    [navigate],
+  );
+
+  // --- Keyboard shortcuts (registered while this page is mounted) ---
+  useShortcut(
+    ["/"],
+    (e) => {
+      e.preventDefault();
+      searchInputRef.current?.focus();
+    },
+    { label: "Focus search", group: "Transactions" },
+  );
+  useShortcut(
+    ["j"],
+    () =>
+      setFocusedIndex((i) =>
+        i == null ? 0 : Math.min(i + 1, rows.length - 1),
+      ),
+    { label: "Move focus down", group: "Transactions" },
+  );
+  useShortcut(
+    ["k"],
+    () => setFocusedIndex((i) => (i == null ? 0 : Math.max(i - 1, 0))),
+    { label: "Move focus up", group: "Transactions" },
+  );
+  useShortcut(
+    ["enter"],
+    () => {
+      if (focusedIndex == null) return;
+      const t = rows[focusedIndex];
+      if (t) openTransaction(t);
+    },
+    { label: "Open focused transaction", group: "Transactions" },
+  );
+  useShortcut(
+    ["x"],
+    () => {
+      if (focusedIndex == null) return;
+      const id = rows[focusedIndex]?.id;
+      if (!id) return;
+      setSelectMode(true);
+      setRowSelection((prev) => ({ ...prev, [id]: !prev[id] }));
+      lastIndexRef.current = focusedIndex;
+    },
+    { label: "Select focused transaction", group: "Transactions" },
+  );
+  useShortcut(
+    ["escape"],
+    () => {
+      if (selectedIds.length > 0) setRowSelection({});
+      else if (selectMode) exitSelectMode();
+      else setFocusedIndex(null);
+    },
+    { label: "Clear selection / focus", group: "Transactions" },
+  );
+
   const hasActiveFilters =
     !!search.q ||
     !!search.account ||
@@ -191,6 +257,7 @@ export function TransactionsPage() {
         <div className="relative w-full max-w-xs">
           <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
           <Input
+            ref={searchInputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search merchant or description…"
@@ -210,15 +277,8 @@ export function TransactionsPage() {
         rowSelection={selectMode ? rowSelection : undefined}
         onRowSelectionChange={setRowSelection}
         meta={tableMeta}
-        onRowClick={
-          selectMode
-            ? undefined
-            : (t) =>
-                navigate({
-                  to: "/transactions/$id",
-                  params: { id: t.short_id },
-                })
-        }
+        focusedRowId={focusedRowId}
+        onRowClick={selectMode ? undefined : openTransaction}
         emptyState={
           <EmptyState
             icon={Receipt}


### PR DESCRIPTION
Top of the stack — keyboard navigation for the transactions list.

## Summary

`j` / `k` move a focus ring through the rows, `Enter` opens the focused transaction, `x` selects it (entering select mode), `/` focuses search, and `Esc` unwinds selection → select mode → focus. All register in the shared shortcut registry, so they show up in the ⌘-backed shortcut sheet.

- **DataTable** gains a `focusedRowId` prop: that row renders a focus ring and is kept scrolled into view.
- The transactions route owns `focusedIndex` and wires the six shortcuts via `useShortcut`; the registry auto-unregisters them when the page unmounts, so they're scoped to the transactions view.

## Test plan

- [x] `tsc -b && vite build` passes; `go build ./...` passes (no Go changes).
- [x] Browser: `j`/`k` move the focus ring, `Enter` opens the focused transaction's detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
