### PR TITLE
v2: redesign the transaction row + reusable row primitives

### DIFF
--- a/web/src/components/category-badge.tsx
+++ b/web/src/components/category-badge.tsx
@@ -12,7 +12,8 @@ interface CategoryBadgeProps {
 
 // CategoryBadge is the single rendering of a transaction category across v2 —
 // list rows, the detail page, pickers. Icon + display name, tinted by the
-// category's own color. Renders an em-dash when there's no category.
+// category's own color. Rounded-rectangle shaped — the pill shape is reserved
+// for tags. Renders an em-dash when there's no category.
 export function CategoryBadge({
   category,
   overridden,
@@ -27,7 +28,7 @@ export function CategoryBadge({
     <Badge
       variant="secondary"
       className={cn(
-        "gap-1",
+        "gap-1 rounded-md",
         overridden && "ring-1 ring-primary/40",
         className,
       )}

--- a/web/src/components/category-command.tsx
+++ b/web/src/components/category-command.tsx
@@ -1,0 +1,107 @@
+import { useCallback } from "react";
+import { Check, RotateCcw } from "lucide-react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { DynamicIcon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { useCategories, flattenCategories } from "@/api/queries/categories";
+import { useUpdateTransactions } from "@/api/queries/transactions";
+
+// A single category change — set a slug, or reset to the provider default.
+export interface CategoryPick {
+  category_slug?: string;
+  reset_category?: boolean;
+}
+
+interface CategoryCommandListProps {
+  /** Slug of the currently-applied category — rendered with a check mark. */
+  currentSlug?: string | null;
+  /** Show a "reset to provider default" entry — for manually-overridden rows. */
+  showReset?: boolean;
+  onPick: (pick: CategoryPick) => void;
+}
+
+// CategoryCommandList is the shared searchable category list behind every
+// category-mutation surface — the detail-page editor and the inline row
+// picker. Pure presentation: the caller owns the mutation.
+export function CategoryCommandList({
+  currentSlug,
+  showReset,
+  onPick,
+}: CategoryCommandListProps) {
+  const { data: tree, isLoading } = useCategories();
+  const categories = flattenCategories(tree);
+
+  return (
+    <Command>
+      <CommandInput placeholder="Search categories…" />
+      <CommandList>
+        <CommandEmpty>
+          {isLoading ? "Loading…" : "No categories found."}
+        </CommandEmpty>
+        {showReset && (
+          <>
+            <CommandGroup>
+              <CommandItem
+                value="reset provider default"
+                onSelect={() => onPick({ reset_category: true })}
+              >
+                <RotateCcw className="size-4" />
+                Reset to provider default
+              </CommandItem>
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        )}
+        <CommandGroup>
+          {categories.map((c) => (
+            <CommandItem
+              key={c.slug}
+              value={`${c.display_name} ${c.parent_display_name ?? ""}`}
+              onSelect={() => onPick({ category_slug: c.slug })}
+            >
+              <DynamicIcon
+                name={c.icon}
+                className="size-4"
+                style={c.color ? { color: c.color } : undefined}
+              />
+              <span className={cn(c.parent_id && "text-muted-foreground")}>
+                {c.parent_display_name
+                  ? `${c.parent_display_name} › ${c.display_name}`
+                  : c.display_name}
+              </span>
+              {currentSlug === c.slug && <Check className="ml-auto size-4" />}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}
+
+// useCategoryEditor wraps the batch mutation for the common
+// single-transaction category change, shared by the detail-page editor and
+// the inline row picker so the toast + op-shaping live in one place.
+export function useCategoryEditor(transactionId: string) {
+  const update = useUpdateTransactions();
+  const apply = useCallback(
+    (pick: CategoryPick) =>
+      withMutationToast(
+        () =>
+          update.mutateAsync({
+            operations: [{ transaction_id: transactionId, ...pick }],
+          }),
+        { success: "Category updated." },
+      ),
+    [update, transactionId],
+  );
+  return { apply, isPending: update.isPending };
+}

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { CategoryBadge } from "@/components/category-badge";
+import {
+  CategoryCommandList,
+  useCategoryEditor,
+  type CategoryPick,
+} from "@/components/category-command";
+import { cn } from "@/lib/utils";
+import type { TransactionCategory } from "@/api/types";
+
+interface CategoryPickerProps {
+  transactionId: string;
+  category: TransactionCategory | null | undefined;
+  /** True when the current category was set by a manual override. */
+  overridden?: boolean;
+  className?: string;
+}
+
+// CategoryPicker is the compact, inline category picker used in transaction
+// rows — a rounded-rect trigger showing the current category (or an "add"
+// affordance when uncategorized) over a searchable popover. stopPropagation
+// keeps a click from also firing the row's navigate handler.
+export function CategoryPicker({
+  transactionId,
+  category,
+  overridden,
+  className,
+}: CategoryPickerProps) {
+  const [open, setOpen] = useState(false);
+  const { apply, isPending } = useCategoryEditor(transactionId);
+
+  const onPick = async (pick: CategoryPick) => {
+    setOpen(false);
+    await apply(pick);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={isPending}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "hover:bg-accent focus-visible:ring-ring rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:opacity-50",
+            className,
+          )}
+        >
+          {category?.display_name ? (
+            <CategoryBadge category={category} overridden={overridden} />
+          ) : (
+            <span className="text-muted-foreground border-border hover:text-foreground inline-flex items-center gap-1 rounded-md border border-dashed px-2 py-0.5 text-xs">
+              <Plus className="size-3" />
+              Category
+            </span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-64 p-0"
+        align="start"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CategoryCommandList
+          currentSlug={category?.slug}
+          showReset={overridden}
+          onPick={onPick}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -5,6 +5,7 @@ import {
   useReactTable,
   type ColumnDef,
   type OnChangeFn,
+  type RowData,
   type RowSelectionState,
   type SortingState,
 } from "@tanstack/react-table";
@@ -18,6 +19,15 @@ import {
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+
+// Per-column className, applied to both the header cell and every body cell.
+// Lets a column opt into width behaviour (e.g. `w-px` to shrink to content).
+declare module "@tanstack/react-table" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    className?: string;
+  }
+}
 
 export interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -108,7 +118,10 @@ export function DataTable<TData, TValue>({
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <TableHead key={header.id}>
+                <TableHead
+                  key={header.id}
+                  className={header.column.columnDef.meta?.className}
+                >
                   {header.isPlaceholder
                     ? null
                     : flexRender(
@@ -166,7 +179,10 @@ export function DataTable<TData, TValue>({
                 )}
               >
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
+                  <TableCell
+                    key={cell.id}
+                    className={cell.column.columnDef.meta?.className}
+                  >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}

--- a/web/src/components/transaction-amount.tsx
+++ b/web/src/components/transaction-amount.tsx
@@ -1,0 +1,33 @@
+import { formatAmount, formatDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { Transaction } from "@/api/types";
+
+interface TransactionAmountProps {
+  transaction: Transaction;
+  className?: string;
+}
+
+// TransactionAmount is the reusable right-aligned amount block — the signed
+// amount with the transaction date beneath it. Inflows (negative amounts)
+// render in the success color.
+export function TransactionAmount({
+  transaction: t,
+  className,
+}: TransactionAmountProps) {
+  const isInflow = t.amount < 0;
+  return (
+    <div className={cn("text-right whitespace-nowrap", className)}>
+      <div
+        className={cn(
+          "font-medium tabular-nums",
+          isInflow && "text-success",
+        )}
+      >
+        {formatAmount(t.amount, t.iso_currency_code)}
+      </div>
+      <div className="text-muted-foreground text-xs tabular-nums">
+        {formatDate(t.date)}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -1,0 +1,57 @@
+import { CategoryIconTile } from "@/components/category-icon-tile";
+import { TagList } from "@/components/tag-chip";
+import { cn } from "@/lib/utils";
+import type { Transaction } from "@/api/types";
+
+interface TransactionPrimaryProps {
+  transaction: Transaction;
+  className?: string;
+}
+
+// TransactionPrimary is the reusable identity block for a transaction — the
+// category icon tile, the bank description as the title with an inline
+// "Pending" marker, and a secondary line of metadata (account · member · tags).
+// Shared by the transactions table and any future transaction list.
+export function TransactionPrimary({
+  transaction: t,
+  className,
+}: TransactionPrimaryProps) {
+  return (
+    <div className={cn("flex items-center gap-3", className)}>
+      <CategoryIconTile
+        icon={t.category?.icon}
+        color={t.category?.color}
+        size="sm"
+      />
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate font-medium">{t.provider_name}</span>
+          {t.pending && (
+            <span className="text-muted-foreground shrink-0 text-xs">
+              Pending
+            </span>
+          )}
+        </div>
+        <TransactionMeta transaction={t} />
+      </div>
+    </div>
+  );
+}
+
+// The secondary metadata line: account and household member as plain text,
+// then tag chips. Renders nothing when there's no metadata to show.
+function TransactionMeta({ transaction: t }: { transaction: Transaction }) {
+  const text: string[] = [];
+  if (t.account_name) text.push(t.account_name);
+  if (t.user_name) text.push(t.user_name);
+  const hasTags = !!t.tags?.length;
+  if (!text.length && !hasTags) return null;
+
+  return (
+    <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
+      {text.length > 0 && <span className="truncate">{text.join(" · ")}</span>}
+      {text.length > 0 && hasTags && <span aria-hidden>·</span>}
+      {hasTags && <TagList slugs={t.tags} max={2} />}
+    </div>
+  );
+}

--- a/web/src/features/transactions/category-editor.tsx
+++ b/web/src/features/transactions/category-editor.tsx
@@ -1,29 +1,17 @@
 import { useState } from "react";
-import { Check, ChevronsUpDown, RotateCcw } from "lucide-react";
+import { ChevronsUpDown } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
 import { CategoryBadge } from "@/components/category-badge";
-import { DynamicIcon } from "@/lib/icon";
-import { cn } from "@/lib/utils";
-import { withMutationToast } from "@/lib/mutation-toast";
 import {
-  useCategories,
-  flattenCategories,
-} from "@/api/queries/categories";
-import { useUpdateTransactions } from "@/api/queries/transactions";
+  CategoryCommandList,
+  useCategoryEditor,
+  type CategoryPick,
+} from "@/components/category-command";
 import type { TransactionCategory } from "@/api/types";
 
 interface CategoryEditorProps {
@@ -34,29 +22,19 @@ interface CategoryEditorProps {
 }
 
 // CategoryEditor is the single-transaction category picker on the detail
-// page. The trigger shows the current category; the popover is a searchable,
-// flattened category list. A reset entry appears only when the category was
-// manually overridden — that's the sole case where "provider default" differs
-// from what's shown.
+// page — a full-width combobox trigger over the shared category command
+// list. The inline row equivalent is CategoryPicker.
 export function CategoryEditor({
   transactionId,
   category,
   overridden,
 }: CategoryEditorProps) {
   const [open, setOpen] = useState(false);
-  const { data: tree, isLoading } = useCategories();
-  const update = useUpdateTransactions();
-  const categories = flattenCategories(tree);
+  const { apply, isPending } = useCategoryEditor(transactionId);
 
-  const apply = async (op: { category_slug?: string; reset_category?: boolean }) => {
+  const onPick = async (pick: CategoryPick) => {
     setOpen(false);
-    await withMutationToast(
-      () =>
-        update.mutateAsync({
-          operations: [{ transaction_id: transactionId, ...op }],
-        }),
-      { success: "Category updated." },
-    );
+    await apply(pick);
   };
 
   return (
@@ -66,59 +44,22 @@ export function CategoryEditor({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          disabled={update.isPending}
+          disabled={isPending}
           className="w-full justify-between"
         >
           <CategoryBadge category={category} overridden={overridden} />
           <ChevronsUpDown className="text-muted-foreground size-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
-        <Command>
-          <CommandInput placeholder="Search categories…" />
-          <CommandList>
-            <CommandEmpty>
-              {isLoading ? "Loading…" : "No categories found."}
-            </CommandEmpty>
-            {overridden && (
-              <>
-                <CommandGroup>
-                  <CommandItem
-                    value="reset provider default"
-                    onSelect={() => apply({ reset_category: true })}
-                  >
-                    <RotateCcw className="size-4" />
-                    Reset to provider default
-                  </CommandItem>
-                </CommandGroup>
-                <CommandSeparator />
-              </>
-            )}
-            <CommandGroup>
-              {categories.map((c) => (
-                <CommandItem
-                  key={c.slug}
-                  value={`${c.display_name} ${c.parent_display_name ?? ""}`}
-                  onSelect={() => apply({ category_slug: c.slug })}
-                >
-                  <DynamicIcon
-                    name={c.icon}
-                    className="size-4"
-                    style={c.color ? { color: c.color } : undefined}
-                  />
-                  <span className={cn(c.parent_id && "text-muted-foreground")}>
-                    {c.parent_display_name
-                      ? `${c.parent_display_name} › ${c.display_name}`
-                      : c.display_name}
-                  </span>
-                  {category?.slug === c.slug && (
-                    <Check className="ml-auto size-4" />
-                  )}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <CategoryCommandList
+          currentSlug={category?.slug}
+          showReset={overridden}
+          onPick={onPick}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -1,11 +1,8 @@
 import type { ColumnDef } from "@tanstack/react-table";
-import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
-import { CategoryBadge } from "@/components/category-badge";
-import { CategoryIconTile } from "@/components/category-icon-tile";
-import { TagList } from "@/components/tag-chip";
-import { formatAmount, formatDate } from "@/lib/format";
-import { cn } from "@/lib/utils";
+import { CategoryPicker } from "@/components/category-picker";
+import { TransactionPrimary } from "@/components/transaction-primary";
+import { TransactionAmount } from "@/components/transaction-amount";
 import type { Transaction } from "@/api/types";
 
 // TransactionTableMeta is the shape passed through DataTable's `meta` prop so
@@ -18,6 +15,7 @@ export interface TransactionTableMeta {
 
 const selectionColumn: ColumnDef<Transaction> = {
   id: "select",
+  meta: { className: "w-px" },
   header: ({ table }) => (
     <Checkbox
       checked={
@@ -50,95 +48,32 @@ const selectionColumn: ColumnDef<Transaction> = {
   enableSorting: false,
 };
 
+// Description is the greedy column (no width class); category and amount
+// shrink to their content via `w-px` so the description gets the slack and
+// its title can truncate.
 const baseColumns: ColumnDef<Transaction>[] = [
-  {
-    accessorKey: "date",
-    header: "Date",
-    cell: ({ row }) => (
-      <span className="text-muted-foreground tabular-nums whitespace-nowrap">
-        {formatDate(row.original.date)}
-      </span>
-    ),
-  },
   {
     id: "description",
     header: "Description",
-    cell: ({ row }) => {
-      const t = row.original;
-      // provider_name is the raw bank description (the primary label, per the
-      // #1072 decision). provider_merchant_name is the cleaned merchant — show
-      // it as a subtitle only when it adds information.
-      const subtitle =
-        t.provider_merchant_name &&
-        t.provider_merchant_name !== t.provider_name
-          ? t.provider_merchant_name
-          : null;
-      return (
-        <div className="flex items-center gap-3">
-          <CategoryIconTile
-            icon={t.category?.icon}
-            color={t.category?.color}
-            size="sm"
-          />
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <span className="truncate font-medium">{t.provider_name}</span>
-              {t.pending && (
-                <Badge
-                  variant="outline"
-                  className="text-muted-foreground shrink-0"
-                >
-                  Pending
-                </Badge>
-              )}
-            </div>
-            {subtitle && (
-              <div className="text-muted-foreground truncate text-xs">
-                {subtitle}
-              </div>
-            )}
-            <TagList slugs={t.tags} max={3} className="mt-1" />
-          </div>
-        </div>
-      );
-    },
+    cell: ({ row }) => <TransactionPrimary transaction={row.original} />,
   },
   {
     id: "category",
     header: "Category",
+    meta: { className: "w-px" },
     cell: ({ row }) => (
-      <CategoryBadge
+      <CategoryPicker
+        transactionId={row.original.id}
         category={row.original.category}
         overridden={row.original.category_override}
       />
     ),
   },
   {
-    accessorKey: "account_name",
-    header: "Account",
-    cell: ({ row }) => (
-      <span className="text-muted-foreground whitespace-nowrap">
-        {row.original.account_name ?? "—"}
-      </span>
-    ),
-  },
-  {
     accessorKey: "amount",
     header: () => <div className="text-right">Amount</div>,
-    cell: ({ row }) => {
-      const t = row.original;
-      const isInflow = t.amount < 0;
-      return (
-        <div
-          className={cn(
-            "text-right font-medium tabular-nums whitespace-nowrap",
-            isInflow && "text-emerald-600 dark:text-emerald-500",
-          )}
-        >
-          {formatAmount(t.amount, t.iso_currency_code)}
-        </div>
-      );
-    },
+    meta: { className: "w-px" },
+    cell: ({ row }) => <TransactionAmount transaction={row.original} />,
   },
 ];
 

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -20,6 +20,7 @@
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
+  --success: oklch(0.596 0.145 163.225);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -56,6 +57,7 @@
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
+  --success: oklch(0.696 0.17 162.48);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
@@ -91,6 +93,7 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);


### PR DESCRIPTION
First iteration of the transactions-page polish sprint — the directed transaction-row redesign. Targets the `v2/transactions-polish` integration branch.

## Summary

The transaction row is rebuilt per directed feedback, and its pieces are extracted into reusable components so transaction rows can appear elsewhere later.

- **Date & Account columns dropped.** Date now sits under the amount (right-aligned); account folds into a secondary metadata line.
- **Description cell** — vertically-centered category icon tile → bank description as the title, with **"Pending"** as plain muted text (pill shape is now reserved for tags). Subtitle is secondary metadata: `account · household member · tag chips`. The redundant merchant subtitle is gone.
- **Category is an inline picker** — a rounded-rectangle trigger (categories are rounded-rect; tags stay pills) that opens a searchable popover to re-categorize a row in place.

## Reusable primitives

- `transaction-primary.tsx` — icon tile + title + inline Pending + metadata subtitle.
- `transaction-amount.tsx` — signed amount + date, inflows in the new `--success` token.
- `category-picker.tsx` — the inline row category picker; `stopPropagation` keeps a click off the row's navigate handler.
- `category-command.tsx` — shared searchable category list + `useCategoryEditor` hook, now used by **both** the row picker and the detail-page `CategoryEditor` (kills the duplicated command list).
- `data-table.tsx` — per-column `meta.className` passthrough, used for `w-px` shrink-to-content columns.

## Before / After

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/t7rmxc39k6.png" width="420" alt="transactions list — before"></td>
    <td><img src="https://i.img402.dev/zby4z7ftf1.png" width="420" alt="transactions list — after"></td>
  </tr>
</table>

Inline category picker:

<img src="https://i.img402.dev/rui4hs512e.png" width="420" alt="inline category picker open">

## Test plan

- [x] `tsc -b && vite build` passes.
- [x] Browser (Chrome DevTools MCP): new row layout renders; inline category picker opens, searches, and applies a category (verified "Shell" → Entertainment, icon tile re-tints); row click still navigates to the detail page; detail-page CategoryEditor still works on the shared command list.
- [x] Reviewed by `code-reviewer` subagent — both findings addressed (`useCallback` on the mutation hook; raw emerald colors replaced with the `--success` theme token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
