### PR TITLE
v2: consolidate the transactions toolbar + pagination polish

### DIFF
--- a/web/src/api/queries/transactions.ts
+++ b/web/src/api/queries/transactions.ts
@@ -84,6 +84,50 @@ export function useTransactions(filters: TransactionFilters) {
   });
 }
 
+// useTransactionCount returns the total number of transactions matching the
+// same filters as useTransactions — the list endpoint is cursor-paginated and
+// carries no total, so the count comes from a dedicated endpoint. Used for the
+// "Showing N of M" footer.
+export function useTransactionCount(filters: TransactionFilters) {
+  const search =
+    filters.search && filters.search.trim().length >= 2
+      ? filters.search.trim()
+      : undefined;
+
+  const key = {
+    search,
+    account: filters.account,
+    category: filters.category,
+    start: filters.start,
+    end: filters.end,
+    minAmount: filters.minAmount,
+    maxAmount: filters.maxAmount,
+    pending: filters.pending,
+  };
+
+  return useQuery({
+    queryKey: ["transactions", "count", key],
+    queryFn: () => {
+      const params = new URLSearchParams();
+      if (search) params.set("search", search);
+      if (filters.account) params.set("account_id", filters.account);
+      if (filters.category) params.set("category_slug", filters.category);
+      if (filters.start) params.set("start_date", filters.start);
+      if (filters.end) params.set("end_date", filters.end);
+      if (filters.minAmount != null)
+        params.set("min_amount", String(filters.minAmount));
+      if (filters.maxAmount != null)
+        params.set("max_amount", String(filters.maxAmount));
+      if (filters.pending != null)
+        params.set("pending", String(filters.pending));
+      const qs = params.toString();
+      return api<{ count: number }>(
+        `/api/v1/transactions/count${qs ? `?${qs}` : ""}`,
+      );
+    },
+  });
+}
+
 // useTransaction loads a single transaction by id or short_id. Disabled until
 // an id is supplied.
 export function useTransaction(id: string | undefined) {

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -1,11 +1,13 @@
-import { useState, type ReactNode } from "react";
+import { useState, type ReactNode, type RefObject } from "react";
 import {
   ArrowUpDown,
   Banknote,
   CalendarRange,
   Check,
+  CheckSquare,
   CircleDot,
   DollarSign,
+  Search,
   Shapes,
   X,
 } from "lucide-react";
@@ -26,6 +28,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { KbdTooltip } from "@/components/kbd-tooltip";
 import { DynamicIcon } from "@/lib/icon";
 import { formatLongDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -33,10 +36,17 @@ import { useAccounts } from "@/api/queries/accounts";
 import { useCategories, flattenCategories } from "@/api/queries/categories";
 import type { TransactionsSearch } from "@/routes/transactions";
 
-interface FilterBarProps {
+interface TransactionsToolbarProps {
   search: TransactionsSearch;
   /** Merge a patch into the URL search params. Pass undefined to clear a key. */
   onChange: (patch: Partial<TransactionsSearch>) => void;
+  /** Free-text search box — debounced into the URL by the route. */
+  query: string;
+  onQueryChange: (value: string) => void;
+  searchRef: RefObject<HTMLInputElement | null>;
+  /** Select-mode toggle, owned by the route. */
+  selectMode: boolean;
+  onToggleSelect: () => void;
 }
 
 const SORT_OPTIONS: {
@@ -50,32 +60,46 @@ const SORT_OPTIONS: {
   { label: "Smallest amount", sort: "amount", dir: "asc" },
 ];
 
-// FilterBar is the transactions filter strip: a row of popover-backed filter
-// pills plus a removable chip for every active filter. It's a controlled
-// component — all state lives in the URL, owned by the route.
-export function FilterBar({ search, onChange }: FilterBarProps) {
+// TransactionsToolbar is the transactions page's single control band: a search
+// box, a row of popover-backed filter pills, a sort control and the select-mode
+// toggle — plus a removable chip for every active filter. It's controlled — all
+// state lives in the URL (filters) or the route (search text, select mode).
+export function TransactionsToolbar({
+  search,
+  onChange,
+  query,
+  onQueryChange,
+  searchRef,
+  selectMode,
+  onToggleSelect,
+}: TransactionsToolbarProps) {
   const { data: accounts } = useAccounts();
   const { data: categoryTree } = useCategories();
   const categories = flattenCategories(categoryTree);
 
   const account = accounts?.find((a) => a.short_id === search.account);
   const category = categories.find((c) => c.slug === search.category);
-  const activeSort =
-    SORT_OPTIONS.find((o) => o.sort === search.sort && o.dir === search.dir) ??
-    SORT_OPTIONS[0];
+  // Only treat sort as "custom" when the params actually resolve to a known
+  // option — a partial/garbage param shouldn't light the pill with the wrong
+  // label.
+  const foundSort = SORT_OPTIONS.find(
+    (o) => o.sort === search.sort && o.dir === search.dir,
+  );
+  const activeSort = foundSort ?? SORT_OPTIONS[0];
+  const sortIsCustom = !!foundSort;
 
-  const chips: { key: keyof TransactionsSearch; label: string }[] = [];
+  const chips: { key: string; label: string }[] = [];
   if (account) chips.push({ key: "account", label: account.name });
   if (category) chips.push({ key: "category", label: category.display_name });
   if (search.start || search.end) {
     const from = search.start ? formatLongDate(search.start) : "Any";
     const to = search.end ? formatLongDate(search.end) : "Any";
-    chips.push({ key: "start", label: `${from} – ${to}` });
+    chips.push({ key: "dateRange", label: `${from} – ${to}` });
   }
   if (search.min != null || search.max != null) {
     const lo = search.min != null ? `$${search.min}` : "Any";
     const hi = search.max != null ? `$${search.max}` : "Any";
-    chips.push({ key: "min", label: `${lo} – ${hi}` });
+    chips.push({ key: "amountRange", label: `${lo} – ${hi}` });
   }
   if (search.pending) {
     chips.push({
@@ -84,9 +108,9 @@ export function FilterBar({ search, onChange }: FilterBarProps) {
     });
   }
 
-  const clearChip = (key: keyof TransactionsSearch) => {
-    if (key === "start") onChange({ start: undefined, end: undefined });
-    else if (key === "min") onChange({ min: undefined, max: undefined });
+  const clearChip = (key: string) => {
+    if (key === "dateRange") onChange({ start: undefined, end: undefined });
+    else if (key === "amountRange") onChange({ min: undefined, max: undefined });
     else onChange({ [key]: undefined } as Partial<TransactionsSearch>);
   };
 
@@ -104,6 +128,18 @@ export function FilterBar({ search, onChange }: FilterBarProps) {
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
+        {/* Search */}
+        <div className="relative w-full min-w-48 sm:w-64">
+          <Search className="text-muted-foreground absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+          <Input
+            ref={searchRef}
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            placeholder="Search merchant or description…"
+            className="pl-8"
+          />
+        </div>
+
         {/* Account */}
         <FilterPill icon={Banknote} label="Account" active={!!account}>
           <Command>
@@ -274,29 +310,49 @@ export function FilterBar({ search, onChange }: FilterBarProps) {
 
         <div className="grow" />
 
-        {/* Sort */}
-        <FilterPill icon={ArrowUpDown} label={activeSort.label} active>
-          <Command>
-            <CommandList>
-              <CommandGroup>
-                {SORT_OPTIONS.map((opt) => (
-                  <CommandItem
-                    key={opt.label}
-                    value={opt.label}
-                    onSelect={() =>
-                      onChange({ sort: opt.sort, dir: opt.dir })
-                    }
-                  >
-                    {opt.label}
-                    {activeSort.label === opt.label && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </FilterPill>
+        {/* Sort + select mode — grouped so they stay together when the row wraps */}
+        <div className="flex items-center gap-2">
+          <FilterPill
+            icon={ArrowUpDown}
+            label={activeSort.label}
+            active={sortIsCustom}
+          >
+            <Command>
+              <CommandList>
+                <CommandGroup>
+                  {SORT_OPTIONS.map((opt) => (
+                    <CommandItem
+                      key={opt.label}
+                      value={opt.label}
+                      onSelect={() => onChange({ sort: opt.sort, dir: opt.dir })}
+                    >
+                      {opt.label}
+                      {activeSort.label === opt.label && (
+                        <Check className="ml-auto size-4" />
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </FilterPill>
+
+          {selectMode ? (
+            <KbdTooltip label="Exit select mode" keys={["Esc"]}>
+              <Button variant="secondary" size="sm" onClick={onToggleSelect}>
+                <X className="size-4" />
+                Done
+              </Button>
+            </KbdTooltip>
+          ) : (
+            <KbdTooltip label="Select transactions" keys={["x"]}>
+              <Button variant="outline" size="sm" onClick={onToggleSelect}>
+                <CheckSquare className="size-4" />
+                Select
+              </Button>
+            </KbdTooltip>
+          )}
+        </div>
       </div>
 
       {chips.length > 0 && (
@@ -356,10 +412,7 @@ function FilterPill({
           {label}
         </Button>
       </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className={cn("w-56 p-0", className)}
-      >
+      <PopoverContent align="start" className={cn("w-56 p-0", className)}>
         {children}
       </PopoverContent>
     </Popover>

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -84,7 +84,7 @@ function DetailBody({ transaction: t }: { transaction: Transaction }) {
         <div
           className={cn(
             "text-xl font-semibold tabular-nums whitespace-nowrap",
-            isInflow && "text-emerald-600 dark:text-emerald-500",
+            isInflow && "text-success",
           )}
         >
           {formatAmount(t.amount, t.iso_currency_code)}

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -8,19 +8,21 @@ import {
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import type { RowSelectionState } from "@tanstack/react-table";
-import { CheckSquare, Receipt, Search, X } from "lucide-react";
+import { Loader2, Receipt } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { DataTable } from "@/components/data-table";
 import { EmptyState } from "@/components/empty-state";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
   buildTransactionColumns,
   type TransactionTableMeta,
 } from "@/features/transactions/columns";
-import { FilterBar } from "@/features/transactions/filter-bar";
+import { TransactionsToolbar } from "@/features/transactions/transactions-toolbar";
 import { SelectionActionBar } from "@/features/transactions/selection-action-bar";
-import { useTransactions } from "@/api/queries/transactions";
+import {
+  useTransactions,
+  useTransactionCount,
+} from "@/api/queries/transactions";
 import type { TransactionFilters } from "@/api/queries/transactions";
 import { flattenPages } from "@/lib/pagination";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
@@ -103,7 +105,9 @@ export function TransactionsPage() {
     [navigate],
   );
 
-  const transactions = useTransactions(searchToFilters(search));
+  const filters = searchToFilters(search);
+  const transactions = useTransactions(filters);
+  const totalCount = useTransactionCount(filters);
   const rows = useMemo(
     () => flattenPages<Transaction>(transactions.data?.pages, "transactions"),
     [transactions.data?.pages],
@@ -126,6 +130,11 @@ export function TransactionsPage() {
     setRowSelection({});
     lastIndexRef.current = null;
   }, []);
+
+  const toggleSelectMode = useCallback(() => {
+    if (selectMode) exitSelectMode();
+    else setSelectMode(true);
+  }, [selectMode, exitSelectMode]);
 
   // getRowId returns the transaction id, so rowSelection keys ARE ids.
   const selectedIds = useMemo(
@@ -200,7 +209,12 @@ export function TransactionsPage() {
   useShortcut(
     ["x"],
     () => {
-      if (focusedIndex == null) return;
+      // No focused row → just enter select mode (matches the toolbar button,
+      // which advertises `x` as its shortcut).
+      if (focusedIndex == null) {
+        setSelectMode(true);
+        return;
+      }
       const id = rows[focusedIndex]?.id;
       if (!id) return;
       setSelectMode(true);
@@ -229,49 +243,41 @@ export function TransactionsPage() {
     search.max != null ||
     !!search.pending;
 
+  const count = totalCount.data?.count;
+  const showCountLine = !transactions.isLoading && !transactions.isError;
+
   return (
     <div>
-      <PageHeader
-        title="Transactions"
-        description="Every transaction synced across your connected accounts."
-        actions={
-          selectMode ? (
-            <Button variant="secondary" size="sm" onClick={exitSelectMode}>
-              <X className="size-4" />
-              Done
-            </Button>
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setSelectMode(true)}
-            >
-              <CheckSquare className="size-4" />
-              Select
-            </Button>
-          )
-        }
-      />
+      <PageHeader title="Transactions" />
 
-      <div className="mb-4 space-y-3">
-        <div className="relative w-full max-w-xs">
-          <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
-          <Input
-            ref={searchInputRef}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search merchant or description…"
-            className="pl-8"
-          />
-        </div>
-        <FilterBar search={search} onChange={setFilter} />
+      <div className="mb-4">
+        <TransactionsToolbar
+          search={search}
+          onChange={setFilter}
+          query={query}
+          onQueryChange={setQuery}
+          searchRef={searchInputRef}
+          selectMode={selectMode}
+          onToggleSelect={toggleSelectMode}
+        />
       </div>
+
+      {showCountLine && rows.length > 0 && (
+        <div className="text-muted-foreground mb-2 text-sm">
+          {count != null && count > rows.length
+            ? `Showing ${rows.length} of ${count.toLocaleString()} transactions`
+            : `${(count ?? rows.length).toLocaleString()} ${
+                (count ?? rows.length) === 1 ? "transaction" : "transactions"
+              }`}
+        </div>
+      )}
 
       <DataTable
         columns={columns}
         data={rows}
         isLoading={transactions.isLoading}
         isError={transactions.isError}
+        loadingRows={6}
         getRowId={(t) => t.id}
         enableRowSelection={selectMode}
         rowSelection={selectMode ? rowSelection : undefined}
@@ -296,23 +302,31 @@ export function TransactionsPage() {
         }
       />
 
-      {transactions.hasNextPage && (
-        <div className="mt-4 flex justify-center">
-          <Button
-            variant="outline"
-            onClick={() => transactions.fetchNextPage()}
-            disabled={transactions.isFetchingNextPage}
-          >
-            {transactions.isFetchingNextPage ? "Loading…" : "Load more"}
-          </Button>
+      {rows.length > 0 && (
+        <div className="text-muted-foreground mt-4 flex justify-center text-sm">
+          {transactions.hasNextPage ? (
+            <Button
+              variant="outline"
+              onClick={() => transactions.fetchNextPage()}
+              disabled={transactions.isFetchingNextPage}
+            >
+              {transactions.isFetchingNextPage && (
+                <Loader2 className="size-4 animate-spin" />
+              )}
+              {transactions.isFetchingNextPage ? "Loading…" : "Load more"}
+            </Button>
+          ) : (
+            <span>
+              {count != null
+                ? `All ${count.toLocaleString()} transactions loaded`
+                : "All transactions loaded"}
+            </span>
+          )}
         </div>
       )}
 
       {selectMode && selectedIds.length > 0 && (
-        <SelectionActionBar
-          selectedIds={selectedIds}
-          onClear={exitSelectMode}
-        />
+        <SelectionActionBar selectedIds={selectedIds} onClear={exitSelectMode} />
       )}
     </div>
   );


### PR DESCRIPTION
Iteration 2 of the transactions-page polish sprint — a holistic page-layout pass on top of the row redesign (#1079). Targets the `v2/transactions-polish` integration branch.

## Summary

A design-audit subagent flagged the page's biggest problem: the header, search box, and filter bar were three disconnected visual bands. This collapses them into a clean control band and polishes pagination.

- **Toolbar consolidation.** `filter-bar.tsx` → `transactions-toolbar.tsx`. The toolbar now hosts the **search input** (first child) and the **select-mode toggle** (grouped with Sort at the right edge). The route no longer renders search/Select separately. The redundant page description ("Every transaction synced…") is gone — `PageHeader` is now title-only.
- **Pagination.** New `useTransactionCount` hook (`GET /api/v1/transactions/count`, filter-aware) drives a **"Showing N of M transactions"** line. The "Load more" footer gets a spinner while fetching and an **"All N transactions loaded"** note when the list is exhausted.
- **Tooltips.** Select / Done buttons get `KbdTooltip`s with their keyboard hints (`x` / `Esc`). `x` with no focused row now enters select mode, matching the button's advertised shortcut.
- **Fixes the audit caught:** the Sort pill no longer renders permanently "active" — it only highlights when the sort resolves to a non-default option (and won't show a stale label for partial params). Date/amount filter chips use explicit sentinel keys instead of reusing a single URL param name. `transaction-detail.tsx` inflow amount uses the `--success` token, matching the table.

## Before / After

<table>
  <tr><th>Before (iter 1)</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/q69nz52o9g.png" width="420" alt="transactions page — before iteration 2"></td>
    <td><img src="https://i.img402.dev/2bskapomox.png" width="420" alt="transactions page — after iteration 2"></td>
  </tr>
</table>

Select mode (toolbar toggle, count line, checkboxes):

<img src="https://i.img402.dev/5zotfay8i5.png" width="420" alt="select mode">

## Test plan

- [x] `tsc -b && vite build` passes.
- [x] Browser (Chrome DevTools MCP): consolidated toolbar renders and wraps cleanly; "Showing 50 of 537" count line; "Load more" advances the count to "Showing 100 of 537"; Select toggles select mode + checkboxes; no console errors.
- [x] Reviewed by `code-reviewer` subagent — three findings addressed (footer count when count query unresolved; Sort pill label/active on partial params; `x` shortcut vs. tooltip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
