### PR TITLE
v2: dedup category/tag pickers + group categories by parent

### DIFF
--- a/web/src/components/category-command.tsx
+++ b/web/src/components/category-command.tsx
@@ -10,10 +10,10 @@ import {
   CommandSeparator,
 } from "@/components/ui/command";
 import { DynamicIcon } from "@/lib/icon";
-import { cn } from "@/lib/utils";
 import { withMutationToast } from "@/lib/mutation-toast";
-import { useCategories, flattenCategories } from "@/api/queries/categories";
+import { useCategories } from "@/api/queries/categories";
 import { useUpdateTransactions } from "@/api/queries/transactions";
+import type { Category } from "@/api/types";
 
 // A single category change — set a slug, or reset to the provider default.
 export interface CategoryPick {
@@ -29,16 +29,47 @@ interface CategoryCommandListProps {
   onPick: (pick: CategoryPick) => void;
 }
 
+// One selectable category row. `value` carries the parent name too, so a
+// search for the parent ("food") still surfaces every child.
+function CategoryItem({
+  category,
+  currentSlug,
+  onPick,
+}: {
+  category: Category;
+  currentSlug?: string | null;
+  onPick: (pick: CategoryPick) => void;
+}) {
+  return (
+    <CommandItem
+      // Slug is in the value so it disambiguates duplicate child names
+      // ("Savings" under two parents) and lets power users search by slug.
+      value={`${category.slug} ${category.display_name} ${category.parent_display_name ?? ""}`}
+      onSelect={() => onPick({ category_slug: category.slug })}
+    >
+      <DynamicIcon
+        name={category.icon}
+        className="size-4"
+        style={category.color ? { color: category.color } : undefined}
+      />
+      <span>{category.display_name}</span>
+      {currentSlug === category.slug && <Check className="ml-auto size-4" />}
+    </CommandItem>
+  );
+}
+
 // CategoryCommandList is the shared searchable category list behind every
-// category-mutation surface — the detail-page editor and the inline row
-// picker. Pure presentation: the caller owns the mutation.
+// category-mutation surface — the detail-page editor, the inline row picker,
+// and bulk categorize. Categories are grouped by their parent so the list
+// reads as sections rather than one flat wall. Pure presentation: the caller
+// owns the mutation.
 export function CategoryCommandList({
   currentSlug,
   showReset,
   onPick,
 }: CategoryCommandListProps) {
   const { data: tree, isLoading } = useCategories();
-  const categories = flattenCategories(tree);
+  const parents = (tree ?? []).filter((c) => !c.hidden);
 
   return (
     <Command>
@@ -61,27 +92,38 @@ export function CategoryCommandList({
             <CommandSeparator />
           </>
         )}
-        <CommandGroup>
-          {categories.map((c) => (
-            <CommandItem
-              key={c.slug}
-              value={`${c.display_name} ${c.parent_display_name ?? ""}`}
-              onSelect={() => onPick({ category_slug: c.slug })}
-            >
-              <DynamicIcon
-                name={c.icon}
-                className="size-4"
-                style={c.color ? { color: c.color } : undefined}
+        {parents.map((parent) => {
+          const children = (parent.children ?? []).filter((c) => !c.hidden);
+          // A childless top-level category renders as a lone item — no point
+          // wrapping it in a one-row group with a redundant heading.
+          if (children.length === 0) {
+            return (
+              <CategoryItem
+                key={parent.slug}
+                category={parent}
+                currentSlug={currentSlug}
+                onPick={onPick}
               />
-              <span className={cn(c.parent_id && "text-muted-foreground")}>
-                {c.parent_display_name
-                  ? `${c.parent_display_name} › ${c.display_name}`
-                  : c.display_name}
-              </span>
-              {currentSlug === c.slug && <Check className="ml-auto size-4" />}
-            </CommandItem>
-          ))}
-        </CommandGroup>
+            );
+          }
+          return (
+            <CommandGroup key={parent.slug} heading={parent.display_name}>
+              <CategoryItem
+                category={parent}
+                currentSlug={currentSlug}
+                onPick={onPick}
+              />
+              {children.map((child) => (
+                <CategoryItem
+                  key={child.slug}
+                  category={child}
+                  currentSlug={currentSlug}
+                  onPick={onPick}
+                />
+              ))}
+            </CommandGroup>
+          );
+        })}
       </CommandList>
     </Command>
   );

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -48,7 +48,7 @@ export function CategoryPicker({
           disabled={isPending}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            "hover:bg-accent focus-visible:ring-ring rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:opacity-50",
+            "hover:bg-accent focus-visible:ring-ring rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
             className,
           )}
         >

--- a/web/src/components/tag-command.tsx
+++ b/web/src/components/tag-command.tsx
@@ -1,0 +1,54 @@
+import { Check } from "lucide-react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { DynamicIcon } from "@/lib/icon";
+import { useTags } from "@/api/queries/tags";
+
+interface TagCommandListProps {
+  /** Slugs already attached — rendered with a check mark. */
+  attachedSlugs?: Set<string>;
+  onPick: (slug: string) => void;
+}
+
+// TagCommandList is the shared searchable tag list behind every tag-mutation
+// surface — the detail-page tag manager and bulk tag. Pure presentation: the
+// caller owns the mutation.
+export function TagCommandList({ attachedSlugs, onPick }: TagCommandListProps) {
+  const { data: tags, isLoading } = useTags();
+
+  return (
+    <Command>
+      <CommandInput placeholder="Search tags…" />
+      <CommandList>
+        <CommandEmpty>
+          {isLoading ? "Loading…" : "No tags found."}
+        </CommandEmpty>
+        <CommandGroup>
+          {(tags ?? []).map((tag) => (
+            <CommandItem
+              key={tag.slug}
+              value={tag.display_name}
+              onSelect={() => onPick(tag.slug)}
+            >
+              <DynamicIcon
+                name={tag.icon}
+                className="size-4"
+                style={tag.color ? { color: tag.color } : undefined}
+              />
+              <span>{tag.display_name}</span>
+              {attachedSlugs?.has(tag.slug) && (
+                <Check className="ml-auto size-4" />
+              )}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -5,20 +5,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { DynamicIcon } from "@/lib/icon";
+import { CategoryCommandList } from "@/components/category-command";
+import { TagCommandList } from "@/components/tag-command";
 import { withMutationToast } from "@/lib/mutation-toast";
-import { useCategories, flattenCategories } from "@/api/queries/categories";
-import { useTags } from "@/api/queries/tags";
 import { useUpdateTransactions } from "@/api/queries/transactions";
 import type { UpdateTransactionsOp } from "@/api/types";
 
@@ -111,8 +102,6 @@ function CategorizeAction({
   onPick: (slug: string) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const { data: tree } = useCategories();
-  const categories = flattenCategories(tree);
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -127,35 +116,13 @@ function CategorizeAction({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-64 p-0" align="center" side="top">
-        <Command>
-          <CommandInput placeholder="Search categories…" />
-          <CommandList>
-            <CommandEmpty>No categories found.</CommandEmpty>
-            <CommandGroup>
-              {categories.map((c) => (
-                <CommandItem
-                  key={c.slug}
-                  value={`${c.display_name} ${c.parent_display_name ?? ""}`}
-                  onSelect={() => {
-                    setOpen(false);
-                    onPick(c.slug);
-                  }}
-                >
-                  <DynamicIcon
-                    name={c.icon}
-                    className="size-4"
-                    style={c.color ? { color: c.color } : undefined}
-                  />
-                  <span>
-                    {c.parent_display_name
-                      ? `${c.parent_display_name} › ${c.display_name}`
-                      : c.display_name}
-                  </span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+        <CategoryCommandList
+          onPick={({ category_slug }) => {
+            if (!category_slug) return;
+            setOpen(false);
+            onPick(category_slug);
+          }}
+        />
       </PopoverContent>
     </Popover>
   );
@@ -169,7 +136,6 @@ function TagAction({
   onPick: (slug: string) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const { data: tags } = useTags();
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -184,31 +150,12 @@ function TagAction({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="center" side="top">
-        <Command>
-          <CommandInput placeholder="Search tags…" />
-          <CommandList>
-            <CommandEmpty>No tags found.</CommandEmpty>
-            <CommandGroup>
-              {(tags ?? []).map((tag) => (
-                <CommandItem
-                  key={tag.slug}
-                  value={tag.display_name}
-                  onSelect={() => {
-                    setOpen(false);
-                    onPick(tag.slug);
-                  }}
-                >
-                  <DynamicIcon
-                    name={tag.icon}
-                    className="size-4"
-                    style={tag.color ? { color: tag.color } : undefined}
-                  />
-                  <span>{tag.display_name}</span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+        <TagCommandList
+          onPick={(slug) => {
+            setOpen(false);
+            onPick(slug);
+          }}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/web/src/features/transactions/tag-manager.tsx
+++ b/web/src/features/transactions/tag-manager.tsx
@@ -1,21 +1,13 @@
-import { useState } from "react";
-import { Check, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Plus } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
 import { TagChip } from "@/components/tag-chip";
-import { DynamicIcon } from "@/lib/icon";
+import { TagCommandList } from "@/components/tag-command";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useTags } from "@/api/queries/tags";
 import { useUpdateTransactions } from "@/api/queries/transactions";
@@ -28,14 +20,14 @@ interface TagManagerProps {
 
 // TagManager is the single-transaction tag editor on the detail page. Current
 // tags render as removable chips; the "Add tag" popover toggles attachment
-// against the full tag catalog. Each toggle is one batch operation — add or
-// remove a single slug — and the cache invalidation refetches the row.
+// against the shared tag command list. Each toggle is one batch operation —
+// add or remove a single slug — and the cache invalidation refetches the row.
 export function TagManager({ transactionId, tags }: TagManagerProps) {
   const [open, setOpen] = useState(false);
-  const { data: catalog, isLoading } = useTags();
+  const { data: catalog } = useTags();
   const update = useUpdateTransactions();
 
-  const attached = new Set(tags);
+  const attached = useMemo(() => new Set(tags), [tags]);
   const bySlug = new Map((catalog ?? []).map((t) => [t.slug, t]));
 
   const toggle = async (slug: string) => {
@@ -87,33 +79,7 @@ export function TagManager({ transactionId, tags }: TagManagerProps) {
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-56 p-0" align="start">
-          <Command>
-            <CommandInput placeholder="Search tags…" />
-            <CommandList>
-              <CommandEmpty>
-                {isLoading ? "Loading…" : "No tags found."}
-              </CommandEmpty>
-              <CommandGroup>
-                {(catalog ?? []).map((tag) => (
-                  <CommandItem
-                    key={tag.slug}
-                    value={tag.display_name}
-                    onSelect={() => toggle(tag.slug)}
-                  >
-                    <DynamicIcon
-                      name={tag.icon}
-                      className="size-4"
-                      style={tag.color ? { color: tag.color } : undefined}
-                    />
-                    <span>{tag.display_name}</span>
-                    {attached.has(tag.slug) && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
+          <TagCommandList attachedSlugs={attached} onPick={toggle} />
         </PopoverContent>
       </Popover>
     </div>


### PR DESCRIPTION
Iteration 3 of the transactions-page polish sprint — deduplicating the category/tag pickers and giving the category list real structure. Targets the `v2/transactions-polish` integration branch.

## Summary

A design-audit subagent found the picker surfaces had drifted into three near-identical hand-rolled command lists. This consolidates them and groups the category list.

- **Category list grouped by parent.** `CategoryCommandList` now renders one `CommandGroup` per top-level category (parent + its children as items) instead of one flat ~130-row wall. Search still matches across parent + child + slug.
- **New shared `TagCommandList`**, mirroring `CategoryCommandList` (`attachedSlugs` check marks, `isLoading` empty state).
- **Dedup.** `selection-action-bar.tsx`'s `CategorizeAction` / `TagAction` hand-rolled their own command lists; both now delegate to the shared components — so the bulk pickers inherit the grouped layout and loading states for free. The detail-page `tag-manager.tsx` does the same. One source of truth per picker.
- `CategoryPicker` shows `cursor-wait` while a mutation is in flight.

## Screenshots

<table>
  <tr><th>Grouped category picker (row)</th><th>Bulk categorize (shared list)</th><th>Detail-page tag manager</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/mcjqxa1am7.png" width="270" alt="grouped category picker"></td>
    <td><img src="https://i.img402.dev/pcs0ctfpjv.png" width="270" alt="bulk categorize"></td>
    <td><img src="https://i.img402.dev/1s5xpca82i.png" width="270" alt="tag manager"></td>
  </tr>
</table>

## Test plan

- [x] `tsc -b && vite build` passes.
- [x] Browser (Chrome DevTools MCP): grouped category list renders with parent headings; search + pick applies a category to a row; bulk Categorize popover shows the same grouped list; detail-page tag manager opens the shared tag list with the attached-tag check; no console errors.
- [x] Reviewed by `code-reviewer` subagent — both findings addressed (slug added to `CommandItem` value for disambiguation + slug search; `attached` Set memoized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
