### PR TITLE
v2: polish select mode + keyboard navigation

### DIFF
--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -22,6 +22,9 @@ export function CommandPalette() {
   useShortcut(["mod", "k"], () => setOpen((v) => !v), {
     label: "Open command palette",
     group: "Global",
+    // ⌘K must toggle from anywhere — including from inside the palette
+    // itself (its own search input / dialog) to close it.
+    global: true,
   });
 
   const go = (to: string) => {

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -175,7 +175,7 @@ export function DataTable<TData, TValue>({
                 onClick={onRowClick ? () => onRowClick(row.original) : undefined}
                 className={cn(
                   onRowClick && "cursor-pointer",
-                  focused && "ring-primary ring-1 ring-inset",
+                  focused && "ring-primary ring-2 ring-inset outline-none",
                 )}
               >
                 {row.getVisibleCells().map((cell) => (

--- a/web/src/components/kbd-tooltip.tsx
+++ b/web/src/components/kbd-tooltip.tsx
@@ -5,6 +5,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { displayKey } from "@/lib/kbd-display";
 
 export interface KbdTooltipProps {
   label: string;
@@ -12,21 +13,6 @@ export interface KbdTooltipProps {
   side?: React.ComponentProps<typeof TooltipContent>["side"];
   align?: React.ComponentProps<typeof TooltipContent>["align"];
   children: React.ReactElement;
-}
-
-const DISPLAY: Record<string, string> = {
-  mod: "⌘",
-  cmd: "⌘",
-  ctrl: "Ctrl",
-  shift: "⇧",
-  alt: "⌥",
-  option: "⌥",
-};
-
-function display(k: string): string {
-  const lower = k.toLowerCase();
-  if (lower in DISPLAY) return DISPLAY[lower];
-  return k.length === 1 ? k.toUpperCase() : k;
 }
 
 export function KbdTooltip({
@@ -44,7 +30,7 @@ export function KbdTooltip({
         {keys && keys.length > 0 && (
           <KbdGroup>
             {keys.map((k) => (
-              <Kbd key={k}>{display(k)}</Kbd>
+              <Kbd key={k}>{displayKey(k)}</Kbd>
             ))}
           </KbdGroup>
         )}

--- a/web/src/components/shortcut-sheet.tsx
+++ b/web/src/components/shortcut-sheet.tsx
@@ -7,27 +7,13 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { displayKey } from "@/lib/kbd-display";
 import {
   listShortcuts,
   subscribeShortcuts,
   useShortcut,
   type Shortcut,
 } from "@/lib/shortcuts";
-
-const DISPLAY: Record<string, string> = {
-  mod: "⌘",
-  cmd: "⌘",
-  ctrl: "Ctrl",
-  shift: "⇧",
-  alt: "⌥",
-  option: "⌥",
-};
-
-function display(k: string): string {
-  const lower = k.toLowerCase();
-  if (lower in DISPLAY) return DISPLAY[lower];
-  return k.length === 1 ? k.toUpperCase() : k;
-}
 
 function useShortcutList(): Shortcut[] {
   const [list, setList] = React.useState<Shortcut[]>(() => listShortcuts());
@@ -52,7 +38,14 @@ export function ShortcutSheet() {
       arr.push(s);
       out.set(key, arr);
     }
-    return Array.from(out.entries());
+    // "Global" first, then the rest alphabetically — stable regardless of
+    // which page registered its shortcuts in what order.
+    return Array.from(out.entries()).sort(([a], [b]) => {
+      if (a === b) return 0;
+      if (a === "Global") return -1;
+      if (b === "Global") return 1;
+      return a.localeCompare(b);
+    });
   }, [list]);
 
   return (
@@ -79,7 +72,7 @@ export function ShortcutSheet() {
                     <span className="text-sm">{s.label}</span>
                     <KbdGroup>
                       {s.keys.map((k) => (
-                        <Kbd key={k}>{display(k)}</Kbd>
+                        <Kbd key={k}>{displayKey(k)}</Kbd>
                       ))}
                     </KbdGroup>
                   </li>

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -34,7 +34,10 @@ const selectionColumn: ColumnDef<Transaction> = {
         // Shift-click extends the selection from the last-toggled row. The
         // normal onCheckedChange still fires and lands the current row in the
         // same (selected) state the range sets, so no preventDefault needed.
+        // stopPropagation keeps the row-body select-mode click from also
+        // toggling — otherwise a checkbox click would toggle twice.
         onClick={(e) => {
+          e.stopPropagation();
           if (e.shiftKey) meta?.onRangeSelect?.(row.index);
         }}
         onCheckedChange={(value) => {

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { CategoryCommandList } from "@/components/category-command";
 import { TagCommandList } from "@/components/tag-command";
+import { KbdTooltip } from "@/components/kbd-tooltip";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useUpdateTransactions } from "@/api/queries/transactions";
 import type { UpdateTransactionsOp } from "@/api/types";
@@ -27,6 +28,9 @@ function chunk<T>(items: T[], size: number): T[][] {
 
 interface SelectionActionBarProps {
   selectedIds: string[];
+  /** Total transactions matching the current filters — gives the count
+   *  context (header select-all only covers the loaded page). */
+  totalCount?: number;
   onClear: () => void;
 }
 
@@ -36,6 +40,7 @@ interface SelectionActionBarProps {
 // chunked to the endpoint's 50-op limit.
 export function SelectionActionBar({
   selectedIds,
+  totalCount,
   onClear,
 }: SelectionActionBarProps) {
   const update = useUpdateTransactions();
@@ -62,7 +67,9 @@ export function SelectionActionBar({
     <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
       <div className="bg-popover text-popover-foreground flex items-center gap-1 rounded-full border p-1 pl-3 shadow-lg">
         <span className="text-sm font-medium">
-          {selectedIds.length} selected
+          {totalCount != null && totalCount > selectedIds.length
+            ? `${selectedIds.length} of ${totalCount.toLocaleString()} selected`
+            : `${selectedIds.length} selected`}
         </span>
         <Separator orientation="vertical" className="mx-1 h-5" />
 
@@ -80,15 +87,17 @@ export function SelectionActionBar({
         />
 
         <Separator orientation="vertical" className="mx-1 h-5" />
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-8 rounded-full"
-          onClick={onClear}
-          aria-label="Clear selection"
-        >
-          <X className="size-4" />
-        </Button>
+        <KbdTooltip label="Clear selection / exit" keys={["Esc"]} side="top">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 rounded-full"
+            onClick={onClear}
+            aria-label="Clear selection"
+          >
+            <X className="size-4" />
+          </Button>
+        </KbdTooltip>
       </div>
     </div>
   );

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -338,7 +338,7 @@ export function TransactionsToolbar({
           </FilterPill>
 
           {selectMode ? (
-            <KbdTooltip label="Exit select mode" keys={["Esc"]}>
+            <KbdTooltip label="Clear selection / exit" keys={["Esc"]}>
               <Button variant="secondary" size="sm" onClick={onToggleSelect}>
                 <X className="size-4" />
                 Done

--- a/web/src/lib/kbd-display.ts
+++ b/web/src/lib/kbd-display.ts
@@ -1,0 +1,19 @@
+// Shared key-label formatting for the shortcut sheet and kbd tooltips — one
+// source of truth so the two surfaces never drift.
+
+const DISPLAY: Record<string, string> = {
+  mod: "⌘",
+  cmd: "⌘",
+  ctrl: "Ctrl",
+  shift: "⇧",
+  alt: "⌥",
+  option: "⌥",
+};
+
+// displayKey maps a raw shortcut key to its glyph — "mod" → "⌘", single
+// letters uppercased, everything else passed through.
+export function displayKey(key: string): string {
+  const lower = key.toLowerCase();
+  if (lower in DISPLAY) return DISPLAY[lower];
+  return key.length === 1 ? key.toUpperCase() : key;
+}

--- a/web/src/lib/shortcuts.ts
+++ b/web/src/lib/shortcuts.ts
@@ -57,6 +57,12 @@ export interface UseShortcutOptions {
   label: string;
   group?: string;
   enabled?: boolean;
+  /**
+   * Fire even when focus is inside an input or an open dialog/popover. Only
+   * for genuinely global, modifier-guarded shortcuts (e.g. ⌘K) that must
+   * toggle from anywhere — never for bare-letter shortcuts.
+   */
+  global?: boolean;
 }
 
 export function useShortcut(
@@ -64,7 +70,7 @@ export function useShortcut(
   handler: (event: KeyboardEvent) => void,
   options: UseShortcutOptions,
 ): void {
-  const { label, group, enabled = true } = options;
+  const { label, group, enabled = true, global = false } = options;
   const id = `${group ?? "global"}:${label}`;
   // Both `keys` (inline array literal) and `handler` (inline arrow) are
   // referentially unstable across renders. Without this, the effect tears
@@ -81,16 +87,25 @@ export function useShortcut(
     const unregister = registerShortcut({ id, keys: parsedKeys, label, group });
     const match = parseKeys(parsedKeys);
     const onKey = (event: KeyboardEvent) => {
+      // Holding a key down repeats keydown — let single-press shortcuts
+      // (j/k navigation especially) fire once per press, not per frame.
+      if (event.repeat) return;
       if (event.key.toLowerCase() !== match.key) return;
       if (!!match.meta !== (event.metaKey || event.ctrlKey)) return;
       if (!!match.shift !== event.shiftKey) return;
       if (!!match.alt !== event.altKey) return;
       const target = event.target as HTMLElement | null;
       if (
+        !global &&
         target &&
         (target.tagName === "INPUT" ||
           target.tagName === "TEXTAREA" ||
-          target.isContentEditable)
+          target.isContentEditable ||
+          // Focus inside an open dialog or popover (command palette, filter
+          // pills, pickers) — the page's list shortcuts must not leak under it.
+          target.closest(
+            '[role="dialog"],[data-radix-popper-content-wrapper]',
+          ))
       ) {
         return;
       }
@@ -101,5 +116,5 @@ export function useShortcut(
       window.removeEventListener("keydown", onKey);
       unregister();
     };
-  }, [enabled, id, keysKey, label, group]);
+  }, [enabled, id, keysKey, label, group, global]);
 }

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -129,6 +129,13 @@ export function TransactionsPage() {
     setSelectMode(false);
     setRowSelection({});
     lastIndexRef.current = null;
+    setFocusedIndex(null);
+  }, []);
+
+  // In select mode a click anywhere on the row toggles its selection — the
+  // checkbox cell stops propagation so it doesn't double-toggle.
+  const toggleRowSelection = useCallback((t: Transaction) => {
+    setRowSelection((prev) => ({ ...prev, [t.id]: !prev[t.id] }));
   }, []);
 
   const toggleSelectMode = useCallback(() => {
@@ -209,10 +216,11 @@ export function TransactionsPage() {
   useShortcut(
     ["x"],
     () => {
-      // No focused row → just enter select mode (matches the toolbar button,
-      // which advertises `x` as its shortcut).
+      // No focused row → enter select mode and land the focus ring on the
+      // first row, so the next `x` has something to select.
       if (focusedIndex == null) {
         setSelectMode(true);
+        setFocusedIndex(0);
         return;
       }
       const id = rows[focusedIndex]?.id;
@@ -263,12 +271,17 @@ export function TransactionsPage() {
       </div>
 
       {showCountLine && rows.length > 0 && (
-        <div className="text-muted-foreground mb-2 text-sm">
-          {count != null && count > rows.length
-            ? `Showing ${rows.length} of ${count.toLocaleString()} transactions`
-            : `${(count ?? rows.length).toLocaleString()} ${
-                (count ?? rows.length) === 1 ? "transaction" : "transactions"
-              }`}
+        <div className="text-muted-foreground mb-2 flex items-center gap-2 text-sm">
+          <span>
+            {count != null && count > rows.length
+              ? `Showing ${rows.length} of ${count.toLocaleString()} transactions`
+              : `${(count ?? rows.length).toLocaleString()} ${
+                  (count ?? rows.length) === 1 ? "transaction" : "transactions"
+                }`}
+          </span>
+          {focusedIndex == null && (
+            <span className="text-xs">· Press J / K to navigate</span>
+          )}
         </div>
       )}
 
@@ -284,7 +297,7 @@ export function TransactionsPage() {
         onRowSelectionChange={setRowSelection}
         meta={tableMeta}
         focusedRowId={focusedRowId}
-        onRowClick={selectMode ? undefined : openTransaction}
+        onRowClick={selectMode ? toggleRowSelection : openTransaction}
         emptyState={
           <EmptyState
             icon={Receipt}
@@ -326,7 +339,11 @@ export function TransactionsPage() {
       )}
 
       {selectMode && selectedIds.length > 0 && (
-        <SelectionActionBar selectedIds={selectedIds} onClear={exitSelectMode} />
+        <SelectionActionBar
+          selectedIds={selectedIds}
+          totalCount={count}
+          onClear={exitSelectMode}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
Iteration 4 of the transactions-page polish sprint — select mode and keyboard navigation. Targets the `v2/transactions-polish` integration branch.

## Summary

A design-audit subagent found correctness bugs in the shortcut registry and several UX gaps in select mode. This fixes them.

**Shortcut registry (`lib/shortcuts.ts`)**
- Ignore `event.repeat` — holding `j`/`k` now steps once per press, not once per frame.
- Bail when focus is inside an open dialog/popover (`[role="dialog"]` / Radix popper) so list shortcuts don't leak under the command palette, filter pills, or pickers.
- New `global` opt-out for genuinely global, modifier-guarded shortcuts — **⌘K** uses it so it still toggles the command palette closed *from inside the palette itself* (verified open + close).

**Select mode**
- `x` with no focused row now enters select mode **and** lands the focus ring on row 0, so the next `x` has a target.
- `exitSelectMode` clears the focus ring (it used to linger after exit).
- In select mode, a click anywhere on a row toggles its selection — the checkbox cell `stopPropagation`s so it doesn't double-toggle.
- `SelectionActionBar` shows **"N of M selected"** (the header select-all only covers the loaded page), and the clear button gets a `KbdTooltip`.
- Focus ring bumped `ring-1` → `ring-2` — it was effectively invisible.
- A muted **"Press J / K to navigate"** hint shows until the first focus.

**Discoverability / cleanup**
- `ShortcutSheet` groups sorted (Global first, then alphabetical).
- `displayKey` extracted to `lib/kbd-display.ts` — was duplicated verbatim in the sheet and the kbd tooltip.

## Screenshot

`j j x` — focus ring (now `ring-2`), row selected, action bar showing "1 of 540 selected":

<img src="https://i.img402.dev/24kahazk1v.png" width="640" alt="keyboard nav + select mode">

## Test plan

- [x] `tsc -b && vite build` passes.
- [x] Browser (Chrome DevTools MCP): `j`/`k` move the (now visible) focus ring; `x` enters select mode + selects the focused row; row-body click toggles selection; Escape clears selection then exits + clears the focus ring; ⌘K toggles the command palette open *and* closed from inside; "N of M selected" + "Press J/K" hint render; no console errors.
- [x] Reviewed by `code-reviewer` subagent — the one finding (dialog guard would have blocked ⌘K from closing the palette) addressed with the `global` opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
