### PR TITLE
v2: command-palette transaction actions + responsive pass

### DIFF
--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { ArrowUpDown, CircleDot, type LucideIcon } from "lucide-react";
 import {
   CommandDialog,
   CommandEmpty,
@@ -13,6 +14,41 @@ import { NAV, navKey } from "@/lib/nav";
 import { openModal } from "@/lib/modals";
 import { useShortcut } from "@/lib/shortcuts";
 import { useLogout } from "@/api/queries/auth";
+
+// Quick "jump to this transactions view" actions. Each navigates to
+// /transactions with a fresh set of search params. `value` carries extra
+// search terms so cmdk surfaces them on partial matches ("pend", "larg").
+const TX_QUICK_ACTIONS: {
+  title: string;
+  value: string;
+  icon: LucideIcon;
+  search: Record<string, string>;
+}[] = [
+  {
+    title: "Filter: Pending",
+    value: "transactions filter pending unreviewed",
+    icon: CircleDot,
+    search: { pending: "true" },
+  },
+  {
+    title: "Filter: Posted",
+    value: "transactions filter posted cleared",
+    icon: CircleDot,
+    search: { pending: "false" },
+  },
+  {
+    title: "Sort: Largest amount",
+    value: "transactions sort amount largest highest",
+    icon: ArrowUpDown,
+    search: { sort: "amount", dir: "desc" },
+  },
+  {
+    title: "Sort: Newest first",
+    value: "transactions sort date newest recent",
+    icon: ArrowUpDown,
+    search: { sort: "date", dir: "desc" },
+  },
+];
 
 export function CommandPalette() {
   const [open, setOpen] = React.useState(false);
@@ -35,6 +71,17 @@ export function CommandPalette() {
   const runOpenModal = (modalKey: string) => {
     setOpen(false);
     navigate({ to: ".", search: openModal(modalKey) });
+  };
+
+  const runQuickFilter = (patch: Record<string, string>) => {
+    setOpen(false);
+    // Merge onto the current search rather than replacing it — "Sort:
+    // Largest" shouldn't wipe an active filter. Unknown keys carried in from
+    // another route's params are stripped by the transactions search schema.
+    navigate({
+      to: "/transactions",
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
+    });
   };
 
   const runLogout = async () => {
@@ -69,6 +116,22 @@ export function CommandPalette() {
             })}
           </CommandGroup>
         ))}
+        <CommandSeparator />
+        <CommandGroup heading="Transactions">
+          {TX_QUICK_ACTIONS.map((action) => {
+            const Icon = action.icon;
+            return (
+              <CommandItem
+                key={action.title}
+                value={action.value}
+                onSelect={() => runQuickFilter(action.search)}
+              >
+                <Icon className="size-4" />
+                <span>{action.title}</span>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
         <CommandSeparator />
         <CommandGroup heading="Account">
           <CommandItem value="logout sign out" onSelect={runLogout}>

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -112,6 +112,9 @@ export function DataTable<TData, TValue>({
   const colCount = columns.length;
 
   return (
+    // The shadcn Table primitive already wraps the <table> in its own
+    // overflow-x-auto container, so narrow viewports scroll horizontally
+    // without a second scroll container here.
     <div className="rounded-md border">
       <Table>
         <TableHeader>

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -17,7 +17,7 @@ export function TransactionPrimary({
   className,
 }: TransactionPrimaryProps) {
   return (
-    <div className={cn("flex items-center gap-3", className)}>
+    <div className={cn("flex min-w-0 items-center gap-3", className)}>
       <CategoryIconTile
         icon={t.category?.icon}
         color={t.category?.color}

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -63,7 +63,9 @@ const baseColumns: ColumnDef<Transaction>[] = [
   {
     id: "category",
     header: "Category",
-    meta: { className: "w-px" },
+    // Hidden on mobile — the description column takes the freed space; the
+    // category is still editable from the detail page.
+    meta: { className: "w-px hidden sm:table-cell" },
     cell: ({ row }) => (
       <CategoryPicker
         transactionId={row.original.id}

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -65,7 +65,7 @@ export function SelectionActionBar({
 
   return (
     <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
-      <div className="bg-popover text-popover-foreground flex items-center gap-1 rounded-full border p-1 pl-3 shadow-lg">
+      <div className="bg-popover text-popover-foreground flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 pl-3 shadow-lg">
         <span className="text-sm font-medium">
           {totalCount != null && totalCount > selectedIds.length
             ? `${selectedIds.length} of ${totalCount.toLocaleString()} selected`
@@ -121,7 +121,7 @@ function CategorizeAction({
           disabled={disabled}
         >
           <Shapes className="size-4" />
-          Categorize
+          <span className="hidden sm:inline">Categorize</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-64 p-0" align="center" side="top">
@@ -155,7 +155,7 @@ function TagAction({
           disabled={disabled}
         >
           <Tag className="size-4" />
-          Tag
+          <span className="hidden sm:inline">Tag</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="center" side="top">

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -140,6 +140,9 @@ export function TransactionsToolbar({
           />
         </div>
 
+        {/* Filter pills — grouped so they wrap as a unit, independent of
+            the sort/select controls. */}
+        <div className="flex flex-wrap items-center gap-2">
         {/* Account */}
         <FilterPill icon={Banknote} label="Account" active={!!account}>
           <Command>
@@ -307,6 +310,7 @@ export function TransactionsToolbar({
             </CommandList>
           </Command>
         </FilterPill>
+        </div>
 
         <div className="grow" />
 

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -92,7 +92,10 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
   return (
     <SidebarProvider>
       <AppSidebar />
-      <SidebarInset>
+      {/* min-w-0: the inset is a flex child — without it, a wide page (e.g. a
+          horizontally-scrolling table) grows the inset past the viewport
+          instead of letting the page's own overflow container scroll. */}
+      <SidebarInset className="min-w-0">
         <header className="flex h-14 shrink-0 items-center gap-2 border-b">
           <div className="flex items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
@@ -106,7 +109,7 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
             <span className="text-sm font-medium">{title}</span>
           </div>
         </header>
-        <main className="flex-1 p-6">
+        <main className="min-w-0 flex-1 p-6">
           <Outlet />
         </main>
       </SidebarInset>

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -280,7 +280,9 @@ export function TransactionsPage() {
                 }`}
           </span>
           {focusedIndex == null && (
-            <span className="text-xs">· Press J / K to navigate</span>
+            <span className="hidden text-xs sm:inline">
+              · Press J / K to navigate
+            </span>
           )}
         </div>
       )}


### PR DESCRIPTION
Iteration 5 of the transactions-page polish sprint — command-palette transaction actions + a responsive pass. Targets the `v2/transactions-polish` integration branch.

## Summary

### Command palette
A new **"Transactions"** group with four quick actions — Filter: Pending / Posted, Sort: Largest amount / Newest first. Each merges its params onto the current transactions search (so "Sort: Largest" doesn't wipe an active filter) and works from any page. cmdk `value` strings carry extra keywords so partial typing ("pend", "larg") surfaces them.

### Responsive pass
The page was desktop-first; audited at mobile / tablet / desktop:
- **Toolbar** — the five filter pills are grouped in their own wrapping flex row, separate from the sort/select controls, so they collapse as a unit instead of interleaving.
- **Category column** hidden below `sm` — the description column takes the freed space; category stays editable from the detail page.
- **Selection action bar** capped at viewport width; Categorize/Tag buttons go icon-only on mobile.
- The **"Press J / K" hint** is desktop-only (keyboard hint = noise on touch).
- `TransactionPrimary` gets `min-w-0` so its subtitle truncates instead of overflowing.
- **Shell fix** — `SidebarInset` and its `<main>` get `min-w-0`. Without it, a flex child with no min-width grows to its content size, so a wide table scrolled the *whole page* horizontally at tablet width. Now the table scrolls within its own container and the page never overflows.

## Screenshots

<table>
  <tr><th>Mobile (390)</th><th>Mobile — select bar</th><th>Tablet (820)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/1vw3zjyoov.png" width="250" alt="mobile"></td>
    <td><img src="https://i.img402.dev/c6hqxuntyy.png" width="250" alt="mobile select bar"></td>
    <td><img src="https://i.img402.dev/0qzhwk182l.png" width="250" alt="tablet"></td>
  </tr>
</table>

<table>
  <tr><th>Desktop (1440)</th><th>Command palette — quick actions</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/80df41xc28.png" width="400" alt="desktop"></td>
    <td><img src="https://i.img402.dev/nvcm0pprdp.png" width="400" alt="command palette"></td>
  </tr>
</table>

## Test plan

- [x] `tsc -b && vite build` passes.
- [x] Browser (Chrome DevTools MCP) at 390 / 820 / 1440: no horizontal page overflow at any width (`docScrollWidth === innerWidth`); toolbar wraps as grouped units; category column hidden < `sm`; selection bar fits; command-palette "Sort: Largest amount" navigates to `/transactions?sort=amount&dir=desc`; no console errors.
- [x] Reviewed by `code-reviewer` subagent — both findings addressed (quick-filter now merges instead of replacing search; removed a redundant `overflow-x-auto` that double-wrapped shadcn `Table`'s own scroll container — re-verified mobile still scrolls correctly via the `min-w-0` chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
