### PR TITLE
v2: /simplify cleanup pass over the transactions sprint

### DIFF
--- a/web/src/api/queries/transactions.ts
+++ b/web/src/api/queries/transactions.ts
@@ -33,16 +33,39 @@ export interface TransactionFilters {
 
 const PAGE_LIMIT = 50;
 
+// The API rejects a 1-char search; treat <2 chars as "no search".
+function normalizeSearch(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed && trimmed.length >= 2 ? trimmed : undefined;
+}
+
+// Serializes the shared filter fields (everything except sort + pagination)
+// into query params with their documented API names. Used by both the list
+// and count endpoints so the param names live in exactly one place.
+function buildFilterParams(
+  filters: TransactionFilters,
+  search: string | undefined,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  if (search) params.set("search", search);
+  if (filters.account) params.set("account_id", filters.account);
+  if (filters.category) params.set("category_slug", filters.category);
+  if (filters.start) params.set("start_date", filters.start);
+  if (filters.end) params.set("end_date", filters.end);
+  if (filters.minAmount != null)
+    params.set("min_amount", String(filters.minAmount));
+  if (filters.maxAmount != null)
+    params.set("max_amount", String(filters.maxAmount));
+  if (filters.pending != null) params.set("pending", String(filters.pending));
+  return params;
+}
+
 // useTransactions paginates GET /api/v1/transactions with cursor pagination.
 // The SPA reaches the public endpoint directly — session auth on /api/v1/*
 // (see internal/api/auth_session.go) makes the cookie sufficient. Every
 // filter maps 1:1 to a documented query param.
 export function useTransactions(filters: TransactionFilters) {
-  // The API rejects a 1-char search; treat <2 chars as "no search".
-  const search =
-    filters.search && filters.search.trim().length >= 2
-      ? filters.search.trim()
-      : undefined;
+  const search = normalizeSearch(filters.search);
 
   // Normalised key — only the fields that actually narrow the query, so two
   // filter objects that mean the same thing share a cache entry.
@@ -62,19 +85,9 @@ export function useTransactions(filters: TransactionFilters) {
   return useInfiniteQuery({
     queryKey: ["transactions", key],
     queryFn: ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+      const params = buildFilterParams(filters, search);
+      params.set("limit", String(PAGE_LIMIT));
       if (pageParam) params.set("cursor", pageParam);
-      if (search) params.set("search", search);
-      if (filters.account) params.set("account_id", filters.account);
-      if (filters.category) params.set("category_slug", filters.category);
-      if (filters.start) params.set("start_date", filters.start);
-      if (filters.end) params.set("end_date", filters.end);
-      if (filters.minAmount != null)
-        params.set("min_amount", String(filters.minAmount));
-      if (filters.maxAmount != null)
-        params.set("max_amount", String(filters.maxAmount));
-      if (filters.pending != null)
-        params.set("pending", String(filters.pending));
       if (filters.sortBy) params.set("sort_by", filters.sortBy);
       if (filters.sortOrder) params.set("sort_order", filters.sortOrder);
       return api<TransactionsPage>(`/api/v1/transactions?${params.toString()}`);
@@ -89,10 +102,7 @@ export function useTransactions(filters: TransactionFilters) {
 // carries no total, so the count comes from a dedicated endpoint. Used for the
 // "Showing N of M" footer.
 export function useTransactionCount(filters: TransactionFilters) {
-  const search =
-    filters.search && filters.search.trim().length >= 2
-      ? filters.search.trim()
-      : undefined;
+  const search = normalizeSearch(filters.search);
 
   const key = {
     search,
@@ -108,19 +118,7 @@ export function useTransactionCount(filters: TransactionFilters) {
   return useQuery({
     queryKey: ["transactions", "count", key],
     queryFn: () => {
-      const params = new URLSearchParams();
-      if (search) params.set("search", search);
-      if (filters.account) params.set("account_id", filters.account);
-      if (filters.category) params.set("category_slug", filters.category);
-      if (filters.start) params.set("start_date", filters.start);
-      if (filters.end) params.set("end_date", filters.end);
-      if (filters.minAmount != null)
-        params.set("min_amount", String(filters.minAmount));
-      if (filters.maxAmount != null)
-        params.set("max_amount", String(filters.maxAmount));
-      if (filters.pending != null)
-        params.set("pending", String(filters.pending));
-      const qs = params.toString();
+      const qs = buildFilterParams(filters, search).toString();
       return api<{ count: number }>(
         `/api/v1/transactions/count${qs ? `?${qs}` : ""}`,
       );

--- a/web/src/components/category-command.tsx
+++ b/web/src/components/category-command.tsx
@@ -42,9 +42,11 @@ function CategoryItem({
 }) {
   return (
     <CommandItem
-      // Slug is in the value so it disambiguates duplicate child names
-      // ("Savings" under two parents) and lets power users search by slug.
-      value={`${category.slug} ${category.display_name} ${category.parent_display_name ?? ""}`}
+      // Parent name is in the value to disambiguate duplicate child names
+      // ("Savings" under two parents). The slug is deliberately NOT included:
+      // slugs repeat words ("income_tax_refund" → two "refund"s) which let
+      // fuzzy search false-match unrelated queries and bury the real result.
+      value={`${category.display_name} ${category.parent_display_name ?? ""}`}
       onSelect={() => onPick({ category_slug: category.slug })}
     >
       <DynamicIcon

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -14,15 +14,16 @@ import { NAV, navKey } from "@/lib/nav";
 import { openModal } from "@/lib/modals";
 import { useShortcut } from "@/lib/shortcuts";
 import { useLogout } from "@/api/queries/auth";
+import type { TransactionsSearch } from "@/routes/transactions";
 
-// Quick "jump to this transactions view" actions. Each navigates to
-// /transactions with a fresh set of search params. `value` carries extra
-// search terms so cmdk surfaces them on partial matches ("pend", "larg").
+// Quick "jump to this transactions view" actions. Each merges its params
+// into the current transactions search. `value` carries extra search terms
+// so cmdk surfaces them on partial matches ("pend", "larg").
 const TX_QUICK_ACTIONS: {
   title: string;
   value: string;
   icon: LucideIcon;
-  search: Record<string, string>;
+  search: Partial<TransactionsSearch>;
 }[] = [
   {
     title: "Filter: Pending",
@@ -73,7 +74,7 @@ export function CommandPalette() {
     navigate({ to: ".", search: openModal(modalKey) });
   };
 
-  const runQuickFilter = (patch: Record<string, string>) => {
+  const runQuickFilter = (patch: Partial<TransactionsSearch>) => {
     setOpen(false);
     // Merge onto the current search rather than replacing it — "Sort:
     // Largest" shouldn't wipe an active filter. Unknown keys carried in from

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -171,25 +171,30 @@ export function DataTable<TData, TValue>({
             table.getRowModel().rows.map((row) => {
               const focused = row.id === focusedRowId;
               return (
-              <TableRow
-                key={row.id}
-                ref={focused ? focusedRowRef : undefined}
-                data-state={row.getIsSelected() ? "selected" : undefined}
-                onClick={onRowClick ? () => onRowClick(row.original) : undefined}
-                className={cn(
-                  onRowClick && "cursor-pointer",
-                  focused && "ring-primary ring-2 ring-inset outline-none",
-                )}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell
-                    key={cell.id}
-                    className={cell.column.columnDef.meta?.className}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
+                <TableRow
+                  key={row.id}
+                  ref={focused ? focusedRowRef : undefined}
+                  data-state={row.getIsSelected() ? "selected" : undefined}
+                  onClick={
+                    onRowClick ? () => onRowClick(row.original) : undefined
+                  }
+                  className={cn(
+                    onRowClick && "cursor-pointer",
+                    focused && "ring-primary ring-2 ring-inset outline-none",
+                  )}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell
+                      key={cell.id}
+                      className={cell.column.columnDef.meta?.className}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
               );
             })
           )}

--- a/web/src/components/tag-chip.tsx
+++ b/web/src/components/tag-chip.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { DynamicIcon } from "@/lib/icon";
@@ -51,9 +52,14 @@ interface TagListProps {
 // falls back to the slug) so a freshly-created tag never silently vanishes.
 export function TagList({ slugs, max, className }: TagListProps) {
   const { data: tags } = useTags();
+  // Memoized above the early return (Rules of Hooks) — TagList renders in
+  // every table row, so rebuilding this Map per row per render is wasteful.
+  const bySlug = useMemo(
+    () => new Map((tags ?? []).map((t) => [t.slug, t])),
+    [tags],
+  );
   if (!slugs?.length) return null;
 
-  const bySlug = new Map((tags ?? []).map((t) => [t.slug, t]));
   const resolved: TagLike[] = slugs.map(
     (slug) =>
       bySlug.get(slug) ?? { slug, display_name: slug, color: null, icon: null },

--- a/web/src/features/transactions/tag-manager.tsx
+++ b/web/src/features/transactions/tag-manager.tsx
@@ -28,7 +28,10 @@ export function TagManager({ transactionId, tags }: TagManagerProps) {
   const update = useUpdateTransactions();
 
   const attached = useMemo(() => new Set(tags), [tags]);
-  const bySlug = new Map((catalog ?? []).map((t) => [t.slug, t]));
+  const bySlug = useMemo(
+    () => new Map((catalog ?? []).map((t) => [t.slug, t])),
+    [catalog],
+  );
 
   const toggle = async (slug: string) => {
     const isAttached = attached.has(slug);

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode, type RefObject } from "react";
+import { useMemo, useState, type ReactNode, type RefObject } from "react";
 import {
   ArrowUpDown,
   Banknote,
@@ -29,7 +29,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { KbdTooltip } from "@/components/kbd-tooltip";
-import { DynamicIcon } from "@/lib/icon";
+import { CategoryCommandList } from "@/components/category-command";
 import { formatLongDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { useAccounts } from "@/api/queries/accounts";
@@ -60,6 +60,10 @@ const SORT_OPTIONS: {
   { label: "Smallest amount", sort: "amount", dir: "asc" },
 ];
 
+// A removable filter chip's key — either a real search param, or a sentinel
+// for the two range filters that clear a pair of params at once.
+type ChipKey = keyof TransactionsSearch | "dateRange" | "amountRange";
+
 // TransactionsToolbar is the transactions page's single control band: a search
 // box, a row of popover-backed filter pills, a sort control and the select-mode
 // toggle — plus a removable chip for every active filter. It's controlled — all
@@ -75,7 +79,12 @@ export function TransactionsToolbar({
 }: TransactionsToolbarProps) {
   const { data: accounts } = useAccounts();
   const { data: categoryTree } = useCategories();
-  const categories = flattenCategories(categoryTree);
+  // Flattened only to resolve the active category's label for its chip — the
+  // Category pill itself uses the shared CategoryCommandList.
+  const categories = useMemo(
+    () => flattenCategories(categoryTree),
+    [categoryTree],
+  );
 
   const account = accounts?.find((a) => a.short_id === search.account);
   const category = categories.find((c) => c.slug === search.category);
@@ -88,7 +97,7 @@ export function TransactionsToolbar({
   const activeSort = foundSort ?? SORT_OPTIONS[0];
   const sortIsCustom = !!foundSort;
 
-  const chips: { key: string; label: string }[] = [];
+  const chips: { key: ChipKey; label: string }[] = [];
   if (account) chips.push({ key: "account", label: account.name });
   if (category) chips.push({ key: "category", label: category.display_name });
   if (search.start || search.end) {
@@ -108,10 +117,10 @@ export function TransactionsToolbar({
     });
   }
 
-  const clearChip = (key: string) => {
+  const clearChip = (key: ChipKey) => {
     if (key === "dateRange") onChange({ start: undefined, end: undefined });
     else if (key === "amountRange") onChange({ min: undefined, max: undefined });
-    else onChange({ [key]: undefined } as Partial<TransactionsSearch>);
+    else onChange({ [key]: undefined });
   };
 
   const clearAll = () =>
@@ -128,7 +137,6 @@ export function TransactionsToolbar({
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
-        {/* Search */}
         <div className="relative w-full min-w-48 sm:w-64">
           <Search className="text-muted-foreground absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
           <Input
@@ -143,173 +151,158 @@ export function TransactionsToolbar({
         {/* Filter pills — grouped so they wrap as a unit, independent of
             the sort/select controls. */}
         <div className="flex flex-wrap items-center gap-2">
-        {/* Account */}
-        <FilterPill icon={Banknote} label="Account" active={!!account}>
-          <Command>
-            <CommandInput placeholder="Search accounts…" />
-            <CommandList>
-              <CommandEmpty>No accounts found.</CommandEmpty>
-              <CommandGroup>
-                {(accounts ?? []).map((a) => (
-                  <CommandItem
-                    key={a.short_id}
-                    value={`${a.name} ${a.institution_name}`}
-                    onSelect={() =>
-                      onChange({
-                        account:
-                          search.account === a.short_id
-                            ? undefined
-                            : a.short_id,
-                      })
-                    }
-                  >
-                    <span className="truncate">{a.name}</span>
-                    <span className="text-muted-foreground ml-1 truncate text-xs">
-                      {a.institution_name}
-                    </span>
-                    {search.account === a.short_id && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </FilterPill>
+          <FilterPill icon={Banknote} label="Account" active={!!account}>
+            <Command>
+              <CommandInput placeholder="Search accounts…" />
+              <CommandList>
+                <CommandEmpty>No accounts found.</CommandEmpty>
+                <CommandGroup>
+                  {(accounts ?? []).map((a) => (
+                    <CommandItem
+                      key={a.short_id}
+                      value={`${a.name} ${a.institution_name}`}
+                      onSelect={() =>
+                        onChange({
+                          account:
+                            search.account === a.short_id
+                              ? undefined
+                              : a.short_id,
+                        })
+                      }
+                    >
+                      <span className="truncate">{a.name}</span>
+                      <span className="text-muted-foreground ml-1 truncate text-xs">
+                        {a.institution_name}
+                      </span>
+                      {search.account === a.short_id && (
+                        <Check className="ml-auto size-4" />
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </FilterPill>
 
-        {/* Category */}
-        <FilterPill icon={Shapes} label="Category" active={!!category}>
-          <Command>
-            <CommandInput placeholder="Search categories…" />
-            <CommandList>
-              <CommandEmpty>No categories found.</CommandEmpty>
-              <CommandGroup>
-                {categories.map((c) => (
-                  <CommandItem
-                    key={c.slug}
-                    value={`${c.display_name} ${c.parent_display_name ?? ""}`}
-                    onSelect={() =>
-                      onChange({
-                        category:
-                          search.category === c.slug ? undefined : c.slug,
-                      })
-                    }
-                  >
-                    <DynamicIcon
-                      name={c.icon}
-                      className="size-4"
-                      style={c.color ? { color: c.color } : undefined}
-                    />
-                    <span className={cn(c.parent_id && "text-muted-foreground")}>
-                      {c.parent_display_name
-                        ? `${c.parent_display_name} › ${c.display_name}`
-                        : c.display_name}
-                    </span>
-                    {search.category === c.slug && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </FilterPill>
+          <FilterPill icon={Shapes} label="Category" active={!!category}>
+            <CategoryCommandList
+              currentSlug={search.category ?? null}
+              onPick={({ category_slug }) =>
+                onChange({
+                  category:
+                    category_slug && search.category === category_slug
+                      ? undefined
+                      : category_slug,
+                })
+              }
+            />
+          </FilterPill>
 
-        {/* Date range */}
-        <FilterPill
-          icon={CalendarRange}
-          label="Date"
-          active={!!(search.start || search.end)}
-          className="w-64 p-3"
-        >
-          <div className="space-y-3">
-            <div className="space-y-1.5">
-              <Label className="text-xs">From</Label>
-              <Input
-                type="date"
-                value={search.start ?? ""}
-                onChange={(e) =>
-                  onChange({ start: e.target.value || undefined })
-                }
-              />
+          <FilterPill
+            icon={CalendarRange}
+            label="Date"
+            active={!!(search.start || search.end)}
+            className="w-64 p-3"
+          >
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">From</Label>
+                <Input
+                  type="date"
+                  value={search.start ?? ""}
+                  onChange={(e) =>
+                    onChange({ start: e.target.value || undefined })
+                  }
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">To</Label>
+                <Input
+                  type="date"
+                  value={search.end ?? ""}
+                  onChange={(e) =>
+                    onChange({ end: e.target.value || undefined })
+                  }
+                />
+              </div>
             </div>
-            <div className="space-y-1.5">
-              <Label className="text-xs">To</Label>
-              <Input
-                type="date"
-                value={search.end ?? ""}
-                onChange={(e) => onChange({ end: e.target.value || undefined })}
-              />
-            </div>
-          </div>
-        </FilterPill>
+          </FilterPill>
 
-        {/* Amount range */}
-        <FilterPill
-          icon={DollarSign}
-          label="Amount"
-          active={search.min != null || search.max != null}
-          className="w-56 p-3"
-        >
-          <div className="space-y-3">
-            <div className="space-y-1.5">
-              <Label className="text-xs">Min</Label>
-              <Input
-                type="number"
-                inputMode="decimal"
-                placeholder="0.00"
-                value={search.min ?? ""}
-                onChange={(e) =>
-                  onChange({
-                    min: e.target.value ? Number(e.target.value) : undefined,
-                  })
-                }
-              />
+          <FilterPill
+            icon={DollarSign}
+            label="Amount"
+            active={search.min != null || search.max != null}
+            className="w-56 p-3"
+          >
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">Min</Label>
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={search.min ?? ""}
+                  onChange={(e) =>
+                    onChange({
+                      min: e.target.value
+                        ? Number(e.target.value)
+                        : undefined,
+                    })
+                  }
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">Max</Label>
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={search.max ?? ""}
+                  onChange={(e) =>
+                    onChange({
+                      max: e.target.value
+                        ? Number(e.target.value)
+                        : undefined,
+                    })
+                  }
+                />
+              </div>
             </div>
-            <div className="space-y-1.5">
-              <Label className="text-xs">Max</Label>
-              <Input
-                type="number"
-                inputMode="decimal"
-                placeholder="0.00"
-                value={search.max ?? ""}
-                onChange={(e) =>
-                  onChange({
-                    max: e.target.value ? Number(e.target.value) : undefined,
-                  })
-                }
-              />
-            </div>
-          </div>
-        </FilterPill>
+          </FilterPill>
 
-        {/* Pending */}
-        <FilterPill icon={CircleDot} label="Status" active={!!search.pending}>
-          <Command>
-            <CommandList>
-              <CommandGroup>
-                {(
-                  [
-                    { label: "Any status", value: undefined },
-                    { label: "Pending only", value: "true" as const },
-                    { label: "Posted only", value: "false" as const },
-                  ] satisfies { label: string; value: "true" | "false" | undefined }[]
-                ).map((opt) => (
-                  <CommandItem
-                    key={opt.label}
-                    value={opt.label}
-                    onSelect={() => onChange({ pending: opt.value })}
-                  >
-                    {opt.label}
-                    {search.pending === opt.value && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </FilterPill>
+          <FilterPill
+            icon={CircleDot}
+            label="Status"
+            active={!!search.pending}
+          >
+            <Command>
+              <CommandList>
+                <CommandGroup>
+                  {(
+                    [
+                      { label: "Any status", value: undefined },
+                      { label: "Pending only", value: "true" as const },
+                      { label: "Posted only", value: "false" as const },
+                    ] satisfies {
+                      label: string;
+                      value: "true" | "false" | undefined;
+                    }[]
+                  ).map((opt) => (
+                    <CommandItem
+                      key={opt.label}
+                      value={opt.label}
+                      onSelect={() => onChange({ pending: opt.value })}
+                    >
+                      {opt.label}
+                      {search.pending === opt.value && (
+                        <Check className="ml-auto size-4" />
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </FilterPill>
         </div>
 
         <div className="grow" />


### PR DESCRIPTION
Final iteration of the transactions-page polish sprint — a `/simplify` cleanup pass over iterations 1–5. Targets the `v2/transactions-polish` integration branch.

## Summary

Three `/simplify` review agents (code-reuse, quality, efficiency) audited the full sprint surface. This applies their high-confidence findings:

**Reuse / dedup**
- `api/queries/transactions.ts` — extracted `normalizeSearch` + `buildFilterParams`; the filter→query-param serialization was copy-pasted verbatim between `useTransactions` and `useTransactionCount`.
- `transactions-toolbar.tsx` — the Category filter pill hand-rolled its own category `<Command>` list; it now reuses the shared **`CategoryCommandList`**, so the filter pill matches the pickers (grouped sections) and the toolbar drops its `flattenCategories`/`DynamicIcon` rendering.

**Quality**
- `category-command.tsx` — **bug fix**: the cmdk item `value` included the category slug, and slugs repeat words (`income_tax_refund` → two "refund"s) — so fuzzy search false-matched unrelated queries (typing "coffee" surfaced "Tax Refund" above "Coffee Shops"). Dropped the slug; the parent name still disambiguates duplicate child names.
- `command-palette.tsx` — `TX_QUICK_ACTIONS.search` typed `Partial<TransactionsSearch>` instead of `Record<string, string>`.
- `transactions-toolbar.tsx` — chip `key` typed (`ChipKey` union, not bare `string`); filter-pill block re-indented under its wrapper; stray `{/* Search */}` comment removed.
- `data-table.tsx` — re-indented a misaligned `<TableRow>` return block.

**Efficiency**
- `tag-chip.tsx` — `TagList`'s `bySlug` Map was rebuilt once per table row per render; now `useMemo`'d (placed above the early return per Rules of Hooks).
- `tag-manager.tsx` / `transactions-toolbar.tsx` — `useMemo` on the `bySlug` Map and the `flattenCategories` call.

> Out of scope (noted, not done): the per-row `useMutation` fan-out in `CategoryPicker` (50 mutation instances on a full page). The efficiency agent itself called this an architectural refactor "for when there are more editable columns" — deferred rather than reshaped in a cleanup PR.

## Test plan

- [x] `tsc -b && vite build` passes.
- [x] Browser (Chrome DevTools MCP): transactions page renders; the Category filter pill opens the shared grouped list, search no longer false-matches ("coffee" no longer surfaces Tax Refund), picking a category filters the list (`?category=…`, chip shows) and clicking it again clears it; no console errors.
- [x] Reviewed by a final `code-reviewer` subagent — confirmed all changes behavior-preserving, hooks-compliant, no dead imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
