### PR TITLE
v2: transactions page deep polish (6-iteration sprint)

### DIFF
--- a/web/src/api/queries/transactions.ts
+++ b/web/src/api/queries/transactions.ts
@@ -84,6 +84,50 @@ export function useTransactions(filters: TransactionFilters) {
   });
 }
 
+// useTransactionCount returns the total number of transactions matching the
+// same filters as useTransactions — the list endpoint is cursor-paginated and
+// carries no total, so the count comes from a dedicated endpoint. Used for the
+// "Showing N of M" footer.
+export function useTransactionCount(filters: TransactionFilters) {
+  const search =
+    filters.search && filters.search.trim().length >= 2
+      ? filters.search.trim()
+      : undefined;
+
+  const key = {
+    search,
+    account: filters.account,
+    category: filters.category,
+    start: filters.start,
+    end: filters.end,
+    minAmount: filters.minAmount,
+    maxAmount: filters.maxAmount,
+    pending: filters.pending,
+  };
+
+  return useQuery({
+    queryKey: ["transactions", "count", key],
+    queryFn: () => {
+      const params = new URLSearchParams();
+      if (search) params.set("search", search);
+      if (filters.account) params.set("account_id", filters.account);
+      if (filters.category) params.set("category_slug", filters.category);
+      if (filters.start) params.set("start_date", filters.start);
+      if (filters.end) params.set("end_date", filters.end);
+      if (filters.minAmount != null)
+        params.set("min_amount", String(filters.minAmount));
+      if (filters.maxAmount != null)
+        params.set("max_amount", String(filters.maxAmount));
+      if (filters.pending != null)
+        params.set("pending", String(filters.pending));
+      const qs = params.toString();
+      return api<{ count: number }>(
+        `/api/v1/transactions/count${qs ? `?${qs}` : ""}`,
+      );
+    },
+  });
+}
+
 // useTransaction loads a single transaction by id or short_id. Disabled until
 // an id is supplied.
 export function useTransaction(id: string | undefined) {

--- a/web/src/api/queries/transactions.ts
+++ b/web/src/api/queries/transactions.ts
@@ -33,16 +33,39 @@ export interface TransactionFilters {
 
 const PAGE_LIMIT = 50;
 
+// The API rejects a 1-char search; treat <2 chars as "no search".
+function normalizeSearch(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed && trimmed.length >= 2 ? trimmed : undefined;
+}
+
+// Serializes the shared filter fields (everything except sort + pagination)
+// into query params with their documented API names. Used by both the list
+// and count endpoints so the param names live in exactly one place.
+function buildFilterParams(
+  filters: TransactionFilters,
+  search: string | undefined,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  if (search) params.set("search", search);
+  if (filters.account) params.set("account_id", filters.account);
+  if (filters.category) params.set("category_slug", filters.category);
+  if (filters.start) params.set("start_date", filters.start);
+  if (filters.end) params.set("end_date", filters.end);
+  if (filters.minAmount != null)
+    params.set("min_amount", String(filters.minAmount));
+  if (filters.maxAmount != null)
+    params.set("max_amount", String(filters.maxAmount));
+  if (filters.pending != null) params.set("pending", String(filters.pending));
+  return params;
+}
+
 // useTransactions paginates GET /api/v1/transactions with cursor pagination.
 // The SPA reaches the public endpoint directly — session auth on /api/v1/*
 // (see internal/api/auth_session.go) makes the cookie sufficient. Every
 // filter maps 1:1 to a documented query param.
 export function useTransactions(filters: TransactionFilters) {
-  // The API rejects a 1-char search; treat <2 chars as "no search".
-  const search =
-    filters.search && filters.search.trim().length >= 2
-      ? filters.search.trim()
-      : undefined;
+  const search = normalizeSearch(filters.search);
 
   // Normalised key — only the fields that actually narrow the query, so two
   // filter objects that mean the same thing share a cache entry.
@@ -62,19 +85,9 @@ export function useTransactions(filters: TransactionFilters) {
   return useInfiniteQuery({
     queryKey: ["transactions", key],
     queryFn: ({ pageParam }) => {
-      const params = new URLSearchParams({ limit: String(PAGE_LIMIT) });
+      const params = buildFilterParams(filters, search);
+      params.set("limit", String(PAGE_LIMIT));
       if (pageParam) params.set("cursor", pageParam);
-      if (search) params.set("search", search);
-      if (filters.account) params.set("account_id", filters.account);
-      if (filters.category) params.set("category_slug", filters.category);
-      if (filters.start) params.set("start_date", filters.start);
-      if (filters.end) params.set("end_date", filters.end);
-      if (filters.minAmount != null)
-        params.set("min_amount", String(filters.minAmount));
-      if (filters.maxAmount != null)
-        params.set("max_amount", String(filters.maxAmount));
-      if (filters.pending != null)
-        params.set("pending", String(filters.pending));
       if (filters.sortBy) params.set("sort_by", filters.sortBy);
       if (filters.sortOrder) params.set("sort_order", filters.sortOrder);
       return api<TransactionsPage>(`/api/v1/transactions?${params.toString()}`);
@@ -89,10 +102,7 @@ export function useTransactions(filters: TransactionFilters) {
 // carries no total, so the count comes from a dedicated endpoint. Used for the
 // "Showing N of M" footer.
 export function useTransactionCount(filters: TransactionFilters) {
-  const search =
-    filters.search && filters.search.trim().length >= 2
-      ? filters.search.trim()
-      : undefined;
+  const search = normalizeSearch(filters.search);
 
   const key = {
     search,
@@ -108,19 +118,7 @@ export function useTransactionCount(filters: TransactionFilters) {
   return useQuery({
     queryKey: ["transactions", "count", key],
     queryFn: () => {
-      const params = new URLSearchParams();
-      if (search) params.set("search", search);
-      if (filters.account) params.set("account_id", filters.account);
-      if (filters.category) params.set("category_slug", filters.category);
-      if (filters.start) params.set("start_date", filters.start);
-      if (filters.end) params.set("end_date", filters.end);
-      if (filters.minAmount != null)
-        params.set("min_amount", String(filters.minAmount));
-      if (filters.maxAmount != null)
-        params.set("max_amount", String(filters.maxAmount));
-      if (filters.pending != null)
-        params.set("pending", String(filters.pending));
-      const qs = params.toString();
+      const qs = buildFilterParams(filters, search).toString();
       return api<{ count: number }>(
         `/api/v1/transactions/count${qs ? `?${qs}` : ""}`,
       );

--- a/web/src/components/category-badge.tsx
+++ b/web/src/components/category-badge.tsx
@@ -12,7 +12,8 @@ interface CategoryBadgeProps {
 
 // CategoryBadge is the single rendering of a transaction category across v2 —
 // list rows, the detail page, pickers. Icon + display name, tinted by the
-// category's own color. Renders an em-dash when there's no category.
+// category's own color. Rounded-rectangle shaped — the pill shape is reserved
+// for tags. Renders an em-dash when there's no category.
 export function CategoryBadge({
   category,
   overridden,
@@ -27,7 +28,7 @@ export function CategoryBadge({
     <Badge
       variant="secondary"
       className={cn(
-        "gap-1",
+        "gap-1 rounded-md",
         overridden && "ring-1 ring-primary/40",
         className,
       )}

--- a/web/src/components/category-command.tsx
+++ b/web/src/components/category-command.tsx
@@ -1,0 +1,107 @@
+import { useCallback } from "react";
+import { Check, RotateCcw } from "lucide-react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { DynamicIcon } from "@/lib/icon";
+import { cn } from "@/lib/utils";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { useCategories, flattenCategories } from "@/api/queries/categories";
+import { useUpdateTransactions } from "@/api/queries/transactions";
+
+// A single category change — set a slug, or reset to the provider default.
+export interface CategoryPick {
+  category_slug?: string;
+  reset_category?: boolean;
+}
+
+interface CategoryCommandListProps {
+  /** Slug of the currently-applied category — rendered with a check mark. */
+  currentSlug?: string | null;
+  /** Show a "reset to provider default" entry — for manually-overridden rows. */
+  showReset?: boolean;
+  onPick: (pick: CategoryPick) => void;
+}
+
+// CategoryCommandList is the shared searchable category list behind every
+// category-mutation surface — the detail-page editor and the inline row
+// picker. Pure presentation: the caller owns the mutation.
+export function CategoryCommandList({
+  currentSlug,
+  showReset,
+  onPick,
+}: CategoryCommandListProps) {
+  const { data: tree, isLoading } = useCategories();
+  const categories = flattenCategories(tree);
+
+  return (
+    <Command>
+      <CommandInput placeholder="Search categories…" />
+      <CommandList>
+        <CommandEmpty>
+          {isLoading ? "Loading…" : "No categories found."}
+        </CommandEmpty>
+        {showReset && (
+          <>
+            <CommandGroup>
+              <CommandItem
+                value="reset provider default"
+                onSelect={() => onPick({ reset_category: true })}
+              >
+                <RotateCcw className="size-4" />
+                Reset to provider default
+              </CommandItem>
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        )}
+        <CommandGroup>
+          {categories.map((c) => (
+            <CommandItem
+              key={c.slug}
+              value={`${c.display_name} ${c.parent_display_name ?? ""}`}
+              onSelect={() => onPick({ category_slug: c.slug })}
+            >
+              <DynamicIcon
+                name={c.icon}
+                className="size-4"
+                style={c.color ? { color: c.color } : undefined}
+              />
+              <span className={cn(c.parent_id && "text-muted-foreground")}>
+                {c.parent_display_name
+                  ? `${c.parent_display_name} › ${c.display_name}`
+                  : c.display_name}
+              </span>
+              {currentSlug === c.slug && <Check className="ml-auto size-4" />}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}
+
+// useCategoryEditor wraps the batch mutation for the common
+// single-transaction category change, shared by the detail-page editor and
+// the inline row picker so the toast + op-shaping live in one place.
+export function useCategoryEditor(transactionId: string) {
+  const update = useUpdateTransactions();
+  const apply = useCallback(
+    (pick: CategoryPick) =>
+      withMutationToast(
+        () =>
+          update.mutateAsync({
+            operations: [{ transaction_id: transactionId, ...pick }],
+          }),
+        { success: "Category updated." },
+      ),
+    [update, transactionId],
+  );
+  return { apply, isPending: update.isPending };
+}

--- a/web/src/components/category-command.tsx
+++ b/web/src/components/category-command.tsx
@@ -10,10 +10,10 @@ import {
   CommandSeparator,
 } from "@/components/ui/command";
 import { DynamicIcon } from "@/lib/icon";
-import { cn } from "@/lib/utils";
 import { withMutationToast } from "@/lib/mutation-toast";
-import { useCategories, flattenCategories } from "@/api/queries/categories";
+import { useCategories } from "@/api/queries/categories";
 import { useUpdateTransactions } from "@/api/queries/transactions";
+import type { Category } from "@/api/types";
 
 // A single category change — set a slug, or reset to the provider default.
 export interface CategoryPick {
@@ -29,16 +29,47 @@ interface CategoryCommandListProps {
   onPick: (pick: CategoryPick) => void;
 }
 
+// One selectable category row. `value` carries the parent name too, so a
+// search for the parent ("food") still surfaces every child.
+function CategoryItem({
+  category,
+  currentSlug,
+  onPick,
+}: {
+  category: Category;
+  currentSlug?: string | null;
+  onPick: (pick: CategoryPick) => void;
+}) {
+  return (
+    <CommandItem
+      // Slug is in the value so it disambiguates duplicate child names
+      // ("Savings" under two parents) and lets power users search by slug.
+      value={`${category.slug} ${category.display_name} ${category.parent_display_name ?? ""}`}
+      onSelect={() => onPick({ category_slug: category.slug })}
+    >
+      <DynamicIcon
+        name={category.icon}
+        className="size-4"
+        style={category.color ? { color: category.color } : undefined}
+      />
+      <span>{category.display_name}</span>
+      {currentSlug === category.slug && <Check className="ml-auto size-4" />}
+    </CommandItem>
+  );
+}
+
 // CategoryCommandList is the shared searchable category list behind every
-// category-mutation surface — the detail-page editor and the inline row
-// picker. Pure presentation: the caller owns the mutation.
+// category-mutation surface — the detail-page editor, the inline row picker,
+// and bulk categorize. Categories are grouped by their parent so the list
+// reads as sections rather than one flat wall. Pure presentation: the caller
+// owns the mutation.
 export function CategoryCommandList({
   currentSlug,
   showReset,
   onPick,
 }: CategoryCommandListProps) {
   const { data: tree, isLoading } = useCategories();
-  const categories = flattenCategories(tree);
+  const parents = (tree ?? []).filter((c) => !c.hidden);
 
   return (
     <Command>
@@ -61,27 +92,38 @@ export function CategoryCommandList({
             <CommandSeparator />
           </>
         )}
-        <CommandGroup>
-          {categories.map((c) => (
-            <CommandItem
-              key={c.slug}
-              value={`${c.display_name} ${c.parent_display_name ?? ""}`}
-              onSelect={() => onPick({ category_slug: c.slug })}
-            >
-              <DynamicIcon
-                name={c.icon}
-                className="size-4"
-                style={c.color ? { color: c.color } : undefined}
+        {parents.map((parent) => {
+          const children = (parent.children ?? []).filter((c) => !c.hidden);
+          // A childless top-level category renders as a lone item — no point
+          // wrapping it in a one-row group with a redundant heading.
+          if (children.length === 0) {
+            return (
+              <CategoryItem
+                key={parent.slug}
+                category={parent}
+                currentSlug={currentSlug}
+                onPick={onPick}
               />
-              <span className={cn(c.parent_id && "text-muted-foreground")}>
-                {c.parent_display_name
-                  ? `${c.parent_display_name} › ${c.display_name}`
-                  : c.display_name}
-              </span>
-              {currentSlug === c.slug && <Check className="ml-auto size-4" />}
-            </CommandItem>
-          ))}
-        </CommandGroup>
+            );
+          }
+          return (
+            <CommandGroup key={parent.slug} heading={parent.display_name}>
+              <CategoryItem
+                category={parent}
+                currentSlug={currentSlug}
+                onPick={onPick}
+              />
+              {children.map((child) => (
+                <CategoryItem
+                  key={child.slug}
+                  category={child}
+                  currentSlug={currentSlug}
+                  onPick={onPick}
+                />
+              ))}
+            </CommandGroup>
+          );
+        })}
       </CommandList>
     </Command>
   );

--- a/web/src/components/category-command.tsx
+++ b/web/src/components/category-command.tsx
@@ -42,9 +42,11 @@ function CategoryItem({
 }) {
   return (
     <CommandItem
-      // Slug is in the value so it disambiguates duplicate child names
-      // ("Savings" under two parents) and lets power users search by slug.
-      value={`${category.slug} ${category.display_name} ${category.parent_display_name ?? ""}`}
+      // Parent name is in the value to disambiguate duplicate child names
+      // ("Savings" under two parents). The slug is deliberately NOT included:
+      // slugs repeat words ("income_tax_refund" → two "refund"s) which let
+      // fuzzy search false-match unrelated queries and bury the real result.
+      value={`${category.display_name} ${category.parent_display_name ?? ""}`}
       onSelect={() => onPick({ category_slug: category.slug })}
     >
       <DynamicIcon

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { CategoryBadge } from "@/components/category-badge";
+import {
+  CategoryCommandList,
+  useCategoryEditor,
+  type CategoryPick,
+} from "@/components/category-command";
+import { cn } from "@/lib/utils";
+import type { TransactionCategory } from "@/api/types";
+
+interface CategoryPickerProps {
+  transactionId: string;
+  category: TransactionCategory | null | undefined;
+  /** True when the current category was set by a manual override. */
+  overridden?: boolean;
+  className?: string;
+}
+
+// CategoryPicker is the compact, inline category picker used in transaction
+// rows — a rounded-rect trigger showing the current category (or an "add"
+// affordance when uncategorized) over a searchable popover. stopPropagation
+// keeps a click from also firing the row's navigate handler.
+export function CategoryPicker({
+  transactionId,
+  category,
+  overridden,
+  className,
+}: CategoryPickerProps) {
+  const [open, setOpen] = useState(false);
+  const { apply, isPending } = useCategoryEditor(transactionId);
+
+  const onPick = async (pick: CategoryPick) => {
+    setOpen(false);
+    await apply(pick);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={isPending}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            "hover:bg-accent focus-visible:ring-ring rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:opacity-50",
+            className,
+          )}
+        >
+          {category?.display_name ? (
+            <CategoryBadge category={category} overridden={overridden} />
+          ) : (
+            <span className="text-muted-foreground border-border hover:text-foreground inline-flex items-center gap-1 rounded-md border border-dashed px-2 py-0.5 text-xs">
+              <Plus className="size-3" />
+              Category
+            </span>
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-64 p-0"
+        align="start"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <CategoryCommandList
+          currentSlug={category?.slug}
+          showReset={overridden}
+          onPick={onPick}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/web/src/components/category-picker.tsx
+++ b/web/src/components/category-picker.tsx
@@ -48,7 +48,7 @@ export function CategoryPicker({
           disabled={isPending}
           onClick={(e) => e.stopPropagation()}
           className={cn(
-            "hover:bg-accent focus-visible:ring-ring rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:opacity-50",
+            "hover:bg-accent focus-visible:ring-ring rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-wait disabled:opacity-50",
             className,
           )}
         >

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -22,6 +22,9 @@ export function CommandPalette() {
   useShortcut(["mod", "k"], () => setOpen((v) => !v), {
     label: "Open command palette",
     group: "Global",
+    // ⌘K must toggle from anywhere — including from inside the palette
+    // itself (its own search input / dialog) to close it.
+    global: true,
   });
 
   const go = (to: string) => {

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -14,15 +14,16 @@ import { NAV, navKey } from "@/lib/nav";
 import { openModal } from "@/lib/modals";
 import { useShortcut } from "@/lib/shortcuts";
 import { useLogout } from "@/api/queries/auth";
+import type { TransactionsSearch } from "@/routes/transactions";
 
-// Quick "jump to this transactions view" actions. Each navigates to
-// /transactions with a fresh set of search params. `value` carries extra
-// search terms so cmdk surfaces them on partial matches ("pend", "larg").
+// Quick "jump to this transactions view" actions. Each merges its params
+// into the current transactions search. `value` carries extra search terms
+// so cmdk surfaces them on partial matches ("pend", "larg").
 const TX_QUICK_ACTIONS: {
   title: string;
   value: string;
   icon: LucideIcon;
-  search: Record<string, string>;
+  search: Partial<TransactionsSearch>;
 }[] = [
   {
     title: "Filter: Pending",
@@ -73,7 +74,7 @@ export function CommandPalette() {
     navigate({ to: ".", search: openModal(modalKey) });
   };
 
-  const runQuickFilter = (patch: Record<string, string>) => {
+  const runQuickFilter = (patch: Partial<TransactionsSearch>) => {
     setOpen(false);
     // Merge onto the current search rather than replacing it — "Sort:
     // Largest" shouldn't wipe an active filter. Unknown keys carried in from

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { ArrowUpDown, CircleDot, type LucideIcon } from "lucide-react";
 import {
   CommandDialog,
   CommandEmpty,
@@ -13,6 +14,41 @@ import { NAV, navKey } from "@/lib/nav";
 import { openModal } from "@/lib/modals";
 import { useShortcut } from "@/lib/shortcuts";
 import { useLogout } from "@/api/queries/auth";
+
+// Quick "jump to this transactions view" actions. Each navigates to
+// /transactions with a fresh set of search params. `value` carries extra
+// search terms so cmdk surfaces them on partial matches ("pend", "larg").
+const TX_QUICK_ACTIONS: {
+  title: string;
+  value: string;
+  icon: LucideIcon;
+  search: Record<string, string>;
+}[] = [
+  {
+    title: "Filter: Pending",
+    value: "transactions filter pending unreviewed",
+    icon: CircleDot,
+    search: { pending: "true" },
+  },
+  {
+    title: "Filter: Posted",
+    value: "transactions filter posted cleared",
+    icon: CircleDot,
+    search: { pending: "false" },
+  },
+  {
+    title: "Sort: Largest amount",
+    value: "transactions sort amount largest highest",
+    icon: ArrowUpDown,
+    search: { sort: "amount", dir: "desc" },
+  },
+  {
+    title: "Sort: Newest first",
+    value: "transactions sort date newest recent",
+    icon: ArrowUpDown,
+    search: { sort: "date", dir: "desc" },
+  },
+];
 
 export function CommandPalette() {
   const [open, setOpen] = React.useState(false);
@@ -35,6 +71,17 @@ export function CommandPalette() {
   const runOpenModal = (modalKey: string) => {
     setOpen(false);
     navigate({ to: ".", search: openModal(modalKey) });
+  };
+
+  const runQuickFilter = (patch: Record<string, string>) => {
+    setOpen(false);
+    // Merge onto the current search rather than replacing it — "Sort:
+    // Largest" shouldn't wipe an active filter. Unknown keys carried in from
+    // another route's params are stripped by the transactions search schema.
+    navigate({
+      to: "/transactions",
+      search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
+    });
   };
 
   const runLogout = async () => {
@@ -69,6 +116,22 @@ export function CommandPalette() {
             })}
           </CommandGroup>
         ))}
+        <CommandSeparator />
+        <CommandGroup heading="Transactions">
+          {TX_QUICK_ACTIONS.map((action) => {
+            const Icon = action.icon;
+            return (
+              <CommandItem
+                key={action.title}
+                value={action.value}
+                onSelect={() => runQuickFilter(action.search)}
+              >
+                <Icon className="size-4" />
+                <span>{action.title}</span>
+              </CommandItem>
+            );
+          })}
+        </CommandGroup>
         <CommandSeparator />
         <CommandGroup heading="Account">
           <CommandItem value="logout sign out" onSelect={runLogout}>

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -171,25 +171,30 @@ export function DataTable<TData, TValue>({
             table.getRowModel().rows.map((row) => {
               const focused = row.id === focusedRowId;
               return (
-              <TableRow
-                key={row.id}
-                ref={focused ? focusedRowRef : undefined}
-                data-state={row.getIsSelected() ? "selected" : undefined}
-                onClick={onRowClick ? () => onRowClick(row.original) : undefined}
-                className={cn(
-                  onRowClick && "cursor-pointer",
-                  focused && "ring-primary ring-2 ring-inset outline-none",
-                )}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell
-                    key={cell.id}
-                    className={cell.column.columnDef.meta?.className}
-                  >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
+                <TableRow
+                  key={row.id}
+                  ref={focused ? focusedRowRef : undefined}
+                  data-state={row.getIsSelected() ? "selected" : undefined}
+                  onClick={
+                    onRowClick ? () => onRowClick(row.original) : undefined
+                  }
+                  className={cn(
+                    onRowClick && "cursor-pointer",
+                    focused && "ring-primary ring-2 ring-inset outline-none",
+                  )}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell
+                      key={cell.id}
+                      className={cell.column.columnDef.meta?.className}
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
               );
             })
           )}

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -175,7 +175,7 @@ export function DataTable<TData, TValue>({
                 onClick={onRowClick ? () => onRowClick(row.original) : undefined}
                 className={cn(
                   onRowClick && "cursor-pointer",
-                  focused && "ring-primary ring-1 ring-inset",
+                  focused && "ring-primary ring-2 ring-inset outline-none",
                 )}
               >
                 {row.getVisibleCells().map((cell) => (

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -5,6 +5,7 @@ import {
   useReactTable,
   type ColumnDef,
   type OnChangeFn,
+  type RowData,
   type RowSelectionState,
   type SortingState,
 } from "@tanstack/react-table";
@@ -18,6 +19,15 @@ import {
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+
+// Per-column className, applied to both the header cell and every body cell.
+// Lets a column opt into width behaviour (e.g. `w-px` to shrink to content).
+declare module "@tanstack/react-table" {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface ColumnMeta<TData extends RowData, TValue> {
+    className?: string;
+  }
+}
 
 export interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -108,7 +118,10 @@ export function DataTable<TData, TValue>({
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>
               {headerGroup.headers.map((header) => (
-                <TableHead key={header.id}>
+                <TableHead
+                  key={header.id}
+                  className={header.column.columnDef.meta?.className}
+                >
                   {header.isPlaceholder
                     ? null
                     : flexRender(
@@ -166,7 +179,10 @@ export function DataTable<TData, TValue>({
                 )}
               >
                 {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
+                  <TableCell
+                    key={cell.id}
+                    className={cell.column.columnDef.meta?.className}
+                  >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
                 ))}

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -112,6 +112,9 @@ export function DataTable<TData, TValue>({
   const colCount = columns.length;
 
   return (
+    // The shadcn Table primitive already wraps the <table> in its own
+    // overflow-x-auto container, so narrow viewports scroll horizontally
+    // without a second scroll container here.
     <div className="rounded-md border">
       <Table>
         <TableHeader>

--- a/web/src/components/kbd-tooltip.tsx
+++ b/web/src/components/kbd-tooltip.tsx
@@ -5,6 +5,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { displayKey } from "@/lib/kbd-display";
 
 export interface KbdTooltipProps {
   label: string;
@@ -12,21 +13,6 @@ export interface KbdTooltipProps {
   side?: React.ComponentProps<typeof TooltipContent>["side"];
   align?: React.ComponentProps<typeof TooltipContent>["align"];
   children: React.ReactElement;
-}
-
-const DISPLAY: Record<string, string> = {
-  mod: "⌘",
-  cmd: "⌘",
-  ctrl: "Ctrl",
-  shift: "⇧",
-  alt: "⌥",
-  option: "⌥",
-};
-
-function display(k: string): string {
-  const lower = k.toLowerCase();
-  if (lower in DISPLAY) return DISPLAY[lower];
-  return k.length === 1 ? k.toUpperCase() : k;
 }
 
 export function KbdTooltip({
@@ -44,7 +30,7 @@ export function KbdTooltip({
         {keys && keys.length > 0 && (
           <KbdGroup>
             {keys.map((k) => (
-              <Kbd key={k}>{display(k)}</Kbd>
+              <Kbd key={k}>{displayKey(k)}</Kbd>
             ))}
           </KbdGroup>
         )}

--- a/web/src/components/shortcut-sheet.tsx
+++ b/web/src/components/shortcut-sheet.tsx
@@ -7,27 +7,13 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { displayKey } from "@/lib/kbd-display";
 import {
   listShortcuts,
   subscribeShortcuts,
   useShortcut,
   type Shortcut,
 } from "@/lib/shortcuts";
-
-const DISPLAY: Record<string, string> = {
-  mod: "⌘",
-  cmd: "⌘",
-  ctrl: "Ctrl",
-  shift: "⇧",
-  alt: "⌥",
-  option: "⌥",
-};
-
-function display(k: string): string {
-  const lower = k.toLowerCase();
-  if (lower in DISPLAY) return DISPLAY[lower];
-  return k.length === 1 ? k.toUpperCase() : k;
-}
 
 function useShortcutList(): Shortcut[] {
   const [list, setList] = React.useState<Shortcut[]>(() => listShortcuts());
@@ -52,7 +38,14 @@ export function ShortcutSheet() {
       arr.push(s);
       out.set(key, arr);
     }
-    return Array.from(out.entries());
+    // "Global" first, then the rest alphabetically — stable regardless of
+    // which page registered its shortcuts in what order.
+    return Array.from(out.entries()).sort(([a], [b]) => {
+      if (a === b) return 0;
+      if (a === "Global") return -1;
+      if (b === "Global") return 1;
+      return a.localeCompare(b);
+    });
   }, [list]);
 
   return (
@@ -79,7 +72,7 @@ export function ShortcutSheet() {
                     <span className="text-sm">{s.label}</span>
                     <KbdGroup>
                       {s.keys.map((k) => (
-                        <Kbd key={k}>{display(k)}</Kbd>
+                        <Kbd key={k}>{displayKey(k)}</Kbd>
                       ))}
                     </KbdGroup>
                   </li>

--- a/web/src/components/tag-chip.tsx
+++ b/web/src/components/tag-chip.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { DynamicIcon } from "@/lib/icon";
@@ -51,9 +52,14 @@ interface TagListProps {
 // falls back to the slug) so a freshly-created tag never silently vanishes.
 export function TagList({ slugs, max, className }: TagListProps) {
   const { data: tags } = useTags();
+  // Memoized above the early return (Rules of Hooks) — TagList renders in
+  // every table row, so rebuilding this Map per row per render is wasteful.
+  const bySlug = useMemo(
+    () => new Map((tags ?? []).map((t) => [t.slug, t])),
+    [tags],
+  );
   if (!slugs?.length) return null;
 
-  const bySlug = new Map((tags ?? []).map((t) => [t.slug, t]));
   const resolved: TagLike[] = slugs.map(
     (slug) =>
       bySlug.get(slug) ?? { slug, display_name: slug, color: null, icon: null },

--- a/web/src/components/tag-command.tsx
+++ b/web/src/components/tag-command.tsx
@@ -1,0 +1,54 @@
+import { Check } from "lucide-react";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { DynamicIcon } from "@/lib/icon";
+import { useTags } from "@/api/queries/tags";
+
+interface TagCommandListProps {
+  /** Slugs already attached — rendered with a check mark. */
+  attachedSlugs?: Set<string>;
+  onPick: (slug: string) => void;
+}
+
+// TagCommandList is the shared searchable tag list behind every tag-mutation
+// surface — the detail-page tag manager and bulk tag. Pure presentation: the
+// caller owns the mutation.
+export function TagCommandList({ attachedSlugs, onPick }: TagCommandListProps) {
+  const { data: tags, isLoading } = useTags();
+
+  return (
+    <Command>
+      <CommandInput placeholder="Search tags…" />
+      <CommandList>
+        <CommandEmpty>
+          {isLoading ? "Loading…" : "No tags found."}
+        </CommandEmpty>
+        <CommandGroup>
+          {(tags ?? []).map((tag) => (
+            <CommandItem
+              key={tag.slug}
+              value={tag.display_name}
+              onSelect={() => onPick(tag.slug)}
+            >
+              <DynamicIcon
+                name={tag.icon}
+                className="size-4"
+                style={tag.color ? { color: tag.color } : undefined}
+              />
+              <span>{tag.display_name}</span>
+              {attachedSlugs?.has(tag.slug) && (
+                <Check className="ml-auto size-4" />
+              )}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  );
+}

--- a/web/src/components/transaction-amount.tsx
+++ b/web/src/components/transaction-amount.tsx
@@ -1,0 +1,33 @@
+import { formatAmount, formatDate } from "@/lib/format";
+import { cn } from "@/lib/utils";
+import type { Transaction } from "@/api/types";
+
+interface TransactionAmountProps {
+  transaction: Transaction;
+  className?: string;
+}
+
+// TransactionAmount is the reusable right-aligned amount block — the signed
+// amount with the transaction date beneath it. Inflows (negative amounts)
+// render in the success color.
+export function TransactionAmount({
+  transaction: t,
+  className,
+}: TransactionAmountProps) {
+  const isInflow = t.amount < 0;
+  return (
+    <div className={cn("text-right whitespace-nowrap", className)}>
+      <div
+        className={cn(
+          "font-medium tabular-nums",
+          isInflow && "text-success",
+        )}
+      >
+        {formatAmount(t.amount, t.iso_currency_code)}
+      </div>
+      <div className="text-muted-foreground text-xs tabular-nums">
+        {formatDate(t.date)}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -1,0 +1,57 @@
+import { CategoryIconTile } from "@/components/category-icon-tile";
+import { TagList } from "@/components/tag-chip";
+import { cn } from "@/lib/utils";
+import type { Transaction } from "@/api/types";
+
+interface TransactionPrimaryProps {
+  transaction: Transaction;
+  className?: string;
+}
+
+// TransactionPrimary is the reusable identity block for a transaction — the
+// category icon tile, the bank description as the title with an inline
+// "Pending" marker, and a secondary line of metadata (account · member · tags).
+// Shared by the transactions table and any future transaction list.
+export function TransactionPrimary({
+  transaction: t,
+  className,
+}: TransactionPrimaryProps) {
+  return (
+    <div className={cn("flex items-center gap-3", className)}>
+      <CategoryIconTile
+        icon={t.category?.icon}
+        color={t.category?.color}
+        size="sm"
+      />
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate font-medium">{t.provider_name}</span>
+          {t.pending && (
+            <span className="text-muted-foreground shrink-0 text-xs">
+              Pending
+            </span>
+          )}
+        </div>
+        <TransactionMeta transaction={t} />
+      </div>
+    </div>
+  );
+}
+
+// The secondary metadata line: account and household member as plain text,
+// then tag chips. Renders nothing when there's no metadata to show.
+function TransactionMeta({ transaction: t }: { transaction: Transaction }) {
+  const text: string[] = [];
+  if (t.account_name) text.push(t.account_name);
+  if (t.user_name) text.push(t.user_name);
+  const hasTags = !!t.tags?.length;
+  if (!text.length && !hasTags) return null;
+
+  return (
+    <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
+      {text.length > 0 && <span className="truncate">{text.join(" · ")}</span>}
+      {text.length > 0 && hasTags && <span aria-hidden>·</span>}
+      {hasTags && <TagList slugs={t.tags} max={2} />}
+    </div>
+  );
+}

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -17,7 +17,7 @@ export function TransactionPrimary({
   className,
 }: TransactionPrimaryProps) {
   return (
-    <div className={cn("flex items-center gap-3", className)}>
+    <div className={cn("flex min-w-0 items-center gap-3", className)}>
       <CategoryIconTile
         icon={t.category?.icon}
         color={t.category?.color}

--- a/web/src/features/transactions/category-editor.tsx
+++ b/web/src/features/transactions/category-editor.tsx
@@ -1,29 +1,17 @@
 import { useState } from "react";
-import { Check, ChevronsUpDown, RotateCcw } from "lucide-react";
+import { ChevronsUpDown } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-} from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
 import { CategoryBadge } from "@/components/category-badge";
-import { DynamicIcon } from "@/lib/icon";
-import { cn } from "@/lib/utils";
-import { withMutationToast } from "@/lib/mutation-toast";
 import {
-  useCategories,
-  flattenCategories,
-} from "@/api/queries/categories";
-import { useUpdateTransactions } from "@/api/queries/transactions";
+  CategoryCommandList,
+  useCategoryEditor,
+  type CategoryPick,
+} from "@/components/category-command";
 import type { TransactionCategory } from "@/api/types";
 
 interface CategoryEditorProps {
@@ -34,29 +22,19 @@ interface CategoryEditorProps {
 }
 
 // CategoryEditor is the single-transaction category picker on the detail
-// page. The trigger shows the current category; the popover is a searchable,
-// flattened category list. A reset entry appears only when the category was
-// manually overridden — that's the sole case where "provider default" differs
-// from what's shown.
+// page — a full-width combobox trigger over the shared category command
+// list. The inline row equivalent is CategoryPicker.
 export function CategoryEditor({
   transactionId,
   category,
   overridden,
 }: CategoryEditorProps) {
   const [open, setOpen] = useState(false);
-  const { data: tree, isLoading } = useCategories();
-  const update = useUpdateTransactions();
-  const categories = flattenCategories(tree);
+  const { apply, isPending } = useCategoryEditor(transactionId);
 
-  const apply = async (op: { category_slug?: string; reset_category?: boolean }) => {
+  const onPick = async (pick: CategoryPick) => {
     setOpen(false);
-    await withMutationToast(
-      () =>
-        update.mutateAsync({
-          operations: [{ transaction_id: transactionId, ...op }],
-        }),
-      { success: "Category updated." },
-    );
+    await apply(pick);
   };
 
   return (
@@ -66,59 +44,22 @@ export function CategoryEditor({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          disabled={update.isPending}
+          disabled={isPending}
           className="w-full justify-between"
         >
           <CategoryBadge category={category} overridden={overridden} />
           <ChevronsUpDown className="text-muted-foreground size-4" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
-        <Command>
-          <CommandInput placeholder="Search categories…" />
-          <CommandList>
-            <CommandEmpty>
-              {isLoading ? "Loading…" : "No categories found."}
-            </CommandEmpty>
-            {overridden && (
-              <>
-                <CommandGroup>
-                  <CommandItem
-                    value="reset provider default"
-                    onSelect={() => apply({ reset_category: true })}
-                  >
-                    <RotateCcw className="size-4" />
-                    Reset to provider default
-                  </CommandItem>
-                </CommandGroup>
-                <CommandSeparator />
-              </>
-            )}
-            <CommandGroup>
-              {categories.map((c) => (
-                <CommandItem
-                  key={c.slug}
-                  value={`${c.display_name} ${c.parent_display_name ?? ""}`}
-                  onSelect={() => apply({ category_slug: c.slug })}
-                >
-                  <DynamicIcon
-                    name={c.icon}
-                    className="size-4"
-                    style={c.color ? { color: c.color } : undefined}
-                  />
-                  <span className={cn(c.parent_id && "text-muted-foreground")}>
-                    {c.parent_display_name
-                      ? `${c.parent_display_name} › ${c.display_name}`
-                      : c.display_name}
-                  </span>
-                  {category?.slug === c.slug && (
-                    <Check className="ml-auto size-4" />
-                  )}
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <CategoryCommandList
+          currentSlug={category?.slug}
+          showReset={overridden}
+          onPick={onPick}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -1,11 +1,8 @@
 import type { ColumnDef } from "@tanstack/react-table";
-import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
-import { CategoryBadge } from "@/components/category-badge";
-import { CategoryIconTile } from "@/components/category-icon-tile";
-import { TagList } from "@/components/tag-chip";
-import { formatAmount, formatDate } from "@/lib/format";
-import { cn } from "@/lib/utils";
+import { CategoryPicker } from "@/components/category-picker";
+import { TransactionPrimary } from "@/components/transaction-primary";
+import { TransactionAmount } from "@/components/transaction-amount";
 import type { Transaction } from "@/api/types";
 
 // TransactionTableMeta is the shape passed through DataTable's `meta` prop so
@@ -18,6 +15,7 @@ export interface TransactionTableMeta {
 
 const selectionColumn: ColumnDef<Transaction> = {
   id: "select",
+  meta: { className: "w-px" },
   header: ({ table }) => (
     <Checkbox
       checked={
@@ -50,95 +48,32 @@ const selectionColumn: ColumnDef<Transaction> = {
   enableSorting: false,
 };
 
+// Description is the greedy column (no width class); category and amount
+// shrink to their content via `w-px` so the description gets the slack and
+// its title can truncate.
 const baseColumns: ColumnDef<Transaction>[] = [
-  {
-    accessorKey: "date",
-    header: "Date",
-    cell: ({ row }) => (
-      <span className="text-muted-foreground tabular-nums whitespace-nowrap">
-        {formatDate(row.original.date)}
-      </span>
-    ),
-  },
   {
     id: "description",
     header: "Description",
-    cell: ({ row }) => {
-      const t = row.original;
-      // provider_name is the raw bank description (the primary label, per the
-      // #1072 decision). provider_merchant_name is the cleaned merchant — show
-      // it as a subtitle only when it adds information.
-      const subtitle =
-        t.provider_merchant_name &&
-        t.provider_merchant_name !== t.provider_name
-          ? t.provider_merchant_name
-          : null;
-      return (
-        <div className="flex items-center gap-3">
-          <CategoryIconTile
-            icon={t.category?.icon}
-            color={t.category?.color}
-            size="sm"
-          />
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <span className="truncate font-medium">{t.provider_name}</span>
-              {t.pending && (
-                <Badge
-                  variant="outline"
-                  className="text-muted-foreground shrink-0"
-                >
-                  Pending
-                </Badge>
-              )}
-            </div>
-            {subtitle && (
-              <div className="text-muted-foreground truncate text-xs">
-                {subtitle}
-              </div>
-            )}
-            <TagList slugs={t.tags} max={3} className="mt-1" />
-          </div>
-        </div>
-      );
-    },
+    cell: ({ row }) => <TransactionPrimary transaction={row.original} />,
   },
   {
     id: "category",
     header: "Category",
+    meta: { className: "w-px" },
     cell: ({ row }) => (
-      <CategoryBadge
+      <CategoryPicker
+        transactionId={row.original.id}
         category={row.original.category}
         overridden={row.original.category_override}
       />
     ),
   },
   {
-    accessorKey: "account_name",
-    header: "Account",
-    cell: ({ row }) => (
-      <span className="text-muted-foreground whitespace-nowrap">
-        {row.original.account_name ?? "—"}
-      </span>
-    ),
-  },
-  {
     accessorKey: "amount",
     header: () => <div className="text-right">Amount</div>,
-    cell: ({ row }) => {
-      const t = row.original;
-      const isInflow = t.amount < 0;
-      return (
-        <div
-          className={cn(
-            "text-right font-medium tabular-nums whitespace-nowrap",
-            isInflow && "text-emerald-600 dark:text-emerald-500",
-          )}
-        >
-          {formatAmount(t.amount, t.iso_currency_code)}
-        </div>
-      );
-    },
+    meta: { className: "w-px" },
+    cell: ({ row }) => <TransactionAmount transaction={row.original} />,
   },
 ];
 

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -34,7 +34,10 @@ const selectionColumn: ColumnDef<Transaction> = {
         // Shift-click extends the selection from the last-toggled row. The
         // normal onCheckedChange still fires and lands the current row in the
         // same (selected) state the range sets, so no preventDefault needed.
+        // stopPropagation keeps the row-body select-mode click from also
+        // toggling — otherwise a checkbox click would toggle twice.
         onClick={(e) => {
+          e.stopPropagation();
           if (e.shiftKey) meta?.onRangeSelect?.(row.index);
         }}
         onCheckedChange={(value) => {

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -63,7 +63,9 @@ const baseColumns: ColumnDef<Transaction>[] = [
   {
     id: "category",
     header: "Category",
-    meta: { className: "w-px" },
+    // Hidden on mobile — the description column takes the freed space; the
+    // category is still editable from the detail page.
+    meta: { className: "w-px hidden sm:table-cell" },
     cell: ({ row }) => (
       <CategoryPicker
         transactionId={row.original.id}

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -65,7 +65,7 @@ export function SelectionActionBar({
 
   return (
     <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
-      <div className="bg-popover text-popover-foreground flex items-center gap-1 rounded-full border p-1 pl-3 shadow-lg">
+      <div className="bg-popover text-popover-foreground flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 pl-3 shadow-lg">
         <span className="text-sm font-medium">
           {totalCount != null && totalCount > selectedIds.length
             ? `${selectedIds.length} of ${totalCount.toLocaleString()} selected`
@@ -121,7 +121,7 @@ function CategorizeAction({
           disabled={disabled}
         >
           <Shapes className="size-4" />
-          Categorize
+          <span className="hidden sm:inline">Categorize</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-64 p-0" align="center" side="top">
@@ -155,7 +155,7 @@ function TagAction({
           disabled={disabled}
         >
           <Tag className="size-4" />
-          Tag
+          <span className="hidden sm:inline">Tag</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="center" side="top">

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { CategoryCommandList } from "@/components/category-command";
 import { TagCommandList } from "@/components/tag-command";
+import { KbdTooltip } from "@/components/kbd-tooltip";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useUpdateTransactions } from "@/api/queries/transactions";
 import type { UpdateTransactionsOp } from "@/api/types";
@@ -27,6 +28,9 @@ function chunk<T>(items: T[], size: number): T[][] {
 
 interface SelectionActionBarProps {
   selectedIds: string[];
+  /** Total transactions matching the current filters — gives the count
+   *  context (header select-all only covers the loaded page). */
+  totalCount?: number;
   onClear: () => void;
 }
 
@@ -36,6 +40,7 @@ interface SelectionActionBarProps {
 // chunked to the endpoint's 50-op limit.
 export function SelectionActionBar({
   selectedIds,
+  totalCount,
   onClear,
 }: SelectionActionBarProps) {
   const update = useUpdateTransactions();
@@ -62,7 +67,9 @@ export function SelectionActionBar({
     <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
       <div className="bg-popover text-popover-foreground flex items-center gap-1 rounded-full border p-1 pl-3 shadow-lg">
         <span className="text-sm font-medium">
-          {selectedIds.length} selected
+          {totalCount != null && totalCount > selectedIds.length
+            ? `${selectedIds.length} of ${totalCount.toLocaleString()} selected`
+            : `${selectedIds.length} selected`}
         </span>
         <Separator orientation="vertical" className="mx-1 h-5" />
 
@@ -80,15 +87,17 @@ export function SelectionActionBar({
         />
 
         <Separator orientation="vertical" className="mx-1 h-5" />
-        <Button
-          variant="ghost"
-          size="icon"
-          className="size-8 rounded-full"
-          onClick={onClear}
-          aria-label="Clear selection"
-        >
-          <X className="size-4" />
-        </Button>
+        <KbdTooltip label="Clear selection / exit" keys={["Esc"]} side="top">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 rounded-full"
+            onClick={onClear}
+            aria-label="Clear selection"
+          >
+            <X className="size-4" />
+          </Button>
+        </KbdTooltip>
       </div>
     </div>
   );

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -5,20 +5,11 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
-import { DynamicIcon } from "@/lib/icon";
+import { CategoryCommandList } from "@/components/category-command";
+import { TagCommandList } from "@/components/tag-command";
 import { withMutationToast } from "@/lib/mutation-toast";
-import { useCategories, flattenCategories } from "@/api/queries/categories";
-import { useTags } from "@/api/queries/tags";
 import { useUpdateTransactions } from "@/api/queries/transactions";
 import type { UpdateTransactionsOp } from "@/api/types";
 
@@ -111,8 +102,6 @@ function CategorizeAction({
   onPick: (slug: string) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const { data: tree } = useCategories();
-  const categories = flattenCategories(tree);
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -127,35 +116,13 @@ function CategorizeAction({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-64 p-0" align="center" side="top">
-        <Command>
-          <CommandInput placeholder="Search categories…" />
-          <CommandList>
-            <CommandEmpty>No categories found.</CommandEmpty>
-            <CommandGroup>
-              {categories.map((c) => (
-                <CommandItem
-                  key={c.slug}
-                  value={`${c.display_name} ${c.parent_display_name ?? ""}`}
-                  onSelect={() => {
-                    setOpen(false);
-                    onPick(c.slug);
-                  }}
-                >
-                  <DynamicIcon
-                    name={c.icon}
-                    className="size-4"
-                    style={c.color ? { color: c.color } : undefined}
-                  />
-                  <span>
-                    {c.parent_display_name
-                      ? `${c.parent_display_name} › ${c.display_name}`
-                      : c.display_name}
-                  </span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+        <CategoryCommandList
+          onPick={({ category_slug }) => {
+            if (!category_slug) return;
+            setOpen(false);
+            onPick(category_slug);
+          }}
+        />
       </PopoverContent>
     </Popover>
   );
@@ -169,7 +136,6 @@ function TagAction({
   onPick: (slug: string) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const { data: tags } = useTags();
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -184,31 +150,12 @@ function TagAction({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="center" side="top">
-        <Command>
-          <CommandInput placeholder="Search tags…" />
-          <CommandList>
-            <CommandEmpty>No tags found.</CommandEmpty>
-            <CommandGroup>
-              {(tags ?? []).map((tag) => (
-                <CommandItem
-                  key={tag.slug}
-                  value={tag.display_name}
-                  onSelect={() => {
-                    setOpen(false);
-                    onPick(tag.slug);
-                  }}
-                >
-                  <DynamicIcon
-                    name={tag.icon}
-                    className="size-4"
-                    style={tag.color ? { color: tag.color } : undefined}
-                  />
-                  <span>{tag.display_name}</span>
-                </CommandItem>
-              ))}
-            </CommandGroup>
-          </CommandList>
-        </Command>
+        <TagCommandList
+          onPick={(slug) => {
+            setOpen(false);
+            onPick(slug);
+          }}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/web/src/features/transactions/tag-manager.tsx
+++ b/web/src/features/transactions/tag-manager.tsx
@@ -28,7 +28,10 @@ export function TagManager({ transactionId, tags }: TagManagerProps) {
   const update = useUpdateTransactions();
 
   const attached = useMemo(() => new Set(tags), [tags]);
-  const bySlug = new Map((catalog ?? []).map((t) => [t.slug, t]));
+  const bySlug = useMemo(
+    () => new Map((catalog ?? []).map((t) => [t.slug, t])),
+    [catalog],
+  );
 
   const toggle = async (slug: string) => {
     const isAttached = attached.has(slug);

--- a/web/src/features/transactions/tag-manager.tsx
+++ b/web/src/features/transactions/tag-manager.tsx
@@ -1,21 +1,13 @@
-import { useState } from "react";
-import { Check, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Plus } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from "@/components/ui/command";
 import { Button } from "@/components/ui/button";
 import { TagChip } from "@/components/tag-chip";
-import { DynamicIcon } from "@/lib/icon";
+import { TagCommandList } from "@/components/tag-command";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useTags } from "@/api/queries/tags";
 import { useUpdateTransactions } from "@/api/queries/transactions";
@@ -28,14 +20,14 @@ interface TagManagerProps {
 
 // TagManager is the single-transaction tag editor on the detail page. Current
 // tags render as removable chips; the "Add tag" popover toggles attachment
-// against the full tag catalog. Each toggle is one batch operation — add or
-// remove a single slug — and the cache invalidation refetches the row.
+// against the shared tag command list. Each toggle is one batch operation —
+// add or remove a single slug — and the cache invalidation refetches the row.
 export function TagManager({ transactionId, tags }: TagManagerProps) {
   const [open, setOpen] = useState(false);
-  const { data: catalog, isLoading } = useTags();
+  const { data: catalog } = useTags();
   const update = useUpdateTransactions();
 
-  const attached = new Set(tags);
+  const attached = useMemo(() => new Set(tags), [tags]);
   const bySlug = new Map((catalog ?? []).map((t) => [t.slug, t]));
 
   const toggle = async (slug: string) => {
@@ -87,33 +79,7 @@ export function TagManager({ transactionId, tags }: TagManagerProps) {
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-56 p-0" align="start">
-          <Command>
-            <CommandInput placeholder="Search tags…" />
-            <CommandList>
-              <CommandEmpty>
-                {isLoading ? "Loading…" : "No tags found."}
-              </CommandEmpty>
-              <CommandGroup>
-                {(catalog ?? []).map((tag) => (
-                  <CommandItem
-                    key={tag.slug}
-                    value={tag.display_name}
-                    onSelect={() => toggle(tag.slug)}
-                  >
-                    <DynamicIcon
-                      name={tag.icon}
-                      className="size-4"
-                      style={tag.color ? { color: tag.color } : undefined}
-                    />
-                    <span>{tag.display_name}</span>
-                    {attached.has(tag.slug) && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
+          <TagCommandList attachedSlugs={attached} onPick={toggle} />
         </PopoverContent>
       </Popover>
     </div>

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode, type RefObject } from "react";
+import { useMemo, useState, type ReactNode, type RefObject } from "react";
 import {
   ArrowUpDown,
   Banknote,
@@ -29,7 +29,7 @@ import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { KbdTooltip } from "@/components/kbd-tooltip";
-import { DynamicIcon } from "@/lib/icon";
+import { CategoryCommandList } from "@/components/category-command";
 import { formatLongDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import { useAccounts } from "@/api/queries/accounts";
@@ -60,6 +60,10 @@ const SORT_OPTIONS: {
   { label: "Smallest amount", sort: "amount", dir: "asc" },
 ];
 
+// A removable filter chip's key — either a real search param, or a sentinel
+// for the two range filters that clear a pair of params at once.
+type ChipKey = keyof TransactionsSearch | "dateRange" | "amountRange";
+
 // TransactionsToolbar is the transactions page's single control band: a search
 // box, a row of popover-backed filter pills, a sort control and the select-mode
 // toggle — plus a removable chip for every active filter. It's controlled — all
@@ -75,7 +79,12 @@ export function TransactionsToolbar({
 }: TransactionsToolbarProps) {
   const { data: accounts } = useAccounts();
   const { data: categoryTree } = useCategories();
-  const categories = flattenCategories(categoryTree);
+  // Flattened only to resolve the active category's label for its chip — the
+  // Category pill itself uses the shared CategoryCommandList.
+  const categories = useMemo(
+    () => flattenCategories(categoryTree),
+    [categoryTree],
+  );
 
   const account = accounts?.find((a) => a.short_id === search.account);
   const category = categories.find((c) => c.slug === search.category);
@@ -88,7 +97,7 @@ export function TransactionsToolbar({
   const activeSort = foundSort ?? SORT_OPTIONS[0];
   const sortIsCustom = !!foundSort;
 
-  const chips: { key: string; label: string }[] = [];
+  const chips: { key: ChipKey; label: string }[] = [];
   if (account) chips.push({ key: "account", label: account.name });
   if (category) chips.push({ key: "category", label: category.display_name });
   if (search.start || search.end) {
@@ -108,10 +117,10 @@ export function TransactionsToolbar({
     });
   }
 
-  const clearChip = (key: string) => {
+  const clearChip = (key: ChipKey) => {
     if (key === "dateRange") onChange({ start: undefined, end: undefined });
     else if (key === "amountRange") onChange({ min: undefined, max: undefined });
-    else onChange({ [key]: undefined } as Partial<TransactionsSearch>);
+    else onChange({ [key]: undefined });
   };
 
   const clearAll = () =>
@@ -128,7 +137,6 @@ export function TransactionsToolbar({
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
-        {/* Search */}
         <div className="relative w-full min-w-48 sm:w-64">
           <Search className="text-muted-foreground absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
           <Input
@@ -143,173 +151,158 @@ export function TransactionsToolbar({
         {/* Filter pills — grouped so they wrap as a unit, independent of
             the sort/select controls. */}
         <div className="flex flex-wrap items-center gap-2">
-        {/* Account */}
-        <FilterPill icon={Banknote} label="Account" active={!!account}>
-          <Command>
-            <CommandInput placeholder="Search accounts…" />
-            <CommandList>
-              <CommandEmpty>No accounts found.</CommandEmpty>
-              <CommandGroup>
-                {(accounts ?? []).map((a) => (
-                  <CommandItem
-                    key={a.short_id}
-                    value={`${a.name} ${a.institution_name}`}
-                    onSelect={() =>
-                      onChange({
-                        account:
-                          search.account === a.short_id
-                            ? undefined
-                            : a.short_id,
-                      })
-                    }
-                  >
-                    <span className="truncate">{a.name}</span>
-                    <span className="text-muted-foreground ml-1 truncate text-xs">
-                      {a.institution_name}
-                    </span>
-                    {search.account === a.short_id && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </FilterPill>
+          <FilterPill icon={Banknote} label="Account" active={!!account}>
+            <Command>
+              <CommandInput placeholder="Search accounts…" />
+              <CommandList>
+                <CommandEmpty>No accounts found.</CommandEmpty>
+                <CommandGroup>
+                  {(accounts ?? []).map((a) => (
+                    <CommandItem
+                      key={a.short_id}
+                      value={`${a.name} ${a.institution_name}`}
+                      onSelect={() =>
+                        onChange({
+                          account:
+                            search.account === a.short_id
+                              ? undefined
+                              : a.short_id,
+                        })
+                      }
+                    >
+                      <span className="truncate">{a.name}</span>
+                      <span className="text-muted-foreground ml-1 truncate text-xs">
+                        {a.institution_name}
+                      </span>
+                      {search.account === a.short_id && (
+                        <Check className="ml-auto size-4" />
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </FilterPill>
 
-        {/* Category */}
-        <FilterPill icon={Shapes} label="Category" active={!!category}>
-          <Command>
-            <CommandInput placeholder="Search categories…" />
-            <CommandList>
-              <CommandEmpty>No categories found.</CommandEmpty>
-              <CommandGroup>
-                {categories.map((c) => (
-                  <CommandItem
-                    key={c.slug}
-                    value={`${c.display_name} ${c.parent_display_name ?? ""}`}
-                    onSelect={() =>
-                      onChange({
-                        category:
-                          search.category === c.slug ? undefined : c.slug,
-                      })
-                    }
-                  >
-                    <DynamicIcon
-                      name={c.icon}
-                      className="size-4"
-                      style={c.color ? { color: c.color } : undefined}
-                    />
-                    <span className={cn(c.parent_id && "text-muted-foreground")}>
-                      {c.parent_display_name
-                        ? `${c.parent_display_name} › ${c.display_name}`
-                        : c.display_name}
-                    </span>
-                    {search.category === c.slug && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </FilterPill>
+          <FilterPill icon={Shapes} label="Category" active={!!category}>
+            <CategoryCommandList
+              currentSlug={search.category ?? null}
+              onPick={({ category_slug }) =>
+                onChange({
+                  category:
+                    category_slug && search.category === category_slug
+                      ? undefined
+                      : category_slug,
+                })
+              }
+            />
+          </FilterPill>
 
-        {/* Date range */}
-        <FilterPill
-          icon={CalendarRange}
-          label="Date"
-          active={!!(search.start || search.end)}
-          className="w-64 p-3"
-        >
-          <div className="space-y-3">
-            <div className="space-y-1.5">
-              <Label className="text-xs">From</Label>
-              <Input
-                type="date"
-                value={search.start ?? ""}
-                onChange={(e) =>
-                  onChange({ start: e.target.value || undefined })
-                }
-              />
+          <FilterPill
+            icon={CalendarRange}
+            label="Date"
+            active={!!(search.start || search.end)}
+            className="w-64 p-3"
+          >
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">From</Label>
+                <Input
+                  type="date"
+                  value={search.start ?? ""}
+                  onChange={(e) =>
+                    onChange({ start: e.target.value || undefined })
+                  }
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">To</Label>
+                <Input
+                  type="date"
+                  value={search.end ?? ""}
+                  onChange={(e) =>
+                    onChange({ end: e.target.value || undefined })
+                  }
+                />
+              </div>
             </div>
-            <div className="space-y-1.5">
-              <Label className="text-xs">To</Label>
-              <Input
-                type="date"
-                value={search.end ?? ""}
-                onChange={(e) => onChange({ end: e.target.value || undefined })}
-              />
-            </div>
-          </div>
-        </FilterPill>
+          </FilterPill>
 
-        {/* Amount range */}
-        <FilterPill
-          icon={DollarSign}
-          label="Amount"
-          active={search.min != null || search.max != null}
-          className="w-56 p-3"
-        >
-          <div className="space-y-3">
-            <div className="space-y-1.5">
-              <Label className="text-xs">Min</Label>
-              <Input
-                type="number"
-                inputMode="decimal"
-                placeholder="0.00"
-                value={search.min ?? ""}
-                onChange={(e) =>
-                  onChange({
-                    min: e.target.value ? Number(e.target.value) : undefined,
-                  })
-                }
-              />
+          <FilterPill
+            icon={DollarSign}
+            label="Amount"
+            active={search.min != null || search.max != null}
+            className="w-56 p-3"
+          >
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <Label className="text-xs">Min</Label>
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={search.min ?? ""}
+                  onChange={(e) =>
+                    onChange({
+                      min: e.target.value
+                        ? Number(e.target.value)
+                        : undefined,
+                    })
+                  }
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label className="text-xs">Max</Label>
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  placeholder="0.00"
+                  value={search.max ?? ""}
+                  onChange={(e) =>
+                    onChange({
+                      max: e.target.value
+                        ? Number(e.target.value)
+                        : undefined,
+                    })
+                  }
+                />
+              </div>
             </div>
-            <div className="space-y-1.5">
-              <Label className="text-xs">Max</Label>
-              <Input
-                type="number"
-                inputMode="decimal"
-                placeholder="0.00"
-                value={search.max ?? ""}
-                onChange={(e) =>
-                  onChange({
-                    max: e.target.value ? Number(e.target.value) : undefined,
-                  })
-                }
-              />
-            </div>
-          </div>
-        </FilterPill>
+          </FilterPill>
 
-        {/* Pending */}
-        <FilterPill icon={CircleDot} label="Status" active={!!search.pending}>
-          <Command>
-            <CommandList>
-              <CommandGroup>
-                {(
-                  [
-                    { label: "Any status", value: undefined },
-                    { label: "Pending only", value: "true" as const },
-                    { label: "Posted only", value: "false" as const },
-                  ] satisfies { label: string; value: "true" | "false" | undefined }[]
-                ).map((opt) => (
-                  <CommandItem
-                    key={opt.label}
-                    value={opt.label}
-                    onSelect={() => onChange({ pending: opt.value })}
-                  >
-                    {opt.label}
-                    {search.pending === opt.value && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </FilterPill>
+          <FilterPill
+            icon={CircleDot}
+            label="Status"
+            active={!!search.pending}
+          >
+            <Command>
+              <CommandList>
+                <CommandGroup>
+                  {(
+                    [
+                      { label: "Any status", value: undefined },
+                      { label: "Pending only", value: "true" as const },
+                      { label: "Posted only", value: "false" as const },
+                    ] satisfies {
+                      label: string;
+                      value: "true" | "false" | undefined;
+                    }[]
+                  ).map((opt) => (
+                    <CommandItem
+                      key={opt.label}
+                      value={opt.label}
+                      onSelect={() => onChange({ pending: opt.value })}
+                    >
+                      {opt.label}
+                      {search.pending === opt.value && (
+                        <Check className="ml-auto size-4" />
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </FilterPill>
         </div>
 
         <div className="grow" />

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -140,6 +140,9 @@ export function TransactionsToolbar({
           />
         </div>
 
+        {/* Filter pills — grouped so they wrap as a unit, independent of
+            the sort/select controls. */}
+        <div className="flex flex-wrap items-center gap-2">
         {/* Account */}
         <FilterPill icon={Banknote} label="Account" active={!!account}>
           <Command>
@@ -307,6 +310,7 @@ export function TransactionsToolbar({
             </CommandList>
           </Command>
         </FilterPill>
+        </div>
 
         <div className="grow" />
 

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -1,11 +1,13 @@
-import { useState, type ReactNode } from "react";
+import { useState, type ReactNode, type RefObject } from "react";
 import {
   ArrowUpDown,
   Banknote,
   CalendarRange,
   Check,
+  CheckSquare,
   CircleDot,
   DollarSign,
+  Search,
   Shapes,
   X,
 } from "lucide-react";
@@ -26,6 +28,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { KbdTooltip } from "@/components/kbd-tooltip";
 import { DynamicIcon } from "@/lib/icon";
 import { formatLongDate } from "@/lib/format";
 import { cn } from "@/lib/utils";
@@ -33,10 +36,17 @@ import { useAccounts } from "@/api/queries/accounts";
 import { useCategories, flattenCategories } from "@/api/queries/categories";
 import type { TransactionsSearch } from "@/routes/transactions";
 
-interface FilterBarProps {
+interface TransactionsToolbarProps {
   search: TransactionsSearch;
   /** Merge a patch into the URL search params. Pass undefined to clear a key. */
   onChange: (patch: Partial<TransactionsSearch>) => void;
+  /** Free-text search box — debounced into the URL by the route. */
+  query: string;
+  onQueryChange: (value: string) => void;
+  searchRef: RefObject<HTMLInputElement | null>;
+  /** Select-mode toggle, owned by the route. */
+  selectMode: boolean;
+  onToggleSelect: () => void;
 }
 
 const SORT_OPTIONS: {
@@ -50,32 +60,46 @@ const SORT_OPTIONS: {
   { label: "Smallest amount", sort: "amount", dir: "asc" },
 ];
 
-// FilterBar is the transactions filter strip: a row of popover-backed filter
-// pills plus a removable chip for every active filter. It's a controlled
-// component — all state lives in the URL, owned by the route.
-export function FilterBar({ search, onChange }: FilterBarProps) {
+// TransactionsToolbar is the transactions page's single control band: a search
+// box, a row of popover-backed filter pills, a sort control and the select-mode
+// toggle — plus a removable chip for every active filter. It's controlled — all
+// state lives in the URL (filters) or the route (search text, select mode).
+export function TransactionsToolbar({
+  search,
+  onChange,
+  query,
+  onQueryChange,
+  searchRef,
+  selectMode,
+  onToggleSelect,
+}: TransactionsToolbarProps) {
   const { data: accounts } = useAccounts();
   const { data: categoryTree } = useCategories();
   const categories = flattenCategories(categoryTree);
 
   const account = accounts?.find((a) => a.short_id === search.account);
   const category = categories.find((c) => c.slug === search.category);
-  const activeSort =
-    SORT_OPTIONS.find((o) => o.sort === search.sort && o.dir === search.dir) ??
-    SORT_OPTIONS[0];
+  // Only treat sort as "custom" when the params actually resolve to a known
+  // option — a partial/garbage param shouldn't light the pill with the wrong
+  // label.
+  const foundSort = SORT_OPTIONS.find(
+    (o) => o.sort === search.sort && o.dir === search.dir,
+  );
+  const activeSort = foundSort ?? SORT_OPTIONS[0];
+  const sortIsCustom = !!foundSort;
 
-  const chips: { key: keyof TransactionsSearch; label: string }[] = [];
+  const chips: { key: string; label: string }[] = [];
   if (account) chips.push({ key: "account", label: account.name });
   if (category) chips.push({ key: "category", label: category.display_name });
   if (search.start || search.end) {
     const from = search.start ? formatLongDate(search.start) : "Any";
     const to = search.end ? formatLongDate(search.end) : "Any";
-    chips.push({ key: "start", label: `${from} – ${to}` });
+    chips.push({ key: "dateRange", label: `${from} – ${to}` });
   }
   if (search.min != null || search.max != null) {
     const lo = search.min != null ? `$${search.min}` : "Any";
     const hi = search.max != null ? `$${search.max}` : "Any";
-    chips.push({ key: "min", label: `${lo} – ${hi}` });
+    chips.push({ key: "amountRange", label: `${lo} – ${hi}` });
   }
   if (search.pending) {
     chips.push({
@@ -84,9 +108,9 @@ export function FilterBar({ search, onChange }: FilterBarProps) {
     });
   }
 
-  const clearChip = (key: keyof TransactionsSearch) => {
-    if (key === "start") onChange({ start: undefined, end: undefined });
-    else if (key === "min") onChange({ min: undefined, max: undefined });
+  const clearChip = (key: string) => {
+    if (key === "dateRange") onChange({ start: undefined, end: undefined });
+    else if (key === "amountRange") onChange({ min: undefined, max: undefined });
     else onChange({ [key]: undefined } as Partial<TransactionsSearch>);
   };
 
@@ -104,6 +128,18 @@ export function FilterBar({ search, onChange }: FilterBarProps) {
   return (
     <div className="space-y-2">
       <div className="flex flex-wrap items-center gap-2">
+        {/* Search */}
+        <div className="relative w-full min-w-48 sm:w-64">
+          <Search className="text-muted-foreground absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+          <Input
+            ref={searchRef}
+            value={query}
+            onChange={(e) => onQueryChange(e.target.value)}
+            placeholder="Search merchant or description…"
+            className="pl-8"
+          />
+        </div>
+
         {/* Account */}
         <FilterPill icon={Banknote} label="Account" active={!!account}>
           <Command>
@@ -274,29 +310,49 @@ export function FilterBar({ search, onChange }: FilterBarProps) {
 
         <div className="grow" />
 
-        {/* Sort */}
-        <FilterPill icon={ArrowUpDown} label={activeSort.label} active>
-          <Command>
-            <CommandList>
-              <CommandGroup>
-                {SORT_OPTIONS.map((opt) => (
-                  <CommandItem
-                    key={opt.label}
-                    value={opt.label}
-                    onSelect={() =>
-                      onChange({ sort: opt.sort, dir: opt.dir })
-                    }
-                  >
-                    {opt.label}
-                    {activeSort.label === opt.label && (
-                      <Check className="ml-auto size-4" />
-                    )}
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </FilterPill>
+        {/* Sort + select mode — grouped so they stay together when the row wraps */}
+        <div className="flex items-center gap-2">
+          <FilterPill
+            icon={ArrowUpDown}
+            label={activeSort.label}
+            active={sortIsCustom}
+          >
+            <Command>
+              <CommandList>
+                <CommandGroup>
+                  {SORT_OPTIONS.map((opt) => (
+                    <CommandItem
+                      key={opt.label}
+                      value={opt.label}
+                      onSelect={() => onChange({ sort: opt.sort, dir: opt.dir })}
+                    >
+                      {opt.label}
+                      {activeSort.label === opt.label && (
+                        <Check className="ml-auto size-4" />
+                      )}
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </FilterPill>
+
+          {selectMode ? (
+            <KbdTooltip label="Exit select mode" keys={["Esc"]}>
+              <Button variant="secondary" size="sm" onClick={onToggleSelect}>
+                <X className="size-4" />
+                Done
+              </Button>
+            </KbdTooltip>
+          ) : (
+            <KbdTooltip label="Select transactions" keys={["x"]}>
+              <Button variant="outline" size="sm" onClick={onToggleSelect}>
+                <CheckSquare className="size-4" />
+                Select
+              </Button>
+            </KbdTooltip>
+          )}
+        </div>
       </div>
 
       {chips.length > 0 && (
@@ -356,10 +412,7 @@ function FilterPill({
           {label}
         </Button>
       </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className={cn("w-56 p-0", className)}
-      >
+      <PopoverContent align="start" className={cn("w-56 p-0", className)}>
         {children}
       </PopoverContent>
     </Popover>

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -338,7 +338,7 @@ export function TransactionsToolbar({
           </FilterPill>
 
           {selectMode ? (
-            <KbdTooltip label="Exit select mode" keys={["Esc"]}>
+            <KbdTooltip label="Clear selection / exit" keys={["Esc"]}>
               <Button variant="secondary" size="sm" onClick={onToggleSelect}>
                 <X className="size-4" />
                 Done

--- a/web/src/globals.css
+++ b/web/src/globals.css
@@ -20,6 +20,7 @@
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
+  --success: oklch(0.596 0.145 163.225);
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
@@ -56,6 +57,7 @@
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
+  --success: oklch(0.696 0.17 162.48);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
@@ -91,6 +93,7 @@
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);

--- a/web/src/lib/kbd-display.ts
+++ b/web/src/lib/kbd-display.ts
@@ -1,0 +1,19 @@
+// Shared key-label formatting for the shortcut sheet and kbd tooltips — one
+// source of truth so the two surfaces never drift.
+
+const DISPLAY: Record<string, string> = {
+  mod: "⌘",
+  cmd: "⌘",
+  ctrl: "Ctrl",
+  shift: "⇧",
+  alt: "⌥",
+  option: "⌥",
+};
+
+// displayKey maps a raw shortcut key to its glyph — "mod" → "⌘", single
+// letters uppercased, everything else passed through.
+export function displayKey(key: string): string {
+  const lower = key.toLowerCase();
+  if (lower in DISPLAY) return DISPLAY[lower];
+  return key.length === 1 ? key.toUpperCase() : key;
+}

--- a/web/src/lib/shortcuts.ts
+++ b/web/src/lib/shortcuts.ts
@@ -57,6 +57,12 @@ export interface UseShortcutOptions {
   label: string;
   group?: string;
   enabled?: boolean;
+  /**
+   * Fire even when focus is inside an input or an open dialog/popover. Only
+   * for genuinely global, modifier-guarded shortcuts (e.g. ⌘K) that must
+   * toggle from anywhere — never for bare-letter shortcuts.
+   */
+  global?: boolean;
 }
 
 export function useShortcut(
@@ -64,7 +70,7 @@ export function useShortcut(
   handler: (event: KeyboardEvent) => void,
   options: UseShortcutOptions,
 ): void {
-  const { label, group, enabled = true } = options;
+  const { label, group, enabled = true, global = false } = options;
   const id = `${group ?? "global"}:${label}`;
   // Both `keys` (inline array literal) and `handler` (inline arrow) are
   // referentially unstable across renders. Without this, the effect tears
@@ -81,16 +87,25 @@ export function useShortcut(
     const unregister = registerShortcut({ id, keys: parsedKeys, label, group });
     const match = parseKeys(parsedKeys);
     const onKey = (event: KeyboardEvent) => {
+      // Holding a key down repeats keydown — let single-press shortcuts
+      // (j/k navigation especially) fire once per press, not per frame.
+      if (event.repeat) return;
       if (event.key.toLowerCase() !== match.key) return;
       if (!!match.meta !== (event.metaKey || event.ctrlKey)) return;
       if (!!match.shift !== event.shiftKey) return;
       if (!!match.alt !== event.altKey) return;
       const target = event.target as HTMLElement | null;
       if (
+        !global &&
         target &&
         (target.tagName === "INPUT" ||
           target.tagName === "TEXTAREA" ||
-          target.isContentEditable)
+          target.isContentEditable ||
+          // Focus inside an open dialog or popover (command palette, filter
+          // pills, pickers) — the page's list shortcuts must not leak under it.
+          target.closest(
+            '[role="dialog"],[data-radix-popper-content-wrapper]',
+          ))
       ) {
         return;
       }
@@ -101,5 +116,5 @@ export function useShortcut(
       window.removeEventListener("keydown", onKey);
       unregister();
     };
-  }, [enabled, id, keysKey, label, group]);
+  }, [enabled, id, keysKey, label, group, global]);
 }

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -92,7 +92,10 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
   return (
     <SidebarProvider>
       <AppSidebar />
-      <SidebarInset>
+      {/* min-w-0: the inset is a flex child — without it, a wide page (e.g. a
+          horizontally-scrolling table) grows the inset past the viewport
+          instead of letting the page's own overflow container scroll. */}
+      <SidebarInset className="min-w-0">
         <header className="flex h-14 shrink-0 items-center gap-2 border-b">
           <div className="flex items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
@@ -106,7 +109,7 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
             <span className="text-sm font-medium">{title}</span>
           </div>
         </header>
-        <main className="flex-1 p-6">
+        <main className="min-w-0 flex-1 p-6">
           <Outlet />
         </main>
       </SidebarInset>

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -84,7 +84,7 @@ function DetailBody({ transaction: t }: { transaction: Transaction }) {
         <div
           className={cn(
             "text-xl font-semibold tabular-nums whitespace-nowrap",
-            isInflow && "text-emerald-600 dark:text-emerald-500",
+            isInflow && "text-success",
           )}
         >
           {formatAmount(t.amount, t.iso_currency_code)}

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -8,19 +8,21 @@ import {
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import type { RowSelectionState } from "@tanstack/react-table";
-import { CheckSquare, Receipt, Search, X } from "lucide-react";
+import { Loader2, Receipt } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { DataTable } from "@/components/data-table";
 import { EmptyState } from "@/components/empty-state";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
   buildTransactionColumns,
   type TransactionTableMeta,
 } from "@/features/transactions/columns";
-import { FilterBar } from "@/features/transactions/filter-bar";
+import { TransactionsToolbar } from "@/features/transactions/transactions-toolbar";
 import { SelectionActionBar } from "@/features/transactions/selection-action-bar";
-import { useTransactions } from "@/api/queries/transactions";
+import {
+  useTransactions,
+  useTransactionCount,
+} from "@/api/queries/transactions";
 import type { TransactionFilters } from "@/api/queries/transactions";
 import { flattenPages } from "@/lib/pagination";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
@@ -103,7 +105,9 @@ export function TransactionsPage() {
     [navigate],
   );
 
-  const transactions = useTransactions(searchToFilters(search));
+  const filters = searchToFilters(search);
+  const transactions = useTransactions(filters);
+  const totalCount = useTransactionCount(filters);
   const rows = useMemo(
     () => flattenPages<Transaction>(transactions.data?.pages, "transactions"),
     [transactions.data?.pages],
@@ -126,6 +130,11 @@ export function TransactionsPage() {
     setRowSelection({});
     lastIndexRef.current = null;
   }, []);
+
+  const toggleSelectMode = useCallback(() => {
+    if (selectMode) exitSelectMode();
+    else setSelectMode(true);
+  }, [selectMode, exitSelectMode]);
 
   // getRowId returns the transaction id, so rowSelection keys ARE ids.
   const selectedIds = useMemo(
@@ -200,7 +209,12 @@ export function TransactionsPage() {
   useShortcut(
     ["x"],
     () => {
-      if (focusedIndex == null) return;
+      // No focused row → just enter select mode (matches the toolbar button,
+      // which advertises `x` as its shortcut).
+      if (focusedIndex == null) {
+        setSelectMode(true);
+        return;
+      }
       const id = rows[focusedIndex]?.id;
       if (!id) return;
       setSelectMode(true);
@@ -229,49 +243,41 @@ export function TransactionsPage() {
     search.max != null ||
     !!search.pending;
 
+  const count = totalCount.data?.count;
+  const showCountLine = !transactions.isLoading && !transactions.isError;
+
   return (
     <div>
-      <PageHeader
-        title="Transactions"
-        description="Every transaction synced across your connected accounts."
-        actions={
-          selectMode ? (
-            <Button variant="secondary" size="sm" onClick={exitSelectMode}>
-              <X className="size-4" />
-              Done
-            </Button>
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setSelectMode(true)}
-            >
-              <CheckSquare className="size-4" />
-              Select
-            </Button>
-          )
-        }
-      />
+      <PageHeader title="Transactions" />
 
-      <div className="mb-4 space-y-3">
-        <div className="relative w-full max-w-xs">
-          <Search className="text-muted-foreground absolute left-2.5 top-1/2 size-4 -translate-y-1/2" />
-          <Input
-            ref={searchInputRef}
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search merchant or description…"
-            className="pl-8"
-          />
-        </div>
-        <FilterBar search={search} onChange={setFilter} />
+      <div className="mb-4">
+        <TransactionsToolbar
+          search={search}
+          onChange={setFilter}
+          query={query}
+          onQueryChange={setQuery}
+          searchRef={searchInputRef}
+          selectMode={selectMode}
+          onToggleSelect={toggleSelectMode}
+        />
       </div>
+
+      {showCountLine && rows.length > 0 && (
+        <div className="text-muted-foreground mb-2 text-sm">
+          {count != null && count > rows.length
+            ? `Showing ${rows.length} of ${count.toLocaleString()} transactions`
+            : `${(count ?? rows.length).toLocaleString()} ${
+                (count ?? rows.length) === 1 ? "transaction" : "transactions"
+              }`}
+        </div>
+      )}
 
       <DataTable
         columns={columns}
         data={rows}
         isLoading={transactions.isLoading}
         isError={transactions.isError}
+        loadingRows={6}
         getRowId={(t) => t.id}
         enableRowSelection={selectMode}
         rowSelection={selectMode ? rowSelection : undefined}
@@ -296,23 +302,31 @@ export function TransactionsPage() {
         }
       />
 
-      {transactions.hasNextPage && (
-        <div className="mt-4 flex justify-center">
-          <Button
-            variant="outline"
-            onClick={() => transactions.fetchNextPage()}
-            disabled={transactions.isFetchingNextPage}
-          >
-            {transactions.isFetchingNextPage ? "Loading…" : "Load more"}
-          </Button>
+      {rows.length > 0 && (
+        <div className="text-muted-foreground mt-4 flex justify-center text-sm">
+          {transactions.hasNextPage ? (
+            <Button
+              variant="outline"
+              onClick={() => transactions.fetchNextPage()}
+              disabled={transactions.isFetchingNextPage}
+            >
+              {transactions.isFetchingNextPage && (
+                <Loader2 className="size-4 animate-spin" />
+              )}
+              {transactions.isFetchingNextPage ? "Loading…" : "Load more"}
+            </Button>
+          ) : (
+            <span>
+              {count != null
+                ? `All ${count.toLocaleString()} transactions loaded`
+                : "All transactions loaded"}
+            </span>
+          )}
         </div>
       )}
 
       {selectMode && selectedIds.length > 0 && (
-        <SelectionActionBar
-          selectedIds={selectedIds}
-          onClear={exitSelectMode}
-        />
+        <SelectionActionBar selectedIds={selectedIds} onClear={exitSelectMode} />
       )}
     </div>
   );

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -280,7 +280,9 @@ export function TransactionsPage() {
                 }`}
           </span>
           {focusedIndex == null && (
-            <span className="text-xs">· Press J / K to navigate</span>
+            <span className="hidden text-xs sm:inline">
+              · Press J / K to navigate
+            </span>
           )}
         </div>
       )}

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -129,6 +129,13 @@ export function TransactionsPage() {
     setSelectMode(false);
     setRowSelection({});
     lastIndexRef.current = null;
+    setFocusedIndex(null);
+  }, []);
+
+  // In select mode a click anywhere on the row toggles its selection — the
+  // checkbox cell stops propagation so it doesn't double-toggle.
+  const toggleRowSelection = useCallback((t: Transaction) => {
+    setRowSelection((prev) => ({ ...prev, [t.id]: !prev[t.id] }));
   }, []);
 
   const toggleSelectMode = useCallback(() => {
@@ -209,10 +216,11 @@ export function TransactionsPage() {
   useShortcut(
     ["x"],
     () => {
-      // No focused row → just enter select mode (matches the toolbar button,
-      // which advertises `x` as its shortcut).
+      // No focused row → enter select mode and land the focus ring on the
+      // first row, so the next `x` has something to select.
       if (focusedIndex == null) {
         setSelectMode(true);
+        setFocusedIndex(0);
         return;
       }
       const id = rows[focusedIndex]?.id;
@@ -263,12 +271,17 @@ export function TransactionsPage() {
       </div>
 
       {showCountLine && rows.length > 0 && (
-        <div className="text-muted-foreground mb-2 text-sm">
-          {count != null && count > rows.length
-            ? `Showing ${rows.length} of ${count.toLocaleString()} transactions`
-            : `${(count ?? rows.length).toLocaleString()} ${
-                (count ?? rows.length) === 1 ? "transaction" : "transactions"
-              }`}
+        <div className="text-muted-foreground mb-2 flex items-center gap-2 text-sm">
+          <span>
+            {count != null && count > rows.length
+              ? `Showing ${rows.length} of ${count.toLocaleString()} transactions`
+              : `${(count ?? rows.length).toLocaleString()} ${
+                  (count ?? rows.length) === 1 ? "transaction" : "transactions"
+                }`}
+          </span>
+          {focusedIndex == null && (
+            <span className="text-xs">· Press J / K to navigate</span>
+          )}
         </div>
       )}
 
@@ -284,7 +297,7 @@ export function TransactionsPage() {
         onRowSelectionChange={setRowSelection}
         meta={tableMeta}
         focusedRowId={focusedRowId}
-        onRowClick={selectMode ? undefined : openTransaction}
+        onRowClick={selectMode ? toggleRowSelection : openTransaction}
         emptyState={
           <EmptyState
             icon={Receipt}
@@ -326,7 +339,11 @@ export function TransactionsPage() {
       )}
 
       {selectMode && selectedIds.length > 0 && (
-        <SelectionActionBar selectedIds={selectedIds} onClear={exitSelectMode} />
+        <SelectionActionBar
+          selectedIds={selectedIds}
+          totalCount={count}
+          onClear={exitSelectMode}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Merges the **`v2/transactions-polish`** sprint — a 6-iteration deep polish of the v2 admin SPA transactions experience (list, detail, row component), built on the merged v2-transactions stack (#1073–#1078).

Each iteration shipped as its own reviewed PR into this integration branch:

- **#1079 — TX-row redesign.** Drop the Date/Account columns; date moves under the amount, account into a metadata subtitle. Reusable row primitives (`TransactionPrimary`, `TransactionAmount`, `CategoryPicker`, shared `CategoryCommandList`). Inline category picker in the row. "Pending" as plain text — pill shape reserved for tags. New `--success` theme token for inflows.
- **#1080 — Toolbar + pagination.** Header, search, and filter bar collapsed into one control band (`transactions-toolbar.tsx`). `useTransactionCount` drives a "Showing N of M" line; "Load more" gets a spinner + "all loaded" footer.
- **#1081 — Picker dedup.** Shared `CategoryCommandList` / `TagCommandList` behind the row picker, detail-page editor, and bulk actions. Categories grouped by parent.
- **#1082 — Select mode + keyboard.** `event.repeat` + dialog-aware shortcut guards (with a `global` opt-out so ⌘K still toggles the palette from inside itself); row-click toggles selection; visible focus ring; "N of M selected".
- **#1083 — Command palette + responsive.** "Transactions" quick-action group in the command palette; a full responsive pass (mobile/tablet/desktop) including a shell `min-w-0` fix so a wide table scrolls within its container instead of overflowing the page.
- **#1084 — `/simplify` cleanup.** Helper extraction, picker dedup into the toolbar, a cmdk fuzzy-search false-match fix, and memoization of per-row work.

## Test plan

- [x] `tsc -b && vite build` passes on the integration branch tip.
- [x] Every iteration browser-validated via Chrome DevTools MCP at the time it merged (row layout, inline pickers + mutations, detail page, filtering, pagination, select mode, keyboard nav, command palette, responsive at 390/820/1440).
- [x] Each iteration reviewed by a `code-reviewer` subagent; findings addressed before merge.
- [ ] Final reviewer pass on the cumulative diff before merge to `main`.

## Notes

- One deferred item (see #1084): `CategoryPicker` instantiates a `useMutation` per table row. The efficiency review judged lifting it to the route an architectural change rather than cleanup — left for a follow-up.
- No `main`-facing docs needed updating; this is all within `web/` plus one `internal/service/transactions.go` change that already landed in the v2-transactions stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
