### PR TITLE
ci: prune unused Docker images after deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,10 @@ jobs:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
-          script: cd ${{ secrets.DEPLOY_PATH }} && docker compose pull && docker compose up -d
+          # Prune unused images after the new one is live — without this,
+          # every deploy leaves the old image behind and the dev box's disk
+          # eventually fills to 100% (wedged the box once; see incident).
+          script: cd ${{ secrets.DEPLOY_PATH }} && docker compose pull && docker compose up -d && docker image prune -af
 
       - name: Verify health
         run: |


### PR DESCRIPTION
## Summary

The deploy step ran `docker compose pull` on every push to `main` but never removed the superseded image. Old images accumulated unbounded on the dev box.

## Why

`breadbox.exe.xyz` went down today. Root cause: the dev box's 19GB root disk hit **100% full** — `docker system df` showed **345 images, only 2 in use, ~14GB reclaimable** plus ~1.8GB build cache. A full disk wedged the host: Postgres couldn't flush WAL, `sshd` couldn't fork sessions (SSH + :8080 unreachable, edge served 503s), and processes spun on failed writes (CPU pinned ~1.7 for ~15h). CI was green the whole time — this was never a code or deploy-failure issue, purely disk exhaustion from accumulated layers. An overnight merge train (20 PRs → 20 deploys) just accelerated it.

Recovered by `docker system prune -a -f` + `docker compose down --remove-orphans && up -d`.

## Change

Append `docker image prune -af` to the deploy script, after `docker compose up -d` — so the new container is live and referencing the current image before the prune runs, leaving only superseded/unused images to be removed. One line, makes each deploy clean up after itself.

## Test plan

- [ ] Merge, observe the `deploy` job's SSH step run the prune without error.
- [ ] `docker system df` on the dev box stays bounded across subsequent deploys.

https://claude.ai/code/session_01SQ8piu23PtRjLcgj46SLeW

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQ8piu23PtRjLcgj46SLeW)_