### PR TITLE
v2: design-system sandbox at /v2/sandbox

### DIFF
--- a/.claude/rules/v2-frontend.md
+++ b/.claude/rules/v2-frontend.md
@@ -64,6 +64,14 @@ Conventions on layout:
 4. **Toasts** via `useToast()` (sonner). No `alert()`. No inline error spans.
 5. **Dialogs / sheets / popovers** use shadcn primitives. Don't roll your own.
 
+### Design-system sandbox — keep it current
+
+There's a living component gallery at `/v2/sandbox` (`web/src/sandbox/`, route in `routes/sandbox.tsx`). It's the demo surface for the reusable layer, organized into sections under `web/src/sandbox/sections/*.tsx`: **foundations** (tokens, type, icons), **primitives** (shadcn `ui/*`), **components** (composed `components/*`), **amounts** (money display), **patterns** (toasts, shortcuts, hooks, date formatters).
+
+- **Adding or meaningfully changing a reusable component, primitive, shared hook, or `lib/` helper → add or update its specimen in the matching sandbox section in the same PR.** A component nobody can find isn't reusable. This applies to anything in `components/`, `components/ui/`, `hooks/`, and reusable `lib/` utilities — **not** to `features/<page>/*` (feature-only, not library) or `routes/*`.
+- The sandbox runs on **static fixtures** (`web/src/sandbox/fixtures.ts`) and a seeded query cache — extend the fixtures rather than fetching live data, and wire `onPick`/mutation props to `toast` instead of real writes.
+- New top-level area? Add a section file + register it in the `SECTIONS` array in `routes/sandbox.tsx`.
+
 ### Styling
 
 - **Tailwind classes only.** No inline `style={}` except dynamic values that can't be expressed in Tailwind (computed colors, animations).

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { ArrowUpDown, CircleDot, type LucideIcon } from "lucide-react";
+import { ArrowUpDown, CircleDot, Palette, type LucideIcon } from "lucide-react";
 import {
   CommandDialog,
   CommandEmpty,
@@ -132,6 +132,16 @@ export function CommandPalette() {
               </CommandItem>
             );
           })}
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="Developer">
+          <CommandItem
+            value="design system sandbox components primitives"
+            onSelect={() => go("/sandbox")}
+          >
+            <Palette className="size-4" />
+            <span>Design system</span>
+          </CommandItem>
         </CommandGroup>
         <CommandSeparator />
         <CommandGroup heading="Account">

--- a/web/src/components/nav-user.tsx
+++ b/web/src/components/nav-user.tsx
@@ -1,5 +1,5 @@
-import { ChevronsUpDown, ExternalLink, LogOut } from "lucide-react";
-import { useNavigate } from "@tanstack/react-router";
+import { ChevronsUpDown, ExternalLink, LogOut, Palette } from "lucide-react";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
@@ -90,6 +90,12 @@ export function NavUser({ me }: { me: Me | null }) {
                 <ExternalLink />
                 Back to classic UI
               </a>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link to="/sandbox">
+                <Palette />
+                Design system
+              </Link>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,7 @@ import {
   createRouter,
   createRootRoute,
   createRoute,
+  lazyRouteComponent,
 } from "@tanstack/react-router";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { AnyRoute } from "@tanstack/react-router";
@@ -70,6 +71,14 @@ const transactionDetailRoute = createRoute({
   component: TransactionDetailPage,
 });
 
+// The design-system sandbox — a dev/reference gallery, not a nav leaf.
+// Lazy-loaded so its fixtures + section code stay out of the main bundle.
+const sandboxRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/sandbox",
+  component: lazyRouteComponent(() => import("@/routes/sandbox"), "SandboxPage"),
+});
+
 const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
   if (leaf.kind !== "link" || leaf.to === "/") return [];
   const override = PAGE_OVERRIDES[leaf.to];
@@ -89,6 +98,7 @@ const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
   transactionDetailRoute,
+  sandboxRoute,
   ...pageRoutes,
 ]);
 

--- a/web/src/routes/sandbox.tsx
+++ b/web/src/routes/sandbox.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -26,6 +26,9 @@ export function SandboxPage() {
   const qc = useQueryClient();
   // Prime the cache once, before the section components mount, so the
   // category/tag pickers render from fixtures instead of hitting the API.
+  // A useState initializer runs synchronously pre-render (unlike useEffect);
+  // StrictMode double-invokes it in dev, which is harmless here — the
+  // fixtures are module constants, so setQueryData is idempotent.
   useState(() => {
     qc.setQueryData(["categories"], sampleCategories);
     qc.setQueryData(["tags"], sampleTags);
@@ -33,9 +36,19 @@ export function SandboxPage() {
   });
 
   const [active, setActive] = useState<SectionId>("foundations");
-  const [dark, setDark] = useState(() =>
+  // The theme toggle is a scoped preview: it flips the global `.dark` class
+  // so the whole gallery re-themes, but restores the original mode on
+  // unmount so it never leaks out to the rest of the app.
+  const [origDark] = useState(() =>
     document.documentElement.classList.contains("dark"),
   );
+  const [dark, setDark] = useState(origDark);
+
+  useEffect(() => {
+    return () => {
+      document.documentElement.classList.toggle("dark", origDark);
+    };
+  }, [origDark]);
 
   const toggleDark = () => {
     const next = !dark;

--- a/web/src/routes/sandbox.tsx
+++ b/web/src/routes/sandbox.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { FoundationsSection } from "@/sandbox/sections/foundations";
+import { PrimitivesSection } from "@/sandbox/sections/primitives";
+import { ComponentsSection } from "@/sandbox/sections/components";
+import { PatternsSection } from "@/sandbox/sections/patterns";
+import { sampleCategories, sampleTags } from "@/sandbox/fixtures";
+
+const SECTIONS = [
+  { id: "foundations", label: "Foundations", Component: FoundationsSection },
+  { id: "primitives", label: "Primitives", Component: PrimitivesSection },
+  { id: "components", label: "Components", Component: ComponentsSection },
+  { id: "patterns", label: "Patterns", Component: PatternsSection },
+] as const;
+
+type SectionId = (typeof SECTIONS)[number]["id"];
+
+// SandboxPage is the v2 design-system gallery — a living reference for the
+// reusable components and primitives. Components that fetch reference data
+// (useCategories / useTags / TagList) read from the query cache, which this
+// page seeds with static fixtures so the gallery needs no real data.
+export function SandboxPage() {
+  const qc = useQueryClient();
+  // Prime the cache once, before the section components mount, so the
+  // category/tag pickers render from fixtures instead of hitting the API.
+  useState(() => {
+    qc.setQueryData(["categories"], sampleCategories);
+    qc.setQueryData(["tags"], sampleTags);
+    return null;
+  });
+
+  const [active, setActive] = useState<SectionId>("foundations");
+  const [dark, setDark] = useState(() =>
+    document.documentElement.classList.contains("dark"),
+  );
+
+  const toggleDark = () => {
+    const next = !dark;
+    document.documentElement.classList.toggle("dark", next);
+    setDark(next);
+  };
+
+  const ActiveSection =
+    SECTIONS.find((s) => s.id === active)?.Component ?? FoundationsSection;
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h1 className="text-xl font-semibold tracking-tight">
+            Design system
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            A living gallery of v2's reusable components, primitives, and
+            patterns. Static fixtures — nothing here writes to your data.
+          </p>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={toggleDark}
+          aria-label="Toggle theme"
+        >
+          {dark ? <Sun className="size-4" /> : <Moon className="size-4" />}
+          {dark ? "Light" : "Dark"}
+        </Button>
+      </div>
+
+      <div className="flex gap-8">
+        <nav className="sticky top-6 hidden h-fit shrink-0 sm:block">
+          <ul className="space-y-0.5">
+            {SECTIONS.map((s) => (
+              <li key={s.id}>
+                <button
+                  type="button"
+                  onClick={() => setActive(s.id)}
+                  className={cn(
+                    "w-full rounded-md px-3 py-1.5 text-left text-sm transition-colors",
+                    active === s.id
+                      ? "bg-accent text-accent-foreground font-medium"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
+                  )}
+                >
+                  {s.label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
+        {/* Mobile section switcher */}
+        <div className="min-w-0 flex-1">
+          <div className="mb-6 flex flex-wrap gap-2 sm:hidden">
+            {SECTIONS.map((s) => (
+              <Button
+                key={s.id}
+                size="sm"
+                variant={active === s.id ? "default" : "outline"}
+                onClick={() => setActive(s.id)}
+              >
+                {s.label}
+              </Button>
+            ))}
+          </div>
+          <ActiveSection />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/sandbox.tsx
+++ b/web/src/routes/sandbox.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 import { FoundationsSection } from "@/sandbox/sections/foundations";
 import { PrimitivesSection } from "@/sandbox/sections/primitives";
 import { ComponentsSection } from "@/sandbox/sections/components";
+import { AmountsSection } from "@/sandbox/sections/amounts";
 import { PatternsSection } from "@/sandbox/sections/patterns";
 import { sampleCategories, sampleTags } from "@/sandbox/fixtures";
 
@@ -13,6 +14,7 @@ const SECTIONS = [
   { id: "foundations", label: "Foundations", Component: FoundationsSection },
   { id: "primitives", label: "Primitives", Component: PrimitivesSection },
   { id: "components", label: "Components", Component: ComponentsSection },
+  { id: "amounts", label: "Amounts", Component: AmountsSection },
   { id: "patterns", label: "Patterns", Component: PatternsSection },
 ] as const;
 

--- a/web/src/sandbox/fixtures.ts
+++ b/web/src/sandbox/fixtures.ts
@@ -1,0 +1,279 @@
+// Static sample data for the design-system sandbox. The sandbox seeds these
+// into the query cache (see routes/sandbox.tsx) so components that fetch
+// reference data — useCategories, useTags, TagList — render without a network
+// round-trip or a logged-in session.
+import type {
+  Account,
+  Category,
+  Tag,
+  Transaction,
+  TransactionCategory,
+} from "@/api/types";
+
+const NOW = "2026-05-14T12:00:00Z";
+
+// --- Categories (parent/children tree, the shape useCategories returns) ---
+
+function cat(
+  partial: Pick<Category, "slug" | "display_name" | "icon" | "color"> &
+    Partial<Category>,
+): Category {
+  return {
+    id: `cat-${partial.slug}`,
+    short_id: partial.slug.slice(0, 8),
+    parent_id: null,
+    parent_slug: null,
+    parent_display_name: null,
+    sort_order: 0,
+    is_system: true,
+    hidden: false,
+    children: [],
+    created_at: NOW,
+    updated_at: NOW,
+    ...partial,
+  };
+}
+
+export const sampleCategories: Category[] = [
+  cat({
+    slug: "food_and_drink",
+    display_name: "Food & Drink",
+    icon: "utensils",
+    color: "#f97316",
+    children: [
+      cat({
+        slug: "food_and_drink_coffee",
+        display_name: "Coffee Shops",
+        icon: "coffee",
+        color: "#f97316",
+        parent_id: "cat-food_and_drink",
+        parent_slug: "food_and_drink",
+        parent_display_name: "Food & Drink",
+      }),
+      cat({
+        slug: "food_and_drink_restaurants",
+        display_name: "Restaurants",
+        icon: "utensils",
+        color: "#f97316",
+        parent_id: "cat-food_and_drink",
+        parent_slug: "food_and_drink",
+        parent_display_name: "Food & Drink",
+      }),
+      cat({
+        slug: "food_and_drink_groceries",
+        display_name: "Groceries",
+        icon: "shopping-basket",
+        color: "#f97316",
+        parent_id: "cat-food_and_drink",
+        parent_slug: "food_and_drink",
+        parent_display_name: "Food & Drink",
+      }),
+    ],
+  }),
+  cat({
+    slug: "transportation",
+    display_name: "Transportation",
+    icon: "car",
+    color: "#3b82f6",
+    children: [
+      cat({
+        slug: "transportation_gas",
+        display_name: "Gas",
+        icon: "fuel",
+        color: "#3b82f6",
+        parent_id: "cat-transportation",
+        parent_slug: "transportation",
+        parent_display_name: "Transportation",
+      }),
+      cat({
+        slug: "transportation_rideshare",
+        display_name: "Taxis & Rideshares",
+        icon: "car-taxi-front",
+        color: "#3b82f6",
+        parent_id: "cat-transportation",
+        parent_slug: "transportation",
+        parent_display_name: "Transportation",
+      }),
+    ],
+  }),
+  cat({
+    slug: "income",
+    display_name: "Income",
+    icon: "banknote",
+    color: "#10b981",
+    children: [
+      cat({
+        slug: "income_wages",
+        display_name: "Wages & Salary",
+        icon: "briefcase",
+        color: "#10b981",
+        parent_id: "cat-income",
+        parent_slug: "income",
+        parent_display_name: "Income",
+      }),
+    ],
+  }),
+  cat({
+    slug: "uncategorized",
+    display_name: "Uncategorized",
+    icon: "circle-help",
+    color: "#71717a",
+  }),
+];
+
+// --- Tags (flat list, the shape useTags returns) ---
+
+function tag(
+  partial: Pick<Tag, "slug" | "display_name" | "color" | "icon"> &
+    Partial<Tag>,
+): Tag {
+  return {
+    id: `tag-${partial.slug}`,
+    short_id: partial.slug.slice(0, 8),
+    description: "",
+    lifecycle: "active",
+    created_at: NOW,
+    updated_at: NOW,
+    ...partial,
+  };
+}
+
+export const sampleTags: Tag[] = [
+  tag({
+    slug: "needs-review",
+    display_name: "Needs Review",
+    color: "#f59e0b",
+    icon: "flag",
+  }),
+  tag({
+    slug: "business",
+    display_name: "Business",
+    color: "#6366f1",
+    icon: "briefcase",
+  }),
+  tag({
+    slug: "subscription",
+    display_name: "Subscription",
+    color: "#ec4899",
+    icon: "repeat",
+  }),
+  tag({
+    slug: "reimbursable",
+    display_name: "Reimbursable",
+    color: "#14b8a6",
+    icon: "receipt",
+  }),
+];
+
+// --- Transactions (the shape useTransactions / a list row carries) ---
+
+const txCategory = (slug: string): TransactionCategory | null => {
+  for (const parent of sampleCategories) {
+    for (const c of [parent, ...parent.children]) {
+      if (c.slug === slug) {
+        return {
+          id: c.id,
+          slug: c.slug,
+          display_name: c.display_name,
+          icon: c.icon,
+          color: c.color,
+        };
+      }
+    }
+  }
+  return null;
+};
+
+function tx(partial: Partial<Transaction> & Pick<Transaction, "id" | "provider_name" | "amount" | "date">): Transaction {
+  return {
+    short_id: partial.id.slice(0, 8),
+    account_id: "acct-checking",
+    account_name: "My Checking",
+    user_name: "Ricardo",
+    iso_currency_code: "USD",
+    datetime: null,
+    authorized_date: null,
+    provider_merchant_name: null,
+    category: null,
+    category_override: false,
+    pending: false,
+    tags: [],
+    created_at: NOW,
+    updated_at: NOW,
+    ...partial,
+  };
+}
+
+export const sampleTransactions: Transaction[] = [
+  tx({
+    id: "tx-coffee",
+    provider_name: "Blue Bottle Coffee",
+    provider_merchant_name: "Blue Bottle",
+    amount: 6.75,
+    date: "2026-05-13",
+    account_name: "Platinum Card",
+    category: txCategory("food_and_drink_coffee"),
+    tags: ["needs-review"],
+  }),
+  tx({
+    id: "tx-payroll",
+    provider_name: "ACME CORP PAYROLL",
+    amount: -3200.0,
+    date: "2026-05-12",
+    category: txCategory("income_wages"),
+    tags: ["business"],
+  }),
+  tx({
+    id: "tx-gas",
+    provider_name: "SHELL OIL 12345",
+    provider_merchant_name: "Shell",
+    amount: 52.18,
+    date: "2026-05-12",
+    pending: true,
+    category: txCategory("transportation_gas"),
+  }),
+  tx({
+    id: "tx-uncategorized",
+    provider_name: "SQ *UNKNOWN MERCHANT",
+    amount: 24.0,
+    date: "2026-05-11",
+    account_name: "Platinum Card",
+    category: null,
+    tags: ["needs-review", "reimbursable"],
+  }),
+  tx({
+    id: "tx-subscription",
+    provider_name: "Figma Monthly",
+    provider_merchant_name: "Figma",
+    amount: 15.0,
+    date: "2026-05-10",
+    category_override: true,
+    category: txCategory("food_and_drink_restaurants"),
+    tags: ["subscription", "business"],
+  }),
+];
+
+// --- Accounts (trimmed view useAccounts returns) ---
+
+export const sampleAccounts: Account[] = [
+  {
+    id: "acct-checking",
+    short_id: "checking",
+    name: "My Checking",
+    institution_name: "Mega Bank",
+    type: "depository",
+    subtype: "checking",
+    mask: "4821",
+    iso_currency_code: "USD",
+  },
+  {
+    id: "acct-platinum",
+    short_id: "platinum",
+    name: "Platinum Card",
+    institution_name: "Card Co",
+    type: "credit",
+    subtype: "credit card",
+    mask: "0093",
+    iso_currency_code: "USD",
+  },
+];

--- a/web/src/sandbox/kit.tsx
+++ b/web/src/sandbox/kit.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+// Shared layout primitives for the design-system sandbox. Kept deliberately
+// plain — they frame the real components without competing with them.
+
+export function SandboxSection({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-lg font-semibold tracking-tight">{title}</h2>
+        {description && (
+          <p className="text-muted-foreground text-sm">{description}</p>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+// A single labeled example. `code` names the component/token so the gallery
+// doubles as a quick "what's it called" reference.
+export function Specimen({
+  label,
+  code,
+  description,
+  children,
+  className,
+}: {
+  label: string;
+  code?: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline gap-2">
+        <h3 className="text-sm font-medium">{label}</h3>
+        {code && (
+          <code className="bg-muted text-muted-foreground rounded px-1 py-0.5 font-mono text-xs">
+            {code}
+          </code>
+        )}
+      </div>
+      {description && (
+        <p className="text-muted-foreground text-xs">{description}</p>
+      )}
+      <div
+        className={cn(
+          "bg-card flex flex-wrap items-center gap-3 rounded-lg border p-4",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// A tighter grid for many small specimens (tokens, icons).
+export function SpecimenGrid({ children }: { children: ReactNode }) {
+  return (
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+      {children}
+    </div>
+  );
+}

--- a/web/src/sandbox/sections/amounts.tsx
+++ b/web/src/sandbox/sections/amounts.tsx
@@ -1,0 +1,136 @@
+import { formatAmount } from "@/lib/format";
+import { TransactionAmount } from "@/components/transaction-amount";
+import { SandboxSection, Specimen } from "@/sandbox/kit";
+import { sampleTransactions } from "@/sandbox/fixtures";
+
+// formatAmount reference — covers the sign convention, grouping, currencies,
+// and the null-currency fallback.
+const AMOUNTS: { code: string; output: string; note?: string }[] = [
+  {
+    code: "formatAmount(6.75, 'USD')",
+    output: formatAmount(6.75, "USD"),
+    note: "outflow — rendered plain",
+  },
+  {
+    code: "formatAmount(-3200, 'USD')",
+    output: formatAmount(-3200, "USD"),
+    note: "inflow — leading +",
+  },
+  {
+    code: "formatAmount(0, 'USD')",
+    output: formatAmount(0, "USD"),
+  },
+  {
+    code: "formatAmount(1234567.5, 'USD')",
+    output: formatAmount(1234567.5, "USD"),
+    note: "thousands grouping",
+  },
+  {
+    code: "formatAmount(42, 'EUR')",
+    output: formatAmount(42, "EUR"),
+  },
+  {
+    code: "formatAmount(42, 'GBP')",
+    output: formatAmount(42, "GBP"),
+  },
+  {
+    code: "formatAmount(4200, 'JPY')",
+    output: formatAmount(4200, "JPY"),
+    note: "no minor units",
+  },
+  {
+    code: "formatAmount(9.99, null)",
+    output: formatAmount(9.99, null),
+    note: "null currency → USD fallback",
+  },
+];
+
+// Outflow / inflow / pending — enough to show TransactionAmount's full range.
+const AMOUNT_ROWS = sampleTransactions.slice(0, 3);
+
+export function AmountsSection() {
+  return (
+    <SandboxSection
+      title="Amounts"
+      description="How money is displayed in v2. One sign convention, one formatter, one component — applied everywhere a balance or transaction amount appears."
+    >
+      <Specimen
+        label="Sign convention"
+        description="Breadbox stores amounts as positive = money out, negative = money in. It's deliberate but counterintuitive — every amount surface relies on it."
+        className="block"
+      >
+        <div className="grid gap-2 sm:grid-cols-2">
+          <div className="rounded-md border p-3">
+            <div className="text-sm font-medium">Positive → outflow</div>
+            <p className="text-muted-foreground text-xs">
+              Spending, fees, payments. Rendered plain.
+            </p>
+            <div className="mt-1 font-mono text-sm tabular-nums">
+              52.18 → {formatAmount(52.18, "USD")}
+            </div>
+          </div>
+          <div className="rounded-md border p-3">
+            <div className="text-sm font-medium">Negative → inflow</div>
+            <p className="text-muted-foreground text-xs">
+              Income, refunds, deposits. Rendered with a leading + in the
+              success color.
+            </p>
+            <div className="text-success mt-1 font-mono text-sm tabular-nums">
+              -3200 → {formatAmount(-3200, "USD")}
+            </div>
+          </div>
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="formatAmount"
+        code="lib/format"
+        description="The single amount formatter. Cached Intl.NumberFormat per currency; absolute value formatted, sign applied after. Never sum across currencies."
+        className="block"
+      >
+        <div className="grid gap-2 sm:grid-cols-2">
+          {AMOUNTS.map((a) => (
+            <div
+              key={a.code}
+              className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+            >
+              <div className="min-w-0">
+                <code className="text-muted-foreground block truncate font-mono text-xs">
+                  {a.code}
+                </code>
+                {a.note && (
+                  <span className="text-muted-foreground text-[10px]">
+                    {a.note}
+                  </span>
+                )}
+              </div>
+              <span className="shrink-0 text-sm font-medium tabular-nums">
+                {a.output}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="TransactionAmount"
+        code="components/transaction-amount"
+        description="The reusable amount block — signed amount over its date, right-aligned, tabular figures. Inflows pick up the success color automatically."
+        className="block divide-y"
+      >
+        {AMOUNT_ROWS.map((t) => (
+          <div
+            key={t.id}
+            className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0"
+          >
+            <span className="text-muted-foreground text-sm">
+              {t.provider_name}
+              {t.pending && " · pending"}
+            </span>
+            <TransactionAmount transaction={t} />
+          </div>
+        ))}
+      </Specimen>
+    </SandboxSection>
+  );
+}

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -1,0 +1,265 @@
+import { useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { toast } from "sonner";
+import { Inbox, Plus, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { PageHeader } from "@/components/page-header";
+import { EmptyState } from "@/components/empty-state";
+import { DataTable } from "@/components/data-table";
+import { CategoryBadge } from "@/components/category-badge";
+import { CategoryIconTile } from "@/components/category-icon-tile";
+import { CategoryCommandList } from "@/components/category-command";
+import { TagChip, TagList } from "@/components/tag-chip";
+import { TagCommandList } from "@/components/tag-command";
+import { TransactionPrimary } from "@/components/transaction-primary";
+import { TransactionAmount } from "@/components/transaction-amount";
+import { KbdTooltip } from "@/components/kbd-tooltip";
+import type { Transaction } from "@/api/types";
+import { SandboxSection, Specimen } from "@/sandbox/kit";
+import {
+  sampleTags,
+  sampleTransactions,
+} from "@/sandbox/fixtures";
+
+const coffeeCategory = sampleTransactions[0].category;
+const gasCategory = sampleTransactions[2].category;
+
+// Lightweight columns for the DataTable demo — the row primitives without the
+// live category mutation, so the sandbox stays display-only.
+const demoColumns: ColumnDef<Transaction>[] = [
+  {
+    id: "description",
+    header: "Description",
+    cell: ({ row }) => <TransactionPrimary transaction={row.original} />,
+  },
+  {
+    id: "category",
+    header: "Category",
+    meta: { className: "w-px" },
+    cell: ({ row }) => (
+      <CategoryBadge
+        category={row.original.category}
+        overridden={row.original.category_override}
+      />
+    ),
+  },
+  {
+    id: "amount",
+    header: () => <div className="text-right">Amount</div>,
+    meta: { className: "w-px" },
+    cell: ({ row }) => <TransactionAmount transaction={row.original} />,
+  },
+];
+
+export function ComponentsSection() {
+  const [tableState, setTableState] = useState<
+    "data" | "loading" | "empty"
+  >("data");
+
+  return (
+    <SandboxSection
+      title="Components"
+      description="Composed, reusable v2 components — the layer built on top of the primitives. Shared across the transactions list, detail page, and (soon) elsewhere."
+    >
+      <Specimen
+        label="PageHeader"
+        code="components/page-header"
+        className="block"
+      >
+        <PageHeader
+          title="Transactions"
+          description="Every transaction synced across your connected accounts."
+          actions={<Button size="sm">Action</Button>}
+        />
+      </Specimen>
+
+      <Specimen
+        label="EmptyState"
+        code="components/empty-state"
+        className="block"
+      >
+        <EmptyState
+          icon={Inbox}
+          title="No matching transactions"
+          description="Try adjusting or clearing your filters."
+          action={<Button variant="outline">Clear filters</Button>}
+        />
+      </Specimen>
+
+      <Specimen
+        label="CategoryIconTile"
+        code="components/category-icon-tile"
+        description="Rounded, color-tinted icon chip that fronts a transaction. Falls back to a neutral receipt glyph."
+      >
+        <CategoryIconTile
+          icon={coffeeCategory?.icon}
+          color={coffeeCategory?.color}
+          size="sm"
+        />
+        <CategoryIconTile
+          icon={gasCategory?.icon}
+          color={gasCategory?.color}
+          size="md"
+        />
+        <CategoryIconTile
+          icon={coffeeCategory?.icon}
+          color={coffeeCategory?.color}
+          size="lg"
+        />
+        <CategoryIconTile size="md" />
+      </Specimen>
+
+      <Specimen
+        label="CategoryBadge"
+        code="components/category-badge"
+        description="Single rendering of a category — rounded-rect, color-tinted. The ring marks a manual override; em-dash when uncategorized."
+      >
+        <CategoryBadge category={coffeeCategory} />
+        <CategoryBadge category={gasCategory} />
+        <CategoryBadge category={coffeeCategory} overridden />
+        <CategoryBadge category={null} />
+      </Specimen>
+
+      <Specimen
+        label="TagChip · TagList"
+        code="components/tag-chip"
+        description="Pill-shaped (the shape category badges deliberately avoid). TagList resolves slugs against the tag catalog and caps with a +N overflow."
+        className="block"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <TagChip tag={sampleTags[0]} />
+          <TagChip tag={sampleTags[1]} />
+          <TagChip
+            tag={sampleTags[2]}
+            onRemove={() => toast.message("Removed Subscription")}
+          />
+        </div>
+        <div className="mt-3">
+          <TagList
+            slugs={["needs-review", "business", "subscription", "reimbursable"]}
+            max={2}
+          />
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="TransactionPrimary · TransactionAmount"
+        code="components/transaction-*"
+        description="The reusable transaction row pieces — icon + title + metadata subtitle, and the signed amount + date. Inflows render in the success color."
+        className="block divide-y"
+      >
+        {sampleTransactions.slice(0, 3).map((t) => (
+          <div
+            key={t.id}
+            className="flex items-center justify-between gap-4 py-2 first:pt-0 last:pb-0"
+          >
+            <TransactionPrimary transaction={t} />
+            <TransactionAmount transaction={t} />
+          </div>
+        ))}
+      </Specimen>
+
+      <Specimen
+        label="CategoryCommandList"
+        code="components/category-command"
+        description="Searchable, parent-grouped category list. Pure — the caller owns the mutation; CategoryPicker / CategoryEditor wrap it with the live update."
+      >
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline">
+              <Plus /> Pick a category
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-64 p-0" align="start">
+            <CategoryCommandList
+              showReset
+              currentSlug="food_and_drink_coffee"
+              onPick={(pick) =>
+                toast.message(
+                  pick.reset_category
+                    ? "Reset to provider default"
+                    : `Picked: ${pick.category_slug}`,
+                )
+              }
+            />
+          </PopoverContent>
+        </Popover>
+        <span className="text-muted-foreground text-xs">
+          <RotateCcw className="mr-1 inline size-3" />
+          showReset adds the reset entry
+        </span>
+      </Specimen>
+
+      <Specimen
+        label="TagCommandList"
+        code="components/tag-command"
+        description="The tag equivalent — flat searchable list with a check on already-attached tags."
+      >
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline">
+              <Plus /> Add a tag
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-56 p-0" align="start">
+            <TagCommandList
+              attachedSlugs={new Set(["needs-review"])}
+              onPick={(slug) => toast.message(`Toggled tag: ${slug}`)}
+            />
+          </PopoverContent>
+        </Popover>
+      </Specimen>
+
+      <Specimen
+        label="KbdTooltip"
+        code="components/kbd-tooltip"
+        description="Tooltip with a keyboard-shortcut hint. Hover the button."
+      >
+        <KbdTooltip label="Select transactions" keys={["x"]}>
+          <Button variant="outline">Select</Button>
+        </KbdTooltip>
+        <KbdTooltip label="Command palette" keys={["mod", "k"]}>
+          <Button variant="outline">Search</Button>
+        </KbdTooltip>
+      </Specimen>
+
+      <Specimen
+        label="DataTable"
+        code="components/data-table"
+        description="The shared table — every v2 list uses it. Owns nothing: data, sorting, selection, and per-column className all come from the caller. Toggle its states:"
+        className="block"
+      >
+        <div className="mb-3 flex gap-2">
+          {(["data", "loading", "empty"] as const).map((s) => (
+            <Button
+              key={s}
+              size="sm"
+              variant={tableState === s ? "default" : "outline"}
+              onClick={() => setTableState(s)}
+            >
+              {s}
+            </Button>
+          ))}
+        </div>
+        <DataTable
+          columns={demoColumns}
+          data={tableState === "data" ? sampleTransactions : []}
+          isLoading={tableState === "loading"}
+          loadingRows={4}
+          emptyState={
+            <EmptyState
+              icon={Inbox}
+              title="No transactions"
+              description="Nothing matches the current view."
+            />
+          }
+        />
+      </Specimen>
+    </SandboxSection>
+  );
+}

--- a/web/src/sandbox/sections/foundations.tsx
+++ b/web/src/sandbox/sections/foundations.tsx
@@ -1,0 +1,179 @@
+import { DynamicIcon } from "@/lib/icon";
+import { SandboxSection, Specimen } from "@/sandbox/kit";
+
+// Static class strings so Tailwind's JIT picks them up — these can't be
+// computed.
+const SURFACES = [
+  { cls: "bg-background", name: "background" },
+  { cls: "bg-card", name: "card" },
+  { cls: "bg-popover", name: "popover" },
+  { cls: "bg-muted", name: "muted" },
+  { cls: "bg-accent", name: "accent" },
+  { cls: "bg-secondary", name: "secondary" },
+  { cls: "bg-sidebar", name: "sidebar" },
+];
+
+const BRAND = [
+  { cls: "bg-primary", fg: "text-primary-foreground", name: "primary" },
+  {
+    cls: "bg-secondary",
+    fg: "text-secondary-foreground",
+    name: "secondary",
+  },
+  {
+    cls: "bg-destructive",
+    fg: "text-destructive-foreground",
+    name: "destructive",
+  },
+  { cls: "bg-success", fg: "text-background", name: "success" },
+];
+
+const LINES = [
+  { cls: "bg-border", name: "border" },
+  { cls: "bg-input", name: "input" },
+  { cls: "bg-ring", name: "ring" },
+];
+
+const CHARTS = [
+  "bg-chart-1",
+  "bg-chart-2",
+  "bg-chart-3",
+  "bg-chart-4",
+  "bg-chart-5",
+];
+
+const RADII = [
+  { cls: "rounded-sm", name: "sm" },
+  { cls: "rounded-md", name: "md" },
+  { cls: "rounded-lg", name: "lg" },
+  { cls: "rounded-xl", name: "xl" },
+];
+
+const ICONS = [
+  "coffee",
+  "car",
+  "banknote",
+  "utensils",
+  "briefcase",
+  "receipt",
+  "flag",
+  "shopping-basket",
+];
+
+function Swatch({ cls, name }: { cls: string; name: string }) {
+  return (
+    <div className="space-y-1.5">
+      <div className={`${cls} h-12 w-full rounded-md border`} />
+      <code className="text-muted-foreground font-mono text-xs">{name}</code>
+    </div>
+  );
+}
+
+export function FoundationsSection() {
+  return (
+    <SandboxSection
+      title="Foundations"
+      description="Theme tokens, shape, type, and the icon system — the layer everything else is built on. Toggle the theme (top right) to check both modes."
+    >
+      <Specimen
+        label="Surfaces"
+        code="globals.css"
+        description="Background layers. Each is paired with a matching -foreground token for text."
+        className="block"
+      >
+        <div className="grid w-full grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-7">
+          {SURFACES.map((s) => (
+            <Swatch key={s.name} cls={s.cls} name={s.name} />
+          ))}
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="Brand & status"
+        description="Solid fills with foreground text. `success` was added for inflow amounts."
+        className="block"
+      >
+        <div className="grid w-full grid-cols-2 gap-3 sm:grid-cols-4">
+          {BRAND.map((b) => (
+            <div key={b.name} className="space-y-1.5">
+              <div
+                className={`${b.cls} ${b.fg} flex h-12 w-full items-center justify-center rounded-md text-xs font-medium`}
+              >
+                Aa
+              </div>
+              <code className="text-muted-foreground font-mono text-xs">
+                {b.name}
+              </code>
+            </div>
+          ))}
+        </div>
+      </Specimen>
+
+      <Specimen label="Lines & focus" className="block">
+        <div className="grid w-full grid-cols-3 gap-3">
+          {LINES.map((l) => (
+            <Swatch key={l.name} cls={l.cls} name={l.name} />
+          ))}
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="Chart palette"
+        code="chart-1…5"
+        description="Reserved for data viz so chart colors never collide with UI semantics."
+        className="block"
+      >
+        <div className="grid w-full grid-cols-5 gap-3">
+          {CHARTS.map((c, i) => (
+            <Swatch key={c} cls={c} name={`chart-${i + 1}`} />
+          ))}
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="Radius"
+        code="--radius"
+        description="One base radius; sm/md/lg/xl derive from it."
+      >
+        {RADII.map((r) => (
+          <div key={r.name} className="space-y-1.5 text-center">
+            <div className={`${r.cls} bg-muted size-14 border`} />
+            <code className="text-muted-foreground font-mono text-xs">
+              {r.name}
+            </code>
+          </div>
+        ))}
+      </Specimen>
+
+      <Specimen label="Typography" className="block space-y-2">
+        <p className="text-lg font-semibold tracking-tight">
+          Heading — text-lg font-semibold
+        </p>
+        <p className="text-sm">Body — text-sm</p>
+        <p className="text-muted-foreground text-xs">
+          Muted caption — text-xs text-muted-foreground
+        </p>
+        <p className="font-mono text-sm tabular-nums">
+          Tabular numerals — 1,234.50 · font-mono tabular-nums
+        </p>
+      </Specimen>
+
+      <Specimen
+        label="Icons"
+        code="DynamicIcon"
+        description="lucide-react/dynamic, kebab-case names, lazily code-split per icon. Unknown names render nothing; category/tag colors tint via style."
+      >
+        {ICONS.map((name) => (
+          <div key={name} className="space-y-1 text-center">
+            <div className="bg-muted flex size-10 items-center justify-center rounded-md">
+              <DynamicIcon name={name} className="size-5" />
+            </div>
+            <code className="text-muted-foreground font-mono text-[10px]">
+              {name}
+            </code>
+          </div>
+        ))}
+      </Specimen>
+    </SandboxSection>
+  );
+}

--- a/web/src/sandbox/sections/patterns.tsx
+++ b/web/src/sandbox/sections/patterns.tsx
@@ -1,0 +1,200 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { useShortcut } from "@/lib/shortcuts";
+import { displayKey } from "@/lib/kbd-display";
+import {
+  formatAmount,
+  formatDate,
+  formatLongDate,
+  formatRelativeTime,
+} from "@/lib/format";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { useMediaQuery } from "@/hooks/use-media-query";
+import { SandboxSection, Specimen } from "@/sandbox/kit";
+
+const FORMATTERS: { code: string; input: string; output: string }[] = [
+  {
+    code: "formatAmount(6.75, 'USD')",
+    input: "6.75",
+    output: formatAmount(6.75, "USD"),
+  },
+  {
+    code: "formatAmount(-3200, 'USD')",
+    input: "-3200 (inflow)",
+    output: formatAmount(-3200, "USD"),
+  },
+  {
+    code: "formatDate('2026-05-13')",
+    input: "2026-05-13",
+    output: formatDate("2026-05-13"),
+  },
+  {
+    code: "formatLongDate('2026-05-13')",
+    input: "2026-05-13",
+    output: formatLongDate("2026-05-13"),
+  },
+  {
+    code: "formatRelativeTime(…-3h)",
+    input: "3 hours ago",
+    output: formatRelativeTime(new Date(Date.now() - 3 * 3600_000).toISOString()),
+  },
+  {
+    code: "formatRelativeTime(…-8d)",
+    input: "8 days ago",
+    output: formatRelativeTime(
+      new Date(Date.now() - 8 * 86_400_000).toISOString(),
+    ),
+  },
+];
+
+const KEY_TOKENS = ["mod", "shift", "alt", "ctrl", "enter", "esc", "k", "/"];
+
+export function PatternsSection() {
+  const [debounceInput, setDebounceInput] = useState("");
+  const debounced = useDebouncedValue(debounceInput, 400);
+  const isMobile = useIsMobile();
+  const isWide = useMediaQuery("(min-width: 1024px)");
+
+  // A live shortcut — press G anywhere on this page. It also shows up in the
+  // ⇧? shortcut sheet while this section is mounted, then auto-unregisters.
+  useShortcut(["g"], () => toast.message("G — sandbox shortcut fired"), {
+    label: "Sandbox demo shortcut",
+    group: "Sandbox",
+  });
+
+  return (
+    <SandboxSection
+      title="Patterns"
+      description="Cross-cutting behaviors — not components, but the shared building blocks every feature reaches for."
+    >
+      <Specimen
+        label="Toasts"
+        code="sonner · withMutationToast"
+        description="One toast surface for the whole app. withMutationToast wraps a mutation: success toast on resolve, the ApiError message on reject."
+      >
+        <Button variant="outline" onClick={() => toast.success("Saved.")}>
+          toast.success
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => toast.error("Something went wrong.")}
+        >
+          toast.error
+        </Button>
+        <Button variant="outline" onClick={() => toast.message("Heads up.")}>
+          toast.message
+        </Button>
+        <Button
+          onClick={() =>
+            withMutationToast(() => Promise.resolve(), {
+              success: "Category updated.",
+            })
+          }
+        >
+          withMutationToast — ok
+        </Button>
+        <Button
+          variant="destructive"
+          onClick={() =>
+            withMutationToast(() => Promise.reject(new Error("nope")), {
+              success: "won't show",
+              error: "Couldn't update the category.",
+            })
+          }
+        >
+          withMutationToast — fail
+        </Button>
+      </Specimen>
+
+      <Specimen
+        label="Keyboard shortcuts"
+        code="useShortcut · ShortcutSheet"
+        description="Shortcuts register into a global registry while their component is mounted. Press G now (live demo). ⌘K opens the command palette; ⇧? opens the full shortcut sheet."
+        className="block"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <KbdGroup>
+            <Kbd>G</Kbd>
+          </KbdGroup>
+          <span className="text-muted-foreground text-sm">
+            press it — fires a toast, and appears in the ⇧? sheet under
+            “Sandbox”
+          </span>
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          <span className="text-muted-foreground text-xs">
+            displayKey() maps raw tokens to glyphs:
+          </span>
+          {KEY_TOKENS.map((k) => (
+            <span key={k} className="flex items-center gap-1 text-xs">
+              <code className="text-muted-foreground font-mono">{k}</code>→
+              <Kbd>{displayKey(k)}</Kbd>
+            </span>
+          ))}
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="Formatters"
+        code="lib/format"
+        description="Cached Intl instances — amounts (inflows get a + sign), short/long dates, relative time."
+        className="block"
+      >
+        <div className="grid gap-2 sm:grid-cols-2">
+          {FORMATTERS.map((f) => (
+            <div
+              key={f.code}
+              className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+            >
+              <code className="text-muted-foreground font-mono text-xs">
+                {f.code}
+              </code>
+              <span className="text-sm font-medium tabular-nums">
+                {f.output}
+              </span>
+            </div>
+          ))}
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="Hooks"
+        code="useDebouncedValue · useIsMobile · useMediaQuery"
+        description="useDebouncedValue keeps URL params from churning per keystroke; the media hooks drive responsive branching."
+        className="block"
+      >
+        <div className="grid max-w-sm gap-1.5">
+          <Label htmlFor="sb-debounce">Type — debounced 400ms</Label>
+          <Input
+            id="sb-debounce"
+            value={debounceInput}
+            onChange={(e) => setDebounceInput(e.target.value)}
+            placeholder="Type fast…"
+          />
+          <p className="text-muted-foreground text-xs">
+            debounced value:{" "}
+            <span className="text-foreground font-mono">
+              {debounced || "—"}
+            </span>
+          </p>
+        </div>
+        <div className="text-muted-foreground mt-3 flex gap-4 text-sm">
+          <span>
+            useIsMobile():{" "}
+            <code className="text-foreground font-mono">{String(isMobile)}</code>
+          </span>
+          <span>
+            useMediaQuery(min-width:1024px):{" "}
+            <code className="text-foreground font-mono">{String(isWide)}</code>
+          </span>
+        </div>
+      </Specimen>
+    </SandboxSection>
+  );
+}

--- a/web/src/sandbox/sections/patterns.tsx
+++ b/web/src/sandbox/sections/patterns.tsx
@@ -8,7 +8,6 @@ import { withMutationToast } from "@/lib/mutation-toast";
 import { useShortcut } from "@/lib/shortcuts";
 import { displayKey } from "@/lib/kbd-display";
 import {
-  formatAmount,
   formatDate,
   formatLongDate,
   formatRelativeTime,
@@ -18,17 +17,8 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { SandboxSection, Specimen } from "@/sandbox/kit";
 
+// Amount formatting has its own section; this covers the date/time formatters.
 const FORMATTERS: { code: string; input: string; output: string }[] = [
-  {
-    code: "formatAmount(6.75, 'USD')",
-    input: "6.75",
-    output: formatAmount(6.75, "USD"),
-  },
-  {
-    code: "formatAmount(-3200, 'USD')",
-    input: "-3200 (inflow)",
-    output: formatAmount(-3200, "USD"),
-  },
   {
     code: "formatDate('2026-05-13')",
     input: "2026-05-13",
@@ -141,9 +131,9 @@ export function PatternsSection() {
       </Specimen>
 
       <Specimen
-        label="Formatters"
+        label="Date formatters"
         code="lib/format"
-        description="Cached Intl instances — amounts (inflows get a + sign), short/long dates, relative time."
+        description="Cached Intl instances — short and long dates, relative time. Amount formatting lives in the Amounts section."
         className="block"
       >
         <div className="grid gap-2 sm:grid-cols-2">

--- a/web/src/sandbox/sections/primitives.tsx
+++ b/web/src/sandbox/sections/primitives.tsx
@@ -1,0 +1,321 @@
+import { Bell, Check, ChevronsUpDown, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { SandboxSection, Specimen } from "@/sandbox/kit";
+
+export function PrimitivesSection() {
+  return (
+    <SandboxSection
+      title="Primitives"
+      description="shadcn/ui components as themed for v2. Generated into components/ui/* — never hand-edited; variants come from theme tokens."
+    >
+      <Specimen label="Button" code="variant × size">
+        <Button>Default</Button>
+        <Button variant="secondary">Secondary</Button>
+        <Button variant="outline">Outline</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button variant="destructive">Destructive</Button>
+        <Button variant="link">Link</Button>
+        <Button size="sm">Small</Button>
+        <Button size="lg">Large</Button>
+        <Button size="icon" aria-label="Add">
+          <Plus />
+        </Button>
+        <Button disabled>Disabled</Button>
+        <Button>
+          <Bell /> With icon
+        </Button>
+      </Specimen>
+
+      <Specimen
+        label="Badge"
+        code="variant"
+        description="Pill-shaped by default. CategoryBadge overrides to rounded-md so pills stay reserved for tags."
+      >
+        <Badge>Default</Badge>
+        <Badge variant="secondary">Secondary</Badge>
+        <Badge variant="destructive">Destructive</Badge>
+        <Badge variant="outline">Outline</Badge>
+        <Badge variant="ghost">Ghost</Badge>
+      </Specimen>
+
+      <Specimen label="Input & Label" className="block">
+        <div className="grid max-w-xs gap-1.5">
+          <Label htmlFor="sb-input">Email</Label>
+          <Input id="sb-input" placeholder="you@example.com" />
+        </div>
+        <div className="mt-3 grid max-w-xs gap-1.5">
+          <Label htmlFor="sb-input-disabled">Disabled</Label>
+          <Input id="sb-input-disabled" placeholder="Disabled" disabled />
+        </div>
+      </Specimen>
+
+      <Specimen label="Checkbox">
+        <Label className="flex items-center gap-2">
+          <Checkbox defaultChecked /> Checked
+        </Label>
+        <Label className="flex items-center gap-2">
+          <Checkbox /> Unchecked
+        </Label>
+        <Label className="flex items-center gap-2">
+          <Checkbox checked="indeterminate" /> Indeterminate
+        </Label>
+        <Label className="text-muted-foreground flex items-center gap-2">
+          <Checkbox disabled /> Disabled
+        </Label>
+      </Specimen>
+
+      <Specimen label="Card" className="block">
+        <Card className="max-w-sm">
+          <CardHeader>
+            <CardTitle>Card title</CardTitle>
+            <CardDescription>
+              Header, content, and footer slots.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-muted-foreground text-sm">
+            Cards frame the detail page's Details and Activity panels.
+          </CardContent>
+          <CardFooter>
+            <Button size="sm">Action</Button>
+          </CardFooter>
+        </Card>
+      </Specimen>
+
+      <Specimen label="Separator">
+        <div className="text-sm">Above</div>
+        <Separator className="my-2" />
+        <div className="text-sm">Below</div>
+        <div className="flex h-5 items-center gap-2 text-sm">
+          Left <Separator orientation="vertical" /> Right
+        </div>
+      </Specimen>
+
+      <Specimen
+        label="Skeleton"
+        description="Loading placeholders — DataTable renders rows of these."
+        className="block"
+      >
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-9 rounded-full" />
+          <div className="space-y-2">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+        </div>
+      </Specimen>
+
+      <Specimen label="Kbd" code="Kbd · KbdGroup">
+        <Kbd>⌘</Kbd>
+        <Kbd>Esc</Kbd>
+        <KbdGroup>
+          <Kbd>⌘</Kbd>
+          <Kbd>K</Kbd>
+        </KbdGroup>
+      </Specimen>
+
+      <Specimen label="Avatar">
+        <Avatar>
+          <AvatarFallback>RC</AvatarFallback>
+        </Avatar>
+        <Avatar className="size-8">
+          <AvatarFallback className="text-xs">v2</AvatarFallback>
+        </Avatar>
+      </Specimen>
+
+      <Specimen
+        label="Tooltip"
+        description="Hover the button. KbdTooltip (see Patterns) wraps this with a key hint."
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="outline">Hover me</Button>
+          </TooltipTrigger>
+          <TooltipContent>A tooltip</TooltipContent>
+        </Tooltip>
+      </Specimen>
+
+      <Specimen
+        label="Overlays"
+        description="Popover, Dialog, Sheet, Dropdown — every floating surface in v2 is one of these. Click to open."
+      >
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline">Popover</Button>
+          </PopoverTrigger>
+          <PopoverContent className="text-sm">
+            Anchored floating panel — used by the filter pills and pickers.
+          </PopoverContent>
+        </Popover>
+
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="outline">Dialog</Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Dialog title</DialogTitle>
+              <DialogDescription>
+                Centered modal with a backdrop.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline">Close</Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="outline">Sheet</Button>
+          </SheetTrigger>
+          <SheetContent>
+            <SheetHeader>
+              <SheetTitle>Sheet title</SheetTitle>
+              <SheetDescription>
+                Edge-anchored panel — the shortcut reference uses this.
+              </SheetDescription>
+            </SheetHeader>
+          </SheetContent>
+        </Sheet>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline">
+              Dropdown <ChevronsUpDown />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuLabel>Menu</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>First item</DropdownMenuItem>
+            <DropdownMenuItem>Second item</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </Specimen>
+
+      <Specimen
+        label="Command"
+        code="cmdk"
+        description="The searchable list behind the command palette and every picker."
+        className="block"
+      >
+        <Command className="max-w-sm rounded-lg border">
+          <CommandInput placeholder="Search…" />
+          <CommandList>
+            <CommandEmpty>No results.</CommandEmpty>
+            <CommandGroup heading="Suggestions">
+              <CommandItem>
+                <Check className="size-4" /> First result
+              </CommandItem>
+              <CommandItem>
+                <Check className="size-4" /> Second result
+              </CommandItem>
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </Specimen>
+
+      <Specimen label="Breadcrumb">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="#">Money</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>Transactions</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </Specimen>
+
+      <Specimen label="Collapsible" className="block">
+        <Collapsible className="max-w-sm space-y-2">
+          <CollapsibleTrigger asChild>
+            <Button variant="outline" size="sm">
+              Toggle details <ChevronsUpDown />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="text-muted-foreground text-sm">
+            Collapsible content — the sidebar nav groups use this.
+          </CollapsibleContent>
+        </Collapsible>
+      </Specimen>
+    </SandboxSection>
+  );
+}


### PR DESCRIPTION
A living gallery of the v2 design system — reusable components, primitives, and patterns — at **`/v2/sandbox`**.

## Approach

Built as an **in-app route**, not Storybook/Ladle: zero new toolchain, the real theme tokens + vite build (so what you see is production), and it `lazyRouteComponent`s into its own chunk (~9 KB gzip) so it never weighs on the main bundle. Reachable by URL; not a sidebar nav leaf — it's a dev/reference tool.

**Static fixtures only** — `routes/sandbox.tsx` seeds the query cache with sample categories/tags so the fetch-backed components (`CategoryCommandList`, `TagList`, …) render with no network round-trip or session, and every `onPick`/`onRemove` toasts instead of mutating.

## Four sections

- **Foundations** — color tokens (surfaces, brand/status, lines, chart palette) in light **and** dark, the radius scale, typography, and the `DynamicIcon` system.
- **Primitives** — every themed shadcn/ui component: Button (variant × size), Badge, Input/Label, Checkbox, Card, Separator, Skeleton, Kbd, Avatar, Tooltip, the overlays (Popover/Dialog/Sheet/Dropdown), Command, Breadcrumb, Collapsible.
- **Components** — the composed v2 layer: `PageHeader`, `EmptyState`, `DataTable` (with a live data/loading/empty toggle), `CategoryBadge`, `CategoryIconTile`, `CategoryCommandList`, `TagChip`/`TagList`, `TagCommandList`, `TransactionPrimary`/`TransactionAmount`, `KbdTooltip`.
- **Patterns** — toasts (`sonner` + `withMutationToast`), keyboard shortcuts (a live `g` demo that registers into the real registry + `displayKey` mapping), the `lib/format` formatters, and the responsive/debounce hooks.

A header theme toggle flips `.dark` so you can check both modes; it's scoped — the original mode is restored when you navigate away.

## Screenshots

<table>
  <tr><th>Foundations</th><th>Components</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/z1tp2659cq.png" width="400" alt="foundations"></td>
    <td><img src="https://i.img402.dev/yg5y68qu64.png" width="400" alt="components"></td>
  </tr>
  <tr><th>Patterns</th><th>Dark mode</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/lxylbo2ygf.png" width="400" alt="patterns"></td>
    <td><img src="https://i.img402.dev/9jtm9ck6rx.png" width="400" alt="dark mode"></td>
  </tr>
</table>

## Test plan

- [x] `tsc -b && vite build` passes; sandbox confirmed as a separate lazy chunk.
- [x] Browser (Chrome DevTools MCP): all four sections render; primitives + overlays interactive; DataTable state toggle works; pickers open from seeded fixtures; toasts fire; the `g` shortcut + debounce hook are live; dark toggle re-themes the gallery and restores on nav-away (verified `documentElement.classList` before/after); no console errors.
- [x] Reviewed by `code-reviewer` subagent — the one finding (dark toggle leaked global state) is fixed; fixture typing, cache-key alignment, `lazyRouteComponent`, and Tailwind class safety all confirmed clean.

Rebased onto `main` after the transactions-polish sprint (#1085) landed, so the diff is just the sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
