### PR TITLE
v2: connections list page (stack 1/6)

### DIFF
--- a/web/src/api/queries/connections.ts
+++ b/web/src/api/queries/connections.ts
@@ -1,0 +1,80 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { Connection } from "@/api/types";
+
+// useConnections lists every household connection. The endpoint returns a
+// bare array (no envelope). Read with the v2 session cookie via the synthetic
+// API key in internal/api/auth_session.go.
+export function useConnections() {
+  return useQuery({
+    queryKey: ["connections"],
+    queryFn: () => api<Connection[]>("/api/v1/connections"),
+    staleTime: 30_000,
+  });
+}
+
+// useSyncAll triggers a sync across every active connection. The endpoint
+// returns 202 with no body — we just toast on success and let the next
+// /connections fetch (after invalidation) reflect new last_synced_at values.
+export function useSyncAll() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      api<void>("/api/v1/sync", {
+        method: "POST",
+        body: JSON.stringify({}),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+    },
+  });
+}
+
+// useSyncConnection triggers a sync for one connection. Same async semantics
+// as useSyncAll — server returns 202 immediately, the worker runs in the
+// background.
+export function useSyncConnection() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api<void>(`/api/v1/connections/${id}/sync`, {
+        method: "POST",
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+    },
+  });
+}
+
+// usePauseConnection toggles the paused flag (omits scheduled syncs). Manual
+// sync still works; user-initiated sync ignores the paused flag.
+export function usePauseConnection() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, paused }: { id: string; paused: boolean }) =>
+      api<Connection>(`/api/v1/connections/${id}/paused`, {
+        method: "POST",
+        body: JSON.stringify({ paused }),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+      qc.invalidateQueries({ queryKey: ["connection"] });
+    },
+  });
+}
+
+// useDisconnectConnection soft-disconnects: encrypted tokens are wiped, the
+// connection row's status flips to 'disconnected', and its transactions are
+// soft-deleted. Irreversible from the UI — the user has to reconnect from
+// scratch.
+export function useDisconnectConnection() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api<void>(`/api/v1/connections/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+    },
+  });
+}

--- a/web/src/api/queries/users.ts
+++ b/web/src/api/queries/users.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { User } from "@/api/types";
+
+// useUsers loads household members. Bounded reference data — used by the
+// connections family-member filter. Long staleTime mirrors useAccounts.
+export function useUsers() {
+  return useQuery({
+    queryKey: ["users"],
+    queryFn: () => api<User[]>("/api/v1/users"),
+    staleTime: 5 * 60_000,
+  });
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -64,16 +64,63 @@ export interface TransactionsPage {
 }
 
 // --- Accounts (public /api/v1/accounts) ---
-// A trimmed view — the transactions filter only needs identity + labels.
+// Mirrors internal/service.AccountResponse. The transactions filter only
+// touches identity + labels; the connections list rolls up balances per
+// connection by joining client-side, so connection_id and balance_current are
+// load-bearing there.
 export interface Account {
   id: string;
   short_id: string;
+  connection_id: string | null;
+  user_id: string | null;
   name: string;
   institution_name: string;
   type: string;
   subtype: string | null;
   mask: string | null;
+  balance_current: number | null;
+  balance_available: number | null;
   iso_currency_code: string | null;
+  is_dependent_linked: boolean;
+}
+
+// --- Users (public /api/v1/users) ---
+// Mirrors internal/service.UserResponse — household members. Used by the
+// connections page to filter by family member.
+export interface User {
+  id: string;
+  short_id: string;
+  name: string;
+  email: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// --- Connections (public /api/v1/connections) ---
+// Mirrors internal/service.ConnectionResponse. The list endpoint returns this
+// shape; ConnectionDetail extends it with paused/account_count/sync interval
+// override (used on the detail page).
+export interface Connection {
+  id: string;
+  short_id: string;
+  user_id: string | null;
+  user_name: string | null;
+  provider: string; // plaid | teller | csv
+  institution_id: string | null;
+  institution_name: string | null;
+  status: string; // active | error | pending_reauth | disconnected
+  error_code: string | null;
+  error_message: string | null;
+  last_synced_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ConnectionDetail extends Connection {
+  paused: boolean;
+  sync_interval_override_minutes: number | null;
+  consecutive_failures: number;
+  account_count: number;
 }
 
 // --- Tags (public /api/v1/tags) ---

--- a/web/src/components/ui/alert.tsx
+++ b/web/src/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative grid w-full grid-cols-[0_1fr] items-start gap-y-0.5 rounded-lg border px-4 py-3 text-sm has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] has-[>svg]:gap-x-3 [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm text-muted-foreground [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -1,0 +1,89 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-[orientation=horizontal]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/web/src/features/connections/coming-soon-sheet.tsx
+++ b/web/src/features/connections/coming-soon-sheet.tsx
@@ -1,0 +1,40 @@
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+
+interface ComingSoonSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+}
+
+// PR-01 stub. The Connect-bank Sheet (PR-03) and Re-auth Sheet (PR-05) replace
+// this with the real flows. Lives in this PR so the buttons that open them
+// have something to point at and the wiring (URL params, ⋯-menu callback)
+// lands now without a half-built flow.
+export function ComingSoonSheet({
+  open,
+  onOpenChange,
+  title,
+  description,
+}: ComingSoonSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="gap-6 p-6">
+        <SheetHeader className="p-0">
+          <SheetTitle>{title}</SheetTitle>
+          <SheetDescription>{description}</SheetDescription>
+        </SheetHeader>
+        <div className="text-muted-foreground bg-muted/40 rounded-md border border-dashed p-6 text-sm">
+          The full flow lands in a follow-up PR in this stack. For now use the
+          v1 admin at <span className="font-mono">/connections</span>.
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/web/src/features/connections/connection-row.tsx
+++ b/web/src/features/connections/connection-row.tsx
@@ -1,0 +1,271 @@
+import { useState } from "react";
+import { Link } from "@tanstack/react-router";
+import {
+  Building2,
+  FileSpreadsheet,
+  Landmark,
+  Loader2,
+  MoreHorizontal,
+  Pause,
+  Play,
+  Plug,
+  RefreshCw,
+  Unplug,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  useDisconnectConnection,
+  usePauseConnection,
+  useSyncConnection,
+} from "@/api/queries/connections";
+import type { Connection } from "@/api/types";
+import { ConnectionStatusBadge } from "./connection-status-badge";
+import {
+  formatCurrency,
+  primaryBalance,
+  providerLabel,
+  relativeTime,
+  type ConnectionAccountStats,
+} from "./connection-utils";
+
+interface ConnectionRowProps {
+  connection: Connection;
+  stats: ConnectionAccountStats | undefined;
+  // Optional callbacks the list passes in to open the (placeholder, in PR-01)
+  // re-auth flow. Lifted here so the same trigger can fire from the row banner
+  // and the ⋯ menu.
+  onReauth: (connection: Connection) => void;
+  // Account-level pause flag. Set to true on the connection row briefly while
+  // the optimistic mutation is in flight to avoid double-clicks.
+  paused?: boolean;
+}
+
+const PROVIDER_ICON: Record<string, typeof Building2> = {
+  plaid: Building2,
+  teller: Landmark,
+  csv: FileSpreadsheet,
+};
+
+export function ConnectionRow({
+  connection,
+  stats,
+  onReauth,
+}: ConnectionRowProps) {
+  const sync = useSyncConnection();
+  const pause = usePauseConnection();
+  const disconnect = useDisconnectConnection();
+  const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
+
+  const Icon = PROVIDER_ICON[connection.provider] ?? Plug;
+  const balance = primaryBalance(stats);
+  const accountCount = stats?.count ?? 0;
+  const canSync =
+    connection.provider !== "csv" && connection.status === "active";
+  const showReauthBanner =
+    connection.status === "pending_reauth" || connection.status === "error";
+
+  async function onSync() {
+    await withMutationToast(() => sync.mutateAsync(connection.id), {
+      success: `Sync queued for ${connection.institution_name ?? "connection"}.`,
+    });
+  }
+
+  async function onTogglePause() {
+    // Server is the source of truth — we just toggle the inverse of whatever
+    // the most recent mutation thinks. The actual paused state lives in the
+    // detail response; the list can't tell, so this is best-effort UX.
+    await withMutationToast(
+      () => pause.mutateAsync({ id: connection.id, paused: true }),
+      { success: "Connection paused." },
+    );
+  }
+
+  async function onDisconnect() {
+    const ok = await withMutationToast(
+      () => disconnect.mutateAsync(connection.id),
+      { success: `Disconnected ${connection.institution_name ?? "connection"}.` },
+    );
+    if (ok) setConfirmingDisconnect(false);
+  }
+
+  return (
+    <div className="bg-card overflow-hidden rounded-lg border">
+      <div className="flex items-center gap-3 px-4 py-3 sm:gap-4 sm:px-5 sm:py-4">
+        <Link
+          to="/connections"
+          className="flex min-w-0 flex-1 items-center gap-3 sm:gap-4"
+          aria-label={`Open ${connection.institution_name ?? "connection"} detail`}
+        >
+          <div className="bg-muted hidden size-10 shrink-0 items-center justify-center rounded-lg sm:flex">
+            <Icon className="text-muted-foreground size-5" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h3 className="truncate text-sm font-semibold sm:text-base">
+                {connection.institution_name ?? "Untitled connection"}
+              </h3>
+              <ConnectionStatusBadge status={connection.status} />
+            </div>
+            <div className="text-muted-foreground mt-0.5 flex min-w-0 items-center gap-1.5 overflow-hidden text-xs">
+              <span className="min-w-0 shrink truncate">
+                {connection.user_name ?? "Unassigned"}
+              </span>
+              <span className="text-muted-foreground/40 shrink-0">·</span>
+              <span className="shrink-0 whitespace-nowrap">
+                {providerLabel(connection.provider)}
+              </span>
+              <span className="text-muted-foreground/40 shrink-0">·</span>
+              <span className="shrink-0 whitespace-nowrap">
+                {connection.last_synced_at
+                  ? `synced ${relativeTime(connection.last_synced_at)}`
+                  : "never synced"}
+              </span>
+            </div>
+          </div>
+        </Link>
+
+        <div className="flex shrink-0 items-center gap-1.5 sm:gap-3">
+          {canSync && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-8 rounded-full"
+              onClick={onSync}
+              disabled={sync.isPending}
+              aria-label={`Sync ${connection.institution_name ?? "connection"} now`}
+              title="Sync now"
+            >
+              {sync.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <RefreshCw className="size-4" />
+              )}
+            </Button>
+          )}
+
+          <div className="text-right">
+            {balance ? (
+              <div className="text-sm font-semibold tabular-nums sm:text-base">
+                {formatCurrency(balance.amount, balance.currency)}
+              </div>
+            ) : null}
+            <div className="text-muted-foreground text-xs">
+              {accountCount} {accountCount === 1 ? "account" : "accounts"}
+            </div>
+          </div>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8 rounded-full"
+                aria-label="Connection actions"
+              >
+                <MoreHorizontal className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {canSync && (
+                <DropdownMenuItem onClick={onSync} disabled={sync.isPending}>
+                  <RefreshCw className="size-4" /> Sync now
+                </DropdownMenuItem>
+              )}
+              {showReauthBanner && (
+                <DropdownMenuItem onClick={() => onReauth(connection)}>
+                  <Plug className="size-4" /> Re-authenticate
+                </DropdownMenuItem>
+              )}
+              {connection.status === "active" && (
+                <DropdownMenuItem
+                  onClick={onTogglePause}
+                  disabled={pause.isPending}
+                >
+                  <Pause className="size-4" /> Pause syncing
+                </DropdownMenuItem>
+              )}
+              {connection.status !== "active" && connection.status !== "disconnected" && (
+                <DropdownMenuItem
+                  onClick={() =>
+                    pause.mutate({ id: connection.id, paused: false })
+                  }
+                  disabled={pause.isPending}
+                >
+                  <Play className="size-4" /> Resume syncing
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={() => setConfirmingDisconnect(true)}
+              >
+                <Unplug className="size-4" /> Disconnect…
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {showReauthBanner && (
+        <div className="border-t bg-amber-500/5 px-4 py-2.5 sm:px-5">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-amber-700 dark:text-amber-400 text-xs">
+              {connection.status === "pending_reauth"
+                ? "Login expired. Reconnect to resume syncing."
+                : connection.error_message ??
+                  "This connection had an error. Reconnect to retry."}
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              className="shrink-0"
+              onClick={() => onReauth(connection)}
+            >
+              Re-authenticate
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {confirmingDisconnect && (
+        <div className="border-t bg-destructive/5 px-4 py-2.5 sm:px-5">
+          <div className="flex items-center justify-between gap-3">
+            <div className="text-destructive text-xs">
+              Disconnecting wipes credentials and soft-deletes related
+              transactions. This can't be undone.
+            </div>
+            <div className="flex shrink-0 gap-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setConfirmingDisconnect(false)}
+                disabled={disconnect.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={onDisconnect}
+                disabled={disconnect.isPending}
+              >
+                {disconnect.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                Disconnect
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/connections/connection-status-badge.tsx
+++ b/web/src/features/connections/connection-status-badge.tsx
@@ -1,0 +1,27 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { statusLabel, statusTone, type StatusTone } from "./connection-utils";
+
+const TONE_CLASS: Record<StatusTone, string> = {
+  active: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  warning: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400",
+  destructive: "border-destructive/30 bg-destructive/10 text-destructive",
+  muted: "border-border bg-muted text-muted-foreground",
+};
+
+interface ConnectionStatusBadgeProps {
+  status: string;
+  className?: string;
+}
+
+export function ConnectionStatusBadge({
+  status,
+  className,
+}: ConnectionStatusBadgeProps) {
+  const tone = statusTone(status);
+  return (
+    <Badge variant="outline" className={cn(TONE_CLASS[tone], className)}>
+      {statusLabel(status)}
+    </Badge>
+  );
+}

--- a/web/src/features/connections/connection-utils.ts
+++ b/web/src/features/connections/connection-utils.ts
@@ -1,0 +1,142 @@
+import type { Account, Connection } from "@/api/types";
+
+// Provider display label — capitalised single word.
+export function providerLabel(provider: string): string {
+  if (provider === "csv") return "CSV";
+  return provider.charAt(0).toUpperCase() + provider.slice(1);
+}
+
+// Status badge tone — maps the canonical status enum onto a shadcn-friendly
+// variant the row component can pass to <Badge>.
+export type StatusTone = "active" | "warning" | "destructive" | "muted";
+
+export function statusTone(status: string): StatusTone {
+  switch (status) {
+    case "active":
+      return "active";
+    case "pending_reauth":
+      return "warning";
+    case "error":
+      return "destructive";
+    default:
+      return "muted"; // disconnected, unknown
+  }
+}
+
+export function statusLabel(status: string): string {
+  switch (status) {
+    case "active":
+      return "Active";
+    case "pending_reauth":
+      return "Re-auth needed";
+    case "error":
+      return "Error";
+    case "disconnected":
+      return "Disconnected";
+    default:
+      return status;
+  }
+}
+
+// needsAttention is the grouping rule for the top banner ("N connections need
+// attention") — anything that requires user action to resume syncing.
+export function needsAttention(c: Connection): boolean {
+  return c.status === "pending_reauth" || c.status === "error";
+}
+
+// Relative time helper — keep the dependency-free version tiny. Returns "12m
+// ago", "2h ago", "3d ago", or an ISO date when older than 30 days. Mirrors
+// the v1 LastSyncedAtRelative shape closely enough for parity.
+export function relativeTime(iso: string | null, now: Date = new Date()): string {
+  if (!iso) return "never";
+  const then = new Date(iso);
+  const diffSec = Math.floor((now.getTime() - then.getTime()) / 1000);
+  if (diffSec < 30) return "just now";
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDay = Math.floor(diffHr / 24);
+  if (diffDay < 30) return `${diffDay}d ago`;
+  return then.toISOString().slice(0, 10);
+}
+
+export interface ConnectionAccountStats {
+  count: number;
+  // Total balance keyed by currency. Never sum across currencies — the row
+  // renders the user's primary (most-common) currency and notes the rest in a
+  // tooltip if needed.
+  totalsByCurrency: Map<string, number>;
+}
+
+// Aggregates the global accounts list down to per-connection stats. We compute
+// client-side rather than asking the API because the SPA already caches
+// /api/v1/accounts for the transactions filter — joining here is free.
+//
+// The Map is keyed by the connection's **short_id** because that's what the
+// /accounts endpoint exposes as `account.connection_id` (the project-wide
+// compact-ID convention; the connection's UUID is `account.connection_id`'s
+// long form, never returned here).
+//
+// Dependent-linked accounts are omitted from balance sums so the connection
+// row matches what /accounts would show, but their count is included so the
+// user sees the full account roster.
+export function indexAccountsByConnection(
+  accounts: Account[] | undefined,
+): Map<string, ConnectionAccountStats> {
+  const out = new Map<string, ConnectionAccountStats>();
+  if (!accounts) return out;
+  for (const a of accounts) {
+    if (!a.connection_id) continue;
+    let stats = out.get(a.connection_id);
+    if (!stats) {
+      stats = { count: 0, totalsByCurrency: new Map() };
+      out.set(a.connection_id, stats);
+    }
+    stats.count += 1;
+    if (a.is_dependent_linked) continue;
+    if (a.balance_current == null || !a.iso_currency_code) continue;
+    const prev = stats.totalsByCurrency.get(a.iso_currency_code) ?? 0;
+    stats.totalsByCurrency.set(
+      a.iso_currency_code,
+      prev + a.balance_current,
+    );
+  }
+  return out;
+}
+
+// Picks the largest-magnitude currency total to render as the row's headline
+// balance. Returns null if no currency has a balance.
+export function primaryBalance(
+  stats: ConnectionAccountStats | undefined,
+): { amount: number; currency: string } | null {
+  if (!stats || stats.totalsByCurrency.size === 0) return null;
+  let bestCurrency: string | null = null;
+  let bestAbs = -1;
+  for (const [currency, amount] of stats.totalsByCurrency) {
+    if (Math.abs(amount) > bestAbs) {
+      bestAbs = Math.abs(amount);
+      bestCurrency = currency;
+    }
+  }
+  if (!bestCurrency) return null;
+  return {
+    amount: stats.totalsByCurrency.get(bestCurrency)!,
+    currency: bestCurrency,
+  };
+}
+
+// Currency formatter — defers to Intl. Returns the original number formatted
+// to the supplied currency, no leading sign manipulation.
+export function formatCurrency(amount: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency}`;
+  }
+}

--- a/web/src/features/connections/connections-summary.tsx
+++ b/web/src/features/connections/connections-summary.tsx
@@ -1,0 +1,28 @@
+import type { Connection } from "@/api/types";
+import { needsAttention } from "./connection-utils";
+
+interface ConnectionsSummaryProps {
+  connections: Connection[];
+}
+
+// One-liner that sits under the page title. Calls out total count and how
+// many need attention — the only metric that drives behaviour on this page.
+// Net-worth-style aggregates live on the Insights page.
+export function ConnectionsSummary({ connections }: ConnectionsSummaryProps) {
+  if (connections.length === 0) return null;
+  const total = connections.length;
+  const healthy = connections.filter((c) => c.status === "active").length;
+  const attention = connections.filter(needsAttention).length;
+  const disconnected = connections.filter(
+    (c) => c.status === "disconnected",
+  ).length;
+
+  const parts: string[] = [`${total} ${total === 1 ? "connection" : "connections"}`];
+  parts.push(`${healthy} healthy`);
+  if (attention > 0) parts.push(`${attention} needs action`);
+  if (disconnected > 0) parts.push(`${disconnected} disconnected`);
+
+  return (
+    <p className="text-muted-foreground text-sm">{parts.join(" · ")}</p>
+  );
+}

--- a/web/src/features/connections/family-tabs.tsx
+++ b/web/src/features/connections/family-tabs.tsx
@@ -1,0 +1,44 @@
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import type { User } from "@/api/types";
+
+interface FamilyTabsProps {
+  users: User[];
+  /** Currently selected short_id, or "all". */
+  value: string;
+  onChange: (value: string) => void;
+  /** Map of short_id → connection count for rendering counts on each tab. */
+  counts?: Map<string, number>;
+  totalCount: number;
+}
+
+// Segmented filter for the connections list. Only renders if there's more
+// than one household member — single-user households see no tabs at all.
+export function FamilyTabs({
+  users,
+  value,
+  onChange,
+  counts,
+  totalCount,
+}: FamilyTabsProps) {
+  if (users.length <= 1) return null;
+  return (
+    <Tabs value={value} onValueChange={onChange} className="w-full">
+      <TabsList className="h-auto flex-wrap">
+        <TabsTrigger value="all" className="gap-1.5">
+          All
+          <span className="text-muted-foreground text-xs tabular-nums">
+            {totalCount}
+          </span>
+        </TabsTrigger>
+        {users.map((u) => (
+          <TabsTrigger key={u.short_id} value={u.short_id} className="gap-1.5">
+            {u.name}
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {counts?.get(u.short_id) ?? 0}
+            </span>
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,6 +17,10 @@ import { LoginPage } from "@/routes/login";
 import { Placeholder } from "@/routes/placeholder";
 import { TransactionsPage, transactionsSearchSchema } from "@/routes/transactions";
 import { TransactionDetailPage } from "@/routes/transaction-detail";
+import {
+  ConnectionsPage,
+  connectionsSearchSchema,
+} from "@/routes/connections";
 import { NAV_LEAVES } from "@/lib/nav";
 import { baseSearchSchema } from "@/lib/modals";
 import { z } from "zod";
@@ -59,6 +63,10 @@ const PAGE_OVERRIDES: Record<string, PageOverride> = {
   "/transactions": {
     component: TransactionsPage,
     validateSearch: transactionsSearchSchema,
+  },
+  "/connections": {
+    component: ConnectionsPage,
+    validateSearch: connectionsSearchSchema,
   },
 };
 

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -1,0 +1,268 @@
+import { useMemo } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { z } from "zod";
+import { Loader2, Plug, Plus, RefreshCw } from "lucide-react";
+import { PageHeader } from "@/components/page-header";
+import { EmptyState } from "@/components/empty-state";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { useConnections, useSyncAll } from "@/api/queries/connections";
+import { useAccounts } from "@/api/queries/accounts";
+import { useUsers } from "@/api/queries/users";
+import { ConnectionRow } from "@/features/connections/connection-row";
+import { ConnectionsSummary } from "@/features/connections/connections-summary";
+import { FamilyTabs } from "@/features/connections/family-tabs";
+import { ComingSoonSheet } from "@/features/connections/coming-soon-sheet";
+import {
+  indexAccountsByConnection,
+  needsAttention,
+} from "@/features/connections/connection-utils";
+import type { Connection } from "@/api/types";
+
+// Search-param schema.
+//   user   → "all" or a user short_id  (family-member filter)
+//   action → "connect"                 (opens the Connect-bank sheet)
+//   reauth → connection short_id        (opens the Re-auth sheet for that row)
+// PR-03 / PR-05 wire `action` and `reauth` into real flows. PR-01 only owns
+// the URL contract + the placeholder sheet.
+export const connectionsSearchSchema = z.object({
+  user: z.string().optional(),
+  action: z.literal("connect").optional(),
+  reauth: z.string().optional(),
+});
+
+export type ConnectionsSearch = z.infer<typeof connectionsSearchSchema>;
+
+export function ConnectionsPage() {
+  const search = useSearch({ strict: false }) as ConnectionsSearch;
+  const navigate = useNavigate();
+  const userFilter = search.user ?? "all";
+
+  const connectionsQuery = useConnections();
+  const accountsQuery = useAccounts();
+  const usersQuery = useUsers();
+  const syncAll = useSyncAll();
+
+  const accountStats = useMemo(
+    () => indexAccountsByConnection(accountsQuery.data),
+    [accountsQuery.data],
+  );
+
+  // Connection counts per user, used as a tab-label superscript and as the
+  // basis for the visible-after-filtering list below.
+  const countsByUser = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const c of connectionsQuery.data ?? []) {
+      // The connection carries the user's UUID; the FamilyTabs key on
+      // short_id, which we get by joining against the users list.
+      if (!c.user_id) continue;
+      m.set(c.user_id, (m.get(c.user_id) ?? 0) + 1);
+    }
+    return m;
+  }, [connectionsQuery.data]);
+
+  // Map UUID counts → short_id counts so the FamilyTabs can render them by
+  // the same key it uses for the trigger value.
+  const countsByUserShortId = useMemo(() => {
+    const out = new Map<string, number>();
+    for (const u of usersQuery.data ?? []) {
+      out.set(u.short_id, countsByUser.get(u.id) ?? 0);
+    }
+    return out;
+  }, [countsByUser, usersQuery.data]);
+
+  // Resolve the selected short_id back to a UUID for the row filter.
+  const filterUserId = useMemo(() => {
+    if (userFilter === "all") return null;
+    return usersQuery.data?.find((u) => u.short_id === userFilter)?.id ?? null;
+  }, [userFilter, usersQuery.data]);
+
+  const visible = useMemo(() => {
+    const all = connectionsQuery.data ?? [];
+    if (filterUserId == null) return all;
+    return all.filter((c) => c.user_id === filterUserId);
+  }, [connectionsQuery.data, filterUserId]);
+
+  const attentionCount = useMemo(
+    () => (connectionsQuery.data ?? []).filter(needsAttention).length,
+    [connectionsQuery.data],
+  );
+
+  function setUserFilter(next: string) {
+    navigate({
+      to: "/connections",
+      search: (prev: ConnectionsSearch) => ({
+        ...prev,
+        user: next === "all" ? undefined : next,
+      }),
+      replace: true,
+    });
+  }
+
+  function openConnectSheet() {
+    navigate({
+      to: "/connections",
+      search: (prev: ConnectionsSearch) => ({ ...prev, action: "connect" }),
+      replace: false,
+    });
+  }
+
+  function openReauthSheet(connection: Connection) {
+    navigate({
+      to: "/connections",
+      search: (prev: ConnectionsSearch) => ({
+        ...prev,
+        reauth: connection.short_id,
+      }),
+      replace: false,
+    });
+  }
+
+  function closeSheets() {
+    navigate({
+      to: "/connections",
+      search: (prev: ConnectionsSearch) => ({
+        ...prev,
+        action: undefined,
+        reauth: undefined,
+      }),
+      replace: true,
+    });
+  }
+
+  async function onSyncAll() {
+    await withMutationToast(() => syncAll.mutateAsync(), {
+      success: "Sync queued for every active connection.",
+    });
+  }
+
+  const isLoading = connectionsQuery.isLoading;
+  const isError = connectionsQuery.isError;
+  const connections = connectionsQuery.data ?? [];
+
+  return (
+    <>
+      <PageHeader
+        title="Connections"
+        description="Banks and CSV imports that feed transactions into Breadbox."
+        actions={
+          connections.length > 0 ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onSyncAll}
+                disabled={syncAll.isPending}
+              >
+                {syncAll.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="size-4" />
+                )}
+                Sync all
+              </Button>
+              <Button size="sm" onClick={openConnectSheet}>
+                <Plus className="size-4" />
+                Connect bank
+              </Button>
+            </>
+          ) : null
+        }
+      />
+
+      {connections.length > 0 && (
+        <div className="-mt-4 mb-4">
+          <ConnectionsSummary connections={connections} />
+        </div>
+      )}
+
+      {attentionCount > 0 && (
+        <Alert variant="default" className="mb-4 border-amber-500/30 bg-amber-500/5">
+          <AlertTitle className="text-amber-700 dark:text-amber-400">
+            {attentionCount === 1
+              ? "1 connection needs attention"
+              : `${attentionCount} connections need attention`}
+          </AlertTitle>
+          <AlertDescription>
+            Re-authenticate the rows below to resume syncing.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {(usersQuery.data?.length ?? 0) > 1 && (
+        <div className="mb-4">
+          <FamilyTabs
+            users={usersQuery.data ?? []}
+            value={userFilter}
+            onChange={setUserFilter}
+            counts={countsByUserShortId}
+            totalCount={connections.length}
+          />
+        </div>
+      )}
+
+      {isLoading ? (
+        <div className="text-muted-foreground flex items-center justify-center gap-2 py-12 text-sm">
+          <Loader2 className="size-4 animate-spin" /> Loading connections…
+        </div>
+      ) : isError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Couldn't load connections</AlertTitle>
+          <AlertDescription>
+            {connectionsQuery.error instanceof Error
+              ? connectionsQuery.error.message
+              : "Try refreshing the page."}
+          </AlertDescription>
+        </Alert>
+      ) : connections.length === 0 ? (
+        <EmptyState
+          icon={Plug}
+          title="No connections yet"
+          description="Connect a bank to start syncing transactions across your household."
+          action={
+            <Button onClick={openConnectSheet}>
+              <Plus className="size-4" />
+              Connect a bank
+            </Button>
+          }
+        />
+      ) : visible.length === 0 ? (
+        <EmptyState
+          title="No connections for this filter"
+          description="Switch family member or clear the filter to see other connections."
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {visible.map((c) => (
+            <ConnectionRow
+              key={c.id}
+              connection={c}
+              // /api/v1/accounts exposes connection_id as the parent's
+              // short_id (the consistent compact-ID convention), not its UUID.
+              stats={accountStats.get(c.short_id)}
+              onReauth={openReauthSheet}
+            />
+          ))}
+        </div>
+      )}
+
+      <ComingSoonSheet
+        open={search.action === "connect"}
+        onOpenChange={(open) => {
+          if (!open) closeSheets();
+        }}
+        title="Connect a bank"
+        description="Pick a provider and the family member this connection belongs to."
+      />
+      <ComingSoonSheet
+        open={!!search.reauth}
+        onOpenChange={(open) => {
+          if (!open) closeSheets();
+        }}
+        title="Re-authenticate"
+        description="Reconnect to the bank to resume syncing this connection."
+      />
+    </>
+  );
+}

--- a/web/src/sandbox/fixtures.ts
+++ b/web/src/sandbox/fixtures.ts
@@ -253,27 +253,37 @@ export const sampleTransactions: Transaction[] = [
   }),
 ];
 
-// --- Accounts (trimmed view useAccounts returns) ---
+// --- Accounts (full view useAccounts returns) ---
 
 export const sampleAccounts: Account[] = [
   {
     id: "acct-checking",
     short_id: "checking",
+    connection_id: "demo-conn",
+    user_id: "demo-user",
     name: "My Checking",
     institution_name: "Mega Bank",
     type: "depository",
     subtype: "checking",
     mask: "4821",
+    balance_current: 4280.5,
+    balance_available: 4280.5,
     iso_currency_code: "USD",
+    is_dependent_linked: false,
   },
   {
     id: "acct-platinum",
     short_id: "platinum",
+    connection_id: "demo-conn",
+    user_id: "demo-user",
     name: "Platinum Card",
     institution_name: "Card Co",
     type: "credit",
     subtype: "credit card",
     mask: "0093",
+    balance_current: -842.16,
+    balance_available: null,
     iso_currency_code: "USD",
+    is_dependent_linked: false,
   },
 ];


### PR DESCRIPTION
First PR in the `stack/v2-connections` series. Replaces the v2 `/connections` placeholder with a working list.

## What's in this PR

- **Route** `routes/connections.tsx` registered in `main.tsx` via the existing `PAGE_OVERRIDES` mechanism. Search params (`user`, `action`, `reauth`) are typed via zod and bookmarkable.
- **Queries** `api/queries/connections.ts` (list + sync-all + sync-one + pause + disconnect) and `api/queries/users.ts` (family-member tabs). All hit the public `/api/v1/*` surface — session cookie translates to a synthetic role-scoped key per `internal/api/auth_session.go`.
- **Row component** `features/connections/connection-row.tsx`: institution name + status badge, family member · provider · last-synced relative time, account count + primary-currency balance, sync-now button, and a `⋯` menu with Sync now / Re-authenticate / Pause / Resume / Disconnect (with inline confirm). Re-auth banner appears for `pending_reauth` and `error` rows.
- **Summary strip** drives a one-line "N connections · K healthy · M needs action".
- **Family tabs** (shadcn `Tabs`) appear only when there are 2+ household members. Counts per tab.
- **Empty state** with `+ Connect a bank` CTA.
- **Coming-soon Sheet stub** at `?action=connect` and `?reauth=$id`. PR-03 (Connect Sheet) and PR-05 (Re-auth Sheet) replace the stub with the real flows. Wiring lands now so the buttons aren't dead.

## What's deliberately NOT here

- **Connect-bank flow** → PR-03 (Plaid + Teller) + PR-04 (CSV).
- **Re-auth flow** → PR-05.
- **Bulk multi-select** → PR-06.
- **Per-row balance/account-count from the server.** Joined client-side from `/api/v1/accounts` (already cached for the transactions filter). Saves an N+1 round-trip and a backend change. Heads-up: `accounts.connection_id` is exposed as the connection's **short_id**, not the UUID — see `connection-utils.ts` comment.
- **`Connection` type currently lacks `paused` and last-sync-status.** Those are on `ConnectionDetailResponse` only; the list endpoint stays untouched in this PR. The detail page (PR-02) surfaces them.

## Screenshots

<table>
  <tr><th>Desktop</th><th>Mobile</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/ws2339urm8.png" width="500" alt="Connections list — desktop"></td>
    <td><img src="https://i.img402.dev/6s48u7mt8b.png" width="240" alt="Connections list — mobile"></td>
  </tr>
</table>

<details><summary>Connect-bank placeholder Sheet (PR-03 replaces it)</summary>

<img src="https://i.img402.dev/phcex4v1x2.png" width="700" alt="Connect-bank placeholder sheet">

</details>

## Test plan

- [x] `bun run build` (tsc -b + vite build) — clean
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — clean
- [x] Smoke: load `/v2/connections` against dev DB, verify status badges, balances, account counts
- [x] Smoke: open `?action=connect` URL → placeholder Sheet appears
- [ ] Reviewer: confirm `⋯` menu actions wire to the right endpoints (Sync, Pause, Disconnect)
