### PR TITLE
v2: connection detail page (stack 2/6)

### DIFF
--- a/web/src/api/queries/connections.ts
+++ b/web/src/api/queries/connections.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import type { Connection } from "@/api/types";
+import type { Connection, ConnectionDetail } from "@/api/types";
 
 // useConnections lists every household connection. The endpoint returns a
 // bare array (no envelope). Read with the v2 session cookie via the synthetic
@@ -10,6 +10,35 @@ export function useConnections() {
     queryKey: ["connections"],
     queryFn: () => api<Connection[]>("/api/v1/connections"),
     staleTime: 30_000,
+  });
+}
+
+// useConnection fetches a single connection by short_id (or UUID). Returns the
+// detail payload — same fields as the list shape plus paused, sync interval
+// override, consecutive_failures, and account_count.
+export function useConnection(id: string | undefined) {
+  return useQuery({
+    queryKey: ["connection", id],
+    queryFn: () => api<ConnectionDetail>(`/api/v1/connections/${id}`),
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}
+
+// useSetSyncInterval writes the per-connection sync-interval override. Pass
+// `minutes: null` to clear the override and fall back to the global default.
+export function useSetSyncInterval() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, minutes }: { id: string; minutes: number | null }) =>
+      api<ConnectionDetail>(`/api/v1/connections/${id}/sync-interval`, {
+        method: "POST",
+        body: JSON.stringify({ interval_minutes: minutes }),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["connection"] });
+      qc.invalidateQueries({ queryKey: ["connections"] });
+    },
   });
 }
 
@@ -42,6 +71,8 @@ export function useSyncConnection() {
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["connections"] });
+      qc.invalidateQueries({ queryKey: ["connection"] });
+      qc.invalidateQueries({ queryKey: ["sync-logs"] });
     },
   });
 }

--- a/web/src/api/queries/sync-logs.ts
+++ b/web/src/api/queries/sync-logs.ts
@@ -1,0 +1,56 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+
+// SyncLog mirrors syncLogResponse in internal/api/sync_visibility.go.
+// `connection_id` on the wire is the connection's UUID (not the short_id).
+export interface SyncLog {
+  id: string;
+  connection_id: string;
+  institution_name: string;
+  provider?: string;
+  trigger: string; // cron | webhook | manual | initial
+  status: string; // in_progress | success | error
+  added_count: number;
+  modified_count: number;
+  removed_count: number;
+  unchanged_count: number;
+  error_message?: string;
+  friendly_error_message?: string;
+  warning_message?: string;
+  started_at?: string;
+  completed_at?: string;
+  duration?: string;
+  duration_ms?: number;
+  accounts_affected: number;
+}
+
+export interface SyncLogsPage {
+  sync_logs: SyncLog[];
+  next_cursor?: string | null;
+  has_more: boolean;
+  limit: number;
+  total: number;
+}
+
+export interface UseSyncLogsParams {
+  // Connection UUID (short_id is not accepted by /api/v1/sync/logs).
+  connectionId?: string;
+  limit?: number;
+}
+
+// useSyncLogs fetches the most-recent sync history. Pass a connection UUID
+// (not the short_id) — the backend filter only resolves UUIDs. Omitting
+// `connectionId` returns the global feed.
+export function useSyncLogs({ connectionId, limit = 30 }: UseSyncLogsParams) {
+  return useQuery({
+    queryKey: ["sync-logs", connectionId ?? null, limit],
+    queryFn: () => {
+      const qs = new URLSearchParams();
+      if (connectionId) qs.set("connection_id", connectionId);
+      qs.set("limit", String(limit));
+      return api<SyncLogsPage>(`/api/v1/sync/logs?${qs.toString()}`);
+    },
+    enabled: connectionId == null || !!connectionId,
+    staleTime: 30_000,
+  });
+}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -1,0 +1,188 @@
+import * as React from "react"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+import { Select as SelectPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot="select" {...props} />
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className="size-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  position = "item-aligned",
+  align = "center",
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot="select-content"
+        className={cn(
+          "relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          position === "popper" &&
+            "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            "p-1",
+            position === "popper" &&
+              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot="select-label"
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot="select-item-indicator"
+        className="absolute right-2 flex size-3.5 items-center justify-center"
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className="size-4" />
+    </SelectPrimitive.ScrollUpButton>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "flex cursor-default items-center justify-center py-1",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className="size-4" />
+    </SelectPrimitive.ScrollDownButton>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/web/src/features/connections/connection-accounts-list.tsx
+++ b/web/src/features/connections/connection-accounts-list.tsx
@@ -1,0 +1,59 @@
+import { Banknote, CreditCard, Landmark, PiggyBank, Wallet } from "lucide-react";
+import type { Account } from "@/api/types";
+import { formatCurrency } from "./connection-utils";
+
+const TYPE_ICON: Record<string, typeof Banknote> = {
+  depository: PiggyBank,
+  credit: CreditCard,
+  loan: Landmark,
+  investment: Wallet,
+};
+
+interface ConnectionAccountsListProps {
+  accounts: Account[];
+}
+
+// Read-only list of accounts attached to a connection. Inline rename / exclude
+// live on the per-account detail page in a future surface; for now each row is
+// a placeholder link that will resolve once /accounts/$shortId ships.
+export function ConnectionAccountsList({ accounts }: ConnectionAccountsListProps) {
+  if (accounts.length === 0) {
+    return (
+      <div className="text-muted-foreground flex flex-col items-center gap-2 py-10 text-sm">
+        <Wallet className="size-8 opacity-40" />
+        <span>No accounts yet</span>
+        <span className="text-xs">Accounts appear after the first sync.</span>
+      </div>
+    );
+  }
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      {accounts.map((a) => (
+        <AccountCard key={a.id} account={a} />
+      ))}
+    </div>
+  );
+}
+
+function AccountCard({ account: a }: { account: Account }) {
+  const Icon = TYPE_ICON[a.type] ?? Banknote;
+  return (
+    <div className="bg-card flex items-center gap-3 rounded-lg border p-3">
+      <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-lg">
+        <Icon className="text-muted-foreground size-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium">{a.name}</div>
+        <div className="text-muted-foreground truncate text-xs">
+          <span className="capitalize">{a.subtype ?? a.type}</span>
+          {a.mask ? ` · ····${a.mask}` : ""}
+        </div>
+      </div>
+      <div className="text-right text-sm font-semibold tabular-nums whitespace-nowrap">
+        {a.balance_current != null && a.iso_currency_code
+          ? formatCurrency(a.balance_current, a.iso_currency_code)
+          : "—"}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/connections/connection-row.tsx
+++ b/web/src/features/connections/connection-row.tsx
@@ -100,7 +100,8 @@ export function ConnectionRow({
     <div className="bg-card overflow-hidden rounded-lg border">
       <div className="flex items-center gap-3 px-4 py-3 sm:gap-4 sm:px-5 sm:py-4">
         <Link
-          to="/connections"
+          to="/connections/$id"
+          params={{ id: connection.short_id }}
           className="flex min-w-0 flex-1 items-center gap-3 sm:gap-4"
           aria-label={`Open ${connection.institution_name ?? "connection"} detail`}
         >

--- a/web/src/features/connections/sync-activity-bars.tsx
+++ b/web/src/features/connections/sync-activity-bars.tsx
@@ -1,0 +1,115 @@
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+import type { SyncLog } from "@/api/queries/sync-logs";
+
+interface SyncActivityBarsProps {
+  logs: SyncLog[];
+  /** Number of trailing days to render. Default 7. */
+  days?: number;
+}
+
+interface DayStats {
+  key: string; // YYYY-MM-DD (local)
+  shortLabel: string; // M, T, W…
+  longLabel: string; // Mon May 5
+  success: number;
+  error: number;
+  total: number;
+}
+
+const SHORT_DAY = ["S", "M", "T", "W", "T", "F", "S"];
+const LONG_DAY = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function localKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+// Tiny inline bar chart (no charting library). Aggregates the supplied logs
+// into the trailing N days, splitting each bar into a green success layer and
+// a red error layer scaled to the day's max. Hover to see the day's totals
+// via the native title tooltip.
+export function SyncActivityBars({ logs, days = 7 }: SyncActivityBarsProps) {
+  const buckets: DayStats[] = useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const out: DayStats[] = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date(today);
+      d.setDate(today.getDate() - i);
+      out.push({
+        key: localKey(d),
+        shortLabel: SHORT_DAY[d.getDay()],
+        longLabel: `${LONG_DAY[d.getDay()]} ${d.getMonth() + 1}/${d.getDate()}`,
+        success: 0,
+        error: 0,
+        total: 0,
+      });
+    }
+    const byKey = new Map(out.map((b) => [b.key, b]));
+    for (const log of logs) {
+      const ts = log.completed_at ?? log.started_at;
+      if (!ts) continue;
+      const d = new Date(ts);
+      if (isNaN(d.getTime())) continue;
+      const key = localKey(d);
+      const bucket = byKey.get(key);
+      if (!bucket) continue;
+      bucket.total += 1;
+      if (log.status === "success") bucket.success += 1;
+      else if (log.status === "error") bucket.error += 1;
+    }
+    return out;
+  }, [logs, days]);
+
+  const maxTotal = Math.max(1, ...buckets.map((b) => b.total));
+
+  return (
+    <div className="flex items-end gap-1.5" style={{ height: 72 }}>
+      {buckets.map((b) => {
+        const pct = b.total === 0 ? 0 : (b.total / maxTotal) * 100;
+        const successPct = b.total === 0 ? 0 : (b.success / b.total) * pct;
+        const errorPct = b.total === 0 ? 0 : (b.error / b.total) * pct;
+        const tooltip =
+          b.total === 0
+            ? `${b.longLabel} — no syncs`
+            : `${b.longLabel} — ${b.total} sync${b.total === 1 ? "" : "s"}` +
+              (b.error ? ` (${b.error} err)` : "");
+        return (
+          <div
+            key={b.key}
+            className="group relative flex flex-1 flex-col items-center gap-1"
+            title={tooltip}
+          >
+            <div
+              className="bg-muted/40 flex w-full flex-col-reverse overflow-hidden rounded-md"
+              style={{ height: 52 }}
+            >
+              {b.success > 0 && (
+                <div
+                  className={cn(
+                    "w-full bg-emerald-500/60 transition-colors group-hover:bg-emerald-500/80",
+                  )}
+                  style={{ height: `${successPct}%` }}
+                />
+              )}
+              {b.error > 0 && (
+                <div
+                  className={cn(
+                    "w-full bg-destructive/60 transition-colors group-hover:bg-destructive/80",
+                  )}
+                  style={{ height: `${errorPct}%` }}
+                />
+              )}
+            </div>
+            <div className="text-muted-foreground text-[0.6rem] leading-none tabular-nums select-none">
+              {b.shortLabel}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/features/connections/sync-history-list.tsx
+++ b/web/src/features/connections/sync-history-list.tsx
@@ -1,0 +1,91 @@
+import { Check, Loader2, RefreshCw, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { relativeTime } from "./connection-utils";
+import type { SyncLog } from "@/api/queries/sync-logs";
+
+interface SyncHistoryListProps {
+  logs: SyncLog[];
+}
+
+const STATUS_TILE: Record<string, string> = {
+  success: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
+  error: "bg-destructive/10 text-destructive",
+  in_progress: "bg-primary/10 text-primary",
+};
+
+export function SyncHistoryList({ logs }: SyncHistoryListProps) {
+  if (logs.length === 0) {
+    return (
+      <div className="text-muted-foreground flex flex-col items-center gap-2 py-10 text-sm">
+        <RefreshCw className="size-8 opacity-40" />
+        <span>No sync history yet</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-border/40 divide-y">
+      {logs.map((log) => (
+        <SyncHistoryRow key={log.id} log={log} />
+      ))}
+    </div>
+  );
+}
+
+function SyncHistoryRow({ log }: { log: SyncLog }) {
+  const ts = log.completed_at ?? log.started_at ?? null;
+  const tile = STATUS_TILE[log.status] ?? STATUS_TILE.in_progress;
+  const counts = formatCounts(log);
+  const errorMessage =
+    log.status === "error"
+      ? (log.friendly_error_message ?? log.error_message ?? null)
+      : null;
+
+  return (
+    <div className="flex gap-3 py-3">
+      <div className={cn("flex size-6 shrink-0 items-center justify-center rounded-full", tile)}>
+        {log.status === "success" ? (
+          <Check className="size-3" />
+        ) : log.status === "error" ? (
+          <X className="size-3" />
+        ) : (
+          <Loader2 className="size-3 animate-spin" />
+        )}
+      </div>
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-medium capitalize">{log.trigger}</span>
+            <span className="text-muted-foreground text-xs tabular-nums">
+              {ts ? relativeTime(ts) : ""}
+            </span>
+            {log.duration && (
+              <span className="text-muted-foreground bg-muted/60 rounded-full px-1.5 py-0.5 text-[0.6rem] tabular-nums">
+                {log.duration}
+              </span>
+            )}
+          </div>
+          {errorMessage && (
+            <p className="text-destructive/80 mt-0.5 truncate text-xs" title={log.error_message ?? errorMessage}>
+              {errorMessage}
+            </p>
+          )}
+        </div>
+        {counts && (
+          <div className="text-muted-foreground shrink-0 text-xs tabular-nums">
+            {counts}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatCounts(log: SyncLog): string | null {
+  const parts: string[] = [];
+  if (log.added_count) parts.push(`${log.added_count} new`);
+  if (log.modified_count) parts.push(`${log.modified_count} updated`);
+  if (log.removed_count) parts.push(`${log.removed_count} removed`);
+  if (parts.length === 0) return null;
+  return parts.join(" · ");
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -21,6 +21,10 @@ import {
   ConnectionsPage,
   connectionsSearchSchema,
 } from "@/routes/connections";
+import {
+  ConnectionDetailPage,
+  connectionDetailSearchSchema,
+} from "@/routes/connection-detail";
 import { NAV_LEAVES } from "@/lib/nav";
 import { baseSearchSchema } from "@/lib/modals";
 import { z } from "zod";
@@ -87,6 +91,13 @@ const sandboxRoute = createRoute({
   component: lazyRouteComponent(() => import("@/routes/sandbox"), "SandboxPage"),
 });
 
+const connectionDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/connections/$id",
+  component: ConnectionDetailPage,
+  validateSearch: connectionDetailSearchSchema,
+});
+
 const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
   if (leaf.kind !== "link" || leaf.to === "/") return [];
   const override = PAGE_OVERRIDES[leaf.to];
@@ -107,6 +118,7 @@ const routeTree = rootRoute.addChildren([
   loginRoute,
   transactionDetailRoute,
   sandboxRoute,
+  connectionDetailRoute,
   ...pageRoutes,
 ]);
 

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -1,0 +1,694 @@
+import { useMemo, useState } from "react";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearch,
+} from "@tanstack/react-router";
+import {
+  ArrowLeft,
+  Building2,
+  ExternalLink,
+  FileSpreadsheet,
+  Landmark,
+  Loader2,
+  MoreHorizontal,
+  Pause,
+  Play,
+  Plug,
+  RefreshCw,
+  Unplug,
+  AlertTriangle,
+} from "lucide-react";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/empty-state";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  useConnection,
+  useDisconnectConnection,
+  usePauseConnection,
+  useSetSyncInterval,
+  useSyncConnection,
+} from "@/api/queries/connections";
+import { useAccounts } from "@/api/queries/accounts";
+import { useSyncLogs } from "@/api/queries/sync-logs";
+import type { Account, ConnectionDetail } from "@/api/types";
+import type { SyncLog } from "@/api/queries/sync-logs";
+import { ConnectionStatusBadge } from "@/features/connections/connection-status-badge";
+import { ComingSoonSheet } from "@/features/connections/coming-soon-sheet";
+import { ConnectionAccountsList } from "@/features/connections/connection-accounts-list";
+import { SyncActivityBars } from "@/features/connections/sync-activity-bars";
+import { SyncHistoryList } from "@/features/connections/sync-history-list";
+import { providerLabel, relativeTime } from "@/features/connections/connection-utils";
+
+// Search-param schema for the detail page. Mirrors the list schema's `reauth`
+// so the same coming-soon Sheet can open from either surface.
+export const connectionDetailSearchSchema = z.object({
+  reauth: z.string().optional(),
+});
+
+type ConnectionDetailSearch = z.infer<typeof connectionDetailSearchSchema>;
+
+// Same option set as the v1 connection_detail.templ — "global default" maps
+// to a cleared (null) override; the others are minute counts.
+const SYNC_INTERVAL_OPTIONS: { value: string; label: string }[] = [
+  { value: "default", label: "Global default" },
+  { value: "15", label: "Every 15 min" },
+  { value: "30", label: "Every 30 min" },
+  { value: "60", label: "Every hour" },
+  { value: "120", label: "Every 2 hours" },
+  { value: "240", label: "Every 4 hours" },
+  { value: "720", label: "Every 12 hours" },
+  { value: "1440", label: "Every 24 hours" },
+];
+
+const PROVIDER_ICON: Record<string, typeof Building2> = {
+  plaid: Building2,
+  teller: Landmark,
+  csv: FileSpreadsheet,
+};
+
+export function ConnectionDetailPage() {
+  const { id } = useParams({ strict: false }) as { id?: string };
+  const search = useSearch({ strict: false }) as ConnectionDetailSearch;
+  const navigate = useNavigate();
+
+  const connQuery = useConnection(id);
+  const accountsQuery = useAccounts();
+  // The /sync/logs endpoint accepts UUIDs only — we pass the connection's
+  // UUID once it's loaded.
+  const syncLogsQuery = useSyncLogs({
+    connectionId: connQuery.data?.id,
+    limit: 30,
+  });
+
+  const accountsForConn = useMemo(() => {
+    if (!connQuery.data || !accountsQuery.data) return [];
+    return accountsQuery.data.filter(
+      (a) => a.connection_id === connQuery.data!.short_id,
+    );
+  }, [accountsQuery.data, connQuery.data]);
+
+  const recentLogs = useMemo(
+    () => syncLogsQuery.data?.sync_logs.slice(0, 10) ?? [],
+    [syncLogsQuery.data],
+  );
+
+  function openReauth() {
+    if (!connQuery.data) return;
+    navigate({
+      to: "/connections/$id",
+      params: { id: connQuery.data.short_id },
+      search: (prev: ConnectionDetailSearch) => ({
+        ...prev,
+        reauth: connQuery.data!.short_id,
+      }),
+      replace: false,
+    });
+  }
+
+  function closeReauth() {
+    if (!connQuery.data) return;
+    navigate({
+      to: "/connections/$id",
+      params: { id: connQuery.data.short_id },
+      search: (prev: ConnectionDetailSearch) => ({
+        ...prev,
+        reauth: undefined,
+      }),
+      replace: true,
+    });
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
+        <Link to="/connections">
+          <ArrowLeft className="size-4" />
+          Connections
+        </Link>
+      </Button>
+
+      {connQuery.isLoading ? (
+        <DetailSkeleton />
+      ) : connQuery.isError || !connQuery.data ? (
+        <EmptyState
+          icon={Plug}
+          title="Connection not found"
+          description="It may have been disconnected, or the link is wrong."
+          action={
+            <Button variant="outline" asChild>
+              <Link to="/connections">Back to connections</Link>
+            </Button>
+          }
+        />
+      ) : (
+        <DetailBody
+          conn={connQuery.data}
+          accounts={accountsForConn}
+          syncLogs={recentLogs}
+          allLogsForActivity={syncLogsQuery.data?.sync_logs ?? []}
+          syncLogsLoading={syncLogsQuery.isLoading}
+          onReauth={openReauth}
+        />
+      )}
+
+      <ComingSoonSheet
+        open={!!search.reauth}
+        onOpenChange={(open) => {
+          if (!open) closeReauth();
+        }}
+        title="Re-authenticate"
+        description="Reconnect to the bank to resume syncing this connection."
+      />
+    </div>
+  );
+}
+
+interface DetailBodyProps {
+  conn: ConnectionDetail;
+  accounts: Account[];
+  syncLogs: SyncLog[];
+  allLogsForActivity: SyncLog[];
+  syncLogsLoading: boolean;
+  onReauth: () => void;
+}
+
+function DetailBody({
+  conn,
+  accounts,
+  syncLogs,
+  allLogsForActivity,
+  syncLogsLoading,
+  onReauth,
+}: DetailBodyProps) {
+  const sync = useSyncConnection();
+  const pause = usePauseConnection();
+  const disconnect = useDisconnectConnection();
+  const setInterval = useSetSyncInterval();
+  const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
+
+  const Icon = PROVIDER_ICON[conn.provider] ?? Plug;
+  const canSync = conn.provider !== "csv" && conn.status === "active";
+  const isReauthBanner =
+    conn.status === "pending_reauth" || conn.status === "error";
+  const showFailureBanner =
+    conn.consecutive_failures >= 3 && !isReauthBanner;
+
+  // Health card metrics — computed from the recent sync logs cache.
+  const successRate = useMemo(() => {
+    const total = allLogsForActivity.length;
+    if (total === 0) return null;
+    const success = allLogsForActivity.filter((l) => l.status === "success").length;
+    return { success, total, pct: Math.round((success / total) * 100) };
+  }, [allLogsForActivity]);
+
+  const failures30 = useMemo(
+    () => allLogsForActivity.filter((l) => l.status === "error").length,
+    [allLogsForActivity],
+  );
+
+  const intervalValue = conn.sync_interval_override_minutes == null
+    ? "default"
+    : String(conn.sync_interval_override_minutes);
+
+  async function onSync() {
+    await withMutationToast(() => sync.mutateAsync(conn.id), {
+      success: `Sync queued for ${conn.institution_name ?? "connection"}.`,
+    });
+  }
+
+  async function onTogglePause() {
+    const next = !conn.paused;
+    await withMutationToast(
+      () => pause.mutateAsync({ id: conn.id, paused: next }),
+      { success: next ? "Connection paused." : "Connection resumed." },
+    );
+  }
+
+  async function onDisconnect() {
+    const ok = await withMutationToast(
+      () => disconnect.mutateAsync(conn.id),
+      { success: `Disconnected ${conn.institution_name ?? "connection"}.` },
+    );
+    if (ok) setConfirmingDisconnect(false);
+  }
+
+  async function onIntervalChange(value: string) {
+    const minutes = value === "default" ? null : Number(value);
+    await withMutationToast(
+      () => setInterval.mutateAsync({ id: conn.id, minutes }),
+      {
+        success:
+          minutes == null
+            ? "Sync interval reset to global default."
+            : `Sync interval set to ${formatIntervalLabel(minutes)}.`,
+      },
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="bg-muted flex size-11 shrink-0 items-center justify-center rounded-lg">
+            <Icon className="text-muted-foreground size-5" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="truncate text-xl font-semibold tracking-tight">
+                {conn.institution_name ?? "Untitled connection"}
+              </h1>
+              <ConnectionStatusBadge status={conn.status} />
+              {conn.paused && (
+                <span className="bg-muted text-muted-foreground rounded-full px-2 py-0.5 text-xs">
+                  Paused
+                </span>
+              )}
+            </div>
+            <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-1.5 text-xs">
+              <span>{providerLabel(conn.provider)}</span>
+              {conn.user_name && (
+                <>
+                  <span className="text-muted-foreground/40">·</span>
+                  <span>{conn.user_name}</span>
+                </>
+              )}
+              {conn.last_synced_at && (
+                <>
+                  <span className="text-muted-foreground/40">·</span>
+                  <span>Synced {relativeTime(conn.last_synced_at)}</span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          {canSync && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onSync}
+              disabled={sync.isPending}
+            >
+              {sync.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <RefreshCw className="size-4" />
+              )}
+              Sync now
+            </Button>
+          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8 rounded-full"
+                aria-label="Connection actions"
+              >
+                <MoreHorizontal className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {conn.status !== "disconnected" && (
+                <DropdownMenuItem onClick={onReauth}>
+                  <Plug className="size-4" /> Re-authenticate
+                </DropdownMenuItem>
+              )}
+              {conn.status !== "disconnected" && (
+                <DropdownMenuItem
+                  onClick={onTogglePause}
+                  disabled={pause.isPending}
+                >
+                  {conn.paused ? (
+                    <>
+                      <Play className="size-4" /> Resume syncing
+                    </>
+                  ) : (
+                    <>
+                      <Pause className="size-4" /> Pause syncing
+                    </>
+                  )}
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={() => setConfirmingDisconnect(true)}
+              >
+                <Unplug className="size-4" /> Disconnect…
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Inline disconnect confirm */}
+      {confirmingDisconnect && (
+        <Alert variant="destructive">
+          <AlertTitle>Disconnect this connection?</AlertTitle>
+          <AlertDescription className="space-y-2">
+            <p>
+              Disconnecting wipes credentials and soft-deletes related
+              transactions. This can&apos;t be undone.
+            </p>
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setConfirmingDisconnect(false)}
+                disabled={disconnect.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="sm"
+                variant="destructive"
+                onClick={onDisconnect}
+                disabled={disconnect.isPending}
+              >
+                {disconnect.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                Disconnect
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Banners */}
+      {isReauthBanner && (
+        <Alert
+          className={
+            conn.status === "error"
+              ? "border-destructive/30 bg-destructive/5"
+              : "border-amber-500/30 bg-amber-500/5"
+          }
+        >
+          <AlertTriangle
+            className={
+              conn.status === "error"
+                ? "text-destructive size-4"
+                : "size-4 text-amber-700 dark:text-amber-400"
+            }
+          />
+          <AlertTitle
+            className={
+              conn.status === "error"
+                ? "text-destructive"
+                : "text-amber-700 dark:text-amber-400"
+            }
+          >
+            {conn.status === "pending_reauth"
+              ? "Login expired"
+              : "This connection had an error"}
+          </AlertTitle>
+          <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+            <span>
+              {conn.error_message ??
+                "Reconnect to the bank to resume syncing this connection."}
+            </span>
+            <Button size="sm" variant="outline" onClick={onReauth}>
+              Re-authenticate
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {showFailureBanner && (
+        <Alert className="border-amber-500/30 bg-amber-500/5">
+          <AlertTriangle className="size-4 text-amber-700 dark:text-amber-400" />
+          <AlertTitle className="text-amber-700 dark:text-amber-400">
+            {conn.consecutive_failures} syncs failed in a row
+          </AlertTitle>
+          <AlertDescription>
+            Recent syncs have been failing. Check the history below for details.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {/* Health + Settings cards */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Health</CardTitle>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+            <Stat
+              label="Success rate"
+              value={
+                successRate
+                  ? `${successRate.pct}%`
+                  : syncLogsLoading
+                    ? "…"
+                    : "—"
+              }
+              hint={
+                successRate
+                  ? `${successRate.success}/${successRate.total} (last 30)`
+                  : undefined
+              }
+            />
+            <Stat
+              label="Last sync"
+              value={
+                conn.last_synced_at ? relativeTime(conn.last_synced_at) : "Never"
+              }
+            />
+            <Stat
+              label="Failures (recent)"
+              value={syncLogsLoading ? "…" : String(failures30)}
+              hint="last 30 syncs"
+            />
+            <Stat
+              label="Total syncs"
+              value={
+                syncLogsQueryTotal(allLogsForActivity.length, syncLogsLoading)
+              }
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Settings</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="sync-interval"
+                className="text-muted-foreground text-xs"
+              >
+                Sync interval
+              </label>
+              <Select
+                value={intervalValue}
+                onValueChange={onIntervalChange}
+                disabled={
+                  setInterval.isPending || conn.status === "disconnected"
+                }
+              >
+                <SelectTrigger id="sync-interval" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {SYNC_INTERVAL_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-muted-foreground text-xs">
+                Override the global default scheduled-sync cadence for this
+                connection.
+              </p>
+            </div>
+            <div className="border-border/40 flex items-center justify-between border-t pt-3">
+              <div>
+                <div className="text-xs font-medium">Status</div>
+                <div className="text-muted-foreground text-xs">
+                  {conn.paused ? "Scheduled syncs paused" : "Syncing on schedule"}
+                </div>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onTogglePause}
+                disabled={pause.isPending || conn.status === "disconnected"}
+              >
+                {pause.isPending ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : conn.paused ? (
+                  <Play className="size-3.5" />
+                ) : (
+                  <Pause className="size-3.5" />
+                )}
+                {conn.paused ? "Resume" : "Pause"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 7-day sync activity */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center justify-between text-base">
+            <span>Sync activity</span>
+            <span className="text-muted-foreground text-xs font-normal">
+              7 days
+            </span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {syncLogsLoading ? (
+            <Skeleton className="h-[72px] w-full" />
+          ) : (
+            <SyncActivityBars logs={allLogsForActivity} days={7} />
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Accounts */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold">
+            Accounts ({conn.account_count})
+          </h2>
+          <Button variant="ghost" size="sm" asChild>
+            <Link to="/accounts">
+              Open in Accounts
+              <ExternalLink className="size-3.5" />
+            </Link>
+          </Button>
+        </div>
+        {accountsQueryLoading(accounts.length, conn.account_count) ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: Math.min(conn.account_count || 1, 3) }).map(
+              (_, i) => (
+                <Skeleton key={i} className="h-[68px] w-full rounded-lg" />
+              ),
+            )}
+          </div>
+        ) : (
+          <ConnectionAccountsList accounts={accounts} />
+        )}
+      </section>
+
+      {/* Sync history */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center justify-between text-base">
+            <span>Sync history</span>
+            <span className="text-muted-foreground text-xs font-normal">
+              Last 10
+            </span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {syncLogsLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          ) : (
+            <SyncHistoryList logs={syncLogs} />
+          )}
+        </CardContent>
+        {syncLogs.length > 0 && (
+          <div className="border-border/40 border-t px-6 py-3 text-right text-xs">
+            <Link
+              to="/sync-logs"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              View all →
+            </Link>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <dt className="text-muted-foreground text-xs">{label}</dt>
+      <dd className="text-base font-semibold tabular-nums">{value}</dd>
+      {hint && <dd className="text-muted-foreground text-[0.65rem]">{hint}</dd>}
+    </div>
+  );
+}
+
+function syncLogsQueryTotal(loadedCount: number, loading: boolean): string {
+  if (loading) return "…";
+  // The `/sync/logs` page response includes a global `total` we could surface
+  // via the query; the simpler "loaded" approximation is fine for the recent
+  // window we render. A full count requires a separate /sync/stats query.
+  return String(loadedCount);
+}
+
+function accountsQueryLoading(loaded: number, expected: number): boolean {
+  // The accounts list is a global cached fetch; treat the section as loading
+  // only if we have nothing yet AND the connection claims accounts exist.
+  return loaded === 0 && expected > 0;
+}
+
+function formatIntervalLabel(minutes: number): string {
+  if (minutes < 60) return `${minutes} min`;
+  const hours = minutes / 60;
+  if (hours < 24) return `${hours}h`;
+  return `${hours / 24}d`;
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Skeleton className="size-11 rounded-lg" />
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-56" />
+        </div>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Skeleton className="h-40 rounded-xl" />
+        <Skeleton className="h-40 rounded-xl" />
+      </div>
+      <Skeleton className="h-32 rounded-xl" />
+      <Skeleton className="h-48 rounded-xl" />
+    </div>
+  );
+}


### PR DESCRIPTION
Second PR in the `stack/v2-connections` series. Wires `/connections/$shortId` from a 404 into a real per-connection detail page.

## What's in this PR

- **Route** `routes/connection-detail.tsx` registered in `main.tsx` with `path: "/connections/$id"` and a typed `?reauth=$shortId` search-param schema. The list-page row link now points here (was `/connections`).
- **Queries**
  - `useConnection(id)` extends `api/queries/connections.ts` — fetches `GET /api/v1/connections/{id}` (accepts short_id or UUID via `internal/service/resolve.go`).
  - `useSetSyncInterval()` writes the per-connection override (`POST /connections/{id}/sync-interval` with `interval_minutes`).
  - `useSyncLogs({ connectionId, limit })` is a new resource hook in `api/queries/sync-logs.ts`. Heads-up: the backend's `connection_id` filter only resolves UUIDs — the hook intentionally takes the connection's UUID (sourced from the loaded detail), not its short_id.
- **Page layout** mirrors the wireframe top-to-bottom: back link, header (provider tile · institution · status badge · paused chip · meta row), `Sync now` + `⋯` menu (Re-authenticate / Pause-Resume / Disconnect with inline `<Alert>` confirm), reauth/error banners, failure-streak banner, two side-by-side cards (Health / Settings), 7-day Sync activity bars, Accounts grid, and a Last-10 Sync history with a `View all →` stub link to `/sync-logs?connection=$shortId`.
- **Settings card** uses the new shadcn `Select` primitive (added via `bunx shadcn add select` — vendored in `components/ui/select.tsx`). Interval options match the v1 templ list (15m → 24h plus "Global default" which clears the override).
- **Sync activity** is implemented in plain Tailwind (`features/connections/sync-activity-bars.tsx`) — flex columns scaled to the day's max, green/red split, native `title` tooltip with the day total. Deliberately no charting library; the visual is small and the bar-only treatment matched what was achievable cleanly.
- **Accounts list** (`connection-accounts-list.tsx`) is read-only: name · subtype · ····mask · balance. Inline rename / exclude lives on the future `/accounts/$shortId` surface, per the brief.
- **Re-auth Sheet** reuses the existing `ComingSoonSheet` placeholder. PR-05 will swap in the real Sheet behind the same `?reauth=` URL contract used by PR-01.

## What's deliberately NOT here

- **No backend change** — every action goes through endpoints PR-01 already used (`/connections/{id}` GET, `/sync`, `/paused`, `/sync-interval`, DELETE) plus the existing `/sync/logs` filter.
- **No per-account inline rename / exclude on this page** — that's the Accounts surface.
- **`/sync-logs?connection=…`** the "View all →" link points at — that route doesn't exist yet. Stub is intentional; it lights up when the sync-logs page ships.
- **Total-syncs in the Health card** approximates by counting the loaded sync-logs window. A precise count needs a separate `/sync/stats` query — out of scope for this PR.
- **Real Re-auth flow** → PR-05.

## Screenshots

<table>
  <tr><th>Desktop</th><th>Mobile</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/21iy5msagz.png" width="500" alt="Connection detail — desktop"></td>
    <td><img src="https://i.img402.dev/bm1ak6ptlp.png" width="240" alt="Connection detail — mobile"></td>
  </tr>
</table>

## Test plan

- [x] `bun run lint` (tsc --noEmit) — clean
- [x] `bun run build` (tsc -b + vite build) — clean
- [x] `go build ./...`, `go vet ./...`, `go test ./...` — clean
- [x] Smoke against dev DB: load `/v2/connections/cnFBnNYP`, verify header, both cards, sync activity, accounts list, history
- [x] Confirm the connection-row in the list now links to `/connections/$short_id`
- [ ] Reviewer: try Sync now / Pause / change sync interval / Disconnect (inline confirm)
- [ ] Reviewer: load a connection in `pending_reauth` or `error` status and verify the banner shows
