### PR TITLE
v2: transactions polish round 2 — multi-select filters + c shortcut + mobile

### DIFF
--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -14,67 +14,87 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// parseTransactionFilters extracts the common filter parameters shared by
-// ListTransactions and CountTransactions. It writes an error response and
-// returns false when any parameter is invalid.
-func parseTransactionFilters(w http.ResponseWriter, r *http.Request) (
-	startDate, endDate *time.Time,
-	accountID, userID, categorySlug *string,
-	minAmount, maxAmount *float64,
-	pending *bool,
-	search, searchMode, excludeSearch *string,
-	tags, anyTag []string,
-	ok bool,
-) {
+// transactionFilters bundles the filter values shared by ListTransactions and
+// CountTransactions. Returning it via a struct keeps the parse function and
+// its call sites readable as the v2 SPA adds new multi-select filters.
+type transactionFilters struct {
+	StartDate     *time.Time
+	EndDate       *time.Time
+	AccountID     *string
+	UserID        *string
+	CategorySlug  *string
+	AccountIDs    []string
+	CategorySlugs []string
+	MinAmount     *float64
+	MaxAmount     *float64
+	Pending       *bool
+	Search        *string
+	SearchMode    *string
+	ExcludeSearch *string
+	Tags          []string
+	AnyTag        []string
+}
+
+func parseTransactionFilters(w http.ResponseWriter, r *http.Request) (f transactionFilters, ok bool) {
 	q := r.URL.Query()
 
 	var err error
 
-	startDate, err = parseDateParam(q, "start_date")
+	f.StartDate, err = parseDateParam(q, "start_date")
 	if err != nil {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
-	endDate, err = parseDateParam(q, "end_date")
+	f.EndDate, err = parseDateParam(q, "end_date")
 	if err != nil {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
-	if startDate != nil && endDate != nil && !startDate.Before(*endDate) {
+	if f.StartDate != nil && f.EndDate != nil && !f.StartDate.Before(*f.EndDate) {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "start_date must be before end_date")
 		return
 	}
 
-	accountID = parseOptionalStringParam(q, "account_id")
-	userID = parseOptionalStringParam(q, "user_id")
-	categorySlug = parseOptionalStringParam(q, "category_slug")
+	// account_id and category_slug accept either a single value or a
+	// comma-separated list; the service layer prefers the slice when present.
+	if list := parseCSVParam(q, "account_id"); len(list) > 1 {
+		f.AccountIDs = list
+	} else {
+		f.AccountID = parseOptionalStringParam(q, "account_id")
+	}
+	f.UserID = parseOptionalStringParam(q, "user_id")
+	if list := parseCSVParam(q, "category_slug"); len(list) > 1 {
+		f.CategorySlugs = list
+	} else {
+		f.CategorySlug = parseOptionalStringParam(q, "category_slug")
+	}
 
-	minAmount, err = parseFloatParam(q, "min_amount")
+	f.MinAmount, err = parseFloatParam(q, "min_amount")
 	if err != nil {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
-	maxAmount, err = parseFloatParam(q, "max_amount")
+	f.MaxAmount, err = parseFloatParam(q, "max_amount")
 	if err != nil {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
-	if minAmount != nil && maxAmount != nil && *minAmount > *maxAmount {
+	if f.MinAmount != nil && f.MaxAmount != nil && *f.MinAmount > *f.MaxAmount {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "min_amount must be less than or equal to max_amount")
 		return
 	}
 
-	pending, err = parseBoolParam(q, "pending")
+	f.Pending, err = parseBoolParam(q, "pending")
 	if err != nil {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
-	search, err = parseMinLengthStringParam(q, "search", 2)
+	f.Search, err = parseMinLengthStringParam(q, "search", 2)
 	if err != nil {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
@@ -85,17 +105,17 @@ func parseTransactionFilters(w http.ResponseWriter, r *http.Request) (
 			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "search_mode must be one of: contains, words, fuzzy")
 			return
 		}
-		searchMode = &v
+		f.SearchMode = &v
 	}
 
-	excludeSearch, err = parseMinLengthStringParam(q, "exclude_search", 2)
+	f.ExcludeSearch, err = parseMinLengthStringParam(q, "exclude_search", 2)
 	if err != nil {
 		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 		return
 	}
 
-	tags = parseCSVParam(q, "tags")
-	anyTag = parseCSVParam(q, "any_tag")
+	f.Tags = parseCSVParam(q, "tags")
+	f.AnyTag = parseCSVParam(q, "any_tag")
 
 	ok = true
 	return
@@ -112,19 +132,17 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			return
 		}
 
-		startDate, endDate, accountID, userID, categorySlug, minAmount, maxAmount, pending, search, searchMode, excludeSearch, tags, anyTag, ok := parseTransactionFilters(w, r)
+		f, ok := parseTransactionFilters(w, r)
 		if !ok {
 			return
 		}
 
-		// Parse sort_by.
 		sortBy, err := parseEnumParam(q, "sort_by", []string{"date", "amount", "provider_name"})
 		if err != nil {
 			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
 			return
 		}
 
-		// Parse sort_order.
 		var sortOrder *string
 		if v := q.Get("sort_order"); v != "" {
 			switch v {
@@ -139,21 +157,23 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 		params := service.TransactionListParams{
 			Cursor:        q.Get("cursor"),
 			Limit:         limit,
-			StartDate:     startDate,
-			EndDate:       endDate,
-			AccountID:     accountID,
-			UserID:        userID,
-			CategorySlug:  categorySlug,
-			MinAmount:     minAmount,
-			MaxAmount:     maxAmount,
-			Pending:       pending,
-			Search:        search,
-			SearchMode:    searchMode,
-			ExcludeSearch: excludeSearch,
+			StartDate:     f.StartDate,
+			EndDate:       f.EndDate,
+			AccountID:     f.AccountID,
+			UserID:        f.UserID,
+			CategorySlug:  f.CategorySlug,
+			AccountIDs:    f.AccountIDs,
+			CategorySlugs: f.CategorySlugs,
+			MinAmount:     f.MinAmount,
+			MaxAmount:     f.MaxAmount,
+			Pending:       f.Pending,
+			Search:        f.Search,
+			SearchMode:    f.SearchMode,
+			ExcludeSearch: f.ExcludeSearch,
 			SortBy:        sortBy,
 			SortOrder:     sortOrder,
-			Tags:          tags,
-			AnyTag:        anyTag,
+			Tags:          f.Tags,
+			AnyTag:        f.AnyTag,
 		}
 
 		// Parse fields for field selection.
@@ -194,25 +214,27 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 // CountTransactionsHandler returns the number of transactions matching optional filters.
 func CountTransactionsHandler(svc *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		startDate, endDate, accountID, userID, categorySlug, minAmount, maxAmount, pending, search, searchMode, excludeSearch, tags, anyTag, ok := parseTransactionFilters(w, r)
+		f, ok := parseTransactionFilters(w, r)
 		if !ok {
 			return
 		}
 
 		params := service.TransactionCountParams{
-			StartDate:     startDate,
-			EndDate:       endDate,
-			AccountID:     accountID,
-			UserID:        userID,
-			CategorySlug:  categorySlug,
-			MinAmount:     minAmount,
-			MaxAmount:     maxAmount,
-			Pending:       pending,
-			Search:        search,
-			SearchMode:    searchMode,
-			ExcludeSearch: excludeSearch,
-			Tags:          tags,
-			AnyTag:        anyTag,
+			StartDate:     f.StartDate,
+			EndDate:       f.EndDate,
+			AccountID:     f.AccountID,
+			UserID:        f.UserID,
+			CategorySlug:  f.CategorySlug,
+			AccountIDs:    f.AccountIDs,
+			CategorySlugs: f.CategorySlugs,
+			MinAmount:     f.MinAmount,
+			MaxAmount:     f.MaxAmount,
+			Pending:       f.Pending,
+			Search:        f.Search,
+			SearchMode:    f.SearchMode,
+			ExcludeSearch: f.ExcludeSearch,
+			Tags:          f.Tags,
+			AnyTag:        f.AnyTag,
 		}
 
 		count, err := svc.CountTransactionsFiltered(r.Context(), params)

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -94,6 +94,115 @@ func FormatCurrency(abs float64) string {
 	return fmt.Sprintf("$%s.%02d", s, cents)
 }
 
+// appendAccountFilter writes the account-filter SQL clause for transactions
+// queries, preferring the multi-value AccountIDs over the singular AccountID
+// when both are populated. Errors out on any unknown id — a bad id is almost
+// always a client bug (vs. a stale category slug, which we tolerate silently
+// in appendCategoryFilter below).
+func (s *Service) appendAccountFilter(
+	ctx context.Context,
+	buf *strings.Builder,
+	args []any,
+	argN int,
+	ids []string,
+	single *string,
+) ([]any, int, error) {
+	if len(ids) > 0 {
+		uuids := make([]pgtype.UUID, 0, len(ids))
+		for _, id := range ids {
+			u, err := s.resolveAccountID(ctx, id)
+			if err != nil {
+				return args, argN, fmt.Errorf("invalid account id %q: %w", id, err)
+			}
+			uuids = append(uuids, u)
+		}
+		buf.WriteString(" AND t.account_id = ANY($")
+		buf.WriteString(strconv.Itoa(argN))
+		buf.WriteString("::uuid[])")
+		args = append(args, uuids)
+		argN++
+		return args, argN, nil
+	}
+	if single != nil {
+		u, err := s.resolveAccountID(ctx, *single)
+		if err != nil {
+			return args, argN, fmt.Errorf("invalid account id: %w", err)
+		}
+		buf.WriteString(" AND t.account_id = $")
+		buf.WriteString(strconv.Itoa(argN))
+		args = append(args, u)
+		argN++
+	}
+	return args, argN, nil
+}
+
+// appendCategoryFilter writes the category-filter SQL clause. Supports both
+// the singular CategorySlug and the multi-value CategorySlugs. When a
+// selected slug names a top-level (parent) category its child categories
+// are automatically included. Returns `matched=false` only when every
+// requested slug failed to resolve — caller should short-circuit to zero
+// results in that case.
+func (s *Service) appendCategoryFilter(
+	ctx context.Context,
+	buf *strings.Builder,
+	args []any,
+	argN int,
+	slugs []string,
+	single *string,
+) (newArgs []any, newArgN int, matched bool, err error) {
+	if len(slugs) > 0 {
+		var selfIDs, parentIDs []pgtype.UUID
+		for _, slug := range slugs {
+			row, e := s.Queries.GetCategoryBySlug(ctx, slug)
+			if e != nil {
+				continue
+			}
+			selfIDs = append(selfIDs, row.ID)
+			if !row.ParentID.Valid {
+				parentIDs = append(parentIDs, row.ID)
+			}
+		}
+		if len(selfIDs) == 0 {
+			return args, argN, false, nil
+		}
+		buf.WriteString(" AND (c.id = ANY($")
+		buf.WriteString(strconv.Itoa(argN))
+		buf.WriteString("::uuid[])")
+		args = append(args, selfIDs)
+		argN++
+		if len(parentIDs) > 0 {
+			buf.WriteString(" OR c.parent_id = ANY($")
+			buf.WriteString(strconv.Itoa(argN))
+			buf.WriteString("::uuid[])")
+			args = append(args, parentIDs)
+			argN++
+		}
+		buf.WriteByte(')')
+		return args, argN, true, nil
+	}
+	if single != nil {
+		row, e := s.Queries.GetCategoryBySlug(ctx, *single)
+		if e != nil {
+			return args, argN, false, nil
+		}
+		n := strconv.Itoa(argN)
+		if !row.ParentID.Valid {
+			buf.WriteString(" AND (c.id = $")
+			buf.WriteString(n)
+			buf.WriteString(" OR c.parent_id = $")
+			buf.WriteString(n)
+			buf.WriteByte(')')
+		} else {
+			buf.WriteString(" AND t.category_id = $")
+			buf.WriteString(n)
+		}
+		args = append(args, row.ID)
+		argN++
+		return args, argN, true, nil
+	}
+	return args, argN, true, nil
+}
+
 func (s *Service) ListTransactions(ctx context.Context, params TransactionListParams) (*TransactionListResult, error) {
 	// Build dynamic SQL query using strings.Builder to reduce allocations.
 	var buf strings.Builder
@@ -110,7 +219,7 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		"a.short_id AS account_short_id, " +
 		"COALESCE(au.name, u.name) AS user_name, " +
 		"t.category_id, t.category_override, " +
-		"c.slug AS cat_slug, c.display_name AS cat_display_name, c.icon AS cat_icon, c.color AS cat_color, " +
+		"c.slug AS cat_slug, c.display_name AS cat_display_name, c.icon AS cat_icon, COALESCE(c.color, pc.color) AS cat_color, " +
 		"pc.slug AS cat_primary_slug, pc.display_name AS cat_primary_display_name, " +
 		"au.short_id AS attributed_user_short_id, au.name AS attributed_user_name, " +
 		"COALESCE(au.short_id, u.short_id) AS effective_user_short_id " +
@@ -149,15 +258,12 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		argN++
 	}
 
-	if params.AccountID != nil {
-		aid, err := s.resolveAccountID(ctx, *params.AccountID)
+	{
+		var err error
+		args, argN, err = s.appendAccountFilter(ctx, &buf, args, argN, params.AccountIDs, params.AccountID)
 		if err != nil {
-			return nil, fmt.Errorf("invalid account id: %w", err)
+			return nil, err
 		}
-		buf.WriteString(" AND t.account_id = $")
-		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, aid)
-		argN++
 	}
 
 	if params.StartDate != nil {
@@ -174,28 +280,18 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		argN++
 	}
 
-	if params.CategorySlug != nil {
-		catRow, err := s.Queries.GetCategoryBySlug(ctx, *params.CategorySlug)
+	{
+		var (
+			err     error
+			matched bool
+		)
+		args, argN, matched, err = s.appendCategoryFilter(ctx, &buf, args, argN, params.CategorySlugs, params.CategorySlug)
 		if err != nil {
-			// Unknown slug — no results
-			return &TransactionListResult{Transactions: []TransactionResponse{}, Limit: limit}, nil
+			return nil, err
 		}
-		n := strconv.Itoa(argN)
-		if !catRow.ParentID.Valid {
-			// Parent category — include self and all children
-			buf.WriteString(" AND (c.id = $")
-			buf.WriteString(n)
-			buf.WriteString(" OR c.parent_id = $")
-			buf.WriteString(n)
-			buf.WriteByte(')')
-			args = append(args, catRow.ID)
-			argN++
-		} else {
-			// Child category — exact match
-			buf.WriteString(" AND t.category_id = $")
-			buf.WriteString(n)
-			args = append(args, catRow.ID)
-			argN++
+		if !matched {
+			// Every requested slug failed to resolve — empty result.
+			return &TransactionListResult{Transactions: []TransactionResponse{}, Limit: limit}, nil
 		}
 	}
 
@@ -542,15 +638,12 @@ func (s *Service) CountTransactionsFiltered(ctx context.Context, params Transact
 		argN++
 	}
 
-	if params.AccountID != nil {
-		aid, err := s.resolveAccountID(ctx, *params.AccountID)
+	{
+		var err error
+		args, argN, err = s.appendAccountFilter(ctx, &buf, args, argN, params.AccountIDs, params.AccountID)
 		if err != nil {
-			return 0, fmt.Errorf("invalid account id: %w", err)
+			return 0, err
 		}
-		buf.WriteString(" AND t.account_id = $")
-		buf.WriteString(strconv.Itoa(argN))
-		args = append(args, aid)
-		argN++
 	}
 
 	if params.StartDate != nil {
@@ -567,28 +660,17 @@ func (s *Service) CountTransactionsFiltered(ctx context.Context, params Transact
 		argN++
 	}
 
-	if params.CategorySlug != nil {
-		catRow, err := s.Queries.GetCategoryBySlug(ctx, *params.CategorySlug)
+	{
+		var (
+			err     error
+			matched bool
+		)
+		args, argN, matched, err = s.appendCategoryFilter(ctx, &buf, args, argN, params.CategorySlugs, params.CategorySlug)
 		if err != nil {
-			// Unknown slug — 0 count
-			return 0, nil
+			return 0, err
 		}
-		n := strconv.Itoa(argN)
-		if !catRow.ParentID.Valid {
-			// Parent category — include self and all children
-			buf.WriteString(" AND (c.id = $")
-			buf.WriteString(n)
-			buf.WriteString(" OR c.parent_id = $")
-			buf.WriteString(n)
-			buf.WriteByte(')')
-			args = append(args, catRow.ID)
-			argN++
-		} else {
-			// Child category — exact match
-			buf.WriteString(" AND t.category_id = $")
-			buf.WriteString(n)
-			args = append(args, catRow.ID)
-			argN++
+		if !matched {
+			return 0, nil
 		}
 	}
 

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -83,6 +83,12 @@ type TransactionListParams struct {
 	AccountID        *string
 	UserID           *string
 	CategorySlug     *string
+	// Multi-select variants. When non-empty they take precedence over the
+	// singular `AccountID` / `CategorySlug` fields above and produce an OR
+	// match across every value in the list (parent categories still include
+	// their children).
+	AccountIDs       []string
+	CategorySlugs    []string
 	MinAmount        *float64
 	MaxAmount        *float64
 	Pending          *bool
@@ -104,6 +110,9 @@ type TransactionCountParams struct {
 	AccountID        *string
 	UserID           *string
 	CategorySlug     *string
+	// Multi-select variants — see TransactionListParams.
+	AccountIDs       []string
+	CategorySlugs    []string
 	MinAmount        *float64
 	MaxAmount        *float64
 	Pending          *bool

--- a/web/src/components/category-command.tsx
+++ b/web/src/components/category-command.tsx
@@ -24,6 +24,12 @@ export interface CategoryPick {
 interface CategoryCommandListProps {
   /** Slug of the currently-applied category — rendered with a check mark. */
   currentSlug?: string | null;
+  /**
+   * Set of currently-selected slugs for multi-select callers (the
+   * transactions toolbar). Each match renders a check mark. Takes
+   * precedence over `currentSlug` when provided.
+   */
+  selectedSlugs?: Set<string>;
   /** Show a "reset to provider default" entry — for manually-overridden rows. */
   showReset?: boolean;
   onPick: (pick: CategoryPick) => void;
@@ -33,11 +39,11 @@ interface CategoryCommandListProps {
 // search for the parent ("food") still surfaces every child.
 function CategoryItem({
   category,
-  currentSlug,
+  isSelected,
   onPick,
 }: {
   category: Category;
-  currentSlug?: string | null;
+  isSelected: boolean;
   onPick: (pick: CategoryPick) => void;
 }) {
   return (
@@ -55,7 +61,7 @@ function CategoryItem({
         style={category.color ? { color: category.color } : undefined}
       />
       <span>{category.display_name}</span>
-      {currentSlug === category.slug && <Check className="ml-auto size-4" />}
+      {isSelected && <Check className="ml-auto size-4" />}
     </CommandItem>
   );
 }
@@ -67,11 +73,17 @@ function CategoryItem({
 // owns the mutation.
 export function CategoryCommandList({
   currentSlug,
+  selectedSlugs,
   showReset,
   onPick,
 }: CategoryCommandListProps) {
   const { data: tree, isLoading } = useCategories();
   const parents = (tree ?? []).filter((c) => !c.hidden);
+
+  const isSelected = (slug: string) => {
+    if (selectedSlugs) return selectedSlugs.has(slug);
+    return currentSlug === slug;
+  };
 
   return (
     <Command>
@@ -103,7 +115,7 @@ export function CategoryCommandList({
               <CategoryItem
                 key={parent.slug}
                 category={parent}
-                currentSlug={currentSlug}
+                isSelected={isSelected(parent.slug)}
                 onPick={onPick}
               />
             );
@@ -112,14 +124,14 @@ export function CategoryCommandList({
             <CommandGroup key={parent.slug} heading={parent.display_name}>
               <CategoryItem
                 category={parent}
-                currentSlug={currentSlug}
+                isSelected={isSelected(parent.slug)}
                 onPick={onPick}
               />
               {children.map((child) => (
                 <CategoryItem
                   key={child.slug}
                   category={child}
-                  currentSlug={currentSlug}
+                  isSelected={isSelected(child.slug)}
                   onPick={onPick}
                 />
               ))}

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -180,7 +180,12 @@ export function DataTable<TData, TValue>({
                   }
                   className={cn(
                     onRowClick && "cursor-pointer",
-                    focused && "ring-primary ring-2 ring-inset outline-none",
+                    // Keyboard-focus indicator: a 3px primary accent bar on
+                    // the left edge plus a faint primary tint, layered via
+                    // inset box-shadow so it doesn't shift the row geometry
+                    // or compete with the row's selected/hover background.
+                    focused &&
+                      "bg-primary/[0.04] shadow-[inset_3px_0_0_0_var(--primary)] outline-none",
                   )}
                 >
                   {row.getVisibleCells().map((cell) => (

--- a/web/src/components/transaction-primary.tsx
+++ b/web/src/components/transaction-primary.tsx
@@ -1,3 +1,4 @@
+import { Tag as TagIcon } from "lucide-react";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { TagList } from "@/components/tag-chip";
 import { cn } from "@/lib/utils";
@@ -38,20 +39,35 @@ export function TransactionPrimary({
   );
 }
 
-// The secondary metadata line: account and household member as plain text,
-// then tag chips. Renders nothing when there's no metadata to show.
+// On sm+ this is "account · user · <tag chips>". On mobile we drop the
+// household member and collapse the tag chips into a compact "N tag-icon" so
+// the row stays narrow enough to keep the amount visible without horizontal
+// scroll.
 function TransactionMeta({ transaction: t }: { transaction: Transaction }) {
-  const text: string[] = [];
-  if (t.account_name) text.push(t.account_name);
-  if (t.user_name) text.push(t.user_name);
   const hasTags = !!t.tags?.length;
-  if (!text.length && !hasTags) return null;
+  if (!t.account_name && !t.user_name && !hasTags) return null;
 
   return (
-    <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
-      {text.length > 0 && <span className="truncate">{text.join(" · ")}</span>}
-      {text.length > 0 && hasTags && <span aria-hidden>·</span>}
-      {hasTags && <TagList slugs={t.tags} max={2} />}
+    <div className="text-muted-foreground mt-0.5 flex min-w-0 items-center gap-1.5 text-xs">
+      {t.account_name && <span className="truncate">{t.account_name}</span>}
+      {t.user_name && (
+        <span className="hidden truncate sm:inline">· {t.user_name}</span>
+      )}
+      {hasTags && (
+        <>
+          <span aria-hidden className="hidden sm:inline">
+            ·
+          </span>
+          <span className="inline-flex shrink-0 items-center gap-0.5 sm:hidden">
+            {t.account_name && <span aria-hidden>·</span>}
+            <TagIcon className="size-3" />
+            {t.tags!.length}
+          </span>
+          <span className="hidden sm:inline-flex">
+            <TagList slugs={t.tags} max={2} />
+          </span>
+        </>
+      )}
     </div>
   );
 }

--- a/web/src/features/transactions/bulk-update.ts
+++ b/web/src/features/transactions/bulk-update.ts
@@ -1,0 +1,38 @@
+import type { UpdateTransactionsOp } from "@/api/types";
+import { withMutationToast } from "@/lib/mutation-toast";
+import type { useUpdateTransactions } from "@/api/queries/transactions";
+
+// The batch endpoint caps each call at 50 operations; larger selections are
+// split into sequential chunks issued in parallel.
+const BATCH_LIMIT = 50;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+// Apply a single batch op (set category, add tag, …) to a list of transaction
+// IDs of any size, splitting into 50-op chunks and surfacing a standard
+// success/error toast. Used by the selection action bar and the `c`
+// keyboard-shortcut categorize flow.
+export function applyBulkTransactionOp(
+  update: ReturnType<typeof useUpdateTransactions>,
+  ids: string[],
+  op: Omit<UpdateTransactionsOp, "transaction_id">,
+  successMessage: string,
+): Promise<boolean> {
+  return withMutationToast(
+    () =>
+      Promise.all(
+        chunk(ids, BATCH_LIMIT).map((batch) =>
+          update.mutateAsync({
+            operations: batch.map((id) => ({ transaction_id: id, ...op })),
+          }),
+        ),
+      ),
+    { success: successMessage },
+  );
+}

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -58,14 +58,21 @@ const baseColumns: ColumnDef<Transaction>[] = [
   {
     id: "description",
     header: "Description",
+    // `max-w-0 w-full` is the classic auto-table truncation trick: the cell
+    // fills available width but its max-width is 0, so descendants with
+    // `truncate` actually clamp. Without this, a long merchant name expands
+    // the column and pushes the amount off-screen on narrow viewports.
+    meta: { className: "max-w-0 w-full" },
     cell: ({ row }) => <TransactionPrimary transaction={row.original} />,
   },
   {
     id: "category",
-    header: "Category",
+    header: () => <div className="text-right">Category</div>,
     // Hidden on mobile — the description column takes the freed space; the
-    // category is still editable from the detail page.
-    meta: { className: "w-px hidden sm:table-cell" },
+    // category is still editable from the detail page. `text-right` keeps the
+    // badge flush against the amount column so the gap is consistent
+    // regardless of category name length.
+    meta: { className: "w-px hidden sm:table-cell text-right" },
     cell: ({ row }) => (
       <CategoryPicker
         transactionId={row.original.id}
@@ -77,7 +84,10 @@ const baseColumns: ColumnDef<Transaction>[] = [
   {
     accessorKey: "amount",
     header: () => <div className="text-right">Amount</div>,
-    meta: { className: "w-px" },
+    // `w-px` shrinks to content on mobile (where space is tight); `sm:min-w-28`
+    // pins a comfortable floor on desktop so the right edge of the column
+    // stays steady across rows of varying amount length.
+    meta: { className: "w-px sm:min-w-28" },
     cell: ({ row }) => <TransactionAmount transaction={row.original} />,
   },
 ];

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -10,21 +10,9 @@ import { Separator } from "@/components/ui/separator";
 import { CategoryCommandList } from "@/components/category-command";
 import { TagCommandList } from "@/components/tag-command";
 import { KbdTooltip } from "@/components/kbd-tooltip";
-import { withMutationToast } from "@/lib/mutation-toast";
 import { useUpdateTransactions } from "@/api/queries/transactions";
 import type { UpdateTransactionsOp } from "@/api/types";
-
-// The batch endpoint caps each call at 50 operations; larger selections are
-// split into sequential chunks.
-const BATCH_LIMIT = 50;
-
-function chunk<T>(items: T[], size: number): T[][] {
-  const out: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    out.push(items.slice(i, i + size));
-  }
-  return out;
-}
+import { applyBulkTransactionOp } from "@/features/transactions/bulk-update";
 
 interface SelectionActionBarProps {
   selectedIds: string[];
@@ -49,16 +37,11 @@ export function SelectionActionBar({
     op: Omit<UpdateTransactionsOp, "transaction_id">,
     successMessage: string,
   ) => {
-    const ok = await withMutationToast(
-      () =>
-        Promise.all(
-          chunk(selectedIds, BATCH_LIMIT).map((ids) =>
-            update.mutateAsync({
-              operations: ids.map((id) => ({ transaction_id: id, ...op })),
-            }),
-          ),
-        ),
-      { success: successMessage },
+    const ok = await applyBulkTransactionOp(
+      update,
+      selectedIds,
+      op,
+      successMessage,
     );
     if (ok) onClear();
   };

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -64,6 +64,33 @@ const SORT_OPTIONS: {
 // for the two range filters that clear a pair of params at once.
 type ChipKey = keyof TransactionsSearch | "dateRange" | "amountRange";
 
+function csvSet(raw: string | undefined): Set<string> {
+  if (!raw) return new Set();
+  return new Set(raw.split(",").map((s) => s.trim()).filter(Boolean));
+}
+
+function setToCsv(set: Set<string>): string | undefined {
+  if (set.size === 0) return undefined;
+  return Array.from(set).join(",");
+}
+
+function toggleInSet(set: Set<string>, value: string): Set<string> {
+  const next = new Set(set);
+  if (next.has(value)) next.delete(value);
+  else next.add(value);
+  return next;
+}
+
+function multiSelectChip(
+  key: ChipKey,
+  selected: { label: string }[],
+  pluralNoun: string,
+): { key: ChipKey; label: string } | null {
+  if (selected.length === 0) return null;
+  if (selected.length === 1) return { key, label: selected[0].label };
+  return { key, label: `${selected.length} ${pluralNoun}` };
+}
+
 // TransactionsToolbar is the transactions page's single control band: a search
 // box, a row of popover-backed filter pills, a sort control and the select-mode
 // toggle — plus a removable chip for every active filter. It's controlled — all
@@ -79,15 +106,37 @@ export function TransactionsToolbar({
 }: TransactionsToolbarProps) {
   const { data: accounts } = useAccounts();
   const { data: categoryTree } = useCategories();
-  // Flattened only to resolve the active category's label for its chip — the
-  // Category pill itself uses the shared CategoryCommandList.
+  // Flattened only to resolve the active categories' labels for their chip —
+  // the Category pill itself uses the shared CategoryCommandList.
   const categories = useMemo(
     () => flattenCategories(categoryTree),
     [categoryTree],
   );
 
-  const account = accounts?.find((a) => a.short_id === search.account);
-  const category = categories.find((c) => c.slug === search.category);
+  // `account` and `category` are comma-separated lists; splitting to Sets up
+  // here lets the rest of the toolbar treat selection as set membership.
+  const accountSlugs = useMemo(
+    () => csvSet(search.account),
+    [search.account],
+  );
+  const categorySlugs = useMemo(
+    () => csvSet(search.category),
+    [search.category],
+  );
+
+  const selectedAccounts = useMemo(
+    () => (accounts ?? []).filter((a) => accountSlugs.has(a.short_id)),
+    [accounts, accountSlugs],
+  );
+  const selectedCategories = useMemo(
+    () => categories.filter((c) => categorySlugs.has(c.slug)),
+    [categories, categorySlugs],
+  );
+
+  const toggleAccount = (shortId: string) =>
+    onChange({ account: setToCsv(toggleInSet(accountSlugs, shortId)) });
+  const toggleCategory = (slug: string) =>
+    onChange({ category: setToCsv(toggleInSet(categorySlugs, slug)) });
   // Only treat sort as "custom" when the params actually resolve to a known
   // option — a partial/garbage param shouldn't light the pill with the wrong
   // label.
@@ -98,8 +147,18 @@ export function TransactionsToolbar({
   const sortIsCustom = !!foundSort;
 
   const chips: { key: ChipKey; label: string }[] = [];
-  if (account) chips.push({ key: "account", label: account.name });
-  if (category) chips.push({ key: "category", label: category.display_name });
+  const accountChip = multiSelectChip(
+    "account",
+    selectedAccounts.map((a) => ({ label: a.name })),
+    "accounts",
+  );
+  if (accountChip) chips.push(accountChip);
+  const categoryChip = multiSelectChip(
+    "category",
+    selectedCategories.map((c) => ({ label: c.display_name })),
+    "categories",
+  );
+  if (categoryChip) chips.push(categoryChip);
   if (search.start || search.end) {
     const from = search.start ? formatLongDate(search.start) : "Any";
     const to = search.end ? formatLongDate(search.end) : "Any";
@@ -143,6 +202,12 @@ export function TransactionsToolbar({
             ref={searchRef}
             value={query}
             onChange={(e) => onQueryChange(e.target.value)}
+            // Esc inside the search box blurs back to the page so the global
+            // shortcuts (j/k/c/Esc-to-clear-selection) regain control without
+            // a manual click-away.
+            onKeyDown={(e) => {
+              if (e.key === "Escape") e.currentTarget.blur();
+            }}
             placeholder="Search merchant or description…"
             className="pl-8"
           />
@@ -151,7 +216,12 @@ export function TransactionsToolbar({
         {/* Filter pills — grouped so they wrap as a unit, independent of
             the sort/select controls. */}
         <div className="flex flex-wrap items-center gap-2">
-          <FilterPill icon={Banknote} label="Account" active={!!account}>
+          <FilterPill
+            icon={Banknote}
+            label="Account"
+            count={selectedAccounts.length}
+            active={selectedAccounts.length > 0}
+          >
             <Command>
               <CommandInput placeholder="Search accounts…" />
               <CommandList>
@@ -161,20 +231,13 @@ export function TransactionsToolbar({
                     <CommandItem
                       key={a.short_id}
                       value={`${a.name} ${a.institution_name}`}
-                      onSelect={() =>
-                        onChange({
-                          account:
-                            search.account === a.short_id
-                              ? undefined
-                              : a.short_id,
-                        })
-                      }
+                      onSelect={() => toggleAccount(a.short_id)}
                     >
                       <span className="truncate">{a.name}</span>
                       <span className="text-muted-foreground ml-1 truncate text-xs">
                         {a.institution_name}
                       </span>
-                      {search.account === a.short_id && (
+                      {accountSlugs.has(a.short_id) && (
                         <Check className="ml-auto size-4" />
                       )}
                     </CommandItem>
@@ -184,17 +247,18 @@ export function TransactionsToolbar({
             </Command>
           </FilterPill>
 
-          <FilterPill icon={Shapes} label="Category" active={!!category}>
+          <FilterPill
+            icon={Shapes}
+            label="Category"
+            count={selectedCategories.length}
+            active={selectedCategories.length > 0}
+          >
             <CategoryCommandList
-              currentSlug={search.category ?? null}
-              onPick={({ category_slug }) =>
-                onChange({
-                  category:
-                    category_slug && search.category === category_slug
-                      ? undefined
-                      : category_slug,
-                })
-              }
+              selectedSlugs={categorySlugs}
+              onPick={({ category_slug }) => {
+                if (!category_slug) return;
+                toggleCategory(category_slug);
+              }}
             />
           </FilterPill>
 
@@ -385,6 +449,8 @@ interface FilterPillProps {
   icon: typeof Banknote;
   label: string;
   active?: boolean;
+  /** When > 1, rendered as a numeric badge after the label — multi-select hint. */
+  count?: number;
   className?: string;
   children: ReactNode;
 }
@@ -393,6 +459,7 @@ function FilterPill({
   icon: Icon,
   label,
   active,
+  count,
   className,
   children,
 }: FilterPillProps) {
@@ -407,6 +474,11 @@ function FilterPill({
         >
           <Icon className="size-3.5" />
           {label}
+          {count != null && count > 1 && (
+            <Badge variant="secondary" className="ml-0.5 px-1.5 py-0">
+              {count}
+            </Badge>
+          )}
         </Button>
       </PopoverTrigger>
       <PopoverContent align="start" className={cn("w-56 p-0", className)}>

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -109,7 +109,7 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
             <span className="text-sm font-medium">{title}</span>
           </div>
         </header>
-        <main className="min-w-0 flex-1 p-6">
+        <main className="min-w-0 flex-1 p-3 sm:p-6">
           <Outlet />
         </main>
       </SidebarInset>

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -13,15 +13,22 @@ import { PageHeader } from "@/components/page-header";
 import { DataTable } from "@/components/data-table";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
+import { CommandDialog } from "@/components/ui/command";
+import {
+  CategoryCommandList,
+  type CategoryPick,
+} from "@/components/category-command";
 import {
   buildTransactionColumns,
   type TransactionTableMeta,
 } from "@/features/transactions/columns";
 import { TransactionsToolbar } from "@/features/transactions/transactions-toolbar";
 import { SelectionActionBar } from "@/features/transactions/selection-action-bar";
+import { applyBulkTransactionOp } from "@/features/transactions/bulk-update";
 import {
   useTransactions,
   useTransactionCount,
+  useUpdateTransactions,
 } from "@/api/queries/transactions";
 import type { TransactionFilters } from "@/api/queries/transactions";
 import { flattenPages } from "@/lib/pagination";
@@ -241,6 +248,50 @@ export function TransactionsPage() {
     { label: "Clear selection / focus", group: "Transactions" },
   );
 
+  // --- Categorize shortcut ---
+  // `c` opens a centered command dialog targeting either the bulk selection
+  // (when select mode has selected rows) or the j/k-focused row.
+  const updateTransactions = useUpdateTransactions();
+  const [categorizeOpen, setCategorizeOpen] = useState(false);
+  const categorizeTargets = useMemo(() => {
+    if (selectedIds.length > 0) return selectedIds;
+    if (focusedIndex != null) {
+      const id = rows[focusedIndex]?.id;
+      return id ? [id] : [];
+    }
+    return [];
+  }, [selectedIds, focusedIndex, rows]);
+
+  useShortcut(
+    ["c"],
+    (e) => {
+      if (categorizeTargets.length === 0) return;
+      // Otherwise the same keypress that triggers us also lands inside the
+      // dialog's auto-focused command input as a literal "c".
+      e.preventDefault();
+      setCategorizeOpen(true);
+    },
+    {
+      label: "Categorize focused / selected",
+      group: "Transactions",
+      enabled: categorizeTargets.length > 0,
+    },
+  );
+
+  const handleCategorizePick = useCallback(
+    (pick: CategoryPick) => {
+      if (!categorizeTargets.length) return;
+      setCategorizeOpen(false);
+      const n = categorizeTargets.length;
+      const plural = n === 1 ? "" : "s";
+      const message = pick.reset_category
+        ? `Category reset on ${n} transaction${plural}.`
+        : `Category applied to ${n} transaction${plural}.`;
+      applyBulkTransactionOp(updateTransactions, categorizeTargets, pick, message);
+    },
+    [categorizeTargets, updateTransactions],
+  );
+
   const hasActiveFilters =
     !!search.q ||
     !!search.account ||
@@ -347,6 +398,19 @@ export function TransactionsPage() {
           onClear={exitSelectMode}
         />
       )}
+
+      <CommandDialog
+        open={categorizeOpen}
+        onOpenChange={setCategorizeOpen}
+        title="Categorize"
+        description={
+          categorizeTargets.length === 1
+            ? "Apply a category to the focused transaction."
+            : `Apply a category to ${categorizeTargets.length} selected transactions.`
+        }
+      >
+        <CategoryCommandList onPick={handleCategorizePick} />
+      </CommandDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Round 2 of polish on the v2 transactions page, building on the merged 6-iteration sprint (#1085).

- **Right-aligned category column** so the gap between badge and amount stays consistent across rows.
- **New j/k focus highlight** — 3px primary left bar + faint tint, replacing the previous boxy ring.
- **Sub-categories inherit parent color** in the list query (already coalesced in the detail/summary queries; this aligns the list path).
- **Mobile responsiveness**: dropped `<main>` padding to `p-3` on narrow viewports, forced the description column to honor truncation (so long merchant names can't push the amount off-screen), and replaced the verbose `Account · User · Needs-Review-chip` subtitle with a compact `Account · N 🏷️`.
- **`c` keyboard shortcut** to categorize the focused row, or every row in the current bulk selection. Shares chunking + toast handling with the selection action bar via a new `applyBulkTransactionOp` helper, so the shortcut also respects the 50-op batch limit.
- **Amount column min-width on desktop** so the right edge stays steady across rows.
- **Multi-select on Account + Category filters**: comma-separated URL params, service layer uses `ANY(...::uuid[])` with parent-includes-child semantics preserved, toolbar pill renders a count badge ("Account 2"), popover ticks multiple items without closing.
- **Esc inside the search input** now blurs back to the page so j/k/c regain control without a manual click-away.

A `/simplify` pass at the end bundled the 15-positional-return `parseTransactionFilters` into a struct, factored `applyBulkTransactionOp` to fix a missing-chunking bug in the new `c` shortcut, extracted `toggleInSet` / `multiSelectChip` helpers to dedupe the account vs category toolbar bookkeeping, and collapsed the mobile/desktop split in `TransactionMeta` into a single flex container.

## Screenshots

Desktop:

<img src="https://i.img402.dev/jjc241e8el.png" width="800" alt="Transactions — desktop after simplify">

Mobile:

<img src="https://i.img402.dev/o657b810di.png" width="320" alt="Transactions — mobile after simplify">

Multi-select Account filter ("2 accounts" chip, count = 233):

<img src="https://i.img402.dev/7gbcujaceb.png" width="800" alt="Account multi-select">

New j/k focus highlight (left primary bar):

<img src="https://i.img402.dev/7ofm7cje37.png" width="800" alt="j/k focus highlight">

## Test plan

- [ ] `j` / `k` move focus, left primary bar renders, no boxy ring
- [ ] Press `c` on a focused row → category dialog opens, picking applies
- [ ] Enter select mode, tick a few rows, press `c` → dialog says "Apply a category to N transactions", picking applies in 50-op chunks
- [ ] Focus the search input, press `Esc` → input blurs, then `j` works again
- [ ] Open Account filter, tick 2 accounts → pill shows "Account 2", chip says "2 accounts", count reflects the filter
- [ ] Same for Category, mixing a parent + a child category (parent should include all children)
- [ ] iPhone-width viewport: amount visible without horizontal scroll, subtitle compact
- [ ] Sub-category transaction (e.g. "Other Income", "Coffee") has its parent's icon color
