### PR TITLE
v2: connect-bank sheet — Plaid + Teller (stack 3/6)

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -24,6 +24,7 @@
         "react": "^19",
         "react-dom": "^19",
         "react-hook-form": "^7.75.0",
+        "react-plaid-link": "^4.1.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^2.5.4",
         "zod": "^4.4.3",
@@ -463,6 +464,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@1.14.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA=="],
@@ -477,6 +480,8 @@
 
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
@@ -485,6 +490,8 @@
 
     "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
 
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
@@ -492,6 +499,10 @@
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
     "react-hook-form": ["react-hook-form@7.75.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw=="],
+
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
+    "react-plaid-link": ["react-plaid-link@4.1.1", "", { "dependencies": { "prop-types": "^15.7.2" }, "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19", "react-dom": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-xzAYWQIT/gk+u6lwFAMEZ20f9+AUsCwVyfm64/iudMsyuWANta4wm3Jb7N+APSwuKIR9VUlTkYDhPjLamIGcPA=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
     "react": "^19",
     "react-dom": "^19",
     "react-hook-form": "^7.75.0",
+    "react-plaid-link": "^4.1.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.5.4",
     "zod": "^4.4.3"

--- a/web/src/api/queries/connections.ts
+++ b/web/src/api/queries/connections.ts
@@ -1,6 +1,14 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import type { Connection, ConnectionDetail } from "@/api/types";
+import type {
+  Connection,
+  ConnectionDetail,
+  CreateConnectionResult,
+  LinkSession,
+  PlaidExchangeCredentials,
+  ProviderInfo,
+  TellerExchangeCredentials,
+} from "@/api/types";
 
 // useConnections lists every household connection. The endpoint returns a
 // bare array (no envelope). Read with the v2 session cookie via the synthetic
@@ -90,6 +98,79 @@ export function usePauseConnection() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["connections"] });
       qc.invalidateQueries({ queryKey: ["connection"] });
+    },
+  });
+}
+
+// useProviders lists available bank-data providers along with their
+// `configured` flag and credential schema. Used by the Connect-bank Sheet to
+// gate the Plaid / Teller cards on whichever providers this server has
+// credentials for. Bounded reference data — long staleTime is fine.
+export function useProviders() {
+  return useQuery({
+    queryKey: ["providers"],
+    queryFn: () => api<ProviderInfo[]>("/api/v1/providers"),
+    staleTime: 5 * 60_000,
+  });
+}
+
+// useProviderLinkSession requests a fresh link token for a provider that
+// needs one (Plaid today). Mutation-shaped because each token is one-shot
+// and short-lived — caching would either yield stale tokens or guarantee a
+// re-fetch. Returns null for providers without an init flow (Teller, CSV)
+// where the server replies 204; the caller should fall through to the
+// provider's client-side launcher in that case.
+export function useProviderLinkSession() {
+  return useMutation({
+    mutationFn: async ({
+      provider,
+      userId,
+    }: {
+      provider: string;
+      userId: string;
+    }): Promise<LinkSession | null> => {
+      const res = await api<LinkSession | undefined>(
+        `/api/v1/providers/${provider}/link-session`,
+        {
+          method: "POST",
+          body: JSON.stringify({ user_id: userId }),
+        },
+      );
+      return res ?? null;
+    },
+  });
+}
+
+// useCreateConnection persists a new connection via the generic dispatch
+// endpoint (POST /api/v1/connections). The caller picks the discriminated
+// `credentials` shape per provider — Plaid returns the public_token from
+// Plaid Link's onSuccess; Teller returns the enrollment payload from
+// Teller Connect. On success we invalidate the connections + accounts
+// caches so the connections list and the new detail page both see the
+// row immediately.
+export type CreateConnectionPlaid = {
+  provider: "plaid";
+  user_id: string;
+  credentials: PlaidExchangeCredentials;
+};
+export type CreateConnectionTeller = {
+  provider: "teller";
+  user_id: string;
+  credentials: TellerExchangeCredentials;
+};
+export type CreateConnectionInput = CreateConnectionPlaid | CreateConnectionTeller;
+
+export function useCreateConnection() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateConnectionInput) =>
+      api<CreateConnectionResult>("/api/v1/connections", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+      qc.invalidateQueries({ queryKey: ["accounts"] });
     },
   });
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -123,6 +123,60 @@ export interface ConnectionDetail extends Connection {
   account_count: number;
 }
 
+// --- Providers (public /api/v1/providers) ---
+// Mirrors internal/api.providerInfo. Used by the Connect-bank Sheet to filter
+// which provider cards are clickable on this server.
+export interface ProviderCredentialField {
+  type: string;
+  required: boolean | string;
+  description?: string;
+}
+
+export interface ProviderInfo {
+  name: string; // plaid | teller | csv
+  configured: boolean;
+  needs_link_session: boolean;
+  capabilities: string[];
+  credentials_schema: Record<string, ProviderCredentialField>;
+}
+
+// --- Connect: link-session response (POST /providers/{name}/link-session) ---
+// Returned by providers that need a server-issued init token (Plaid today).
+// Providers without one (Teller, CSV) get a 204 — surfaced here as a null
+// result.
+export interface LinkSession {
+  link_token: string;
+  expiration: string;
+}
+
+// --- Connect: connection-create envelope (POST /connections) ---
+// Mirrors internal/api.connectionEnvelope. The detail page consumes
+// connection_id (which is the new connection's short_id).
+export interface CreateConnectionResult {
+  connection_id: string;
+  institution_name: string;
+  status: string;
+}
+
+// --- Connect: per-provider credentials shapes (POST /connections body) ---
+// What goes in the `credentials` field for each provider — the shape the
+// generic dispatch endpoint hands to the provider extractor in
+// internal/api/providers.go.
+export interface PlaidExchangeCredentials {
+  public_token: string;
+  institution_id: string;
+  institution_name: string;
+  accounts: { id: string; name?: string; mask?: string; type?: string; subtype?: string }[];
+}
+
+export interface TellerExchangeCredentials {
+  access_token: string;
+  enrollment_id: string;
+  institution_id?: string;
+  institution_name: string;
+  accounts?: { id: string; name?: string; type?: string; subtype?: string; last_four?: string }[];
+}
+
 // --- Tags (public /api/v1/tags) ---
 // Mirrors internal/client/tags.go Tag.
 export interface Tag {

--- a/web/src/features/connections/connect-bank-sheet.tsx
+++ b/web/src/features/connections/connect-bank-sheet.tsx
@@ -1,0 +1,363 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { toast } from "sonner";
+import { ApiError } from "@/api/client";
+import {
+  useCreateConnection,
+  useProviderLinkSession,
+  useProviders,
+  type CreateConnectionInput,
+} from "@/api/queries/connections";
+import { useUsers } from "@/api/queries/users";
+import { ProviderPicker, PROVIDER_META } from "./provider-picker";
+import { PlaidLinkButton } from "./plaid-link-button";
+import { TellerConnectButton } from "./teller-connect-button";
+
+interface ConnectBankSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+// Stage drives the inner switch between provider-pick (step 1) and the
+// active provider hand-off (step 2). Returning to step 1 from a hand-off
+// (cancel / error) is just `setStage("pick")` — nothing about the SDK
+// component lives across that transition since both wrappers re-mount when
+// they re-appear.
+type Stage =
+  | { kind: "pick" }
+  | { kind: "plaid"; userId: string; linkToken: string }
+  | { kind: "teller"; userId: string; applicationId: string };
+
+// ConnectBankSheet is the real Connect-bank flow that replaces the v1
+// /connections/new wizard for the v2 SPA. Two steps inside one Sheet:
+//
+//   1. Pick provider + family member, click Continue. We call
+//      useProviderLinkSession() to get a link token (Plaid only — Teller
+//      returns 204 because Teller Connect runs entirely client-side).
+//   2. Render the matching provider launcher (PlaidLinkButton or
+//      TellerConnectButton) which auto-opens its hosted UI. On success the
+//      launcher hands back the public_token / enrollment payload, we POST
+//      to the generic /api/v1/connections endpoint, toast success, and
+//      navigate to the new connection's detail page (PR-02).
+export function ConnectBankSheet({
+  open,
+  onOpenChange,
+}: ConnectBankSheetProps) {
+  const navigate = useNavigate();
+  const providersQuery = useProviders();
+  const usersQuery = useUsers();
+  const linkSession = useProviderLinkSession();
+  const createConnection = useCreateConnection();
+
+  const [provider, setProvider] = useState<string | null>(null);
+  const [userId, setUserId] = useState<string>("");
+  const [stage, setStage] = useState<Stage>({ kind: "pick" });
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const enabledProviders = useMemo(
+    () =>
+      (providersQuery.data ?? [])
+        .filter((p) => p.configured && p.name !== "csv")
+        .map((p) => p.name),
+    [providersQuery.data],
+  );
+
+  // Default the family member to the only household member when there's just
+  // one, so the picker doesn't render a single-option dropdown the user has
+  // to acknowledge. Multi-user households start blank.
+  const users = usersQuery.data ?? [];
+  const effectiveUserId =
+    userId || (users.length === 1 ? users[0].id : "");
+
+  function reset() {
+    setProvider(null);
+    setUserId("");
+    setStage({ kind: "pick" });
+    setCreateError(null);
+    linkSession.reset();
+    createConnection.reset();
+  }
+
+  function handleSheetChange(next: boolean) {
+    if (!next) reset();
+    onOpenChange(next);
+  }
+
+  async function onContinue() {
+    if (!provider || !effectiveUserId) return;
+    setCreateError(null);
+    try {
+      const session = await linkSession.mutateAsync({
+        provider,
+        userId: effectiveUserId,
+      });
+      if (provider === "plaid") {
+        if (!session?.link_token) {
+          toast.error("Plaid did not return a link token. Try again.");
+          return;
+        }
+        setStage({
+          kind: "plaid",
+          userId: effectiveUserId,
+          linkToken: session.link_token,
+        });
+      } else if (provider === "teller") {
+        // Teller's link-session endpoint replies 204 — nothing in the body.
+        // The application id Teller Connect needs comes from the env, not
+        // the API. Until the backend exposes it, fall through with the
+        // env-supplied value (set on a global by the Vite shell). We toast
+        // on missing config so the user gets actionable feedback rather
+        // than a silent open-then-close.
+        const applicationId =
+          (typeof window !== "undefined" &&
+            (window as Window & { __TELLER_APP_ID__?: string }).__TELLER_APP_ID__) ||
+          "";
+        if (!applicationId) {
+          toast.error(
+            "Teller application ID is not configured on this server.",
+          );
+          return;
+        }
+        setStage({ kind: "teller", userId: effectiveUserId, applicationId });
+      }
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.message
+          : "Couldn't start the connection flow. Try again.";
+      toast.error(msg);
+    }
+  }
+
+  async function onPlaidSuccess(input: {
+    publicToken: string;
+    metadata: {
+      institution: { institution_id: string; name: string } | null;
+      accounts: { id: string; name?: string; mask?: string; type?: string; subtype?: string }[];
+    };
+  }) {
+    if (stage.kind !== "plaid") return;
+    const { metadata, publicToken } = input;
+    if (!metadata.institution) {
+      toast.error("Plaid did not return an institution. Try again.");
+      setStage({ kind: "pick" });
+      return;
+    }
+    const payload: CreateConnectionInput = {
+      provider: "plaid",
+      user_id: stage.userId,
+      credentials: {
+        public_token: publicToken,
+        institution_id: metadata.institution.institution_id,
+        institution_name: metadata.institution.name,
+        accounts: metadata.accounts ?? [],
+      },
+    };
+    await runCreate(payload);
+  }
+
+  async function onTellerSuccess(result: {
+    accessToken: string;
+    enrollmentId: string;
+    institutionName: string;
+    institutionId: string;
+  }) {
+    if (stage.kind !== "teller") return;
+    const payload: CreateConnectionInput = {
+      provider: "teller",
+      user_id: stage.userId,
+      credentials: {
+        access_token: result.accessToken,
+        enrollment_id: result.enrollmentId,
+        institution_id: result.institutionId,
+        institution_name: result.institutionName,
+      },
+    };
+    await runCreate(payload);
+  }
+
+  async function runCreate(payload: CreateConnectionInput) {
+    setCreateError(null);
+    try {
+      const result = await createConnection.mutateAsync(payload);
+      toast.success(`Connected ${result.institution_name}.`);
+      handleSheetChange(false);
+      navigate({
+        to: "/connections/$short_id",
+        params: { short_id: result.connection_id },
+      });
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.message
+          : "Couldn't save the connection. Try again.";
+      setCreateError(msg);
+      toast.error(msg);
+      // Drop back to the picker so the user can retry without re-launching
+      // the SDK in a half-broken state.
+      setStage({ kind: "pick" });
+    }
+  }
+
+  function onLaunchExit(message: string | null) {
+    if (message) toast.error(message);
+    setStage({ kind: "pick" });
+  }
+
+  const continueDisabled =
+    !provider ||
+    !effectiveUserId ||
+    linkSession.isPending ||
+    createConnection.isPending;
+
+  return (
+    <Sheet open={open} onOpenChange={handleSheetChange}>
+      <SheetContent className="flex flex-col gap-6 p-6">
+        <SheetHeader className="p-0">
+          <SheetTitle>Connect a bank</SheetTitle>
+          <SheetDescription>
+            Pick a provider and the family member this connection belongs to.
+          </SheetDescription>
+        </SheetHeader>
+
+        {stage.kind === "pick" && (
+          <div className="flex flex-1 flex-col gap-6 overflow-y-auto">
+            {providersQuery.isLoading ? (
+              <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                <Loader2 className="size-4 animate-spin" /> Loading providers…
+              </div>
+            ) : enabledProviders.length === 0 ? (
+              <Alert variant="default">
+                <AlertTitle>No bank providers configured</AlertTitle>
+                <AlertDescription>
+                  Set up Plaid or Teller credentials on this server, or use a
+                  CSV import (coming soon).
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <div className="flex flex-col gap-2">
+                <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                  Provider
+                </Label>
+                <ProviderPicker
+                  enabledProviders={enabledProviders}
+                  value={provider}
+                  onChange={setProvider}
+                />
+              </div>
+            )}
+
+            <div className="flex flex-col gap-2">
+              <Label className="text-xs uppercase tracking-wide text-muted-foreground">
+                Family member
+              </Label>
+              <Select value={effectiveUserId} onValueChange={setUserId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Pick a household member" />
+                </SelectTrigger>
+                <SelectContent>
+                  {users.map((u) => (
+                    <SelectItem key={u.id} value={u.id}>
+                      {u.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {createError && (
+              <Alert variant="destructive">
+                <AlertTitle>Couldn't save the connection</AlertTitle>
+                <AlertDescription>{createError}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+        )}
+
+        {stage.kind !== "pick" && (
+          <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+            <Loader2 className="text-muted-foreground size-6 animate-spin" />
+            <div className="text-sm font-medium">
+              Opening {PROVIDER_META[stage.kind]?.name ?? stage.kind}…
+            </div>
+            <p className="text-muted-foreground max-w-xs text-xs">
+              Finish the flow in the popup. Closing it brings you back here.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-2"
+              onClick={() => setStage({ kind: "pick" })}
+            >
+              Cancel
+            </Button>
+          </div>
+        )}
+
+        {stage.kind === "plaid" && (
+          <PlaidLinkButton
+            linkToken={stage.linkToken}
+            onSuccess={onPlaidSuccess}
+            onExit={(err) =>
+              onLaunchExit(
+                err
+                  ? err.display_message ||
+                      err.error_message ||
+                      "Plaid Link exited with an error."
+                  : null,
+              )
+            }
+          />
+        )}
+
+        {stage.kind === "teller" && (
+          <TellerConnectButton
+            applicationId={stage.applicationId}
+            onSuccess={onTellerSuccess}
+            onExit={() => onLaunchExit(null)}
+            onFailure={(f) =>
+              onLaunchExit(f.message || "Teller Connect failed.")
+            }
+          />
+        )}
+
+        {stage.kind === "pick" && (
+          <SheetFooter className="px-0">
+            <Button
+              variant="outline"
+              onClick={() => handleSheetChange(false)}
+              disabled={linkSession.isPending}
+            >
+              Cancel
+            </Button>
+            <Button onClick={onContinue} disabled={continueDisabled}>
+              {linkSession.isPending ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : null}
+              Continue
+            </Button>
+          </SheetFooter>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/web/src/features/connections/plaid-link-button.tsx
+++ b/web/src/features/connections/plaid-link-button.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from "react";
+import {
+  usePlaidLink,
+  type PlaidLinkOnExitMetadata,
+  type PlaidLinkOnSuccessMetadata,
+} from "react-plaid-link";
+
+export interface PlaidLinkResult {
+  publicToken: string;
+  metadata: PlaidLinkOnSuccessMetadata;
+}
+
+export interface PlaidLinkButtonProps {
+  linkToken: string;
+  /** Called when Plaid Link's onSuccess fires. */
+  onSuccess: (result: PlaidLinkResult) => void;
+  /** Called when the user dismisses Plaid Link or it errors out. The error
+   *  argument is null on plain cancellation. */
+  onExit?: (
+    error: { display_message?: string; error_message?: string } | null,
+    metadata: PlaidLinkOnExitMetadata,
+  ) => void;
+  /** When true, opens Plaid Link as soon as the SDK signals `ready`. The
+   *  Connect-bank Sheet uses this so step 2 of the wizard launches the
+   *  popup automatically without a second user click. */
+  autoOpen?: boolean;
+}
+
+// PlaidLinkButton encapsulates Plaid's official `usePlaidLink` hook. It
+// renders nothing visible — Plaid Link itself is a popup the SDK manages —
+// but exposes its `open()` via auto-launch so the parent Sheet can drive the
+// flow declaratively. Reused for new connections (PR-03) and re-auth in
+// update mode (PR-05) by passing different link tokens.
+export function PlaidLinkButton({
+  linkToken,
+  onSuccess,
+  onExit,
+  autoOpen = true,
+}: PlaidLinkButtonProps) {
+  const { open, ready } = usePlaidLink({
+    token: linkToken,
+    onSuccess: (publicToken, metadata) => onSuccess({ publicToken, metadata }),
+    onExit: (err, metadata) => {
+      // Plaid's err type is broader than what callers typically need; collapse
+      // to the two strings the v1 wizard already surfaces.
+      onExit?.(
+        err ? { display_message: err.display_message, error_message: err.error_message } : null,
+        metadata,
+      );
+    },
+  });
+
+  // Track whether we already opened so a re-render (e.g. token swap) doesn't
+  // double-fire the popup.
+  const openedRef = useRef(false);
+  useEffect(() => {
+    if (autoOpen && ready && !openedRef.current) {
+      openedRef.current = true;
+      open();
+    }
+  }, [autoOpen, ready, open]);
+
+  return null;
+}

--- a/web/src/features/connections/provider-picker.tsx
+++ b/web/src/features/connections/provider-picker.tsx
@@ -1,0 +1,111 @@
+import { Building2, FileSpreadsheet, Landmark } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// PROVIDER_META is the static labelling for every known provider. Centralised
+// so the picker, sandbox, and any future hosted-link surface render the same
+// names + tagline + icon for `plaid` / `teller` / `csv`.
+export const PROVIDER_META: Record<
+  string,
+  { name: string; tagline: string; Icon: typeof Landmark }
+> = {
+  plaid: {
+    name: "Plaid",
+    tagline: "12,000+ banks across the US, Canada, and Europe.",
+    Icon: Landmark,
+  },
+  teller: {
+    name: "Teller",
+    tagline: "US banks via Teller Connect.",
+    Icon: Building2,
+  },
+  csv: {
+    name: "CSV import",
+    tagline: "Upload a statement export from any bank.",
+    Icon: FileSpreadsheet,
+  },
+};
+
+export interface ProviderPickerProps {
+  /** Provider names that should appear as enabled cards. Anything not in this
+   *  list still renders, but is disabled with a "not configured" hint so the
+   *  user knows this server hasn't been wired up for it. */
+  enabledProviders: string[];
+  /** Subset of providers to show. Defaults to plaid + teller; the future
+   *  CSV PR (PR-04) will pass `["plaid", "teller", "csv"]`. */
+  providers?: string[];
+  value: string | null;
+  onChange: (provider: string) => void;
+  className?: string;
+}
+
+// ProviderPicker is the step-1 surface of the Connect-bank Sheet — a stacked
+// list of provider cards. Pure: takes value/onChange, leaves the form-state
+// to the caller. Reused by the sandbox specimen (display-only) and, soon, by
+// the hosted-link page (`/link/{token}`) where a household member finishes
+// a connection without an admin login.
+export function ProviderPicker({
+  enabledProviders,
+  providers = ["plaid", "teller"],
+  value,
+  onChange,
+  className,
+}: ProviderPickerProps) {
+  const enabled = new Set(enabledProviders);
+  return (
+    <div className={cn("flex flex-col gap-2", className)}>
+      {providers.map((p) => {
+        const meta = PROVIDER_META[p] ?? {
+          name: p,
+          tagline: "",
+          Icon: Landmark,
+        };
+        const isConfigured = enabled.has(p);
+        const isSelected = value === p;
+        return (
+          <button
+            key={p}
+            type="button"
+            disabled={!isConfigured}
+            onClick={() => onChange(p)}
+            aria-pressed={isSelected}
+            className={cn(
+              "group flex w-full items-start gap-3 rounded-md border p-4 text-left transition",
+              "hover:border-primary/60 hover:bg-accent/40",
+              isSelected
+                ? "border-primary bg-accent/40 ring-2 ring-primary/20"
+                : "border-border",
+              !isConfigured &&
+                "cursor-not-allowed opacity-50 hover:border-border hover:bg-transparent",
+            )}
+          >
+            <div
+              className={cn(
+                "flex size-9 shrink-0 items-center justify-center rounded-md border",
+                isSelected
+                  ? "border-primary/40 bg-primary/10 text-primary"
+                  : "border-border bg-muted/40 text-muted-foreground",
+              )}
+            >
+              <meta.Icon className="size-4" />
+            </div>
+            <div className="flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium">{meta.name}</span>
+                {!isConfigured && (
+                  <span className="text-muted-foreground text-xs">
+                    Not configured
+                  </span>
+                )}
+              </div>
+              {meta.tagline && (
+                <p className="text-muted-foreground mt-0.5 text-xs">
+                  {meta.tagline}
+                </p>
+              )}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/features/connections/teller-connect-button.tsx
+++ b/web/src/features/connections/teller-connect-button.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef } from "react";
+
+// Teller doesn't ship a packaged React wrapper, so this component is
+// hand-rolled around the script-tag-loaded SDK. Keeps the same shape as
+// PlaidLinkButton so a future hosted-link page can branch on `provider` and
+// call into either component without learning two integration patterns.
+
+export interface TellerEnrollment {
+  accessToken: string;
+  enrollment: {
+    id: string;
+    institution: { name: string };
+  };
+}
+
+export interface TellerEnrollmentResult {
+  accessToken: string;
+  enrollmentId: string;
+  institutionName: string;
+  institutionId: string;
+}
+
+export interface TellerConnectButtonProps {
+  applicationId: string;
+  /** "sandbox" | "development" | "production". Sandbox is the default since
+   *  it works without provisioning real Teller credentials. */
+  environment?: string;
+  onSuccess: (result: TellerEnrollmentResult) => void;
+  onExit?: () => void;
+  onFailure?: (failure: { message?: string }) => void;
+  autoOpen?: boolean;
+}
+
+const TELLER_SDK_URL = "https://cdn.teller.io/connect/connect.js";
+
+declare global {
+  interface Window {
+    TellerConnect?: {
+      setup: (options: {
+        applicationId: string;
+        environment?: string;
+        products?: string[];
+        onSuccess: (enrollment: TellerEnrollment) => void;
+        onExit?: () => void;
+        onFailure?: (failure: { message?: string }) => void;
+      }) => { open: () => void };
+    };
+  }
+}
+
+// loadTellerSDK injects the Teller Connect script tag once and resolves when
+// the global `TellerConnect` is available. Re-uses the in-flight load if a
+// second component mounts during the first fetch.
+let tellerLoadPromise: Promise<void> | null = null;
+function loadTellerSDK(): Promise<void> {
+  if (typeof window === "undefined") return Promise.resolve();
+  if (window.TellerConnect) return Promise.resolve();
+  if (tellerLoadPromise) return tellerLoadPromise;
+  tellerLoadPromise = new Promise<void>((resolve, reject) => {
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${TELLER_SDK_URL}"]`,
+    );
+    const script = existing ?? document.createElement("script");
+    script.src = TELLER_SDK_URL;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      tellerLoadPromise = null;
+      reject(new Error("Failed to load Teller Connect SDK"));
+    };
+    if (!existing) document.head.appendChild(script);
+  });
+  return tellerLoadPromise;
+}
+
+// TellerConnectButton mirrors PlaidLinkButton's shape: renders nothing
+// visible, opens Teller Connect on mount when `autoOpen` is true. The parent
+// Sheet stays in control of the rest of the wizard.
+export function TellerConnectButton({
+  applicationId,
+  environment = "sandbox",
+  onSuccess,
+  onExit,
+  onFailure,
+  autoOpen = true,
+}: TellerConnectButtonProps) {
+  const openedRef = useRef(false);
+
+  useEffect(() => {
+    if (!autoOpen || openedRef.current) return;
+    let cancelled = false;
+    loadTellerSDK()
+      .then(() => {
+        if (cancelled || !window.TellerConnect) return;
+        openedRef.current = true;
+        const tc = window.TellerConnect.setup({
+          applicationId,
+          environment,
+          products: ["transactions", "balance"],
+          onSuccess: (enrollment) => {
+            onSuccess({
+              accessToken: enrollment.accessToken,
+              enrollmentId: enrollment.enrollment.id,
+              institutionName: enrollment.enrollment.institution.name,
+              // Teller doesn't expose a stable institution_id; the v1 wizard
+              // reuses the institution name as the id, so we mirror that.
+              institutionId: enrollment.enrollment.institution.name,
+            });
+          },
+          onExit: () => onExit?.(),
+          onFailure: (failure) => onFailure?.(failure),
+        });
+        tc.open();
+      })
+      .catch((err: Error) => {
+        onFailure?.({ message: err.message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [autoOpen, applicationId, environment, onSuccess, onExit, onFailure]);
+
+  return null;
+}

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -14,6 +14,7 @@ import { ConnectionRow } from "@/features/connections/connection-row";
 import { ConnectionsSummary } from "@/features/connections/connections-summary";
 import { FamilyTabs } from "@/features/connections/family-tabs";
 import { ComingSoonSheet } from "@/features/connections/coming-soon-sheet";
+import { ConnectBankSheet } from "@/features/connections/connect-bank-sheet";
 import {
   indexAccountsByConnection,
   needsAttention,
@@ -247,13 +248,11 @@ export function ConnectionsPage() {
         </div>
       )}
 
-      <ComingSoonSheet
+      <ConnectBankSheet
         open={search.action === "connect"}
         onOpenChange={(open) => {
           if (!open) closeSheets();
         }}
-        title="Connect a bank"
-        description="Pick a provider and the family member this connection belongs to."
       />
       <ComingSoonSheet
         open={!!search.reauth}

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -19,6 +19,7 @@ import { TagCommandList } from "@/components/tag-command";
 import { TransactionPrimary } from "@/components/transaction-primary";
 import { TransactionAmount } from "@/components/transaction-amount";
 import { KbdTooltip } from "@/components/kbd-tooltip";
+import { ProviderPicker } from "@/features/connections/provider-picker";
 import type { Transaction } from "@/api/types";
 import { SandboxSection, Specimen } from "@/sandbox/kit";
 import {
@@ -60,6 +61,7 @@ export function ComponentsSection() {
   const [tableState, setTableState] = useState<
     "data" | "loading" | "empty"
   >("data");
+  const [pickedProvider, setPickedProvider] = useState<string | null>("plaid");
 
   return (
     <SandboxSection
@@ -226,6 +228,22 @@ export function ComponentsSection() {
         <KbdTooltip label="Command palette" keys={["mod", "k"]}>
           <Button variant="outline">Search</Button>
         </KbdTooltip>
+      </Specimen>
+
+      <Specimen
+        label="ProviderPicker"
+        code="features/connections/provider-picker"
+        description="Stacked provider cards used in the Connect-bank Sheet (and the future hosted-link page). `enabledProviders` gates which cards are clickable; everything else renders as 'Not configured'."
+        className="block"
+      >
+        <div className="max-w-sm">
+          <ProviderPicker
+            enabledProviders={["plaid"]}
+            providers={["plaid", "teller", "csv"]}
+            value={pickedProvider}
+            onChange={setPickedProvider}
+          />
+        </div>
       </Specimen>
 
       <Specimen


### PR DESCRIPTION
Third PR in the `stack/v2-connections` series. Replaces the `?action=connect` placeholder Sheet with a real Plaid + Teller Connect flow.

## What's in this PR

- **`features/connections/connect-bank-sheet.tsx`** — two-step Sheet replacing `ComingSoonSheet` for `?action=connect`. Step 1 is provider + family-member; step 2 hands off to the matching SDK and persists the connection on success.
- **`features/connections/provider-picker.tsx`** — reusable card list. Takes `enabledProviders` so providers without server-side credentials render disabled (`Not configured` hint). Already future-proofed for CSV (PR-04) via the optional `providers` prop. Carries a sandbox specimen.
- **`features/connections/plaid-link-button.tsx`** — wraps `usePlaidLink` from the official `react-plaid-link`. Renders nothing visible; auto-opens Plaid Link on `ready`. Same shape will service PR-05 (re-auth, update mode).
- **`features/connections/teller-connect-button.tsx`** — script-tag launcher for `https://cdn.teller.io/connect/connect.js` (Teller doesn't ship a React wrapper). Same `autoOpen` + `onSuccess`/`onExit`/`onFailure` shape as the Plaid wrapper so the Sheet branches on `provider` only.
- **Queries** — extended `api/queries/connections.ts` with `useProviders()`, `useProviderLinkSession()` (mutation, since each token is one-shot), and `useCreateConnection()` (POSTs to the generic dispatch endpoint). Mirrors response/credential shapes added to `api/types.ts`.

## What's deliberately NOT here

- **CSV import** → PR-04 (slots into `ProviderPicker` via the `providers` prop).
- **Re-authentication** → PR-05 (re-uses `PlaidLinkButton` in update mode against an existing connection's link token).
- **Bulk select** → PR-06.
- **No new backend endpoints.** This PR consumes the generic `/api/v1/providers`, `/api/v1/providers/{name}/link-session`, and `/api/v1/connections` surfaces shipped earlier.
- **No global state library, no fetch outside `client.ts`.** Plaid + Teller SDK loads happen via the official hook / a one-shot script-tag injector (cached in module scope).

## Empty-config behaviour

Step 1 stays functional even when neither provider has credentials: the cards render disabled with a `Not configured` hint, and the `Continue` action stays unreachable. If a provider is configured but its link-token request fails (e.g. Plaid creds wired wrong), `useProviderLinkSession` rejects, the `ApiError` message gets toasted, and the Sheet stays on step 1 so the user can retry without re-mounting. Teller is launched even though its `/link-session` returns 204; the application id comes from a `window.__TELLER_APP_ID__` global so a missing value toasts the user rather than silently opening a half-broken popup.

## Screenshots

<table>
  <tr><th>Step 1 — desktop</th><th>Step 1 — mobile</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/qivz3jbppb.png" width="500" alt="Connect-bank Sheet — desktop"></td>
    <td><img src="https://i.img402.dev/44bk0ybwel.png" width="240" alt="Connect-bank Sheet — mobile"></td>
  </tr>
</table>

<details><summary>After Continue — Plaid hand-off (popup opens out-of-frame)</summary>

<img src="https://i.img402.dev/7n16l0hiib.png" width="700" alt="Connect-bank Sheet — Plaid hand-off">

</details>

## Test plan

- [x] `bun run lint` (tsc) — clean
- [x] `bun run build` (tsc -b + vite build) — clean
- [x] `templ generate && go build ./... && go vet ./... && go test ./...` — clean
- [x] Smoke: `/v2/connections?action=connect` — Sheet opens, providers populate from `/api/v1/providers`, family-member select populates from `/api/v1/users`
- [x] Smoke: pick Plaid + Continue — `POST /api/v1/providers/plaid/link-session` succeeds, Plaid Link launches in popup, step 2 spinner appears
- [ ] Reviewer: confirm sandbox specimen at `/v2/sandbox` renders the picker with Plaid enabled, Teller and CSV disabled
- [ ] Reviewer: cancel-out of Plaid Link → toast appears, Sheet returns to step 1
- [ ] Reviewer: full happy path against Plaid sandbox (optional — requires real creds)
