### PR TITLE
v2: CSV import in connect-bank sheet (stack 4/6)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -5,11 +5,20 @@ export class ApiError extends Error {
 }
 
 export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
+  // Default Content-Type is JSON, but skip it when the body is a FormData
+  // (multipart) — the browser MUST set Content-Type itself so it can include
+  // the auto-generated multipart boundary. Forcing application/json here
+  // would leave the server unable to parse the body.
+  const isFormData =
+    typeof FormData !== "undefined" && init.body instanceof FormData;
+  const baseHeaders: Record<string, string> = isFormData
+    ? {}
+    : { "Content-Type": "application/json" };
   const res = await fetch(path, {
     credentials: "include",
     ...init,
     headers: {
-      "Content-Type": "application/json",
+      ...baseHeaders,
       ...(init.headers ?? {}),
     },
   });

--- a/web/src/api/queries/connections.ts
+++ b/web/src/api/queries/connections.ts
@@ -4,6 +4,8 @@ import type {
   Connection,
   ConnectionDetail,
   CreateConnectionResult,
+  CsvImportResult,
+  CsvPreviewResult,
   LinkSession,
   PlaidExchangeCredentials,
   ProviderInfo,
@@ -171,6 +173,73 @@ export function useCreateConnection() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["connections"] });
       qc.invalidateQueries({ queryKey: ["accounts"] });
+    },
+  });
+}
+
+// useCsvPreview parses a CSV upload server-side and returns the headers +
+// preview rows + auto-detected column mapping. Multipart-only — the backend
+// also accepts JSON+base64 but using FormData on the client side keeps the
+// upload streamable and avoids a 33%-base64 inflation. The endpoint never
+// persists, so we don't invalidate any caches.
+export function useCsvPreview() {
+  return useMutation({
+    mutationFn: (file: File) => {
+      const fd = new FormData();
+      fd.append("file", file);
+      return api<CsvPreviewResult>("/api/v1/connections/csv/preview", {
+        method: "POST",
+        body: fd,
+      });
+    },
+  });
+}
+
+// useCsvImport commits a parsed CSV. Either creates a brand-new CSV
+// connection (no `connectionId`) or appends rows to an existing one. On
+// success we invalidate the connections + accounts + transactions caches so
+// every list reflects the new rows immediately.
+export interface CsvImportInput {
+  file: File;
+  columnMapping: Partial<Record<string, number>>;
+  positiveIsDebit: boolean;
+  hasDebitCredit: boolean;
+  dateFormat?: string;
+  // For new connections — the household member that owns the import.
+  // Ignored when `connectionId` is set (the existing connection's user wins).
+  userId?: string;
+  accountName?: string;
+  // Set to append to an existing CSV connection. Accepts the connection's
+  // short_id (the public-facing 8-char ID) or its full UUID.
+  connectionId?: string;
+}
+
+export function useCsvImport() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CsvImportInput) => {
+      const fd = new FormData();
+      fd.append("file", input.file);
+      fd.append("column_mapping", JSON.stringify(input.columnMapping));
+      fd.append("positive_is_debit", String(input.positiveIsDebit));
+      fd.append("has_debit_credit", String(input.hasDebitCredit));
+      if (input.dateFormat) fd.append("date_format", input.dateFormat);
+      if (input.connectionId) {
+        fd.append("connection_id", input.connectionId);
+      } else {
+        if (input.userId) fd.append("user_id", input.userId);
+        if (input.accountName) fd.append("account_name", input.accountName);
+      }
+      return api<CsvImportResult>("/api/v1/connections/csv/import", {
+        method: "POST",
+        body: fd,
+      });
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["connections"] });
+      qc.invalidateQueries({ queryKey: ["connection"] });
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      qc.invalidateQueries({ queryKey: ["transactions"] });
     },
   });
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -177,6 +177,45 @@ export interface TellerExchangeCredentials {
   accounts?: { id: string; name?: string; type?: string; subtype?: string; last_four?: string }[];
 }
 
+// --- Connect: CSV preview / import (POST /connections/csv/{preview,import}) ---
+// Mirrors the JSON shapes returned by internal/api/csv_import.go. The CSV
+// branch in the Connect-bank Sheet posts the file as multipart/form-data; the
+// preview returns parsed headers + the first N rows + an inferred column
+// mapping (with optional auto-detected template hints), and the import
+// commits the file with the user-chosen mapping.
+export interface CsvPreviewResult {
+  headers: string[];
+  preview_rows: string[][];
+  total_rows: number;
+  delimiter: string; // "," | ";" | "|" | "tab"
+  inferred_mapping: Partial<Record<CsvColumnKey, number>>;
+  template_name?: string;
+  positive_is_debit?: boolean;
+  date_format?: string;
+  has_debit_credit?: boolean;
+}
+
+// CsvColumnKey is the union of every field the backend importer recognises.
+// `date` + `description` are always required; `amount` is required unless
+// `has_debit_credit` is true (then `debit` + `credit` carry the value).
+export type CsvColumnKey =
+  | "date"
+  | "description"
+  | "amount"
+  | "debit"
+  | "credit"
+  | "category"
+  | "merchant_name";
+
+export interface CsvImportResult {
+  connection_id: string;
+  account_id: string;
+  imported_transactions: number;
+  updated_transactions: number;
+  skipped_duplicates: number;
+  total_rows: number;
+}
+
 // --- Tags (public /api/v1/tags) ---
 // Mirrors internal/client/tags.go Tag.
 export interface Tag {

--- a/web/src/features/connections/connect-bank-sheet.tsx
+++ b/web/src/features/connections/connect-bank-sheet.tsx
@@ -31,10 +31,16 @@ import { useUsers } from "@/api/queries/users";
 import { ProviderPicker, PROVIDER_META } from "./provider-picker";
 import { PlaidLinkButton } from "./plaid-link-button";
 import { TellerConnectButton } from "./teller-connect-button";
+import { CsvImportForm } from "./csv-import-form";
 
 interface ConnectBankSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  // When set, the Sheet skips step 1 and renders the CSV form directly,
+  // pre-targeted to append to this connection. Used by the connection-
+  // detail page's "Import more" button so admins can append rows to an
+  // existing CSV connection without re-picking a provider.
+  appendToConnectionId?: string;
 }
 
 // Stage drives the inner switch between provider-pick (step 1) and the
@@ -45,7 +51,8 @@ interface ConnectBankSheetProps {
 type Stage =
   | { kind: "pick" }
   | { kind: "plaid"; userId: string; linkToken: string }
-  | { kind: "teller"; userId: string; applicationId: string };
+  | { kind: "teller"; userId: string; applicationId: string }
+  | { kind: "csv"; userId: string };
 
 // ConnectBankSheet is the real Connect-bank flow that replaces the v1
 // /connections/new wizard for the v2 SPA. Two steps inside one Sheet:
@@ -61,6 +68,7 @@ type Stage =
 export function ConnectBankSheet({
   open,
   onOpenChange,
+  appendToConnectionId,
 }: ConnectBankSheetProps) {
   const navigate = useNavigate();
   const providersQuery = useProviders();
@@ -70,16 +78,20 @@ export function ConnectBankSheet({
 
   const [provider, setProvider] = useState<string | null>(null);
   const [userId, setUserId] = useState<string>("");
-  const [stage, setStage] = useState<Stage>({ kind: "pick" });
+  const [stage, setStage] = useState<Stage>(
+    appendToConnectionId ? { kind: "csv", userId: "" } : { kind: "pick" },
+  );
   const [createError, setCreateError] = useState<string | null>(null);
 
-  const enabledProviders = useMemo(
-    () =>
-      (providersQuery.data ?? [])
-        .filter((p) => p.configured && p.name !== "csv")
-        .map((p) => p.name),
-    [providersQuery.data],
-  );
+  // CSV is always available (the importer is in-binary, not a provider
+  // requiring credentials). Plaid + Teller cards are gated on the
+  // /api/v1/providers `configured` flag.
+  const enabledProviders = useMemo(() => {
+    const fromApi = (providersQuery.data ?? [])
+      .filter((p) => p.configured && p.name !== "csv")
+      .map((p) => p.name);
+    return [...fromApi, "csv"];
+  }, [providersQuery.data]);
 
   // Default the family member to the only household member when there's just
   // one, so the picker doesn't render a single-option dropdown the user has
@@ -91,7 +103,11 @@ export function ConnectBankSheet({
   function reset() {
     setProvider(null);
     setUserId("");
-    setStage({ kind: "pick" });
+    // When the Sheet is bound to an existing CSV connection (append mode)
+    // it stays on the CSV stage across re-opens; the picker is irrelevant.
+    setStage(
+      appendToConnectionId ? { kind: "csv", userId: "" } : { kind: "pick" },
+    );
     setCreateError(null);
     linkSession.reset();
     createConnection.reset();
@@ -105,6 +121,12 @@ export function ConnectBankSheet({
   async function onContinue() {
     if (!provider || !effectiveUserId) return;
     setCreateError(null);
+    // CSV doesn't need a server-issued link session — skip straight to the
+    // upload form. The form itself owns the file → preview → import flow.
+    if (provider === "csv") {
+      setStage({ kind: "csv", userId: effectiveUserId });
+      return;
+    }
     try {
       const session = await linkSession.mutateAsync({
         provider,
@@ -293,7 +315,7 @@ export function ConnectBankSheet({
           </div>
         )}
 
-        {stage.kind !== "pick" && (
+        {(stage.kind === "plaid" || stage.kind === "teller") && (
           <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
             <Loader2 className="text-muted-foreground size-6 animate-spin" />
             <div className="text-sm font-medium">
@@ -311,6 +333,34 @@ export function ConnectBankSheet({
               Cancel
             </Button>
           </div>
+        )}
+
+        {stage.kind === "csv" && (
+          <CsvImportForm
+            appendToConnectionId={appendToConnectionId}
+            userId={stage.userId || undefined}
+            onSuccess={(result) => {
+              toast.success(
+                result.appended
+                  ? `Imported ${result.imported} more transactions.`
+                  : `Imported ${result.imported} transactions.`,
+              );
+              handleSheetChange(false);
+              if (!result.appended) {
+                navigate({
+                  to: "/connections/$short_id",
+                  params: { short_id: result.connection_id },
+                });
+              }
+            }}
+            onCancel={() => {
+              if (appendToConnectionId) {
+                handleSheetChange(false);
+              } else {
+                setStage({ kind: "pick" });
+              }
+            }}
+          />
         )}
 
         {stage.kind === "plaid" && (

--- a/web/src/features/connections/csv-import-form.tsx
+++ b/web/src/features/connections/csv-import-form.tsx
@@ -1,0 +1,580 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { FileSpreadsheet, Loader2, Upload, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "sonner";
+import { ApiError } from "@/api/client";
+import {
+  useCsvImport,
+  useCsvPreview,
+  type CsvImportInput,
+} from "@/api/queries/connections";
+import type { CsvColumnKey, CsvPreviewResult } from "@/api/types";
+import { cn } from "@/lib/utils";
+
+// Cap CSV uploads on the client side. The backend tolerates up to 50MB but
+// 10MB matches the v1 admin behaviour and gives the user instant local
+// feedback before the network round-trip.
+const MAX_CSV_BYTES = 10 * 1024 * 1024;
+
+// CsvImportForm is the CSV branch of the Connect-bank Sheet. It owns the
+// upload → mapping → import flow inside whichever Sheet renders it (the
+// Connect-bank Sheet on the connections list page, or the same Sheet
+// inlined on the detail page in append mode).
+export interface CsvImportFormProps {
+  // Pre-target an existing CSV connection. When set, the form skips the
+  // family-member + account-name fields and POSTs `connection_id` so the
+  // backend appends rows to that connection.
+  appendToConnectionId?: string;
+  // Pre-selected family-member UUID for new connections. Ignored when
+  // `appendToConnectionId` is set.
+  userId?: string;
+  onSuccess: (result: {
+    connection_id: string;
+    imported: number;
+    appended: boolean;
+  }) => void;
+  onCancel: () => void;
+}
+
+type Stage =
+  | { kind: "drop" }
+  | {
+      kind: "map";
+      file: File;
+      preview: CsvPreviewResult;
+    };
+
+export function CsvImportForm({
+  appendToConnectionId,
+  userId,
+  onSuccess,
+  onCancel,
+}: CsvImportFormProps) {
+  const [stage, setStage] = useState<Stage>({ kind: "drop" });
+  const previewMut = useCsvPreview();
+  const importMut = useCsvImport();
+
+  async function onFilePicked(file: File | null) {
+    if (!file) return;
+    if (file.size > MAX_CSV_BYTES) {
+      toast.error(
+        `File is too large. Keep CSVs under ${Math.floor(MAX_CSV_BYTES / 1024 / 1024)} MB.`,
+      );
+      return;
+    }
+    try {
+      const preview = await previewMut.mutateAsync(file);
+      setStage({ kind: "map", file, preview });
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.message
+          : "Couldn't parse that CSV. Try a different file.";
+      toast.error(msg);
+    }
+  }
+
+  async function onImport(mapping: CsvImportInput) {
+    try {
+      const result = await importMut.mutateAsync(mapping);
+      onSuccess({
+        connection_id: result.connection_id,
+        imported: result.imported_transactions,
+        appended: !!appendToConnectionId,
+      });
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? err.message
+          : "Couldn't import that CSV. Try again.";
+      toast.error(msg);
+    }
+  }
+
+  if (stage.kind === "drop") {
+    return (
+      <CsvDropStage
+        onFile={onFilePicked}
+        loading={previewMut.isPending}
+        onCancel={onCancel}
+      />
+    );
+  }
+
+  return (
+    <CsvMapStage
+      file={stage.file}
+      preview={stage.preview}
+      onBack={() => {
+        previewMut.reset();
+        setStage({ kind: "drop" });
+      }}
+      onImport={onImport}
+      importing={importMut.isPending}
+      appendToConnectionId={appendToConnectionId}
+      userId={userId}
+    />
+  );
+}
+
+// -- Stage 1: drop / browse -------------------------------------------------
+
+function CsvDropStage({
+  onFile,
+  loading,
+  onCancel,
+}: {
+  onFile: (file: File | null) => void;
+  loading: boolean;
+  onCancel: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 overflow-y-auto">
+      <label
+        htmlFor="csv-file"
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragOver(false);
+          if (loading) return;
+          const file = e.dataTransfer.files[0];
+          if (file) onFile(file);
+        }}
+        className={cn(
+          "border-border/60 hover:border-primary/40 hover:bg-accent/30 flex min-h-[180px] cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed p-6 text-center transition",
+          dragOver && "border-primary bg-accent/40",
+          loading && "pointer-events-none opacity-60",
+        )}
+      >
+        <input
+          id="csv-file"
+          ref={inputRef}
+          type="file"
+          accept=".csv,text/csv"
+          className="hidden"
+          onChange={(e) => onFile(e.target.files?.[0] ?? null)}
+          disabled={loading}
+        />
+        {loading ? (
+          <Loader2 className="text-muted-foreground size-8 animate-spin" />
+        ) : (
+          <Upload className="text-muted-foreground size-8" />
+        )}
+        <div>
+          <div className="text-sm font-medium">
+            {loading ? "Parsing CSV…" : "Drop a CSV here, or click to browse"}
+          </div>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Up to {Math.floor(MAX_CSV_BYTES / 1024 / 1024)} MB. We'll detect
+            columns automatically — you can adjust them on the next step.
+          </p>
+        </div>
+      </label>
+
+      <div className="text-muted-foreground flex items-start gap-2 rounded-md border bg-muted/30 p-3 text-xs">
+        <FileSpreadsheet className="text-muted-foreground/80 mt-0.5 size-4 shrink-0" />
+        <span>
+          Header row required. Common bank exports (Chase, Capital One, Amex,
+          BofA) are auto-detected.
+        </span>
+      </div>
+
+      <div className="mt-auto flex justify-end gap-2 pt-2">
+        <Button variant="outline" onClick={onCancel} disabled={loading}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// -- Stage 2: map columns + import -----------------------------------------
+
+const REQUIRED_KEYS: CsvColumnKey[] = ["date", "description"];
+// `amount` is required when has_debit_credit is false. When true, debit +
+// credit are required instead.
+const OPTIONAL_KEYS: CsvColumnKey[] = ["category", "merchant_name"];
+
+const COLUMN_LABELS: Record<CsvColumnKey, string> = {
+  date: "Date",
+  description: "Description",
+  amount: "Amount",
+  debit: "Debit",
+  credit: "Credit",
+  category: "Category",
+  merchant_name: "Merchant",
+};
+
+function CsvMapStage({
+  file,
+  preview,
+  onBack,
+  onImport,
+  importing,
+  appendToConnectionId,
+  userId,
+}: {
+  file: File;
+  preview: CsvPreviewResult;
+  onBack: () => void;
+  onImport: (input: CsvImportInput) => void;
+  importing: boolean;
+  appendToConnectionId?: string;
+  userId?: string;
+}) {
+  const [hasDebitCredit, setHasDebitCredit] = useState<boolean>(
+    !!preview.has_debit_credit,
+  );
+  const [positiveIsDebit, setPositiveIsDebit] = useState<boolean>(
+    !!preview.positive_is_debit,
+  );
+  const [accountName, setAccountName] = useState("CSV Import");
+
+  // Mapping state — pre-fill from the inferred mapping. Map "no selection"
+  // as -1 to mirror the v1 admin convention.
+  const [mapping, setMapping] = useState<Record<CsvColumnKey, number>>(() => {
+    const seed: Record<CsvColumnKey, number> = {
+      date: -1,
+      description: -1,
+      amount: -1,
+      debit: -1,
+      credit: -1,
+      category: -1,
+      merchant_name: -1,
+    };
+    for (const k of Object.keys(preview.inferred_mapping) as CsvColumnKey[]) {
+      const v = preview.inferred_mapping[k];
+      if (typeof v === "number") seed[k] = v;
+    }
+    return seed;
+  });
+
+  // Keep the debit/credit toggle's defaults consistent with the inferred
+  // mapping if the toggle changes. We don't clear amount; the backend
+  // ignores it when has_debit_credit is true.
+  useEffect(() => {
+    if (hasDebitCredit && (mapping.debit === -1 || mapping.credit === -1)) {
+      // Best-effort: if the inferred mapping had debit/credit, restore them.
+      const inferredDebit = preview.inferred_mapping.debit;
+      const inferredCredit = preview.inferred_mapping.credit;
+      setMapping((m) => ({
+        ...m,
+        debit: m.debit === -1 && typeof inferredDebit === "number" ? inferredDebit : m.debit,
+        credit: m.credit === -1 && typeof inferredCredit === "number" ? inferredCredit : m.credit,
+      }));
+    }
+  }, [hasDebitCredit, preview.inferred_mapping, mapping.debit, mapping.credit]);
+
+  function setColumn(key: CsvColumnKey, raw: string) {
+    const v = raw === "none" ? -1 : Number(raw);
+    setMapping((m) => ({ ...m, [key]: v }));
+  }
+
+  // Validate the mapping. Returns an error message or null when good to go.
+  const validation = useMemo(() => {
+    for (const k of REQUIRED_KEYS) {
+      if (mapping[k] < 0) return `Map a column for ${COLUMN_LABELS[k]}.`;
+    }
+    if (hasDebitCredit) {
+      if (mapping.debit < 0 || mapping.credit < 0) {
+        return "Map both Debit and Credit columns, or switch to a single Amount column.";
+      }
+    } else {
+      if (mapping.amount < 0) return "Map a column for Amount.";
+    }
+    return null;
+  }, [mapping, hasDebitCredit]);
+
+  function buildImportInput(): CsvImportInput {
+    // Strip -1 sentinels — the API expects real column indexes.
+    const m: Record<string, number> = {};
+    for (const [k, v] of Object.entries(mapping)) {
+      if (v >= 0) m[k] = v;
+    }
+    if (hasDebitCredit) {
+      // The backend looks at `debit` + `credit` and ignores `amount`; drop
+      // `amount` so the request is minimal.
+      delete m.amount;
+    } else {
+      delete m.debit;
+      delete m.credit;
+    }
+    return {
+      file,
+      columnMapping: m,
+      positiveIsDebit,
+      hasDebitCredit,
+      dateFormat: preview.date_format,
+      ...(appendToConnectionId
+        ? { connectionId: appendToConnectionId }
+        : {
+            userId,
+            accountName: accountName.trim() || "CSV Import",
+          }),
+    };
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-5 overflow-y-auto">
+      <Alert variant="default">
+        <AlertTitle className="text-sm">
+          {file.name}
+          <span className="text-muted-foreground ml-2 text-xs font-normal">
+            {preview.total_rows} rows · {preview.headers.length} columns
+            {preview.template_name ? ` · ${preview.template_name}` : ""}
+          </span>
+        </AlertTitle>
+        <AlertDescription className="text-xs">
+          {preview.template_name
+            ? "Detected template — column mapping pre-filled. Review before importing."
+            : "No template detected — confirm each column is mapped to the right field."}
+        </AlertDescription>
+      </Alert>
+
+      <div className="space-y-3">
+        <Label className="text-muted-foreground text-xs uppercase tracking-wide">
+          Map columns
+        </Label>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <ColumnSelect
+            id="map-date"
+            label={COLUMN_LABELS.date + " *"}
+            headers={preview.headers}
+            value={mapping.date}
+            required
+            onChange={(v) => setColumn("date", v)}
+          />
+          <ColumnSelect
+            id="map-description"
+            label={COLUMN_LABELS.description + " *"}
+            headers={preview.headers}
+            value={mapping.description}
+            required
+            onChange={(v) => setColumn("description", v)}
+          />
+          {hasDebitCredit ? (
+            <>
+              <ColumnSelect
+                id="map-debit"
+                label={COLUMN_LABELS.debit + " *"}
+                headers={preview.headers}
+                value={mapping.debit}
+                required
+                onChange={(v) => setColumn("debit", v)}
+              />
+              <ColumnSelect
+                id="map-credit"
+                label={COLUMN_LABELS.credit + " *"}
+                headers={preview.headers}
+                value={mapping.credit}
+                required
+                onChange={(v) => setColumn("credit", v)}
+              />
+            </>
+          ) : (
+            <ColumnSelect
+              id="map-amount"
+              label={COLUMN_LABELS.amount + " *"}
+              headers={preview.headers}
+              value={mapping.amount}
+              required
+              onChange={(v) => setColumn("amount", v)}
+            />
+          )}
+          {OPTIONAL_KEYS.map((k) => (
+            <ColumnSelect
+              key={k}
+              id={`map-${k}`}
+              label={COLUMN_LABELS[k]}
+              headers={preview.headers}
+              value={mapping[k]}
+              onChange={(v) => setColumn(k, v)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <fieldset className="space-y-2">
+        <Label className="text-muted-foreground text-xs uppercase tracking-wide">
+          Amount format
+        </Label>
+        <label className="text-muted-foreground flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            className="size-4 accent-primary"
+            checked={hasDebitCredit}
+            onChange={(e) => setHasDebitCredit(e.target.checked)}
+          />
+          Separate Debit and Credit columns (instead of one Amount column)
+        </label>
+        {!hasDebitCredit && (
+          <div className="ml-6 mt-2 flex flex-col gap-1.5 text-sm">
+            <label className="text-muted-foreground flex items-center gap-2">
+              <input
+                type="radio"
+                name="csv-sign"
+                className="size-4 accent-primary"
+                checked={positiveIsDebit}
+                onChange={() => setPositiveIsDebit(true)}
+              />
+              Positive numbers are charges (money out)
+            </label>
+            <label className="text-muted-foreground flex items-center gap-2">
+              <input
+                type="radio"
+                name="csv-sign"
+                className="size-4 accent-primary"
+                checked={!positiveIsDebit}
+                onChange={() => setPositiveIsDebit(false)}
+              />
+              Negative numbers are charges (money out)
+            </label>
+          </div>
+        )}
+      </fieldset>
+
+      {!appendToConnectionId && (
+        <div className="space-y-1.5">
+          <Label
+            htmlFor="account-name"
+            className="text-muted-foreground text-xs uppercase tracking-wide"
+          >
+            Account name
+          </Label>
+          <Input
+            id="account-name"
+            value={accountName}
+            onChange={(e) => setAccountName(e.target.value)}
+            placeholder="CSV Import"
+          />
+          <p className="text-muted-foreground text-xs">
+            Shown in the accounts list. You can rename it later.
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label className="text-muted-foreground text-xs uppercase tracking-wide">
+          Preview ({Math.min(preview.preview_rows.length, 10)} of {preview.total_rows} rows)
+        </Label>
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full text-xs">
+            <thead className="bg-muted/40">
+              <tr>
+                {preview.headers.map((h, i) => (
+                  <th key={i} className="px-2 py-1.5 text-left font-medium">
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {preview.preview_rows.slice(0, 10).map((row, ri) => (
+                <tr key={ri} className="border-border/60 border-t">
+                  {row.map((cell, ci) => (
+                    <td
+                      key={ci}
+                      className="text-muted-foreground max-w-[16ch] truncate px-2 py-1.5"
+                    >
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {validation && (
+        <Alert variant="default">
+          <AlertDescription className="text-xs">{validation}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="mt-auto flex flex-wrap items-center justify-end gap-2 pt-2">
+        <Button variant="ghost" onClick={onBack} disabled={importing}>
+          <X className="size-4" />
+          Pick a different file
+        </Button>
+        <Button
+          onClick={() => onImport(buildImportInput())}
+          disabled={!!validation || importing}
+        >
+          {importing ? <Loader2 className="size-4 animate-spin" /> : null}
+          Import {preview.total_rows} rows
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ColumnSelect({
+  id,
+  label,
+  headers,
+  value,
+  required,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  headers: string[];
+  value: number;
+  required?: boolean;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id} className="text-xs">
+        {label}
+      </Label>
+      <Select
+        value={value < 0 ? "none" : String(value)}
+        onValueChange={onChange}
+      >
+        <SelectTrigger id={id}>
+          <SelectValue placeholder={required ? "Pick a column…" : "— None —"} />
+        </SelectTrigger>
+        <SelectContent>
+          {!required && <SelectItem value="none">— None —</SelectItem>}
+          {headers.map((h, i) => (
+            <SelectItem key={i} value={String(i)}>
+              {h}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+// CsvImportFormSkeleton renders an approximate skeleton for the form — used
+// by the sandbox specimen so the layout shows up without needing a live file
+// preview.
+export function CsvImportFormSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Skeleton className="h-32 w-full rounded-lg" />
+      <Skeleton className="h-10 w-full" />
+    </div>
+  );
+}

--- a/web/src/features/connections/provider-picker.tsx
+++ b/web/src/features/connections/provider-picker.tsx
@@ -30,8 +30,7 @@ export interface ProviderPickerProps {
    *  list still renders, but is disabled with a "not configured" hint so the
    *  user knows this server hasn't been wired up for it. */
   enabledProviders: string[];
-  /** Subset of providers to show. Defaults to plaid + teller; the future
-   *  CSV PR (PR-04) will pass `["plaid", "teller", "csv"]`. */
+  /** Subset of providers to show. Defaults to plaid + teller + csv. */
   providers?: string[];
   value: string | null;
   onChange: (provider: string) => void;
@@ -45,7 +44,7 @@ export interface ProviderPickerProps {
 // a connection without an admin login.
 export function ProviderPicker({
   enabledProviders,
-  providers = ["plaid", "teller"],
+  providers = ["plaid", "teller", "csv"],
   value,
   onChange,
   className,

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -54,15 +54,20 @@ import type { Account, ConnectionDetail } from "@/api/types";
 import type { SyncLog } from "@/api/queries/sync-logs";
 import { ConnectionStatusBadge } from "@/features/connections/connection-status-badge";
 import { ComingSoonSheet } from "@/features/connections/coming-soon-sheet";
+import { ConnectBankSheet } from "@/features/connections/connect-bank-sheet";
 import { ConnectionAccountsList } from "@/features/connections/connection-accounts-list";
 import { SyncActivityBars } from "@/features/connections/sync-activity-bars";
 import { SyncHistoryList } from "@/features/connections/sync-history-list";
 import { providerLabel, relativeTime } from "@/features/connections/connection-utils";
+import { Upload } from "lucide-react";
 
 // Search-param schema for the detail page. Mirrors the list schema's `reauth`
-// so the same coming-soon Sheet can open from either surface.
+// so the same coming-soon Sheet can open from either surface. `import_csv`
+// opens the CSV upload Sheet inline, pre-targeted to append rows to this
+// connection.
 export const connectionDetailSearchSchema = z.object({
   reauth: z.string().optional(),
+  import_csv: z.string().optional(),
 });
 
 type ConnectionDetailSearch = z.infer<typeof connectionDetailSearchSchema>;
@@ -138,6 +143,32 @@ export function ConnectionDetailPage() {
     });
   }
 
+  function openImportCsv() {
+    if (!connQuery.data) return;
+    navigate({
+      to: "/connections/$id",
+      params: { id: connQuery.data.short_id },
+      search: (prev: ConnectionDetailSearch) => ({
+        ...prev,
+        import_csv: connQuery.data!.short_id,
+      }),
+      replace: false,
+    });
+  }
+
+  function closeImportCsv() {
+    if (!connQuery.data) return;
+    navigate({
+      to: "/connections/$id",
+      params: { id: connQuery.data.short_id },
+      search: (prev: ConnectionDetailSearch) => ({
+        ...prev,
+        import_csv: undefined,
+      }),
+      replace: true,
+    });
+  }
+
   return (
     <div className="mx-auto max-w-5xl">
       <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
@@ -168,6 +199,7 @@ export function ConnectionDetailPage() {
           allLogsForActivity={syncLogsQuery.data?.sync_logs ?? []}
           syncLogsLoading={syncLogsQuery.isLoading}
           onReauth={openReauth}
+          onImportCsv={openImportCsv}
         />
       )}
 
@@ -179,6 +211,15 @@ export function ConnectionDetailPage() {
         title="Re-authenticate"
         description="Reconnect to the bank to resume syncing this connection."
       />
+      {connQuery.data?.provider === "csv" && (
+        <ConnectBankSheet
+          open={!!search.import_csv}
+          onOpenChange={(open) => {
+            if (!open) closeImportCsv();
+          }}
+          appendToConnectionId={connQuery.data.short_id}
+        />
+      )}
     </div>
   );
 }
@@ -190,6 +231,7 @@ interface DetailBodyProps {
   allLogsForActivity: SyncLog[];
   syncLogsLoading: boolean;
   onReauth: () => void;
+  onImportCsv: () => void;
 }
 
 function DetailBody({
@@ -199,6 +241,7 @@ function DetailBody({
   allLogsForActivity,
   syncLogsLoading,
   onReauth,
+  onImportCsv,
 }: DetailBodyProps) {
   const sync = useSyncConnection();
   const pause = usePauseConnection();
@@ -317,6 +360,12 @@ function DetailBody({
                 <RefreshCw className="size-4" />
               )}
               Sync now
+            </Button>
+          )}
+          {conn.provider === "csv" && conn.status !== "disconnected" && (
+            <Button variant="outline" size="sm" onClick={onImportCsv}>
+              <Upload className="size-4" />
+              Import more
             </Button>
           )}
           <DropdownMenu>


### PR DESCRIPTION
Fourth PR in the `stack/v2-connections` series. Adds a CSV branch to the Connect-bank Sheet from PR-03 and an "Import more" button on the connection-detail page so admins can append rows to an existing CSV connection.

## What's in this PR

- **`features/connections/csv-import-form.tsx`** — the upload → mapping → import form. Two stages inside the same Sheet:
  - **Drop / browse** — `<label>`-wrapped `<input type="file" accept=".csv">` with drag-and-drop styling. POSTs to `/api/v1/connections/csv/preview` (multipart) on file selection. 10MB client-side cap with a friendly toast (backend still allows 50MB; the smaller cap gives faster local feedback).
  - **Map columns + import** — `<Select>` per recognised field, pre-filled from the preview's `inferred_mapping`. Required fields (date, description, amount or debit/credit) are validated client-side before the import button enables. Includes a debit-vs-credit toggle and a positive-vs-negative sign convention; both honour the auto-detected template defaults. Renders a 10-row preview table below.
- **`features/connections/connect-bank-sheet.tsx`** — adds a `csv` arm to the discriminated `Stage` union. Picking CSV in the picker + Continue swaps the Sheet body to `CsvImportForm`. New optional `appendToConnectionId` prop lets the same Sheet skip the picker and pre-target an existing connection in append mode (used by the detail page below). On success, toast and navigate to the new connection's detail page; in append mode, just close.
- **`routes/connection-detail.tsx`** — adds an `import_csv` search param and an "Import more" header button for CSV connections (`provider === "csv"`). The button opens the same `ConnectBankSheet` inline, pre-targeted to this connection. URL-driven so the sheet is shareable / back-button-friendly, mirroring the existing `?reauth=` pattern.
- **`features/connections/provider-picker.tsx`** — CSV is now in the default `providers` list (was Plaid + Teller only). The Connect-bank Sheet always marks CSV as enabled — the importer is in-binary, not a credentialled provider — so the previous "Not configured" placeholder is gone.
- **Queries** — `useCsvPreview()` and `useCsvImport()` in `api/queries/connections.ts`, both `multipart/form-data`. Import invalidates `connections`, `connection`, `accounts`, and `transactions`.
- **`api/types.ts`** — adds `CsvPreviewResult`, `CsvImportResult`, and a `CsvColumnKey` union mirroring the column names the backend recognises.

## `client.ts` change worth flagging

`api()` previously hard-set `Content-Type: application/json` on every request, which would break the multipart upload (the browser must set the `boundary=…` parameter itself). Reworked to detect `body instanceof FormData` and skip the default header in that case. JSON callers are unaffected — the default behaviour is preserved when `body` isn't a `FormData`. No new helper; one path through `api()` keeps the call sites uniform.

## What's deliberately NOT here

- **No new backend endpoints.** Reuses the public `POST /api/v1/connections/csv/{preview,import}` shipped earlier. The `connection_id` field on the import endpoint already supports append mode — we just wire the SPA to it.
- **No CSV parsing on the client.** All parsing + dedup + template detection happens server-side; the SPA only renders what the preview returns.
- **No re-auth wiring** (PR-05) and **no bulk-action glue** (PR-06).
- **No sandbox specimen for `CsvImportForm`** — it lives in `features/connections/`, which the v2-frontend rule explicitly excludes from the sandbox-update requirement.

## Notes for follow-on PRs

- **PR-05 (re-auth)**: the `Stage` union is now a four-way discriminated union (`pick | plaid | teller | csv`); re-auth will likely become a fifth arm or a top-level prop on the Sheet rather than another stage, depending on whether re-auth ever needs to coexist with the picker. The `appendToConnectionId` precedent — a prop that pre-targets an existing connection and skips step 1 — is a reasonable shape to copy for the re-auth case.
- **PR-06 (bulk actions)**: untouched.

## Stale v1 reference, FYI

The v1 admin CSV wizard (`internal/templates/components/pages/csv_import.templ` + `static/js/admin/components/csv_import.js`) talks to a *different* set of endpoints — `/-/csv/upload` (server-side caches the file, returns headers + detected mapping) plus `/-/csv/preview` and `/-/csv/import` against the cached file. The public REST API this PR consumes (`/api/v1/connections/csv/{preview,import}`) is stateless: every call carries the file. So the v1 client logic isn't directly portable. The auto-detect + template handling on the backend is shared, so the inferred mapping shape is identical — but the v1 sequence (upload-then-preview-then-import) is collapsed to (preview, then import) here.

## Screenshots

<table>
  <tr><th>Drop zone</th><th>Mapping + preview</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/a3af1qzbqs.png" width="450" alt="Connect-bank Sheet — CSV drop zone"></td>
    <td><img src="https://i.img402.dev/d78446las9.png" width="450" alt="Connect-bank Sheet — CSV mapping + preview"></td>
  </tr>
</table>

<details><summary>Mapping — mobile (390×844)</summary>

<img src="https://i.img402.dev/b68kdnn70f.png" width="280" alt="CSV mapping — mobile">

</details>

## Test plan

- [x] `bun run lint` (tsc) — clean
- [x] `bun run build` (tsc -b + vite build) — clean
- [x] `templ generate && go build ./... && go vet ./... && go test ./...` — clean
- [x] Smoke (Playwright + dev server): pick CSV in `/v2/connections?action=connect`, Continue, drop a 5-row CSV → preview parses, columns auto-detect, mapping form renders with the right defaults
- [ ] Reviewer: actually click Import on a real CSV against a fresh user — confirm the toast, the redirect, and that the new connection's detail page renders
- [ ] Reviewer: from a CSV connection's detail page, click "Import more", confirm the same Sheet opens with no provider picker, the import succeeds, and the page stays on the same connection (no redirect)
- [ ] Reviewer: oversize file (>10MB) → friendly toast, no upload attempt
- [ ] Reviewer: malformed CSV (no header row) → preview-error toast, Sheet stays on the drop stage so the user can pick a different file
