### PR TITLE
v2: transactions polish round 3 — pagination + skeleton + action bar redesign

### DIFF
--- a/internal/api/transactions.go
+++ b/internal/api/transactions.go
@@ -154,8 +154,15 @@ func ListTransactionsHandler(svc *service.Service) http.HandlerFunc {
 			}
 		}
 
+		offset, err := parseIntParam(q, "offset", 0, 0, 1_000_000)
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", err.Error())
+			return
+		}
+
 		params := service.TransactionListParams{
 			Cursor:        q.Get("cursor"),
+			Offset:        offset,
 			Limit:         limit,
 			StartDate:     f.StartDate,
 			EndDate:       f.EndDate,

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -355,7 +355,9 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 		argN++
 	}
 
-	if params.Cursor != "" {
+	// Offset takes precedence over cursor — random-access pagination for the
+	// v2 SPA. External REST clients keep using the stable cursor path.
+	if params.Offset == 0 && params.Cursor != "" {
 		cursorDate, cursorID, err := DecodeCursor(params.Cursor)
 		if err != nil {
 			return nil, err
@@ -401,6 +403,14 @@ func (s *Service) ListTransactions(ctx context.Context, params TransactionListPa
 	buf.WriteString(" LIMIT $")
 	buf.WriteString(strconv.Itoa(argN))
 	args = append(args, limit+1)
+	argN++
+
+	if params.Offset > 0 {
+		buf.WriteString(" OFFSET $")
+		buf.WriteString(strconv.Itoa(argN))
+		args = append(args, params.Offset)
+		argN++
+	}
 
 	query := buf.String()
 	rows, err := s.Pool.Query(ctx, query, args...)

--- a/internal/service/types.go
+++ b/internal/service/types.go
@@ -77,6 +77,11 @@ type TransactionListResult struct {
 
 type TransactionListParams struct {
 	Cursor           string
+	// Offset enables random-access pagination (LIMIT/OFFSET) — used by the
+	// v2 SPA's page-numbered Pagination component. Cursor pagination
+	// remains the default for external REST clients; when Offset > 0 the
+	// service ignores Cursor.
+	Offset           int
 	Limit            int
 	StartDate        *time.Time
 	EndDate          *time.Time

--- a/web/src/api/queries/transactions.ts
+++ b/web/src/api/queries/transactions.ts
@@ -31,7 +31,7 @@ export interface TransactionFilters {
   sortOrder?: "asc" | "desc";
 }
 
-const PAGE_LIMIT = 50;
+export const PAGE_LIMIT = 50;
 
 // The API rejects a 1-char search; treat <2 chars as "no search".
 function normalizeSearch(raw: string | undefined): string | undefined {
@@ -94,6 +94,79 @@ export function useTransactions(filters: TransactionFilters) {
     },
     initialPageParam: "",
     getNextPageParam: (last) => nextCursor(last),
+  });
+}
+
+// fetchAllMatchingTransactionIds fetches every transaction id matching the
+// given filters by walking the cursor-paginated list endpoint. Used by the
+// selection action bar's "Select all N" affordance. Capped at MAX_BULK_SELECT
+// to keep one runaway click from triggering hundreds of requests; the caller
+// should surface a truncation hint when the real match count is higher.
+const MAX_BULK_SELECT = 5_000;
+
+export async function fetchAllMatchingTransactionIds(
+  filters: TransactionFilters,
+): Promise<string[]> {
+  const search = normalizeSearch(filters.search);
+  const ids: string[] = [];
+  let cursor = "";
+  while (ids.length < MAX_BULK_SELECT) {
+    const params = buildFilterParams(filters, search);
+    params.set("limit", "500");
+    params.set("fields", "id");
+    if (cursor) params.set("cursor", cursor);
+    if (filters.sortBy) params.set("sort_by", filters.sortBy);
+    if (filters.sortOrder) params.set("sort_order", filters.sortOrder);
+    const page = await api<{
+      transactions: { id: string }[];
+      next_cursor?: string | null;
+      has_more?: boolean;
+    }>(`/api/v1/transactions?${params.toString()}`);
+    for (const t of page.transactions) ids.push(t.id);
+    if (!page.has_more || !page.next_cursor) break;
+    cursor = page.next_cursor;
+  }
+  return ids;
+}
+
+// useTransactionsPage fetches a single page worth of transactions by offset —
+// the path used by the v2 list view's numbered pagination. The cursor path
+// (useTransactions above) is preserved for any future infinite-scroll surface
+// and remains the only path external REST clients can rely on.
+export function useTransactionsPage(
+  filters: TransactionFilters,
+  page: number,
+  pageSize: number = PAGE_LIMIT,
+) {
+  const search = normalizeSearch(filters.search);
+
+  const key = {
+    search,
+    account: filters.account,
+    category: filters.category,
+    start: filters.start,
+    end: filters.end,
+    minAmount: filters.minAmount,
+    maxAmount: filters.maxAmount,
+    pending: filters.pending,
+    sortBy: filters.sortBy,
+    sortOrder: filters.sortOrder,
+    page,
+    pageSize,
+  };
+
+  return useQuery({
+    queryKey: ["transactions", "page", key],
+    queryFn: () => {
+      const params = buildFilterParams(filters, search);
+      params.set("limit", String(pageSize));
+      const offset = Math.max(0, page - 1) * pageSize;
+      if (offset > 0) params.set("offset", String(offset));
+      if (filters.sortBy) params.set("sort_by", filters.sortBy);
+      if (filters.sortOrder) params.set("sort_order", filters.sortOrder);
+      return api<TransactionsPage>(`/api/v1/transactions?${params.toString()}`);
+    },
+    placeholderData: (prev) => prev,
   });
 }
 

--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -41,6 +41,12 @@ export interface DataTableProps<TData, TValue> {
   /** Number of skeleton rows to show while loading. */
   loadingRows?: number;
   /**
+   * Optional row-shaped skeleton renderer. When provided it replaces the
+   * generic full-width bars with placeholders shaped like the real row, so
+   * loading state mirrors the data layout without a layout shift on arrival.
+   */
+  renderSkeletonRow?: () => React.ReactNode;
+  /**
    * Controlled sorting. Owned by the route (typically synced to URL search
    * params), so DataTable stays presentational. Omit for an unsorted table.
    */
@@ -78,6 +84,7 @@ export function DataTable<TData, TValue>({
   emptyState,
   errorState,
   loadingRows = 8,
+  renderSkeletonRow,
   sorting,
   onSortingChange,
   onRowClick,
@@ -140,11 +147,13 @@ export function DataTable<TData, TValue>({
           {isLoading ? (
             Array.from({ length: loadingRows }).map((_, r) => (
               <TableRow key={`skeleton-${r}`}>
-                {Array.from({ length: colCount }).map((__, c) => (
-                  <TableCell key={c}>
-                    <Skeleton className="h-4 w-full" />
-                  </TableCell>
-                ))}
+                {renderSkeletonRow
+                  ? renderSkeletonRow()
+                  : Array.from({ length: colCount }).map((__, c) => (
+                      <TableCell key={c}>
+                        <Skeleton className="h-4 w-full" />
+                      </TableCell>
+                    ))}
               </TableRow>
             ))
           ) : isError ? (

--- a/web/src/components/ui/pagination.tsx
+++ b/web/src/components/ui/pagination.tsx
@@ -1,0 +1,127 @@
+import * as React from "react"
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  MoreHorizontalIcon,
+} from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants, type Button } from "@/components/ui/button"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      role="navigation"
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem({ ...props }: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function PaginationPrevious({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to previous page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pl-2.5", className)}
+      {...props}
+    >
+      <ChevronLeftIcon />
+      <span className="hidden sm:block">Previous</span>
+    </PaginationLink>
+  )
+}
+
+function PaginationNext({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) {
+  return (
+    <PaginationLink
+      aria-label="Go to next page"
+      size="default"
+      className={cn("gap-1 px-2.5 sm:pr-2.5", className)}
+      {...props}
+    >
+      <span className="hidden sm:block">Next</span>
+      <ChevronRightIcon />
+    </PaginationLink>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontalIcon className="size-4" />
+      <span className="sr-only">More pages</span>
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationLink,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+}

--- a/web/src/features/transactions/selection-action-bar.tsx
+++ b/web/src/features/transactions/selection-action-bar.tsx
@@ -1,11 +1,12 @@
 import { useState } from "react";
-import { Shapes, Tag, X } from "lucide-react";
+import { Check, Loader2, Shapes, Tag, X } from "lucide-react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { Kbd } from "@/components/ui/kbd";
 import { Separator } from "@/components/ui/separator";
 import { CategoryCommandList } from "@/components/category-command";
 import { TagCommandList } from "@/components/tag-command";
@@ -13,6 +14,7 @@ import { KbdTooltip } from "@/components/kbd-tooltip";
 import { useUpdateTransactions } from "@/api/queries/transactions";
 import type { UpdateTransactionsOp } from "@/api/types";
 import { applyBulkTransactionOp } from "@/features/transactions/bulk-update";
+import { cn } from "@/lib/utils";
 
 interface SelectionActionBarProps {
   selectedIds: string[];
@@ -20,18 +22,22 @@ interface SelectionActionBarProps {
    *  context (header select-all only covers the loaded page). */
   totalCount?: number;
   onClear: () => void;
+  /**
+   * Expand the selection to cover every transaction matching the current
+   * filters. Returns a promise so the bar can render a pending state until
+   * the IDs are fetched. Omit to hide the "Select all N" affordance.
+   */
+  onSelectAllMatching?: () => Promise<void> | void;
 }
 
-// SelectionActionBar is the floating bar that appears in select mode once at
-// least one row is selected — a count, bulk categorize / tag actions, and a
-// clear button. Each action fans the selection out into batch-update ops,
-// chunked to the endpoint's 50-op limit.
 export function SelectionActionBar({
   selectedIds,
   totalCount,
   onClear,
+  onSelectAllMatching,
 }: SelectionActionBarProps) {
   const update = useUpdateTransactions();
+  const [isExpanding, setIsExpanding] = useState(false);
 
   const applyToAll = async (
     op: Omit<UpdateTransactionsOp, "transaction_id">,
@@ -46,41 +52,99 @@ export function SelectionActionBar({
     if (ok) onClear();
   };
 
+  const canExpand =
+    !!onSelectAllMatching &&
+    totalCount != null &&
+    totalCount > selectedIds.length;
+
   return (
-    <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
-      <div className="bg-popover text-popover-foreground flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 pl-3 shadow-lg">
-        <span className="text-sm font-medium">
-          {totalCount != null && totalCount > selectedIds.length
-            ? `${selectedIds.length} of ${totalCount.toLocaleString()} selected`
-            : `${selectedIds.length} selected`}
-        </span>
-        <Separator orientation="vertical" className="mx-1 h-5" />
+    // pointer-events-none on the outer wrapper so the empty space around the
+    // pill stays click-through, while the pill itself re-enables events.
+    <div className="pointer-events-none fixed inset-x-0 bottom-4 z-40 flex justify-center px-4 sm:bottom-6">
+      <div
+        data-state="open"
+        className={cn(
+          "pointer-events-auto flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border bg-popover/95 p-1 pl-3 text-popover-foreground shadow-xl backdrop-blur-sm",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-4 data-[state=open]:duration-200",
+        )}
+      >
+        {update.isPending ? (
+          <div className="flex items-center gap-2 px-2 py-1 text-sm">
+            <Loader2 className="size-4 animate-spin" />
+            <span className="font-medium">
+              Applying to {selectedIds.length.toLocaleString()}…
+            </span>
+          </div>
+        ) : (
+          <>
+            <span className="text-sm font-medium whitespace-nowrap">
+              {selectedIds.length.toLocaleString()}
+              {totalCount != null && totalCount > selectedIds.length && (
+                <span className="text-muted-foreground font-normal">
+                  {" "}
+                  / {totalCount.toLocaleString()}
+                </span>
+              )}
+              <span className="text-muted-foreground font-normal">
+                {" "}
+                selected
+              </span>
+            </span>
 
-        <CategorizeAction
-          disabled={update.isPending}
-          onPick={(slug) =>
-            applyToAll({ category_slug: slug }, "Category applied.")
-          }
-        />
-        <TagAction
-          disabled={update.isPending}
-          onPick={(slug) =>
-            applyToAll({ tags_to_add: [{ slug }] }, "Tag applied.")
-          }
-        />
+            {canExpand && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 rounded-full px-2 text-xs"
+                disabled={isExpanding}
+                onClick={async () => {
+                  if (!onSelectAllMatching) return;
+                  setIsExpanding(true);
+                  try {
+                    await onSelectAllMatching();
+                  } finally {
+                    setIsExpanding(false);
+                  }
+                }}
+              >
+                {isExpanding ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Check className="size-3" />
+                )}
+                Select all
+              </Button>
+            )}
 
-        <Separator orientation="vertical" className="mx-1 h-5" />
-        <KbdTooltip label="Clear selection / exit" keys={["Esc"]} side="top">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="size-8 rounded-full"
-            onClick={onClear}
-            aria-label="Clear selection"
-          >
-            <X className="size-4" />
-          </Button>
-        </KbdTooltip>
+            <Separator orientation="vertical" className="mx-1 h-5" />
+
+            <CategorizeAction
+              disabled={update.isPending}
+              onPick={(slug) =>
+                applyToAll({ category_slug: slug }, "Category applied.")
+              }
+            />
+            <TagAction
+              disabled={update.isPending}
+              onPick={(slug) =>
+                applyToAll({ tags_to_add: [{ slug }] }, "Tag applied.")
+              }
+            />
+
+            <Separator orientation="vertical" className="mx-1 h-5" />
+            <KbdTooltip label="Clear selection / exit" keys={["Esc"]} side="top">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-8 rounded-full"
+                onClick={onClear}
+                aria-label="Clear selection"
+              >
+                <X className="size-4" />
+              </Button>
+            </KbdTooltip>
+          </>
+        )}
       </div>
     </div>
   );
@@ -98,13 +162,16 @@ function CategorizeAction({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
-          variant="ghost"
+          variant="default"
           size="sm"
           className="h-8 gap-1.5 rounded-full"
           disabled={disabled}
         >
           <Shapes className="size-4" />
           <span className="hidden sm:inline">Categorize</span>
+          <Kbd className="ml-1 hidden bg-primary-foreground/10 text-primary-foreground/80 sm:inline-flex">
+            C
+          </Kbd>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-64 p-0" align="center" side="top">
@@ -139,6 +206,7 @@ function TagAction({
         >
           <Tag className="size-4" />
           <span className="hidden sm:inline">Tag</span>
+          <Kbd className="ml-1 hidden sm:inline-flex">T</Kbd>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-56 p-0" align="center" side="top">

--- a/web/src/features/transactions/transaction-row-skeleton.tsx
+++ b/web/src/features/transactions/transaction-row-skeleton.tsx
@@ -1,0 +1,42 @@
+import { TableCell } from "@/components/ui/table";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface TransactionRowSkeletonProps {
+  /** True when the table is in select mode and renders a checkbox column. */
+  showSelect?: boolean;
+}
+
+// TransactionRowSkeleton mirrors the real transaction row layout while data
+// loads — same icon tile, title + subtitle stack, category chip, amount stack
+// — so the table doesn't shift visually when the rows arrive.
+export function TransactionRowSkeleton({
+  showSelect,
+}: TransactionRowSkeletonProps) {
+  return (
+    <>
+      {showSelect && (
+        <TableCell className="w-px">
+          <Skeleton className="size-4 rounded-sm" />
+        </TableCell>
+      )}
+      <TableCell className="max-w-0">
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-7 shrink-0 rounded-md" />
+          <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+            <Skeleton className="h-3.5 w-2/5" />
+            <Skeleton className="h-3 w-3/5" />
+          </div>
+        </div>
+      </TableCell>
+      <TableCell className="hidden w-px sm:table-cell">
+        <Skeleton className="ml-auto h-5 w-24 rounded-md" />
+      </TableCell>
+      <TableCell className="w-px sm:min-w-28">
+        <div className="flex flex-col items-end gap-1.5">
+          <Skeleton className="h-3.5 w-16" />
+          <Skeleton className="h-3 w-10" />
+        </div>
+      </TableCell>
+    </>
+  );
+}

--- a/web/src/features/transactions/transactions-pagination.tsx
+++ b/web/src/features/transactions/transactions-pagination.tsx
@@ -1,0 +1,131 @@
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+import { cn } from "@/lib/utils";
+
+interface TransactionsPaginationProps {
+  /** 1-indexed current page. */
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (next: number) => void;
+  /** Dim controls while a page is in flight to discourage rapid clicks. */
+  isFetching?: boolean;
+}
+
+// pageWindow returns the 1-based page numbers to render between Prev/Next.
+// At ≤7 pages every page is listed; beyond that the middle window slides
+// around the current page with leading / trailing ellipses (sentinel value 0).
+function pageWindow(current: number, totalPages: number): number[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  if (current <= 4) return [1, 2, 3, 4, 5, 0, totalPages];
+  if (current >= totalPages - 3) {
+    return [
+      1,
+      0,
+      totalPages - 4,
+      totalPages - 3,
+      totalPages - 2,
+      totalPages - 1,
+      totalPages,
+    ];
+  }
+  return [1, 0, current - 1, current, current + 1, 0, totalPages];
+}
+
+// TransactionsPagination wraps the shadcn pagination primitive with the
+// concrete state the transactions route owns: a 1-indexed `page` driven by
+// the URL `?p=` param, a fixed page size, and a click handler that updates
+// the search params.
+export function TransactionsPagination({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  isFetching,
+}: TransactionsPaginationProps) {
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const safePage = Math.min(Math.max(page, 1), totalPages);
+  const pages = pageWindow(safePage, totalPages);
+
+  const go = (next: number) => {
+    if (next < 1 || next > totalPages || next === safePage) return;
+    onPageChange(next);
+  };
+
+  return (
+    <div className={cn("mt-4 space-y-2", isFetching && "opacity-70")}>
+      <Pagination>
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              href="#"
+              aria-disabled={safePage === 1}
+              className={cn(
+                safePage === 1 && "pointer-events-none opacity-50",
+              )}
+              onClick={(e) => {
+                e.preventDefault();
+                go(safePage - 1);
+              }}
+            />
+          </PaginationItem>
+          {pages.map((n, i) =>
+            n === 0 ? (
+              <PaginationItem
+                key={`ellipsis-${i}`}
+                className="hidden sm:block"
+              >
+                <PaginationEllipsis />
+              </PaginationItem>
+            ) : (
+              <PaginationItem
+                key={n}
+                className={cn(
+                  // Show only the current page on mobile — Prev/Next handle the
+                  // rest. On sm+ the full numbered window appears.
+                  n === safePage ? "block" : "hidden sm:block",
+                )}
+              >
+                <PaginationLink
+                  href="#"
+                  isActive={n === safePage}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    go(n);
+                  }}
+                >
+                  {n}
+                </PaginationLink>
+              </PaginationItem>
+            ),
+          )}
+          <PaginationItem>
+            <PaginationNext
+              href="#"
+              aria-disabled={safePage === totalPages}
+              className={cn(
+                safePage === totalPages && "pointer-events-none opacity-50",
+              )}
+              onClick={(e) => {
+                e.preventDefault();
+                go(safePage + 1);
+              }}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
+      <p className="text-muted-foreground text-center text-xs">
+        Page {safePage} of {totalPages} · {total.toLocaleString()} transactions
+      </p>
+    </div>
+  );
+}

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -8,11 +8,10 @@ import {
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import type { RowSelectionState } from "@tanstack/react-table";
-import { Loader2, Receipt } from "lucide-react";
+import { Receipt } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { DataTable } from "@/components/data-table";
 import { EmptyState } from "@/components/empty-state";
-import { Button } from "@/components/ui/button";
 import { CommandDialog } from "@/components/ui/command";
 import {
   CategoryCommandList,
@@ -25,13 +24,18 @@ import {
 import { TransactionsToolbar } from "@/features/transactions/transactions-toolbar";
 import { SelectionActionBar } from "@/features/transactions/selection-action-bar";
 import { applyBulkTransactionOp } from "@/features/transactions/bulk-update";
+import { TransactionsPagination } from "@/features/transactions/transactions-pagination";
+import { TransactionRowSkeleton } from "@/features/transactions/transaction-row-skeleton";
+import { TagCommandList } from "@/components/tag-command";
 import {
-  useTransactions,
+  PAGE_LIMIT,
+  fetchAllMatchingTransactionIds,
+  useTransactionsPage,
   useTransactionCount,
   useUpdateTransactions,
 } from "@/api/queries/transactions";
 import type { TransactionFilters } from "@/api/queries/transactions";
-import { flattenPages } from "@/lib/pagination";
+import { toast } from "sonner";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useShortcut } from "@/lib/shortcuts";
 import type { Transaction } from "@/api/types";
@@ -49,6 +53,8 @@ export const transactionsSearchSchema = z.object({
   pending: z.enum(["true", "false"]).optional(),
   sort: z.enum(["date", "amount"]).optional(),
   dir: z.enum(["asc", "desc"]).optional(),
+  /** 1-indexed page number for the offset-paginated list view. */
+  p: z.coerce.number().int().min(1).optional(),
 });
 
 export type TransactionsSearch = z.infer<typeof transactionsSearchSchema>;
@@ -92,7 +98,7 @@ export function TransactionsPage() {
     const q = debounced.trim() || undefined;
     navigate({
       to: ".",
-      search: (prev: Record<string, unknown>) => ({ ...prev, q }),
+      search: (prev: Record<string, unknown>) => ({ ...prev, q, p: undefined }),
     });
   }, [debounced, navigate]);
 
@@ -106,18 +112,39 @@ export function TransactionsPage() {
     (patch: Partial<TransactionsSearch>) => {
       navigate({
         to: ".",
-        search: (prev: Record<string, unknown>) => ({ ...prev, ...patch }),
+        // Any filter change collapses back to page 1 — staying on page 11
+        // when the filtered result has only 2 pages would land on an empty
+        // view. The pagination control itself patches `p` directly and
+        // doesn't go through setFilter.
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          ...patch,
+          p: undefined,
+        }),
       });
     },
     [navigate],
   );
 
   const filters = searchToFilters(search);
-  const transactions = useTransactions(filters);
+  const page = search.p ?? 1;
+  const transactions = useTransactionsPage(filters, page, PAGE_LIMIT);
   const totalCount = useTransactionCount(filters);
-  const rows = useMemo(
-    () => flattenPages<Transaction>(transactions.data?.pages, "transactions"),
-    [transactions.data?.pages],
+  const rows = useMemo<Transaction[]>(
+    () => transactions.data?.transactions ?? [],
+    [transactions.data?.transactions],
+  );
+  const goToPage = useCallback(
+    (next: number) => {
+      navigate({
+        to: ".",
+        search: (prev: Record<string, unknown>) => ({
+          ...prev,
+          p: next > 1 ? next : undefined,
+        }),
+      });
+    },
+    [navigate],
   );
 
   // --- Select mode ---
@@ -248,12 +275,12 @@ export function TransactionsPage() {
     { label: "Clear selection / focus", group: "Transactions" },
   );
 
-  // --- Categorize shortcut ---
-  // `c` opens a centered command dialog targeting either the bulk selection
-  // (when select mode has selected rows) or the j/k-focused row.
+  // `c` and `t` open centered command dialogs targeting either the bulk
+  // selection (when select mode has selected rows) or the j/k-focused row.
   const updateTransactions = useUpdateTransactions();
   const [categorizeOpen, setCategorizeOpen] = useState(false);
-  const categorizeTargets = useMemo(() => {
+  const [tagOpen, setTagOpen] = useState(false);
+  const bulkTargets = useMemo(() => {
     if (selectedIds.length > 0) return selectedIds;
     if (focusedIndex != null) {
       const id = rows[focusedIndex]?.id;
@@ -265,7 +292,7 @@ export function TransactionsPage() {
   useShortcut(
     ["c"],
     (e) => {
-      if (categorizeTargets.length === 0) return;
+      if (bulkTargets.length === 0) return;
       // Otherwise the same keypress that triggers us also lands inside the
       // dialog's auto-focused command input as a literal "c".
       e.preventDefault();
@@ -274,22 +301,51 @@ export function TransactionsPage() {
     {
       label: "Categorize focused / selected",
       group: "Transactions",
-      enabled: categorizeTargets.length > 0,
+      enabled: bulkTargets.length > 0,
+    },
+  );
+  useShortcut(
+    ["t"],
+    (e) => {
+      if (bulkTargets.length === 0) return;
+      e.preventDefault();
+      setTagOpen(true);
+    },
+    {
+      label: "Tag focused / selected",
+      group: "Transactions",
+      enabled: bulkTargets.length > 0,
     },
   );
 
   const handleCategorizePick = useCallback(
     (pick: CategoryPick) => {
-      if (!categorizeTargets.length) return;
+      if (!bulkTargets.length) return;
       setCategorizeOpen(false);
-      const n = categorizeTargets.length;
+      const n = bulkTargets.length;
       const plural = n === 1 ? "" : "s";
       const message = pick.reset_category
         ? `Category reset on ${n} transaction${plural}.`
         : `Category applied to ${n} transaction${plural}.`;
-      applyBulkTransactionOp(updateTransactions, categorizeTargets, pick, message);
+      applyBulkTransactionOp(updateTransactions, bulkTargets, pick, message);
     },
-    [categorizeTargets, updateTransactions],
+    [bulkTargets, updateTransactions],
+  );
+
+  const handleTagPick = useCallback(
+    (slug: string) => {
+      if (!bulkTargets.length) return;
+      setTagOpen(false);
+      const n = bulkTargets.length;
+      const plural = n === 1 ? "" : "s";
+      applyBulkTransactionOp(
+        updateTransactions,
+        bulkTargets,
+        { tags_to_add: [{ slug }] },
+        `Tag applied to ${n} transaction${plural}.`,
+      );
+    },
+    [bulkTargets, updateTransactions],
   );
 
   const hasActiveFilters =
@@ -344,6 +400,9 @@ export function TransactionsPage() {
         isLoading={transactions.isLoading}
         isError={transactions.isError}
         loadingRows={6}
+        renderSkeletonRow={() => (
+          <TransactionRowSkeleton showSelect={selectMode} />
+        )}
         getRowId={(t) => t.id}
         enableRowSelection={selectMode}
         rowSelection={selectMode ? rowSelection : undefined}
@@ -368,27 +427,14 @@ export function TransactionsPage() {
         }
       />
 
-      {rows.length > 0 && (
-        <div className="text-muted-foreground mt-4 flex justify-center text-sm">
-          {transactions.hasNextPage ? (
-            <Button
-              variant="outline"
-              onClick={() => transactions.fetchNextPage()}
-              disabled={transactions.isFetchingNextPage}
-            >
-              {transactions.isFetchingNextPage && (
-                <Loader2 className="size-4 animate-spin" />
-              )}
-              {transactions.isFetchingNextPage ? "Loading…" : "Load more"}
-            </Button>
-          ) : (
-            <span>
-              {count != null
-                ? `All ${count.toLocaleString()} transactions loaded`
-                : "All transactions loaded"}
-            </span>
-          )}
-        </div>
+      {count != null && count > PAGE_LIMIT && (
+        <TransactionsPagination
+          page={page}
+          pageSize={PAGE_LIMIT}
+          total={count}
+          onPageChange={goToPage}
+          isFetching={transactions.isFetching}
+        />
       )}
 
       {selectMode && selectedIds.length > 0 && (
@@ -396,6 +442,21 @@ export function TransactionsPage() {
           selectedIds={selectedIds}
           totalCount={count}
           onClear={exitSelectMode}
+          onSelectAllMatching={async () => {
+            try {
+              const ids = await fetchAllMatchingTransactionIds(filters);
+              setRowSelection(
+                Object.fromEntries(ids.map((id) => [id, true])),
+              );
+              if (count != null && ids.length < count) {
+                toast.info(
+                  `Selected the first ${ids.length.toLocaleString()} of ${count.toLocaleString()} matches.`,
+                );
+              }
+            } catch {
+              toast.error("Couldn't select all matching transactions.");
+            }
+          }}
         />
       )}
 
@@ -404,12 +465,25 @@ export function TransactionsPage() {
         onOpenChange={setCategorizeOpen}
         title="Categorize"
         description={
-          categorizeTargets.length === 1
+          bulkTargets.length === 1
             ? "Apply a category to the focused transaction."
-            : `Apply a category to ${categorizeTargets.length} selected transactions.`
+            : `Apply a category to ${bulkTargets.length} selected transactions.`
         }
       >
         <CategoryCommandList onPick={handleCategorizePick} />
+      </CommandDialog>
+
+      <CommandDialog
+        open={tagOpen}
+        onOpenChange={setTagOpen}
+        title="Tag"
+        description={
+          bulkTargets.length === 1
+            ? "Add a tag to the focused transaction."
+            : `Add a tag to ${bulkTargets.length} selected transactions.`
+        }
+      >
+        <TagCommandList onPick={handleTagPick} />
       </CommandDialog>
     </div>
   );

--- a/web/src/sandbox/sections/primitives.tsx
+++ b/web/src/sandbox/sections/primitives.tsx
@@ -15,6 +15,15 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import {
   Tooltip,
@@ -161,6 +170,40 @@ export function PrimitivesSection() {
         <div className="flex h-5 items-center gap-2 text-sm">
           Left <Separator orientation="vertical" /> Right
         </div>
+      </Specimen>
+
+      <Specimen
+        label="Pagination"
+        description="Numbered prev/next with ellipses — wrap with a feature-level helper that derives the page window from your data."
+        className="block"
+      >
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationPrevious href="#" />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href="#">1</PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href="#" isActive>
+                2
+              </PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href="#">3</PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationEllipsis />
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationLink href="#">11</PaginationLink>
+            </PaginationItem>
+            <PaginationItem>
+              <PaginationNext href="#" />
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
       </Specimen>
 
       <Specimen


### PR DESCRIPTION
> Stacked on top of #1091 — until that lands the GitHub diff includes both rounds.

## Summary

Round 3 of v2 transactions polish, building on #1091.

- **Numbered pagination** via shadcn's `Pagination` primitive (new file). Backend gains `Offset` support on `ListTransactions` alongside the existing cursor pagination — cursor stays the default for external REST clients, the v2 SPA uses offset via `?p=`. Filter and search changes always reset to page 1.
- **Row-shaped loading skeletons** — `DataTable` gains an optional `renderSkeletonRow` prop. The transactions list passes a placeholder shaped like the real row (icon tile, title + subtitle, category chip, amount/date stack), so the table doesn't reflow when data arrives.
- **Selection action bar redesign**:
  - **Categorize as primary**, Tag as secondary, X as tertiary.
  - **Inline `<Kbd>C</Kbd>` / `<Kbd>T</Kbd>` badges** on the two action buttons; the `t` keyboard shortcut now opens a centered tag dialog matching the existing `c` pattern.
  - **"Select all N" affordance** that walks the cursor-paginated list to collect every matching id (capped at 5,000 with a truncation toast) and dumps them into the selection state.
  - **Inline applying state** — actions are replaced by `Applying to N…` + spinner while the mutation is in flight.
  - **Slide-in-from-bottom entrance**, frosted-glass backdrop blur, `pointer-events-none` on the wrapper so empty space around the pill stays click-through.

A `/simplify` pass at the end hoisted `PAGE_SIZE` onto the shared `PAGE_LIMIT` constant in the queries module, renamed a `const window` that was shadowing the global, dropped a spurious `export` on the bulk-select cap, and wrapped the "Select all matching" fetch in a try/catch that surfaces success-truncation and failure as toasts.

## Screenshots

### Pagination
<img src="https://i.img402.dev/u1gj5t2noy.png" width="800" alt="Pagination — desktop">
<img src="https://i.img402.dev/immjfdlj4g.png" width="800" alt="Pagination — bottom of table">
<img src="https://i.img402.dev/mipicq7hxc.png" width="320" alt="Pagination — mobile">

### Row-shaped skeleton
<img src="https://i.img402.dev/rve27monka.png" width="800" alt="Row-shaped loading skeleton">

### Selection action bar
<img src="https://i.img402.dev/0gl44tf1yi.png" width="800" alt="Selection action bar — desktop">
<img src="https://i.img402.dev/kaabz7uj32.png" width="320" alt="Selection action bar — mobile">

## Test plan

- [ ] Click page 3 in the pagination control → URL updates to `?p=3`, list re-fetches with `offset=100`
- [ ] Change a filter while on page 3 → URL drops `p`, list resets to page 1
- [ ] Reload at `?p=11` → 11th page renders; on mobile only the current-page number + Prev/Next show
- [ ] Slow-network reload → skeleton placeholders match the real row layout, no shift when data lands
- [ ] Enter select mode, focus a row, press `c` → category dialog opens; press `t` → tag dialog opens
- [ ] Select a couple of rows → action bar slides up; click "Select all" → selection grows to all matching, toast fires if matches > 5,000
- [ ] Trigger a bulk categorize on a large selection → bar shows "Applying to N…" with a spinner until done
- [ ] Mobile-width viewport: bar fits without overflow, only icons render on Categorize/Tag
