### PR TITLE
v2: bulk multi-select on connections list (stack 6/6)

### DIFF
--- a/web/src/components/ui/alert-dialog.tsx
+++ b/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,194 @@
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-semibold sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Action
+        data-slot="alert-dialog-action"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel> &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <Button variant={variant} size={size} asChild>
+      <AlertDialogPrimitive.Cancel
+        data-slot="alert-dialog-cancel"
+        className={cn(className)}
+        {...props}
+      />
+    </Button>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/web/src/features/connections/connection-row.tsx
+++ b/web/src/features/connections/connection-row.tsx
@@ -13,6 +13,7 @@ import {
   Unplug,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -46,6 +47,11 @@ interface ConnectionRowProps {
   // Account-level pause flag. Set to true on the connection row briefly while
   // the optimistic mutation is in flight to avoid double-clicks.
   paused?: boolean;
+  // Multi-select state, lifted to the page so the bulk action bar can read
+  // the union of selected ids. Optional — pages that don't render a bulk bar
+  // can omit and the checkbox UI stays hidden.
+  selected?: boolean;
+  onSelectChange?: (next: boolean) => void;
 }
 
 const PROVIDER_ICON: Record<string, typeof Building2> = {
@@ -58,6 +64,8 @@ export function ConnectionRow({
   connection,
   stats,
   onReauth,
+  selected,
+  onSelectChange,
 }: ConnectionRowProps) {
   const sync = useSyncConnection();
   const pause = usePauseConnection();
@@ -97,8 +105,27 @@ export function ConnectionRow({
   }
 
   return (
-    <div className="bg-card overflow-hidden rounded-lg border">
+    <div
+      className={`bg-card overflow-hidden rounded-lg border transition-colors ${
+        selected ? "border-primary/60 ring-primary/20 ring-2" : ""
+      }`}
+    >
       <div className="flex items-center gap-3 px-4 py-3 sm:gap-4 sm:px-5 sm:py-4">
+        {onSelectChange && (
+          // Wrapper stops the click from bubbling to the surrounding Link, so
+          // toggling selection never navigates to the detail page. The label
+          // is generous (full size) so it's an easy mobile tap target.
+          <label
+            className="flex shrink-0 cursor-pointer items-center justify-center p-1"
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Select ${connection.institution_name ?? "connection"}`}
+          >
+            <Checkbox
+              checked={!!selected}
+              onCheckedChange={(value) => onSelectChange(!!value)}
+            />
+          </label>
+        )}
         <Link
           to="/connections/$id"
           params={{ id: connection.short_id }}

--- a/web/src/features/connections/selection-action-bar.tsx
+++ b/web/src/features/connections/selection-action-bar.tsx
@@ -1,0 +1,243 @@
+import { useState } from "react";
+import { Pause, Play, RefreshCw, Unplug, X } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { KbdTooltip } from "@/components/kbd-tooltip";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  useDisconnectConnection,
+  usePauseConnection,
+  useSyncConnection,
+} from "@/api/queries/connections";
+import type { Connection } from "@/api/types";
+
+// Cap concurrent per-connection mutations. The backend handlers are fine with
+// fan-out, but the household connections universe is small and a thundering
+// herd of 50 concurrent DELETEs is impolite. Sequential per chunk smooths it.
+const BATCH_LIMIT = 25;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+interface SelectionActionBarProps {
+  selected: Connection[];
+  onClear: () => void;
+}
+
+// SelectionActionBar is the floating bar shown when ≥1 connection row is
+// checked. Mirrors the transactions page layout (sticky-bottom pill, count +
+// actions + clear). Each button fans the selection out into the existing
+// per-id mutations — there's no batch endpoint for connections, but the
+// universe is small enough that chunked sequential calls are fine.
+export function SelectionActionBar({
+  selected,
+  onClear,
+}: SelectionActionBarProps) {
+  const sync = useSyncConnection();
+  const pause = usePauseConnection();
+  const disconnect = useDisconnectConnection();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const isPending = sync.isPending || pause.isPending || disconnect.isPending;
+
+  const syncable = selected.filter(
+    (c) => c.provider !== "csv" && c.status === "active",
+  );
+  const pausable = selected.filter((c) => c.status === "active");
+  // Resume = un-pause anything that isn't disconnected (covers paused-active
+  // rows the list can't see, plus pending_reauth/error rows that may have been
+  // paused alongside their re-auth state).
+  const resumable = selected.filter(
+    (c) => c.status !== "disconnected" && c.status !== "active",
+  );
+
+  async function runChunked<T>(
+    items: T[],
+    fn: (item: T) => Promise<unknown>,
+  ): Promise<void> {
+    for (const batch of chunk(items, BATCH_LIMIT)) {
+      // Promise.all within a chunk = bounded concurrency; await between chunks
+      // smooths out the request rate.
+      await Promise.all(batch.map(fn));
+    }
+  }
+
+  async function onSync() {
+    if (syncable.length === 0) return;
+    const ok = await withMutationToast(
+      () => runChunked(syncable, (c) => sync.mutateAsync(c.id)),
+      { success: `Sync queued for ${syncable.length} connection${syncable.length === 1 ? "" : "s"}.` },
+    );
+    if (ok) onClear();
+  }
+
+  async function onPause() {
+    if (pausable.length === 0) return;
+    const ok = await withMutationToast(
+      () =>
+        runChunked(pausable, (c) =>
+          pause.mutateAsync({ id: c.id, paused: true }),
+        ),
+      { success: `Paused ${pausable.length} connection${pausable.length === 1 ? "" : "s"}.` },
+    );
+    if (ok) onClear();
+  }
+
+  async function onResume() {
+    if (resumable.length === 0) return;
+    const ok = await withMutationToast(
+      () =>
+        runChunked(resumable, (c) =>
+          pause.mutateAsync({ id: c.id, paused: false }),
+        ),
+      { success: `Resumed ${resumable.length} connection${resumable.length === 1 ? "" : "s"}.` },
+    );
+    if (ok) onClear();
+  }
+
+  async function onDisconnect() {
+    const ok = await withMutationToast(
+      () => runChunked(selected, (c) => disconnect.mutateAsync(c.id)),
+      { success: `Disconnected ${selected.length} connection${selected.length === 1 ? "" : "s"}.` },
+    );
+    setConfirmOpen(false);
+    if (ok) onClear();
+  }
+
+  return (
+    <>
+      <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2">
+        <div className="bg-popover text-popover-foreground flex max-w-[calc(100vw-2rem)] items-center gap-1 overflow-hidden rounded-full border p-1 pl-3 shadow-lg">
+          <span className="text-sm font-medium whitespace-nowrap">
+            {selected.length} selected
+          </span>
+          <Separator orientation="vertical" className="mx-1 h-5" />
+
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1.5 rounded-full"
+            onClick={onSync}
+            disabled={isPending || syncable.length === 0}
+            title={
+              syncable.length === 0
+                ? "No active bank connections selected"
+                : `Sync ${syncable.length} active connection${syncable.length === 1 ? "" : "s"}`
+            }
+          >
+            <RefreshCw className="size-4" />
+            <span className="hidden sm:inline">Sync</span>
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1.5 rounded-full"
+            onClick={onPause}
+            disabled={isPending || pausable.length === 0}
+            title={
+              pausable.length === 0
+                ? "No active connections to pause"
+                : `Pause ${pausable.length} active connection${pausable.length === 1 ? "" : "s"}`
+            }
+          >
+            <Pause className="size-4" />
+            <span className="hidden sm:inline">Pause</span>
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1.5 rounded-full"
+            onClick={onResume}
+            disabled={isPending || resumable.length === 0}
+            title={
+              resumable.length === 0
+                ? "No paused or errored connections to resume"
+                : `Resume ${resumable.length} connection${resumable.length === 1 ? "" : "s"}`
+            }
+          >
+            <Play className="size-4" />
+            <span className="hidden sm:inline">Resume</span>
+          </Button>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:bg-destructive/10 hover:text-destructive h-8 gap-1.5 rounded-full"
+            onClick={() => setConfirmOpen(true)}
+            disabled={isPending || selected.length === 0}
+            title={`Disconnect ${selected.length} connection${selected.length === 1 ? "" : "s"}`}
+          >
+            <Unplug className="size-4" />
+            <span className="hidden sm:inline">Disconnect…</span>
+          </Button>
+
+          <Separator orientation="vertical" className="mx-1 h-5" />
+          <KbdTooltip label="Clear selection" keys={["Esc"]} side="top">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-8 rounded-full"
+              onClick={onClear}
+              aria-label="Clear selection"
+            >
+              <X className="size-4" />
+            </Button>
+          </KbdTooltip>
+        </div>
+      </div>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Disconnect {selected.length} connection
+              {selected.length === 1 ? "" : "s"}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Disconnecting wipes saved credentials and soft-deletes the
+              connection's transactions. Accounts stay in the household for
+              historical reference, but no new transactions will sync. This
+              can't be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={disconnect.isPending}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={(e) => {
+                // Keep the dialog open until the mutation resolves so the user
+                // sees the spinner instead of an instant close on a slow link.
+                e.preventDefault();
+                void onDisconnect();
+              }}
+              disabled={disconnect.isPending}
+            >
+              {disconnect.isPending
+                ? "Disconnecting…"
+                : `Disconnect ${selected.length}`}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -1,12 +1,14 @@
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import { Loader2, Plug, Plus, RefreshCw } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { withMutationToast } from "@/lib/mutation-toast";
+import { useShortcut } from "@/lib/shortcuts";
 import { useConnections, useSyncAll } from "@/api/queries/connections";
 import { useAccounts } from "@/api/queries/accounts";
 import { useUsers } from "@/api/queries/users";
@@ -15,6 +17,7 @@ import { ConnectionsSummary } from "@/features/connections/connections-summary";
 import { FamilyTabs } from "@/features/connections/family-tabs";
 import { ConnectBankSheet } from "@/features/connections/connect-bank-sheet";
 import { ReauthSheet } from "@/features/connections/reauth-sheet";
+import { SelectionActionBar } from "@/features/connections/selection-action-bar";
 import {
   indexAccountsByConnection,
   needsAttention,
@@ -90,7 +93,59 @@ export function ConnectionsPage() {
     [connectionsQuery.data],
   );
 
+  // Multi-select state — Set of UUIDs (Connection.id, not short_id). Lifted
+  // here so the action bar reads the union and the rows pass selection back
+  // up. Ephemeral by design: not stored in URL search, cleared after a
+  // successful bulk mutation or on family-tab switch.
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  // Selected connections that are still visible after filtering — used by the
+  // action bar. Filtering also drops any stale ids that may have been removed
+  // from the underlying data (e.g. after a bulk disconnect refetch).
+  const selectedConnections = useMemo(
+    () => visible.filter((c) => selectedIds.has(c.id)),
+    [visible, selectedIds],
+  );
+
+  const allVisibleSelected =
+    visible.length > 0 && selectedConnections.length === visible.length;
+  const someVisibleSelected =
+    selectedConnections.length > 0 && !allVisibleSelected;
+
+  const toggleRowSelection = useCallback((id: string, next: boolean) => {
+    setSelectedIds((prev) => {
+      const out = new Set(prev);
+      if (next) out.add(id);
+      else out.delete(id);
+      return out;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      if (prev.size > 0) return new Set();
+      return new Set(visible.map((c) => c.id));
+    });
+  }, [visible]);
+
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
+
+  // Esc clears selection. Mirrors the transactions page convention so the
+  // same muscle memory works here. Always-registered (cheap) — the handler
+  // gates on having something to clear, which avoids the registry churn from
+  // toggling `enabled` on every selection change.
+  useShortcut(
+    ["escape"],
+    () => {
+      if (selectedIds.size > 0) clearSelection();
+    },
+    { label: "Clear selection", group: "Connections" },
+  );
+
   function setUserFilter(next: string) {
+    // Selection is per-visible-set; switching tabs would otherwise carry
+    // hidden rows along silently.
+    setSelectedIds(new Set());
     navigate({
       to: "/connections",
       search: (prev: ConnectionsSearch) => ({
@@ -235,6 +290,30 @@ export function ConnectionsPage() {
         />
       ) : (
         <div className="flex flex-col gap-3">
+          <div className="text-muted-foreground flex items-center gap-3 px-1 text-xs">
+            <Checkbox
+              checked={
+                allVisibleSelected
+                  ? true
+                  : someVisibleSelected
+                    ? "indeterminate"
+                    : false
+              }
+              onCheckedChange={() => toggleSelectAll()}
+              aria-label={
+                selectedIds.size > 0 ? "Clear selection" : "Select all visible"
+              }
+            />
+            <button
+              type="button"
+              onClick={toggleSelectAll}
+              className="hover:text-foreground transition-colors"
+            >
+              {selectedIds.size > 0
+                ? `${selectedConnections.length} selected`
+                : `Select all (${visible.length})`}
+            </button>
+          </div>
           {visible.map((c) => (
             <ConnectionRow
               key={c.id}
@@ -243,9 +322,18 @@ export function ConnectionsPage() {
               // short_id (the consistent compact-ID convention), not its UUID.
               stats={accountStats.get(c.short_id)}
               onReauth={openReauthSheet}
+              selected={selectedIds.has(c.id)}
+              onSelectChange={(next) => toggleRowSelection(c.id, next)}
             />
           ))}
         </div>
+      )}
+
+      {selectedConnections.length > 0 && (
+        <SelectionActionBar
+          selected={selectedConnections}
+          onClear={clearSelection}
+        />
       )}
 
       <ConnectBankSheet


### PR DESCRIPTION
Final PR (6/6) in the `stack/v2-connections` series. Adds row checkboxes + a sticky selection action bar to `/v2/connections` so households with many institutions can sync, pause, resume, or disconnect connections in a single gesture.

## What's in this PR

- **`features/connections/selection-action-bar.tsx`** — new sticky-bottom pill mirroring the transactions page bar (same `bg-popover` rounded shell, `KbdTooltip` Esc affordance, separator slots). Buttons: **Sync**, **Pause**, **Resume**, **Disconnect…** (destructive), and **Clear** (the X). Each button is gated independently on the slice of the selection it can act on:
  - **Sync** → connections with `provider !== "csv" && status === "active"` (CSV / non-active rows are silently skipped).
  - **Pause** → only `status === "active"` rows.
  - **Resume** → anything that isn't already `active` or `disconnected` (covers paused-active rows and `pending_reauth`/`error` rows that may have been paused alongside).
  - **Disconnect** → applies to every selected row, including CSV. The existing `DELETE /api/v1/connections/{id}` already soft-deletes the connection's transactions for every provider — bulk just fans the same call out.
- **`features/connections/connection-row.tsx`** — accepts new optional `selected` + `onSelectChange` props. When `onSelectChange` is provided, a leading `<Checkbox>` is rendered inside a label with `e.stopPropagation()` on click, so checking the box never navigates to the detail page. Selected rows get a subtle `border-primary/60 ring-primary/20 ring-2` highlight. Per-row sync button + ⋯ menu stay live in select mode (matching the transactions page UX).
- **`routes/connections.tsx`** —
  - Selection state is a `useState<Set<string>>` of UUIDs (Connection.id, not short_id), lifted here so the action bar reads the union and rows fire callbacks back up. Ephemeral by design: not stored in URL search.
  - Header strip above the list shows a tri-state select-all checkbox (`checked` / `indeterminate` / `unchecked`) with a clickable `Select all (N)` / `N selected` label. Selects every visible row after the family-tab filter, not the entire dataset.
  - Switching family tabs clears selection (otherwise hidden rows would be carried along silently).
  - Esc clears selection via `useShortcut("escape", …, { group: "Connections" })`.
- **`components/ui/alert-dialog.tsx`** — installed via `bunx shadcn@latest add alert-dialog`. Used for the Disconnect confirmation. The action button calls `e.preventDefault()` to keep the dialog open until the mutation resolves, so the user sees `Disconnecting…` instead of an instant close on a slow link.

## Chunking

Each bulk action fans the existing per-id mutations (`useSyncConnection`, `usePauseConnection`, `useDisconnectConnection`) out via a small `runChunked()` helper that caps concurrency at **25 per chunk** and awaits sequentially between chunks. Connections universes are small (typical household: ~5 rows; future power user: ~50), so this is purely belt-and-suspenders to avoid a thundering herd of 50 concurrent DELETEs against the backend if a power user selects everything. No new endpoints — the action bar is pure client-side composition over the per-id REST routes.

## CSV behavior in bulk-disconnect

CSV connections are intentionally included in bulk-disconnect — the dialog warning ("wipes saved credentials and soft-deletes the connection's transactions") applies. Sanity-checked against `internal/api/connections_disconnect.go` + the existing inline disconnect banner copy on the row (PR-01): the per-id `DELETE` handler already does the right thing for every provider (CSV has no token to wipe but its transactions get the same `deleted_at` treatment), so no provider-specific carve-out is needed in the action bar.

## What's deliberately NOT here

- **No backend changes.** All four actions reuse existing per-id mutation hooks.
- **No bulk-reauth Sheet.** Bulk reauth would need a separate sequential walker over the broken connections — out of scope here.
- **No URL-state persistence for selection.** Selections are ephemeral by design.

## Screenshots

<table>
  <tr><th>One row selected (action bar appears)</th><th>Two rows selected</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/34daagcs85.png" width="480" alt="Bulk select — one row"></td>
    <td><img src="https://i.img402.dev/2he8ptascg.png" width="480" alt="Bulk select — two rows"></td>
  </tr>
  <tr><th>Disconnect confirm dialog</th><th>Mobile (two selected)</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/tiuqapd8v5.png" width="480" alt="Bulk disconnect confirm dialog"></td>
    <td><img src="https://i.img402.dev/h7peew6tqw.png" width="240" alt="Bulk select — mobile"></td>
  </tr>
</table>

## Test plan

- [x] `bun run lint` (tsc --noEmit) — clean
- [x] `bun run build` (tsc -b + vite build) — clean
- [x] `templ generate && go build ./... && go vet ./... && go test ./...` — clean
- [x] Smoke: select rows, action bar appears with correct count
- [x] Smoke: select-all toggle works (tri-state behavior)
- [x] Smoke: Disconnect dialog opens, Cancel dismisses without firing the mutation
- [ ] Reviewer: live test bulk pause/resume/sync with two real Plaid + Teller connections; verify CSV bulk-disconnect soft-deletes transactions

## Stack summary (6/6)

This closes the `stack/v2-connections` series — a v2 SPA reimagining of the Connections experience.

1. **#1089** — page scaffold: list, family tabs, summary, status badges, placeholder Sheets, route + URL contract
2. **#1090** — `/v2/connections/$id` detail page (accounts list, sync controls, pause toggle, disconnect)
3. **#1093** — Connect-bank Sheet (Plaid / Teller / CSV) with provider routing
4. **#1094** — CSV import wizard (preview + column mapping + commit)
5. **#1095** — re-auth Sheet (Plaid update mode + Teller reconnection)
6. **THIS PR** — bulk multi-select on the list

The stack is feature-complete; reviewer can land bottom-to-top in order.
