### PR TITLE
v2: simplify-pass over connections stack (stack 7/7)

### DIFF
--- a/web/src/api/queries/sync-logs.ts
+++ b/web/src/api/queries/sync-logs.ts
@@ -36,12 +36,19 @@ export interface UseSyncLogsParams {
   // Connection UUID (short_id is not accepted by /api/v1/sync/logs).
   connectionId?: string;
   limit?: number;
+  // Defaults true — pass false to defer the fetch until the parent has the
+  // info it needs (e.g. resolving a short_id → UUID first).
+  enabled?: boolean;
 }
 
 // useSyncLogs fetches the most-recent sync history. Pass a connection UUID
 // (not the short_id) — the backend filter only resolves UUIDs. Omitting
 // `connectionId` returns the global feed.
-export function useSyncLogs({ connectionId, limit = 30 }: UseSyncLogsParams) {
+export function useSyncLogs({
+  connectionId,
+  limit = 30,
+  enabled = true,
+}: UseSyncLogsParams) {
   return useQuery({
     queryKey: ["sync-logs", connectionId ?? null, limit],
     queryFn: () => {
@@ -50,7 +57,7 @@ export function useSyncLogs({ connectionId, limit = 30 }: UseSyncLogsParams) {
       qs.set("limit", String(limit));
       return api<SyncLogsPage>(`/api/v1/sync/logs?${qs.toString()}`);
     },
-    enabled: connectionId == null || !!connectionId,
+    enabled,
     staleTime: 30_000,
   });
 }

--- a/web/src/features/connections/connect-bank-sheet.tsx
+++ b/web/src/features/connections/connect-bank-sheet.tsx
@@ -64,7 +64,7 @@ type Stage =
 //      TellerConnectButton) which auto-opens its hosted UI. On success the
 //      launcher hands back the public_token / enrollment payload, we POST
 //      to the generic /api/v1/connections endpoint, toast success, and
-//      navigate to the new connection's detail page (PR-02).
+//      navigate to the new connection's detail page.
 export function ConnectBankSheet({
   open,
   onOpenChange,
@@ -224,8 +224,8 @@ export function ConnectBankSheet({
       toast.success(`Connected ${result.institution_name}.`);
       handleSheetChange(false);
       navigate({
-        to: "/connections/$short_id",
-        params: { short_id: result.connection_id },
+        to: "/connections/$id",
+        params: { id: result.connection_id },
       });
     } catch (err) {
       const msg =
@@ -271,8 +271,8 @@ export function ConnectBankSheet({
               <Alert variant="default">
                 <AlertTitle>No bank providers configured</AlertTitle>
                 <AlertDescription>
-                  Set up Plaid or Teller credentials on this server, or use a
-                  CSV import (coming soon).
+                  Set up Plaid or Teller credentials on this server, or import
+                  a CSV statement.
                 </AlertDescription>
               </Alert>
             ) : (
@@ -348,8 +348,8 @@ export function ConnectBankSheet({
               handleSheetChange(false);
               if (!result.appended) {
                 navigate({
-                  to: "/connections/$short_id",
-                  params: { short_id: result.connection_id },
+                  to: "/connections/$id",
+                  params: { id: result.connection_id },
                 });
               }
             }}

--- a/web/src/features/connections/connection-row.tsx
+++ b/web/src/features/connections/connection-row.tsx
@@ -7,7 +7,6 @@ import {
   Loader2,
   MoreHorizontal,
   Pause,
-  Play,
   Plug,
   RefreshCw,
   Unplug,
@@ -40,13 +39,9 @@ import {
 interface ConnectionRowProps {
   connection: Connection;
   stats: ConnectionAccountStats | undefined;
-  // Optional callbacks the list passes in to open the (placeholder, in PR-01)
-  // re-auth flow. Lifted here so the same trigger can fire from the row banner
-  // and the ⋯ menu.
+  // Lifted to the page so the same trigger fires from the inline banner and
+  // the row's ⋯ menu.
   onReauth: (connection: Connection) => void;
-  // Account-level pause flag. Set to true on the connection row briefly while
-  // the optimistic mutation is in flight to avoid double-clicks.
-  paused?: boolean;
   // Multi-select state, lifted to the page so the bulk action bar can read
   // the union of selected ids. Optional — pages that don't render a bulk bar
   // can omit and the checkbox UI stays hidden.
@@ -87,9 +82,9 @@ export function ConnectionRow({
   }
 
   async function onTogglePause() {
-    // Server is the source of truth — we just toggle the inverse of whatever
-    // the most recent mutation thinks. The actual paused state lives in the
-    // detail response; the list can't tell, so this is best-effort UX.
+    // The list endpoint doesn't return the paused flag, so this row can only
+    // pause (not toggle). Resume lives on the detail page where paused is
+    // visible, and on the bulk action bar.
     await withMutationToast(
       () => pause.mutateAsync({ id: connection.id, paused: true }),
       { success: "Connection paused." },
@@ -218,16 +213,6 @@ export function ConnectionRow({
                   disabled={pause.isPending}
                 >
                   <Pause className="size-4" /> Pause syncing
-                </DropdownMenuItem>
-              )}
-              {connection.status !== "active" && connection.status !== "disconnected" && (
-                <DropdownMenuItem
-                  onClick={() =>
-                    pause.mutate({ id: connection.id, paused: false })
-                  }
-                  disabled={pause.isPending}
-                >
-                  <Play className="size-4" /> Resume syncing
                 </DropdownMenuItem>
               )}
               <DropdownMenuSeparator />

--- a/web/src/features/connections/plaid-link-button.tsx
+++ b/web/src/features/connections/plaid-link-button.tsx
@@ -29,8 +29,8 @@ export interface PlaidLinkButtonProps {
 // PlaidLinkButton encapsulates Plaid's official `usePlaidLink` hook. It
 // renders nothing visible — Plaid Link itself is a popup the SDK manages —
 // but exposes its `open()` via auto-launch so the parent Sheet can drive the
-// flow declaratively. Reused for new connections (PR-03) and re-auth in
-// update mode (PR-05) by passing different link tokens.
+// flow declaratively. Reused for new connections and re-auth in update mode
+// by passing different link tokens.
 export function PlaidLinkButton({
   linkToken,
   onSuccess,

--- a/web/src/features/connections/reauth-sheet.tsx
+++ b/web/src/features/connections/reauth-sheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Loader2, ShieldAlert } from "lucide-react";
 import {
   Sheet,
@@ -63,15 +63,24 @@ export function ReauthSheet({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // Reset internal state every time the Sheet closes so a re-open lands on
-  // the confirmation step rather than mid-flow leftovers.
+  // the confirmation step rather than mid-flow leftovers. The mutation
+  // objects from useMutation are rebuilt every render, so adding them to the
+  // dep array would re-fire the effect (and call reset()) on every render —
+  // the source of the "Maximum update depth" warning when the Sheet sits
+  // mounted-but-closed on the connections page. Their `reset` methods are
+  // referentially stable per TanStack Query design, so a [open]-only dep is
+  // safe; we read them through refs to keep the dep array honest.
+  const reauthStartRef = useRef(reauthStart);
+  reauthStartRef.current = reauthStart;
+  const reauthCompleteRef = useRef(reauthComplete);
+  reauthCompleteRef.current = reauthComplete;
   useEffect(() => {
-    if (!open) {
-      setStage({ kind: "confirm" });
-      setErrorMessage(null);
-      reauthStart.reset();
-      reauthComplete.reset();
-    }
-  }, [open, reauthStart, reauthComplete]);
+    if (open) return;
+    setStage({ kind: "confirm" });
+    setErrorMessage(null);
+    reauthStartRef.current.reset();
+    reauthCompleteRef.current.reset();
+  }, [open]);
 
   const conn = connQuery.data;
   const institutionName = conn?.institution_name ?? "Untitled connection";

--- a/web/src/features/connections/teller-connect-button.tsx
+++ b/web/src/features/connections/teller-connect-button.tsx
@@ -26,8 +26,7 @@ export interface TellerConnectButtonProps {
    *  it works without provisioning real Teller credentials. */
   environment?: string;
   /** Pass the existing connection's enrollment ID to switch Teller Connect
-   *  into reconnection mode (re-auth). Used by the Re-auth Sheet (PR-05);
-   *  omit it for new-connection flows. */
+   *  into reconnection mode (re-auth). Omit for new-connection flows. */
   enrollmentId?: string;
   onSuccess: (result: TellerEnrollmentResult) => void;
   onExit?: () => void;

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -6,6 +6,7 @@ import {
   useSearch,
 } from "@tanstack/react-router";
 import {
+  AlertTriangle,
   ArrowLeft,
   Building2,
   ExternalLink,
@@ -18,7 +19,7 @@ import {
   Plug,
   RefreshCw,
   Unplug,
-  AlertTriangle,
+  Upload,
 } from "lucide-react";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
@@ -59,12 +60,10 @@ import { ConnectionAccountsList } from "@/features/connections/connection-accoun
 import { SyncActivityBars } from "@/features/connections/sync-activity-bars";
 import { SyncHistoryList } from "@/features/connections/sync-history-list";
 import { providerLabel, relativeTime } from "@/features/connections/connection-utils";
-import { Upload } from "lucide-react";
 
 // Search-param schema for the detail page. Mirrors the list schema's `reauth`
-// so the same coming-soon Sheet can open from either surface. `import_csv`
-// opens the CSV upload Sheet inline, pre-targeted to append rows to this
-// connection.
+// so the same Re-auth Sheet can open from either surface. `import_csv` opens
+// the CSV upload Sheet inline, pre-targeted to append rows to this connection.
 export const connectionDetailSearchSchema = z.object({
   reauth: z.string().optional(),
   import_csv: z.string().optional(),
@@ -98,10 +97,11 @@ export function ConnectionDetailPage() {
 
   const connQuery = useConnection(id);
   const accountsQuery = useAccounts();
-  // The /sync/logs endpoint accepts UUIDs only — we pass the connection's
-  // UUID once it's loaded.
+  // The /sync/logs endpoint accepts UUIDs only — wait for the connection so
+  // we don't fire a global-feed fetch we'll immediately discard.
   const syncLogsQuery = useSyncLogs({
     connectionId: connQuery.data?.id,
+    enabled: !!connQuery.data?.id,
     limit: 30,
   });
 

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -28,8 +28,6 @@ import type { Connection } from "@/api/types";
 //   user   → "all" or a user short_id  (family-member filter)
 //   action → "connect"                 (opens the Connect-bank sheet)
 //   reauth → connection short_id        (opens the Re-auth sheet for that row)
-// PR-03 / PR-05 wire `action` and `reauth` into real flows. PR-01 only owns
-// the URL contract + the placeholder sheet.
 export const connectionsSearchSchema = z.object({
   user: z.string().optional(),
   action: z.literal("connect").optional(),


### PR DESCRIPTION
Cleanup pass over PRs [#1089](https://github.com/canalesb93/breadbox/pull/1089), [#1090](https://github.com/canalesb93/breadbox/pull/1090), [#1093](https://github.com/canalesb93/breadbox/pull/1093), [#1094](https://github.com/canalesb93/breadbox/pull/1094), [#1095](https://github.com/canalesb93/breadbox/pull/1095), and [#1097](https://github.com/canalesb93/breadbox/pull/1097). Two real bug fixes plus dead-code/comment trimming. No new features.

## What changed

- **Fix infinite-loop on `/v2/connections`.** `ReauthSheet` had a `useEffect` whose dep array included the `useReauthStart()` and `useReauthComplete()` mutation result objects. TanStack Query rebuilds those wrapper objects on every render (the methods inside are stable), so the effect re-fired every render and called `mutation.reset()` — which itself triggers a query-store re-render. Result: the React "Maximum update depth exceeded" warning the PR-06 agent flagged. Fix is to depend only on `[open]` and read the mutations through refs.
- **Fix bad route param in the post-create navigate.** `ConnectBankSheet` and the CSV success handler navigated to `to: "/connections/$short_id"` with `params.short_id`, but the registered route is `path: "/connections/$id"`. The mismatch silently failed. Now uses `to: "/connections/$id"` with `params.id`.
- **Defer the per-connection `useSyncLogs` fetch** until the connection is loaded. Previously fired a global-feed request on first render, then immediately discarded it.
- **Drop the misleading "Resume syncing" item from the connection-row menu.** The list endpoint doesn't return `paused`, so the row can't tell paused-active rows from active rows. The dropped item was wired to fire only on `error` / `pending_reauth` rows, which actually need re-auth, not a paused-flag flip. Resume lives on the detail page (where `paused` is visible) and on the bulk action bar.
- **Drop the unused `paused?: boolean` prop on `ConnectionRowProps`.** Added in PR-01 for an optimistic-pause UI that never landed.
- **Sweep PR-NN comment references** out of the touched files (`PR-01` / `PR-02` / `PR-03` / `PR-05` mentions in `connections.tsx`, `connect-bank-sheet.tsx`, `plaid-link-button.tsx`, `teller-connect-button.tsx`, `connection-detail.tsx`).
- **Drop the "(coming soon)" qualifier** on the no-providers Alert copy — CSV is in-binary and always available.
- **Tidy import grouping** in `connection-detail.tsx` (an `Upload` icon was imported on its own trailing line; folded into the main lucide import block).

## What I considered and rejected

- **Generic `<ResourceList>` extraction across `connections.tsx` and (eventual) `accounts.tsx`.** Right shape, but `accounts.tsx` is still a placeholder — extracting now would be inventing the abstraction off one call site. Revisit when `/accounts` lands.
- **Collapsing `countsByUser` + `countsByUserShortId` into a single pass over users.** It's already O(N + M) and reads more clearly as two narrow steps than as one fused loop.
- **Removing the dead `enabledProviders.length === 0` branch in `ConnectBankSheet`** (CSV is always pushed onto the array, so the branch can't fire). Visually inert; removing changes the surface area of an already-validated component for zero behavioural gain. Left as defensive.
- **Replacing the row's `Pause` action with a real toggle.** Would require either fetching the per-connection detail per row or adding `paused` to the public `Connection` shape. Both are out of scope for a simplify pass.

## "Maximum update depth" warning

Reproduced on a fresh load of `/v2/connections` before the fix. After the `ReauthSheet` effect change the warning is gone (verified by re-loading the page with the dev console captured — only event was an unrelated 404 on the login route).

## Validation

- `bun run lint` ✓
- `bun run build` ✓
- `templ generate && go build ./... && go vet ./... && go test ./...` ✓
- Smoke `/v2/connections` and `/v2/connections/$id` in the dev browser, console captured, no React update-depth warning observed.

Screenshot of `/v2/connections` after the cleanup: ![connections list](https://i.img402.dev/vu933cslto.png)

Screenshot of the detail page: ![connection detail](https://i.img402.dev/h0nwd3xgla.png)

## Stack is now 7/7 complete

Stack: 1089 → 1090 → 1093 → 1094 → 1095 → 1097 → this. Ready for review end-to-end.
