### PR TITLE
v2: trim sidebar — drop Reviews/Insights/Account links, regroup as Money/Library/System

### DIFF
--- a/web/src/lib/nav.ts
+++ b/web/src/lib/nav.ts
@@ -3,10 +3,8 @@ import {
   BadgeDollarSign,
   Banknote,
   Bot,
-  ClipboardCheck,
   FileText,
   Key,
-  Link2,
   Plug,
   Settings,
   Shapes,
@@ -57,30 +55,23 @@ export const NAV: NavGroup[] = [
     items: [
       { kind: "link", title: "Home", to: "/", icon: BadgeDollarSign },
       { kind: "link", title: "Transactions", to: "/transactions", icon: ArrowLeftRight },
-      { kind: "link", title: "Reviews", to: "/reviews", icon: ClipboardCheck },
       { kind: "link", title: "Reports", to: "/reports", icon: FileText },
     ],
   },
   {
-    label: "Setup",
+    label: "Library",
     items: [
       { kind: "link", title: "Accounts", to: "/accounts", icon: Banknote },
       { kind: "link", title: "Connections", to: "/connections", icon: Plug },
-      { kind: "link", title: "Account links", to: "/account-links", icon: Link2 },
-    ],
-  },
-  {
-    label: "Automation",
-    items: [
-      { kind: "link", title: "Rules", to: "/rules", icon: Wand2 },
-      { kind: "link", title: "Agents", to: "/agents", icon: Bot },
-    ],
-  },
-  {
-    label: "Admin",
-    items: [
       { kind: "link", title: "Categories", to: "/categories", icon: Shapes },
       { kind: "link", title: "Tags", to: "/tags", icon: Tags },
+      { kind: "link", title: "Rules", to: "/rules", icon: Wand2 },
+    ],
+  },
+  {
+    label: "System",
+    items: [
+      { kind: "link", title: "Agents", to: "/agents", icon: Bot },
       { kind: "link", title: "API keys", to: "/api-keys", icon: Key },
       { kind: "modal", title: "Settings", modalKey: "settings", icon: Settings },
     ],


### PR DESCRIPTION
## Summary

- Drop **Reviews**, **Insights**, and **Account links** from the v2 sidebar — Reviews and Insights aren't P0 for the preview, and Account links has no v2 page.
- Regroup the remainder into three buckets:
  - **Money** — Home · Transactions · Reports
  - **Library** — Accounts · Connections · Categories · Tags · Rules
  - **System** — Agents · API keys · Settings

Rationale: the previous `Setup` and `Automation` groups had two items each once Account links and Reviews were gone. The new shape puts the nouns transactions resolve against (accounts, connections, categories, tags) and the rules that assign them in one place, and isolates the rarely-touched system config.

## Test plan

- [ ] `bun run lint` passes
- [ ] Sidebar renders with the three new groups at `/v2/`
- [ ] Command palette still resolves nav targets