### PR TITLE
ci: shard integration tests + drop SPA build from test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,27 @@ permissions:
 
 jobs:
   test:
-    name: Test
+    # Integration tests are sharded across parallel jobs so the two
+    # heavy packages (api, service) don't run end-to-end on one
+    # runner. api+service alone are ~76% of integration time.
+    name: Test (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - name: api
+            packages: ./internal/api/...
+            run_unit: false
+          - name: service
+            packages: ./internal/service/...
+            run_unit: false
+          - name: rest
+            # Everything except api + service. Also carries go vet and
+            # the untagged unit-test suite for the whole repo, since
+            # those don't shard cleanly and are cheap (~20s combined).
+            packages: $(go list ./... | grep -v -E '^breadbox/internal/(api|service)(/|$)' | tr '\n' ' ')
+            run_unit: true
     services:
       postgres:
         image: postgres:16-alpine
@@ -41,9 +60,32 @@ jobs:
         with:
           go-version: "1.25"
 
-      - name: Install sqlc and generate
+      - name: Cache generator binaries (sqlc, templ, goose)
+        id: gen-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            /usr/local/bin/sqlc
+            ~/go/bin/templ
+            ~/go/bin/goose
+          # Version-keyed so a bump (sqlc release, templ tag, goose
+          # release) invalidates cleanly.
+          key: ${{ runner.os }}-gentools-sqlc1.30.0-templ-latest-goose-latest-v1
+
+      - name: Install sqlc
+        if: steps.gen-cache.outputs.cache-hit != 'true'
+        run: curl -sL https://github.com/sqlc-dev/sqlc/releases/download/v1.30.0/sqlc_1.30.0_linux_amd64.tar.gz | tar xz -C /usr/local/bin sqlc
+
+      - name: Install templ
+        if: steps.gen-cache.outputs.cache-hit != 'true'
+        run: go install github.com/a-h/templ/cmd/templ@latest
+
+      - name: Install goose
+        if: steps.gen-cache.outputs.cache-hit != 'true'
+        run: go install github.com/pressly/goose/v3/cmd/goose@latest
+
+      - name: Generate sqlc
         run: |
-          curl -sL https://github.com/sqlc-dev/sqlc/releases/download/v1.30.0/sqlc_1.30.0_linux_amd64.tar.gz | tar xz -C /usr/local/bin sqlc
           sqlc generate
           # Prepend //go:build !lite to every generated file so they're
           # excluded from -tags=lite builds. Mirrors `make sqlc-tag`.
@@ -53,9 +95,8 @@ jobs:
             fi
           done
 
-      - name: Install templ and generate
+      - name: Generate templ
         run: |
-          go install github.com/a-h/templ/cmd/templ@latest
           templ generate
           # Prepend //go:build !headless && !lite to every generated templ
           # file in internal/templates/components. Mirrors `make templ`.
@@ -75,18 +116,13 @@ jobs:
       - name: Build CSS
         run: make css
 
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Build v2 SPA
-        run: |
-          cd web
-          bun install --frozen-lockfile
-          bun run build
+      # The v2 SPA bundle is intentionally NOT built here: //go:embed
+      # all:dist is satisfied by the committed web/dist/.gitkeep, and
+      # no test exercises the bundle's content. Bundle build lives in
+      # the release/docker-build jobs that actually ship the binary.
 
       - name: Check for duplicate migration versions
+        if: matrix.shard.run_unit
         run: |
           dupes=$(ls internal/db/migrations/*.sql | sed 's/.*\///' | sed 's/_.*//' | sort | uniq -d)
           if [ -n "$dupes" ]; then
@@ -95,22 +131,22 @@ jobs:
           fi
 
       - name: Run go vet
+        if: matrix.shard.run_unit
         run: go vet ./...
 
       - name: Run migrations
         env:
           DATABASE_URL: postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable
-        run: |
-          go install github.com/pressly/goose/v3/cmd/goose@latest
-          goose -dir internal/db/migrations postgres "$DATABASE_URL" up
+        run: goose -dir internal/db/migrations postgres "$DATABASE_URL" up
 
       - name: Run unit tests
+        if: matrix.shard.run_unit
         run: go test ./...
 
       - name: Run integration tests
         env:
           DATABASE_URL: postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable
-        run: go test -tags integration -count=1 -p 1 ./...
+        run: go test -tags integration -count=1 -p 1 ${{ matrix.shard.packages }}
 
   test-headless:
     name: Test (headless)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ permissions:
   packages: write
 
 jobs:
-  test:
+  test-shards:
     # Integration tests are sharded across parallel jobs so the two
     # heavy packages (api, service) don't run end-to-end on one
-    # runner. api+service alone are ~76% of integration time.
+    # runner. api+service alone are ~76% of integration time. The
+    # `test` aggregator below collapses the matrix into one required
+    # check named "Test" for the branch ruleset.
     name: Test (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
     strategy:
@@ -147,6 +149,25 @@ jobs:
         env:
           DATABASE_URL: postgres://breadbox:breadbox@localhost:5432/breadbox_test?sslmode=disable
         run: go test -tags integration -count=1 -p 1 ${{ matrix.shard.packages }}
+
+  # Aggregator that the branch ruleset's required status check ("Test")
+  # targets. Without this, the rename to "Test (api)" / "Test (service)"
+  # / "Test (rest)" would leave the required "Test" check in Expected
+  # state forever. Keeping the gate as a single name also means future
+  # shard count changes don't require ruleset edits.
+  test:
+    name: Test
+    needs: test-shards
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all shards passed
+        run: |
+          if [ "${{ needs.test-shards.result }}" != "success" ]; then
+            echo "::error::One or more test shards failed: ${{ needs.test-shards.result }}"
+            exit 1
+          fi
+          echo "All shards green"
 
   test-headless:
     name: Test (headless)


### PR DESCRIPTION
## Summary

The merge-blocking **Test** job has been running ~**4m23s** on recent main pushes, dominated by `go test -tags integration -p 1 ./...` at **2m53s**. Looking at the per-package breakdown from run [25953431573](https://github.com/canalesb93/breadbox/actions/runs/25953431573):

| package | time |
|---|---|
| `internal/api` | **68s** |
| `internal/service` | **63s** |
| `internal/sync` | 11s |
| `internal/cli` | 7s |
| `internal/admin` | 4s |
| `internal/mcp` | 3s |
| all others | <1s combined |

`api` + `service` alone are ~76% of integration time. Two changes here:

### 1. Shard the Test job into a 3-way matrix (`api`, `service`, `rest`)

Each shard gets its own Postgres service and runs only its slice of the integration suite. The `rest` shard carries the one-time work (`go vet`, untagged unit tests, duplicate-migration check) since those don't shard cleanly and only cost ~20s combined.

### 2. Drop `bun install` + `bun run build` from the test job

The `//go:embed all:dist` directive in `internal/webui` is satisfied by the committed `web/dist/.gitkeep`, and `webui.Handler()` already has an explicit stub fallback for the bundle-missing case. No test exercises bundle content (grep for `dist/index`, `webui.*Serve`, `SPAHandler` in `_test.go` returns nothing). The SPA build still runs in the release-binaries and Docker-build jobs that actually ship artifacts. Direct savings on the critical path: **~19s**.

### Also: cache the generator binaries

`sqlc`, `templ`, and `goose` are now cached between runs. Tiny win (a few seconds on cache hit) but mostly removes a couple of network round-trips.

## Projected impact

| | before | after (est.) |
|---|---|---|
| Test job wall time | ~4:23 | **~2:15** |
| Critical path to merge | ~4:30 | **~2:30** |

About **45–50% faster** for PR merges. Trade-off: ~2× runner-minutes per run (3 shards instead of 1), which is the right call for merge velocity.

## Test plan

- [ ] CI passes on this PR — the three shards (`Test (api)`, `Test (service)`, `Test (rest)`) all go green
- [ ] Confirm actual wall-time is in the 2–2.5 min range (check the run timing once it lands)
- [ ] `build` job still kicks off after all three test shards succeed (the `needs: [test, test-headless, test-lite]` reference is by job ID, which fans out across matrix instances automatically)
- [ ] No drift in `test-headless` / `test-lite` jobs (untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)