### PR TITLE
v2: accounts list + detail pages with inline account linking

### DIFF
--- a/web/src/api/queries/account-links.ts
+++ b/web/src/api/queries/account-links.ts
@@ -1,0 +1,94 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type { AccountLink, MatchReconciliationResult } from "@/api/types";
+
+// useAccountLinks loads every household account-link. Bounded reference
+// data so it's fetched once with a long staleTime, then filtered client-side
+// on the per-account detail page. Returns a bare array (no envelope).
+export function useAccountLinks() {
+  return useQuery({
+    queryKey: ["account-links"],
+    queryFn: () => api<AccountLink[]>("/api/v1/account-links"),
+    staleTime: 60_000,
+  });
+}
+
+export interface CreateAccountLinkInput {
+  primary_account_id: string;
+  dependent_account_id: string;
+  match_strategy?: string;
+  match_tolerance_days?: number;
+}
+
+// useCreateAccountLink establishes a new primary→dependent link. The backend
+// fails fast on circular links (a reverse link already exists) and self-
+// linking — surface those errors via withMutationToast.
+export function useCreateAccountLink() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateAccountLinkInput) =>
+      api<AccountLink>("/api/v1/account-links", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      // The dependent account flips to is_dependent_linked=true after
+      // creation, so refresh both lists and any open detail panes.
+      qc.invalidateQueries({ queryKey: ["account-links"] });
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      qc.invalidateQueries({ queryKey: ["account"] });
+    },
+  });
+}
+
+export interface UpdateAccountLinkInput {
+  match_strategy?: string;
+  match_tolerance_days?: number;
+  enabled?: boolean;
+}
+
+export function useUpdateAccountLink() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateAccountLinkInput }) =>
+      api<AccountLink>(`/api/v1/account-links/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["account-links"] });
+    },
+  });
+}
+
+// useDeleteAccountLink removes a link. The dependent account flips back to
+// is_dependent_linked=false; matches are also removed.
+export function useDeleteAccountLink() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api<void>(`/api/v1/account-links/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["account-links"] });
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+      qc.invalidateQueries({ queryKey: ["account"] });
+    },
+  });
+}
+
+// useReconcileAccountLink triggers a fresh match scan for an existing link.
+// Returns a count of new matches found, plus the running totals. Safe to
+// call repeatedly — runs are idempotent against already-matched txns.
+export function useReconcileAccountLink() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api<MatchReconciliationResult>(
+        `/api/v1/account-links/${id}/reconcile`,
+        { method: "POST" },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["account-links"] });
+    },
+  });
+}

--- a/web/src/api/queries/accounts.ts
+++ b/web/src/api/queries/accounts.ts
@@ -1,14 +1,52 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import type { Account } from "@/api/types";
+import type { Account, AccountDetail } from "@/api/types";
 
 // useAccounts loads the bank-account list. Bounded reference data — used by
-// the transactions account filter — so it's fetched once with a long
-// staleTime. The endpoint returns a bare array (no envelope).
+// the transactions account filter and the Accounts page — so it's fetched
+// once with a long staleTime. The endpoint returns a bare array (no envelope).
 export function useAccounts() {
   return useQuery({
     queryKey: ["accounts"],
     queryFn: () => api<Account[]>("/api/v1/accounts"),
     staleTime: 5 * 60_000,
+  });
+}
+
+// useAccount fetches the full detail payload for a single account by
+// short_id (or UUID): balances, the institution + connection, the most
+// recent transactions, and the editable fields used on the detail page.
+export function useAccount(id: string | undefined) {
+  return useQuery({
+    queryKey: ["account", id],
+    queryFn: () => api<AccountDetail>(`/api/v1/accounts/${id}/detail`),
+    enabled: !!id,
+    staleTime: 30_000,
+  });
+}
+
+export interface UpdateAccountInput {
+  display_name?: string;
+  is_excluded?: boolean;
+  is_dependent_linked?: boolean;
+}
+
+// useUpdateAccount PATCHes a single account. Send an explicit empty
+// `display_name: ""` to clear the override; omit the field to leave it
+// unchanged. The endpoint returns the updated AccountResponse — we
+// invalidate the list and detail caches so other surfaces (transactions
+// filter, connection detail) pick up the new value.
+export function useUpdateAccount() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateAccountInput }) =>
+      api<Account>(`/api/v1/accounts/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: (_, vars) => {
+      qc.invalidateQueries({ queryKey: ["account", vars.id] });
+      qc.invalidateQueries({ queryKey: ["accounts"] });
+    },
   });
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -64,24 +64,82 @@ export interface TransactionsPage {
 }
 
 // --- Accounts (public /api/v1/accounts) ---
-// Mirrors internal/service.AccountResponse. The transactions filter only
-// touches identity + labels; the connections list rolls up balances per
-// connection by joining client-side, so connection_id and balance_current are
-// load-bearing there.
+// Mirrors internal/service.AccountResponse. The accounts page surfaces every
+// field; the connections page joins on `connection_id` + sums `balance_current`
+// per currency.
 export interface Account {
   id: string;
   short_id: string;
   connection_id: string | null;
   user_id: string | null;
+  institution_name: string | null;
   name: string;
-  institution_name: string;
+  official_name: string | null;
   type: string;
   subtype: string | null;
   mask: string | null;
   balance_current: number | null;
   balance_available: number | null;
+  balance_limit: number | null;
   iso_currency_code: string | null;
+  last_balance_update: string | null;
+  created_at: string;
+  updated_at: string;
+  connection_status: string | null;
   is_dependent_linked: boolean;
+}
+
+// AccountBalance mirrors internal/service.AccountBalance. Today every
+// Breadbox account has a single balance; the slice shape exists so the
+// payload stays stable if multi-currency accounts ever land.
+export interface AccountBalance {
+  iso_currency_code: string | null;
+  balance_current: number | null;
+  balance_available: number | null;
+  balance_limit: number | null;
+}
+
+// AccountDetail mirrors internal/service.AccountDetailResponse. Composes the
+// list-row shape with admin-only fields (display_name, excluded), balances
+// per currency, and the most recent N transactions for the account.
+export interface AccountDetail extends Account {
+  display_name: string | null;
+  excluded: boolean;
+  provider?: string;
+  connection_user_name?: string;
+  connection_short_id?: string;
+  balances: AccountBalance[];
+  recent_transactions: Transaction[];
+}
+
+// AccountLink mirrors internal/service.AccountLinkResponse. Links a primary
+// account to a dependent account so the dependent's transactions are
+// attributed to the primary cardholder. The dependent account is excluded
+// from totals; matched transactions are attributed via attributed_user_id.
+export interface AccountLink {
+  id: string;
+  short_id: string;
+  primary_account_id: string;
+  primary_account_name: string;
+  primary_user_name: string;
+  dependent_account_id: string;
+  dependent_account_name: string;
+  dependent_user_name: string;
+  match_strategy: string;
+  match_tolerance_days: number;
+  enabled: boolean;
+  match_count: number;
+  unmatched_dependent_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+// MatchReconciliationResult mirrors internal/service.MatchReconciliationResult.
+// Returned from POST /account-links/{id}/reconcile after a manual rerun.
+export interface MatchReconciliationResult {
+  new_matches: number;
+  total_matched: number;
+  unmatched: number;
 }
 
 // --- Users (public /api/v1/users) ---

--- a/web/src/components/ui/toggle-group.tsx
+++ b/web/src/components/ui/toggle-group.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import * as React from "react"
+import { type VariantProps } from "class-variance-authority"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=default]:data-[variant=outline]:shadow-xs",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        "w-auto min-w-0 shrink-0 px-3 focus:z-10 focus-visible:z-10",
+        "data-[spacing=0]:rounded-none data-[spacing=0]:shadow-none data-[spacing=0]:first:rounded-l-md data-[spacing=0]:last:rounded-r-md data-[spacing=0]:data-[variant=outline]:border-l-0 data-[spacing=0]:data-[variant=outline]:first:border-l",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/web/src/components/ui/toggle.tsx
+++ b/web/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Toggle as TogglePrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-[color,box-shadow] outline-none hover:bg-muted hover:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline:
+          "border border-input bg-transparent shadow-xs hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-9 min-w-9 px-2",
+        sm: "h-8 min-w-8 px-1.5",
+        lg: "h-10 min-w-10 px-2.5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant,
+  size,
+  ...props
+}: React.ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/web/src/features/accounts/account-card.tsx
+++ b/web/src/features/accounts/account-card.tsx
@@ -1,0 +1,145 @@
+import { Link } from "@tanstack/react-router";
+import { AlertTriangle, ChevronRight, Link2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { Account } from "@/api/types";
+import {
+  accountLabel,
+  accountTypeIcon,
+  accountTypeLabel,
+  creditUtilization,
+  formatCurrency,
+  isLiability,
+  utilizationBarClass,
+} from "./account-utils";
+
+interface AccountCardProps {
+  account: Account;
+  className?: string;
+}
+
+// AccountCard is the list-row shown on the Accounts page and on the
+// connection-detail accounts grid. Click anywhere to open the account
+// detail page. Keeps the visual rhythm tight: a 9×9 type-tile, the label,
+// a metadata subline (type · mask), and the current balance to the right.
+// Credit cards render their utilization bar below; non-active connections
+// show an inline status pill so problem accounts stand out without an
+// extra trip to /connections.
+export function AccountCard({ account: a, className }: AccountCardProps) {
+  const Icon = accountTypeIcon(a.type);
+  const liability = isLiability(a.type);
+  const util = creditUtilization(a);
+  const statusPill = statusBadge(a.connection_status);
+  return (
+    <Link
+      to="/accounts/$id"
+      params={{ id: a.short_id }}
+      className={cn(
+        "bg-card hover:bg-accent/40 group flex items-center gap-3 rounded-lg border p-3 transition-colors",
+        className,
+      )}
+    >
+      <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-lg">
+        <Icon className="text-muted-foreground size-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium">{accountLabel(a)}</span>
+          {a.is_dependent_linked && (
+            <Badge variant="secondary" className="gap-1 px-1.5 py-0 text-[10px]">
+              <Link2 className="size-2.5" /> Linked
+            </Badge>
+          )}
+          {statusPill}
+        </div>
+        <div className="text-muted-foreground mt-0.5 flex flex-wrap items-center gap-x-1.5 truncate text-xs">
+          <span className="capitalize">{accountTypeLabel(a.type, a.subtype)}</span>
+          {a.mask && (
+            <>
+              <span className="text-muted-foreground/40">·</span>
+              <span className="tabular-nums">····{a.mask}</span>
+            </>
+          )}
+          {a.institution_name && (
+            <>
+              <span className="text-muted-foreground/40">·</span>
+              <span className="truncate">{a.institution_name}</span>
+            </>
+          )}
+        </div>
+        {util != null && (
+          <div className="mt-2">
+            <div className="text-muted-foreground mb-1 flex items-center justify-between text-[10px] tabular-nums">
+              <span>{Math.round(util)}% used</span>
+              {a.balance_limit != null && (
+                <span>
+                  {formatCurrency(a.balance_limit, a.iso_currency_code)} limit
+                </span>
+              )}
+            </div>
+            <div className="bg-muted h-1 overflow-hidden rounded-full">
+              <div
+                className={cn("h-full transition-all", utilizationBarClass(util))}
+                style={{ width: `${util}%` }}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <div className="text-right">
+          <div
+            className={cn(
+              "text-sm font-semibold tabular-nums whitespace-nowrap",
+              liability && a.balance_current != null && a.balance_current > 0
+                ? "text-foreground"
+                : undefined,
+            )}
+          >
+            {a.balance_current != null
+              ? formatCurrency(
+                  liability ? -a.balance_current : a.balance_current,
+                  a.iso_currency_code,
+                )
+              : "—"}
+          </div>
+          {a.iso_currency_code && (
+            <div className="text-muted-foreground text-[10px]">
+              {a.iso_currency_code}
+            </div>
+          )}
+        </div>
+        <ChevronRight className="text-muted-foreground/40 group-hover:text-muted-foreground size-4 transition-colors" />
+      </div>
+    </Link>
+  );
+}
+
+function statusBadge(status: string | null) {
+  if (!status || status === "active") return null;
+  if (status === "pending_reauth") {
+    return (
+      <Badge
+        variant="outline"
+        className="gap-1 border-amber-500/40 bg-amber-500/5 px-1.5 py-0 text-[10px] text-amber-700 dark:text-amber-400"
+      >
+        <AlertTriangle className="size-2.5" /> Re-auth
+      </Badge>
+    );
+  }
+  if (status === "error") {
+    return (
+      <Badge variant="destructive" className="px-1.5 py-0 text-[10px]">
+        Error
+      </Badge>
+    );
+  }
+  if (status === "disconnected") {
+    return (
+      <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+        Disconnected
+      </Badge>
+    );
+  }
+  return null;
+}

--- a/web/src/features/accounts/account-links-section.tsx
+++ b/web/src/features/accounts/account-links-section.tsx
@@ -11,7 +11,13 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -71,11 +77,11 @@ export function AccountLinksSection({
 
   return (
     <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="flex items-center justify-between text-base">
-          <span className="flex items-center gap-2">
-            <Link2 className="size-4" /> Account links
-          </span>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Link2 className="size-4" /> Account links
+        </CardTitle>
+        <CardAction>
           <Button
             size="sm"
             variant="outline"
@@ -85,7 +91,7 @@ export function AccountLinksSection({
             <Plus className="size-3.5" />
             Link an account
           </Button>
-        </CardTitle>
+        </CardAction>
       </CardHeader>
       <CardContent className="space-y-3">
         {linksQuery.isLoading ? (

--- a/web/src/features/accounts/account-links-section.tsx
+++ b/web/src/features/accounts/account-links-section.tsx
@@ -1,0 +1,262 @@
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import {
+  ArrowRight,
+  Link2,
+  Loader2,
+  MoreHorizontal,
+  Plus,
+  RotateCw,
+  Unlink,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  useAccountLinks,
+  useDeleteAccountLink,
+  useReconcileAccountLink,
+} from "@/api/queries/account-links";
+import type { Account, AccountLink } from "@/api/types";
+
+interface AccountLinksSectionProps {
+  account: Pick<Account, "id" | "short_id" | "name" | "is_dependent_linked">;
+  // The full account list — needed because account-links carry only the
+  // account short_id, and we link to detail pages by short_id elsewhere.
+  accounts: Account[];
+  onAddLink: () => void;
+}
+
+// AccountLinksSection lists every link this account participates in —
+// either as the primary cardholder ("This account covers …") or as a
+// dependent ("Attributed to …"). Each row shows match counts and exposes
+// reconcile + unlink actions.
+//
+// Account-linking lives here because the dedicated top-level "Account
+// Links" page was removed; surfacing the links inline on each account is
+// the better UX anyway — you set them up where you're already looking.
+export function AccountLinksSection({
+  account,
+  accounts,
+  onAddLink,
+}: AccountLinksSectionProps) {
+  const linksQuery = useAccountLinks();
+
+  // Index by short_id — that's the value the list endpoint returns in
+  // `primary_account_id`/`dependent_account_id` (the project-wide compact-ID
+  // convention).
+  const accountByShortId = useMemo(() => {
+    const m = new Map<string, Account>();
+    for (const a of accounts) m.set(a.short_id, a);
+    return m;
+  }, [accounts]);
+
+  const myLinks = useMemo(() => {
+    if (!linksQuery.data) return [] as AccountLink[];
+    return linksQuery.data.filter(
+      (l) =>
+        l.primary_account_id === account.short_id ||
+        l.dependent_account_id === account.short_id,
+    );
+  }, [linksQuery.data, account.short_id]);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center justify-between text-base">
+          <span className="flex items-center gap-2">
+            <Link2 className="size-4" /> Account links
+          </span>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={onAddLink}
+            disabled={account.is_dependent_linked}
+          >
+            <Plus className="size-3.5" />
+            Link an account
+          </Button>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {linksQuery.isLoading ? (
+          <div className="text-muted-foreground flex items-center gap-2 text-xs">
+            <Loader2 className="size-3 animate-spin" /> Loading links…
+          </div>
+        ) : linksQuery.isError ? (
+          <Alert variant="destructive">
+            <AlertTitle>Couldn't load account links</AlertTitle>
+            <AlertDescription>
+              {linksQuery.error instanceof Error
+                ? linksQuery.error.message
+                : "Try refreshing the page."}
+            </AlertDescription>
+          </Alert>
+        ) : myLinks.length === 0 ? (
+          <EmptyLinkState
+            account={account}
+          />
+        ) : (
+          <ul className="space-y-2">
+            {myLinks.map((link) => (
+              <LinkRow
+                key={link.id}
+                link={link}
+                viewingShortId={account.short_id}
+                accountByShortId={accountByShortId}
+              />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface EmptyLinkStateProps {
+  account: Pick<Account, "is_dependent_linked" | "name">;
+}
+
+function EmptyLinkState({ account }: EmptyLinkStateProps) {
+  if (account.is_dependent_linked) {
+    return (
+      <div className="text-muted-foreground text-sm">
+        This account is linked as a dependent. Its transactions are attributed
+        to a primary cardholder. Open the primary account to manage the link.
+      </div>
+    );
+  }
+  return (
+    <div className="text-muted-foreground space-y-2 text-sm">
+      <p>
+        Link a dependent account when one person&apos;s charges show up on
+        another person&apos;s statement (e.g. a family card). Breadbox
+        attributes matched transactions to the dependent user and removes the
+        dependent account from totals so spending isn&apos;t double-counted.
+      </p>
+    </div>
+  );
+}
+
+interface LinkRowProps {
+  link: AccountLink;
+  viewingShortId: string;
+  accountByShortId: Map<string, Account>;
+}
+
+function LinkRow({ link, viewingShortId, accountByShortId }: LinkRowProps) {
+  const reconcile = useReconcileAccountLink();
+  const remove = useDeleteAccountLink();
+
+  const isPrimary = link.primary_account_id === viewingShortId;
+  const otherShortId = isPrimary
+    ? link.dependent_account_id
+    : link.primary_account_id;
+  // The list endpoint returns short_ids in *_account_id; the singular
+  // endpoint returns UUIDs. Look up by short_id so the rendered link to
+  // the other account works in both shapes — falls back to the link's
+  // own labels when the account isn't in the cache.
+  const other = accountByShortId.get(otherShortId);
+  const otherName = isPrimary
+    ? link.dependent_account_name
+    : link.primary_account_name;
+  const otherUser = isPrimary ? link.dependent_user_name : link.primary_user_name;
+
+  async function onReconcile() {
+    await withMutationToast(
+      async () => {
+        const r = await reconcile.mutateAsync(link.id);
+        return r;
+      },
+      {
+        success: `Reconciled — ${reconcile.data?.new_matches ?? 0} new matches.`,
+      },
+    );
+  }
+
+  async function onDelete() {
+    if (!confirm("Unlink these accounts? Matches will be discarded.")) return;
+    await withMutationToast(() => remove.mutateAsync(link.id), {
+      success: "Accounts unlinked.",
+    });
+  }
+
+  return (
+    <li className="bg-muted/30 flex items-start gap-3 rounded-md border p-3 text-sm">
+      <div className="flex-1 space-y-1.5">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant={isPrimary ? "default" : "secondary"} className="text-[10px]">
+            {isPrimary ? "Primary" : "Dependent"}
+          </Badge>
+          <span className="text-muted-foreground text-xs">
+            {isPrimary ? "Covers" : "Attributed to"}
+          </span>
+          <ArrowRight className="text-muted-foreground size-3" />
+          {other ? (
+            <Link
+              to="/accounts/$id"
+              params={{ id: other.short_id }}
+              className="text-sm font-medium hover:underline"
+            >
+              {otherName}
+            </Link>
+          ) : (
+            <span className="text-sm font-medium">{otherName}</span>
+          )}
+          {otherUser && (
+            <span className="text-muted-foreground text-xs">· {otherUser}</span>
+          )}
+        </div>
+        <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1 text-xs tabular-nums">
+          <span>{link.match_count} matched</span>
+          {link.unmatched_dependent_count > 0 && (
+            <span className="text-amber-700 dark:text-amber-400">
+              {link.unmatched_dependent_count} unmatched
+            </span>
+          )}
+          <span>± {link.match_tolerance_days}d tolerance</span>
+          {!link.enabled && <Badge variant="outline" className="text-[10px]">Disabled</Badge>}
+        </div>
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="size-7"
+            aria-label="Link actions"
+            disabled={reconcile.isPending || remove.isPending}
+          >
+            {reconcile.isPending || remove.isPending ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <MoreHorizontal className="size-3.5" />
+            )}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={onReconcile} disabled={reconcile.isPending}>
+            <RotateCw className="size-3.5" /> Reconcile matches
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            variant="destructive"
+            onClick={onDelete}
+            disabled={remove.isPending}
+          >
+            <Unlink className="size-3.5" /> Unlink
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </li>
+  );
+}

--- a/web/src/features/accounts/account-recent-transactions.tsx
+++ b/web/src/features/accounts/account-recent-transactions.tsx
@@ -1,7 +1,13 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { EmptyState } from "@/components/empty-state";
 import { TransactionPrimary } from "@/components/transaction-primary";
 import { TransactionAmount } from "@/components/transaction-amount";
@@ -21,15 +27,15 @@ export function AccountRecentTransactions({
 }: AccountRecentTransactionsProps) {
   return (
     <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="flex items-center justify-between text-base">
-          <span>Recent transactions</span>
-          {transactions.length > 0 && (
-            <span className="text-muted-foreground text-xs font-normal">
+      <CardHeader>
+        <CardTitle>Recent transactions</CardTitle>
+        {transactions.length > 0 && (
+          <CardAction>
+            <span className="text-muted-foreground text-xs">
               Last {transactions.length}
             </span>
-          )}
-        </CardTitle>
+          </CardAction>
+        )}
       </CardHeader>
       <CardContent className="p-0">
         {transactions.length === 0 ? (

--- a/web/src/features/accounts/account-recent-transactions.tsx
+++ b/web/src/features/accounts/account-recent-transactions.tsx
@@ -51,7 +51,7 @@ export function AccountRecentTransactions({
                 <Link
                   to="/transactions/$id"
                   params={{ id: t.short_id }}
-                  className="hover:bg-accent/40 flex items-center gap-3 px-6 py-3 transition-colors"
+                  className="hover:bg-accent/40 flex items-center gap-3 px-6 py-2 transition-colors"
                 >
                   <TransactionPrimary transaction={t} className="flex-1" />
                   <TransactionAmount transaction={t} />

--- a/web/src/features/accounts/account-recent-transactions.tsx
+++ b/web/src/features/accounts/account-recent-transactions.tsx
@@ -1,0 +1,73 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/empty-state";
+import { TransactionPrimary } from "@/components/transaction-primary";
+import { TransactionAmount } from "@/components/transaction-amount";
+import type { Transaction } from "@/api/types";
+
+interface AccountRecentTransactionsProps {
+  accountShortId: string;
+  transactions: Transaction[];
+}
+
+// AccountRecentTransactions surfaces the last N transactions inline on the
+// account detail page. Each row links to the transaction detail; the footer
+// jumps to the Transactions table pre-filtered to this account.
+export function AccountRecentTransactions({
+  accountShortId,
+  transactions,
+}: AccountRecentTransactionsProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center justify-between text-base">
+          <span>Recent transactions</span>
+          {transactions.length > 0 && (
+            <span className="text-muted-foreground text-xs font-normal">
+              Last {transactions.length}
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        {transactions.length === 0 ? (
+          <EmptyState
+            title="No transactions yet"
+            description="They appear after the first sync."
+            className="py-8"
+          />
+        ) : (
+          <ul className="divide-y">
+            {transactions.map((t) => (
+              <li key={t.id}>
+                <Link
+                  to="/transactions/$id"
+                  params={{ id: t.short_id }}
+                  className="hover:bg-accent/40 flex items-center gap-3 px-6 py-3 transition-colors"
+                >
+                  <TransactionPrimary transaction={t} className="flex-1" />
+                  <TransactionAmount transaction={t} />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+      {transactions.length > 0 && (
+        <div className="border-border/40 border-t px-6 py-3 text-right">
+          <Button variant="ghost" size="sm" asChild>
+            <Link
+              to="/transactions"
+              search={{ account: accountShortId }}
+            >
+              See all transactions for this account
+              <ArrowRight className="size-3.5" />
+            </Link>
+          </Button>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/src/features/accounts/account-settings-card.tsx
+++ b/web/src/features/accounts/account-settings-card.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Check, ExternalLink, Loader2, Pencil, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { useUpdateAccount } from "@/api/queries/accounts";
+import type { AccountDetail } from "@/api/types";
+
+interface AccountSettingsCardProps {
+  account: AccountDetail;
+}
+
+// AccountSettingsCard is the "what about this account" panel: an inline
+// rename for display_name (overrides the bank-provided name everywhere),
+// the exclude-from-sync toggle, and quick links to the parent connection
+// and household member. Each mutation toasts on its own — failed writes
+// roll back to the cached value because we don't optimistic-update.
+export function AccountSettingsCard({ account: a }: AccountSettingsCardProps) {
+  const update = useUpdateAccount();
+  const [editingName, setEditingName] = useState(false);
+  const [draft, setDraft] = useState(a.display_name ?? "");
+
+  // Keep the draft in sync if a server refetch lands while we're not
+  // editing (e.g. another tab renames the same account).
+  useEffect(() => {
+    if (!editingName) setDraft(a.display_name ?? "");
+  }, [a.display_name, editingName]);
+
+  async function saveName() {
+    const next = draft.trim();
+    if (next === (a.display_name ?? "")) {
+      setEditingName(false);
+      return;
+    }
+    const ok = await withMutationToast(
+      () => update.mutateAsync({ id: a.short_id, input: { display_name: next } }),
+      { success: next === "" ? "Display name cleared." : "Display name updated." },
+    );
+    if (ok) setEditingName(false);
+  }
+
+  function cancelName() {
+    setDraft(a.display_name ?? "");
+    setEditingName(false);
+  }
+
+  async function onToggleExcluded(next: boolean) {
+    await withMutationToast(
+      () => update.mutateAsync({ id: a.short_id, input: { is_excluded: next } }),
+      {
+        success: next
+          ? "Account excluded — future syncs will skip it."
+          : "Account included in sync.",
+      },
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Settings</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5 text-sm">
+        <div className="space-y-1.5">
+          <Label htmlFor="display-name" className="text-muted-foreground text-xs">
+            Display name
+          </Label>
+          {editingName ? (
+            <div className="flex items-center gap-1.5">
+              <Input
+                id="display-name"
+                autoFocus
+                value={draft}
+                placeholder={a.name}
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") saveName();
+                  if (e.key === "Escape") cancelName();
+                }}
+                disabled={update.isPending}
+                className="h-9"
+              />
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={saveName}
+                disabled={update.isPending}
+                aria-label="Save display name"
+                className="size-9"
+              >
+                {update.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Check className="size-4" />
+                )}
+              </Button>
+              <Button
+                size="icon"
+                variant="ghost"
+                onClick={cancelName}
+                disabled={update.isPending}
+                aria-label="Cancel"
+                className="size-9"
+              >
+                <X className="size-4" />
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center justify-between gap-2">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium">
+                  {a.display_name ?? a.name}
+                </div>
+                {a.display_name && (
+                  <div className="text-muted-foreground truncate text-xs">
+                    Overrides bank name: {a.name}
+                  </div>
+                )}
+              </div>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setEditingName(true)}
+              >
+                <Pencil className="size-3.5" /> Edit
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <div className="border-border/40 flex items-start justify-between gap-3 border-t pt-4">
+          <div className="space-y-0.5">
+            <Label
+              htmlFor="excluded"
+              className="text-sm font-medium"
+            >
+              Exclude from sync
+            </Label>
+            <p className="text-muted-foreground text-xs">
+              Skip future transaction syncs for this account.
+            </p>
+          </div>
+          <Checkbox
+            id="excluded"
+            checked={a.excluded}
+            disabled={update.isPending}
+            onCheckedChange={(next) => onToggleExcluded(next === true)}
+          />
+        </div>
+
+        {(a.connection_short_id || a.connection_user_name) && (
+          <div className="border-border/40 grid grid-cols-2 gap-4 border-t pt-4">
+            {a.connection_short_id && (
+              <div>
+                <div className="text-muted-foreground text-xs">Connection</div>
+                <Button
+                  variant="link"
+                  size="sm"
+                  asChild
+                  className="-ml-2 h-auto p-2 text-sm font-medium"
+                >
+                  <Link
+                    to="/connections/$id"
+                    params={{ id: a.connection_short_id }}
+                  >
+                    {a.institution_name ?? "Open connection"}
+                    <ExternalLink className="size-3" />
+                  </Link>
+                </Button>
+              </div>
+            )}
+            {a.connection_user_name && (
+              <div>
+                <div className="text-muted-foreground text-xs">Family member</div>
+                <div className="mt-1 text-sm font-medium">
+                  {a.connection_user_name}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/features/accounts/account-settings-card.tsx
+++ b/web/src/features/accounts/account-settings-card.tsx
@@ -61,8 +61,8 @@ export function AccountSettingsCard({ account: a }: AccountSettingsCardProps) {
 
   return (
     <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="text-base">Settings</CardTitle>
+      <CardHeader>
+        <CardTitle>Settings</CardTitle>
       </CardHeader>
       <CardContent className="space-y-5 text-sm">
         <div className="space-y-1.5">

--- a/web/src/features/accounts/account-utils.ts
+++ b/web/src/features/accounts/account-utils.ts
@@ -1,0 +1,164 @@
+import {
+  Banknote,
+  CreditCard,
+  Landmark,
+  PiggyBank,
+  Wallet,
+  type LucideIcon,
+} from "lucide-react";
+import type { Account } from "@/api/types";
+
+// TYPE_ICON maps Plaid-ish account types to lucide icons. The same map
+// powers list rows, the detail page hero, and the connection-detail
+// account cards — keep it as the single source.
+const TYPE_ICON: Record<string, LucideIcon> = {
+  depository: PiggyBank,
+  credit: CreditCard,
+  loan: Landmark,
+  investment: Wallet,
+};
+
+export function accountTypeIcon(type: string): LucideIcon {
+  return TYPE_ICON[type] ?? Banknote;
+}
+
+// Liabilities (credit cards, loans) render the balance as money owed —
+// flipped sign convention vs depository/investment.
+export function isLiability(type: string): boolean {
+  return type === "credit" || type === "loan";
+}
+
+// Account "label" — the bank-provided name unless the user has set a
+// display_name override. Keep the precedence logic in one place so the
+// list and the detail header always pick the same label.
+export function accountLabel(a: Pick<Account, "name"> & { display_name?: string | null }): string {
+  if (a.display_name && a.display_name.trim().length > 0) return a.display_name;
+  return a.name;
+}
+
+const TYPE_LABEL: Record<string, string> = {
+  depository: "Bank",
+  credit: "Credit card",
+  loan: "Loan",
+  investment: "Investment",
+  other: "Account",
+};
+
+// Capitalised type label e.g. "Bank · checking", "Credit card · personal".
+// Subtypes arrive snake_cased from providers; normalise to spaces so the
+// `capitalize` Tailwind class doesn't render "Credit_card".
+export function accountTypeLabel(type: string, subtype: string | null): string {
+  const base = TYPE_LABEL[type] ?? type;
+  if (!subtype) return base;
+  const sub = subtype.toLowerCase().replace(/_/g, " ");
+  // Avoid double-printing when the subtype already names the type
+  // ("credit card · credit card" reads worse than just "Credit card").
+  if (base.toLowerCase().includes(sub) || sub.includes(base.toLowerCase())) {
+    return base;
+  }
+  return `${base} · ${sub}`;
+}
+
+// Credit-utilisation as a 0–100 percentage. Returns null when the account
+// doesn't carry a limit (or the limit is zero — defensive against bad data).
+export function creditUtilization(a: Pick<Account, "balance_current" | "balance_limit">): number | null {
+  if (a.balance_limit == null || a.balance_limit <= 0) return null;
+  if (a.balance_current == null) return null;
+  return Math.min(100, Math.max(0, (a.balance_current / a.balance_limit) * 100));
+}
+
+// Tailwind utility for the utilization bar — escalates green → amber → red
+// as the bar approaches the limit.
+export function utilizationBarClass(pct: number): string {
+  if (pct >= 90) return "bg-destructive";
+  if (pct >= 75) return "bg-amber-500";
+  return "bg-emerald-500";
+}
+
+// formatCurrency renders an amount in the supplied ISO code via Intl.
+// Currency keys are scarce enough that we don't bother caching formatters
+// (cf. lib/format.ts) — most accounts use one of two currencies and
+// list pages re-render rarely.
+export function formatCurrency(amount: number, currency: string | null): string {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency ?? "USD",
+      maximumFractionDigits: 2,
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${currency ?? ""}`.trim();
+  }
+}
+
+export interface CurrencyTotal {
+  currency: string;
+  total: number;
+  count: number;
+}
+
+// totalsByCurrency aggregates account balances across the supplied set,
+// keyed by ISO currency. Sign convention matches the user's mental model:
+// assets (depository, investment) are positive; liabilities (credit, loan)
+// flip sign so the total reads as net worth. Dependent-linked accounts are
+// excluded — they're already counted under their primary cardholder.
+export function totalsByCurrency(accounts: Account[]): CurrencyTotal[] {
+  const m = new Map<string, CurrencyTotal>();
+  for (const a of accounts) {
+    if (a.is_dependent_linked) continue;
+    if (a.balance_current == null || !a.iso_currency_code) continue;
+    const signed = isLiability(a.type) ? -a.balance_current : a.balance_current;
+    const prev = m.get(a.iso_currency_code) ?? {
+      currency: a.iso_currency_code,
+      total: 0,
+      count: 0,
+    };
+    prev.total += signed;
+    prev.count += 1;
+    m.set(a.iso_currency_code, prev);
+  }
+  // Most accounts share a single currency — present the biggest set first.
+  return [...m.values()].sort((a, b) => b.count - a.count);
+}
+
+// Group accounts by a chosen dimension. We render the page grouped by
+// connection (institution) by default since that's how users think about
+// their money; "type" gives a depository-vs-credit overview.
+export type AccountGroupBy = "institution" | "type";
+
+export interface AccountGroup {
+  key: string;
+  label: string;
+  accounts: Account[];
+}
+
+export function groupAccounts(
+  accounts: Account[],
+  by: AccountGroupBy,
+): AccountGroup[] {
+  const m = new Map<string, AccountGroup>();
+  for (const a of accounts) {
+    let key: string;
+    let label: string;
+    if (by === "institution") {
+      key = a.connection_id ?? "_unlinked";
+      label = a.institution_name ?? "Manual / CSV";
+    } else {
+      key = a.type;
+      label = TYPE_LABEL[a.type] ?? a.type;
+    }
+    let g = m.get(key);
+    if (!g) {
+      g = { key, label, accounts: [] };
+      m.set(key, g);
+    }
+    g.accounts.push(a);
+  }
+  // Most-populated groups first; ties fall back to alphabetical label.
+  return [...m.values()].sort((a, b) => {
+    if (b.accounts.length !== a.accounts.length) {
+      return b.accounts.length - a.accounts.length;
+    }
+    return a.label.localeCompare(b.label);
+  });
+}

--- a/web/src/features/accounts/accounts-summary.tsx
+++ b/web/src/features/accounts/accounts-summary.tsx
@@ -70,9 +70,13 @@ interface SummaryStatProps {
 }
 
 function SummaryStat({ icon: Icon, label, value, sublabel, tone }: SummaryStatProps) {
+  // Override the Card primitive's default `py-6` — these stat cards are
+  // dense one-liners, not full-bleed content panels, so they need just
+  // enough breathing room to feel like a card without dominating the
+  // top of the page.
   return (
-    <Card>
-      <CardContent className="flex items-center gap-3 py-4">
+    <Card className="py-4">
+      <CardContent className="flex items-center gap-3">
         <div
           className={cn(
             "flex size-9 shrink-0 items-center justify-center rounded-lg",
@@ -83,13 +87,13 @@ function SummaryStat({ icon: Icon, label, value, sublabel, tone }: SummaryStatPr
         >
           <Icon className="size-4" />
         </div>
-        <div className="min-w-0">
+        <div className="min-w-0 leading-tight">
           <div className="text-muted-foreground text-xs">{label}</div>
           <div className="truncate text-lg font-semibold tabular-nums">
             {value}
           </div>
           {sublabel && (
-            <div className="text-muted-foreground truncate text-[10px]">
+            <div className="text-muted-foreground mt-0.5 truncate text-[10px]">
               {sublabel}
             </div>
           )}

--- a/web/src/features/accounts/accounts-summary.tsx
+++ b/web/src/features/accounts/accounts-summary.tsx
@@ -1,0 +1,100 @@
+import { ArrowDownRight, ArrowUpRight, Wallet } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import type { Account } from "@/api/types";
+import { formatCurrency, isLiability, totalsByCurrency } from "./account-utils";
+
+interface AccountsSummaryProps {
+  accounts: Account[];
+}
+
+// AccountsSummary is the three-stat strip at the top of /accounts: net
+// worth (assets − liabilities) for the primary currency, total assets,
+// total liabilities. Multi-currency households are rare in practice; when
+// they show up, the strip falls back to the most-populated currency and
+// notes the rest in the subline.
+export function AccountsSummary({ accounts }: AccountsSummaryProps) {
+  const totals = totalsByCurrency(accounts);
+  if (totals.length === 0) return null;
+
+  const primary = totals[0];
+  const others = totals.slice(1);
+
+  const { assets, liabilities } = accounts.reduce(
+    (acc, a) => {
+      if (a.is_dependent_linked) return acc;
+      if (a.balance_current == null) return acc;
+      if (a.iso_currency_code !== primary.currency) return acc;
+      if (isLiability(a.type)) acc.liabilities += a.balance_current;
+      else acc.assets += a.balance_current;
+      return acc;
+    },
+    { assets: 0, liabilities: 0 },
+  );
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <SummaryStat
+        icon={Wallet}
+        label="Net worth"
+        value={formatCurrency(primary.total, primary.currency)}
+        sublabel={
+          others.length > 0
+            ? `+ ${others.length} other currenc${others.length === 1 ? "y" : "ies"}`
+            : `${primary.count} accounts`
+        }
+        tone="primary"
+      />
+      <SummaryStat
+        icon={ArrowUpRight}
+        label="Assets"
+        value={formatCurrency(assets, primary.currency)}
+        tone="success"
+      />
+      <SummaryStat
+        icon={ArrowDownRight}
+        label="Liabilities"
+        value={formatCurrency(liabilities, primary.currency)}
+        tone="muted"
+      />
+    </div>
+  );
+}
+
+interface SummaryStatProps {
+  icon: typeof Wallet;
+  label: string;
+  value: string;
+  sublabel?: string;
+  tone: "primary" | "success" | "muted";
+}
+
+function SummaryStat({ icon: Icon, label, value, sublabel, tone }: SummaryStatProps) {
+  return (
+    <Card>
+      <CardContent className="flex items-center gap-3 py-4">
+        <div
+          className={cn(
+            "flex size-9 shrink-0 items-center justify-center rounded-lg",
+            tone === "primary" && "bg-primary/10 text-primary",
+            tone === "success" && "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+            tone === "muted" && "bg-muted text-muted-foreground",
+          )}
+        >
+          <Icon className="size-4" />
+        </div>
+        <div className="min-w-0">
+          <div className="text-muted-foreground text-xs">{label}</div>
+          <div className="truncate text-lg font-semibold tabular-nums">
+            {value}
+          </div>
+          {sublabel && (
+            <div className="text-muted-foreground truncate text-[10px]">
+              {sublabel}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/features/accounts/link-account-sheet.tsx
+++ b/web/src/features/accounts/link-account-sheet.tsx
@@ -1,0 +1,199 @@
+import { useMemo, useState } from "react";
+import { Link2, Loader2 } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  useAccountLinks,
+  useCreateAccountLink,
+} from "@/api/queries/account-links";
+import type { Account } from "@/api/types";
+import { accountLabel } from "./account-utils";
+
+interface LinkAccountSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  // The account currently being viewed — becomes the primary side of the
+  // new link. We never let users pick which side is primary from this sheet
+  // because the detail page is the primary's home; we just pick the
+  // dependent.
+  primary: Pick<Account, "id" | "short_id" | "name"> & {
+    display_name?: string | null;
+  };
+  accounts: Account[];
+}
+
+// LinkAccountSheet creates a new primary→dependent link from the detail
+// page. Filters the eligible-dependent list to exclude the primary itself,
+// accounts already linked as dependents anywhere, and accounts that have a
+// reverse link with this primary (the backend rejects those — we mirror
+// the rule client-side so we can disable the options and show why).
+export function LinkAccountSheet({
+  open,
+  onOpenChange,
+  primary,
+  accounts,
+}: LinkAccountSheetProps) {
+  const linksQuery = useAccountLinks();
+  const create = useCreateAccountLink();
+
+  const [dependentId, setDependentId] = useState<string>("");
+  const [toleranceDays, setToleranceDays] = useState<string>("3");
+
+  const links = linksQuery.data ?? [];
+
+  const candidates = useMemo(() => {
+    return accounts.filter((a) => {
+      if (a.short_id === primary.short_id) return false;
+      // Already a dependent in another link — backend hides these too.
+      if (a.is_dependent_linked) return false;
+      // Reverse link exists: this candidate is primary for our viewing
+      // account. The backend rejects creating the inverse — we mirror the
+      // rule client-side so users see why the option is missing. The list
+      // endpoint returns short_ids in *_account_id (cf. the project's
+      // compact-ID convention), so we compare on short_id here.
+      const reverse = links.find(
+        (l) =>
+          l.primary_account_id === a.short_id &&
+          l.dependent_account_id === primary.short_id,
+      );
+      if (reverse) return false;
+      return true;
+    });
+  }, [accounts, links, primary.short_id]);
+
+  const eligibleCount = candidates.length;
+
+  async function onSubmit() {
+    if (!dependentId) return;
+    const tol = Number(toleranceDays);
+    const ok = await withMutationToast(
+      () =>
+        create.mutateAsync({
+          primary_account_id: primary.id,
+          dependent_account_id: dependentId,
+          match_tolerance_days: Number.isFinite(tol) && tol >= 0 ? tol : undefined,
+        }),
+      { success: "Accounts linked. Matches will reconcile on the next sync." },
+    );
+    if (ok) {
+      setDependentId("");
+      onOpenChange(false);
+    }
+  }
+
+  const primaryLabel = accountLabel(primary);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex w-full flex-col sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <Link2 className="size-4" />
+            Link an account
+          </SheetTitle>
+          <SheetDescription>
+            Attribute matched transactions on a dependent account to its
+            primary cardholder. The dependent account is excluded from totals
+            so charges aren&apos;t double-counted.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 space-y-5 overflow-y-auto px-4">
+          <div className="space-y-1.5">
+            <Label className="text-muted-foreground text-xs">
+              Primary (this account)
+            </Label>
+            <div className="bg-muted/40 rounded-md border px-3 py-2 text-sm">
+              {primaryLabel}
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="dependent" className="text-muted-foreground text-xs">
+              Dependent account
+            </Label>
+            {eligibleCount === 0 ? (
+              <Alert>
+                <AlertTitle>No eligible accounts</AlertTitle>
+                <AlertDescription>
+                  Every other account is either already linked as a dependent,
+                  or would create a circular link with this one.
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <Select value={dependentId} onValueChange={setDependentId}>
+                <SelectTrigger id="dependent" className="w-full">
+                  <SelectValue placeholder="Pick an account…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {candidates.map((a) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      <span className="font-medium">{accountLabel(a)}</span>
+                      <span className="text-muted-foreground ml-2 text-xs">
+                        {a.institution_name ?? "Manual"}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+            <p className="text-muted-foreground text-xs">
+              Matched transactions on the dependent account will be
+              attributed to the same person as this account.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="tolerance" className="text-muted-foreground text-xs">
+              Match tolerance (days)
+            </Label>
+            <Input
+              id="tolerance"
+              type="number"
+              min={0}
+              max={30}
+              value={toleranceDays}
+              onChange={(e) => setToleranceDays(e.target.value)}
+              className="h-9 w-24"
+            />
+            <p className="text-muted-foreground text-xs">
+              How far apart two transactions can post and still match. 3 days
+              is a safe default for most billing-cycle delays.
+            </p>
+          </div>
+        </div>
+
+        <SheetFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={onSubmit}
+            disabled={!dependentId || create.isPending || eligibleCount === 0}
+          >
+            {create.isPending && <Loader2 className="size-4 animate-spin" />}
+            Link accounts
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/web/src/features/connections/connection-accounts-list.tsx
+++ b/web/src/features/connections/connection-accounts-list.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import { Banknote, CreditCard, Landmark, PiggyBank, Wallet } from "lucide-react";
 import type { Account } from "@/api/types";
 import { formatCurrency } from "./connection-utils";
@@ -13,9 +14,8 @@ interface ConnectionAccountsListProps {
   accounts: Account[];
 }
 
-// Read-only list of accounts attached to a connection. Inline rename / exclude
-// live on the per-account detail page in a future surface; for now each row is
-// a placeholder link that will resolve once /accounts/$shortId ships.
+// Compact list of accounts attached to a connection — each card links to
+// the per-account detail page where rename / exclude / linking live.
 export function ConnectionAccountsList({ accounts }: ConnectionAccountsListProps) {
   if (accounts.length === 0) {
     return (
@@ -38,7 +38,11 @@ export function ConnectionAccountsList({ accounts }: ConnectionAccountsListProps
 function AccountCard({ account: a }: { account: Account }) {
   const Icon = TYPE_ICON[a.type] ?? Banknote;
   return (
-    <div className="bg-card flex items-center gap-3 rounded-lg border p-3">
+    <Link
+      to="/accounts/$id"
+      params={{ id: a.short_id }}
+      className="bg-card hover:bg-accent/40 flex items-center gap-3 rounded-lg border p-3 transition-colors"
+    >
       <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-lg">
         <Icon className="text-muted-foreground size-4" />
       </div>
@@ -54,6 +58,6 @@ function AccountCard({ account: a }: { account: Account }) {
           ? formatCurrency(a.balance_current, a.iso_currency_code)
           : "—"}
       </div>
-    </div>
+    </Link>
   );
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -31,6 +31,11 @@ import {
   ConnectionDetailPage,
   connectionDetailSearchSchema,
 } from "@/routes/connection-detail";
+import { AccountsPage, accountsSearchSchema } from "@/routes/accounts";
+import {
+  AccountDetailPage,
+  accountDetailSearchSchema,
+} from "@/routes/account-detail";
 import { NAV_LEAVES } from "@/lib/nav";
 import { baseSearchSchema } from "@/lib/modals";
 import { z } from "zod";
@@ -84,6 +89,10 @@ const PAGE_OVERRIDES: Record<string, PageOverride> = {
     component: ConnectionsPage,
     validateSearch: connectionsSearchSchema,
   },
+  "/accounts": {
+    component: AccountsPage,
+    validateSearch: accountsSearchSchema,
+  },
 };
 
 // Detail routes aren't nav leaves, so they're registered explicitly rather
@@ -134,6 +143,13 @@ const connectionDetailRoute = createRoute({
   validateSearch: connectionDetailSearchSchema,
 });
 
+const accountDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/accounts/$id",
+  component: AccountDetailPage,
+  validateSearch: accountDetailSearchSchema,
+});
+
 const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
   if (leaf.kind !== "link" || leaf.to === "/") return [];
   const override = PAGE_OVERRIDES[leaf.to];
@@ -159,6 +175,7 @@ const routeTree = rootRoute.addChildren([
   tagDetailRoute,
   sandboxRoute,
   connectionDetailRoute,
+  accountDetailRoute,
   ...pageRoutes,
 ]);
 

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -234,7 +234,11 @@ function DetailBody({ account: a, accounts, onAddLink }: DetailBodyProps) {
 
       <AccountRecentTransactions
         accountShortId={a.short_id}
-        transactions={a.recent_transactions}
+        // The detail endpoint returns up to 25; cap at 15 here so the
+        // section reads as a preview rather than a second-tier list. The
+        // footer link jumps to the full Transactions table filtered to
+        // this account.
+        transactions={a.recent_transactions.slice(0, 15)}
       />
     </div>
   );

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -17,7 +17,14 @@ import {
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { EmptyState } from "@/components/empty-state";
@@ -308,15 +315,18 @@ function BalanceCard({ account: a, liability, util }: BalanceCardProps) {
   // to mean "you owe this much". The label is "Balance owed", so show the
   // raw positive — the destructive tint already conveys it's a negative
   // line on the household sheet.
+  //
+  // Stat-card layout follows shadcn's dashboard pattern: label as
+  // CardDescription and value as CardTitle inside CardHeader (gap-2),
+  // optional context in CardFooter — no separate CardHeader / CardContent
+  // split with the wide gap-6 between them.
   return (
     <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-muted-foreground text-xs font-medium">
+      <CardHeader>
+        <CardDescription>
           {liability ? "Balance owed" : "Current balance"}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        <div
+        </CardDescription>
+        <CardTitle
           className={cn(
             "text-3xl font-semibold tabular-nums tracking-tight",
             liability && current != null && current > 0 && "text-destructive/90",
@@ -325,34 +335,38 @@ function BalanceCard({ account: a, liability, util }: BalanceCardProps) {
           {current != null
             ? formatCurrency(current, a.iso_currency_code)
             : "—"}
-        </div>
-        {util != null && (
-          <div className="space-y-1">
-            <div className="text-muted-foreground flex items-center justify-between text-xs tabular-nums">
-              <span>{Math.round(util)}% utilization</span>
-              {a.balance_limit != null && (
-                <span>
-                  of {formatCurrency(a.balance_limit, a.iso_currency_code)}
-                </span>
-              )}
-            </div>
-            <div className="bg-muted h-1.5 overflow-hidden rounded-full">
-              <div
-                className={cn(
-                  "h-full transition-all",
-                  utilizationBarClass(util),
+        </CardTitle>
+      </CardHeader>
+      {(util != null || a.iso_currency_code) && (
+        <CardFooter className="flex-col items-stretch gap-2">
+          {util != null && (
+            <>
+              <div className="text-muted-foreground flex items-center justify-between text-xs tabular-nums">
+                <span>{Math.round(util)}% utilization</span>
+                {a.balance_limit != null && (
+                  <span>
+                    of {formatCurrency(a.balance_limit, a.iso_currency_code)}
+                  </span>
                 )}
-                style={{ width: `${util}%` }}
-              />
+              </div>
+              <div className="bg-muted h-1.5 overflow-hidden rounded-full">
+                <div
+                  className={cn(
+                    "h-full transition-all",
+                    utilizationBarClass(util),
+                  )}
+                  style={{ width: `${util}%` }}
+                />
+              </div>
+            </>
+          )}
+          {a.iso_currency_code && util == null && (
+            <div className="text-muted-foreground text-xs">
+              {a.iso_currency_code}
             </div>
-          </div>
-        )}
-        {a.iso_currency_code && (
-          <div className="text-muted-foreground text-[10px]">
-            {a.iso_currency_code}
-          </div>
-        )}
-      </CardContent>
+          )}
+        </CardFooter>
+      )}
     </Card>
   );
 }
@@ -395,27 +409,27 @@ function SecondaryCard({
       value: new Date(a.last_balance_update).toLocaleString(),
     });
   }
-
   if (a.official_name) {
     rows.push({ label: "Bank official name", value: a.official_name });
   }
 
+  // No CardHeader — the "Details" label was generic filler. Mirror the
+  // balance card's vertical rhythm (py-6 + a single inner block) so the
+  // pair sits flush, then list the rows directly.
   return (
     <Card>
-      <CardHeader className="pb-2">
-        <CardTitle className="text-muted-foreground text-xs font-medium">
-          Details
-        </CardTitle>
-      </CardHeader>
       <CardContent>
         {rows.length === 0 ? (
           <p className="text-muted-foreground text-sm">
             No additional balance or refresh information.
           </p>
         ) : (
-          <dl className="space-y-2 text-sm">
+          <dl className="space-y-2.5 text-sm">
             {rows.map((r) => (
-              <div key={r.label} className="flex items-baseline justify-between gap-3">
+              <div
+                key={r.label}
+                className="flex items-baseline justify-between gap-3"
+              >
                 <dt className="text-muted-foreground text-xs">{r.label}</dt>
                 <dd className="truncate text-right font-medium tabular-nums">
                   {r.value}

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -1,0 +1,450 @@
+import { useMemo } from "react";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearch,
+} from "@tanstack/react-router";
+import { z } from "zod";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  Banknote,
+  Eye,
+  EyeOff,
+  Link2,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { EmptyState } from "@/components/empty-state";
+import { useAccount, useAccounts } from "@/api/queries/accounts";
+import type { AccountDetail } from "@/api/types";
+import {
+  accountLabel,
+  accountTypeIcon,
+  accountTypeLabel,
+  creditUtilization,
+  formatCurrency,
+  isLiability,
+  utilizationBarClass,
+} from "@/features/accounts/account-utils";
+import { AccountSettingsCard } from "@/features/accounts/account-settings-card";
+import { AccountRecentTransactions } from "@/features/accounts/account-recent-transactions";
+import { AccountLinksSection } from "@/features/accounts/account-links-section";
+import { LinkAccountSheet } from "@/features/accounts/link-account-sheet";
+import { cn } from "@/lib/utils";
+
+// Search-param schema.
+//   action → "link" opens the LinkAccountSheet pre-targeted at this account.
+export const accountDetailSearchSchema = z.object({
+  action: z.literal("link").optional(),
+});
+
+type AccountDetailSearch = z.infer<typeof accountDetailSearchSchema>;
+
+export function AccountDetailPage() {
+  const { id } = useParams({ strict: false }) as { id?: string };
+  const search = useSearch({ strict: false }) as AccountDetailSearch;
+  const navigate = useNavigate();
+
+  const acctQuery = useAccount(id);
+  // The accounts list powers the dependent-picker inside LinkAccountSheet
+  // and resolves link short_ids inside AccountLinksSection.
+  const accountsQuery = useAccounts();
+
+  function openLinkSheet() {
+    if (!acctQuery.data) return;
+    navigate({
+      to: "/accounts/$id",
+      params: { id: acctQuery.data.short_id },
+      search: (prev: AccountDetailSearch) => ({ ...prev, action: "link" }),
+      replace: false,
+    });
+  }
+
+  function closeLinkSheet() {
+    if (!acctQuery.data) return;
+    navigate({
+      to: "/accounts/$id",
+      params: { id: acctQuery.data.short_id },
+      search: (prev: AccountDetailSearch) => ({ ...prev, action: undefined }),
+      replace: true,
+    });
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
+        <Link to="/accounts">
+          <ArrowLeft className="size-4" />
+          Accounts
+        </Link>
+      </Button>
+
+      {acctQuery.isLoading ? (
+        <DetailSkeleton />
+      ) : acctQuery.isError || !acctQuery.data ? (
+        <EmptyState
+          icon={Banknote}
+          title="Account not found"
+          description="It may have been disconnected, or the link is wrong."
+          action={
+            <Button variant="outline" asChild>
+              <Link to="/accounts">Back to accounts</Link>
+            </Button>
+          }
+        />
+      ) : (
+        <DetailBody
+          account={acctQuery.data}
+          accounts={accountsQuery.data ?? []}
+          onAddLink={openLinkSheet}
+        />
+      )}
+
+      {acctQuery.data && (
+        <LinkAccountSheet
+          open={search.action === "link"}
+          onOpenChange={(open) => {
+            if (!open) closeLinkSheet();
+          }}
+          primary={acctQuery.data}
+          accounts={accountsQuery.data ?? []}
+        />
+      )}
+    </div>
+  );
+}
+
+interface DetailBodyProps {
+  account: AccountDetail;
+  accounts: ReturnType<typeof useAccounts>["data"] extends infer T
+    ? T extends undefined
+      ? never
+      : T
+    : never;
+  onAddLink: () => void;
+}
+
+function DetailBody({ account: a, accounts, onAddLink }: DetailBodyProps) {
+  const Icon = accountTypeIcon(a.type);
+  const liability = isLiability(a.type);
+  const util = creditUtilization(a);
+  const statusAlert = useMemo(() => connectionStatusAlert(a), [a]);
+
+  return (
+    <div className="space-y-6">
+      {/* Hero */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="bg-muted flex size-12 shrink-0 items-center justify-center rounded-lg">
+            <Icon className="text-muted-foreground size-5" />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="truncate text-xl font-semibold tracking-tight">
+                {accountLabel(a)}
+              </h1>
+              {a.excluded && (
+                <Badge variant="outline" className="gap-1 text-[10px]">
+                  <EyeOff className="size-2.5" /> Excluded
+                </Badge>
+              )}
+              {a.is_dependent_linked && (
+                <Badge variant="secondary" className="gap-1 text-[10px]">
+                  <Link2 className="size-2.5" /> Linked dependent
+                </Badge>
+              )}
+            </div>
+            <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-1.5 text-xs">
+              <span className="capitalize">
+                {accountTypeLabel(a.type, a.subtype)}
+              </span>
+              {a.mask && (
+                <>
+                  <span className="text-muted-foreground/40">·</span>
+                  <span className="tabular-nums">····{a.mask}</span>
+                </>
+              )}
+              {a.institution_name && (
+                <>
+                  <span className="text-muted-foreground/40">·</span>
+                  <span>{a.institution_name}</span>
+                </>
+              )}
+              {a.connection_user_name && (
+                <>
+                  <span className="text-muted-foreground/40">·</span>
+                  <span>{a.connection_user_name}</span>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 flex-wrap items-center gap-2">
+          {!a.is_dependent_linked && (
+            <Button variant="outline" size="sm" onClick={onAddLink}>
+              <Link2 className="size-4" />
+              Link account
+            </Button>
+          )}
+          <Button variant="outline" size="sm" asChild>
+            <Link to="/transactions" search={{ account: a.short_id }}>
+              <Eye className="size-4" />
+              View transactions
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {statusAlert}
+
+      {/* Balance cards */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <BalanceCard account={a} liability={liability} util={util} />
+        <SecondaryCard account={a} liability={liability} />
+      </div>
+
+      <AccountSettingsCard account={a} />
+
+      {/* Account links - skip when the account is itself a dependent.
+          Showing a "Link an account" CTA on a dependent would let users
+          create the second hop of an A→B→C chain, which the backend
+          rejects anyway. The settings card still surfaces the dependent
+          state, and the LinkAccountSheet's filter logic mirrors it. */}
+      {!a.is_dependent_linked && (
+        <AccountLinksSection
+          account={a}
+          accounts={accounts}
+          onAddLink={onAddLink}
+        />
+      )}
+
+      <AccountRecentTransactions
+        accountShortId={a.short_id}
+        transactions={a.recent_transactions}
+      />
+    </div>
+  );
+}
+
+function connectionStatusAlert(a: AccountDetail) {
+  const status = a.connection_status;
+  if (!status || status === "active") return null;
+  if (status === "pending_reauth") {
+    return (
+      <Alert className="border-amber-500/30 bg-amber-500/5">
+        <AlertTriangle className="size-4 text-amber-700 dark:text-amber-400" />
+        <AlertTitle className="text-amber-700 dark:text-amber-400">
+          Connection needs re-authentication
+        </AlertTitle>
+        <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+          <span>Recent syncs may be stale until you reconnect.</span>
+          {a.connection_short_id && (
+            <Button size="sm" variant="outline" asChild>
+              <Link
+                to="/connections/$id"
+                params={{ id: a.connection_short_id }}
+              >
+                Open connection
+                <ArrowRight className="size-3.5" />
+              </Link>
+            </Button>
+          )}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  if (status === "error") {
+    return (
+      <Alert variant="destructive">
+        <AlertTriangle className="size-4" />
+        <AlertTitle>Connection error</AlertTitle>
+        <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+          <span>Sync is currently failing. Check the connection for details.</span>
+          {a.connection_short_id && (
+            <Button size="sm" variant="outline" asChild>
+              <Link
+                to="/connections/$id"
+                params={{ id: a.connection_short_id }}
+              >
+                Open connection
+                <ArrowRight className="size-3.5" />
+              </Link>
+            </Button>
+          )}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  if (status === "disconnected") {
+    return (
+      <Alert>
+        <AlertTitle>Connection disconnected</AlertTitle>
+        <AlertDescription>
+          This account is read-only — its parent connection no longer syncs.
+          Historical transactions remain.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  return null;
+}
+
+interface BalanceCardProps {
+  account: AccountDetail;
+  liability: boolean;
+  util: number | null;
+}
+
+function BalanceCard({ account: a, liability, util }: BalanceCardProps) {
+  const current = a.balance_current;
+  // For liabilities (credit/loan), Plaid returns positive `balance_current`
+  // to mean "you owe this much". The label is "Balance owed", so show the
+  // raw positive — the destructive tint already conveys it's a negative
+  // line on the household sheet.
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-muted-foreground text-xs font-medium">
+          {liability ? "Balance owed" : "Current balance"}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div
+          className={cn(
+            "text-3xl font-semibold tabular-nums tracking-tight",
+            liability && current != null && current > 0 && "text-destructive/90",
+          )}
+        >
+          {current != null
+            ? formatCurrency(current, a.iso_currency_code)
+            : "—"}
+        </div>
+        {util != null && (
+          <div className="space-y-1">
+            <div className="text-muted-foreground flex items-center justify-between text-xs tabular-nums">
+              <span>{Math.round(util)}% utilization</span>
+              {a.balance_limit != null && (
+                <span>
+                  of {formatCurrency(a.balance_limit, a.iso_currency_code)}
+                </span>
+              )}
+            </div>
+            <div className="bg-muted h-1.5 overflow-hidden rounded-full">
+              <div
+                className={cn(
+                  "h-full transition-all",
+                  utilizationBarClass(util),
+                )}
+                style={{ width: `${util}%` }}
+              />
+            </div>
+          </div>
+        )}
+        {a.iso_currency_code && (
+          <div className="text-muted-foreground text-[10px]">
+            {a.iso_currency_code}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SecondaryCard({
+  account: a,
+  liability,
+}: {
+  account: AccountDetail;
+  liability: boolean;
+}) {
+  // Depository / investment: show "available" balance and last update.
+  // Credit / loan: show available credit (limit − current) and last update.
+  // The point is to give users a second useful number, not the same number
+  // twice.
+  const rows: { label: string; value: string }[] = [];
+  if (liability) {
+    if (a.balance_limit != null && a.balance_current != null) {
+      const avail = Math.max(0, a.balance_limit - a.balance_current);
+      rows.push({
+        label: "Available credit",
+        value: formatCurrency(avail, a.iso_currency_code),
+      });
+    }
+    if (a.balance_limit != null) {
+      rows.push({
+        label: "Credit limit",
+        value: formatCurrency(a.balance_limit, a.iso_currency_code),
+      });
+    }
+  } else if (a.balance_available != null) {
+    rows.push({
+      label: "Available",
+      value: formatCurrency(a.balance_available, a.iso_currency_code),
+    });
+  }
+  if (a.last_balance_update) {
+    rows.push({
+      label: "Last balance update",
+      value: new Date(a.last_balance_update).toLocaleString(),
+    });
+  }
+
+  if (a.official_name) {
+    rows.push({ label: "Bank official name", value: a.official_name });
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-muted-foreground text-xs font-medium">
+          Details
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No additional balance or refresh information.
+          </p>
+        ) : (
+          <dl className="space-y-2 text-sm">
+            {rows.map((r) => (
+              <div key={r.label} className="flex items-baseline justify-between gap-3">
+                <dt className="text-muted-foreground text-xs">{r.label}</dt>
+                <dd className="truncate text-right font-medium tabular-nums">
+                  {r.value}
+                </dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Skeleton className="size-12 rounded-lg" />
+        <div className="space-y-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-4 w-56" />
+        </div>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Skeleton className="h-32 rounded-xl" />
+        <Skeleton className="h-32 rounded-xl" />
+      </div>
+      <Skeleton className="h-40 rounded-xl" />
+      <Skeleton className="h-48 rounded-xl" />
+    </div>
+  );
+}

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -1,0 +1,214 @@
+import { useMemo } from "react";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { z } from "zod";
+import { Banknote, Building2, Layers, Loader2, Plus } from "lucide-react";
+import { PageHeader } from "@/components/page-header";
+import { EmptyState } from "@/components/empty-state";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@/components/ui/toggle-group";
+import { useAccounts } from "@/api/queries/accounts";
+import { useUsers } from "@/api/queries/users";
+import { FamilyTabs } from "@/features/connections/family-tabs";
+import { AccountCard } from "@/features/accounts/account-card";
+import { AccountsSummary } from "@/features/accounts/accounts-summary";
+import {
+  groupAccounts,
+  type AccountGroupBy,
+} from "@/features/accounts/account-utils";
+
+// Search-param schema.
+//   user → "all" or a user short_id  (family-member filter)
+//   group → "institution" (default) or "type" (grouping dimension)
+//   action → "connect" (passthrough into the connect-bank flow on
+//            /connections; sending users here would be confusing since this
+//            page never opens its own sheet, so we just navigate.)
+export const accountsSearchSchema = z.object({
+  user: z.string().optional(),
+  group: z.enum(["institution", "type"]).optional(),
+});
+
+export type AccountsSearch = z.infer<typeof accountsSearchSchema>;
+
+export function AccountsPage() {
+  const search = useSearch({ strict: false }) as AccountsSearch;
+  const navigate = useNavigate();
+  const userFilter = search.user ?? "all";
+  const groupBy: AccountGroupBy = search.group ?? "institution";
+
+  const accountsQuery = useAccounts();
+  const usersQuery = useUsers();
+
+  // Counts per user, shared by the FamilyTabs labels and by the filter
+  // resolution below. We key on user short_id to match the tab's value.
+  const countsByUserShortId = useMemo(() => {
+    const out = new Map<string, number>();
+    const idToShortId = new Map<string, string>();
+    for (const u of usersQuery.data ?? []) {
+      idToShortId.set(u.id, u.short_id);
+      out.set(u.short_id, 0);
+    }
+    for (const a of accountsQuery.data ?? []) {
+      if (!a.user_id) continue;
+      const sid = idToShortId.get(a.user_id);
+      if (!sid) continue;
+      out.set(sid, (out.get(sid) ?? 0) + 1);
+    }
+    return out;
+  }, [accountsQuery.data, usersQuery.data]);
+
+  // Resolve the selected short_id back to a UUID so we can filter the
+  // accounts (which carry the user's UUID, not short_id).
+  const filterUserId = useMemo(() => {
+    if (userFilter === "all") return null;
+    return usersQuery.data?.find((u) => u.short_id === userFilter)?.id ?? null;
+  }, [userFilter, usersQuery.data]);
+
+  const visible = useMemo(() => {
+    const all = accountsQuery.data ?? [];
+    if (filterUserId == null) return all;
+    return all.filter((a) => a.user_id === filterUserId);
+  }, [accountsQuery.data, filterUserId]);
+
+  const groups = useMemo(() => groupAccounts(visible, groupBy), [visible, groupBy]);
+
+  function setUserFilter(next: string) {
+    navigate({
+      to: "/accounts",
+      search: (prev: AccountsSearch) => ({
+        ...prev,
+        user: next === "all" ? undefined : next,
+      }),
+      replace: true,
+    });
+  }
+
+  function setGroupBy(next: AccountGroupBy) {
+    navigate({
+      to: "/accounts",
+      search: (prev: AccountsSearch) => ({
+        ...prev,
+        group: next === "institution" ? undefined : next,
+      }),
+      replace: true,
+    });
+  }
+
+  const isLoading = accountsQuery.isLoading;
+  const isError = accountsQuery.isError;
+  const accounts = accountsQuery.data ?? [];
+  const totalCount = accounts.length;
+
+  return (
+    <>
+      <PageHeader
+        title="Accounts"
+        description="Every bank account, credit card, loan, and investment Breadbox has synced. Click an account to edit, exclude, or link it."
+        actions={
+          accounts.length > 0 ? (
+            <Button size="sm" asChild>
+              <Link to="/connections" search={{ action: "connect" }}>
+                <Plus className="size-4" />
+                Connect bank
+              </Link>
+            </Button>
+          ) : null
+        }
+      />
+
+      {accounts.length > 0 && (
+        <div className="-mt-4 mb-4">
+          <AccountsSummary accounts={visible} />
+        </div>
+      )}
+
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        {(usersQuery.data?.length ?? 0) > 1 ? (
+          <FamilyTabs
+            users={usersQuery.data ?? []}
+            value={userFilter}
+            onChange={setUserFilter}
+            counts={countsByUserShortId}
+            totalCount={totalCount}
+          />
+        ) : (
+          <div />
+        )}
+
+        {accounts.length > 0 && (
+          <ToggleGroup
+            type="single"
+            size="sm"
+            value={groupBy}
+            onValueChange={(v) => v && setGroupBy(v as AccountGroupBy)}
+            variant="outline"
+          >
+            <ToggleGroupItem value="institution" aria-label="Group by institution">
+              <Building2 className="size-3.5" /> Institution
+            </ToggleGroupItem>
+            <ToggleGroupItem value="type" aria-label="Group by type">
+              <Layers className="size-3.5" /> Type
+            </ToggleGroupItem>
+          </ToggleGroup>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="text-muted-foreground flex items-center justify-center gap-2 py-12 text-sm">
+          <Loader2 className="size-4 animate-spin" /> Loading accounts…
+        </div>
+      ) : isError ? (
+        <Alert variant="destructive">
+          <AlertTitle>Couldn't load accounts</AlertTitle>
+          <AlertDescription>
+            {accountsQuery.error instanceof Error
+              ? accountsQuery.error.message
+              : "Try refreshing the page."}
+          </AlertDescription>
+        </Alert>
+      ) : accounts.length === 0 ? (
+        <EmptyState
+          icon={Banknote}
+          title="No accounts yet"
+          description="Connect a bank to start syncing accounts and transactions."
+          action={
+            <Button asChild>
+              <Link to="/connections" search={{ action: "connect" }}>
+                <Plus className="size-4" />
+                Connect a bank
+              </Link>
+            </Button>
+          }
+        />
+      ) : visible.length === 0 ? (
+        <EmptyState
+          title="No accounts for this filter"
+          description="Switch family member or clear the filter to see other accounts."
+        />
+      ) : (
+        <div className="space-y-6">
+          {groups.map((g) => (
+            <section key={g.key} className="space-y-2">
+              <div className="flex items-baseline justify-between">
+                <h2 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                  {g.label}
+                </h2>
+                <span className="text-muted-foreground text-xs tabular-nums">
+                  {g.accounts.length}
+                </span>
+              </div>
+              <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                {g.accounts.map((a) => (
+                  <AccountCard key={a.id} account={a} />
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/sandbox/fixtures.ts
+++ b/web/src/sandbox/fixtures.ts
@@ -255,8 +255,18 @@ export const sampleTransactions: Transaction[] = [
 
 // --- Accounts (full view useAccounts returns) ---
 
+const sampleAccountBase = {
+  official_name: null,
+  balance_limit: null,
+  last_balance_update: null,
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2026-05-01T00:00:00Z",
+  connection_status: "active" as const,
+};
+
 export const sampleAccounts: Account[] = [
   {
+    ...sampleAccountBase,
     id: "acct-checking",
     short_id: "checking",
     connection_id: "demo-conn",
@@ -272,6 +282,7 @@ export const sampleAccounts: Account[] = [
     is_dependent_linked: false,
   },
   {
+    ...sampleAccountBase,
     id: "acct-platinum",
     short_id: "platinum",
     connection_id: "demo-conn",
@@ -281,8 +292,9 @@ export const sampleAccounts: Account[] = [
     type: "credit",
     subtype: "credit card",
     mask: "0093",
-    balance_current: -842.16,
+    balance_current: 842.16,
     balance_available: null,
+    balance_limit: 5000,
     iso_currency_code: "USD",
     is_dependent_linked: false,
   },


### PR DESCRIPTION
## Summary

Adds the Accounts surface to the v2 SPA: a list page grouped by institution or type, and a per-account detail page that hosts inline rename, exclude, and **account linking** (which is now scoped to the account it's set up on, since the top-level Account links page was removed in #1098).

### What's new

- **`/v2/accounts`** — list grouped by institution (default) or type, with a net-worth/assets/liabilities strip, family-member tab filter, dependent badges, credit utilization bars, and inline connection-status pills for accounts on a degraded connection. Pulls from `/api/v1/accounts`.
- **`/v2/accounts/$id`** — balance hero (sign-aware: "Balance owed" for credit/loan, "Current balance" otherwise), inline display-name editor, exclude-from-sync toggle, parent-connection link, the most recent 25 transactions, and an **Account links** card.
- **Account linking inline** — the detail page lists every link this account participates in (as primary "covers" or as dependent "attributed to"), with reconcile + unlink dropdown actions. A `LinkAccountSheet` creates a new primary→dependent link, filtering out ineligible accounts (already-dependent, reverse-link conflicts) the way the backend would. Dependents themselves hide the linking UI to avoid offering an A→B→C chain the backend would reject.
- **`Account links` nav entry removed** from the sidebar (it pointed at a page that no longer exists post-#1098). Setup now reads as Accounts / Connections.

### Backend

Untouched — the page uses the existing `/api/v1/accounts`, `/api/v1/accounts/{id}/detail`, `/api/v1/account-links` (list / create / update / delete / reconcile) endpoints via new TanStack Query hooks in `web/src/api/queries/{accounts,account-links}.ts`. The `Account` TS type was widened to mirror the full `AccountResponse` (was a subset).

### Conventions

- Routes registered via `PAGE_OVERRIDES` + an explicit detail route in `web/src/main.tsx`.
- Reusable atoms (`AccountCard`, `AccountsSummary`, `account-utils`) live under `web/src/features/accounts/` — used only by these two routes for now, so feature-scoped per the v2 rules.
- ShadCN `toggle-group` primitive installed for the institution/type grouping switch.
- The list endpoint returns `*_account_id` as short_ids (cf. the project's compact-ID convention); the singular endpoints return UUIDs. The links section and link-sheet filter on `short_id` so the current shape works — noted inline.

## Evidence

Validated in Chrome DevTools MCP against `make dev` on port 8082 (Plaid sandbox data). `bun run lint` and `bun run build` both pass.

**Accounts list (desktop)** — net-worth / assets / liabilities strip, institution grouping, credit-card sign flip on the Platinum row:
<img src="https://i.img402.dev/jlvyjiktrp.png" width="900" alt="accounts list — desktop">

**Accounts list (mobile, 420px)** — same content, single column:
<img src="https://i.img402.dev/f7n05ueq6w.png" width="320" alt="accounts list — mobile">

**Account detail — credit card** — "Balance owed $2,571.04" hero, settings card, empty account-links section, recent transactions:
<img src="https://i.img402.dev/8hcogtf0pc.jpg" width="900" alt="account detail — credit card">

**Account detail — depository with active link** — "Current balance $55,807.95", with an active "Primary · Covers → Essential Savings" link in the Account links section:
<img src="https://i.img402.dev/3hef7jzo8b.jpg" width="900" alt="account detail — depository, with link">

**Link account sheet** — primary fixed to the current account, dependent picker filters out ineligible accounts, tolerance defaults to 3 days:
<img src="https://i.img402.dev/bgkhz1w0ja.png" width="700" alt="link account sheet">

**Account detail — dependent state** — the "Linked dependent" badge appears, the Link CTA is hidden, and the AccountLinksSection is suppressed:
<img src="https://i.img402.dev/h4o2mki0d8.png" width="900" alt="account detail — dependent">

I exercised the create + delete link flow end-to-end during validation (verified the dependent badge propagates and the link sheet's eligible-dependent filter updates after creation) and cleaned up the test link after capturing evidence.

## Test plan

- [ ] Click into each account from `/v2/accounts` and confirm the detail page loads with correct balance / utilization / recent transactions
- [ ] Rename an account via the inline editor; confirm the list reflects the new name (cache invalidates on success)
- [ ] Toggle "Exclude from sync" and confirm the badge appears in the hero
- [ ] Link two of your own accounts via the sheet; confirm the dependent shows the "Linked dependent" badge and the link disappears from the eligible-dependent picker for other accounts
- [ ] Unlink via the dropdown menu; confirm the dependent badge clears
- [ ] Switch the grouping toggle on the list between Institution and Type and confirm the URL `?group=` updates
- [ ] On a single-user household, confirm no FamilyTabs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)
