### PR TITLE
v2: drop appearance, billing, notifications from settings model

### DIFF
--- a/web/src/lib/settings-sections.ts
+++ b/web/src/lib/settings-sections.ts
@@ -1,11 +1,4 @@
-import {
-  Bell,
-  Brush,
-  CreditCard,
-  Lock,
-  User,
-  type LucideIcon,
-} from "lucide-react";
+import { Lock, User, type LucideIcon } from "lucide-react";
 
 export interface SettingsSection {
   slug: string;
@@ -20,24 +13,6 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     title: "Account",
     description: "Profile, password, and identity.",
     icon: User,
-  },
-  {
-    slug: "appearance",
-    title: "Appearance",
-    description: "Theme follows your system preference.",
-    icon: Brush,
-  },
-  {
-    slug: "notifications",
-    title: "Notifications",
-    description: "Email and in-app alerts.",
-    icon: Bell,
-  },
-  {
-    slug: "billing",
-    title: "Billing",
-    description: "Plan and invoices.",
-    icon: CreditCard,
   },
   {
     slug: "security",


### PR DESCRIPTION
## Summary
- Removes the **Appearance**, **Notifications**, and **Billing** entries from `SETTINGS_SECTIONS`; they were placeholders rendering "Coming soon." with no backing functionality.
- Leaves only **Account** (real form) and **Security** (still a placeholder, kept since sessions/API keys are real upcoming work).
- Drops the now-unused `Bell`, `Brush`, `CreditCard` icon imports.

## Test plan
- [x] `bun run lint` (tsc --noEmit) passes
- [ ] Open the settings modal at `/v2/` — sidebar shows only Account and Security; default lands on Account; mobile sheet shows both stacked

🤖 Generated with [Claude Code](https://claude.com/claude-code)