### PR TITLE
v2: API keys management pages

### DIFF
--- a/web/src/api/queries/api-keys.ts
+++ b/web/src/api/queries/api-keys.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type {
+  APIKey,
+  APIKeyActorType,
+  APIKeyScope,
+  CreateAPIKeyResult,
+} from "@/api/types";
+
+// useAPIKeys loads the full key catalog. The list endpoint requires a
+// full_access scope (session admins/editors qualify) — read-only sessions
+// will see a 403 surfaced as ApiError.
+export function useAPIKeys() {
+  return useQuery({
+    queryKey: ["api-keys"],
+    queryFn: () => api<APIKey[]>("/api/v1/api-keys"),
+    staleTime: 30_000,
+  });
+}
+
+export interface CreateAPIKeyInput {
+  name: string;
+  scope: APIKeyScope;
+  actor_type: APIKeyActorType;
+  actor_name?: string;
+}
+
+export function useCreateAPIKey() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateAPIKeyInput) =>
+      api<CreateAPIKeyResult>("/api/v1/api-keys", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["api-keys"] });
+    },
+  });
+}
+
+export function useRevokeAPIKey() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api<void>(`/api/v1/api-keys/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["api-keys"] });
+    },
+  });
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -307,3 +307,25 @@ export interface UpdateTransactionsResult {
   aborted?: boolean;
   error?: string;
 }
+
+// --- API keys (public /api/v1/api-keys) ---
+// Mirrors internal/service.APIKeyResponse. Plaintext is returned only on the
+// create response and surfaced once at /api-keys/created.
+export type APIKeyScope = "full_access" | "read_only";
+export type APIKeyActorType = "user" | "agent" | "system";
+
+export interface APIKey {
+  id: string;
+  name: string;
+  key_prefix: string;
+  scope: APIKeyScope;
+  actor_type: APIKeyActorType;
+  actor_name?: string | null;
+  last_used_at: string | null;
+  revoked_at: string | null;
+  created_at: string;
+}
+
+export interface CreateAPIKeyResult extends APIKey {
+  plaintext_key: string;
+}

--- a/web/src/components/ui/radio-group.tsx
+++ b/web/src/components/ui/radio-group.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+import { CircleIcon } from "lucide-react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/web/src/features/api-keys/api-key-badges.tsx
+++ b/web/src/features/api-keys/api-key-badges.tsx
@@ -47,7 +47,7 @@ const ACTOR_LABEL: Record<APIKeyActorType, string> = {
 // muted text — useful when a household has several agent integrations and
 // the type alone isn't enough to tell them apart.
 export function ActorBadge({ type, name }: ActorBadgeProps) {
-  const Icon = ACTOR_ICON[type] ?? Bot;
+  const Icon = ACTOR_ICON[type];
   return (
     <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
       <Icon className="size-3.5" />

--- a/web/src/features/api-keys/api-key-badges.tsx
+++ b/web/src/features/api-keys/api-key-badges.tsx
@@ -1,0 +1,58 @@
+import { Bot, ShieldCheck, ShieldOff, User as UserIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { APIKeyActorType, APIKeyScope } from "@/api/types";
+
+interface ScopeBadgeProps {
+  scope: APIKeyScope;
+}
+
+// ScopeBadge shows whether a key can write. Read-only is a muted secondary
+// chip; full-access wears the primary outline so it reads as the elevated
+// permission.
+export function ScopeBadge({ scope }: ScopeBadgeProps) {
+  if (scope === "read_only") {
+    return (
+      <Badge variant="secondary" className="gap-1">
+        <ShieldOff className="size-3" />
+        Read only
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="gap-1">
+      <ShieldCheck className="size-3" />
+      Full access
+    </Badge>
+  );
+}
+
+interface ActorBadgeProps {
+  type: APIKeyActorType;
+  name?: string | null;
+}
+
+const ACTOR_ICON = {
+  user: UserIcon,
+  agent: Bot,
+  system: ShieldCheck,
+} as const;
+
+const ACTOR_LABEL: Record<APIKeyActorType, string> = {
+  user: "User",
+  agent: "Agent",
+  system: "System",
+};
+
+// ActorBadge captures who minted the key. The optional `name` is appended in
+// muted text — useful when a household has several agent integrations and
+// the type alone isn't enough to tell them apart.
+export function ActorBadge({ type, name }: ActorBadgeProps) {
+  const Icon = ACTOR_ICON[type] ?? Bot;
+  return (
+    <span className="text-muted-foreground inline-flex items-center gap-1.5 text-xs">
+      <Icon className="size-3.5" />
+      <span className="text-foreground">{ACTOR_LABEL[type]}</span>
+      {name && <span className="text-muted-foreground/70">· {name}</span>}
+    </span>
+  );
+}

--- a/web/src/features/api-keys/api-key-form.tsx
+++ b/web/src/features/api-keys/api-key-form.tsx
@@ -2,7 +2,16 @@ import { useForm, type Resolver, type SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useNavigate } from "@tanstack/react-router";
-import { Bot, Loader2, ShieldCheck, ShieldOff, User } from "lucide-react";
+import {
+  Bot,
+  Loader2,
+  ShieldCheck,
+  ShieldOff,
+  User,
+  type LucideIcon,
+} from "lucide-react";
+import { toast } from "sonner";
+import { ApiError } from "@/api/client";
 import {
   Form,
   FormControl,
@@ -17,9 +26,7 @@ import { Button } from "@/components/ui/button";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { cn } from "@/lib/utils";
 import { useCreateAPIKey } from "@/api/queries/api-keys";
-import { withMutationToast } from "@/lib/mutation-toast";
 import { storePendingPlaintextKey } from "@/features/api-keys/plaintext-store";
-import type { CreateAPIKeyResult } from "@/api/types";
 
 const formSchema = z.object({
   name: z
@@ -41,7 +48,7 @@ interface ScopeOption {
   value: APIKeyFormValues["scope"];
   label: string;
   description: string;
-  Icon: typeof ShieldCheck;
+  Icon: LucideIcon;
 }
 
 const SCOPE_OPTIONS: ScopeOption[] = [
@@ -63,7 +70,7 @@ interface ActorOption {
   value: APIKeyFormValues["actor_type"];
   label: string;
   description: string;
-  Icon: typeof Bot;
+  Icon: LucideIcon;
 }
 
 const ACTOR_OPTIONS: ActorOption[] = [
@@ -102,27 +109,24 @@ export function APIKeyForm() {
   });
 
   const onSubmit: SubmitHandler<APIKeyFormValues> = async (values) => {
-    let created: CreateAPIKeyResult | null = null;
-    const ok = await withMutationToast(
-      async () => {
-        created = await create.mutateAsync({
-          name: values.name,
-          scope: values.scope,
-          actor_type: values.actor_type,
-          actor_name: values.actor_name || undefined,
-        });
-      },
-      { success: `Created "${values.name}".` },
-    );
-    if (ok && created) {
-      // Stash plaintext in sessionStorage so the /created page can render it
-      // exactly once and the user can refresh without losing it mid-copy.
-      storePendingPlaintextKey({
-        id: (created as CreateAPIKeyResult).id,
-        name: (created as CreateAPIKeyResult).name,
-        plaintext: (created as CreateAPIKeyResult).plaintext_key,
+    try {
+      const created = await create.mutateAsync({
+        name: values.name,
+        scope: values.scope,
+        actor_type: values.actor_type,
+        actor_name: values.actor_name || undefined,
       });
+      storePendingPlaintextKey({
+        id: created.id,
+        name: created.name,
+        plaintext: created.plaintext_key,
+      });
+      toast.success(`Created "${values.name}".`);
       navigate({ to: "/api-keys/created" });
+    } catch (err) {
+      const msg =
+        err instanceof ApiError ? err.message : "Couldn't create the key.";
+      toast.error(msg);
     }
   };
 
@@ -265,7 +269,7 @@ interface OptionCardProps {
   selected: boolean;
   label: string;
   description: string;
-  Icon: typeof Bot;
+  Icon: LucideIcon;
 }
 
 // OptionCard is a wrapped RadioGroupItem styled as a tappable tile —

--- a/web/src/features/api-keys/api-key-form.tsx
+++ b/web/src/features/api-keys/api-key-form.tsx
@@ -1,0 +1,309 @@
+import { useForm, type Resolver, type SubmitHandler } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useNavigate } from "@tanstack/react-router";
+import { Bot, Loader2, ShieldCheck, ShieldOff, User } from "lucide-react";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { cn } from "@/lib/utils";
+import { useCreateAPIKey } from "@/api/queries/api-keys";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { storePendingPlaintextKey } from "@/features/api-keys/plaintext-store";
+import type { CreateAPIKeyResult } from "@/api/types";
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .min(1, "Name is required")
+    .max(120, "Keep it under 120 characters"),
+  scope: z.enum(["full_access", "read_only"]),
+  actor_type: z.enum(["agent", "user", "system"]),
+  actor_name: z
+    .string()
+    .max(120, "Keep it under 120 characters")
+    .optional()
+    .or(z.literal("")),
+});
+
+type APIKeyFormValues = z.infer<typeof formSchema>;
+
+interface ScopeOption {
+  value: APIKeyFormValues["scope"];
+  label: string;
+  description: string;
+  Icon: typeof ShieldCheck;
+}
+
+const SCOPE_OPTIONS: ScopeOption[] = [
+  {
+    value: "full_access",
+    label: "Full access",
+    description: "Read everything, write everything. Triggers syncs, edits transactions.",
+    Icon: ShieldCheck,
+  },
+  {
+    value: "read_only",
+    label: "Read only",
+    description: "Query data only. Cannot categorize, sync, or use write MCP tools.",
+    Icon: ShieldOff,
+  },
+];
+
+interface ActorOption {
+  value: APIKeyFormValues["actor_type"];
+  label: string;
+  description: string;
+  Icon: typeof Bot;
+}
+
+const ACTOR_OPTIONS: ActorOption[] = [
+  {
+    value: "agent",
+    label: "Agent",
+    description: "AI assistants, Claude integrations, MCP clients.",
+    Icon: Bot,
+  },
+  {
+    value: "user",
+    label: "User",
+    description: "A human-driven script, CLI, or one-off integration.",
+    Icon: User,
+  },
+  {
+    value: "system",
+    label: "System",
+    description: "Internal automation — schedulers, jobs, infra plumbing.",
+    Icon: ShieldCheck,
+  },
+];
+
+export function APIKeyForm() {
+  const navigate = useNavigate();
+  const create = useCreateAPIKey();
+
+  const form = useForm<APIKeyFormValues>({
+    resolver: zodResolver(formSchema) as Resolver<APIKeyFormValues>,
+    defaultValues: {
+      name: "",
+      scope: "full_access",
+      actor_type: "agent",
+      actor_name: "",
+    },
+  });
+
+  const onSubmit: SubmitHandler<APIKeyFormValues> = async (values) => {
+    let created: CreateAPIKeyResult | null = null;
+    const ok = await withMutationToast(
+      async () => {
+        created = await create.mutateAsync({
+          name: values.name,
+          scope: values.scope,
+          actor_type: values.actor_type,
+          actor_name: values.actor_name || undefined,
+        });
+      },
+      { success: `Created "${values.name}".` },
+    );
+    if (ok && created) {
+      // Stash plaintext in sessionStorage so the /created page can render it
+      // exactly once and the user can refresh without losing it mid-copy.
+      storePendingPlaintextKey({
+        id: (created as CreateAPIKeyResult).id,
+        name: (created as CreateAPIKeyResult).name,
+        plaintext: (created as CreateAPIKeyResult).plaintext_key,
+      });
+      navigate({ to: "/api-keys/created" });
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Name</FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="e.g. Claude MCP, Mobile CLI"
+                  autoFocus
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                A descriptive name so you recognise this key in the audit log.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="scope"
+          render={({ field }) => (
+            <FormItem className="space-y-3">
+              <FormLabel>Scope</FormLabel>
+              <FormControl>
+                <RadioGroup
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  className="grid gap-3 sm:grid-cols-2"
+                >
+                  {SCOPE_OPTIONS.map((option) => (
+                    <OptionCard
+                      key={option.value}
+                      value={option.value}
+                      selected={field.value === option.value}
+                      label={option.label}
+                      description={option.description}
+                      Icon={option.Icon}
+                    />
+                  ))}
+                </RadioGroup>
+              </FormControl>
+              <FormDescription>
+                Scope is fixed at mint — to change it, revoke this key and
+                create a new one.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="actor_type"
+          render={({ field }) => (
+            <FormItem className="space-y-3">
+              <FormLabel>Actor type</FormLabel>
+              <FormControl>
+                <RadioGroup
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  className="grid gap-3 sm:grid-cols-3"
+                >
+                  {ACTOR_OPTIONS.map((option) => (
+                    <OptionCard
+                      key={option.value}
+                      value={option.value}
+                      selected={field.value === option.value}
+                      label={option.label}
+                      description={option.description}
+                      Icon={option.Icon}
+                    />
+                  ))}
+                </RadioGroup>
+              </FormControl>
+              <FormDescription>
+                Drives attribution on every action this key takes — visible in
+                the activity timeline.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="actor_name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Actor display name{" "}
+                <span className="text-muted-foreground font-normal">
+                  · optional
+                </span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  placeholder="Defaults to the key name"
+                  {...field}
+                />
+              </FormControl>
+              <FormDescription>
+                Override the display name shown in the activity timeline.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex gap-2 border-t pt-6">
+          <Button type="submit" disabled={create.isPending}>
+            {create.isPending && <Loader2 className="size-4 animate-spin" />}
+            {create.isPending ? "Creating…" : "Create key"}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => navigate({ to: "/api-keys" })}
+            disabled={create.isPending}
+          >
+            Cancel
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+interface OptionCardProps {
+  value: string;
+  selected: boolean;
+  label: string;
+  description: string;
+  Icon: typeof Bot;
+}
+
+// OptionCard is a wrapped RadioGroupItem styled as a tappable tile —
+// the indicator stays in the corner; the whole card is the hit target.
+function OptionCard({
+  value,
+  selected,
+  label,
+  description,
+  Icon,
+}: OptionCardProps) {
+  const id = `option-${value}`;
+  return (
+    <label
+      htmlFor={id}
+      className={cn(
+        "group relative flex cursor-pointer flex-col gap-2 rounded-lg border p-4 transition-colors",
+        "hover:border-foreground/30",
+        selected
+          ? "border-primary bg-primary/[0.04] ring-primary/30 ring-1"
+          : "border-border bg-card",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <Icon
+          className={cn(
+            "size-4 transition-colors",
+            selected ? "text-primary" : "text-muted-foreground",
+          )}
+        />
+        <RadioGroupItem id={id} value={value} className="mt-0.5" />
+      </div>
+      <div className="space-y-1">
+        <div className="text-sm font-medium">{label}</div>
+        <p className="text-muted-foreground text-xs leading-relaxed">
+          {description}
+        </p>
+      </div>
+    </label>
+  );
+}

--- a/web/src/features/api-keys/api-keys-table.tsx
+++ b/web/src/features/api-keys/api-keys-table.tsx
@@ -1,0 +1,217 @@
+import { useMemo, useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Ban, Loader2, MoreHorizontal } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { DataTable } from "@/components/data-table";
+import { formatLongDate, formatRelativeTime } from "@/lib/format";
+import { withMutationToast } from "@/lib/mutation-toast";
+import { useRevokeAPIKey } from "@/api/queries/api-keys";
+import type { APIKey } from "@/api/types";
+import {
+  ActorBadge,
+  ScopeBadge,
+} from "@/features/api-keys/api-key-badges";
+
+export interface APIKeysTableProps {
+  keys: APIKey[];
+  isLoading: boolean;
+  isError: boolean;
+  /** Hide the actions column — used for the revoked tab where nothing's actionable. */
+  revoked?: boolean;
+  emptyState: React.ReactNode;
+  /** Optional override so the sandbox can render without firing real mutations. */
+  onRevoke?: (key: APIKey) => Promise<void> | void;
+}
+
+export function APIKeysTable({
+  keys,
+  isLoading,
+  isError,
+  revoked = false,
+  emptyState,
+  onRevoke,
+}: APIKeysTableProps) {
+  const [confirmRevoke, setConfirmRevoke] = useState<APIKey | null>(null);
+  const revokeMutation = useRevokeAPIKey();
+
+  const columns = useMemo<ColumnDef<APIKey>[]>(() => {
+    const base: ColumnDef<APIKey>[] = [
+      {
+        id: "name",
+        header: "Name",
+        cell: ({ row }) => (
+          <div className="flex flex-col gap-0.5">
+            <span className="font-medium">{row.original.name}</span>
+            <code className="text-muted-foreground text-xs font-mono">
+              {row.original.key_prefix}…
+            </code>
+          </div>
+        ),
+      },
+      {
+        id: "scope",
+        header: "Scope",
+        cell: ({ row }) => <ScopeBadge scope={row.original.scope} />,
+      },
+      {
+        id: "actor",
+        header: "Actor",
+        meta: { className: "hidden md:table-cell" },
+        cell: ({ row }) => (
+          <ActorBadge
+            type={row.original.actor_type}
+            name={row.original.actor_name}
+          />
+        ),
+      },
+      {
+        id: "last_used",
+        header: revoked ? "Revoked" : "Last used",
+        meta: { className: "hidden lg:table-cell" },
+        cell: ({ row }) => {
+          const ts = revoked
+            ? row.original.revoked_at
+            : row.original.last_used_at;
+          if (!ts) {
+            return (
+              <span className="text-muted-foreground/60 text-sm">Never</span>
+            );
+          }
+          return (
+            <span
+              className="text-muted-foreground text-sm"
+              title={formatLongDate(ts.slice(0, 10))}
+            >
+              {formatRelativeTime(ts)}
+            </span>
+          );
+        },
+      },
+      {
+        id: "created",
+        header: "Created",
+        meta: { className: "hidden xl:table-cell" },
+        cell: ({ row }) => (
+          <span className="text-muted-foreground text-sm">
+            {formatLongDate(row.original.created_at.slice(0, 10))}
+          </span>
+        ),
+      },
+    ];
+
+    if (revoked) return base;
+
+    return [
+      ...base,
+      {
+        id: "actions",
+        header: () => <span className="sr-only">Actions</span>,
+        meta: { className: "w-px" },
+        cell: ({ row }) => (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={`Actions for ${row.original.name}`}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <MoreHorizontal className="size-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => setConfirmRevoke(row.original)}
+              >
+                <Ban className="size-4" />
+                Revoke
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ),
+      },
+    ];
+  }, [revoked]);
+
+  const onConfirmRevoke = async () => {
+    if (!confirmRevoke) return;
+    if (onRevoke) {
+      await onRevoke(confirmRevoke);
+      setConfirmRevoke(null);
+      return;
+    }
+    const ok = await withMutationToast(
+      () => revokeMutation.mutateAsync(confirmRevoke.id),
+      { success: `Revoked "${confirmRevoke.name}".` },
+    );
+    if (ok) setConfirmRevoke(null);
+  };
+
+  const revokeInFlight = revokeMutation.isPending;
+
+  return (
+    <>
+      <DataTable
+        columns={columns}
+        data={keys}
+        isLoading={isLoading}
+        isError={isError}
+        getRowId={(k) => k.id}
+        emptyState={emptyState}
+      />
+
+      <Dialog
+        open={confirmRevoke !== null}
+        onOpenChange={(o) =>
+          !o && !revokeInFlight && setConfirmRevoke(null)
+        }
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke "{confirmRevoke?.name}"?</DialogTitle>
+            <DialogDescription>
+              The next request using this key will be rejected. Existing
+              activity history is preserved, but the key can't be restored —
+              you'll need to mint a new one.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setConfirmRevoke(null)}
+              disabled={revokeInFlight}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={onConfirmRevoke}
+              disabled={revokeInFlight}
+            >
+              {revokeInFlight && <Loader2 className="size-4 animate-spin" />}
+              Revoke key
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/features/api-keys/plaintext-store.ts
+++ b/web/src/features/api-keys/plaintext-store.ts
@@ -1,0 +1,42 @@
+// The freshly-minted plaintext key only ever exists on the create response;
+// the API never returns it again. We stash it in sessionStorage so the
+// /api-keys/created subpage can read it on first paint and survive a single
+// browser refresh (which is fast enough for users typing into a password
+// manager). The store is cleared the moment the user navigates away or
+// explicitly dismisses it — see clearPendingPlaintextKey.
+const STORAGE_KEY = "breadbox.v2.api-keys.pending-plaintext";
+
+export interface PendingPlaintextKey {
+  id: string;
+  name: string;
+  plaintext: string;
+}
+
+export function storePendingPlaintextKey(key: PendingPlaintextKey): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(key));
+  } catch {
+    // SessionStorage can throw in private mode / quota-exceeded — the
+    // /created page handles the empty case by redirecting back to the list.
+  }
+}
+
+export function readPendingPlaintextKey(): PendingPlaintextKey | null {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PendingPlaintextKey;
+    if (!parsed?.plaintext || !parsed?.name) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingPlaintextKey(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -31,6 +31,9 @@ import {
   ConnectionDetailPage,
   connectionDetailSearchSchema,
 } from "@/routes/connection-detail";
+import { APIKeysPage, apiKeysSearchSchema } from "@/routes/api-keys";
+import { APIKeyNewPage } from "@/routes/api-key-new";
+import { APIKeyCreatedPage } from "@/routes/api-key-created";
 import { NAV_LEAVES } from "@/lib/nav";
 import { baseSearchSchema } from "@/lib/modals";
 import { z } from "zod";
@@ -84,6 +87,10 @@ const PAGE_OVERRIDES: Record<string, PageOverride> = {
     component: ConnectionsPage,
     validateSearch: connectionsSearchSchema,
   },
+  "/api-keys": {
+    component: APIKeysPage,
+    validateSearch: apiKeysSearchSchema,
+  },
 };
 
 // Detail routes aren't nav leaves, so they're registered explicitly rather
@@ -134,6 +141,21 @@ const connectionDetailRoute = createRoute({
   validateSearch: connectionDetailSearchSchema,
 });
 
+// /api-keys/new and /api-keys/created sit beside the list (declared via
+// PAGE_OVERRIDES) but aren't nav leaves themselves. The list match still
+// keeps the sidebar item active thanks to the prefix match in isNavMatch.
+const apiKeyNewRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/api-keys/new",
+  component: APIKeyNewPage,
+});
+
+const apiKeyCreatedRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/api-keys/created",
+  component: APIKeyCreatedPage,
+});
+
 const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
   if (leaf.kind !== "link" || leaf.to === "/") return [];
   const override = PAGE_OVERRIDES[leaf.to];
@@ -159,6 +181,8 @@ const routeTree = rootRoute.addChildren([
   tagDetailRoute,
   sandboxRoute,
   connectionDetailRoute,
+  apiKeyNewRoute,
+  apiKeyCreatedRoute,
   ...pageRoutes,
 ]);
 

--- a/web/src/routes/api-key-created.tsx
+++ b/web/src/routes/api-key-created.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, Navigate, useNavigate } from "@tanstack/react-router";
 import { Check, Copy, KeyRound, ShieldAlert } from "lucide-react";
 import { toast } from "sonner";
@@ -16,6 +16,7 @@ import {
   AlertDescription,
   AlertTitle,
 } from "@/components/ui/alert";
+import { Input } from "@/components/ui/input";
 import {
   clearPendingPlaintextKey,
   readPendingPlaintextKey,
@@ -30,12 +31,18 @@ export function APIKeyCreatedPage() {
   );
   const navigate = useNavigate();
   const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<number | null>(null);
 
   // Clear from storage on unmount — the value should not survive a fresh
   // visit to /api-keys/created. The component-local `pending` keeps the
   // page rendered for as long as the user stays.
   useEffect(() => {
-    return () => clearPendingPlaintextKey();
+    return () => {
+      clearPendingPlaintextKey();
+      if (copyTimerRef.current !== null) {
+        window.clearTimeout(copyTimerRef.current);
+      }
+    };
   }, []);
 
   if (!pending) {
@@ -47,7 +54,13 @@ export function APIKeyCreatedPage() {
       await navigator.clipboard.writeText(pending.plaintext);
       setCopied(true);
       toast.success("API key copied to clipboard.");
-      window.setTimeout(() => setCopied(false), 2000);
+      if (copyTimerRef.current !== null) {
+        window.clearTimeout(copyTimerRef.current);
+      }
+      copyTimerRef.current = window.setTimeout(() => {
+        setCopied(false);
+        copyTimerRef.current = null;
+      }, 2000);
     } catch {
       toast.error(
         "Couldn't access the clipboard. Select the value and copy manually.",
@@ -91,12 +104,12 @@ export function APIKeyCreatedPage() {
               API key
             </label>
             <div className="flex flex-col gap-2 sm:flex-row">
-              <input
+              <Input
                 id="api-key-plaintext"
                 readOnly
                 value={pending.plaintext}
                 onFocus={(e) => e.currentTarget.select()}
-                className="bg-muted/40 text-foreground border-input focus-visible:border-ring focus-visible:ring-ring/40 min-w-0 flex-1 truncate rounded-md border px-3 py-2 font-mono text-xs shadow-xs outline-none focus-visible:ring-[3px]"
+                className="bg-muted/40 min-w-0 flex-1 truncate font-mono text-xs"
               />
               <Button
                 type="button"

--- a/web/src/routes/api-key-created.tsx
+++ b/web/src/routes/api-key-created.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useState } from "react";
+import { Link, Navigate, useNavigate } from "@tanstack/react-router";
+import { Check, Copy, KeyRound, ShieldAlert } from "lucide-react";
+import { toast } from "sonner";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import {
+  clearPendingPlaintextKey,
+  readPendingPlaintextKey,
+  type PendingPlaintextKey,
+} from "@/features/api-keys/plaintext-store";
+
+export function APIKeyCreatedPage() {
+  // Read synchronously so a missing key redirects on first render — avoids
+  // a frame of empty content before the bounce.
+  const [pending] = useState<PendingPlaintextKey | null>(() =>
+    readPendingPlaintextKey(),
+  );
+  const navigate = useNavigate();
+  const [copied, setCopied] = useState(false);
+
+  // Clear from storage on unmount — the value should not survive a fresh
+  // visit to /api-keys/created. The component-local `pending` keeps the
+  // page rendered for as long as the user stays.
+  useEffect(() => {
+    return () => clearPendingPlaintextKey();
+  }, []);
+
+  if (!pending) {
+    return <Navigate to="/api-keys" />;
+  }
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(pending.plaintext);
+      setCopied(true);
+      toast.success("API key copied to clipboard.");
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error(
+        "Couldn't access the clipboard. Select the value and copy manually.",
+      );
+    }
+  };
+
+  const onDone = () => {
+    clearPendingPlaintextKey();
+    navigate({ to: "/api-keys" });
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <PageHeader
+        title="Key created"
+        description="Copy the plaintext now — it isn't shown again."
+      />
+
+      <Card className="overflow-hidden">
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="bg-primary/10 text-primary flex size-9 items-center justify-center rounded-lg">
+              <KeyRound className="size-4" />
+            </div>
+            <div>
+              <CardTitle className="text-base">{pending.name}</CardTitle>
+              <CardDescription>
+                Stash this in your password manager before leaving the page.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-5">
+          <div className="space-y-1.5">
+            <label
+              htmlFor="api-key-plaintext"
+              className="text-muted-foreground text-xs font-medium"
+            >
+              API key
+            </label>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <input
+                id="api-key-plaintext"
+                readOnly
+                value={pending.plaintext}
+                onFocus={(e) => e.currentTarget.select()}
+                className="bg-muted/40 text-foreground border-input focus-visible:border-ring focus-visible:ring-ring/40 min-w-0 flex-1 truncate rounded-md border px-3 py-2 font-mono text-xs shadow-xs outline-none focus-visible:ring-[3px]"
+              />
+              <Button
+                type="button"
+                onClick={onCopy}
+                className="shrink-0"
+                variant={copied ? "secondary" : "default"}
+              >
+                {copied ? (
+                  <Check className="size-4" />
+                ) : (
+                  <Copy className="size-4" />
+                )}
+                {copied ? "Copied" : "Copy"}
+              </Button>
+            </div>
+            <p className="text-muted-foreground text-xs">
+              Send it as the{" "}
+              <code className="bg-muted text-foreground rounded px-1.5 py-0.5 font-mono text-[11px]">
+                X-API-Key
+              </code>{" "}
+              header on every request to{" "}
+              <code className="bg-muted text-foreground rounded px-1.5 py-0.5 font-mono text-[11px]">
+                /api/v1/*
+              </code>
+              .
+            </p>
+          </div>
+
+          <Alert variant="default" className="bg-muted/40 border-muted">
+            <ShieldAlert className="size-4" />
+            <AlertTitle>One-time disclosure</AlertTitle>
+            <AlertDescription>
+              Breadbox only stores a SHA-256 hash of the key. If you lose this
+              plaintext you'll need to revoke and mint a new one.
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+
+      <div className="mt-6 flex items-center justify-between gap-2">
+        <Button variant="ghost" asChild>
+          <Link to="/api-keys/new">Mint another</Link>
+        </Button>
+        <Button onClick={onDone}>I've saved it — done</Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/routes/api-key-new.tsx
+++ b/web/src/routes/api-key-new.tsx
@@ -1,0 +1,23 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/page-header";
+import { APIKeyForm } from "@/features/api-keys/api-key-form";
+
+export function APIKeyNewPage() {
+  return (
+    <div className="mx-auto max-w-2xl">
+      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
+        <Link to="/api-keys">
+          <ArrowLeft className="size-4" />
+          API keys
+        </Link>
+      </Button>
+      <PageHeader
+        title="New API key"
+        description="Mint a credential for agents, the CLI, or the MCP server. The plaintext shows once after creation."
+      />
+      <APIKeyForm />
+    </div>
+  );
+}

--- a/web/src/routes/api-keys.tsx
+++ b/web/src/routes/api-keys.tsx
@@ -1,0 +1,129 @@
+import { useMemo, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { Key, Plus, Search } from "lucide-react";
+import { z } from "zod";
+import { PageHeader } from "@/components/page-header";
+import { EmptyState } from "@/components/empty-state";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useAPIKeys } from "@/api/queries/api-keys";
+import { APIKeysTable } from "@/features/api-keys/api-keys-table";
+import type { APIKey } from "@/api/types";
+
+// URL state lives in `?status=active|revoked&q=…` so a refresh keeps the
+// filter context — same convention as the connections/transactions pages.
+export const apiKeysSearchSchema = z.object({
+  status: z.enum(["active", "revoked"]).optional(),
+  q: z.string().optional(),
+});
+
+function filterKeys(keys: APIKey[], query: string): APIKey[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return keys;
+  return keys.filter(
+    (k) =>
+      k.name.toLowerCase().includes(q) ||
+      k.key_prefix.toLowerCase().includes(q) ||
+      (k.actor_name?.toLowerCase().includes(q) ?? false),
+  );
+}
+
+export function APIKeysPage() {
+  const { data: keys, isLoading, isError } = useAPIKeys();
+  const [tab, setTab] = useState<"active" | "revoked">("active");
+  const [query, setQuery] = useState("");
+
+  const { active, revoked } = useMemo(() => {
+    const all = keys ?? [];
+    return {
+      active: all.filter((k) => !k.revoked_at),
+      revoked: all.filter((k) => k.revoked_at),
+    };
+  }, [keys]);
+
+  const rows = filterKeys(tab === "active" ? active : revoked, query);
+
+  const newKeyButton = (
+    <Button asChild>
+      <Link to="/api-keys/new">
+        <Plus className="size-4" />
+        New key
+      </Link>
+    </Button>
+  );
+
+  const emptyState =
+    tab === "active" ? (
+      query ? (
+        <EmptyState
+          icon={Key}
+          title="No matching keys"
+          description="Try a different search."
+        />
+      ) : (
+        <EmptyState
+          icon={Key}
+          title="No API keys yet"
+          description="Mint a key to let agents, scripts, or the CLI talk to Breadbox."
+          action={newKeyButton}
+        />
+      )
+    ) : (
+      <EmptyState
+        icon={Key}
+        title="No revoked keys"
+        description="Revoked keys show up here so you can audit the trail."
+      />
+    );
+
+  return (
+    <div>
+      <PageHeader
+        title="API keys"
+        description="Credentials for programmatic access — agents, the CLI, the MCP server."
+        actions={newKeyButton}
+      />
+
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <Tabs
+          value={tab}
+          onValueChange={(v) => setTab(v as "active" | "revoked")}
+        >
+          <TabsList>
+            <TabsTrigger value="active">
+              Active
+              <span className="text-muted-foreground ml-1.5 text-xs tabular-nums">
+                {active.length}
+              </span>
+            </TabsTrigger>
+            <TabsTrigger value="revoked">
+              Revoked
+              <span className="text-muted-foreground ml-1.5 text-xs tabular-nums">
+                {revoked.length}
+              </span>
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        <div className="relative ml-auto w-full max-w-xs">
+          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search by name, prefix, actor…"
+            className="pl-8"
+          />
+        </div>
+      </div>
+
+      <APIKeysTable
+        keys={rows}
+        isLoading={isLoading}
+        isError={isError}
+        revoked={tab === "revoked"}
+        emptyState={emptyState}
+      />
+    </div>
+  );
+}

--- a/web/src/routes/api-keys.tsx
+++ b/web/src/routes/api-keys.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useState } from "react";
-import { Link } from "@tanstack/react-router";
+import { useMemo } from "react";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { Key, Plus, Search } from "lucide-react";
 import { z } from "zod";
 import { PageHeader } from "@/components/page-header";
@@ -18,6 +18,9 @@ export const apiKeysSearchSchema = z.object({
   q: z.string().optional(),
 });
 
+type APIKeysSearch = z.infer<typeof apiKeysSearchSchema>;
+type Tab = "active" | "revoked";
+
 function filterKeys(keys: APIKey[], query: string): APIKey[] {
   const q = query.trim().toLowerCase();
   if (!q) return keys;
@@ -31,8 +34,10 @@ function filterKeys(keys: APIKey[], query: string): APIKey[] {
 
 export function APIKeysPage() {
   const { data: keys, isLoading, isError } = useAPIKeys();
-  const [tab, setTab] = useState<"active" | "revoked">("active");
-  const [query, setQuery] = useState("");
+  const search = useSearch({ strict: false }) as APIKeysSearch;
+  const navigate = useNavigate();
+  const tab: Tab = search.status ?? "active";
+  const query = search.q ?? "";
 
   const { active, revoked } = useMemo(() => {
     const all = keys ?? [];
@@ -42,7 +47,32 @@ export function APIKeysPage() {
     };
   }, [keys]);
 
-  const rows = filterKeys(tab === "active" ? active : revoked, query);
+  const rows = useMemo(
+    () => filterKeys(tab === "active" ? active : revoked, query),
+    [tab, active, revoked, query],
+  );
+
+  function setTab(next: Tab) {
+    navigate({
+      to: "/api-keys",
+      search: (prev: APIKeysSearch) => ({
+        ...prev,
+        status: next === "active" ? undefined : next,
+      }),
+      replace: true,
+    });
+  }
+
+  function setQuery(next: string) {
+    navigate({
+      to: "/api-keys",
+      search: (prev: APIKeysSearch) => ({
+        ...prev,
+        q: next || undefined,
+      }),
+      replace: true,
+    });
+  }
 
   const newKeyButton = (
     <Button asChild>
@@ -53,29 +83,7 @@ export function APIKeysPage() {
     </Button>
   );
 
-  const emptyState =
-    tab === "active" ? (
-      query ? (
-        <EmptyState
-          icon={Key}
-          title="No matching keys"
-          description="Try a different search."
-        />
-      ) : (
-        <EmptyState
-          icon={Key}
-          title="No API keys yet"
-          description="Mint a key to let agents, scripts, or the CLI talk to Breadbox."
-          action={newKeyButton}
-        />
-      )
-    ) : (
-      <EmptyState
-        icon={Key}
-        title="No revoked keys"
-        description="Revoked keys show up here so you can audit the trail."
-      />
-    );
+  const emptyState = renderEmptyState({ tab, query, newKeyButton });
 
   return (
     <div>
@@ -86,10 +94,7 @@ export function APIKeysPage() {
       />
 
       <div className="mb-4 flex flex-wrap items-center gap-3">
-        <Tabs
-          value={tab}
-          onValueChange={(v) => setTab(v as "active" | "revoked")}
-        >
+        <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
           <TabsList>
             <TabsTrigger value="active">
               Active
@@ -125,5 +130,40 @@ export function APIKeysPage() {
         emptyState={emptyState}
       />
     </div>
+  );
+}
+
+interface EmptyStateArgs {
+  tab: Tab;
+  query: string;
+  newKeyButton: React.ReactNode;
+}
+
+function renderEmptyState({ tab, query, newKeyButton }: EmptyStateArgs) {
+  if (tab === "revoked") {
+    return (
+      <EmptyState
+        icon={Key}
+        title="No revoked keys"
+        description="Revoked keys show up here so you can audit the trail."
+      />
+    );
+  }
+  if (query) {
+    return (
+      <EmptyState
+        icon={Key}
+        title="No matching keys"
+        description="Try a different search."
+      />
+    );
+  }
+  return (
+    <EmptyState
+      icon={Key}
+      title="No API keys yet"
+      description="Mint a key to let agents, scripts, or the CLI talk to Breadbox."
+      action={newKeyButton}
+    />
   );
 }

--- a/web/src/sandbox/sections/primitives.tsx
+++ b/web/src/sandbox/sections/primitives.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   Card,
   CardContent,
@@ -152,6 +153,20 @@ export function PrimitivesSection() {
         <Label className="text-muted-foreground flex items-center gap-2">
           <Checkbox disabled /> Disabled
         </Label>
+      </Specimen>
+
+      <Specimen label="RadioGroup" className="block">
+        <RadioGroup defaultValue="full" className="gap-2">
+          <Label className="flex items-center gap-2">
+            <RadioGroupItem value="full" /> Full access
+          </Label>
+          <Label className="flex items-center gap-2">
+            <RadioGroupItem value="read" /> Read only
+          </Label>
+          <Label className="text-muted-foreground flex items-center gap-2">
+            <RadioGroupItem value="disabled" disabled /> Disabled
+          </Label>
+        </RadioGroup>
       </Specimen>
 
       <Specimen label="Card" className="block">


### PR DESCRIPTION
## Summary

Build out the v2 SPA's API keys surface — list page, new-key form, and one-time plaintext disclosure subpage. Drops the user into the same conventions as the rest of v2 (shadcn primitives, RHF + zod, shared `DataTable`, `withMutationToast`).

- **`/v2/api-keys`** — Active / Revoked tabs over the shared `DataTable`, with name/prefix/actor search. Per-row dropdown opens a revoke confirm dialog that wires straight into `useRevokeAPIKey`. Read-only sessions hit the existing `ApiError` path because `GET /api/v1/api-keys` requires write scope.
- **`/v2/api-keys/new`** — shadcn `Form` + RHF + zod. Scope and actor type are `OptionCard`-wrapped `RadioGroup` tiles so the choice reads as a deliberate decision rather than a buried dropdown. Optional actor display name lets you label an integration ("Claude — Ricardo's laptop") without renaming the key itself.
- **`/v2/api-keys/created`** — `Card` with a one-time-copy plaintext input, an `X-API-Key` usage hint, and a one-line "stored as SHA-256 hash" warning. Plaintext lives in `sessionStorage` so a refresh mid-copy isn't fatal; it clears on unmount or on **"I've saved it — done"**.

New shadcn primitive (`radio-group`) added via the CLI plus a sandbox specimen so the component is discoverable in the gallery.

## Screens

**List — Active / Revoked tabs, search, per-row actions** (desktop / tablet / mobile):

<img src="https://i.img402.dev/nl16aipwif.jpg" width="900" alt="API keys list">

**New key form** (desktop):

<img src="https://i.img402.dev/tgvkpm6dr0.png" width="800" alt="New API key form">

**New key form — responsive composite**:

<img src="https://i.img402.dev/w32mbipji7.jpg" width="900" alt="New API key form — responsive">

**Key created — one-time plaintext disclosure**:

<img src="https://i.img402.dev/3a3ajeq2yk.jpg" width="900" alt="Key created — one-time disclosure">

## Test plan

- [x] `bun run lint` (tsc --noEmit) — clean
- [x] `bun run build` — clean
- [x] Validated `/v2/api-keys`, `/v2/api-keys/new`, `/v2/api-keys/created` in headless Chromium against a locally-built `breadbox serve` on port 8083
- [x] Drove the new-key form end-to-end — list refetches and the new row shows up after returning from `/created`
- [x] Sandbox `RadioGroup` specimen renders in `/v2/sandbox` → Primitives

🤖 Generated with [Claude Code](https://claude.com/claude-code)
