### PR TITLE
v2: providers settings page

### DIFF
--- a/internal/api/provider_config.go
+++ b/internal/api/provider_config.go
@@ -39,8 +39,9 @@ import (
 
 // providerConfigResponse is the wire shape of GET /settings/providers.
 type providerConfigResponse struct {
-	Plaid  plaidConfigView  `json:"plaid"`
-	Teller tellerConfigView `json:"teller"`
+	Plaid             plaidConfigView  `json:"plaid"`
+	Teller            tellerConfigView `json:"teller"`
+	HasEncryptionKey  bool             `json:"has_encryption_key"`
 }
 
 type plaidConfigView struct {
@@ -358,6 +359,7 @@ func buildProviderConfigResponse(a *app.App) providerConfigResponse {
 			CertificateSet:   tellerCertPresent,
 			WebhookSecretSet: a.Config.TellerWebhookSecret != "",
 		},
+		HasEncryptionKey: len(a.Config.EncryptionKey) > 0,
 	}
 }
 

--- a/web/src/api/queries/provider-config.ts
+++ b/web/src/api/queries/provider-config.ts
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import type {
+  ProviderConfigResponse,
+  ProviderHealthResponse,
+  ProviderTestResult,
+  UpdatePlaidConfigRequest,
+  UpdateTellerConfigRequest,
+} from "@/api/types";
+
+// useProviderConfig returns the redacted provider configuration (Plaid +
+// Teller). Sensitive fields are exposed as boolean *_set flags only.
+export function useProviderConfig() {
+  return useQuery({
+    queryKey: ["provider-config"],
+    queryFn: () => api<ProviderConfigResponse>("/api/v1/settings/providers"),
+    staleTime: 30_000,
+  });
+}
+
+// useProviderHealth surfaces per-provider connection counts and last-sync
+// status. Used to render the health badge on each card.
+export function useProviderHealth() {
+  return useQuery({
+    queryKey: ["provider-health"],
+    queryFn: async () => {
+      const res = await api<{ providers: Record<string, ProviderHealthResponse> }>(
+        "/api/v1/sync/health/providers",
+      );
+      return res.providers;
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function useUpdatePlaidConfig() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UpdatePlaidConfigRequest) =>
+      api<ProviderConfigResponse>("/api/v1/settings/providers/plaid", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: (data) => {
+      qc.setQueryData(["provider-config"], data);
+      qc.invalidateQueries({ queryKey: ["provider-health"] });
+    },
+  });
+}
+
+export function useUpdateTellerConfig() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: UpdateTellerConfigRequest) =>
+      api<ProviderConfigResponse>("/api/v1/settings/providers/teller", {
+        method: "PUT",
+        body: JSON.stringify(body),
+      }),
+    onSuccess: (data) => {
+      qc.setQueryData(["provider-config"], data);
+      qc.invalidateQueries({ queryKey: ["provider-health"] });
+    },
+  });
+}
+
+// useDisableProvider clears stored credentials and tears down the live
+// provider. Existing connections stay in the DB but their syncs will fail
+// until credentials are restored. Calls DELETE /api/v1/providers/{name}.
+export function useDisableProvider() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: "plaid" | "teller") =>
+      api<ProviderTestResult>(`/api/v1/providers/${name}`, {
+        method: "DELETE",
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["provider-config"] });
+      qc.invalidateQueries({ queryKey: ["provider-health"] });
+    },
+  });
+}
+
+// useTestProvider runs the server-side credentials check for plaid/teller.
+// 200 OK with {ok:false, message} for invalid creds — caller branches on
+// data.ok rather than catching ApiError.
+export function useTestProvider() {
+  return useMutation({
+    mutationFn: (name: "plaid" | "teller") =>
+      api<ProviderTestResult>(`/api/v1/providers/${name}/test`, {
+        method: "POST",
+      }),
+  });
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -307,3 +307,64 @@ export interface UpdateTransactionsResult {
   aborted?: boolean;
   error?: string;
 }
+
+// --- Provider configuration (GET/PUT /settings/providers/*) ---
+// Wire shapes for the v2 providers page. Sensitive fields (Plaid secret,
+// Teller PEM cert/key) never leave the server in plaintext — clients see
+// boolean *_set flags only.
+
+export interface PlaidConfigView {
+  configured: boolean;
+  from_env: boolean;
+  client_id?: string;
+  environment?: string;
+  webhook_url?: string;
+  secret_set: boolean;
+}
+
+export interface TellerConfigView {
+  configured: boolean;
+  from_env: boolean;
+  application_id?: string;
+  environment?: string;
+  certificate_set: boolean;
+  webhook_secret_set: boolean;
+}
+
+export interface ProviderConfigResponse {
+  plaid: PlaidConfigView;
+  teller: TellerConfigView;
+  has_encryption_key: boolean;
+}
+
+export interface UpdatePlaidConfigRequest {
+  client_id: string;
+  // null/omitted preserves the existing secret. Required on first save.
+  secret?: string | null;
+  environment: "sandbox" | "development" | "production";
+  webhook_url?: string;
+}
+
+export interface UpdateTellerConfigRequest {
+  application_id: string;
+  environment: "sandbox" | "development" | "production";
+  // PEM bodies. Send both together to rotate; omit to keep the existing pair.
+  certificate?: string | null;
+  private_key?: string | null;
+  webhook_secret?: string | null;
+}
+
+export interface ProviderHealthResponse {
+  provider: string;
+  connection_count: number;
+  account_count: number;
+  last_sync_status?: string;
+  last_sync_time?: string;
+  last_sync_error?: string;
+}
+
+export interface ProviderTestResult {
+  provider: string;
+  ok: boolean;
+  message?: string;
+}

--- a/web/src/features/providers/csv-card.tsx
+++ b/web/src/features/providers/csv-card.tsx
@@ -1,0 +1,55 @@
+import { Link } from "@tanstack/react-router";
+import { FileSpreadsheet, Upload } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { ProviderHealthResponse } from "@/api/types";
+import { ProviderStats } from "./provider-status";
+
+interface CsvCardProps {
+  health: ProviderHealthResponse | undefined;
+}
+
+export function CsvCard({ health }: CsvCardProps) {
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="border-b">
+        <div className="flex items-center gap-3">
+          <div className="bg-amber-500/10 text-amber-600 dark:text-amber-400 flex size-10 items-center justify-center rounded-lg">
+            <FileSpreadsheet className="size-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <CardTitle className="text-base">CSV import</CardTitle>
+            <CardDescription className="text-xs">
+              Drop in transactions exported from any bank — no API credentials required.
+            </CardDescription>
+          </div>
+          <Badge variant="outline" className="border-emerald-500/40 text-emerald-600 dark:text-emerald-400">
+            Always available
+          </Badge>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-6 pt-2">
+        <ProviderStats health={health} />
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-muted-foreground max-w-md text-sm">
+            Useful when a bank isn't supported by Plaid or Teller, or as a one-time backfill for historical transactions.
+          </p>
+          <Button asChild size="sm">
+            <Link to="/connections" search={{ action: "connect" }}>
+              <Upload className="size-3.5" />
+              Import CSV
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/features/providers/env-locked-notice.tsx
+++ b/web/src/features/providers/env-locked-notice.tsx
@@ -1,0 +1,20 @@
+import { Lock } from "lucide-react";
+
+interface EnvLockedNoticeProps {
+  provider: string;
+}
+
+// Shown in place of the form when the provider was configured via env vars.
+// The server-side handler rejects writes in this state (returns 409
+// PROVIDER_FROM_ENV), so editing inputs would just lead to a failed submit.
+export function EnvLockedNotice({ provider }: EnvLockedNoticeProps) {
+  return (
+    <div className="bg-muted/50 text-muted-foreground flex items-start gap-2 rounded-md border px-3 py-2.5 text-xs">
+      <Lock className="mt-0.5 size-3.5 shrink-0" />
+      <div>
+        <span className="text-foreground font-medium">{provider} is configured via environment variables.</span>{" "}
+        To change these values, update the env vars and restart Breadbox.
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/providers/index.tsx
+++ b/web/src/features/providers/index.tsx
@@ -1,0 +1,3 @@
+export { PlaidCard } from "./plaid-card";
+export { TellerCard } from "./teller-card";
+export { CsvCard } from "./csv-card";

--- a/web/src/features/providers/plaid-card.tsx
+++ b/web/src/features/providers/plaid-card.tsx
@@ -1,0 +1,323 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Building2, Trash2, Webhook } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  useDisableProvider,
+  useUpdatePlaidConfig,
+} from "@/api/queries/provider-config";
+import type {
+  PlaidConfigView,
+  ProviderHealthResponse,
+} from "@/api/types";
+import { EnvLockedNotice } from "./env-locked-notice";
+import { ProviderStats, ProviderStatusBadge } from "./provider-status";
+import { TestConnectionButton } from "./test-connection-button";
+
+const ENVS = ["sandbox", "development", "production"] as const;
+
+// We don't validate the secret as required at the schema level. When the
+// provider already has a stored secret, an empty input means "keep the
+// existing one" — that's the same UX as the v1 admin form. The schema
+// `.refine` below enforces required only for first-time setup.
+const schema = z
+  .object({
+    client_id: z.string().min(1, "Client ID is required"),
+    secret: z.string(),
+    environment: z.enum(ENVS),
+    webhook_url: z.string(),
+    secret_already_set: z.boolean(),
+  })
+  .refine((v) => v.secret_already_set || v.secret.trim().length > 0, {
+    path: ["secret"],
+    message: "Secret is required",
+  })
+  .refine(
+    (v) => {
+      const url = v.webhook_url.trim();
+      return url === "" || url.startsWith("https://");
+    },
+    { path: ["webhook_url"], message: "Must start with https://" },
+  );
+
+type Values = z.infer<typeof schema>;
+
+interface PlaidCardProps {
+  config: PlaidConfigView;
+  health: ProviderHealthResponse | undefined;
+}
+
+export function PlaidCard({ config, health }: PlaidCardProps) {
+  const update = useUpdatePlaidConfig();
+  const disable = useDisableProvider();
+  const [confirmingDisable, setConfirmingDisable] = useState(false);
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    values: {
+      client_id: config.client_id ?? "",
+      secret: "",
+      environment: (config.environment as (typeof ENVS)[number]) || "sandbox",
+      webhook_url: config.webhook_url ?? "",
+      secret_already_set: config.secret_set,
+    },
+  });
+
+  async function onSubmit(values: Values) {
+    const body = {
+      client_id: values.client_id.trim(),
+      secret: values.secret.trim() === "" ? null : values.secret.trim(),
+      environment: values.environment,
+      webhook_url: values.webhook_url.trim(),
+    };
+    const ok = await withMutationToast(() => update.mutateAsync(body), {
+      success: "Plaid settings saved.",
+    });
+    if (ok) form.resetField("secret");
+  }
+
+  async function onDisable() {
+    setConfirmingDisable(false);
+    await withMutationToast(() => disable.mutateAsync("plaid"), {
+      success: "Plaid disabled. Stored credentials were cleared.",
+    });
+  }
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="border-b">
+        <div className="flex items-center gap-3">
+          <div className="bg-blue-500/10 text-blue-600 dark:text-blue-400 flex size-10 items-center justify-center rounded-lg">
+            <Building2 className="size-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <CardTitle className="text-base">Plaid</CardTitle>
+            <CardDescription className="text-xs">
+              Thousands of financial institutions across the US, Canada, and Europe.
+            </CardDescription>
+          </div>
+          <ProviderStatusBadge health={health} configured={config.configured} />
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-6 pt-2">
+        <ProviderStats health={health} />
+
+        {config.from_env ? (
+          <>
+            <EnvLockedNotice provider="Plaid" />
+            <dl className="grid grid-cols-1 gap-y-3 text-sm sm:grid-cols-[max-content_1fr] sm:gap-x-6">
+              <Row label="Client ID" value={config.client_id ?? "—"} mono />
+              <Row label="Secret" value={config.secret_set ? "••••••••" : "Not set"} mono />
+              <Row label="Environment" value={config.environment ?? "—"} />
+              <Row label="Webhook URL" value={config.webhook_url || "Not set"} mono />
+            </dl>
+          </>
+        ) : (
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="client_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Client ID</FormLabel>
+                      <FormControl>
+                        <Input placeholder="Plaid Client ID" autoComplete="off" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="environment"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Environment</FormLabel>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {ENVS.map((e) => (
+                            <SelectItem key={e} value={e}>
+                              {e[0].toUpperCase() + e.slice(1)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="secret"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Secret</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          config.secret_set
+                            ? "Unchanged (enter a new value to rotate)"
+                            : "Plaid secret"
+                        }
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Credentials are validated against Plaid before they're stored.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="webhook_url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Webhook URL</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="url"
+                        placeholder="https://your-domain.com/webhooks/plaid"
+                        autoComplete="off"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Plaid pushes real-time transaction updates to this URL during link-token creation.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
+                <Button type="submit" disabled={update.isPending}>
+                  {update.isPending ? "Saving…" : "Save Plaid settings"}
+                </Button>
+                {config.configured && (
+                  <AlertDialog open={confirmingDisable} onOpenChange={setConfirmingDisable}>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-muted-foreground hover:text-destructive"
+                      >
+                        <Trash2 className="size-3.5" />
+                        Disable Plaid
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Disable Plaid?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Stored credentials will be deleted from the database. Existing Plaid connections stay in your
+                          household but syncs will fail until you re-enter credentials.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={onDisable}
+                          className="bg-destructive text-white hover:bg-destructive/90"
+                        >
+                          Disable
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
+              </div>
+            </form>
+          </Form>
+        )}
+
+        {config.configured && (
+          <div className="border-t pt-4">
+            <TestConnectionButton provider="plaid" />
+          </div>
+        )}
+
+        {config.configured && (
+          <details className="group rounded-md border bg-muted/30 px-3 py-2 text-sm">
+            <summary className="text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-2 text-xs font-medium">
+              <Webhook className="size-3.5" />
+              Webhook setup
+            </summary>
+            <div className="text-muted-foreground mt-3 space-y-2 text-xs">
+              <p>
+                Plaid automatically subscribes to webhooks when the URL above is set during link-token creation. No
+                separate Plaid-dashboard step needed.
+              </p>
+              <p>Point Plaid at:</p>
+              <code className="bg-background block break-all rounded border px-2 py-1.5 font-mono text-xs select-all">
+                https://&lt;your-domain&gt;/webhooks/plaid
+              </code>
+            </div>
+          </details>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className={mono ? "font-mono text-xs break-all" : ""}>{value}</dd>
+    </>
+  );
+}

--- a/web/src/features/providers/provider-status.tsx
+++ b/web/src/features/providers/provider-status.tsx
@@ -1,0 +1,100 @@
+import { Activity, AlertTriangle, CheckCircle2, CircleDashed, Loader2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { ProviderHealthResponse } from "@/api/types";
+
+interface ProviderStatusBadgeProps {
+  health: ProviderHealthResponse | undefined;
+  configured: boolean;
+}
+
+// ProviderStatusBadge mirrors the 4-way state surfaced by the v1 provider
+// card header — healthy, sync error, configured-not-synced, not configured.
+// The colored dot is part of the badge so the row reads at a glance without
+// landing on the text first.
+export function ProviderStatusBadge({ health, configured }: ProviderStatusBadgeProps) {
+  if (health?.last_sync_time && health.last_sync_status === "error") {
+    return (
+      <Badge variant="outline" className="border-destructive/40 text-destructive">
+        <AlertTriangle className="size-3" />
+        Sync error
+      </Badge>
+    );
+  }
+  if (health?.last_sync_time && health.last_sync_status === "success") {
+    return (
+      <Badge variant="outline" className="border-emerald-500/40 text-emerald-600 dark:text-emerald-400">
+        <CheckCircle2 className="size-3" />
+        Healthy
+      </Badge>
+    );
+  }
+  if (configured) {
+    return (
+      <Badge variant="outline" className="border-emerald-500/40 text-emerald-600 dark:text-emerald-400">
+        <CheckCircle2 className="size-3" />
+        Configured
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="text-muted-foreground">
+      <CircleDashed className="size-3" />
+      Not configured
+    </Badge>
+  );
+}
+
+interface ProviderStatsProps {
+  health: ProviderHealthResponse | undefined;
+}
+
+// ProviderStats renders the connections / accounts / last-sync row under the
+// card header. Hides itself entirely if there's no data — empty stats look
+// like a loading state and confuse users.
+export function ProviderStats({ health }: ProviderStatsProps) {
+  if (!health) return null;
+  const inProgress = health.last_sync_status === "in_progress";
+  return (
+    <dl className="text-muted-foreground flex flex-wrap items-center gap-x-6 gap-y-1.5 text-xs">
+      <Stat label="Connections" value={String(health.connection_count)} />
+      <Stat label="Accounts" value={String(health.account_count)} />
+      {health.last_sync_time && (
+        <div className="flex items-center gap-1.5">
+          <Activity className="size-3" />
+          <dt>Last sync</dt>
+          <dd
+            className={cn(
+              "text-foreground font-medium",
+              health.last_sync_status === "success" && "text-emerald-600 dark:text-emerald-400",
+              health.last_sync_status === "error" && "text-destructive",
+            )}
+          >
+            {health.last_sync_status === "error" ? `failed ${health.last_sync_time}` : health.last_sync_time}
+          </dd>
+        </div>
+      )}
+      {!health.last_sync_time && health.connection_count > 0 && (
+        <div className="flex items-center gap-1.5">
+          <Activity className="size-3" />
+          <span>Never synced</span>
+        </div>
+      )}
+      {inProgress && (
+        <div className="text-foreground flex items-center gap-1.5 font-medium">
+          <Loader2 className="size-3 animate-spin" />
+          In progress
+        </div>
+      )}
+    </dl>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <dt>{label}</dt>
+      <dd className="text-foreground font-medium">{value}</dd>
+    </div>
+  );
+}

--- a/web/src/features/providers/teller-card.tsx
+++ b/web/src/features/providers/teller-card.tsx
@@ -1,0 +1,410 @@
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  AlertTriangle,
+  Check,
+  FileKey2,
+  Landmark,
+  Trash2,
+  Upload,
+  Webhook,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { withMutationToast } from "@/lib/mutation-toast";
+import {
+  useDisableProvider,
+  useUpdateTellerConfig,
+} from "@/api/queries/provider-config";
+import type {
+  ProviderHealthResponse,
+  TellerConfigView,
+} from "@/api/types";
+import { EnvLockedNotice } from "./env-locked-notice";
+import { ProviderStats, ProviderStatusBadge } from "./provider-status";
+import { TestConnectionButton } from "./test-connection-button";
+
+const ENVS = ["sandbox", "development", "production"] as const;
+
+const schema = z.object({
+  application_id: z.string().min(1, "Application ID is required"),
+  environment: z.enum(ENVS),
+  webhook_secret: z.string(),
+});
+
+type Values = z.infer<typeof schema>;
+
+interface TellerCardProps {
+  config: TellerConfigView;
+  health: ProviderHealthResponse | undefined;
+  hasEncryptionKey: boolean;
+}
+
+// readPemFile reads an uploaded PEM file (cert or key). Returns null if the
+// file is empty or unreadable so the submit can short-circuit.
+async function readPemFile(file: File | undefined): Promise<string | null> {
+  if (!file) return null;
+  const text = await file.text();
+  return text.trim() === "" ? null : text;
+}
+
+export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps) {
+  const update = useUpdateTellerConfig();
+  const disable = useDisableProvider();
+  const [certFile, setCertFile] = useState<File | undefined>();
+  const [keyFile, setKeyFile] = useState<File | undefined>();
+  const [confirmingDisable, setConfirmingDisable] = useState(false);
+
+  const form = useForm<Values>({
+    resolver: zodResolver(schema),
+    values: {
+      application_id: config.application_id ?? "",
+      environment: (config.environment as (typeof ENVS)[number]) || "sandbox",
+      webhook_secret: "",
+    },
+  });
+
+  async function onSubmit(values: Values) {
+    if ((certFile && !keyFile) || (!certFile && keyFile)) {
+      toast.error("Upload both certificate and private key, or neither.");
+      return;
+    }
+    if (certFile && keyFile && !hasEncryptionKey) {
+      toast.error("ENCRYPTION_KEY must be set on the server before certificates can be stored.");
+      return;
+    }
+
+    const [cert, key] = await Promise.all([readPemFile(certFile), readPemFile(keyFile)]);
+
+    const ok = await withMutationToast(
+      () =>
+        update.mutateAsync({
+          application_id: values.application_id.trim(),
+          environment: values.environment,
+          certificate: cert,
+          private_key: key,
+          webhook_secret:
+            values.webhook_secret.trim() === "" ? null : values.webhook_secret.trim(),
+        }),
+      { success: "Teller settings saved." },
+    );
+    if (ok) {
+      form.resetField("webhook_secret");
+      setCertFile(undefined);
+      setKeyFile(undefined);
+    }
+  }
+
+  async function onDisable() {
+    setConfirmingDisable(false);
+    await withMutationToast(() => disable.mutateAsync("teller"), {
+      success: "Teller disabled. Stored credentials were cleared.",
+    });
+  }
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader className="border-b">
+        <div className="flex items-center gap-3">
+          <div className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 flex size-10 items-center justify-center rounded-lg">
+            <Landmark className="size-5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <CardTitle className="text-base">Teller</CardTitle>
+            <CardDescription className="text-xs">
+              US bank coverage via mutual-TLS authentication.
+            </CardDescription>
+          </div>
+          <ProviderStatusBadge health={health} configured={config.configured} />
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-6 pt-2">
+        <ProviderStats health={health} />
+
+        {config.from_env ? (
+          <>
+            <EnvLockedNotice provider="Teller" />
+            <dl className="grid grid-cols-1 gap-y-3 text-sm sm:grid-cols-[max-content_1fr] sm:gap-x-6">
+              <Row label="Application ID" value={config.application_id ?? "—"} mono />
+              <Row label="Environment" value={config.environment ?? "—"} />
+              <Row label="Certificate" value={config.certificate_set ? "Configured" : "Not configured"} />
+              <Row
+                label="Webhook secret"
+                value={config.webhook_secret_set ? "Configured" : "Not configured"}
+              />
+            </dl>
+          </>
+        ) : (
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <FormField
+                  control={form.control}
+                  name="application_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Application ID</FormLabel>
+                      <FormControl>
+                        <Input placeholder="app_..." autoComplete="off" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="environment"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Environment</FormLabel>
+                      <Select value={field.value} onValueChange={field.onChange}>
+                        <FormControl>
+                          <SelectTrigger className="w-full">
+                            <SelectValue />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {ENVS.map((e) => (
+                            <SelectItem key={e} value={e}>
+                              {e[0].toUpperCase() + e.slice(1)}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              {!hasEncryptionKey && (
+                <Alert variant="default" className="border-amber-500/40 bg-amber-500/5">
+                  <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400" />
+                  <AlertTitle className="text-amber-700 dark:text-amber-400">
+                    ENCRYPTION_KEY is not set
+                  </AlertTitle>
+                  <AlertDescription>
+                    Teller certificates are encrypted at rest. Set the <code className="font-mono text-xs">ENCRYPTION_KEY</code>{" "}
+                    environment variable before uploading a certificate.
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+                <div className="flex items-center gap-2">
+                  <FileKey2 className="text-muted-foreground size-4" />
+                  <span className="text-sm font-medium">mTLS certificate</span>
+                  {config.certificate_set && (
+                    <span className="text-emerald-600 dark:text-emerald-400 flex items-center gap-1 text-xs">
+                      <Check className="size-3" />
+                      Stored
+                    </span>
+                  )}
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <PemFileInput
+                    id="teller-cert"
+                    label="Certificate (.pem)"
+                    accept=".pem,.crt,.cert"
+                    file={certFile}
+                    onChange={setCertFile}
+                  />
+                  <PemFileInput
+                    id="teller-key"
+                    label="Private key (.pem)"
+                    accept=".pem,.key"
+                    file={keyFile}
+                    onChange={setKeyFile}
+                  />
+                </div>
+                <p className="text-muted-foreground text-xs">
+                  Upload both files together to {config.certificate_set ? "rotate" : "configure"} the certificate. Leave blank to{" "}
+                  {config.certificate_set ? "keep the stored pair" : "skip"}.
+                </p>
+              </div>
+
+              <FormField
+                control={form.control}
+                name="webhook_secret"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Webhook signing secret</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          config.webhook_secret_set
+                            ? "Unchanged (enter a new value to rotate)"
+                            : "Optional"
+                        }
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      Used to verify HMAC signatures on incoming Teller webhooks.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
+                <Button type="submit" disabled={update.isPending}>
+                  {update.isPending ? "Saving…" : "Save Teller settings"}
+                </Button>
+                {config.configured && (
+                  <AlertDialog open={confirmingDisable} onOpenChange={setConfirmingDisable}>
+                    <AlertDialogTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-muted-foreground hover:text-destructive"
+                      >
+                        <Trash2 className="size-3.5" />
+                        Disable Teller
+                      </Button>
+                    </AlertDialogTrigger>
+                    <AlertDialogContent>
+                      <AlertDialogHeader>
+                        <AlertDialogTitle>Disable Teller?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                          Stored credentials (application ID, webhook secret, and encrypted certificate) will be
+                          deleted from the database. Existing Teller connections stay in your household but syncs
+                          will fail until you re-enter credentials.
+                        </AlertDialogDescription>
+                      </AlertDialogHeader>
+                      <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction
+                          onClick={onDisable}
+                          className="bg-destructive text-white hover:bg-destructive/90"
+                        >
+                          Disable
+                        </AlertDialogAction>
+                      </AlertDialogFooter>
+                    </AlertDialogContent>
+                  </AlertDialog>
+                )}
+              </div>
+            </form>
+          </Form>
+        )}
+
+        {config.configured && (
+          <div className="border-t pt-4">
+            <TestConnectionButton provider="teller" />
+          </div>
+        )}
+
+        {config.configured && (
+          <details className="group rounded-md border bg-muted/30 px-3 py-2 text-sm">
+            <summary className="text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-2 text-xs font-medium">
+              <Webhook className="size-3.5" />
+              Webhook setup
+            </summary>
+            <div className="text-muted-foreground mt-3 space-y-2 text-xs">
+              <ol className="ml-4 list-decimal space-y-1">
+                <li>Open the Teller dashboard and navigate to your application settings.</li>
+                <li>Set the webhook URL to:</li>
+              </ol>
+              <code className="bg-background block break-all rounded border px-2 py-1.5 font-mono text-xs select-all">
+                https://&lt;your-domain&gt;/webhooks/teller
+              </code>
+              <ol className="ml-4 list-decimal space-y-1" start={3}>
+                <li>Copy the webhook signing secret from Teller and paste it above.</li>
+              </ol>
+            </div>
+          </details>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface PemFileInputProps {
+  id: string;
+  label: string;
+  accept: string;
+  file: File | undefined;
+  onChange: (file: File | undefined) => void;
+}
+
+function PemFileInput({ id, label, accept, file, onChange }: PemFileInputProps) {
+  return (
+    <div className="space-y-1.5">
+      <label htmlFor={id} className="text-xs font-medium">
+        {label}
+      </label>
+      <label
+        htmlFor={id}
+        className="border-input hover:bg-muted/60 flex cursor-pointer items-center gap-2 rounded-md border border-dashed bg-background px-3 py-2 text-xs transition-colors"
+      >
+        <Upload className="text-muted-foreground size-3.5" />
+        <span className={file ? "text-foreground truncate" : "text-muted-foreground"}>
+          {file ? file.name : "Choose file"}
+        </span>
+      </label>
+      <input
+        id={id}
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={(e) => onChange(e.target.files?.[0])}
+      />
+    </div>
+  );
+}
+
+function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className={mono ? "font-mono text-xs break-all" : ""}>{value}</dd>
+    </>
+  );
+}

--- a/web/src/features/providers/test-connection-button.tsx
+++ b/web/src/features/providers/test-connection-button.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { CheckCircle2, Plug, XCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/api/client";
+import { useTestProvider } from "@/api/queries/provider-config";
+import { cn } from "@/lib/utils";
+
+interface TestConnectionButtonProps {
+  provider: "plaid" | "teller";
+  disabled?: boolean;
+}
+
+// TestConnectionButton hits the server-side credentials probe and surfaces
+// the result inline. The endpoint returns 200 OK with {ok:false, message}
+// on bad creds — we still branch on data.ok rather than catching ApiError.
+export function TestConnectionButton({ provider, disabled }: TestConnectionButtonProps) {
+  const test = useTestProvider();
+  const [result, setResult] = useState<{ ok: boolean; message: string } | null>(null);
+
+  async function onClick() {
+    setResult(null);
+    try {
+      const data = await test.mutateAsync(provider);
+      setResult({ ok: data.ok, message: data.message || (data.ok ? "Connection OK" : "Test failed") });
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : "Test failed";
+      setResult({ ok: false, message: msg });
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button type="button" variant="outline" size="sm" onClick={onClick} disabled={disabled || test.isPending}>
+        {test.isPending ? <Loader2 className="size-3.5 animate-spin" /> : <Plug className="size-3.5" />}
+        Test connection
+      </Button>
+      {result && (
+        <span
+          className={cn(
+            "flex items-center gap-1.5 text-xs",
+            result.ok ? "text-emerald-600 dark:text-emerald-400" : "text-destructive",
+          )}
+        >
+          {result.ok ? <CheckCircle2 className="size-3.5" /> : <XCircle className="size-3.5" />}
+          {result.message}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/nav.ts
+++ b/web/src/lib/nav.ts
@@ -11,6 +11,7 @@ import {
   Settings,
   Shapes,
   Tags,
+  ToyBrick,
   Wand2,
   type LucideIcon,
 } from "lucide-react";
@@ -67,6 +68,7 @@ export const NAV: NavGroup[] = [
       { kind: "link", title: "Accounts", to: "/accounts", icon: Banknote },
       { kind: "link", title: "Connections", to: "/connections", icon: Plug },
       { kind: "link", title: "Account links", to: "/account-links", icon: Link2 },
+      { kind: "link", title: "Providers", to: "/providers", icon: ToyBrick },
     ],
   },
   {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -31,6 +31,7 @@ import {
   ConnectionDetailPage,
   connectionDetailSearchSchema,
 } from "@/routes/connection-detail";
+import { ProvidersPage } from "@/routes/providers";
 import { NAV_LEAVES } from "@/lib/nav";
 import { baseSearchSchema } from "@/lib/modals";
 import { z } from "zod";
@@ -83,6 +84,9 @@ const PAGE_OVERRIDES: Record<string, PageOverride> = {
   "/connections": {
     component: ConnectionsPage,
     validateSearch: connectionsSearchSchema,
+  },
+  "/providers": {
+    component: ProvidersPage,
   },
 };
 

--- a/web/src/routes/providers.tsx
+++ b/web/src/routes/providers.tsx
@@ -1,0 +1,67 @@
+import { Loader2 } from "lucide-react";
+import { PageHeader } from "@/components/page-header";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  useProviderConfig,
+  useProviderHealth,
+} from "@/api/queries/provider-config";
+import { CsvCard, PlaidCard, TellerCard } from "@/features/providers";
+
+export function ProvidersPage() {
+  const config = useProviderConfig();
+  const health = useProviderHealth();
+
+  if (config.isLoading) {
+    return (
+      <>
+        <PageHeader
+          title="Providers"
+          description="Configure bank data providers that sync accounts and transactions."
+        />
+        <div className="text-muted-foreground flex items-center justify-center gap-2 py-16 text-sm">
+          <Loader2 className="size-4 animate-spin" /> Loading provider configuration…
+        </div>
+      </>
+    );
+  }
+
+  if (config.isError || !config.data) {
+    return (
+      <>
+        <PageHeader
+          title="Providers"
+          description="Configure bank data providers that sync accounts and transactions."
+        />
+        <Alert variant="destructive">
+          <AlertTitle>Couldn't load provider configuration</AlertTitle>
+          <AlertDescription>
+            {config.error instanceof Error
+              ? config.error.message
+              : "Try refreshing the page."}
+          </AlertDescription>
+        </Alert>
+      </>
+    );
+  }
+
+  const { plaid, teller, has_encryption_key } = config.data;
+  const healthMap = health.data ?? {};
+
+  return (
+    <>
+      <PageHeader
+        title="Providers"
+        description="Configure bank data providers that sync accounts and transactions into Breadbox."
+      />
+      <div className="grid gap-4">
+        <PlaidCard config={plaid} health={healthMap["plaid"]} />
+        <TellerCard
+          config={teller}
+          health={healthMap["teller"]}
+          hasEncryptionKey={has_encryption_key}
+        />
+        <CsvCard health={healthMap["csv"]} />
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- New v2 Setup → Providers page that wraps `GET/PUT /api/v1/settings/providers` so the SPA gets the same provider configuration UX as the legacy admin form, but with the shadcn/Tailwind design used everywhere else in `/v2`.
- One card per provider (Plaid, Teller, CSV) with the existing status badge + live last-sync chip from `/sync/health/providers`.
- Per-card actions: validated zod form → PUT, server-side **Test connection** probe, **Disable provider** confirmation dialog wired to `DELETE /api/v1/providers/{name}`.
- Mirrors the v1 form's "leave blank to keep" UX for secrets and PEM certificates so users don't have to retype values on every save.
- Adds `has_encryption_key` to `providerConfigResponse` so the Teller card can warn the user before a cert upload that would 500 with `ENCRYPTION_KEY_MISSING` server-side.

## Why a new page instead of nesting in the existing Settings modal
The legacy admin UI had a real `/settings/providers` route that handled cert uploads, env-var-locked deployments, and webhook setup hints. None of that fits cleanly into a modal sheet, and a "provider configuration" surface is also reasonably the first thing a brand-new install lands on. Putting it under the **Setup** sidebar group puts it next to Connections / Account links, which is where the work actually flows.

## Build tag note
No new Go files — only an additive field on `providerConfigResponse` in `internal/api/provider_config.go`. The integration tests in `internal/api/provider_config_integration_test.go` decode into the same struct, so they keep compiling/passing.

## Test plan
- [x] `bun run build` — clean
- [x] `go vet ./...` and `go build ./...` — clean
- [x] Captured at desktop / tablet / mobile via `bun run validate /v2/providers` (see screenshot)
- [ ] Smoke `PUT /api/v1/settings/providers/plaid` from the SPA against a non-env-var deployment
- [ ] Smoke Teller cert pair upload against a deployment with `ENCRYPTION_KEY` set
- [ ] Confirm DELETE flow on a sandbox install

🤖 Generated with [Claude Code](https://claude.com/claude-code)
