### PR TITLE
v2: backups management page in settings

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -276,6 +276,7 @@ func NewRouter(a *app.App, version string) http.Handler {
 					r.Get("/me", webui.MeHandler(sm))
 					r.Post("/logout", webui.LogoutHandler(sm))
 					r.Post("/account/password", webui.ChangePasswordHandler(sm, a.Queries))
+					webui.MountBackupRoutes(r, a, sm)
 				})
 			})
 			// /v2/* — embedded SPA static bundle. The session middleware lets

--- a/web/backups.go
+++ b/web/backups.go
@@ -1,0 +1,292 @@
+//go:build !headless && !lite
+
+package webui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"breadbox/internal/admin"
+	"breadbox/internal/app"
+	"breadbox/internal/db"
+	mw "breadbox/internal/middleware"
+	"breadbox/internal/pgconv"
+	"breadbox/internal/service"
+
+	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
+)
+
+// MountBackupRoutes attaches /web/v1/backups/* under an already-mounted,
+// already session-gated chi.Router. Routes are admin-only — anyone else gets
+// 403. Backups are infrastructure-tier; the standard editor/viewer split is
+// not strict enough.
+func MountBackupRoutes(r chi.Router, a *app.App, sm *scs.SessionManager) {
+	r.Group(func(r chi.Router) {
+		r.Use(requireAdminJSON(sm))
+		r.Get("/backups", BackupsListHandler(a))
+		r.Post("/backups", CreateBackupHandler(a))
+		r.Put("/backups/schedule", UpdateBackupScheduleHandler(a))
+		r.Get("/backups/{filename}/download", DownloadBackupHandler(a))
+		r.Delete("/backups/{filename}", DeleteBackupHandler(a))
+		r.Post("/backups/{filename}/restore", RestoreExistingBackupHandler(a))
+		r.Post("/backups/restore", RestoreUploadedBackupHandler(a))
+	})
+}
+
+func requireAdminJSON(sm *scs.SessionManager) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !admin.IsAdmin(sm, r) {
+				mw.WriteError(w, http.StatusForbidden, "FORBIDDEN", "Admin role required")
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// BackupRow is the wire shape for one backup entry.
+type BackupRow struct {
+	Filename      string `json:"filename"`
+	Size          int64  `json:"size"`
+	SizeFormatted string `json:"size_formatted"`
+	CreatedAt     string `json:"created_at"`
+	Trigger       string `json:"trigger"`
+}
+
+// BackupStatus is the at-a-glance summary the page renders above the list.
+type BackupStatus struct {
+	ServiceAvailable bool   `json:"service_available"`
+	HasEncryptionKey bool   `json:"has_encryption_key"`
+	BackupCount      int    `json:"backup_count"`
+	TotalSizeBytes   int64  `json:"total_size_bytes"`
+	TotalSize        string `json:"total_size"`
+	Schedule         string `json:"schedule"`
+	RetentionDays    int    `json:"retention_days"`
+	BackupDir        string `json:"backup_dir"`
+	DatabaseName     string `json:"database_name"`
+	PreflightOK      bool   `json:"preflight_ok"`
+	PreflightMessage string `json:"preflight_message"`
+}
+
+// BackupsListResponse is the GET /web/v1/backups payload.
+type BackupsListResponse struct {
+	Status  BackupStatus `json:"status"`
+	Backups []BackupRow  `json:"backups"`
+}
+
+// BackupsListHandler returns the full overview the page needs in one round
+// trip — status + the file list. Avoids a second fetch dance from the SPA.
+func BackupsListHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		status := BackupStatus{
+			HasEncryptionKey: len(a.Config.EncryptionKey) > 0,
+			DatabaseName:     service.ParseDatabaseName(a.Config.DatabaseURL),
+		}
+
+		if a.BackupService == nil {
+			status.PreflightMessage = "Backup service is not available. pg_dump may not be installed."
+			mw.WriteJSON(w, http.StatusOK, BackupsListResponse{Status: status, Backups: []BackupRow{}})
+			return
+		}
+
+		status.ServiceAvailable = true
+		status.BackupDir = a.BackupService.BackupDir()
+		status.Schedule = a.Service.GetBackupSchedule(ctx)
+		status.RetentionDays = a.Service.GetBackupRetentionDays(ctx)
+
+		preflight := a.BackupService.Preflight(ctx)
+		status.PreflightOK = preflight.OK
+		status.PreflightMessage = preflight.Message
+
+		infos, err := a.BackupService.ListBackups()
+		if err != nil {
+			a.Logger.Error("list backups", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "LIST_FAILED", "Failed to list backups")
+			return
+		}
+
+		var total int64
+		rows := make([]BackupRow, 0, len(infos))
+		for _, b := range infos {
+			total += b.Size
+			rows = append(rows, BackupRow{
+				Filename:      b.Filename,
+				Size:          b.Size,
+				SizeFormatted: service.FormatBytes(b.Size),
+				CreatedAt:     b.CreatedAt.UTC().Format(time.RFC3339),
+				Trigger:       b.Trigger,
+			})
+		}
+		status.BackupCount = len(rows)
+		status.TotalSizeBytes = total
+		status.TotalSize = service.FormatBytes(total)
+
+		mw.WriteJSON(w, http.StatusOK, BackupsListResponse{Status: status, Backups: rows})
+	}
+}
+
+// CreateBackupHandler triggers a manual backup.
+func CreateBackupHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if a.BackupService == nil {
+			mw.WriteError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Backup service is not available")
+			return
+		}
+		filename, err := a.BackupService.CreateBackup(r.Context(), "manual")
+		if err != nil {
+			a.Logger.Error("create backup", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "CREATE_FAILED", err.Error())
+			return
+		}
+		mw.WriteJSON(w, http.StatusCreated, map[string]string{"filename": filename})
+	}
+}
+
+// DeleteBackupHandler removes a backup file.
+func DeleteBackupHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if a.BackupService == nil {
+			mw.WriteError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Backup service is not available")
+			return
+		}
+		filename := chi.URLParam(r, "filename")
+		if err := a.BackupService.DeleteBackup(filename); err != nil {
+			a.Logger.Error("delete backup", "error", err, "filename", filename)
+			mw.WriteError(w, http.StatusBadRequest, "DELETE_FAILED", err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// DownloadBackupHandler streams a .sql.gz file back to the browser.
+func DownloadBackupHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if a.BackupService == nil {
+			mw.WriteError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Backup service is not available")
+			return
+		}
+		filename := chi.URLParam(r, "filename")
+		fullPath, err := a.BackupService.GetBackupPath(filename)
+		if err != nil {
+			mw.WriteError(w, http.StatusNotFound, "NOT_FOUND", "Backup file not found")
+			return
+		}
+		w.Header().Set("Content-Type", "application/gzip")
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filename))
+		http.ServeFile(w, r, fullPath)
+	}
+}
+
+// RestoreExistingBackupHandler restores from a stored backup file.
+func RestoreExistingBackupHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if a.BackupService == nil {
+			mw.WriteError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Backup service is not available")
+			return
+		}
+		filename := chi.URLParam(r, "filename")
+		if err := a.BackupService.RestoreBackup(r.Context(), filename); err != nil {
+			a.Logger.Error("restore backup", "error", err, "filename", filename)
+			mw.WriteError(w, http.StatusInternalServerError, "RESTORE_FAILED", err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// RestoreUploadedBackupHandler accepts a multipart .sql.gz upload and pipes
+// it through psql. Capped at 500MB to match the v1 handler.
+func RestoreUploadedBackupHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if a.BackupService == nil {
+			mw.WriteError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "Backup service is not available")
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, 500<<20)
+
+		file, header, err := r.FormFile("backup_file")
+		if err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "MISSING_FILE", "No backup file provided")
+			return
+		}
+		defer file.Close()
+
+		if !strings.HasSuffix(header.Filename, ".sql.gz") {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_FILE", "Only .sql.gz files are supported")
+			return
+		}
+
+		if err := a.BackupService.RestoreFromReader(r.Context(), file); err != nil {
+			a.Logger.Error("restore from upload", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "RESTORE_FAILED", err.Error())
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// UpdateBackupScheduleRequest is the PUT body for /web/v1/backups/schedule.
+type UpdateBackupScheduleRequest struct {
+	Schedule      string `json:"schedule"`
+	RetentionDays int    `json:"retention_days"`
+}
+
+var validBackupSchedules = map[string]struct{}{
+	"":          {}, // disabled
+	"daily_2am": {},
+	"daily_3am": {},
+	"daily_4am": {},
+	"weekly":    {},
+}
+
+// UpdateBackupScheduleHandler persists the schedule + retention settings.
+func UpdateBackupScheduleHandler(a *app.App) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req UpdateBackupScheduleRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Request body must be valid JSON")
+			return
+		}
+
+		if _, ok := validBackupSchedules[req.Schedule]; !ok {
+			mw.WriteError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Invalid backup schedule")
+			return
+		}
+		if req.RetentionDays < 1 || req.RetentionDays > 365 {
+			mw.WriteError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Retention must be between 1 and 365 days")
+			return
+		}
+
+		ctx := r.Context()
+		if err := saveBackupSchedule(ctx, a.Queries, req.Schedule, req.RetentionDays); err != nil {
+			a.Logger.Error("save backup schedule", "error", err)
+			mw.WriteError(w, http.StatusInternalServerError, "SAVE_FAILED", "Failed to save backup settings")
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func saveBackupSchedule(ctx context.Context, q *db.Queries, schedule string, retentionDays int) error {
+	if err := q.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   "backup_schedule",
+		Value: pgconv.Text(schedule),
+	}); err != nil {
+		return errors.New("set backup_schedule: " + err.Error())
+	}
+	return q.SetAppConfig(ctx, db.SetAppConfigParams{
+		Key:   "backup_retention_days",
+		Value: pgconv.Text(fmt.Sprintf("%d", retentionDays)),
+	})
+}

--- a/web/embed_headless.go
+++ b/web/embed_headless.go
@@ -12,10 +12,16 @@ package webui
 import (
 	"net/http"
 
+	"breadbox/internal/app"
 	"breadbox/internal/db"
 
 	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
 )
+
+// MountBackupRoutes is a no-op stub. Headless builds strip the SPA, so the
+// /web/v1/backups/* surface is unreachable.
+func MountBackupRoutes(_ chi.Router, _ *app.App, _ *scs.SessionManager) {}
 
 // Handler returns a 410 Gone for every request. The real Handler embeds the
 // SPA bundle and serves /v2/*.

--- a/web/src/api/queries/backups.ts
+++ b/web/src/api/queries/backups.ts
@@ -1,0 +1,108 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+
+export interface BackupRow {
+  filename: string;
+  size: number;
+  size_formatted: string;
+  created_at: string;
+  trigger: string; // "manual" | "scheduled" | "unknown"
+}
+
+export interface BackupStatus {
+  service_available: boolean;
+  has_encryption_key: boolean;
+  backup_count: number;
+  total_size_bytes: number;
+  total_size: string;
+  schedule: string; // "" | "daily_2am" | "daily_3am" | "daily_4am" | "weekly"
+  retention_days: number;
+  backup_dir: string;
+  database_name: string;
+  preflight_ok: boolean;
+  preflight_message: string;
+}
+
+export interface BackupsListResponse {
+  status: BackupStatus;
+  backups: BackupRow[];
+}
+
+const BACKUPS_KEY = ["backups"] as const;
+
+export function useBackups() {
+  return useQuery({
+    queryKey: BACKUPS_KEY,
+    queryFn: () => api<BackupsListResponse>("/web/v1/backups"),
+    staleTime: 15_000,
+  });
+}
+
+export function useCreateBackup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      api<{ filename: string }>("/web/v1/backups", { method: "POST" }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: BACKUPS_KEY });
+    },
+  });
+}
+
+export function useDeleteBackup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (filename: string) =>
+      api<void>(`/web/v1/backups/${encodeURIComponent(filename)}`, {
+        method: "DELETE",
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: BACKUPS_KEY });
+    },
+  });
+}
+
+export function useRestoreExistingBackup() {
+  return useMutation({
+    mutationFn: (filename: string) =>
+      api<void>(`/web/v1/backups/${encodeURIComponent(filename)}/restore`, {
+        method: "POST",
+      }),
+  });
+}
+
+export function useRestoreUploadedBackup() {
+  return useMutation({
+    mutationFn: (file: File) => {
+      const fd = new FormData();
+      fd.append("backup_file", file);
+      return api<void>("/web/v1/backups/restore", {
+        method: "POST",
+        body: fd,
+      });
+    },
+  });
+}
+
+export interface UpdateBackupScheduleInput {
+  schedule: string;
+  retention_days: number;
+}
+
+export function useUpdateBackupSchedule() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: UpdateBackupScheduleInput) =>
+      api<void>("/web/v1/backups/schedule", {
+        method: "PUT",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: BACKUPS_KEY });
+    },
+  });
+}
+
+export function backupDownloadHref(filename: string): string {
+  return `/web/v1/backups/${encodeURIComponent(filename)}/download`;
+}

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -18,6 +18,7 @@ import { SETTINGS_SECTIONS, type SettingsSection } from "@/lib/settings-sections
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { closeModal, openModal, useActiveModal } from "@/lib/modals";
 import { AccountSection } from "@/features/settings/account-section";
+import { BackupsSection } from "@/features/settings/backups-section";
 
 const SETTINGS_MODAL_KEY = "settings";
 
@@ -139,6 +140,14 @@ function SectionContent({
     return (
       <div className={wrapper}>
         <AccountSection />
+      </div>
+    );
+  }
+
+  if (section.slug === "backups") {
+    return (
+      <div className={wrapper}>
+        <BackupsSection />
       </div>
     );
   }

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -1,0 +1,691 @@
+import { useRef, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  AlertTriangle,
+  Calendar,
+  CheckCircle2,
+  Download,
+  HardDrive,
+  Loader2,
+  RotateCcw,
+  Trash2,
+  Upload,
+} from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  backupDownloadHref,
+  useBackups,
+  useCreateBackup,
+  useDeleteBackup,
+  useRestoreExistingBackup,
+  useRestoreUploadedBackup,
+  useUpdateBackupSchedule,
+  type BackupRow,
+  type BackupStatus,
+} from "@/api/queries/backups";
+import { withMutationToast } from "@/lib/mutation-toast";
+
+const SCHEDULE_OPTIONS = [
+  { value: "off", label: "Disabled — manual only" },
+  { value: "daily_2am", label: "Daily at 2:00 AM" },
+  { value: "daily_3am", label: "Daily at 3:00 AM" },
+  { value: "daily_4am", label: "Daily at 4:00 AM" },
+  { value: "weekly", label: "Weekly (Sunday at 3:00 AM)" },
+] as const;
+
+const SCHEDULE_LABEL: Record<string, string> = Object.fromEntries(
+  SCHEDULE_OPTIONS.map((o) => [o.value === "off" ? "" : o.value, o.label]),
+);
+
+export function BackupsSection() {
+  const query = useBackups();
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-1">
+        <h2 className="text-lg font-medium">Backups</h2>
+        <p className="text-muted-foreground text-sm">
+          Compressed PostgreSQL dumps (<code className="font-mono text-xs">.sql.gz</code>) of the
+          household database. Restore replaces every row — handle with care.
+        </p>
+      </div>
+
+      {query.isLoading ? (
+        <BackupsSkeleton />
+      ) : query.isError ? (
+        <Alert variant="destructive">
+          <AlertTriangle className="size-4" />
+          <AlertTitle>Couldn't load backups</AlertTitle>
+          <AlertDescription>{query.error.message}</AlertDescription>
+        </Alert>
+      ) : query.data ? (
+        <BackupsContent data={query.data.status} backups={query.data.backups} />
+      ) : null}
+    </div>
+  );
+}
+
+function BackupsContent({
+  data,
+  backups,
+}: {
+  data: BackupStatus;
+  backups: BackupRow[];
+}) {
+  return (
+    <div className="space-y-6">
+      {!data.service_available && (
+        <Alert variant="destructive">
+          <AlertTriangle className="size-4" />
+          <AlertTitle>Backup service unavailable</AlertTitle>
+          <AlertDescription>
+            {data.preflight_message ||
+              "pg_dump is not on PATH. Install the PostgreSQL client on the host."}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {data.service_available && !data.preflight_ok && (
+        <Alert variant="destructive">
+          <AlertTriangle className="size-4" />
+          <AlertTitle>Preflight check failed</AlertTitle>
+          <AlertDescription>{data.preflight_message}</AlertDescription>
+        </Alert>
+      )}
+
+      {!data.has_encryption_key && (
+        <Alert>
+          <AlertTriangle className="size-4" />
+          <AlertTitle>No encryption key configured</AlertTitle>
+          <AlertDescription>
+            Backups include encrypted provider tokens. Without{" "}
+            <code className="font-mono text-xs">ENCRYPTION_KEY</code>, they cannot be restored on
+            another host.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <StatusGrid data={data} />
+
+      <Separator />
+
+      <BackupActions disabled={!data.service_available || !data.preflight_ok} />
+
+      <Separator />
+
+      <ScheduleForm
+        initialSchedule={data.schedule}
+        initialRetentionDays={data.retention_days}
+      />
+
+      <Separator />
+
+      <BackupsTable
+        backups={backups}
+        restoreDisabled={!data.service_available || !data.preflight_ok}
+      />
+    </div>
+  );
+}
+
+function StatusGrid({ data }: { data: BackupStatus }) {
+  const scheduleLabel =
+    data.schedule in SCHEDULE_LABEL
+      ? SCHEDULE_LABEL[data.schedule]
+      : data.schedule || "Disabled";
+
+  return (
+    <dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+      <Stat label="Backups" value={String(data.backup_count)} icon={<HardDrive className="size-3.5" />} />
+      <Stat label="Total size" value={data.total_size} />
+      <Stat label="Schedule" value={scheduleLabel} icon={<Calendar className="size-3.5" />} />
+      <Stat label="Retention" value={`${data.retention_days} days`} />
+      <Stat label="Database" value={data.database_name} mono className="col-span-2" />
+      <Stat
+        label="Backup directory"
+        value={data.backup_dir || "—"}
+        mono
+        className="col-span-2"
+      />
+    </dl>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  mono,
+  icon,
+  className,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  icon?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={"space-y-0.5 " + (className ?? "")}>
+      <dt className="text-muted-foreground flex items-center gap-1 text-xs uppercase tracking-wider">
+        {icon}
+        {label}
+      </dt>
+      <dd
+        className={
+          mono
+            ? "truncate font-mono text-sm"
+            : "truncate text-sm font-medium"
+        }
+        title={value}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function BackupActions({ disabled }: { disabled: boolean }) {
+  const fileInput = useRef<HTMLInputElement>(null);
+  const create = useCreateBackup();
+  const upload = useRestoreUploadedBackup();
+  const [pendingUpload, setPendingUpload] = useState<File | null>(null);
+
+  const runCreate = () => {
+    void withMutationToast(() => create.mutateAsync(), {
+      success: "Backup created.",
+    });
+  };
+
+  const confirmUpload = async () => {
+    if (!pendingUpload) return;
+    const file = pendingUpload;
+    setPendingUpload(null);
+    await withMutationToast(() => upload.mutateAsync(file), {
+      success: "Restored from uploaded backup. Restart the server to be safe.",
+    });
+    if (fileInput.current) fileInput.current.value = "";
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <h3 className="font-medium">Actions</h3>
+        <p className="text-muted-foreground text-sm">
+          Create an on-demand backup, or restore from a file you have on disk.
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          onClick={runCreate}
+          disabled={disabled || create.isPending}
+        >
+          {create.isPending ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <HardDrive className="size-4" />
+          )}
+          {create.isPending ? "Creating…" : "Create backup now"}
+        </Button>
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => fileInput.current?.click()}
+          disabled={disabled || upload.isPending}
+        >
+          {upload.isPending ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Upload className="size-4" />
+          )}
+          {upload.isPending ? "Restoring…" : "Restore from upload"}
+        </Button>
+
+        <input
+          ref={fileInput}
+          type="file"
+          accept=".sql.gz,application/gzip"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) setPendingUpload(file);
+          }}
+        />
+      </div>
+
+      <ConfirmRestoreDialog
+        title="Restore from uploaded file?"
+        description={
+          pendingUpload
+            ? `This will OVERWRITE the current database with the contents of ${pendingUpload.name}. The action runs in a single transaction and rolls back on error, but on success the existing rows are gone.`
+            : ""
+        }
+        open={!!pendingUpload}
+        onCancel={() => {
+          setPendingUpload(null);
+          if (fileInput.current) fileInput.current.value = "";
+        }}
+        onConfirm={confirmUpload}
+      />
+    </div>
+  );
+}
+
+const scheduleSchema = z.object({
+  schedule: z.string(),
+  retention_days: z
+    .number({ error: "Retention is required" })
+    .int()
+    .min(1, "Must be at least 1 day")
+    .max(365, "Must be 365 days or fewer"),
+});
+
+type ScheduleValues = z.infer<typeof scheduleSchema>;
+
+function ScheduleForm({
+  initialSchedule,
+  initialRetentionDays,
+}: {
+  initialSchedule: string;
+  initialRetentionDays: number;
+}) {
+  const save = useUpdateBackupSchedule();
+  const form = useForm<ScheduleValues>({
+    resolver: zodResolver(scheduleSchema),
+    defaultValues: {
+      schedule: initialSchedule === "" ? "off" : initialSchedule,
+      retention_days: initialRetentionDays || 7,
+    },
+  });
+
+  const onSubmit = async (values: ScheduleValues) => {
+    await withMutationToast(
+      () =>
+        save.mutateAsync({
+          schedule: values.schedule === "off" ? "" : values.schedule,
+          retention_days: values.retention_days,
+        }),
+      { success: "Schedule saved." },
+    );
+  };
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4"
+        noValidate
+      >
+        <div className="space-y-1">
+          <h3 className="font-medium">Automatic schedule</h3>
+          <p className="text-muted-foreground text-sm">
+            Backups older than the retention window are pruned at the end of each scheduled run.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-[2fr_1fr]">
+          <FormField
+            control={form.control}
+            name="schedule"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Cadence</FormLabel>
+                <Select
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  disabled={save.isPending}
+                >
+                  <FormControl>
+                    <SelectTrigger className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {SCHEDULE_OPTIONS.map((opt) => (
+                      <SelectItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="retention_days"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Retention (days)</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    inputMode="numeric"
+                    min={1}
+                    max={365}
+                    value={field.value}
+                    onChange={(e) => field.onChange(e.target.valueAsNumber)}
+                    disabled={save.isPending}
+                  />
+                </FormControl>
+                <FormDescription>1–365</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        <Button type="submit" disabled={save.isPending}>
+          {save.isPending ? "Saving…" : "Save schedule"}
+        </Button>
+      </form>
+    </Form>
+  );
+}
+
+function BackupsTable({
+  backups,
+  restoreDisabled,
+}: {
+  backups: BackupRow[];
+  restoreDisabled: boolean;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <h3 className="font-medium">Stored backups</h3>
+        <p className="text-muted-foreground text-sm">
+          Newest first. Filenames carry the trigger (manual or scheduled) and a UTC timestamp.
+        </p>
+      </div>
+
+      {backups.length === 0 ? (
+        <div className="border-border rounded-md border border-dashed p-8 text-center">
+          <CheckCircle2 className="text-muted-foreground mx-auto mb-2 size-5" />
+          <p className="text-muted-foreground text-sm">
+            No backups yet. Create one above or set a schedule.
+          </p>
+        </div>
+      ) : (
+        <div className="border-border overflow-hidden rounded-md border">
+          <ul className="divide-border divide-y">
+            {backups.map((b) => (
+              <BackupRowItem
+                key={b.filename}
+                row={b}
+                restoreDisabled={restoreDisabled}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BackupRowItem({
+  row,
+  restoreDisabled,
+}: {
+  row: BackupRow;
+  restoreDisabled: boolean;
+}) {
+  const restore = useRestoreExistingBackup();
+  const del = useDeleteBackup();
+  const [confirm, setConfirm] = useState<"restore" | "delete" | null>(null);
+
+  const runRestore = async () => {
+    setConfirm(null);
+    await withMutationToast(() => restore.mutateAsync(row.filename), {
+      success: `Restored from ${row.filename}. Restart the server to be safe.`,
+    });
+  };
+
+  const runDelete = async () => {
+    setConfirm(null);
+    await withMutationToast(() => del.mutateAsync(row.filename), {
+      success: `Deleted ${row.filename}.`,
+    });
+  };
+
+  const busy = restore.isPending || del.isPending;
+
+  return (
+    <li className="flex flex-col gap-2 px-3 py-2 sm:flex-row sm:items-center sm:gap-4">
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-mono text-xs">{row.filename}</span>
+          <Badge variant={row.trigger === "manual" ? "secondary" : "outline"}>
+            {row.trigger}
+          </Badge>
+        </div>
+        <div className="text-muted-foreground flex items-center gap-3 text-xs">
+          <span>{row.size_formatted}</span>
+          <span>·</span>
+          <RelativeTime iso={row.created_at} />
+        </div>
+      </div>
+
+      <TooltipProvider delayDuration={200}>
+        <div className="flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                asChild
+                aria-label="Download backup"
+              >
+                <a href={backupDownloadHref(row.filename)}>
+                  <Download className="size-4" />
+                </a>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Download</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => setConfirm("restore")}
+                disabled={busy || restoreDisabled}
+                aria-label="Restore from this backup"
+              >
+                {restore.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <RotateCcw className="size-4" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Restore</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => setConfirm("delete")}
+                disabled={busy}
+                aria-label="Delete backup"
+                className="text-destructive hover:text-destructive"
+              >
+                {del.isPending ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : (
+                  <Trash2 className="size-4" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Delete</TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
+
+      <ConfirmRestoreDialog
+        title="Restore this backup?"
+        description={`This will OVERWRITE the current database with the contents of ${row.filename}. The action runs in a single transaction and rolls back on error, but on success the existing rows are gone.`}
+        open={confirm === "restore"}
+        onCancel={() => setConfirm(null)}
+        onConfirm={runRestore}
+      />
+
+      <ConfirmDeleteDialog
+        filename={row.filename}
+        open={confirm === "delete"}
+        onCancel={() => setConfirm(null)}
+        onConfirm={runDelete}
+      />
+    </li>
+  );
+}
+
+function ConfirmRestoreDialog({
+  title,
+  description,
+  open,
+  onCancel,
+  onConfirm,
+}: {
+  title: string;
+  description: string;
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onConfirm}>
+            Restore
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function ConfirmDeleteDialog({
+  filename,
+  open,
+  onCancel,
+  onConfirm,
+}: {
+  filename: string;
+  open: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={(o) => !o && onCancel()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete backup?</AlertDialogTitle>
+          <AlertDialogDescription>
+            <span className="font-mono text-xs">{filename}</span> will be removed from disk. This
+            cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onConfirm}>
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function BackupsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <Skeleton className="h-10" />
+        <Skeleton className="h-10" />
+        <Skeleton className="h-10" />
+        <Skeleton className="h-10" />
+      </div>
+      <Skeleton className="h-9 w-40" />
+      <Skeleton className="h-32" />
+    </div>
+  );
+}
+
+function RelativeTime({ iso }: { iso: string }) {
+  const date = new Date(iso);
+  const label = formatRelative(date);
+  return (
+    <time dateTime={iso} title={date.toLocaleString()}>
+      {label}
+    </time>
+  );
+}
+
+function formatRelative(date: Date): string {
+  const diffMs = date.getTime() - Date.now();
+  const diffSec = Math.round(diffMs / 1000);
+  const abs = Math.abs(diffSec);
+  const fmt = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  if (abs < 60) return fmt.format(diffSec, "second");
+  if (abs < 3600) return fmt.format(Math.round(diffSec / 60), "minute");
+  if (abs < 86_400) return fmt.format(Math.round(diffSec / 3600), "hour");
+  if (abs < 2_592_000) return fmt.format(Math.round(diffSec / 86_400), "day");
+  if (abs < 31_536_000)
+    return fmt.format(Math.round(diffSec / 2_592_000), "month");
+  return fmt.format(Math.round(diffSec / 31_536_000), "year");
+}

--- a/web/src/lib/settings-sections.ts
+++ b/web/src/lib/settings-sections.ts
@@ -1,4 +1,4 @@
-import { Lock, User, type LucideIcon } from "lucide-react";
+import { DatabaseBackup, Lock, User, type LucideIcon } from "lucide-react";
 
 export interface SettingsSection {
   slug: string;
@@ -19,5 +19,11 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     title: "Security",
     description: "Sessions and API keys.",
     icon: Lock,
+  },
+  {
+    slug: "backups",
+    title: "Backups",
+    description: "Snapshot the database, restore, and schedule automatic backups.",
+    icon: DatabaseBackup,
   },
 ];


### PR DESCRIPTION
## Summary

Adds a **Backups** section to the v2 settings modal so admins can manage PostgreSQL dumps from the new dashboard. Previously the only way to manage backups was the v1 admin UI at `/settings/backups`.

The page wraps the existing `internal/service.BackupService` via a new admin-only `/web/v1/backups/*` surface:

| Method | Path | What |
| --- | --- | --- |
| `GET` | `/web/v1/backups` | list backups + status (count, total size, schedule, retention, preflight, db name, backup dir) |
| `POST` | `/web/v1/backups` | create a manual backup |
| `DELETE` | `/web/v1/backups/{filename}` | delete a backup |
| `GET` | `/web/v1/backups/{filename}/download` | stream `.sql.gz` to the browser |
| `POST` | `/web/v1/backups/{filename}/restore` | restore from an existing file (`AlertDialog` confirm) |
| `POST` | `/web/v1/backups/restore` | restore from an uploaded `.sql.gz` (multipart, capped at 500 MB) |
| `PUT` | `/web/v1/backups/schedule` | update schedule + retention |

All routes are session-only and admin-only (`admin.IsAdmin` gate — editor/viewer get 403). The v1 admin handlers at `/-/backups/*` are unchanged; both UIs coexist.

The SPA side is one new `BackupsSection` feature component built on existing shadcn primitives (`Alert`, `AlertDialog`, `Badge`, `Button`, `Form`, `Input`, `Select`, `Separator`, `Skeleton`, `Tooltip`). No new components added to `components/ui` or `components/`.

## Validation

Tested live against a worktree server with a real PostgreSQL backup created end-to-end (create → list → schedule → confirmations all wired). Desktop and mobile both render cleanly.

**Desktop — initial view (1280×1100, dialog clipped to its 600 px max):**

<img src="https://i.img402.dev/rpxhddiixu.jpg" width="800" alt="Backups settings — desktop (top)">

**Desktop — full content (dialog auto-height so the file list and schedule form are visible):**

<img src="https://i.img402.dev/xawp30qxsv.jpg" width="800" alt="Backups settings — desktop (full)">

**Mobile (390×844, sheet scrolled to the Backups heading):**

<img src="https://i.img402.dev/srto6q75ou.jpg" width="320" alt="Backups settings — mobile">

## Test plan

- [ ] `GET /web/v1/backups` returns status + list with stored files
- [ ] `POST /web/v1/backups` produces a new `.sql.gz` and the row appears in the list
- [ ] `DELETE /web/v1/backups/{filename}` removes it
- [ ] Schedule form persists `backup_schedule` + `backup_retention_days` (visible in `app_config`)
- [ ] Restore from upload accepts only `.sql.gz`; other file types are rejected with `INVALID_FILE`
- [ ] Non-admin sessions hitting any `/web/v1/backups/*` route receive `403 FORBIDDEN`
- [ ] Toggling between Account / Backups in the modal preserves the URL-based modal state
