### PR TITLE
v2: household settings page + native setup-account flow

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -270,6 +270,11 @@ func NewRouter(a *app.App, version string) http.Handler {
 				r.Use(webui.RequireSameOrigin())
 				// Pre-auth (login + first-run signup-style routes): no session required.
 				r.Post("/login", webui.LoginHandler(sm, a.Queries))
+				// Setup-account: token-gated password set for new members.
+				// Pre-auth — the one-time token is the credential. POST also
+				// starts a session so the SPA can route straight into /v2/.
+				r.Get("/setup-account/{token}", webui.SetupAccountInfoHandler(a.Queries))
+				r.Post("/setup-account/{token}", webui.SetupAccountHandler(sm, a.Queries))
 				// Post-auth routes.
 				r.Group(func(r chi.Router) {
 					r.Use(webui.RequireSessionJSON(sm))

--- a/web/embed.go
+++ b/web/embed.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"breadbox/internal/admin"
 	"breadbox/internal/db"
@@ -20,6 +21,7 @@ import (
 	"breadbox/internal/pgconv"
 
 	"github.com/alexedwards/scs/v2"
+	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -266,3 +268,123 @@ func ChangePasswordHandler(sm *scs.SessionManager, queries *db.Queries) http.Han
 // responses against unknown usernames so timing can't be used for
 // enumeration.
 var loginDummyHash, _ = bcrypt.GenerateFromPassword([]byte("dummy-password-for-timing"), 12)
+
+// SetupAccountInfoResponse is the GET shape for /web/v1/setup-account/{token}:
+// just enough for the SPA to greet the new member with their email.
+type SetupAccountInfoResponse struct {
+	Username string `json:"username"`
+}
+
+// SetupAccountInfoHandler validates a setup token and returns the username
+// the SPA should display. Pre-auth (no session required) — the token *is*
+// the credential. Returns 404 for unknown/expired tokens; 410 GONE when the
+// password has already been set so the SPA can route the visitor to /login.
+func SetupAccountInfoHandler(queries *db.Queries) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := chi.URLParam(r, "token")
+		account, ok := lookupSetupToken(w, r, queries, token)
+		if !ok {
+			return
+		}
+		mw.WriteJSON(w, http.StatusOK, SetupAccountInfoResponse{Username: account.Username})
+	}
+}
+
+// SetupAccountRequest is the POST body for /web/v1/setup-account/{token}.
+type SetupAccountRequest struct {
+	Password        string `json:"password"`
+	ConfirmPassword string `json:"confirm_password"`
+}
+
+// SetupAccountHandler consumes a setup token, hashes + stores the password,
+// clears the token, and opens a session so the SPA can route the visitor
+// straight into /v2/ without a second login round-trip. Pre-auth.
+func SetupAccountHandler(sm *scs.SessionManager, queries *db.Queries) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token := chi.URLParam(r, "token")
+		account, ok := lookupSetupToken(w, r, queries, token)
+		if !ok {
+			return
+		}
+
+		var req SetupAccountRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			mw.WriteError(w, http.StatusBadRequest, "INVALID_BODY", "Request body must be valid JSON")
+			return
+		}
+		if len(req.Password) < 8 {
+			mw.WriteError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Password must be at least 8 characters")
+			return
+		}
+		if req.Password != req.ConfirmPassword {
+			mw.WriteError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "Passwords do not match")
+			return
+		}
+
+		hashed, err := bcrypt.GenerateFromPassword([]byte(req.Password), 12)
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "HASH_ERROR", "Failed to hash password")
+			return
+		}
+		if err := queries.UpdateAuthAccountPassword(r.Context(), db.UpdateAuthAccountPasswordParams{
+			ID:             account.ID,
+			HashedPassword: hashed,
+		}); err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "UPDATE_FAILED", "Failed to set password")
+			return
+		}
+		_ = queries.ClearAuthAccountSetupToken(r.Context(), account.ID)
+
+		// Re-read so the session keys reflect the freshly-set password and the
+		// row has no stale token state. Mirrors the LoginHandler path.
+		fresh, err := queries.GetAuthAccountByID(r.Context(), account.ID)
+		if err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "Account refresh failed")
+			return
+		}
+		if err := sm.RenewToken(r.Context()); err != nil {
+			mw.WriteError(w, http.StatusInternalServerError, "SESSION_ERROR", "Failed to start session")
+			return
+		}
+		admin.SetLoginSessionKeys(r.Context(), sm, fresh, queries)
+
+		mw.WriteJSON(w, http.StatusOK, MeResponse{
+			AccountID: pgconv.FormatUUID(fresh.ID),
+			Username:  fresh.Username,
+			Role:      fresh.Role,
+		})
+	}
+}
+
+// lookupSetupToken resolves the URL `token` parameter to an `auth_accounts`
+// row, writing the canonical error envelope (and HTTP status) if anything is
+// off so callers can early-return.
+//
+// Returns ok=false in three cases the SPA should distinguish:
+//   - 400 BAD_REQUEST: empty token (almost always a SPA bug).
+//   - 410 GONE / ALREADY_SETUP: token row exists but password is already
+//     stored — the SPA reads this and bounces to /login instead of showing
+//     the form a second time.
+//   - 404 NOT_FOUND / SETUP_TOKEN_INVALID: unknown token, or expired. We
+//     collapse these to one code on purpose so a malicious caller can't tell
+//     "expired" from "never existed".
+func lookupSetupToken(w http.ResponseWriter, r *http.Request, queries *db.Queries, token string) (db.AuthAccount, bool) {
+	if token == "" {
+		mw.WriteError(w, http.StatusBadRequest, "INVALID_PARAMETER", "Missing setup token")
+		return db.AuthAccount{}, false
+	}
+	account, err := queries.GetAuthAccountBySetupToken(r.Context(), pgconv.Text(token))
+	if err != nil {
+		mw.WriteError(w, http.StatusNotFound, "SETUP_TOKEN_INVALID", "This setup link is invalid or has expired.")
+		return db.AuthAccount{}, false
+	}
+	if account.SetupTokenExpiresAt.Valid && account.SetupTokenExpiresAt.Time.Before(time.Now()) {
+		mw.WriteError(w, http.StatusNotFound, "SETUP_TOKEN_INVALID", "This setup link is invalid or has expired.")
+		return db.AuthAccount{}, false
+	}
+	if account.HashedPassword != nil {
+		mw.WriteError(w, http.StatusGone, "ALREADY_SETUP", "This account is already set up. Please sign in.")
+		return db.AuthAccount{}, false
+	}
+	return account, true
+}

--- a/web/src/api/queries/auth.ts
+++ b/web/src/api/queries/auth.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import type { Me } from "@/api/types";
 
@@ -28,6 +28,46 @@ export function useLogout() {
     mutationFn: () => api<void>("/web/v1/logout", { method: "POST" }),
     onSuccess: () => {
       qc.clear();
+    },
+  });
+}
+
+// --- Token-gated setup-account flow (new member sets their password) ---
+
+export interface SetupAccountInfo {
+  username: string;
+}
+
+// useSetupAccountInfo validates the token and returns the username we'll
+// greet the new member with. retry:false on purpose — the error code carries
+// the routing decision (ALREADY_SETUP → bounce to /login, otherwise show
+// "this link is invalid"), and a retry would just delay the inevitable.
+export function useSetupAccountInfo(token: string) {
+  return useQuery({
+    queryKey: ["setup-account", token],
+    queryFn: () => api<SetupAccountInfo>(`/web/v1/setup-account/${token}`),
+    retry: false,
+    enabled: !!token,
+  });
+}
+
+export interface SetupAccountInput {
+  password: string;
+  confirm_password: string;
+}
+
+// useSetupAccount submits the password and seeds the me-cache from the
+// response so the SPA can navigate straight into /v2/ without re-fetching.
+export function useSetupAccount(token: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: SetupAccountInput) =>
+      api<Me>(`/web/v1/setup-account/${token}`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: (data) => {
+      qc.setQueryData(["me"], data);
     },
   });
 }

--- a/web/src/api/queries/users.ts
+++ b/web/src/api/queries/users.ts
@@ -1,13 +1,151 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import type { User } from "@/api/types";
+import type { LoginAccount, LoginAccountRole, User } from "@/api/types";
 
 // useUsers loads household members. Bounded reference data — used by the
-// connections family-member filter. Long staleTime mirrors useAccounts.
+// connections family-member filter and the Household settings section.
 export function useUsers() {
   return useQuery({
     queryKey: ["users"],
     queryFn: () => api<User[]>("/api/v1/users"),
     staleTime: 5 * 60_000,
   });
+}
+
+export interface CreateUserInput {
+  name: string;
+  email?: string;
+}
+
+export function useCreateUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateUserInput) =>
+      api<User>("/api/v1/users", {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["users"] });
+    },
+  });
+}
+
+export interface UpdateUserInput {
+  name?: string;
+  email?: string;
+}
+
+export function useUpdateUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateUserInput }) =>
+      api<User>(`/api/v1/users/${id}`, {
+        method: "PATCH",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["users"] });
+    },
+  });
+}
+
+export function useDeleteUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api<void>(`/api/v1/users/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["users"] });
+      qc.invalidateQueries({ queryKey: ["user-logins"] });
+    },
+  });
+}
+
+// useUserLogins lists the login accounts belonging to a single member. Bounded
+// to 0 or 1 entries — the schema enforces one login per user.
+export function useUserLogins(userId: string | undefined) {
+  return useQuery({
+    queryKey: ["user-logins", userId],
+    queryFn: () => api<LoginAccount[]>(`/api/v1/users/${userId}/login`),
+    enabled: !!userId,
+    staleTime: 60_000,
+  });
+}
+
+export interface CreateUserLoginInput {
+  username: string;
+  role: LoginAccountRole;
+}
+
+export function useCreateUserLogin(userId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateUserLoginInput) =>
+      api<LoginAccount>(`/api/v1/users/${userId}/login`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["user-logins", userId] });
+      qc.invalidateQueries({ queryKey: ["user-logins"] });
+    },
+  });
+}
+
+// useCreateLoginForUser takes userId in the mutation variables instead of as a
+// hook arg. Used by the add-member flow where the user doesn't exist yet at
+// hook-call time.
+export function useCreateLoginForUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      userId,
+      ...input
+    }: CreateUserLoginInput & { userId: string }) =>
+      api<LoginAccount>(`/api/v1/users/${userId}/login`, {
+        method: "POST",
+        body: JSON.stringify(input),
+      }),
+    onSuccess: (_, vars) => {
+      qc.invalidateQueries({ queryKey: ["user-logins", vars.userId] });
+      qc.invalidateQueries({ queryKey: ["user-logins"] });
+    },
+  });
+}
+
+// useRegenerateUserLogin issues a fresh setup token. Response carries only
+// `setup_token` — the rest of the login row is unchanged.
+export function useRegenerateUserLogin(userId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (loginId: string) =>
+      api<{ setup_token: string }>(
+        `/api/v1/users/${userId}/login/${loginId}/regenerate-token`,
+        { method: "POST" },
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["user-logins", userId] });
+    },
+  });
+}
+
+export function useDeleteUserLogin(userId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (loginId: string) =>
+      api<void>(`/api/v1/users/${userId}/login/${loginId}`, {
+        method: "DELETE",
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["user-logins", userId] });
+      qc.invalidateQueries({ queryKey: ["user-logins"] });
+    },
+  });
+}
+
+// setupAccountURL builds the link a new member uses to set their password.
+// Mirrors the v1 admin flow (`/setup-account/<token>`).
+export function setupAccountURL(token: string): string {
+  return `${window.location.origin}/setup-account/${token}`;
 }

--- a/web/src/api/queries/users.ts
+++ b/web/src/api/queries/users.ts
@@ -145,7 +145,8 @@ export function useDeleteUserLogin(userId: string) {
 }
 
 // setupAccountURL builds the link a new member uses to set their password.
-// Mirrors the v1 admin flow (`/setup-account/<token>`).
+// Points at the v2 SPA route; the legacy `/setup-account/<token>` admin form
+// is still mounted so previously-issued tokens keep working.
 export function setupAccountURL(token: string): string {
-  return `${window.location.origin}/setup-account/${token}`;
+  return `${window.location.origin}/v2/setup-account/${token}`;
 }

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -154,6 +154,25 @@ export interface User {
   updated_at: string;
 }
 
+// --- Login accounts (public /api/v1/users/{id}/login) ---
+// Mirrors internal/service.LoginAccountResponse. setup_token is only
+// populated on create + regenerate; list/update strip it.
+export type LoginAccountRole = "admin" | "editor" | "viewer";
+
+export interface LoginAccount {
+  id: string;
+  user_id: string;
+  user_name: string;
+  user_email: string | null;
+  username: string;
+  role: LoginAccountRole;
+  has_password: boolean;
+  setup_token?: string;
+  setup_token_expires_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
 // --- Connections (public /api/v1/connections) ---
 // Mirrors internal/service.ConnectionResponse. The list endpoint returns this
 // shape; ConnectionDetail extends it with paused/account_count/sync interval

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -19,6 +19,7 @@ import { useMediaQuery } from "@/hooks/use-media-query";
 import { closeModal, openModal, useActiveModal } from "@/lib/modals";
 import { AccountSection } from "@/features/settings/account-section";
 import { BackupsSection } from "@/features/settings/backups-section";
+import { HouseholdSection } from "@/features/settings/household-section";
 
 const SETTINGS_MODAL_KEY = "settings";
 
@@ -140,6 +141,14 @@ function SectionContent({
     return (
       <div className={wrapper}>
         <AccountSection />
+      </div>
+    );
+  }
+
+  if (section.slug === "household") {
+    return (
+      <div className={wrapper}>
+        <HouseholdSection />
       </div>
     );
   }

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -80,9 +80,11 @@ export function HouseholdSection() {
   const { data: users, isLoading } = useUsers();
   const [addOpen, setAddOpen] = useState(false);
 
+  const hasMembers = !!users && users.length > 0;
+
   return (
     <div className="space-y-6">
-      <div className="flex items-start justify-between gap-4">
+      <div className="space-y-3">
         <div className="space-y-1">
           <h2 className="text-lg font-medium">Household</h2>
           <p className="text-muted-foreground text-sm">
@@ -92,9 +94,9 @@ export function HouseholdSection() {
         </div>
         <Dialog open={addOpen} onOpenChange={setAddOpen}>
           <DialogTrigger asChild>
-            <Button size="sm">
+            <Button size="sm" variant={hasMembers ? "outline" : "default"}>
               <UserPlus className="size-4" />
-              Add member
+              {hasMembers ? "Add member" : "Add your first member"}
             </Button>
           </DialogTrigger>
           <AddMemberDialog onDone={() => setAddOpen(false)} />
@@ -103,8 +105,8 @@ export function HouseholdSection() {
 
       {isLoading ? (
         <p className="text-muted-foreground text-sm">Loading members…</p>
-      ) : !users || users.length === 0 ? (
-        <EmptyState onAdd={() => setAddOpen(true)} />
+      ) : !hasMembers ? (
+        <EmptyState />
       ) : (
         <ul className="space-y-3">
           {users.map((u) => (
@@ -116,7 +118,7 @@ export function HouseholdSection() {
   );
 }
 
-function EmptyState({ onAdd }: { onAdd: () => void }) {
+function EmptyState() {
   return (
     <div className="border-border rounded-lg border border-dashed p-8 text-center">
       <div className="bg-muted mx-auto mb-3 flex size-12 items-center justify-center rounded-xl">
@@ -124,12 +126,9 @@ function EmptyState({ onAdd }: { onAdd: () => void }) {
       </div>
       <h3 className="text-sm font-medium">No family members yet</h3>
       <p className="text-muted-foreground mx-auto mt-1 max-w-sm text-sm">
-        Add members to connect their banks and attribute transactions by person.
+        Add members to connect their banks and attribute transactions by
+        person.
       </p>
-      <Button onClick={onAdd} size="sm" className="mt-4">
-        <UserPlus className="size-4" />
-        Add your first member
-      </Button>
     </div>
   );
 }

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -1,0 +1,770 @@
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import {
+  Check,
+  Copy,
+  Link2,
+  MoreVertical,
+  RefreshCw,
+  Trash2,
+  UserPlus,
+  Users,
+} from "lucide-react";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+import {
+  setupAccountURL,
+  useCreateLoginForUser,
+  useCreateUser,
+  useCreateUserLogin,
+  useDeleteUser,
+  useDeleteUserLogin,
+  useRegenerateUserLogin,
+  useUserLogins,
+  useUsers,
+} from "@/api/queries/users";
+import { withMutationToast } from "@/lib/mutation-toast";
+import type { LoginAccount, User } from "@/api/types";
+import { cn } from "@/lib/utils";
+
+export function HouseholdSection() {
+  const { data: users, isLoading } = useUsers();
+  const [addOpen, setAddOpen] = useState(false);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium">Household</h2>
+          <p className="text-muted-foreground text-sm">
+            Add family members to track everyone's accounts in one place. Each
+            member can be invited to sign in with their own login.
+          </p>
+        </div>
+        <Dialog open={addOpen} onOpenChange={setAddOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm">
+              <UserPlus className="size-4" />
+              Add member
+            </Button>
+          </DialogTrigger>
+          <AddMemberDialog onDone={() => setAddOpen(false)} />
+        </Dialog>
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground text-sm">Loading members…</p>
+      ) : !users || users.length === 0 ? (
+        <EmptyState onAdd={() => setAddOpen(true)} />
+      ) : (
+        <ul className="space-y-3">
+          {users.map((u) => (
+            <MemberRow key={u.id} user={u} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="border-border rounded-lg border border-dashed p-8 text-center">
+      <div className="bg-muted mx-auto mb-3 flex size-12 items-center justify-center rounded-xl">
+        <Users className="text-muted-foreground size-6" />
+      </div>
+      <h3 className="text-sm font-medium">No family members yet</h3>
+      <p className="text-muted-foreground mx-auto mt-1 max-w-sm text-sm">
+        Add members to connect their banks and attribute transactions by person.
+      </p>
+      <Button onClick={onAdd} size="sm" className="mt-4">
+        <UserPlus className="size-4" />
+        Add your first member
+      </Button>
+    </div>
+  );
+}
+
+function MemberRow({ user }: { user: User }) {
+  const { data: logins } = useUserLogins(user.id);
+  const login = logins?.[0];
+  const [shareToken, setShareToken] = useState<string | null>(null);
+  const [createLoginOpen, setCreateLoginOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  return (
+    <li className="border-border bg-card rounded-lg border p-4">
+      <div className="flex items-center gap-3">
+        <Avatar className="size-10">
+          <AvatarFallback>{initials(user.name)}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="truncate font-medium">{user.name}</p>
+            <LoginBadge login={login} />
+          </div>
+          <p className="text-muted-foreground truncate text-xs">
+            {user.email ?? login?.username ?? "No email"}
+          </p>
+        </div>
+        <MemberMenu
+          user={user}
+          login={login}
+          onCreateLogin={() => setCreateLoginOpen(true)}
+          onRegenerate={(token) => setShareToken(token)}
+          onDelete={() => setDeleteOpen(true)}
+        />
+      </div>
+
+      <Dialog open={createLoginOpen} onOpenChange={setCreateLoginOpen}>
+        <CreateLoginDialog
+          user={user}
+          onDone={(token) => {
+            setCreateLoginOpen(false);
+            if (token) setShareToken(token);
+          }}
+        />
+      </Dialog>
+
+      <ShareLinkDialog
+        open={!!shareToken}
+        token={shareToken}
+        memberName={user.name}
+        onClose={() => setShareToken(null)}
+      />
+
+      <DeleteMemberDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        user={user}
+      />
+    </li>
+  );
+}
+
+function LoginBadge({ login }: { login?: LoginAccount }) {
+  if (!login) {
+    return (
+      <Badge variant="outline" className="text-muted-foreground">
+        no login
+      </Badge>
+    );
+  }
+  if (!login.has_password) {
+    return (
+      <Badge
+        variant="secondary"
+        className="border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300"
+      >
+        setup pending
+      </Badge>
+    );
+  }
+  return <Badge variant="secondary">{login.role}</Badge>;
+}
+
+function MemberMenu({
+  user,
+  login,
+  onCreateLogin,
+  onRegenerate,
+  onDelete,
+}: {
+  user: User;
+  login?: LoginAccount;
+  onCreateLogin: () => void;
+  onRegenerate: (token: string) => void;
+  onDelete: () => void;
+}) {
+  const regenerate = useRegenerateUserLogin(user.id);
+  const deleteLogin = useDeleteUserLogin(user.id);
+
+  const onRegenerateClick = async () => {
+    if (!login) return;
+    try {
+      const res = await regenerate.mutateAsync(login.id);
+      onRegenerate(res.setup_token);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Couldn't generate setup link.",
+      );
+    }
+  };
+
+  const onUnlinkLogin = async () => {
+    if (!login) return;
+    await withMutationToast(() => deleteLogin.mutateAsync(login.id), {
+      success: "Login removed.",
+    });
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="text-muted-foreground hover:text-foreground size-8"
+        >
+          <MoreVertical className="size-4" />
+          <span className="sr-only">Member actions</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        {login ? (
+          <>
+            {!login.has_password && (
+              <DropdownMenuItem
+                onSelect={(e) => {
+                  e.preventDefault();
+                  onRegenerateClick();
+                }}
+              >
+                <Link2 className="size-4" />
+                Get setup link
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuItem
+              onSelect={(e) => {
+                e.preventDefault();
+                onRegenerateClick();
+              }}
+            >
+              <RefreshCw className="size-4" />
+              Reset password
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={(e) => {
+                e.preventDefault();
+                onUnlinkLogin();
+              }}
+            >
+              <Trash2 className="size-4" />
+              Remove login
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        ) : (
+          <>
+            <DropdownMenuItem
+              onSelect={(e) => {
+                e.preventDefault();
+                onCreateLogin();
+              }}
+            >
+              <UserPlus className="size-4" />
+              Invite to sign in
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        <DropdownMenuItem
+          variant="destructive"
+          onSelect={(e) => {
+            e.preventDefault();
+            onDelete();
+          }}
+        >
+          <Trash2 className="size-4" />
+          Delete member
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+const addMemberSchema = z
+  .object({
+    name: z.string().trim().min(1, "Name is required").max(128),
+    email: z
+      .string()
+      .trim()
+      .email("Enter a valid email")
+      .optional()
+      .or(z.literal("")),
+    create_login: z.boolean(),
+    role: z.enum(["viewer", "editor", "admin"]),
+  })
+  .refine((v) => !v.create_login || (v.email && v.email.length > 0), {
+    path: ["email"],
+    message: "Email is required to send a login invite",
+  });
+
+type AddMemberValues = z.infer<typeof addMemberSchema>;
+
+function AddMemberDialog({ onDone }: { onDone: () => void }) {
+  const createUser = useCreateUser();
+  const createLogin = useCreateLoginForUser();
+  const [shareToken, setShareToken] = useState<string | null>(null);
+  const [memberName, setMemberName] = useState<string>("");
+
+  const form = useForm<AddMemberValues>({
+    resolver: zodResolver(addMemberSchema),
+    defaultValues: { name: "", email: "", create_login: false, role: "viewer" },
+  });
+
+  const createLoginFlag = form.watch("create_login");
+
+  const onSubmit = async (values: AddMemberValues) => {
+    try {
+      const user = await createUser.mutateAsync({
+        name: values.name,
+        email: values.email ? values.email : undefined,
+      });
+      if (!values.create_login) {
+        toast.success(`${user.name} added to the household.`);
+        onDone();
+        return;
+      }
+      const login = await createLogin.mutateAsync({
+        userId: user.id,
+        username: values.email!,
+        role: values.role,
+      });
+      if (login.setup_token) {
+        setMemberName(user.name);
+        setShareToken(login.setup_token);
+      } else {
+        toast.success(`${user.name} added with login.`);
+        onDone();
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Couldn't add member.",
+      );
+    }
+  };
+
+  if (shareToken) {
+    return (
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share their setup link</DialogTitle>
+          <DialogDescription>
+            {memberName} can use this one-time link to set their password. It
+            expires in 7 days.
+          </DialogDescription>
+        </DialogHeader>
+        <SetupLinkBox token={shareToken} />
+        <DialogFooter>
+          <Button onClick={onDone}>Done</Button>
+        </DialogFooter>
+      </DialogContent>
+    );
+  }
+
+  const submitting = createUser.isPending || createLogin.isPending;
+
+  return (
+    <DialogContent className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>Add a household member</DialogTitle>
+        <DialogDescription>
+          New members are added without a login by default. Invite them to sign
+          in to share read or edit access.
+        </DialogDescription>
+      </DialogHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input placeholder="e.g. Alex Canales" autoFocus {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Email{" "}
+                  <span className="text-muted-foreground text-xs">
+                    {createLoginFlag ? "(required for login)" : "(optional)"}
+                  </span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="e.g. alex@example.com"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="create_login"
+            render={({ field }) => (
+              <FormItem className="border-border rounded-md border p-3">
+                <div className="flex items-start gap-3">
+                  <FormControl>
+                    <Checkbox
+                      checked={field.value}
+                      onCheckedChange={(v) => field.onChange(v === true)}
+                      id="create-login"
+                    />
+                  </FormControl>
+                  <div className="flex-1 space-y-1">
+                    <Label htmlFor="create-login" className="cursor-pointer">
+                      Invite them to sign in
+                    </Label>
+                    <FormDescription>
+                      We'll create a login and give you a one-time link to
+                      share. They set their own password.
+                    </FormDescription>
+                  </div>
+                </div>
+              </FormItem>
+            )}
+          />
+          {createLoginFlag && (
+            <FormField
+              control={form.control}
+              name="role"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Role</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="viewer">
+                        Viewer — sees only their own data
+                      </SelectItem>
+                      <SelectItem value="editor">
+                        Editor — view and edit all household data
+                      </SelectItem>
+                      <SelectItem value="admin">
+                        Admin — full access including settings
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onDone}
+              disabled={submitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Adding…" : "Add member"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </DialogContent>
+  );
+}
+
+const createLoginSchema = z.object({
+  username: z.string().trim().email("Must be a valid email"),
+  role: z.enum(["viewer", "editor", "admin"]),
+});
+
+type CreateLoginValues = z.infer<typeof createLoginSchema>;
+
+function CreateLoginDialog({
+  user,
+  onDone,
+}: {
+  user: User;
+  onDone: (token: string | null) => void;
+}) {
+  const createLogin = useCreateUserLogin(user.id);
+  const form = useForm<CreateLoginValues>({
+    resolver: zodResolver(createLoginSchema),
+    defaultValues: {
+      username: user.email ?? "",
+      role: "viewer",
+    },
+  });
+
+  const onSubmit = async (values: CreateLoginValues) => {
+    try {
+      const login = await createLogin.mutateAsync(values);
+      if (login.setup_token) {
+        onDone(login.setup_token);
+      } else {
+        toast.success("Login created.");
+        onDone(null);
+      }
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Couldn't create login.",
+      );
+    }
+  };
+
+  return (
+    <DialogContent className="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>Invite {user.name} to sign in</DialogTitle>
+        <DialogDescription>
+          We'll create a login and give you a one-time setup link to share.
+        </DialogDescription>
+      </DialogHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="username"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input type="email" autoFocus {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="role"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Role</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="viewer">
+                      Viewer — sees only their own data
+                    </SelectItem>
+                    <SelectItem value="editor">
+                      Editor — view and edit all household data
+                    </SelectItem>
+                    <SelectItem value="admin">
+                      Admin — full access including settings
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onDone(null)}
+              disabled={createLogin.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createLogin.isPending}>
+              {createLogin.isPending ? "Creating…" : "Create login"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </Form>
+    </DialogContent>
+  );
+}
+
+function ShareLinkDialog({
+  open,
+  token,
+  memberName,
+  onClose,
+}: {
+  open: boolean;
+  token: string | null;
+  memberName: string;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Share their setup link</DialogTitle>
+          <DialogDescription>
+            {memberName} can use this one-time link to set their password. It
+            expires in 7 days.
+          </DialogDescription>
+        </DialogHeader>
+        {token && <SetupLinkBox token={token} />}
+        <DialogFooter>
+          <Button onClick={onClose}>Done</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SetupLinkBox({ token }: { token: string }) {
+  const url = useMemo(() => setupAccountURL(token), [token]);
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Couldn't copy. Select the link and copy manually.");
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Input
+          value={url}
+          readOnly
+          className="bg-muted/40 font-mono text-xs"
+          onFocus={(e) => e.currentTarget.select()}
+        />
+        <Button
+          type="button"
+          variant={copied ? "default" : "outline"}
+          size="sm"
+          onClick={copy}
+          className={cn(copied && "bg-emerald-600 hover:bg-emerald-600/90")}
+        >
+          {copied ? (
+            <>
+              <Check className="size-4" />
+              Copied
+            </>
+          ) : (
+            <>
+              <Copy className="size-4" />
+              Copy
+            </>
+          )}
+        </Button>
+      </div>
+      <p className="text-muted-foreground text-xs">
+        Anyone with this link can set the password. Share it directly with the
+        person and don't post it anywhere public.
+      </p>
+    </div>
+  );
+}
+
+function DeleteMemberDialog({
+  open,
+  onOpenChange,
+  user,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  user: User;
+}) {
+  const deleteUser = useDeleteUser();
+
+  const onConfirm = async () => {
+    const ok = await withMutationToast(() => deleteUser.mutateAsync(user.id), {
+      success: `${user.name} removed.`,
+      error:
+        "Couldn't remove this member. They may still have bank connections attached — disconnect those first.",
+    });
+    if (ok) onOpenChange(false);
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove {user.name}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This deletes the household member and their login (if any). Bank
+            connections attached to them must be disconnected first. This can't
+            be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              onConfirm();
+            }}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            Remove member
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean).slice(0, 2);
+  if (parts.length === 0) return "?";
+  return parts.map((p) => p[0]?.toUpperCase() ?? "").join("");
+}

--- a/web/src/lib/settings-sections.ts
+++ b/web/src/lib/settings-sections.ts
@@ -1,4 +1,10 @@
-import { DatabaseBackup, Lock, User, type LucideIcon } from "lucide-react";
+import {
+  DatabaseBackup,
+  Lock,
+  User,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
 
 export interface SettingsSection {
   slug: string;
@@ -13,6 +19,12 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     title: "Account",
     description: "Profile, password, and identity.",
     icon: User,
+  },
+  {
+    slug: "household",
+    title: "Household",
+    description: "Family members and shared access.",
+    icon: Users,
   },
   {
     slug: "security",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -14,6 +14,7 @@ import type { AnyRoute } from "@tanstack/react-router";
 import { RootLayout } from "@/routes/__root";
 import { HomePage } from "@/routes/home";
 import { LoginPage } from "@/routes/login";
+import { SetupAccountPage } from "@/routes/setup-account";
 import { Placeholder } from "@/routes/placeholder";
 import { TransactionsPage, transactionsSearchSchema } from "@/routes/transactions";
 import { TransactionDetailPage } from "@/routes/transaction-detail";
@@ -68,6 +69,12 @@ const loginRoute = createRoute({
   path: "/login",
   component: LoginPage,
   validateSearch: loginSearchSchema,
+});
+
+const setupAccountRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/setup-account/$token",
+  component: SetupAccountPage,
 });
 
 // PAGE_OVERRIDES swaps the default Placeholder for a real page on a given
@@ -222,6 +229,7 @@ const pageRoutes = NAV_LEAVES.flatMap(({ leaf }) => {
 const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
+  setupAccountRoute,
   transactionDetailRoute,
   categoryNewRoute,
   categoryDetailRoute,

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -17,11 +17,19 @@ import { useMe } from "@/api/queries/me";
 import { ApiError } from "@/api/client";
 
 const UNAUTHENTICATED_PATHS = new Set(["/login"]);
+// Setup-account is parameterized (`/setup-account/$token`), so the prefix
+// check covers every token variant without listing them.
+const UNAUTHENTICATED_PREFIXES = ["/setup-account/"];
+
+function isUnauthenticatedPath(pathname: string): boolean {
+  if (UNAUTHENTICATED_PATHS.has(pathname)) return true;
+  return UNAUTHENTICATED_PREFIXES.some((p) => pathname.startsWith(p));
+}
 
 export function RootLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
 
-  if (UNAUTHENTICATED_PATHS.has(pathname)) {
+  if (isUnauthenticatedPath(pathname)) {
     return (
       <>
         <Outlet />

--- a/web/src/routes/setup-account.tsx
+++ b/web/src/routes/setup-account.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { CheckCircle2, ShieldAlert } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { useSetupAccount, useSetupAccountInfo } from "@/api/queries/auth";
+import { ApiError } from "@/api/client";
+
+const setupSchema = z
+  .object({
+    password: z.string().min(8, "Must be at least 8 characters"),
+    confirm_password: z.string().min(1, "Confirm your password"),
+  })
+  .refine((v) => v.password === v.confirm_password, {
+    path: ["confirm_password"],
+    message: "Passwords do not match",
+  });
+
+type SetupValues = z.infer<typeof setupSchema>;
+
+export function SetupAccountPage() {
+  const navigate = useNavigate();
+  const { token } = useParams({ strict: false }) as { token?: string };
+  const safeToken = token ?? "";
+  const info = useSetupAccountInfo(safeToken);
+  const submit = useSetupAccount(safeToken);
+  const [submitting, setSubmitting] = useState(false);
+
+  const form = useForm<SetupValues>({
+    resolver: zodResolver(setupSchema),
+    defaultValues: { password: "", confirm_password: "" },
+  });
+
+  const onSubmit = async (values: SetupValues) => {
+    setSubmitting(true);
+    try {
+      await submit.mutateAsync(values);
+      toast.success("Password set. Welcome to Breadbox.");
+      navigate({ to: "/" });
+    } catch (err) {
+      const msg =
+        err instanceof ApiError ? err.message : "Something went wrong. Try again.";
+      toast.error(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-muted/30 flex min-h-screen items-center justify-center p-6">
+      <Card className="w-full max-w-sm">
+        {info.isLoading ? (
+          <>
+            <CardHeader>
+              <CardTitle>Checking your link…</CardTitle>
+              <CardDescription>One moment.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="bg-muted h-9 animate-pulse rounded-md" />
+            </CardContent>
+          </>
+        ) : info.error instanceof ApiError &&
+          info.error.code === "ALREADY_SETUP" ? (
+          <>
+            <CardHeader>
+              <div className="bg-emerald-500/10 mb-2 flex size-10 items-center justify-center rounded-xl">
+                <CheckCircle2 className="size-5 text-emerald-600 dark:text-emerald-400" />
+              </div>
+              <CardTitle>This account is already set up</CardTitle>
+              <CardDescription>
+                You've already chosen a password. Sign in below.
+              </CardDescription>
+            </CardHeader>
+            <CardFooter>
+              <Button onClick={() => navigate({ to: "/login" })} className="w-full">
+                Go to sign in
+              </Button>
+            </CardFooter>
+          </>
+        ) : info.error ? (
+          <>
+            <CardHeader>
+              <div className="bg-destructive/10 mb-2 flex size-10 items-center justify-center rounded-xl">
+                <ShieldAlert className="text-destructive size-5" />
+              </div>
+              <CardTitle>This setup link is invalid</CardTitle>
+              <CardDescription>
+                {info.error instanceof ApiError
+                  ? info.error.message
+                  : "The link is invalid or has expired."}
+                {" "}
+                Ask the person who invited you to send a fresh link.
+              </CardDescription>
+            </CardHeader>
+          </>
+        ) : (
+          <>
+            <CardHeader>
+              <CardTitle>Set your password</CardTitle>
+              <CardDescription>
+                Welcome,{" "}
+                <span className="text-foreground font-medium">
+                  {info.data?.username}
+                </span>
+                . Choose a password to finish setting up your Breadbox account.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Form {...form}>
+                <form
+                  onSubmit={form.handleSubmit(onSubmit)}
+                  className="space-y-4"
+                >
+                  <FormField
+                    control={form.control}
+                    name="password"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Password</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            autoComplete="new-password"
+                            autoFocus
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="confirm_password"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Confirm password</FormLabel>
+                        <FormControl>
+                          <Input
+                            type="password"
+                            autoComplete="new-password"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <Button type="submit" className="w-full" disabled={submitting}>
+                    {submitting ? "Setting password…" : "Set password & sign in"}
+                  </Button>
+                </form>
+              </Form>
+            </CardContent>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a **Household** section to the v2 settings modal: lists family members, lets the admin invite each one with a role (viewer / editor / admin), and surfaces a one-time setup link to share.
- Replaces the legacy `/setup-account/<token>` admin form with a **v2-native setup page** at `/v2/setup-account/<token>`. Greets the new member by email, takes their password, and signs them straight into `/v2/`. Pre-auth JSON endpoints under `/web/v1/setup-account/{token}` back it.
- Moves the "Add member" primary out of the settings-dialog header (it was overlapping the dialog's close X) into the section body.

Legacy `/setup-account/<token>` admin route stays mounted so previously-issued tokens keep working.

## Screens

**Household section** — desktop / tablet / mobile

<img src="https://i.img402.dev/lx5wjt8mx3.jpg" width="800" alt="Household section across breakpoints">

**Setup-account page** — what a new member sees on the share link

<img src="https://i.img402.dev/83r45j1hti.jpg" width="600" alt="Setup-account page — set your password">

## Flow

1. Admin opens **Settings → Household → Add member**, fills name + email, ticks **Invite them to sign in**, picks role.
2. Backend creates the user, creates the login, returns a `setup_token`. SPA shows a copy-able link to `/v2/setup-account/<token>`.
3. Member opens the link (no auth needed). SPA hits `GET /web/v1/setup-account/<token>` → renders form, or `SETUP_TOKEN_INVALID` / `ALREADY_SETUP` cards.
4. Member submits password → `POST /web/v1/setup-account/<token>` hashes + stores it, clears the token, opens a session, returns `{account_id, username, role}`. SPA navigates to `/v2/`.

## Test plan

- [x] `bun run lint` (tsc --noEmit) clean
- [x] `bun run build` (vite production build) clean
- [x] `go build ./...` clean
- [x] Add a member without a login → row shows "no login" badge
- [x] Add a member with a login invite → share-link dialog appears with the `/v2/setup-account/<token>` URL
- [x] Open setup link in an incognito tab → form renders with the right email, password validation works, success signs into `/v2/`
- [x] Bad/expired token → "This setup link is invalid" card
- [x] Already-set-up token → "Already set up" card with "Go to sign in"
- [x] Delete-member confirmation refuses when the user still has bank connections (server-side; surfaces via toast)
- [ ] Smoke against `make build && ./breadbox serve` (embedded SPA path) one more time before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
