### PR TITLE
fix: route Teller link-session through provider so app_id reaches the SPA

### DIFF
--- a/internal/api/providers_teller.go
+++ b/internal/api/providers_teller.go
@@ -29,7 +29,7 @@ type tellerCredentials struct {
 
 var tellerEntry = providerEntry{
 	name:             "teller",
-	needsLinkSession: false, // Teller Connect runs entirely client-side; no init token
+	needsLinkSession: true, // Teller Connect needs the server-configured app_id; returned as link_token
 	capabilities:     []string{"transactions", "balances"},
 	credentialsSchema: map[string]CredentialField{
 		"access_token": {

--- a/web/src/features/connections/connect-bank-sheet.tsx
+++ b/web/src/features/connections/connect-bank-sheet.tsx
@@ -143,16 +143,10 @@ export function ConnectBankSheet({
           linkToken: session.link_token,
         });
       } else if (provider === "teller") {
-        // Teller's link-session endpoint replies 204 — nothing in the body.
-        // The application id Teller Connect needs comes from the env, not
-        // the API. Until the backend exposes it, fall through with the
-        // env-supplied value (set on a global by the Vite shell). We toast
-        // on missing config so the user gets actionable feedback rather
-        // than a silent open-then-close.
-        const applicationId =
-          (typeof window !== "undefined" &&
-            (window as Window & { __TELLER_APP_ID__?: string }).__TELLER_APP_ID__) ||
-          "";
+        // Teller's link-session endpoint returns the server-configured
+        // application_id as link_token; Teller Connect is initialized with
+        // it client-side. An empty token means the server has no app_id set.
+        const applicationId = session?.link_token ?? "";
         if (!applicationId) {
           toast.error(
             "Teller application ID is not configured on this server.",


### PR DESCRIPTION
## Summary

- The generic `/api/v1/providers/{name}/link-session` handler returns 204 No Content for any entry with `needsLinkSession:false`. Teller had this flag false, so `TellerProvider.CreateLinkSession` (which returns the configured `app_id` as the link token) was never called.
- The connect sheet then read `window.__TELLER_APP_ID__` (a global nobody sets) and toasted "Teller application ID is not configured on this server" — even though Test connection on `/v2/providers` reported the Teller integration as healthy.

Two-line fix:
- `internal/api/providers_teller.go`: flip `needsLinkSession` to true so the handler invokes the provider.
- `web/src/features/connections/connect-bank-sheet.tsx`: read `session.link_token` instead of the unset window global.

## Test plan

- [x] Reproduced locally — Connect → Teller → Continue threw the toast on `main`.
- [x] After the fix: `POST /api/v1/providers/teller/link-session` returns `200` with `{link_token: "app_..."}`, Teller Connect iframe opens with that `app_id`, and the sheet advances to the in-iframe enrollment screen.
- [x] No change to Plaid path; CSV still skips the link-session call entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)