### PR TITLE
design(v2): polish app shell + sidebar

### DIFF
--- a/web/src/components/brand-header.tsx
+++ b/web/src/components/brand-header.tsx
@@ -6,16 +6,34 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 
+// Top-of-sidebar brand mark. The icon sits in a tinted tile so the brand
+// reads as a logo lockup rather than a generic nav item, and the "v2 ·
+// preview" tag is a real badge — same visual language we use elsewhere
+// (Badge primitive) — so it's clearly a status pill, not body copy.
 export function BrandHeader() {
   return (
     <SidebarMenu>
       <SidebarMenuItem>
-        <SidebarMenuButton tooltip="Breadbox" asChild>
+        <SidebarMenuButton
+          tooltip="Breadbox"
+          asChild
+          size="lg"
+          className="group-data-[collapsible=icon]:!p-1.5"
+        >
           <Link to="/">
-            <Box className="text-primary" />
-            <div className="flex flex-1 items-baseline gap-1.5 truncate">
-              <span className="font-semibold">Breadbox</span>
-              <span className="text-xs text-muted-foreground">v2 · preview</span>
+            <span className="bg-primary text-primary-foreground flex aspect-square size-8 items-center justify-center rounded-md">
+              <Box className="size-4" />
+            </span>
+            <div className="flex flex-1 flex-col gap-0.5 truncate leading-none">
+              <span className="text-sm font-semibold tracking-tight">
+                Breadbox
+              </span>
+              <span className="text-muted-foreground inline-flex items-center gap-1.5 text-[10px] font-medium tracking-wide uppercase">
+                <span className="bg-primary/15 text-primary rounded-sm px-1 py-px text-[10px] font-semibold tracking-wider">
+                  v2
+                </span>
+                Preview
+              </span>
             </div>
           </Link>
         </SidebarMenuButton>

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -64,6 +64,15 @@ export function CommandPalette() {
     global: true,
   });
 
+  // Topbar search affordance fires this event — keeps the palette as the
+  // sole source of open state without exposing a global store.
+  React.useEffect(() => {
+    const onOpen = () => setOpen(true);
+    window.addEventListener("breadbox:command-palette:open", onOpen);
+    return () =>
+      window.removeEventListener("breadbox:command-palette:open", onOpen);
+  }, []);
+
   const go = (to: string) => {
     setOpen(false);
     navigate({ to });

--- a/web/src/components/nav-main.tsx
+++ b/web/src/components/nav-main.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/sidebar";
 import { isNavMatch, navKey, type NavGroup, type NavLeaf } from "@/lib/nav";
 import { openModal, useActiveModal } from "@/lib/modals";
+import { cn } from "@/lib/utils";
 
 export function NavMain({ group }: { group: NavGroup }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
@@ -16,7 +17,9 @@ export function NavMain({ group }: { group: NavGroup }) {
 
   return (
     <SidebarGroup>
-      <SidebarGroupLabel>{group.label}</SidebarGroupLabel>
+      <SidebarGroupLabel className="text-muted-foreground/80 text-[10px] font-semibold tracking-[0.08em] uppercase">
+        {group.label}
+      </SidebarGroupLabel>
       <SidebarMenu>
         {group.items.map((item) => (
           <NavRow
@@ -34,6 +37,29 @@ export function NavMain({ group }: { group: NavGroup }) {
   );
 }
 
+// Shared classes for the active-state polish. The shadcn
+// SidebarMenuButton is `overflow-hidden`, which would clip a pseudo
+// element drawn on the button itself — so the left rail lives on the
+// SidebarMenuItem wrapper (which is `relative` and has no overflow
+// clipping) and uses the button's `data-[active=true]` selector via
+// `:has` so the row stays declarative.
+const NAV_ITEM_CLS = cn(
+  // Active rail: a primary-tinted chip that animates in next to the
+  // active row. Hidden when the sidebar collapses to icon-only.
+  "before:bg-primary before:absolute before:top-1.5 before:bottom-1.5 before:-left-2 before:w-[3px] before:scale-y-0 before:rounded-r-full before:transition-transform before:duration-200 before:ease-out",
+  "has-[[data-active=true]]:before:scale-y-100",
+  "group-data-[collapsible=icon]:before:hidden",
+);
+
+const NAV_ROW_CLS = cn(
+  "transition-colors",
+  // Icon picks up the primary tint on active so the row reads at a glance
+  // even when the eye skips the rail. Inactive icons stay muted so the
+  // active one carries the visual weight.
+  "[&>svg]:text-muted-foreground/80 [&>svg]:transition-colors",
+  "data-[active=true]:[&>svg]:text-primary",
+);
+
 interface NavRowProps {
   item: NavLeaf;
   pathname: string;
@@ -46,11 +72,12 @@ function NavRow({ item, pathname, activeModal, onOpenModal }: NavRowProps) {
 
   if (item.kind === "modal") {
     return (
-      <SidebarMenuItem>
+      <SidebarMenuItem className={NAV_ITEM_CLS}>
         <SidebarMenuButton
           isActive={activeModal === item.modalKey}
           tooltip={item.title}
           onClick={() => onOpenModal(item.modalKey)}
+          className={NAV_ROW_CLS}
         >
           <Icon />
           <span>{item.title}</span>
@@ -60,11 +87,12 @@ function NavRow({ item, pathname, activeModal, onOpenModal }: NavRowProps) {
   }
 
   return (
-    <SidebarMenuItem>
+    <SidebarMenuItem className={NAV_ITEM_CLS}>
       <SidebarMenuButton
         asChild
         isActive={isNavMatch(item, pathname)}
         tooltip={item.title}
+        className={NAV_ROW_CLS}
       >
         <Link to={item.to}>
           <Icon />

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -1,6 +1,10 @@
 import { cn } from "@/lib/utils";
 
 export interface PageHeaderProps {
+  /** Optional small label rendered above the title. Use sparingly — only
+      when the page needs a section label that isn't already visible in
+      the topbar breadcrumb (e.g. "Settings ›" on a deep detail page). */
+  eyebrow?: string;
   title: string;
   description?: string;
   /** Optional right-aligned actions — usually a <Button> or a cluster. */
@@ -12,6 +16,7 @@ export interface PageHeaderProps {
 // breadcrumb bar. Every v2 page uses this so the title/description/action
 // layout stays consistent.
 export function PageHeader({
+  eyebrow,
   title,
   description,
   actions,
@@ -20,17 +25,26 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        "mb-6 flex items-start justify-between gap-4",
+        "mb-6 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end",
         className,
       )}
     >
-      <div className="space-y-1">
-        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+      <div className="min-w-0 space-y-1.5">
+        {eyebrow && (
+          <p className="text-muted-foreground text-[11px] font-medium tracking-[0.08em] uppercase">
+            {eyebrow}
+          </p>
+        )}
+        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
         {description && (
-          <p className="text-muted-foreground text-sm">{description}</p>
+          <p className="text-muted-foreground max-w-prose text-sm">
+            {description}
+          </p>
         )}
       </div>
-      {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+      {actions && (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      )}
     </div>
   );
 }

--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -85,8 +85,11 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
   if (desktop) {
     return (
       <div className="flex h-full">
-        <nav className="bg-muted/40 w-56 shrink-0 border-r p-2">
-          <ul className="space-y-1">
+        <nav className="bg-muted/40 w-56 shrink-0 border-r p-3">
+          <p className="text-muted-foreground/80 mb-2 px-2 text-[10px] font-semibold tracking-[0.08em] uppercase">
+            Settings
+          </p>
+          <ul className="space-y-0.5">
             {SETTINGS_SECTIONS.map((s) => {
               const Icon = s.icon;
               const isActive = s.slug === active.slug;
@@ -95,14 +98,17 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
                   <button
                     type="button"
                     onClick={() => onSelect(s.slug)}
+                    data-active={isActive ? "true" : undefined}
                     className={cn(
-                      "flex w-full items-center gap-2 rounded-md px-3 py-2 text-left text-sm",
+                      "group relative flex w-full items-center gap-2 rounded-md py-2 pr-3 pl-3.5 text-left text-sm transition-colors",
+                      "before:absolute before:inset-y-1.5 before:left-0 before:w-0.5 before:rounded-r-full before:bg-transparent before:transition-all",
+                      "[&>svg]:size-4 [&>svg]:text-muted-foreground",
                       isActive
-                        ? "bg-accent text-accent-foreground"
-                        : "hover:bg-accent/50",
+                        ? "bg-accent text-accent-foreground before:bg-primary before:inset-y-1 [&>svg]:text-primary"
+                        : "hover:bg-accent/60",
                     )}
                   >
-                    <Icon className="size-4" />
+                    <Icon />
                     <span>{s.title}</span>
                   </button>
                 </li>

--- a/web/src/routes/__root.tsx
+++ b/web/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { Outlet, useNavigate, useRouterState } from "@tanstack/react-router";
-import { Loader2 } from "lucide-react";
+import { Loader2, Search } from "lucide-react";
 import { AppSidebar } from "@/components/app-sidebar";
 import { CommandPalette } from "@/components/command-palette";
 import { SettingsShell } from "@/components/settings-shell";
@@ -11,6 +11,14 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { Separator } from "@/components/ui/separator";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
 import { Toaster } from "@/components/ui/sonner";
 import { NAV_LEAVES, isNavMatch } from "@/lib/nav";
 import { useMe } from "@/api/queries/me";
@@ -104,17 +112,30 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
           horizontally-scrolling table) grows the inset past the viewport
           instead of letting the page's own overflow container scroll. */}
       <SidebarInset className="min-w-0">
-        <header className="flex h-14 shrink-0 items-center gap-2 border-b">
-          <div className="flex items-center gap-2 px-4">
+        <header className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-30 flex h-14 shrink-0 items-center gap-2 border-b backdrop-blur">
+          <div className="flex w-full items-center gap-2 px-4">
             <SidebarTrigger className="-ml-1" />
-            <Separator orientation="vertical" className="mr-2 h-4" />
-            {group && (
-              <>
-                <span className="text-muted-foreground text-sm">{group}</span>
-                <span className="text-muted-foreground text-sm">/</span>
-              </>
-            )}
-            <span className="text-sm font-medium">{title}</span>
+            <Separator orientation="vertical" className="mr-1 h-4" />
+            <Breadcrumb>
+              <BreadcrumbList>
+                {group && (
+                  <>
+                    <BreadcrumbItem className="hidden md:inline-flex">
+                      <span className="text-muted-foreground">{group}</span>
+                    </BreadcrumbItem>
+                    <BreadcrumbSeparator className="hidden md:inline-flex" />
+                  </>
+                )}
+                <BreadcrumbItem>
+                  <BreadcrumbPage className="text-foreground font-medium">
+                    {title}
+                  </BreadcrumbPage>
+                </BreadcrumbItem>
+              </BreadcrumbList>
+            </Breadcrumb>
+            <div className="ml-auto flex items-center gap-2">
+              <CommandPaletteTrigger />
+            </div>
           </div>
         </header>
         <main className="min-w-0 flex-1 p-3 sm:p-6">
@@ -126,5 +147,32 @@ function AuthenticatedShell({ pathname }: { pathname: string }) {
       <SettingsShell />
       <Toaster />
     </SidebarProvider>
+  );
+}
+
+// Topbar pill that mirrors the command palette's purpose: tap or press
+// ⌘K. The visual is intentionally search-input-ish (faded text, leading
+// icon, trailing kbd hint) so it advertises the shortcut to first-time
+// users without consuming a discrete keyboard control.
+function CommandPaletteTrigger() {
+  const open = () =>
+    window.dispatchEvent(new CustomEvent("breadbox:command-palette:open"));
+
+  return (
+    <button
+      type="button"
+      onClick={open}
+      className="text-muted-foreground hover:text-foreground hover:border-ring focus-visible:ring-ring/40 inline-flex h-8 items-center gap-2 rounded-md border bg-transparent px-2.5 text-xs transition-colors focus-visible:ring-2 focus-visible:outline-none sm:min-w-56"
+      aria-label="Open command palette"
+    >
+      <Search className="size-3.5 shrink-0" aria-hidden />
+      <span className="hidden flex-1 text-left sm:inline">
+        Search or jump to…
+      </span>
+      <KbdGroup className="ml-auto hidden sm:inline-flex">
+        <Kbd className="bg-muted/60">⌘</Kbd>
+        <Kbd className="bg-muted/60">K</Kbd>
+      </KbdGroup>
+    </button>
   );
 }

--- a/web/src/routes/home.tsx
+++ b/web/src/routes/home.tsx
@@ -1,51 +1,63 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { PageHeader } from "@/components/page-header";
 import { useMe } from "@/api/queries/me";
 
 export function HomePage() {
   const { data: me } = useMe();
 
   return (
-    <div className="flex flex-col gap-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">
-          {me ? `Welcome, ${me.username}` : "Welcome"}
-        </h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          You're using the v2 admin preview. Real dashboard data lands in the next PR.
-        </p>
-      </div>
+    <div className="flex flex-col gap-8">
+      <PageHeader
+        eyebrow="Overview"
+        title={me ? `Welcome, ${me.username}` : "Welcome"}
+        description="You're using the v2 admin preview. Real dashboard data lands in the next PR."
+      />
 
       <div className="grid gap-4 md:grid-cols-3">
-        <Card>
-          <CardHeader>
-            <CardDescription>Tech stack</CardDescription>
-            <CardTitle className="text-base font-medium">
+        <Card className="gap-3 py-5">
+          <CardHeader className="px-5">
+            <CardDescription className="text-[11px] font-medium tracking-[0.06em] uppercase">
+              Tech stack
+            </CardDescription>
+            <CardTitle className="text-sm leading-snug font-medium">
               React · TypeScript · Vite · TanStack · shadcn/ui
             </CardTitle>
           </CardHeader>
-          <CardContent className="text-muted-foreground text-sm">
+          <CardContent className="text-muted-foreground px-5 text-sm">
             Single binary in production. Old admin UI stays at <code>/</code>.
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardDescription>API split</CardDescription>
-            <CardTitle className="text-base font-medium">
+        <Card className="gap-3 py-5">
+          <CardHeader className="px-5">
+            <CardDescription className="text-[11px] font-medium tracking-[0.06em] uppercase">
+              API split
+            </CardDescription>
+            <CardTitle className="text-sm leading-snug font-medium">
               <code>/api/v1/*</code> public · <code>/web/v1/*</code> internal
             </CardTitle>
           </CardHeader>
-          <CardContent className="text-muted-foreground text-sm">
+          <CardContent className="text-muted-foreground px-5 text-sm">
             Session-cookie auth on <code>/web/v1/*</code>. Zero stability promise.
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardDescription>Status</CardDescription>
-            <CardTitle className="text-base font-medium">Phase 0 · shell</CardTitle>
+        <Card className="gap-3 py-5">
+          <CardHeader className="px-5">
+            <CardDescription className="text-[11px] font-medium tracking-[0.06em] uppercase">
+              Status
+            </CardDescription>
+            <CardTitle className="text-sm leading-snug font-medium">
+              Phase 0 · shell
+            </CardTitle>
           </CardHeader>
-          <CardContent className="text-muted-foreground text-sm">
+          <CardContent className="text-muted-foreground px-5 text-sm">
             Navigable scaffold. Pages built one at a time per weekend.
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary

- **Sidebar active state**: primary-tinted left rail + brighter icon + slightly stronger row tint, so the current page reads at a glance instead of relying on a faint background shift.
- **Topbar**: real shadcn `Breadcrumb` (with chevron) replaces the loose "Money / Home" text; new `⌘K` command-palette trigger on the right uses search-input visual language with a kbd hint to advertise the shortcut. The header is now sticky with a subtle backdrop blur.
- **Brand header**: lockup-style icon tile + "V2 Preview" mini-badge, so the brand reads as intentional design instead of body-text breadcrumbs.
- **PageHeader**: gains an optional `eyebrow` slot, tighter spacing, and the Home page routes through it for consistency.
- **Settings modal**: section list adopts the same active-state language (primary rail + tinted icon) as the main sidebar, so the two navs feel like one design system.

## Before / After

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/2bqxsxqhlr.jpg" width="420" alt="app shell — before"></td>
    <td><img src="https://i.img402.dev/rt65cjxcvj.jpg" width="420" alt="app shell — after"></td>
  </tr>
</table>

## Notes

- Establishes the shared active-state vocabulary (3px primary rail at the row's outer left edge + tinted icon + accent bg) — reused inside `settings-shell.tsx` and ready for any future nav pattern.
- `CommandPalette` now also listens for a `window` `breadbox:command-palette:open` event so the topbar trigger can open it without exposing a global store or imperative ref.
- Tailwind `before:` pseudo for the rail lives on `SidebarMenuItem`, not the button, because the shadcn button is `overflow-hidden` and would clip it. Documented inline.
- Follow-ups queued for the backlog: empty-state component visual audit; topbar could grow a sync-status badge once we have real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)