### PR TITLE
v2: source Teller app id from link-session endpoint

### DIFF
--- a/internal/api/connections_teller_setup_integration_test.go
+++ b/internal/api/connections_teller_setup_integration_test.go
@@ -44,7 +44,7 @@ type fakeTellerProvider struct {
 }
 
 func (f *fakeTellerProvider) CreateLinkSession(context.Context, string) (provider.LinkSession, error) {
-	panic("fakeTellerProvider.CreateLinkSession not implemented")
+	return provider.LinkSession{Token: "teller-app-fake"}, nil
 }
 
 func (f *fakeTellerProvider) ExchangeToken(_ context.Context, publicToken string) (provider.Connection, []provider.Account, error) {

--- a/internal/api/providers.go
+++ b/internal/api/providers.go
@@ -174,9 +174,10 @@ type linkSessionResponse struct {
 //
 // Returns:
 //   - 200 OK with {link_token, expiration} for providers that issue a token
-//     (Plaid today; MoneyKit / Salt Edge in the future).
+//     (Plaid; Teller returns the server-configured application id here so the
+//     SPA can bootstrap Teller Connect without a window global).
 //   - 204 No Content for providers where the link flow is fully client-side
-//     and no init token is needed (Teller, CSV).
+//     and no init token is needed (CSV).
 //   - 404 NOT_FOUND for an unknown provider name.
 //   - 400 INVALID_PARAMETER when the provider isn't configured.
 func LinkSessionHandler(a *app.App) http.HandlerFunc {

--- a/internal/api/providers_generic_integration_test.go
+++ b/internal/api/providers_generic_integration_test.go
@@ -179,8 +179,8 @@ func TestListProviders_ReturnsAll(t *testing.T) {
 	if !gotByName["plaid"].NeedsLinkSession {
 		t.Errorf("plaid should need link session")
 	}
-	if gotByName["teller"].NeedsLinkSession {
-		t.Errorf("teller should not need link session")
+	if !gotByName["teller"].NeedsLinkSession {
+		t.Errorf("teller should need link session (server returns app_id as link_token)")
 	}
 	if gotByName["csv"].NeedsLinkSession {
 		t.Errorf("csv should not need link session")
@@ -299,7 +299,13 @@ func TestLinkSession_Teller(t *testing.T) {
 	resp := env.doPostJSON(t, "/api/v1/providers/teller/link-session", map[string]string{
 		"user_id": pgconv.FormatUUID(user.ID),
 	})
-	assertStatus(t, resp, http.StatusNoContent)
+	assertStatus(t, resp, http.StatusOK)
+
+	var body linkSessionResponse
+	parseJSON(t, resp, &body)
+	if body.LinkToken != "teller-app-fake" {
+		t.Errorf("want link_token %q, got %q", "teller-app-fake", body.LinkToken)
+	}
 }
 
 func TestLinkSession_CSV(t *testing.T) {

--- a/internal/api/providers_teller.go
+++ b/internal/api/providers_teller.go
@@ -29,7 +29,7 @@ type tellerCredentials struct {
 
 var tellerEntry = providerEntry{
 	name:             "teller",
-	needsLinkSession: false, // Teller Connect runs entirely client-side; no init token
+	needsLinkSession: true, // Teller Connect needs the server-configured app_id; returned as link_token
 	capabilities:     []string{"transactions", "balances"},
 	credentialsSchema: map[string]CredentialField{
 		"access_token": {

--- a/web/src/features/connections/connect-bank-sheet.tsx
+++ b/web/src/features/connections/connect-bank-sheet.tsx
@@ -143,16 +143,10 @@ export function ConnectBankSheet({
           linkToken: session.link_token,
         });
       } else if (provider === "teller") {
-        // Teller's link-session endpoint replies 204 — nothing in the body.
-        // The application id Teller Connect needs comes from the env, not
-        // the API. Until the backend exposes it, fall through with the
-        // env-supplied value (set on a global by the Vite shell). We toast
-        // on missing config so the user gets actionable feedback rather
-        // than a silent open-then-close.
-        const applicationId =
-          (typeof window !== "undefined" &&
-            (window as Window & { __TELLER_APP_ID__?: string }).__TELLER_APP_ID__) ||
-          "";
+        // Teller's link-session endpoint returns the server-configured
+        // application_id as link_token; Teller Connect is initialized with
+        // it client-side. An empty token means the server has no app_id set.
+        const applicationId = session?.link_token ?? "";
         if (!applicationId) {
           toast.error(
             "Teller application ID is not configured on this server.",


### PR DESCRIPTION
## Summary

- `web/src/features/connections/connect-bank-sheet.tsx` was reading the Teller application id from `window.__TELLER_APP_ID__`, but nothing in the codebase sets that global — every Teller connect attempt fell through to the "application id not configured" toast.
- Flip Teller's \`needsLinkSession\` to \`true\` so the existing \`LinkSessionHandler\` returns the server-configured app id as \`link_token\` (the Teller provider's \`CreateLinkSession\` already returns the app id as its \`Token\` — see \`internal/provider/teller/link.go:42\`).
- Read \`session.link_token\` in the connect sheet, the same way Plaid reads its link token.

## Follow-up

\`web/src/features/connections/reauth-sheet.tsx:158\` still reads the unset window global for the Teller reauth flow. Same bug, different sheet — leaving it for a separate PR since the reauth path's \`session.link_token\` carries the enrollment id rather than the app id and needs a second source.

## Test plan

- [x] \`go build ./... && go vet ./...\`
- [x] \`bun run lint\` (tsc --noEmit) clean
- [x] Updated and ran \`TestListProviders_*\`, \`TestLinkSession_Teller\`, \`TestGetProvider_*\`, \`TestConnectionsReauth\` — pass
- [ ] Manual: connect a Teller account end-to-end with \`TELLER_APP_ID\` set
- [ ] Manual: confirm error toast still fires when server has no Teller app id

🤖 Generated with [Claude Code](https://claude.com/claude-code)