### PR TITLE
design(v2): real dashboard for the v2 home page

### DIFF
--- a/web/src/features/home/home-connections-panel.tsx
+++ b/web/src/features/home/home-connections-panel.tsx
@@ -1,0 +1,147 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Building2, FileSpreadsheet, Landmark, Plug } from "lucide-react";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/empty-state";
+import { ConnectionStatusBadge } from "@/features/connections/connection-status-badge";
+import { relativeTime } from "@/features/connections/connection-utils";
+import { cn } from "@/lib/utils";
+import type { Connection } from "@/api/types";
+
+interface HomeConnectionsPanelProps {
+  connections: Connection[] | undefined;
+  isLoading: boolean;
+}
+
+const PROVIDER_ICON: Record<string, typeof Building2> = {
+  plaid: Building2,
+  teller: Landmark,
+  csv: FileSpreadsheet,
+};
+
+// Side-rail summary of household connections. Sorts attention-needed ones to
+// the top so the user sees what to fix first. Caps at 5 rows; the card
+// header's "Manage" link goes to the full Connections page.
+export function HomeConnectionsPanel({
+  connections,
+  isLoading,
+}: HomeConnectionsPanelProps) {
+  const visible = connections ? rankForDashboard(connections).slice(0, 5) : [];
+  const remaining = connections ? Math.max(0, connections.length - visible.length) : 0;
+
+  return (
+    <Card className="gap-0 py-0">
+      <CardHeader className="border-b py-4">
+        <CardTitle className="text-sm font-medium">Connections</CardTitle>
+        <CardAction>
+          <Button asChild variant="ghost" size="sm" className="-mr-2 h-8 px-2">
+            <Link
+              to="/connections"
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"
+            >
+              Manage
+              <ArrowRight className="size-3.5" />
+            </Link>
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="px-0 py-0">
+        {isLoading ? (
+          <ConnectionsSkeleton />
+        ) : !connections || connections.length === 0 ? (
+          <EmptyState
+            icon={Plug}
+            title="No banks connected"
+            description="Link a bank or upload a CSV to start syncing transactions."
+            action={
+              <Button asChild size="sm">
+                <Link to="/connections" search={{ action: "connect" }}>
+                  Connect a bank
+                </Link>
+              </Button>
+            }
+          />
+        ) : (
+          <>
+            <ul className="divide-y">
+              {visible.map((c) => (
+                <ConnectionRow key={c.id} connection={c} />
+              ))}
+            </ul>
+            {remaining > 0 && (
+              <div className="text-muted-foreground border-t px-5 py-3 text-xs">
+                +{remaining} more on the Connections page
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ConnectionRow({ connection: c }: { connection: Connection }) {
+  const Icon = PROVIDER_ICON[c.provider] ?? Building2;
+  return (
+    <li className="flex items-center gap-3 px-5 py-3">
+      <div
+        className={cn(
+          "flex size-9 shrink-0 items-center justify-center rounded-md border",
+          "bg-muted/40 text-muted-foreground",
+        )}
+      >
+        <Icon className="size-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium">
+          {c.institution_name || "Untitled connection"}
+        </div>
+        <div className="text-muted-foreground mt-0.5 truncate text-xs">
+          Synced {relativeTime(c.last_synced_at)}
+        </div>
+      </div>
+      <ConnectionStatusBadge status={c.status} />
+    </li>
+  );
+}
+
+function ConnectionsSkeleton() {
+  return (
+    <ul className="divide-y">
+      {[0, 1, 2, 3].map((i) => (
+        <li key={i} className="flex items-center gap-3 px-5 py-3.5">
+          <Skeleton className="size-9 rounded-md" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-36" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+          <Skeleton className="h-5 w-16 rounded-md" />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// Attention first (pending_reauth, error), then active, then disconnected.
+// Within each bucket, most-recently-synced first.
+function rankForDashboard(connections: Connection[]): Connection[] {
+  const score = (c: Connection): number => {
+    if (c.status === "pending_reauth" || c.status === "error") return 0;
+    if (c.status === "active") return 1;
+    return 2;
+  };
+  return [...connections].sort((a, b) => {
+    const s = score(a) - score(b);
+    if (s !== 0) return s;
+    const ta = a.last_synced_at ? new Date(a.last_synced_at).getTime() : 0;
+    const tb = b.last_synced_at ? new Date(b.last_synced_at).getTime() : 0;
+    return tb - ta;
+  });
+}

--- a/web/src/features/home/home-recent-transactions.tsx
+++ b/web/src/features/home/home-recent-transactions.tsx
@@ -1,0 +1,101 @@
+import { Link } from "@tanstack/react-router";
+import { ArrowRight, Receipt } from "lucide-react";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/empty-state";
+import { TransactionPrimary } from "@/components/transaction-primary";
+import { TransactionAmount } from "@/components/transaction-amount";
+import type { Transaction } from "@/api/types";
+
+interface HomeRecentTransactionsProps {
+  transactions: Transaction[] | undefined;
+  isLoading: boolean;
+}
+
+// Recent activity feed for the home page. Mirrors the row style of the
+// Transactions list (TransactionPrimary + TransactionAmount) so the user's
+// scanning vocabulary doesn't change between the two surfaces. Rows link to
+// the transaction detail, and the card header links to the full list.
+export function HomeRecentTransactions({
+  transactions,
+  isLoading,
+}: HomeRecentTransactionsProps) {
+  return (
+    <Card className="gap-0 py-0">
+      <CardHeader className="border-b py-4">
+        <CardTitle className="text-sm font-medium">
+          Recent activity
+        </CardTitle>
+        <CardAction>
+          <Button asChild variant="ghost" size="sm" className="-mr-2 h-8 px-2">
+            <Link
+              to="/transactions"
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"
+            >
+              View all
+              <ArrowRight className="size-3.5" />
+            </Link>
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="px-0 py-0">
+        {isLoading ? (
+          <RecentSkeleton />
+        ) : !transactions || transactions.length === 0 ? (
+          <EmptyState
+            icon={Receipt}
+            title="No transactions yet"
+            description="Connect a bank or import a CSV to start seeing activity here."
+          />
+        ) : (
+          <ul className="divide-y">
+            {transactions.map((t) => (
+              <li key={t.id}>
+                <Link
+                  to="/transactions/$txId"
+                  params={{ txId: t.short_id }}
+                  className="hover:bg-muted/50 focus-visible:bg-muted/50 flex min-w-0 items-center gap-4 px-5 py-3 outline-none transition-colors"
+                >
+                  <div className="min-w-0 flex-1">
+                    <TransactionPrimary transaction={t} />
+                  </div>
+                  <TransactionAmount transaction={t} />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentSkeleton() {
+  return (
+    <ul className="divide-y">
+      {[0, 1, 2, 3, 4].map((i) => (
+        <li
+          key={i}
+          className="flex items-center gap-4 px-5 py-3.5"
+        >
+          <Skeleton className="size-9 rounded-md" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3.5 w-44" />
+            <Skeleton className="h-3 w-28" />
+          </div>
+          <div className="space-y-1.5 text-right">
+            <Skeleton className="ml-auto h-3.5 w-16" />
+            <Skeleton className="ml-auto h-3 w-10" />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/web/src/features/home/home-stats.tsx
+++ b/web/src/features/home/home-stats.tsx
@@ -1,0 +1,185 @@
+import {
+  Banknote,
+  CreditCard,
+  Plug,
+  TrendingUp,
+  type LucideIcon,
+} from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { Account, Connection } from "@/api/types";
+
+interface HomeStatsProps {
+  accounts: Account[] | undefined;
+  connections: Connection[] | undefined;
+  isLoading: boolean;
+}
+
+// Aggregates the same /api/v1/accounts payload that the Accounts page reads,
+// bucketed into the four card metrics. Currency is kept per-bucket so the
+// header rendering never sums across currencies — we just show the largest
+// bucket and a "+N more" hint if other currencies exist (rare on a household
+// dataset; keeps the card honest without inventing a single number).
+interface CurrencyTotals {
+  totals: Map<string, number>;
+  count: number;
+}
+
+function bucket(): CurrencyTotals {
+  return { totals: new Map(), count: 0 };
+}
+
+function add(b: CurrencyTotals, amount: number | null, currency: string | null) {
+  if (amount == null) return;
+  const c = currency ?? "USD";
+  b.totals.set(c, (b.totals.get(c) ?? 0) + amount);
+  b.count += 1;
+}
+
+function primary(b: CurrencyTotals): { amount: number; currency: string } {
+  if (b.totals.size === 0) return { amount: 0, currency: "USD" };
+  let bestC = "USD";
+  let bestAbs = -Infinity;
+  for (const [c, a] of b.totals) {
+    if (Math.abs(a) > bestAbs) {
+      bestAbs = Math.abs(a);
+      bestC = c;
+    }
+  }
+  return { amount: b.totals.get(bestC) ?? 0, currency: bestC };
+}
+
+function formatCompact(amount: number, currency: string): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export function HomeStats({ accounts, connections, isLoading }: HomeStatsProps) {
+  if (isLoading || !accounts || !connections) {
+    return (
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {[0, 1, 2, 3].map((i) => (
+          <StatCardSkeleton key={i} />
+        ))}
+      </div>
+    );
+  }
+
+  const cash = bucket();
+  const credit = bucket();
+  // Net = depository minus credit/loan (loans counted as debt, positive
+  // balance_current). Same logic as the v1 dashboard summary.
+  const netByCurrency = new Map<string, number>();
+  for (const a of accounts) {
+    if (a.is_dependent_linked) continue;
+    const c = a.iso_currency_code ?? "USD";
+    const bal = a.balance_current ?? 0;
+    if (a.type === "depository") {
+      add(cash, bal, c);
+      netByCurrency.set(c, (netByCurrency.get(c) ?? 0) + bal);
+    } else if (a.type === "credit" || a.type === "loan") {
+      add(credit, bal, c);
+      netByCurrency.set(c, (netByCurrency.get(c) ?? 0) - bal);
+    }
+  }
+  const net: CurrencyTotals = { totals: netByCurrency, count: accounts.length };
+
+  const healthy = connections.filter((c) => c.status === "active").length;
+  const attention = connections.filter(
+    (c) => c.status === "pending_reauth" || c.status === "error",
+  ).length;
+
+  const cashP = primary(cash);
+  const creditP = primary(credit);
+  const netP = primary(net);
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard
+        icon={TrendingUp}
+        label="Net cash"
+        value={formatCompact(netP.amount, netP.currency)}
+        accent={netP.amount >= 0 ? "positive" : "negative"}
+        hint={`${accounts.length} ${accounts.length === 1 ? "account" : "accounts"}${net.totals.size > 1 ? ` · ${net.totals.size} currencies` : ""}`}
+      />
+      <StatCard
+        icon={Banknote}
+        label="Cash"
+        value={formatCompact(cashP.amount, cashP.currency)}
+        hint={`${cash.count} depository`}
+      />
+      <StatCard
+        icon={CreditCard}
+        label="Credit & loans"
+        value={formatCompact(creditP.amount, creditP.currency)}
+        accent={creditP.amount > 0 ? "negative" : "neutral"}
+        hint={`${credit.count} balance${credit.count === 1 ? "" : "s"}`}
+      />
+      <StatCard
+        icon={Plug}
+        label="Connections"
+        value={String(connections.length)}
+        hint={
+          attention > 0
+            ? `${healthy} healthy · ${attention} need action`
+            : `${healthy} healthy`
+        }
+        accent={attention > 0 ? "warning" : "neutral"}
+      />
+    </div>
+  );
+}
+
+interface StatCardProps {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  hint?: string;
+  accent?: "positive" | "negative" | "warning" | "neutral";
+}
+
+// One stat tile: tiny uppercase label, big tabular-num value, a footnote line.
+// Border-only card — flatter than the default shadcn Card so a row of four
+// reads as a scoreboard, not a deck of feature cards.
+function StatCard({ icon: Icon, label, value, hint, accent = "neutral" }: StatCardProps) {
+  const valueColor =
+    accent === "positive"
+      ? "text-success"
+      : accent === "negative"
+        ? "text-destructive"
+        : accent === "warning"
+          ? "text-amber-600 dark:text-amber-400"
+          : undefined;
+  return (
+    <div className="bg-card rounded-xl border p-5 shadow-sm">
+      <div className="text-muted-foreground flex items-center gap-2 text-[11px] font-medium tracking-[0.08em] uppercase">
+        <Icon className="size-3.5" />
+        {label}
+      </div>
+      <div
+        className={cn(
+          "mt-3 text-2xl font-semibold tracking-tight tabular-nums",
+          valueColor,
+        )}
+      >
+        {value}
+      </div>
+      {hint && (
+        <div className="text-muted-foreground mt-1 text-xs">{hint}</div>
+      )}
+    </div>
+  );
+}
+
+function StatCardSkeleton() {
+  return (
+    <div className="bg-card rounded-xl border p-5 shadow-sm">
+      <Skeleton className="h-3 w-20" />
+      <Skeleton className="mt-3 h-7 w-32" />
+      <Skeleton className="mt-2 h-3 w-24" />
+    </div>
+  );
+}

--- a/web/src/routes/home.tsx
+++ b/web/src/routes/home.tsx
@@ -1,66 +1,102 @@
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { useMemo } from "react";
+import { Link } from "@tanstack/react-router";
+import { ArrowUpRight, Plus } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
 import { useMe } from "@/api/queries/me";
+import { useAccounts } from "@/api/queries/accounts";
+import { useConnections } from "@/api/queries/connections";
+import { useTransactions } from "@/api/queries/transactions";
+import { relativeTime } from "@/features/connections/connection-utils";
+import { HomeStats } from "@/features/home/home-stats";
+import { HomeRecentTransactions } from "@/features/home/home-recent-transactions";
+import { HomeConnectionsPanel } from "@/features/home/home-connections-panel";
+
+// Greeting strips the email domain so "admin@example.com" reads as "admin".
+// Username can already be a display name on real installs, in which case it
+// passes through unchanged.
+function greetingName(username: string | undefined): string {
+  if (!username) return "";
+  const at = username.indexOf("@");
+  return at === -1 ? username : username.slice(0, at);
+}
 
 export function HomePage() {
   const { data: me } = useMe();
+  const accountsQuery = useAccounts();
+  const connectionsQuery = useConnections();
+  // Default sort = date desc; cap to one page worth and only render the top
+  // few. Reuses the same cache key the Transactions list uses for an empty
+  // filter set, so navigating to /transactions hits a warm cache.
+  const txQuery = useTransactions({});
+
+  const recent = useMemo(
+    () => txQuery.data?.pages?.[0]?.transactions?.slice(0, 6),
+    [txQuery.data],
+  );
+
+  // The freshest `last_synced_at` across all connections is the household-level
+  // "synced X ago" stamp — matches what the v1 dashboard's header showed and
+  // gives the page a single trustworthy freshness signal.
+  const lastSyncedAt = useMemo(() => {
+    const stamps = (connectionsQuery.data ?? [])
+      .map((c) => c.last_synced_at)
+      .filter((s): s is string => !!s)
+      .map((s) => new Date(s).getTime());
+    if (stamps.length === 0) return null;
+    return new Date(Math.max(...stamps)).toISOString();
+  }, [connectionsQuery.data]);
+
+  const isLoadingShell =
+    accountsQuery.isLoading || connectionsQuery.isLoading;
 
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-6">
       <PageHeader
-        eyebrow="Overview"
-        title={me ? `Welcome, ${me.username}` : "Welcome"}
-        description="You're using the v2 admin preview. Real dashboard data lands in the next PR."
+        eyebrow={lastSyncedAt ? `Synced ${relativeTime(lastSyncedAt)}` : "Overview"}
+        title={me ? `Welcome back, ${greetingName(me.username)}` : "Welcome"}
+        description="A quick read on balances, recent activity, and the health of your bank connections."
+        actions={
+          <>
+            <Button asChild variant="outline" size="sm">
+              <Link to="/transactions" className="inline-flex items-center gap-1.5">
+                <ArrowUpRight className="size-4" />
+                Transactions
+              </Link>
+            </Button>
+            <Button asChild size="sm">
+              <Link
+                to="/connections"
+                search={{ action: "connect" }}
+                className="inline-flex items-center gap-1.5"
+              >
+                <Plus className="size-4" />
+                Connect bank
+              </Link>
+            </Button>
+          </>
+        }
       />
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <Card className="gap-3 py-5">
-          <CardHeader className="px-5">
-            <CardDescription className="text-[11px] font-medium tracking-[0.06em] uppercase">
-              Tech stack
-            </CardDescription>
-            <CardTitle className="text-sm leading-snug font-medium">
-              React · TypeScript · Vite · TanStack · shadcn/ui
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-muted-foreground px-5 text-sm">
-            Single binary in production. Old admin UI stays at <code>/</code>.
-          </CardContent>
-        </Card>
+      <HomeStats
+        accounts={accountsQuery.data}
+        connections={connectionsQuery.data}
+        isLoading={isLoadingShell}
+      />
 
-        <Card className="gap-3 py-5">
-          <CardHeader className="px-5">
-            <CardDescription className="text-[11px] font-medium tracking-[0.06em] uppercase">
-              API split
-            </CardDescription>
-            <CardTitle className="text-sm leading-snug font-medium">
-              <code>/api/v1/*</code> public · <code>/web/v1/*</code> internal
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-muted-foreground px-5 text-sm">
-            Session-cookie auth on <code>/web/v1/*</code>. Zero stability promise.
-          </CardContent>
-        </Card>
-
-        <Card className="gap-3 py-5">
-          <CardHeader className="px-5">
-            <CardDescription className="text-[11px] font-medium tracking-[0.06em] uppercase">
-              Status
-            </CardDescription>
-            <CardTitle className="text-sm leading-snug font-medium">
-              Phase 0 · shell
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-muted-foreground px-5 text-sm">
-            Navigable scaffold. Pages built one at a time per weekend.
-          </CardContent>
-        </Card>
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <HomeRecentTransactions
+            transactions={recent}
+            isLoading={txQuery.isLoading}
+          />
+        </div>
+        <div className="lg:col-span-1">
+          <HomeConnectionsPanel
+            connections={connectionsQuery.data}
+            isLoading={connectionsQuery.isLoading}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Replaces the placeholder three-card home with a live dashboard: KPI strip (net cash, cash, credit & loans, connections health), recent-activity feed, and a connections side panel.
- Recent-activity rows reuse \`TransactionPrimary\` + \`TransactionAmount\` so the row vocabulary matches the Transactions list verbatim; rows link straight to transaction detail. Cap of 6, then "View all".
- Connections side panel sorts attention-needed rows to the top, shows status badge + relative last-sync, links to the full Connections page. Empty state offers a one-click "Connect a bank".
- PageHeader gets a \`Synced X ago\` eyebrow (max \`last_synced_at\` across all connections) and primary/secondary CTAs (Connect bank, Transactions).
- Skeletons + empty states wired for every section so the page never flashes blank or shows "No data" without affordance.

## Before / After

| Before | After |
| --- | --- |
| <img src="https://i.img402.dev/epc0yut8rs.jpg" width="800" alt="Home — before"> | <img src="https://i.img402.dev/66g0falbw4.jpg" width="800" alt="Home — after"> |

## Notes

- Reuses \`ConnectionStatusBadge\` and \`relativeTime\` from \`features/connections\` rather than forking — single source of truth for connection rendering.
- New \`StatCard\` is intentionally local to \`features/home/home-stats.tsx\`; if a third surface (Reports, Accounts) wants the same scoreboard, we can extract it then. Added to the sprint state as a watch item.
- \`useTransactions({})\` deliberately shares its cache key with the Transactions list's empty-filter state, so navigating to \`/transactions\` from "View all" hits a warm cache.
- The Net cash card honours per-currency separation (no cross-currency sum); when multiple currencies exist it picks the largest absolute bucket and footnotes the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)