### PR TITLE
design(v2): polish transactions list table chrome

### DIFF
--- a/web/src/components/data-table.tsx
+++ b/web/src/components/data-table.tsx
@@ -70,6 +70,18 @@ export interface DataTableProps<TData, TValue> {
    * scrolled into view — drives j/k list navigation.
    */
   focusedRowId?: string;
+  /**
+   * Render the column header as a sticky band that pins to the top of the
+   * scroll container. Pairs well with long lists. Uses a subtle muted
+   * backdrop so it visually separates from the body without a hard line.
+   */
+  stickyHeader?: boolean;
+  /**
+   * When true, render the column headers with the v2 list vocabulary —
+   * uppercase, tracked, smaller, muted. The default is the shadcn table's
+   * standard sentence-case treatment used by other list pages.
+   */
+  refinedHeader?: boolean;
 }
 
 // Shared table wrapper over @tanstack/react-table + the shadcn Table
@@ -94,6 +106,8 @@ export function DataTable<TData, TValue>({
   getRowId,
   meta,
   focusedRowId,
+  stickyHeader = false,
+  refinedHeader = false,
 }: DataTableProps<TData, TValue>) {
   const focusedRowRef = useRef<HTMLTableRowElement>(null);
   useEffect(() => {
@@ -122,15 +136,30 @@ export function DataTable<TData, TValue>({
     // The shadcn Table primitive already wraps the <table> in its own
     // overflow-x-auto container, so narrow viewports scroll horizontally
     // without a second scroll container here.
-    <div className="rounded-md border">
+    <div className="bg-card overflow-hidden rounded-lg border">
       <Table>
-        <TableHeader>
+        <TableHeader
+          className={cn(
+            stickyHeader &&
+              "bg-muted/40 supports-[backdrop-filter]:bg-muted/30 sticky top-0 z-10 backdrop-blur-sm",
+          )}
+        >
           {table.getHeaderGroups().map((headerGroup) => (
-            <TableRow key={headerGroup.id}>
+            <TableRow
+              key={headerGroup.id}
+              className={cn(
+                // Header rows never react to hover; they're chrome, not data.
+                "hover:bg-transparent",
+              )}
+            >
               {headerGroup.headers.map((header) => (
                 <TableHead
                   key={header.id}
-                  className={header.column.columnDef.meta?.className}
+                  className={cn(
+                    refinedHeader &&
+                      "text-muted-foreground h-9 text-[11px] font-medium tracking-[0.06em] uppercase",
+                    header.column.columnDef.meta?.className,
+                  )}
                 >
                   {header.isPlaceholder
                     ? null

--- a/web/src/components/ui/table.tsx
+++ b/web/src/components/ui/table.tsx
@@ -55,7 +55,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        "border-b border-border/60 transition-colors hover:bg-muted/40 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
         className
       )}
       {...props}
@@ -68,7 +68,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-10 px-3 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}
@@ -81,7 +81,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "px-3 py-2.5 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}

--- a/web/src/features/transactions/columns.tsx
+++ b/web/src/features/transactions/columns.tsx
@@ -57,7 +57,7 @@ const selectionColumn: ColumnDef<Transaction> = {
 const baseColumns: ColumnDef<Transaction>[] = [
   {
     id: "description",
-    header: "Description",
+    header: "Transaction",
     // `max-w-0 w-full` is the classic auto-table truncation trick: the cell
     // fills available width but its max-width is 0, so descendants with
     // `truncate` actually clamp. Without this, a long merchant name expands
@@ -87,7 +87,7 @@ const baseColumns: ColumnDef<Transaction>[] = [
     // `w-px` shrinks to content on mobile (where space is tight); `sm:min-w-28`
     // pins a comfortable floor on desktop so the right edge of the column
     // stays steady across rows of varying amount length.
-    meta: { className: "w-px sm:min-w-28" },
+    meta: { className: "w-px sm:min-w-28 text-right" },
     cell: ({ row }) => <TransactionAmount transaction={row.original} />,
   },
 ];

--- a/web/src/routes/transactions.tsx
+++ b/web/src/routes/transactions.tsx
@@ -8,8 +8,10 @@ import {
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
 import type { RowSelectionState } from "@tanstack/react-table";
-import { Receipt } from "lucide-react";
+import { Plus, Receipt } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/data-table";
 import { EmptyState } from "@/components/empty-state";
 import { CommandDialog } from "@/components/ui/command";
@@ -359,13 +361,40 @@ export function TransactionsPage() {
     !!search.pending;
 
   const count = totalCount.data?.count;
-  const showCountLine = !transactions.isLoading && !transactions.isError;
+  const eyebrow = (() => {
+    if (transactions.isLoading) return "Loading";
+    if (transactions.isError) return "Error";
+    if (rows.length === 0) {
+      return hasActiveFilters ? "No matches" : "No transactions";
+    }
+    if (count != null && count > rows.length) {
+      return `Showing ${rows.length.toLocaleString()} of ${count.toLocaleString()}`;
+    }
+    const total = count ?? rows.length;
+    return `${total.toLocaleString()} ${total === 1 ? "transaction" : "transactions"}`;
+  })();
 
   return (
-    <div>
-      <PageHeader title="Transactions" />
+    <div className="flex flex-col gap-5">
+      <PageHeader
+        eyebrow={eyebrow}
+        title="Transactions"
+        description="Search, filter, and review every transaction across your connected accounts."
+        actions={
+          <Button asChild size="sm">
+            <Link
+              to="/connections"
+              search={{ action: "connect" }}
+              className="inline-flex items-center gap-1.5"
+            >
+              <Plus className="size-4" />
+              Connect bank
+            </Link>
+          </Button>
+        }
+      />
 
-      <div className="mb-4">
+      <div className="flex flex-col gap-3">
         <TransactionsToolbar
           search={search}
           onChange={setFilter}
@@ -377,29 +406,12 @@ export function TransactionsPage() {
         />
       </div>
 
-      {showCountLine && rows.length > 0 && (
-        <div className="text-muted-foreground mb-2 flex items-center gap-2 text-sm">
-          <span>
-            {count != null && count > rows.length
-              ? `Showing ${rows.length} of ${count.toLocaleString()} transactions`
-              : `${(count ?? rows.length).toLocaleString()} ${
-                  (count ?? rows.length) === 1 ? "transaction" : "transactions"
-                }`}
-          </span>
-          {focusedIndex == null && (
-            <span className="hidden text-xs sm:inline">
-              · Press J / K to navigate
-            </span>
-          )}
-        </div>
-      )}
-
       <DataTable
         columns={columns}
         data={rows}
         isLoading={transactions.isLoading}
         isError={transactions.isError}
-        loadingRows={6}
+        loadingRows={8}
         renderSkeletonRow={() => (
           <TransactionRowSkeleton showSelect={selectMode} />
         )}
@@ -410,6 +422,8 @@ export function TransactionsPage() {
         meta={tableMeta}
         focusedRowId={focusedRowId}
         onRowClick={selectMode ? toggleRowSelection : openTransaction}
+        stickyHeader
+        refinedHeader
         emptyState={
           <EmptyState
             icon={Receipt}
@@ -420,8 +434,22 @@ export function TransactionsPage() {
             }
             description={
               hasActiveFilters
-                ? "Try adjusting or clearing your filters."
-                : "Transactions appear here once an account finishes syncing."
+                ? "Adjust or clear your filters to see more results."
+                : "Once a connected account finishes syncing, transactions will land here."
+            }
+            action={
+              hasActiveFilters ? undefined : (
+                <Button asChild size="sm">
+                  <Link
+                    to="/connections"
+                    search={{ action: "connect" }}
+                    className="inline-flex items-center gap-1.5"
+                  >
+                    <Plus className="size-4" />
+                    Connect a bank
+                  </Link>
+                </Button>
+              )
             }
           />
         }


### PR DESCRIPTION
## Summary
- PageHeader picks up a description + `Showing N of M` eyebrow + primary "Connect bank" CTA so the densest page in the app lands with intent instead of a naked H1.
- `DataTable` gains optional `stickyHeader` + `refinedHeader` props. The transactions table opts into both: pinned, blurred column band with small uppercase tracked labels (Transaction / Category / Amount).
- Table chrome: lighter `border-border/60` separators, calmer hover, uniform `px-3 py-2.5` cells, larger rounded-lg container — denser scan path without feeling cramped.
- No-filters empty state now offers a real "Connect a bank" CTA instead of dead-ending.

## Before / After
<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/jfqefom1p6.jpg" width="420" alt="transactions — before"></td>
    <td><img src="https://i.img402.dev/ddho5rxvnz.jpg" width="420" alt="transactions — after"></td>
  </tr>
</table>

## Notes
- New `DataTable` props are opt-in — other list pages (Accounts, Categories, Rules, etc.) keep their current sentence-case headers. They can adopt `refinedHeader` page-by-page if/when we standardize.
- The `Table` primitive now ships a softer `border-border/60` separator and `px-3 py-2.5` cells across the whole app. Worth a quick visual once-over on Categories / Rules tables next iteration to confirm nothing regressed.
- Drift to log: the redundant `Showing 50 of 879 · Press J / K to navigate` line is gone — count moved to the PageHeader eyebrow. The j/k discoverability now relies on the global shortcut sheet (good enough; if we miss it, surface a `kbd` hint in the toolbar instead of duplicating the line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)