### PR TITLE
design(v2): polish tags list with refined table chrome

### DIFF
--- a/web/src/features/tags/tags-table.tsx
+++ b/web/src/features/tags/tags-table.tsx
@@ -60,6 +60,7 @@ export function TagsTable({
       {
         id: "tag",
         header: "Tag",
+        meta: { className: "w-[28%]" },
         cell: ({ row }) => (
           <div className="flex items-center gap-2">
             <TagChip tag={row.original} />
@@ -69,9 +70,12 @@ export function TagsTable({
       {
         id: "slug",
         header: "Slug",
-        meta: { className: "hidden md:table-cell" },
+        meta: { className: "hidden w-[22%] md:table-cell" },
         cell: ({ row }) => (
-          <code className="text-muted-foreground text-xs">
+          // Render the slug as a faint mono pill — it visually reads as a
+          // machine identifier (used in the API + rule DSL) without competing
+          // with the human-facing display name in the Tag column.
+          <code className="bg-muted/60 text-muted-foreground rounded px-1.5 py-0.5 font-mono text-[11px]">
             {row.original.slug}
           </code>
         ),
@@ -154,6 +158,11 @@ export function TagsTable({
           navigate({ to: "/tags/$slug", params: { slug: t.slug } })
         }
         emptyState={emptyState}
+        // Validates the iter-3 DataTable abstraction on a second list:
+        // tag pages tend to grow long and benefit from the same column
+        // band + uppercase vocabulary as the Transactions list.
+        stickyHeader
+        refinedHeader
       />
 
       <Dialog

--- a/web/src/routes/tags.tsx
+++ b/web/src/routes/tags.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { Plus, Search, Tags as TagsIcon } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
@@ -12,13 +12,43 @@ export function TagsPage() {
   const [query, setQuery] = useState("");
   const { data: tags, isLoading, isError } = useTags();
 
+  // Match the Transactions list "Showing N of M" / "N tags" vocabulary so the
+  // page lands with intent instead of a naked H1. Filtering shows the
+  // narrowed slice; an empty page just calls itself "Tags".
+  const total = tags?.length ?? 0;
+  const filteredCount = useMemo(() => {
+    if (!tags) return 0;
+    const q = query.trim().toLowerCase();
+    if (!q) return tags.length;
+    return tags.filter(
+      (t) =>
+        t.slug.toLowerCase().includes(q) ||
+        t.display_name.toLowerCase().includes(q) ||
+        t.description.toLowerCase().includes(q),
+    ).length;
+  }, [tags, query]);
+
+  const eyebrow = (() => {
+    if (isLoading) return "Loading";
+    if (isError) return "Error";
+    if (total === 0) return "No tags";
+    if (query.trim()) {
+      if (filteredCount === 0) return "No matches";
+      if (filteredCount < total) {
+        return `Showing ${filteredCount.toLocaleString()} of ${total.toLocaleString()}`;
+      }
+    }
+    return `${total.toLocaleString()} ${total === 1 ? "tag" : "tags"}`;
+  })();
+
   return (
-    <div>
+    <div className="flex flex-col gap-5">
       <PageHeader
+        eyebrow={eyebrow}
         title="Tags"
-        description="Free-form labels you can attach to any transaction."
+        description="Free-form labels you can attach to any transaction. Use tags for cross-cutting context that doesn't fit a single category — like recurring, business, or trip names."
         actions={
-          <Button asChild>
+          <Button asChild size="sm">
             <Link to="/tags/new">
               <Plus className="size-4" />
               New tag
@@ -27,47 +57,49 @@ export function TagsPage() {
         }
       />
 
-      <div className="mb-4">
-        <div className="relative max-w-sm">
-          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
-          <Input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search tags…"
-            className="pl-8"
-          />
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="relative w-full max-w-sm">
+            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by name, slug, or description…"
+              className="pl-8"
+            />
+          </div>
         </div>
-      </div>
 
-      <TagsTable
-        tags={tags ?? []}
-        isLoading={isLoading}
-        isError={isError}
-        query={query}
-        emptyState={
-          query ? (
-            <EmptyState
-              icon={TagsIcon}
-              title="No matching tags"
-              description="Try a different search term."
-            />
-          ) : (
-            <EmptyState
-              icon={TagsIcon}
-              title="No tags yet"
-              description="Create your first tag to start labelling transactions."
-              action={
-                <Button asChild>
-                  <Link to="/tags/new">
-                    <Plus className="size-4" />
-                    New tag
-                  </Link>
-                </Button>
-              }
-            />
-          )
-        }
-      />
+        <TagsTable
+          tags={tags ?? []}
+          isLoading={isLoading}
+          isError={isError}
+          query={query}
+          emptyState={
+            query ? (
+              <EmptyState
+                icon={TagsIcon}
+                title="No matching tags"
+                description="Try a different search term."
+              />
+            ) : (
+              <EmptyState
+                icon={TagsIcon}
+                title="No tags yet"
+                description="Create your first tag to start labelling transactions."
+                action={
+                  <Button asChild>
+                    <Link to="/tags/new">
+                      <Plus className="size-4" />
+                      New tag
+                    </Link>
+                  </Button>
+                }
+              />
+            )
+          }
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Tags page adopts the Transactions-list eyebrow vocabulary ("N tags" / "Showing N of M" / "No matches"), expanded description, and `size=\"sm\"` "New tag" CTA so the densest library page lands with intent instead of a naked H1.
- `TagsTable` opts into the iter-3 `DataTable` `stickyHeader` + `refinedHeader` props — validates the abstraction on a second list (column band stays pinned + uppercase tracked headers, matching the Transactions list).
- Slug column renders as a muted mono pill instead of a bare `<code>` tag, reading as a machine identifier without crowding the display-name column. Tag + slug columns get width hints so the description column doesn't get squashed against the actions column.

## Before / After
<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td><img src="https://i.img402.dev/vbwitju3rs.jpg" width="500" alt="tags list — before"></td>
    <td><img src="https://i.img402.dev/iujs4cjnex.jpg" width="500" alt="tags list — after"></td>
  </tr>
</table>

## Notes
- The new `DataTable` props (`stickyHeader`, `refinedHeader`) introduced in iter 3 (#1116) now run on two surfaces (Transactions list + Tags list) — abstraction validated, no per-page divergence needed. Future list pages (API keys, Categories, Connections) can adopt the same two-flag opt-in.
- Toolbar pattern (search input above the table inside a `flex flex-col gap-3` block) mirrors the Transactions list. When API keys + Categories migrate, this should harden into a `ListToolbar` primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)