### PR TITLE
design(v2): account detail hero + extract IdPill/SectionCard primitives

### DIFF
--- a/web/src/components/id-pill.tsx
+++ b/web/src/components/id-pill.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils";
+
+interface IdPillProps {
+  value: string;
+  className?: string;
+  // When true, lay out as a small inline pill (default). When false, use the
+  // block-level pill for sidebar/detail rows.
+  inline?: boolean;
+}
+
+// IdPill renders a machine identifier (short_id, slug) as a muted monospace
+// pill — reads as "this is a stable reference, not display copy" wherever
+// it lands. Established by the Tags slug column and Transaction-detail
+// Reference row; promoted to a primitive in the Account-detail pass.
+//
+// Visual contract: `bg-muted/60 rounded px-1.5 py-0.5 font-mono text-[11px]`.
+// Don't fork the look — change this primitive instead.
+export function IdPill({ value, className, inline = true }: IdPillProps) {
+  return (
+    <span
+      className={cn(
+        "bg-muted/60 rounded font-mono text-[11px]",
+        inline ? "inline-block px-1.5 py-0.5" : "px-1.5 py-0.5",
+        className,
+      )}
+    >
+      {value}
+    </span>
+  );
+}

--- a/web/src/components/section-card.tsx
+++ b/web/src/components/section-card.tsx
@@ -1,0 +1,90 @@
+import * as React from "react";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface SectionCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: React.ReactNode;
+  // Slot rendered on the right of the bordered header (button, badge, etc).
+  action?: React.ReactNode;
+  // Optional small icon rendered before the title.
+  icon?: React.ReactNode;
+  // When true, the body becomes flush (px-0 py-0) so the consumer can drop
+  // a `<ul className="divide-y">` straight in. Default leaves comfortable
+  // padding for prose / forms.
+  flushBody?: boolean;
+  // Optional footer slot rendered with a top border. Use for "See all" links.
+  footer?: React.ReactNode;
+  children: React.ReactNode;
+  cardClassName?: string;
+  headerClassName?: string;
+  bodyClassName?: string;
+  footerClassName?: string;
+}
+
+// SectionCard is the canonical "page section in a card" container — bordered
+// header that names the section, optional trailing action, body that hosts
+// the content. Established across the v2 design pass on Home (recent
+// activity / connections), Transaction-detail (Activity / Details), and now
+// Account-detail (Settings / Links / Recent transactions / Details). Wraps
+// shadcn `Card` so every surface speaks the same vocabulary.
+//
+// Visual contract:
+//   `<Card className="gap-0 py-0">`
+//     `<CardHeader className="border-b px-5 py-3.5">` title (text-sm font-medium)
+//     `<CardContent className="px-5 py-5">` content (or px-0 py-0 when flushBody)
+//     optional `<div className="border-t px-5 py-3 text-right">` footer
+//
+// Don't fork the look — change this primitive.
+export function SectionCard({
+  title,
+  action,
+  icon,
+  flushBody = false,
+  footer,
+  children,
+  className,
+  cardClassName,
+  headerClassName,
+  bodyClassName,
+  footerClassName,
+  ...rest
+}: SectionCardProps) {
+  return (
+    <Card
+      className={cn("gap-0 py-0", cardClassName, className)}
+      {...rest}
+    >
+      <CardHeader className={cn("border-b px-5 py-3.5", headerClassName)}>
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          {icon}
+          {title}
+        </CardTitle>
+        {action && <CardAction>{action}</CardAction>}
+      </CardHeader>
+      <CardContent
+        className={cn(
+          flushBody ? "px-0 py-0" : "px-5 py-5",
+          bodyClassName,
+        )}
+      >
+        {children}
+      </CardContent>
+      {footer && (
+        <div
+          className={cn(
+            "border-t px-5 py-3 text-right",
+            footerClassName,
+          )}
+        >
+          {footer}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/src/features/accounts/account-links-section.tsx
+++ b/web/src/features/accounts/account-links-section.tsx
@@ -12,13 +12,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-  Card,
-  CardAction,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -26,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { SectionCard } from "@/components/section-card";
 import { withMutationToast } from "@/lib/mutation-toast";
 import {
   useAccountLinks,
@@ -76,24 +70,22 @@ export function AccountLinksSection({
   }, [linksQuery.data, account.short_id]);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Link2 className="size-4" /> Account links
-        </CardTitle>
-        <CardAction>
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={onAddLink}
-            disabled={account.is_dependent_linked}
-          >
-            <Plus className="size-3.5" />
-            Link an account
-          </Button>
-        </CardAction>
-      </CardHeader>
-      <CardContent className="space-y-3">
+    <SectionCard
+      title="Account links"
+      icon={<Link2 className="size-4" />}
+      action={
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={onAddLink}
+          disabled={account.is_dependent_linked}
+        >
+          <Plus className="size-3.5" />
+          Link an account
+        </Button>
+      }
+      bodyClassName="space-y-3 px-5 py-5"
+    >
         {linksQuery.isLoading ? (
           <div className="text-muted-foreground flex items-center gap-2 text-xs">
             <Loader2 className="size-3 animate-spin" /> Loading links…
@@ -123,8 +115,7 @@ export function AccountLinksSection({
             ))}
           </ul>
         )}
-      </CardContent>
-    </Card>
+    </SectionCard>
   );
 }
 

--- a/web/src/features/accounts/account-recent-transactions.tsx
+++ b/web/src/features/accounts/account-recent-transactions.tsx
@@ -1,14 +1,8 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { EmptyState } from "@/components/empty-state";
+import { SectionCard } from "@/components/section-card";
 import { TransactionPrimary } from "@/components/transaction-primary";
 import { TransactionAmount } from "@/components/transaction-amount";
 import type { Transaction } from "@/api/types";
@@ -20,60 +14,58 @@ interface AccountRecentTransactionsProps {
 
 // AccountRecentTransactions surfaces the last N transactions inline on the
 // account detail page. Each row links to the transaction detail; the footer
-// jumps to the Transactions table pre-filtered to this account.
+// jumps to the Transactions table pre-filtered to this account. Uses the
+// shared SectionCard so the card vocabulary matches the rest of the detail
+// page (Settings / Links / Details all bordered-header + flush body).
 export function AccountRecentTransactions({
   accountShortId,
   transactions,
 }: AccountRecentTransactionsProps) {
+  const hasRows = transactions.length > 0;
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Recent transactions</CardTitle>
-        {transactions.length > 0 && (
-          <CardAction>
-            <span className="text-muted-foreground text-xs">
-              Last {transactions.length}
-            </span>
-          </CardAction>
-        )}
-      </CardHeader>
-      <CardContent className="p-0">
-        {transactions.length === 0 ? (
-          <EmptyState
-            title="No transactions yet"
-            description="They appear after the first sync."
-            className="py-8"
-          />
-        ) : (
-          <ul className="divide-y">
-            {transactions.map((t) => (
-              <li key={t.id}>
-                <Link
-                  to="/transactions/$id"
-                  params={{ id: t.short_id }}
-                  className="hover:bg-accent/40 flex items-center gap-3 px-6 py-2 transition-colors"
-                >
-                  <TransactionPrimary transaction={t} className="flex-1" />
-                  <TransactionAmount transaction={t} />
-                </Link>
-              </li>
-            ))}
-          </ul>
-        )}
-      </CardContent>
-      {transactions.length > 0 && (
-        <div className="border-border/40 border-t px-6 py-3 text-right">
+    <SectionCard
+      title="Recent transactions"
+      action={
+        hasRows ? (
+          <span className="text-muted-foreground text-xs">
+            Last {transactions.length}
+          </span>
+        ) : undefined
+      }
+      flushBody
+      footer={
+        hasRows ? (
           <Button variant="ghost" size="sm" asChild>
-            <Link
-              to="/transactions"
-              search={{ account: accountShortId }}
-            >
+            <Link to="/transactions" search={{ account: accountShortId }}>
               See all transactions for this account
               <ArrowRight className="size-3.5" />
             </Link>
           </Button>
-        </div>
+        ) : undefined
+      }
+    >
+      {hasRows ? (
+        <ul className="divide-y">
+          {transactions.map((t) => (
+            <li key={t.id}>
+              <Link
+                to="/transactions/$id"
+                params={{ id: t.short_id }}
+                className="hover:bg-accent/40 flex items-center gap-3 px-5 py-2.5 transition-colors"
+              >
+                <TransactionPrimary transaction={t} className="flex-1" />
+                <TransactionAmount transaction={t} />
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <EmptyState
+          title="No transactions yet"
+          description="They appear after the first sync."
+          className="py-10"
+        />
       )}
-    </Card>
+    </SectionCard>
   );
 }

--- a/web/src/features/accounts/account-settings-card.tsx
+++ b/web/src/features/accounts/account-settings-card.tsx
@@ -2,10 +2,10 @@ import { useEffect, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { Check, ExternalLink, Loader2, Pencil, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SectionCard } from "@/components/section-card";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useUpdateAccount } from "@/api/queries/accounts";
 import type { AccountDetail } from "@/api/types";
@@ -60,11 +60,10 @@ export function AccountSettingsCard({ account: a }: AccountSettingsCardProps) {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Settings</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-5 text-sm">
+    <SectionCard
+      title="Settings"
+      bodyClassName="space-y-5 px-5 py-5 text-sm"
+    >
         <div className="space-y-1.5">
           <Label htmlFor="display-name" className="text-muted-foreground text-xs">
             Display name
@@ -183,7 +182,6 @@ export function AccountSettingsCard({ account: a }: AccountSettingsCardProps) {
             )}
           </div>
         )}
-      </CardContent>
-    </Card>
+    </SectionCard>
   );
 }

--- a/web/src/features/tags/tags-table.tsx
+++ b/web/src/features/tags/tags-table.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { DataTable } from "@/components/data-table";
+import { IdPill } from "@/components/id-pill";
 import { TagChip } from "@/components/tag-chip";
 import { useDeleteTag } from "@/api/queries/tags";
 import { withMutationToast } from "@/lib/mutation-toast";
@@ -75,9 +76,10 @@ export function TagsTable({
           // Render the slug as a faint mono pill — it visually reads as a
           // machine identifier (used in the API + rule DSL) without competing
           // with the human-facing display name in the Tag column.
-          <code className="bg-muted/60 text-muted-foreground rounded px-1.5 py-0.5 font-mono text-[11px]">
-            {row.original.slug}
-          </code>
+          <IdPill
+            value={row.original.slug}
+            className="text-muted-foreground"
+          />
         ),
       },
       {

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -3,6 +3,7 @@ import {
   Link,
   useNavigate,
   useParams,
+  useRouter,
   useSearch,
 } from "@tanstack/react-router";
 import { z } from "zod";
@@ -13,21 +14,17 @@ import {
   Banknote,
   Eye,
   EyeOff,
+  Landmark,
   Link2,
+  Wallet,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { EmptyState } from "@/components/empty-state";
+import { IdPill } from "@/components/id-pill";
+import { SectionCard } from "@/components/section-card";
 import { useAccount, useAccounts } from "@/api/queries/accounts";
 import type { AccountDetail } from "@/api/types";
 import {
@@ -85,12 +82,7 @@ export function AccountDetailPage() {
 
   return (
     <div className="mx-auto max-w-5xl">
-      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
-        <Link to="/accounts">
-          <ArrowLeft className="size-4" />
-          Accounts
-        </Link>
-      </Button>
+      <BackButton />
 
       {acctQuery.isLoading ? (
         <DetailSkeleton />
@@ -127,6 +119,44 @@ export function AccountDetailPage() {
   );
 }
 
+// BackButton renders as a real link to /accounts (so middle-click and
+// "open in new tab" still work), but on a normal left-click it prefers
+// `router.history.back()` — that lands the user on the exact list state
+// they came from (filters, family tab, group-by). Mirrors the TX-detail
+// back button so the muscle memory matches.
+function BackButton() {
+  const router = useRouter();
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      asChild
+      className="text-muted-foreground hover:text-foreground mb-3 -ml-2 h-7 px-2 text-xs"
+    >
+      <Link
+        to="/accounts"
+        onClick={(e) => {
+          if (
+            !e.defaultPrevented &&
+            !e.metaKey &&
+            !e.ctrlKey &&
+            !e.shiftKey &&
+            !e.altKey &&
+            e.button === 0 &&
+            window.history.length > 1
+          ) {
+            e.preventDefault();
+            router.history.back();
+          }
+        }}
+      >
+        <ArrowLeft className="size-3.5" />
+        Back to accounts
+      </Link>
+    </Button>
+  );
+}
+
 interface DetailBodyProps {
   account: AccountDetail;
   accounts: ReturnType<typeof useAccounts>["data"] extends infer T
@@ -138,108 +168,338 @@ interface DetailBodyProps {
 }
 
 function DetailBody({ account: a, accounts, onAddLink }: DetailBodyProps) {
-  const Icon = accountTypeIcon(a.type);
-  const liability = isLiability(a.type);
-  const util = creditUtilization(a);
   const statusAlert = useMemo(() => connectionStatusAlert(a), [a]);
 
   return (
     <div className="space-y-6">
-      {/* Hero */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="flex min-w-0 items-center gap-3">
-          <div className="bg-muted flex size-12 shrink-0 items-center justify-center rounded-lg">
-            <Icon className="text-muted-foreground size-5" />
-          </div>
-          <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <h1 className="truncate text-xl font-semibold tracking-tight">
-                {accountLabel(a)}
-              </h1>
-              {a.excluded && (
-                <Badge variant="outline" className="gap-1 text-[10px]">
-                  <EyeOff className="size-2.5" /> Excluded
-                </Badge>
-              )}
-              {a.is_dependent_linked && (
-                <Badge variant="secondary" className="gap-1 text-[10px]">
-                  <Link2 className="size-2.5" /> Linked dependent
-                </Badge>
-              )}
-            </div>
-            <div className="text-muted-foreground mt-1 flex flex-wrap items-center gap-1.5 text-xs">
-              <span className="capitalize">
-                {accountTypeLabel(a.type, a.subtype)}
-              </span>
-              {a.mask && (
-                <>
-                  <span className="text-muted-foreground/40">·</span>
-                  <span className="tabular-nums">····{a.mask}</span>
-                </>
-              )}
-              {a.institution_name && (
-                <>
-                  <span className="text-muted-foreground/40">·</span>
-                  <span>{a.institution_name}</span>
-                </>
-              )}
-              {a.connection_user_name && (
-                <>
-                  <span className="text-muted-foreground/40">·</span>
-                  <span>{a.connection_user_name}</span>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex shrink-0 flex-wrap items-center gap-2">
-          {!a.is_dependent_linked && (
-            <Button variant="outline" size="sm" onClick={onAddLink}>
-              <Link2 className="size-4" />
-              Link account
-            </Button>
-          )}
-          <Button variant="outline" size="sm" asChild>
-            <Link to="/transactions" search={{ account: a.short_id }}>
-              <Eye className="size-4" />
-              View transactions
-            </Link>
-          </Button>
-        </div>
-      </div>
+      <Hero account={a} onAddLink={onAddLink} />
 
       {statusAlert}
 
-      {/* Balance cards */}
-      <div className="grid gap-4 md:grid-cols-2">
-        <BalanceCard account={a} liability={liability} util={util} />
-        <SecondaryCard account={a} liability={liability} />
+      <QuickActions account={a} />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div className="space-y-6 min-w-0">
+          <AccountRecentTransactions
+            accountShortId={a.short_id}
+            transactions={a.recent_transactions.slice(0, 15)}
+          />
+          {/* Account links - skip when the account is itself a dependent.
+              Showing a "Link an account" CTA on a dependent would let users
+              create the second hop of an A→B→C chain, which the backend
+              rejects anyway. The settings card still surfaces the dependent
+              state, and the LinkAccountSheet's filter logic mirrors it. */}
+          {!a.is_dependent_linked && (
+            <AccountLinksSection
+              account={a}
+              accounts={accounts}
+              onAddLink={onAddLink}
+            />
+          )}
+        </div>
+
+        <aside className="space-y-6">
+          <AccountSettingsCard account={a} />
+          <DetailsCard account={a} />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+// Hero condenses identity + classification + balance into one composed card
+// — paralleling the iter-5 transaction-detail hero so detail pages across
+// the app speak the same visual vocabulary. The left rail is tinted by the
+// account's accounting role (success for assets, destructive for
+// liabilities, muted when excluded) — the colour is meaningful, not
+// decorative, so the eye lands on what kind of money this is before reading
+// the number.
+function Hero({
+  account: a,
+  onAddLink,
+}: {
+  account: AccountDetail;
+  onAddLink: () => void;
+}) {
+  const Icon = accountTypeIcon(a.type);
+  const liability = isLiability(a.type);
+  const util = creditUtilization(a);
+  const current = a.balance_current;
+  const accent = a.excluded
+    ? "var(--muted)"
+    : liability
+      ? "var(--destructive)"
+      : "var(--success, oklch(0.65 0.18 145))";
+  const directionLabel = liability ? "Balance owed" : "Current balance";
+
+  return (
+    <div className="bg-card relative overflow-hidden rounded-xl border">
+      {/* Asset/liability rail anchored to the account's accounting role.
+          Excluded accounts collapse to neutral so the card reads "shelved"
+          rather than "demands attention". */}
+      <div
+        aria-hidden
+        className="absolute inset-y-0 left-0 w-1"
+        style={{ backgroundColor: accent }}
+      />
+
+      <div className="grid gap-6 px-6 py-6 sm:px-7 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-10">
+        {/* Identity column */}
+        <div className="min-w-0 space-y-3">
+          <div className="flex items-start gap-4">
+            <div
+              className={cn(
+                "bg-muted flex size-12 shrink-0 items-center justify-center rounded-lg",
+                a.excluded && "opacity-60",
+              )}
+            >
+              <Icon className="text-muted-foreground size-5" />
+            </div>
+            <div className="min-w-0 space-y-1">
+              <p className="text-muted-foreground text-[10px] font-medium tracking-[0.12em] uppercase">
+                {liability ? "Liability" : "Asset"}
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="truncate text-xl font-semibold tracking-tight">
+                  {accountLabel(a)}
+                </h1>
+                {a.excluded && (
+                  <Badge variant="outline" className="gap-1 text-[10px]">
+                    <EyeOff className="size-2.5" /> Excluded
+                  </Badge>
+                )}
+                {a.is_dependent_linked && (
+                  <Badge variant="secondary" className="gap-1 text-[10px]">
+                    <Link2 className="size-2.5" /> Linked dependent
+                  </Badge>
+                )}
+              </div>
+              <p className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">
+                <span className="capitalize">
+                  {accountTypeLabel(a.type, a.subtype)}
+                </span>
+                {a.mask && (
+                  <>
+                    <span aria-hidden className="opacity-50">·</span>
+                    <span className="tabular-nums">····{a.mask}</span>
+                  </>
+                )}
+                {a.institution_name && (
+                  <>
+                    <span aria-hidden className="opacity-50">·</span>
+                    <span>{a.institution_name}</span>
+                  </>
+                )}
+                {a.connection_user_name && (
+                  <>
+                    <span aria-hidden className="opacity-50">·</span>
+                    <span>{a.connection_user_name}</span>
+                  </>
+                )}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Amount column */}
+        <div
+          className={cn(
+            "flex flex-col items-start gap-1.5",
+            "lg:items-end lg:text-right",
+          )}
+        >
+          <div
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase whitespace-nowrap",
+              liability
+                ? "bg-destructive/10 text-destructive"
+                : "bg-success/10 text-success",
+              a.excluded && "bg-muted text-muted-foreground",
+            )}
+          >
+            {directionLabel}
+          </div>
+          <div
+            className={cn(
+              "font-semibold tabular-nums",
+              "text-3xl sm:text-4xl",
+              liability && current != null && current > 0 && "text-destructive/90",
+              a.excluded && "opacity-60",
+            )}
+          >
+            {current != null
+              ? formatCurrency(current, a.iso_currency_code)
+              : "—"}
+          </div>
+
+          {util != null ? (
+            <div className="w-full max-w-[12rem] space-y-1.5 pt-2">
+              <div className="text-muted-foreground flex items-center justify-between text-[11px] tabular-nums">
+                <span>{Math.round(util)}% used</span>
+                {a.balance_limit != null && (
+                  <span>
+                    of {formatCurrency(a.balance_limit, a.iso_currency_code)}
+                  </span>
+                )}
+              </div>
+              <div className="bg-muted h-1.5 overflow-hidden rounded-full">
+                <div
+                  className={cn(
+                    "h-full transition-all",
+                    utilizationBarClass(util),
+                  )}
+                  style={{ width: `${util}%` }}
+                />
+              </div>
+            </div>
+          ) : a.balance_available != null ? (
+            <p className="text-muted-foreground pt-1 text-[11px] tabular-nums">
+              {formatCurrency(a.balance_available, a.iso_currency_code)} available
+            </p>
+          ) : a.iso_currency_code ? (
+            <p className="text-muted-foreground pt-1 text-[11px]">
+              {a.iso_currency_code}
+            </p>
+          ) : null}
+        </div>
       </div>
 
-      <AccountSettingsCard account={a} />
+      {/* Inline action strip lives inside the hero so primary actions sit
+          adjacent to the identity they act on. Keeps the page from leading
+          with a row of "Link / View" buttons floating above the card. */}
+      <div className="border-t bg-muted/20 flex flex-wrap items-center justify-end gap-2 px-6 py-2.5 sm:px-7">
+        {!a.is_dependent_linked && (
+          <Button variant="ghost" size="sm" onClick={onAddLink} className="h-7 gap-1.5 text-xs">
+            <Link2 className="size-3.5" />
+            Link account
+          </Button>
+        )}
+        <Button variant="ghost" size="sm" asChild className="h-7 gap-1.5 text-xs">
+          <Link to="/transactions" search={{ account: a.short_id }}>
+            <Eye className="size-3.5" />
+            View transactions
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+}
 
-      {/* Account links - skip when the account is itself a dependent.
-          Showing a "Link an account" CTA on a dependent would let users
-          create the second hop of an A→B→C chain, which the backend
-          rejects anyway. The settings card still surfaces the dependent
-          state, and the LinkAccountSheet's filter logic mirrors it. */}
-      {!a.is_dependent_linked && (
-        <AccountLinksSection
-          account={a}
-          accounts={accounts}
-          onAddLink={onAddLink}
-        />
+function QuickActions({ account: a }: { account: AccountDetail }) {
+  // The hero already carries the primary CTAs (link / view). Quick actions
+  // here cover the lateral jumps the user reaches for from a detail page —
+  // their connection (sync status, reauth) and the account-filter on the
+  // transactions table. Matches the TX-detail "Jump to" pill row.
+  const hasAny = !!(a.connection_short_id || a.short_id);
+  if (!hasAny) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-muted-foreground mr-1 text-[10px] font-medium tracking-[0.1em] uppercase">
+        Jump to
+      </span>
+      <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" asChild>
+        <Link to="/transactions" search={{ account: a.short_id }}>
+          <Wallet className="size-3" />
+          All transactions
+        </Link>
+      </Button>
+      {a.connection_short_id && (
+        <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" asChild>
+          <Link
+            to="/connections/$id"
+            params={{ id: a.connection_short_id }}
+          >
+            <Landmark className="size-3" />
+            {a.institution_name ?? "Connection"}
+          </Link>
+        </Button>
       )}
+    </div>
+  );
+}
 
-      <AccountRecentTransactions
-        accountShortId={a.short_id}
-        // The detail endpoint returns up to 25; cap at 15 here so the
-        // section reads as a preview rather than a second-tier list. The
-        // footer link jumps to the full Transactions table filtered to
-        // this account.
-        transactions={a.recent_transactions.slice(0, 15)}
-      />
+function DetailsCard({ account: a }: { account: AccountDetail }) {
+  const balanceRows: DetailRowData[] = compactRows([
+    a.balance_limit != null && isLiability(a.type)
+      ? {
+          label: "Credit limit",
+          value: formatCurrency(a.balance_limit, a.iso_currency_code),
+        }
+      : null,
+    a.balance_available != null && !isLiability(a.type)
+      ? {
+          label: "Available",
+          value: formatCurrency(a.balance_available, a.iso_currency_code),
+        }
+      : null,
+    a.iso_currency_code ? { label: "Currency", value: a.iso_currency_code } : null,
+    a.last_balance_update
+      ? {
+          label: "Last update",
+          value: new Date(a.last_balance_update).toLocaleString(),
+        }
+      : null,
+  ]);
+
+  const providerRows: DetailRowData[] = compactRows([
+    a.official_name ? { label: "Bank name", value: a.official_name } : null,
+    a.mask ? { label: "Mask", value: `····${a.mask}`, mono: false } : null,
+    a.subtype ? { label: "Subtype", value: a.subtype } : null,
+  ]);
+
+  const referenceRows: DetailRowData[] = compactRows([
+    { label: "ID", value: a.short_id, mono: true },
+  ]);
+
+  return (
+    <SectionCard title="Details" bodyClassName="space-y-5 px-5 py-5 text-sm">
+      {balanceRows.length > 0 && (
+        <DetailGroup label="Balance" rows={balanceRows} />
+      )}
+      {providerRows.length > 0 && (
+        <DetailGroup label="Provider" rows={providerRows} />
+      )}
+      {referenceRows.length > 0 && (
+        <DetailGroup label="Reference" rows={referenceRows} />
+      )}
+    </SectionCard>
+  );
+}
+
+interface DetailRowData {
+  label: string;
+  value: string | null | undefined;
+  mono?: boolean;
+}
+
+function compactRows(
+  rows: (DetailRowData | null | undefined | false)[],
+): DetailRowData[] {
+  return rows.filter((r): r is DetailRowData => !!r && !!r.value);
+}
+
+function DetailGroup({ label, rows }: { label: string; rows: DetailRowData[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <div className="space-y-2.5">
+      <h3 className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
+        {label}
+      </h3>
+      <dl className="space-y-2">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className="flex items-baseline justify-between gap-3"
+          >
+            <dt className="text-muted-foreground shrink-0 text-xs">
+              {row.label}
+            </dt>
+            <dd className="min-w-0 truncate text-right text-xs">
+              {row.mono ? <IdPill value={row.value as string} /> : row.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
     </div>
   );
 }
@@ -307,162 +567,44 @@ function connectionStatusAlert(a: AccountDetail) {
   return null;
 }
 
-interface BalanceCardProps {
-  account: AccountDetail;
-  liability: boolean;
-  util: number | null;
-}
-
-function BalanceCard({ account: a, liability, util }: BalanceCardProps) {
-  const current = a.balance_current;
-  // For liabilities (credit/loan), Plaid returns positive `balance_current`
-  // to mean "you owe this much". The label is "Balance owed", so show the
-  // raw positive — the destructive tint already conveys it's a negative
-  // line on the household sheet.
-  //
-  // Stat-card layout follows shadcn's dashboard pattern: label as
-  // CardDescription and value as CardTitle inside CardHeader (gap-2),
-  // optional context in CardFooter — no separate CardHeader / CardContent
-  // split with the wide gap-6 between them.
-  return (
-    <Card>
-      <CardHeader>
-        <CardDescription>
-          {liability ? "Balance owed" : "Current balance"}
-        </CardDescription>
-        <CardTitle
-          className={cn(
-            "text-3xl font-semibold tabular-nums tracking-tight",
-            liability && current != null && current > 0 && "text-destructive/90",
-          )}
-        >
-          {current != null
-            ? formatCurrency(current, a.iso_currency_code)
-            : "—"}
-        </CardTitle>
-      </CardHeader>
-      {(util != null || a.iso_currency_code) && (
-        <CardFooter className="flex-col items-stretch gap-2">
-          {util != null && (
-            <>
-              <div className="text-muted-foreground flex items-center justify-between text-xs tabular-nums">
-                <span>{Math.round(util)}% utilization</span>
-                {a.balance_limit != null && (
-                  <span>
-                    of {formatCurrency(a.balance_limit, a.iso_currency_code)}
-                  </span>
-                )}
-              </div>
-              <div className="bg-muted h-1.5 overflow-hidden rounded-full">
-                <div
-                  className={cn(
-                    "h-full transition-all",
-                    utilizationBarClass(util),
-                  )}
-                  style={{ width: `${util}%` }}
-                />
-              </div>
-            </>
-          )}
-          {a.iso_currency_code && util == null && (
-            <div className="text-muted-foreground text-xs">
-              {a.iso_currency_code}
-            </div>
-          )}
-        </CardFooter>
-      )}
-    </Card>
-  );
-}
-
-function SecondaryCard({
-  account: a,
-  liability,
-}: {
-  account: AccountDetail;
-  liability: boolean;
-}) {
-  // Depository / investment: show "available" balance and last update.
-  // Credit / loan: show available credit (limit − current) and last update.
-  // The point is to give users a second useful number, not the same number
-  // twice.
-  const rows: { label: string; value: string }[] = [];
-  if (liability) {
-    if (a.balance_limit != null && a.balance_current != null) {
-      const avail = Math.max(0, a.balance_limit - a.balance_current);
-      rows.push({
-        label: "Available credit",
-        value: formatCurrency(avail, a.iso_currency_code),
-      });
-    }
-    if (a.balance_limit != null) {
-      rows.push({
-        label: "Credit limit",
-        value: formatCurrency(a.balance_limit, a.iso_currency_code),
-      });
-    }
-  } else if (a.balance_available != null) {
-    rows.push({
-      label: "Available",
-      value: formatCurrency(a.balance_available, a.iso_currency_code),
-    });
-  }
-  if (a.last_balance_update) {
-    rows.push({
-      label: "Last balance update",
-      value: new Date(a.last_balance_update).toLocaleString(),
-    });
-  }
-  if (a.official_name) {
-    rows.push({ label: "Bank official name", value: a.official_name });
-  }
-
-  // No CardHeader — the "Details" label was generic filler. Mirror the
-  // balance card's vertical rhythm (py-6 + a single inner block) so the
-  // pair sits flush, then list the rows directly.
-  return (
-    <Card>
-      <CardContent>
-        {rows.length === 0 ? (
-          <p className="text-muted-foreground text-sm">
-            No additional balance or refresh information.
-          </p>
-        ) : (
-          <dl className="space-y-2.5 text-sm">
-            {rows.map((r) => (
-              <div
-                key={r.label}
-                className="flex items-baseline justify-between gap-3"
-              >
-                <dt className="text-muted-foreground text-xs">{r.label}</dt>
-                <dd className="truncate text-right font-medium tabular-nums">
-                  {r.value}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
 function DetailSkeleton() {
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Skeleton className="size-12 rounded-lg" />
-        <div className="space-y-2">
-          <Skeleton className="h-5 w-40" />
-          <Skeleton className="h-4 w-56" />
+      <div className="bg-card relative overflow-hidden rounded-xl border">
+        <div className="bg-muted absolute inset-y-0 left-0 w-1" />
+        <div className="grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_auto]">
+          <div className="space-y-3">
+            <div className="flex items-start gap-4">
+              <Skeleton className="size-12 rounded-lg" />
+              <div className="space-y-2 py-1">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+            </div>
+          </div>
+          <div className="space-y-2 lg:items-end">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-9 w-32" />
+            <Skeleton className="h-3 w-28" />
+          </div>
+        </div>
+        <div className="border-t flex justify-end gap-2 px-6 py-2.5">
+          <Skeleton className="h-7 w-24 rounded-md" />
+          <Skeleton className="h-7 w-32 rounded-md" />
         </div>
       </div>
-      <div className="grid gap-4 md:grid-cols-2">
-        <Skeleton className="h-32 rounded-xl" />
-        <Skeleton className="h-32 rounded-xl" />
+      <div className="flex gap-2">
+        <Skeleton className="h-7 w-32 rounded-md" />
+        <Skeleton className="h-7 w-32 rounded-md" />
       </div>
-      <Skeleton className="h-40 rounded-xl" />
-      <Skeleton className="h-48 rounded-xl" />
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <Skeleton className="h-96 rounded-xl" />
+        <div className="space-y-6">
+          <Skeleton className="h-56 rounded-xl" />
+          <Skeleton className="h-72 rounded-xl" />
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -8,13 +8,14 @@ import {
   Search,
   Wallet,
 } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { CategoryIconTile } from "@/components/category-icon-tile";
+import { IdPill } from "@/components/id-pill";
+import { SectionCard } from "@/components/section-card";
 import { CategoryEditor } from "@/features/transactions/category-editor";
 import { TagManager } from "@/features/transactions/tag-manager";
 import { ActivityTimeline } from "@/features/transactions/activity-timeline";
@@ -99,16 +100,14 @@ function DetailBody({ transaction: t }: { transaction: Transaction }) {
       <QuickActions transaction={t} merchantQuery={merchantQuery} />
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
-        <Card className="gap-0 py-0">
-          <CardHeader className="border-b px-5 py-3.5">
-            <CardTitle className="text-sm font-medium">Activity</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-5 px-5 py-5">
-            <CommentComposer transactionId={t.id} />
-            <Separator />
-            <ActivityTimeline transactionId={t.id} />
-          </CardContent>
-        </Card>
+        <SectionCard
+          title="Activity"
+          bodyClassName="space-y-5 px-5 py-5"
+        >
+          <CommentComposer transactionId={t.id} />
+          <Separator />
+          <ActivityTimeline transactionId={t.id} />
+        </SectionCard>
 
         <aside className="space-y-6">
           <DetailsCard transaction={t} />
@@ -359,20 +358,15 @@ function DetailsCard({ transaction: t }: { transaction: Transaction }) {
   ]);
 
   return (
-    <Card className="gap-0 py-0">
-      <CardHeader className="border-b px-5 py-3.5">
-        <CardTitle className="text-sm font-medium">Details</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-5 px-5 py-5 text-sm">
-        <DetailGroup label="Account" rows={accountRows} />
-        {providerRows.length > 0 && (
-          <DetailGroup label="Provider" rows={providerRows} />
-        )}
-        {referenceRows.length > 0 && (
-          <DetailGroup label="Reference" rows={referenceRows} />
-        )}
-      </CardContent>
-    </Card>
+    <SectionCard title="Details" bodyClassName="space-y-5 px-5 py-5 text-sm">
+      <DetailGroup label="Account" rows={accountRows} />
+      {providerRows.length > 0 && (
+        <DetailGroup label="Provider" rows={providerRows} />
+      )}
+      {referenceRows.length > 0 && (
+        <DetailGroup label="Reference" rows={referenceRows} />
+      )}
+    </SectionCard>
   );
 }
 
@@ -412,13 +406,7 @@ function DetailGroup({
               {row.label}
             </dt>
             <dd className="min-w-0 truncate text-right text-xs">
-              {row.mono ? (
-                <span className="bg-muted/60 inline-block rounded px-1.5 py-0.5 font-mono text-[11px]">
-                  {row.value}
-                </span>
-              ) : (
-                row.value
-              )}
+              {row.mono ? <IdPill value={row.value} /> : row.value}
               {row.hint && (
                 <span className="text-muted-foreground mt-1 block text-[11px] leading-snug whitespace-normal">
                   {row.hint}


### PR DESCRIPTION
## Summary

- **Account detail hero**: mirror the iter-5 TX-detail hero pattern — icon tile + name + meta in one identity column, balance pill + value + utilization / available credit in the amount column, wrapped in a card with a 1px left rail tinted by accounting role (success for assets, destructive for liabilities, muted when excluded). Inline Link / View action strip lives in the card footer adjacent to the identity it acts on, and a "Jump to" pill row below mirrors the TX-detail vocabulary.
- **`IdPill` primitive** — promoted from the 3 fork sites (Tags slug column, TX-detail Reference row, Account-detail Reference row) into `web/src/components/id-pill.tsx`. Now sourced from one place.
- **`SectionCard` primitive** — promoted the bordered-CardHeader + flush/padded-body pattern Home, TX-detail, and Account-detail all use into `web/src/components/section-card.tsx`. Migrated TX-detail Activity + Details, Account Settings + Links + Recent transactions + Details to use it. Every "page section in a card" surface now speaks the same vocabulary.

## Before / After

### Savings (asset)

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/1xlfl0n9pk.jpg) | ![after](https://i.img402.dev/2rt2g50fi2.jpg) |

### Credit card (liability)

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/bs5otxyqky.jpg) | ![after](https://i.img402.dev/0a9jb8hl4o.jpg) |

## Notes

- **Two design-system promotions** at once — `IdPill` (3 surfaces) and `SectionCard` (4 surfaces). Both pre-flagged in the sprint state as candidates; this iteration was the natural threshold.
- The hero's left rail vocabulary (1px-wide colored stripe) is now used on 2 detail pages (TX, Account). If a 3rd detail page (Category, Rule, Connection) adopts it, extract `<ColorRailCard>`.
- Sidebar inverts the iter-5 layout — instead of one Details card, the Account-detail sidebar stacks **Settings + Details**, with **Recent transactions + Account links** in the main column. Account-detail has more first-class affordances (rename, exclude, link, reauth) than TX-detail, so Settings earned its own sidebar slot.
- The Hero "Asset / Liability" eyebrow encodes the accounting role into a tiny tracked-uppercase label so the visual accent has a textual anchor. Color alone shouldn't carry the meaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
