### PR TITLE
design(v2): categories list — eyebrow + unified list card + slug pills

### DIFF
--- a/web/src/features/categories/category-list.tsx
+++ b/web/src/features/categories/category-list.tsx
@@ -1,17 +1,11 @@
 import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
-import {
-  ChevronDown,
-  ChevronRight,
-  EyeOff,
-  Lock,
-  MoreHorizontal,
-  Pencil,
-} from "lucide-react";
+import { ChevronRight, EyeOff, Lock, Pencil } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { CategoryIconTile } from "@/components/category-icon-tile";
+import { IdPill } from "@/components/id-pill";
 import { cn } from "@/lib/utils";
 import type { Category } from "@/api/types";
 
@@ -23,6 +17,13 @@ interface CategoryListProps {
   emptyState?: React.ReactNode;
 }
 
+// CategoryList renders the full parent → child tree as one bordered card with
+// `divide-y` rows — matching the Home / Tags / TX-detail "Card gap-0 py-0 +
+// CardHeader border-b + ul divide-y" vocabulary. Each parent row toggles its
+// children inline; the expanded children sit in a tinted band with a 2px
+// left rail tinted by the parent's color, so the nesting is both visible
+// and meaningful (the rail encodes which parent owns the group, not just
+// "these are indented").
 export function CategoryList({ tree, query, emptyState }: CategoryListProps) {
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -44,15 +45,17 @@ export function CategoryList({ tree, query, emptyState }: CategoryListProps) {
   if (filtered.length === 0) return emptyState ?? null;
 
   return (
-    <div className="space-y-3">
-      {filtered.map((parent) => (
-        <CategoryCard key={parent.id} category={parent} forceOpen={!!query} />
-      ))}
-    </div>
+    <Card className="gap-0 py-0">
+      <ul className="divide-y">
+        {filtered.map((parent) => (
+          <CategoryRow key={parent.id} category={parent} forceOpen={!!query} />
+        ))}
+      </ul>
+    </Card>
   );
 }
 
-function CategoryCard({
+function CategoryRow({
   category,
   forceOpen,
 }: {
@@ -62,101 +65,143 @@ function CategoryCard({
   const [open, setOpen] = useState(false);
   const isOpen = forceOpen || open;
   const children = category.children ?? [];
+  const hasChildren = children.length > 0;
+  const accent = category.color ?? undefined;
 
   return (
-    <Card className="overflow-hidden gap-0 py-0">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="hover:bg-muted/30 flex w-full items-center gap-3 px-4 py-3 text-left transition"
+    <li>
+      <div
+        className={cn(
+          "group hover:bg-muted/40 flex items-center gap-3 px-4 py-2.5 transition-colors",
+          isOpen && hasChildren && "bg-muted/20",
+        )}
       >
+        <button
+          type="button"
+          onClick={hasChildren ? () => setOpen((v) => !v) : undefined}
+          aria-expanded={hasChildren ? isOpen : undefined}
+          aria-label={
+            hasChildren
+              ? `${isOpen ? "Collapse" : "Expand"} ${category.display_name}`
+              : undefined
+          }
+          disabled={!hasChildren}
+          className={cn(
+            "text-muted-foreground -ml-1 flex size-6 shrink-0 items-center justify-center rounded-md transition-all",
+            hasChildren
+              ? "hover:bg-muted hover:text-foreground cursor-pointer"
+              : "cursor-default opacity-0",
+            isOpen && "text-foreground rotate-90",
+          )}
+        >
+          <ChevronRight className="size-3.5" />
+        </button>
+
         <CategoryIconTile
           icon={category.icon}
           color={category.color}
           size="md"
         />
-        <div className="min-w-0 flex-1">
+
+        <Link
+          to="/categories/$id"
+          params={{ id: category.short_id }}
+          className="min-w-0 flex-1 outline-none"
+        >
           <div className="flex items-center gap-2">
-            <span className="font-medium">{category.display_name}</span>
+            <span className="truncate text-sm font-medium">
+              {category.display_name}
+            </span>
             {category.is_system && (
-              <Badge variant="outline" className="gap-1 text-xs">
-                <Lock className="size-3" /> System
+              <Badge
+                variant="outline"
+                className="text-muted-foreground gap-1 px-1.5 py-0 text-[10px] font-normal"
+              >
+                <Lock className="size-2.5" /> System
               </Badge>
             )}
             {category.hidden && (
-              <Badge variant="outline" className="gap-1 text-xs">
-                <EyeOff className="size-3" /> Hidden
+              <Badge
+                variant="outline"
+                className="text-muted-foreground gap-1 px-1.5 py-0 text-[10px] font-normal"
+              >
+                <EyeOff className="size-2.5" /> Hidden
               </Badge>
             )}
           </div>
-          <div className="text-muted-foreground text-xs">
-            {children.length === 0
-              ? "No sub-categories"
-              : `${children.length} sub-categor${children.length === 1 ? "y" : "ies"}`}
+          <div className="text-muted-foreground mt-0.5 flex items-center gap-2 text-xs">
+            <IdPill value={category.slug} />
+            {hasChildren && (
+              <span className="text-muted-foreground/80">
+                {children.length}{" "}
+                {children.length === 1 ? "sub-category" : "sub-categories"}
+              </span>
+            )}
           </div>
-        </div>
-        <div className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="icon"
-            asChild
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Link
-              to="/categories/$id"
-              params={{ id: category.short_id }}
-              aria-label={`Edit ${category.display_name}`}
-            >
-              <Pencil className="size-4" />
-            </Link>
-          </Button>
-          {children.length > 0 ? (
-            isOpen ? (
-              <ChevronDown className="text-muted-foreground size-4" />
-            ) : (
-              <ChevronRight className="text-muted-foreground size-4" />
-            )
-          ) : (
-            <span className="size-4" aria-hidden />
-          )}
-        </div>
-      </button>
+        </Link>
 
-      {isOpen && children.length > 0 && (
-        <div className="border-t">
+        <Button
+          variant="ghost"
+          size="icon"
+          asChild
+          className="text-muted-foreground hover:text-foreground size-8 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+        >
+          <Link
+            to="/categories/$id"
+            params={{ id: category.short_id }}
+            aria-label={`Edit ${category.display_name}`}
+          >
+            <Pencil className="size-3.5" />
+          </Link>
+        </Button>
+      </div>
+
+      {isOpen && hasChildren && (
+        <ul
+          className="bg-muted/15 divide-y border-t"
+          style={
+            accent ? { boxShadow: `inset 2px 0 0 0 ${accent}40` } : undefined
+          }
+        >
           {children.map((child) => (
-            <Link
-              key={child.id}
-              to="/categories/$id"
-              params={{ id: child.short_id }}
-              className={cn(
-                "hover:bg-muted/30 flex items-center gap-3 px-4 py-2.5 pl-8 transition",
-                child.hidden && "text-muted-foreground",
-              )}
-            >
-              <CategoryIconTile
-                icon={child.icon}
-                color={child.color}
-                size="sm"
-              />
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="truncate text-sm">{child.display_name}</span>
-                  {child.hidden && (
-                    <Badge variant="outline" className="gap-1 text-xs">
-                      <EyeOff className="size-3" /> Hidden
-                    </Badge>
-                  )}
+            <li key={child.id}>
+              <Link
+                to="/categories/$id"
+                params={{ id: child.short_id }}
+                className={cn(
+                  "hover:bg-muted/40 flex items-center gap-3 py-2 pr-4 pl-12 transition-colors",
+                  child.hidden && "text-muted-foreground",
+                )}
+              >
+                <CategoryIconTile
+                  icon={child.icon}
+                  color={child.color ?? category.color}
+                  size="sm"
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm">
+                      {child.display_name}
+                    </span>
+                    {child.hidden && (
+                      <Badge
+                        variant="outline"
+                        className="text-muted-foreground gap-1 px-1.5 py-0 text-[10px] font-normal"
+                      >
+                        <EyeOff className="size-2.5" /> Hidden
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="mt-0.5">
+                    <IdPill value={child.slug} />
+                  </div>
                 </div>
-                <code className="text-muted-foreground text-xs">
-                  {child.slug}
-                </code>
-              </div>
-              <MoreHorizontal className="text-muted-foreground/50 size-4" />
-            </Link>
+                <ChevronRight className="text-muted-foreground/60 size-3.5" />
+              </Link>
+            </li>
           ))}
-        </div>
+        </ul>
       )}
-    </Card>
+    </li>
   );
 }

--- a/web/src/routes/categories.tsx
+++ b/web/src/routes/categories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { Plus, Search, Shapes } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
@@ -6,6 +6,7 @@ import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Card } from "@/components/ui/card";
 import { CategoryList } from "@/features/categories/category-list";
 import { useCategories } from "@/api/queries/categories";
 
@@ -13,13 +14,57 @@ export function CategoriesPage() {
   const [query, setQuery] = useState("");
   const { data: tree, isLoading, isError } = useCategories();
 
+  // Mirror the iter-3/4 list-page eyebrow vocabulary
+  // ("Loading" / "Error" / "N categories" / "Showing N of M" / "No matches" /
+  // "No categories"). Counts include children — the page is dominantly a tree
+  // of sub-categories, so the visible total should reflect what scrolls.
+  const total = useMemo(() => {
+    if (!tree) return 0;
+    return tree.reduce((acc, p) => acc + 1 + (p.children?.length ?? 0), 0);
+  }, [tree]);
+
+  const filteredCount = useMemo(() => {
+    if (!tree) return 0;
+    const q = query.trim().toLowerCase();
+    if (!q) return total;
+    let count = 0;
+    for (const parent of tree) {
+      const parentMatch =
+        parent.display_name.toLowerCase().includes(q) ||
+        parent.slug.toLowerCase().includes(q);
+      const matchingChildren =
+        parent.children?.filter(
+          (c) =>
+            c.display_name.toLowerCase().includes(q) ||
+            c.slug.toLowerCase().includes(q),
+        ) ?? [];
+      if (parentMatch) count += 1 + (parent.children?.length ?? 0);
+      else if (matchingChildren.length > 0) count += 1 + matchingChildren.length;
+    }
+    return count;
+  }, [tree, total, query]);
+
+  const eyebrow = (() => {
+    if (isLoading) return "Loading";
+    if (isError) return "Error";
+    if (total === 0) return "No categories";
+    if (query.trim()) {
+      if (filteredCount === 0) return "No matches";
+      if (filteredCount < total) {
+        return `Showing ${filteredCount.toLocaleString()} of ${total.toLocaleString()}`;
+      }
+    }
+    return `${total.toLocaleString()} ${total === 1 ? "category" : "categories"}`;
+  })();
+
   return (
-    <div>
+    <div className="flex flex-col gap-5">
       <PageHeader
+        eyebrow={eyebrow}
         title="Categories"
-        description="Organize spending into groups. Sub-categories nest under a parent."
+        description="Organize spending into groups. Sub-categories nest under a parent and inherit the parent's colour and icon."
         actions={
-          <Button asChild>
+          <Button asChild size="sm">
             <Link to="/categories/new">
               <Plus className="size-4" />
               New category
@@ -28,59 +73,70 @@ export function CategoriesPage() {
         }
       />
 
-      <div className="mb-4">
-        <div className="relative max-w-sm">
-          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
-          <Input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search categories…"
-            className="pl-8"
-          />
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="relative w-full max-w-sm">
+            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by name or slug…"
+              className="pl-8"
+            />
+          </div>
         </div>
-      </div>
 
-      {isLoading ? (
-        <div className="space-y-3">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-16 rounded-xl" />
-          ))}
-        </div>
-      ) : isError ? (
-        <EmptyState
-          icon={Shapes}
-          title="Couldn't load categories"
-          description="Refresh the page or check back in a moment."
-        />
-      ) : !tree || tree.length === 0 ? (
-        <EmptyState
-          icon={Shapes}
-          title="No categories yet"
-          description="Create your first category to start organizing transactions."
-          action={
-            <Button asChild>
-              <Link to="/categories/new">
-                <Plus className="size-4" />
-                New category
-              </Link>
-            </Button>
-          }
-        />
-      ) : (
-        <CategoryList
-          tree={tree}
-          query={query}
-          emptyState={
-            query ? (
-              <EmptyState
-                icon={Shapes}
-                title="No matching categories"
-                description="Try a different search term."
-              />
-            ) : null
-          }
-        />
-      )}
+        {isLoading ? (
+          <Card className="gap-0 py-0">
+            <ul className="divide-y">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <li key={i} className="flex items-center gap-3 px-4 py-3">
+                  <Skeleton className="size-9 rounded-md" />
+                  <div className="flex-1 space-y-1.5">
+                    <Skeleton className="h-3.5 w-40" />
+                    <Skeleton className="h-3 w-24" />
+                  </div>
+                  <Skeleton className="h-5 w-10 rounded-full" />
+                </li>
+              ))}
+            </ul>
+          </Card>
+        ) : isError ? (
+          <EmptyState
+            icon={Shapes}
+            title="Couldn't load categories"
+            description="Refresh the page or check back in a moment."
+          />
+        ) : !tree || tree.length === 0 ? (
+          <EmptyState
+            icon={Shapes}
+            title="No categories yet"
+            description="Create your first category to start organizing transactions."
+            action={
+              <Button asChild>
+                <Link to="/categories/new">
+                  <Plus className="size-4" />
+                  New category
+                </Link>
+              </Button>
+            }
+          />
+        ) : (
+          <CategoryList
+            tree={tree}
+            query={query}
+            emptyState={
+              query ? (
+                <EmptyState
+                  icon={Shapes}
+                  title="No matching categories"
+                  description="Try a different search term, or clear the filter to see every category."
+                />
+              ) : null
+            }
+          />
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Categories now lands with the iter-3/4 list vocabulary: PageHeader eyebrow ("123 categories" / "Showing N of M" / "No matches" / "Loading" / "Error"), expanded description, `size="sm"` "New category" CTA, and the same `flex flex-col gap-3` toolbar block used by Transactions + Tags.
- The 17 floating cards become **one bordered list card** (`<Card gap-0 py-0>` + `<ul divide-y>`) — matches the Home recent-activity / connections panels and TX-detail's section cards. Density drops from ~64px/row to ~44px/row, scan path is shorter, and the parent → child grouping reads as one continuous list rather than a card soup.
- Each parent row gets a true expand affordance: a chevron toggle on the left that rotates 90° when open, plus a subtle `bg-muted/20` row tint so the open state is visible without shouting. Expanded children sit in a tinted band (`bg-muted/15`) with a **2px inset left rail tinted by the parent's own color** — so the visual nesting *encodes which parent owns the group*, not just "these are indented." Same pattern as the iter-5/6 color-rail cards on TX + Account detail.
- Slugs render as `<IdPill>` (the iter-6 primitive) — fourth surface now reuses it (Tags, TX-detail, Account-detail, Categories). The misleading `MoreHorizontal` glyph on child rows (it didn't open a menu) is gone, replaced with a calm right-aligned chevron pointing to "/categories/$id". Edit pencils on parent rows fade in on hover instead of being permanently loud.
- System / Hidden badges trade their default sizing for a tighter `text-[10px] px-1.5 py-0` muted-foreground variant — the parent name reads first, the system flag second.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/kchlr3ipui.jpg) | ![after](https://i.img402.dev/rsf7fo1g4t.jpg) |
| ![before-expanded](https://i.img402.dev/92ss92bg1k.jpg) | ![after-expanded](https://i.img402.dev/pqx05wawa4.jpg) |

## Notes

- `IdPill` is now on 4 surfaces — strong validation of the iter-6 promotion. No drift detected.
- The "list of items in one bordered Card with `divide-y` rows" pattern is now on Home / Tags / TX-detail / Account-detail / Categories. Worth promoting `<ListCard>` (a thin wrapper over `<Card className="gap-0 py-0">` + `<ul className="divide-y">`) once a sixth surface adopts it — Connections list is the obvious next candidate and would seal the decision.
- Detail page for a single category (`category-detail.tsx`) is still on the old vocabulary — added as the next backlog candidate; it would also be the natural third surface for a `ColorRailCard` primitive (per iter-6 note: TX-detail + Account-detail share a color-rail hero, Category detail should adopt it before extracting).
- Sub-category count moved from a chatty "7 sub-categories" line under the name to a quiet inline metadata pill alongside the slug. If we ever add transaction counts per category, this row is where it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)