### PR TITLE
design(v2): promote ListCard primitive + unify Connections list

### DIFF
--- a/web/src/components/list-card.tsx
+++ b/web/src/components/list-card.tsx
@@ -1,0 +1,132 @@
+import * as React from "react";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface ListCardProps<T> extends Omit<React.HTMLAttributes<HTMLDivElement>, "children"> {
+  // Optional bordered header — matches the SectionCard vocabulary. Omit for
+  // a header-less list (just a card holding rows).
+  title?: React.ReactNode;
+  icon?: React.ReactNode;
+  // Slot rendered on the right of the bordered header.
+  action?: React.ReactNode;
+  // Optional footer slot rendered with a top border. Use for "See all" links
+  // or "+N more" hints.
+  footer?: React.ReactNode;
+
+  // The two-arg shape: pass rows + a renderer. Each rendered node is wrapped
+  // in an `<li>` automatically, so the divide-y rail is consistent across
+  // every surface that uses the primitive.
+  rows: ReadonlyArray<T>;
+  renderRow: (row: T, index: number) => React.ReactNode;
+  // React key extractor for each row. Defaults to the index, but every real
+  // call site should pass a stable key.
+  getRowKey?: (row: T, index: number) => React.Key;
+
+  // Rendered when `rows` is empty. Typically an `<EmptyState>` or a small
+  // muted string.
+  empty?: React.ReactNode;
+  // Rendered above the ul when set — e.g. a multi-select toolbar that has
+  // to sit inside the card border but above the row band.
+  toolbar?: React.ReactNode;
+
+  className?: string;
+  cardClassName?: string;
+  headerClassName?: string;
+  bodyClassName?: string;
+  footerClassName?: string;
+  listClassName?: string;
+}
+
+// ListCard is the canonical "bordered card hosting a divide-y list" container.
+// Promoted in iter 8 after the same shape appeared on six surfaces (Home
+// recent activity, Home connections, TX-detail Activity, Account-detail
+// Recent transactions, Categories, and now Connections).
+//
+// Visual contract — identical to SectionCard but the body is always a
+// `<ul className="divide-y">`:
+//   `<Card className="gap-0 py-0">`
+//     optional `<CardHeader className="border-b px-5 py-3.5">` title + action
+//     optional `<div className="border-b px-5 py-2">` toolbar slot
+//     `<ul className="divide-y">` rows (each `renderRow` result wrapped in `<li>`)
+//     optional `<div className="border-t px-5 py-3 text-right">` footer
+//
+// When `rows.length === 0`, the `empty` slot replaces the `<ul>`. Pass
+// `<EmptyState>` for first-class look + CTA, or a short muted string for a
+// quieter inline state.
+//
+// Don't fork the look — change this primitive. SectionCard remains the right
+// choice when the body is *not* a list (forms, prose, KV blocks).
+export function ListCard<T>({
+  title,
+  icon,
+  action,
+  footer,
+  rows,
+  renderRow,
+  getRowKey,
+  empty,
+  toolbar,
+  className,
+  cardClassName,
+  headerClassName,
+  bodyClassName,
+  footerClassName,
+  listClassName,
+  ...rest
+}: ListCardProps<T>) {
+  const showHeader = title !== undefined || action !== undefined;
+  const isEmpty = rows.length === 0;
+
+  return (
+    <Card
+      className={cn("gap-0 py-0", cardClassName, className)}
+      {...rest}
+    >
+      {showHeader && (
+        <CardHeader className={cn("border-b px-5 py-3.5", headerClassName)}>
+          {title !== undefined && (
+            <CardTitle className="flex items-center gap-2 text-sm font-medium">
+              {icon}
+              {title}
+            </CardTitle>
+          )}
+          {action !== undefined && <CardAction>{action}</CardAction>}
+        </CardHeader>
+      )}
+      {toolbar && (
+        <div className="bg-muted/20 text-muted-foreground border-b px-5 py-2 text-xs">
+          {toolbar}
+        </div>
+      )}
+      <CardContent className={cn("px-0 py-0", bodyClassName)}>
+        {isEmpty ? (
+          empty ?? null
+        ) : (
+          <ul className={cn("divide-y", listClassName)}>
+            {rows.map((row, i) => (
+              <li key={getRowKey ? getRowKey(row, i) : i}>
+                {renderRow(row, i)}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+      {footer && (
+        <div
+          className={cn(
+            "border-t px-5 py-3 text-right",
+            footerClassName,
+          )}
+        >
+          {footer}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/src/features/connections/connection-row.tsx
+++ b/web/src/features/connections/connection-row.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { withMutationToast } from "@/lib/mutation-toast";
+import { cn } from "@/lib/utils";
 import {
   useDisconnectConnection,
   usePauseConnection,
@@ -90,11 +91,17 @@ export function ConnectionRow({
 
   return (
     <div
-      className={`bg-card overflow-hidden rounded-lg border transition-colors ${
-        selected ? "border-primary/60 ring-primary/20 ring-2" : ""
-      }`}
+      className={cn(
+        "group transition-colors",
+        selected && "bg-primary/5",
+      )}
     >
-      <div className="flex items-center gap-3 px-4 py-3 sm:gap-4 sm:px-5 sm:py-4">
+      <div
+        className={cn(
+          "hover:bg-muted/40 flex items-center gap-3 px-5 py-3.5 transition-colors sm:gap-4",
+          selected && "hover:bg-primary/5",
+        )}
+      >
         {onSelectChange && (
           // Wrapper stops the click from bubbling to the surrounding Link, so
           // toggling selection never navigates to the detail page. The label
@@ -116,12 +123,22 @@ export function ConnectionRow({
           className="flex min-w-0 flex-1 items-center gap-3 sm:gap-4"
           aria-label={`Open ${connection.institution_name ?? "connection"} detail`}
         >
-          <div className="bg-muted hidden size-10 shrink-0 items-center justify-center rounded-lg sm:flex">
-            <Icon className="text-muted-foreground size-5" />
+          <div
+            className={cn(
+              "bg-muted/40 hidden size-9 shrink-0 items-center justify-center rounded-md border sm:flex",
+              showReauthBanner && "bg-amber-500/10 border-amber-500/30",
+            )}
+          >
+            <Icon
+              className={cn(
+                "text-muted-foreground size-4",
+                showReauthBanner && "text-amber-700 dark:text-amber-400",
+              )}
+            />
           </div>
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
-              <h3 className="truncate text-sm font-semibold sm:text-base">
+              <h3 className="truncate text-sm font-semibold">
                 {connection.institution_name ?? "Untitled connection"}
               </h3>
               <ConnectionStatusBadge status={connection.status} />
@@ -147,7 +164,7 @@ export function ConnectionRow({
         <div className="flex shrink-0 items-center gap-1.5 sm:gap-3">
           <div className="text-right">
             {balance ? (
-              <div className="text-sm font-semibold tabular-nums sm:text-base">
+              <div className="text-sm font-semibold tabular-nums">
                 {formatCurrency(balance.amount, balance.currency)}
               </div>
             ) : null}
@@ -161,7 +178,7 @@ export function ConnectionRow({
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-8 rounded-full"
+                className="text-muted-foreground hover:text-foreground size-8"
                 aria-label="Connection actions"
               >
                 <MoreHorizontal className="size-4" />

--- a/web/src/features/home/home-connections-panel.tsx
+++ b/web/src/features/home/home-connections-panel.tsx
@@ -1,15 +1,9 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowRight, Building2, FileSpreadsheet, Landmark, Plug } from "lucide-react";
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
+import { ListCard } from "@/components/list-card";
 import { ConnectionStatusBadge } from "@/features/connections/connection-status-badge";
 import { relativeTime } from "@/features/connections/connection-utils";
 import { cn } from "@/lib/utils";
@@ -36,26 +30,47 @@ export function HomeConnectionsPanel({
   const visible = connections ? rankForDashboard(connections).slice(0, 5) : [];
   const remaining = connections ? Math.max(0, connections.length - visible.length) : 0;
 
-  return (
-    <Card className="gap-0 py-0">
-      <CardHeader className="border-b py-4">
-        <CardTitle className="text-sm font-medium">Connections</CardTitle>
-        <CardAction>
-          <Button asChild variant="ghost" size="sm" className="-mr-2 h-8 px-2">
-            <Link
-              to="/connections"
-              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"
-            >
-              Manage
-              <ArrowRight className="size-3.5" />
-            </Link>
-          </Button>
-        </CardAction>
-      </CardHeader>
-      <CardContent className="px-0 py-0">
-        {isLoading ? (
-          <ConnectionsSkeleton />
-        ) : !connections || connections.length === 0 ? (
+  const manage = (
+    <Button asChild variant="ghost" size="sm" className="-mr-2 h-8 px-2">
+      <Link
+        to="/connections"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"
+      >
+        Manage
+        <ArrowRight className="size-3.5" />
+      </Link>
+    </Button>
+  );
+
+  if (isLoading) {
+    return (
+      <ListCard
+        title="Connections"
+        action={manage}
+        rows={[0, 1, 2, 3]}
+        getRowKey={(i) => i}
+        renderRow={(i) => (
+          <div className="flex items-center gap-3 px-5 py-3.5" key={i}>
+            <Skeleton className="size-9 rounded-md" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3.5 w-36" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+            <Skeleton className="h-5 w-16 rounded-md" />
+          </div>
+        )}
+      />
+    );
+  }
+
+  if (!connections || connections.length === 0) {
+    return (
+      <ListCard
+        title="Connections"
+        action={manage}
+        rows={[]}
+        renderRow={() => null}
+        empty={
           <EmptyState
             icon={Plug}
             title="No banks connected"
@@ -68,29 +83,34 @@ export function HomeConnectionsPanel({
               </Button>
             }
           />
-        ) : (
-          <>
-            <ul className="divide-y">
-              {visible.map((c) => (
-                <ConnectionRow key={c.id} connection={c} />
-              ))}
-            </ul>
-            {remaining > 0 && (
-              <div className="text-muted-foreground border-t px-5 py-3 text-xs">
-                +{remaining} more on the Connections page
-              </div>
-            )}
-          </>
-        )}
-      </CardContent>
-    </Card>
+        }
+      />
+    );
+  }
+
+  return (
+    <ListCard
+      title="Connections"
+      action={manage}
+      rows={visible}
+      getRowKey={(c) => c.id}
+      renderRow={(c) => <ConnectionRow connection={c} />}
+      footer={
+        remaining > 0 ? (
+          <span className="text-muted-foreground text-xs">
+            +{remaining} more on the Connections page
+          </span>
+        ) : undefined
+      }
+      footerClassName="text-left"
+    />
   );
 }
 
 function ConnectionRow({ connection: c }: { connection: Connection }) {
   const Icon = PROVIDER_ICON[c.provider] ?? Building2;
   return (
-    <li className="flex items-center gap-3 px-5 py-3">
+    <div className="flex items-center gap-3 px-5 py-3">
       <div
         className={cn(
           "flex size-9 shrink-0 items-center justify-center rounded-md border",
@@ -108,24 +128,7 @@ function ConnectionRow({ connection: c }: { connection: Connection }) {
         </div>
       </div>
       <ConnectionStatusBadge status={c.status} />
-    </li>
-  );
-}
-
-function ConnectionsSkeleton() {
-  return (
-    <ul className="divide-y">
-      {[0, 1, 2, 3].map((i) => (
-        <li key={i} className="flex items-center gap-3 px-5 py-3.5">
-          <Skeleton className="size-9 rounded-md" />
-          <div className="flex-1 space-y-1.5">
-            <Skeleton className="h-3.5 w-36" />
-            <Skeleton className="h-3 w-20" />
-          </div>
-          <Skeleton className="h-5 w-16 rounded-md" />
-        </li>
-      ))}
-    </ul>
+    </div>
   );
 }
 

--- a/web/src/features/home/home-recent-transactions.tsx
+++ b/web/src/features/home/home-recent-transactions.tsx
@@ -1,15 +1,9 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowRight, Receipt } from "lucide-react";
-import {
-  Card,
-  CardAction,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/empty-state";
+import { ListCard } from "@/components/list-card";
 import { TransactionPrimary } from "@/components/transaction-primary";
 import { TransactionAmount } from "@/components/transaction-amount";
 import type { Transaction } from "@/api/types";
@@ -27,75 +21,70 @@ export function HomeRecentTransactions({
   transactions,
   isLoading,
 }: HomeRecentTransactionsProps) {
-  return (
-    <Card className="gap-0 py-0">
-      <CardHeader className="border-b py-4">
-        <CardTitle className="text-sm font-medium">
-          Recent activity
-        </CardTitle>
-        <CardAction>
-          <Button asChild variant="ghost" size="sm" className="-mr-2 h-8 px-2">
-            <Link
-              to="/transactions"
-              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"
-            >
-              View all
-              <ArrowRight className="size-3.5" />
-            </Link>
-          </Button>
-        </CardAction>
-      </CardHeader>
-      <CardContent className="px-0 py-0">
-        {isLoading ? (
-          <RecentSkeleton />
-        ) : !transactions || transactions.length === 0 ? (
-          <EmptyState
-            icon={Receipt}
-            title="No transactions yet"
-            description="Connect a bank or import a CSV to start seeing activity here."
-          />
-        ) : (
-          <ul className="divide-y">
-            {transactions.map((t) => (
-              <li key={t.id}>
-                <Link
-                  to="/transactions/$txId"
-                  params={{ txId: t.short_id }}
-                  className="hover:bg-muted/50 focus-visible:bg-muted/50 flex min-w-0 items-center gap-4 px-5 py-3 outline-none transition-colors"
-                >
-                  <div className="min-w-0 flex-1">
-                    <TransactionPrimary transaction={t} />
-                  </div>
-                  <TransactionAmount transaction={t} />
-                </Link>
-              </li>
-            ))}
-          </ul>
-        )}
-      </CardContent>
-    </Card>
+  const viewAll = (
+    <Button asChild variant="ghost" size="sm" className="-mr-2 h-8 px-2">
+      <Link
+        to="/transactions"
+        className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 text-xs"
+      >
+        View all
+        <ArrowRight className="size-3.5" />
+      </Link>
+    </Button>
   );
-}
 
-function RecentSkeleton() {
+  if (isLoading) {
+    return (
+      <ListCard
+        title="Recent activity"
+        action={viewAll}
+        rows={[0, 1, 2, 3, 4]}
+        getRowKey={(i) => i}
+        renderRow={(i) => (
+          <div
+            className="flex items-center gap-4 px-5 py-3.5"
+            key={i}
+          >
+            <Skeleton className="size-9 rounded-md" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-3.5 w-44" />
+              <Skeleton className="h-3 w-28" />
+            </div>
+            <div className="space-y-1.5 text-right">
+              <Skeleton className="ml-auto h-3.5 w-16" />
+              <Skeleton className="ml-auto h-3 w-10" />
+            </div>
+          </div>
+        )}
+      />
+    );
+  }
+
   return (
-    <ul className="divide-y">
-      {[0, 1, 2, 3, 4].map((i) => (
-        <li
-          key={i}
-          className="flex items-center gap-4 px-5 py-3.5"
+    <ListCard
+      title="Recent activity"
+      action={viewAll}
+      rows={transactions ?? []}
+      getRowKey={(t) => t.id}
+      renderRow={(t) => (
+        <Link
+          to="/transactions/$txId"
+          params={{ txId: t.short_id }}
+          className="hover:bg-muted/50 focus-visible:bg-muted/50 flex min-w-0 items-center gap-4 px-5 py-3 outline-none transition-colors"
         >
-          <Skeleton className="size-9 rounded-md" />
-          <div className="flex-1 space-y-1.5">
-            <Skeleton className="h-3.5 w-44" />
-            <Skeleton className="h-3 w-28" />
+          <div className="min-w-0 flex-1">
+            <TransactionPrimary transaction={t} />
           </div>
-          <div className="space-y-1.5 text-right">
-            <Skeleton className="ml-auto h-3.5 w-16" />
-            <Skeleton className="ml-auto h-3 w-10" />
-          </div>
-        </li>
-      ))}
-    </ul>
+          <TransactionAmount transaction={t} />
+        </Link>
+      )}
+      empty={
+        <EmptyState
+          icon={Receipt}
+          title="No transactions yet"
+          description="Connect a bank or import a CSV to start seeing activity here."
+        />
+      }
+    />
   );
 }

--- a/web/src/routes/connections.tsx
+++ b/web/src/routes/connections.tsx
@@ -4,8 +4,10 @@ import { z } from "zod";
 import { Loader2, Plug, Plus, RefreshCw } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
+import { ListCard } from "@/components/list-card";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useShortcut } from "@/lib/shortcuts";
@@ -195,11 +197,25 @@ export function ConnectionsPage() {
   const isError = connectionsQuery.isError;
   const connections = connectionsQuery.data ?? [];
 
+  // Eyebrow tracks the same vocabulary as the other v2 list pages (Transactions,
+  // Tags, Categories): N entities, then Showing N of M when a filter narrows
+  // the view. Empty / loading / error get their own short string.
+  const eyebrow = isLoading
+    ? "Loading"
+    : isError
+      ? "Error loading"
+      : connections.length === 0
+        ? "No connections yet"
+        : visible.length === connections.length
+          ? `${connections.length} ${connections.length === 1 ? "connection" : "connections"}`
+          : `Showing ${visible.length} of ${connections.length}`;
+
   return (
-    <>
+    <div className="flex flex-col gap-5">
       <PageHeader
+        eyebrow={eyebrow}
         title="Connections"
-        description="Banks and CSV imports that feed transactions into Breadbox."
+        description="Banks and CSV imports that feed transactions into Breadbox. Re-authenticate broken ones and sync on demand."
         actions={
           connections.length > 0 ? (
             <>
@@ -226,13 +242,11 @@ export function ConnectionsPage() {
       />
 
       {connections.length > 0 && (
-        <div className="-mt-4 mb-4">
-          <ConnectionsSummary connections={connections} />
-        </div>
+        <ConnectionsSummary connections={connections} />
       )}
 
       {attentionCount > 0 && (
-        <Alert variant="default" className="mb-4 border-amber-500/30 bg-amber-500/5">
+        <Alert variant="default" className="border-amber-500/30 bg-amber-500/5">
           <AlertTitle className="text-amber-700 dark:text-amber-400">
             {attentionCount === 1
               ? "1 connection needs attention"
@@ -245,21 +259,33 @@ export function ConnectionsPage() {
       )}
 
       {(usersQuery.data?.length ?? 0) > 1 && (
-        <div className="mb-4">
-          <FamilyTabs
-            users={usersQuery.data ?? []}
-            value={userFilter}
-            onChange={setUserFilter}
-            counts={countsByUserShortId}
-            totalCount={connections.length}
-          />
-        </div>
+        <FamilyTabs
+          users={usersQuery.data ?? []}
+          value={userFilter}
+          onChange={setUserFilter}
+          counts={countsByUserShortId}
+          totalCount={connections.length}
+        />
       )}
 
       {isLoading ? (
-        <div className="text-muted-foreground flex items-center justify-center gap-2 py-12 text-sm">
-          <Loader2 className="size-4 animate-spin" /> Loading connections…
-        </div>
+        <ListCard
+          rows={[0, 1, 2]}
+          getRowKey={(i) => i}
+          renderRow={(i) => (
+            <div className="flex items-center gap-4 px-5 py-3.5" key={i}>
+              <Skeleton className="size-9 rounded-md" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-3.5 w-40" />
+                <Skeleton className="h-3 w-56" />
+              </div>
+              <div className="space-y-1.5 text-right">
+                <Skeleton className="ml-auto h-3.5 w-20" />
+                <Skeleton className="ml-auto h-3 w-12" />
+              </div>
+            </div>
+          )}
+        />
       ) : isError ? (
         <Alert variant="destructive">
           <AlertTitle>Couldn't load connections</AlertTitle>
@@ -281,40 +307,12 @@ export function ConnectionsPage() {
             </Button>
           }
         />
-      ) : visible.length === 0 ? (
-        <EmptyState
-          title="No connections for this filter"
-          description="Switch family member or clear the filter to see other connections."
-        />
       ) : (
-        <div className="flex flex-col gap-3">
-          <div className="text-muted-foreground flex items-center gap-3 px-1 text-xs">
-            <Checkbox
-              checked={
-                allVisibleSelected
-                  ? true
-                  : someVisibleSelected
-                    ? "indeterminate"
-                    : false
-              }
-              onCheckedChange={() => toggleSelectAll()}
-              aria-label={
-                selectedIds.size > 0 ? "Clear selection" : "Select all visible"
-              }
-            />
-            <button
-              type="button"
-              onClick={toggleSelectAll}
-              className="hover:text-foreground transition-colors"
-            >
-              {selectedIds.size > 0
-                ? `${selectedConnections.length} selected`
-                : `Select all (${visible.length})`}
-            </button>
-          </div>
-          {visible.map((c) => (
+        <ListCard
+          rows={visible}
+          getRowKey={(c) => c.id}
+          renderRow={(c) => (
             <ConnectionRow
-              key={c.id}
               connection={c}
               // /api/v1/accounts exposes connection_id as the parent's
               // short_id (the consistent compact-ID convention), not its UUID.
@@ -323,8 +321,45 @@ export function ConnectionsPage() {
               selected={selectedIds.has(c.id)}
               onSelectChange={(next) => toggleRowSelection(c.id, next)}
             />
-          ))}
-        </div>
+          )}
+          toolbar={
+            visible.length === 0 ? undefined : (
+            <div className="flex items-center gap-3">
+              <Checkbox
+                checked={
+                  allVisibleSelected
+                    ? true
+                    : someVisibleSelected
+                      ? "indeterminate"
+                      : false
+                }
+                onCheckedChange={() => toggleSelectAll()}
+                aria-label={
+                  selectedIds.size > 0
+                    ? "Clear selection"
+                    : "Select all visible"
+                }
+              />
+              <button
+                type="button"
+                onClick={toggleSelectAll}
+                className="hover:text-foreground transition-colors"
+              >
+                {selectedIds.size > 0
+                  ? `${selectedConnections.length} selected`
+                  : `Select all visible (${visible.length})`}
+              </button>
+            </div>
+            )
+          }
+          empty={
+            <EmptyState
+              title="No connections for this filter"
+              description="Switch family member or clear the filter to see other connections."
+              className="py-10"
+            />
+          }
+        />
       )}
 
       {selectedConnections.length > 0 && (
@@ -347,6 +382,6 @@ export function ConnectionsPage() {
         }}
         connectionShortId={search.reauth}
       />
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Promotes the "bordered Card + divide-y rows" pattern (now on six v2 surfaces) into a shared `<ListCard>` primitive at `web/src/components/list-card.tsx` — sibling of `<SectionCard>` but pre-tuned for list bodies (rows + renderRow, empty slot, inner toolbar slot, bordered footer).
- Connections list unifies onto ListCard: three floating per-row Cards collapse into a single bordered list card whose internal toolbar band hosts the multi-select control (now sits *with* the rows it controls), with the iter-3/4/7 eyebrow vocabulary ("3 connections" / "Showing N of M" / "Loading" / "Error") wired up.
- Home recent-activity and home connections panel migrate onto ListCard to validate the API on three surfaces in one PR.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/9apfcfbbxf.jpg) | ![after](https://i.img402.dev/77k307zmpc.jpg) |

## Notes

- `<ListCard>` always renders a `<ul className="divide-y">` body. Empty arrays render the `empty` slot instead. `toolbar` sits between the header and the rows in a `bg-muted/20` band — used by Connections for its multi-select control.
- Connection rows lost their per-row rounded border + 2px primary-ring selection treatment in favour of an inline `bg-primary/5` selected state; the unified card border + divide-y rail now does the chrome work that the per-row border used to.
- Categories list (nested-band variant) and Account-detail recent-transactions (SectionCard + flushBody) intentionally not migrated this iteration — they're noted as follow-ups in sprint state. Categories needs more thought before folding the nested mechanic into the primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)