### PR TITLE
design(v2): sweep Categories list + Account recent transactions onto ListCard

### DIFF
--- a/web/src/features/accounts/account-recent-transactions.tsx
+++ b/web/src/features/accounts/account-recent-transactions.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/empty-state";
-import { SectionCard } from "@/components/section-card";
+import { ListCard } from "@/components/list-card";
 import { TransactionPrimary } from "@/components/transaction-primary";
 import { TransactionAmount } from "@/components/transaction-amount";
 import type { Transaction } from "@/api/types";
@@ -15,15 +15,15 @@ interface AccountRecentTransactionsProps {
 // AccountRecentTransactions surfaces the last N transactions inline on the
 // account detail page. Each row links to the transaction detail; the footer
 // jumps to the Transactions table pre-filtered to this account. Uses the
-// shared SectionCard so the card vocabulary matches the rest of the detail
-// page (Settings / Links / Details all bordered-header + flush body).
+// shared ListCard primitive so the bordered-header + divide-y rail vocabulary
+// stays unified across every list surface in the v2 SPA.
 export function AccountRecentTransactions({
   accountShortId,
   transactions,
 }: AccountRecentTransactionsProps) {
   const hasRows = transactions.length > 0;
   return (
-    <SectionCard
+    <ListCard
       title="Recent transactions"
       action={
         hasRows ? (
@@ -32,7 +32,25 @@ export function AccountRecentTransactions({
           </span>
         ) : undefined
       }
-      flushBody
+      rows={transactions}
+      getRowKey={(t) => t.id}
+      renderRow={(t) => (
+        <Link
+          to="/transactions/$id"
+          params={{ id: t.short_id }}
+          className="hover:bg-accent/40 flex items-center gap-3 px-5 py-2.5 transition-colors"
+        >
+          <TransactionPrimary transaction={t} className="flex-1" />
+          <TransactionAmount transaction={t} />
+        </Link>
+      )}
+      empty={
+        <EmptyState
+          title="No transactions yet"
+          description="They appear after the first sync."
+          className="py-10"
+        />
+      }
       footer={
         hasRows ? (
           <Button variant="ghost" size="sm" asChild>
@@ -43,29 +61,6 @@ export function AccountRecentTransactions({
           </Button>
         ) : undefined
       }
-    >
-      {hasRows ? (
-        <ul className="divide-y">
-          {transactions.map((t) => (
-            <li key={t.id}>
-              <Link
-                to="/transactions/$id"
-                params={{ id: t.short_id }}
-                className="hover:bg-accent/40 flex items-center gap-3 px-5 py-2.5 transition-colors"
-              >
-                <TransactionPrimary transaction={t} className="flex-1" />
-                <TransactionAmount transaction={t} />
-              </Link>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <EmptyState
-          title="No transactions yet"
-          description="They appear after the first sync."
-          className="py-10"
-        />
-      )}
-    </SectionCard>
+    />
   );
 }

--- a/web/src/features/categories/category-list.tsx
+++ b/web/src/features/categories/category-list.tsx
@@ -3,7 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { ChevronRight, EyeOff, Lock, Pencil } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { ListCard } from "@/components/list-card";
 import { CategoryIconTile } from "@/components/category-icon-tile";
 import { IdPill } from "@/components/id-pill";
 import { cn } from "@/lib/utils";
@@ -17,13 +17,12 @@ interface CategoryListProps {
   emptyState?: React.ReactNode;
 }
 
-// CategoryList renders the full parent → child tree as one bordered card with
-// `divide-y` rows — matching the Home / Tags / TX-detail "Card gap-0 py-0 +
-// CardHeader border-b + ul divide-y" vocabulary. Each parent row toggles its
-// children inline; the expanded children sit in a tinted band with a 2px
-// left rail tinted by the parent's color, so the nesting is both visible
-// and meaningful (the rail encodes which parent owns the group, not just
-// "these are indented").
+// CategoryList renders the full parent → child tree using the shared
+// `<ListCard>` primitive so the bordered card + divide-y rail comes from one
+// place across the v2 surface. Each parent row toggles its children inline;
+// the expanded children sit in a tinted band with a 2px left rail tinted by
+// the parent's color, so the nesting is both visible and meaningful (the
+// rail encodes which parent owns the group, not just "these are indented").
 export function CategoryList({ tree, query, emptyState }: CategoryListProps) {
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -45,13 +44,13 @@ export function CategoryList({ tree, query, emptyState }: CategoryListProps) {
   if (filtered.length === 0) return emptyState ?? null;
 
   return (
-    <Card className="gap-0 py-0">
-      <ul className="divide-y">
-        {filtered.map((parent) => (
-          <CategoryRow key={parent.id} category={parent} forceOpen={!!query} />
-        ))}
-      </ul>
-    </Card>
+    <ListCard
+      rows={filtered}
+      getRowKey={(parent) => parent.id}
+      renderRow={(parent) => (
+        <CategoryRow category={parent} forceOpen={!!query} />
+      )}
+    />
   );
 }
 
@@ -69,7 +68,7 @@ function CategoryRow({
   const accent = category.color ?? undefined;
 
   return (
-    <li>
+    <>
       <div
         className={cn(
           "group hover:bg-muted/40 flex items-center gap-3 px-4 py-2.5 transition-colors",
@@ -202,6 +201,6 @@ function CategoryRow({
           ))}
         </ul>
       )}
-    </li>
+    </>
   );
 }

--- a/web/src/routes/categories.tsx
+++ b/web/src/routes/categories.tsx
@@ -6,7 +6,7 @@ import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Card } from "@/components/ui/card";
+import { ListCard } from "@/components/list-card";
 import { CategoryList } from "@/features/categories/category-list";
 import { useCategories } from "@/api/queries/categories";
 
@@ -87,20 +87,20 @@ export function CategoriesPage() {
         </div>
 
         {isLoading ? (
-          <Card className="gap-0 py-0">
-            <ul className="divide-y">
-              {Array.from({ length: 6 }).map((_, i) => (
-                <li key={i} className="flex items-center gap-3 px-4 py-3">
-                  <Skeleton className="size-9 rounded-md" />
-                  <div className="flex-1 space-y-1.5">
-                    <Skeleton className="h-3.5 w-40" />
-                    <Skeleton className="h-3 w-24" />
-                  </div>
-                  <Skeleton className="h-5 w-10 rounded-full" />
-                </li>
-              ))}
-            </ul>
-          </Card>
+          <ListCard
+            rows={Array.from({ length: 6 })}
+            getRowKey={(_, i) => i}
+            renderRow={() => (
+              <div className="flex items-center gap-3 px-4 py-3">
+                <Skeleton className="size-9 rounded-md" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton className="h-3.5 w-40" />
+                  <Skeleton className="h-3 w-24" />
+                </div>
+                <Skeleton className="h-5 w-10 rounded-full" />
+              </div>
+            )}
+          />
         ) : isError ? (
           <EmptyState
             icon={Shapes}


### PR DESCRIPTION
## Summary

- Migrate `CategoryList` (parents + nested children band) and the Categories page loading skeleton onto the shared `<ListCard>` primitive.
- Migrate `AccountRecentTransactions` from `SectionCard` + open-coded `<ul divide-y>` onto `<ListCard>` with the same title/action/footer slots and an `empty` slot for the no-transactions EmptyState.
- No visual change — both pages render identical markup. This is a pure structural unification so the list-card vocabulary lives in one place.

## Before / After

The migration is byte-identical at the pixel level (both screenshots produce the same MD5), which is the point — the primitive replaces hand-rolled markup without drift.

<img src="https://i.img402.dev/09s2c716is.jpg" width="800" alt="Categories list rendered through the shared ListCard primitive (visually identical to before)">

## Notes

- ListCard now covers seven surfaces (Home recent activity, Home connections, Account-detail recent transactions, Categories, Connections list, Connections skeleton, Categories skeleton). Pattern is well-validated.
- TX-detail Activity intentionally stays on `SectionCard` — its body is prose (comment composer + timeline), not a list.
- The settings backups list (`features/settings/backups-section.tsx`), the sync history list (`features/connections/sync-history-list.tsx`), and the rules preview panel still use bespoke list markup. They are different shapes (no bordered card wrapper, or non-card containers) — flag for later, don't force them onto ListCard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)