### PR TITLE
design(v2): category detail hero + ColorRailCard primitive

### DIFF
--- a/web/src/components/color-rail-card.tsx
+++ b/web/src/components/color-rail-card.tsx
@@ -1,0 +1,82 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface ColorRailCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * CSS color value for the 4px left rail. Pass a CSS variable
+   * (`"var(--destructive)"`) or a literal (`"#f97316"`). When omitted
+   * the rail collapses to `--muted` so the card still reads as a hero,
+   * but the colour stops carrying meaning.
+   */
+  accent?: string | null;
+  /** Optional class applied to the bordered card wrapper. */
+  cardClassName?: string;
+  /**
+   * Optional footer slot rendered with a top border + tinted muted
+   * background — matches the inline action strip used on the
+   * transaction- and account-detail heroes.
+   */
+  footer?: React.ReactNode;
+  /** Optional class applied to the footer wrapper. */
+  footerClassName?: string;
+  children: React.ReactNode;
+}
+
+// ColorRailCard is the canonical "detail-page hero card" container — a
+// bordered card with a 4px coloured left rail that encodes meaning
+// (category color for transactions, accounting role for accounts,
+// category's own color on the category-detail page). Sibling of
+// `<SectionCard>` and `<ListCard>`; this is the third primitive in the
+// v2 design vocabulary established by iter 5 (TX-detail hero) and iter 6
+// (Account-detail hero, where the iter-5/6 drift note explicitly called
+// for extraction once a third surface adopts it).
+//
+// Visual contract:
+//   `bg-card relative overflow-hidden rounded-xl border`
+//     `<div aria-hidden className="absolute inset-y-0 left-0 w-1" />`  ← rail
+//     children
+//     optional `<div className="border-t bg-muted/20 ...">footer</div>`
+//
+// The colour-rail principle: the rail's tint encodes *meaning* (asset vs
+// liability, this transaction's category, this category's own colour),
+// not decoration. Excluded / muted states collapse to `--muted` so the
+// card reads "shelved" rather than "demands attention". Always pair the
+// rail with a small uppercase eyebrow so colour alone never carries the
+// signal.
+export function ColorRailCard({
+  accent,
+  cardClassName,
+  className,
+  footer,
+  footerClassName,
+  children,
+  ...rest
+}: ColorRailCardProps) {
+  return (
+    <div
+      className={cn(
+        "bg-card relative overflow-hidden rounded-xl border",
+        cardClassName,
+        className,
+      )}
+      {...rest}
+    >
+      <div
+        aria-hidden
+        className="absolute inset-y-0 left-0 w-1"
+        style={{ backgroundColor: accent ?? "var(--muted)" }}
+      />
+      {children}
+      {footer && (
+        <div
+          className={cn(
+            "border-t bg-muted/20 flex flex-wrap items-center justify-end gap-2 px-6 py-2.5 sm:px-7",
+            footerClassName,
+          )}
+        >
+          {footer}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/categories/category-form.tsx
+++ b/web/src/features/categories/category-form.tsx
@@ -125,20 +125,23 @@ export function CategoryForm({ mode, category }: CategoryFormProps) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        <div className="bg-muted/30 flex items-center gap-3 rounded-md border p-3">
-          <CategoryIconTile icon={icon} color={color} size="lg" />
-          <div className="min-w-0">
-            <div className="truncate font-medium">
-              {displayName || "Untitled category"}
-            </div>
-            <div className="text-muted-foreground text-xs">
-              {category?.parent_display_name ??
-                (mode === "create" && parentId
-                  ? "Sub-category"
-                  : "Top-level category")}
+        {/* In create mode the form is the only thing on the page so it
+            needs its own live preview. In edit mode the hero card above
+            already carries the identity preview live (icon + colour are
+            sourced from the same Category), so skip the redundant tile. */}
+        {mode === "create" && (
+          <div className="bg-muted/30 flex items-center gap-3 rounded-md border p-3">
+            <CategoryIconTile icon={icon} color={color} size="lg" />
+            <div className="min-w-0">
+              <div className="truncate font-medium">
+                {displayName || "Untitled category"}
+              </div>
+              <div className="text-muted-foreground text-xs">
+                {parentId ? "Sub-category" : "Top-level category"}
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
         <FormField
           control={form.control}

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { ColorRailCard } from "@/components/color-rail-card";
 import { EmptyState } from "@/components/empty-state";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
@@ -233,16 +234,25 @@ function Hero({
   const directionLabel = liability ? "Balance owed" : "Current balance";
 
   return (
-    <div className="bg-card relative overflow-hidden rounded-xl border">
-      {/* Asset/liability rail anchored to the account's accounting role.
-          Excluded accounts collapse to neutral so the card reads "shelved"
-          rather than "demands attention". */}
-      <div
-        aria-hidden
-        className="absolute inset-y-0 left-0 w-1"
-        style={{ backgroundColor: accent }}
-      />
-
+    <ColorRailCard
+      accent={accent}
+      footer={
+        <>
+          {!a.is_dependent_linked && (
+            <Button variant="ghost" size="sm" onClick={onAddLink} className="h-7 gap-1.5 text-xs">
+              <Link2 className="size-3.5" />
+              Link account
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" asChild className="h-7 gap-1.5 text-xs">
+            <Link to="/transactions" search={{ account: a.short_id }}>
+              <Eye className="size-3.5" />
+              View transactions
+            </Link>
+          </Button>
+        </>
+      }
+    >
       <div className="grid gap-6 px-6 py-6 sm:px-7 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-10">
         {/* Identity column */}
         <div className="min-w-0 space-y-3">
@@ -364,24 +374,7 @@ function Hero({
         </div>
       </div>
 
-      {/* Inline action strip lives inside the hero so primary actions sit
-          adjacent to the identity they act on. Keeps the page from leading
-          with a row of "Link / View" buttons floating above the card. */}
-      <div className="border-t bg-muted/20 flex flex-wrap items-center justify-end gap-2 px-6 py-2.5 sm:px-7">
-        {!a.is_dependent_linked && (
-          <Button variant="ghost" size="sm" onClick={onAddLink} className="h-7 gap-1.5 text-xs">
-            <Link2 className="size-3.5" />
-            Link account
-          </Button>
-        )}
-        <Button variant="ghost" size="sm" asChild className="h-7 gap-1.5 text-xs">
-          <Link to="/transactions" search={{ account: a.short_id }}>
-            <Eye className="size-3.5" />
-            View transactions
-          </Link>
-        </Button>
-      </div>
-    </div>
+    </ColorRailCard>
   );
 }
 

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -1,19 +1,37 @@
 import { useMemo } from "react";
-import { Link, useNavigate, useParams } from "@tanstack/react-router";
-import { ArrowLeft, Shapes } from "lucide-react";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useRouter,
+} from "@tanstack/react-router";
+import {
+  ArrowLeft,
+  ArrowRight,
+  EyeOff,
+  Folder,
+  Hash,
+  Receipt,
+  Shapes,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Badge } from "@/components/ui/badge";
-import { PageHeader } from "@/components/page-header";
-import { EmptyState } from "@/components/empty-state";
+import { CategoryIconTile } from "@/components/category-icon-tile";
+import { ColorRailCard } from "@/components/color-rail-card";
 import { DangerZone } from "@/components/danger-zone";
+import { EmptyState } from "@/components/empty-state";
+import { IdPill } from "@/components/id-pill";
+import { SectionCard } from "@/components/section-card";
 import { CategoryForm } from "@/features/categories/category-form";
 import {
   flattenCategories,
   useCategories,
   useDeleteCategory,
 } from "@/api/queries/categories";
+import { useTransactionCount } from "@/api/queries/transactions";
 import { withMutationToast } from "@/lib/mutation-toast";
+import { cn } from "@/lib/utils";
 import type { Category } from "@/api/types";
 
 export function CategoryDetailPage() {
@@ -28,16 +46,11 @@ export function CategoryDetailPage() {
   );
 
   return (
-    <div className="mx-auto max-w-2xl">
-      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
-        <Link to="/categories">
-          <ArrowLeft className="size-4" />
-          Categories
-        </Link>
-      </Button>
+    <div className="mx-auto max-w-5xl">
+      <BackButton />
 
       {isLoading ? (
-        <Skeleton className="h-96 rounded-xl" />
+        <DetailSkeleton />
       ) : isError || !category ? (
         <EmptyState
           icon={Shapes}
@@ -50,33 +63,373 @@ export function CategoryDetailPage() {
           }
         />
       ) : (
-        <DetailBody category={category} />
+        <DetailBody category={category} tree={tree ?? []} />
       )}
     </div>
   );
 }
 
-function DetailBody({ category }: { category: Category }) {
+// BackButton mirrors the TX-detail / Account-detail muscle memory: real
+// link to /categories so middle-click works, but a normal left-click
+// prefers `router.history.back()` to land on the exact list state the
+// user came from (filter + expanded parents).
+function BackButton() {
+  const router = useRouter();
   return (
-    <>
-      <PageHeader
-        title={category.display_name}
-        description={
-          category.parent_display_name
-            ? `Sub-category of ${category.parent_display_name}.`
-            : "Top-level category."
-        }
-        actions={
-          category.is_system ? (
-            <Badge variant="outline" className="gap-1">System</Badge>
-          ) : undefined
-        }
-      />
+    <Button
+      variant="ghost"
+      size="sm"
+      asChild
+      className="text-muted-foreground hover:text-foreground mb-3 -ml-2 h-7 px-2 text-xs"
+    >
+      <Link
+        to="/categories"
+        onClick={(e) => {
+          if (
+            !e.defaultPrevented &&
+            !e.metaKey &&
+            !e.ctrlKey &&
+            !e.shiftKey &&
+            !e.altKey &&
+            e.button === 0 &&
+            window.history.length > 1
+          ) {
+            e.preventDefault();
+            router.history.back();
+          }
+        }}
+      >
+        <ArrowLeft className="size-3.5" />
+        Back to categories
+      </Link>
+    </Button>
+  );
+}
 
-      <CategoryForm mode="edit" category={category} />
+function DetailBody({ category, tree }: { category: Category; tree: Category[] }) {
+  // Find the parent (for sub-categories) so the Jump-to strip can offer
+  // a one-click hop to the parent category's detail page.
+  const parent = useMemo(
+    () =>
+      category.parent_id
+        ? flattenCategories(tree).find((c) => c.id === category.parent_id)
+        : undefined,
+    [tree, category.parent_id],
+  );
 
-      {!category.is_system && <DeleteCategory category={category} />}
-    </>
+  // Sibling sub-categories (only meaningful for parent categories that
+  // actually have children — their colour is shared with the children
+  // they own).
+  const visibleChildren = useMemo(
+    () => (category.children ?? []).filter((c) => !c.hidden),
+    [category.children],
+  );
+
+  return (
+    <div className="space-y-6">
+      <Hero category={category} childCount={visibleChildren.length} />
+
+      <QuickActions category={category} parent={parent} />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div className="min-w-0 space-y-6">
+          <SectionCard
+            title="Appearance & metadata"
+            bodyClassName="px-5 py-5"
+          >
+            <CategoryForm mode="edit" category={category} />
+          </SectionCard>
+
+          {!category.is_system && (
+            <SectionCard title="Danger zone" bodyClassName="px-5 py-5">
+              <DeleteCategory category={category} />
+            </SectionCard>
+          )}
+        </div>
+
+        <aside className="space-y-6">
+          {visibleChildren.length > 0 && (
+            <ChildrenCard parent={category} children_={visibleChildren} />
+          )}
+          <DetailsCard category={category} parent={parent} />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+// Hero condenses identity + classification + scope into one composed card
+// — paralleling the iter-5 TX-detail and iter-6 Account-detail heroes.
+// The left rail tint is the category's own colour, so the card reads as
+// "this is what that colour means across the app" — a single source of
+// truth for the palette token used in transaction rows, picker chips,
+// and the categories-list nested band.
+function Hero({
+  category,
+  childCount,
+}: {
+  category: Category;
+  childCount: number;
+}) {
+  const txQuery = useTransactionCount({ category: category.slug });
+  const accent = category.color ?? null;
+  const eyebrow = category.parent_display_name ? "Sub-category" : "Category";
+
+  return (
+    <ColorRailCard accent={accent}>
+      <div className="grid gap-6 px-6 py-6 sm:px-7 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-10">
+        {/* Identity column */}
+        <div className="min-w-0 space-y-3">
+          <div className="flex items-start gap-4">
+            <CategoryIconTile
+              icon={category.icon}
+              color={category.color}
+              size="lg"
+            />
+            <div className="min-w-0 space-y-1">
+              <p className="text-muted-foreground text-[10px] font-medium tracking-[0.12em] uppercase">
+                {eyebrow}
+              </p>
+              <div className="flex flex-wrap items-center gap-2">
+                <h1 className="truncate text-xl font-semibold tracking-tight">
+                  {category.display_name}
+                </h1>
+                {category.is_system && (
+                  <Badge variant="outline" className="text-[10px]">
+                    System
+                  </Badge>
+                )}
+                {category.hidden && (
+                  <Badge variant="outline" className="gap-1 text-[10px]">
+                    <EyeOff className="size-2.5" /> Hidden
+                  </Badge>
+                )}
+              </div>
+              <p className="text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">
+                {category.parent_display_name ? (
+                  <>
+                    <span className="inline-flex items-center gap-1">
+                      <Folder className="size-3 opacity-60" />
+                      Under {category.parent_display_name}
+                    </span>
+                    <span aria-hidden className="opacity-50">·</span>
+                  </>
+                ) : childCount > 0 ? (
+                  <>
+                    <span>
+                      {childCount} sub-categor{childCount === 1 ? "y" : "ies"}
+                    </span>
+                    <span aria-hidden className="opacity-50">·</span>
+                  </>
+                ) : null}
+                <span className="inline-flex items-center gap-1">
+                  <Hash className="size-3 opacity-60" />
+                  <span className="font-mono">{category.slug}</span>
+                </span>
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Scope / scoreboard column. The TX detail page uses this slot for
+            the transaction amount; the Account detail page uses it for the
+            balance. The category equivalent is the count of transactions
+            currently classified into this group — the headline metric for
+            "is this category pulling its weight?". */}
+        <div className="flex flex-col items-start gap-1.5 lg:items-end lg:text-right">
+          <div
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase whitespace-nowrap",
+              "bg-muted text-muted-foreground",
+            )}
+            style={
+              accent
+                ? { backgroundColor: `${accent}1a`, color: accent }
+                : undefined
+            }
+          >
+            <Receipt className="size-3" aria-hidden />
+            Transactions
+          </div>
+          <div className="font-semibold tabular-nums text-3xl sm:text-4xl">
+            {txQuery.isLoading ? (
+              <Skeleton className="h-9 w-20 inline-block align-middle" />
+            ) : txQuery.data ? (
+              txQuery.data.count.toLocaleString()
+            ) : (
+              "—"
+            )}
+          </div>
+          <p className="text-muted-foreground pt-1 text-[11px]">
+            {category.parent_display_name
+              ? "Tagged with this sub-category"
+              : childCount > 0
+                ? "Across this group and its sub-categories"
+                : "Tagged with this category"}
+          </p>
+        </div>
+      </div>
+    </ColorRailCard>
+  );
+}
+
+function QuickActions({
+  category,
+  parent,
+}: {
+  category: Category;
+  parent: Category | undefined;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="text-muted-foreground mr-1 text-[10px] font-medium tracking-[0.1em] uppercase">
+        Jump to
+      </span>
+      <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" asChild>
+        <Link to="/transactions" search={{ category: category.slug }}>
+          <Receipt className="size-3" />
+          Transactions in {category.display_name}
+        </Link>
+      </Button>
+      {parent && (
+        <Button variant="outline" size="sm" className="h-7 gap-1.5 text-xs" asChild>
+          <Link
+            to="/categories/$id"
+            params={{ id: parent.short_id }}
+          >
+            <Folder className="size-3" />
+            {parent.display_name}
+          </Link>
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function ChildrenCard({
+  parent,
+  children_,
+}: {
+  parent: Category;
+  children_: Category[];
+}) {
+  return (
+    <SectionCard
+      title="Sub-categories"
+      action={
+        <Badge variant="secondary" className="text-[10px]">
+          {children_.length}
+        </Badge>
+      }
+      bodyClassName="px-0 py-0"
+      flushBody
+    >
+      <ul className="divide-y">
+        {children_.map((child) => (
+          <li key={child.id}>
+            <Link
+              to="/categories/$id"
+              params={{ id: child.short_id }}
+              className="hover:bg-muted/40 flex items-center gap-3 px-5 py-2.5 text-sm transition-colors"
+            >
+              <CategoryIconTile
+                icon={child.icon ?? parent.icon}
+                color={child.color ?? parent.color}
+                size="sm"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="truncate font-medium">{child.display_name}</div>
+                <div className="text-muted-foreground truncate text-[11px] font-mono">
+                  {child.slug}
+                </div>
+              </div>
+              <ArrowRight className="text-muted-foreground/60 size-3.5" />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </SectionCard>
+  );
+}
+
+function DetailsCard({
+  category,
+  parent,
+}: {
+  category: Category;
+  parent: Category | undefined;
+}) {
+  const identityRows: DetailRowData[] = compactRows([
+    { label: "Slug", value: category.slug, mono: true },
+    { label: "Sort order", value: String(category.sort_order) },
+    parent ? { label: "Parent", value: parent.display_name } : null,
+  ]);
+
+  const stateRows: DetailRowData[] = compactRows([
+    { label: "System", value: category.is_system ? "Yes" : "No" },
+    { label: "Hidden", value: category.hidden ? "Yes" : "No" },
+  ]);
+
+  const referenceRows: DetailRowData[] = compactRows([
+    { label: "ID", value: category.short_id, mono: true },
+    category.created_at
+      ? {
+          label: "Created",
+          value: new Date(category.created_at).toLocaleDateString(),
+        }
+      : null,
+  ]);
+
+  return (
+    <SectionCard title="Details" bodyClassName="space-y-5 px-5 py-5 text-sm">
+      {identityRows.length > 0 && (
+        <DetailGroup label="Identity" rows={identityRows} />
+      )}
+      {stateRows.length > 0 && (
+        <DetailGroup label="State" rows={stateRows} />
+      )}
+      {referenceRows.length > 0 && (
+        <DetailGroup label="Reference" rows={referenceRows} />
+      )}
+    </SectionCard>
+  );
+}
+
+interface DetailRowData {
+  label: string;
+  value: string | null | undefined;
+  mono?: boolean;
+}
+
+function compactRows(
+  rows: (DetailRowData | null | undefined | false)[],
+): DetailRowData[] {
+  return rows.filter((r): r is DetailRowData => !!r && !!r.value);
+}
+
+function DetailGroup({ label, rows }: { label: string; rows: DetailRowData[] }) {
+  if (rows.length === 0) return null;
+  return (
+    <div className="space-y-2.5">
+      <h3 className="text-muted-foreground text-[10px] font-medium tracking-[0.1em] uppercase">
+        {label}
+      </h3>
+      <dl className="space-y-2">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className="flex items-baseline justify-between gap-3"
+          >
+            <dt className="text-muted-foreground shrink-0 text-xs">
+              {row.label}
+            </dt>
+            <dd className="min-w-0 truncate text-right text-xs">
+              {row.mono ? <IdPill value={row.value as string} /> : row.value}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
   );
 }
 
@@ -112,5 +465,43 @@ function DeleteCategory({ category }: { category: Category }) {
         if (ok) navigate({ to: "/categories" });
       }}
     />
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="bg-card relative overflow-hidden rounded-xl border">
+        <div className="bg-muted absolute inset-y-0 left-0 w-1" />
+        <div className="grid gap-6 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_auto]">
+          <div className="space-y-3">
+            <div className="flex items-start gap-4">
+              <Skeleton className="size-12 rounded-lg" />
+              <div className="space-y-2 py-1">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-3 w-48" />
+              </div>
+            </div>
+          </div>
+          <div className="space-y-2 lg:items-end">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-9 w-32" />
+            <Skeleton className="h-3 w-28" />
+          </div>
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <Skeleton className="h-7 w-48 rounded-md" />
+        <Skeleton className="h-7 w-32 rounded-md" />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <Skeleton className="h-96 rounded-xl" />
+        <div className="space-y-6">
+          <Skeleton className="h-48 rounded-xl" />
+          <Skeleton className="h-64 rounded-xl" />
+        </div>
+      </div>
+    </div>
   );
 }

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -14,6 +14,7 @@ import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/empty-state";
 import { CategoryIconTile } from "@/components/category-icon-tile";
+import { ColorRailCard } from "@/components/color-rail-card";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
 import { CategoryEditor } from "@/features/transactions/category-editor";
@@ -133,20 +134,10 @@ function Hero({ transaction: t }: { transaction: Transaction }) {
   const accent = t.category?.color ?? null;
 
   return (
-    <div
-      className={cn(
-        "bg-card relative overflow-hidden rounded-xl border",
-        t.pending && "border-dashed",
-      )}
+    <ColorRailCard
+      accent={accent}
+      cardClassName={cn(t.pending && "border-dashed")}
     >
-      {/* Color rail anchored to the category. Stays neutral when uncategorised
-          so the card reads "needs attention" rather than "decorative". */}
-      <div
-        aria-hidden
-        className="absolute inset-y-0 left-0 w-1"
-        style={{ backgroundColor: accent ?? "var(--muted)" }}
-      />
-
       <div className="grid gap-6 px-6 py-6 sm:px-7 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-start lg:gap-10">
         {/* Identity column */}
         <div className="min-w-0 space-y-5">
@@ -248,7 +239,7 @@ function Hero({ transaction: t }: { transaction: Transaction }) {
           )}
         </div>
       </div>
-    </div>
+    </ColorRailCard>
   );
 }
 


### PR DESCRIPTION
## Summary

- Promote `<ColorRailCard>` to `web/src/components/color-rail-card.tsx` — the bordered-card-with-coloured-left-rail pattern open-coded in iter 5 (TX detail) and iter 6 (Account detail). The iter 5/6 drift note explicitly called for extraction once a third detail page adopts the look. Category detail is that surface.
- Refactor TX-detail hero and Account-detail hero onto the new primitive. Account-detail uses the `footer` slot for the inline Link / View action strip.
- Rebuild the Category-detail page around the new hero: icon tile + eyebrow ("Category" / "Sub-category") + display name + parent breadcrumb + slug, paired with a "Transactions" scoreboard on the right (count via `useTransactionCount`). Add a Jump-to pill strip below, then a two-column body — form in `SectionCard` + DangerZone in `SectionCard` on the left, sub-categories `ListCard` + Details `SectionCard` on the right.
- Drop the redundant preview tile from `CategoryForm` in edit mode (the hero already shows live identity); create mode keeps it so the form can stand alone.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/bc3eh9um91.jpg) | ![after](https://i.img402.dev/ybsnlqljbm.jpg) |

## Notes

- **New primitive — `<ColorRailCard>`.** Sibling of `<SectionCard>` and `<ListCard>`. Three surfaces now share it (TX, account, category). `accent` prop accepts a CSS variable or literal colour; collapses to `--muted` when null so the rail still anchors the card without claiming meaning. Optional `footer` slot ships pre-styled with a top border + `bg-muted/20` so the action-strip lives inside the hero (no floating "Link / View" buttons above the card).
- **Category hero scoreboard.** The TX hero uses the right column for amount, the account hero for balance, the category hero for "Transactions tagged with this category" (parents include sub-categories per the slug filter behaviour). Same shape across three surfaces, different metric per entity. Tint of the eyebrow pill picks up the category colour so the right column also lands in the palette.
- **Sub-categories panel** on the right column is a `<ListCard>` of children — same primitive established in iter 8, picks up the parent's colour for child icons when the child has no own colour (mirrors the iter-7 nested-band behaviour on the categories list).
- **CategoryForm preview tile** now only renders in `create` mode. In `edit` mode the hero card already shows the live identity (same icon, same colour, same name), so the inline tile was duplicative.
- **Followups (queued in sprint state):**
  - Category-new could now mount the same hero shell with placeholder text so the create flow lands with the same vocabulary instead of dropping straight into a form.
  - `<ColorRailCard>` could grow a `scoreboard` slot prop if a fourth surface wants the identity + amount split — for now the layout is open-coded inside each consumer because the right column shape varies (amount vs balance vs count).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
