### PR TITLE
design(v2): accounts list — ListCard per group with net subtotal

### DIFF
--- a/web/src/features/accounts/account-row.tsx
+++ b/web/src/features/accounts/account-row.tsx
@@ -13,19 +13,20 @@ import {
   utilizationBarClass,
 } from "./account-utils";
 
-interface AccountCardProps {
+interface AccountRowProps {
   account: Account;
-  className?: string;
 }
 
-// AccountCard is the list-row shown on the Accounts page and on the
-// connection-detail accounts grid. Click anywhere to open the account
-// detail page. Keeps the visual rhythm tight: a 9×9 type-tile, the label,
-// a metadata subline (type · mask), and the current balance to the right.
-// Credit cards render their utilization bar below; non-active connections
-// show an inline status pill so problem accounts stand out without an
-// extra trip to /connections.
-export function AccountCard({ account: a, className }: AccountCardProps) {
+// AccountRow is the in-card row used by the Accounts list — each
+// institution / type group is a `ListCard` and each row inside is one of
+// these. No self-border (the parent ListCard owns the bordered card +
+// divide-y rail); padding + hover match the established `px-5 py-3.5`
+// density shared by ConnectionRow / TransactionPrimary.
+//
+// The connection-detail accounts grid uses its own local `AccountCard`
+// (defined inline in `features/connections/connection-accounts-list.tsx`)
+// because that surface is a two-column bordered grid, not a divide-y list.
+export function AccountRow({ account: a }: AccountRowProps) {
   const Icon = accountTypeIcon(a.type);
   const liability = isLiability(a.type);
   const util = creditUtilization(a);
@@ -34,13 +35,10 @@ export function AccountCard({ account: a, className }: AccountCardProps) {
     <Link
       to="/accounts/$id"
       params={{ id: a.short_id }}
-      className={cn(
-        "bg-card hover:bg-accent/40 group flex items-center gap-3 rounded-lg border p-3 transition-colors",
-        className,
-      )}
+      className="hover:bg-muted/40 group flex items-center gap-3 px-5 py-3.5 transition-colors sm:gap-4"
     >
-      <div className="bg-muted flex size-10 shrink-0 items-center justify-center rounded-lg">
-        <Icon className="text-muted-foreground size-4" />
+      <div className="bg-muted text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-lg">
+        <Icon className="size-4" />
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
@@ -60,15 +58,9 @@ export function AccountCard({ account: a, className }: AccountCardProps) {
               <span className="tabular-nums">····{a.mask}</span>
             </>
           )}
-          {a.institution_name && (
-            <>
-              <span className="text-muted-foreground/40">·</span>
-              <span className="truncate">{a.institution_name}</span>
-            </>
-          )}
         </div>
         {util != null && (
-          <div className="mt-2">
+          <div className="mt-2 max-w-xs">
             <div className="text-muted-foreground mb-1 flex items-center justify-between text-[10px] tabular-nums">
               <span>{Math.round(util)}% used</span>
               {a.balance_limit != null && (

--- a/web/src/features/accounts/account-utils.ts
+++ b/web/src/features/accounts/account-utils.ts
@@ -132,6 +132,53 @@ export interface AccountGroup {
   accounts: Account[];
 }
 
+// groupNetTotal returns the signed net balance for a group of accounts in
+// the group's dominant currency. Liabilities flip sign so the total reads
+// as "what this slice contributes to net worth." Mixed-currency groups
+// fall back to the most-populated currency; the count of accounts excluded
+// from the total (because they're in a different currency or have no
+// balance) is returned alongside so the header can hint at it.
+export interface GroupTotal {
+  currency: string | null;
+  total: number;
+  excluded: number;
+}
+
+export function groupNetTotal(accounts: Account[]): GroupTotal {
+  // Pick the most-populated currency in the group as the display currency.
+  const counts = new Map<string, number>();
+  for (const a of accounts) {
+    if (!a.iso_currency_code) continue;
+    counts.set(a.iso_currency_code, (counts.get(a.iso_currency_code) ?? 0) + 1);
+  }
+  let primary: string | null = null;
+  let max = 0;
+  for (const [k, v] of counts) {
+    if (v > max) {
+      max = v;
+      primary = k;
+    }
+  }
+  if (primary == null) {
+    return { currency: null, total: 0, excluded: accounts.length };
+  }
+  let total = 0;
+  let excluded = 0;
+  for (const a of accounts) {
+    if (a.is_dependent_linked) continue;
+    if (a.balance_current == null) {
+      excluded += 1;
+      continue;
+    }
+    if (a.iso_currency_code !== primary) {
+      excluded += 1;
+      continue;
+    }
+    total += isLiability(a.type) ? -a.balance_current : a.balance_current;
+  }
+  return { currency: primary, total, excluded };
+}
+
 export function groupAccounts(
   accounts: Account[],
   by: AccountGroupBy,

--- a/web/src/routes/accounts.tsx
+++ b/web/src/routes/accounts.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from "react";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
-import { Banknote, Building2, Layers, Loader2, Plus } from "lucide-react";
+import { Banknote, Building2, Layers, Plus } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
+import { ListCard } from "@/components/list-card";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   ToggleGroup,
@@ -13,10 +15,12 @@ import {
 import { useAccounts } from "@/api/queries/accounts";
 import { useUsers } from "@/api/queries/users";
 import { FamilyTabs } from "@/features/connections/family-tabs";
-import { AccountCard } from "@/features/accounts/account-card";
+import { AccountRow } from "@/features/accounts/account-row";
 import { AccountsSummary } from "@/features/accounts/accounts-summary";
 import {
+  formatCurrency,
   groupAccounts,
+  groupNetTotal,
   type AccountGroupBy,
 } from "@/features/accounts/account-utils";
 
@@ -102,9 +106,23 @@ export function AccountsPage() {
   const accounts = accountsQuery.data ?? [];
   const totalCount = accounts.length;
 
+  // Eyebrow matches the vocabulary of the other v2 list pages (Connections,
+  // Tags, Categories, Transactions): one short string per state, "Showing N
+  // of M" only when filtering narrows the view.
+  const eyebrow = isLoading
+    ? "Loading"
+    : isError
+      ? "Error loading"
+      : totalCount === 0
+        ? "No accounts yet"
+        : visible.length === totalCount
+          ? `${totalCount} ${totalCount === 1 ? "account" : "accounts"}`
+          : `Showing ${visible.length} of ${totalCount}`;
+
   return (
-    <>
+    <div className="flex flex-col gap-5">
       <PageHeader
+        eyebrow={eyebrow}
         title="Accounts"
         description="Every bank account, credit card, loan, and investment Breadbox has synced. Click an account to edit, exclude, or link it."
         actions={
@@ -119,26 +137,20 @@ export function AccountsPage() {
         }
       />
 
-      {accounts.length > 0 && (
-        <div className="-mt-4 mb-4">
-          <AccountsSummary accounts={visible} />
-        </div>
+      {accounts.length > 0 && <AccountsSummary accounts={visible} />}
+
+      {(usersQuery.data?.length ?? 0) > 1 && (
+        <FamilyTabs
+          users={usersQuery.data ?? []}
+          value={userFilter}
+          onChange={setUserFilter}
+          counts={countsByUserShortId}
+          totalCount={totalCount}
+        />
       )}
 
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-        {(usersQuery.data?.length ?? 0) > 1 ? (
-          <FamilyTabs
-            users={usersQuery.data ?? []}
-            value={userFilter}
-            onChange={setUserFilter}
-            counts={countsByUserShortId}
-            totalCount={totalCount}
-          />
-        ) : (
-          <div />
-        )}
-
-        {accounts.length > 0 && (
+      {accounts.length > 0 && (
+        <div className="flex items-center justify-end">
           <ToggleGroup
             type="single"
             size="sm"
@@ -153,13 +165,27 @@ export function AccountsPage() {
               <Layers className="size-3.5" /> Type
             </ToggleGroupItem>
           </ToggleGroup>
-        )}
-      </div>
+        </div>
+      )}
 
       {isLoading ? (
-        <div className="text-muted-foreground flex items-center justify-center gap-2 py-12 text-sm">
-          <Loader2 className="size-4 animate-spin" /> Loading accounts…
-        </div>
+        <ListCard
+          rows={[0, 1, 2, 3]}
+          getRowKey={(i) => i}
+          renderRow={(i) => (
+            <div className="flex items-center gap-4 px-5 py-3.5" key={i}>
+              <Skeleton className="size-10 rounded-lg" />
+              <div className="flex-1 space-y-1.5">
+                <Skeleton className="h-3.5 w-40" />
+                <Skeleton className="h-3 w-56" />
+              </div>
+              <div className="space-y-1.5 text-right">
+                <Skeleton className="ml-auto h-3.5 w-20" />
+                <Skeleton className="ml-auto h-3 w-8" />
+              </div>
+            </div>
+          )}
+        />
       ) : isError ? (
         <Alert variant="destructive">
           <AlertTitle>Couldn't load accounts</AlertTitle>
@@ -189,26 +215,33 @@ export function AccountsPage() {
           description="Switch family member or clear the filter to see other accounts."
         />
       ) : (
-        <div className="space-y-6">
-          {groups.map((g) => (
-            <section key={g.key} className="space-y-2">
-              <div className="flex items-baseline justify-between">
-                <h2 className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-                  {g.label}
-                </h2>
-                <span className="text-muted-foreground text-xs tabular-nums">
-                  {g.accounts.length}
-                </span>
-              </div>
-              <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
-                {g.accounts.map((a) => (
-                  <AccountCard key={a.id} account={a} />
-                ))}
-              </div>
-            </section>
-          ))}
+        <div className="flex flex-col gap-4">
+          {groups.map((g) => {
+            const totals = groupNetTotal(g.accounts);
+            return (
+              <ListCard
+                key={g.key}
+                title={g.label}
+                rows={g.accounts}
+                getRowKey={(a) => a.id}
+                renderRow={(a) => <AccountRow account={a} />}
+                action={
+                  <div className="flex items-center gap-3">
+                    {totals.currency != null && (
+                      <span className="text-sm font-medium tabular-nums whitespace-nowrap">
+                        {formatCurrency(totals.total, totals.currency)}
+                      </span>
+                    )}
+                    <span className="bg-muted text-muted-foreground inline-flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[11px] font-medium tabular-nums">
+                      {g.accounts.length}
+                    </span>
+                  </div>
+                }
+              />
+            );
+          })}
         </div>
       )}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Migrates the **Accounts list** from a 2-col bare-bordered-`AccountCard` grid to one `ListCard` per institution / type group, unifying the page with the v2 vocabulary already in use by Connections, Categories, Tags, and Home.
- Each group header now carries the institution / type name, the **signed net subtotal** in the dominant currency (liabilities flipped, so it reads as contribution-to-net-worth), and a pill count — the page reads as a scoreboard-of-groups instead of a soup of equal cards.
- PageHeader picks up the standard `eyebrow` (`N accounts` / `Showing N of M`); loading state migrates to a `ListCard` skeleton matching Connections.

## Before / After

| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/t0njyrrzf0.jpg) | ![after](https://i.img402.dev/5xyzzkueoh.jpg) |

## Notes

- New `AccountRow` ships in `features/accounts/`. The old `account-card.tsx` (unused after the migration — `connection-detail` defines its own local `AccountCard` inline) is removed.
- New `groupNetTotal` helper in `account-utils.ts` signs liabilities the same way the page-level `AccountsSummary` does, so subtotals tell the same story.
- Eighth surface to share `ListCard` — primitive holds steady, no fork needed.
- Toggle group (Institution / Type) parked to its own row aligned right, so the FamilyTabs sit alone on their own line and don't compete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)