### PR TITLE
design(v2): polish API keys family + extract SoftBackButton primitive

### DIFF
--- a/web/src/components/soft-back-button.tsx
+++ b/web/src/components/soft-back-button.tsx
@@ -1,0 +1,67 @@
+import { Link, useRouter, type LinkProps } from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface SoftBackButtonProps {
+  // The canonical list URL this page belongs under. Acts as both the visible
+  // `<a href>` (so middle-click / cmd-click / "open in new tab" all work) and
+  // the fallback navigation target when there is no in-app history.
+  to: LinkProps["to"];
+  // Visible label — e.g. "Back to transactions". Render it as a short,
+  // verb-led phrase: "Back to <plural-noun>".
+  children: React.ReactNode;
+  className?: string;
+}
+
+// SoftBackButton renders a small ghost back-link that prefers the in-app
+// history stack on a plain left-click — landing the user on the exact list
+// state they came from (filters, scroll, focus) — and falls through to a
+// real navigation when the history is empty or the user is opening in a
+// new context. Shared across every detail / form page that hangs off a list
+// (TX detail, Account detail, Connection detail, Category detail, API-key
+// new — promoted to a primitive in the iter-13 api-keys pass).
+//
+// Visual contract:
+//   `<Button variant="ghost" size="sm" className="-ml-2 mb-3 h-7 px-2 text-xs">`
+//
+// Don't fork the look — change this primitive instead.
+export function SoftBackButton({
+  to,
+  children,
+  className,
+}: SoftBackButtonProps) {
+  const router = useRouter();
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      asChild
+      className={cn(
+        "text-muted-foreground hover:text-foreground mb-3 -ml-2 h-7 px-2 text-xs",
+        className,
+      )}
+    >
+      <Link
+        to={to}
+        onClick={(e) => {
+          if (
+            !e.defaultPrevented &&
+            !e.metaKey &&
+            !e.ctrlKey &&
+            !e.shiftKey &&
+            !e.altKey &&
+            e.button === 0 &&
+            window.history.length > 1
+          ) {
+            e.preventDefault();
+            router.history.back();
+          }
+        }}
+      >
+        <ArrowLeft className="size-3.5" />
+        {children}
+      </Link>
+    </Button>
+  );
+}

--- a/web/src/features/api-keys/api-key-form.tsx
+++ b/web/src/features/api-keys/api-key-form.tsx
@@ -245,18 +245,19 @@ export function APIKeyForm() {
           )}
         />
 
-        <div className="flex gap-2 border-t pt-6">
-          <Button type="submit" disabled={create.isPending}>
-            {create.isPending && <Loader2 className="size-4 animate-spin" />}
-            {create.isPending ? "Creating…" : "Create key"}
-          </Button>
+        <div className="bg-muted/20 -mx-5 -mb-5 mt-2 flex items-center justify-end gap-2 border-t px-5 py-3">
           <Button
             type="button"
             variant="ghost"
+            size="sm"
             onClick={() => navigate({ to: "/api-keys" })}
             disabled={create.isPending}
           >
             Cancel
+          </Button>
+          <Button type="submit" size="sm" disabled={create.isPending}>
+            {create.isPending && <Loader2 className="size-4 animate-spin" />}
+            {create.isPending ? "Creating…" : "Create key"}
           </Button>
         </div>
       </form>

--- a/web/src/features/api-keys/api-keys-table.tsx
+++ b/web/src/features/api-keys/api-keys-table.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { DataTable } from "@/components/data-table";
+import { IdPill } from "@/components/id-pill";
 import { formatLongDate, formatRelativeTime } from "@/lib/format";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useRevokeAPIKey } from "@/api/queries/api-keys";
@@ -53,12 +54,14 @@ export function APIKeysTable({
       {
         id: "name",
         header: "Name",
+        meta: { className: "w-[32%]" },
         cell: ({ row }) => (
-          <div className="flex flex-col gap-0.5">
+          <div className="flex flex-col gap-1">
             <span className="font-medium">{row.original.name}</span>
-            <code className="text-muted-foreground text-xs font-mono">
-              {row.original.key_prefix}…
-            </code>
+            <IdPill
+              value={`${row.original.key_prefix}…`}
+              className="text-muted-foreground self-start"
+            />
           </div>
         ),
       },
@@ -176,6 +179,8 @@ export function APIKeysTable({
         isError={isError}
         getRowId={(k) => k.id}
         emptyState={emptyState}
+        stickyHeader
+        refinedHeader
       />
 
       <Dialog

--- a/web/src/routes/account-detail.tsx
+++ b/web/src/routes/account-detail.tsx
@@ -3,13 +3,11 @@ import {
   Link,
   useNavigate,
   useParams,
-  useRouter,
   useSearch,
 } from "@tanstack/react-router";
 import { z } from "zod";
 import {
   AlertTriangle,
-  ArrowLeft,
   ArrowRight,
   Banknote,
   Eye,
@@ -26,6 +24,7 @@ import { ColorRailCard } from "@/components/color-rail-card";
 import { EmptyState } from "@/components/empty-state";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { useAccount, useAccounts } from "@/api/queries/accounts";
 import type { AccountDetail } from "@/api/types";
 import {
@@ -83,7 +82,7 @@ export function AccountDetailPage() {
 
   return (
     <div className="mx-auto max-w-5xl">
-      <BackButton />
+      <SoftBackButton to="/accounts">Back to accounts</SoftBackButton>
 
       {acctQuery.isLoading ? (
         <DetailSkeleton />
@@ -117,44 +116,6 @@ export function AccountDetailPage() {
         />
       )}
     </div>
-  );
-}
-
-// BackButton renders as a real link to /accounts (so middle-click and
-// "open in new tab" still work), but on a normal left-click it prefers
-// `router.history.back()` — that lands the user on the exact list state
-// they came from (filters, family tab, group-by). Mirrors the TX-detail
-// back button so the muscle memory matches.
-function BackButton() {
-  const router = useRouter();
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      asChild
-      className="text-muted-foreground hover:text-foreground mb-3 -ml-2 h-7 px-2 text-xs"
-    >
-      <Link
-        to="/accounts"
-        onClick={(e) => {
-          if (
-            !e.defaultPrevented &&
-            !e.metaKey &&
-            !e.ctrlKey &&
-            !e.shiftKey &&
-            !e.altKey &&
-            e.button === 0 &&
-            window.history.length > 1
-          ) {
-            e.preventDefault();
-            router.history.back();
-          }
-        }}
-      >
-        <ArrowLeft className="size-3.5" />
-        Back to accounts
-      </Link>
-    </Button>
   );
 }
 

--- a/web/src/routes/api-key-created.tsx
+++ b/web/src/routes/api-key-created.tsx
@@ -5,18 +5,13 @@ import { toast } from "sonner";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
   Alert,
   AlertDescription,
   AlertTitle,
 } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
+import { IdPill } from "@/components/id-pill";
+import { SectionCard } from "@/components/section-card";
 import {
   clearPendingPlaintextKey,
   readPendingPlaintextKey,
@@ -76,26 +71,16 @@ export function APIKeyCreatedPage() {
   return (
     <div className="mx-auto max-w-2xl">
       <PageHeader
-        title="Key created"
-        description="Copy the plaintext now — it isn't shown again."
+        eyebrow="Key created"
+        title={pending.name}
+        description="Copy the plaintext now — Breadbox only stores a SHA-256 hash, so this is the one and only time it appears."
       />
 
-      <Card className="overflow-hidden">
-        <CardHeader>
-          <div className="flex items-center gap-3">
-            <div className="bg-primary/10 text-primary flex size-9 items-center justify-center rounded-lg">
-              <KeyRound className="size-4" />
-            </div>
-            <div>
-              <CardTitle className="text-base">{pending.name}</CardTitle>
-              <CardDescription>
-                Stash this in your password manager before leaving the page.
-              </CardDescription>
-            </div>
-          </div>
-        </CardHeader>
-
-        <CardContent className="space-y-5">
+      <SectionCard
+        icon={<KeyRound className="text-muted-foreground size-4" />}
+        title="Plaintext key"
+      >
+        <div className="space-y-5">
           <div className="space-y-1.5">
             <label
               htmlFor="api-key-plaintext"
@@ -126,15 +111,8 @@ export function APIKeyCreatedPage() {
               </Button>
             </div>
             <p className="text-muted-foreground text-xs">
-              Send it as the{" "}
-              <code className="bg-muted text-foreground rounded px-1.5 py-0.5 font-mono text-[11px]">
-                X-API-Key
-              </code>{" "}
-              header on every request to{" "}
-              <code className="bg-muted text-foreground rounded px-1.5 py-0.5 font-mono text-[11px]">
-                /api/v1/*
-              </code>
-              .
+              Send it as the <IdPill value="X-API-Key" /> header on every
+              request to <IdPill value="/api/v1/*" />.
             </p>
           </div>
 
@@ -146,14 +124,16 @@ export function APIKeyCreatedPage() {
               plaintext you'll need to revoke and mint a new one.
             </AlertDescription>
           </Alert>
-        </CardContent>
-      </Card>
+        </div>
+      </SectionCard>
 
       <div className="mt-6 flex items-center justify-between gap-2">
-        <Button variant="ghost" asChild>
+        <Button variant="ghost" size="sm" asChild>
           <Link to="/api-keys/new">Mint another</Link>
         </Button>
-        <Button onClick={onDone}>I've saved it — done</Button>
+        <Button size="sm" onClick={onDone}>
+          I've saved it — done
+        </Button>
       </div>
     </div>
   );

--- a/web/src/routes/api-key-new.tsx
+++ b/web/src/routes/api-key-new.tsx
@@ -1,23 +1,24 @@
-import { Link } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { KeyRound } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
+import { SectionCard } from "@/components/section-card";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { APIKeyForm } from "@/features/api-keys/api-key-form";
 
 export function APIKeyNewPage() {
   return (
     <div className="mx-auto max-w-2xl">
-      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
-        <Link to="/api-keys">
-          <ArrowLeft className="size-4" />
-          API keys
-        </Link>
-      </Button>
+      <SoftBackButton to="/api-keys">Back to API keys</SoftBackButton>
       <PageHeader
-        title="New API key"
-        description="Mint a credential for agents, the CLI, or the MCP server. The plaintext shows once after creation."
+        eyebrow="New credential"
+        title="Mint an API key"
+        description="A credential for agents, the CLI, or the MCP server. The plaintext shows once after creation — copy it to your password manager before leaving the page."
       />
-      <APIKeyForm />
+      <SectionCard
+        icon={<KeyRound className="text-muted-foreground size-4" />}
+        title="Key details"
+      >
+        <APIKeyForm />
+      </SectionCard>
     </div>
   );
 }

--- a/web/src/routes/api-keys.tsx
+++ b/web/src/routes/api-keys.tsx
@@ -47,10 +47,29 @@ export function APIKeysPage() {
     };
   }, [keys]);
 
+  const tabRows = tab === "active" ? active : revoked;
   const rows = useMemo(
-    () => filterKeys(tab === "active" ? active : revoked, query),
-    [tab, active, revoked, query],
+    () => filterKeys(tabRows, query),
+    [tabRows, query],
   );
+
+  // Eyebrow vocabulary matches Tags / Transactions / Connections list pages:
+  // "Loading" / "Error" / "N keys" / "Showing N of M" / "No matches".
+  const tabLabel = tab === "active" ? "active" : "revoked";
+  const eyebrow = (() => {
+    if (isLoading) return "Loading";
+    if (isError) return "Error";
+    if (tabRows.length === 0) {
+      return tab === "active" ? "No active keys" : "No revoked keys";
+    }
+    if (query.trim()) {
+      if (rows.length === 0) return "No matches";
+      if (rows.length < tabRows.length) {
+        return `Showing ${rows.length.toLocaleString()} of ${tabRows.length.toLocaleString()}`;
+      }
+    }
+    return `${tabRows.length.toLocaleString()} ${tabLabel} ${tabRows.length === 1 ? "key" : "keys"}`;
+  })();
 
   function setTab(next: Tab) {
     navigate({
@@ -75,7 +94,7 @@ export function APIKeysPage() {
   }
 
   const newKeyButton = (
-    <Button asChild>
+    <Button asChild size="sm">
       <Link to="/api-keys/new">
         <Plus className="size-4" />
         New key
@@ -86,49 +105,52 @@ export function APIKeysPage() {
   const emptyState = renderEmptyState({ tab, query, newKeyButton });
 
   return (
-    <div>
+    <div className="flex flex-col gap-5">
       <PageHeader
+        eyebrow={eyebrow}
         title="API keys"
-        description="Credentials for programmatic access — agents, the CLI, the MCP server."
+        description="Credentials for programmatic access — agents, the CLI, the MCP server. Each key carries a fixed scope and an attributed actor, and is hashed in storage."
         actions={newKeyButton}
       />
 
-      <div className="mb-4 flex flex-wrap items-center gap-3">
-        <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
-          <TabsList>
-            <TabsTrigger value="active">
-              Active
-              <span className="text-muted-foreground ml-1.5 text-xs tabular-nums">
-                {active.length}
-              </span>
-            </TabsTrigger>
-            <TabsTrigger value="revoked">
-              Revoked
-              <span className="text-muted-foreground ml-1.5 text-xs tabular-nums">
-                {revoked.length}
-              </span>
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <Tabs value={tab} onValueChange={(v) => setTab(v as Tab)}>
+            <TabsList>
+              <TabsTrigger value="active">
+                Active
+                <span className="text-muted-foreground ml-1.5 text-xs tabular-nums">
+                  {active.length}
+                </span>
+              </TabsTrigger>
+              <TabsTrigger value="revoked">
+                Revoked
+                <span className="text-muted-foreground ml-1.5 text-xs tabular-nums">
+                  {revoked.length}
+                </span>
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
 
-        <div className="relative ml-auto w-full max-w-xs">
-          <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
-          <Input
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search by name, prefix, actor…"
-            className="pl-8"
-          />
+          <div className="relative w-full max-w-xs">
+            <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by name, prefix, actor…"
+              className="pl-8"
+            />
+          </div>
         </div>
-      </div>
 
-      <APIKeysTable
-        keys={rows}
-        isLoading={isLoading}
-        isError={isError}
-        revoked={tab === "revoked"}
-        emptyState={emptyState}
-      />
+        <APIKeysTable
+          keys={rows}
+          isLoading={isLoading}
+          isError={isError}
+          revoked={tab === "revoked"}
+          emptyState={emptyState}
+        />
+      </div>
     </div>
   );
 }

--- a/web/src/routes/category-detail.tsx
+++ b/web/src/routes/category-detail.tsx
@@ -3,10 +3,8 @@ import {
   Link,
   useNavigate,
   useParams,
-  useRouter,
 } from "@tanstack/react-router";
 import {
-  ArrowLeft,
   ArrowRight,
   EyeOff,
   Folder,
@@ -23,6 +21,7 @@ import { DangerZone } from "@/components/danger-zone";
 import { EmptyState } from "@/components/empty-state";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { CategoryForm } from "@/features/categories/category-form";
 import {
   flattenCategories,
@@ -47,7 +46,7 @@ export function CategoryDetailPage() {
 
   return (
     <div className="mx-auto max-w-5xl">
-      <BackButton />
+      <SoftBackButton to="/categories">Back to categories</SoftBackButton>
 
       {isLoading ? (
         <DetailSkeleton />
@@ -66,43 +65,6 @@ export function CategoryDetailPage() {
         <DetailBody category={category} tree={tree ?? []} />
       )}
     </div>
-  );
-}
-
-// BackButton mirrors the TX-detail / Account-detail muscle memory: real
-// link to /categories so middle-click works, but a normal left-click
-// prefers `router.history.back()` to land on the exact list state the
-// user came from (filter + expanded parents).
-function BackButton() {
-  const router = useRouter();
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      asChild
-      className="text-muted-foreground hover:text-foreground mb-3 -ml-2 h-7 px-2 text-xs"
-    >
-      <Link
-        to="/categories"
-        onClick={(e) => {
-          if (
-            !e.defaultPrevented &&
-            !e.metaKey &&
-            !e.ctrlKey &&
-            !e.shiftKey &&
-            !e.altKey &&
-            e.button === 0 &&
-            window.history.length > 1
-          ) {
-            e.preventDefault();
-            router.history.back();
-          }
-        }}
-      >
-        <ArrowLeft className="size-3.5" />
-        Back to categories
-      </Link>
-    </Button>
   );
 }
 

--- a/web/src/routes/connection-detail.tsx
+++ b/web/src/routes/connection-detail.tsx
@@ -3,13 +3,11 @@ import {
   Link,
   useNavigate,
   useParams,
-  useRouter,
   useSearch,
 } from "@tanstack/react-router";
 import {
   Activity,
   AlertTriangle,
-  ArrowLeft,
   Building2,
   ExternalLink,
   FileSpreadsheet,
@@ -46,6 +44,7 @@ import {
 import { ColorRailCard } from "@/components/color-rail-card";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { cn } from "@/lib/utils";
 import {
@@ -197,7 +196,7 @@ export function ConnectionDetailPage() {
 
   return (
     <div className="mx-auto max-w-5xl">
-      <BackButton />
+      <SoftBackButton to="/connections">Back to connections</SoftBackButton>
 
       {connQuery.isLoading ? (
         <DetailSkeleton />
@@ -241,43 +240,6 @@ export function ConnectionDetailPage() {
         />
       )}
     </div>
-  );
-}
-
-// BackButton mirrors the TX-detail/Account-detail back-button pattern —
-// real link to the list (middle-click + open-in-new-tab still work),
-// soft-back on a plain left-click so the user lands on the exact list
-// state they came from (filter tabs, search).
-function BackButton() {
-  const router = useRouter();
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      asChild
-      className="text-muted-foreground hover:text-foreground mb-3 -ml-2 h-7 px-2 text-xs"
-    >
-      <Link
-        to="/connections"
-        onClick={(e) => {
-          if (
-            !e.defaultPrevented &&
-            !e.metaKey &&
-            !e.ctrlKey &&
-            !e.shiftKey &&
-            !e.altKey &&
-            e.button === 0 &&
-            window.history.length > 1
-          ) {
-            e.preventDefault();
-            router.history.back();
-          }
-        }}
-      >
-        <ArrowLeft className="size-3.5" />
-        Back to connections
-      </Link>
-    </Button>
   );
 }
 

--- a/web/src/routes/transaction-detail.tsx
+++ b/web/src/routes/transaction-detail.tsx
@@ -1,7 +1,6 @@
-import { Link, useParams, useRouter } from "@tanstack/react-router";
+import { Link, useParams } from "@tanstack/react-router";
 import {
   ArrowDownLeft,
-  ArrowLeft,
   ArrowUpRight,
   Building2,
   Receipt,
@@ -17,6 +16,7 @@ import { CategoryIconTile } from "@/components/category-icon-tile";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { IdPill } from "@/components/id-pill";
 import { SectionCard } from "@/components/section-card";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { CategoryEditor } from "@/features/transactions/category-editor";
 import { TagManager } from "@/features/transactions/tag-manager";
 import { ActivityTimeline } from "@/features/transactions/activity-timeline";
@@ -32,7 +32,7 @@ export function TransactionDetailPage() {
 
   return (
     <div className="mx-auto max-w-5xl">
-      <BackButton />
+      <SoftBackButton to="/transactions">Back to transactions</SoftBackButton>
 
       {isLoading ? (
         <DetailSkeleton />
@@ -51,43 +51,6 @@ export function TransactionDetailPage() {
         <DetailBody transaction={data} />
       )}
     </div>
-  );
-}
-
-// BackButton renders as a real link to /transactions (so middle-click and
-// "open in new tab" still work), but on a normal left-click it prefers
-// `router.history.back()` — that lands the user on the exact list state they
-// came from (filters, scroll, focus) instead of resetting to defaults.
-function BackButton() {
-  const router = useRouter();
-  return (
-    <Button
-      variant="ghost"
-      size="sm"
-      asChild
-      className="text-muted-foreground hover:text-foreground mb-3 -ml-2 h-7 px-2 text-xs"
-    >
-      <Link
-        to="/transactions"
-        onClick={(e) => {
-          if (
-            !e.defaultPrevented &&
-            !e.metaKey &&
-            !e.ctrlKey &&
-            !e.shiftKey &&
-            !e.altKey &&
-            e.button === 0 &&
-            window.history.length > 1
-          ) {
-            e.preventDefault();
-            router.history.back();
-          }
-        }}
-      >
-        <ArrowLeft className="size-3.5" />
-        Back to transactions
-      </Link>
-    </Button>
   );
 }
 


### PR DESCRIPTION
## Summary
- API keys family (list + new + created) lands on the v2 design vocabulary: PageHeader eyebrow, `flex flex-col gap-3` toolbar, `stickyHeader`/`refinedHeader` DataTable, SectionCard-wrapped form, IdPill for `bb_xxx…` prefixes and the `X-API-Key` / `/api/v1/*` literals on the created page (retires the iter-6 `<code className="bg-muted">` drift note).
- New `SoftBackButton` primitive at `web/src/components/soft-back-button.tsx`. Migrates TX-detail, Account-detail, Connection-detail, Category-detail off their inline copies (queued from iter 11) and the new api-key-new form picks it up too — five surfaces share one back-link now.
- `api-key-new` gets a real "Mint an API key" heading + "New credential" eyebrow + SectionCard ("Key details") with a flush bordered Cancel/Create action strip in the card footer; `api-key-created` promotes the key name into PageHeader and replaces the bespoke Card with a SectionCard.

## Before / After
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/lot1j2ft1e.jpg) | ![after](https://i.img402.dev/y2pg5fb8yx.jpg) |
| ![before](https://i.img402.dev/zq4pulqcct.jpg) | ![after](https://i.img402.dev/4dljjon2dv.jpg) |
| ![before](https://i.img402.dev/zbse5wox5k.jpg) | ![after](https://i.img402.dev/s5s8oz6iw1.jpg) |

## Notes
- `SoftBackButton` is the third primitive added in this sprint (after `SectionCard`, `IdPill`, `ListCard`, `ColorRailCard`). Lives at `web/src/components/soft-back-button.tsx`; the four detail pages and api-key-new all source from it.
- IdPill now hits six surfaces (Tags slug, TX-detail Reference, Account-detail Reference, Categories parent/child, Connection-detail Institution/Reference, and now API-keys prefix column + api-key-created header literals).
- The api-key-form footer adopts the `-mx-5 -mb-5 ... border-t bg-muted/20 px-5 py-3` pattern — same vocabulary as the ColorRailCard footer slot. If the category-form (queued) or any future form picks this up, promote to a `FormFooter` prop on SectionCard.
- Cross-cutting form/empty-state primitives remain queued for a future iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
