### PR TITLE
design(v2): auth pages — Login + Setup account share an AuthShell

### DIFF
--- a/web/src/components/auth-shell.tsx
+++ b/web/src/components/auth-shell.tsx
@@ -1,0 +1,223 @@
+import * as React from "react";
+import { Link } from "@tanstack/react-router";
+import {
+  Box,
+  Lock,
+  RadioTower,
+  Sparkles,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// Two-pane shell for unauthenticated pages (login + setup-account). Left
+// pane is a brand panel that echoes the sidebar lockup so signing in feels
+// like stepping into the same product, not a separate marketing site. The
+// pane collapses on small screens — `lg:` is the breakpoint for showing the
+// full split. Right pane carries the page-specific form/card.
+//
+// Visual contract:
+// - Outer container: `min-h-screen bg-background` with a soft grid pattern
+//   in the brand panel; the rest of the chrome (header, footer note) lives
+//   in the form pane so the brand never has to know about the page state.
+// - Brand pane: bg-sidebar (matches the in-app sidebar surface so it reads
+//   as "Breadbox") + tinted accents (`primary/12`, `primary/5`) for the
+//   glow + feature pills. Decorative dot grid uses `mask-image` so it fades
+//   to the edges, avoiding the "tablecloth" effect.
+// - Form pane: the page passes `eyebrow` + `title` + `description` (echoes
+//   PageHeader vocabulary) and any form body / footer node. Optional
+//   `secondaryAction` slot sits on the right of the title row for things
+//   like "Need help?" or "Switch account".
+//
+// Keep this primitive simple — it does layout + brand, not state. State
+// (loading, success, error) belongs in the consumer.
+
+export interface AuthShellProps {
+  eyebrow?: React.ReactNode;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  children: React.ReactNode;
+  /** Optional node rendered below the card (legal copy, footnote). */
+  footer?: React.ReactNode;
+  /** Optional right-aligned link/badge at the top-right of the form pane. */
+  topRight?: React.ReactNode;
+}
+
+export function AuthShell({
+  eyebrow,
+  title,
+  description,
+  children,
+  footer,
+  topRight,
+}: AuthShellProps) {
+  return (
+    <div className="bg-background min-h-screen">
+      <div className="grid min-h-screen lg:grid-cols-2">
+        <BrandPane />
+        <div className="relative flex flex-col">
+          <header className="flex items-center justify-between px-6 pt-6 sm:px-10 lg:hidden">
+            <BrandLockup compact />
+            {topRight ? (
+              <div className="text-muted-foreground text-xs">{topRight}</div>
+            ) : null}
+          </header>
+          <header className="hidden items-center justify-end px-10 pt-8 lg:flex">
+            {topRight ? (
+              <div className="text-muted-foreground text-xs">{topRight}</div>
+            ) : null}
+          </header>
+          <main className="flex flex-1 items-center justify-center px-6 py-10 sm:px-10">
+            <div className="w-full max-w-sm">
+              <div className="mb-7 flex flex-col gap-2">
+                {eyebrow ? (
+                  <span className="text-muted-foreground inline-flex items-center gap-2 text-[11px] font-medium tracking-wider uppercase">
+                    {eyebrow}
+                  </span>
+                ) : null}
+                <h1 className="text-foreground text-2xl font-semibold tracking-tight">
+                  {title}
+                </h1>
+                {description ? (
+                  <p className="text-muted-foreground text-sm leading-relaxed">
+                    {description}
+                  </p>
+                ) : null}
+              </div>
+              {children}
+              {footer ? (
+                <div className="text-muted-foreground mt-6 text-center text-xs">
+                  {footer}
+                </div>
+              ) : null}
+            </div>
+          </main>
+          <footer className="text-muted-foreground/80 hidden items-center justify-between px-10 pb-6 text-[11px] lg:flex">
+            <span>© Breadbox</span>
+            <span className="inline-flex items-center gap-3">
+              <Link to="/" className="hover:text-foreground transition-colors">
+                breadbox.sh
+              </Link>
+              <span aria-hidden>·</span>
+              <a
+                href="https://docs.breadbox.sh"
+                className="hover:text-foreground transition-colors"
+              >
+                Docs
+              </a>
+            </span>
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BrandPane() {
+  return (
+    <aside
+      className={cn(
+        "bg-sidebar text-sidebar-foreground relative hidden flex-col justify-between overflow-hidden p-10 lg:flex",
+        "border-sidebar-border border-r",
+      )}
+    >
+      {/* Decorative dot grid (mask fades to the edges) */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-[0.35]"
+        style={{
+          backgroundImage:
+            "radial-gradient(circle at 1px 1px, var(--sidebar-border) 1px, transparent 0)",
+          backgroundSize: "22px 22px",
+          maskImage:
+            "radial-gradient(ellipse 80% 80% at 30% 40%, black 30%, transparent 80%)",
+        }}
+      />
+      {/* Soft glow blob */}
+      <div
+        aria-hidden
+        className="bg-primary/[0.08] pointer-events-none absolute -top-24 -left-24 size-[26rem] rounded-full blur-3xl"
+      />
+
+      <div className="relative">
+        <BrandLockup />
+      </div>
+
+      <div className="relative flex flex-col gap-8">
+        <div className="flex flex-col gap-3">
+          <span className="text-muted-foreground inline-flex w-fit items-center gap-1.5 text-[11px] font-medium tracking-wider uppercase">
+            <Sparkles className="size-3" />
+            Self-hosted finance
+          </span>
+          <h2 className="text-foreground max-w-md text-2xl leading-tight font-semibold tracking-tight sm:text-[1.65rem]">
+            Your household's financial data, in one place you actually control.
+          </h2>
+          <p className="text-muted-foreground max-w-md text-sm leading-relaxed">
+            Breadbox syncs accounts from Plaid, Teller, and CSV imports into a
+            Postgres database you own — then exposes it to AI agents over MCP.
+          </p>
+        </div>
+        <ul className="flex flex-col gap-2.5">
+          <FeaturePill icon={Lock} label="End-to-end encrypted tokens at rest" />
+          <FeaturePill icon={RadioTower} label="MCP-native — works with Claude, agents, scripts" />
+          <FeaturePill icon={Box} label="One Go binary, one Postgres, zero SaaS" />
+        </ul>
+      </div>
+
+      <div className="text-muted-foreground relative flex items-center justify-between text-[11px]">
+        <span>v2 Preview</span>
+        <span>breadbox.sh</span>
+      </div>
+    </aside>
+  );
+}
+
+function FeaturePill({
+  icon: Icon,
+  label,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+}) {
+  return (
+    <li className="border-sidebar-border/60 bg-sidebar-accent/40 inline-flex items-center gap-2.5 rounded-md border px-3 py-1.5 text-xs">
+      <span className="bg-primary/12 text-primary flex size-5 shrink-0 items-center justify-center rounded-[5px]">
+        <Icon className="size-3" />
+      </span>
+      <span className="text-foreground/85">{label}</span>
+    </li>
+  );
+}
+
+function BrandLockup({ compact = false }: { compact?: boolean }) {
+  return (
+    <Link
+      to="/"
+      className="group inline-flex items-center gap-2.5 outline-none"
+      aria-label="Breadbox home"
+    >
+      <span
+        className={cn(
+          "bg-primary text-primary-foreground flex aspect-square items-center justify-center rounded-md shadow-sm transition-transform group-hover:scale-[1.03]",
+          compact ? "size-7" : "size-9",
+        )}
+      >
+        <Box className={compact ? "size-3.5" : "size-[18px]"} />
+      </span>
+      <span className="flex flex-col leading-none">
+        <span
+          className={cn(
+            "text-foreground font-semibold tracking-tight",
+            compact ? "text-sm" : "text-base",
+          )}
+        >
+          Breadbox
+        </span>
+        <span className="text-muted-foreground mt-1 inline-flex items-center gap-1.5 text-[10px] font-medium tracking-wider uppercase">
+          <span className="bg-primary/15 text-primary rounded-sm px-1 py-px text-[10px] font-semibold">
+            v2
+          </span>
+          Preview
+        </span>
+      </span>
+    </Link>
+  );
+}

--- a/web/src/routes/login.tsx
+++ b/web/src/routes/login.tsx
@@ -3,13 +3,7 @@ import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { ArrowRight, Loader2 } from "lucide-react";
 import {
   Form,
   FormControl,
@@ -20,6 +14,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { AuthShell } from "@/components/auth-shell";
 import { toast } from "sonner";
 import { useLogin } from "@/api/queries/auth";
 import { ApiError } from "@/api/client";
@@ -49,7 +44,8 @@ export function LoginPage() {
       await login.mutateAsync(values);
       // `redirect` is an arbitrary pathname captured by the auth gate, not a
       // statically-known route — cast past the typed-router `to` constraint.
-      const target = search.redirect && search.redirect.startsWith("/") ? search.redirect : "/";
+      const target =
+        search.redirect && search.redirect.startsWith("/") ? search.redirect : "/";
       navigate({ to: target as string });
     } catch (err) {
       const msg =
@@ -61,57 +57,77 @@ export function LoginPage() {
   };
 
   return (
-    <div className="bg-muted/30 flex min-h-screen items-center justify-center p-6">
-      <Card className="w-full max-w-sm">
-        <CardHeader>
-          <CardTitle>Sign in to Breadbox</CardTitle>
-          <CardDescription>Use your admin email and password.</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-              <FormField
-                control={form.control}
-                name="username"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="email"
-                        autoComplete="username"
-                        autoFocus
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name="password"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Password</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="password"
-                        autoComplete="current-password"
-                        {...field}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <Button type="submit" className="w-full" disabled={submitting}>
-                {submitting ? "Signing in…" : "Sign in"}
-              </Button>
-            </form>
-          </Form>
-        </CardContent>
-      </Card>
-    </div>
+    <AuthShell
+      eyebrow="Sign in"
+      title="Welcome back"
+      description="Sign in to your Breadbox household with your admin credentials."
+      footer={
+        <span>
+          Need an account?{" "}
+          <span className="text-foreground/80">
+            Ask the household admin for a setup link.
+          </span>
+        </span>
+      }
+    >
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex flex-col gap-5"
+          noValidate
+        >
+          <FormField
+            control={form.control}
+            name="username"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email or username</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="you@example.com"
+                    autoComplete="username"
+                    autoFocus
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="••••••••"
+                    autoComplete="current-password"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Signing in…
+              </>
+            ) : (
+              <>
+                Sign in
+                <ArrowRight className="size-4" />
+              </>
+            )}
+          </Button>
+        </form>
+      </Form>
+    </AuthShell>
   );
 }

--- a/web/src/routes/setup-account.tsx
+++ b/web/src/routes/setup-account.tsx
@@ -3,15 +3,8 @@ import { useNavigate, useParams } from "@tanstack/react-router";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { CheckCircle2, ShieldAlert } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { ArrowRight, CheckCircle2, Loader2, ShieldAlert, UserPlus } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Form,
   FormControl,
@@ -22,6 +15,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { AuthShell } from "@/components/auth-shell";
 import { toast } from "sonner";
 import { useSetupAccount, useSetupAccountInfo } from "@/api/queries/auth";
 import { ApiError } from "@/api/client";
@@ -66,115 +60,200 @@ export function SetupAccountPage() {
     }
   };
 
+  if (info.isLoading) {
+    return (
+      <AuthShell
+        eyebrow={
+          <>
+            <Loader2 className="size-3 animate-spin" />
+            Verifying invitation
+          </>
+        }
+        title="Checking your link…"
+        description="One moment while we validate this setup token."
+      >
+        <div className="flex flex-col gap-4">
+          <Skeleton className="h-9 w-full rounded-md" />
+          <Skeleton className="h-9 w-full rounded-md" />
+          <Skeleton className="h-9 w-full rounded-md" />
+        </div>
+      </AuthShell>
+    );
+  }
+
+  if (info.error instanceof ApiError && info.error.code === "ALREADY_SETUP") {
+    return (
+      <AuthShell
+        eyebrow="Already set up"
+        title="This account is already set up"
+        description="You've already chosen a password for this Breadbox account. Sign in below to continue."
+      >
+        <StatusPanel
+          tone="success"
+          icon={CheckCircle2}
+          heading="Setup complete"
+          body="Your password is already on file. The setup link won't be valid a second time."
+        />
+        <Button
+          onClick={() => navigate({ to: "/login" })}
+          className="mt-5 w-full"
+        >
+          Go to sign in
+          <ArrowRight className="size-4" />
+        </Button>
+      </AuthShell>
+    );
+  }
+
+  if (info.error) {
+    return (
+      <AuthShell
+        eyebrow="Invalid link"
+        title="This setup link won't work"
+        description={
+          info.error instanceof ApiError
+            ? info.error.message
+            : "The link is invalid or has expired."
+        }
+      >
+        <StatusPanel
+          tone="destructive"
+          icon={ShieldAlert}
+          heading="Setup link expired or invalid"
+          body="Ask the person who invited you to send a fresh link from their household admin dashboard. Existing links can be regenerated from Settings → Accounts."
+        />
+      </AuthShell>
+    );
+  }
+
   return (
-    <div className="bg-muted/30 flex min-h-screen items-center justify-center p-6">
-      <Card className="w-full max-w-sm">
-        {info.isLoading ? (
-          <>
-            <CardHeader>
-              <CardTitle>Checking your link…</CardTitle>
-              <CardDescription>One moment.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="bg-muted h-9 animate-pulse rounded-md" />
-            </CardContent>
-          </>
-        ) : info.error instanceof ApiError &&
-          info.error.code === "ALREADY_SETUP" ? (
-          <>
-            <CardHeader>
-              <div className="bg-emerald-500/10 mb-2 flex size-10 items-center justify-center rounded-xl">
-                <CheckCircle2 className="size-5 text-emerald-600 dark:text-emerald-400" />
-              </div>
-              <CardTitle>This account is already set up</CardTitle>
-              <CardDescription>
-                You've already chosen a password. Sign in below.
-              </CardDescription>
-            </CardHeader>
-            <CardFooter>
-              <Button onClick={() => navigate({ to: "/login" })} className="w-full">
-                Go to sign in
-              </Button>
-            </CardFooter>
-          </>
-        ) : info.error ? (
-          <>
-            <CardHeader>
-              <div className="bg-destructive/10 mb-2 flex size-10 items-center justify-center rounded-xl">
-                <ShieldAlert className="text-destructive size-5" />
-              </div>
-              <CardTitle>This setup link is invalid</CardTitle>
-              <CardDescription>
-                {info.error instanceof ApiError
-                  ? info.error.message
-                  : "The link is invalid or has expired."}
-                {" "}
-                Ask the person who invited you to send a fresh link.
-              </CardDescription>
-            </CardHeader>
-          </>
-        ) : (
-          <>
-            <CardHeader>
-              <CardTitle>Set your password</CardTitle>
-              <CardDescription>
-                Welcome,{" "}
-                <span className="text-foreground font-medium">
-                  {info.data?.username}
-                </span>
-                . Choose a password to finish setting up your Breadbox account.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Form {...form}>
-                <form
-                  onSubmit={form.handleSubmit(onSubmit)}
-                  className="space-y-4"
-                >
-                  <FormField
-                    control={form.control}
-                    name="password"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Password</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="password"
-                            autoComplete="new-password"
-                            autoFocus
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
+    <AuthShell
+      eyebrow={
+        <>
+          <UserPlus className="size-3" />
+          Finish setup
+        </>
+      }
+      title="Set your password"
+      description={
+        <>
+          Welcome,{" "}
+          <span className="text-foreground font-medium">
+            {info.data?.username}
+          </span>
+          . Choose a password to finish setting up your Breadbox account.
+        </>
+      }
+      footer={
+        <span>
+          Passwords are hashed with bcrypt and never leave your server.
+        </span>
+      }
+    >
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="flex flex-col gap-5"
+          noValidate
+        >
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="At least 8 characters"
+                    autoComplete="new-password"
+                    autoFocus
+                    {...field}
                   />
-                  <FormField
-                    control={form.control}
-                    name="confirm_password"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Confirm password</FormLabel>
-                        <FormControl>
-                          <Input
-                            type="password"
-                            autoComplete="new-password"
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirm_password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm password</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="Re-enter your password"
+                    autoComplete="new-password"
+                    {...field}
                   />
-                  <Button type="submit" className="w-full" disabled={submitting}>
-                    {submitting ? "Setting password…" : "Set password & sign in"}
-                  </Button>
-                </form>
-              </Form>
-            </CardContent>
-          </>
-        )}
-      </Card>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting ? (
+              <>
+                <Loader2 className="size-4 animate-spin" />
+                Setting password…
+              </>
+            ) : (
+              <>
+                Set password & sign in
+                <ArrowRight className="size-4" />
+              </>
+            )}
+          </Button>
+        </form>
+      </Form>
+    </AuthShell>
+  );
+}
+
+function StatusPanel({
+  tone,
+  icon: Icon,
+  heading,
+  body,
+}: {
+  tone: "success" | "destructive";
+  icon: React.ComponentType<{ className?: string }>;
+  heading: string;
+  body: string;
+}) {
+  // Inline panel used by setup-account's success / error states. Color is
+  // load-bearing here: success-tinted rail for "already set up" reads as
+  // resolution; destructive rail for "invalid link" reads as friction. Same
+  // colour-encodes-meaning principle as ColorRailCard, but inline-only.
+  const palette =
+    tone === "success"
+      ? {
+          rail: "before:bg-success",
+          iconBg: "bg-success/12 text-success",
+        }
+      : {
+          rail: "before:bg-destructive",
+          iconBg: "bg-destructive/10 text-destructive",
+        };
+  return (
+    <div
+      className={`bg-muted/30 relative overflow-hidden rounded-md border p-4 pl-5 before:absolute before:top-0 before:bottom-0 before:left-0 before:w-[3px] ${palette.rail}`}
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className={`flex size-8 shrink-0 items-center justify-center rounded-md ${palette.iconBg}`}
+        >
+          <Icon className="size-4" />
+        </span>
+        <div className="flex flex-col gap-0.5">
+          <span className="text-foreground text-sm font-medium">{heading}</span>
+          <span className="text-muted-foreground text-xs leading-relaxed">
+            {body}
+          </span>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- New `<AuthShell>` primitive (`web/src/components/auth-shell.tsx`) — a two-pane layout for unauthenticated pages. Left pane echoes the in-app sidebar (same `bg-sidebar` surface, same brand lockup, soft dot-grid + primary glow + feature pills); right pane carries the page-specific form with eyebrow / title / description (mirrors PageHeader vocabulary), optional `topRight`, and a `footer` slot for fine print. Single column at mobile, two columns at `lg`+.
- `LoginPage` adopts the shell: form gains placeholders, arrow-loader CTA, "Need an account?" footer copy. The bare centered card is gone; signing in now feels like stepping into Breadbox, not a generic shadcn demo.
- `SetupAccountPage` adopts the shell across all four states. Loading uses real `<Skeleton>`s instead of a single bar. Already-setup and invalid-token states share a new inline `StatusPanel` (3px left rail tinted success or destructive — same colour-encodes-meaning principle as `ColorRailCard`). The valid-token form gets the same arrow-loader CTA, a "passwords are hashed with bcrypt and never leave your server" footer, and proper placeholders.

## Before / After

| Before (Login) | After (Login) |
| --- | --- |
| ![before-login](https://i.img402.dev/80784n03a9.jpg) | ![after-login](https://i.img402.dev/mp9sq0vpjp.jpg) |

| Before (Setup, invalid token) | After (Setup, invalid token) |
| --- | --- |
| ![before-setup-invalid](https://i.img402.dev/7kzz1ywox8.jpg) | ![after-setup-invalid](https://i.img402.dev/facco1gm77.jpg) |

| After (Setup, valid token — mocked) |
| --- |
| ![after-setup-fresh](https://i.img402.dev/9ku8pkh51j.jpg) |

## Notes

- `AuthShell` is the third "shell" in the v2 vocabulary alongside the in-app sidebar shell (`app-sidebar.tsx`) and the settings shell (`settings-shell.tsx`). It is intentionally narrow in scope — pure layout + brand, no state. State (loading / success / error) is the consumer's job, the same split we landed for `ListCard` and `SectionCard`.
- The brand pane reuses the existing `BrandHeader` vocabulary (Box icon in primary tile + "v2 Preview" pill) so the user sees the same lockup in sign-in that they see in the sidebar two seconds later. The dot-grid + glow are tinted via `--primary` / `--sidebar-border` so they pick up the active theme without hardcoding hex.
- Setup-account's success and error states adopt a new inline `<StatusPanel>` — colour-tinted rail + icon + heading + body. If a fourth surface wants the same pattern (an error inline on a form? a banner on the top of a list?), promote to `web/src/components/status-panel.tsx`; for now it lives inline since only this page consumes it.
- Followup: when we add password-reset, the same `<AuthShell>` should host it. The shell also doesn't render the `topRight` slot in the desktop layout when the page passes nothing — once we have something to put there (e.g. "Switch to a different account"), the prop is already wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)