### PR TITLE
design(v2): unify Tag/Category form pages around SectionCard + FormFooter

### DIFF
--- a/web/src/components/form-footer.tsx
+++ b/web/src/components/form-footer.tsx
@@ -1,0 +1,56 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface FormFooterProps {
+  /** Primary action — submit button (right). */
+  primary: React.ReactNode;
+  /** Secondary action — typically Cancel (left of primary). */
+  secondary?: React.ReactNode;
+  /** Optional helper text rendered left-aligned (e.g. validation hint). */
+  hint?: React.ReactNode;
+  className?: string;
+}
+
+// FormFooter renders the canonical flush bordered action strip at the bottom
+// of a `<SectionCard>` that wraps a form. Established in iter 13 on
+// api-key-new (`features/api-keys/api-key-form.tsx`); the iter-13 drift
+// note explicitly queued promotion to a primitive once a second/third form
+// adopts it. Iter 15 brings tag-form and category-form onto the pattern, so
+// it lives here.
+//
+// Visual contract (matches the api-key-new pattern):
+//   `<div className="bg-muted/20 -mx-5 -mb-5 mt-2 flex items-center justify-end
+//                    gap-2 border-t px-5 py-3">`
+//
+// The negative margins (`-mx-5 -mb-5`) push the strip out to the SectionCard
+// body's edges so the top border lines up with the card's outer border and
+// the action strip reads as a footer of the card, not as floating content.
+// Drop it inside a SectionCard with the default `bodyClassName="px-5 py-5"`.
+//
+// Don't fork the look — change this primitive instead.
+export function FormFooter({
+  primary,
+  secondary,
+  hint,
+  className,
+}: FormFooterProps) {
+  return (
+    <div
+      className={cn(
+        "bg-muted/20 -mx-5 -mb-5 mt-2 flex flex-wrap items-center justify-end gap-2 border-t px-5 py-3",
+        hint && "sm:justify-between",
+        className,
+      )}
+    >
+      {hint && (
+        <div className="text-muted-foreground order-last text-xs sm:order-first">
+          {hint}
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        {secondary}
+        {primary}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/categories/category-form.tsx
+++ b/web/src/features/categories/category-form.tsx
@@ -7,7 +7,7 @@ import {
 } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Check, ChevronsUpDown, X } from "lucide-react";
+import { Check, ChevronsUpDown, Loader2, X } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import {
   Form,
@@ -33,9 +33,9 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
+import { FormFooter } from "@/components/form-footer";
 import { IconPicker } from "@/components/icon-picker";
 import { ColorPicker } from "@/components/color-picker";
-import { CategoryIconTile } from "@/components/category-icon-tile";
 import { DynamicIcon } from "@/lib/icon";
 import {
   useCategories,
@@ -81,9 +81,9 @@ export function CategoryForm({ mode, category }: CategoryFormProps) {
     },
   });
 
-  const [icon, color, displayName, parentId] = useWatch({
+  const [color] = useWatch({
     control: form.control,
-    name: ["icon", "color", "display_name", "parent_id"],
+    name: ["color"],
   });
 
   const onSubmit: SubmitHandler<CategoryFormValues> = async (values) => {
@@ -125,24 +125,6 @@ export function CategoryForm({ mode, category }: CategoryFormProps) {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        {/* In create mode the form is the only thing on the page so it
-            needs its own live preview. In edit mode the hero card above
-            already carries the identity preview live (icon + colour are
-            sourced from the same Category), so skip the redundant tile. */}
-        {mode === "create" && (
-          <div className="bg-muted/30 flex items-center gap-3 rounded-md border p-3">
-            <CategoryIconTile icon={icon} color={color} size="lg" />
-            <div className="min-w-0">
-              <div className="truncate font-medium">
-                {displayName || "Untitled category"}
-              </div>
-              <div className="text-muted-foreground text-xs">
-                {parentId ? "Sub-category" : "Top-level category"}
-              </div>
-            </div>
-          </div>
-        )}
-
         <FormField
           control={form.control}
           name="display_name"
@@ -279,18 +261,25 @@ export function CategoryForm({ mode, category }: CategoryFormProps) {
           />
         )}
 
-        <div className="flex gap-2 border-t pt-6">
-          <Button type="submit" disabled={isPending}>
-            {isPending ? "Saving…" : submitLabel}
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => navigate({ to: "/categories" })}
-          >
-            Cancel
-          </Button>
-        </div>
+        <FormFooter
+          secondary={
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate({ to: "/categories" })}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+          }
+          primary={
+            <Button type="submit" size="sm" disabled={isPending}>
+              {isPending && <Loader2 className="size-4 animate-spin" />}
+              {isPending ? "Saving…" : submitLabel}
+            </Button>
+          }
+        />
       </form>
     </Form>
   );

--- a/web/src/features/tags/tag-form.tsx
+++ b/web/src/features/tags/tag-form.tsx
@@ -7,6 +7,7 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { useNavigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
 import {
   Form,
   FormControl,
@@ -19,9 +20,9 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
+import { FormFooter } from "@/components/form-footer";
 import { IconPicker } from "@/components/icon-picker";
 import { ColorPicker } from "@/components/color-picker";
-import { TagChip } from "@/components/tag-chip";
 import { useCreateTag, useUpdateTag } from "@/api/queries/tags";
 import { withMutationToast } from "@/lib/mutation-toast";
 import type { Tag } from "@/api/types";
@@ -66,9 +67,9 @@ export function TagForm({ mode, tag }: TagFormProps) {
     },
   });
 
-  const [slug, displayName, icon, color] = useWatch({
+  const [color] = useWatch({
     control: form.control,
-    name: ["slug", "display_name", "icon", "color"],
+    name: ["color"],
   });
 
   const onSubmit: SubmitHandler<TagFormValues> = async (values) => {
@@ -106,21 +107,9 @@ export function TagForm({ mode, tag }: TagFormProps) {
   const isPending = create.isPending || update.isPending;
   const submitLabel = mode === "create" ? "Create tag" : "Save changes";
 
-  const previewTag = {
-    slug: slug || "tag",
-    display_name: displayName || "Untitled tag",
-    icon,
-    color,
-  };
-
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-        <div className="bg-muted/30 flex items-center gap-3 rounded-md border p-3">
-          <TagChip tag={previewTag} />
-          <span className="text-muted-foreground text-xs">Live preview</span>
-        </div>
-
         {mode === "create" ? (
           <FormField
             control={form.control}
@@ -229,18 +218,25 @@ export function TagForm({ mode, tag }: TagFormProps) {
           />
         </div>
 
-        <div className="flex gap-2 border-t pt-6">
-          <Button type="submit" disabled={isPending}>
-            {isPending ? "Saving…" : submitLabel}
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => navigate({ to: "/tags" })}
-          >
-            Cancel
-          </Button>
-        </div>
+        <FormFooter
+          secondary={
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate({ to: "/tags" })}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+          }
+          primary={
+            <Button type="submit" size="sm" disabled={isPending}>
+              {isPending && <Loader2 className="size-4 animate-spin" />}
+              {isPending ? "Saving…" : submitLabel}
+            </Button>
+          }
+        />
       </form>
     </Form>
   );

--- a/web/src/routes/category-new.tsx
+++ b/web/src/routes/category-new.tsx
@@ -1,23 +1,24 @@
-import { Link } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Shapes } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
+import { SectionCard } from "@/components/section-card";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { CategoryForm } from "@/features/categories/category-form";
 
 export function CategoryNewPage() {
   return (
     <div className="mx-auto max-w-2xl">
-      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
-        <Link to="/categories">
-          <ArrowLeft className="size-4" />
-          Categories
-        </Link>
-      </Button>
+      <SoftBackButton to="/categories">Back to categories</SoftBackButton>
       <PageHeader
-        title="New category"
-        description="Top-level categories form the spine of your spending breakdown. Sub-categories let you slice further."
+        eyebrow="New category"
+        title="Create a category"
+        description="Top-level categories form the spine of your spending breakdown. Sub-categories let you slice further. Pick a parent to nest, or leave empty for a fresh group."
       />
-      <CategoryForm mode="create" />
+      <SectionCard
+        icon={<Shapes className="text-muted-foreground size-4" />}
+        title="Category details"
+      >
+        <CategoryForm mode="create" />
+      </SectionCard>
     </div>
   );
 }

--- a/web/src/routes/tag-detail.tsx
+++ b/web/src/routes/tag-detail.tsx
@@ -1,11 +1,14 @@
 import { useMemo } from "react";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
-import { ArrowLeft, Tags as TagsIcon } from "lucide-react";
+import { Tags as TagsIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { DangerZone } from "@/components/danger-zone";
+import { SectionCard } from "@/components/section-card";
+import { SoftBackButton } from "@/components/soft-back-button";
+import { TagChip } from "@/components/tag-chip";
 import { TagForm } from "@/features/tags/tag-form";
 import { useDeleteTag, useTags } from "@/api/queries/tags";
 import { withMutationToast } from "@/lib/mutation-toast";
@@ -21,15 +24,10 @@ export function TagDetailPage() {
 
   return (
     <div className="mx-auto max-w-2xl">
-      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
-        <Link to="/tags">
-          <ArrowLeft className="size-4" />
-          Tags
-        </Link>
-      </Button>
+      <SoftBackButton to="/tags">Back to tags</SoftBackButton>
 
       {isLoading ? (
-        <Skeleton className="h-96 rounded-xl" />
+        <DetailSkeleton />
       ) : isError || !tag ? (
         <EmptyState
           icon={TagsIcon}
@@ -51,13 +49,29 @@ export function TagDetailPage() {
 function DetailBody({ tag }: { tag: Tag }) {
   const navigate = useNavigate();
   const del = useDeleteTag();
+
+  // Tag identity: title carries the human name; eyebrow holds the canonical
+  // "Tag" label so the page reads the same as the other detail pages
+  // (Category, Account, Transaction, Connection) that anchor on an eyebrow.
+  // The live preview chip in the page header makes the icon + colour
+  // immediately visible above the form — same role the inline "Live
+  // preview" tile used to play, but lifted up so the form body stays clean.
   return (
-    <>
+    <div className="space-y-6">
       <PageHeader
+        eyebrow="Tag"
         title={tag.display_name}
         description={tag.description || "No description yet."}
+        actions={<TagChip tag={tag} />}
       />
-      <TagForm mode="edit" tag={tag} />
+
+      <SectionCard
+        icon={<TagsIcon className="text-muted-foreground size-4" />}
+        title="Tag details"
+      >
+        <TagForm mode="edit" tag={tag} />
+      </SectionCard>
+
       <DangerZone
         description="The tag will be removed from every transaction it's attached to. Activity history is preserved. This can't be undone."
         confirmTarget={<span className="font-semibold">{tag.display_name}</span>}
@@ -71,6 +85,20 @@ function DetailBody({ tag }: { tag: Tag }) {
           if (ok) navigate({ to: "/tags" });
         }}
       />
-    </>
+    </div>
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-3 w-12" />
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-4 w-72" />
+      </div>
+      <Skeleton className="h-[28rem] rounded-xl" />
+      <Skeleton className="h-32 rounded-xl" />
+    </div>
   );
 }

--- a/web/src/routes/tag-new.tsx
+++ b/web/src/routes/tag-new.tsx
@@ -1,23 +1,24 @@
-import { Link } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Tags as TagsIcon } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
+import { SectionCard } from "@/components/section-card";
+import { SoftBackButton } from "@/components/soft-back-button";
 import { TagForm } from "@/features/tags/tag-form";
 
 export function TagNewPage() {
   return (
     <div className="mx-auto max-w-2xl">
-      <Button variant="ghost" size="sm" asChild className="mb-4 -ml-2">
-        <Link to="/tags">
-          <ArrowLeft className="size-4" />
-          Tags
-        </Link>
-      </Button>
+      <SoftBackButton to="/tags">Back to tags</SoftBackButton>
       <PageHeader
-        title="New tag"
-        description="Tags are reusable labels. Pick a stable slug — rules and exports reference it."
+        eyebrow="New tag"
+        title="Create a tag"
+        description="Tags are reusable labels you attach to any transaction. Pick a stable slug — rules, exports, and the URL reference it."
       />
-      <TagForm mode="create" />
+      <SectionCard
+        icon={<TagsIcon className="text-muted-foreground size-4" />}
+        title="Tag details"
+      >
+        <TagForm mode="create" />
+      </SectionCard>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Promotes `<FormFooter>` (`web/src/components/form-footer.tsx`) — flush bordered action strip (Cancel left, primary right with Loader2 spinner) that drops into a `<SectionCard>` body and pushes out to the card's edges via `-mx-5 -mb-5`. Established inline in iter-13 api-key-new; the drift note explicitly queued promotion once a second/third form picked it up.
- Migrates tag-new, tag-detail, category-new, and category-detail onto the canonical form-page shell: `<SoftBackButton>` + `<PageHeader>` (eyebrow) + `<SectionCard>` wrapping the form, with `<FormFooter>` at the bottom. tag-new and category-new now read like siblings of api-key-new instead of bare \"form on the page\".
- tag-detail picks up a real identity layer — PageHeader eyebrow (\"Tag\"), title (display name), description, and a `<TagChip>` preview pinned to the actions slot. The inline preview tiles inside `TagForm` / `CategoryForm` are gone — the icon + colour pickers already show their current selection live, and the page-level identity carries the rest.

## Before / After

### Tag new
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/n2kid4qqg4.jpg) | ![after](https://i.img402.dev/yr43x0595a.jpg) |

### Tag detail
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/x9jikln89r.jpg) | ![after](https://i.img402.dev/mju0ps67sc.jpg) |

### Category new
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/k1bc2ixdkm.jpg) | ![after](https://i.img402.dev/jfo29ou168.jpg) |

### Category detail (form footer sweep only)
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/rc2ndh46fh.jpg) | ![after](https://i.img402.dev/g4jl0u44ys.jpg) |

## Notes
- `<FormFooter>` is the third \"form\" primitive in the v2 vocabulary alongside `<SectionCard>` and `<SoftBackButton>` — every form-page now speaks the same vocabulary. Three surfaces share it today (api-key-new still has the open-coded version inline; sweep next time we touch api-key-form for parity).
- Removed `import { TagChip }` and `import { CategoryIconTile }` from the form files (no longer needed once the live preview tile is gone) — `useWatch` now only tracks `color` (for the `IconPicker tint` prop).
- Drift updates queued: api-key-form still hand-rolls the FormFooter; sweep when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)