### PR TITLE
design(v2): providers page + promote StatusPanel primitive

### DIFF
--- a/web/src/components/status-panel.tsx
+++ b/web/src/components/status-panel.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export type StatusPanelTone = "success" | "destructive" | "warning" | "info";
+
+interface StatusPanelProps {
+  tone: StatusPanelTone;
+  icon: React.ComponentType<{ className?: string }>;
+  heading: React.ReactNode;
+  body?: React.ReactNode;
+  /** Optional trailing slot (e.g. small action button or pill). */
+  trailing?: React.ReactNode;
+  className?: string;
+}
+
+// StatusPanel renders the canonical inline tone-tinted status block: 3px
+// left rail in the tone colour + tinted icon tile + heading + body. Same
+// "colour encodes meaning" principle as ColorRailCard, but inline-only and
+// smaller — meant for "this surface is in state X" notices that aren't the
+// primary hero.
+//
+// Originally established inline in `routes/setup-account.tsx` (iter 14) for
+// already-setup + invalid-token states. Promoted in iter 16 once the
+// Providers page needed the same vocabulary for env-locked + ENCRYPTION_KEY
+// warnings. Don't fork the look — change this primitive.
+//
+// Visual contract:
+//   `bg-muted/30 relative overflow-hidden rounded-md border p-4 pl-5`
+//     `before:` 3px tone-tinted left rail
+//     row: tinted icon tile (size-8) + heading + body
+//     optional trailing slot at the right edge
+const PALETTES: Record<
+  StatusPanelTone,
+  { rail: string; iconBg: string }
+> = {
+  success: {
+    rail: "before:bg-success",
+    iconBg: "bg-success/12 text-success",
+  },
+  destructive: {
+    rail: "before:bg-destructive",
+    iconBg: "bg-destructive/10 text-destructive",
+  },
+  warning: {
+    rail: "before:bg-amber-500",
+    iconBg: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
+  },
+  info: {
+    rail: "before:bg-muted-foreground/40",
+    iconBg: "bg-muted text-muted-foreground",
+  },
+};
+
+export function StatusPanel({
+  tone,
+  icon: Icon,
+  heading,
+  body,
+  trailing,
+  className,
+}: StatusPanelProps) {
+  const palette = PALETTES[tone];
+  return (
+    <div
+      className={cn(
+        "bg-muted/30 relative overflow-hidden rounded-md border p-4 pl-5 before:absolute before:top-0 before:bottom-0 before:left-0 before:w-[3px]",
+        palette.rail,
+        className,
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className={cn(
+            "flex size-8 shrink-0 items-center justify-center rounded-md",
+            palette.iconBg,
+          )}
+        >
+          <Icon className="size-4" />
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="text-foreground text-sm font-medium">{heading}</span>
+          {body && (
+            <span className="text-muted-foreground text-xs leading-relaxed">
+              {body}
+            </span>
+          )}
+        </div>
+        {trailing && (
+          <div className="ml-2 flex shrink-0 items-center">{trailing}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/providers/csv-card.tsx
+++ b/web/src/features/providers/csv-card.tsx
@@ -1,55 +1,68 @@
 import { Link } from "@tanstack/react-router";
 import { FileSpreadsheet, Upload } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { ColorRailCard } from "@/components/color-rail-card";
+import { SectionCard } from "@/components/section-card";
 import type { ProviderHealthResponse } from "@/api/types";
-import { ProviderStats } from "./provider-status";
+import {
+  ProviderScoreboard,
+  providerToneAccent,
+  resolveProviderTone,
+} from "./provider-status";
 
 interface CsvCardProps {
   health: ProviderHealthResponse | undefined;
 }
 
 export function CsvCard({ health }: CsvCardProps) {
-  return (
-    <Card className="overflow-hidden">
-      <CardHeader className="border-b">
-        <div className="flex items-center gap-3">
-          <div className="bg-amber-500/10 text-amber-600 dark:text-amber-400 flex size-10 items-center justify-center rounded-lg">
-            <FileSpreadsheet className="size-5" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <CardTitle className="text-base">CSV import</CardTitle>
-            <CardDescription className="text-xs">
-              Drop in transactions exported from any bank — no API credentials required.
-            </CardDescription>
-          </div>
-          <Badge variant="outline" className="border-emerald-500/40 text-emerald-600 dark:text-emerald-400">
-            Always available
-          </Badge>
-        </div>
-      </CardHeader>
+  // CSV is always available — there are no credentials to configure. Use the
+  // "configured" tone so the rail still encodes "this provider is usable"
+  // (warning when never imported, success after a successful import).
+  const tone = resolveProviderTone(health, true);
 
-      <CardContent className="space-y-6 pt-2">
-        <ProviderStats health={health} />
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <p className="text-muted-foreground max-w-md text-sm">
-            Useful when a bank isn't supported by Plaid or Teller, or as a one-time backfill for historical transactions.
-          </p>
+  return (
+    <div className="space-y-4">
+      <ColorRailCard accent={providerToneAccent(tone)}>
+        <div className="flex flex-col gap-5 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="bg-amber-500/10 text-amber-600 dark:text-amber-400 flex size-11 shrink-0 items-center justify-center rounded-lg">
+              <FileSpreadsheet className="size-5" />
+            </div>
+            <div className="min-w-0 space-y-1">
+              <div className="text-muted-foreground text-[11px] font-medium tracking-[0.08em] uppercase">
+                Provider
+              </div>
+              <h2 className="text-foreground text-lg font-semibold tracking-tight">
+                CSV import
+              </h2>
+              <p className="text-muted-foreground max-w-md text-sm">
+                Drop in transactions exported from any bank — no API credentials required.
+              </p>
+            </div>
+          </div>
+          <ProviderScoreboard health={health} tone={tone} alwaysAvailable />
+        </div>
+      </ColorRailCard>
+
+      <SectionCard
+        title="Import"
+        icon={<Upload className="text-muted-foreground size-4" />}
+        action={
           <Button asChild size="sm">
             <Link to="/connections" search={{ action: "connect" }}>
               <Upload className="size-3.5" />
               Import CSV
             </Link>
           </Button>
-        </div>
-      </CardContent>
-    </Card>
+        }
+      >
+        <p className="text-muted-foreground text-sm">
+          Useful when a bank isn't supported by Plaid or Teller, or as a one-time backfill
+          for historical transactions. Drag-and-drop a CSV file in the connections wizard,
+          map columns, and Breadbox will normalise the data into the same shape as
+          API-synced transactions.
+        </p>
+      </SectionCard>
+    </div>
   );
 }

--- a/web/src/features/providers/env-locked-notice.tsx
+++ b/web/src/features/providers/env-locked-notice.tsx
@@ -1,4 +1,5 @@
 import { Lock } from "lucide-react";
+import { StatusPanel } from "@/components/status-panel";
 
 interface EnvLockedNoticeProps {
   provider: string;
@@ -7,14 +8,16 @@ interface EnvLockedNoticeProps {
 // Shown in place of the form when the provider was configured via env vars.
 // The server-side handler rejects writes in this state (returns 409
 // PROVIDER_FROM_ENV), so editing inputs would just lead to a failed submit.
+//
+// Uses the shared `<StatusPanel>` primitive (iter 16 promotion) so this
+// matches the setup-account success/error vocabulary.
 export function EnvLockedNotice({ provider }: EnvLockedNoticeProps) {
   return (
-    <div className="bg-muted/50 text-muted-foreground flex items-start gap-2 rounded-md border px-3 py-2.5 text-xs">
-      <Lock className="mt-0.5 size-3.5 shrink-0" />
-      <div>
-        <span className="text-foreground font-medium">{provider} is configured via environment variables.</span>{" "}
-        To change these values, update the env vars and restart Breadbox.
-      </div>
-    </div>
+    <StatusPanel
+      tone="info"
+      icon={Lock}
+      heading={`${provider} is configured via environment variables.`}
+      body="To change these values, update the env vars on the server and restart Breadbox."
+    />
   );
 }

--- a/web/src/features/providers/plaid-card.tsx
+++ b/web/src/features/providers/plaid-card.tsx
@@ -2,15 +2,8 @@ import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { Building2, Trash2, Webhook } from "lucide-react";
+import { Building2, Loader2, Trash2, Webhook } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import {
   Form,
   FormControl,
@@ -39,6 +32,10 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { ColorRailCard } from "@/components/color-rail-card";
+import { SectionCard } from "@/components/section-card";
+import { FormFooter } from "@/components/form-footer";
+import { IdPill } from "@/components/id-pill";
 import { withMutationToast } from "@/lib/mutation-toast";
 import {
   useDisableProvider,
@@ -49,15 +46,16 @@ import type {
   ProviderHealthResponse,
 } from "@/api/types";
 import { EnvLockedNotice } from "./env-locked-notice";
-import { ProviderStats, ProviderStatusBadge } from "./provider-status";
+import {
+  ProviderScoreboard,
+  ProviderStatusBadge,
+  providerToneAccent,
+  resolveProviderTone,
+} from "./provider-status";
 import { TestConnectionButton } from "./test-connection-button";
 
 const ENVS = ["sandbox", "development", "production"] as const;
 
-// We don't validate the secret as required at the schema level. When the
-// provider already has a stored secret, an empty input means "keep the
-// existing one" — that's the same UX as the v1 admin form. The schema
-// `.refine` below enforces required only for first-time setup.
 const schema = z
   .object({
     client_id: z.string().min(1, "Client ID is required"),
@@ -121,28 +119,41 @@ export function PlaidCard({ config, health }: PlaidCardProps) {
     });
   }
 
+  const tone = resolveProviderTone(health, config.configured);
+
   return (
-    <Card className="overflow-hidden">
-      <CardHeader className="border-b">
-        <div className="flex items-center gap-3">
-          <div className="bg-blue-500/10 text-blue-600 dark:text-blue-400 flex size-10 items-center justify-center rounded-lg">
-            <Building2 className="size-5" />
+    <div className="space-y-4">
+      <ColorRailCard accent={providerToneAccent(tone)}>
+        <div className="flex flex-col gap-5 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="bg-blue-500/10 text-blue-600 dark:text-blue-400 flex size-11 shrink-0 items-center justify-center rounded-lg">
+              <Building2 className="size-5" />
+            </div>
+            <div className="min-w-0 space-y-1">
+              <div className="text-muted-foreground text-[11px] font-medium tracking-[0.08em] uppercase">
+                Provider
+              </div>
+              <div className="flex items-center gap-2">
+                <h2 className="text-foreground text-lg font-semibold tracking-tight">
+                  Plaid
+                </h2>
+                <ProviderStatusBadge health={health} configured={config.configured} />
+              </div>
+              <p className="text-muted-foreground max-w-md text-sm">
+                Thousands of financial institutions across the US, Canada, and Europe.
+              </p>
+            </div>
           </div>
-          <div className="min-w-0 flex-1">
-            <CardTitle className="text-base">Plaid</CardTitle>
-            <CardDescription className="text-xs">
-              Thousands of financial institutions across the US, Canada, and Europe.
-            </CardDescription>
-          </div>
-          <ProviderStatusBadge health={health} configured={config.configured} />
+          <ProviderScoreboard health={health} tone={tone} />
         </div>
-      </CardHeader>
+      </ColorRailCard>
 
-      <CardContent className="space-y-6 pt-2">
-        <ProviderStats health={health} />
-
+      <SectionCard
+        title="Credentials"
+        icon={<Building2 className="text-muted-foreground size-4" />}
+      >
         {config.from_env ? (
-          <>
+          <div className="space-y-4">
             <EnvLockedNotice provider="Plaid" />
             <dl className="grid grid-cols-1 gap-y-3 text-sm sm:grid-cols-[max-content_1fr] sm:gap-x-6">
               <Row label="Client ID" value={config.client_id ?? "—"} mono />
@@ -150,10 +161,10 @@ export function PlaidCard({ config, health }: PlaidCardProps) {
               <Row label="Environment" value={config.environment ?? "—"} />
               <Row label="Webhook URL" value={config.webhook_url || "Not set"} mono />
             </dl>
-          </>
+          </div>
         ) : (
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
               <div className="grid gap-4 sm:grid-cols-2">
                 <FormField
                   control={form.control}
@@ -242,74 +253,77 @@ export function PlaidCard({ config, health }: PlaidCardProps) {
                 )}
               />
 
-              <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
-                <Button type="submit" disabled={update.isPending}>
-                  {update.isPending ? "Saving…" : "Save Plaid settings"}
-                </Button>
-                {config.configured && (
-                  <AlertDialog open={confirmingDisable} onOpenChange={setConfirmingDisable}>
-                    <AlertDialogTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="text-muted-foreground hover:text-destructive"
-                      >
-                        <Trash2 className="size-3.5" />
-                        Disable Plaid
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Disable Plaid?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Stored credentials will be deleted from the database. Existing Plaid connections stay in your
-                          household but syncs will fail until you re-enter credentials.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={onDisable}
-                          className="bg-destructive text-white hover:bg-destructive/90"
+              <FormFooter
+                secondary={
+                  config.configured ? (
+                    <AlertDialog
+                      open={confirmingDisable}
+                      onOpenChange={setConfirmingDisable}
+                    >
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="text-muted-foreground hover:text-destructive"
                         >
+                          <Trash2 className="size-3.5" />
                           Disable
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                )}
-              </div>
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Disable Plaid?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Stored credentials will be deleted from the database. Existing
+                            Plaid connections stay in your household but syncs will fail until
+                            you re-enter credentials.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={onDisable}
+                            className="bg-destructive text-white hover:bg-destructive/90"
+                          >
+                            Disable
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  ) : null
+                }
+                primary={
+                  <Button type="submit" size="sm" disabled={update.isPending}>
+                    {update.isPending && <Loader2 className="size-4 animate-spin" />}
+                    {update.isPending ? "Saving…" : "Save settings"}
+                  </Button>
+                }
+              />
             </form>
           </Form>
         )}
+      </SectionCard>
 
-        {config.configured && (
-          <div className="border-t pt-4">
-            <TestConnectionButton provider="plaid" />
-          </div>
-        )}
-
-        {config.configured && (
-          <details className="group rounded-md border bg-muted/30 px-3 py-2 text-sm">
-            <summary className="text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-2 text-xs font-medium">
-              <Webhook className="size-3.5" />
-              Webhook setup
-            </summary>
-            <div className="text-muted-foreground mt-3 space-y-2 text-xs">
-              <p>
-                Plaid automatically subscribes to webhooks when the URL above is set during link-token creation. No
-                separate Plaid-dashboard step needed.
-              </p>
-              <p>Point Plaid at:</p>
-              <code className="bg-background block break-all rounded border px-2 py-1.5 font-mono text-xs select-all">
-                https://&lt;your-domain&gt;/webhooks/plaid
-              </code>
+      {config.configured && (
+        <SectionCard
+          title="Diagnostics"
+          icon={<Webhook className="text-muted-foreground size-4" />}
+          action={<TestConnectionButton provider="plaid" />}
+        >
+          <div className="text-muted-foreground space-y-3 text-xs">
+            <p className="text-foreground text-sm font-medium">Webhook endpoint</p>
+            <p>
+              Plaid automatically subscribes to webhooks when the URL above is set during
+              link-token creation. No separate Plaid-dashboard step needed.
+            </p>
+            <div>
+              <IdPill value="https://<your-domain>/webhooks/plaid" />
             </div>
-          </details>
-        )}
-      </CardContent>
-    </Card>
+          </div>
+        </SectionCard>
+      )}
+    </div>
   );
 }
 

--- a/web/src/features/providers/provider-status.tsx
+++ b/web/src/features/providers/provider-status.tsx
@@ -3,6 +3,44 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import type { ProviderHealthResponse } from "@/api/types";
 
+export type ProviderTone = "success" | "destructive" | "warning" | "muted";
+
+// resolveProviderTone returns the meaning-encoded tone for a provider row.
+// Mirrors the connection-detail hero pattern: success when last sync passed,
+// destructive on a sync error, warning when configured-but-never-synced,
+// muted when not configured at all. Used to drive the ColorRailCard rail
+// colour + the inline status badge.
+export function resolveProviderTone(
+  health: ProviderHealthResponse | undefined,
+  configured: boolean,
+): ProviderTone {
+  if (health?.last_sync_time && health.last_sync_status === "error") {
+    return "destructive";
+  }
+  if (health?.last_sync_time && health.last_sync_status === "success") {
+    return "success";
+  }
+  if (configured) return "warning";
+  return "muted";
+}
+
+// providerToneAccent returns the CSS colour for the ColorRailCard rail.
+// Uses the same fallback pattern as connection-detail: prefer the token,
+// fall back to an oklch literal so themes without the token still resolve.
+export function providerToneAccent(tone: ProviderTone): string {
+  switch (tone) {
+    case "success":
+      return "var(--success, oklch(0.62 0.18 145))";
+    case "destructive":
+      return "var(--destructive)";
+    case "warning":
+      return "var(--warning, oklch(0.78 0.16 75))";
+    case "muted":
+    default:
+      return "var(--muted)";
+  }
+}
+
 interface ProviderStatusBadgeProps {
   health: ProviderHealthResponse | undefined;
   configured: boolean;
@@ -13,7 +51,8 @@ interface ProviderStatusBadgeProps {
 // The colored dot is part of the badge so the row reads at a glance without
 // landing on the text first.
 export function ProviderStatusBadge({ health, configured }: ProviderStatusBadgeProps) {
-  if (health?.last_sync_time && health.last_sync_status === "error") {
+  const tone = resolveProviderTone(health, configured);
+  if (tone === "destructive") {
     return (
       <Badge variant="outline" className="border-destructive/40 text-destructive">
         <AlertTriangle className="size-3" />
@@ -21,7 +60,7 @@ export function ProviderStatusBadge({ health, configured }: ProviderStatusBadgeP
       </Badge>
     );
   }
-  if (health?.last_sync_time && health.last_sync_status === "success") {
+  if (tone === "success") {
     return (
       <Badge variant="outline" className="border-emerald-500/40 text-emerald-600 dark:text-emerald-400">
         <CheckCircle2 className="size-3" />
@@ -29,9 +68,9 @@ export function ProviderStatusBadge({ health, configured }: ProviderStatusBadgeP
       </Badge>
     );
   }
-  if (configured) {
+  if (tone === "warning") {
     return (
-      <Badge variant="outline" className="border-emerald-500/40 text-emerald-600 dark:text-emerald-400">
+      <Badge variant="outline" className="border-amber-500/40 text-amber-600 dark:text-amber-400">
         <CheckCircle2 className="size-3" />
         Configured
       </Badge>
@@ -87,6 +126,70 @@ export function ProviderStats({ health }: ProviderStatsProps) {
         </div>
       )}
     </dl>
+  );
+}
+
+interface ProviderScoreboardProps {
+  health: ProviderHealthResponse | undefined;
+  tone: ProviderTone;
+  // Optional "always available" override (used by CSV which has no toggle).
+  alwaysAvailable?: boolean;
+}
+
+// ProviderScoreboard is the right-column metric block on the provider hero.
+// Mirrors the ColorRailCard right-column shape used by Connection-detail /
+// Account-detail heroes: small uppercase label + tabular value, plus an
+// inline status pill in the tone colour. Hides the "connections / accounts"
+// scoreboard when health hasn't loaded yet so it doesn't read as zeros.
+export function ProviderScoreboard({ health, tone, alwaysAvailable }: ProviderScoreboardProps) {
+  const tonePill =
+    tone === "success"
+      ? "border-emerald-500/40 text-emerald-600 dark:text-emerald-400 bg-emerald-500/10"
+      : tone === "destructive"
+        ? "border-destructive/40 text-destructive bg-destructive/10"
+        : tone === "warning"
+          ? "border-amber-500/40 text-amber-600 dark:text-amber-400 bg-amber-500/10"
+          : "border-border text-muted-foreground bg-muted/40";
+  const headlineLabel = alwaysAvailable
+    ? "Always available"
+    : tone === "success"
+      ? `Synced ${health?.last_sync_time ?? ""}`
+      : tone === "destructive"
+        ? `Failed ${health?.last_sync_time ?? ""}`
+        : tone === "warning"
+          ? health?.connection_count
+            ? "Never synced"
+            : "Awaiting connection"
+          : "Not connected";
+
+  return (
+    <div className="flex flex-col items-end gap-2 sm:items-end">
+      <span
+        className={cn(
+          "inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium",
+          tonePill,
+        )}
+      >
+        {headlineLabel}
+      </span>
+      {health && (
+        <div className="flex items-center gap-4 text-right">
+          <ScoreCell label="Connections" value={String(health.connection_count)} />
+          <ScoreCell label="Accounts" value={String(health.account_count)} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ScoreCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-muted-foreground text-[10px] font-medium tracking-[0.08em] uppercase">
+        {label}
+      </div>
+      <div className="text-foreground text-lg font-semibold tabular-nums">{value}</div>
+    </div>
   );
 }
 

--- a/web/src/features/providers/teller-card.tsx
+++ b/web/src/features/providers/teller-card.tsx
@@ -7,18 +7,12 @@ import {
   Check,
   FileKey2,
   Landmark,
+  Loader2,
   Trash2,
   Upload,
   Webhook,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import {
   Form,
   FormControl,
@@ -37,11 +31,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/components/ui/alert";
-import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -52,6 +41,11 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
+import { ColorRailCard } from "@/components/color-rail-card";
+import { SectionCard } from "@/components/section-card";
+import { FormFooter } from "@/components/form-footer";
+import { IdPill } from "@/components/id-pill";
+import { StatusPanel } from "@/components/status-panel";
 import { toast } from "sonner";
 import { withMutationToast } from "@/lib/mutation-toast";
 import {
@@ -63,7 +57,12 @@ import type {
   TellerConfigView,
 } from "@/api/types";
 import { EnvLockedNotice } from "./env-locked-notice";
-import { ProviderStats, ProviderStatusBadge } from "./provider-status";
+import {
+  ProviderScoreboard,
+  ProviderStatusBadge,
+  providerToneAccent,
+  resolveProviderTone,
+} from "./provider-status";
 import { TestConnectionButton } from "./test-connection-button";
 
 const ENVS = ["sandbox", "development", "production"] as const;
@@ -144,28 +143,41 @@ export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps
     });
   }
 
+  const tone = resolveProviderTone(health, config.configured);
+
   return (
-    <Card className="overflow-hidden">
-      <CardHeader className="border-b">
-        <div className="flex items-center gap-3">
-          <div className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 flex size-10 items-center justify-center rounded-lg">
-            <Landmark className="size-5" />
+    <div className="space-y-4">
+      <ColorRailCard accent={providerToneAccent(tone)}>
+        <div className="flex flex-col gap-5 px-6 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-7">
+          <div className="flex min-w-0 items-start gap-3">
+            <div className="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 flex size-11 shrink-0 items-center justify-center rounded-lg">
+              <Landmark className="size-5" />
+            </div>
+            <div className="min-w-0 space-y-1">
+              <div className="text-muted-foreground text-[11px] font-medium tracking-[0.08em] uppercase">
+                Provider
+              </div>
+              <div className="flex items-center gap-2">
+                <h2 className="text-foreground text-lg font-semibold tracking-tight">
+                  Teller
+                </h2>
+                <ProviderStatusBadge health={health} configured={config.configured} />
+              </div>
+              <p className="text-muted-foreground max-w-md text-sm">
+                US bank coverage via mutual-TLS authentication.
+              </p>
+            </div>
           </div>
-          <div className="min-w-0 flex-1">
-            <CardTitle className="text-base">Teller</CardTitle>
-            <CardDescription className="text-xs">
-              US bank coverage via mutual-TLS authentication.
-            </CardDescription>
-          </div>
-          <ProviderStatusBadge health={health} configured={config.configured} />
+          <ProviderScoreboard health={health} tone={tone} />
         </div>
-      </CardHeader>
+      </ColorRailCard>
 
-      <CardContent className="space-y-6 pt-2">
-        <ProviderStats health={health} />
-
+      <SectionCard
+        title="Credentials"
+        icon={<Landmark className="text-muted-foreground size-4" />}
+      >
         {config.from_env ? (
-          <>
+          <div className="space-y-4">
             <EnvLockedNotice provider="Teller" />
             <dl className="grid grid-cols-1 gap-y-3 text-sm sm:grid-cols-[max-content_1fr] sm:gap-x-6">
               <Row label="Application ID" value={config.application_id ?? "—"} mono />
@@ -176,10 +188,10 @@ export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps
                 value={config.webhook_secret_set ? "Configured" : "Not configured"}
               />
             </dl>
-          </>
+          </div>
         ) : (
           <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
               <div className="grid gap-4 sm:grid-cols-2">
                 <FormField
                   control={form.control}
@@ -221,19 +233,23 @@ export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps
               </div>
 
               {!hasEncryptionKey && (
-                <Alert variant="default" className="border-amber-500/40 bg-amber-500/5">
-                  <AlertTriangle className="size-4 text-amber-600 dark:text-amber-400" />
-                  <AlertTitle className="text-amber-700 dark:text-amber-400">
-                    ENCRYPTION_KEY is not set
-                  </AlertTitle>
-                  <AlertDescription>
-                    Teller certificates are encrypted at rest. Set the <code className="font-mono text-xs">ENCRYPTION_KEY</code>{" "}
-                    environment variable before uploading a certificate.
-                  </AlertDescription>
-                </Alert>
+                <StatusPanel
+                  tone="warning"
+                  icon={AlertTriangle}
+                  heading="ENCRYPTION_KEY is not set"
+                  body={
+                    <>
+                      Teller certificates are encrypted at rest. Set the{" "}
+                      <code className="bg-muted/60 rounded px-1 py-0.5 font-mono text-[11px]">
+                        ENCRYPTION_KEY
+                      </code>{" "}
+                      environment variable before uploading a certificate.
+                    </>
+                  }
+                />
               )}
 
-              <div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+              <div className="bg-muted/20 space-y-3 rounded-lg border p-4">
                 <div className="flex items-center gap-2">
                   <FileKey2 className="text-muted-foreground size-4" />
                   <span className="text-sm font-medium">mTLS certificate</span>
@@ -292,77 +308,81 @@ export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps
                 )}
               />
 
-              <div className="flex flex-wrap items-center justify-between gap-3 pt-1">
-                <Button type="submit" disabled={update.isPending}>
-                  {update.isPending ? "Saving…" : "Save Teller settings"}
-                </Button>
-                {config.configured && (
-                  <AlertDialog open={confirmingDisable} onOpenChange={setConfirmingDisable}>
-                    <AlertDialogTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="text-muted-foreground hover:text-destructive"
-                      >
-                        <Trash2 className="size-3.5" />
-                        Disable Teller
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>Disable Teller?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Stored credentials (application ID, webhook secret, and encrypted certificate) will be
-                          deleted from the database. Existing Teller connections stay in your household but syncs
-                          will fail until you re-enter credentials.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Cancel</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={onDisable}
-                          className="bg-destructive text-white hover:bg-destructive/90"
+              <FormFooter
+                secondary={
+                  config.configured ? (
+                    <AlertDialog
+                      open={confirmingDisable}
+                      onOpenChange={setConfirmingDisable}
+                    >
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="text-muted-foreground hover:text-destructive"
                         >
+                          <Trash2 className="size-3.5" />
                           Disable
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
-                )}
-              </div>
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Disable Teller?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            Stored credentials (application ID, webhook secret, and encrypted
+                            certificate) will be deleted from the database. Existing Teller
+                            connections stay in your household but syncs will fail until you
+                            re-enter credentials.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={onDisable}
+                            className="bg-destructive text-white hover:bg-destructive/90"
+                          >
+                            Disable
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  ) : null
+                }
+                primary={
+                  <Button type="submit" size="sm" disabled={update.isPending}>
+                    {update.isPending && <Loader2 className="size-4 animate-spin" />}
+                    {update.isPending ? "Saving…" : "Save settings"}
+                  </Button>
+                }
+              />
             </form>
           </Form>
         )}
+      </SectionCard>
 
-        {config.configured && (
-          <div className="border-t pt-4">
-            <TestConnectionButton provider="teller" />
+      {config.configured && (
+        <SectionCard
+          title="Diagnostics"
+          icon={<Webhook className="text-muted-foreground size-4" />}
+          action={<TestConnectionButton provider="teller" />}
+        >
+          <div className="text-muted-foreground space-y-3 text-xs">
+            <p className="text-foreground text-sm font-medium">Webhook setup</p>
+            <ol className="ml-4 list-decimal space-y-2">
+              <li>Open the Teller dashboard and navigate to your application settings.</li>
+              <li>
+                Set the webhook URL to{" "}
+                <span className="inline-block align-middle">
+                  <IdPill value="https://<your-domain>/webhooks/teller" />
+                </span>
+              </li>
+              <li>Copy the webhook signing secret from Teller and paste it above.</li>
+            </ol>
           </div>
-        )}
-
-        {config.configured && (
-          <details className="group rounded-md border bg-muted/30 px-3 py-2 text-sm">
-            <summary className="text-muted-foreground hover:text-foreground flex cursor-pointer items-center gap-2 text-xs font-medium">
-              <Webhook className="size-3.5" />
-              Webhook setup
-            </summary>
-            <div className="text-muted-foreground mt-3 space-y-2 text-xs">
-              <ol className="ml-4 list-decimal space-y-1">
-                <li>Open the Teller dashboard and navigate to your application settings.</li>
-                <li>Set the webhook URL to:</li>
-              </ol>
-              <code className="bg-background block break-all rounded border px-2 py-1.5 font-mono text-xs select-all">
-                https://&lt;your-domain&gt;/webhooks/teller
-              </code>
-              <ol className="ml-4 list-decimal space-y-1" start={3}>
-                <li>Copy the webhook signing secret from Teller and paste it above.</li>
-              </ol>
-            </div>
-          </details>
-        )}
-      </CardContent>
-    </Card>
+        </SectionCard>
+      )}
+    </div>
   );
 }
 
@@ -382,7 +402,7 @@ function PemFileInput({ id, label, accept, file, onChange }: PemFileInputProps) 
       </label>
       <label
         htmlFor={id}
-        className="border-input hover:bg-muted/60 flex cursor-pointer items-center gap-2 rounded-md border border-dashed bg-background px-3 py-2 text-xs transition-colors"
+        className="border-input bg-background hover:bg-muted/60 flex cursor-pointer items-center gap-2 rounded-md border border-dashed px-3 py-2 text-xs transition-colors"
       >
         <Upload className="text-muted-foreground size-3.5" />
         <span className={file ? "text-foreground truncate" : "text-muted-foreground"}>

--- a/web/src/routes/providers.tsx
+++ b/web/src/routes/providers.tsx
@@ -6,6 +6,29 @@ import {
   useProviderHealth,
 } from "@/api/queries/provider-config";
 import { CsvCard, PlaidCard, TellerCard } from "@/features/providers";
+import type { ProviderConfigResponse, ProviderHealthResponse } from "@/api/types";
+
+// Build the small "N healthy · M of 3 configured" eyebrow that lands in
+// PageHeader so the page reads as a status overview before the cards.
+function buildEyebrow(
+  config: ProviderConfigResponse,
+  health: Record<string, ProviderHealthResponse>,
+): string {
+  const configured = [
+    config.plaid.configured,
+    config.teller.configured,
+    true, // CSV is always available
+  ].filter(Boolean).length;
+  const healthyCount = ["plaid", "teller", "csv"].reduce((acc, key) => {
+    const h = health[key];
+    if (h && h.last_sync_time && h.last_sync_status === "success") return acc + 1;
+    return acc;
+  }, 0);
+  if (healthyCount > 0) {
+    return `${healthyCount} healthy · ${configured} of 3 configured`;
+  }
+  return `${configured} of 3 configured`;
+}
 
 export function ProvidersPage() {
   const config = useProviderConfig();
@@ -15,6 +38,7 @@ export function ProvidersPage() {
     return (
       <>
         <PageHeader
+          eyebrow="Settings"
           title="Providers"
           description="Configure bank data providers that sync accounts and transactions."
         />
@@ -29,6 +53,7 @@ export function ProvidersPage() {
     return (
       <>
         <PageHeader
+          eyebrow="Settings"
           title="Providers"
           description="Configure bank data providers that sync accounts and transactions."
         />
@@ -46,14 +71,16 @@ export function ProvidersPage() {
 
   const { plaid, teller, has_encryption_key } = config.data;
   const healthMap = health.data ?? {};
+  const eyebrow = buildEyebrow(config.data, healthMap);
 
   return (
     <>
       <PageHeader
+        eyebrow={eyebrow}
         title="Providers"
-        description="Configure bank data providers that sync accounts and transactions into Breadbox."
+        description="Bank data providers that sync accounts and transactions into Breadbox. Each provider stores its own encrypted credentials."
       />
-      <div className="grid gap-4">
+      <div className="grid gap-5">
         <PlaidCard config={plaid} health={healthMap["plaid"]} />
         <TellerCard
           config={teller}

--- a/web/src/routes/setup-account.tsx
+++ b/web/src/routes/setup-account.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { AuthShell } from "@/components/auth-shell";
+import { StatusPanel } from "@/components/status-panel";
 import { toast } from "sonner";
 import { useSetupAccount, useSetupAccountInfo } from "@/api/queries/auth";
 import { ApiError } from "@/api/client";
@@ -212,48 +213,3 @@ export function SetupAccountPage() {
   );
 }
 
-function StatusPanel({
-  tone,
-  icon: Icon,
-  heading,
-  body,
-}: {
-  tone: "success" | "destructive";
-  icon: React.ComponentType<{ className?: string }>;
-  heading: string;
-  body: string;
-}) {
-  // Inline panel used by setup-account's success / error states. Color is
-  // load-bearing here: success-tinted rail for "already set up" reads as
-  // resolution; destructive rail for "invalid link" reads as friction. Same
-  // colour-encodes-meaning principle as ColorRailCard, but inline-only.
-  const palette =
-    tone === "success"
-      ? {
-          rail: "before:bg-success",
-          iconBg: "bg-success/12 text-success",
-        }
-      : {
-          rail: "before:bg-destructive",
-          iconBg: "bg-destructive/10 text-destructive",
-        };
-  return (
-    <div
-      className={`bg-muted/30 relative overflow-hidden rounded-md border p-4 pl-5 before:absolute before:top-0 before:bottom-0 before:left-0 before:w-[3px] ${palette.rail}`}
-    >
-      <div className="flex items-start gap-3">
-        <span
-          className={`flex size-8 shrink-0 items-center justify-center rounded-md ${palette.iconBg}`}
-        >
-          <Icon className="size-4" />
-        </span>
-        <div className="flex flex-col gap-0.5">
-          <span className="text-foreground text-sm font-medium">{heading}</span>
-          <span className="text-muted-foreground text-xs leading-relaxed">
-            {body}
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}


### PR DESCRIPTION
## Summary
- Each provider becomes a `<ColorRailCard>` hero with a status-tinted rail (success / destructive / warning / muted), an identity column (icon tile + name + description + status badge), and a `ProviderScoreboard` right column (Connections / Accounts cells + tone-tinted "Synced …" pill). Same vocabulary as the iter-11 connection-detail hero.
- Below each hero: a `<SectionCard>` "Credentials" (form or env-locked KV) + a `<SectionCard>` "Diagnostics" (Test connection + webhook setup), with the save/disable action strip migrated to `<FormFooter>` — fourth surface for the iter-15 primitive.
- Promoted `<StatusPanel>` to `web/src/components/status-panel.tsx` (tones: success / destructive / warning / info). The iter-14 drift note queued this once a second surface needed it; Providers brings two (env-locked notices on both providers + the Teller `ENCRYPTION_KEY` warning), so the primitive lands now. `setup-account` migrates onto the shared component; the previously open-coded amber `Alert` on Teller for the missing encryption key also retires onto `StatusPanel`.
- PageHeader now carries a status eyebrow ("N healthy · M of 3 configured") matching the list-page vocabulary (Tags / Transactions / Connections / Categories / Accounts / API keys / Providers). Webhook URLs render via `IdPill`.

## Before / After
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/dxeinvm6c2.jpg) | ![after](https://i.img402.dev/nrcv5c9zpw.jpg) |

## Notes
- `StatusPanel` is the fifth shell-style primitive in the v2 vocabulary (after `ColorRailCard`, `SectionCard`, `ListCard`, `AuthShell`, `FormFooter`). Tones reuse the same "colour encodes meaning" principle as ColorRailCard but inline and smaller.
- The Teller card's bespoke amber `<Alert>` for the missing `ENCRYPTION_KEY` is gone — `StatusPanel tone="warning"` carries the same signal with one less border-radius family.
- CSV card drops the duplicate "Always available" badge (the scoreboard pill already says it).
- `ProviderStats` is kept exported but no longer rendered; the scoreboard subsumes it. Safe to drop in a future sweep — left in place this iteration because nothing else consumes it and the function reads as a useful fallback for a tighter layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)