### PR TITLE
design(v2): command palette polish

### DIFF
--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -1,6 +1,16 @@
 import * as React from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { ArrowUpDown, CircleDot, Palette, type LucideIcon } from "lucide-react";
+import {
+  ArrowUpDown,
+  ChevronRight,
+  CircleDot,
+  Clock,
+  CornerDownLeft,
+  Keyboard,
+  LogOut,
+  Palette,
+  type LucideIcon,
+} from "lucide-react";
 import {
   CommandDialog,
   CommandEmpty,
@@ -9,8 +19,10 @@ import {
   CommandItem,
   CommandList,
   CommandSeparator,
+  CommandShortcut,
 } from "@/components/ui/command";
-import { NAV, navKey } from "@/lib/nav";
+import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import { NAV, NAV_LEAVES, navKey, type NavLeaf } from "@/lib/nav";
 import { openModal } from "@/lib/modals";
 import { useShortcut } from "@/lib/shortcuts";
 import { useLogout } from "@/api/queries/auth";
@@ -51,8 +63,64 @@ const TX_QUICK_ACTIONS: {
   },
 ];
 
+// Recent nav-jumps live in localStorage so they survive reloads. Cap at 4
+// so the section doesn't crowd the palette; LRU eviction.
+const RECENTS_KEY = "breadbox:cmdk:recents";
+const RECENTS_MAX = 4;
+
+function readRecents(): string[] {
+  try {
+    const raw = localStorage.getItem(RECENTS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    return [];
+  }
+}
+
+function pushRecent(key: string) {
+  try {
+    const current = readRecents().filter((k) => k !== key);
+    const next = [key, ...current].slice(0, RECENTS_MAX);
+    localStorage.setItem(RECENTS_KEY, JSON.stringify(next));
+  } catch {
+    // ignore — quota / private mode
+  }
+}
+
+// Build an "ItemRow" so every line in the palette renders with the same
+// vocabulary (icon, label, optional kbd hint, optional trailing chevron).
+function ItemRow({
+  icon: Icon,
+  title,
+  hint,
+  trailingChevron = false,
+}: {
+  icon: LucideIcon;
+  title: string;
+  hint?: React.ReactNode;
+  trailingChevron?: boolean;
+}) {
+  return (
+    <>
+      <Icon className="size-4" />
+      <span>{title}</span>
+      {hint ? <CommandShortcut>{hint}</CommandShortcut> : null}
+      {trailingChevron ? (
+        <ChevronRight
+          className="text-muted-foreground/0 group-data-[selected=true]:text-muted-foreground/70 ml-auto size-3.5 transition-colors"
+          aria-hidden
+        />
+      ) : null}
+    </>
+  );
+}
+
 export function CommandPalette() {
   const [open, setOpen] = React.useState(false);
+  const [recents, setRecents] = React.useState<string[]>([]);
   const navigate = useNavigate();
   const logout = useLogout();
 
@@ -73,14 +141,31 @@ export function CommandPalette() {
       window.removeEventListener("breadbox:command-palette:open", onOpen);
   }, []);
 
-  const go = (to: string) => {
+  // Re-read recents whenever the palette opens — cheap, and avoids stale
+  // state if another tab pushed an entry while we were closed.
+  React.useEffect(() => {
+    if (open) setRecents(readRecents());
+  }, [open]);
+
+  const go = (to: string, recentKey?: string) => {
     setOpen(false);
+    if (recentKey) pushRecent(recentKey);
     navigate({ to });
   };
 
-  const runOpenModal = (modalKey: string) => {
+  const runOpenModal = (modalKey: string, recentKey?: string) => {
     setOpen(false);
+    if (recentKey) pushRecent(recentKey);
     navigate({ to: ".", search: openModal(modalKey) });
+  };
+
+  const runNavLeaf = (leaf: NavLeaf, group: string) => {
+    const key = navKey(leaf);
+    if (leaf.kind === "link") go(leaf.to, key);
+    else runOpenModal(leaf.modalKey, key);
+    // group is in scope so we could later record group→item analytics; for
+    // now it's the value used by cmdk for fuzzy matching.
+    void group;
   };
 
   const runQuickFilter = (patch: Partial<TransactionsSearch>) => {
@@ -100,65 +185,175 @@ export function CommandPalette() {
     navigate({ to: "/login" });
   };
 
+  // Resolve the recent keys to nav leaves once per render — keeps the
+  // recents section in sync with NAV ordering / icons (no forked metadata).
+  const recentLeaves = React.useMemo(() => {
+    if (!recents.length) return [];
+    const byKey = new Map(NAV_LEAVES.map((l) => [navKey(l.leaf), l]));
+    return recents
+      .map((k) => byKey.get(k))
+      .filter((v): v is (typeof NAV_LEAVES)[number] => Boolean(v));
+  }, [recents]);
+
   return (
-    <CommandDialog open={open} onOpenChange={setOpen}>
-      <CommandInput placeholder="Type a command or search…" />
-      <CommandList>
-        <CommandEmpty>No results found.</CommandEmpty>
-        {NAV.map((group) => (
-          <CommandGroup key={group.label} heading={group.label}>
-            {group.items.map((item) => {
-              const Icon = item.icon;
-              return (
+    <CommandDialog
+      open={open}
+      onOpenChange={setOpen}
+      // Tighten the default cmdk wrapper so rows scan denser. Default ships
+      // with py-3 / size-5 icons — overshoots for a navigation-heavy
+      // palette. We also style group headings as uppercase eyebrows so
+      // they read as section labels, not titles.
+      className="overflow-hidden p-0 sm:max-w-xl"
+    >
+      <CommandInput placeholder="Search or jump to anything…" />
+      <CommandList className="max-h-[440px] [&_[cmdk-group-heading]]:text-muted-foreground/70 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:pt-2.5 [&_[cmdk-group-heading]]:pb-1 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group]]:px-2 [&_[cmdk-input]]:h-11 [&_[cmdk-input-wrapper]_svg]:size-4 [&_[cmdk-item]]:gap-2.5 [&_[cmdk-item]]:px-2.5 [&_[cmdk-item]]:py-2 [&_[cmdk-item]_svg]:size-4">
+        <CommandEmpty>
+          <div className="text-muted-foreground flex flex-col items-center gap-1 py-4 text-sm">
+            <span className="font-medium">No matches</span>
+            <span className="text-xs">
+              Try a page name, a tag, or a quick action.
+            </span>
+          </div>
+        </CommandEmpty>
+
+        {recentLeaves.length > 0 ? (
+          <>
+            <CommandGroup heading="Recent">
+              {recentLeaves.map(({ leaf, group }) => (
+                <CommandItem
+                  key={`recent:${navKey(leaf)}`}
+                  // Make recents searchable both by their own name and the
+                  // group they belong to, while keeping cmdk's scoring
+                  // honest (uniqueness via the explicit prefix).
+                  value={`recent ${group} ${leaf.title}`}
+                  onSelect={() => runNavLeaf(leaf, group)}
+                  className="group"
+                >
+                  <ItemRow
+                    icon={Clock}
+                    title={leaf.title}
+                    hint={<span className="text-[10px]">{group}</span>}
+                    trailingChevron
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+            <CommandSeparator />
+          </>
+        ) : null}
+
+        {NAV.map((group, idx) => (
+          <React.Fragment key={group.label}>
+            <CommandGroup heading={`Jump to · ${group.label}`}>
+              {group.items.map((item) => (
                 <CommandItem
                   key={navKey(item)}
                   value={`${group.label} ${item.title}`}
-                  onSelect={() =>
-                    item.kind === "link"
-                      ? go(item.to)
-                      : runOpenModal(item.modalKey)
-                  }
+                  onSelect={() => runNavLeaf(item, group.label)}
+                  className="group"
                 >
-                  <Icon className="size-4" />
-                  <span>{item.title}</span>
+                  <ItemRow
+                    icon={item.icon}
+                    title={item.title}
+                    trailingChevron
+                  />
                 </CommandItem>
-              );
-            })}
-          </CommandGroup>
+              ))}
+            </CommandGroup>
+            {idx < NAV.length - 1 ? <CommandSeparator /> : null}
+          </React.Fragment>
         ))}
+
         <CommandSeparator />
-        <CommandGroup heading="Transactions">
-          {TX_QUICK_ACTIONS.map((action) => {
-            const Icon = action.icon;
-            return (
-              <CommandItem
-                key={action.title}
-                value={action.value}
-                onSelect={() => runQuickFilter(action.search)}
-              >
-                <Icon className="size-4" />
-                <span>{action.title}</span>
-              </CommandItem>
-            );
-          })}
+        <CommandGroup heading="Transactions · Quick actions">
+          {TX_QUICK_ACTIONS.map((action) => (
+            <CommandItem
+              key={action.title}
+              value={action.value}
+              onSelect={() => runQuickFilter(action.search)}
+              className="group"
+            >
+              <ItemRow
+                icon={action.icon}
+                title={action.title}
+                trailingChevron
+              />
+            </CommandItem>
+          ))}
         </CommandGroup>
+
         <CommandSeparator />
-        <CommandGroup heading="Developer">
+        <CommandGroup heading="Help & developer">
+          <CommandItem
+            value="keyboard shortcuts kbd help cheatsheet"
+            onSelect={() => {
+              setOpen(false);
+              window.dispatchEvent(
+                new CustomEvent("breadbox:shortcut-sheet:open"),
+              );
+            }}
+            className="group"
+          >
+            <ItemRow
+              icon={Keyboard}
+              title="Keyboard shortcuts"
+              hint={
+                <KbdGroup>
+                  <Kbd className="bg-muted/60">⇧</Kbd>
+                  <Kbd className="bg-muted/60">?</Kbd>
+                </KbdGroup>
+              }
+            />
+          </CommandItem>
           <CommandItem
             value="design system sandbox components primitives"
             onSelect={() => go("/sandbox")}
+            className="group"
           >
-            <Palette className="size-4" />
-            <span>Design system</span>
+            <ItemRow
+              icon={Palette}
+              title="Design system"
+              trailingChevron
+            />
           </CommandItem>
         </CommandGroup>
+
         <CommandSeparator />
         <CommandGroup heading="Account">
-          <CommandItem value="logout sign out" onSelect={runLogout}>
-            <span>Sign out</span>
+          <CommandItem
+            value="logout sign out"
+            onSelect={runLogout}
+            className="group"
+          >
+            <ItemRow icon={LogOut} title="Sign out" />
           </CommandItem>
         </CommandGroup>
       </CommandList>
+
+      {/* Action strip — matches the standard cmdk vocabulary (Linear,
+          Raycast, shadcn examples) so first-time users know what the
+          keys do without leaving the palette. */}
+      <div className="bg-muted/30 text-muted-foreground flex items-center justify-between gap-3 border-t px-3 py-2 text-[11px]">
+        <div className="flex items-center gap-3">
+          <span className="inline-flex items-center gap-1.5">
+            <KbdGroup>
+              <Kbd className="bg-background/80">↑</Kbd>
+              <Kbd className="bg-background/80">↓</Kbd>
+            </KbdGroup>
+            Navigate
+          </span>
+          <span className="inline-flex items-center gap-1.5">
+            <Kbd className="bg-background/80">
+              <CornerDownLeft className="size-3" aria-hidden />
+            </Kbd>
+            Select
+          </span>
+        </div>
+        <span className="inline-flex items-center gap-1.5">
+          <Kbd className="bg-background/80">esc</Kbd>
+          Close
+        </span>
+      </div>
     </CommandDialog>
   );
 }

--- a/web/src/components/shortcut-sheet.tsx
+++ b/web/src/components/shortcut-sheet.tsx
@@ -30,6 +30,16 @@ export function ShortcutSheet() {
     group: "Global",
   });
 
+  // Command palette (and any other surface) can ask us to open without
+  // owning a ref — keeps `open` state local but lets external callers
+  // surface the sheet on demand.
+  React.useEffect(() => {
+    const onOpen = () => setOpen(true);
+    window.addEventListener("breadbox:shortcut-sheet:open", onOpen);
+    return () =>
+      window.removeEventListener("breadbox:shortcut-sheet:open", onOpen);
+  }, []);
+
   const grouped = React.useMemo(() => {
     const out = new Map<string, Shortcut[]>();
     for (const s of list) {


### PR DESCRIPTION
## Summary
- Renames each NAV group to "Jump to · <Group>" and the misleading "Transactions" group to "Transactions · Quick actions"; tightens cmdk density (uppercase tracked eyebrow group headings, denser rows) so the palette scans like the rest of the v2 surfaces.
- Adds a localStorage-backed Recent section (top 4, LRU) so the highest-frequency jumps land first; sources icons/labels from `NAV_LEAVES` so there's no forked metadata.
- Adds a footer action strip (`↑↓ Navigate · ↵ Select · esc Close`) using the existing `Kbd` primitive — standard cmdk vocabulary that matches the topbar trigger pill.
- Adds a "Keyboard shortcuts" entry that opens the existing `ShortcutSheet` via a new `breadbox:shortcut-sheet:open` event, with an inline `⇧?` hint so mouse-first users discover the global shortcut.
- Adds a subtle `ChevronRight` on the selected nav row so "this is a jump target" reads at a glance.

## Before / After
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/uz1ea9u6lq.jpg) | ![after](https://i.img402.dev/z6kvck0yfu.jpg) |

Filtered state (typing `trans`) showing the renamed "Transactions · Quick actions" group, the chevron affordance on the selected row, and the footer:

![after-filtered](https://i.img402.dev/ajw9yorait.jpg)

## Notes
- New cross-component contract: `window.dispatchEvent(new CustomEvent("breadbox:shortcut-sheet:open"))` opens the shortcut sheet from anywhere (mirrors the existing `breadbox:command-palette:open` pattern).
- Recents key: `localStorage["breadbox:cmdk:recents"]`, capped at 4. Eviction is LRU at write time.
- No changes to the underlying `command.tsx` shadcn primitive — all density / heading-style tweaks live in the `CommandPalette` wrapper via the `CommandList` className. Keeps `ui/command.tsx` upgradeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)