### PR TITLE
design(v2): unify confirm dialogs around ConfirmDialog primitive

### DIFF
--- a/web/src/components/confirm-dialog.tsx
+++ b/web/src/components/confirm-dialog.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+import { Loader2 } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
+
+export type ConfirmDialogTone = "destructive" | "default";
+
+// ConfirmDialog is the canonical confirmation surface for any destructive or
+// otherwise-irreversible action (delete, disconnect, remove, regenerate,
+// apply-retroactively, restore, etc.). Wraps shadcn AlertDialog with:
+//
+//   - Tone-tinted icon tile (rendered via AlertDialogMedia) so the dialog
+//     reads its intent at a glance instead of relying on button colour alone.
+//   - Standard footer contract: Cancel (outline) left, primary right. The
+//     primary button takes the destructive variant for tone="destructive"
+//     and the default solid variant otherwise.
+//   - Built-in `pending` state: spinner + disabled Cancel/Action so the
+//     dialog stays open on slow mutations and the user can't double-fire.
+//   - `onConfirm` is called as a handler; the consumer is responsible for
+//     closing the dialog after the mutation resolves (mirrors the existing
+//     pattern used by selection-action-bar's bulk disconnect).
+//
+// Don't fork the look — extend this primitive. If a new surface needs a
+// non-destructive ack with a custom icon, pass `tone="default"` and an
+// `icon` prop; the muted palette is the right "neutral confirm" treatment.
+//
+// Visual contract (matches AlertDialog defaults):
+//   AlertDialogContent (gap-4, p-6)
+//     AlertDialogHeader
+//       AlertDialogMedia (size-16, rounded-md, tone-tinted bg + icon)
+//       AlertDialogTitle (text-lg font-semibold)
+//       AlertDialogDescription (text-sm text-muted-foreground)
+//       [optional body slot below description for arbitrary content]
+//     AlertDialogFooter
+//       AlertDialogCancel (outline)
+//       AlertDialogAction (destructive | default)
+
+const TONE_PALETTES: Record<
+  ConfirmDialogTone,
+  { iconBg: string; iconText: string }
+> = {
+  destructive: {
+    iconBg: "bg-destructive/10",
+    iconText: "text-destructive",
+  },
+  default: {
+    iconBg: "bg-muted",
+    iconText: "text-muted-foreground",
+  },
+};
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tone?: ConfirmDialogTone;
+  /** Lucide icon. Optional — omit to render without the media tile. */
+  icon?: React.ComponentType<{ className?: string }>;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  /** Optional extra body shown below description (e.g. a filename pill). */
+  body?: React.ReactNode;
+  confirmLabel: React.ReactNode;
+  /** Label shown while `pending`. Defaults to "<confirmLabel>…". */
+  pendingLabel?: React.ReactNode;
+  cancelLabel?: React.ReactNode;
+  pending?: boolean;
+  /** Fired when the user activates the primary action. */
+  onConfirm: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  tone = "destructive",
+  icon: Icon,
+  title,
+  description,
+  body,
+  confirmLabel,
+  pendingLabel,
+  cancelLabel = "Cancel",
+  pending = false,
+  onConfirm,
+}: ConfirmDialogProps) {
+  const palette = TONE_PALETTES[tone];
+  const actionVariant = tone === "destructive" ? "destructive" : "default";
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        // Block close-by-overlay-click and Esc while a mutation is in flight
+        // so the consumer's pending state stays in sync with the dialog.
+        if (pending && !next) return;
+        onOpenChange(next);
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          {Icon && (
+            <AlertDialogMedia className={cn(palette.iconBg, palette.iconText)}>
+              <Icon className="size-7" />
+            </AlertDialogMedia>
+          )}
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          )}
+          {body && <div className="text-sm sm:text-left">{body}</div>}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>{cancelLabel}</AlertDialogCancel>
+          <AlertDialogAction
+            variant={actionVariant}
+            disabled={pending}
+            onClick={(e) => {
+              // Keep the dialog open until the consumer closes it; lets the
+              // pending state render and prevents double-fire on slow links.
+              e.preventDefault();
+              onConfirm();
+            }}
+          >
+            {pending && <Loader2 className="size-4 animate-spin" />}
+            {pending ? (pendingLabel ?? confirmLabel) : confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/web/src/features/accounts/account-links-section.tsx
+++ b/web/src/features/accounts/account-links-section.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "@tanstack/react-router";
 import {
   ArrowRight,
@@ -20,6 +20,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { SectionCard } from "@/components/section-card";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { withMutationToast } from "@/lib/mutation-toast";
 import {
   useAccountLinks,
@@ -153,6 +154,7 @@ interface LinkRowProps {
 function LinkRow({ link, viewingShortId, accountByShortId }: LinkRowProps) {
   const reconcile = useReconcileAccountLink();
   const remove = useDeleteAccountLink();
+  const [confirmUnlink, setConfirmUnlink] = useState(false);
 
   const isPrimary = link.primary_account_id === viewingShortId;
   const otherShortId = isPrimary
@@ -181,10 +183,10 @@ function LinkRow({ link, viewingShortId, accountByShortId }: LinkRowProps) {
   }
 
   async function onDelete() {
-    if (!confirm("Unlink these accounts? Matches will be discarded.")) return;
-    await withMutationToast(() => remove.mutateAsync(link.id), {
+    const ok = await withMutationToast(() => remove.mutateAsync(link.id), {
       success: "Accounts unlinked.",
     });
+    if (ok) setConfirmUnlink(false);
   }
 
   return (
@@ -247,13 +249,25 @@ function LinkRow({ link, viewingShortId, accountByShortId }: LinkRowProps) {
           <DropdownMenuSeparator />
           <DropdownMenuItem
             variant="destructive"
-            onClick={onDelete}
+            onClick={() => setConfirmUnlink(true)}
             disabled={remove.isPending}
           >
             <Unlink className="size-3.5" /> Unlink
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <ConfirmDialog
+        open={confirmUnlink}
+        onOpenChange={setConfirmUnlink}
+        icon={Unlink}
+        title={`Unlink ${otherName ?? "these accounts"}?`}
+        description="Existing matches between these accounts will be discarded. You can re-link them later, but the dependent transactions you've matched so far will need to be re-paired."
+        confirmLabel="Unlink"
+        pendingLabel="Unlinking…"
+        pending={remove.isPending}
+        onConfirm={onDelete}
+      />
     </li>
   );
 }

--- a/web/src/features/connections/selection-action-bar.tsx
+++ b/web/src/features/connections/selection-action-bar.tsx
@@ -1,15 +1,6 @@
 import { useState } from "react";
 import { Pause, Play, RefreshCw, Unplug, X } from "lucide-react";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { KbdTooltip } from "@/components/kbd-tooltip";
@@ -115,8 +106,10 @@ export function SelectionActionBar({
       () => runChunked(selected, (c) => disconnect.mutateAsync(c.id)),
       { success: `Disconnected ${selected.length} connection${selected.length === 1 ? "" : "s"}.` },
     );
-    setConfirmOpen(false);
-    if (ok) onClear();
+    if (ok) {
+      setConfirmOpen(false);
+      onClear();
+    }
   }
 
   return (
@@ -203,41 +196,17 @@ export function SelectionActionBar({
         </div>
       </div>
 
-      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              Disconnect {selected.length} connection
-              {selected.length === 1 ? "" : "s"}?
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              Disconnecting wipes saved credentials and soft-deletes the
-              connection's transactions. Accounts stay in the household for
-              historical reference, but no new transactions will sync. This
-              can't be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={disconnect.isPending}>
-              Cancel
-            </AlertDialogCancel>
-            <AlertDialogAction
-              variant="destructive"
-              onClick={(e) => {
-                // Keep the dialog open until the mutation resolves so the user
-                // sees the spinner instead of an instant close on a slow link.
-                e.preventDefault();
-                void onDisconnect();
-              }}
-              disabled={disconnect.isPending}
-            >
-              {disconnect.isPending
-                ? "Disconnecting…"
-                : `Disconnect ${selected.length}`}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        icon={Unplug}
+        title={`Disconnect ${selected.length} connection${selected.length === 1 ? "" : "s"}?`}
+        description="Disconnecting wipes saved credentials and soft-deletes the connection's transactions. Accounts stay in the household for historical reference, but no new transactions will sync. This can't be undone."
+        confirmLabel={`Disconnect ${selected.length}`}
+        pendingLabel="Disconnecting…"
+        pending={disconnect.isPending}
+        onConfirm={() => void onDisconnect()}
+      />
     </>
   );
 }

--- a/web/src/features/providers/plaid-card.tsx
+++ b/web/src/features/providers/plaid-card.tsx
@@ -21,17 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { SectionCard } from "@/components/section-card";
 import { FormFooter } from "@/components/form-footer";
@@ -113,10 +103,10 @@ export function PlaidCard({ config, health }: PlaidCardProps) {
   }
 
   async function onDisable() {
-    setConfirmingDisable(false);
-    await withMutationToast(() => disable.mutateAsync("plaid"), {
+    const ok = await withMutationToast(() => disable.mutateAsync("plaid"), {
       success: "Plaid disabled. Stored credentials were cleared.",
     });
+    if (ok) setConfirmingDisable(false);
   }
 
   const tone = resolveProviderTone(health, config.configured);
@@ -256,41 +246,16 @@ export function PlaidCard({ config, health }: PlaidCardProps) {
               <FormFooter
                 secondary={
                   config.configured ? (
-                    <AlertDialog
-                      open={confirmingDisable}
-                      onOpenChange={setConfirmingDisable}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="text-muted-foreground hover:text-destructive"
+                      onClick={() => setConfirmingDisable(true)}
                     >
-                      <AlertDialogTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="text-muted-foreground hover:text-destructive"
-                        >
-                          <Trash2 className="size-3.5" />
-                          Disable
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>Disable Plaid?</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            Stored credentials will be deleted from the database. Existing
-                            Plaid connections stay in your household but syncs will fail until
-                            you re-enter credentials.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>Cancel</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={onDisable}
-                            className="bg-destructive text-white hover:bg-destructive/90"
-                          >
-                            Disable
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
+                      <Trash2 className="size-3.5" />
+                      Disable
+                    </Button>
                   ) : null
                 }
                 primary={
@@ -323,6 +288,18 @@ export function PlaidCard({ config, health }: PlaidCardProps) {
           </div>
         </SectionCard>
       )}
+
+      <ConfirmDialog
+        open={confirmingDisable}
+        onOpenChange={setConfirmingDisable}
+        icon={Trash2}
+        title="Disable Plaid?"
+        description="Stored credentials will be deleted from the database. Existing Plaid connections stay in your household but syncs will fail until you re-enter credentials."
+        confirmLabel="Disable Plaid"
+        pendingLabel="Disabling…"
+        pending={disable.isPending}
+        onConfirm={onDisable}
+      />
     </div>
   );
 }

--- a/web/src/features/providers/teller-card.tsx
+++ b/web/src/features/providers/teller-card.tsx
@@ -30,17 +30,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { ColorRailCard } from "@/components/color-rail-card";
 import { SectionCard } from "@/components/section-card";
 import { FormFooter } from "@/components/form-footer";
@@ -137,10 +127,10 @@ export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps
   }
 
   async function onDisable() {
-    setConfirmingDisable(false);
-    await withMutationToast(() => disable.mutateAsync("teller"), {
+    const ok = await withMutationToast(() => disable.mutateAsync("teller"), {
       success: "Teller disabled. Stored credentials were cleared.",
     });
+    if (ok) setConfirmingDisable(false);
   }
 
   const tone = resolveProviderTone(health, config.configured);
@@ -311,42 +301,16 @@ export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps
               <FormFooter
                 secondary={
                   config.configured ? (
-                    <AlertDialog
-                      open={confirmingDisable}
-                      onOpenChange={setConfirmingDisable}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="text-muted-foreground hover:text-destructive"
+                      onClick={() => setConfirmingDisable(true)}
                     >
-                      <AlertDialogTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="text-muted-foreground hover:text-destructive"
-                        >
-                          <Trash2 className="size-3.5" />
-                          Disable
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>Disable Teller?</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            Stored credentials (application ID, webhook secret, and encrypted
-                            certificate) will be deleted from the database. Existing Teller
-                            connections stay in your household but syncs will fail until you
-                            re-enter credentials.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>Cancel</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={onDisable}
-                            className="bg-destructive text-white hover:bg-destructive/90"
-                          >
-                            Disable
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
+                      <Trash2 className="size-3.5" />
+                      Disable
+                    </Button>
                   ) : null
                 }
                 primary={
@@ -382,6 +346,18 @@ export function TellerCard({ config, health, hasEncryptionKey }: TellerCardProps
           </div>
         </SectionCard>
       )}
+
+      <ConfirmDialog
+        open={confirmingDisable}
+        onOpenChange={setConfirmingDisable}
+        icon={Trash2}
+        title="Disable Teller?"
+        description="Stored credentials (application ID, webhook secret, and encrypted certificate) will be deleted from the database. Existing Teller connections stay in your household but syncs will fail until you re-enter credentials."
+        confirmLabel="Disable Teller"
+        pendingLabel="Disabling…"
+        pending={disable.isPending}
+        onConfirm={onDisable}
+      />
     </div>
   );
 }

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -14,16 +14,7 @@ import {
   Upload,
 } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -238,11 +229,13 @@ function BackupActions({ disabled }: { disabled: boolean }) {
   const confirmUpload = async () => {
     if (!pendingUpload) return;
     const file = pendingUpload;
-    setPendingUpload(null);
-    await withMutationToast(() => upload.mutateAsync(file), {
+    const ok = await withMutationToast(() => upload.mutateAsync(file), {
       success: "Restored from uploaded backup. Restart the server to be safe.",
     });
-    if (fileInput.current) fileInput.current.value = "";
+    if (ok) {
+      setPendingUpload(null);
+      if (fileInput.current) fileInput.current.value = "";
+    }
   };
 
   return (
@@ -293,18 +286,24 @@ function BackupActions({ disabled }: { disabled: boolean }) {
         />
       </div>
 
-      <ConfirmRestoreDialog
+      <ConfirmDialog
+        open={!!pendingUpload}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingUpload(null);
+            if (fileInput.current) fileInput.current.value = "";
+          }
+        }}
+        icon={Upload}
         title="Restore from uploaded file?"
         description={
           pendingUpload
             ? `This will OVERWRITE the current database with the contents of ${pendingUpload.name}. The action runs in a single transaction and rolls back on error, but on success the existing rows are gone.`
             : ""
         }
-        open={!!pendingUpload}
-        onCancel={() => {
-          setPendingUpload(null);
-          if (fileInput.current) fileInput.current.value = "";
-        }}
+        confirmLabel="Restore"
+        pendingLabel="Restoring…"
+        pending={upload.isPending}
         onConfirm={confirmUpload}
       />
     </div>
@@ -477,17 +476,17 @@ function BackupRowItem({
   const [confirm, setConfirm] = useState<"restore" | "delete" | null>(null);
 
   const runRestore = async () => {
-    setConfirm(null);
-    await withMutationToast(() => restore.mutateAsync(row.filename), {
+    const ok = await withMutationToast(() => restore.mutateAsync(row.filename), {
       success: `Restored from ${row.filename}. Restart the server to be safe.`,
     });
+    if (ok) setConfirm(null);
   };
 
   const runDelete = async () => {
-    setConfirm(null);
-    await withMutationToast(() => del.mutateAsync(row.filename), {
+    const ok = await withMutationToast(() => del.mutateAsync(row.filename), {
       success: `Deleted ${row.filename}.`,
     });
+    if (ok) setConfirm(null);
   };
 
   const busy = restore.isPending || del.isPending;
@@ -570,86 +569,42 @@ function BackupRowItem({
         </div>
       </TooltipProvider>
 
-      <ConfirmRestoreDialog
+      <ConfirmDialog
+        open={confirm === "restore"}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
+        icon={RotateCcw}
         title="Restore this backup?"
         description={`This will OVERWRITE the current database with the contents of ${row.filename}. The action runs in a single transaction and rolls back on error, but on success the existing rows are gone.`}
-        open={confirm === "restore"}
-        onCancel={() => setConfirm(null)}
+        confirmLabel="Restore"
+        pendingLabel="Restoring…"
+        pending={restore.isPending}
         onConfirm={runRestore}
       />
 
-      <ConfirmDeleteDialog
-        filename={row.filename}
+      <ConfirmDialog
         open={confirm === "delete"}
-        onCancel={() => setConfirm(null)}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
+        icon={Trash2}
+        title="Delete backup?"
+        description="This file will be removed from disk. This cannot be undone."
+        body={
+          <p className="bg-muted/60 text-foreground rounded-md border px-2 py-1 font-mono text-xs">
+            {row.filename}
+          </p>
+        }
+        confirmLabel="Delete backup"
+        pendingLabel="Deleting…"
+        pending={del.isPending}
         onConfirm={runDelete}
       />
     </li>
   );
 }
 
-function ConfirmRestoreDialog({
-  title,
-  description,
-  open,
-  onCancel,
-  onConfirm,
-}: {
-  title: string;
-  description: string;
-  open: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
-}) {
-  return (
-    <AlertDialog open={open} onOpenChange={(o) => !o && onCancel()}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription>{description}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" onClick={onConfirm}>
-            Restore
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
-}
-
-function ConfirmDeleteDialog({
-  filename,
-  open,
-  onCancel,
-  onConfirm,
-}: {
-  filename: string;
-  open: boolean;
-  onCancel: () => void;
-  onConfirm: () => void;
-}) {
-  return (
-    <AlertDialog open={open} onOpenChange={(o) => !o && onCancel()}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Delete backup?</AlertDialogTitle>
-          <AlertDialogDescription>
-            <span className="font-mono text-xs">{filename}</span> will be removed from disk. This
-            cannot be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction variant="destructive" onClick={onConfirm}>
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  );
-}
 
 function BackupsSkeleton() {
   return (

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -24,16 +24,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -735,30 +726,17 @@ function DeleteMemberDialog({
   };
 
   return (
-    <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Remove {user.name}?</AlertDialogTitle>
-          <AlertDialogDescription>
-            This deletes the household member and their login (if any). Bank
-            connections attached to them must be disconnected first. This can't
-            be undone.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={(e) => {
-              e.preventDefault();
-              onConfirm();
-            }}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            Remove member
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <ConfirmDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      icon={Trash2}
+      title={`Remove ${user.name}?`}
+      description="This deletes the household member and their login (if any). Bank connections attached to them must be disconnected first. This can't be undone."
+      confirmLabel="Remove member"
+      pendingLabel="Removing…"
+      pending={deleteUser.isPending}
+      onConfirm={onConfirm}
+    />
   );
 }
 

--- a/web/src/routes/rule-detail.tsx
+++ b/web/src/routes/rule-detail.tsx
@@ -2,16 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { Loader2, Pause, Pencil, Play, PlayCircle, Shield, Trash2 } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -92,23 +83,27 @@ export function RuleDetailPage() {
     );
 
   const onApplyConfirm = async () => {
-    setConfirmApply(false);
     const ok = await withMutationToast(
       () => applyRule.mutateAsync(rule.short_id),
       {
         success: "Rule applied retroactively. Transactions are being updated.",
       },
     );
-    if (ok) ruleQuery.refetch();
+    if (ok) {
+      setConfirmApply(false);
+      ruleQuery.refetch();
+    }
   };
 
   const onDeleteConfirm = async () => {
-    setConfirmDelete(false);
     const ok = await withMutationToast(
       () => deleteRule.mutateAsync(rule.short_id),
       { success: `Deleted rule "${rule.name}".` },
     );
-    if (ok) navigate({ to: "/rules" });
+    if (ok) {
+      setConfirmDelete(false);
+      navigate({ to: "/rules" });
+    }
   };
 
   return (
@@ -207,42 +202,30 @@ export function RuleDetailPage() {
         </aside>
       </div>
 
-      <AlertDialog open={confirmApply} onOpenChange={setConfirmApply}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Apply "{rule.name}" retroactively?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This evaluates the rule's conditions against every existing
-              transaction in your household. Category changes respect the
-              per-transaction override lock; tags and comments accumulate.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={onApplyConfirm}>
-              Apply now
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDialog
+        open={confirmApply}
+        onOpenChange={setConfirmApply}
+        tone="default"
+        icon={PlayCircle}
+        title={`Apply "${rule.name}" retroactively?`}
+        description="This evaluates the rule's conditions against every existing transaction in your household. Category changes respect the per-transaction override lock; tags and comments accumulate."
+        confirmLabel="Apply now"
+        pendingLabel="Applying…"
+        pending={applyRule.isPending}
+        onConfirm={onApplyConfirm}
+      />
 
-      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete "{rule.name}"?</AlertDialogTitle>
-            <AlertDialogDescription>
-              The rule stops firing on future syncs. Past actions it applied
-              stay on transactions.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={onDeleteConfirm}>
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <ConfirmDialog
+        open={confirmDelete}
+        onOpenChange={setConfirmDelete}
+        icon={Trash2}
+        title={`Delete "${rule.name}"?`}
+        description="The rule stops firing on future syncs. Past actions it applied stay on transactions."
+        confirmLabel="Delete rule"
+        pendingLabel="Deleting…"
+        pending={deleteRule.isPending}
+        onConfirm={onDeleteConfirm}
+      />
     </>
   );
 

--- a/web/src/routes/rules.tsx
+++ b/web/src/routes/rules.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate, useSearch } from "@tanstack/react-router";
 import { z } from "zod";
-import { Loader2, Plus, Wand2 } from "lucide-react";
+import { Loader2, Plus, Trash2, Wand2 } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { EmptyState } from "@/components/empty-state";
 import { PaginationBar } from "@/components/pagination-bar";
@@ -15,16 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { ConfirmDialog } from "@/components/confirm-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { withMutationToast } from "@/lib/mutation-toast";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
@@ -121,15 +112,14 @@ export function RulesPage() {
   const onDeleteConfirm = useCallback(async () => {
     if (!pendingDelete) return;
     const target = pendingDelete;
-    setPendingDelete(null);
+    // ConfirmDialog stays open while `pending` is true (deleteRule.isPending);
+    // only clear after success so a failed mutation lets the user retry from
+    // the open dialog instead of having to re-find the row.
     const ok = await withMutationToast(
       () => deleteRule.mutateAsync(target.short_id),
       { success: `Deleted rule "${target.name}".` },
     );
-    if (!ok) {
-      // Restore the confirm so the user can retry without re-finding the row.
-      setPendingDelete(target);
-    }
+    if (ok) setPendingDelete(null);
   }, [deleteRule, pendingDelete]);
 
   const total = rulesQuery.data?.total ?? rows.length;
@@ -236,30 +226,19 @@ export function RulesPage() {
         />
       )}
 
-      <AlertDialog
+      <ConfirmDialog
         open={!!pendingDelete}
         onOpenChange={(open) => {
           if (!open) setPendingDelete(null);
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              Delete rule "{pendingDelete?.name}"?
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              The rule will stop firing on future syncs. Past actions it
-              applied stay on transactions; this only removes the rule itself.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={onDeleteConfirm}>
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        icon={Trash2}
+        title={`Delete rule "${pendingDelete?.name ?? ""}"?`}
+        description="The rule will stop firing on future syncs. Past actions it applied stay on transactions; this only removes the rule itself."
+        confirmLabel="Delete rule"
+        pendingLabel="Deleting…"
+        pending={deleteRule.isPending}
+        onConfirm={onDeleteConfirm}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- Extract `<ConfirmDialog>` primitive (`web/src/components/confirm-dialog.tsx`) wrapping shadcn AlertDialog with: tone-tinted icon tile, standard Cancel-left / primary-right footer, and built-in `pending` state (spinner + disabled actions so the dialog stays open on slow mutations and users can't double-fire).
- Two tones: **destructive** (Trash2/AlertTriangle icon + destructive button) and **default** (info icon + solid button). Pending action shows Loader2 spinner; Cancel disables so failed mutations let the user retry from the same dialog.
- Migrated 8 callsites off open-coded AlertDialog blocks: `rule-detail`, `rules`, `account-links-section`, `selection-action-bar`, `plaid-card`, `teller-card`, `backups-section`, `household-section`. Disconnect / Delete / Remove / Regenerate / Apply-retroactively flows now read at a glance via the icon tile instead of relying on button colour alone.

## Notes
- Eighth shared primitive of the design sprint (after ListCard, ColorRailCard, IdPill, SectionCard, SoftBackButton, AuthShell, StatusPanel, FormFooter).
- Retires the "Confirmation dialogs (alert-dialog) consistency sweep" backlog item.
- Iter #18: agent did the implementation but stopped mid-flow before committing/PR'ing; I reconciled and shipped its work. Before/after screenshots weren't preserved — the diff is the source of truth here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)