### PR TITLE
design(v2): EmptyState variants + drift sweep

### DIFF
--- a/web/src/components/empty-state.tsx
+++ b/web/src/components/empty-state.tsx
@@ -1,38 +1,75 @@
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+export type EmptyStateVariant = "default" | "card" | "inline";
+
 export interface EmptyStateProps {
   icon?: LucideIcon;
   title: string;
   description?: string;
   /** Optional call-to-action — usually a <Button>. */
   action?: React.ReactNode;
+  /**
+   * `default` — bare centered block. Reach for this inside an already-bordered
+   * container (table emptyState slot, ListCard's `empty` slot, SectionCard
+   * body).
+   *
+   * `card` — adds a dashed bordered card around the block. Reach for this
+   * when the empty state lives in raw page space (settings section, sub-panel
+   * that doesn't carry its own card wrapper) so it reads as a placeholder
+   * waiting to be filled instead of floating text.
+   *
+   * `inline` — tighter centered block with a smaller icon tile. Use for
+   * compact secondary panels where the full empty-state weight would be too
+   * loud (a sync history rail inside a section, or the right-column accounts
+   * list on connection-detail).
+   */
+  variant?: EmptyStateVariant;
   className?: string;
 }
 
 // Zero-data state for a page or section that loaded fine but has nothing to
 // show. Distinct from routes/placeholder.tsx, which marks a page that hasn't
 // been built yet.
+//
+// Visual contract:
+// - Always centered, icon tile → title → description → action.
+// - Icon tile is a soft muted square (`rounded-xl`), never a circle — matches
+//   the rest of the v2 icon language (see ColorRailCard, StatusPanel).
+// - Title is `text-sm font-medium`; description is `text-sm text-muted-foreground`
+//   so an empty state nested inside a card body doesn't dominate.
 export function EmptyState({
   icon: Icon,
   title,
   description,
   action,
+  variant = "default",
   className,
 }: EmptyStateProps) {
+  const tileSize = variant === "inline" ? "size-9" : "size-11";
+  const iconSize = variant === "inline" ? "size-4" : "size-5";
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center gap-2 py-12 text-center",
+        "flex flex-col items-center justify-center gap-2 text-center",
+        variant === "default" && "py-12",
+        variant === "card" &&
+          "border-border/70 bg-muted/10 rounded-lg border border-dashed px-6 py-10",
+        variant === "inline" && "py-8",
         className,
       )}
     >
       {Icon && (
-        <div className="bg-muted text-muted-foreground mb-2 rounded-full p-3">
-          <Icon className="size-5" />
+        <div
+          className={cn(
+            "bg-muted text-muted-foreground mb-2 flex items-center justify-center rounded-xl",
+            tileSize,
+          )}
+        >
+          <Icon className={iconSize} />
         </div>
       )}
-      <h3 className="font-medium">{title}</h3>
+      <h3 className="text-sm font-medium">{title}</h3>
       {description && (
         <p className="text-muted-foreground max-w-sm text-sm">{description}</p>
       )}

--- a/web/src/features/connections/connection-accounts-list.tsx
+++ b/web/src/features/connections/connection-accounts-list.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { Banknote, CreditCard, Landmark, PiggyBank, Wallet } from "lucide-react";
 import type { Account } from "@/api/types";
+import { EmptyState } from "@/components/empty-state";
 import { formatCurrency } from "./connection-utils";
 
 const TYPE_ICON: Record<string, typeof Banknote> = {
@@ -19,11 +20,12 @@ interface ConnectionAccountsListProps {
 export function ConnectionAccountsList({ accounts }: ConnectionAccountsListProps) {
   if (accounts.length === 0) {
     return (
-      <div className="text-muted-foreground flex flex-col items-center gap-2 py-10 text-sm">
-        <Wallet className="size-8 opacity-40" />
-        <span>No accounts yet</span>
-        <span className="text-xs">Accounts appear after the first sync.</span>
-      </div>
+      <EmptyState
+        variant="inline"
+        icon={Wallet}
+        title="No accounts yet"
+        description="Accounts will appear here after the first successful sync."
+      />
     );
   }
   return (

--- a/web/src/features/connections/sync-history-list.tsx
+++ b/web/src/features/connections/sync-history-list.tsx
@@ -1,5 +1,6 @@
 import { Check, Loader2, RefreshCw, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { EmptyState } from "@/components/empty-state";
 import { relativeTime } from "./connection-utils";
 import type { SyncLog } from "@/api/queries/sync-logs";
 
@@ -16,10 +17,12 @@ const STATUS_TILE: Record<string, string> = {
 export function SyncHistoryList({ logs }: SyncHistoryListProps) {
   if (logs.length === 0) {
     return (
-      <div className="text-muted-foreground flex flex-col items-center gap-2 py-10 text-sm">
-        <RefreshCw className="size-8 opacity-40" />
-        <span>No sync history yet</span>
-      </div>
+      <EmptyState
+        variant="inline"
+        icon={RefreshCw}
+        title="No sync history yet"
+        description="Each sync run will appear here with its timing and result."
+      />
     );
   }
 

--- a/web/src/features/settings/backups-section.tsx
+++ b/web/src/features/settings/backups-section.tsx
@@ -63,6 +63,7 @@ import {
   type BackupStatus,
 } from "@/api/queries/backups";
 import { withMutationToast } from "@/lib/mutation-toast";
+import { EmptyState } from "@/components/empty-state";
 
 const SCHEDULE_OPTIONS = [
   { value: "off", label: "Disabled — manual only" },
@@ -442,12 +443,12 @@ function BackupsTable({
       </div>
 
       {backups.length === 0 ? (
-        <div className="border-border rounded-md border border-dashed p-8 text-center">
-          <CheckCircle2 className="text-muted-foreground mx-auto mb-2 size-5" />
-          <p className="text-muted-foreground text-sm">
-            No backups yet. Create one above or set a schedule.
-          </p>
-        </div>
+        <EmptyState
+          variant="card"
+          icon={HardDrive}
+          title="No backups yet"
+          description="Create one above or set a schedule to start a regular cadence."
+        />
       ) : (
         <div className="border-border overflow-hidden rounded-md border">
           <ul className="divide-border divide-y">

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -75,6 +75,7 @@ import {
 import { withMutationToast } from "@/lib/mutation-toast";
 import type { LoginAccount, User } from "@/api/types";
 import { cn } from "@/lib/utils";
+import { EmptyState } from "@/components/empty-state";
 
 export function HouseholdSection() {
   const { data: users, isLoading } = useUsers();
@@ -106,7 +107,12 @@ export function HouseholdSection() {
       {isLoading ? (
         <p className="text-muted-foreground text-sm">Loading members…</p>
       ) : !hasMembers ? (
-        <EmptyState />
+        <EmptyState
+          variant="card"
+          icon={Users}
+          title="No family members yet"
+          description="Add members to connect their banks and attribute transactions by person."
+        />
       ) : (
         <ul className="space-y-3">
           {users.map((u) => (
@@ -114,21 +120,6 @@ export function HouseholdSection() {
           ))}
         </ul>
       )}
-    </div>
-  );
-}
-
-function EmptyState() {
-  return (
-    <div className="border-border rounded-lg border border-dashed p-8 text-center">
-      <div className="bg-muted mx-auto mb-3 flex size-12 items-center justify-center rounded-xl">
-        <Users className="text-muted-foreground size-6" />
-      </div>
-      <h3 className="text-sm font-medium">No family members yet</h3>
-      <p className="text-muted-foreground mx-auto mt-1 max-w-sm text-sm">
-        Add members to connect their banks and attribute transactions by
-        person.
-      </p>
     </div>
   );
 }

--- a/web/src/sandbox/sections/components.tsx
+++ b/web/src/sandbox/sections/components.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { ColumnDef } from "@tanstack/react-table";
 import { toast } from "sonner";
-import { Inbox, Plus, RotateCcw } from "lucide-react";
+import { Inbox, Plus, RefreshCw, RotateCcw, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -90,14 +90,44 @@ export function ComponentsSection() {
       <Specimen
         label="EmptyState"
         code="components/empty-state"
+        description="Three variants share one primitive — pick the weight that fits the surface. Same icon-tile vocabulary as the rest of v2 (square rounded-xl, not circle)."
         className="block"
       >
-        <EmptyState
-          icon={Inbox}
-          title="No matching transactions"
-          description="Try adjusting or clearing your filters."
-          action={<Button variant="outline">Clear filters</Button>}
-        />
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="rounded-lg border">
+            <div className="text-muted-foreground border-b px-3 py-2 text-[11px] tracking-wide uppercase">
+              default · inside a container
+            </div>
+            <EmptyState
+              icon={Inbox}
+              title="No matching transactions"
+              description="Try adjusting or clearing your filters."
+              action={<Button variant="outline">Clear filters</Button>}
+            />
+          </div>
+          <div>
+            <div className="text-muted-foreground mb-2 px-1 text-[11px] tracking-wide uppercase">
+              card · in raw page space
+            </div>
+            <EmptyState
+              variant="card"
+              icon={Users}
+              title="No family members yet"
+              description="Add members to connect their banks and attribute transactions by person."
+            />
+          </div>
+          <div className="bg-card rounded-lg border p-4">
+            <div className="text-muted-foreground mb-1 text-[11px] tracking-wide uppercase">
+              inline · compact sub-panel
+            </div>
+            <EmptyState
+              variant="inline"
+              icon={RefreshCw}
+              title="No sync history yet"
+              description="Each sync will appear here with timing and result."
+            />
+          </div>
+        </div>
       </Specimen>
 
       <Specimen


### PR DESCRIPTION
## Summary
- Promote `<EmptyState>` to three variants — `default` (current), `card` (dashed bordered card for raw page space), `inline` (compact for sub-panels). Icon tile switches from rounded-full to rounded-xl to match the rest of v2 (ColorRailCard / StatusPanel / category tiles).
- Migrate four hand-rolled empties onto the primitive: `household-section`, `backups-section`, `connection-accounts-list`, `sync-history-list`.
- Sandbox showcase rebuilt around all three variants side-by-side with labelled wrappers showing the intended host surface for each.

## Before / After
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/vityi0r6t1.jpg) | ![after](https://i.img402.dev/gyvlvqqgb0.jpg) |

## Notes
- Two remaining inline-empty strings (rule-form actions empty, preview-panel no-matches) stay as one-line muted text inside small form panels — full empty-state weight would be too loud at that scale; not drift to retire.
- `home-recent-transactions`, `home-connections-panel`, `account-recent-transactions`, `activity-timeline`, and the route-level usages (transactions / tags / categories / connections / accounts / api-keys / rules) already use `<EmptyState>` and pick up the new icon-tile shape automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)