### PR TITLE
design(v2): tone-tinted toast sweep (sonner)

### DIFF
--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -8,6 +8,17 @@ import {
 import { useTheme } from "next-themes"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
+// Sonner Toaster customized to match the v2 design vocabulary established by
+// <StatusPanel>: a 3px tone-tinted left rail + a tone-tinted icon tile + the
+// existing popover surface. Tone is encoded in the rail/icon colour so
+// success/error/warning/info are scannable at a glance without changing the
+// background fill (which keeps the toast quiet enough to live next to dense
+// surfaces like the transactions table).
+//
+// All polish lives here; `lib/mutation-toast.ts` and direct `toast.*` calls
+// stay one-liners. Default position bottom-right, expand-on-hover, and a
+// close button on every toast (mutation results are often quick reads and
+// dismissing them feels right).
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
 
@@ -15,12 +26,67 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
+      position="bottom-right"
+      expand
+      closeButton
+      visibleToasts={4}
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,
         warning: <TriangleAlertIcon className="size-4" />,
         error: <OctagonXIcon className="size-4" />,
         loading: <Loader2Icon className="size-4 animate-spin" />,
+      }}
+      toastOptions={{
+        // Class hooks are concatenated by Sonner onto each toast/element.
+        // The base toast keeps `pl-5` so the absolute `before:` rail and
+        // the icon both clear the left edge. `data-[type=*]` selectors
+        // tint the rail and the icon tile per variant; "message" (the
+        // default toast.message call) falls through to the neutral
+        // info-style rail.
+        classNames: {
+          toast:
+            "group/toast toast relative overflow-hidden " +
+            "!bg-popover !text-popover-foreground !border !border-border !rounded-md " +
+            "!gap-3 !p-4 !pl-5 " +
+            "before:absolute before:inset-y-0 before:left-0 before:w-[3px] " +
+            "data-[type=success]:before:bg-success " +
+            "data-[type=error]:before:bg-destructive " +
+            "data-[type=warning]:before:bg-amber-500 " +
+            "data-[type=info]:before:bg-sky-500 " +
+            "data-[type=default]:before:bg-muted-foreground/40 " +
+            "data-[type=loading]:before:bg-muted-foreground/40",
+          icon:
+            "!m-0 !size-8 !shrink-0 !rounded-md !flex !items-center !justify-center " +
+            "group-data-[type=success]/toast:!bg-success/12 " +
+            "group-data-[type=success]/toast:!text-success " +
+            "group-data-[type=error]/toast:!bg-destructive/10 " +
+            "group-data-[type=error]/toast:!text-destructive " +
+            "group-data-[type=warning]/toast:!bg-amber-500/10 " +
+            "group-data-[type=warning]/toast:!text-amber-600 " +
+            "dark:group-data-[type=warning]/toast:!text-amber-400 " +
+            "group-data-[type=info]/toast:!bg-sky-500/10 " +
+            "group-data-[type=info]/toast:!text-sky-600 " +
+            "dark:group-data-[type=info]/toast:!text-sky-400 " +
+            "group-data-[type=default]/toast:!bg-muted " +
+            "group-data-[type=default]/toast:!text-muted-foreground " +
+            "group-data-[type=loading]/toast:!bg-muted " +
+            "group-data-[type=loading]/toast:!text-muted-foreground",
+          content: "!gap-0.5",
+          title: "!text-sm !font-medium !text-foreground !leading-snug",
+          description:
+            "!text-xs !text-muted-foreground !leading-relaxed !mt-0.5",
+          actionButton:
+            "!bg-primary !text-primary-foreground hover:!bg-primary/90 " +
+            "!h-7 !rounded-md !px-2.5 !text-xs !font-medium",
+          cancelButton:
+            "!bg-transparent !text-muted-foreground hover:!text-foreground " +
+            "!h-7 !rounded-md !px-2 !text-xs",
+          closeButton:
+            "!bg-popover !border !border-border !text-muted-foreground " +
+            "hover:!bg-muted hover:!text-foreground " +
+            "!left-auto !right-2 !top-2 !translate-x-0 !translate-y-0",
+        },
       }}
       style={
         {

--- a/web/src/features/connections/connect-bank-sheet.tsx
+++ b/web/src/features/connections/connect-bank-sheet.tsx
@@ -215,7 +215,9 @@ export function ConnectBankSheet({
     setCreateError(null);
     try {
       const result = await createConnection.mutateAsync(payload);
-      toast.success(`Connected ${result.institution_name}.`);
+      toast.success(`Connected ${result.institution_name}.`, {
+        description: "Initial sync queued — accounts and transactions will appear shortly.",
+      });
       handleSheetChange(false);
       navigate({
         to: "/connections/$id",
@@ -338,6 +340,11 @@ export function ConnectBankSheet({
                 result.appended
                   ? `Imported ${result.imported} more transactions.`
                   : `Imported ${result.imported} transactions.`,
+                {
+                  description: result.appended
+                    ? "Appended to the existing connection — new rows will appear after re-categorisation."
+                    : "Connection created. Categorise or apply rules to enrich the new rows.",
+                },
               );
               handleSheetChange(false);
               if (!result.appended) {

--- a/web/src/features/connections/reauth-sheet.tsx
+++ b/web/src/features/connections/reauth-sheet.tsx
@@ -131,7 +131,9 @@ export function ReauthSheet({
     setStage({ kind: "completing" });
     try {
       await reauthComplete.mutateAsync(conn.id);
-      toast.success(`Reconnected ${institutionName}.`);
+      toast.success(`Reconnected ${institutionName}.`, {
+        description: "Sync resumed — accounts will refresh on the next webhook.",
+      });
       handleSheetChange(false);
     } catch (err) {
       const msg =

--- a/web/src/lib/mutation-toast.ts
+++ b/web/src/lib/mutation-toast.ts
@@ -3,6 +3,8 @@ import { ApiError } from "@/api/client";
 
 export interface MutationToastMessages {
   success: string;
+  /** Optional secondary line under the success title (rendered muted). */
+  successDescription?: string;
   /** Fallback when the thrown error isn't an ApiError with a message. */
   error?: string;
 }
@@ -18,6 +20,13 @@ export interface MutationToastMessages {
 //   );
 //   if (ok) form.reset();
 //
+// The optional `successDescription` slot lets callers add a muted secondary
+// line under the title for "what happened, in detail" copy — useful for
+// destructive ops ("Deleted 12 transactions.") or imports where the headline
+// alone reads thin. The error path keeps the single-line shape: API errors
+// already say what went wrong, and stacking a fallback description on top
+// reads as noise.
+//
 // Not a hook — it holds no React state, so it's callable conditionally and
 // inside event handlers without rules-of-hooks constraints.
 export async function withMutationToast(
@@ -26,7 +35,9 @@ export async function withMutationToast(
 ): Promise<boolean> {
   try {
     await run();
-    toast.success(messages.success);
+    toast.success(messages.success, {
+      description: messages.successDescription,
+    });
     return true;
   } catch (err) {
     const msg =

--- a/web/src/sandbox/sections/patterns.tsx
+++ b/web/src/sandbox/sections/patterns.tsx
@@ -66,40 +66,83 @@ export function PatternsSection() {
       <Specimen
         label="Toasts"
         code="sonner · withMutationToast"
-        description="One toast surface for the whole app. withMutationToast wraps a mutation: success toast on resolve, the ApiError message on reject."
+        description="One toast surface for the whole app. Each tone gets a coloured left rail + tinted icon tile — same vocabulary as <StatusPanel>. withMutationToast wraps a mutation: success toast on resolve, the ApiError message on reject."
+        className="block"
       >
-        <Button variant="outline" onClick={() => toast.success("Saved.")}>
-          toast.success
-        </Button>
-        <Button
-          variant="outline"
-          onClick={() => toast.error("Something went wrong.")}
-        >
-          toast.error
-        </Button>
-        <Button variant="outline" onClick={() => toast.message("Heads up.")}>
-          toast.message
-        </Button>
-        <Button
-          onClick={() =>
-            withMutationToast(() => Promise.resolve(), {
-              success: "Category updated.",
-            })
-          }
-        >
-          withMutationToast — ok
-        </Button>
-        <Button
-          variant="destructive"
-          onClick={() =>
-            withMutationToast(() => Promise.reject(new Error("nope")), {
-              success: "won't show",
-              error: "Couldn't update the category.",
-            })
-          }
-        >
-          withMutationToast — fail
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={() => toast.success("Saved.")}>
+            success
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => toast.error("Something went wrong.")}
+          >
+            error
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() =>
+              toast.warning("Sync took longer than usual.", {
+                description: "Two accounts returned partial data on the last pull.",
+              })
+            }
+          >
+            warning
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() =>
+              toast.info("Imported 50 of 1,243 transactions.", {
+                description: "Showing the first page — keep scrolling to load more.",
+              })
+            }
+          >
+            info
+          </Button>
+          <Button variant="outline" onClick={() => toast.message("Heads up.")}>
+            message
+          </Button>
+          <Button variant="outline" onClick={() => toast.loading("Re-syncing…")}>
+            loading
+          </Button>
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Button
+            onClick={() =>
+              withMutationToast(() => Promise.resolve(), {
+                success: "Rule applied.",
+                successDescription: "12 transactions matched and were re-categorised.",
+              })
+            }
+          >
+            withMutationToast — ok (with description)
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() =>
+              withMutationToast(() => Promise.reject(new Error("nope")), {
+                success: "won't show",
+                error: "Couldn't update the category.",
+              })
+            }
+          >
+            withMutationToast — fail
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() =>
+              toast.success("Plaid sync queued.", {
+                description: "Webhook will fire when the next batch lands.",
+                action: {
+                  label: "View",
+                  onClick: () => toast.message("Action clicked."),
+                },
+              })
+            }
+          >
+            success + action
+          </Button>
+        </div>
       </Specimen>
 
       <Specimen


### PR DESCRIPTION
## Summary
- Adopts the `<StatusPanel>` vocabulary on every toast — 3px tone-tinted left rail + tinted icon tile + optional description — via Sonner's `toastOptions.classNames` slot. No fork of `ui/sonner.tsx`; the upstream primitive stays one prop swap away. Success / error / warning / info / message / loading + default each scan as a distinct tone without leaning on coloured backgrounds.
- Promotes three high-signal call sites to use the new description slot: connect-bank success ("Initial sync queued…"), CSV import success (appended vs new), reauth success ("Sync resumed…"). `withMutationToast` gains an optional `successDescription` so existing call sites can opt in without rewriting their try/catch.
- Sandbox patterns specimen rebuilt to show every tone side-by-side — success / error / warning / info / message / loading — plus `withMutationToast — ok (with description)` and a `success + action` toast (descriptive secondary line + inline action button).

## Before / After
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/3n17257g1i.jpg) | ![after](https://i.img402.dev/0dn8fxlzmr.jpg) |

## Notes
- Position pinned to `bottom-right`, `expand` on, `closeButton` on, `visibleToasts={4}` — matches modern shadcn toast vocabulary (Linear / Raycast).
- Ninth shared primitive of the sprint (after ListCard, ColorRailCard, IdPill, SectionCard, SoftBackButton, AuthShell, StatusPanel, FormFooter, ConfirmDialog) — though this one's a styling layer on top of an existing primitive (sonner Toaster), not a new component.
- Open observation: warning tone uses `amber-500` to match `StatusPanel`; info uses `sky-500` (StatusPanel's `info` tone is muted-neutral by design). Worth aligning if a third surface picks up tonal "info" — for now the toast variant is loud enough to be useful and the StatusPanel info is quiet enough to live inside surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)