### PR TITLE
chore: simplify drift from recent PRs

### DIFF
--- a/web/src/api/queries/users.ts
+++ b/web/src/api/queries/users.ts
@@ -31,25 +31,6 @@ export function useCreateUser() {
   });
 }
 
-export interface UpdateUserInput {
-  name?: string;
-  email?: string;
-}
-
-export function useUpdateUser() {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, input }: { id: string; input: UpdateUserInput }) =>
-      api<User>(`/api/v1/users/${id}`, {
-        method: "PATCH",
-        body: JSON.stringify(input),
-      }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["users"] });
-    },
-  });
-}
-
 export function useDeleteUser() {
   const qc = useQueryClient();
   return useMutation({

--- a/web/src/features/settings/household-section.tsx
+++ b/web/src/features/settings/household-section.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -666,12 +666,27 @@ function ShareLinkDialog({
 function SetupLinkBox({ token }: { token: string }) {
   const url = useMemo(() => setupAccountURL(token), [token]);
   const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
 
   const copy = async () => {
     try {
       await navigator.clipboard.writeText(url);
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+      }
+      resetTimerRef.current = window.setTimeout(() => {
+        setCopied(false);
+        resetTimerRef.current = null;
+      }, 2000);
     } catch {
       toast.error("Couldn't copy. Select the link and copy manually.");
     }


### PR DESCRIPTION
## Summary

Daily simplify-drift review of the 14 PRs merged in the last 24 hours. Surface was dominated by net-new v2 SPA pages — three parallel reviews (reuse / quality / efficiency) turned up only two findings worth acting on.

## PRs reviewed

- #1099 — v2: transactions detail page — hero, classify strip, inline notes
- #1100 — v2: date-range picker with presets + relax start/end validation
- #1101 — v2: categories and tags management pages
- #1102 — v2: trim sidebar — drop Reviews/Insights/Account links, regroup as Money/Library/System
- #1103 — ci: shard integration tests + drop SPA build from test job
- #1104 — v2: accounts list + detail pages with inline account linking
- #1105 — v2: drop appearance, billing, notifications from settings model
- #1106 — v2: API keys management pages
- #1107 — v2: rules page — list, detail, create/edit form
- #1108 — v2: providers settings page
- #1109 — v2: backups management page in settings
- #1110 — chore: track shadcn skill bundle and skills lockfile
- #1111 — v2: household settings page + native setup-account flow
- #1114 — v2: source Teller app id from link-session endpoint

## Changes

- `web/src/api/queries/users.ts` — remove unused `useUpdateUser` hook + `UpdateUserInput` interface added in #1111. Nothing in the SPA imports it; `household-section` uses `useCreateUser` / `useDeleteUser` / `useCreateLoginForUser`, none of which PATCH a user record.
- `web/src/features/settings/household-section.tsx:670–678` — fix `setTimeout` leak in `SetupLinkBox.copy`. The 2s "Copied" reset timer ran without an unmount guard, so closing the share-link dialog within 2s of clicking Copy left a pending `setCopied` call against an unmounted component. Mirrors the `useRef` + `useEffect` cleanup pattern already used by `api-key-created.tsx` (also added in #1106).

Everything else looked clean:

- The Go side of the batch (Teller link-session refactor in #1114, CI shard in #1103, backups handlers in #1109, provider-config flag in #1108) was already minimal — no helpers reinvented, no dead branches, comments earn their keep.
- The new query hooks (`api-keys`, `backups`, `provider-config`, `rules`, `account-links`) all route through `api/client.ts` and follow the established `useQuery` + `useMutation` + `invalidateQueries` shape; no near-duplicates worth deduplicating.
- New shadcn primitives (`radio-group`, `textarea`, `toggle`, `toggle-group`, `calendar`) are stock generated output — left alone per the v2 frontend rules.
- A couple of borderline comment-trim findings (`rule-form.tsx`, `condition-row.tsx`) were skipped per the "if in doubt, skip" guardrail.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `bun run lint` (tsc --noEmit) in `web/`

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJz393vEx6gmRpwRTKfWNY)_