### PR TITLE
design(v2): fix Transactions toolbar + page-header gap on mobile

### DIFF
--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -25,7 +25,11 @@ export function PageHeader({
   return (
     <div
       className={cn(
-        "mb-6 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end",
+        // No outer margin — every caller wraps PageHeader in a flex column
+        // with its own `gap-*`, so an `mb-*` here stacks with that gap and
+        // produces a ~44px void on mobile (visible because the action chip
+        // wraps below the description). Let the parent layout own spacing.
+        "flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-end sm:gap-4",
         className,
       )}
     >

--- a/web/src/features/transactions/transactions-toolbar.tsx
+++ b/web/src/features/transactions/transactions-toolbar.tsx
@@ -350,10 +350,12 @@ export function TransactionsToolbar({
           </FilterPill>
         </div>
 
-        <div className="grow" />
-
-        {/* Sort + select mode — grouped so they stay together when the row wraps */}
-        <div className="flex items-center gap-2">
+        {/* Sort + select mode — grouped so they stay together when the row wraps.
+            On sm+, `ml-auto` pushes them to the right edge alongside the filter
+            pills. On mobile we deliberately omit the spacer so they sit inline
+            with the filter pills instead of getting flung to the right of an
+            empty row. */}
+        <div className="flex items-center gap-2 sm:ml-auto">
           <FilterPill
             icon={ArrowUpDown}
             label={activeSort.label}


### PR DESCRIPTION
## Summary

- Drop `mb-6` from `PageHeader` — every caller wraps it in a `flex flex-col gap-*` parent, so the margin stacked with the parent gap and produced a ~44px void below the wrapped action button on mobile.
- Replace the `<div className='grow' />` spacer in `TransactionsToolbar` with `sm:ml-auto` on the sort/select cluster. On mobile, Sort + Select now flow inline with the filter pills instead of being flung to the far right with empty space beside an orphan Status pill. Desktop right-alignment preserved.

Both issues were flagged in iter 22's mobile audit. Verified at 375x812 (mobile) and 1440x900 (desktop sanity check).

## Before / After (mobile, 375x812)
| Before | After |
| --- | --- |
| ![before](https://i.img402.dev/m248903qtq.jpg) | ![after](https://i.img402.dev/7gp7tvlf30.jpg) |

## Desktop sanity (1440x900)
![desktop](https://i.img402.dev/0sak6j3dka.jpg)

## Notes
- PageHeader change is cross-cutting but safe: all 15+ callers already provide a flex-column `gap-*` parent (verified by grep). Pages that legitimately need more breathing room can add `mt-*` on their next sibling.
- Retires the "Transactions list mobile" observation in `.claude/v2-design-sprint.md`. Accounts + Providers mobile audit still TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)