### PR TITLE
design(v2): tab strip for settings shell on mobile

### DIFF
--- a/web/src/components/settings-shell.tsx
+++ b/web/src/components/settings-shell.tsx
@@ -64,10 +64,15 @@ export function SettingsShell() {
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="bottom" className="h-[92dvh] p-0">
-        <SheetHeader>
-          <SheetTitle>Settings</SheetTitle>
-          <SheetDescription>Manage your account and app preferences.</SheetDescription>
+      <SheetContent
+        side="bottom"
+        className="flex h-[92dvh] flex-col gap-0 p-0"
+      >
+        <SheetHeader className="border-b px-4 pt-5 pb-3">
+          <SheetTitle className="text-base">Settings</SheetTitle>
+          <SheetDescription className="text-xs">
+            Manage your account and app preferences.
+          </SheetDescription>
         </SheetHeader>
         {body}
       </SheetContent>
@@ -124,51 +129,61 @@ function SettingsBody({ active, onSelect, desktop }: SettingsBodyProps) {
   }
 
   return (
-    <div className="space-y-6 overflow-y-auto p-4">
-      {SETTINGS_SECTIONS.map((s) => (
-        <SectionContent key={s.slug} section={s} mobile />
-      ))}
+    <div className="flex min-h-0 flex-1 flex-col">
+      <nav
+        aria-label="Settings sections"
+        className="bg-background/95 supports-[backdrop-filter]:bg-background/80 sticky top-0 z-10 -mx-px border-b px-2 backdrop-blur"
+      >
+        <ul
+          className="-mx-2 flex w-max flex-nowrap items-center gap-1 overflow-x-auto px-2 py-2 whitespace-nowrap [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        >
+          {SETTINGS_SECTIONS.map((s) => {
+            const Icon = s.icon;
+            const isActive = s.slug === active.slug;
+            return (
+              <li key={s.slug}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(s.slug)}
+                  data-active={isActive ? "true" : undefined}
+                  className={cn(
+                    "group flex h-8 shrink-0 items-center gap-1.5 rounded-full border px-3 text-xs font-medium transition-colors",
+                    "[&>svg]:size-3.5",
+                    isActive
+                      ? "border-primary/30 bg-primary/10 text-primary [&>svg]:text-primary"
+                      : "border-border bg-card text-muted-foreground hover:bg-accent/60 hover:text-foreground [&>svg]:text-muted-foreground",
+                  )}
+                >
+                  <Icon />
+                  <span>{s.title}</span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+      <section className="flex-1 overflow-y-auto p-4">
+        <SectionContent section={active} />
+      </section>
     </div>
   );
 }
 
-function SectionContent({
-  section,
-  mobile = false,
-}: {
-  section: SettingsSection;
-  mobile?: boolean;
-}) {
-  const wrapper = mobile
-    ? "border-border border-t pt-4 first:border-t-0 first:pt-0"
-    : "";
-
+function SectionContent({ section }: { section: SettingsSection }) {
   if (section.slug === "account") {
-    return (
-      <div className={wrapper}>
-        <AccountSection />
-      </div>
-    );
+    return <AccountSection />;
   }
 
   if (section.slug === "household") {
-    return (
-      <div className={wrapper}>
-        <HouseholdSection />
-      </div>
-    );
+    return <HouseholdSection />;
   }
 
   if (section.slug === "backups") {
-    return (
-      <div className={wrapper}>
-        <BackupsSection />
-      </div>
-    );
+    return <BackupsSection />;
   }
 
   return (
-    <div className={cn(wrapper, mobile ? "space-y-2" : "space-y-1")}>
+    <div className="space-y-1">
       <h2 className="text-lg font-medium">{section.title}</h2>
       <p className="text-muted-foreground text-sm">{section.description}</p>
       <p className="text-muted-foreground mt-4 text-sm">Coming soon.</p>


### PR DESCRIPTION
## Summary
- Mobile settings sheet was rendering every section stacked vertically (Account → Change password → Household with N members → Security → Backups). To reach Backups, you had to scroll past everything.
- Now mobile renders one section at a time using a horizontally-scrollable tab strip (pills with icon + label) above the section body, mirroring the desktop "select one in the sidebar" pattern.
- Tightens the sheet header to ``text-base`` title + ``text-xs`` description with a sticky ``border-b``, so the tab strip reads as part of the chrome and not as content.
- Closes the iter-22 mobile-audit residual for ``/settings/*``.

## Before / After
| Before (mobile, all sections stacked) | After – Account | After – Household |
| --- | --- | --- |
| ![before](https://i.img402.dev/8wv0fms9wl.jpg) | ![after-account](https://i.img402.dev/wq17wsd3h0.jpg) | ![after-household](https://i.img402.dev/k9tlfqbc60.jpg) |

## Notes
- The pill strip uses the same horizontally-scrollable pattern that iter-24 (#1137) applied to ``FamilyTabs`` — ``overflow-x-auto``, ``w-max``, ``flex-nowrap``, ``whitespace-nowrap``, scrollbar hidden — so the vocabulary for "tab pile that doesn't wrap on mobile" is consistent across the SPA.
- Active pill uses the ``border-primary/30 bg-primary/10 text-primary`` token combo already used by the desktop sidebar active state.
- Desktop view (``min-width: 768px``) is unchanged — same dialog + left sidebar.
- The mobile shell still reads from ``useActiveModal``'s ``section`` slug, so opening ``/?m=settings&ms=backups`` lands on the Backups pane on both viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)