### PR TITLE
design(v2): brand polish — favicon, OG image, meta tags

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3,8 +3,51 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Breadbox v2</title>
+
+    <title>Breadbox — Self-hosted finance for households</title>
+    <meta
+      name="description"
+      content="Aggregate Plaid, Teller, and CSV bank data into one Postgres database you control. AI-ready via MCP, deploys as a single Go binary."
+    />
+
+    <!-- Branding / browser chrome.
+
+         The favicon and theme-color match the v2 primary token in
+         `web/src/globals.css` (oklch(0.205 0 0) ≈ #1a1a1a) and the
+         `BrandHeader` lockup so the tab icon reads as a smaller copy
+         of the in-app brand mark. -->
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
+    <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#1a1a1a" media="(prefers-color-scheme: dark)" />
+    <meta name="color-scheme" content="light dark" />
+
+    <!-- Open Graph — Slack / Discord / iMessage / Linear link previews. -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Breadbox" />
+    <meta property="og:title" content="Breadbox — Self-hosted finance for households" />
+    <meta
+      property="og:description"
+      content="Aggregate Plaid, Teller, and CSV bank data into one Postgres database you control. AI-ready via MCP, deploys as a single Go binary."
+    />
+    <meta property="og:image" content="./og-image.svg" />
+    <meta property="og:image:type" content="image/svg+xml" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Breadbox — self-hosted finance for households. Encrypted at rest, MCP-native, single binary." />
+
+    <!-- Twitter / X card. -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Breadbox — Self-hosted finance for households" />
+    <meta
+      name="twitter:description"
+      content="Aggregate Plaid, Teller, and CSV bank data into one Postgres database you control."
+    />
+    <meta name="twitter:image" content="./og-image.svg" />
+
     <script>
+      // Light/dark theme follows the OS — same contract as `BrandHeader`
+      // and the rest of the v2 SPA. Inline + synchronous so the first
+      // paint never flashes the wrong theme.
       (function () {
         var mql = window.matchMedia("(prefers-color-scheme: dark)");
         function apply(e) {

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <title>Breadbox</title>
+  <rect width="32" height="32" rx="7" fill="#1a1a1a"/>
+  <g fill="none" stroke="#fafafa" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" transform="translate(4 4)">
+    <path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/>
+    <path d="M12 22V12"/>
+    <path d="m3.3 7 7.703 4.734a2 2 0 0 0 1.994 0L20.7 7"/>
+    <path d="m7.5 4.27 9 5.15"/>
+  </g>
+</svg>

--- a/web/public/og-image.svg
+++ b/web/public/og-image.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <title>Breadbox — self-hosted finance for households</title>
+
+  <defs>
+    <pattern id="dots" x="0" y="0" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="2" cy="2" r="1.25" fill="#e4e4e7"/>
+    </pattern>
+    <radialGradient id="glow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#1a1a1a" stop-opacity="0.06"/>
+      <stop offset="100%" stop-color="#1a1a1a" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1200" height="630" fill="#fafafa"/>
+  <rect width="1200" height="630" fill="url(#dots)" opacity="0.55"/>
+  <circle cx="180" cy="240" r="220" fill="url(#glow)"/>
+
+  <g transform="translate(80 76)">
+    <rect width="56" height="56" rx="12" fill="#1a1a1a"/>
+    <g fill="none" stroke="#fafafa" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" transform="translate(10 10) scale(1.5)">
+      <path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/>
+      <path d="M12 22V12"/>
+      <path d="m3.3 7 7.703 4.734a2 2 0 0 0 1.994 0L20.7 7"/>
+      <path d="m7.5 4.27 9 5.15"/>
+    </g>
+    <text x="76" y="26" font-family="ui-sans-serif, system-ui, -apple-system, 'Inter', sans-serif" font-size="22" font-weight="600" fill="#1a1a1a" letter-spacing="-0.2">Breadbox</text>
+    <g transform="translate(76 38)">
+      <rect width="40" height="16" rx="3" fill="#1a1a1a" fill-opacity="0.08"/>
+      <text x="20" y="12" font-family="ui-sans-serif, system-ui, -apple-system, 'Inter', sans-serif" font-size="10" font-weight="700" fill="#1a1a1a" letter-spacing="1" text-anchor="middle">V2</text>
+    </g>
+  </g>
+
+  <g transform="translate(80 290)">
+    <text x="0" y="0" font-family="ui-sans-serif, system-ui, -apple-system, 'Inter', sans-serif" font-size="14" font-weight="600" fill="#71717a" letter-spacing="2.5">SELF&#8209;HOSTED FINANCE FOR HOUSEHOLDS</text>
+    <text x="0" y="76" font-family="ui-sans-serif, system-ui, -apple-system, 'Inter', sans-serif" font-size="84" font-weight="700" fill="#1a1a1a" letter-spacing="-2.5">Your money, on</text>
+    <text x="0" y="172" font-family="ui-sans-serif, system-ui, -apple-system, 'Inter', sans-serif" font-size="84" font-weight="700" fill="#1a1a1a" letter-spacing="-2.5">your server.</text>
+    <text x="0" y="222" font-family="ui-sans-serif, system-ui, -apple-system, 'Inter', sans-serif" font-size="22" font-weight="400" fill="#71717a" letter-spacing="-0.2">Aggregates Plaid, Teller, and CSV bank data into one Postgres database</text>
+    <text x="0" y="252" font-family="ui-sans-serif, system-ui, -apple-system, 'Inter', sans-serif" font-size="22" font-weight="400" fill="#71717a" letter-spacing="-0.2">you control. AI&#8209;ready via MCP.</text>
+  </g>
+
+  <g transform="translate(80 562)" font-family="ui-sans-serif, system-ui, -apple-system, 'Inter', sans-serif" font-size="13" font-weight="500" fill="#1a1a1a">
+    <g>
+      <rect width="178" height="32" rx="16" fill="#f4f4f5" stroke="#e4e4e7"/>
+      <circle cx="18" cy="16" r="3" fill="#16a34a"/>
+      <text x="32" y="20">Encrypted at rest</text>
+    </g>
+    <g transform="translate(192 0)">
+      <rect width="158" height="32" rx="16" fill="#f4f4f5" stroke="#e4e4e7"/>
+      <circle cx="18" cy="16" r="3" fill="#2563eb"/>
+      <text x="32" y="20">MCP-native</text>
+    </g>
+    <g transform="translate(364 0)">
+      <rect width="174" height="32" rx="16" fill="#f4f4f5" stroke="#e4e4e7"/>
+      <circle cx="18" cy="16" r="3" fill="#a855f7"/>
+      <text x="32" y="20">Single binary</text>
+    </g>
+  </g>
+
+  <text x="1120" y="582" font-family="ui-monospace, 'JetBrains Mono', SFMono-Regular, Menlo, monospace" font-size="14" font-weight="500" fill="#71717a" text-anchor="end">breadbox.sh</text>
+</svg>


### PR DESCRIPTION
## Summary
- New brand-aligned SVG favicon (`web/public/favicon.svg`) — small copy of the in-app brand mark, matched to the v2 primary token.
- New OG image (`web/public/og-image.svg`) — 1200x630 social card with the brand lockup + tagline.
- `web/index.html` meta sweep:
  - Title: `Breadbox — Self-hosted finance for households` (was `Breadbox v2`).
  - description meta for SEO + link previews.
  - theme-color split by `prefers-color-scheme`; `color-scheme` dual.
  - Open Graph (type/site_name/title/description/image + 1200x630 dimensions + alt) for Slack/Discord/iMessage/Linear previews.
  - Twitter `summary_large_image` card.

## Notes
- Iter #29: agent did the implementation but stopped mid-screenshot step before committing/PR'ing. Main session reconciled and shipped.
- Lint + go build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)